### PR TITLE
fix(smoke): pre-pull python:3.11-slim so A7 matches on cold-cache CI

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -15,7 +15,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get PR commits
+        id: get-pr-commits
+        uses: tim-actions/get-pr-commits@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Check DCO
         uses: tim-actions/dco@master
         with:
-          commits: ${{ github.event.pull_request.commits }}
+          commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/demo_network/smoke.sh
+++ b/demo_network/smoke.sh
@@ -197,6 +197,11 @@ assert_audit_hash_chain_integrity() {
     fi
 
     # Recompute hashes with the exact canonical form used by the broker.
+    # Pre-pull the image so `docker run` stderr stays clean — otherwise the
+    # "Unable to find image... Pulling from..." noise prepends the script
+    # output and the `^OK N` regex below stops matching on cold-cache runners.
+    docker pull python:3.11-slim >/dev/null 2>&1 || true
+
     local verified
     verified="$(docker run --rm \
         -v "$check_dir":/in:ro \


### PR DESCRIPTION
## Summary

Smoke workflow has been failing at assertion A7 (audit hash chain integrity) on every run since commit `12d701e`. Root cause is cosmetic, not a real hash chain break — the test passes once the image cache is warm.

- `demo_network/smoke.sh:204` captures `docker run ... 2>&1`. On a cold cache (always the case in CI), `docker run` emits "Unable to find image 'python:3.11-slim' locally / Pulling from..." on stderr before executing.
- That noise gets prepended to `$verified`, so the `^OK[[:space:]]([0-9]+)` regex at line 208 no longer matches (the string no longer *starts* with `OK`).
- The Python verifier itself was printing `OK 33` correctly the whole time — visible in [run 24309340942](https://github.com/cullis-security/cullis/actions/runs/24309340942) logs.

Fix: `docker pull python:3.11-slim >/dev/null 2>&1 || true` before the `docker run`, so the subsequent run finds the image cached and stderr stays empty.

## Test plan

- [ ] Smoke workflow on this PR goes green on both `rsa` and `ec` matrix legs
- [ ] Local `./demo_network/smoke.sh full` still passes (already does — local cache always warm)