### PR TITLE
fix(ops): restart policy on all services + deploy_broker --down/--rebuild

### DIFF
--- a/deploy_broker.sh
+++ b/deploy_broker.sh
@@ -73,6 +73,7 @@ ARG_DOMAIN=""
 ARG_EMAIL=""
 ARG_CERT=""
 ARG_KEY=""
+ACTION="up"              # "up" | "down" | "rebuild"
 
 print_help() {
     cat <<EOF
@@ -86,11 +87,17 @@ Profiles (mutually exclusive):
   --prod-byoca                Production with Bring Your Own CA cert
                               Requires --domain, --cert, --key
 
+Lifecycle actions (mutually exclusive, no profile needed):
+  --down                      Stop + remove containers (volumes preserved)
+  --down --purge              Stop + remove containers AND volumes (data lost)
+  --rebuild                   Rebuild images and restart (use after git pull)
+
 Options:
   --domain <name>             FQDN for production deployment
   --email  <addr>             Email for Let's Encrypt notifications (--prod-acme only)
   --cert   <path>             Path to TLS certificate PEM (--prod-byoca only)
   --key    <path>             Path to TLS private key PEM (--prod-byoca only)
+  --purge                     With --down: also remove data volumes (destructive)
   --help, -h                  Show this help and exit
 
 Examples:
@@ -99,11 +106,15 @@ Examples:
   $0 --prod-byoca --domain broker.example.com \\
                   --cert /etc/ssl/cullis/fullchain.pem \\
                   --key  /etc/ssl/cullis/privkey.pem
+  $0 --down                   # stop containers, keep data
+  $0 --down --purge           # stop + wipe data volumes
+  $0 --rebuild                # rebuild images after git pull + restart
 
 When no profile is given, the script runs in interactive mode (legacy).
 EOF
 }
 
+PURGE=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dev)         MODE="development"; TLS_PROFILE="selfsigned"; shift ;;
@@ -114,6 +125,9 @@ while [[ $# -gt 0 ]]; do
         --email)       ARG_EMAIL="${2:-}"; shift 2 ;;
         --cert)        ARG_CERT="${2:-}"; shift 2 ;;
         --key)         ARG_KEY="${2:-}"; shift 2 ;;
+        --down)        ACTION="down"; shift ;;
+        --rebuild)     ACTION="rebuild"; shift ;;
+        --purge)       PURGE=1; shift ;;
         --help|-h)     print_help; exit 0 ;;
         *)             die "Unknown argument: $1 (use --help)" ;;
     esac
@@ -153,6 +167,35 @@ fi
 
 command -v openssl &>/dev/null  || die "openssl is not installed"
 ok "openssl found"
+
+# ─── Lifecycle short-circuits (down/rebuild) ─────────────────────────────────
+# These actions don't need TLS profiles, mode selection, or env generation —
+# they just wrap docker compose in the right project namespace.
+if [[ "$ACTION" == "down" ]]; then
+    step "Stopping broker"
+    if [[ $PURGE -eq 1 ]]; then
+        warn "--purge specified — data volumes will be removed (Postgres + Vault)"
+        $COMPOSE down -v
+        ok "Broker stopped and volumes purged"
+    else
+        $COMPOSE down
+        ok "Broker stopped (data volumes preserved — use --down --purge to wipe)"
+    fi
+    exit 0
+fi
+
+if [[ "$ACTION" == "rebuild" ]]; then
+    step "Rebuilding broker images"
+    [[ ! -f "$SCRIPT_DIR/.env" ]] && die ".env not found — run full deploy first (./deploy_broker.sh --dev or --prod-*)"
+    $COMPOSE build --pull
+    ok "Images rebuilt"
+    step "Restarting broker"
+    $COMPOSE up -d
+    ok "Broker restarted with new images"
+    warn "If Alembic migrations changed, they run automatically on broker startup — tail logs to confirm:"
+    echo "       $COMPOSE logs -f broker"
+    exit 0
+fi
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # 2. Interactive mode selection

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       timeout: 5s
       retries: 10
       start_period: 5s
+    restart: unless-stopped
 
   postgres:
     image: postgres:16-alpine
@@ -42,6 +43,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+    restart: unless-stopped
 
   redis:
     image: redis:7-alpine
@@ -50,6 +52,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+    restart: unless-stopped
 
   jaeger:
     image: jaegertracing/all-in-one:1.58
@@ -58,6 +61,7 @@ services:
       - "4317:4317"
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
+    restart: unless-stopped
 
   # Mock PDPs removed — each org runs its own PDP via the MCP Proxy.
   # See docker-compose.proxy.yml for the built-in PDP.
@@ -121,6 +125,7 @@ services:
       timeout: 5s
       retries: 12
       start_period: 15s
+    restart: unless-stopped
 
 volumes:
   postgres_data:


### PR DESCRIPTION
## Summary

Two ops findings from shake-out round 2 (retest after PR #45 landed).

### P0-13 — Services don't restart after VM reboot
\`docker-compose.yml\` had \`restart: unless-stopped\` only on nginx. After a reboot of the host, broker/postgres/vault/redis/jaeger all stayed stopped — the dashboard went dark and agents couldn't refresh tokens. Added the policy to all five.

### P1-14 — \`deploy_broker.sh\` has no lifecycle subcommands
PR #42 pinned the compose project to \`cullis-broker\` (to avoid volume collision with the demo), but that meant users running \`docker compose down\` from the repo root silently no-op'd and then got \"volume is in use\" when trying to \`docker volume rm\`. Added:

- \`--down\` → stop + remove containers (data preserved)
- \`--down --purge\` → stop + wipe volumes (destructive, opt-in)
- \`--rebuild\` → \`compose build --pull && up -d\`, the standard update path after \`git pull\`. Points users at \`compose logs -f broker\` to watch the Alembic migrations that run on startup.

## Impact

Closes the \"how do we handle reboot / how do we update\" question from the shake-out retest. Without these, a stranger who reboots their box or pulls latest is left to figure out Docker Compose internals on their own.

## Test plan

- [ ] CI green (compose + script changes, should be smoke-neutral)
- [ ] \`./deploy_broker.sh --help\` shows the new lifecycle section
- [ ] \`./deploy_broker.sh --down\` on a running broker stops it, volumes intact
- [ ] \`./deploy_broker.sh --down --purge\` stops AND wipes postgres data
- [ ] \`./deploy_broker.sh --rebuild\` on an existing \`.env\` rebuilds images + restarts (no prompt flow)
- [ ] After reboot, \`docker ps\` shows all six containers back up (not just nginx)