### PR TITLE
feat(proxy): ADR-001 Phase 2 — SPIFFE routing decision (flag-gated)

### DIFF
--- a/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
@@ -31,6 +31,12 @@ data:
   MCP_PROXY_ORG_ID: {{ .Values.proxy.orgId | quote }}
   {{- end }}
 
+  # ADR-001 Phase 2 — SPIFFE routing decision. trust_domain is the SPIFFE
+  # trust domain this proxy serves; intra_org_routing gates the new routing
+  # decision (default off — Phase 3 wires real local delivery).
+  PROXY_TRUST_DOMAIN: {{ .Values.proxy.trustDomain | default "cullis.local" | quote }}
+  PROXY_INTRA_ORG: {{ .Values.proxy.intraOrgRouting | default false | quote }}
+
   MCP_PROXY_ALLOWED_ORIGINS: {{ .Values.proxy.allowedOrigins | quote }}
 
   # PROXY_DB_URL is the canonical name (ADR-001 Phase 1.3). The legacy

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -69,6 +69,17 @@ proxy:
   # configured through the setup wizard (DB-resident).
   orgId: ""
 
+  # -- SPIFFE trust domain this proxy serves (ADR-001 Phase 2). Used by
+  # the routing decision to classify recipients as intra vs cross-org.
+  # Must match the trust domain configured on the broker.
+  trustDomain: "cullis.local"
+
+  # -- Feature flag for intra-org routing decision (ADR-001 Phase 2).
+  # When false (default) every message forwards to the broker as today.
+  # When true, intra-org targets are short-circuited with 501 until
+  # Phase 3 wires real local delivery — do NOT flip until Phase 3 lands.
+  intraOrgRouting: false
+
   # -- Comma-separated CORS origins allowed to call the proxy dashboard.
   # Empty = no CORS middleware (fail-safe).
   allowedOrigins: ""

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -68,11 +68,30 @@ class ProxySettings(BaseSettings):
     # Rate limiting
     rate_limit_per_minute: int = 60
 
+    # ADR-001 Phase 2 — SPIFFE routing decision.
+    # trust_domain is the SPIFFE trust domain this proxy serves (matched against
+    # recipient SPIFFE IDs to decide intra vs cross-org). intra_org_routing is
+    # the feature flag; when false (default) behavior is unchanged and every
+    # message forwards to the broker. When true, intra-org targets are
+    # short-circuited with 501 until Phase 3 wires real local delivery.
+    trust_domain: str = "cullis.local"
+    intra_org_routing: bool = False
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")
         if override:
             self.database_url = override
+        return self
+
+    @model_validator(mode="after")
+    def _apply_routing_overrides(self):
+        td = os.environ.get("PROXY_TRUST_DOMAIN")
+        if td:
+            self.trust_domain = td
+        flag = os.environ.get("PROXY_INTRA_ORG")
+        if flag is not None:
+            self.intra_org_routing = flag.lower() in ("1", "true", "yes", "on")
         return self
 
 

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -9,7 +9,10 @@ import asyncio
 import logging
 from typing import Any
 
+from fastapi import HTTPException
+
 from cullis_sdk.client import CullisClient
+from mcp_proxy.egress.routing import decide_route
 
 logger = logging.getLogger("mcp_proxy.egress.broker_bridge")
 
@@ -22,11 +25,22 @@ class BrokerBridge:
     Clients are lazily initialized and cached.
     """
 
-    def __init__(self, broker_url: str, org_id: str, agent_manager: Any, *, verify_tls: bool = True):
+    def __init__(
+        self,
+        broker_url: str,
+        org_id: str,
+        agent_manager: Any,
+        *,
+        verify_tls: bool = True,
+        trust_domain: str = "cullis.local",
+        intra_org_routing: bool = False,
+    ):
         self._broker_url = broker_url
         self._org_id = org_id
         self._agent_manager = agent_manager
         self._verify_tls = verify_tls
+        self._trust_domain = trust_domain
+        self._intra_org_routing = intra_org_routing
         self._clients: dict[str, CullisClient] = {}
         self._lock = asyncio.Lock()
 
@@ -115,7 +129,29 @@ class BrokerBridge:
         payload: dict,
         recipient_agent_id: str,
     ) -> None:
-        """Send E2E encrypted message via broker on behalf of internal agent."""
+        """Send E2E encrypted message via broker on behalf of internal agent.
+
+        ADR-001 Phase 2: when the `intra_org_routing` flag is enabled and the
+        recipient resolves to the same (trust_domain, org), short-circuit with
+        501 — real local delivery lands in Phase 3. When the flag is off
+        (default) behavior is unchanged and everything forwards to the broker.
+        """
+        if self._intra_org_routing:
+            route = decide_route(
+                recipient_agent_id,
+                local_org=self._org_id,
+                local_trust_domain=self._trust_domain,
+            )
+            if route == "intra":
+                logger.info(
+                    "intra_org_routing_pending: sender=%s recipient=%s session=%s",
+                    agent_id, recipient_agent_id, session_id,
+                )
+                raise HTTPException(
+                    status_code=501,
+                    detail="intra-org routing not implemented (ADR-001 Phase 3)",
+                )
+
         client = await self.get_client(agent_id)
         try:
             await asyncio.to_thread(

--- a/mcp_proxy/egress/routing.py
+++ b/mcp_proxy/egress/routing.py
@@ -1,0 +1,43 @@
+"""
+Egress routing decision — ADR-001 Phase 2.
+
+Given a recipient identifier and the proxy's local (trust_domain, org),
+return whether the message should route intra-org (future local delivery,
+Phase 3) or cross-org (forward to broker — today's only path).
+
+The decision is pure and has no side effects. Callers gate on the feature
+flag `MCP_PROXY_INTRA_ORG_ROUTING` before acting on the intra verdict.
+"""
+from typing import Literal
+
+from mcp_proxy.spiffe import InvalidRecipient, parse_recipient
+
+Route = Literal["intra", "cross"]
+
+
+def decide_route(
+    recipient_id: str,
+    local_org: str,
+    local_trust_domain: str,
+) -> Route:
+    """Classify the recipient as intra-org or cross-org.
+
+    Rules:
+      - SPIFFE recipient: intra iff trust_domain AND org both match local.
+      - Internal `org::agent` recipient: trust domain is implicit-local, so
+        intra iff org matches local.
+      - Unparseable recipient: treated as cross-org (safe default — the
+        broker will reject downstream if it's also invalid).
+    """
+    try:
+        trust_domain, org, _agent = parse_recipient(recipient_id)
+    except InvalidRecipient:
+        return "cross"
+
+    if org != local_org:
+        return "cross"
+
+    if trust_domain is not None and trust_domain != local_trust_domain:
+        return "cross"
+
+    return "intra"

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -81,16 +81,21 @@ async def lifespan(app: FastAPI):
     if broker_url:
         from mcp_proxy.egress.agent_manager import AgentManager
         from mcp_proxy.egress.broker_bridge import BrokerBridge
-        agent_mgr = AgentManager(org_id=org_id)
+        agent_mgr = AgentManager(org_id=org_id, trust_domain=settings.trust_domain)
         await agent_mgr.load_org_ca_from_config()
         bridge = BrokerBridge(
             broker_url=broker_url,
             org_id=org_id,
             agent_manager=agent_mgr,
             verify_tls=settings.broker_verify_tls,
+            trust_domain=settings.trust_domain,
+            intra_org_routing=settings.intra_org_routing,
         )
         app.state.broker_bridge = bridge
-        _log.info("BrokerBridge initialized (broker=%s, org=%s)", broker_url, org_id)
+        _log.info(
+            "BrokerBridge initialized (broker=%s, org=%s, trust_domain=%s, intra_org=%s)",
+            broker_url, org_id, settings.trust_domain, settings.intra_org_routing,
+        )
     else:
         _log.warning("No broker_url configured — egress endpoints will return 503")
 

--- a/mcp_proxy/spiffe.py
+++ b/mcp_proxy/spiffe.py
@@ -1,0 +1,81 @@
+"""
+SPIFFE parsing utilities for the proxy.
+
+Mirrors the subset of app/spiffe.py needed by the egress routing decision
+(ADR-001 Phase 2). Kept proxy-local to preserve the broker↔proxy module
+boundary; the future cullis_core shared library (roadmap Phase 1.5) will
+dedupe both copies.
+
+Accepts two recipient formats used across the codebase:
+  - SPIFFE URI:    spiffe://<trust-domain>/<org>/<agent>
+  - Internal form: <org>::<agent>   (no trust domain — assumed local)
+"""
+import re
+from urllib.parse import urlparse
+
+_SPIFFE_SCHEME = "spiffe"
+_TRUST_DOMAIN_RE = re.compile(r"^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$")
+_PATH_COMPONENT_RE = re.compile(r"^[a-zA-Z0-9\-_\.]+$")
+
+
+class InvalidRecipient(ValueError):
+    """Raised when a recipient identifier cannot be parsed."""
+
+
+def _is_spiffe(recipient_id: str) -> bool:
+    return recipient_id.startswith("spiffe://")
+
+
+def parse_spiffe(spiffe_id: str) -> tuple[str, str, str]:
+    """Parse a SPIFFE URI into (trust_domain, org, agent).
+
+    Raises InvalidRecipient on malformed input.
+    """
+    parsed = urlparse(spiffe_id)
+    if parsed.scheme != _SPIFFE_SCHEME:
+        raise InvalidRecipient(f"not a SPIFFE URI: {spiffe_id!r}")
+    trust_domain = parsed.netloc
+    if not trust_domain or not _TRUST_DOMAIN_RE.match(trust_domain):
+        raise InvalidRecipient(f"invalid trust domain: {trust_domain!r}")
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 2:
+        raise InvalidRecipient(
+            f"SPIFFE path must have 2 components (org/agent), got {len(parts)}"
+        )
+    org, agent = parts
+    for name, value in (("org", org), ("agent", agent)):
+        if not value or not _PATH_COMPONENT_RE.match(value):
+            raise InvalidRecipient(f"invalid {name} component: {value!r}")
+    if parsed.query or parsed.fragment:
+        raise InvalidRecipient("SPIFFE URI must not have query or fragment")
+    return trust_domain, org, agent
+
+
+def parse_internal(internal_id: str) -> tuple[str, str]:
+    """Parse an internal `org::agent` identifier into (org, agent).
+
+    Raises InvalidRecipient if the separator is missing or components empty.
+    """
+    parts = internal_id.split("::", 1)
+    if len(parts) != 2:
+        raise InvalidRecipient(
+            f"internal id must be 'org::agent', got {internal_id!r}"
+        )
+    org, agent = parts
+    if not org or not agent:
+        raise InvalidRecipient(f"empty component in internal id: {internal_id!r}")
+    return org, agent
+
+
+def parse_recipient(recipient_id: str) -> tuple[str | None, str, str]:
+    """Parse either form into (trust_domain | None, org, agent).
+
+    Returns None as trust_domain for internal format — callers should treat
+    that as "assumed local trust domain".
+    """
+    if not recipient_id:
+        raise InvalidRecipient("empty recipient id")
+    if _is_spiffe(recipient_id):
+        return parse_spiffe(recipient_id)
+    org, agent = parse_internal(recipient_id)
+    return None, org, agent

--- a/tests/test_proxy_routing.py
+++ b/tests/test_proxy_routing.py
@@ -10,7 +10,7 @@ Verifies:
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi import HTTPException

--- a/tests/test_proxy_routing.py
+++ b/tests/test_proxy_routing.py
@@ -1,0 +1,195 @@
+"""ADR-001 Phase 2 — SPIFFE routing decision in the proxy.
+
+Verifies:
+  - `mcp_proxy.spiffe.parse_recipient` accepts both SPIFFE URIs and the
+    internal `org::agent` form, rejects malformed input.
+  - `mcp_proxy.egress.routing.decide_route` classifies recipients as intra
+    vs cross-org correctly.
+  - `BrokerBridge.send_message` honors the `intra_org_routing` feature flag:
+    off → forwards; on + intra → 501; on + cross → forwards.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from mcp_proxy.egress.broker_bridge import BrokerBridge
+from mcp_proxy.egress.routing import decide_route
+from mcp_proxy.spiffe import InvalidRecipient, parse_recipient
+
+
+# ── parse_recipient ──────────────────────────────────────────────────
+
+def test_parse_recipient_spiffe():
+    td, org, agent = parse_recipient("spiffe://cullis.local/acme/sales-bot")
+    assert (td, org, agent) == ("cullis.local", "acme", "sales-bot")
+
+
+def test_parse_recipient_internal():
+    td, org, agent = parse_recipient("acme::sales-bot")
+    assert td is None
+    assert (org, agent) == ("acme", "sales-bot")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "spiffe://",
+        "spiffe:///acme/bot",
+        "spiffe://cullis.local/toomany/levels/here",
+        "spiffe://cullis.local/onlyorg",
+        "spiffe://CULLIS.LOCAL/acme/bot",  # trust domain must be lowercase
+        "acme::",
+        "::bot",
+        "no-separator",
+        "spiffe://cullis.local/acme/bot?query=1",
+    ],
+)
+def test_parse_recipient_invalid(bad):
+    with pytest.raises(InvalidRecipient):
+        parse_recipient(bad)
+
+
+# ── decide_route ─────────────────────────────────────────────────────
+
+def test_decide_route_intra_spiffe_match():
+    assert decide_route(
+        "spiffe://cullis.local/acme/bot",
+        local_org="acme",
+        local_trust_domain="cullis.local",
+    ) == "intra"
+
+
+def test_decide_route_intra_internal_match():
+    assert decide_route(
+        "acme::bot",
+        local_org="acme",
+        local_trust_domain="cullis.local",
+    ) == "intra"
+
+
+def test_decide_route_cross_different_org():
+    assert decide_route(
+        "spiffe://cullis.local/beta-corp/bot",
+        local_org="acme",
+        local_trust_domain="cullis.local",
+    ) == "cross"
+
+
+def test_decide_route_cross_different_trust_domain():
+    assert decide_route(
+        "spiffe://beta-corp.com/acme/bot",
+        local_org="acme",
+        local_trust_domain="cullis.local",
+    ) == "cross"
+
+
+def test_decide_route_internal_different_org():
+    assert decide_route(
+        "beta-corp::bot",
+        local_org="acme",
+        local_trust_domain="cullis.local",
+    ) == "cross"
+
+
+def test_decide_route_unparseable_falls_through_to_cross():
+    # Safe default: let the broker reject malformed ids downstream.
+    assert decide_route(
+        "not a valid id",
+        local_org="acme",
+        local_trust_domain="cullis.local",
+    ) == "cross"
+
+
+# ── BrokerBridge.send_message feature flag ───────────────────────────
+
+def _make_bridge(*, intra_org_routing: bool) -> BrokerBridge:
+    bridge = BrokerBridge(
+        broker_url="https://broker.test",
+        org_id="acme",
+        agent_manager=MagicMock(),
+        trust_domain="cullis.local",
+        intra_org_routing=intra_org_routing,
+    )
+    # Inject a fake authenticated client so we don't touch the real network.
+    fake_client = MagicMock()
+    fake_client.send = MagicMock(return_value=None)
+    bridge._clients["sender-bot"] = fake_client
+    return bridge
+
+
+@pytest.mark.asyncio
+async def test_send_message_flag_off_forwards_even_for_intra_target():
+    bridge = _make_bridge(intra_org_routing=False)
+    await bridge.send_message(
+        agent_id="sender-bot",
+        session_id="sess-1",
+        payload={"hello": "world"},
+        recipient_agent_id="acme::peer-bot",
+    )
+    bridge._clients["sender-bot"].send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_message_flag_on_intra_raises_501():
+    bridge = _make_bridge(intra_org_routing=True)
+    with pytest.raises(HTTPException) as exc:
+        await bridge.send_message(
+            agent_id="sender-bot",
+            session_id="sess-1",
+            payload={"hello": "world"},
+            recipient_agent_id="acme::peer-bot",
+        )
+    assert exc.value.status_code == 501
+    assert "Phase 3" in exc.value.detail
+    bridge._clients["sender-bot"].send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_message_flag_on_cross_forwards():
+    bridge = _make_bridge(intra_org_routing=True)
+    await bridge.send_message(
+        agent_id="sender-bot",
+        session_id="sess-1",
+        payload={"hello": "world"},
+        recipient_agent_id="beta-corp::peer-bot",
+    )
+    bridge._clients["sender-bot"].send.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_send_message_flag_on_spiffe_cross_trust_domain_forwards():
+    bridge = _make_bridge(intra_org_routing=True)
+    await bridge.send_message(
+        agent_id="sender-bot",
+        session_id="sess-1",
+        payload={"hello": "world"},
+        recipient_agent_id="spiffe://beta-corp.com/acme/peer-bot",
+    )
+    # Same org string "acme" but different trust domain → cross → forward.
+    bridge._clients["sender-bot"].send.assert_called_once()
+
+
+# ── Config flag parsing ──────────────────────────────────────────────
+
+def test_proxy_settings_env_overrides(monkeypatch):
+    from mcp_proxy.config import ProxySettings
+
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "acme.com")
+    settings = ProxySettings()
+    assert settings.intra_org_routing is True
+    assert settings.trust_domain == "acme.com"
+
+
+def test_proxy_settings_flag_defaults_off(monkeypatch):
+    from mcp_proxy.config import ProxySettings
+
+    monkeypatch.delenv("PROXY_INTRA_ORG", raising=False)
+    monkeypatch.delenv("PROXY_TRUST_DOMAIN", raising=False)
+    settings = ProxySettings()
+    assert settings.intra_org_routing is False
+    assert settings.trust_domain == "cullis.local"


### PR DESCRIPTION
## Summary

Implements **Phase 2** of ADR-001: adds the SPIFFE routing decision and feature-flag plumbing in the proxy, without changing any live routing yet.

- `PROXY_INTRA_ORG=false` (default) → behavior unchanged, every message forwards to the broker as today
- `PROXY_INTRA_ORG=true` → intra-org targets (same trust_domain + same org) short-circuit with HTTP 501 until Phase 3 wires real local delivery

Closes #51. Refs `imp/adr_001_intra_org_routing.md` §5 Phase 2 (reordered 2026-04-14 — Guardian moved to Phase 5).

## Files
- `mcp_proxy/spiffe.py` — parser for SPIFFE (`spiffe://td/org/agent`) and internal (`org::agent`) forms
- `mcp_proxy/egress/routing.py` — pure `decide_route` helper
- `mcp_proxy/egress/broker_bridge.py` — `send_message` gated on flag; 501 on intra when enabled
- `mcp_proxy/config.py` — `trust_domain` + `intra_org_routing` in `ProxySettings`; `PROXY_TRUST_DOMAIN` / `PROXY_INTRA_ORG` env overrides
- `mcp_proxy/main.py` — wires settings through to `BrokerBridge` + `AgentManager`
- `deploy/helm/cullis-proxy/` — `trustDomain` / `intraOrgRouting` in `values.yaml` → configmap env vars
- `tests/test_proxy_routing.py` — 24 tests

## Test plan
- [x] `pytest tests/test_proxy_routing.py` — 24/24 green
- [x] Full `pytest tests/` (no e2e) — 429 passed, 1 pre-existing failure (`test_postgres_integration::test_pg_session_and_signed_messages`, also red on `main`), 4 skipped
- [x] `./demo_network/smoke.sh full` — PASS (flag at default off)
- [ ] CI: helm-test, demo_network smoke matrix, test (3.11), security, DCO

## Out of scope (future phases)
- Real intra-org delivery (Phase 3 — M3-twin proxy, message queue, local sessions)
- Sync broker↔proxy SSE (Phase 4)
- Guardian inspection (Phase 5 — moved from Phase 2 on 2026-04-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)