### PR TITLE
fix(deploy): proper --help in deploy_proxy.sh + default hint on BROKER_PUBLIC_URL prompt

### DIFF
--- a/deploy_proxy.sh
+++ b/deploy_proxy.sh
@@ -41,6 +41,32 @@ else
 fi
 
 # ── Parse args ──────────────────────────────────────────────────────────────
+print_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Deploys the MCP Proxy for one organization. Combines with --down / --rebuild
+for lifecycle management, and --standalone when the proxy runs on a different
+host than the broker.
+
+Options:
+  (no flags)                  Dev mode, same host as the broker (default)
+  --prod                      Production: fail-fast on insecure defaults,
+                              requires proxy.env pre-provisioned
+  --standalone                Proxy runs on a different host than the broker
+                              (reads BROKER_URL from proxy.env)
+  --down                      Stop and remove containers
+  --rebuild                   Rebuild images and restart
+  --help, -h                  Show this help and exit
+
+Examples:
+  ./deploy_proxy.sh                          # dev, same host as broker
+  ./deploy_proxy.sh --standalone             # dev, proxy on its own host
+  ./deploy_proxy.sh --prod --standalone      # prod, proxy on its own host
+  ./deploy_proxy.sh --down                   # stop + remove containers
+EOF
+}
+
 ACTION="up"
 MODE="development"
 STANDALONE=0
@@ -50,8 +76,7 @@ for arg in "$@"; do
         --rebuild)    ACTION="rebuild" ;;
         --prod)       MODE="production" ;;
         --standalone) STANDALONE=1 ;;
-        --help|-h)
-            sed -n '2,20p' "$0"; exit 0 ;;
+        --help|-h)    print_help; exit 0 ;;
         *) die "Unknown argument: $arg (use --help)" ;;
     esac
 done

--- a/scripts/generate-env.sh
+++ b/scripts/generate-env.sh
@@ -119,11 +119,12 @@ else
         echo ""
         echo "  Detected LAN IP: ${_DETECTED_IP}"
         echo "  Agents on other machines need BROKER_PUBLIC_URL to match their BROKER_URL."
+        echo "  If you're just trying Cullis on this machine, press Enter to accept option 1."
         echo ""
-        echo "  1) https://localhost:8443  (local only — agents on this machine)"
+        echo "  1) https://localhost:8443  (local only — agents on this machine) [default]"
         echo "  2) http://${_DETECTED_IP}:8000   (LAN — agents on other VMs, no TLS)"
         echo "  3) https://${_DETECTED_IP}:8443  (LAN — agents on other VMs, self-signed TLS)"
-        read -rp "  Choose BROKER_PUBLIC_URL [1/2/3]: " _url_choice
+        read -rp "  Choose BROKER_PUBLIC_URL [1/2/3, default 1]: " _url_choice
         case "$_url_choice" in
             2) BROKER_URL="http://${_DETECTED_IP}:8000" ;;
             3) BROKER_URL="https://${_DETECTED_IP}:8443" ;;


### PR DESCRIPTION
## Summary

Two trivial deploy-script UX fixes from the manual shake-out session (findings P1-01, P2-02 in \`imp/shake-out-notes.md\`).

### P1-01 — \`deploy_proxy.sh --help\`
Previously dumped the raw comment header via \`sed -n '2,20p' "\$0"\` — leading \`#\` markers, no Usage/Options/Examples structure, asymmetric with \`deploy_broker.sh --help\`. Replaced with a proper \`print_help()\` heredoc.

### P2-02 — \`BROKER_PUBLIC_URL\` prompt had no default hint
The \`Choose BROKER_PUBLIC_URL [1/2/3]\` interactive prompt in \`scripts/generate-env.sh\` didn't tell the user that pressing Enter falls through to option 1. Now prompt reads \`[1/2/3, default 1]\`, option 1 label ends with \`[default]\`, and an explainer line tells solo-host users to press Enter.

## Scope

- Single-purpose: only these two trivial wins.
- No functional change beyond UX copy.
- Group A (broker first-boot flow), Group B (frontend cleanup), Group C (deploy + CA generator) are in flight on separate branches.

## Test plan

- [ ] CI green (cosmetic change, should be a no-op for smoke)
- [ ] \`./deploy_proxy.sh --help\` prints Usage/Options/Examples (no \`#\` markers)
- [ ] Running \`./deploy_broker.sh --dev\` interactively and pressing Enter at the BROKER_PUBLIC_URL prompt picks option 1 (localhost:8443), as the copy now advertises