### PR TITLE
feat(proxy): network directory page for discovering remote agents

### DIFF
--- a/cullis_sdk/types.py
+++ b/cullis_sdk/types.py
@@ -18,6 +18,7 @@ class AgentInfo:
     capabilities: list[str] = field(default_factory=list)
     description: str | None = None
     status: str | None = None
+    agent_uri: str | None = None
 
     @classmethod
     def from_dict(cls, d: dict) -> AgentInfo:
@@ -28,6 +29,7 @@ class AgentInfo:
             capabilities=d.get("capabilities", []),
             description=d.get("description"),
             status=d.get("status"),
+            agent_uri=d.get("agent_uri"),
         )
 
 

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -8,6 +8,7 @@ Routes:
   /proxy/register        — One-shot: set the admin password (first run only)
   /proxy/setup           — Broker uplink wizard (URL + invite token, org details, CA, Vault)
   /proxy/agents          — Internal agent management
+  /proxy/network         — Network directory (discover remote agents via broker)
   /proxy/tools           — Tool registry viewer
   /proxy/policies        — Policy editor
   /proxy/audit           — Audit log viewer
@@ -1251,6 +1252,80 @@ async def tools_page(request: Request):
         request, session,
         active="tools",
         tools=tools,
+    ))
+
+
+@router.get("/network", response_class=HTMLResponse)
+async def network_page(request: Request):
+    """Network directory — discover agents across the trust network via broker."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.db import list_agents, get_config
+
+    q = (request.query_params.get("q") or "").strip() or None
+    pattern = (request.query_params.get("pattern") or "").strip() or None
+    org_filter = (request.query_params.get("org_id") or "").strip() or None
+    capabilities_raw = (request.query_params.get("capabilities") or "").strip()
+    capabilities = [c.strip() for c in capabilities_raw.split(",") if c.strip()] or None
+    include_own_org = request.query_params.get("include_own_org") == "on"
+    querier = (request.query_params.get("querier") or "").strip() or None
+    submitted = any(k in request.query_params for k in ("q", "pattern", "org_id", "capabilities"))
+
+    internal_agents = await list_agents()
+    own_org_id = await get_config("org_id") or ""
+    broker_url = await get_config("broker_url") or ""
+
+    bridge = getattr(request.app.state, "broker_bridge", None)
+
+    # Default querier: first active internal agent.
+    if not querier and internal_agents:
+        querier = next(
+            (a["agent_id"] for a in internal_agents if a.get("is_active", True)),
+            internal_agents[0]["agent_id"],
+        )
+
+    agents: list[dict] = []
+    error: str | None = None
+
+    if submitted:
+        if bridge is None:
+            error = "Broker bridge not initialized — complete the Setup wizard first."
+        elif not internal_agents:
+            error = "Create an internal agent first — discovery queries go through an agent identity."
+        elif not querier:
+            error = "Select a querier agent."
+        else:
+            try:
+                agents = await bridge.discover_agents(
+                    querier,
+                    capabilities=capabilities,
+                    q=q,
+                    org_id=org_filter,
+                    pattern=pattern,
+                )
+                if not include_own_org and own_org_id:
+                    agents = [a for a in agents if a.get("org_id") != own_org_id]
+            except Exception as exc:
+                _log.warning("Network directory query failed: %s", exc)
+                error = f"Discovery failed: {exc}"
+
+    return templates.TemplateResponse("network.html", _ctx(
+        request, session,
+        active="network",
+        internal_agents=internal_agents,
+        querier=querier,
+        q=q or "",
+        pattern=pattern or "",
+        org_filter=org_filter or "",
+        capabilities=capabilities_raw,
+        include_own_org=include_own_org,
+        submitted=submitted,
+        agents=agents,
+        own_org_id=own_org_id,
+        broker_url=broker_url,
+        error=error,
     ))
 
 

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -40,6 +40,11 @@
                 Agents
                 <span hx-get="/proxy/badge/agents" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
+            <a href="/proxy/network"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'network' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                Network
+            </a>
             <a href="/proxy/tools"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'tools' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/></svg>

--- a/mcp_proxy/dashboard/templates/network.html
+++ b/mcp_proxy/dashboard/templates/network.html
@@ -1,0 +1,161 @@
+{% extends "base.html" %}
+{% block title %}Network{% endblock %}
+{% block header_title %}Network Directory{% endblock %}
+{% block content %}
+<div class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Discover Agents</h2>
+            <p class="text-xs text-gray-600 mt-0.5">
+                Search the trust network via
+                {% if broker_url %}
+                <code class="font-mono text-gray-500">{{ broker_url }}</code>
+                {% else %}
+                <span class="text-amber-500">broker not configured</span>
+                {% endif %}
+            </p>
+        </div>
+    </div>
+
+    {% if error %}
+    <div class="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
+    {% endif %}
+
+    <!-- Search form -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-5 card-glow backdrop-blur-sm mb-6">
+        <form method="get" action="/proxy/network" class="space-y-4">
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">Free text</label>
+                    <input type="text" name="q" value="{{ q }}"
+                           placeholder="name, description, agent_id, org_id…"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white font-mono placeholder:text-gray-700 focus:border-accent-400/50 focus:outline-none">
+                </div>
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">Capabilities (AND, CSV)</label>
+                    <input type="text" name="capabilities" value="{{ capabilities }}"
+                           placeholder="order.read, invoice.write"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white font-mono placeholder:text-gray-700 focus:border-accent-400/50 focus:outline-none">
+                </div>
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">agent_id glob</label>
+                    <input type="text" name="pattern" value="{{ pattern }}"
+                           placeholder="italmetal::*"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white font-mono placeholder:text-gray-700 focus:border-accent-400/50 focus:outline-none">
+                </div>
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">Organization</label>
+                    <input type="text" name="org_id" value="{{ org_filter }}"
+                           placeholder="acme-corp"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white font-mono placeholder:text-gray-700 focus:border-accent-400/50 focus:outline-none">
+                </div>
+            </div>
+
+            <div class="flex flex-wrap items-end justify-between gap-4 pt-2">
+                <div class="flex flex-wrap items-center gap-4">
+                    <div>
+                        <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">Querier agent</label>
+                        <select name="querier"
+                                class="bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white font-mono focus:border-accent-400/50 focus:outline-none min-w-[14rem]">
+                            {% if not internal_agents %}
+                            <option value="">— no internal agents —</option>
+                            {% endif %}
+                            {% for a in internal_agents %}
+                            <option value="{{ a.agent_id }}" {% if a.agent_id == querier %}selected{% endif %}>
+                                {{ a.agent_id }}{% if not a.is_active %} (inactive){% endif %}
+                            </option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <label class="flex items-center gap-2 text-xs text-gray-400 pb-2.5">
+                        <input type="checkbox" name="include_own_org" {% if include_own_org %}checked{% endif %}
+                               class="w-3.5 h-3.5 rounded border-gray-700 bg-surface-950 text-accent-400 focus:ring-accent-400/30 focus:ring-offset-0">
+                        Include own org ({{ own_org_id or '—' }})
+                    </label>
+                </div>
+                <button type="submit"
+                        class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-accent-400/10 border border-accent-400/40 text-accent-400 rounded hover:bg-accent-400/20 transition-colors">
+                    <svg class="w-3.5 h-3.5 inline mr-1.5 -mt-px" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+                    Search
+                </button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Results -->
+    {% if submitted and not error %}
+    <div class="mb-3 flex items-center justify-between">
+        <h3 class="text-xs text-gray-500 uppercase tracking-wider">
+            {{ agents | length }} result{{ 's' if agents | length != 1 else '' }}
+        </h3>
+    </div>
+
+    {% if agents %}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {% for a in agents %}
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-5 card-glow backdrop-blur-sm">
+            <div class="flex items-start justify-between mb-2 gap-3">
+                <div class="min-w-0">
+                    <h3 class="text-sm font-mono font-medium text-white truncate">{{ a.display_name or a.agent_id }}</h3>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mt-0.5">{{ a.org_id }}</p>
+                </div>
+                {% if a.org_id == own_org_id %}
+                <span class="flex-shrink-0 px-2 py-0.5 rounded text-[10px] font-medium bg-accent-400/10 text-accent-400 uppercase tracking-wider">Own org</span>
+                {% endif %}
+            </div>
+
+            {% if a.description %}
+            <p class="text-xs text-gray-500 mb-3">{{ a.description }}</p>
+            {% endif %}
+
+            {% if a.agent_uri %}
+            <div class="mb-3">
+                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">SPIFFE URI</p>
+                <div class="flex items-center gap-2">
+                    <code class="flex-1 min-w-0 bg-surface-950 border border-gray-800/60 rounded px-2 py-1.5 text-[11px] font-mono text-accent-400 truncate">{{ a.agent_uri }}</code>
+                    <button type="button" onclick="copyToClipboard('{{ a.agent_uri }}')"
+                            class="flex-shrink-0 px-2 py-1.5 border border-gray-700 rounded text-xs text-gray-400 hover:text-white hover:bg-gray-800 transition-colors"
+                            title="Copy SPIFFE URI">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
+                    </button>
+                </div>
+            </div>
+            {% endif %}
+
+            <div>
+                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">agent_id</p>
+                <code class="block bg-surface-950 border border-gray-800/60 rounded px-2 py-1.5 text-[11px] font-mono text-gray-400 truncate">{{ a.agent_id }}</code>
+            </div>
+
+            {% if a.capabilities %}
+            <div class="mt-3">
+                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Capabilities</p>
+                <div class="flex flex-wrap gap-1">
+                    {% for cap in a.capabilities %}
+                    <span class="px-1.5 py-0.5 rounded text-[10px] font-mono bg-surface-950 text-gray-400 border border-gray-800/50">{{ cap }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-12 text-center backdrop-blur-sm">
+        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+        <p class="text-sm text-gray-500">No agents matched these filters.</p>
+        <p class="text-xs text-gray-600 mt-1">Try relaxing the filters, or toggle <span class="text-gray-400">Include own org</span>.</p>
+    </div>
+    {% endif %}
+    {% elif not submitted %}
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-12 text-center backdrop-blur-sm">
+        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        <p class="text-sm text-gray-500">Search the network by capability, SPIFFE pattern, organization, or free text.</p>
+        <p class="text-xs text-gray-600 mt-2 max-w-md mx-auto">Results come from the broker registry. Queries run under a selected internal agent identity — peers visible are those your org is bound to.</p>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -204,12 +204,14 @@ class BrokerBridge:
         agent_id: str,
         capabilities: list[str] | None = None,
         q: str | None = None,
+        org_id: str | None = None,
+        pattern: str | None = None,
     ) -> list[dict]:
         """Discover remote agents via broker."""
         client = await self.get_client(agent_id)
         try:
             agents = await asyncio.to_thread(
-                client.discover, capabilities, None, None, q,
+                client.discover, capabilities, org_id, pattern, q,
             )
             return [_agent_info_to_dict(a) for a in agents]
         except Exception as exc:
@@ -217,7 +219,7 @@ class BrokerBridge:
                 logger.warning("Auth error for %s, re-authenticating: %s", agent_id, exc)
                 client = await self._evict_and_retry(agent_id)
                 agents = await asyncio.to_thread(
-                    client.discover, capabilities, None, None, q,
+                    client.discover, capabilities, org_id, pattern, q,
                 )
                 return [_agent_info_to_dict(a) for a in agents]
             raise


### PR DESCRIPTION
## Summary
- New **/proxy/network** dashboard page that queries the broker registry for agents across the trust network, filterable by capability (AND), agent_id glob, org_id, or free text
- Each result shows the agent's **SPIFFE URI** with a one-click copy button — the intended flow is: operator finds a target, copies its SPIFFE URI, pastes it into instructions to an internal agent
- Queries run under an internal-agent identity (dropdown selector, defaults to first active agent) because the broker's `/registry/agents/search` requires an agent JWT
- "Include own org" toggle is off by default, matching the API default

## Changes
- `mcp_proxy/dashboard/router.py` — new `GET /proxy/network` handler
- `mcp_proxy/dashboard/templates/network.html` — new template (matches existing Tailwind design system)
- `mcp_proxy/dashboard/templates/base.html` — "Network" nav entry between Agents and Tools
- `mcp_proxy/egress/broker_bridge.py` — `discover_agents()` now accepts `org_id` and `pattern` (was: capabilities + q only)
- `cullis_sdk/types.py` — `AgentInfo` gains optional `agent_uri` field (broker already returns it; the SDK was dropping it)

## Motivation
The proxy advertised itself as giving operators a view of "the network", but the dashboard only listed **internal** agents. Network-wide discovery was reachable via the broker API and the SDK, but never surfaced in the UI. This closes that gap so an admin can point an agent at a peer via SPIFFE URI without reaching for the API directly.

## Test plan
- [x] Unit tests green (`tests/ -k "proxy or discover or agent_info or broker_bridge"` → 16 passed)
- [ ] Manual: open `/proxy/network`, run an empty-filter search, confirm querier dropdown populated from internal agents
- [ ] Manual: filter by `capability`, `pattern` (`italmetal::*`), `org_id`, and free-text — verify each combination
- [ ] Manual: copy SPIFFE URI button places text in clipboard (toast confirms)
- [ ] Manual: toggling "Include own org" adds/removes own-org rows
- [ ] Shake-out Leg 3 validation: use copied SPIFFE URI as target of a session from the querier agent