### PR TITLE
feat(helm): add Helm chart for MCP Proxy

### DIFF
--- a/deploy/helm/cullis-proxy/Chart.yaml
+++ b/deploy/helm/cullis-proxy/Chart.yaml
@@ -1,0 +1,30 @@
+apiVersion: v2
+name: cullis-proxy
+description: |
+  Cullis MCP Proxy — org-level gateway between internal AI agents and the
+  Cullis trust broker. Production-ready Helm chart with HPA,
+  PodDisruptionBudget, NetworkPolicy, cert-manager TLS termination and
+  Prometheus Operator integration.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+kubeVersion: ">=1.25.0-0"
+home: https://cullis.tech
+sources:
+  - https://github.com/cullis-security/cullis
+maintainers:
+  - name: Cullis Maintainers
+    url: https://github.com/cullis-security
+keywords:
+  - cullis
+  - mcp
+  - mcp-proxy
+  - agent-trust
+  - gateway
+  - pdp
+  - dpop
+  - zero-trust
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/changes: |
+    - Initial Helm chart for production deployments of the MCP Proxy.

--- a/deploy/helm/cullis-proxy/README.md
+++ b/deploy/helm/cullis-proxy/README.md
@@ -1,0 +1,201 @@
+# Cullis MCP Proxy Helm Chart
+
+Helm chart for the Cullis **MCP Proxy** — the org-level gateway that sits
+between internal AI agents and the [Cullis](https://cullis.io) trust
+broker. The chart is a structural mirror of the broker chart
+(`deploy/helm/cullis/`): same label scheme, same security posture, same
+ingress story.
+
+> Status: work in progress, not yet production-validated. `helm lint` and
+> `helm template` pass; end-to-end install on a managed cluster has not
+> been exercised. Fork and harden for your environment.
+
+## Quick start
+
+Production install:
+
+```bash
+helm install cullis-proxy ./deploy/helm/cullis-proxy \
+  --namespace cullis-proxy --create-namespace \
+  --set ingress.host=proxy.myorg.example.com \
+  --set proxy.brokerUrl=https://broker.cullis.example.com \
+  --set proxy.brokerJwksUrl=https://broker.cullis.example.com/.well-known/jwks.json \
+  --set proxy.proxyPublicUrl=https://proxy.myorg.example.com \
+  --set proxy.pdpUrl=https://proxy.myorg.example.com/pdp/policy \
+  --set secrets.adminSecret="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')" \
+  --set secrets.dashboardSigningKey="$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+```
+
+Dev install on `kind` / `minikube`:
+
+```bash
+helm install cullis-proxy ./deploy/helm/cullis-proxy \
+  --namespace cullis-proxy --create-namespace \
+  -f deploy/helm/cullis-proxy/values-dev.yaml
+```
+
+## What the chart deploys
+
+| Component        | Resource                 | Notes                                        |
+|------------------|--------------------------|----------------------------------------------|
+| Proxy            | Deployment, Service      | Single replica by default (SQLite-backed)    |
+| Proxy (HA)       | HPA, PodDisruptionBudget | Opt-in, requires RWX storage for >1 replicas |
+| Proxy (security) | NetworkPolicy            | Ingress from nginx + broker ns; egress locked down |
+| Proxy (config)   | ConfigMap, Secret        | Secret can be replaced by SealedSecret / ExternalSecret |
+| Proxy (auth)     | ServiceAccount           | Annotate for IRSA / Workload Identity        |
+| Data             | PersistentVolumeClaim    | SQLite DB + audit log on /data               |
+| Ingress          | Ingress (nginx + cert-manager) | Websocket annotations, TLS via ClusterIssuer |
+| Monitoring       | ServiceMonitor (opt-in)  | Prometheus Operator CRD                      |
+| Postgres (stub)  | StatefulSet, Service     | Only when `postgres.internal=true`; forward-compatible stub, proxy code does not use Postgres today |
+
+## Persistence
+
+The proxy persists two things on `/data`:
+
+1. A SQLite database (`mcp_proxy.db`) with registered internal agents,
+   audit log and dashboard configuration.
+2. An append-only audit log (same DB file; rows never deleted).
+
+The chart defaults to a 5 Gi PVC with `ReadWriteOnce`. Single-replica
+deployments work on any StorageClass. To run multiple replicas the
+volume must be `ReadWriteMany` — pick EFS (AWS), Filestore (GCP), Azure
+Files or Longhorn RWX.
+
+```yaml
+proxy:
+  replicaCount: 2
+persistence:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: efs-sc
+```
+
+## Broker uplink
+
+Three values must point at the broker:
+
+| Key                        | Purpose                                              |
+|----------------------------|------------------------------------------------------|
+| `proxy.brokerUrl`          | Base URL for admin + egress calls to the broker       |
+| `proxy.brokerJwksUrl`      | JWKS endpoint for validating broker-signed JWTs       |
+| `proxy.pdpUrl`             | URL the broker calls to reach this proxy's PDP       |
+
+When the broker TLS cert is signed by a non-public CA (corporate root,
+Let's Encrypt staging, etc) mount the CA bundle and point the proxy at
+it:
+
+```yaml
+proxy:
+  brokerCaBundle: /certs/corporate-ca.pem
+  extraVolumes:
+    - name: broker-ca
+      configMap:
+        name: broker-ca-bundle
+        items:
+          - key: ca.pem
+            path: corporate-ca.pem
+  extraVolumeMounts:
+    - name: broker-ca
+      mountPath: /certs
+      readOnly: true
+```
+
+## Vault backend (optional)
+
+When `vault.enabled=true` the proxy reads tool secrets from Vault KV v2
+instead of environment variables:
+
+```yaml
+vault:
+  enabled: true
+  addr: https://vault.corp.example.com:8200
+  secretPrefix: secret/data/mcp-proxy/tools
+
+secrets:
+  vaultToken: "hvs.xxxx"   # or use Kubernetes auth via the SA below
+
+proxy:
+  serviceAccount:
+    annotations:
+      vault.hashicorp.com/role: cullis-proxy
+```
+
+For production prefer the Vault Agent Injector (sidecar) or External
+Secrets Operator over a static token in Helm values — see the commented
+examples in `values.yaml`.
+
+## Secrets via SealedSecret or ExternalSecret
+
+Set `secrets.create=false` and create the Secret yourself:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cullis-proxy-env
+  namespace: cullis-proxy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secretsmanager
+    kind: ClusterSecretStore
+  target:
+    name: cullis-proxy-env
+    creationPolicy: Owner
+  data:
+    - secretKey: MCP_PROXY_ADMIN_SECRET
+      remoteRef:
+        key: cullis-proxy/admin_secret
+    - secretKey: MCP_PROXY_DASHBOARD_SIGNING_KEY
+      remoteRef:
+        key: cullis-proxy/dashboard_signing_key
+```
+
+Then install with:
+
+```bash
+helm install cullis-proxy ./deploy/helm/cullis-proxy \
+  --set secrets.create=false \
+  --set secrets.existingSecret=cullis-proxy-env
+```
+
+## Security posture
+
+* `podSecurityContext`: `runAsNonRoot: true`, `runAsUser: 1000`,
+  `fsGroup: 1000`, `seccompProfile: RuntimeDefault`.
+* `securityContext`: `allowPrivilegeEscalation: false`, `capabilities:
+  drop: [ALL]`.
+* `automountServiceAccountToken: false` on the ServiceAccount.
+* NetworkPolicy restricts ingress to the nginx ingress controller
+  namespace (+ optionally the broker namespace for the PDP webhook) and
+  egress to DNS, HTTPS and, when enabled, Vault.
+* Ingress annotates websocket support and backend protocol for the
+  nginx ingress controller.
+
+`readOnlyRootFilesystem` is left false because the proxy writes SQLite
+temp files next to the DB. Flip it to true by adding a dedicated
+`emptyDir` mount on `/tmp` if your security baseline requires it.
+
+## Validation
+
+```bash
+helm lint deploy/helm/cullis-proxy
+helm template deploy/helm/cullis-proxy > /dev/null
+helm template deploy/helm/cullis-proxy -f deploy/helm/cullis-proxy/values-dev.yaml > /dev/null
+```
+
+The `ServiceMonitor` is only rendered when
+`monitoring.serviceMonitor.enabled=true`. The Prometheus Operator CRDs do
+not need to be installed at `helm template` time; they must exist in the
+cluster at `helm install` time.
+
+## Upgrade
+
+```bash
+helm upgrade cullis-proxy ./deploy/helm/cullis-proxy -f values-prod.yaml
+```
+
+The Deployment uses `maxSurge: 1, maxUnavailable: 0` and a 5 s
+`preStop sleep` so there is always a Ready pod behind the Service during
+a rolling update. A `PodDisruptionBudget` (opt-in) protects against
+simultaneous voluntary evictions during a node drain.

--- a/deploy/helm/cullis-proxy/templates/NOTES.txt
+++ b/deploy/helm/cullis-proxy/templates/NOTES.txt
@@ -1,0 +1,62 @@
+Cullis MCP Proxy — org-level gateway — has been installed.
+
+Release : {{ .Release.Name }}
+Chart   : {{ .Chart.Name }}-{{ .Chart.Version }} (appVersion {{ .Chart.AppVersion }})
+
+1. Check that proxy pods reached Ready:
+
+   kubectl -n {{ .Release.Namespace }} get pods -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=proxy
+
+2. Tail the proxy logs:
+
+   kubectl -n {{ .Release.Namespace }} logs -l app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=proxy -f
+
+{{- if .Values.ingress.enabled }}
+3. Public URL:
+
+   {{ if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}{{ .Values.ingress.path }}
+
+   Dashboard login:
+
+   {{ if .Values.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.ingress.host }}/proxy/login
+{{- else }}
+3. Ingress is disabled. Port-forward the proxy Service to reach it:
+
+   kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "cullis-proxy.proxy.fullname" . }} 9100:{{ .Values.proxy.service.port }}
+   open http://127.0.0.1:9100/health
+{{- end }}
+
+{{- if not .Values.proxy.brokerUrl }}
+
+WARNING: proxy.brokerUrl is empty. The proxy will start but egress to the
+         broker is disabled until you set it (configure via helm upgrade or
+         through the setup wizard in the proxy dashboard).
+{{- end }}
+
+{{- if and .Values.secrets.create (not .Values.secrets.adminSecret) }}
+
+WARNING: secrets.adminSecret is empty. A random value has been generated on
+         install but will be re-generated on every `helm upgrade` unless you
+         set it explicitly. Generate once with:
+
+             python -c "import secrets; print(secrets.token_urlsafe(32))"
+
+         and provide it via --set secrets.adminSecret=... or a values file.
+{{- end }}
+
+{{- if and .Values.secrets.create (not .Values.secrets.dashboardSigningKey) }}
+
+WARNING: secrets.dashboardSigningKey is empty. Admin dashboard sessions
+         will be invalidated on every pod restart because a random key is
+         generated per-process. Pin it to survive rollouts.
+{{- end }}
+
+{{- if and (gt (int .Values.proxy.replicaCount) 1) (has "ReadWriteOnce" .Values.persistence.accessModes) }}
+
+WARNING: proxy.replicaCount > 1 but persistence.accessModes is ReadWriteOnce.
+         SQLite cannot be shared across pods on RWO storage. Either scale
+         back to 1 replica or switch to a RWX-capable StorageClass
+         (EFS / Filestore / Azure Files / Longhorn RWX).
+{{- end }}
+
+For upgrade and operational runbooks see deploy/helm/cullis-proxy/README.md.

--- a/deploy/helm/cullis-proxy/templates/_helpers.tpl
+++ b/deploy/helm/cullis-proxy/templates/_helpers.tpl
@@ -1,0 +1,154 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cullis-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars because some Kubernetes name fields are limited.
+*/}}
+{{- define "cullis-proxy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Chart label value (chart name + version, dots replaced by underscores).
+*/}}
+{{- define "cullis-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Standard Helm 3 labels applied to every object rendered by the chart.
+*/}}
+{{- define "cullis-proxy.labels" -}}
+helm.sh/chart: {{ include "cullis-proxy.chart" . }}
+{{ include "cullis-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: cullis
+{{- end -}}
+
+{{/*
+Selector labels — stable subset used in matchLabels of workloads.
+*/}}
+{{- define "cullis-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cullis-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Proxy-specific labels (adds the component tag).
+*/}}
+{{- define "cullis-proxy.proxy.labels" -}}
+{{ include "cullis-proxy.labels" . }}
+app.kubernetes.io/component: proxy
+{{- end -}}
+
+{{- define "cullis-proxy.proxy.selectorLabels" -}}
+{{ include "cullis-proxy.selectorLabels" . }}
+app.kubernetes.io/component: proxy
+{{- end -}}
+
+{{/*
+Proxy ServiceAccount name.
+*/}}
+{{- define "cullis-proxy.serviceAccountName" -}}
+{{- if .Values.proxy.serviceAccount.create -}}
+{{- default (include "cullis-proxy.fullname" .) .Values.proxy.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.proxy.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Workload resource names.
+*/}}
+{{- define "cullis-proxy.proxy.fullname" -}}
+{{- include "cullis-proxy.fullname" . -}}
+{{- end -}}
+
+{{/*
+Name of the proxy Secret (user-managed or chart-managed).
+*/}}
+{{- define "cullis-proxy.secretName" -}}
+{{- if .Values.secrets.existingSecret -}}
+{{- .Values.secrets.existingSecret -}}
+{{- else -}}
+{{- printf "%s-env" (include "cullis-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the proxy ConfigMap.
+*/}}
+{{- define "cullis-proxy.configMapName" -}}
+{{- printf "%s-env" (include "cullis-proxy.fullname" .) -}}
+{{- end -}}
+
+{{/*
+Name of the PVC that backs /data.
+*/}}
+{{- define "cullis-proxy.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{- .Values.persistence.existingClaim -}}
+{{- else -}}
+{{- printf "%s-data" (include "cullis-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Proxy image reference.
+*/}}
+{{- define "cullis-proxy.image" -}}
+{{- $tag := .Values.proxy.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" .Values.proxy.image.repository $tag -}}
+{{- end -}}
+
+{{/*
+Name of the TLS secret referenced by the Ingress.
+*/}}
+{{- define "cullis-proxy.ingress.tlsSecretName" -}}
+{{- if .Values.ingress.tls.secretName -}}
+{{- .Values.ingress.tls.secretName -}}
+{{- else -}}
+{{- printf "%s-tls" (include "cullis-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Postgres-specific labels.
+*/}}
+{{- define "cullis-proxy.postgres.labels" -}}
+{{ include "cullis-proxy.labels" . }}
+app.kubernetes.io/component: postgres
+{{- end -}}
+
+{{- define "cullis-proxy.postgres.selectorLabels" -}}
+{{ include "cullis-proxy.selectorLabels" . }}
+app.kubernetes.io/component: postgres
+{{- end -}}
+
+{{- define "cullis-proxy.postgres.fullname" -}}
+{{- printf "%s-postgres" (include "cullis-proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+SQLite database URL pointing at the PVC mount.
+*/}}
+{{- define "cullis-proxy.databaseUrl" -}}
+{{- printf "sqlite+aiosqlite:///%s/mcp_proxy.db" .Values.persistence.mountPath -}}
+{{- end -}}

--- a/deploy/helm/cullis-proxy/templates/postgres-pvc.yaml
+++ b/deploy/helm/cullis-proxy/templates/postgres-pvc.yaml
@@ -1,0 +1,8 @@
+{{/*
+The in-cluster Postgres (when postgres.internal=true) uses a StatefulSet
+with `volumeClaimTemplates` so the PVC is rendered automatically per
+replica with a stable name.
+
+This file is intentionally left empty: defining a standalone PVC alongside
+the StatefulSet would shadow the per-replica claim and break upgrades.
+*/}}

--- a/deploy/helm/cullis-proxy/templates/postgres-service.yaml
+++ b/deploy/helm/cullis-proxy/templates/postgres-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.postgres.internal }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cullis-proxy.postgres.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.postgres.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: {{ .Values.postgres.port }}
+      targetPort: postgres
+      protocol: TCP
+  selector:
+    {{- include "cullis-proxy.postgres.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/postgres-statefulset.yaml
+++ b/deploy/helm/cullis-proxy/templates/postgres-statefulset.yaml
@@ -1,0 +1,80 @@
+{{- if .Values.postgres.internal }}
+# NOTE: the current proxy image does NOT read from Postgres — see
+# mcp_proxy/db.py (aiosqlite only). This StatefulSet is provided as a
+# forward-compatible stub and is disabled by default.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "cullis-proxy.postgres.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.postgres.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "cullis-proxy.postgres.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "cullis-proxy.postgres.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cullis-proxy.postgres.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.postgres.port }}
+              protocol: TCP
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.username | quote }}
+            - name: POSTGRES_PASSWORD
+              value: {{ .Values.postgres.password | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database | quote }}
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.username | quote }}
+                - -d
+                - {{ .Values.postgres.database | quote }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - {{ .Values.postgres.username | quote }}
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          {{- with .Values.postgres.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "cullis-proxy.postgres.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- if .Values.postgres.storageClassName }}
+        storageClassName: {{ .Values.postgres.storageClassName | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storageSize }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cullis-proxy.configMapName" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+data:
+  MCP_PROXY_ENVIRONMENT: {{ .Values.proxy.environment | quote }}
+  MCP_PROXY_HOST: "0.0.0.0"
+  MCP_PROXY_PORT: {{ .Values.proxy.containerPort | quote }}
+
+  {{- if .Values.proxy.brokerUrl }}
+  MCP_PROXY_BROKER_URL: {{ .Values.proxy.brokerUrl | quote }}
+  {{- end }}
+  {{- if .Values.proxy.brokerJwksUrl }}
+  MCP_PROXY_BROKER_JWKS_URL: {{ .Values.proxy.brokerJwksUrl | quote }}
+  {{- end }}
+  MCP_PROXY_BROKER_VERIFY_TLS: {{ .Values.proxy.brokerVerifyTls | quote }}
+
+  {{- if .Values.proxy.proxyPublicUrl }}
+  MCP_PROXY_PROXY_PUBLIC_URL: {{ .Values.proxy.proxyPublicUrl | quote }}
+  {{- else if .Values.ingress.enabled }}
+  MCP_PROXY_PROXY_PUBLIC_URL: {{ printf "%s://%s" (ternary "https" "http" .Values.ingress.tls.enabled) .Values.ingress.host | quote }}
+  {{- end }}
+
+  {{- if .Values.proxy.pdpUrl }}
+  MCP_PROXY_PDP_URL: {{ .Values.proxy.pdpUrl | quote }}
+  {{- end }}
+
+  {{- if .Values.proxy.orgId }}
+  MCP_PROXY_ORG_ID: {{ .Values.proxy.orgId | quote }}
+  {{- end }}
+
+  MCP_PROXY_ALLOWED_ORIGINS: {{ .Values.proxy.allowedOrigins | quote }}
+
+  MCP_PROXY_DATABASE_URL: {{ include "cullis-proxy.databaseUrl" . | quote }}
+
+  {{- if .Values.vault.enabled }}
+  MCP_PROXY_SECRET_BACKEND: "vault"
+  MCP_PROXY_VAULT_ADDR: {{ .Values.vault.addr | quote }}
+  MCP_PROXY_VAULT_SECRET_PREFIX: {{ .Values.vault.secretPrefix | quote }}
+  {{- else }}
+  MCP_PROXY_SECRET_BACKEND: "env"
+  {{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
@@ -1,0 +1,136 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.proxy.replicaCount }}
+  {{- end }}
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # Roll one pod at a time so /readyz draining always keeps an
+      # available endpoint behind the Service.
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 8 }}
+        {{- with .Values.proxy.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        # Roll the Deployment when ConfigMap or Secret content changes so
+        # graceful drain is observed for every config rotation.
+        checksum/config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") . | sha256sum }}
+        {{- if .Values.secrets.create }}
+        checksum/secret: {{ include (print $.Template.BasePath "/proxy-secret.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.proxy.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "cullis-proxy.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.proxy.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.proxy.terminationGracePeriodSeconds }}
+      {{- with .Values.proxy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.proxy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.proxy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: proxy
+          image: {{ include "cullis-proxy.image" . }}
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          {{- with .Values.proxy.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.proxy.containerPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "cullis-proxy.configMapName" . }}
+            {{- if or .Values.secrets.create .Values.secrets.existingSecret }}
+            - secretRef:
+                name: {{ include "cullis-proxy.secretName" . }}
+            {{- end }}
+            {{- with .Values.proxy.extraEnvFrom }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          env:
+            {{- if .Values.proxy.brokerCaBundle }}
+            # Broker CA bundle — consumed by stdlib ssl + httpx via certifi.
+            - name: SSL_CERT_FILE
+              value: {{ .Values.proxy.brokerCaBundle | quote }}
+            - name: REQUESTS_CA_BUNDLE
+              value: {{ .Values.proxy.brokerCaBundle | quote }}
+            {{- end }}
+            {{- with .Values.proxy.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.proxy.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.proxy.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.proxy.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.proxy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                # Give kube-proxy / endpoints controller time to remove the
+                # pod from the Service before uvicorn receives SIGTERM.
+                command:
+                  - /bin/sh
+                  - -c
+                  - sleep {{ .Values.proxy.preStopSleepSeconds }}
+          volumeMounts:
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+            {{- with .Values.proxy.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "cullis-proxy.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- with .Values.proxy.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-hpa.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-hpa.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "cullis-proxy.proxy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if and .Values.autoscaling.targetMemoryUtilizationPercentage (gt (int .Values.autoscaling.targetMemoryUtilizationPercentage) 0) }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+        - type: Percent
+          value: 50
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 30
+      policies:
+        - type: Percent
+          value: 100
+          periodSeconds: 30
+        - type: Pods
+          value: 2
+          periodSeconds: 30
+      selectPolicy: Max
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-ingress.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-ingress.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+  annotations:
+    # Websocket-friendly defaults for the nginx ingress controller. Proxy
+    # egress relies on long-lived Server-Sent Events so high timeouts are
+    # necessary.
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+    nginx.ingress.kubernetes.io/enable-websocket: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- if and .Values.ingress.tls.enabled .Values.ingress.tls.certManagerIssuer }}
+    cert-manager.io/{{ lower .Values.ingress.tls.certManagerIssuerKind }}: {{ .Values.ingress.tls.certManagerIssuer | quote }}
+    {{- end }}
+    {{- with .Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host | quote }}
+      secretName: {{ include "cullis-proxy.ingress.tlsSecretName" . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: {{ include "cullis-proxy.proxy.fullname" . }}
+                port:
+                  number: {{ .Values.proxy.service.port }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-networkpolicy.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-networkpolicy.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Ingress controller namespace — the nginx ingress controller reaches
+    # the proxy dashboard and ingress/egress APIs.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.ingressNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.proxy.containerPort }}
+    {{- if .Values.networkPolicy.brokerNamespace }}
+    # Allow the broker (when deployed in the same cluster) to call the
+    # /pdp/policy webhook on this proxy.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.brokerNamespace | quote }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.proxy.containerPort }}
+    {{- end }}
+    {{- with .Values.networkPolicy.extraIngress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Broker uplink over HTTPS (and plain HTTP for dev; tighten with
+    # extraEgress/ipBlock when the broker IP is known).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 8000
+    {{- if .Values.vault.enabled }}
+    # Vault API (external). Restrict via extraEgress in production.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 169.254.0.0/16
+      ports:
+        - protocol: TCP
+          port: 8200
+    {{- end }}
+    {{- with .Values.networkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-pdb.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+spec:
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-pvc.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "cullis-proxy.pvcName" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+  annotations:
+    # Keep the claim (and thus the SQLite data) if the release is deleted.
+    helm.sh/resource-policy: keep
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-secret.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-secret.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.secrets.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "cullis-proxy.secretName" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+  annotations:
+    # Allow SealedSecrets / ExternalSecrets controllers to adopt the same
+    # name without Helm overwriting their managed data on upgrade.
+    helm.sh/resource-policy: keep
+type: Opaque
+stringData:
+  MCP_PROXY_ADMIN_SECRET: {{ .Values.secrets.adminSecret | default (randAlphaNum 48) | quote }}
+  {{- if .Values.secrets.dashboardSigningKey }}
+  MCP_PROXY_DASHBOARD_SIGNING_KEY: {{ .Values.secrets.dashboardSigningKey | quote }}
+  {{- end }}
+  {{- if .Values.secrets.orgSecret }}
+  MCP_PROXY_ORG_SECRET: {{ .Values.secrets.orgSecret | quote }}
+  {{- end }}
+  {{- if and .Values.vault.enabled .Values.secrets.vaultToken }}
+  MCP_PROXY_VAULT_TOKEN: {{ .Values.secrets.vaultToken | quote }}
+  {{- end }}
+  {{- range $k, $v := .Values.secrets.extra }}
+  {{ $k }}: {{ $v | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-service.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+  {{- with .Values.proxy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.proxy.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.proxy.service.port }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+  selector:
+    {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cullis-proxy/templates/proxy-serviceaccount.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.proxy.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cullis-proxy.serviceAccountName" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+  {{- with .Values.proxy.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: false
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/servicemonitor.yaml
+++ b/deploy/helm/cullis-proxy/templates/servicemonitor.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.monitoring.serviceMonitor.path }}
+      scheme: http
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout }}
+      honorLabels: true
+      {{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitoring.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  {{- with .Values.monitoring.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/cullis-proxy/values-dev.yaml
+++ b/deploy/helm/cullis-proxy/values-dev.yaml
@@ -1,0 +1,49 @@
+# Dev values override — relaxed settings for kind / minikube / k3d.
+# NEVER use on a real production cluster.
+#
+#   helm install cullis-proxy ./deploy/helm/cullis-proxy \
+#     -f deploy/helm/cullis-proxy/values-dev.yaml
+
+proxy:
+  environment: development
+  replicaCount: 1
+  brokerUrl: "http://cullis-broker.cullis.svc.cluster.local:8000"
+  brokerJwksUrl: "http://cullis-broker.cullis.svc.cluster.local:8000/.well-known/jwks.json"
+  proxyPublicUrl: "http://cullis-proxy.127.0.0.1.nip.io"
+  brokerVerifyTls: false
+  resources:
+    limits:
+      cpu: "250m"
+      memory: "256Mi"
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+
+secrets:
+  adminSecret: "dev-admin-secret-change-me"
+  dashboardSigningKey: "dev-dashboard-signing-key-change-me"
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  host: cullis-proxy.127.0.0.1.nip.io
+  tls:
+    enabled: false
+    certManagerIssuer: ""
+
+monitoring:
+  serviceMonitor:
+    enabled: false
+
+networkPolicy:
+  enabled: false
+
+autoscaling:
+  enabled: false
+
+podDisruptionBudget:
+  enabled: false

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -1,0 +1,437 @@
+# Cullis MCP Proxy Helm chart — default values.
+#
+# This file is tuned for PRODUCTION deployments on managed Kubernetes
+# (EKS, GKE, AKS). The proxy persists state in SQLite on a PVC mounted at
+# /data — this is the backend the app supports today (see mcp_proxy/db.py,
+# which uses aiosqlite directly). For multi-replica HA the SQLite volume
+# must be RWX (e.g. EFS / Filestore) — otherwise keep a single replica and
+# rely on an external Postgres once the app grows such a backend.
+#
+# Any value marked REQUIRED must be overridden via --set or a custom values
+# file before `helm install` on a real cluster.
+
+# -- Override the chart name (defaults to chart metadata name).
+nameOverride: ""
+# -- Override the fully-qualified release name (defaults to release-name-chart).
+fullnameOverride: ""
+
+# -- Global image pull secrets applied to every workload in the chart.
+imagePullSecrets: []
+  # - name: ghcr-credentials
+
+# ---------------------------------------------------------------------------
+# Proxy — the MCP Proxy FastAPI/uvicorn workload.
+# ---------------------------------------------------------------------------
+proxy:
+  image:
+    # -- Container image repository for the MCP proxy.
+    repository: ghcr.io/daenaihax/cullis-proxy
+    # -- Image tag. When empty the chart appVersion is used.
+    tag: ""
+    # -- Image pull policy.
+    pullPolicy: IfNotPresent
+
+  # -- Static replica count. The proxy keeps state (SQLite, DPoP nonce,
+  # JWKS cache) in-pod. Running >1 replica requires a RWX PVC backend
+  # (EFS, Filestore, Azure Files, Longhorn RWX) and sticky sessions on
+  # the Ingress — see README.
+  replicaCount: 1
+
+  # -- Value for MCP_PROXY_ENVIRONMENT env var (development | production).
+  # production rejects insecure defaults at boot (see mcp_proxy/config.py).
+  environment: production
+
+  # -- Container port the proxy listens on. Matches the Dockerfile.
+  containerPort: 9100
+
+  # -- Broker uplink URL. REQUIRED. In production MUST be HTTPS.
+  # The proxy calls this to join the org and bridge egress traffic.
+  brokerUrl: ""
+    # e.g. "https://broker.cullis.example.com"
+
+  # -- Broker JWKS endpoint used to validate broker-signed JWTs. REQUIRED
+  # in production (config.validate_config enforces HTTPS here).
+  brokerJwksUrl: ""
+    # e.g. "https://broker.cullis.example.com/.well-known/jwks.json"
+
+  # -- Public URL where THIS proxy is reachable from its internal agents.
+  # Used for DPoP htu validation on the ingress endpoints.
+  proxyPublicUrl: ""
+    # e.g. "https://proxy.myorg.example.com"
+
+  # -- PDP webhook URL the broker calls to get policy decisions from this
+  # proxy. Must be reachable from the broker. When empty, the proxy does
+  # not advertise a PDP to the broker.
+  pdpUrl: ""
+    # e.g. "https://proxy.myorg.example.com/pdp/policy"
+
+  # -- Org ID the proxy represents. Set after bootstrap; can also be
+  # configured through the setup wizard (DB-resident).
+  orgId: ""
+
+  # -- Comma-separated CORS origins allowed to call the proxy dashboard.
+  # Empty = no CORS middleware (fail-safe).
+  allowedOrigins: ""
+
+  # -- Verify broker TLS certificate. Disable ONLY for local dev with a
+  # self-signed broker.
+  brokerVerifyTls: true
+
+  # -- When the broker TLS cert is signed by a non-public CA, mount the
+  # CA bundle via extraVolumes/extraVolumeMounts and set this to the path
+  # inside the container. Exported as SSL_CERT_FILE + REQUESTS_CA_BUNDLE.
+  # Example wiring below under extraVolumes.
+  brokerCaBundle: ""
+    # e.g. "/certs/corporate-ca.pem"
+
+  # -- CPU/memory resource requests and limits.
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+
+  # -- Grace period for pod termination. Aligned with uvicorn graceful
+  # timeout and preStop sleep.
+  terminationGracePeriodSeconds: 40
+
+  # -- Arbitrary extra environment variables merged into the proxy
+  # Deployment container. Use for tool-specific config, feature flags, etc.
+  # Each entry must be a full Kubernetes env var object (name/value or
+  # name/valueFrom). Keep secrets out of here — use proxy.extraEnvFrom or
+  # the proxy Secret below.
+  extraEnv: []
+    # - name: MCP_PROXY_RATE_LIMIT_PER_MINUTE
+    #   value: "120"
+
+  # -- Additional envFrom sources (e.g. External Secret-backed Secrets).
+  extraEnvFrom: []
+    # - secretRef:
+    #     name: cullis-proxy-external-secrets
+
+  # -- Extra volumes injected into the proxy pod. Typical uses:
+  #   * Mount a ConfigMap holding the corporate CA bundle (VAULT_CACERT
+  #     / broker CA) — see proxy.brokerCaBundle.
+  #   * Mount a Vault Agent Injector sidecar-managed secret file.
+  #   * Mount an External Secrets-synced Secret as a file.
+  extraVolumes: []
+    # - name: broker-ca
+    #   configMap:
+    #     name: broker-ca-bundle
+    #     items:
+    #       - key: ca.pem
+    #         path: corporate-ca.pem
+    # - name: vault-ca
+    #   configMap:
+    #     name: vault-ca-bundle
+
+  # -- Extra volume mounts on the proxy container. Pair with extraVolumes.
+  extraVolumeMounts: []
+    # - name: broker-ca
+    #   mountPath: /certs
+    #   readOnly: true
+
+  # -- Additional annotations on proxy pods.
+  podAnnotations: {}
+    # Example: inject a secret via HashiCorp Vault Agent Injector.
+    # vault.hashicorp.com/agent-inject: "true"
+    # vault.hashicorp.com/role: "cullis-proxy"
+    # vault.hashicorp.com/agent-inject-secret-proxy.env: "secret/data/cullis-proxy/env"
+
+  # -- Additional labels on proxy pods.
+  podLabels: {}
+
+  # -- Pod-level securityContext. Stringent defaults: non-root, seccomp
+  # RuntimeDefault, dedicated UID/GID matching the Dockerfile user.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+
+  # -- Container-level securityContext. Drops ALL capabilities; keeps a
+  # writable root FS because SQLite temp files sit next to the DB file on
+  # the persistent volume. Set readOnlyRootFilesystem=true if you front
+  # the proxy with an emptyDir for /tmp and mount /data separately.
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop:
+        - ALL
+
+  # -- Node selector for proxy pods.
+  nodeSelector: {}
+  # -- Tolerations for proxy pods.
+  tolerations: []
+  # -- Affinity for proxy pods. Default anti-affinity spreads replicas
+  # across nodes for HA during a node-drain event.
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: cullis-proxy
+                app.kubernetes.io/component: proxy
+
+  # -- Liveness probe configuration. Hits /healthz.
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 20
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+  # -- Readiness probe configuration. Hits /readyz — returns 503 when the
+  # DB is unwritable or the JWKS cache is stale beyond 2x refresh.
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3
+    successThreshold: 1
+
+  # -- Startup probe (optional — useful on first DB init).
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    failureThreshold: 30
+
+  # -- preStop hook. Sleep gives Kubernetes time to propagate the pod
+  # removal through the Service endpoints before uvicorn gets SIGTERM.
+  preStopSleepSeconds: 5
+
+  service:
+    # -- Service type. Keep ClusterIP and front it with the Ingress.
+    type: ClusterIP
+    # -- Service port exposed to the Ingress controller.
+    port: 9100
+    # -- Extra annotations on the proxy Service.
+    annotations: {}
+
+  serviceAccount:
+    # -- Create a dedicated ServiceAccount for the proxy.
+    create: true
+    # -- Name of the ServiceAccount. Auto-generated when empty.
+    name: ""
+    # -- Extra annotations on the ServiceAccount (e.g. IRSA role ARN,
+    # GKE Workload Identity SA).
+    annotations: {}
+
+# ---------------------------------------------------------------------------
+# Persistence — SQLite DB backing the proxy.
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Postgres — NOT used by the current proxy code (mcp_proxy/db.py uses
+# aiosqlite directly). These hooks are kept as forward-compatible stubs for
+# a future Postgres backend and are disabled by default. Do not enable them
+# unless the proxy image has Postgres support wired in.
+# ---------------------------------------------------------------------------
+postgres:
+  # -- Set to true to deploy a dedicated in-cluster Postgres StatefulSet
+  # for the proxy. Today the proxy does not read from Postgres; enabling
+  # this only provisions the infrastructure.
+  internal: false
+  # -- External Postgres URL (SQLAlchemy async format). Used to override
+  # MCP_PROXY_DATABASE_URL when the proxy image supports it.
+  externalUrl: ""
+
+  # Only used when internal: true — settings for the bundled StatefulSet.
+  image: postgres:16-alpine
+  storageSize: 10Gi
+  storageClassName: ""
+  username: cullis_proxy
+  password: cullis-proxy-dev-password
+  database: cullis_proxy
+  port: 5432
+  resources:
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+    requests:
+      cpu: "100m"
+      memory: "128Mi"
+
+persistence:
+  # -- Enable PVC-backed storage for /data (SQLite DB, audit log). When
+  # false the proxy falls back to an emptyDir — data is lost on pod
+  # restart. Never do this in production.
+  enabled: true
+  # -- Size of the PVC.
+  size: 5Gi
+  # -- StorageClass override. Leave empty to use the cluster default.
+  storageClassName: ""
+  # -- AccessModes. Use ReadWriteMany if you run multiple replicas; this
+  # requires a RWX-capable StorageClass (EFS, Filestore, Azure Files).
+  accessModes:
+    - ReadWriteOnce
+  # -- Mount path inside the container (matches the Dockerfile).
+  mountPath: /data
+  # -- Re-use an existing PVC instead of creating one.
+  existingClaim: ""
+
+# ---------------------------------------------------------------------------
+# Secrets (rendered into a Kubernetes Secret). Prefer wiring via SealedSecret
+# or ExternalSecret — see README for examples. The values here are the
+# last-resort path for quick installs.
+# ---------------------------------------------------------------------------
+secrets:
+  # -- When false the chart will NOT create the proxy Secret and will
+  # instead expect a user-managed Secret with the same name (see
+  # secrets.existingSecret).
+  create: true
+  # -- Name of a user-managed Secret to bind to the Deployment instead
+  # of the one generated by this chart. Useful with SealedSecrets /
+  # ExternalSecrets / CSI secret providers.
+  existingSecret: ""
+  # -- Admin secret for the proxy dashboard and admin API. REQUIRED in
+  # production (config.validate_config refuses the default). Generate with:
+  #   python -c "import secrets; print(secrets.token_urlsafe(32))"
+  adminSecret: ""
+  # -- Persistent HMAC key for the proxy dashboard cookies. Without this
+  # admin sessions are invalidated on every proxy restart because a random
+  # key is generated per-process. Pin it to survive rollouts.
+  dashboardSigningKey: ""
+  # -- Org-level secret used by the proxy to authenticate to the broker
+  # for admin/egress operations (when the broker is configured to require
+  # one). Optional.
+  orgSecret: ""
+  # -- Vault token used by the secret_backend=vault option (scoped, NOT
+  # the root token). Prefer Kubernetes auth via the ServiceAccount token
+  # in production — see proxy.serviceAccount.annotations.
+  vaultToken: ""
+  # -- Extra raw secret entries. Each key becomes an env var in the pod.
+  extra: {}
+
+# ---------------------------------------------------------------------------
+# Vault integration — used when secret_backend=vault in proxy config.
+# ---------------------------------------------------------------------------
+vault:
+  # -- Enable the vault secret backend in the proxy (sets
+  # MCP_PROXY_SECRET_BACKEND=vault).
+  enabled: false
+  # -- External Vault address. REQUIRED when vault.enabled=true.
+  addr: ""
+    # e.g. "https://vault.corp.example.com:8200"
+  # -- KV v2 secret prefix the proxy reads tool secrets from.
+  secretPrefix: "secret/data/mcp-proxy/tools"
+
+# ---------------------------------------------------------------------------
+# Ingress — cert-manager TLS termination with websocket-friendly annotations.
+# ---------------------------------------------------------------------------
+ingress:
+  enabled: true
+  className: nginx
+  # -- Public hostname for the proxy.
+  host: proxy.example.com
+  # -- Path prefix exposed by the Ingress.
+  path: /
+  # -- Path type (Prefix | Exact | ImplementationSpecific).
+  pathType: Prefix
+  # -- Extra Ingress annotations merged with the websocket/TLS defaults.
+  annotations: {}
+    # Example: cert-manager issuer override.
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    # Example: limit to internal network.
+    # nginx.ingress.kubernetes.io/whitelist-source-range: "10.0.0.0/8,192.168.0.0/16"
+  tls:
+    enabled: true
+    # -- Name of the cert-manager ClusterIssuer or Issuer. When empty
+    # cert-manager is not wired and you must provide a pre-existing
+    # Secret via tls.secretName.
+    certManagerIssuer: letsencrypt-prod
+    # -- Kind of issuer — `ClusterIssuer` (default) or `Issuer`.
+    certManagerIssuerKind: ClusterIssuer
+    # -- Name of the TLS Secret to reference in the Ingress. When empty
+    # the chart generates one from the release name and host.
+    secretName: ""
+
+# ---------------------------------------------------------------------------
+# Monitoring — Prometheus Operator integration. The proxy does not expose a
+# /metrics endpoint today; the ServiceMonitor is provided as a no-op that
+# will start scraping once metrics are added. Set monitoring.enabled=false
+# if you are not running Prometheus Operator.
+# ---------------------------------------------------------------------------
+monitoring:
+  serviceMonitor:
+    # -- Render ServiceMonitor CRD pointing at /metrics.
+    enabled: false
+    # -- Scrape interval.
+    interval: 30s
+    # -- Scrape timeout.
+    scrapeTimeout: 10s
+    # -- Metrics path exposed by the proxy.
+    path: /metrics
+    # -- Extra labels on the ServiceMonitor (Prometheus Operator selector).
+    labels: {}
+      # release: kube-prometheus-stack
+    # -- Extra labels applied to every scraped metric.
+    targetLabels: []
+    # -- Metric relabel configs.
+    metricRelabelings: []
+    # -- Relabel configs.
+    relabelings: []
+
+# ---------------------------------------------------------------------------
+# NetworkPolicy — ingress from the nginx ingress namespace + the broker
+# namespace (for the PDP webhook); egress to the broker public endpoint and
+# DNS only.
+# ---------------------------------------------------------------------------
+networkPolicy:
+  enabled: true
+  # -- Namespace where the ingress controller runs (used for ingress
+  # NetworkPolicy selector).
+  ingressNamespace: ingress-nginx
+  # -- Namespace where the Cullis broker runs. When the broker is in the
+  # same cluster, the broker pods need to reach the proxy /pdp/policy
+  # webhook. Set to empty string to disable the rule (broker is remote).
+  brokerNamespace: cullis
+  # -- Extra ingress rules merged with the defaults.
+  extraIngress: []
+  # -- Extra egress rules merged with the defaults (DNS + HTTPS).
+  extraEgress: []
+    # - to:
+    #     - ipBlock:
+    #         cidr: 10.200.0.0/16
+    #   ports:
+    #     - protocol: TCP
+    #       port: 8200
+
+# ---------------------------------------------------------------------------
+# Autoscaling — HPA on CPU utilisation. Only useful if persistence is backed
+# by a RWX volume and the dashboard sessions are sticky behind the Ingress
+# (see README).
+# ---------------------------------------------------------------------------
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+  # -- Optional additional metric (e.g. memory). Leave empty to disable.
+  targetMemoryUtilizationPercentage: 0
+
+# ---------------------------------------------------------------------------
+# PodDisruptionBudget — protects the proxy during voluntary drains.
+# ---------------------------------------------------------------------------
+podDisruptionBudget:
+  # -- Disabled by default because replicaCount=1 makes a PDB meaningless.
+  # Enable when you bump replicaCount or enable autoscaling with RWX storage.
+  enabled: false
+  minAvailable: 1
+  # -- Use maxUnavailable instead of minAvailable when not empty.
+  maxUnavailable: ""


### PR DESCRIPTION
## Summary

Introduces `deploy/helm/cullis-proxy/`, a new Helm chart for the MCP Proxy. Mirrors the structure of the existing `deploy/helm/cullis/` broker chart, adapted for the proxy's needs (SQLite on PVC, no Redis/Vault inline, SSE-friendly Ingress annotations).

- 17 templates: Deployment, Service, Ingress, HPA, PDB, NetworkPolicy, ServiceAccount, ConfigMap, Secret, PVC, Postgres stubs (disabled), ServiceMonitor, \_helpers, NOTES
- Default: single replica + SQLite on RWO PVC (matches current `mcp_proxy/db.py`)
- Security baseline: runAsNonRoot, UID 1000, seccompProfile RuntimeDefault, cap drop ALL, automountServiceAccountToken off
- Probes wired to `/healthz` and `/readyz` (validates DB writable + JWKS freshness)
- Env auto-derivation: `MCP_PROXY_DATABASE_URL` from persistence path, `MCP_PROXY_PROXY_PUBLIC_URL` from Ingress host, `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` when `brokerCaBundle` set

## Deviations from broker chart (intentional)

- No Redis/Vault StatefulSets — proxy doesn't need them, Vault is always external
- No `prometheusrule.yaml` — no proxy-specific alerts defined yet
- HPA/PDB/Postgres disabled by default (single-replica story, SQLite-first)

## Test plan

- [x] `helm lint deploy/helm/cullis-proxy/` → 0 failures (1 info: icon recommended)
- [x] `helm template cullis-proxy deploy/helm/cullis-proxy/` → 341 lines, 0 errors
- [ ] `helm install` on kind/k3d (follow-up in Fase 1.3 shake-out)

## Next step

Fase 1.3 roadmap: shake-out end-to-end on k3d (install broker chart + this chart + demo_network smoke assertions inside the cluster). Planned as a separate PR.