### PR TITLE
refactor(proxy): migrate db.py + callers from aiosqlite raw to SQLAlchemy async (ADR-001 Phase 1.2)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1021,16 +1021,15 @@ async def agent_detail_page(request: Request, agent_id: str):
         raise HTTPException(status_code=404, detail="Agent not found")
 
     # Fetch recent audit entries for this agent
+    from sqlalchemy import text
+
     from mcp_proxy.db import get_db
-    import aiosqlite
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM audit_log WHERE agent_id = ? ORDER BY timestamp DESC LIMIT 20",
-            (agent_id,),
+        result = await db.execute(
+            text("SELECT * FROM audit_log WHERE agent_id = :agent_id ORDER BY timestamp DESC LIMIT 20"),
+            {"agent_id": agent_id},
         )
-        rows = await cursor.fetchall()
-        audit_entries = [dict(row) for row in rows]
+        audit_entries = [dict(row) for row in result.mappings().all()]
 
     # Extra context for integration snippets
     settings = get_settings()
@@ -1074,14 +1073,13 @@ async def agent_rotate_key(request: Request, agent_id: str):
     raw_key = generate_api_key(base_name)
     key_hash = hash_api_key(raw_key)
 
-    import aiosqlite
+    from sqlalchemy import text
+
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
         await db.execute(
-            "UPDATE internal_agents SET api_key_hash = ? WHERE agent_id = ?",
-            (key_hash, agent_id),
+            text("UPDATE internal_agents SET api_key_hash = :api_key_hash WHERE agent_id = :agent_id"),
+            {"api_key_hash": key_hash, "agent_id": agent_id},
         )
-        await db.commit()
 
     await log_audit(
         agent_id=agent_id,
@@ -1092,13 +1090,11 @@ async def agent_rotate_key(request: Request, agent_id: str):
     # Re-fetch agent and audit
     agent = await get_agent(agent_id)
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM audit_log WHERE agent_id = ? ORDER BY timestamp DESC LIMIT 20",
-            (agent_id,),
+        result = await db.execute(
+            text("SELECT * FROM audit_log WHERE agent_id = :agent_id ORDER BY timestamp DESC LIMIT 20"),
+            {"agent_id": agent_id},
         )
-        rows = await cursor.fetchall()
-        audit_entries = [dict(row) for row in rows]
+        audit_entries = [dict(row) for row in result.mappings().all()]
 
     # Extra context for integration snippets (show real key after rotation)
     from mcp_proxy.config import get_settings
@@ -1194,8 +1190,9 @@ async def agent_delete(request: Request, agent_id: str):
     if not await verify_csrf(request, session):
         raise HTTPException(status_code=403, detail="Invalid CSRF token")
 
-    from mcp_proxy.db import get_agent, get_db, log_audit, get_config
-    import aiosqlite
+    from sqlalchemy import text
+
+    from mcp_proxy.db import get_agent, get_config, get_db, log_audit
 
     agent = await get_agent(agent_id)
     if agent is None:
@@ -1203,11 +1200,15 @@ async def agent_delete(request: Request, agent_id: str):
 
     # Delete from local DB
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        await db.execute("DELETE FROM internal_agents WHERE agent_id = ?", (agent_id,))
+        await db.execute(
+            text("DELETE FROM internal_agents WHERE agent_id = :agent_id"),
+            {"agent_id": agent_id},
+        )
         # Also remove stored key from proxy_config if present
-        await db.execute("DELETE FROM proxy_config WHERE key = ?", (f"agent_key:{agent_id}",))
-        await db.commit()
+        await db.execute(
+            text("DELETE FROM proxy_config WHERE key = :key"),
+            {"key": f"agent_key:{agent_id}"},
+        )
 
     # Best-effort: unregister from broker
     broker_url = await get_config("broker_url")
@@ -1419,36 +1420,38 @@ async def audit_page(request: Request):
     per_page = 50
 
     # Build query
+    from sqlalchemy import text
+
     conditions: list[str] = []
-    params: list[str] = []
+    params: dict[str, object] = {}
     if agent_filter:
-        conditions.append("agent_id = ?")
-        params.append(agent_filter)
+        conditions.append("agent_id = :agent_id")
+        params["agent_id"] = agent_filter
     if action_filter:
-        conditions.append("action = ?")
-        params.append(action_filter)
+        conditions.append("action = :action")
+        params["action"] = action_filter
     if status_filter:
-        conditions.append("status = ?")
-        params.append(status_filter)
+        conditions.append("status = :status")
+        params["status"] = status_filter
 
     where = (" WHERE " + " AND ".join(conditions)) if conditions else ""
 
-    import aiosqlite
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
         # Count total
-        cursor = await db.execute(f"SELECT COUNT(*) as cnt FROM audit_log{where}", params)
-        row = await cursor.fetchone()
+        result = await db.execute(
+            text(f"SELECT COUNT(*) as cnt FROM audit_log{where}"), params,
+        )
+        row = result.mappings().first()
         total = row["cnt"] if row else 0
 
         # Fetch page
         offset = (page - 1) * per_page
-        cursor = await db.execute(
-            f"SELECT * FROM audit_log{where} ORDER BY timestamp DESC LIMIT ? OFFSET ?",
-            [*params, per_page, offset],
+        page_params = {**params, "limit": per_page, "offset": offset}
+        result = await db.execute(
+            text(f"SELECT * FROM audit_log{where} ORDER BY timestamp DESC LIMIT :limit OFFSET :offset"),
+            page_params,
         )
-        rows = await cursor.fetchall()
-        entries = [dict(r) for r in rows]
+        entries = [dict(r) for r in result.mappings().all()]
 
     # Distinct agents and actions for filter dropdowns
     agents = await list_agents()
@@ -1645,13 +1648,13 @@ async def vault_page(request: Request):
     vault_token = await get_config("vault_token") or ""
 
     # Count local keys (agent_key:* in proxy_config)
-    import aiosqlite
+    from sqlalchemy import text
+
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT COUNT(*) as cnt FROM proxy_config WHERE key LIKE 'agent_key:%'"
+        result = await db.execute(
+            text("SELECT COUNT(*) as cnt FROM proxy_config WHERE key LIKE 'agent_key:%'")
         )
-        row = await cursor.fetchone()
+        row = result.mappings().first()
         local_key_count = row["cnt"] if row else 0
 
     # Test vault status if configured
@@ -1803,14 +1806,14 @@ async def vault_migrate_keys(request: Request):
     import httpx
 
     # Find all agent keys stored in proxy_config (agent_key:* pattern)
-    import aiosqlite
+    from sqlalchemy import text
+
     migrated = 0
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT key, value FROM proxy_config WHERE key LIKE 'agent_key:%'"
+        result = await db.execute(
+            text("SELECT key, value FROM proxy_config WHERE key LIKE 'agent_key:%'")
         )
-        rows = await cursor.fetchall()
+        rows = result.mappings().all()
 
     for row in rows:
         agent_id = row["key"].replace("agent_key:", "", 1)
@@ -1867,17 +1870,15 @@ async def badge_audit(request: Request):
     if not session.logged_in:
         return HTMLResponse("")
 
+    from sqlalchemy import text
+
     from mcp_proxy.db import get_db
-    import aiosqlite
-    import time as _time
-    one_hour_ago = _time.time() - 3600
 
     async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT COUNT(*) as cnt FROM audit_log WHERE timestamp > datetime('now', '-1 hour')"
+        result = await db.execute(
+            text("SELECT COUNT(*) as cnt FROM audit_log WHERE timestamp > datetime('now', '-1 hour')")
         )
-        row = await cursor.fetchone()
+        row = result.mappings().first()
         count = row["cnt"] if row else 0
 
     if count:

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1,5 +1,5 @@
 """
-MCP Proxy database — lightweight async SQLite via aiosqlite.
+MCP Proxy database — async SQLAlchemy 2.x Core over aiosqlite / asyncpg.
 
 Tables:
   - internal_agents: locally registered agents (for egress API key auth)
@@ -7,105 +7,111 @@ Tables:
   - proxy_config: key-value store for broker uplink config from setup wizard
 
 Design choices:
-  - aiosqlite directly (no SQLAlchemy) — minimal footprint for a sidecar proxy
+  - SQLAlchemy Core with AsyncEngine — single async driver, portable SQLite/Postgres
   - audit_log is append-only: no UPDATE or DELETE operations exposed
-  - WAL mode enabled for concurrent readers
+  - WAL mode enabled on SQLite for concurrent readers (no-op on Postgres)
+  - get_db() yields an AsyncConnection already inside engine.begin(): callers no
+    longer call db.commit(), transactions commit on context exit.
 """
 import json
 import logging
-import time
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import AsyncIterator
 
-import aiosqlite
+from sqlalchemy import text
+from sqlalchemy.engine import RowMapping
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+
+from mcp_proxy.db_models import metadata
 
 _log = logging.getLogger("mcp_proxy")
 
-# Module-level connection path — set by init_db()
-_db_path: str = ""
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Schema
-# ─────────────────────────────────────────────────────────────────────────────
-
-_SCHEMA_SQL = """
-CREATE TABLE IF NOT EXISTS internal_agents (
-    agent_id       TEXT PRIMARY KEY,
-    display_name   TEXT NOT NULL,
-    capabilities   TEXT NOT NULL DEFAULT '[]',  -- JSON array
-    api_key_hash   TEXT NOT NULL,
-    cert_pem       TEXT,
-    created_at     TEXT NOT NULL,
-    is_active      INTEGER NOT NULL DEFAULT 1
-);
-
-CREATE TABLE IF NOT EXISTS audit_log (
-    id             INTEGER PRIMARY KEY AUTOINCREMENT,
-    timestamp      TEXT NOT NULL,
-    agent_id       TEXT NOT NULL,
-    action         TEXT NOT NULL,
-    tool_name      TEXT,
-    status         TEXT NOT NULL,
-    detail         TEXT,
-    request_id     TEXT,
-    duration_ms    REAL
-);
-
-CREATE INDEX IF NOT EXISTS idx_audit_log_agent_id ON audit_log(agent_id);
-CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
-CREATE INDEX IF NOT EXISTS idx_audit_log_request_id ON audit_log(request_id);
-
-CREATE TABLE IF NOT EXISTS proxy_config (
-    key   TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-"""
+# Module-level engine — set by init_db()
+_engine: AsyncEngine | None = None
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Initialization
 # ─────────────────────────────────────────────────────────────────────────────
 
-async def init_db(db_path: str) -> None:
-    """Create tables if they don't exist. Enable WAL mode."""
-    global _db_path
-    # Strip SQLAlchemy prefix if present
-    clean_path = db_path
+def _normalize_url(db_url: str) -> str:
+    """Accept a SQLAlchemy URL or a raw SQLite path; return a SQLAlchemy URL."""
+    if "://" in db_url:
+        return db_url
+    # Raw filesystem path — wrap as sqlite+aiosqlite
+    return f"sqlite+aiosqlite:///{db_url}"
+
+
+def _sqlite_path(db_url: str) -> str | None:
+    """Extract the filesystem path from a sqlite URL, or None if not SQLite."""
     for prefix in ("sqlite+aiosqlite:///", "sqlite:///"):
-        if clean_path.startswith(prefix):
-            clean_path = clean_path[len(prefix):]
-            break
-
-    _db_path = clean_path
-
-    # Ensure parent directory exists
-    parent = Path(_db_path).parent
-    if str(parent) != ".":
-        parent.mkdir(parents=True, exist_ok=True)
-
-    async with aiosqlite.connect(_db_path) as db:
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.executescript(_SCHEMA_SQL)
-        await db.commit()
-
-    _log.info("Database initialized: %s", _db_path)
+        if db_url.startswith(prefix):
+            return db_url[len(prefix):]
+    return None
 
 
-def get_db() -> aiosqlite.Connection:
-    """Return a fresh aiosqlite connection handle (NOT yet opened).
+async def init_db(db_url: str) -> None:
+    """Initialize the module-level AsyncEngine and ensure schema exists.
 
-    Callers MUST use ``async with``::
+    Accepts either a SQLAlchemy URL (``sqlite+aiosqlite:///path``) or a raw
+    filesystem path for backward compatibility.
 
-        async with get_db() as db:
-            db.row_factory = aiosqlite.Row
-            await db.execute(...)
-
-    Do NOT ``await get_db()`` — the context manager handles startup.
+    Schema bootstrap still uses ``metadata.create_all`` — callers that want
+    Alembic-managed upgrades should run ``alembic upgrade head`` out of band.
     """
-    if not _db_path:
+    global _engine
+
+    url = _normalize_url(db_url)
+
+    # Ensure parent directory exists for SQLite file DBs
+    sqlite_path = _sqlite_path(url)
+    if sqlite_path:
+        parent = Path(sqlite_path).parent
+        if str(parent) not in ("", "."):
+            parent.mkdir(parents=True, exist_ok=True)
+
+    _engine = create_async_engine(url, echo=False, future=True)
+
+    async with _engine.begin() as conn:
+        if _engine.dialect.name == "sqlite":
+            await conn.execute(text("PRAGMA journal_mode=WAL"))
+        await conn.run_sync(metadata.create_all)
+
+    _log.info("Database initialized: %s", url)
+
+
+async def dispose_db() -> None:
+    """Dispose the module-level engine (shutdown hook)."""
+    global _engine
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+
+
+def _require_engine() -> AsyncEngine:
+    if _engine is None:
         raise RuntimeError("Database not initialized — call init_db() first")
-    return aiosqlite.connect(_db_path)
+    return _engine
+
+
+@asynccontextmanager
+async def get_db() -> AsyncIterator[AsyncConnection]:
+    """Yield an AsyncConnection inside an active transaction.
+
+    The transaction auto-commits when the context exits cleanly and rolls
+    back on exception. Callers MUST NOT call ``await conn.commit()``.
+
+    Usage::
+
+        async with get_db() as conn:
+            result = await conn.execute(text("SELECT ..."), {"param": value})
+            row = result.mappings().first()
+    """
+    engine = _require_engine()
+    async with engine.begin() as conn:
+        yield conn
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -124,14 +130,23 @@ async def log_audit(
 ) -> None:
     """Insert an immutable audit log entry."""
     ts = datetime.now(timezone.utc).isoformat()
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        await db.execute(
-            """INSERT INTO audit_log (timestamp, agent_id, action, tool_name, status, detail, request_id, duration_ms)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-            (ts, agent_id, action, tool_name, status, detail, request_id, duration_ms),
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO audit_log (timestamp, agent_id, action, tool_name, status, detail, request_id, duration_ms)
+                   VALUES (:timestamp, :agent_id, :action, :tool_name, :status, :detail, :request_id, :duration_ms)"""
+            ),
+            {
+                "timestamp": ts,
+                "agent_id": agent_id,
+                "action": action,
+                "tool_name": tool_name,
+                "status": status,
+                "detail": detail,
+                "request_id": request_id,
+                "duration_ms": duration_ms,
+            },
         )
-        await db.commit()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -147,24 +162,31 @@ async def create_agent(
 ) -> None:
     """Register a new internal agent."""
     ts = datetime.now(timezone.utc).isoformat()
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        await db.execute(
-            """INSERT INTO internal_agents (agent_id, display_name, capabilities, api_key_hash, cert_pem, created_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (agent_id, display_name, json.dumps(capabilities), api_key_hash, cert_pem, ts),
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO internal_agents (agent_id, display_name, capabilities, api_key_hash, cert_pem, created_at)
+                   VALUES (:agent_id, :display_name, :capabilities, :api_key_hash, :cert_pem, :created_at)"""
+            ),
+            {
+                "agent_id": agent_id,
+                "display_name": display_name,
+                "capabilities": json.dumps(capabilities),
+                "api_key_hash": api_key_hash,
+                "cert_pem": cert_pem,
+                "created_at": ts,
+            },
         )
-        await db.commit()
 
 
 async def get_agent(agent_id: str) -> dict | None:
     """Fetch a single agent by ID."""
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM internal_agents WHERE agent_id = ?", (agent_id,)
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT * FROM internal_agents WHERE agent_id = :agent_id"),
+            {"agent_id": agent_id},
         )
-        row = await cursor.fetchone()
+        row = result.mappings().first()
         if row is None:
             return None
         return _agent_row_to_dict(row)
@@ -180,15 +202,13 @@ async def get_agent_by_key_hash(raw_api_key: str) -> dict | None:
     """
     import bcrypt
 
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM internal_agents WHERE is_active = 1"
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT * FROM internal_agents WHERE is_active = 1")
         )
-        rows = await cursor.fetchall()
+        rows = result.mappings().all()
         for row in rows:
             stored_hash = row["api_key_hash"]
-            # bcrypt.checkpw expects bytes
             if bcrypt.checkpw(raw_api_key.encode(), stored_hash.encode()):
                 return _agent_row_to_dict(row)
     return None
@@ -196,25 +216,21 @@ async def get_agent_by_key_hash(raw_api_key: str) -> dict | None:
 
 async def list_agents() -> list[dict]:
     """List all internal agents."""
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT * FROM internal_agents ORDER BY created_at DESC"
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT * FROM internal_agents ORDER BY created_at DESC")
         )
-        rows = await cursor.fetchall()
-        return [_agent_row_to_dict(row) for row in rows]
+        return [_agent_row_to_dict(row) for row in result.mappings().all()]
 
 
 async def deactivate_agent(agent_id: str) -> bool:
     """Soft-delete an agent by setting is_active = 0. Returns True if found."""
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "UPDATE internal_agents SET is_active = 0 WHERE agent_id = ?",
-            (agent_id,),
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("UPDATE internal_agents SET is_active = 0 WHERE agent_id = :agent_id"),
+            {"agent_id": agent_id},
         )
-        await db.commit()
-        return cursor.rowcount > 0
+        return result.rowcount > 0
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -223,33 +239,37 @@ async def deactivate_agent(agent_id: str) -> bool:
 
 async def get_config(key: str) -> str | None:
     """Get a config value by key."""
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        cursor = await db.execute(
-            "SELECT value FROM proxy_config WHERE key = ?", (key,)
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT value FROM proxy_config WHERE key = :key"),
+            {"key": key},
         )
-        row = await cursor.fetchone()
+        row = result.mappings().first()
         return row["value"] if row else None
 
 
 async def set_config(key: str, value: str) -> None:
-    """Set a config value (upsert)."""
-    async with get_db() as db:
-        db.row_factory = aiosqlite.Row
-        await db.execute(
-            """INSERT INTO proxy_config (key, value) VALUES (?, ?)
-               ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
-            (key, value),
+    """Set a config value (upsert).
+
+    SQLite and PostgreSQL both support ON CONFLICT ... DO UPDATE with the
+    same syntax, so a raw text() upsert stays portable.
+    """
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO proxy_config (key, value) VALUES (:key, :value)
+                   ON CONFLICT(key) DO UPDATE SET value = excluded.value"""
+            ),
+            {"key": key, "value": value},
         )
-        await db.commit()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _agent_row_to_dict(row: aiosqlite.Row) -> dict:
-    """Convert an aiosqlite Row to a plain dict with parsed capabilities."""
+def _agent_row_to_dict(row: RowMapping) -> dict:
+    """Convert a RowMapping to a plain dict with parsed capabilities."""
     return {
         "agent_id": row["agent_id"],
         "display_name": row["display_name"],

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -37,11 +37,11 @@ class InternalAgent(Base):
 
     agent_id = Column(Text, primary_key=True)
     display_name = Column(Text, nullable=False)
-    capabilities = Column(Text, nullable=False, default="[]")  # JSON array
+    capabilities = Column(Text, nullable=False, server_default="[]")  # JSON array
     api_key_hash = Column(Text, nullable=False)
     cert_pem = Column(Text, nullable=True)
     created_at = Column(Text, nullable=False)
-    is_active = Column(Integer, nullable=False, default=1)
+    is_active = Column(Integer, nullable=False, server_default="1")
 
 
 class AuditLogEntry(Base):
@@ -84,12 +84,12 @@ class LocalAgent(Base):
 
     agent_id = Column(Text, primary_key=True)
     display_name = Column(Text, nullable=False)
-    capabilities = Column(Text, nullable=False, default="[]")  # JSON array
+    capabilities = Column(Text, nullable=False, server_default="[]")  # JSON array
     cert_pem = Column(Text, nullable=True)
     api_key_hash = Column(Text, nullable=True)
-    scope = Column(Text, nullable=False, default="local")  # reserved: "local" | "federated-cache"
+    scope = Column(Text, nullable=False, server_default="local")  # reserved: "local" | "federated-cache"
     created_at = Column(Text, nullable=False)
-    is_active = Column(Integer, nullable=False, default=1)
+    is_active = Column(Integer, nullable=False, server_default="1")
 
 
 class LocalSession(Base):
@@ -139,9 +139,9 @@ class LocalPolicy(Base):
 
     policy_id = Column(Text, primary_key=True)
     name = Column(Text, nullable=False)
-    scope = Column(Text, nullable=False, default="intra")  # reserved: "intra" | "egress"
-    rules_json = Column(Text, nullable=False, default="{}")
-    enabled = Column(Integer, nullable=False, default=1)
+    scope = Column(Text, nullable=False, server_default="intra")  # reserved: "intra" | "egress"
+    rules_json = Column(Text, nullable=False, server_default="{}")
+    enabled = Column(Integer, nullable=False, server_default="1")
     created_at = Column(Text, nullable=False)
     updated_at = Column(Text, nullable=False)
 

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -217,15 +217,14 @@ class AgentManager:
         new_hash = hash_api_key(new_key)
 
         # Update hash in DB
-        import aiosqlite
+        from sqlalchemy import text
+
         from mcp_proxy.db import get_db
         async with get_db() as db:
-            db.row_factory = aiosqlite.Row
             await db.execute(
-                "UPDATE internal_agents SET api_key_hash = ? WHERE agent_id = ?",
-                (new_hash, agent_id),
+                text("UPDATE internal_agents SET api_key_hash = :api_key_hash WHERE agent_id = :agent_id"),
+                {"api_key_hash": new_hash, "agent_id": agent_id},
             )
-            await db.commit()
 
         logger.info("API key rotated for agent: %s", agent_id)
         return new_key

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -10,13 +10,13 @@ import logging
 import time
 from contextlib import asynccontextmanager
 
-import aiosqlite
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
 from mcp_proxy.config import get_settings, validate_config
-from mcp_proxy.db import init_db, get_db
+from mcp_proxy.db import dispose_db, get_db, init_db
 from mcp_proxy.logging_setup import configure_json_logging
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -103,6 +103,7 @@ async def lifespan(app: FastAPI):
         await app.state.broker_bridge.shutdown()
     if _jwks_client:
         await _jwks_client.close()
+    await dispose_db()
     _log.info("MCP Proxy shutdown complete")
 
 
@@ -299,8 +300,7 @@ async def readyz():
     # Database writable
     try:
         async with get_db() as db:
-            db.row_factory = aiosqlite.Row
-            await db.execute("SELECT 1")
+            await db.execute(text("SELECT 1"))
         checks["database"] = "ok"
     except Exception as exc:
         checks["database"] = f"error: {exc}"


### PR DESCRIPTION
Second slice of **ADR-001 Phase 1** (#34). Stacked on top of #35 (already merged into main).

## What this PR does
Swaps the proxy DB layer from raw aiosqlite to **SQLAlchemy 2.x async**, preserving every public function signature and return shape so callers don't need behavioural changes. This is the prerequisite for Postgres runtime support (Phase 1.3).

- \`mcp_proxy/db.py\` rewritten on top of \`AsyncEngine\` + \`text()\` queries. Module-level engine created in \`init_db()\`, disposed in new \`dispose_db()\` wired into the FastAPI lifespan.
- \`get_db()\` still exposed as \`@asynccontextmanager\` but now yields an \`AsyncConnection\` inside \`engine.begin()\` — transactions auto-commit on context exit, removing every manual \`await db.commit()\` (4 sites).
- \`db_models.py\`: 5 columns moved from \`default=\` (Python-side, only fires on ORM inserts) to \`server_default=\` so \`metadata.create_all()\` emits the same DDL the legacy \`_SCHEMA_SQL\` produced. Avoids \`NOT NULL\` violations on raw \`text()\` inserts.
- 10 raw callsites refactored: \`dashboard/router.py\` (×8), \`egress/agent_manager.py\` (×1), \`main.py\` healthcheck (×1). \`db.row_factory = aiosqlite.Row\` removed everywhere; rows now come back as \`RowMapping\`.
- \`?\` placeholders → \`:name\` named placeholders. \`ON CONFLICT (...) DO UPDATE SET value = excluded.value\` kept verbatim — works identically on SQLite and Postgres.
- WAL mode applied via PRAGMA only when \`engine.dialect.name == "sqlite"\`. Postgres skips it.
- \`init_db\` accepts both raw filesystem paths (legacy contract) and full SQLAlchemy URLs — backcompat preserved for existing deployments.

## What this PR does NOT do
- Does not introduce \`PROXY_DB_URL\` config or change config.py — that's Phase 1.3.
- Does not run \`alembic upgrade head\` at startup. Lifespan still calls \`metadata.create_all\` for backcompat with deployments that have no \`alembic_version\` row. Programmatic alembic migration lands Phase 1.3 alongside the stamp-existing logic.
- Does not touch the Helm chart or smoke pipeline — Phase 1.4.

## Verification
- \`pytest tests/ --ignore=tests/test_postgres_integration.py\`: **506 passed, 4 skipped, 3 unrelated pre-existing failures** in \`test_spiffe.py\` (identical baseline on main, not caused by this PR).
- Ad-hoc end-to-end against a temp SQLite DB exercising every public function in \`db.py\` (\`init_db\`/\`create_agent\`/\`get_agent\`/\`get_agent_by_key_hash\`/\`list_agents\`/\`log_audit\`/\`set_config\` upsert/\`get_config\`/\`deactivate_agent\`) — all green, both with raw-path and \`sqlite+aiosqlite:///\` URL forms.

## Net diff
+219 / −199 LOC across 5 files. No new files.

## Test plan
- [ ] CI: \`test (3.11)\` green
- [ ] CI: \`smoke (ec/rsa)\` green — runtime contract preserved, smoke must still pass on SQLite
- [ ] CI: \`helm-test\` skipped (no \`deploy/helm/**\` change)
- [ ] CI: \`Signed-off-by\` pass
- [ ] Manual: spin up the proxy locally, exercise dashboard CRUD endpoints to catch any regression

Refs #34