### PR TITLE
feat(helm): broker.pki.existingSecret auto-mounts BYOCA Secret

### DIFF
--- a/deploy/helm/cullis/templates/broker-deployment.yaml
+++ b/deploy/helm/cullis/templates/broker-deployment.yaml
@@ -117,11 +117,30 @@ spec:
                   - /bin/sh
                   - -c
                   - sleep {{ .Values.broker.preStopSleepSeconds }}
-          {{- with .Values.broker.extraVolumeMounts }}
+          {{- if or .Values.broker.pki.existingSecret .Values.broker.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.broker.pki.existingSecret }}
+            # Mount the pre-existing PKI Secret at /app/certs where
+            # the broker's Settings() expects broker-ca.pem and
+            # broker-ca-key.pem by default. BYOCA pattern — the
+            # customer creates this Secret separately.
+            - name: broker-pki
+              mountPath: {{ .Values.broker.pki.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- with .Values.broker.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
-      {{- with .Values.broker.extraVolumes }}
+      {{- if or .Values.broker.pki.existingSecret .Values.broker.extraVolumes }}
       volumes:
+        {{- if .Values.broker.pki.existingSecret }}
+        - name: broker-pki
+          secret:
+            secretName: {{ .Values.broker.pki.existingSecret }}
+            defaultMode: 0400
+        {{- end }}
+        {{- with .Values.broker.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}

--- a/deploy/helm/cullis/values.yaml
+++ b/deploy/helm/cullis/values.yaml
@@ -95,9 +95,26 @@ broker:
     # - secretRef:
     #     name: cullis-vault-token   # CSI-mounted Vault token
 
+  # -- Bring Your Own CA (BYOCA). If `existingSecret` is set, the chart
+  # mounts that Secret at `mountPath` on the broker pod. The customer
+  # creates the Secret externally with kubectl or their secret manager:
+  #
+  #   kubectl -n cullis create secret generic broker-pki \
+  #     --from-file=broker-ca.pem=/path/to/your/ca.crt \
+  #     --from-file=broker-ca-key.pem=/path/to/your/ca.key
+  #
+  # The broker's default Settings() reads `certs/broker-ca.pem` and
+  # `certs/broker-ca-key.pem` (relative to /app), so mountPath defaults
+  # to /app/certs. Leave existingSecret empty to use `extraVolumes` /
+  # `extraVolumeMounts` directly (same effect, more verbose).
+  pki:
+    existingSecret: ""
+    mountPath: /app/certs
+
   # -- Volumes injected into the broker pod. Loops via `range` over the
   # full list so every Kubernetes Volume source (ConfigMap, Secret,
-  # emptyDir, projected, CSI, etc.) is supported.
+  # emptyDir, projected, CSI, etc.) is supported. Combined with any
+  # volume mounted via `pki.existingSecret` above.
   extraVolumes: []
     #
     # --- Pattern 1: mount an internal-CA bundle for Vault HTTPS ---


### PR DESCRIPTION
## Summary

Adds a first-class BYOCA knob in the broker values.yaml:

\`\`\`yaml
broker:
  pki:
    existingSecret: \"broker-pki\"   # customer-created Secret
    mountPath: /app/certs
\`\`\`

When set, the chart mounts the Secret read-only at \`mountPath\` (default \`/app/certs\`, matching where the broker's \`Settings()\` expects \`broker-ca.pem\` and \`broker-ca-key.pem\`).

## Why

Before this, customers wishing to BYOCA had to hand-write \`broker.extraVolumes\` + \`broker.extraVolumeMounts\` blocks — doable but verbose, and a friction point discovered during the Fase 1.3 k3d shake-out. First \`helm install\` simply did not start because nothing mounted the CA and the broker looked for \`certs/broker-ca.pem\` in vain.

## Backwards compatibility

- Default \`existingSecret: \"\"\` → chart renders identically to before (no extra volume, no mount)
- \`extraVolumes\` / \`extraVolumeMounts\` still work and compose with this knob

## Test plan

- [x] \`helm lint deploy/helm/cullis/\` passes
- [x] \`helm template --set broker.pki.existingSecret=my-ca-secret\` renders both the volume and the mount
- [x] Default render (no existingSecret) is byte-identical to previous behaviour