### PR TITLE
fix(tests): align test_spiffe integration cases with cullis.local default

### DIFF
--- a/tests/test_spiffe.py
+++ b/tests/test_spiffe.py
@@ -142,7 +142,7 @@ async def _register_agent_with_spiffe(
     client: AsyncClient,
     agent_id: str,
     org_id: str,
-    trust_domain: str = "atn.local",
+    trust_domain: str = "cullis.local",
 ):
     """Registra org + CA + agente + binding approvato, con SAN SPIFFE nel cert."""
     org_secret = org_id + "-secret"
@@ -184,7 +184,7 @@ async def test_jwt_sub_e_spiffe_id(client: AsyncClient, dpop):
     """
     agent_id = "spiffe-jwt-org::agent-1"
     org_id = "spiffe-jwt-org"
-    trust_domain = "atn.local"
+    trust_domain = "cullis.local"
 
     await _register_agent_with_spiffe(client, agent_id, org_id, trust_domain)
 
@@ -247,7 +247,7 @@ async def test_autenticazione_con_san_corretto(client: AsyncClient, dpop):
 
     await _register_agent_with_spiffe(client, agent_id, org_id)
 
-    assertion = make_assertion(agent_id, org_id, trust_domain="atn.local")
+    assertion = make_assertion(agent_id, org_id, trust_domain="cullis.local")
     proof = dpop.proof("POST", "/v1/auth/token")
     resp = await client.post(
         "/v1/auth/token",
@@ -316,7 +316,7 @@ async def test_registry_espone_agent_uri(client: AsyncClient, dpop):
     await _register_agent_with_spiffe(client, agent_id, org_id)
 
     # Ottieni token per fare la query
-    token = await dpop.get_token(client, agent_id, org_id, trust_domain="atn.local")
+    token = await dpop.get_token(client, agent_id, org_id, trust_domain="cullis.local")
 
     resp = await client.get(
         "/v1/registry/agents",
@@ -328,4 +328,4 @@ async def test_registry_espone_agent_uri(client: AsyncClient, dpop):
     agent = next(a for a in agents if a["agent_id"] == agent_id)
     assert "agent_uri" in agent
     assert agent["agent_uri"].startswith("spiffe://")
-    assert agent["agent_uri"] == f"spiffe://atn.local/{org_id}/agent-1"
+    assert agent["agent_uri"] == f"spiffe://cullis.local/{org_id}/agent-1"


### PR DESCRIPTION
## Summary
Four integration cases in `tests/test_spiffe.py` hardcode `trust_domain="atn.local"`, but the broker under test defaults to `cullis.local` since commit `12ac626` (rename `atn.* → cullis.*`). The rename landed `app/config.py` on main but never landed `tests/test_spiffe.py`. Result: the SPIFFE SAN check fails with `401 "SPIFFE ID in SAN does not match the registered agent"` on those four cases.

## Changes
- `_register_agent_with_spiffe` default fixture → `cullis.local`
- `test_jwt_sub_e_spiffe_id` trust_domain → `cullis.local`
- `test_autenticazione_con_san_corretto` → `cullis.local`
- `test_registry_espone_agent_uri` → `cullis.local` (both in `get_token` call and in the `agent_uri` assertion)

## Not changed
- Pure-string unit tests (lines 24–134): use `atn.local` as an arbitrary parameter to mapping functions, no broker involvement — keep unchanged to minimise churn.
- `test_autenticazione_fallisce_con_san_sbagliato`: uses `evil.example.com` as intentional mismatch, correctly still asserts 401.

## Test plan
- [x] `pytest tests/test_spiffe.py` → 24/24 green (was 21/24 on main)
- [ ] CI full suite green