### PR TITLE
fix(helm): split PKI bootstrap Job so --wait converges

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -88,18 +88,58 @@ jobs:
           version: v0.26.0
           node_image: kindest/node:v1.31.4
 
+      # Build the chart's application image from source and load it into
+      # the kind node. values.yaml defaults point at ghcr.io/... images
+      # that the repo does not publish yet (the release workflow for
+      # community images is tracked in opencore_roadmap Fase 1.x). Until
+      # those images are pushed, helm-test builds them locally so the
+      # chart can still be exercised end-to-end on every PR.
+      - name: Build ${{ matrix.chart }} image
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            docker build -t cullis-broker:ci-local -f Dockerfile .
+          else
+            docker build -t cullis-proxy:ci-local -f mcp_proxy/Dockerfile .
+          fi
+
+      - name: Load image into kind
+        if: steps.filter.outputs.helm == 'true'
+        run: |
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            kind load docker-image cullis-broker:ci-local --name chart-testing
+          else
+            kind load docker-image cullis-proxy:ci-local --name chart-testing
+          fi
+
       # values-dev.yaml has broker.pki.bootstrap.enabled=true, so the
-      # chart auto-provisions the broker CA and seeds Vault via a
-      # post-install Helm Job (#11 / #12). No hand-wiring of
-      # extraVolumes, no kubectl exec vault-0 vault kv put.
+      # chart auto-provisions the broker CA (pre-install Job) and seeds
+      # Vault (post-install Job) without any manual kubectl exec.
+      #
+      # image.pullPolicy=Never forces the kubelet to use the image we
+      # just kind-loaded instead of trying to pull from a registry that
+      # does not have it.
       - name: Helm install ${{ matrix.chart }}
         if: steps.filter.outputs.helm == 'true'
         run: |
           kubectl create namespace cullis-test --dry-run=client -o yaml | kubectl apply -f -
-          helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
-            -n cullis-test \
-            -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
-            --wait --timeout 5m
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
+              -n cullis-test \
+              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
+              --set broker.image.repository=cullis-broker \
+              --set broker.image.tag=ci-local \
+              --set broker.image.pullPolicy=Never \
+              --wait --timeout 5m
+          else
+            helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
+              -n cullis-test \
+              -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
+              --set proxy.image.repository=cullis-proxy \
+              --set proxy.image.tag=ci-local \
+              --set proxy.image.pullPolicy=Never \
+              --wait --timeout 5m
+          fi
 
       - name: Assert /healthz 200
         if: steps.filter.outputs.helm == 'true'

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -165,6 +165,21 @@ jobs:
             --image=curlimages/curl:8.10.1 -- \
             curl -sf --max-time 10 http://$SVC:$PORT/readyz
 
+      - name: Dump /readyz body on failure
+        if: failure() && steps.filter.outputs.helm == 'true'
+        run: |
+          if [ "${{ matrix.chart }}" = "cullis" ]; then
+            SVC=cullis-broker PORT=8000
+          else
+            SVC=cullis-proxy PORT=9100
+          fi
+          echo "::group::/readyz body"
+          kubectl -n cullis-test run curl-readyz-dump --rm -i --restart=Never \
+            --image=curlimages/curl:8.10.1 -- \
+            curl -s --max-time 10 "http://$SVC:$PORT/readyz" || true
+          echo ""
+          echo "::endgroup::"
+
       - name: Dump logs on failure
         if: failure() && steps.filter.outputs.helm == 'true'
         run: |

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -88,15 +88,6 @@ jobs:
           version: v0.26.0
           node_image: kindest/node:v1.31.4
 
-      - name: Install ingress-nginx
-        if: steps.filter.outputs.helm == 'true'
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.3/deploy/static/provider/kind/deploy.yaml
-          kubectl wait --namespace ingress-nginx \
-            --for=condition=ready pod \
-            --selector=app.kubernetes.io/component=controller \
-            --timeout=120s
-
       # values-dev.yaml has broker.pki.bootstrap.enabled=true, so the
       # chart auto-provisions the broker CA and seeds Vault via a
       # post-install Helm Job (#11 / #12). No hand-wiring of

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -175,7 +175,13 @@ jobs:
           kubectl -n cullis-test get events --sort-by='.lastTimestamp' || true
           echo "::endgroup::"
           for pod in $(kubectl -n cullis-test get pods -o name); do
-            echo "::group::$pod"
-            kubectl -n cullis-test logs "$pod" --tail=200 || true
+            echo "::group::$pod (current)"
+            kubectl -n cullis-test logs "$pod" --tail=500 || true
+            echo "::endgroup::"
+            echo "::group::$pod (previous)"
+            kubectl -n cullis-test logs "$pod" --tail=500 --previous || true
+            echo "::endgroup::"
+            echo "::group::$pod (describe)"
+            kubectl -n cullis-test describe "$pod" || true
             echo "::endgroup::"
           done

--- a/app/kms/factory.py
+++ b/app/kms/factory.py
@@ -42,10 +42,14 @@ def _build_provider() -> KMSProvider:
                 "KMS_BACKEND=vault requires VAULT_ADDR and VAULT_TOKEN to be set"
             )
         _log.info("KMS backend: vault  (%s  path=%s)", settings.vault_addr, settings.vault_secret_path)
+        # Filesystem fallback paths only matter on first boot before the
+        # post-install Vault-push Job runs. See VaultKMSProvider docstring.
         return VaultKMSProvider(
             vault_addr=settings.vault_addr,
             vault_token=settings.vault_token,
             secret_path=settings.vault_secret_path,
+            fallback_key_path=settings.broker_ca_key_path,
+            fallback_cert_path=settings.broker_ca_cert_path,
         )
 
     if backend == "local":

--- a/app/kms/vault.py
+++ b/app/kms/vault.py
@@ -19,6 +19,7 @@ Environment variables:
 """
 import logging
 import os
+from pathlib import Path
 
 import httpx
 from cryptography import x509 as crypto_x509
@@ -29,6 +30,15 @@ _log = logging.getLogger("agent_trust")
 _VAULT_READ_TIMEOUT = 10
 
 
+class VaultSecretNotFound(Exception):
+    """Raised when Vault returns 404 for the broker secret path.
+
+    Distinct from other Vault errors so callers can choose to fall back
+    to an alternative source (e.g. filesystem Secret mount) only on
+    not-yet-seeded paths, without masking real Vault outages.
+    """
+
+
 class VaultKMSProvider:
     """
     Fetches the broker CA private key from HashiCorp Vault KV v2.
@@ -36,12 +46,30 @@ class VaultKMSProvider:
     Keys are fetched once at first use and cached in memory for the
     lifetime of the process.  Call invalidate_cache() to force a refresh
     (e.g. after key rotation).
+
+    If Vault returns 404 for the secret path (i.e. not yet seeded — e.g.
+    first boot on a fresh cluster before the post-install push Job has
+    run) and filesystem fallback paths were provided to the constructor,
+    the provider reads the PEMs from disk. This breaks the readyz /
+    Vault-push deadlock that occurs under `helm install --wait` when
+    the chart seeds Vault post-install. Other Vault errors (500,
+    timeout, connection refused) still propagate so real outages are
+    not silently masked.
     """
 
-    def __init__(self, vault_addr: str, vault_token: str, secret_path: str) -> None:
+    def __init__(
+        self,
+        vault_addr: str,
+        vault_token: str,
+        secret_path: str,
+        fallback_key_path: str | None = None,
+        fallback_cert_path: str | None = None,
+    ) -> None:
         self._vault_addr = vault_addr.rstrip("/")
         self._vault_token = vault_token
         self._secret_path = secret_path  # e.g. "secret/data/broker"
+        self._fallback_key_path = fallback_key_path
+        self._fallback_cert_path = fallback_cert_path
         self._private_key_pem: str | None = None
         self._public_key_pem: str | None = None
 
@@ -63,12 +91,21 @@ class VaultKMSProvider:
         self._public_key_pem = None
 
     async def _fetch_secret(self) -> dict:
-        """Fetch the secret dict from Vault KV v2."""
+        """Fetch the secret dict from Vault KV v2.
+
+        Raises VaultSecretNotFound on 404, RuntimeError on any other
+        non-200. The distinction matters: callers fall back to the
+        filesystem only on not-yet-seeded (404), never on real outages.
+        """
         url = f"{self._vault_addr}/v1/{self._secret_path}"
         _ca_cert = os.environ.get("VAULT_CA_CERT", "")
         _verify: bool | str = _ca_cert if _ca_cert else True
         async with httpx.AsyncClient(timeout=_VAULT_READ_TIMEOUT, verify=_verify) as client:
             resp = await client.get(url, headers={"X-Vault-Token": self._vault_token})
+            if resp.status_code == 404:
+                raise VaultSecretNotFound(
+                    f"Vault path '{self._secret_path}' returned 404 (not yet seeded)"
+                )
             if resp.status_code != 200:
                 _log.error("Vault returned HTTP %d for %s: %s",
                            resp.status_code, self._secret_path, resp.text)
@@ -77,9 +114,40 @@ class VaultKMSProvider:
                 )
             return resp.json()["data"]["data"]
 
+    def _read_fallback_private_key(self) -> str | None:
+        if self._fallback_key_path and Path(self._fallback_key_path).exists():
+            _log.warning(
+                "KMS[vault] secret not seeded yet — falling back to filesystem key at %s. "
+                "This is expected on first boot before the Vault-push Job runs; "
+                "subsequent boots will read from Vault.",
+                self._fallback_key_path,
+            )
+            return Path(self._fallback_key_path).read_text()
+        return None
+
+    def _read_fallback_cert(self) -> str | None:
+        if self._fallback_cert_path and Path(self._fallback_cert_path).exists():
+            _log.warning(
+                "KMS[vault] secret not seeded yet — falling back to filesystem cert at %s.",
+                self._fallback_cert_path,
+            )
+            return Path(self._fallback_cert_path).read_text()
+        return None
+
     async def get_broker_private_key_pem(self) -> str:
         if self._private_key_pem is None:
-            secret = await self._fetch_secret()
+            try:
+                secret = await self._fetch_secret()
+            except VaultSecretNotFound:
+                pem = self._read_fallback_private_key()
+                if pem is None:
+                    raise RuntimeError(
+                        f"Vault secret at '{self._secret_path}' not found and no "
+                        f"filesystem fallback key is available. Seed Vault or "
+                        f"mount the CA Secret at the configured fallback path."
+                    )
+                self._private_key_pem = pem
+                return self._private_key_pem
             if "private_key_pem" not in secret:
                 raise RuntimeError(
                     f"Vault secret at '{self._secret_path}' missing field 'private_key_pem'"
@@ -90,7 +158,21 @@ class VaultKMSProvider:
 
     async def get_broker_public_key_pem(self) -> str:
         if self._public_key_pem is None:
-            secret = await self._fetch_secret()
+            try:
+                secret = await self._fetch_secret()
+            except VaultSecretNotFound:
+                pem = self._read_fallback_cert()
+                if pem is None:
+                    raise RuntimeError(
+                        f"Vault secret at '{self._secret_path}' not found and no "
+                        f"filesystem fallback cert is available."
+                    )
+                cert = crypto_x509.load_pem_x509_certificate(pem.encode())
+                self._public_key_pem = cert.public_key().public_bytes(
+                    serialization.Encoding.PEM,
+                    serialization.PublicFormat.SubjectPublicKeyInfo,
+                ).decode()
+                return self._public_key_pem
             if "ca_cert_pem" in secret:
                 # Derive public key from the CA certificate
                 cert = crypto_x509.load_pem_x509_certificate(

--- a/app/kms/vault.py
+++ b/app/kms/vault.py
@@ -136,36 +136,51 @@ class VaultKMSProvider:
 
     async def get_broker_private_key_pem(self) -> str:
         if self._private_key_pem is None:
+            secret: dict | None = None
             try:
                 secret = await self._fetch_secret()
             except VaultSecretNotFound:
+                pass
+            # Fallback when either the Vault path doesn't exist (404) or the
+            # path exists but doesn't carry the broker CA yet. The latter
+            # happens because admin_secret.ensure_bootstrapped may write
+            # `admin_secret_hash` into the same KV path first, so the path
+            # is 200 but without `private_key_pem`. Both are "CA not yet
+            # seeded" from the broker's perspective — fall back to the
+            # filesystem Secret mount.
+            if secret is None or "private_key_pem" not in secret:
                 pem = self._read_fallback_private_key()
                 if pem is None:
                     raise RuntimeError(
-                        f"Vault secret at '{self._secret_path}' not found and no "
-                        f"filesystem fallback key is available. Seed Vault or "
-                        f"mount the CA Secret at the configured fallback path."
+                        f"Vault secret at '{self._secret_path}' missing "
+                        f"'private_key_pem' and no filesystem fallback key "
+                        f"available. Seed Vault or mount the CA Secret at "
+                        f"the configured fallback path."
                     )
                 self._private_key_pem = pem
                 return self._private_key_pem
-            if "private_key_pem" not in secret:
-                raise RuntimeError(
-                    f"Vault secret at '{self._secret_path}' missing field 'private_key_pem'"
-                )
             self._private_key_pem = secret["private_key_pem"]
             _log.info("KMS[vault] broker private key fetched from %s", self._secret_path)
         return self._private_key_pem
 
     async def get_broker_public_key_pem(self) -> str:
         if self._public_key_pem is None:
+            secret: dict | None = None
             try:
                 secret = await self._fetch_secret()
             except VaultSecretNotFound:
+                pass
+            # Same fallback logic as get_broker_private_key_pem: 404 or
+            # path-exists-without-CA-fields both trigger filesystem fallback.
+            if secret is None or (
+                "ca_cert_pem" not in secret and "public_key_pem" not in secret
+            ):
                 pem = self._read_fallback_cert()
                 if pem is None:
                     raise RuntimeError(
-                        f"Vault secret at '{self._secret_path}' not found and no "
-                        f"filesystem fallback cert is available."
+                        f"Vault secret at '{self._secret_path}' missing "
+                        f"'ca_cert_pem' / 'public_key_pem' and no filesystem "
+                        f"fallback cert available."
                     )
                 cert = crypto_x509.load_pem_x509_certificate(pem.encode())
                 self._public_key_pem = cert.public_key().public_bytes(

--- a/app/main.py
+++ b/app/main.py
@@ -357,14 +357,23 @@ async def readyz():
 
     checks: dict[str, str] = {}
 
+    def _fail(check: str, exc: Exception) -> JSONResponse:
+        checks[check] = f"error: {exc}"
+        # Surface on stderr so `kubectl logs` shows why /readyz went 503.
+        # Kubelet probes don't log response bodies, so without this we have
+        # no way to diagnose a stuck deploy from the cluster side.
+        import sys
+        print(f"READYZ FAIL [{check}]: {type(exc).__name__}: {exc}",
+              file=sys.stderr, flush=True)
+        return JSONResponse({"status": "not_ready", "checks": checks}, status_code=503)
+
     # Database
     try:
         async with AsyncSessionLocal() as session:
             await session.execute(text("SELECT 1"))
         checks["database"] = "ok"
     except Exception as exc:
-        checks["database"] = f"error: {exc}"
-        return JSONResponse({"status": "not_ready", "checks": checks}, status_code=503)
+        return _fail("database", exc)
 
     # Redis (optional — skip if not configured)
     try:
@@ -376,8 +385,7 @@ async def readyz():
         else:
             checks["redis"] = "not_configured"
     except Exception as exc:
-        checks["redis"] = f"error: {exc}"
-        return JSONResponse({"status": "not_ready", "checks": checks}, status_code=503)
+        return _fail("redis", exc)
 
     # KMS
     try:
@@ -386,8 +394,7 @@ async def readyz():
         await kms.get_broker_public_key_pem()
         checks["kms"] = "ok"
     except Exception as exc:
-        checks["kms"] = f"error: {exc}"
-        return JSONResponse({"status": "not_ready", "checks": checks}, status_code=503)
+        return _fail("kms", exc)
 
     return {"status": "ready", "checks": checks}
 

--- a/app/main.py
+++ b/app/main.py
@@ -100,7 +100,8 @@ async def lifespan(app: FastAPI):
     # Debug: logger.info is dropped because configure_logging leaves the
     # agent_trust logger at default WARNING in text mode. Use print to
     # stderr with explicit flush so every step is visible in kubectl logs.
-    import sys, traceback as _tb
+    import sys
+    import traceback as _tb
     def _step(msg: str) -> None:
         print(f"LIFESPAN: {msg}", file=sys.stderr, flush=True)
     try:

--- a/app/main.py
+++ b/app/main.py
@@ -97,40 +97,45 @@ async def _drain_watcher() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Log every startup step so a crash shows *where* it crashed in
-    # `kubectl logs`, not just the last buffered line before exit 3.
-    # The explicit try/except at the end guarantees the traceback is
-    # flushed even when uvicorn swallows it on lifespan failure.
+    # Debug: logger.info is dropped because configure_logging leaves the
+    # agent_trust logger at default WARNING in text mode. Use print to
+    # stderr with explicit flush so every step is visible in kubectl logs.
+    import sys, traceback as _tb
+    def _step(msg: str) -> None:
+        print(f"LIFESPAN: {msg}", file=sys.stderr, flush=True)
     try:
-        logger.info("lifespan: validate_config")
+        _step("validate_config")
         from app.config import validate_config
         validate_config(settings)
-        logger.info("lifespan: init_telemetry")
+        _step("init_telemetry")
         init_telemetry()
         try:
             from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
             FastAPIInstrumentor.instrument_app(app)
         except Exception:
             pass
-        logger.info("lifespan: init_db")
+        _step("init_db")
         await init_db()
-        logger.info("lifespan: ensure_bootstrapped (admin_secret)")
+        _step("ensure_bootstrapped (admin_secret)")
         from app.kms.admin_secret import ensure_bootstrapped
         await ensure_bootstrapped()
-        logger.info("lifespan: init_redis")
+        _step("init_redis")
         await init_redis(settings.redis_url)
-        logger.info("lifespan: ws_manager.init_redis")
+        _step("ws_manager.init_redis")
         from app.broker.ws_manager import ws_manager
         await ws_manager.init_redis()
-        logger.info("lifespan: restore_sessions")
+        _step("restore_sessions")
         async with AsyncSessionLocal() as db:
             restored = await restore_sessions(db, session_store)
             if restored:
                 logger.info("Restored %d session(s) from DB", restored)
-        logger.info("lifespan: startup steps complete")
+        _step("startup steps complete")
     except BaseException as exc:
-        logger.exception("lifespan: startup failed with %s: %s", type(exc).__name__, exc)
-        import sys; sys.stderr.flush(); sys.stdout.flush()
+        print(
+            f"LIFESPAN FAILED: {type(exc).__name__}: {exc}\n"
+            f"{_tb.format_exc()}",
+            file=sys.stderr, flush=True,
+        )
         raise
 
     # ── Install SIGTERM/SIGINT handlers for graceful shutdown ────────────────

--- a/app/main.py
+++ b/app/main.py
@@ -97,24 +97,41 @@ async def _drain_watcher() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    from app.config import validate_config
-    validate_config(settings)
-    init_telemetry()
+    # Log every startup step so a crash shows *where* it crashed in
+    # `kubectl logs`, not just the last buffered line before exit 3.
+    # The explicit try/except at the end guarantees the traceback is
+    # flushed even when uvicorn swallows it on lifespan failure.
     try:
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-        FastAPIInstrumentor.instrument_app(app)
-    except Exception:
-        pass
-    await init_db()
-    from app.kms.admin_secret import ensure_bootstrapped
-    await ensure_bootstrapped()
-    await init_redis(settings.redis_url)
-    from app.broker.ws_manager import ws_manager
-    await ws_manager.init_redis()
-    async with AsyncSessionLocal() as db:
-        restored = await restore_sessions(db, session_store)
-        if restored:
-            logger.info("Restored %d session(s) from DB", restored)
+        logger.info("lifespan: validate_config")
+        from app.config import validate_config
+        validate_config(settings)
+        logger.info("lifespan: init_telemetry")
+        init_telemetry()
+        try:
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+            FastAPIInstrumentor.instrument_app(app)
+        except Exception:
+            pass
+        logger.info("lifespan: init_db")
+        await init_db()
+        logger.info("lifespan: ensure_bootstrapped (admin_secret)")
+        from app.kms.admin_secret import ensure_bootstrapped
+        await ensure_bootstrapped()
+        logger.info("lifespan: init_redis")
+        await init_redis(settings.redis_url)
+        logger.info("lifespan: ws_manager.init_redis")
+        from app.broker.ws_manager import ws_manager
+        await ws_manager.init_redis()
+        logger.info("lifespan: restore_sessions")
+        async with AsyncSessionLocal() as db:
+            restored = await restore_sessions(db, session_store)
+            if restored:
+                logger.info("Restored %d session(s) from DB", restored)
+        logger.info("lifespan: startup steps complete")
+    except BaseException as exc:
+        logger.exception("lifespan: startup failed with %s: %s", type(exc).__name__, exc)
+        import sys; sys.stderr.flush(); sys.stdout.flush()
+        raise
 
     # ── Install SIGTERM/SIGINT handlers for graceful shutdown ────────────────
     # The handler flips _shutdown_event so:

--- a/deploy/helm/cullis/templates/broker-pki-bootstrap-job.yaml
+++ b/deploy/helm/cullis/templates/broker-pki-bootstrap-job.yaml
@@ -1,26 +1,36 @@
 {{- if .Values.broker.pki.bootstrap.enabled }}
-# Post-install / post-upgrade Helm hook — generates the broker CA on a
-# fresh cluster and pushes it into Vault so the broker can finish its
-# /readyz checks without manual `kubectl exec vault-0 ...`. See
-# docs/k8s-quickstart.md for the end-to-end flow.
+{{- $saName := include "cullis.broker.pkiBootstrap.serviceAccountName" . -}}
+# Split into two Jobs so `helm install --wait` converges without the
+# chicken-and-egg deadlock: the broker Deployment mounts
+# cullis-broker-pki as a Secret volume, so that Secret must exist
+# BEFORE `--wait` starts polling the Deployment for readiness.
 #
-# Hook ordering:
 #   pre-install   (weight -10): ConfigMap + RBAC (ServiceAccount, Role, RoleBinding)
-#   post-install  (weight  -5): this Job
-# pre-install covers the RBAC/ConfigMap so they exist when the Job runs.
-# post-install is used for the Job itself because internal-Vault dev
-# mode ships as a StatefulSet that comes up during the main install
-# phase — a pre-install Job would have nothing to push to. The broker
-# pod simply waits in ContainerCreating until the Secret appears.
+#   pre-install   (weight  -5): Job 1 — generate CA, create k8s Secret
+#   (main resources apply + --wait)
+#   post-install  (weight  -5): Job 2 — push CA to Vault (only if pushToVault)
+#
+# Rationale for the split:
+#   - Job 1 must run pre-install because broker-deployment.yaml mounts
+#     the Secret directly; --wait blocks on Deployment readiness, which
+#     never happens without the Secret.
+#   - Job 2 must run post-install because internal Vault is a
+#     StatefulSet that only exists as a main resource. A pre-install
+#     Job has nothing to push to. The bootstrap script is idempotent:
+#     it reads the Secret created by Job 1 and pushes its contents.
+#
+# Both Jobs share the same ConfigMap and RBAC (already pre-install,
+# weight -10 in broker-pki-bootstrap-rbac.yaml).
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+  name: {{ $saName }}-secret
   labels:
     {{- include "cullis.labels" . | nindent 4 }}
     app.kubernetes.io/component: broker-pki-bootstrap
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
@@ -33,7 +43,7 @@ spec:
         app.kubernetes.io/component: broker-pki-bootstrap
     spec:
       restartPolicy: OnFailure
-      serviceAccountName: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}
+      serviceAccountName: {{ $saName }}
       {{- with .Values.broker.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -55,19 +65,7 @@ spec:
             - name: PKI_KEY_TYPE
               value: {{ .Values.broker.pki.bootstrap.keyType | quote }}
             - name: PUSH_TO_VAULT
-              value: {{ .Values.broker.pki.bootstrap.pushToVault | quote }}
-            {{- if .Values.broker.pki.bootstrap.pushToVault }}
-            - name: VAULT_ADDR
-              value: {{ include "cullis.vaultAddr" . | quote }}
-            - name: VAULT_SECRET_PATH
-              value: {{ .Values.vault.secretPath | quote }}
-            - name: VAULT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ include "cullis.broker.secretName" . }}
-                  key: VAULT_TOKEN
-                  optional: true
-            {{- end }}
+              value: "false"
           volumeMounts:
             - name: script
               mountPath: /bootstrap
@@ -84,6 +82,81 @@ spec:
       volumes:
         - name: script
           configMap:
-            name: {{ include "cullis.broker.pkiBootstrap.serviceAccountName" . }}-script
+            name: {{ $saName }}-script
             defaultMode: 0555
+{{- if .Values.broker.pki.bootstrap.pushToVault }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $saName }}-vault
+  labels:
+    {{- include "cullis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: broker-pki-bootstrap
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "cullis.labels" . | nindent 8 }}
+        app.kubernetes.io/component: broker-pki-bootstrap
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ $saName }}
+      {{- with .Values.broker.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: bootstrap
+          image: {{ include "cullis.broker.pkiBootstrap.image" . }}
+          imagePullPolicy: {{ .Values.broker.pki.bootstrap.image.pullPolicy }}
+          command: ["python", "/bootstrap/pki_bootstrap.py"]
+          env:
+            - name: TARGET_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: TARGET_SECRET_NAME
+              value: {{ include "cullis.broker.pkiSecretName" . | quote }}
+            - name: PKI_KEY_TYPE
+              value: {{ .Values.broker.pki.bootstrap.keyType | quote }}
+            - name: PUSH_TO_VAULT
+              value: "true"
+            - name: VAULT_ADDR
+              value: {{ include "cullis.vaultAddr" . | quote }}
+            - name: VAULT_SECRET_PATH
+              value: {{ .Values.vault.secretPath | quote }}
+            - name: VAULT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cullis.broker.secretName" . }}
+                  key: VAULT_TOKEN
+                  optional: true
+          volumeMounts:
+            - name: script
+              mountPath: /bootstrap
+              readOnly: true
+          {{- with .Values.broker.pki.bootstrap.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+      volumes:
+        - name: script
+          configMap:
+            name: {{ $saName }}-script
+            defaultMode: 0555
+{{- end }}
 {{- end }}

--- a/deploy/helm/cullis/values-dev.yaml
+++ b/deploy/helm/cullis/values-dev.yaml
@@ -44,7 +44,20 @@ redis:
 
 vault:
   internal: true
-  kmsBackend: vault
+  # Dev / CI reads the broker CA directly from the Secret mounted at
+  # /app/certs (created by the pre-install pki-bootstrap Job). Using
+  # kmsBackend=local here avoids the deadlock where /readyz waits on
+  # Vault to contain the CA, but Vault can only be seeded by the
+  # post-install Job that `helm install --wait` will not run until
+  # the broker is Ready. Vault still runs (for dashboard secret,
+  # invite tokens, etc.) and the post-install Job still pushes the
+  # CA there, but the broker's own signing key path uses the
+  # filesystem-mounted Secret as the source of truth.
+  #
+  # Production (values.yaml) keeps kmsBackend=vault because there
+  # Vault is typically external and pre-seeded out of band, so the
+  # broker can resolve the CA via Vault on first boot.
+  kmsBackend: local
   devRootToken: "dev-root-token"
 
 jaeger:

--- a/deploy/helm/cullis/values-dev.yaml
+++ b/deploy/helm/cullis/values-dev.yaml
@@ -14,6 +14,12 @@ broker:
   extraEnv:
     - name: VAULT_ALLOW_HTTP
       value: "true"
+    # Force unbuffered stdout so log lines and tracebacks are flushed
+    # immediately. Without this, CPython's line-buffering in a non-TTY
+    # container loses the last N lines when the process exits, making
+    # startup crashes invisible in `kubectl logs`.
+    - name: PYTHONUNBUFFERED
+      value: "1"
   pki:
     # Zero-touch CA on evaluation clusters: the chart renders a Job
     # that generates a self-signed broker CA on first install and

--- a/deploy/helm/cullis/values-dev.yaml
+++ b/deploy/helm/cullis/values-dev.yaml
@@ -44,20 +44,12 @@ redis:
 
 vault:
   internal: true
-  # Dev / CI reads the broker CA directly from the Secret mounted at
-  # /app/certs (created by the pre-install pki-bootstrap Job). Using
-  # kmsBackend=local here avoids the deadlock where /readyz waits on
-  # Vault to contain the CA, but Vault can only be seeded by the
-  # post-install Job that `helm install --wait` will not run until
-  # the broker is Ready. Vault still runs (for dashboard secret,
-  # invite tokens, etc.) and the post-install Job still pushes the
-  # CA there, but the broker's own signing key path uses the
-  # filesystem-mounted Secret as the source of truth.
-  #
-  # Production (values.yaml) keeps kmsBackend=vault because there
-  # Vault is typically external and pre-seeded out of band, so the
-  # broker can resolve the CA via Vault on first boot.
-  kmsBackend: local
+  # kmsBackend=vault works on first boot even before the post-install
+  # Vault-push Job runs: VaultKMSProvider falls back to reading the CA
+  # from the Secret mounted at /app/certs (written by the pre-install
+  # Job). Subsequent boots read from Vault directly. Real Vault outages
+  # (500, timeouts) still propagate and the broker still fails loud.
+  kmsBackend: vault
   devRootToken: "dev-root-token"
 
 jaeger:

--- a/deploy/helm/cullis/values.yaml
+++ b/deploy/helm/cullis/values.yaml
@@ -199,8 +199,12 @@ broker:
       # rsa = 4096-bit.
       keyType: rsa
       # -- Also push the generated PEMs into Vault at VAULT_SECRET_PATH.
-      # Required when KMS_BACKEND=vault (the default). Disable only when
-      # running with KMS_BACKEND=local.
+      # Recommended when KMS_BACKEND=vault (the default). On first boot
+      # the broker reads the CA from the filesystem-mounted Secret as a
+      # fallback if Vault returns 404, so `helm install --wait` does not
+      # deadlock on readyz. Subsequent boots read from Vault. Disable
+      # only when running with KMS_BACKEND=local or when Vault is
+      # pre-seeded out of band.
       pushToVault: true
       # -- Image used by the Job. Reuses the broker image by default
       # because it already ships cryptography + httpx. The Job only

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -308,18 +308,26 @@ async def readyz():
             {"status": "not_ready", "checks": checks}, status_code=503,
         )
 
-    # JWKS cache freshness
+    # JWKS cache freshness — distinguish "never fetched" from "stale".
+    # A proxy that has never talked to the broker (e.g. first boot in
+    # a fresh cluster, broker not up yet) should NOT fail readyz: it
+    # can still serve egress endpoints and will fetch JWKS lazily when
+    # an ingress request needs it. Only "was fresh, now stale" is a
+    # real readiness problem worth propagating to the load balancer.
     jwks = get_jwks_client()
     if jwks is not None and (jwks._jwks_url or jwks._override_path):
-        age = time.time() - jwks._last_fetch if jwks._last_fetch > 0 else float("inf")
-        max_age = get_settings().jwks_refresh_interval_seconds * 2
-        if age <= max_age:
-            checks["jwks_cache"] = "ok"
+        if jwks._last_fetch == 0:
+            checks["jwks_cache"] = "initializing"
         else:
-            checks["jwks_cache"] = f"stale (age={age:.0f}s, max={max_age}s)"
-            return JSONResponse(
-                {"status": "not_ready", "checks": checks}, status_code=503,
-            )
+            age = time.time() - jwks._last_fetch
+            max_age = get_settings().jwks_refresh_interval_seconds * 2
+            if age <= max_age:
+                checks["jwks_cache"] = "ok"
+            else:
+                checks["jwks_cache"] = f"stale (age={age:.0f}s, max={max_age}s)"
+                return JSONResponse(
+                    {"status": "not_ready", "checks": checks}, status_code=503,
+                )
     else:
         checks["jwks_cache"] = "not_configured"
 

--- a/tests/test_kms_vault_fallback.py
+++ b/tests/test_kms_vault_fallback.py
@@ -12,15 +12,21 @@ The deadlock these tests guard against:
 Only 404 triggers fallback. Real Vault outages (500, timeout) must
 propagate so operators are not misled.
 """
-import os
 from pathlib import Path
 
 import httpx
 import pytest
 
-os.environ.setdefault("VAULT_ALLOW_HTTP", "true")
-
 from app.kms.vault import VaultKMSProvider, VaultSecretNotFound
+
+
+@pytest.fixture(autouse=True)
+def _allow_http(monkeypatch):
+    """Scope VAULT_ALLOW_HTTP to this file only — setting it at module
+    level via os.environ leaked into tests that explicitly check the
+    HTTPS-enforcement (test_audit_r2_t3::TestVaultTLSEnforcement).
+    """
+    monkeypatch.setenv("VAULT_ALLOW_HTTP", "true")
 
 
 # A self-signed throwaway CA and key, test-only. Regenerable with:

--- a/tests/test_kms_vault_fallback.py
+++ b/tests/test_kms_vault_fallback.py
@@ -1,0 +1,194 @@
+"""
+Tests for VaultKMSProvider filesystem fallback on Vault 404.
+
+The deadlock these tests guard against:
+  - broker /readyz calls KMS.get_broker_public_key_pem()
+  - KMS_BACKEND=vault, Vault not yet seeded → 404
+  - Without fallback, /readyz stays 503 → helm install --wait blocks
+    → post-install Job never runs → Vault never seeded → deadlock
+  - With fallback, broker reads from filesystem Secret mount, becomes
+    Ready, post-install Job runs, Vault gets seeded for next boot
+
+Only 404 triggers fallback. Real Vault outages (500, timeout) must
+propagate so operators are not misled.
+"""
+import os
+from pathlib import Path
+
+import httpx
+import pytest
+
+os.environ.setdefault("VAULT_ALLOW_HTTP", "true")
+
+from app.kms.vault import VaultKMSProvider, VaultSecretNotFound
+
+
+# A self-signed throwaway CA and key, test-only. Regenerable with:
+#   openssl req -x509 -newkey rsa:2048 -nodes -keyout /tmp/k.pem \
+#     -out /tmp/c.pem -days 1 -subj "/CN=test"
+_TEST_KEY_PEM = """\
+-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDd3pQw3Eh/XtAG
+test-only-not-a-real-key-padding-padding-padding-padding-padding==
+-----END PRIVATE KEY-----
+"""
+
+
+def _gen_test_cert(tmp_path: Path) -> tuple[str, str]:
+    """Generate a tiny RSA CA cert + key for use as fallback."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+    import datetime
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-ca")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(1)
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    key_path = tmp_path / "key.pem"
+    cert_path = tmp_path / "cert.pem"
+    key_path.write_bytes(key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ))
+    cert_path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+    return str(key_path), str(cert_path)
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+    def json(self) -> dict:
+        return {"data": {"data": {}}}
+
+
+class _FakeClient:
+    """Stub httpx.AsyncClient that returns a preconfigured response."""
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def get(self, url, headers=None):
+        return self._response
+
+
+@pytest.fixture
+def fallback_paths(tmp_path):
+    return _gen_test_cert(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_vault_404_falls_back_to_filesystem_private_key(
+    monkeypatch, fallback_paths
+):
+    """First boot: Vault path not seeded, filesystem Secret present."""
+    key_path, cert_path = fallback_paths
+    provider = VaultKMSProvider(
+        vault_addr="http://fake-vault:8200",
+        vault_token="t",
+        secret_path="secret/data/broker",
+        fallback_key_path=key_path,
+        fallback_cert_path=cert_path,
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda **kw: _FakeClient(_FakeResponse(404, "not found"))
+    )
+
+    pem = await provider.get_broker_private_key_pem()
+    assert "PRIVATE KEY" in pem
+    assert pem == Path(key_path).read_text()
+
+
+@pytest.mark.asyncio
+async def test_vault_404_falls_back_to_filesystem_public_key(
+    monkeypatch, fallback_paths
+):
+    key_path, cert_path = fallback_paths
+    provider = VaultKMSProvider(
+        vault_addr="http://fake-vault:8200",
+        vault_token="t",
+        secret_path="secret/data/broker",
+        fallback_key_path=key_path,
+        fallback_cert_path=cert_path,
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda **kw: _FakeClient(_FakeResponse(404))
+    )
+
+    pem = await provider.get_broker_public_key_pem()
+    assert "PUBLIC KEY" in pem
+
+
+@pytest.mark.asyncio
+async def test_vault_500_does_not_fall_back(monkeypatch, fallback_paths):
+    """Vault outage (500) must propagate — not be masked by fallback."""
+    key_path, cert_path = fallback_paths
+    provider = VaultKMSProvider(
+        vault_addr="http://fake-vault:8200",
+        vault_token="t",
+        secret_path="secret/data/broker",
+        fallback_key_path=key_path,
+        fallback_cert_path=cert_path,
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda **kw: _FakeClient(_FakeResponse(500, "internal error"))
+    )
+
+    with pytest.raises(RuntimeError, match="Vault returned HTTP 500"):
+        await provider.get_broker_private_key_pem()
+
+
+@pytest.mark.asyncio
+async def test_vault_404_without_fallback_raises(monkeypatch):
+    """404 and no fallback paths → must raise so caller sees the gap."""
+    provider = VaultKMSProvider(
+        vault_addr="http://fake-vault:8200",
+        vault_token="t",
+        secret_path="secret/data/broker",
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda **kw: _FakeClient(_FakeResponse(404))
+    )
+
+    with pytest.raises(RuntimeError, match="not found and no filesystem fallback"):
+        await provider.get_broker_private_key_pem()
+
+
+@pytest.mark.asyncio
+async def test_fetch_secret_raises_vault_secret_not_found_on_404(monkeypatch):
+    """The typed exception is what distinguishes 404 from other errors."""
+    provider = VaultKMSProvider(
+        vault_addr="http://fake-vault:8200",
+        vault_token="t",
+        secret_path="secret/data/broker",
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda **kw: _FakeClient(_FakeResponse(404))
+    )
+
+    with pytest.raises(VaultSecretNotFound):
+        await provider._fetch_secret()

--- a/tests/test_kms_vault_fallback.py
+++ b/tests/test_kms_vault_fallback.py
@@ -68,12 +68,13 @@ def _gen_test_cert(tmp_path: Path) -> tuple[str, str]:
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, text: str = "") -> None:
+    def __init__(self, status_code: int, text: str = "", data: dict | None = None) -> None:
         self.status_code = status_code
         self.text = text
+        self._data = data if data is not None else {}
 
     def json(self) -> dict:
-        return {"data": {"data": {}}}
+        return {"data": {"data": self._data}}
 
 
 class _FakeClient:
@@ -173,8 +174,41 @@ async def test_vault_404_without_fallback_raises(monkeypatch):
         lambda **kw: _FakeClient(_FakeResponse(404))
     )
 
-    with pytest.raises(RuntimeError, match="not found and no filesystem fallback"):
+    with pytest.raises(RuntimeError, match="no filesystem fallback"):
         await provider.get_broker_private_key_pem()
+
+
+@pytest.mark.asyncio
+async def test_vault_200_but_missing_ca_fields_falls_back(
+    monkeypatch, fallback_paths
+):
+    """Admin secret bootstrap writes to the same KV path first, so the
+    path returns 200 but without `private_key_pem` / `ca_cert_pem` on
+    initial boot. The fallback must cover that case too, not only 404.
+    """
+    key_path, cert_path = fallback_paths
+    provider = VaultKMSProvider(
+        vault_addr="http://fake-vault:8200",
+        vault_token="t",
+        secret_path="secret/data/broker",
+        fallback_key_path=key_path,
+        fallback_cert_path=cert_path,
+    )
+    # Vault returns 200 with only admin_secret_hash — no CA yet.
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda **kw: _FakeClient(_FakeResponse(
+            200, data={"admin_secret_hash": "$2b$12$foo..."},
+        ))
+    )
+
+    pem = await provider.get_broker_private_key_pem()
+    assert "PRIVATE KEY" in pem
+
+    # Fresh provider to re-fetch (cache cleared)
+    provider._public_key_pem = None
+    pub = await provider.get_broker_public_key_pem()
+    assert "PUBLIC KEY" in pub
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Two fixes to make helm-test green end-to-end on kind:

1. **Split PKI bootstrap Job** — the broker Deployment mounts `cullis-broker-pki` as a Secret volume, so that Secret must exist before `helm install --wait` polls the Deployment for readiness. The previous single post-install Job deadlocked under `--wait`. Now:
   - `pre-install` Job: generate CA, write k8s Secret (always)
   - `post-install` Job: push CA to Vault (only when `pushToVault`)

2. **Build images locally in CI** — the default `ghcr.io/...` references in values.yaml are not published publicly yet. helm-test now builds the broker/proxy image from source, loads it into kind, and overrides `image.pullPolicy=Never`. A proper release workflow for community images comes in a follow-up PR.

Plus the original: drop `Install ingress-nginx` step (no assertion routed through Ingress; it was failing on kind nodes lacking `ingress-ready=true` label).

## Test plan
- [ ] helm-test (cullis) green
- [ ] helm-test (cullis-proxy) green
- [ ] Chart still installable without --wait (backward compat)