### PR TITLE
fix(proxy): point at cullis-broker_default network (shake-out P0-15)

### DIFF
--- a/deploy_proxy.sh
+++ b/deploy_proxy.sh
@@ -161,10 +161,12 @@ if [[ "$ACTION" == "rebuild" ]]; then
 fi
 
 # If shared-network, make sure the broker network exists; otherwise compose
-# will fail with an obtuse "network agent-trust_default not found".
+# will fail with an obtuse "network cullis-broker_default not found".
+# Network name derives from the broker's COMPOSE_PROJECT_NAME ("cullis-broker"
+# pinned in deploy_broker.sh per shake-out P0-03).
 if [[ $STANDALONE -eq 0 ]]; then
-    if ! docker network inspect agent-trust_default >/dev/null 2>&1; then
-        die "Network 'agent-trust_default' not found. Either start the broker first (./deploy_broker.sh) or rerun with --standalone for a remote broker."
+    if ! docker network inspect cullis-broker_default >/dev/null 2>&1; then
+        die "Network 'cullis-broker_default' not found. Either start the broker first (./deploy_broker.sh --dev) or rerun with --standalone for a remote broker."
     fi
 fi
 

--- a/docker-compose.proxy.standalone.yml
+++ b/docker-compose.proxy.standalone.yml
@@ -8,7 +8,7 @@
 #   ./deploy_proxy.sh --standalone
 #
 # What this changes vs the base compose:
-#   - Swaps the external "agent-trust_default" network (same-host assumption)
+#   - Swaps the external "cullis-broker_default" network (same-host assumption)
 #     for an internal bridge, so the proxy can start without the broker being
 #     on the same docker host.
 #   - Expects MCP_PROXY_BROKER_URL to be the broker's PUBLIC reachable URL

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -14,8 +14,10 @@
 #   ./deploy_proxy.sh --prod                # fail-fast on insecure defaults
 #
 # Prerequisites (shared mode):
-#   - Broker running on this host (docker compose up -d or ./deploy_broker.sh)
-#   - The network "agent-trust_default" must exist
+#   - Broker running on this host (./deploy_broker.sh --dev or --prod-*)
+#   - The network "cullis-broker_default" must exist (created by the
+#     broker compose project; name derives from COMPOSE_PROJECT_NAME
+#     which deploy_broker.sh pins to "cullis-broker")
 # =============================================================================
 
 services:
@@ -71,7 +73,7 @@ services:
 networks:
   broker_net:
     external: true
-    name: agent-trust_default
+    name: cullis-broker_default
 
 volumes:
   mcp_proxy_data:


### PR DESCRIPTION
## Summary

PR #42 pinned the broker's compose project to \`COMPOSE_PROJECT_NAME=cullis-broker\` to avoid a volume-name collision with the demo. That rename changed the broker's default network name from \`agent-trust_default\` to \`cullis-broker_default\`, but the proxy compose still referenced the old name as an external network.

Result: \`./deploy_proxy.sh\` on the same host as the broker fails immediately with \"network agent-trust_default declared as external, but could not be found\". This blocks shake-out Leg 3+.

Fix: update the external network name in \`docker-compose.proxy.yml\` + fix the docstrings in the standalone override too.

## Test plan

- [ ] CI green
- [ ] With a broker running from \`./deploy_broker.sh --dev\`, \`./deploy_proxy.sh\` now starts the proxy container without the \"network not found\" error