### PR TITLE
feat(observability): Grafana dashboard + M3 alerts for Session Reliability Layer

### DIFF
--- a/deploy/helm/cullis/README.md
+++ b/deploy/helm/cullis/README.md
@@ -327,6 +327,16 @@ spec:
 7. `broker.image.tag` — pin to a specific release tag, do not rely on the
    chart `appVersion` in production.
 
+## Dashboards
+
+The chart renders the Prometheus Operator CRDs (`ServiceMonitor` +
+`PrometheusRule`), but does not bundle a Grafana dashboard. A drop-in
+dashboard for the Session Reliability Layer (M1 + M2 + M3 — offline
+queue, WebSocket heartbeat, session resume, sweeper) lives at
+[`enterprise-kit/monitoring/cullis-session-reliability.json`](../../../enterprise-kit/monitoring/cullis-session-reliability.json).
+Import it via **Grafana → Dashboards → New → Import** and point the
+`$datasource` variable at the Prometheus instance scraping this chart.
+
 ## Validation
 
 ```bash

--- a/enterprise-kit/monitoring/README.md
+++ b/enterprise-kit/monitoring/README.md
@@ -82,10 +82,19 @@ The other metrics (auth success/deny, session created/denied, policy
 allow/deny, rate-limit reject, PDP webhook latency) drive the operational
 alerts and are straightforward operational signals.
 
+## Grafana dashboard
+
+`cullis-session-reliability.json` is a drop-in Grafana dashboard covering
+the Session Reliability Layer (M1 + M2 + M3): offline message queue,
+WebSocket heartbeat, session resume, and sweeper activity.
+
+Import via **Dashboards → New → Import → Upload JSON file**, then pick
+your Prometheus datasource when prompted (the dashboard exposes a
+`$datasource` variable so you can point it at the right instance without
+editing the file).
+
 ## SIEM integration
 
-Cullis already emits structured JSON logs when `LOG_FORMAT=json` is set.
-Combine the alert rules above with log shipping to your SIEM (Loki, Splunk,
-Elastic, Datadog) for full incident response context. There is no native
-"business dashboard" inside Cullis — metrics flow to your existing
-observability stack.
+Cullis emits structured JSON logs when `LOG_FORMAT=json` is set. Combine
+the alert rules above with log shipping to your SIEM (Loki, Splunk,
+Elastic, Datadog) for full incident response context.

--- a/enterprise-kit/monitoring/cullis-alerts.yml
+++ b/enterprise-kit/monitoring/cullis-alerts.yml
@@ -19,6 +19,10 @@
 #   atn.policy.deny                   -->   atn_policy_deny_total
 #   atn.ratelimit.reject              -->   atn_ratelimit_reject_total
 #   atn.pdp_webhook.latency           -->   atn_pdp_webhook_latency_milliseconds
+#   atn.message.queued                -->   atn_message_queued_total
+#   atn.message.expired               -->   atn_message_expired_total
+#   atn.ws.pong_timeout               -->   atn_ws_pong_timeout_total
+#   atn.ws.queue_drained              -->   atn_ws_queue_drained_total
 #
 # Validate locally with:
 #   promtool check rules cullis-alerts.yml
@@ -168,6 +172,40 @@ groups:
             Vault is sealed or unreachable. The broker can keep serving
             existing sessions from cached keys, but cannot rotate or write
             new secrets. Unseal Vault before any maintenance windows.
+
+      - alert: CullisMessageExpirySpike
+        expr: |
+          sum(increase(atn_message_expired_total[10m]))
+          /
+          clamp_min(sum(increase(atn_message_queued_total[10m])), 1)
+          > 0.1
+        for: 10m
+        labels:
+          severity: warning
+          component: cullis-broker
+        annotations:
+          summary: "More than 10% of queued messages expired over 10 minutes"
+          description: |
+            A non-trivial fraction of offline-queued messages are hitting TTL
+            before the recipient comes back. Either recipients are dying and
+            not reconnecting, or the TTL values requested by senders are too
+            aggressive for the current agent availability. Inspect
+            `atn_message_expired_total` by org_id and correlate with WS
+            connection counts.
+
+      - alert: CullisWsPongTimeoutSpike
+        expr: sum(rate(atn_ws_pong_timeout_total[5m])) > 0.2
+        for: 5m
+        labels:
+          severity: warning
+          component: cullis-broker
+        annotations:
+          summary: "WebSocket pong timeouts elevated"
+          description: |
+            The broker is dropping WS connections because clients are not
+            answering pings. Sustained rate indicates network path
+            degradation between clients and broker, or clients frozen in
+            userland. Cross-check with session closures by reason.
 
       - alert: CullisSessionDeniedSpike
         expr: |

--- a/enterprise-kit/monitoring/cullis-session-reliability.json
+++ b/enterprise-kit/monitoring/cullis-session-reliability.json
@@ -1,0 +1,357 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "uid": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Cullis Session Reliability Layer (M1 + M2 + M3). Drop into Grafana and point the datasource variable at the Prometheus instance scraping the broker /metrics endpoint. See enterprise-kit/monitoring/README.md for scrape config.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "M3 — Message durability",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Rate of messages enqueued because the recipient was offline. Sustained non-zero = healthy offline delivery; sharp spike = recipient agent is down.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 1},
+      "id": 1,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (org_id) (rate(atn_message_queued_total[5m]))",
+          "legendFormat": "{{org_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Messages queued (offline enqueue) — rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Messages pushed to a client when it connects or resumes. Confirms the drain path is working.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 1},
+      "id": 2,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (org_id) (rate(atn_ws_queue_drained_total[5m]))",
+          "legendFormat": "{{org_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue drained on WS connect/resume — rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Queued messages flipped to expired by the sweeper. Non-zero = TTL was hit before the recipient ever came back. A few are normal; sustained spikes mean dead agents or TTLs too short.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.05},
+              {"color": "red", "value": 0.5}
+            ]
+          }
+        }
+      },
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 1},
+      "id": 3,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (org_id) (rate(atn_message_expired_total[5m]))",
+          "legendFormat": "{{org_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Messages expired by TTL — rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Enqueue attempts collapsed by idempotency key. Sustained non-zero is expected if senders retry aggressively; a sudden spike can indicate an SDK bug regenerating unstable keys.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 7, "w": 12, "x": 0, "y": 9},
+      "id": 4,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (org_id) (rate(atn_message_queue_deduped_total[5m]))",
+          "legendFormat": "{{org_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Enqueue dedup hits (idempotency) — rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Ratio of expired messages over queued messages in the last 1h. Anything above a few % suggests dead recipients or TTLs set too aggressively.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "orange", "value": 0.05},
+              {"color": "red", "value": 0.2}
+            ]
+          },
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1
+        }
+      },
+      "gridPos": {"h": 7, "w": 12, "x": 12, "y": 9},
+      "id": 5,
+      "options": {
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum(increase(atn_message_expired_total[1h])) / clamp_min(sum(increase(atn_message_queued_total[1h])), 1)",
+          "legendFormat": "expired / queued (1h)",
+          "refId": "A"
+        }
+      ],
+      "title": "Expired / queued ratio (1h)",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 16},
+      "id": 200,
+      "panels": [],
+      "title": "M2 — WebSocket heartbeat + resume",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Server-initiated WS pings versus pong timeouts. A healthy link is all green pings with zero red timeouts. Rising timeouts = flaky network or frozen clients.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 17},
+      "id": 6,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum(rate(atn_ws_ping_sent_total[5m]))",
+          "legendFormat": "pings sent",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum(rate(atn_ws_pong_timeout_total[5m]))",
+          "legendFormat": "pong timeouts",
+          "refId": "B"
+        }
+      ],
+      "title": "WS heartbeat — pings vs pong timeouts",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Session resume requests and how many messages they replayed. Shows that clients are actually using the reliability layer.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 17},
+      "id": 7,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum(rate(atn_ws_resume_total[5m]))",
+          "legendFormat": "resumes",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum(rate(atn_ws_resume_messages_delivered_total[5m]))",
+          "legendFormat": "messages replayed",
+          "refId": "B"
+        }
+      ],
+      "title": "Resume requests + replayed messages",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 25},
+      "id": 300,
+      "panels": [],
+      "title": "M1 — Session lifecycle",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Sessions closed broken out by reason. Watch for sudden shifts in the reason mix — e.g. a spike in `pong_timeout` signals network degradation.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 20, "stacking": {"mode": "normal"}},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 26},
+      "id": 8,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (reason) (rate(atn_session_closed_total[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Sessions closed by reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Session creates rejected because the per-agent ACTIVE cap was hit. Non-zero means an agent is leaking sessions or a tenant is spamming.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 26},
+      "id": 9,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (org_id) (rate(atn_session_cap_rejected_total[5m]))",
+          "legendFormat": "{{org_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Session cap rejections — rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "$datasource"},
+      "description": "Sweeper cycles and sessions closed by the sweeper. Cycles should be steady; sweeper closures spike when many clients disappear at once.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"lineWidth": 2, "fillOpacity": 10},
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 34},
+      "id": 10,
+      "options": {"legend": {"displayMode": "table", "placement": "bottom", "calcs": ["last", "max"]}},
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum(rate(atn_session_sweeper_cycles_total[5m]))",
+          "legendFormat": "sweeper cycles",
+          "refId": "A"
+        },
+        {
+          "datasource": {"type": "prometheus", "uid": "$datasource"},
+          "expr": "sum by (reason) (rate(atn_session_sweeper_closed_total[5m]))",
+          "legendFormat": "closed: {{reason}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Sweeper activity",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["cullis", "session-reliability", "m1", "m2", "m3"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "Cullis — Session Reliability Layer",
+  "uid": "cullis-session-reliability",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## Summary
- New drop-in Grafana dashboard at `enterprise-kit/monitoring/cullis-session-reliability.json` covering the Session Reliability Layer (M1 sweeper + cap, M2 heartbeat/resume, M3 offline queue / drain / expire / dedup).
- Two new Prometheus alert rules in `enterprise-kit/monitoring/cullis-alerts.yml`:
  - `CullisMessageExpirySpike` — >10% of queued messages hit TTL over 10m (dead recipients or TTL too aggressive).
  - `CullisWsPongTimeoutSpike` — WS pong timeouts sustained, signalling flaky network or frozen clients.
- READMEs updated: enterprise-kit monitoring README references the dashboard; the Helm chart README links it.

Closes **M3.7** from `imp/session_reliability_layer.md`.

## Why nudge the Helm README
The path filter on `helm-test` keys on `deploy/helm/**`. M3 merged in `#28`, `#29`, `#31`, `#32` all touched `app/` and `cullis_sdk/` but never `deploy/helm/**`, so the kind-based `helm-test` job never actually exercised M3 code. Adding the Dashboards subsection to `deploy/helm/cullis/README.md` forces a full kind deploy of the current main (M3 included) during CI for this PR — i.e. the "k3d shake-out con M3 attivo" from today's plan.

## Test plan
- [x] `python3 -m json.tool` on the dashboard JSON (parses clean)
- [x] `yaml.safe_load` on `cullis-alerts.yml` (3 groups, 14 rules)
- [ ] CI: `helm-test` (cullis + cullis-proxy matrix) green on kind — first real kind deploy that includes M3 code paths
- [ ] CI: `smoke` and `pytest` unaffected (PR is docs + monitoring only)
- [ ] Manual: import the dashboard JSON into a Grafana instance pointing at a broker with `PROMETHEUS_ENABLED=true` and confirm the panels render

🤖 Generated with [Claude Code](https://claude.com/claude-code)