### PR TITLE
feat(proxy): PROXY_DB_URL + programmatic Alembic at startup (ADR-001 Phase 1.3)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -5,8 +5,10 @@ All settings are read from environment variables (prefix MCP_PROXY_) or .env fil
 validate_config() enforces production-safety invariants at startup.
 """
 import logging
+import os
 from functools import lru_cache
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _log = logging.getLogger("mcp_proxy.startup")
@@ -57,10 +59,21 @@ class ProxySettings(BaseSettings):
     pdp_url: str = ""
 
     # DB
+    # Default reads from MCP_PROXY_DATABASE_URL (legacy contract).
+    # PROXY_DB_URL (no prefix) takes precedence — see _apply_proxy_db_url_override.
+    # ADR-001 Phase 1.3 adds PROXY_DB_URL so Helm + smoke can target Postgres
+    # without touching the legacy MCP_PROXY_* surface.
     database_url: str = "sqlite+aiosqlite:///./mcp_proxy.db"
 
     # Rate limiting
     rate_limit_per_minute: int = 60
+
+    @model_validator(mode="after")
+    def _apply_proxy_db_url_override(self):
+        override = os.environ.get("PROXY_DB_URL")
+        if override:
+            self.database_url = override
+        return self
 
 
 def validate_config(settings: ProxySettings) -> None:

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -5,6 +5,7 @@ Tables:
   - internal_agents: locally registered agents (for egress API key auth)
   - audit_log: append-only immutable audit trail
   - proxy_config: key-value store for broker uplink config from setup wizard
+  - local_*: ADR-001 Phase 4 surface, schema-only until then
 
 Design choices:
   - SQLAlchemy Core with AsyncEngine — single async driver, portable SQLite/Postgres
@@ -12,7 +13,11 @@ Design choices:
   - WAL mode enabled on SQLite for concurrent readers (no-op on Postgres)
   - get_db() yields an AsyncConnection already inside engine.begin(): callers no
     longer call db.commit(), transactions commit on context exit.
+  - Schema bootstrap runs Alembic programmatically. Legacy SQLite proxies that
+    pre-date Alembic are stamped at 0001_initial_snapshot before upgrade so
+    their existing tables aren't recreated.
 """
+import asyncio
 import json
 import logging
 from contextlib import asynccontextmanager
@@ -20,11 +25,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator
 
-from sqlalchemy import text
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import RowMapping
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 
 from mcp_proxy.db_models import metadata
+
+_PROXY_PKG_DIR = Path(__file__).resolve().parent
+_ALEMBIC_INI = _PROXY_PKG_DIR / "alembic.ini"
+_ALEMBIC_INITIAL_REVISION = "0001_initial_snapshot"
 
 _log = logging.getLogger("mcp_proxy")
 
@@ -52,34 +63,100 @@ def _sqlite_path(db_url: str) -> str | None:
     return None
 
 
+def _alembic_config(url: str) -> AlembicConfig:
+    cfg = AlembicConfig(str(_ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+def _detect_legacy_unstamped(sync_conn) -> bool:
+    """True when the legacy schema is present but alembic_version is missing.
+
+    Pre-Phase-1 deployments created tables via raw CREATE TABLE IF NOT EXISTS
+    without Alembic. We stamp those at 0001_initial_snapshot so the upgrade
+    chain doesn't try to recreate tables that already exist.
+    """
+    inspector = inspect(sync_conn)
+    table_names = set(inspector.get_table_names())
+    return "internal_agents" in table_names and "alembic_version" not in table_names
+
+
+def _run_migrations_sync(url: str) -> None:
+    """Run alembic stamp (if needed) + upgrade head. Synchronous on purpose:
+    invoked from a thread via asyncio.to_thread to avoid blocking the loop.
+
+    Stamp-existing detection runs only on SQLite — no proxy was ever deployed
+    on Postgres pre-Phase-1, so legacy unstamped Postgres DBs cannot exist.
+    """
+    cfg = _alembic_config(url)
+
+    needs_stamp = False
+    sqlite_path = _sqlite_path(url)
+    if sqlite_path and sqlite_path != ":memory:" and Path(sqlite_path).exists():
+        from sqlalchemy import create_engine as create_sync_engine
+        sync_url = url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+        try:
+            sync_engine = create_sync_engine(sync_url, future=True)
+            with sync_engine.connect() as conn:
+                needs_stamp = _detect_legacy_unstamped(conn)
+            sync_engine.dispose()
+        except Exception as exc:
+            _log.debug("Pre-migration inspection skipped: %s", exc)
+
+    if needs_stamp:
+        _log.info("Legacy schema detected — stamping %s before upgrade",
+                  _ALEMBIC_INITIAL_REVISION)
+        command.stamp(cfg, _ALEMBIC_INITIAL_REVISION)
+
+    command.upgrade(cfg, "head")
+
+
 async def init_db(db_url: str) -> None:
-    """Initialize the module-level AsyncEngine and ensure schema exists.
+    """Initialize the module-level AsyncEngine and run Alembic migrations.
 
     Accepts either a SQLAlchemy URL (``sqlite+aiosqlite:///path``) or a raw
     filesystem path for backward compatibility.
 
-    Schema bootstrap still uses ``metadata.create_all`` — callers that want
-    Alembic-managed upgrades should run ``alembic upgrade head`` out of band.
+    Schema bootstrap runs ``alembic upgrade head``. Pre-Phase-1 SQLite
+    deployments (which created tables outside Alembic) are detected and
+    stamped at 0001_initial_snapshot first, so existing rows survive.
+
+    Set ``PROXY_SKIP_MIGRATIONS=1`` to skip the alembic step — used by tests
+    that build their own engine inside the same process.
     """
     global _engine
+    import os
 
     url = _normalize_url(db_url)
 
     # Ensure parent directory exists for SQLite file DBs
     sqlite_path = _sqlite_path(url)
-    if sqlite_path:
+    if sqlite_path and sqlite_path != ":memory:":
         parent = Path(sqlite_path).parent
         if str(parent) not in ("", "."):
             parent.mkdir(parents=True, exist_ok=True)
 
+    if os.environ.get("PROXY_SKIP_MIGRATIONS") == "1":
+        _log.warning("PROXY_SKIP_MIGRATIONS=1 — using metadata.create_all "
+                     "instead of alembic upgrade head")
+        _engine = create_async_engine(url, echo=False, future=True)
+        async with _engine.begin() as conn:
+            if _engine.dialect.name == "sqlite":
+                await conn.execute(text("PRAGMA journal_mode=WAL"))
+            await conn.run_sync(metadata.create_all)
+        _log.info("Database initialized (no-migrations mode): %s", url)
+        return
+
+    # Run alembic in a worker thread — alembic.command is synchronous and
+    # would block the event loop otherwise.
+    await asyncio.to_thread(_run_migrations_sync, url)
+
     _engine = create_async_engine(url, echo=False, future=True)
-
-    async with _engine.begin() as conn:
-        if _engine.dialect.name == "sqlite":
+    if _engine.dialect.name == "sqlite":
+        async with _engine.begin() as conn:
             await conn.execute(text("PRAGMA journal_mode=WAL"))
-        await conn.run_sync(metadata.create_all)
 
-    _log.info("Database initialized: %s", url)
+    _log.info("Database initialized (alembic upgrade head): %s", url)
 
 
 async def dispose_db() -> None:

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -1,0 +1,158 @@
+"""Validate proxy Alembic bootstrap (ADR-001 Phase 1.3).
+
+Covers the three startup paths:
+- Fresh DB: alembic upgrade head creates every table.
+- Legacy SQLite (pre-Phase-1 schema, no alembic_version): stamped at
+  0001_initial_snapshot, then upgraded; existing rows survive.
+- Postgres: same upgrade chain runs cleanly. Skipped unless
+  TEST_POSTGRES_URL is set, mirroring tests/test_postgres_integration.py.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect
+
+from mcp_proxy.db import dispose_db, init_db
+
+EXPECTED_TABLES = {
+    "internal_agents",
+    "audit_log",
+    "proxy_config",
+    "local_agents",
+    "local_sessions",
+    "local_messages",
+    "local_policies",
+    "local_audit",
+    "alembic_version",
+}
+
+
+def _table_names_sqlite(path: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
+    db_file = tmp_path / "fresh.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+
+    await init_db(url)
+    await dispose_db()
+
+    tables = _table_names_sqlite(str(db_file))
+    assert EXPECTED_TABLES.issubset(tables), (
+        f"missing tables after upgrade: {EXPECTED_TABLES - tables}"
+    )
+
+    # alembic_version contains the head revision.
+    conn = sqlite3.connect(str(db_file))
+    try:
+        rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("0002_local_tables",)]
+
+
+@pytest.mark.asyncio
+async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
+    db_file = tmp_path / "legacy.db"
+
+    # Seed the pre-Phase-1 schema (matches the old _SCHEMA_SQL byte for byte)
+    # and a row that must survive the upgrade.
+    seed = sqlite3.connect(str(db_file))
+    try:
+        seed.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS internal_agents (
+                agent_id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+                capabilities TEXT NOT NULL DEFAULT '[]', api_key_hash TEXT NOT NULL,
+                cert_pem TEXT, created_at TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1
+            );
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL, action TEXT NOT NULL, tool_name TEXT,
+                status TEXT NOT NULL, detail TEXT, request_id TEXT,
+                duration_ms REAL
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_log_agent_id ON audit_log(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_request_id ON audit_log(request_id);
+            CREATE TABLE IF NOT EXISTS proxy_config (
+                key TEXT PRIMARY KEY, value TEXT NOT NULL
+            );
+            """
+        )
+        seed.execute(
+            "INSERT INTO internal_agents VALUES "
+            "('legacy-agent','Legacy Agent','[]','hash',NULL,'2026-04-13',1)"
+        )
+        seed.commit()
+    finally:
+        seed.close()
+
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    tables = _table_names_sqlite(str(db_file))
+    assert EXPECTED_TABLES.issubset(tables)
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        rows = conn.execute(
+            "SELECT agent_id FROM internal_agents WHERE agent_id='legacy-agent'"
+        ).fetchall()
+        version = conn.execute(
+            "SELECT version_num FROM alembic_version"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
+    assert version == [("0002_local_tables",)]
+
+
+@pytest.mark.asyncio
+async def test_proxy_db_url_env_overrides_settings(monkeypatch, tmp_path):
+    """PROXY_DB_URL beats MCP_PROXY_DATABASE_URL — Phase 1.3 contract."""
+    from mcp_proxy.config import ProxySettings
+
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", "sqlite+aiosqlite:///legacy.db")
+    monkeypatch.setenv("PROXY_DB_URL", f"sqlite+aiosqlite:///{tmp_path / 'override.db'}")
+
+    settings = ProxySettings()
+    assert settings.database_url.endswith("override.db")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES_URL"),
+    reason="TEST_POSTGRES_URL not set; skipping cross-dialect migration test",
+)
+@pytest.mark.asyncio
+async def test_init_db_postgres_runs_alembic_upgrade():
+    """Same upgrade chain runs cleanly on Postgres."""
+    url = os.environ["TEST_POSTGRES_URL"]
+    await init_db(url)
+    await dispose_db()
+
+    sync_url = url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
+    sync_engine = create_engine(sync_url, future=True)
+    try:
+        with sync_engine.connect() as conn:
+            tables = set(inspect(conn).get_table_names())
+    finally:
+        sync_engine.dispose()
+    assert EXPECTED_TABLES.issubset(tables)


### PR DESCRIPTION
Third slice of **ADR-001 Phase 1** (#34). Stacks on top of #36 (already merged into main).

## What this PR does
Replaces the legacy \`metadata.create_all\` bootstrap with programmatic \`alembic upgrade head\` driven from the FastAPI lifespan, and introduces \`PROXY_DB_URL\` so future Helm + smoke targets can flip to Postgres without touching the existing \`MCP_PROXY_DATABASE_URL\` contract.

### config.py
- New \`@model_validator(mode="after")\` reads \`PROXY_DB_URL\` from \`os.environ\` and overrides \`settings.database_url\`. Legacy \`MCP_PROXY_DATABASE_URL\` keeps working — \`PROXY_DB_URL\` wins when both are set.

### db.py
- \`init_db()\` runs \`alembic.command.upgrade(cfg, "head")\` via \`asyncio.to_thread\` so the synchronous alembic API doesn't block the event loop.
- **Stamp-existing logic**: pre-Phase-1 SQLite deployments (tables present but no \`alembic_version\` row) are detected and stamped at \`0001_initial_snapshot\` before the upgrade, so existing rows survive untouched. Detection runs only on SQLite (no proxy was ever deployed on Postgres pre-Phase-1, so legacy unstamped Postgres can't exist).
- Escape hatch \`PROXY_SKIP_MIGRATIONS=1\` falls back to \`metadata.create_all\` — kept for callers that build their own engine in-process (test fixture parity with broker pattern).

### tests/test_proxy_migrations.py (new)
- Fresh SQLite: \`upgrade head\` creates all 8 tables + \`alembic_version\`.
- Legacy SQLite: seed pre-Phase-1 schema + one row, run \`init_db()\`, assert row preserved + \`local_*\` added + alembic stamped.
- \`PROXY_DB_URL\` precedence over \`MCP_PROXY_DATABASE_URL\`.
- Postgres parity test (gated on \`TEST_POSTGRES_URL\`, mirrors \`test_postgres_integration.py\` pattern).

## What this PR does NOT do
- Does not touch the Helm chart — Phase 1.4.
- Does not add a smoke Postgres variant — Phase 1.4.

## Verification
- \`pytest tests/test_proxy_migrations.py\`: **4/4 pass** (Postgres leg verified against an ephemeral Postgres 16 container, then SKIP path re-verified).
- \`pytest tests/ --ignore=tests/test_postgres_integration.py\`: **509 pass / 5 skip / 3 unrelated pre-existing failures** (\`test_spiffe.py\` on main).

## Test plan
- [ ] CI \`test (3.11)\` green (includes new \`test_proxy_migrations.py\`)
- [ ] CI \`smoke (ec/rsa)\` green — proxy boots via alembic now
- [ ] CI \`helm-test\` skipped (no \`deploy/helm/**\` change)
- [ ] CI \`Signed-off-by\` pass
- [ ] Manual: spin up the proxy on a fresh \`MCP_PROXY_DATABASE_URL\` and verify logs show "Database initialized (alembic upgrade head)"

Refs #34