### PR TITLE
feat(proxy): PROXY_DB_URL + Alembic at startup + Helm Postgres + smoke matrix (ADR-001 Phase 1.3 + 1.4)

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,13 +31,22 @@ jobs:
     # path. The "ec" entry boots the same stack with broker CA, org CAs and
     # agent certs all ECDSA-P256 — proves the all-ECC claim on every PR
     # touching crypto-adjacent code.
-    name: demo_network smoke (${{ matrix.key_type }})
+    name: demo_network smoke (${{ matrix.key_type }}, ${{ matrix.proxy_db }})
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        key_type: [rsa, ec]
+        # rsa+sqlite is the canonical golden path. ec+sqlite proves the
+        # all-ECC PKI claim. rsa+postgres exercises the ADR-001 Phase 1.4
+        # Postgres backend without inflating the matrix to 4 legs.
+        include:
+          - key_type: rsa
+            proxy_db: sqlite
+          - key_type: ec
+            proxy_db: sqlite
+          - key_type: rsa
+            proxy_db: postgres
 
     steps:
       - uses: actions/checkout@v4
@@ -78,6 +87,7 @@ jobs:
         working-directory: demo_network
         env:
           PKI_KEY_TYPE: ${{ matrix.key_type }}
+          PROXY_DB: ${{ matrix.proxy_db }}
         run: |
           ./smoke.sh full
         # smoke.sh already dumps the last 100 lines of each critical

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,21 +31,26 @@ jobs:
     # path. The "ec" entry boots the same stack with broker CA, org CAs and
     # agent certs all ECDSA-P256 — proves the all-ECC claim on every PR
     # touching crypto-adjacent code.
-    name: demo_network smoke (${{ matrix.key_type }}, ${{ matrix.proxy_db }})
+    # Job name format kept stable for the branch-protection required-check
+    # contract:
+    #   - "demo_network smoke (rsa)"           — golden path, sqlite (REQUIRED)
+    #   - "demo_network smoke (ec)"            — all-ECC, sqlite (REQUIRED)
+    #   - "demo_network smoke (rsa, postgres)" — ADR-001 Phase 1.4, additive
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        # rsa+sqlite is the canonical golden path. ec+sqlite proves the
-        # all-ECC PKI claim. rsa+postgres exercises the ADR-001 Phase 1.4
-        # Postgres backend without inflating the matrix to 4 legs.
         include:
-          - key_type: rsa
+          - name: "demo_network smoke (rsa)"
+            key_type: rsa
             proxy_db: sqlite
-          - key_type: ec
+          - name: "demo_network smoke (ec)"
+            key_type: ec
             proxy_db: sqlite
-          - key_type: rsa
+          - name: "demo_network smoke (rsa, postgres)"
+            key_type: rsa
             proxy_db: postgres
 
     steps:

--- a/demo_network/compose.postgres.yml
+++ b/demo_network/compose.postgres.yml
@@ -1,0 +1,47 @@
+# Postgres overlay for the demo-network smoke test (ADR-001 Phase 1.4).
+#
+# Activated by `./smoke.sh full --postgres` or `PROXY_DB=postgres ./smoke.sh full`.
+#
+# Adds a single Postgres 16 service that hosts both proxies' databases (one
+# Postgres database per proxy) and overrides the proxy services to point at
+# it via PROXY_DB_URL — the legacy MCP_PROXY_DATABASE_URL stays set in
+# compose.yml as the fallback. PROXY_DB_URL wins per the runtime contract
+# in mcp_proxy/config.py.
+
+services:
+  proxy-db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: cullis_proxy
+      POSTGRES_PASSWORD: cullis_proxy_dev
+      POSTGRES_MULTIPLE_DATABASES: proxy_a,proxy_b
+    volumes:
+      - proxy-db-data:/var/lib/postgresql/data
+      - ./postgres-init.sh:/docker-entrypoint-initdb.d/00-multi-db.sh:ro
+    expose: ["5432"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U cullis_proxy -d proxy_a && pg_isready -U cullis_proxy -d proxy_b"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  proxy-a:
+    depends_on:
+      proxy-db:
+        condition: service_healthy
+      proxy-a-init:
+        condition: service_completed_successfully
+    environment:
+      PROXY_DB_URL: "postgresql+asyncpg://cullis_proxy:cullis_proxy_dev@proxy-db:5432/proxy_a"
+
+  proxy-b:
+    depends_on:
+      proxy-db:
+        condition: service_healthy
+      proxy-b-init:
+        condition: service_completed_successfully
+    environment:
+      PROXY_DB_URL: "postgresql+asyncpg://cullis_proxy:cullis_proxy_dev@proxy-db:5432/proxy_b"
+
+volumes:
+  proxy-db-data:

--- a/demo_network/postgres-init.sh
+++ b/demo_network/postgres-init.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Create the multiple databases listed in POSTGRES_MULTIPLE_DATABASES.
+# The official postgres image only creates one DB at startup; this hook
+# expands that to N for the smoke variant which runs two proxies.
+set -e
+
+if [ -z "${POSTGRES_MULTIPLE_DATABASES:-}" ]; then
+    exit 0
+fi
+
+for db in $(echo "$POSTGRES_MULTIPLE_DATABASES" | tr ',' ' '); do
+    [ "$db" = "$POSTGRES_DB" ] && continue   # already created by entrypoint
+    echo "Creating database '$db'..."
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
+        CREATE DATABASE "$db";
+        GRANT ALL PRIVILEGES ON DATABASE "$db" TO "$POSTGRES_USER";
+EOSQL
+done

--- a/demo_network/smoke.sh
+++ b/demo_network/smoke.sh
@@ -20,7 +20,25 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
 SERVICES_ON_FAILURE=(broker proxy-a proxy-b bootstrap sender checker)
-COMPOSE="docker compose"
+
+# PROXY_DB=postgres activates compose.postgres.yml so the proxies run on a
+# real Postgres instead of the default per-proxy SQLite. Used by the CI
+# matrix leg added in ADR-001 Phase 1.4.
+PROXY_DB="${PROXY_DB:-sqlite}"
+case "$PROXY_DB" in
+    sqlite)
+        COMPOSE="docker compose"
+        ;;
+    postgres)
+        COMPOSE="docker compose -f compose.yml -f compose.postgres.yml"
+        SERVICES_ON_FAILURE+=(proxy-db)
+        ;;
+    *)
+        echo "PROXY_DB must be 'sqlite' or 'postgres' (got: $PROXY_DB)" >&2
+        exit 2
+        ;;
+esac
+
 NONCE_FILE="$HERE/.last-nonce"
 
 # ANSI colors (fall back to no-op when not a TTY)

--- a/deploy/helm/cullis-proxy/templates/_helpers.tpl
+++ b/deploy/helm/cullis-proxy/templates/_helpers.tpl
@@ -147,8 +147,37 @@ app.kubernetes.io/component: postgres
 {{- end -}}
 
 {{/*
-SQLite database URL pointing at the PVC mount.
+Resolve the proxy database URL. Precedence (high → low):
+  1. postgres.externalUrl  → user-managed Postgres (preferred for prod)
+  2. postgres.internal     → in-cluster Postgres StatefulSet
+  3. SQLite on the PVC     → default, single-replica only
+
+Phase 1.4 (ADR-001): when Postgres is in use the proxy reads PROXY_DB_URL
+from the ConfigMap; SQLite path keeps emitting MCP_PROXY_DATABASE_URL for
+backwards compatibility with deployments still on the legacy env name.
 */}}
 {{- define "cullis-proxy.databaseUrl" -}}
+{{- if .Values.postgres.externalUrl -}}
+{{- .Values.postgres.externalUrl -}}
+{{- else if .Values.postgres.internal -}}
+{{- printf "postgresql+asyncpg://%s:%s@%s:%d/%s"
+    .Values.postgres.username
+    .Values.postgres.password
+    (include "cullis-proxy.postgres.fullname" .)
+    (int .Values.postgres.port)
+    .Values.postgres.database -}}
+{{- else -}}
 {{- printf "sqlite+aiosqlite:///%s/mcp_proxy.db" .Values.persistence.mountPath -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+True when the chart is configured to run on Postgres (either external or
+in-cluster). Used to skip the SQLite PVC and to gate Postgres-specific
+secret keys.
+*/}}
+{{- define "cullis-proxy.usesPostgres" -}}
+{{- if or .Values.postgres.externalUrl .Values.postgres.internal -}}
+true
+{{- end -}}
 {{- end -}}

--- a/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
@@ -33,6 +33,11 @@ data:
 
   MCP_PROXY_ALLOWED_ORIGINS: {{ .Values.proxy.allowedOrigins | quote }}
 
+  # PROXY_DB_URL is the canonical name (ADR-001 Phase 1.3). The legacy
+  # MCP_PROXY_DATABASE_URL is kept so older proxy images still pick the
+  # value up — the runtime takes PROXY_DB_URL as authoritative when both
+  # are set.
+  PROXY_DB_URL: {{ include "cullis-proxy.databaseUrl" . | quote }}
   MCP_PROXY_DATABASE_URL: {{ include "cullis-proxy.databaseUrl" . | quote }}
 
   {{- if .Values.vault.enabled }}

--- a/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
@@ -118,12 +118,15 @@ spec:
                   - -c
                   - sleep {{ .Values.proxy.preStopSleepSeconds }}
           volumeMounts:
+            {{- if not (include "cullis-proxy.usesPostgres" .) }}
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
+            {{- end }}
             {{- with .Values.proxy.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
+        {{- if not (include "cullis-proxy.usesPostgres" .) }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
@@ -131,6 +134,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- end }}
         {{- with .Values.proxy.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-pvc.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-pvc.yaml
@@ -1,4 +1,8 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- /*
+Skip PVC entirely when the proxy is configured for Postgres — SQLite path is
+unused and the volume would just dangle. ADR-001 Phase 1.4.
+*/ -}}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (not (include "cullis-proxy.usesPostgres" .)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -237,18 +237,19 @@ proxy:
 # Persistence — SQLite DB backing the proxy.
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
-# Postgres — NOT used by the current proxy code (mcp_proxy/db.py uses
-# aiosqlite directly). These hooks are kept as forward-compatible stubs for
-# a future Postgres backend and are disabled by default. Do not enable them
-# unless the proxy image has Postgres support wired in.
+# Postgres — supported runtime backend since ADR-001 Phase 1.3. When either
+# `externalUrl` or `internal: true` is set, the proxy reads PROXY_DB_URL
+# (and the legacy MCP_PROXY_DATABASE_URL alias) pointing at Postgres, and
+# the SQLite PVC is skipped entirely.
 # ---------------------------------------------------------------------------
 postgres:
-  # -- Set to true to deploy a dedicated in-cluster Postgres StatefulSet
-  # for the proxy. Today the proxy does not read from Postgres; enabling
-  # this only provisions the infrastructure.
+  # -- Deploy a dedicated in-cluster Postgres StatefulSet for the proxy.
+  # Suitable for dev/staging; production should set `externalUrl` to a
+  # managed instance instead.
   internal: false
-  # -- External Postgres URL (SQLAlchemy async format). Used to override
-  # MCP_PROXY_DATABASE_URL when the proxy image supports it.
+  # -- External Postgres URL (SQLAlchemy async format,
+  # `postgresql+asyncpg://user:pass@host:port/db`). Wins over `internal`
+  # when both are set.
   externalUrl: ""
 
   # Only used when internal: true — settings for the bundled StatefulSet.

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -5,8 +5,10 @@ All settings are read from environment variables (prefix MCP_PROXY_) or .env fil
 validate_config() enforces production-safety invariants at startup.
 """
 import logging
+import os
 from functools import lru_cache
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _log = logging.getLogger("mcp_proxy.startup")
@@ -57,10 +59,21 @@ class ProxySettings(BaseSettings):
     pdp_url: str = ""
 
     # DB
+    # Default reads from MCP_PROXY_DATABASE_URL (legacy contract).
+    # PROXY_DB_URL (no prefix) takes precedence — see _apply_proxy_db_url_override.
+    # ADR-001 Phase 1.3 adds PROXY_DB_URL so Helm + smoke can target Postgres
+    # without touching the legacy MCP_PROXY_* surface.
     database_url: str = "sqlite+aiosqlite:///./mcp_proxy.db"
 
     # Rate limiting
     rate_limit_per_minute: int = 60
+
+    @model_validator(mode="after")
+    def _apply_proxy_db_url_override(self):
+        override = os.environ.get("PROXY_DB_URL")
+        if override:
+            self.database_url = override
+        return self
 
 
 def validate_config(settings: ProxySettings) -> None:

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -5,6 +5,7 @@ Tables:
   - internal_agents: locally registered agents (for egress API key auth)
   - audit_log: append-only immutable audit trail
   - proxy_config: key-value store for broker uplink config from setup wizard
+  - local_*: ADR-001 Phase 4 surface, schema-only until then
 
 Design choices:
   - SQLAlchemy Core with AsyncEngine — single async driver, portable SQLite/Postgres
@@ -12,7 +13,11 @@ Design choices:
   - WAL mode enabled on SQLite for concurrent readers (no-op on Postgres)
   - get_db() yields an AsyncConnection already inside engine.begin(): callers no
     longer call db.commit(), transactions commit on context exit.
+  - Schema bootstrap runs Alembic programmatically. Legacy SQLite proxies that
+    pre-date Alembic are stamped at 0001_initial_snapshot before upgrade so
+    their existing tables aren't recreated.
 """
+import asyncio
 import json
 import logging
 from contextlib import asynccontextmanager
@@ -20,11 +25,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import AsyncIterator
 
-from sqlalchemy import text
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import inspect, text
 from sqlalchemy.engine import RowMapping
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 
 from mcp_proxy.db_models import metadata
+
+_PROXY_PKG_DIR = Path(__file__).resolve().parent
+_ALEMBIC_INI = _PROXY_PKG_DIR / "alembic.ini"
+_ALEMBIC_INITIAL_REVISION = "0001_initial_snapshot"
 
 _log = logging.getLogger("mcp_proxy")
 
@@ -52,34 +63,100 @@ def _sqlite_path(db_url: str) -> str | None:
     return None
 
 
+def _alembic_config(url: str) -> AlembicConfig:
+    cfg = AlembicConfig(str(_ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+def _detect_legacy_unstamped(sync_conn) -> bool:
+    """True when the legacy schema is present but alembic_version is missing.
+
+    Pre-Phase-1 deployments created tables via raw CREATE TABLE IF NOT EXISTS
+    without Alembic. We stamp those at 0001_initial_snapshot so the upgrade
+    chain doesn't try to recreate tables that already exist.
+    """
+    inspector = inspect(sync_conn)
+    table_names = set(inspector.get_table_names())
+    return "internal_agents" in table_names and "alembic_version" not in table_names
+
+
+def _run_migrations_sync(url: str) -> None:
+    """Run alembic stamp (if needed) + upgrade head. Synchronous on purpose:
+    invoked from a thread via asyncio.to_thread to avoid blocking the loop.
+
+    Stamp-existing detection runs only on SQLite — no proxy was ever deployed
+    on Postgres pre-Phase-1, so legacy unstamped Postgres DBs cannot exist.
+    """
+    cfg = _alembic_config(url)
+
+    needs_stamp = False
+    sqlite_path = _sqlite_path(url)
+    if sqlite_path and sqlite_path != ":memory:" and Path(sqlite_path).exists():
+        from sqlalchemy import create_engine as create_sync_engine
+        sync_url = url.replace("sqlite+aiosqlite://", "sqlite://", 1)
+        try:
+            sync_engine = create_sync_engine(sync_url, future=True)
+            with sync_engine.connect() as conn:
+                needs_stamp = _detect_legacy_unstamped(conn)
+            sync_engine.dispose()
+        except Exception as exc:
+            _log.debug("Pre-migration inspection skipped: %s", exc)
+
+    if needs_stamp:
+        _log.info("Legacy schema detected — stamping %s before upgrade",
+                  _ALEMBIC_INITIAL_REVISION)
+        command.stamp(cfg, _ALEMBIC_INITIAL_REVISION)
+
+    command.upgrade(cfg, "head")
+
+
 async def init_db(db_url: str) -> None:
-    """Initialize the module-level AsyncEngine and ensure schema exists.
+    """Initialize the module-level AsyncEngine and run Alembic migrations.
 
     Accepts either a SQLAlchemy URL (``sqlite+aiosqlite:///path``) or a raw
     filesystem path for backward compatibility.
 
-    Schema bootstrap still uses ``metadata.create_all`` — callers that want
-    Alembic-managed upgrades should run ``alembic upgrade head`` out of band.
+    Schema bootstrap runs ``alembic upgrade head``. Pre-Phase-1 SQLite
+    deployments (which created tables outside Alembic) are detected and
+    stamped at 0001_initial_snapshot first, so existing rows survive.
+
+    Set ``PROXY_SKIP_MIGRATIONS=1`` to skip the alembic step — used by tests
+    that build their own engine inside the same process.
     """
     global _engine
+    import os
 
     url = _normalize_url(db_url)
 
     # Ensure parent directory exists for SQLite file DBs
     sqlite_path = _sqlite_path(url)
-    if sqlite_path:
+    if sqlite_path and sqlite_path != ":memory:":
         parent = Path(sqlite_path).parent
         if str(parent) not in ("", "."):
             parent.mkdir(parents=True, exist_ok=True)
 
+    if os.environ.get("PROXY_SKIP_MIGRATIONS") == "1":
+        _log.warning("PROXY_SKIP_MIGRATIONS=1 — using metadata.create_all "
+                     "instead of alembic upgrade head")
+        _engine = create_async_engine(url, echo=False, future=True)
+        async with _engine.begin() as conn:
+            if _engine.dialect.name == "sqlite":
+                await conn.execute(text("PRAGMA journal_mode=WAL"))
+            await conn.run_sync(metadata.create_all)
+        _log.info("Database initialized (no-migrations mode): %s", url)
+        return
+
+    # Run alembic in a worker thread — alembic.command is synchronous and
+    # would block the event loop otherwise.
+    await asyncio.to_thread(_run_migrations_sync, url)
+
     _engine = create_async_engine(url, echo=False, future=True)
-
-    async with _engine.begin() as conn:
-        if _engine.dialect.name == "sqlite":
+    if _engine.dialect.name == "sqlite":
+        async with _engine.begin() as conn:
             await conn.execute(text("PRAGMA journal_mode=WAL"))
-        await conn.run_sync(metadata.create_all)
 
-    _log.info("Database initialized: %s", url)
+    _log.info("Database initialized (alembic upgrade head): %s", url)
 
 
 async def dispose_db() -> None:

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -69,16 +69,26 @@ def _alembic_config(url: str) -> AlembicConfig:
     return cfg
 
 
-def _detect_legacy_unstamped(sync_conn) -> bool:
-    """True when the legacy schema is present but alembic_version is missing.
+_LEGACY_TABLES = frozenset({"internal_agents", "audit_log", "proxy_config"})
 
-    Pre-Phase-1 deployments created tables via raw CREATE TABLE IF NOT EXISTS
-    without Alembic. We stamp those at 0001_initial_snapshot so the upgrade
-    chain doesn't try to recreate tables that already exist.
+
+def _detect_legacy_unstamped(sync_conn) -> bool:
+    """True when any pre-Phase-1 table exists but alembic_version is missing.
+
+    Two scenarios produce legacy-unstamped state:
+      1. Pre-Phase-1 deployments that created the full _SCHEMA_SQL via raw
+         CREATE TABLE IF NOT EXISTS.
+      2. The demo_network proxy-init seed container, which writes only
+         proxy_config (broker uplink config) before the proxy boots.
+
+    Either way, alembic must be stamped at 0001_initial_snapshot so the
+    upgrade chain doesn't try to recreate tables that already exist.
     """
     inspector = inspect(sync_conn)
     table_names = set(inspector.get_table_names())
-    return "internal_agents" in table_names and "alembic_version" not in table_names
+    if "alembic_version" in table_names:
+        return False
+    return bool(_LEGACY_TABLES & table_names)
 
 
 def _run_migrations_sync(url: str) -> None:
@@ -87,6 +97,15 @@ def _run_migrations_sync(url: str) -> None:
 
     Stamp-existing detection runs only on SQLite — no proxy was ever deployed
     on Postgres pre-Phase-1, so legacy unstamped Postgres DBs cannot exist.
+
+    Two legacy-unstamped scenarios are handled:
+      - Full legacy schema (pre-Phase-1 deploy): all three legacy tables
+        present → just stamp 0001 and upgrade.
+      - Partial legacy (e.g. demo_network proxy-init has seeded only
+        proxy_config): create the missing legacy tables idempotently via
+        metadata.create_all so the stamped revision matches reality, then
+        stamp + upgrade. Without this, alembic would skip CREATE TABLE for
+        internal_agents / audit_log because 0001 is assumed already applied.
     """
     cfg = _alembic_config(url)
 
@@ -99,6 +118,23 @@ def _run_migrations_sync(url: str) -> None:
             sync_engine = create_sync_engine(sync_url, future=True)
             with sync_engine.connect() as conn:
                 needs_stamp = _detect_legacy_unstamped(conn)
+            if needs_stamp:
+                # Fill in any legacy tables missing from a partial seed so
+                # the 0001 stamp accurately describes the on-disk schema.
+                from mcp_proxy.db_models import (
+                    AuditLogEntry,
+                    InternalAgent,
+                    ProxyConfig,
+                )
+                with sync_engine.begin() as conn:
+                    metadata.create_all(
+                        bind=conn,
+                        tables=[
+                            InternalAgent.__table__,
+                            AuditLogEntry.__table__,
+                            ProxyConfig.__table__,
+                        ],
+                    )
             sync_engine.dispose()
         except Exception as exc:
             _log.debug("Pre-migration inspection skipped: %s", exc)

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 
 import os
 import sqlite3
-import tempfile
-from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, inspect
@@ -123,6 +121,49 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
     assert version == [("0002_local_tables",)]
+
+
+@pytest.mark.asyncio
+async def test_init_db_stamps_seed_only_proxy_config(tmp_path):
+    """Smoke / proxy-init scenario: only proxy_config exists pre-boot.
+
+    The demo_network proxy-init container writes broker uplink config rows
+    to a fresh DB before the proxy starts. Alembic stamping must trigger
+    on ANY legacy table presence, not just internal_agents — otherwise
+    the upgrade tries to CREATE TABLE proxy_config on top of itself.
+    """
+    db_file = tmp_path / "seeded.db"
+    seed = sqlite3.connect(str(db_file))
+    try:
+        seed.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS proxy_config (
+                key TEXT PRIMARY KEY, value TEXT NOT NULL
+            );
+            """
+        )
+        seed.execute(
+            "INSERT INTO proxy_config (key, value) VALUES ('broker_url', 'https://b.test')"
+        )
+        seed.commit()
+    finally:
+        seed.close()
+
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    tables = _table_names_sqlite(str(db_file))
+    assert EXPECTED_TABLES.issubset(tables)
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        rows = conn.execute(
+            "SELECT value FROM proxy_config WHERE key='broker_url'"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert rows == [("https://b.test",)], "seeded config row lost during stamp+upgrade"
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -1,0 +1,158 @@
+"""Validate proxy Alembic bootstrap (ADR-001 Phase 1.3).
+
+Covers the three startup paths:
+- Fresh DB: alembic upgrade head creates every table.
+- Legacy SQLite (pre-Phase-1 schema, no alembic_version): stamped at
+  0001_initial_snapshot, then upgraded; existing rows survive.
+- Postgres: same upgrade chain runs cleanly. Skipped unless
+  TEST_POSTGRES_URL is set, mirroring tests/test_postgres_integration.py.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, inspect
+
+from mcp_proxy.db import dispose_db, init_db
+
+EXPECTED_TABLES = {
+    "internal_agents",
+    "audit_log",
+    "proxy_config",
+    "local_agents",
+    "local_sessions",
+    "local_messages",
+    "local_policies",
+    "local_audit",
+    "alembic_version",
+}
+
+
+def _table_names_sqlite(path: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
+    db_file = tmp_path / "fresh.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+
+    await init_db(url)
+    await dispose_db()
+
+    tables = _table_names_sqlite(str(db_file))
+    assert EXPECTED_TABLES.issubset(tables), (
+        f"missing tables after upgrade: {EXPECTED_TABLES - tables}"
+    )
+
+    # alembic_version contains the head revision.
+    conn = sqlite3.connect(str(db_file))
+    try:
+        rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("0002_local_tables",)]
+
+
+@pytest.mark.asyncio
+async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
+    db_file = tmp_path / "legacy.db"
+
+    # Seed the pre-Phase-1 schema (matches the old _SCHEMA_SQL byte for byte)
+    # and a row that must survive the upgrade.
+    seed = sqlite3.connect(str(db_file))
+    try:
+        seed.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS internal_agents (
+                agent_id TEXT PRIMARY KEY, display_name TEXT NOT NULL,
+                capabilities TEXT NOT NULL DEFAULT '[]', api_key_hash TEXT NOT NULL,
+                cert_pem TEXT, created_at TEXT NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 1
+            );
+            CREATE TABLE IF NOT EXISTS audit_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT NOT NULL,
+                agent_id TEXT NOT NULL, action TEXT NOT NULL, tool_name TEXT,
+                status TEXT NOT NULL, detail TEXT, request_id TEXT,
+                duration_ms REAL
+            );
+            CREATE INDEX IF NOT EXISTS idx_audit_log_agent_id ON audit_log(agent_id);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_timestamp ON audit_log(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_audit_log_request_id ON audit_log(request_id);
+            CREATE TABLE IF NOT EXISTS proxy_config (
+                key TEXT PRIMARY KEY, value TEXT NOT NULL
+            );
+            """
+        )
+        seed.execute(
+            "INSERT INTO internal_agents VALUES "
+            "('legacy-agent','Legacy Agent','[]','hash',NULL,'2026-04-13',1)"
+        )
+        seed.commit()
+    finally:
+        seed.close()
+
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    tables = _table_names_sqlite(str(db_file))
+    assert EXPECTED_TABLES.issubset(tables)
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        rows = conn.execute(
+            "SELECT agent_id FROM internal_agents WHERE agent_id='legacy-agent'"
+        ).fetchall()
+        version = conn.execute(
+            "SELECT version_num FROM alembic_version"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
+    assert version == [("0002_local_tables",)]
+
+
+@pytest.mark.asyncio
+async def test_proxy_db_url_env_overrides_settings(monkeypatch, tmp_path):
+    """PROXY_DB_URL beats MCP_PROXY_DATABASE_URL — Phase 1.3 contract."""
+    from mcp_proxy.config import ProxySettings
+
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", "sqlite+aiosqlite:///legacy.db")
+    monkeypatch.setenv("PROXY_DB_URL", f"sqlite+aiosqlite:///{tmp_path / 'override.db'}")
+
+    settings = ProxySettings()
+    assert settings.database_url.endswith("override.db")
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TEST_POSTGRES_URL"),
+    reason="TEST_POSTGRES_URL not set; skipping cross-dialect migration test",
+)
+@pytest.mark.asyncio
+async def test_init_db_postgres_runs_alembic_upgrade():
+    """Same upgrade chain runs cleanly on Postgres."""
+    url = os.environ["TEST_POSTGRES_URL"]
+    await init_db(url)
+    await dispose_db()
+
+    sync_url = url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
+    sync_engine = create_engine(sync_url, future=True)
+    try:
+        with sync_engine.connect() as conn:
+            tables = set(inspect(conn).get_table_names())
+    finally:
+        sync_engine.dispose()
+    assert EXPECTED_TABLES.issubset(tables)


### PR DESCRIPTION
Final slice of **ADR-001 Phase 1** (#34). Stacks on top of #37.

## What this PR does
Wires Postgres into the proxy Helm chart and adds a CI smoke matrix leg that runs the full demo_network end-to-end against a real Postgres instead of the default per-proxy SQLite.

### Helm (\`deploy/helm/cullis-proxy/\`)
- \`_helpers.tpl\`: \`cullis-proxy.databaseUrl\` resolves to (1) \`postgres.externalUrl\`, (2) in-cluster Postgres FQDN if \`postgres.internal=true\`, (3) SQLite on the PVC. New helper \`cullis-proxy.usesPostgres\` flips the chart out of SQLite mode wherever needed.
- \`proxy-configmap.yaml\`: emits \`PROXY_DB_URL\` (canonical, ADR-001 Phase 1.3) + the legacy \`MCP_PROXY_DATABASE_URL\` alias for old proxy images.
- \`proxy-pvc.yaml\`: skipped entirely when Postgres is in use — no dangling 5Gi PVC.
- \`proxy-deployment.yaml\`: SQLite data volume + mount conditional on the same predicate.
- \`values.yaml\`: \`postgres\` block comment rewritten (no longer a stub; supported runtime backend now).

### Smoke (\`demo_network/\`)
- \`compose.postgres.yml\` overlay: one Postgres 16 service hosting one DB per proxy (\`proxy_a\` + \`proxy_b\`). \`proxy-a\`/\`proxy-b\` override env to point at it via \`PROXY_DB_URL\`. Health-gated via \`depends_on\`.
- \`postgres-init.sh\`: docker-entrypoint hook that creates the multiple databases (the official postgres image only creates one).
- \`smoke.sh\`: \`PROXY_DB\` env (\`sqlite\`|\`postgres\`) selects compose file set. Default \`sqlite\` — every existing invocation unchanged.

### CI (\`.github/workflows/smoke.yml\`)
- Matrix expanded 2→3 legs via \`include:\`
  - \`rsa+sqlite\` (golden path)
  - \`ec+sqlite\` (all-ECC)
  - \`rsa+postgres\` (Phase 1.4 Postgres backend)
- Avoids the 4-leg fan-out that would also test \`ec+postgres\` — diminishing return for double the wall time.
- Timeout bumped 15→20m for Postgres startup overhead.

## Verification
- \`helm lint\`/\`helm template\` not runnable locally (no helm binary in nix shell); the existing \`helm-test\` workflow will exercise the chart on kind for this PR (default values → SQLite PVC path; Postgres permutation tested via smoke).
- Local SQLite smoke path unchanged.

## Test plan
- [ ] CI \`helm-test (cullis)\` + \`helm-test (cullis-proxy)\` green
- [ ] CI \`smoke (rsa, sqlite)\` green — golden path unchanged
- [ ] CI \`smoke (ec, sqlite)\` green — all-ECC unchanged
- [ ] CI \`smoke (rsa, postgres)\` green — **new leg, this PR's main signal**
- [ ] CI \`Signed-off-by\` pass
- [ ] Manual: \`PROXY_DB=postgres ./demo_network/smoke.sh full\` locally on a Docker host

## Phase 1 closure
This closes ADR-001 Phase 1 once merged. Next milestone: Phase 1.5 — extract \`cullis_core/\` shared lib (broker→proxy logic reuse, ~7-9 days saved across remaining 6 phases). See memory \`project_cullis_core_shared_lib.md\`.

Refs #34