### PR TITLE
feat(helm): add PKI bootstrap Job for zero-touch broker CA (closes #11)

### DIFF
--- a/deploy/helm/cullis/files/pki_bootstrap.py
+++ b/deploy/helm/cullis/files/pki_bootstrap.py
@@ -1,0 +1,207 @@
+"""Helm-chart PKI bootstrap — runs as a post-install Job.
+
+Generates a self-signed broker root CA, writes it into a Kubernetes
+Secret (so the broker Deployment can mount it at /app/certs), and
+optionally pushes the same PEMs into Vault at VAULT_SECRET_PATH so the
+broker's KMS_BACKEND=vault path resolves on first boot.
+
+Idempotent: if the target Secret already has both PEMs, skip
+regeneration and only refresh the Vault copy when PUSH_TO_VAULT=true.
+
+Uses the in-cluster Kubernetes API via the pod's projected ServiceAccount
+token (no extra dependencies — the broker image already ships
+cryptography + httpx).
+
+Required env:
+  - TARGET_NAMESPACE     (k8s namespace where the Secret lives)
+  - TARGET_SECRET_NAME   (name of the Secret to create/update)
+  - PKI_KEY_TYPE         ("rsa" | "ec", default "rsa")
+  - PUSH_TO_VAULT        ("true" | "false", default "false")
+
+Vault-only env (when PUSH_TO_VAULT=true):
+  - VAULT_ADDR
+  - VAULT_TOKEN          (via env or file at VAULT_TOKEN_FILE)
+  - VAULT_SECRET_PATH    (default "secret/data/broker")
+"""
+import base64
+import datetime
+import os
+import pathlib
+import sys
+import time
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+NAMESPACE = os.environ["TARGET_NAMESPACE"]
+SECRET_NAME = os.environ["TARGET_SECRET_NAME"]
+KEY_TYPE = os.environ.get("PKI_KEY_TYPE", "rsa").strip().lower()
+PUSH_TO_VAULT = os.environ.get("PUSH_TO_VAULT", "false").strip().lower() == "true"
+
+SA_TOKEN = pathlib.Path(
+    "/var/run/secrets/kubernetes.io/serviceaccount/token"
+).read_text().strip()
+SA_CA = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+K8S_HOST = os.environ.get("KUBERNETES_SERVICE_HOST", "kubernetes.default.svc")
+K8S_PORT = os.environ.get("KUBERNETES_SERVICE_PORT", "443")
+K8S_API = f"https://{K8S_HOST}:{K8S_PORT}"
+K8S_HEADERS = {"Authorization": f"Bearer {SA_TOKEN}"}
+
+
+def _k8s_get_secret() -> dict | None:
+    r = httpx.get(
+        f"{K8S_API}/api/v1/namespaces/{NAMESPACE}/secrets/{SECRET_NAME}",
+        headers=K8S_HEADERS, verify=SA_CA, timeout=10.0,
+    )
+    if r.status_code == 404:
+        return None
+    r.raise_for_status()
+    return r.json()
+
+
+def _k8s_upsert_secret(data: dict[str, bytes]) -> None:
+    body = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "type": "Opaque",
+        "metadata": {
+            "name": SECRET_NAME,
+            "namespace": NAMESPACE,
+            "labels": {
+                "app.kubernetes.io/managed-by": "cullis-pki-bootstrap",
+            },
+        },
+        "data": {k: base64.b64encode(v).decode() for k, v in data.items()},
+    }
+    existing = _k8s_get_secret()
+    if existing is None:
+        r = httpx.post(
+            f"{K8S_API}/api/v1/namespaces/{NAMESPACE}/secrets",
+            json=body, headers=K8S_HEADERS, verify=SA_CA, timeout=10.0,
+        )
+    else:
+        r = httpx.put(
+            f"{K8S_API}/api/v1/namespaces/{NAMESPACE}/secrets/{SECRET_NAME}",
+            json=body, headers=K8S_HEADERS, verify=SA_CA, timeout=10.0,
+        )
+    if r.status_code >= 300:
+        raise SystemExit(
+            f"pki-bootstrap: failed to write Secret {SECRET_NAME}: "
+            f"HTTP {r.status_code} {r.text[:300]}"
+        )
+
+
+def _generate_ca() -> tuple[bytes, bytes, bytes]:
+    if KEY_TYPE == "ec":
+        print("pki-bootstrap: generating broker root CA (ECDSA P-256)")
+        key = ec.generate_private_key(ec.SECP256R1())
+    elif KEY_TYPE == "rsa":
+        print("pki-bootstrap: generating broker root CA (RSA-4096)")
+        key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    else:
+        raise SystemExit(f"pki-bootstrap: unsupported PKI_KEY_TYPE={KEY_TYPE!r}")
+
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "Cullis Broker CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "Cullis"),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365 * 10))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False)
+        .sign(key, hashes.SHA256())
+    )
+    priv_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    pub_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv_pem, cert_pem, pub_pem
+
+
+def _push_to_vault(priv_pem: bytes, pub_pem: bytes, cert_pem: bytes) -> None:
+    vault_addr = os.environ.get("VAULT_ADDR", "")
+    token_file = os.environ.get("VAULT_TOKEN_FILE", "")
+    vault_token = ""
+    if token_file and pathlib.Path(token_file).exists():
+        vault_token = pathlib.Path(token_file).read_text().strip()
+    else:
+        vault_token = os.environ.get("VAULT_TOKEN", "")
+
+    secret_path = os.environ.get("VAULT_SECRET_PATH", "secret/data/broker")
+    if not vault_addr or not vault_token:
+        raise SystemExit(
+            "pki-bootstrap: PUSH_TO_VAULT=true but VAULT_ADDR/VAULT_TOKEN missing"
+        )
+
+    url = f"{vault_addr.rstrip('/')}/v1/{secret_path}"
+    body = {
+        "data": {
+            "private_key_pem": priv_pem.decode(),
+            "public_key_pem":  pub_pem.decode(),
+            "ca_cert_pem":     cert_pem.decode(),
+        }
+    }
+    ca_bundle = os.environ.get("SSL_CERT_FILE") or True
+    last_exc: Exception | None = None
+    for attempt in range(60):
+        try:
+            r = httpx.post(
+                url, json=body,
+                headers={"X-Vault-Token": vault_token},
+                verify=ca_bundle, timeout=5.0,
+            )
+            if r.status_code in (200, 204):
+                print(f"pki-bootstrap: pushed broker keys to Vault at {secret_path}")
+                return
+            last_exc = RuntimeError(f"HTTP {r.status_code}: {r.text[:200]}")
+        except Exception as exc:
+            last_exc = exc
+        time.sleep(2)
+    raise SystemExit(f"pki-bootstrap: Vault push failed after retries: {last_exc}")
+
+
+def main() -> None:
+    existing = _k8s_get_secret()
+    if existing and all(
+        k in existing.get("data", {}) for k in ("broker-ca.pem", "broker-ca-key.pem")
+    ):
+        print(f"pki-bootstrap: Secret {SECRET_NAME} already populated, reusing")
+        priv_pem = base64.b64decode(existing["data"]["broker-ca-key.pem"])
+        cert_pem = base64.b64decode(existing["data"]["broker-ca.pem"])
+        cert_obj = x509.load_pem_x509_certificate(cert_pem)
+        pub_pem = cert_obj.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+    else:
+        priv_pem, cert_pem, pub_pem = _generate_ca()
+        _k8s_upsert_secret({
+            "broker-ca.pem":     cert_pem,
+            "broker-ca-key.pem": priv_pem,
+        })
+        print(f"pki-bootstrap: wrote Secret {NAMESPACE}/{SECRET_NAME}")
+
+    if PUSH_TO_VAULT:
+        _push_to_vault(priv_pem, pub_pem, cert_pem)
+    else:
+        print("pki-bootstrap: PUSH_TO_VAULT=false, skipping Vault")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/helm/cullis/templates/_helpers.tpl
+++ b/deploy/helm/cullis/templates/_helpers.tpl
@@ -214,6 +214,45 @@ Resolved VAULT_ADDR for the in-cluster fallback.
 {{- end -}}
 
 {{/*
+Name of the Secret holding the broker CA (broker-ca.pem + broker-ca-key.pem).
+Resolution order:
+  1. broker.pki.existingSecret (explicit BYOCA)
+  2. broker.pki.bootstrap.secretName (explicit bootstrap override)
+  3. bootstrap default: <release>-broker-pki (when bootstrap enabled)
+Returns empty string when no PKI source is configured — caller must
+guard with `if`.
+*/}}
+{{- define "cullis.broker.pkiSecretName" -}}
+{{- if .Values.broker.pki.existingSecret -}}
+{{- .Values.broker.pki.existingSecret -}}
+{{- else if .Values.broker.pki.bootstrap.enabled -}}
+{{- if .Values.broker.pki.bootstrap.secretName -}}
+{{- .Values.broker.pki.bootstrap.secretName -}}
+{{- else -}}
+{{- printf "%s-broker-pki" (include "cullis.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Name of the ServiceAccount used by the PKI bootstrap Job (needs
+create/get Secrets RBAC in the release namespace).
+*/}}
+{{- define "cullis.broker.pkiBootstrap.serviceAccountName" -}}
+{{- printf "%s-broker-pki-bootstrap" (include "cullis.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Broker PKI bootstrap image — defaults to the broker image (which ships
+cryptography + httpx).
+*/}}
+{{- define "cullis.broker.pkiBootstrap.image" -}}
+{{- $repo := .Values.broker.pki.bootstrap.image.repository | default .Values.broker.image.repository -}}
+{{- $tag  := .Values.broker.pki.bootstrap.image.tag | default (.Values.broker.image.tag | default .Chart.AppVersion) -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+
+{{/*
 Name of the TLS secret referenced by the Ingress.
 */}}
 {{- define "cullis.ingress.tlsSecretName" -}}

--- a/deploy/helm/cullis/templates/broker-deployment.yaml
+++ b/deploy/helm/cullis/templates/broker-deployment.yaml
@@ -117,13 +117,10 @@ spec:
                   - /bin/sh
                   - -c
                   - sleep {{ .Values.broker.preStopSleepSeconds }}
-          {{- if or .Values.broker.pki.existingSecret .Values.broker.extraVolumeMounts }}
+          {{- $pkiSecret := include "cullis.broker.pkiSecretName" . }}
+          {{- if or $pkiSecret .Values.broker.extraVolumeMounts }}
           volumeMounts:
-            {{- if .Values.broker.pki.existingSecret }}
-            # Mount the pre-existing PKI Secret at /app/certs where
-            # the broker's Settings() expects broker-ca.pem and
-            # broker-ca-key.pem by default. BYOCA pattern — the
-            # customer creates this Secret separately.
+            {{- if $pkiSecret }}
             - name: broker-pki
               mountPath: {{ .Values.broker.pki.mountPath }}
               readOnly: true
@@ -132,13 +129,14 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.broker.pki.existingSecret .Values.broker.extraVolumes }}
+      {{- $pkiSecret := include "cullis.broker.pkiSecretName" . }}
+      {{- if or $pkiSecret .Values.broker.extraVolumes }}
       volumes:
-        {{- if .Values.broker.pki.existingSecret }}
+        {{- if $pkiSecret }}
         - name: broker-pki
           secret:
-            secretName: {{ .Values.broker.pki.existingSecret }}
-            defaultMode: 0400
+            secretName: {{ $pkiSecret }}
+            defaultMode: 0444
         {{- end }}
         {{- with .Values.broker.extraVolumes }}
         {{- toYaml . | nindent 8 }}

--- a/deploy/helm/cullis/templates/broker-pki-bootstrap-configmap.yaml
+++ b/deploy/helm/cullis/templates/broker-pki-bootstrap-configmap.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.broker.pki.bootstrap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}-script
+  labels:
+    {{- include "cullis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker-pki-bootstrap
+  annotations:
+    # Render alongside RBAC so the Job can read this script. Match the
+    # Job's hook so Helm keeps the trio in lock-step during upgrade.
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+data:
+  pki_bootstrap.py: |-
+{{ .Files.Get "files/pki_bootstrap.py" | indent 4 }}
+{{- end }}

--- a/deploy/helm/cullis/templates/broker-pki-bootstrap-job.yaml
+++ b/deploy/helm/cullis/templates/broker-pki-bootstrap-job.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.broker.pki.bootstrap.enabled }}
+# Post-install / post-upgrade Helm hook — generates the broker CA on a
+# fresh cluster and pushes it into Vault so the broker can finish its
+# /readyz checks without manual `kubectl exec vault-0 ...`. See
+# docs/k8s-quickstart.md for the end-to-end flow.
+#
+# Hook ordering:
+#   pre-install   (weight -10): ConfigMap + RBAC (ServiceAccount, Role, RoleBinding)
+#   post-install  (weight  -5): this Job
+# pre-install covers the RBAC/ConfigMap so they exist when the Job runs.
+# post-install is used for the Job itself because internal-Vault dev
+# mode ships as a StatefulSet that comes up during the main install
+# phase — a pre-install Job would have nothing to push to. The broker
+# pod simply waits in ContainerCreating until the Secret appears.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+  labels:
+    {{- include "cullis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker-pki-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "cullis.labels" . | nindent 8 }}
+        app.kubernetes.io/component: broker-pki-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+      {{- with .Values.broker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: bootstrap
+          image: {{ include "cullis.broker.pkiBootstrap.image" . }}
+          imagePullPolicy: {{ .Values.broker.pki.bootstrap.image.pullPolicy }}
+          command: ["python", "/bootstrap/pki_bootstrap.py"]
+          env:
+            - name: TARGET_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: TARGET_SECRET_NAME
+              value: {{ include "cullis.broker.pkiSecretName" . | quote }}
+            - name: PKI_KEY_TYPE
+              value: {{ .Values.broker.pki.bootstrap.keyType | quote }}
+            - name: PUSH_TO_VAULT
+              value: {{ .Values.broker.pki.bootstrap.pushToVault | quote }}
+            {{- if .Values.broker.pki.bootstrap.pushToVault }}
+            - name: VAULT_ADDR
+              value: {{ include "cullis.vaultAddr" . | quote }}
+            - name: VAULT_SECRET_PATH
+              value: {{ .Values.vault.secretPath | quote }}
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cullis.broker.secretName" . }}
+                  key: VAULT_TOKEN
+                  optional: true
+            {{- end }}
+          volumeMounts:
+            - name: script
+              mountPath: /bootstrap
+              readOnly: true
+          {{- with .Values.broker.pki.bootstrap.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: script
+          configMap:
+            name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}-script
+            defaultMode: 0555
+{{- end }}

--- a/deploy/helm/cullis/templates/broker-pki-bootstrap-rbac.yaml
+++ b/deploy/helm/cullis/templates/broker-pki-bootstrap-rbac.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.broker.pki.bootstrap.enabled }}
+# Scoped RBAC so the bootstrap Job can create and read the single
+# Secret holding the broker CA. Intentionally narrow — no wildcards,
+# no cluster-scoped permissions, no update/delete on arbitrary Secrets.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+  labels:
+    {{- include "cullis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker-pki-bootstrap
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+  labels:
+    {{- include "cullis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker-pki-bootstrap
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ include "cullis.broker.pkiSecretName" . }}
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    # Create cannot be restricted by resourceNames — scoped to this
+    # namespace only via the RoleBinding below.
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+  labels:
+    {{- include "cullis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker-pki-bootstrap
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+{{- end }}

--- a/deploy/helm/cullis/values-dev.yaml
+++ b/deploy/helm/cullis/values-dev.yaml
@@ -14,6 +14,14 @@ broker:
   extraEnv:
     - name: VAULT_ALLOW_HTTP
       value: "true"
+  pki:
+    # Zero-touch CA on evaluation clusters: the chart renders a Job
+    # that generates a self-signed broker CA on first install and
+    # pushes it into the in-cluster Vault. For production use BYOCA
+    # via broker.pki.existingSecret instead (see values.yaml).
+    bootstrap:
+      enabled: true
+      pushToVault: true
   resources:
     limits:
       cpu: "500m"

--- a/deploy/helm/cullis/values.yaml
+++ b/deploy/helm/cullis/values.yaml
@@ -95,26 +95,10 @@ broker:
     # - secretRef:
     #     name: cullis-vault-token   # CSI-mounted Vault token
 
-  # -- Bring Your Own CA (BYOCA). If `existingSecret` is set, the chart
-  # mounts that Secret at `mountPath` on the broker pod. The customer
-  # creates the Secret externally with kubectl or their secret manager:
-  #
-  #   kubectl -n cullis create secret generic broker-pki \
-  #     --from-file=broker-ca.pem=/path/to/your/ca.crt \
-  #     --from-file=broker-ca-key.pem=/path/to/your/ca.key
-  #
-  # The broker's default Settings() reads `certs/broker-ca.pem` and
-  # `certs/broker-ca-key.pem` (relative to /app), so mountPath defaults
-  # to /app/certs. Leave existingSecret empty to use `extraVolumes` /
-  # `extraVolumeMounts` directly (same effect, more verbose).
-  pki:
-    existingSecret: ""
-    mountPath: /app/certs
-
   # -- Volumes injected into the broker pod. Loops via `range` over the
   # full list so every Kubernetes Volume source (ConfigMap, Secret,
   # emptyDir, projected, CSI, etc.) is supported. Combined with any
-  # volume mounted via `pki.existingSecret` above.
+  # volume mounted via `pki.existingSecret` below.
   extraVolumes: []
     #
     # --- Pattern 1: mount an internal-CA bundle for Vault HTTPS ---
@@ -176,6 +160,64 @@ broker:
     #   mountPath: /tmp
     # - name: cache
     #   mountPath: /var/cache/cullis
+
+  # -- Broker PKI (the root CA used to sign agent certificates).
+  #
+  # The broker's Settings() expects `broker-ca.pem` + `broker-ca-key.pem`
+  # on disk at `pki.mountPath`. Two ways to populate them:
+  #
+  #   1. BYOCA (production-preferred) — create a Kubernetes Secret
+  #      out-of-band with those two keys and set `pki.existingSecret`
+  #      to its name. The chart will mount it read-only.
+  #
+  #   2. Bootstrap (evaluation / dev clusters) — flip
+  #      `pki.bootstrap.enabled=true` and the chart will render a Job
+  #      that generates a fresh self-signed CA on first install, writes
+  #      it into a Secret, and (optionally) pushes it into Vault so
+  #      KMS_BACKEND=vault resolves without manual `kubectl exec`.
+  pki:
+    # -- Name of an existing Secret holding `broker-ca.pem` +
+    # `broker-ca-key.pem`. Leave empty to rely on bootstrap below
+    # or to hand-wire via extraVolumes / extraVolumeMounts.
+    existingSecret: ""
+    # -- Mount path for the CA Secret. Must match the broker's
+    # Settings().broker_ca_cert_path which defaults to `certs/` relative
+    # to WORKDIR=/app, i.e. /app/certs.
+    mountPath: /app/certs
+    bootstrap:
+      # -- Render a post-install Job that generates a self-signed broker
+      # CA and writes it into a Secret. OFF by default — production
+      # deployments should ship a CA via existingSecret. Useful for
+      # evaluating on kind/k3d and for hermetic CI.
+      enabled: false
+      # -- Name of the Secret the Job creates / updates. When empty the
+      # chart derives it from the release name. The same value is mounted
+      # into the broker when existingSecret is also empty, so the default
+      # is "bootstrap creates it AND broker consumes it".
+      secretName: ""
+      # -- Key algorithm for the generated CA ("rsa" | "ec"). ec = P-256,
+      # rsa = 4096-bit.
+      keyType: rsa
+      # -- Also push the generated PEMs into Vault at VAULT_SECRET_PATH.
+      # Required when KMS_BACKEND=vault (the default). Disable only when
+      # running with KMS_BACKEND=local.
+      pushToVault: true
+      # -- Image used by the Job. Reuses the broker image by default
+      # because it already ships cryptography + httpx. The Job only
+      # reads /app/pki_bootstrap.py which is mounted from a ConfigMap
+      # the chart renders next to this Job.
+      image:
+        repository: ""   # defaults to broker.image.repository
+        tag: ""          # defaults to broker.image.tag (chart appVersion)
+        pullPolicy: IfNotPresent
+      # -- Resources for the short-lived bootstrap Job.
+      resources:
+        limits:
+          cpu: "500m"
+          memory: "256Mi"
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
 
   # -- Additional annotations on broker pods. Common use:
   #    - Vault Agent Injector (vault.hashicorp.com/agent-inject: "true")


### PR DESCRIPTION
## Summary

- Opt-in Helm hook Job that generates the broker root CA, writes it into a Secret the Deployment mounts at `/app/certs`, and pushes the PEMs into Vault on a fresh cluster
- Closes the last gap from the Fase 1.3 k3d shake-out: first `helm install` on an empty cluster no longer requires a manual `kubectl exec vault-0 vault kv put ...`
- Default OFF (production stays BYOCA); `values-dev.yaml` flips it on so kind/k3d evaluation is zero-touch

## Depends on

Based on #9 (`feat/helm-broker-existing-pki-secret`) — that PR adds the `broker.pki.existingSecret` mount this one piggybacks on. Merge order: #9 → this.

## Design notes

- `pre-install,-10` hook renders the RBAC (ServiceAccount + narrow Role: `get/update` on its own Secret, `create` in the release namespace — no wildcards) and the ConfigMap holding the Python bootstrap script
- `post-install,-5` hook runs the Job itself; post-install is necessary because internal-Vault dev mode's StatefulSet comes up during main install — a pre-install Job would have nothing to push to. The broker pod simply waits in ContainerCreating until the Secret appears
- Reuses the broker image (already ships `cryptography` + `httpx`) to avoid publishing a second image
- Idempotent: existing Secret is reused, Vault push is retried 60×2s to cover cold StatefulSet

## Test plan

- [x] `helm lint` clean on default + `values-dev.yaml`
- [x] `helm template` parses as valid multi-doc YAML
- [x] Default render (bootstrap OFF, no `existingSecret`) produces no `broker-pki` volumes — byte-identical to pre-change behaviour
- [x] BYOCA render mounts `existingSecret` at `/app/certs`
- [x] `values-dev.yaml` render wires Job → ConfigMap, SA → Role → Binding, and broker Deployment mounts `cullis-broker-pki`
- [ ] End-to-end on k3d: `helm install` + wait for `/readyz` ready without any manual step (to be exercised when helm-test CI from #8 lands, or locally)

## Follow-up

- `docs/k8s-quickstart.md` — Step 3's "Bootstrap Vault secret" subsection needs to switch to the automated flow. Deferred until #10 (docs PR) merges to avoid cross-branch conflicts.
- Dedicated NetworkPolicy for the bootstrap pod when `networkPolicy.enabled=true` (today relies on the pod running with a different `component` label than the broker, so the broker NP does not apply).