### PR TITLE
ci(helm): add helm-test workflow as deployment-plumbing gate

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,0 +1,187 @@
+name: helm-test
+
+# Helm chart deployment gate. Complements the smoke workflow:
+#   - smoke validates BEHAVIOR (A1-A8 inside docker-compose)
+#   - helm-test validates DEPLOYMENT PLUMBING (lint, template, install
+#     on kind, /healthz + /readyz respond)
+#
+# These are intentionally non-overlapping. helm-test does not re-run
+# the smoke assertions — that's the smoke workflow's job on the
+# docker stack. helm-test only asserts that the chart materialises
+# into a cluster correctly.
+#
+# Runs on every PR so the required status check always reports. When
+# no files under deploy/helm/** changed, the heavy kind cluster
+# creation is skipped and the check reports success.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: helm-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  helm-test:
+    name: helm-test (${{ matrix.chart }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: [cullis, cullis-proxy]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect Helm chart changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            helm:
+              - 'deploy/helm/**'
+              - '.github/workflows/helm-test.yml'
+
+      - name: Skip (no Helm chart changes)
+        if: steps.filter.outputs.helm != 'true'
+        run: |
+          echo "No files under deploy/helm/ changed in this PR."
+          echo "helm-test check reports success without spinning up kind."
+
+      - name: Install Helm
+        if: steps.filter.outputs.helm == 'true'
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Helm lint
+        if: steps.filter.outputs.helm == 'true'
+        run: helm lint deploy/helm/${{ matrix.chart }}/
+
+      - name: Helm template (default values)
+        if: steps.filter.outputs.helm == 'true'
+        run: helm template ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ > /tmp/template-default.yaml
+
+      - name: Helm template (dev values)
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          if [ -f deploy/helm/${{ matrix.chart }}/values-dev.yaml ]; then
+            helm template ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
+              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
+              > /tmp/template-dev.yaml
+          else
+            echo "No values-dev.yaml for ${{ matrix.chart }}, skipping dev template."
+          fi
+
+      - name: Create kind cluster
+        if: steps.filter.outputs.helm == 'true'
+        uses: helm/kind-action@v1
+        with:
+          version: v0.26.0
+          node_image: kindest/node:v1.31.4
+
+      - name: Install ingress-nginx
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.3/deploy/static/provider/kind/deploy.yaml
+          kubectl wait --namespace ingress-nginx \
+            --for=condition=ready pod \
+            --selector=app.kubernetes.io/component=controller \
+            --timeout=120s
+
+      # The broker needs its PKI secret present before install, otherwise
+      # /readyz hangs. We generate an ephemeral CA here — this is NOT a
+      # real chart capability, it's only to let helm-test reach "pod
+      # Running + /healthz 200". The chart bug for auto-bootstrap PKI
+      # is tracked separately; this step unblocks the deployment gate.
+      - name: Generate ephemeral CA + create broker-pki Secret (broker only)
+        if: steps.filter.outputs.helm == 'true' && matrix.chart == 'cullis'
+        run: |
+          kubectl create namespace cullis-test
+          mkdir -p /tmp/ca
+          openssl genrsa -out /tmp/ca/ca.key 4096
+          openssl req -x509 -new -nodes -key /tmp/ca/ca.key -sha256 -days 365 \
+            -subj "/CN=helm-test CA/O=Cullis CI" -out /tmp/ca/ca.crt
+          kubectl -n cullis-test create secret generic broker-pki \
+            --from-file=broker-ca.pem=/tmp/ca/ca.crt \
+            --from-file=broker-ca-key.pem=/tmp/ca/ca.key
+
+      - name: Helm install ${{ matrix.chart }}
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
+              -n cullis-test \
+              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
+              --set-json='broker.extraVolumes=[{"name":"broker-pki","secret":{"secretName":"broker-pki"}}]' \
+              --set-json='broker.extraVolumeMounts=[{"name":"broker-pki","mountPath":"/app/certs","readOnly":true}]' \
+              --wait --timeout 5m
+          else
+            kubectl create namespace cullis-test --dry-run=client -o yaml | kubectl apply -f -
+            helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
+              -n cullis-test \
+              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
+              --wait --timeout 5m
+          fi
+
+      # Bootstrap Vault secret for broker (mimics the missing PKI Job).
+      # Tracked as a separate chart bug; this CI step unblocks the gate.
+      - name: Bootstrap Vault secret (broker only)
+        if: steps.filter.outputs.helm == 'true' && matrix.chart == 'cullis'
+        run: |
+          kubectl -n cullis-test wait --for=condition=ready pod/cullis-vault-0 --timeout=60s
+          CA_CERT=$(cat /tmp/ca/ca.crt)
+          CA_KEY=$(cat /tmp/ca/ca.key)
+          kubectl -n cullis-test exec cullis-vault-0 -- sh -c "
+            export VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=dev-root-token
+            vault kv put secret/broker private_key_pem='$CA_KEY' ca_cert_pem='$CA_CERT'
+          "
+          kubectl -n cullis-test rollout restart deployment/cullis-broker
+          kubectl -n cullis-test rollout status deployment/cullis-broker --timeout=3m
+
+      - name: Assert /healthz 200
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            SVC=cullis-broker PORT=8000
+          else
+            SVC=cullis-proxy PORT=9100
+          fi
+          kubectl -n cullis-test run curl-healthz --rm -i --restart=Never \
+            --image=curlimages/curl:8.10.1 -- \
+            curl -sf --max-time 10 http://$SVC:$PORT/healthz
+
+      - name: Assert /readyz 200
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            SVC=cullis-broker PORT=8000
+          else
+            SVC=cullis-proxy PORT=9100
+          fi
+          kubectl -n cullis-test run curl-readyz --rm -i --restart=Never \
+            --image=curlimages/curl:8.10.1 -- \
+            curl -sf --max-time 10 http://$SVC:$PORT/readyz
+
+      - name: Dump logs on failure
+        if: failure() && steps.filter.outputs.helm == 'true'
+        run: |
+          echo "::group::pods"
+          kubectl -n cullis-test get pods -o wide || true
+          echo "::endgroup::"
+          echo "::group::events"
+          kubectl -n cullis-test get events --sort-by='.lastTimestamp' || true
+          echo "::endgroup::"
+          for pod in $(kubectl -n cullis-test get pods -o name); do
+            echo "::group::$pod"
+            kubectl -n cullis-test logs "$pod" --tail=200 || true
+            echo "::endgroup::"
+          done

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -97,55 +97,18 @@ jobs:
             --selector=app.kubernetes.io/component=controller \
             --timeout=120s
 
-      # The broker needs its PKI secret present before install, otherwise
-      # /readyz hangs. We generate an ephemeral CA here — this is NOT a
-      # real chart capability, it's only to let helm-test reach "pod
-      # Running + /healthz 200". The chart bug for auto-bootstrap PKI
-      # is tracked separately; this step unblocks the deployment gate.
-      - name: Generate ephemeral CA + create broker-pki Secret (broker only)
-        if: steps.filter.outputs.helm == 'true' && matrix.chart == 'cullis'
-        run: |
-          kubectl create namespace cullis-test
-          mkdir -p /tmp/ca
-          openssl genrsa -out /tmp/ca/ca.key 4096
-          openssl req -x509 -new -nodes -key /tmp/ca/ca.key -sha256 -days 365 \
-            -subj "/CN=helm-test CA/O=Cullis CI" -out /tmp/ca/ca.crt
-          kubectl -n cullis-test create secret generic broker-pki \
-            --from-file=broker-ca.pem=/tmp/ca/ca.crt \
-            --from-file=broker-ca-key.pem=/tmp/ca/ca.key
-
+      # values-dev.yaml has broker.pki.bootstrap.enabled=true, so the
+      # chart auto-provisions the broker CA and seeds Vault via a
+      # post-install Helm Job (#11 / #12). No hand-wiring of
+      # extraVolumes, no kubectl exec vault-0 vault kv put.
       - name: Helm install ${{ matrix.chart }}
         if: steps.filter.outputs.helm == 'true'
         run: |
-          if [ "${{ matrix.chart }}" = "cullis" ]; then
-            helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
-              -n cullis-test \
-              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
-              --set-json='broker.extraVolumes=[{"name":"broker-pki","secret":{"secretName":"broker-pki"}}]' \
-              --set-json='broker.extraVolumeMounts=[{"name":"broker-pki","mountPath":"/app/certs","readOnly":true}]' \
-              --wait --timeout 5m
-          else
-            kubectl create namespace cullis-test --dry-run=client -o yaml | kubectl apply -f -
-            helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
-              -n cullis-test \
-              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
-              --wait --timeout 5m
-          fi
-
-      # Bootstrap Vault secret for broker (mimics the missing PKI Job).
-      # Tracked as a separate chart bug; this CI step unblocks the gate.
-      - name: Bootstrap Vault secret (broker only)
-        if: steps.filter.outputs.helm == 'true' && matrix.chart == 'cullis'
-        run: |
-          kubectl -n cullis-test wait --for=condition=ready pod/cullis-vault-0 --timeout=60s
-          CA_CERT=$(cat /tmp/ca/ca.crt)
-          CA_KEY=$(cat /tmp/ca/ca.key)
-          kubectl -n cullis-test exec cullis-vault-0 -- sh -c "
-            export VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=dev-root-token
-            vault kv put secret/broker private_key_pem='$CA_KEY' ca_cert_pem='$CA_CERT'
-          "
-          kubectl -n cullis-test rollout restart deployment/cullis-broker
-          kubectl -n cullis-test rollout status deployment/cullis-broker --timeout=3m
+          kubectl create namespace cullis-test --dry-run=client -o yaml | kubectl apply -f -
+          helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
+            -n cullis-test \
+            -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
+            --wait --timeout 5m
 
       - name: Assert /healthz 200
         if: steps.filter.outputs.helm == 'true'


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/helm-test.yml\` as a new CI gate for Helm chart changes. Complements the smoke workflow with non-overlapping scope:

| Workflow | Scope |
|---|---|
| \`smoke\` | Behavior — A1-A8 assertions inside docker-compose |
| \`helm-test\` | Deployment plumbing — lint, template, install on kind, /healthz + /readyz |

Runs on every PR (skip-as-success when no \`deploy/helm/**\` changes). Matrix across \`cullis\` and \`cullis-proxy\`. Each leg:

1. \`helm lint\` + \`helm template\` (default + dev values)
2. \`kind\` cluster + \`ingress-nginx\`
3. \`helm install\` with dev values
4. Broker only: generate ephemeral CA, create \`broker-pki\` Secret, bootstrap Vault \`secret/broker\` via \`kubectl exec\` (workaround for the missing PKI bootstrap Job — tracked as separate chart bug)
5. Assert \`/healthz\` 200 and \`/readyz\` 200 via in-cluster curl Pod

## Why this shape

- **Does not re-run smoke assertions** — docker smoke stays authoritative for message flow
- **Catches deployment-layer regressions** the docker smoke cannot see (Ingress rewrite bugs, proxy header misconfig, Secret mount mismatch)
- **Unblocks the next cluster deploy** the team attempts after Fase 1.3

## Follow-up work this does NOT do

- The PKI bootstrap Job that should live IN the chart — workaround is inside the workflow, real fix is separate PR
- Running a full agent-login-session e2e inside k8s — that would duplicate docker smoke; intentionally skipped

## Test plan

- [ ] This PR modifies \`.github/workflows/helm-test.yml\` — the workflow triggers on itself
- [ ] Both matrix legs \`cullis\` and \`cullis-proxy\` reach green
- [ ] After merge, add \`helm-test (cullis)\` and \`helm-test (cullis-proxy)\` to branch protection required checks