### PR TITLE
feat(reliability): M3 message durability — queue + ack + WS drain + TTL expire

### DIFF
--- a/alembic/versions/d4e5f6a7b8c9_add_session_last_activity_and_close_reason.py
+++ b/alembic/versions/d4e5f6a7b8c9_add_session_last_activity_and_close_reason.py
@@ -1,0 +1,40 @@
+"""add last_activity_at and close_reason to sessions
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-04-12 16:30:00.000000
+
+M1 Session Reliability Layer:
+- last_activity_at tracks the last send/poll on a session (idle timeout detection)
+- close_reason records why the session was terminated (normal/idle_timeout/ttl_expired/peer_lost/policy_revoked)
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, Sequence[str], None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'sessions',
+        sa.Column('last_activity_at', sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        'sessions',
+        sa.Column('close_reason', sa.String(length=32), nullable=True),
+    )
+    # Backfill last_activity_at with created_at for existing rows
+    op.execute(
+        "UPDATE sessions SET last_activity_at = created_at WHERE last_activity_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('sessions', 'close_reason')
+    op.drop_column('sessions', 'last_activity_at')

--- a/alembic/versions/e5f6a7b8c9d0_add_proxy_message_queue.py
+++ b/alembic/versions/e5f6a7b8c9d0_add_proxy_message_queue.py
@@ -1,0 +1,79 @@
+"""add proxy_message_queue for M3 message durability
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-04-12 23:30:00.000000
+
+M3 Session Reliability Layer — message durability:
+messages awaiting recipient ack are persisted here with explicit TTL
+and idempotency. Schema validated in imp/m0_storage_spike.md (6/6 PASS).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, Sequence[str], None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'proxy_message_queue',
+        sa.Column('msg_id', sa.String(length=64), primary_key=True),
+        sa.Column('session_id', sa.String(length=128), nullable=False),
+        sa.Column('recipient_agent_id', sa.String(length=256), nullable=False),
+        sa.Column('sender_agent_id', sa.String(length=256), nullable=False),
+        sa.Column('ciphertext', sa.LargeBinary(), nullable=False),
+        sa.Column('seq', sa.Integer(), nullable=False),
+        sa.Column('enqueued_at', sa.DateTime(timezone=True),
+                  nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column('ttl_expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('delivery_status', sa.SmallInteger(),
+                  nullable=False, server_default='0'),
+        sa.Column('attempts', sa.SmallInteger(),
+                  nullable=False, server_default='0'),
+        sa.Column('idempotency_key', sa.String(length=256), nullable=True),
+        sa.Column('delivered_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('expired_at', sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            'recipient_agent_id', 'idempotency_key',
+            name='uq_proxy_queue_idempotency',
+        ),
+    )
+    op.create_index(
+        'ix_proxy_message_queue_session_id',
+        'proxy_message_queue', ['session_id'],
+    )
+    op.create_index(
+        'ix_proxy_message_queue_delivery_status',
+        'proxy_message_queue', ['delivery_status'],
+    )
+    op.create_index(
+        'idx_proxy_queue_recipient_pending',
+        'proxy_message_queue', ['recipient_agent_id', 'seq'],
+    )
+    op.create_index(
+        'idx_proxy_queue_ttl',
+        'proxy_message_queue', ['ttl_expires_at'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('idx_proxy_queue_ttl', table_name='proxy_message_queue')
+    op.drop_index(
+        'idx_proxy_queue_recipient_pending',
+        table_name='proxy_message_queue',
+    )
+    op.drop_index(
+        'ix_proxy_message_queue_delivery_status',
+        table_name='proxy_message_queue',
+    )
+    op.drop_index(
+        'ix_proxy_message_queue_session_id',
+        table_name='proxy_message_queue',
+    )
+    op.drop_table('proxy_message_queue')

--- a/app/broker/db_models.py
+++ b/app/broker/db_models.py
@@ -3,7 +3,10 @@ SQLAlchemy models for session, message, and RFQ persistence.
 """
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, String, Text, DateTime, Integer, UniqueConstraint
+from sqlalchemy import (
+    Column, String, Text, DateTime, Integer, LargeBinary,
+    SmallInteger, UniqueConstraint, Index,
+)
 
 from app.db.database import Base
 
@@ -41,6 +44,56 @@ class SessionMessageRecord(Base):
                              default=lambda: datetime.now(timezone.utc))
     signature       = Column(Text, nullable=True)   # base64 RSA-PKCS1v15-SHA256
     client_seq      = Column(Integer, nullable=True)
+
+
+class ProxyMessageQueueRecord(Base):
+    """M3 message durability — queued messages awaiting recipient ack.
+
+    Schema validated in the M0.3 spike (imp/m0_storage_spike.md):
+    ~53k enqueue/s single writer, <1ms p99 dequeue, 1M TTL sweep in ~5s.
+
+    A row is enqueued when a message arrives and cannot be confirmed
+    delivered (recipient offline, WS send failed, etc.). It is dequeued
+    on explicit ack, or swept when ttl_expires_at passes. Metadata-only
+    audit survives in session_messages — this table holds the ciphertext
+    and is pruned aggressively.
+
+    ``delivery_status`` values:
+      0 = pending   — enqueued, awaiting delivery/ack
+      1 = delivered — recipient ack'd, row eligible for pruning
+      2 = expired   — TTL passed before ack, sender notified
+    """
+
+    __tablename__ = "proxy_message_queue"
+    __table_args__ = (
+        UniqueConstraint(
+            "recipient_agent_id", "idempotency_key",
+            name="uq_proxy_queue_idempotency",
+        ),
+        Index(
+            "idx_proxy_queue_recipient_pending",
+            "recipient_agent_id", "seq",
+        ),
+        Index(
+            "idx_proxy_queue_ttl",
+            "ttl_expires_at",
+        ),
+    )
+
+    msg_id              = Column(String(64), primary_key=True)
+    session_id          = Column(String(128), nullable=False, index=True)
+    recipient_agent_id  = Column(String(256), nullable=False)
+    sender_agent_id     = Column(String(256), nullable=False)
+    ciphertext          = Column(LargeBinary, nullable=False)
+    seq                 = Column(Integer, nullable=False)
+    enqueued_at         = Column(DateTime(timezone=True), nullable=False,
+                                 default=lambda: datetime.now(timezone.utc))
+    ttl_expires_at      = Column(DateTime(timezone=True), nullable=False)
+    delivery_status     = Column(SmallInteger, nullable=False, default=0, index=True)
+    attempts            = Column(SmallInteger, nullable=False, default=0)
+    idempotency_key     = Column(String(256), nullable=True)
+    delivered_at        = Column(DateTime(timezone=True), nullable=True)
+    expired_at          = Column(DateTime(timezone=True), nullable=True)
 
 
 class RfqRecord(Base):

--- a/app/broker/db_models.py
+++ b/app/broker/db_models.py
@@ -21,6 +21,8 @@ class SessionRecord(Base):
     created_at          = Column(DateTime(timezone=True), nullable=False)
     expires_at          = Column(DateTime(timezone=True), nullable=True)
     closed_at           = Column(DateTime(timezone=True), nullable=True)
+    last_activity_at    = Column(DateTime(timezone=True), nullable=True)
+    close_reason        = Column(String(32),  nullable=True)
 
 
 class SessionMessageRecord(Base):

--- a/app/broker/message_queue.py
+++ b/app/broker/message_queue.py
@@ -1,0 +1,314 @@
+"""
+Proxy message queue — at-least-once delivery with TTL + idempotency (M3).
+
+This module owns the lifecycle of queued ciphertext messages:
+
+- ``enqueue`` persists a message awaiting ack, respecting the
+  ``(recipient_agent_id, idempotency_key)`` UNIQUE constraint so replays
+  from a retrying sender collapse into a single stored row.
+- ``mark_delivered`` ack's a message (recipient confirms receipt).
+- ``fetch_pending_for_recipient`` returns pending messages for drain on
+  reconnect or WS resume.
+- ``sweep_expired`` (used by the session_sweeper) flips TTL-expired rows
+  to status=expired and yields the sender/session pairs so the router
+  can notify senders via ``message.expired`` events.
+
+Scope for M3 v1: the queue lives in the broker DB next to
+session_messages. When per-org proxy storage ships (M5+), only the DSN
+and the SQL dialect-specific dedup change — the public API here stays
+stable.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.broker.db_models import ProxyMessageQueueRecord
+
+_log = logging.getLogger("agent_trust")
+
+
+# Delivery status enum values (kept as ints on the row for index efficiency)
+DELIVERY_PENDING = 0
+DELIVERY_DELIVERED = 1
+DELIVERY_EXPIRED = 2
+
+
+@dataclass
+class QueuedMessage:
+    """Lightweight DTO for dequeue-side consumers."""
+    msg_id: str
+    session_id: str
+    recipient_agent_id: str
+    sender_agent_id: str
+    ciphertext: bytes
+    seq: int
+    enqueued_at: datetime
+    ttl_expires_at: datetime
+    attempts: int
+    idempotency_key: Optional[str]
+
+
+@dataclass
+class ExpiredMessageNotice:
+    """Returned by sweep_expired so the router can notify senders."""
+    msg_id: str
+    session_id: str
+    sender_agent_id: str
+    recipient_agent_id: str
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Enqueue
+# ─────────────────────────────────────────────────────────────────────
+async def enqueue(
+    db: AsyncSession,
+    *,
+    session_id: str,
+    recipient_agent_id: str,
+    sender_agent_id: str,
+    ciphertext: bytes,
+    seq: int,
+    ttl_seconds: int,
+    idempotency_key: Optional[str] = None,
+) -> tuple[str, bool]:
+    """Enqueue a ciphertext for later delivery (M3.2).
+
+    Returns ``(msg_id, inserted)``:
+      - ``inserted=True`` means a new row was created.
+      - ``inserted=False`` means an existing row with the same
+        ``(recipient_agent_id, idempotency_key)`` was found — the caller
+        should treat the send as already-queued (idempotency, M3.5).
+
+    ``idempotency_key`` is optional; when None the insert always succeeds
+    (no dedupe surface). When provided, collisions are resolved at the
+    DB level via the UNIQUE constraint — no race window.
+    """
+    msg_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    ttl = now + timedelta(seconds=ttl_seconds)
+
+    values = dict(
+        msg_id=msg_id,
+        session_id=session_id,
+        recipient_agent_id=recipient_agent_id,
+        sender_agent_id=sender_agent_id,
+        ciphertext=ciphertext,
+        seq=seq,
+        enqueued_at=now,
+        ttl_expires_at=ttl,
+        delivery_status=DELIVERY_PENDING,
+        attempts=0,
+        idempotency_key=idempotency_key,
+    )
+
+    dialect_name = db.bind.dialect.name if db.bind else "unknown"
+
+    if idempotency_key is None:
+        # No dedupe: a plain insert suffices. Wrap in IntegrityError catch
+        # only as a belt-and-braces; the happy path does not hit it.
+        try:
+            db.add(ProxyMessageQueueRecord(**values))
+            await db.commit()
+            return msg_id, True
+        except IntegrityError:
+            await db.rollback()
+            raise
+    else:
+        # Dedupe path: ON CONFLICT DO NOTHING targeting the UNIQUE
+        # constraint. If the insert is skipped, re-read the existing
+        # msg_id so the caller can continue their flow transparently.
+        if dialect_name == "postgresql":
+            stmt = pg_insert(ProxyMessageQueueRecord).values(**values)
+            stmt = stmt.on_conflict_do_nothing(
+                constraint="uq_proxy_queue_idempotency",
+            )
+        else:
+            stmt = sqlite_insert(ProxyMessageQueueRecord).values(**values)
+            stmt = stmt.on_conflict_do_nothing(
+                index_elements=["recipient_agent_id", "idempotency_key"],
+            )
+        result = await db.execute(stmt)
+        await db.commit()
+
+        if result.rowcount > 0:
+            return msg_id, True
+
+        # Re-fetch the canonical msg_id for the dedupe row.
+        existing = await db.execute(
+            select(ProxyMessageQueueRecord.msg_id).where(
+                ProxyMessageQueueRecord.recipient_agent_id == recipient_agent_id,
+                ProxyMessageQueueRecord.idempotency_key == idempotency_key,
+            )
+        )
+        canonical = existing.scalar_one()
+        return canonical, False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Dequeue + ack
+# ─────────────────────────────────────────────────────────────────────
+async def fetch_pending_for_recipient(
+    db: AsyncSession,
+    recipient_agent_id: str,
+    limit: int = 500,
+) -> list[QueuedMessage]:
+    """Fetch pending messages for ``recipient_agent_id`` ordered by seq.
+
+    Does NOT mutate state — mark_delivered must be called after the
+    client ack's. Safe to call from WS reconnect / resume / polling.
+    """
+    result = await db.execute(
+        select(ProxyMessageQueueRecord)
+        .where(
+            ProxyMessageQueueRecord.recipient_agent_id == recipient_agent_id,
+            ProxyMessageQueueRecord.delivery_status == DELIVERY_PENDING,
+        )
+        .order_by(ProxyMessageQueueRecord.seq)
+        .limit(limit)
+    )
+    out: list[QueuedMessage] = []
+    for r in result.scalars().all():
+        out.append(QueuedMessage(
+            msg_id=r.msg_id,
+            session_id=r.session_id,
+            recipient_agent_id=r.recipient_agent_id,
+            sender_agent_id=r.sender_agent_id,
+            ciphertext=bytes(r.ciphertext) if r.ciphertext else b"",
+            seq=r.seq,
+            enqueued_at=r.enqueued_at.replace(tzinfo=timezone.utc),
+            ttl_expires_at=r.ttl_expires_at.replace(tzinfo=timezone.utc),
+            attempts=r.attempts,
+            idempotency_key=r.idempotency_key,
+        ))
+    return out
+
+
+async def mark_delivered(
+    db: AsyncSession,
+    msg_id: str,
+    *,
+    recipient_agent_id: Optional[str] = None,
+) -> bool:
+    """Flip a pending row to delivered (M3.2 ack endpoint).
+
+    Returns True when exactly one pending row was updated. Returns False
+    when the row is already delivered/expired/missing — caller can log
+    and respond 404/409 as appropriate but must NOT treat the duplicate
+    ack as fatal.
+
+    ``recipient_agent_id`` is optional; when provided it scopes the
+    update so an attacker who guesses a msg_id cannot ack someone else's
+    message (defense in depth on top of the router-level auth check).
+    """
+    now = datetime.now(timezone.utc)
+    conditions = [
+        ProxyMessageQueueRecord.msg_id == msg_id,
+        ProxyMessageQueueRecord.delivery_status == DELIVERY_PENDING,
+    ]
+    if recipient_agent_id is not None:
+        conditions.append(
+            ProxyMessageQueueRecord.recipient_agent_id == recipient_agent_id
+        )
+    stmt = (
+        update(ProxyMessageQueueRecord)
+        .where(*conditions)
+        .values(delivery_status=DELIVERY_DELIVERED, delivered_at=now)
+    )
+    result = await db.execute(stmt)
+    await db.commit()
+    return result.rowcount == 1
+
+
+async def bump_attempts(db: AsyncSession, msg_id: str) -> None:
+    """Increment attempts counter after a failed delivery try (M3.6)."""
+    stmt = (
+        update(ProxyMessageQueueRecord)
+        .where(
+            ProxyMessageQueueRecord.msg_id == msg_id,
+            ProxyMessageQueueRecord.delivery_status == DELIVERY_PENDING,
+        )
+        .values(attempts=ProxyMessageQueueRecord.attempts + 1)
+    )
+    await db.execute(stmt)
+    await db.commit()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Sweep (TTL expiry)
+# ─────────────────────────────────────────────────────────────────────
+async def sweep_expired(
+    db: AsyncSession,
+    *,
+    limit: int = 1000,
+) -> list[ExpiredMessageNotice]:
+    """Flip pending rows whose ``ttl_expires_at`` has passed to expired.
+
+    Returns the rows transitioned so the sweeper can emit a
+    ``message.expired`` event to each original sender (M3.3). Capped by
+    ``limit`` so a burst of expirations does not block the sweeper loop.
+    """
+    now = datetime.now(timezone.utc)
+
+    # Select first so we can return the set of senders/sessions to notify.
+    # The subsequent UPDATE is narrow (by msg_id IN …) so concurrent
+    # updates to unrelated rows don't contend.
+    candidates = await db.execute(
+        select(
+            ProxyMessageQueueRecord.msg_id,
+            ProxyMessageQueueRecord.session_id,
+            ProxyMessageQueueRecord.sender_agent_id,
+            ProxyMessageQueueRecord.recipient_agent_id,
+        )
+        .where(
+            ProxyMessageQueueRecord.delivery_status == DELIVERY_PENDING,
+            ProxyMessageQueueRecord.ttl_expires_at < now,
+        )
+        .limit(limit)
+    )
+    notices = [
+        ExpiredMessageNotice(
+            msg_id=row.msg_id,
+            session_id=row.session_id,
+            sender_agent_id=row.sender_agent_id,
+            recipient_agent_id=row.recipient_agent_id,
+        )
+        for row in candidates.all()
+    ]
+
+    if not notices:
+        return []
+
+    ids = [n.msg_id for n in notices]
+    await db.execute(
+        update(ProxyMessageQueueRecord)
+        .where(ProxyMessageQueueRecord.msg_id.in_(ids))
+        .values(delivery_status=DELIVERY_EXPIRED, expired_at=now)
+    )
+    await db.commit()
+    _log.info("message_queue: expired %d message(s)", len(notices))
+    return notices
+
+
+async def queue_depth_for_recipient(
+    db: AsyncSession,
+    recipient_agent_id: str,
+) -> int:
+    """Number of pending messages for an agent (M3.7 metrics)."""
+    from sqlalchemy import func
+    result = await db.execute(
+        select(func.count()).select_from(ProxyMessageQueueRecord).where(
+            ProxyMessageQueueRecord.recipient_agent_id == recipient_agent_id,
+            ProxyMessageQueueRecord.delivery_status == DELIVERY_PENDING,
+        )
+    )
+    return int(result.scalar() or 0)

--- a/app/broker/models.py
+++ b/app/broker/models.py
@@ -20,6 +20,17 @@ class SessionStatus(str, Enum):
     denied = "denied"
 
 
+class SessionCloseReason(str, Enum):
+    """Why a session was terminated. Attached to session.closed events (M1.3)."""
+    normal = "normal"                # explicit close() by a peer
+    idle_timeout = "idle_timeout"    # no activity within SESSION_IDLE_TIMEOUT
+    ttl_expired = "ttl_expired"      # hard TTL reached (expires_at)
+    peer_lost = "peer_lost"          # peer disconnected beyond grace (reserved for M2)
+    policy_revoked = "policy_revoked"  # binding/policy revocation
+    pending_timeout = "pending_timeout"  # accept not received within pending window
+    rejected = "rejected"            # explicit reject() by target
+
+
 class SessionRequest(BaseModel):
     target_agent_id: str = Field(..., description="ID of the target agent")
     target_org_id: str = Field(..., description="Target org — cross-checked against the registered org")

--- a/app/broker/persistence.py
+++ b/app/broker/persistence.py
@@ -95,6 +95,44 @@ async def save_message(
     return result.rowcount > 0
 
 
+async def fetch_messages_for_resume(
+    db: AsyncSession,
+    session_id: str,
+    recipient_agent_id: str,
+    after_seq: int,
+    limit: int = 500,
+) -> list[dict]:
+    """Fetch messages for a session-resume request (M2.2).
+
+    Returns messages with ``seq > after_seq`` whose ``sender_agent_id``
+    is NOT the resuming agent (we replay incoming traffic only — the
+    resumer's own outbound messages are not re-delivered). Ordered by
+    seq ascending. Capped by ``limit`` to bound a single resume payload.
+    """
+    result = await db.execute(
+        select(SessionMessageRecord)
+        .where(
+            SessionMessageRecord.session_id == session_id,
+            SessionMessageRecord.seq > after_seq,
+            SessionMessageRecord.sender_agent_id != recipient_agent_id,
+        )
+        .order_by(SessionMessageRecord.seq)
+        .limit(limit)
+    )
+    out: list[dict] = []
+    for rec in result.scalars().all():
+        out.append({
+            "seq": rec.seq,
+            "sender_agent_id": rec.sender_agent_id,
+            "payload": json.loads(rec.payload),
+            "nonce": rec.nonce,
+            "timestamp": rec.timestamp.replace(tzinfo=timezone.utc).isoformat(),
+            "signature": rec.signature,
+            "client_seq": rec.client_seq,
+        })
+    return out
+
+
 async def restore_sessions(db: AsyncSession, store: SessionStore) -> int:
     """
     Load from DB all non-expired, non-closed sessions,

--- a/app/broker/persistence.py
+++ b/app/broker/persistence.py
@@ -29,10 +29,16 @@ async def save_session(db: AsyncSession, session: Session) -> None:
     if session.status in (SessionStatus.closed, SessionStatus.denied):
         closed_at = datetime.now(timezone.utc)
 
+    close_reason_value = (
+        session.close_reason.value if session.close_reason is not None else None
+    )
+
     existing = await db.get(SessionRecord, session.session_id)
     if existing:
         existing.status = session.status.value
         existing.closed_at = closed_at
+        existing.last_activity_at = session.last_activity_at
+        existing.close_reason = close_reason_value
     else:
         db.add(SessionRecord(
             session_id=session.session_id,
@@ -45,6 +51,8 @@ async def save_session(db: AsyncSession, session: Session) -> None:
             created_at=session.created_at,
             expires_at=session.expires_at,
             closed_at=closed_at,
+            last_activity_at=session.last_activity_at,
+            close_reason=close_reason_value,
         ))
     await db.commit()
 
@@ -150,6 +158,12 @@ async def restore_sessions(db: AsyncSession, store: SessionStore) -> int:
             await db.commit()
             continue
 
+        last_activity = (
+            rec.last_activity_at.replace(tzinfo=timezone.utc)
+            if rec.last_activity_at is not None
+            else rec.created_at.replace(tzinfo=timezone.utc)
+        )
+
         session = Session(
             session_id=rec.session_id,
             initiator_agent_id=rec.initiator_agent_id,
@@ -160,6 +174,7 @@ async def restore_sessions(db: AsyncSession, store: SessionStore) -> int:
             status=SessionStatus(rec.status),
             created_at=rec.created_at.replace(tzinfo=timezone.utc),
             expires_at=rec.expires_at.replace(tzinfo=timezone.utc) if rec.expires_at else None,
+            last_activity_at=last_activity,
         )
 
         # Reload messages and rebuild nonce set

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -730,6 +730,62 @@ async def send_message(
     return response
 
 
+@router.post(
+    "/sessions/{session_id}/messages/{msg_id}/ack",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def ack_queued_message(
+    session_id: str,
+    msg_id: str,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Acknowledge a queued message (M3.6).
+
+    Called by the recipient SDK after it has successfully decrypted and
+    processed a message delivered via the queue-drain path. Scoped to
+    the caller's agent_id so an attacker who guesses a msg_id cannot
+    ack someone else's message.
+
+    Returns 204 on success, 404 if the message does not exist for this
+    recipient, 409 if it is already delivered or has expired.
+    """
+    _validate_session_id(session_id)
+    if not _UUID_RE.match(msg_id):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="msg_id must be a UUID")
+
+    from app.broker import message_queue as mq
+    from app.broker.db_models import ProxyMessageQueueRecord
+    from sqlalchemy import select as _select
+
+    ok = await mq.mark_delivered(
+        db, msg_id, recipient_agent_id=current_agent.agent_id,
+    )
+    if ok:
+        await log_event(
+            db, "broker.message_acked", "ok",
+            agent_id=current_agent.agent_id, session_id=session_id,
+            org_id=current_agent.org,
+            details={"msg_id": msg_id},
+        )
+        return
+
+    # Distinguish missing vs already-terminal to give the SDK a clear signal.
+    existing = (await db.execute(
+        _select(ProxyMessageQueueRecord.delivery_status).where(
+            ProxyMessageQueueRecord.msg_id == msg_id,
+            ProxyMessageQueueRecord.recipient_agent_id == current_agent.agent_id,
+        )
+    )).scalar_one_or_none()
+    if existing is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
+                            detail="Message not found for this recipient")
+    # delivered (1) or expired (2) — terminal state, ack is a no-op 409.
+    raise HTTPException(status_code=status.HTTP_409_CONFLICT,
+                        detail="Message already in a terminal state")
+
+
 @router.get("/sessions", response_model=list[SessionResponse])
 async def list_sessions(
     status: SessionStatus | None = None,

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -41,6 +41,8 @@ from app.telemetry import tracer
 from app.telemetry_metrics import (
     SESSION_CREATED_COUNTER, SESSION_DENIED_COUNTER,
     SESSION_CLOSED_COUNTER, SESSION_CAP_REJECTED_COUNTER,
+    WS_PING_SENT_COUNTER, WS_PONG_TIMEOUT_COUNTER,
+    WS_RESUME_COUNTER, WS_RESUME_MESSAGES_DELIVERED_COUNTER,
 )
 from app.injection.detector import injection_detector
 from app.registry.store import get_agent_by_id as _get_agent_by_id
@@ -840,6 +842,94 @@ async def get_rfq_status(
 _WS_AUTH_TIMEOUT = 10  # seconds — max time to wait for initial auth message
 
 
+def _ws_env_int(name: str, default: int) -> int:
+    import os as _os
+    raw = _os.environ.get(name)
+    try:
+        return int(raw) if raw is not None else default
+    except ValueError:
+        return default
+
+
+# M2 heartbeat config — all overridable via env for tuning / tests
+_WS_PING_INTERVAL_SECONDS = _ws_env_int("WS_PING_INTERVAL_SECONDS", 30)
+_WS_PONG_TIMEOUT_SECONDS = _ws_env_int("WS_PONG_TIMEOUT_SECONDS", 10)
+_WS_RECV_POLL_SECONDS = _ws_env_int("WS_RECV_POLL_SECONDS", 5)
+_WS_RESUME_MAX_MESSAGES = _ws_env_int("WS_RESUME_MAX_MESSAGES", 500)
+
+
+async def _handle_ws_resume(
+    websocket: WebSocket,
+    msg: dict,
+    agent_id: str,
+    db: AsyncSession,
+    store: SessionStore,
+) -> None:
+    """Handle ``{"type":"resume","session_id":..,"last_seq":N}`` (M2.2).
+
+    Replays messages for the given session with ``seq > last_seq``,
+    excluding those sent by the resuming agent. Fetches from the DB
+    directly — the in-memory store is authoritative for state but the
+    DB is authoritative for message bytes (survives restarts).
+    """
+    session_id = msg.get("session_id")
+    if not isinstance(session_id, str) or not _UUID_RE.match(session_id):
+        await websocket.send_json({
+            "type": "resume_error",
+            "detail": "Invalid or missing session_id",
+        })
+        return
+
+    try:
+        last_seq = int(msg.get("last_seq", -1))
+    except (TypeError, ValueError):
+        await websocket.send_json({
+            "type": "resume_error",
+            "session_id": session_id,
+            "detail": "last_seq must be integer",
+        })
+        return
+
+    session = store.get(session_id)
+    if session is None:
+        await websocket.send_json({
+            "type": "resume_error",
+            "session_id": session_id,
+            "detail": "Session not found",
+        })
+        return
+    if agent_id not in (session.initiator_agent_id, session.target_agent_id):
+        await websocket.send_json({
+            "type": "resume_error",
+            "session_id": session_id,
+            "detail": "Not a participant",
+        })
+        return
+
+    from app.broker.persistence import fetch_messages_for_resume
+    replay = await fetch_messages_for_resume(
+        db, session_id, agent_id, last_seq, limit=_WS_RESUME_MAX_MESSAGES,
+    )
+
+    WS_RESUME_COUNTER.add(1, {"org": session.initiator_org_id})
+    WS_RESUME_MESSAGES_DELIVERED_COUNTER.add(len(replay), {"org": session.initiator_org_id})
+    session.touch()
+
+    await websocket.send_json({
+        "type": "resume_ok",
+        "session_id": session_id,
+        "last_seq_server": session._next_seq - 1,
+        "delivered": len(replay),
+    })
+    for m in replay:
+        await websocket.send_json({
+            "type": "new_message",
+            "session_id": session_id,
+            "message": m,
+            "replayed": True,
+        })
+
+
 @router.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket, db: AsyncSession = Depends(get_db)):
     """
@@ -962,30 +1052,74 @@ async def websocket_endpoint(websocket: WebSocket, db: AsyncSession = Depends(ge
             return
         await websocket.send_json({"type": "auth_ok", "agent_id": agent_id})
 
-        # Step 4: keepalive — server pushes; client can send ping
-        _WS_IDLE_TIMEOUT = 300   # 5 minutes
+        # Step 4: keepalive loop with M2 server-initiated heartbeat.
+        _WS_IDLE_TIMEOUT = 300   # 5 minutes — upper bound on total client inactivity
         _WS_MSG_LIMIT = 30       # max messages per window
         _WS_MSG_WINDOW = 60      # window in seconds
         _msg_times: list[float] = []
 
+        # Heartbeat state: last time we heard anything from the client
+        # (including pongs), and whether we are currently awaiting a pong.
+        _last_client_activity = _time.monotonic()
+        _awaiting_pong_since: float | None = None
+
         while True:
-            # Check token expiry
+            now_mono = _time.monotonic()
+
+            # Token expiry check (wall-clock)
             if _time.time() > agent.exp:
                 _log.info("Token expired during WebSocket session for agent %s", agent_id)
                 await websocket.send_json({"type": "auth_error", "detail": "Token expired"})
                 await websocket.close(code=1000, reason="Token expired")
                 break
 
-            # Receive with idle timeout
-            try:
-                msg = await asyncio.wait_for(
-                    websocket.receive_json(),
-                    timeout=_WS_IDLE_TIMEOUT,
+            # M2.1 — if we pinged earlier and no pong within grace, declare dead
+            if (
+                _awaiting_pong_since is not None
+                and now_mono - _awaiting_pong_since >= _WS_PONG_TIMEOUT_SECONDS
+            ):
+                WS_PONG_TIMEOUT_COUNTER.add(1, {"org": agent_org or ""})
+                _log.info(
+                    "WebSocket pong timeout for agent %s (%.1fs since ping)",
+                    agent_id, now_mono - _awaiting_pong_since,
                 )
-            except asyncio.TimeoutError:
+                await websocket.close(code=1001, reason="Pong timeout")
+                break
+
+            # M2.1 — proactively send a ping when the connection has been
+            # silent for PING_INTERVAL (and we are not already waiting on one)
+            if (
+                _awaiting_pong_since is None
+                and now_mono - _last_client_activity >= _WS_PING_INTERVAL_SECONDS
+            ):
+                try:
+                    await websocket.send_json({"type": "ping"})
+                except Exception:
+                    break
+                WS_PING_SENT_COUNTER.add(1, {"org": agent_org or ""})
+                _awaiting_pong_since = now_mono
+
+            # Overall idle guard: if the client has been totally silent for
+            # IDLE_TIMEOUT (no pings, no pongs, no messages), close.
+            if now_mono - _last_client_activity >= _WS_IDLE_TIMEOUT:
                 _log.info("WebSocket idle timeout for agent %s", agent_id)
                 await websocket.close(code=1000, reason="Idle timeout")
                 break
+
+            # Receive with a short poll so we can re-check ping cadence
+            try:
+                msg = await asyncio.wait_for(
+                    websocket.receive_json(),
+                    timeout=_WS_RECV_POLL_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                continue  # loop back to re-evaluate ping/idle conditions
+            except Exception:
+                break
+
+            # Any valid client frame counts as activity and clears pong-wait
+            _last_client_activity = _time.monotonic()
+            _awaiting_pong_since = None
 
             # Rate limit incoming messages
             now = _time.monotonic()
@@ -996,8 +1130,19 @@ async def websocket_endpoint(websocket: WebSocket, db: AsyncSession = Depends(ge
                 break
             _msg_times.append(now)
 
-            if msg.get("type") == "ping":
+            mtype = msg.get("type")
+            if mtype == "ping":
+                # Client-initiated ping — reply with pong (legacy behaviour)
                 await websocket.send_json({"type": "pong"})
+            elif mtype == "pong":
+                # Pong acknowledging our server ping — already handled by
+                # clearing _awaiting_pong_since above; no-op here.
+                pass
+            elif mtype == "resume":
+                await _handle_ws_resume(
+                    websocket, msg, agent_id, db,
+                    get_session_store(),
+                )
 
     except WebSocketDisconnect:
         pass

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -949,6 +949,47 @@ async def get_rfq_status(
     return result
 
 
+async def _drain_queue_for_agent(
+    websocket: WebSocket,
+    agent_id: str,
+    db: AsyncSession,
+) -> int:
+    """Push queued offline messages to the just-connected agent (M3.6).
+
+    Called after ``auth_ok`` and at the end of ``_handle_ws_resume``.
+    Messages stay in the queue (status=pending) until the recipient
+    ack's via POST /messages/{msg_id}/ack — this function only pushes
+    the frames, it does not mutate state. Delivered frames carry
+    ``queued: true`` and ``msg_id`` so the SDK knows to ack.
+    """
+    from app.broker import message_queue as mq
+    from app.telemetry_metrics import WS_QUEUE_DRAINED_COUNTER
+    import json as _json_inner
+
+    pending = await mq.fetch_pending_for_recipient(db, agent_id)
+    for q in pending:
+        try:
+            payload = _json_inner.loads(q.ciphertext.decode())
+        except Exception:
+            _log.exception("drain: bad ciphertext in queue row %s", q.msg_id)
+            continue
+        await websocket.send_json({
+            "type": "new_message",
+            "session_id": q.session_id,
+            "msg_id": q.msg_id,
+            "queued": True,
+            "message": {
+                "seq": q.seq,
+                "sender_agent_id": q.sender_agent_id,
+                "payload": payload,
+                "timestamp": q.enqueued_at.isoformat(),
+            },
+        })
+    if pending:
+        WS_QUEUE_DRAINED_COUNTER.add(len(pending))
+    return len(pending)
+
+
 _WS_AUTH_TIMEOUT = 10  # seconds — max time to wait for initial auth message
 
 
@@ -1038,6 +1079,12 @@ async def _handle_ws_resume(
             "message": m,
             "replayed": True,
         })
+
+    # M3.6 — after in-session replay, drain offline queue for this agent.
+    try:
+        await _drain_queue_for_agent(websocket, agent_id, db)
+    except Exception:
+        _log.exception("WS drain failed for agent %s (resume path)", agent_id)
 
 
 @router.websocket("/ws")
@@ -1161,6 +1208,13 @@ async def websocket_endpoint(websocket: WebSocket, db: AsyncSession = Depends(ge
             await websocket.close()
             return
         await websocket.send_json({"type": "auth_ok", "agent_id": agent_id})
+
+        # M3.6 — drain any offline-queued messages for this agent.
+        # Best-effort: drain failures don't abort the WS session.
+        try:
+            await _drain_queue_for_agent(websocket, agent_id, db)
+        except Exception:
+            _log.exception("WS drain failed for agent %s (auth_ok path)", agent_id)
 
         # Step 4: keepalive loop with M2 server-initiated heartbeat.
         _WS_IDLE_TIMEOUT = 300   # 5 minutes — upper bound on total client inactivity

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -24,8 +24,13 @@ from app.db.database import get_db
 from app.db.audit import log_event
 from app.registry.store import get_agent_by_id
 from app.registry.binding_store import get_approved_binding
-from app.broker.models import SessionRequest, SessionResponse, SessionStatus, MessageEnvelope, InboxMessage
-from app.broker.session import get_session_store, SessionStore
+from app.broker.models import (
+    SessionRequest, SessionResponse, SessionStatus,
+    SessionCloseReason, MessageEnvelope, InboxMessage,
+)
+from app.broker.session import (
+    get_session_store, SessionStore, AgentSessionCapExceeded,
+)
 from app.broker.persistence import save_session, save_message
 from app.broker.ws_manager import ws_manager
 from app.policy.backend import evaluate_session_policy
@@ -33,7 +38,10 @@ from app.policy.engine import PolicyEngine
 from app.rate_limit.limiter import rate_limiter
 from app.auth.message_signer import verify_message_signature
 from app.telemetry import tracer
-from app.telemetry_metrics import SESSION_CREATED_COUNTER, SESSION_DENIED_COUNTER
+from app.telemetry_metrics import (
+    SESSION_CREATED_COUNTER, SESSION_DENIED_COUNTER,
+    SESSION_CLOSED_COUNTER, SESSION_CAP_REJECTED_COUNTER,
+)
 from app.injection.detector import injection_detector
 from app.registry.store import get_agent_by_id as _get_agent_by_id
 from app.registry.org_store import get_org_by_id
@@ -51,6 +59,34 @@ def _validate_session_id(session_id: str) -> None:
     if not _UUID_RE.match(session_id):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
                             detail="Invalid session_id format (expected UUID)")
+
+
+async def _emit_session_closed(
+    session_obj,
+    reason: SessionCloseReason,
+    *,
+    triggered_by: str | None = None,
+) -> None:
+    """Best-effort notification of session close to both peers (M1.3, O3).
+
+    The event is pushed via the WebSocket manager (which transparently
+    falls back to Redis pub/sub for cross-worker delivery). If a peer
+    is offline, the notification is lost — by design. Upgrade to
+    durable notifications is an M3 opt-in, not default.
+    """
+    event = {
+        "type": "session_closed",
+        "session_id": session_obj.session_id,
+        "reason": reason.value,
+    }
+    if triggered_by:
+        event["triggered_by"] = triggered_by
+    for peer in (session_obj.initiator_agent_id, session_obj.target_agent_id):
+        try:
+            await ws_manager.send_to_agent(peer, event)
+        except Exception:  # noqa: BLE001 — best-effort
+            _log.debug("session_closed notify failed for peer %s", peer)
+    SESSION_CLOSED_COUNTER.add(1, {"reason": reason.value, "source": "router"})
 
 
 @router.post("/sessions", response_model=SessionResponse, status_code=status.HTTP_201_CREATED)
@@ -190,6 +226,15 @@ async def _create_session_inner(body, current_agent, store, db, span):
             target_org_id=body.target_org_id,
             requested_capabilities=body.requested_capabilities,
         )
+    except AgentSessionCapExceeded as exc:
+        SESSION_CAP_REJECTED_COUNTER.add(1, {"org": current_agent.org})
+        await log_event(db, "broker.session_cap_rejected", "denied",
+                        agent_id=current_agent.agent_id, org_id=current_agent.org,
+                        details={"current": exc.current, "cap": exc.cap})
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=f"Too many active sessions ({exc.current}/{exc.cap}) — close some before opening new ones",
+        )
     except RuntimeError as exc:
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                             detail=str(exc))
@@ -318,13 +363,20 @@ async def reject_session(
                     agent_id=current_agent.agent_id, session_id=session_id,
                     org_id=current_agent.org)
 
-    # Notify initiator via WebSocket
+    # Notify initiator via WebSocket (legacy session_rejected event)
     if ws_manager.is_connected(session.initiator_agent_id):
         await ws_manager.send_to_agent(session.initiator_agent_id, {
             "type": "session_rejected",
             "session_id": session.session_id,
             "rejected_by": current_agent.agent_id,
         })
+
+    # M1.3 — unified session_closed event for all terminal transitions
+    await _emit_session_closed(
+        session,
+        SessionCloseReason.rejected,
+        triggered_by=current_agent.agent_id,
+    )
 
     return SessionResponse(
         session_id=session.session_id,
@@ -375,12 +427,20 @@ async def close_session(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT,
                                 detail=f"Session is in state '{session.status}', cannot be closed")
 
-        store.close(session_id)
+        store.close(session_id, SessionCloseReason.normal)
         await save_session(db, session)
 
     await log_event(db, "session_closed", "ok",
                     agent_id=current_agent.agent_id, session_id=session_id,
-                    org_id=current_agent.org)
+                    org_id=current_agent.org,
+                    details={"reason": SessionCloseReason.normal.value})
+
+    # M1.3 — notify both peers of the close
+    await _emit_session_closed(
+        session,
+        SessionCloseReason.normal,
+        triggered_by=current_agent.agent_id,
+    )
 
     return SessionResponse(
         session_id=session.session_id,
@@ -552,6 +612,8 @@ async def send_message(
 
         seq = session.store_message(current_agent.agent_id, envelope.payload, envelope.nonce,
                                     envelope.signature, client_seq=envelope.client_seq)
+        # M1.2 — record activity to defer idle timeout
+        session.touch()
 
         # Atomic DB insert — source of truth for nonce uniqueness.
         # Rollback in-memory state on ANY failure (nonce conflict or DB error).
@@ -672,6 +734,10 @@ async def poll_messages(
                             detail="You are not a participant of this session")
 
     messages = session.get_messages_for(current_agent.agent_id, after=after)
+    # M1.2 — touch only when poll actually delivers messages: an empty
+    # poll loop from a dead client must not keep a stale session alive.
+    if messages:
+        session.touch()
     return [
         InboxMessage(
             seq=m.seq,

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -459,6 +459,16 @@ async def close_session(
 async def send_message(
     session_id: str,
     envelope: MessageEnvelope,
+    ttl_seconds: int = Query(
+        default=300, ge=1, le=86400,
+        description="TTL for queued delivery when recipient is offline (M3). "
+                    "Ignored on direct WS push.",
+    ),
+    idempotency_key: str | None = Query(
+        default=None, max_length=128,
+        description="Optional dedupe key — a retry with the same "
+                    "(recipient_agent_id, idempotency_key) returns the same queued msg_id (M3).",
+    ),
     current_agent: TokenPayload = Depends(get_current_agent),
     store: SessionStore = Depends(get_session_store),
     db: AsyncSession = Depends(get_db),
@@ -469,7 +479,9 @@ async def send_message(
       - session is active and not expired
       - sender is a legitimate participant
       - nonce has not already been used (replay protection)
-    After saving, pushes the message via WS to the recipient if connected.
+    If the recipient is connected locally, the message is pushed via WS.
+    Otherwise it is persisted in the proxy message queue (M3) and drained
+    on the recipient's next WS connect/resume.
     """
     await rate_limiter.check(current_agent.agent_id, "broker.message")
 
@@ -652,7 +664,7 @@ async def send_message(
                     })
     _log.info("✔ message accepted + audit logged  (seq=%d, session=%s)", seq, session_id)
 
-    # Push WS to the recipient if connected
+    # ── Delivery: WS push if recipient locally connected, else enqueue (M3) ──
     recipient_id = (
         session.target_agent_id
         if current_agent.agent_id == session.initiator_agent_id
@@ -672,8 +684,50 @@ async def send_message(
         if envelope.client_seq is not None:
             ws_msg["message"]["client_seq"] = envelope.client_seq
         await ws_manager.send_to_agent(recipient_id, ws_msg)
+        response: dict = {"status": "accepted", "session_id": session_id}
+    else:
+        from app.broker import message_queue as mq
+        from app.telemetry_metrics import (
+            MESSAGE_QUEUED_COUNTER, MESSAGE_QUEUE_DEDUPED_COUNTER,
+        )
+        ciphertext = _json.dumps(
+            envelope.payload, sort_keys=True, separators=(",", ":")
+        ).encode()
+        msg_id, inserted = await mq.enqueue(
+            db,
+            session_id=session_id,
+            recipient_agent_id=recipient_id,
+            sender_agent_id=current_agent.agent_id,
+            ciphertext=ciphertext,
+            seq=seq,
+            ttl_seconds=ttl_seconds,
+            idempotency_key=idempotency_key,
+        )
+        if inserted:
+            MESSAGE_QUEUED_COUNTER.add(1)
+        else:
+            MESSAGE_QUEUE_DEDUPED_COUNTER.add(1)
+        await log_event(
+            db, "broker.message_queued",
+            "ok" if inserted else "deduped",
+            agent_id=current_agent.agent_id, session_id=session_id,
+            org_id=current_agent.org,
+            details={
+                "msg_id": msg_id,
+                "recipient_agent_id": recipient_id,
+                "ttl_seconds": ttl_seconds,
+                "idempotency_key": idempotency_key,
+                "inserted": inserted,
+            },
+        )
+        response = {
+            "status": "queued",
+            "session_id": session_id,
+            "msg_id": msg_id,
+            "deduped": not inserted,
+        }
 
-    return {"status": "accepted", "session_id": session_id}
+    return response
 
 
 @router.get("/sessions", response_model=list[SessionResponse])

--- a/app/broker/session.py
+++ b/app/broker/session.py
@@ -10,13 +10,31 @@ Each session has a unique ID and tracks:
 """
 import asyncio
 import logging
+import os
 import uuid
 from datetime import datetime, timezone, timedelta
 from dataclasses import dataclass, field
 
-from app.broker.models import SessionStatus
+from app.broker.models import SessionStatus, SessionCloseReason
 
 _log = logging.getLogger("agent_trust")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        _log.warning("Invalid %s=%r, falling back to default %d", name, raw, default)
+        return default
+
+
+# M1 reliability layer defaults (overridable via env for tests / per-org tuning)
+SESSION_IDLE_TIMEOUT_SECONDS = _env_int("SESSION_IDLE_TIMEOUT_SECONDS", 600)   # 10 min
+SESSION_HARD_TTL_MINUTES     = _env_int("SESSION_HARD_TTL_MINUTES", 60)        # 1 hour
+SESSION_CAP_ACTIVE_PER_AGENT = _env_int("SESSION_CAP_ACTIVE_PER_AGENT", 50)    # O4 decision: only ACTIVE capped
 
 
 @dataclass
@@ -41,6 +59,8 @@ class Session:
     status: SessionStatus = SessionStatus.pending
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     expires_at: datetime | None = None
+    last_activity_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    close_reason: SessionCloseReason | None = None
     used_nonces: set[str] = field(default_factory=set)
     _messages: list[StoredMessage] = field(default_factory=list)
     _next_seq: int = 0
@@ -51,6 +71,24 @@ class Session:
         if self.expires_at is None:
             return False
         return datetime.now(timezone.utc) > self.expires_at
+
+    def is_idle(self, timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS) -> bool:
+        """True if no activity has been recorded in the last ``timeout_seconds``.
+
+        Activity is anything that calls :meth:`touch`: send, poll, accept.
+        Idle sessions are terminal candidates for the sweeper (M1.1).
+        """
+        if self.status not in (SessionStatus.active, SessionStatus.pending):
+            return False
+        age = (datetime.now(timezone.utc) - self.last_activity_at).total_seconds()
+        return age > timeout_seconds
+
+    def touch(self) -> None:
+        """Record activity on the session. Resets the idle timer.
+
+        Called from the router on every send, poll, and accept. Idempotent.
+        """
+        self.last_activity_at = datetime.now(timezone.utc)
 
     def is_nonce_cached(self, nonce: str) -> bool:
         """Fast-path replay check against the in-memory cache.
@@ -99,27 +137,57 @@ class Session:
         ]
 
 
+class AgentSessionCapExceeded(Exception):
+    """Raised when an agent has too many concurrent ACTIVE sessions (O4)."""
+
+    def __init__(self, agent_id: str, current: int, cap: int):
+        self.agent_id = agent_id
+        self.current = current
+        self.cap = cap
+        super().__init__(
+            f"Agent {agent_id} has {current} ACTIVE sessions "
+            f"(cap {cap}) — cannot open new session"
+        )
+
+
 class SessionStore:
     _MAX_SESSIONS: int = 10_000  # hard cap — prevents unbounded memory growth
 
-    def __init__(self, session_ttl_minutes: int = 60):
+    def __init__(
+        self,
+        session_ttl_minutes: int | None = None,
+        active_cap_per_agent: int | None = None,
+    ):
         self._sessions: dict[str, Session] = {}
-        self._ttl = timedelta(minutes=session_ttl_minutes)
+        self._ttl = timedelta(
+            minutes=session_ttl_minutes
+            if session_ttl_minutes is not None
+            else SESSION_HARD_TTL_MINUTES
+        )
+        self._active_cap_per_agent = (
+            active_cap_per_agent
+            if active_cap_per_agent is not None
+            else SESSION_CAP_ACTIVE_PER_AGENT
+        )
         self._lock = asyncio.Lock()  # protects state transitions (accept/reject/close)
 
     # ── Eviction ─────────────────────────────────────────────────────────
 
     def _evict_stale(self) -> int:
-        """Remove expired and terminal sessions from the in-memory store.
+        """Remove already-terminated sessions from the in-memory store.
 
         Called automatically before creating a new session.  Returns the
         number of sessions evicted.
+
+        Only sessions in CLOSED/DENIED states are evicted here — sessions
+        whose ``expires_at`` has passed but are still PENDING/ACTIVE are
+        left in place so the background sweeper (M1.1) can transition
+        them to CLOSED and emit a ``session.closed`` event with reason
+        ``ttl_expired`` before they disappear.
         """
-        now = datetime.now(timezone.utc)
         to_remove = [
             sid for sid, s in self._sessions.items()
             if s.status in (SessionStatus.closed, SessionStatus.denied)
-            or (s.expires_at is not None and s.expires_at < now)
         ]
         for sid in to_remove:
             del self._sessions[sid]
@@ -128,6 +196,20 @@ class SessionStore:
         return len(to_remove)
 
     # ── CRUD ─────────────────────────────────────────────────────────────
+
+    def count_active_for_agent(self, agent_id: str) -> int:
+        """Count ACTIVE sessions involving ``agent_id`` (as initiator or target).
+
+        Used by :meth:`create` to enforce the per-agent cap (O4 decision:
+        only ACTIVE is capped; PENDING is rate-limited at the route level
+        and auto-swept when it times out).
+        """
+        return sum(
+            1
+            for s in self._sessions.values()
+            if s.status == SessionStatus.active
+            and (s.initiator_agent_id == agent_id or s.target_agent_id == agent_id)
+        )
 
     def create(
         self,
@@ -144,6 +226,16 @@ class SessionStore:
             raise RuntimeError(
                 f"Session store full ({self._MAX_SESSIONS} sessions) — "
                 "cannot create new session"
+            )
+
+        # M1.4 per-agent ACTIVE cap (applies to the initiator; the target's
+        # cap is re-checked when they accept).
+        active_for_initiator = self.count_active_for_agent(initiator_agent_id)
+        if active_for_initiator >= self._active_cap_per_agent:
+            raise AgentSessionCapExceeded(
+                agent_id=initiator_agent_id,
+                current=active_for_initiator,
+                cap=self._active_cap_per_agent,
             )
 
         session_id = str(uuid.uuid4())
@@ -171,20 +263,39 @@ class SessionStore:
         session = self.get(session_id)
         if session and session.status == SessionStatus.pending:
             session.status = SessionStatus.active
+            session.touch()
         return session
 
     def reject(self, session_id: str) -> Session | None:
         session = self.get(session_id)
         if session and session.status == SessionStatus.pending:
             session.status = SessionStatus.denied
+            session.close_reason = SessionCloseReason.rejected
         return session
 
-    def close(self, session_id: str) -> None:
-        session = self._sessions.get(session_id)
-        if session:
-            session.status = SessionStatus.closed
+    def close(
+        self,
+        session_id: str,
+        reason: SessionCloseReason = SessionCloseReason.normal,
+    ) -> Session | None:
+        """Close a session, recording why.
 
-    def close_all_for_agent(self, agent_id: str) -> list[Session]:
+        ``reason`` is attached to the session and propagated to peers via
+        the ``session.closed`` event (M1.3). The event emission itself
+        lives at the router level — this method only mutates state.
+        """
+        session = self._sessions.get(session_id)
+        if session and session.status != SessionStatus.closed:
+            session.status = SessionStatus.closed
+            if session.close_reason is None:
+                session.close_reason = reason
+        return session
+
+    def close_all_for_agent(
+        self,
+        agent_id: str,
+        reason: SessionCloseReason = SessionCloseReason.normal,
+    ) -> list[Session]:
         """Close all active/pending sessions involving the given agent.
         Returns the list of sessions that were closed."""
         closed = []
@@ -193,8 +304,33 @@ class SessionStore:
                 s.initiator_agent_id == agent_id or s.target_agent_id == agent_id
             ):
                 s.status = SessionStatus.closed
+                if s.close_reason is None:
+                    s.close_reason = reason
                 closed.append(s)
         return closed
+
+    def find_stale(
+        self,
+        idle_timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS,
+    ) -> list[tuple[Session, SessionCloseReason]]:
+        """Return sessions that should be closed by the sweeper (M1.1).
+
+        A session is stale when:
+          - expires_at < now                → ttl_expired
+          - status in (active, pending) AND idle > idle_timeout_seconds → idle_timeout
+
+        Returns ``[(session, reason)]`` so the sweeper can emit per-session
+        close events with the right reason.
+        """
+        out: list[tuple[Session, SessionCloseReason]] = []
+        for s in self._sessions.values():
+            if s.status in (SessionStatus.closed, SessionStatus.denied):
+                continue
+            if s.is_expired():
+                out.append((s, SessionCloseReason.ttl_expired))
+            elif s.is_idle(idle_timeout_seconds):
+                out.append((s, SessionCloseReason.idle_timeout))
+        return out
 
     def list_for_agent(self, agent_id: str, *, limit: int = 100, offset: int = 0) -> list[Session]:
         matches = [

--- a/app/broker/session_sweeper.py
+++ b/app/broker/session_sweeper.py
@@ -66,6 +66,48 @@ async def _emit_closed_event(session: Session, reason: SessionCloseReason) -> No
             )
 
 
+async def _sweep_message_queue() -> int:
+    """Expire TTL-lapsed queued messages and notify their senders (M3.6).
+
+    Runs on each sweeper cycle. Isolated so DB or WS failures don't
+    kill the session sweep. Returns the number of messages expired.
+    """
+    try:
+        from app.broker import message_queue as mq
+        from app.broker.ws_manager import ws_manager
+        from app.db.database import AsyncSessionLocal
+        from app.telemetry_metrics import MESSAGE_EXPIRED_COUNTER
+    except Exception:
+        return 0
+
+    try:
+        async with AsyncSessionLocal() as db:
+            notices = await mq.sweep_expired(db)
+    except Exception:
+        _log.exception("sweeper: message queue sweep failed")
+        return 0
+
+    for n in notices:
+        payload = {
+            "type": "message_expired",
+            "session_id": n.session_id,
+            "msg_id": n.msg_id,
+            "recipient_agent_id": n.recipient_agent_id,
+            "reason": "ttl",
+        }
+        try:
+            await ws_manager.send_to_agent(n.sender_agent_id, payload)
+        except Exception as exc:  # noqa: BLE001
+            _log.debug(
+                "message_expired notify failed for sender %s (msg %s): %s",
+                n.sender_agent_id, n.msg_id, exc,
+            )
+
+    if notices:
+        MESSAGE_EXPIRED_COUNTER.add(len(notices))
+    return len(notices)
+
+
 async def _persist_closed(session: Session) -> None:
     """Persist the close to the DB. Isolated so failures don't kill the sweep."""
     try:
@@ -119,6 +161,9 @@ async def sweep_once(
             session.session_id, reason.value,
             session.initiator_agent_id, session.target_agent_id,
         )
+
+    # M3.6 — also sweep TTL-expired queued messages (independent of session close).
+    await _sweep_message_queue()
 
     SESSION_SWEEPER_CYCLES_COUNTER.add(1, {"closed": str(closed)})
     return closed

--- a/app/broker/session_sweeper.py
+++ b/app/broker/session_sweeper.py
@@ -1,0 +1,157 @@
+"""
+Background session sweeper (M1.1).
+
+Periodically scans the in-memory session store for sessions that should
+be closed:
+
+- ``ttl_expired``  → hard TTL (``expires_at``) reached
+- ``idle_timeout`` → no activity within ``SESSION_IDLE_TIMEOUT_SECONDS``
+
+For each stale session the sweeper:
+1. Mutates the in-memory state via ``store.close(session_id, reason)``
+2. Persists the new state to the DB (``save_session``)
+3. Emits a best-effort ``session.closed`` event to both peers via the
+   WebSocket manager (M1.3 — O3 decision: best-effort, not durable)
+4. Records metrics
+
+The task is owned by the FastAPI lifespan: started in ``lifespan`` and
+cancelled on shutdown.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from app.broker.models import SessionCloseReason, SessionStatus
+from app.broker.session import (
+    SESSION_IDLE_TIMEOUT_SECONDS,
+    Session,
+    SessionStore,
+)
+
+_log = logging.getLogger("agent_trust")
+
+# Default cycle interval. Overridable via env for tests (see app/broker/session.py
+# for the _env_int helper pattern; kept simple here to avoid a back-import).
+import os
+
+try:
+    SWEEP_INTERVAL_SECONDS = max(1, int(os.environ.get("SESSION_SWEEP_INTERVAL_SECONDS", "30")))
+except ValueError:
+    SWEEP_INTERVAL_SECONDS = 30
+
+
+async def _emit_closed_event(session: Session, reason: SessionCloseReason) -> None:
+    """Best-effort notification to both peers (M1.3, O3 decision)."""
+    # Imported lazily so the sweeper module does not force ws_manager wiring
+    # in contexts (tests, tools) that don't need it.
+    try:
+        from app.broker.ws_manager import ws_manager
+    except Exception:
+        return
+
+    payload = {
+        "type": "session_closed",
+        "session_id": session.session_id,
+        "reason": reason.value,
+    }
+    for agent_id in (session.initiator_agent_id, session.target_agent_id):
+        try:
+            await ws_manager.send_to_agent(agent_id, payload)
+        except Exception as exc:  # noqa: BLE001 — best-effort, swallow
+            _log.debug(
+                "session.closed notify failed for %s (session %s): %s",
+                agent_id, session.session_id, exc,
+            )
+
+
+async def _persist_closed(session: Session) -> None:
+    """Persist the close to the DB. Isolated so failures don't kill the sweep."""
+    try:
+        from app.broker.persistence import save_session
+        from app.db.database import AsyncSessionLocal
+    except Exception:
+        return
+
+    try:
+        async with AsyncSessionLocal() as db:
+            await save_session(db, session)
+    except Exception:  # noqa: BLE001
+        _log.exception(
+            "sweeper: failed to persist session %s close", session.session_id
+        )
+
+
+async def sweep_once(
+    store: SessionStore,
+    idle_timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS,
+) -> int:
+    """Run a single sweep pass. Returns the number of sessions closed.
+
+    Extracted so tests can trigger sweeps deterministically without waiting
+    for the background loop.
+    """
+    # Import here to avoid import cycles during test bootstrap.
+    from app.telemetry_metrics import (
+        SESSION_CLOSED_COUNTER,
+        SESSION_SWEEPER_CLOSED_COUNTER,
+        SESSION_SWEEPER_CYCLES_COUNTER,
+    )
+
+    stale = store.find_stale(idle_timeout_seconds=idle_timeout_seconds)
+    closed = 0
+    for session, reason in stale:
+        # Re-check under lock: another task may have closed it in the meantime.
+        async with store._lock:
+            if session.status == SessionStatus.closed:
+                continue
+            store.close(session.session_id, reason)
+
+        await _persist_closed(session)
+        await _emit_closed_event(session, reason)
+
+        SESSION_CLOSED_COUNTER.add(1, {"reason": reason.value, "source": "sweeper"})
+        SESSION_SWEEPER_CLOSED_COUNTER.add(1, {"reason": reason.value})
+        closed += 1
+        _log.info(
+            "sweeper closed session %s (reason=%s, initiator=%s, target=%s)",
+            session.session_id, reason.value,
+            session.initiator_agent_id, session.target_agent_id,
+        )
+
+    SESSION_SWEEPER_CYCLES_COUNTER.add(1, {"closed": str(closed)})
+    return closed
+
+
+async def sweeper_loop(
+    store: SessionStore,
+    interval_seconds: int = SWEEP_INTERVAL_SECONDS,
+    idle_timeout_seconds: int = SESSION_IDLE_TIMEOUT_SECONDS,
+    stop_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Run the sweeper loop until ``stop_event`` fires (or cancel)."""
+    _log.info(
+        "session sweeper started (interval=%ds, idle_timeout=%ds)",
+        interval_seconds, idle_timeout_seconds,
+    )
+    while True:
+        try:
+            if stop_event is not None and stop_event.is_set():
+                break
+            await sweep_once(store, idle_timeout_seconds=idle_timeout_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            _log.exception("sweeper cycle failed — continuing")
+        # Wait out the interval, waking early if shutdown signalled.
+        if stop_event is not None:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+                break  # stop_event set
+            except asyncio.TimeoutError:
+                continue
+        else:
+            await asyncio.sleep(interval_seconds)
+
+    _log.info("session sweeper stopped")

--- a/app/main.py
+++ b/app/main.py
@@ -172,6 +172,15 @@ async def lifespan(app: FastAPI):
     # WebSocket notification path the moment a signal arrives.
     drain_task = asyncio.create_task(_drain_watcher(), name="cullis-drain-watcher")
 
+    # M1.1 — Session sweeper: periodically close idle/expired sessions,
+    # persist state, and notify peers via session.closed events.
+    from app.broker.session_sweeper import sweeper_loop
+    sweeper_stop = asyncio.Event()
+    sweeper_task = asyncio.create_task(
+        sweeper_loop(session_store, stop_event=sweeper_stop),
+        name="cullis-session-sweeper",
+    )
+
     yield
 
     # ── Drain phase ──────────────────────────────────────────────────────────
@@ -194,6 +203,14 @@ async def lifespan(app: FastAPI):
             await drain_task
         except (asyncio.CancelledError, Exception):
             pass
+
+    # Stop the session sweeper cleanly.
+    sweeper_stop.set()
+    sweeper_task.cancel()
+    try:
+        await sweeper_task
+    except (asyncio.CancelledError, Exception):
+        pass
 
     await ws_manager.shutdown()
     await close_redis()

--- a/app/telemetry_metrics.py
+++ b/app/telemetry_metrics.py
@@ -65,6 +65,28 @@ SESSION_SWEEPER_CLOSED_COUNTER = meter.create_counter(
     unit="1",
 )
 
+# ── M2 Heartbeat + Resume ────────────────────────────────────────────────────
+WS_PING_SENT_COUNTER = meter.create_counter(
+    name="atn.ws.ping_sent",
+    description="Server-initiated WebSocket pings",
+    unit="1",
+)
+WS_PONG_TIMEOUT_COUNTER = meter.create_counter(
+    name="atn.ws.pong_timeout",
+    description="WebSocket connections closed due to pong timeout",
+    unit="1",
+)
+WS_RESUME_COUNTER = meter.create_counter(
+    name="atn.ws.resume",
+    description="Session resume requests received via WS",
+    unit="1",
+)
+WS_RESUME_MESSAGES_DELIVERED_COUNTER = meter.create_counter(
+    name="atn.ws.resume_messages_delivered",
+    description="Messages replayed on resume",
+    unit="1",
+)
+
 # ── Histograms ────────────────────────────────────────────────────────────────
 AUTH_DURATION_HISTOGRAM = meter.create_histogram(
     name="atn.auth.duration",

--- a/app/telemetry_metrics.py
+++ b/app/telemetry_metrics.py
@@ -163,3 +163,8 @@ MESSAGE_QUEUE_DEDUPED_COUNTER = meter.create_counter(
     description="Enqueue attempts collapsed by idempotency key (M3).",
     unit="1",
 )
+WS_QUEUE_DRAINED_COUNTER = meter.create_counter(
+    name="atn.ws.queue_drained",
+    description="Messages pushed to a client via queue-drain on WS connect/resume (M3).",
+    unit="1",
+)

--- a/app/telemetry_metrics.py
+++ b/app/telemetry_metrics.py
@@ -153,3 +153,13 @@ POLICY_DUAL_ORG_MISMATCH_COUNTER = meter.create_counter(
     ),
     unit="1",
 )
+MESSAGE_QUEUED_COUNTER = meter.create_counter(
+    name="atn.message.queued",
+    description="Messages enqueued because the recipient was not connected (M3).",
+    unit="1",
+)
+MESSAGE_QUEUE_DEDUPED_COUNTER = meter.create_counter(
+    name="atn.message.queue_deduped",
+    description="Enqueue attempts collapsed by idempotency key (M3).",
+    unit="1",
+)

--- a/app/telemetry_metrics.py
+++ b/app/telemetry_metrics.py
@@ -43,6 +43,28 @@ RATE_LIMIT_REJECT_COUNTER = meter.create_counter(
     unit="1",
 )
 
+# ── M1 Session Reliability Layer ─────────────────────────────────────────────
+SESSION_CLOSED_COUNTER = meter.create_counter(
+    name="atn.session.closed",
+    description="Sessions closed, tagged with the reason",
+    unit="1",
+)
+SESSION_CAP_REJECTED_COUNTER = meter.create_counter(
+    name="atn.session.cap_rejected",
+    description="Session creations rejected due to per-agent ACTIVE cap",
+    unit="1",
+)
+SESSION_SWEEPER_CYCLES_COUNTER = meter.create_counter(
+    name="atn.session.sweeper_cycles",
+    description="Sweeper cycles executed",
+    unit="1",
+)
+SESSION_SWEEPER_CLOSED_COUNTER = meter.create_counter(
+    name="atn.session.sweeper_closed",
+    description="Sessions closed by the sweeper, tagged with reason",
+    unit="1",
+)
+
 # ── Histograms ────────────────────────────────────────────────────────────────
 AUTH_DURATION_HISTOGRAM = meter.create_histogram(
     name="atn.auth.duration",

--- a/app/telemetry_metrics.py
+++ b/app/telemetry_metrics.py
@@ -168,3 +168,8 @@ WS_QUEUE_DRAINED_COUNTER = meter.create_counter(
     description="Messages pushed to a client via queue-drain on WS connect/resume (M3).",
     unit="1",
 )
+MESSAGE_EXPIRED_COUNTER = meter.create_counter(
+    name="atn.message.expired",
+    description="Queued messages flipped to expired by the sweeper (M3).",
+    unit="1",
+)

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -578,13 +578,28 @@ class CullisClient:
 
 
 class WebSocketConnection:
-    """
-    Authenticated WebSocket connection that yields parsed event dicts.
+    """Authenticated WebSocket connection with heartbeat + auto-reconnect (M2).
+
+    Features added for the reliability layer:
+      - Auto-responds to server ``{"type":"ping"}`` with ``{"type":"pong"}``
+        so the M2.1 server heartbeat does not flag the client as dead.
+      - Auto-reconnect with exponential backoff (1s/3s/10s/30s, max 5
+        attempts by default) on any recv error, unless ``auto_reconnect=False``.
+      - Session resume (M2.2): for every session whose messages the caller
+        has observed, the SDK remembers the highest ``seq`` it received.
+        On reconnect it sends ``{"type":"resume", "session_id":.., "last_seq": N}``
+        for each tracked session and transparently drains the replay.
+      - Gap detection (M2.4): if a ``new_message`` arrives with a
+        non-contiguous ``seq``, the yielded event carries an extra
+        ``gap_detected`` dict ``{expected, got}`` so the caller can react
+        (log, re-fetch, raise) without silently ignoring the reorder.
 
     Usage::
 
         ws = client.connect_websocket()
         for event in ws:
+            if event.get("gap_detected"):
+                print("seq gap:", event["gap_detected"])
             if event["type"] == "new_message":
                 msg = client.decrypt_payload(event["message"], session_id=event["session_id"])
                 print(msg["payload"])
@@ -593,9 +608,26 @@ class WebSocketConnection:
         ws.close()
     """
 
-    def __init__(self, client: CullisClient) -> None:
+    _RECONNECT_BACKOFF_SECONDS = (1, 3, 10, 30, 30)
+
+    def __init__(
+        self,
+        client: CullisClient,
+        *,
+        auto_reconnect: bool = True,
+        max_reconnect_attempts: int | None = None,
+    ) -> None:
         self._client = client
         self._ws = None
+        self._auto_reconnect = auto_reconnect
+        self._max_reconnect_attempts = (
+            max_reconnect_attempts
+            if max_reconnect_attempts is not None
+            else len(self._RECONNECT_BACKOFF_SECONDS)
+        )
+        # session_id → last seq observed (for resume + gap detection)
+        self._last_seq: dict[str, int] = {}
+        self._closed = False
         self._connect()
 
     def _connect(self) -> None:
@@ -625,21 +657,79 @@ class WebSocketConnection:
             self._ws.close()
             raise ConnectionError(f"WebSocket auth failed: {resp}")
 
+        # M2.2 — ask the server to replay anything missed for every
+        # session we had been tracking before the drop.
+        for session_id, last_seq in list(self._last_seq.items()):
+            self._ws.send(json.dumps({
+                "type": "resume",
+                "session_id": session_id,
+                "last_seq": last_seq,
+            }))
+
+    def _reconnect(self) -> bool:
+        """Try to re-establish the connection with exponential backoff."""
+        import time as _time
+
+        for attempt in range(self._max_reconnect_attempts):
+            delay = self._RECONNECT_BACKOFF_SECONDS[
+                min(attempt, len(self._RECONNECT_BACKOFF_SECONDS) - 1)
+            ]
+            _time.sleep(delay)
+            try:
+                self._connect()
+                return True
+            except Exception:
+                continue
+        return False
+
     def __iter__(self) -> WebSocketConnection:
         return self
 
     def __next__(self) -> dict:
-        if self._ws is None:
+        if self._closed or self._ws is None:
             raise StopIteration
-        try:
-            raw = self._ws.recv()
-            return json.loads(raw)
-        except Exception:
-            self.close()
-            raise StopIteration
+        while True:
+            try:
+                raw = self._ws.recv()
+                event = json.loads(raw)
+            except Exception:
+                if self._auto_reconnect and self._reconnect():
+                    continue
+                self.close()
+                raise StopIteration
+
+            etype = event.get("type")
+
+            # Server heartbeat — reply and keep reading.
+            if etype == "ping":
+                try:
+                    self._ws.send(json.dumps({"type": "pong"}))
+                except Exception:
+                    pass
+                continue
+
+            # Track inbound seq per session for resume + gap detection.
+            if etype == "new_message":
+                sid = event.get("session_id")
+                msg = event.get("message") or {}
+                seq = msg.get("seq")
+                if isinstance(sid, str) and isinstance(seq, int):
+                    prev = self._last_seq.get(sid)
+                    if (
+                        prev is not None
+                        and seq != prev + 1
+                        and not event.get("replayed")
+                    ):
+                        event["gap_detected"] = {"expected": prev + 1, "got": seq}
+                    self._last_seq[sid] = (
+                        max(seq, prev) if prev is not None else seq
+                    )
+
+            return event
 
     def close(self) -> None:
         """Close the WebSocket connection."""
+        self._closed = True
         if self._ws:
             try:
                 self._ws.close()

--- a/imp/changelog.md
+++ b/imp/changelog.md
@@ -4,6 +4,63 @@ Log delle implementazioni per sessione. Aggiornato dopo ogni sessione di lavoro.
 
 ---
 
+## 2026-04-13 — Session Reliability Layer M3.6 (router integration)
+
+Chiuso M3.6 (router integration) sul branch `feature/m3-message-durability`
+sopra M3.1 (schema) + M3.2 (queue ops) già presenti. Ripreso dopo
+discussione architetturale che ha prodotto ADR-001 (intra-org routing +
+Guardian). M3 broker-side resta valido per path cross-org.
+
+### Nuovi endpoint / comportamento broker
+- `POST /v1/broker/sessions/{id}/messages` accetta due nuovi query params:
+  - `ttl_seconds` (1..86400, default 300) — TTL della riga in coda
+  - `idempotency_key` (opt, max 128) — dedup chiave `(recipient, key)`
+- Se il recipient NON è connesso via WS localmente → `mq.enqueue()` con
+  ciphertext = canonical JSON di `envelope.payload`; risposta
+  `{status:"queued", msg_id, deduped}`
+- Se il recipient è connesso → push WS diretto invariato, risposta `{status:"accepted"}`
+- Nuovo `POST /v1/broker/sessions/{id}/messages/{msg_id}/ack` —
+  204/400/404/409, scoped a `current_agent.agent_id` (niente info leak)
+
+### WS drain su connect/resume
+- Helper `_drain_queue_for_agent` chiamato dopo `auth_ok` e alla fine di
+  `_handle_ws_resume`
+- Ogni messaggio queued consegnato come `new_message` con `queued:true` + `msg_id`
+- Drain non muta stato — SDK deve ack via REST per chiudere la riga
+- Failure durante drain loggati, non abortono la sessione WS
+
+### Sweeper TTL expiry
+- `session_sweeper._sweep_message_queue()` invocato ad ogni ciclo `sweep_once`
+- Chiama `mq.sweep_expired()` e per ogni riga scaduta emette `message_expired`
+  best-effort al sender (fields: type, session_id, msg_id, recipient_agent_id, reason="ttl")
+- Isolato in try/except — errori DB/WS non rompono il session sweep
+
+### Metriche nuove (OpenTelemetry)
+- `atn.message.queued`, `atn.message.queue_deduped`, `atn.ws.queue_drained`,
+  `atn.message.expired`
+
+### Test
+- `tests/test_m3_router_integration.py` (8), `tests/test_m3_ws_drain.py` (4),
+  `tests/test_m3_sweeper_ttl.py` (3) — totale 15 nuovi test
+- Tutte le suite reliability/queue esistenti invariate (M1+M2+M3 unit)
+
+### Commit sequence sul branch
+- `3d265ca` — queue fallback + query params
+- `0131546` — ack endpoint
+- `9fcae25` — WS drain
+- `9b13ea0` — sweeper TTL + notify
+
+### Decisioni chiave (vedi anche ADR-001)
+- Presence: enqueue solo se `ws_manager.is_connected` locale è False.
+  Multi-worker deliverato via Redis pub/sub + drain al reconnect, dedupe
+  client-side su msg_id.
+- Query params invece di wrapper body — zero regressione sui ~20 test
+  esistenti. SDK aggiungerà i params in M3.4/M3.5.
+- Ack 409 vs 404 distinti: extra SELECT utile per diagnostica SDK.
+- Sender scoping: ack da non-recipient ritorna 404 (no info leak).
+
+---
+
 ## 2026-04-12 — Attach-CA + smoke production-grade + deploy hardening (sessione 8)
 
 ### Flusso attach-CA (onboarding org pre-registrate)

--- a/tests/test_audit_r2_t2.py
+++ b/tests/test_audit_r2_t2.py
@@ -88,13 +88,18 @@ class TestSessionStoreEviction:
         assert evicted == 1
         assert s.session_id not in store._sessions
 
-    def test_evict_stale_removes_expired_sessions(self):
+    def test_evict_stale_keeps_expired_pending_sessions(self):
+        """M1: TTL-expired sessions stay in the store until the sweeper
+        transitions them to CLOSED and emits session.closed — _evict_stale
+        no longer deletes them silently. Only already-closed/denied are evicted.
+        """
         store = SessionStore(session_ttl_minutes=0)  # immediate expiry
         s = store.create("a", "org-a", "b", "org-b", [])
         s.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
         evicted = store._evict_stale()
-        assert evicted == 1
-        assert s.session_id not in store._sessions
+        assert evicted == 0
+        # Still there — sweeper will handle it with reason=ttl_expired.
+        assert s.session_id in store._sessions
 
     def test_evict_stale_keeps_active_sessions(self):
         store = SessionStore(session_ttl_minutes=60)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -225,7 +225,10 @@ async def test_step7_agente_a_invia_messaggio(client: AsyncClient):
     )
 
     assert resp.status_code == 202, resp.text
-    assert resp.json()["status"] == "accepted"
+    # M3.6 — recipient is not WS-connected in this TestClient flow, so the
+    # broker falls back to the offline queue. Either status is a valid
+    # "delivered for processing" signal from the broker's perspective.
+    assert resp.json()["status"] in ("accepted", "queued")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_m3_router_integration.py
+++ b/tests/test_m3_router_integration.py
@@ -33,7 +33,7 @@ async def _open_session(client, dpop, org_a: str, agent_a: str, org_b: str, agen
         f"/v1/broker/sessions/{sid}/accept",
         headers=dpop.headers("POST", f"/v1/broker/sessions/{sid}/accept", token_b),
     )
-    return sid, token_a, agent_a, agent_b
+    return sid, token_a, token_b, agent_a, agent_b
 
 
 async def _count_queue_rows(recipient_agent_id: str) -> int:
@@ -47,7 +47,7 @@ async def _count_queue_rows(recipient_agent_id: str) -> int:
 
 
 async def test_send_enqueues_when_recipient_offline(client: AsyncClient, dpop):
-    sid, token_a, agent_a, agent_b = await _open_session(
+    sid, token_a, token_b, agent_a, agent_b = await _open_session(
         client, dpop, "m3q-a", "m3q-a::agent", "m3q-b", "m3q-b::agent",
     )
     envelope = make_encrypted_envelope(
@@ -67,7 +67,7 @@ async def test_send_enqueues_when_recipient_offline(client: AsyncClient, dpop):
 
 
 async def test_idempotency_key_dedupes_via_query_param(client: AsyncClient, dpop):
-    sid, token_a, agent_a, agent_b = await _open_session(
+    sid, token_a, token_b, agent_a, agent_b = await _open_session(
         client, dpop, "m3qd-a", "m3qd-a::agent", "m3qd-b", "m3qd-b::agent",
     )
     path = f"/v1/broker/sessions/{sid}/messages?idempotency_key=order-42&ttl_seconds=120"
@@ -90,7 +90,7 @@ async def test_idempotency_key_dedupes_via_query_param(client: AsyncClient, dpop
 
 
 async def test_ttl_seconds_query_param_respected(client: AsyncClient, dpop):
-    sid, token_a, agent_a, agent_b = await _open_session(
+    sid, token_a, token_b, agent_a, agent_b = await _open_session(
         client, dpop, "m3qt-a", "m3qt-a::agent", "m3qt-b", "m3qt-b::agent",
     )
     path = f"/v1/broker/sessions/{sid}/messages?ttl_seconds=7200"
@@ -108,3 +108,76 @@ async def test_ttl_seconds_query_param_respected(client: AsyncClient, dpop):
         )).scalar_one()
         delta = (row.ttl_expires_at - row.enqueued_at).total_seconds()
         assert 7100 < delta < 7300  # ~2h window, tolerate clock drift
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Ack endpoint
+# ─────────────────────────────────────────────────────────────────────
+
+
+async def _enqueue_one_and_get_msg_id(client, dpop, org_a, agent_a, org_b, agent_b):
+    sid, token_a, token_b, _a, _b = await _open_session(client, dpop, org_a, agent_a, org_b, agent_b)
+    envelope = make_encrypted_envelope(
+        agent_a, org_a, agent_b, org_b, sid, str(uuid.uuid4()), {"k": 1},
+    )
+    path = f"/v1/broker/sessions/{sid}/messages"
+    resp = await client.post(path, json=envelope, headers=dpop.headers("POST", path, token_a))
+    assert resp.status_code == 202 and resp.json()["status"] == "queued"
+    return sid, resp.json()["msg_id"], token_b
+
+
+async def test_ack_happy_path_returns_204(client: AsyncClient, dpop):
+    sid, msg_id, token_b = await _enqueue_one_and_get_msg_id(
+        client, dpop, "m3ack-a", "m3ack-a::agent", "m3ack-b", "m3ack-b::agent",
+    )
+    path = f"/v1/broker/sessions/{sid}/messages/{msg_id}/ack"
+    resp = await client.post(path, headers=dpop.headers("POST", path, token_b))
+    assert resp.status_code == 204
+
+
+async def test_ack_unknown_msg_returns_404(client: AsyncClient, dpop):
+    sid, _, token_b = await _enqueue_one_and_get_msg_id(
+        client, dpop, "m3ack2-a", "m3ack2-a::agent", "m3ack2-b", "m3ack2-b::agent",
+    )
+    bogus = str(uuid.uuid4())
+    path = f"/v1/broker/sessions/{sid}/messages/{bogus}/ack"
+    resp = await client.post(path, headers=dpop.headers("POST", path, token_b))
+    assert resp.status_code == 404
+
+
+async def test_ack_twice_returns_409(client: AsyncClient, dpop):
+    sid, msg_id, token_b = await _enqueue_one_and_get_msg_id(
+        client, dpop, "m3ack3-a", "m3ack3-a::agent", "m3ack3-b", "m3ack3-b::agent",
+    )
+    path = f"/v1/broker/sessions/{sid}/messages/{msg_id}/ack"
+    r1 = await client.post(path, headers=dpop.headers("POST", path, token_b))
+    assert r1.status_code == 204
+    r2 = await client.post(path, headers=dpop.headers("POST", path, token_b))
+    assert r2.status_code == 409
+
+
+async def test_ack_from_non_recipient_returns_404(client: AsyncClient, dpop):
+    # Sender tries to ack their own queued message — scoping by recipient_agent_id
+    # hides the row so the sender sees a 404, not a 409 (no info leak).
+    sid, token_a, token_b, agent_a, agent_b = await _open_session(
+        client, dpop, "m3ack4-a", "m3ack4-a::agent", "m3ack4-b", "m3ack4-b::agent",
+    )
+    envelope = make_encrypted_envelope(
+        agent_a, "m3ack4-a", agent_b, "m3ack4-b", sid, str(uuid.uuid4()), {"x": 1},
+    )
+    path_send = f"/v1/broker/sessions/{sid}/messages"
+    r = await client.post(path_send, json=envelope, headers=dpop.headers("POST", path_send, token_a))
+    msg_id = r.json()["msg_id"]
+
+    path_ack = f"/v1/broker/sessions/{sid}/messages/{msg_id}/ack"
+    resp = await client.post(path_ack, headers=dpop.headers("POST", path_ack, token_a))
+    assert resp.status_code == 404
+
+
+async def test_ack_malformed_msg_id_returns_400(client: AsyncClient, dpop):
+    sid, _, token_b = await _enqueue_one_and_get_msg_id(
+        client, dpop, "m3ack5-a", "m3ack5-a::agent", "m3ack5-b", "m3ack5-b::agent",
+    )
+    path = f"/v1/broker/sessions/{sid}/messages/not-a-uuid/ack"
+    resp = await client.post(path, headers=dpop.headers("POST", path, token_b))
+    assert resp.status_code == 400

--- a/tests/test_m3_router_integration.py
+++ b/tests/test_m3_router_integration.py
@@ -1,0 +1,110 @@
+"""M3.6 — router-level queue fallback integration tests.
+
+Verifies that POST /sessions/{id}/messages enqueues via mq.enqueue when
+the recipient is not WS-connected locally, and that idempotency replay
+collapses to a single queued row.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.broker import message_queue as mq
+from app.broker.db_models import ProxyMessageQueueRecord
+from app.db.database import AsyncSessionLocal
+from tests.cert_factory import make_encrypted_envelope
+from tests.test_broker import _register_and_login
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _open_session(client, dpop, org_a: str, agent_a: str, org_b: str, agent_b: str):
+    token_a = await _register_and_login(client, dpop, agent_a, org_a)
+    token_b = await _register_and_login(client, dpop, agent_b, org_b)
+    resp = await client.post("/v1/broker/sessions", json={
+        "target_agent_id": agent_b, "target_org_id": org_b,
+        "requested_capabilities": ["kyc.read"],
+    }, headers=dpop.headers("POST", "/v1/broker/sessions", token_a))
+    sid = resp.json()["session_id"]
+    await client.post(
+        f"/v1/broker/sessions/{sid}/accept",
+        headers=dpop.headers("POST", f"/v1/broker/sessions/{sid}/accept", token_b),
+    )
+    return sid, token_a, agent_a, agent_b
+
+
+async def _count_queue_rows(recipient_agent_id: str) -> int:
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(ProxyMessageQueueRecord).where(
+                ProxyMessageQueueRecord.recipient_agent_id == recipient_agent_id,
+            )
+        )
+        return len(result.scalars().all())
+
+
+async def test_send_enqueues_when_recipient_offline(client: AsyncClient, dpop):
+    sid, token_a, agent_a, agent_b = await _open_session(
+        client, dpop, "m3q-a", "m3q-a::agent", "m3q-b", "m3q-b::agent",
+    )
+    envelope = make_encrypted_envelope(
+        agent_a, "m3q-a", agent_b, "m3q-b", sid, str(uuid.uuid4()), {"hi": "there"},
+    )
+    path = f"/v1/broker/sessions/{sid}/messages"
+    resp = await client.post(
+        path, json=envelope,
+        headers=dpop.headers("POST", path, token_a),
+    )
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "queued"
+    assert "msg_id" in body
+    assert body["deduped"] is False
+    assert await _count_queue_rows(agent_b) == 1
+
+
+async def test_idempotency_key_dedupes_via_query_param(client: AsyncClient, dpop):
+    sid, token_a, agent_a, agent_b = await _open_session(
+        client, dpop, "m3qd-a", "m3qd-a::agent", "m3qd-b", "m3qd-b::agent",
+    )
+    path = f"/v1/broker/sessions/{sid}/messages?idempotency_key=order-42&ttl_seconds=120"
+
+    env1 = make_encrypted_envelope(
+        agent_a, "m3qd-a", agent_b, "m3qd-b", sid, str(uuid.uuid4()), {"n": 1},
+    )
+    r1 = await client.post(path, json=env1, headers=dpop.headers("POST", path, token_a))
+    assert r1.status_code == 202 and r1.json()["deduped"] is False
+    first_msg_id = r1.json()["msg_id"]
+
+    env2 = make_encrypted_envelope(
+        agent_a, "m3qd-a", agent_b, "m3qd-b", sid, str(uuid.uuid4()), {"n": 2},
+    )
+    r2 = await client.post(path, json=env2, headers=dpop.headers("POST", path, token_a))
+    assert r2.status_code == 202
+    assert r2.json()["deduped"] is True
+    assert r2.json()["msg_id"] == first_msg_id
+    assert await _count_queue_rows(agent_b) == 1
+
+
+async def test_ttl_seconds_query_param_respected(client: AsyncClient, dpop):
+    sid, token_a, agent_a, agent_b = await _open_session(
+        client, dpop, "m3qt-a", "m3qt-a::agent", "m3qt-b", "m3qt-b::agent",
+    )
+    path = f"/v1/broker/sessions/{sid}/messages?ttl_seconds=7200"
+    envelope = make_encrypted_envelope(
+        agent_a, "m3qt-a", agent_b, "m3qt-b", sid, str(uuid.uuid4()), {"x": 1},
+    )
+    resp = await client.post(path, json=envelope, headers=dpop.headers("POST", path, token_a))
+    assert resp.status_code == 202
+
+    async with AsyncSessionLocal() as db:
+        row = (await db.execute(
+            select(ProxyMessageQueueRecord).where(
+                ProxyMessageQueueRecord.recipient_agent_id == agent_b,
+            )
+        )).scalar_one()
+        delta = (row.ttl_expires_at - row.enqueued_at).total_seconds()
+        assert 7100 < delta < 7300  # ~2h window, tolerate clock drift

--- a/tests/test_m3_router_integration.py
+++ b/tests/test_m3_router_integration.py
@@ -12,7 +12,6 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 
-from app.broker import message_queue as mq
 from app.broker.db_models import ProxyMessageQueueRecord
 from app.db.database import AsyncSessionLocal
 from tests.cert_factory import make_encrypted_envelope

--- a/tests/test_m3_sweeper_ttl.py
+++ b/tests/test_m3_sweeper_ttl.py
@@ -1,0 +1,109 @@
+"""M3.6 — session sweeper TTL expiry tests.
+
+Verifies that ``_sweep_message_queue`` flips expired rows and emits
+``message_expired`` frames to the sender best-effort. Uses the real
+AsyncSessionLocal DB (setup by tests/conftest.py) and monkeypatches
+ws_manager.send_to_agent to capture frames.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.broker import message_queue as mq
+from app.broker.db_models import ProxyMessageQueueRecord
+from app.db.database import AsyncSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _insert_expired(session_id: str, sender: str, recipient: str) -> str:
+    """Insert a queue row already past its TTL."""
+    async with AsyncSessionLocal() as db:
+        ct = json.dumps({"x": 1}, sort_keys=True, separators=(",", ":")).encode()
+        msg_id, _ = await mq.enqueue(
+            db,
+            session_id=session_id,
+            recipient_agent_id=recipient,
+            sender_agent_id=sender,
+            ciphertext=ct, seq=0, ttl_seconds=1,
+        )
+        # Backdate ttl_expires_at so sweep_expired picks it up immediately.
+        from sqlalchemy import update
+        await db.execute(
+            update(ProxyMessageQueueRecord)
+            .where(ProxyMessageQueueRecord.msg_id == msg_id)
+            .values(ttl_expires_at=datetime.now(timezone.utc) - timedelta(seconds=60))
+        )
+        await db.commit()
+        return msg_id
+
+
+async def test_sweep_message_queue_expires_and_notifies(monkeypatch):
+    captured: list[tuple[str, dict]] = []
+
+    async def fake_send(agent_id: str, data: dict) -> None:
+        captured.append((agent_id, data))
+
+    from app.broker import ws_manager as ws_mod
+    monkeypatch.setattr(ws_mod.ws_manager, "send_to_agent", fake_send)
+
+    sid = "00000000-0000-0000-0000-00000000ab01"
+    msg_id = await _insert_expired(sid, "org-q::sender", "org-q::recipient")
+
+    from app.broker.session_sweeper import _sweep_message_queue
+    n = await _sweep_message_queue()
+    assert n == 1
+
+    # Row flipped to expired (status=2).
+    from sqlalchemy import select
+    async with AsyncSessionLocal() as db:
+        status = (await db.execute(
+            select(ProxyMessageQueueRecord.delivery_status).where(
+                ProxyMessageQueueRecord.msg_id == msg_id,
+            )
+        )).scalar_one()
+        assert status == mq.DELIVERY_EXPIRED
+
+    # Sender got a message_expired frame.
+    assert len(captured) == 1
+    recv_agent, payload = captured[0]
+    assert recv_agent == "org-q::sender"
+    assert payload["type"] == "message_expired"
+    assert payload["msg_id"] == msg_id
+    assert payload["reason"] == "ttl"
+    assert payload["recipient_agent_id"] == "org-q::recipient"
+
+
+async def test_sweep_message_queue_noop_when_empty():
+    from app.broker.session_sweeper import _sweep_message_queue
+    n = await _sweep_message_queue()
+    assert n == 0
+
+
+async def test_sweep_message_queue_tolerates_ws_failures(monkeypatch):
+    async def fake_send(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    from app.broker import ws_manager as ws_mod
+    monkeypatch.setattr(ws_mod.ws_manager, "send_to_agent", fake_send)
+
+    sid = "00000000-0000-0000-0000-00000000ab02"
+    msg_id = await _insert_expired(sid, "org-qq::s", "org-qq::r")
+
+    from app.broker.session_sweeper import _sweep_message_queue
+    n = await _sweep_message_queue()
+    # Even though ws_manager raises, the row was still expired.
+    assert n == 1
+
+    from sqlalchemy import select
+    async with AsyncSessionLocal() as db:
+        status = (await db.execute(
+            select(ProxyMessageQueueRecord.delivery_status).where(
+                ProxyMessageQueueRecord.msg_id == msg_id,
+            )
+        )).scalar_one()
+        assert status == mq.DELIVERY_EXPIRED

--- a/tests/test_m3_ws_drain.py
+++ b/tests/test_m3_ws_drain.py
@@ -1,0 +1,115 @@
+"""M3.6 — WS queue drain unit tests.
+
+Covers ``_drain_queue_for_agent`` — the helper invoked after
+``auth_ok`` and at the end of ``_handle_ws_resume`` to push queued
+offline messages to a just-connected recipient. The full WS flow is
+covered by e2e/smoke; here we verify the helper in isolation with an
+in-memory SQLite DB + a FakeWS that captures sent frames.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.broker import message_queue as mq
+from app.broker.router import _drain_queue_for_agent
+from app.db.database import Base
+
+
+class FakeWS:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_drain_pushes_pending_in_seq_order(db_session):
+    payload_b = {"iv": "aa", "ciphertext": "bb"}
+    ct = json.dumps(payload_b, sort_keys=True, separators=(",", ":")).encode()
+
+    await mq.enqueue(
+        db_session,
+        session_id="00000000-0000-0000-0000-000000000001",
+        recipient_agent_id="org-x::agent-recv",
+        sender_agent_id="org-x::agent-send",
+        ciphertext=ct, seq=2, ttl_seconds=300,
+    )
+    await mq.enqueue(
+        db_session,
+        session_id="00000000-0000-0000-0000-000000000001",
+        recipient_agent_id="org-x::agent-recv",
+        sender_agent_id="org-x::agent-send",
+        ciphertext=ct, seq=1, ttl_seconds=300,
+    )
+
+    ws = FakeWS()
+    n = await _drain_queue_for_agent(ws, "org-x::agent-recv", db_session)
+    assert n == 2
+    assert len(ws.sent) == 2
+    # Ordered by seq ascending
+    assert [f["message"]["seq"] for f in ws.sent] == [1, 2]
+    # Each frame has msg_id + queued flag + reconstructed payload
+    for f in ws.sent:
+        assert f["type"] == "new_message"
+        assert f["queued"] is True
+        assert "msg_id" in f
+        assert f["message"]["sender_agent_id"] == "org-x::agent-send"
+        assert f["message"]["payload"] == payload_b
+
+
+@pytest.mark.asyncio
+async def test_drain_is_noop_when_no_pending(db_session):
+    ws = FakeWS()
+    n = await _drain_queue_for_agent(ws, "org-x::empty-recv", db_session)
+    assert n == 0
+    assert ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_drain_does_not_mutate_queue_state(db_session):
+    ct = json.dumps({"k": "v"}, sort_keys=True, separators=(",", ":")).encode()
+    await mq.enqueue(
+        db_session,
+        session_id="00000000-0000-0000-0000-000000000002",
+        recipient_agent_id="org-y::recv",
+        sender_agent_id="org-y::send",
+        ciphertext=ct, seq=0, ttl_seconds=300,
+    )
+    ws = FakeWS()
+    await _drain_queue_for_agent(ws, "org-y::recv", db_session)
+
+    # Row must still be pending (ack is separate) — a second drain re-delivers.
+    ws2 = FakeWS()
+    n2 = await _drain_queue_for_agent(ws2, "org-y::recv", db_session)
+    assert n2 == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_skips_recipient_mismatch(db_session):
+    ct = json.dumps({"k": "v"}, sort_keys=True, separators=(",", ":")).encode()
+    await mq.enqueue(
+        db_session,
+        session_id="00000000-0000-0000-0000-000000000003",
+        recipient_agent_id="org-z::target",
+        sender_agent_id="org-z::src",
+        ciphertext=ct, seq=0, ttl_seconds=300,
+    )
+    ws = FakeWS()
+    n = await _drain_queue_for_agent(ws, "org-z::other", db_session)
+    assert n == 0

--- a/tests/test_message_queue_m3.py
+++ b/tests/test_message_queue_m3.py
@@ -1,0 +1,206 @@
+"""M3 message durability — queue module unit tests.
+
+Uses an in-memory SQLite async DB so the tests run without external
+dependencies. The production target is Postgres (validated in
+imp/m0_storage_spike.md) but the schema and ops are dialect-portable.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.broker import message_queue as mq
+from app.broker.db_models import ProxyMessageQueueRecord
+from app.db.database import Base
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncSession:
+    """Isolated in-memory SQLite DB per test."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with maker() as session:
+        yield session
+    await engine.dispose()
+
+
+# ─────────────────────────────────────────────────────────────────────
+# enqueue
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_enqueue_without_idempotency_always_inserts(db_session):
+    mid1, inserted1 = await mq.enqueue(
+        db_session,
+        session_id="sess-1", recipient_agent_id="r",
+        sender_agent_id="s", ciphertext=b"c1", seq=0, ttl_seconds=60,
+    )
+    mid2, inserted2 = await mq.enqueue(
+        db_session,
+        session_id="sess-1", recipient_agent_id="r",
+        sender_agent_id="s", ciphertext=b"c2", seq=1, ttl_seconds=60,
+    )
+    assert inserted1 is True and inserted2 is True
+    assert mid1 != mid2
+
+
+@pytest.mark.asyncio
+async def test_enqueue_with_idempotency_key_dedupes(db_session):
+    key = "order-12345"
+    mid1, inserted1 = await mq.enqueue(
+        db_session,
+        session_id="sess-1", recipient_agent_id="r",
+        sender_agent_id="s", ciphertext=b"c1", seq=0, ttl_seconds=60,
+        idempotency_key=key,
+    )
+    mid2, inserted2 = await mq.enqueue(
+        db_session,
+        session_id="sess-1", recipient_agent_id="r",
+        sender_agent_id="s", ciphertext=b"c2-REPLAY", seq=1, ttl_seconds=60,
+        idempotency_key=key,
+    )
+    assert inserted1 is True
+    assert inserted2 is False
+    assert mid1 == mid2  # canonical msg_id returned for the replay
+
+
+@pytest.mark.asyncio
+async def test_enqueue_same_key_different_recipient_both_succeed(db_session):
+    """UNIQUE is (recipient, idempotency_key) — same key can target two peers."""
+    key = "broadcast-1"
+    mid_a, ia = await mq.enqueue(
+        db_session,
+        session_id="s", recipient_agent_id="A",
+        sender_agent_id="origin", ciphertext=b"x", seq=0, ttl_seconds=60,
+        idempotency_key=key,
+    )
+    mid_b, ib = await mq.enqueue(
+        db_session,
+        session_id="s", recipient_agent_id="B",
+        sender_agent_id="origin", ciphertext=b"x", seq=0, ttl_seconds=60,
+        idempotency_key=key,
+    )
+    assert ia is True and ib is True
+    assert mid_a != mid_b
+
+
+# ─────────────────────────────────────────────────────────────────────
+# fetch + ack
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_pending_returns_in_seq_order(db_session):
+    for seq in (2, 0, 1):
+        await mq.enqueue(
+            db_session,
+            session_id="sess-1", recipient_agent_id="r",
+            sender_agent_id="s", ciphertext=b"c", seq=seq, ttl_seconds=60,
+        )
+    pending = await mq.fetch_pending_for_recipient(db_session, "r")
+    assert [m.seq for m in pending] == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_mark_delivered_removes_from_pending(db_session):
+    mid, _ = await mq.enqueue(
+        db_session,
+        session_id="sess-1", recipient_agent_id="r",
+        sender_agent_id="s", ciphertext=b"c", seq=0, ttl_seconds=60,
+    )
+    ok = await mq.mark_delivered(db_session, mid)
+    assert ok is True
+    # Second ack of the same msg: must NOT raise, but returns False
+    again = await mq.mark_delivered(db_session, mid)
+    assert again is False
+    pending = await mq.fetch_pending_for_recipient(db_session, "r")
+    assert pending == []
+
+
+@pytest.mark.asyncio
+async def test_mark_delivered_scoped_to_recipient_blocks_spoofing(db_session):
+    mid, _ = await mq.enqueue(
+        db_session,
+        session_id="sess-1", recipient_agent_id="victim",
+        sender_agent_id="s", ciphertext=b"c", seq=0, ttl_seconds=60,
+    )
+    # Attacker guesses msg_id but ack'ing with their own agent_id fails
+    acked = await mq.mark_delivered(db_session, mid, recipient_agent_id="attacker")
+    assert acked is False
+    # Legitimate recipient can still ack
+    acked = await mq.mark_delivered(db_session, mid, recipient_agent_id="victim")
+    assert acked is True
+
+
+# ─────────────────────────────────────────────────────────────────────
+# sweep
+# ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sweep_expired_flips_status_and_returns_notices(db_session):
+    # Enqueue one fresh + one expired
+    mid_fresh, _ = await mq.enqueue(
+        db_session,
+        session_id="s", recipient_agent_id="r",
+        sender_agent_id="a", ciphertext=b"c", seq=0, ttl_seconds=60,
+    )
+    mid_exp, _ = await mq.enqueue(
+        db_session,
+        session_id="s", recipient_agent_id="r",
+        sender_agent_id="a", ciphertext=b"c", seq=1, ttl_seconds=60,
+    )
+    # Force one row into the past
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    row = await db_session.get(ProxyMessageQueueRecord, mid_exp)
+    row.ttl_expires_at = past
+    await db_session.commit()
+
+    notices = await mq.sweep_expired(db_session)
+    assert len(notices) == 1
+    assert notices[0].msg_id == mid_exp
+    assert notices[0].sender_agent_id == "a"
+
+    # Expired row is no longer in pending; fresh row is.
+    pending = await mq.fetch_pending_for_recipient(db_session, "r")
+    assert [p.msg_id for p in pending] == [mid_fresh]
+
+
+@pytest.mark.asyncio
+async def test_queue_depth_counts_only_pending(db_session):
+    assert await mq.queue_depth_for_recipient(db_session, "r") == 0
+    mid, _ = await mq.enqueue(
+        db_session,
+        session_id="s", recipient_agent_id="r",
+        sender_agent_id="a", ciphertext=b"c", seq=0, ttl_seconds=60,
+    )
+    assert await mq.queue_depth_for_recipient(db_session, "r") == 1
+    await mq.mark_delivered(db_session, mid)
+    assert await mq.queue_depth_for_recipient(db_session, "r") == 0
+
+
+@pytest.mark.asyncio
+async def test_bump_attempts_increments_only_pending(db_session):
+    mid, _ = await mq.enqueue(
+        db_session,
+        session_id="s", recipient_agent_id="r",
+        sender_agent_id="a", ciphertext=b"c", seq=0, ttl_seconds=60,
+    )
+    await mq.bump_attempts(db_session, mid)
+    await mq.bump_attempts(db_session, mid)
+    row = await db_session.get(ProxyMessageQueueRecord, mid)
+    await db_session.refresh(row)
+    assert row.attempts == 2
+    # After delivery, bump is a no-op
+    await mq.mark_delivered(db_session, mid)
+    await mq.bump_attempts(db_session, mid)
+    await db_session.refresh(row)
+    assert row.attempts == 2

--- a/tests/test_session_reliability_m1.py
+++ b/tests/test_session_reliability_m1.py
@@ -1,0 +1,179 @@
+"""M1 session reliability layer — unit tests.
+
+Covers:
+- Session.touch() / is_idle() / find_stale()
+- SessionStore per-agent ACTIVE cap (O4 decision)
+- close(reason) / reject() propagation
+- Sweeper sweep_once closes idle and TTL-expired sessions
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.broker.models import SessionCloseReason, SessionStatus
+from app.broker.session import (
+    AgentSessionCapExceeded,
+    Session,
+    SessionStore,
+)
+
+
+def _mk_store(cap: int = 50) -> SessionStore:
+    return SessionStore(active_cap_per_agent=cap)
+
+
+def test_touch_updates_last_activity():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", ["x"])
+    t0 = s.last_activity_at
+    # Simulate old activity
+    s.last_activity_at = t0 - timedelta(hours=1)
+    s.touch()
+    assert s.last_activity_at > t0
+
+
+def test_is_idle_only_for_live_sessions():
+    s = Session(
+        session_id="sid",
+        initiator_agent_id="a1",
+        initiator_org_id="o1",
+        target_agent_id="a2",
+        target_org_id="o2",
+        requested_capabilities=["x"],
+    )
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    assert s.is_idle(timeout_seconds=60)
+    # Closed sessions are never "idle" (already terminal)
+    s.status = SessionStatus.closed
+    assert not s.is_idle(timeout_seconds=60)
+
+
+def test_per_agent_active_cap_enforced():
+    """O4: only ACTIVE sessions count toward the cap (PENDING unlimited)."""
+    store = _mk_store(cap=2)
+    # 2 active for agent A1
+    s1 = store.create("a1", "o1", "target1", "o2", [])
+    s1.status = SessionStatus.active
+    s2 = store.create("a1", "o1", "target2", "o2", [])
+    s2.status = SessionStatus.active
+    # 3rd active should raise
+    with pytest.raises(AgentSessionCapExceeded) as exc:
+        store.create("a1", "o1", "target3", "o2", [])
+    assert exc.value.current == 2
+    assert exc.value.cap == 2
+
+
+def test_pending_sessions_do_not_count_toward_cap():
+    """Unlimited PENDING is by design — they are auto-swept on pending timeout."""
+    store = _mk_store(cap=1)
+    # 5 pending is fine
+    for i in range(5):
+        store.create("a1", "o1", f"t{i}", "o2", [])
+    # count_active_for_agent sees zero
+    assert store.count_active_for_agent("a1") == 0
+
+
+def test_close_records_reason():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.close(s.session_id, SessionCloseReason.idle_timeout)
+    assert s.status == SessionStatus.closed
+    assert s.close_reason == SessionCloseReason.idle_timeout
+
+
+def test_close_is_idempotent_on_reason():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.close(s.session_id, SessionCloseReason.normal)
+    # A second close (e.g., sweeper racing with explicit close) must not
+    # overwrite the original reason.
+    store.close(s.session_id, SessionCloseReason.idle_timeout)
+    assert s.close_reason == SessionCloseReason.normal
+
+
+def test_reject_sets_rejected_reason():
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.reject(s.session_id)
+    assert s.status == SessionStatus.denied
+    assert s.close_reason == SessionCloseReason.rejected
+
+
+def test_find_stale_flags_idle_and_ttl():
+    store = _mk_store()
+    s_idle = store.create("a1", "o1", "a2", "o2", [])
+    store.activate(s_idle.session_id)
+    s_idle.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+    s_ttl = store.create("a1", "o1", "a3", "o2", [])
+    s_ttl.expires_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+
+    s_fresh = store.create("a1", "o1", "a4", "o2", [])
+    store.activate(s_fresh.session_id)
+
+    stale = store.find_stale(idle_timeout_seconds=60)
+    ids = {s.session_id: reason for s, reason in stale}
+    assert ids[s_idle.session_id] == SessionCloseReason.idle_timeout
+    assert ids[s_ttl.session_id] == SessionCloseReason.ttl_expired
+    assert s_fresh.session_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_sweep_once_closes_stale(monkeypatch):
+    """Sweeper closes stale sessions and tolerates DB unavailability."""
+    from app.broker import session_sweeper
+
+    # Monkey-patch persistence + WS notify so sweep_once runs purely in-memory.
+    persisted: list[str] = []
+    notified: list[tuple[str, str]] = []
+
+    async def fake_persist(session):
+        persisted.append(session.session_id)
+
+    async def fake_notify(session, reason):
+        notified.append((session.session_id, reason.value))
+
+    monkeypatch.setattr(session_sweeper, "_persist_closed", fake_persist)
+    monkeypatch.setattr(session_sweeper, "_emit_closed_event", fake_notify)
+
+    store = _mk_store()
+    s = store.create("a1", "o1", "a2", "o2", [])
+    store.activate(s.session_id)
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(hours=2)
+
+    closed = await session_sweeper.sweep_once(store, idle_timeout_seconds=60)
+    assert closed == 1
+    assert s.status == SessionStatus.closed
+    assert s.close_reason == SessionCloseReason.idle_timeout
+    assert persisted == [s.session_id]
+    assert notified == [(s.session_id, "idle_timeout")]
+
+
+@pytest.mark.asyncio
+async def test_sweeper_loop_stops_on_event(monkeypatch):
+    """sweeper_loop must exit promptly when stop_event is set."""
+    from app.broker import session_sweeper
+
+    async def noop_persist(_):
+        pass
+
+    async def noop_notify(_, __):
+        pass
+
+    monkeypatch.setattr(session_sweeper, "_persist_closed", noop_persist)
+    monkeypatch.setattr(session_sweeper, "_emit_closed_event", noop_notify)
+
+    store = _mk_store()
+    stop = asyncio.Event()
+    task = asyncio.create_task(
+        session_sweeper.sweeper_loop(
+            store, interval_seconds=60, idle_timeout_seconds=60, stop_event=stop,
+        )
+    )
+    await asyncio.sleep(0.05)
+    stop.set()
+    await asyncio.wait_for(task, timeout=2)
+    assert task.done()

--- a/tests/test_session_reliability_m2.py
+++ b/tests/test_session_reliability_m2.py
@@ -10,11 +10,7 @@ by the smoke tests; here we focus on:
 """
 from __future__ import annotations
 
-import json
-
 import pytest
-
-from app.broker.models import SessionStatus
 
 
 # ─────────────────────────────────────────────────────────────────────

--- a/tests/test_session_reliability_m2.py
+++ b/tests/test_session_reliability_m2.py
@@ -1,0 +1,187 @@
+"""M2 heartbeat + resume — unit tests.
+
+The full WS integration flow requires a live FastAPI app and is covered
+by the smoke tests; here we focus on:
+
+- fetch_messages_for_resume() filtering (seq gate + sender exclusion)
+- _handle_ws_resume() correctness (session not found, not participant,
+  bad input, happy path)
+- Resume payload is capped by ``limit``
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.broker.models import SessionStatus
+
+
+# ─────────────────────────────────────────────────────────────────────
+# In-memory fakes for the resume handler — no FastAPI, no real DB.
+# ─────────────────────────────────────────────────────────────────────
+
+
+class FakeWS:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send_json(self, payload: dict) -> None:
+        self.sent.append(payload)
+
+
+class FakeStore:
+    """Minimal stand-in for SessionStore: only .get() is exercised."""
+
+    def __init__(self, session=None):
+        self._session = session
+
+    def get(self, _session_id):
+        return self._session
+
+
+class FakeSession:
+    def __init__(self, session_id: str, initiator: str, target: str, next_seq: int = 3):
+        self.session_id = session_id
+        self.initiator_agent_id = initiator
+        self.target_agent_id = target
+        self.initiator_org_id = "org-i"
+        self.target_org_id = "org-t"
+        self._next_seq = next_seq
+        self._touched = False
+
+    def touch(self):
+        self._touched = True
+
+
+VALID_SID = "00000000-0000-0000-0000-000000000001"
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_bad_session_id(monkeypatch):
+    from app.broker.router import _handle_ws_resume
+
+    ws = FakeWS()
+    await _handle_ws_resume(
+        websocket=ws,
+        msg={"type": "resume", "session_id": "not-a-uuid", "last_seq": 0},
+        agent_id="a1",
+        db=None,  # never touched when session_id fails validation
+        store=FakeStore(),
+    )
+    assert ws.sent == [
+        {"type": "resume_error", "detail": "Invalid or missing session_id"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_non_int_last_seq():
+    from app.broker.router import _handle_ws_resume
+
+    ws = FakeWS()
+    await _handle_ws_resume(
+        websocket=ws,
+        msg={"type": "resume", "session_id": VALID_SID, "last_seq": "nope"},
+        agent_id="a1",
+        db=None,
+        store=FakeStore(),
+    )
+    assert len(ws.sent) == 1
+    assert ws.sent[0]["type"] == "resume_error"
+    assert "integer" in ws.sent[0]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_resume_session_not_found():
+    from app.broker.router import _handle_ws_resume
+
+    ws = FakeWS()
+    await _handle_ws_resume(
+        websocket=ws,
+        msg={"type": "resume", "session_id": VALID_SID, "last_seq": 0},
+        agent_id="a1",
+        db=None,
+        store=FakeStore(session=None),
+    )
+    assert ws.sent[0]["type"] == "resume_error"
+    assert ws.sent[0]["detail"] == "Session not found"
+
+
+@pytest.mark.asyncio
+async def test_resume_not_participant():
+    from app.broker.router import _handle_ws_resume
+
+    ws = FakeWS()
+    session = FakeSession(VALID_SID, initiator="a1", target="a2")
+    await _handle_ws_resume(
+        websocket=ws,
+        msg={"type": "resume", "session_id": VALID_SID, "last_seq": 0},
+        agent_id="stranger",
+        db=None,
+        store=FakeStore(session=session),
+    )
+    assert ws.sent[0]["type"] == "resume_error"
+    assert ws.sent[0]["detail"] == "Not a participant"
+
+
+@pytest.mark.asyncio
+async def test_resume_happy_path_replays_messages(monkeypatch):
+    """Resume returns resume_ok + one new_message per replayed entry."""
+    from app.broker import router
+    from app.broker.router import _handle_ws_resume
+
+    replayed = [
+        {
+            "seq": 1,
+            "sender_agent_id": "a1",
+            "payload": {"hello": "world"},
+            "nonce": "n1",
+            "timestamp": "2026-04-12T12:00:00+00:00",
+            "signature": None,
+            "client_seq": None,
+        },
+        {
+            "seq": 2,
+            "sender_agent_id": "a1",
+            "payload": {"bye": "world"},
+            "nonce": "n2",
+            "timestamp": "2026-04-12T12:00:01+00:00",
+            "signature": None,
+            "client_seq": None,
+        },
+    ]
+
+    async def fake_fetch(db, sid, aid, last_seq, limit):
+        assert sid == VALID_SID
+        assert aid == "a2"  # resuming agent
+        assert last_seq == 0
+        assert limit == router._WS_RESUME_MAX_MESSAGES
+        return replayed
+
+    monkeypatch.setattr(
+        "app.broker.persistence.fetch_messages_for_resume", fake_fetch,
+    )
+
+    ws = FakeWS()
+    session = FakeSession(VALID_SID, initiator="a1", target="a2", next_seq=3)
+    await _handle_ws_resume(
+        websocket=ws,
+        msg={"type": "resume", "session_id": VALID_SID, "last_seq": 0},
+        agent_id="a2",
+        db=None,
+        store=FakeStore(session=session),
+    )
+
+    assert session._touched is True
+    assert ws.sent[0] == {
+        "type": "resume_ok",
+        "session_id": VALID_SID,
+        "last_seq_server": 2,  # next_seq - 1
+        "delivered": 2,
+    }
+    assert len(ws.sent) == 3
+    for i, frame in enumerate(ws.sent[1:]):
+        assert frame["type"] == "new_message"
+        assert frame["session_id"] == VALID_SID
+        assert frame["replayed"] is True
+        assert frame["message"]["seq"] == i + 1


### PR DESCRIPTION
## Summary
Ships M3 of the Session Reliability Layer: at-least-once message delivery when the recipient is offline. Messages persist in a new broker-side queue with TTL + idempotency, drain to the recipient on their next WS connect/resume, and TTL-expire via the session sweeper with a best-effort sender notification.

Stacked on top of #28 (M1) and #29 (M2) — base is \`feature/m2-heartbeat-resume\`, will auto-rebase to main once those merge.

### Commits
- M3.1 \`0c0e24e\` — \`proxy_message_queue\` schema + Alembic \`e5f6a7b8c9d0\`
- M3.2 \`738d715\` — queue ops module (enqueue / ack / fetch / sweep / dedupe)
- M3.6 \`3d265ca\` — router enqueue fallback + \`ttl_seconds\` / \`idempotency_key\` query params
- M3.6 \`0131546\` — \`POST .../messages/{msg_id}/ack\` (204/400/404/409, recipient-scoped)
- M3.6 \`9fcae25\` — WS drain on connect + end of resume
- M3.6 \`9b13ea0\` — sweeper TTL expiry + \`message_expired\` sender notify
- \`2b00b2e\` — changelog entry

### New broker surface
- \`POST /v1/broker/sessions/{id}/messages\` now accepts:
  - \`ttl_seconds\` (1..86400, default 300)
  - \`idempotency_key\` (opt, max 128 chars)
- When the recipient is not locally WS-connected → response is \`{status: "queued", msg_id, deduped}\`
- When connected → direct WS push unchanged → response is \`{status: "accepted"}\`
- \`POST /v1/broker/sessions/{id}/messages/{msg_id}/ack\` — 204 success, 404 unknown, 409 terminal state, scoped to \`current_agent.agent_id\`

### WS drain
- After \`auth_ok\` and end of \`_handle_ws_resume\`, queued messages are pushed as \`new_message\` frames with \`queued: true\` + \`msg_id\`. SDK acks via REST.
- Drain is non-mutating; a reconnect without ack redelivers.

### Sweeper
- \`sweep_once\` now also calls \`_sweep_message_queue()\` which flips TTL-expired rows and emits best-effort \`message_expired\` to each sender.

### New metrics (OpenTelemetry)
- \`atn.message.queued\`, \`atn.message.queue_deduped\`, \`atn.ws.queue_drained\`, \`atn.message.expired\`

### Key design decisions
- **Presence**: enqueue only when \`ws_manager.is_connected\` is locally False. Cross-worker delivery still flows via Redis pub/sub; SDK dedupes on \`msg_id\`. Documented in ADR-001 for multi-proxy scenario.
- **Wire shape**: \`ttl_seconds\` + \`idempotency_key\` are **query params** rather than a body wrapper — zero regression on the ~20 existing tests that POST raw \`MessageEnvelope\`. SDK will add the params in M3.4/M3.5.
- **Ack scoping**: non-recipients get 404 (not 409) so no info leak about msg_id existence.

## Test plan
- [x] 15 new tests: 8 integration (\`test_m3_router_integration.py\`), 4 unit (\`test_m3_ws_drain.py\`), 3 sweeper (\`test_m3_sweeper_ttl.py\`)
- [x] M1/M2 reliability suites unchanged and green
- [x] Existing broker suites (\`test_broker.py\`, \`test_message_signature.py\`) unchanged and green — 47/47 total
- [ ] CI full matrix (will run on PR open)
- [ ] Smoke \`./demo_network/smoke.sh full\` — pending (per \`feedback_smoke_gate.md\`, this PR touches \`app/broker/\` so smoke is required before merge)
- [ ] SDK M3.4/M3.5 client params + auto-ack — follow-up PR, separate scope

## Follow-ups
- M3.4 \`cullis_sdk/client.py\` — accept \`ttl_seconds\` + \`idempotency_key\` on \`send_message()\`
- M3.5 SDK auto-ack handler — on \`new_message\` with \`queued: true\`, POST to \`/messages/{msg_id}/ack\`
- M3.7 metrics dashboard panel (Grafana)
- M3.8 e2e integration test: enqueue → offline → reconnect → drain → ack → expire
- M3-twin lato proxy for intra-org durability — deferred until ADR-001 is approved