### PR TITLE
fix(helm): set VAULT_ALLOW_HTTP=true in broker values-dev

### DIFF
--- a/deploy/helm/cullis/values-dev.yaml
+++ b/deploy/helm/cullis/values-dev.yaml
@@ -8,6 +8,12 @@ broker:
   logFormat: text
   replicaCount: 1
   prometheusEnabled: true
+  # Vault StatefulSet below runs in dev mode on plain HTTP. Without this
+  # flag the broker refuses to talk to Vault and /readyz stays at 503.
+  # Never set this in production — production uses Vault HTTPS.
+  extraEnv:
+    - name: VAULT_ALLOW_HTTP
+      value: "true"
   resources:
     limits:
       cpu: "500m"


### PR DESCRIPTION
## Summary

Discovered during Fase 1.3 shake-out on k3d: a fresh \`helm install cullis ./deploy/helm/cullis -f values-dev.yaml\` boots with broker \`/readyz\` stuck at 503 forever.

Root cause: \`values-dev.yaml\` spins up Vault in dev mode (plain HTTP), but the broker's \`VaultKMSProvider\` refuses to send the Vault token over HTTP unless \`VAULT_ALLOW_HTTP=true\` is set — a safety guard that prevents accidentally shipping a production deployment with plaintext Vault traffic.

Error visible in \`/readyz\`:

\`\`\`json
{"status":"not_ready","checks":{
  "database":"ok","redis":"ok",
  "kms":"error: Vault address must use https:// (got 'http://cullis-vault:8200'). Set VAULT_ALLOW_HTTP=true to override for development only."
}}
\`\`\`

## Fix

Add \`VAULT_ALLOW_HTTP=true\` to \`broker.extraEnv\` in \`values-dev.yaml\`.

**Scoped to dev only**: the prod values (\`values.yaml\`) do NOT set this; production uses Vault HTTPS.

## Test plan

- [x] \`helm lint deploy/helm/cullis/\` passes
- [x] \`helm template\` passes
- [ ] On a fresh k3d cluster, \`helm install cullis ./deploy/helm/cullis -f values-dev.yaml\` + PKI bootstrap → broker \`/readyz\` reaches \`status: ready\`