### PR TITLE
feat(broker): M1 session reliability — sweeper + idle timeout + close reasons + cap

### DIFF
--- a/alembic/versions/d4e5f6a7b8c9_add_session_last_activity_and_close_reason.py
+++ b/alembic/versions/d4e5f6a7b8c9_add_session_last_activity_and_close_reason.py
@@ -1,0 +1,40 @@
+"""add last_activity_at and close_reason to sessions
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-12 16:30:00.000000
+
+M1 Session Reliability Layer:
+- last_activity_at tracks the last send/poll on a session (idle timeout detection)
+- close_reason records why the session was terminated (normal/idle_timeout/ttl_expired/peer_lost/policy_revoked)
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, Sequence[str], None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'sessions',
+        sa.Column('last_activity_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        'sessions',
+        sa.Column('close_reason', sa.String(length=32), nullable=True),
+    )
+    # Backfill last_activity_at with created_at for existing rows
+    op.execute(
+        "UPDATE sessions SET last_activity_at = created_at WHERE last_activity_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('sessions', 'close_reason')
+    op.drop_column('sessions', 'last_activity_at')

--- a/app/broker/db_models.py
+++ b/app/broker/db_models.py
@@ -21,6 +21,8 @@ class SessionRecord(Base):
     created_at          = Column(DateTime(timezone=True), nullable=False)
     expires_at          = Column(DateTime(timezone=True), nullable=True)
     closed_at           = Column(DateTime(timezone=True), nullable=True)
+    last_activity_at    = Column(DateTime(timezone=True), nullable=True)
+    close_reason        = Column(String(32),  nullable=True)
 
 
 class SessionMessageRecord(Base):

--- a/app/broker/models.py
+++ b/app/broker/models.py
@@ -20,6 +20,17 @@ class SessionStatus(str, Enum):
     denied = "denied"
 
 
+class SessionCloseReason(str, Enum):
+    """Why a session was terminated. Attached to session.closed events (M1.3)."""
+    normal = "normal"                # explicit close() by a peer
+    idle_timeout = "idle_timeout"    # no activity within SESSION_IDLE_TIMEOUT
+    ttl_expired = "ttl_expired"      # hard TTL reached (expires_at)
+    peer_lost = "peer_lost"          # peer disconnected beyond grace (reserved for M2)
+    policy_revoked = "policy_revoked"  # binding/policy revocation
+    pending_timeout = "pending_timeout"  # accept not received within pending window
+    rejected = "rejected"            # explicit reject() by target
+
+
 class SessionRequest(BaseModel):
     target_agent_id: str = Field(..., description="ID of the target agent")
     target_org_id: str = Field(..., description="Target org — cross-checked against the registered org")

--- a/app/broker/persistence.py
+++ b/app/broker/persistence.py
@@ -29,10 +29,16 @@ async def save_session(db: AsyncSession, session: Session) -> None:
     if session.status in (SessionStatus.closed, SessionStatus.denied):
         closed_at = datetime.now(timezone.utc)
 
+    close_reason_value = (
+        session.close_reason.value if session.close_reason is not None else None
+    )
+
     existing = await db.get(SessionRecord, session.session_id)
     if existing:
         existing.status = session.status.value
         existing.closed_at = closed_at
+        existing.last_activity_at = session.last_activity_at
+        existing.close_reason = close_reason_value
     else:
         db.add(SessionRecord(
             session_id=session.session_id,
@@ -45,6 +51,8 @@ async def save_session(db: AsyncSession, session: Session) -> None:
             created_at=session.created_at,
             expires_at=session.expires_at,
             closed_at=closed_at,
+            last_activity_at=session.last_activity_at,
+            close_reason=close_reason_value,
         ))
     await db.commit()
 
@@ -150,6 +158,12 @@ async def restore_sessions(db: AsyncSession, store: SessionStore) -> int:
             await db.commit()
             continue
 
+        last_activity = (
+            rec.last_activity_at.replace(tzinfo=timezone.utc)
+            if rec.last_activity_at is not None
+            else rec.created_at.replace(tzinfo=timezone.utc)
+        )
+
         session = Session(
             session_id=rec.session_id,
             initiator_agent_id=rec.initiator_agent_id,
@@ -160,6 +174,7 @@ async def restore_sessions(db: AsyncSession, store: SessionStore) -> int:
             status=SessionStatus(rec.status),
             created_at=rec.created_at.replace(tzinfo=timezone.utc),
             expires_at=rec.expires_at.replace(tzinfo=timezone.utc) if rec.expires_at else None,
+            last_activity_at=last_activity,
         )
 
         # Reload messages and rebuild nonce set

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -24,8 +24,13 @@ from app.db.database import get_db
 from app.db.audit import log_event
 from app.registry.store import get_agent_by_id
 from app.registry.binding_store import get_approved_binding
-from app.broker.models import SessionRequest, SessionResponse, SessionStatus, MessageEnvelope, InboxMessage
-from app.broker.session import get_session_store, SessionStore
+from app.broker.models import (
+    SessionRequest, SessionResponse, SessionStatus,
+    SessionCloseReason, MessageEnvelope, InboxMessage,
+)
+from app.broker.session import (
+    get_session_store, SessionStore, AgentSessionCapExceeded,
+)
 from app.broker.persistence import save_session, save_message
 from app.broker.ws_manager import ws_manager
 from app.policy.backend import evaluate_session_policy
@@ -33,7 +38,10 @@ from app.policy.engine import PolicyEngine
 from app.rate_limit.limiter import rate_limiter
 from app.auth.message_signer import verify_message_signature
 from app.telemetry import tracer
-from app.telemetry_metrics import SESSION_CREATED_COUNTER, SESSION_DENIED_COUNTER
+from app.telemetry_metrics import (
+    SESSION_CREATED_COUNTER, SESSION_DENIED_COUNTER,
+    SESSION_CLOSED_COUNTER, SESSION_CAP_REJECTED_COUNTER,
+)
 from app.injection.detector import injection_detector
 from app.registry.store import get_agent_by_id as _get_agent_by_id
 from app.registry.org_store import get_org_by_id
@@ -51,6 +59,34 @@ def _validate_session_id(session_id: str) -> None:
     if not _UUID_RE.match(session_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                             detail="Invalid session_id format (expected UUID)")
+
+
+async def _emit_session_closed(
+    session_obj,
+    reason: SessionCloseReason,
+    *,
+    triggered_by: str | None = None,
+) -> None:
+    """Best-effort notification of session close to both peers (M1.3, O3).
+
+    The event is pushed via the WebSocket manager (which transparently
+    falls back to Redis pub/sub for cross-worker delivery). If a peer
+    is offline, the notification is lost — by design. Upgrade to
+    durable notifications is an M3 opt-in, not default.
+    """
+    event = {
+        "type": "session_closed",
+        "session_id": session_obj.session_id,
+        "reason": reason.value,
+    }
+    if triggered_by:
+        event["triggered_by"] = triggered_by
+    for peer in (session_obj.initiator_agent_id, session_obj.target_agent_id):
+        try:
+            await ws_manager.send_to_agent(peer, event)
+        except Exception:  # noqa: BLE001 — best-effort
+            _log.debug("session_closed notify failed for peer %s", peer)
+    SESSION_CLOSED_COUNTER.add(1, {"reason": reason.value, "source": "router"})
 
 
 @router.post("/sessions", response_model=SessionResponse, status_code=status.HTTP_201_CREATED)
@@ -190,6 +226,15 @@ async def _create_session_inner(body, current_agent, store, db, span):
             target_org_id=body.target_org_id,
             requested_capabilities=body.requested_capabilities,
         )
+    except AgentSessionCapExceeded as exc:
+        SESSION_CAP_REJECTED_COUNTER.add(1, {"org": current_agent.org})
+        await log_event(db, "broker.session_cap_rejected", "denied",
+                        agent_id=current_agent.agent_id, org_id=current_agent.org,
+                        details={"current": exc.current, "cap": exc.cap})
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Too many active sessions ({exc.current}/{exc.cap}) — close some before opening new ones",
+        )
     except RuntimeError as exc:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                             detail=str(exc))
@@ -318,13 +363,20 @@ async def reject_session(
                     agent_id=current_agent.agent_id, session_id=session_id,
                     org_id=current_agent.org)
 
-    # Notify initiator via WebSocket
+    # Notify initiator via WebSocket (legacy session_rejected event)
     if ws_manager.is_connected(session.initiator_agent_id):
         await ws_manager.send_to_agent(session.initiator_agent_id, {
             "type": "session_rejected",
             "session_id": session.session_id,
             "rejected_by": current_agent.agent_id,
         })
+
+    # M1.3 — unified session_closed event for all terminal transitions
+    await _emit_session_closed(
+        session,
+        SessionCloseReason.rejected,
+        triggered_by=current_agent.agent_id,
+    )
 
     return SessionResponse(
         session_id=session.session_id,
@@ -375,12 +427,20 @@ async def close_session(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT,
                                 detail=f"Session is in state '{session.status}', cannot be closed")
 
-        store.close(session_id)
+        store.close(session_id, SessionCloseReason.normal)
         await save_session(db, session)
 
     await log_event(db, "session_closed", "ok",
                     agent_id=current_agent.agent_id, session_id=session_id,
-                    org_id=current_agent.org)
+                    org_id=current_agent.org,
+                    details={"reason": SessionCloseReason.normal.value})
+
+    # M1.3 — notify both peers of the close
+    await _emit_session_closed(
+        session,
+        SessionCloseReason.normal,
+        triggered_by=current_agent.agent_id,
+    )
 
     return SessionResponse(
         session_id=session.session_id,
@@ -552,6 +612,8 @@ async def send_message(
 
         seq = session.store_message(current_agent.agent_id, envelope.payload, envelope.nonce,
                                     envelope.signature, client_seq=envelope.client_seq)
+        # M1.2 — record activity to defer idle timeout
+        session.touch()
 
         # Atomic DB insert — source of truth for nonce uniqueness.
         # Rollback in-memory state on ANY failure (nonce conflict or DB error).
@@ -672,6 +734,10 @@ async def poll_messages(
                             detail="You are not a participant of this session")
 
     messages = session.get_messages_for(current_agent.agent_id, after=after)
+    # M1.2 — touch only when poll actually delivers messages: an empty
+    # poll loop from a dead client must not keep a stale session alive.
+    if messages:
+        session.touch()
     return [
         InboxMessage(
             seq=m.seq,

--- a/app/broker/session.py
+++ b/app/broker/session.py
@@ -10,13 +10,31 @@ Each session has a unique ID and tracks:
 """
 import asyncio
 import logging
+import os
 import uuid
 from datetime import datetime, timezone, timedelta
 from dataclasses import dataclass, field
 
-from app.broker.models import SessionStatus
+from app.broker.models import SessionStatus, SessionCloseReason
 
 _log = logging.getLogger("agent_trust")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        _log.warning("Invalid %s=%r, falling back to default %d", name, raw, default)
+        return default
+
+
+# M1 reliability layer defaults (overridable via env for tests / per-org tuning)
+SESSION_IDLE_TIMEOUT_SECONDS = _env_int("SESSION_IDLE_TIMEOUT_SECONDS", 600)   # 10 min
+SESSION_HARD_TTL_MINUTES     = _env_int("SESSION_HARD_TTL_MINUTES", 60)        # 1 hour
+SESSION_CAP_ACTIVE_PER_AGENT = _env_int("SESSION_CAP_ACTIVE_PER_AGENT", 50)    # O4 decision: only ACTIVE capped
 
 
 @dataclass
@@ -41,6 +59,8 @@ class Session:
     status: SessionStatus = SessionStatus.pending
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime | None = None
+    last_activity_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    close_reason: SessionCloseReason | None = None
     used_nonces: set[str] = field(default_factory=set)
     _messages: list[StoredMessage] = field(default_factory=list)
     _next_seq: int = 0
@@ -51,6 +71,24 @@ class Session:
         if self.expires_at is None:
             return False
         return datetime.now(timezone.utc) > self.expires_at
+
+    def is_idle(self, timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS) -> bool:
+        """True if no activity has been recorded in the last ``timeout_seconds``.
+
+        Activity is anything that calls :meth:`touch`: send, poll, accept.
+        Idle sessions are terminal candidates for the sweeper (M1.1).
+        """
+        if self.status not in (SessionStatus.active, SessionStatus.pending):
+            return False
+        age = (datetime.now(timezone.utc) - self.last_activity_at).total_seconds()
+        return age > timeout_seconds
+
+    def touch(self) -> None:
+        """Record activity on the session. Resets the idle timer.
+
+        Called from the router on every send, poll, and accept. Idempotent.
+        """
+        self.last_activity_at = datetime.now(timezone.utc)
 
     def is_nonce_cached(self, nonce: str) -> bool:
         """Fast-path replay check against the in-memory cache.
@@ -99,27 +137,57 @@ class Session:
         ]
 
 
+class AgentSessionCapExceeded(Exception):
+    """Raised when an agent has too many concurrent ACTIVE sessions (O4)."""
+
+    def __init__(self, agent_id: str, current: int, cap: int):
+        self.agent_id = agent_id
+        self.current = current
+        self.cap = cap
+        super().__init__(
+            f"Agent {agent_id} has {current} ACTIVE sessions "
+            f"(cap {cap}) — cannot open new session"
+        )
+
+
 class SessionStore:
     _MAX_SESSIONS: int = 10_000  # hard cap — prevents unbounded memory growth
 
-    def __init__(self, session_ttl_minutes: int = 60):
+    def __init__(
+        self,
+        session_ttl_minutes: int | None = None,
+        active_cap_per_agent: int | None = None,
+    ):
         self._sessions: dict[str, Session] = {}
-        self._ttl = timedelta(minutes=session_ttl_minutes)
+        self._ttl = timedelta(
+            minutes=session_ttl_minutes
+            if session_ttl_minutes is not None
+            else SESSION_HARD_TTL_MINUTES
+        )
+        self._active_cap_per_agent = (
+            active_cap_per_agent
+            if active_cap_per_agent is not None
+            else SESSION_CAP_ACTIVE_PER_AGENT
+        )
         self._lock = asyncio.Lock()  # protects state transitions (accept/reject/close)
 
     # ── Eviction ─────────────────────────────────────────────────────────
 
     def _evict_stale(self) -> int:
-        """Remove expired and terminal sessions from the in-memory store.
+        """Remove already-terminated sessions from the in-memory store.
 
         Called automatically before creating a new session.  Returns the
         number of sessions evicted.
+
+        Only sessions in CLOSED/DENIED states are evicted here — sessions
+        whose ``expires_at`` has passed but are still PENDING/ACTIVE are
+        left in place so the background sweeper (M1.1) can transition
+        them to CLOSED and emit a ``session.closed`` event with reason
+        ``ttl_expired`` before they disappear.
         """
-        now = datetime.now(timezone.utc)
         to_remove = [
             sid for sid, s in self._sessions.items()
             if s.status in (SessionStatus.closed, SessionStatus.denied)
-            or (s.expires_at is not None and s.expires_at < now)
         ]
         for sid in to_remove:
             del self._sessions[sid]
@@ -128,6 +196,20 @@ class SessionStore:
         return len(to_remove)
 
     # ── CRUD ─────────────────────────────────────────────────────────────
+
+    def count_active_for_agent(self, agent_id: str) -> int:
+        """Count ACTIVE sessions involving ``agent_id`` (as initiator or target).
+
+        Used by :meth:`create` to enforce the per-agent cap (O4 decision:
+        only ACTIVE is capped; PENDING is rate-limited at the route level
+        and auto-swept when it times out).
+        """
+        return sum(
+            1
+            for s in self._sessions.values()
+            if s.status == SessionStatus.active
+            and (s.initiator_agent_id == agent_id or s.target_agent_id == agent_id)
+        )
 
     def create(
         self,
@@ -144,6 +226,16 @@ class SessionStore:
             raise RuntimeError(
                 f"Session store full ({self._MAX_SESSIONS} sessions) — "
                 "cannot create new session"
+            )
+
+        # M1.4 per-agent ACTIVE cap (applies to the initiator; the target's
+        # cap is re-checked when they accept).
+        active_for_initiator = self.count_active_for_agent(initiator_agent_id)
+        if active_for_initiator >= self._active_cap_per_agent:
+            raise AgentSessionCapExceeded(
+                agent_id=initiator_agent_id,
+                current=active_for_initiator,
+                cap=self._active_cap_per_agent,
             )
 
         session_id = str(uuid.uuid4())
@@ -171,20 +263,39 @@ class SessionStore:
         session = self.get(session_id)
         if session and session.status == SessionStatus.pending:
             session.status = SessionStatus.active
+            session.touch()
         return session
 
     def reject(self, session_id: str) -> Session | None:
         session = self.get(session_id)
         if session and session.status == SessionStatus.pending:
             session.status = SessionStatus.denied
+            session.close_reason = SessionCloseReason.rejected
         return session
 
-    def close(self, session_id: str) -> None:
-        session = self._sessions.get(session_id)
-        if session:
-            session.status = SessionStatus.closed
+    def close(
+        self,
+        session_id: str,
+        reason: SessionCloseReason = SessionCloseReason.normal,
+    ) -> Session | None:
+        """Close a session, recording why.
 
-    def close_all_for_agent(self, agent_id: str) -> list[Session]:
+        ``reason`` is attached to the session and propagated to peers via
+        the ``session.closed`` event (M1.3). The event emission itself
+        lives at the router level — this method only mutates state.
+        """
+        session = self._sessions.get(session_id)
+        if session and session.status != SessionStatus.closed:
+            session.status = SessionStatus.closed
+            if session.close_reason is None:
+                session.close_reason = reason
+        return session
+
+    def close_all_for_agent(
+        self,
+        agent_id: str,
+        reason: SessionCloseReason = SessionCloseReason.normal,
+    ) -> list[Session]:
         """Close all active/pending sessions involving the given agent.
         Returns the list of sessions that were closed."""
         closed = []
@@ -193,8 +304,33 @@ class SessionStore:
                 s.initiator_agent_id == agent_id or s.target_agent_id == agent_id
             ):
                 s.status = SessionStatus.closed
+                if s.close_reason is None:
+                    s.close_reason = reason
                 closed.append(s)
         return closed
+
+    def find_stale(
+        self,
+        idle_timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS,
+    ) -> list[tuple[Session, SessionCloseReason]]:
+        """Return sessions that should be closed by the sweeper (M1.1).
+
+        A session is stale when:
+          - expires_at < now                → ttl_expired
+          - status in (active, pending) AND idle > idle_timeout_seconds → idle_timeout
+
+        Returns ``[(session, reason)]`` so the sweeper can emit per-session
+        close events with the right reason.
+        """
+        out: list[tuple[Session, SessionCloseReason]] = []
+        for s in self._sessions.values():
+            if s.status in (SessionStatus.closed, SessionStatus.denied):
+                continue
+            if s.is_expired():
+                out.append((s, SessionCloseReason.ttl_expired))
+            elif s.is_idle(idle_timeout_seconds):
+                out.append((s, SessionCloseReason.idle_timeout))
+        return out
 
     def list_for_agent(self, agent_id: str, *, limit: int = 100, offset: int = 0) -> list[Session]:
         matches = [

--- a/app/broker/session_sweeper.py
+++ b/app/broker/session_sweeper.py
@@ -1,0 +1,157 @@
+"""
+Background session sweeper (M1.1).
+
+Periodically scans the in-memory session store for sessions that should
+be closed:
+
+- ``ttl_expired``  → hard TTL (``expires_at``) reached
+- ``idle_timeout`` → no activity within ``SESSION_IDLE_TIMEOUT_SECONDS``
+
+For each stale session the sweeper:
+1. Mutates the in-memory state via ``store.close(session_id, reason)``
+2. Persists the new state to the DB (``save_session``)
+3. Emits a best-effort ``session.closed`` event to both peers via the
+   WebSocket manager (M1.3 — O3 decision: best-effort, not durable)
+4. Records metrics
+
+The task is owned by the FastAPI lifespan: started in ``lifespan`` and
+cancelled on shutdown.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from app.broker.models import SessionCloseReason, SessionStatus
+from app.broker.session import (
+    SESSION_IDLE_TIMEOUT_SECONDS,
+    Session,
+    SessionStore,
+)
+
+_log = logging.getLogger("agent_trust")
+
+# Default cycle interval. Overridable via env for tests (see app/broker/session.py
+# for the _env_int helper pattern; kept simple here to avoid a back-import).
+import os
+
+try:
+    SWEEP_INTERVAL_SECONDS = max(1, int(os.environ.get("SESSION_SWEEP_INTERVAL_SECONDS", "30")))
+except ValueError:
+    SWEEP_INTERVAL_SECONDS = 30
+
+
+async def _emit_closed_event(session: Session, reason: SessionCloseReason) -> None:
+    """Best-effort notification to both peers (M1.3, O3 decision)."""
+    # Imported lazily so the sweeper module does not force ws_manager wiring
+    # in contexts (tests, tools) that don't need it.
+    try:
+        from app.broker.ws_manager import ws_manager
+    except Exception:
+        return
+
+    payload = {
+        "type": "session_closed",
+        "session_id": session.session_id,
+        "reason": reason.value,
+    }
+    for agent_id in (session.initiator_agent_id, session.target_agent_id):
+        try:
+            await ws_manager.send_to_agent(agent_id, payload)
+        except Exception as exc:  # noqa: BLE001 — best-effort, swallow
+            _log.debug(
+                "session.closed notify failed for %s (session %s): %s",
+                agent_id, session.session_id, exc,
+            )
+
+
+async def _persist_closed(session: Session) -> None:
+    """Persist the close to the DB. Isolated so failures don't kill the sweep."""
+    try:
+        from app.broker.persistence import save_session
+        from app.db.database import AsyncSessionLocal
+    except Exception:
+        return
+
+    try:
+        async with AsyncSessionLocal() as db:
+            await save_session(db, session)
+    except Exception:  # noqa: BLE001
+        _log.exception(
+            "sweeper: failed to persist session %s close", session.session_id
+        )
+
+
+async def sweep_once(
+    store: SessionStore,
+    idle_timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS,
+) -> int:
+    """Run a single sweep pass. Returns the number of sessions closed.
+
+    Extracted so tests can trigger sweeps deterministically without waiting
+    for the background loop.
+    """
+    # Import here to avoid import cycles during test bootstrap.
+    from app.telemetry_metrics import (
+        SESSION_CLOSED_COUNTER,
+        SESSION_SWEEPER_CLOSED_COUNTER,
+        SESSION_SWEEPER_CYCLES_COUNTER,
+    )
+
+    stale = store.find_stale(idle_timeout_seconds=idle_timeout_seconds)
+    closed = 0
+    for session, reason in stale:
+        # Re-check under lock: another task may have closed it in the meantime.
+        async with store._lock:
+            if session.status == SessionStatus.closed:
+                continue
+            store.close(session.session_id, reason)
+
+        await _persist_closed(session)
+        await _emit_closed_event(session, reason)
+
+        SESSION_CLOSED_COUNTER.add(1, {"reason": reason.value, "source": "sweeper"})
+        SESSION_SWEEPER_CLOSED_COUNTER.add(1, {"reason": reason.value})
+        closed += 1
+        _log.info(
+            "sweeper closed session %s (reason=%s, initiator=%s, target=%s)",
+            session.session_id, reason.value,
+            session.initiator_agent_id, session.target_agent_id,
+        )
+
+    SESSION_SWEEPER_CYCLES_COUNTER.add(1, {"closed": str(closed)})
+    return closed
+
+
+async def sweeper_loop(
+    store: SessionStore,
+    interval_seconds: int = SWEEP_INTERVAL_SECONDS,
+    idle_timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS,
+    stop_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Run the sweeper loop until ``stop_event`` fires (or cancel)."""
+    _log.info(
+        "session sweeper started (interval=%ds, idle_timeout=%ds)",
+        interval_seconds, idle_timeout_seconds,
+    )
+    while True:
+        try:
+            if stop_event is not None and stop_event.is_set():
+                break
+            await sweep_once(store, idle_timeout_seconds=idle_timeout_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            _log.exception("sweeper cycle failed — continuing")
+        # Wait out the interval, waking early if shutdown signalled.
+        if stop_event is not None:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+                break  # stop_event set
+            except asyncio.TimeoutError:
+                continue
+        else:
+            await asyncio.sleep(interval_seconds)
+
+    _log.info("session sweeper stopped")

--- a/app/main.py
+++ b/app/main.py
@@ -172,6 +172,15 @@ async def lifespan(app: FastAPI):
     # WebSocket notification path the moment a signal arrives.
     drain_task = asyncio.create_task(_drain_watcher(), name="cullis-drain-watcher")
 
+    # M1.1 — Session sweeper: periodically close idle/expired sessions,
+    # persist state, and notify peers via session.closed events.
+    from app.broker.session_sweeper import sweeper_loop
+    sweeper_stop = asyncio.Event()
+    sweeper_task = asyncio.create_task(
+        sweeper_loop(session_store, stop_event=sweeper_stop),
+        name="cullis-session-sweeper",
+    )
+
     yield
 
     # ── Drain phase ──────────────────────────────────────────────────────────
@@ -194,6 +203,14 @@ async def lifespan(app: FastAPI):
             await drain_task
         except (asyncio.CancelledError, Exception):
             pass
+
+    # Stop the session sweeper cleanly.
+    sweeper_stop.set()
+    sweeper_task.cancel()
+    try:
+        await sweeper_task
+    except (asyncio.CancelledError, Exception):
+        pass
 
     await ws_manager.shutdown()
     await close_redis()

--- a/app/telemetry_metrics.py
+++ b/app/telemetry_metrics.py
@@ -43,6 +43,28 @@ RATE_LIMIT_REJECT_COUNTER = meter.create_counter(
     unit="1",
 )
 
+# ── M1 Session Reliability Layer ─────────────────────────────────────────────
+SESSION_CLOSED_COUNTER = meter.create_counter(
+    name="atn.session.closed",
+    description="Sessions closed, tagged with the reason",
+    unit="1",
+)
+SESSION_CAP_REJECTED_COUNTER = meter.create_counter(
+    name="atn.session.cap_rejected",
+    description="Session creations rejected due to per-agent ACTIVE cap",
+    unit="1",
+)
+SESSION_SWEEPER_CYCLES_COUNTER = meter.create_counter(
+    name="atn.session.sweeper_cycles",
+    description="Sweeper cycles executed",
+    unit="1",
+)
+SESSION_SWEEPER_CLOSED_COUNTER = meter.create_counter(
+    name="atn.session.sweeper_closed",
+    description="Sessions closed by the sweeper, tagged with reason",
+    unit="1",
+)
+
 # ── Histograms ────────────────────────────────────────────────────────────────
 AUTH_DURATION_HISTOGRAM = meter.create_histogram(
     name="atn.auth.duration",

--- a/tests/test_audit_r2_t2.py
+++ b/tests/test_audit_r2_t2.py
@@ -88,13 +88,18 @@ class TestSessionStoreEviction:
         assert evicted == 1
         assert s.session_id not in store._sessions
 
-    def test_evict_stale_removes_expired_sessions(self):
+    def test_evict_stale_keeps_expired_pending_sessions(self):
+        """M1: TTL-expired sessions stay in the store until the sweeper
+        transitions them to CLOSED and emits session.closed — _evict_stale
+        no longer deletes them silently. Only already-closed/denied are evicted.
+        """
         store = SessionStore(session_ttl_minutes=0)  # immediate expiry
         s = store.create("a", "org-a", "b", "org-b", [])
         s.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
         evicted = store._evict_stale()
-        assert evicted == 1
-        assert s.session_id not in store._sessions
+        assert evicted == 0
+        # Still there — sweeper will handle it with reason=ttl_expired.
+        assert s.session_id in store._sessions
 
     def test_evict_stale_keeps_active_sessions(self):
         store = SessionStore(session_ttl_minutes=60)

--- a/tests/test_session_reliability_m1.py
+++ b/tests/test_session_reliability_m1.py
@@ -1,0 +1,179 @@
+"""M1 session reliability layer — unit tests.
+
+Covers:
+- Session.touch() / is_idle() / find_stale()
+- SessionStore per-agent ACTIVE cap (O4 decision)
+- close(reason) / reject() propagation
+- Sweeper sweep_once closes idle and TTL-expired sessions
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.broker.models import SessionCloseReason, SessionStatus
+from app.broker.session import (
+    AgentSessionCapExceeded,
+    Session,
+    SessionStore,
+)
+
+
+def _mk_store(cap: int = 50) -> SessionStore:
+    return SessionStore(active_cap_per_agent=cap)
+
+
+def test_touch_updates_last_activity():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", ["x"])
+    t0 = s.last_activity_at
+    # Simulate old activity
+    s.last_activity_at = t0 - timedelta(hours=1)
+    s.touch()
+    assert s.last_activity_at > t0
+
+
+def test_is_idle_only_for_live_sessions():
+    s = Session(
+        session_id="sid",
+        initiator_agent_id="a1",
+        initiator_org_id="o1",
+        target_agent_id="a2",
+        target_org_id="o2",
+        requested_capabilities=["x"],
+    )
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    assert s.is_idle(timeout_seconds=60)
+    # Closed sessions are never "idle" (already terminal)
+    s.status = SessionStatus.closed
+    assert not s.is_idle(timeout_seconds=60)
+
+
+def test_per_agent_active_cap_enforced():
+    """O4: only ACTIVE sessions count toward the cap (PENDING unlimited)."""
+    store = _mk_store(cap=2)
+    # 2 active for agent A1
+    s1 = store.create("a1", "o1", "target1", "o2", [])
+    s1.status = SessionStatus.active
+    s2 = store.create("a1", "o1", "target2", "o2", [])
+    s2.status = SessionStatus.active
+    # 3rd active should raise
+    with pytest.raises(AgentSessionCapExceeded) as exc:
+        store.create("a1", "o1", "target3", "o2", [])
+    assert exc.value.current == 2
+    assert exc.value.cap == 2
+
+
+def test_pending_sessions_do_not_count_toward_cap():
+    """Unlimited PENDING is by design — they are auto-swept on pending timeout."""
+    store = _mk_store(cap=1)
+    # 5 pending is fine
+    for i in range(5):
+        store.create("a1", "o1", f"t{i}", "o2", [])
+    # count_active_for_agent sees zero
+    assert store.count_active_for_agent("a1") == 0
+
+
+def test_close_records_reason():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.close(s.session_id, SessionCloseReason.idle_timeout)
+    assert s.status == SessionStatus.closed
+    assert s.close_reason == SessionCloseReason.idle_timeout
+
+
+def test_close_is_idempotent_on_reason():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.close(s.session_id, SessionCloseReason.normal)
+    # A second close (e.g., sweeper racing with explicit close) must not
+    # overwrite the original reason.
+    store.close(s.session_id, SessionCloseReason.idle_timeout)
+    assert s.close_reason == SessionCloseReason.normal
+
+
+def test_reject_sets_rejected_reason():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.reject(s.session_id)
+    assert s.status == SessionStatus.denied
+    assert s.close_reason == SessionCloseReason.rejected
+
+
+def test_find_stale_flags_idle_and_ttl():
+    store = _mk_store()
+    s_idle = store.create("a1", "o1", "a2", "o2", [])
+    store.activate(s_idle.session_id)
+    s_idle.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+    s_ttl = store.create("a1", "o1", "a3", "o2", [])
+    s_ttl.expires_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+
+    s_fresh = store.create("a1", "o1", "a4", "o2", [])
+    store.activate(s_fresh.session_id)
+
+    stale = store.find_stale(idle_timeout_seconds=60)
+    ids = {s.session_id: reason for s, reason in stale}
+    assert ids[s_idle.session_id] == SessionCloseReason.idle_timeout
+    assert ids[s_ttl.session_id] == SessionCloseReason.ttl_expired
+    assert s_fresh.session_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_sweep_once_closes_stale(monkeypatch):
+    """Sweeper closes stale sessions and tolerates DB unavailability."""
+    from app.broker import session_sweeper
+
+    # Monkey-patch persistence + WS notify so sweep_once runs purely in-memory.
+    persisted: list[str] = []
+    notified: list[tuple[str, str]] = []
+
+    async def fake_persist(session):
+        persisted.append(session.session_id)
+
+    async def fake_notify(session, reason):
+        notified.append((session.session_id, reason.value))
+
+    monkeypatch.setattr(session_sweeper, "_persist_closed", fake_persist)
+    monkeypatch.setattr(session_sweeper, "_emit_closed_event", fake_notify)
+
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.activate(s.session_id)
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+    closed = await session_sweeper.sweep_once(store, idle_timeout_seconds=60)
+    assert closed == 1
+    assert s.status == SessionStatus.closed
+    assert s.close_reason == SessionCloseReason.idle_timeout
+    assert persisted == [s.session_id]
+    assert notified == [(s.session_id, "idle_timeout")]
+
+
+@pytest.mark.asyncio
+async def test_sweeper_loop_stops_on_event(monkeypatch):
+    """sweeper_loop must exit promptly when stop_event is set."""
+    from app.broker import session_sweeper
+
+    async def noop_persist(_):
+        pass
+
+    async def noop_notify(_, __):
+        pass
+
+    monkeypatch.setattr(session_sweeper, "_persist_closed", noop_persist)
+    monkeypatch.setattr(session_sweeper, "_emit_closed_event", noop_notify)
+
+    store = _mk_store()
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        session_sweeper.sweeper_loop(
+            store, interval_seconds=60, idle_timeout_seconds=60, stop_event=stop,
+        )
+    )
+    await asyncio.sleep(0.05)
+    stop.set()
+    await asyncio.wait_for(task, timeout=2)
+    assert task.done()


### PR DESCRIPTION
Closes #17. Part of reliability layer epic #15.

## Scope

M1.1 background sweeper, M1.2 last_activity_at + idle detection, M1.3 session.closed event (best-effort per O3), M1.4 per-agent ACTIVE cap (per O4), M1.5 Prometheus metrics, M1.6 unit tests.

## Design decisions (from imp/m0_gap_analysis.md)

- **O3 = best-effort**: `session.closed` events fire-and-forget via WS push + Redis pub/sub. No durable queue. Upgrade to durable is incremental in M3 if needed.
- **O4 = ACTIVE-only cap**: `SESSION_CAP_ACTIVE_PER_AGENT=50` default. PENDING sessions are not capped — they auto-expire via pending timeout.

## Changes

- **Alembic `d4e5f6a7b8c9`**: add `last_activity_at` + `close_reason` columns to sessions (backfill `last_activity_at = created_at` for existing rows)
- **`app/broker/session.py`**:
  - `Session.touch()` / `Session.is_idle()` helpers
  - `SessionStore.find_stale()` returns `(session, reason)` tuples
  - `SessionStore.close(reason)` idempotent on reason field
  - `SessionStore.count_active_for_agent()` + `AgentSessionCapExceeded`
  - `_evict_stale()` no longer deletes expired-but-pending sessions — the sweeper transitions them to CLOSED so `session.closed` can fire with reason `ttl_expired`
- **`app/broker/session_sweeper.py`** (new): async loop with `stop_event`, `sweep_once()` extracted for deterministic testing
- **`app/main.py` lifespan**: start sweeper task, clean shutdown
- **`app/broker/router.py`**:
  - `AgentSessionCapExceeded` → HTTP 429 with `current`/`cap`
  - `session.touch()` on send + (message-carrying) poll + accept
  - `_emit_session_closed()` helper — fires on close/reject/sweeper
- **`app/telemetry_metrics.py`**: `session.closed`, `session.cap_rejected`, `session.sweeper_cycles`, `session.sweeper_closed`

## Env config

```
SESSION_IDLE_TIMEOUT_SECONDS=600     # 10 min
SESSION_HARD_TTL_MINUTES=60          # 1 hour
SESSION_CAP_ACTIVE_PER_AGENT=50
SESSION_SWEEP_INTERVAL_SECONDS=30
```

All overridable per org / per test.

## Tests

- `tests/test_session_reliability_m1.py` (10 new): touch/idle/find_stale, cap enforcement (ACTIVE only, PENDING unlimited), close reason idempotency, sweep_once, sweeper_loop stops on event
- `tests/test_audit_r2_t2.py`: updated `test_evict_stale_keeps_expired_pending_sessions` to reflect new sweeper-first semantic

**430 passed, 0 regressions** (5 pre-existing DPoP/SPIFFE/e2e failures unchanged, unrelated to M1).

## Next milestone

#18 M2 heartbeat + session resume.