### PR TITLE
feat(proxy): ADR-001 Phase 3a — local session lifecycle (intra-org)

### DIFF
--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -15,7 +15,16 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from mcp_proxy.auth.api_key import get_agent_from_api_key
+from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
+from mcp_proxy.egress.routing import decide_route
+from mcp_proxy.local.models import SessionCloseReason
+from mcp_proxy.local.persistence import save_session as save_local_session
+from mcp_proxy.local.session import (
+    LocalAgentSessionCapExceeded,
+    LocalSession,
+    LocalSessionStore,
+)
 from mcp_proxy.models import InternalAgent
 
 logger = logging.getLogger("mcp_proxy.egress.router")
@@ -85,6 +94,47 @@ def _get_bridge(request: Request):
     return bridge
 
 
+def _get_local_store(request: Request) -> LocalSessionStore | None:
+    """Return the local session store when ADR-001 Phase 3 is active."""
+    return getattr(request.app.state, "local_session_store", None)
+
+
+def _should_route_intra(recipient_agent_id: str, target_org_id: str = "") -> bool:
+    """Check whether the caller should be routed by the local store.
+
+    Called from each session endpoint before falling through to the
+    broker bridge. When PROXY_INTRA_ORG is off, always false (preserves
+    the pre-Phase-2 behavior). When on, the session-open path prefers
+    the explicit target_org_id (authoritative from the caller's intent);
+    other paths fall back to the SPIFFE-driven decide_route helper.
+    """
+    settings = get_settings()
+    if not settings.intra_org_routing:
+        return False
+    if target_org_id:
+        return target_org_id == settings.org_id
+    route = decide_route(
+        recipient_agent_id,
+        local_org=settings.org_id,
+        local_trust_domain=settings.trust_domain,
+    )
+    return route == "intra"
+
+
+def _local_session_to_dict(session: LocalSession) -> dict:
+    return {
+        "session_id": session.session_id,
+        "initiator_agent_id": session.initiator_agent_id,
+        "target_agent_id": session.responder_agent_id,
+        "status": session.status.value,
+        "requested_capabilities": list(session.requested_capabilities),
+        "created_at": session.created_at.isoformat(),
+        "last_activity_at": session.last_activity_at.isoformat(),
+        "close_reason": session.close_reason.value if session.close_reason else None,
+        "scope": "local",
+    }
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Endpoints
 # ─────────────────────────────────────────────────────────────────────────────
@@ -96,11 +146,49 @@ async def open_session(
     request: Request,
     agent: InternalAgent = Depends(get_agent_from_api_key),
 ):
-    """Open a broker session on behalf of internal agent."""
-    bridge = _get_bridge(request)
+    """Open a session on behalf of an internal agent.
+
+    ADR-001 Phase 3a: when `PROXY_INTRA_ORG` is on and the target resolves
+    to this proxy's (trust_domain, org), the session is created in the
+    local store and never touches the broker. Otherwise the request falls
+    through to the broker bridge exactly like before.
+    """
     request_id = str(uuid.uuid4())
     t0 = time.monotonic()
 
+    local_store = _get_local_store(request)
+    if local_store is not None and _should_route_intra(body.target_agent_id, body.target_org_id):
+        try:
+            session = local_store.create(
+                initiator_agent_id=agent.agent_id,
+                responder_agent_id=body.target_agent_id,
+                requested_capabilities=body.capabilities,
+            )
+            await save_local_session(session)
+            duration_ms = (time.monotonic() - t0) * 1000
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_session_open_local",
+                status="success",
+                detail=f"target={body.target_agent_id} session={session.session_id}",
+                request_id=request_id,
+                duration_ms=duration_ms,
+            )
+            return OpenSessionResponse(session_id=session.session_id, status="opened")
+        except LocalAgentSessionCapExceeded as exc:
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_session_open_local",
+                status="error",
+                detail=str(exc)[:500],
+                request_id=request_id,
+            )
+            raise HTTPException(
+                status_code=429,
+                detail={"error": "session_cap_exceeded", "current": exc.current, "cap": exc.cap},
+            ) from exc
+
+    bridge = _get_bridge(request)
     try:
         session_id = await bridge.open_session(
             agent.agent_id,
@@ -141,14 +229,25 @@ async def list_sessions(
     status: str | None = None,
     agent: InternalAgent = Depends(get_agent_from_api_key),
 ):
-    """List broker sessions for the authenticated agent."""
-    bridge = _get_bridge(request)
-    try:
-        sessions = await bridge.list_sessions(agent.agent_id, status)
-        return {"sessions": sessions}
-    except Exception as exc:
-        logger.error("Failed to list sessions for %s: %s", agent.agent_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+    """List sessions for the authenticated agent — local + broker merged."""
+    local_store = _get_local_store(request)
+    local_sessions: list[dict] = []
+    if local_store is not None:
+        for s in local_store.list_for_agent(agent.agent_id):
+            if status is None or s.status.value == status:
+                local_sessions.append(_local_session_to_dict(s))
+
+    broker_sessions: list[dict] = []
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is not None:
+        try:
+            broker_sessions = await bridge.list_sessions(agent.agent_id, status)
+        except Exception as exc:
+            logger.error("Failed to list broker sessions for %s: %s", agent.agent_id, exc)
+            # Broker failure degrades to local-only listing rather than 502.
+            broker_sessions = []
+
+    return {"sessions": local_sessions + broker_sessions}
 
 
 @router.post("/sessions/{session_id}/accept")
@@ -157,8 +256,25 @@ async def accept_session(
     request: Request,
     agent: InternalAgent = Depends(get_agent_from_api_key),
 ):
-    """Accept a pending broker session."""
+    """Accept a pending session (local or broker)."""
     _validate_session_id(session_id)
+    local_store = _get_local_store(request)
+    if local_store is not None:
+        async with local_store._lock:
+            session = local_store.get(session_id)
+            if session is not None:
+                if session.responder_agent_id != agent.agent_id:
+                    raise HTTPException(status_code=403, detail="not the responder")
+                session = local_store.activate(session_id)
+                await save_local_session(session)
+                await log_audit(
+                    agent_id=agent.agent_id,
+                    action="egress_session_accept_local",
+                    status="success",
+                    detail=f"session={session_id}",
+                )
+                return {"status": "accepted", "session_id": session_id}
+
     bridge = _get_bridge(request)
     try:
         await bridge.accept_session(agent.agent_id, session_id)
@@ -189,8 +305,25 @@ async def close_session(
     request: Request,
     agent: InternalAgent = Depends(get_agent_from_api_key),
 ):
-    """Close a broker session."""
+    """Close a session (local or broker)."""
     _validate_session_id(session_id)
+    local_store = _get_local_store(request)
+    if local_store is not None:
+        async with local_store._lock:
+            session = local_store.get(session_id)
+            if session is not None:
+                if not session.involves(agent.agent_id):
+                    raise HTTPException(status_code=403, detail="not a participant")
+                session = local_store.close(session_id, SessionCloseReason.normal)
+                await save_local_session(session)
+                await log_audit(
+                    agent_id=agent.agent_id,
+                    action="egress_session_close_local",
+                    status="success",
+                    detail=f"session={session_id}",
+                )
+                return {"status": "closed", "session_id": session_id}
+
     bridge = _get_bridge(request)
     try:
         await bridge.close_session(agent.agent_id, session_id)

--- a/mcp_proxy/local/__init__.py
+++ b/mcp_proxy/local/__init__.py
@@ -1,0 +1,7 @@
+"""ADR-001 Phase 3 — local mini-broker surface for intra-org traffic.
+
+This subpackage hosts the proxy's in-process session + message machinery
+that mirrors the broker's M3 stack (`app/broker/`). It is exercised only
+when the `PROXY_INTRA_ORG` feature flag is true and the routing decision
+(ADR-001 Phase 2) classifies the recipient as intra-org.
+"""

--- a/mcp_proxy/local/models.py
+++ b/mcp_proxy/local/models.py
@@ -1,0 +1,21 @@
+"""Shared enums for the local mini-broker. Intentionally mirrors
+`app/broker/models.py` so the two stacks can be compared side by side."""
+from enum import Enum
+
+
+class SessionStatus(str, Enum):
+    pending = "pending"
+    active = "active"
+    closed = "closed"
+    denied = "denied"
+
+
+class SessionCloseReason(str, Enum):
+    """Why a session was terminated. Mirrors the broker semantics."""
+    normal = "normal"
+    idle_timeout = "idle_timeout"
+    ttl_expired = "ttl_expired"
+    peer_lost = "peer_lost"
+    policy_revoked = "policy_revoked"
+    pending_timeout = "pending_timeout"
+    rejected = "rejected"

--- a/mcp_proxy/local/persistence.py
+++ b/mcp_proxy/local/persistence.py
@@ -1,0 +1,117 @@
+"""Persistence for local_sessions — save on every state change, restore
+non-terminal rows at startup so the in-memory store survives restarts.
+
+Schema (alembic 0002_local_tables.py): session_id, initiator_agent_id,
+responder_agent_id, status, created_at, last_activity_at, close_reason.
+Capabilities and expires_at are NOT persisted — they're reconstructed
+in-memory (see LocalSession / LocalSessionStore).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+from mcp_proxy.local.models import SessionCloseReason, SessionStatus
+from mcp_proxy.local.session import LocalSession, LocalSessionStore
+
+_log = logging.getLogger("mcp_proxy.local.persistence")
+
+
+def _iso(dt: datetime | None) -> str | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso(raw: str | None) -> datetime | None:
+    if raw is None:
+        return None
+    dt = datetime.fromisoformat(raw)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+async def save_session(session: LocalSession) -> None:
+    """UPSERT a session row. Called from the router on every state change."""
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_sessions
+                    (session_id, initiator_agent_id, responder_agent_id,
+                     status, created_at, last_activity_at, close_reason)
+                VALUES
+                    (:session_id, :initiator_agent_id, :responder_agent_id,
+                     :status, :created_at, :last_activity_at, :close_reason)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    status = excluded.status,
+                    last_activity_at = excluded.last_activity_at,
+                    close_reason = excluded.close_reason
+                """
+            ),
+            {
+                "session_id": session.session_id,
+                "initiator_agent_id": session.initiator_agent_id,
+                "responder_agent_id": session.responder_agent_id,
+                "status": session.status.value,
+                "created_at": _iso(session.created_at),
+                "last_activity_at": _iso(session.last_activity_at),
+                "close_reason": session.close_reason.value if session.close_reason else None,
+            },
+        )
+
+
+async def restore_sessions(store: LocalSessionStore) -> int:
+    """Load all non-terminal sessions into the in-memory store on startup.
+
+    Rebuilds expires_at from created_at + store.hard_ttl (schema has no
+    expires_at column). Sessions already past expiry are left persisted
+    but NOT loaded — the sweeper (Phase 3d) will observe them as closed
+    via the DB next sweep; nothing to deliver meanwhile.
+    """
+    restored = 0
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT session_id, initiator_agent_id, responder_agent_id,
+                       status, created_at, last_activity_at, close_reason
+                  FROM local_sessions
+                 WHERE status IN ('pending', 'active')
+                """
+            )
+        )
+        rows = list(result.mappings())
+
+    now = datetime.now(timezone.utc)
+    for row in rows:
+        created_at = _parse_iso(row["created_at"]) or now
+        expires_at = created_at + store.hard_ttl
+        if expires_at <= now:
+            continue
+        session = LocalSession(
+            session_id=row["session_id"],
+            initiator_agent_id=row["initiator_agent_id"],
+            responder_agent_id=row["responder_agent_id"],
+            requested_capabilities=[],
+            status=SessionStatus(row["status"]),
+            created_at=created_at,
+            expires_at=expires_at,
+            last_activity_at=_parse_iso(row["last_activity_at"]) or created_at,
+            close_reason=(
+                SessionCloseReason(row["close_reason"])
+                if row["close_reason"] else None
+            ),
+        )
+        store.restore(session)
+        restored += 1
+
+    if restored:
+        _log.info("Restored %d local session(s) from DB", restored)
+    return restored

--- a/mcp_proxy/local/session.py
+++ b/mcp_proxy/local/session.py
@@ -1,0 +1,228 @@
+"""In-memory session store for intra-org traffic.
+
+Mirrors the subset of `app/broker/session.py` needed for proxy-side
+delivery. Simplifications vs the broker:
+
+  - Single org: both peers are registered in `internal_agents` under the
+    proxy's own org_id, so no org_id column and no binding check.
+  - No in-memory message buffer: messages live in `local_messages`
+    (Phase 3c).
+  - No nonce cache: message-level replay protection lands with messages
+    (Phase 3c).
+  - Capabilities and expires_at are held in memory but NOT persisted
+    (the `local_sessions` schema doesn't have those columns). On
+    restart, expires_at is reconstructed as created_at + HARD_TTL.
+
+Concurrency: `LocalSessionStore._lock` protects state transitions so
+`activate`/`reject`/`close` are atomic against each other. Individual
+Session instances are not locked here — that'll come with the message
+queue in 3c (per broker pattern).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from mcp_proxy.local.models import SessionCloseReason, SessionStatus
+
+_log = logging.getLogger("mcp_proxy.local.session")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        _log.warning("Invalid %s=%r, falling back to default %d", name, raw, default)
+        return default
+
+
+LOCAL_SESSION_IDLE_TIMEOUT_SECONDS = _env_int("PROXY_LOCAL_SESSION_IDLE_TIMEOUT_SECONDS", 600)
+LOCAL_SESSION_HARD_TTL_MINUTES = _env_int("PROXY_LOCAL_SESSION_HARD_TTL_MINUTES", 60)
+LOCAL_SESSION_CAP_ACTIVE_PER_AGENT = _env_int("PROXY_LOCAL_SESSION_CAP_ACTIVE_PER_AGENT", 50)
+
+
+@dataclass
+class LocalSession:
+    session_id: str
+    initiator_agent_id: str
+    responder_agent_id: str
+    requested_capabilities: list[str]
+    status: SessionStatus = SessionStatus.pending
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    expires_at: datetime | None = None
+    last_activity_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    close_reason: SessionCloseReason | None = None
+
+    def is_expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return datetime.now(timezone.utc) > self.expires_at
+
+    def is_idle(self, timeout_seconds: int = LOCAL_SESSION_IDLE_TIMEOUT_SECONDS) -> bool:
+        if self.status not in (SessionStatus.active, SessionStatus.pending):
+            return False
+        age = (datetime.now(timezone.utc) - self.last_activity_at).total_seconds()
+        return age > timeout_seconds
+
+    def touch(self) -> None:
+        self.last_activity_at = datetime.now(timezone.utc)
+
+    def involves(self, agent_id: str) -> bool:
+        return agent_id in (self.initiator_agent_id, self.responder_agent_id)
+
+
+class LocalAgentSessionCapExceeded(Exception):
+    """Raised when an agent has too many concurrent ACTIVE local sessions."""
+
+    def __init__(self, agent_id: str, current: int, cap: int):
+        self.agent_id = agent_id
+        self.current = current
+        self.cap = cap
+        super().__init__(
+            f"Agent {agent_id} has {current} ACTIVE local sessions "
+            f"(cap {cap}) — cannot open new session"
+        )
+
+
+class LocalSessionStore:
+    _MAX_SESSIONS: int = 10_000
+
+    def __init__(
+        self,
+        session_ttl_minutes: int | None = None,
+        active_cap_per_agent: int | None = None,
+    ):
+        self._sessions: dict[str, LocalSession] = {}
+        self._ttl = timedelta(
+            minutes=session_ttl_minutes
+            if session_ttl_minutes is not None
+            else LOCAL_SESSION_HARD_TTL_MINUTES
+        )
+        self._active_cap_per_agent = (
+            active_cap_per_agent
+            if active_cap_per_agent is not None
+            else LOCAL_SESSION_CAP_ACTIVE_PER_AGENT
+        )
+        self._lock = asyncio.Lock()
+
+    # ── Eviction ────────────────────────────────────────────────────
+
+    def _evict_terminated(self) -> int:
+        to_remove = [
+            sid for sid, s in self._sessions.items()
+            if s.status in (SessionStatus.closed, SessionStatus.denied)
+        ]
+        for sid in to_remove:
+            del self._sessions[sid]
+        if to_remove:
+            _log.info("Evicted %d terminated local session(s)", len(to_remove))
+        return len(to_remove)
+
+    # ── CRUD ────────────────────────────────────────────────────────
+
+    def count_active_for_agent(self, agent_id: str) -> int:
+        return sum(
+            1
+            for s in self._sessions.values()
+            if s.status == SessionStatus.active and s.involves(agent_id)
+        )
+
+    def create(
+        self,
+        initiator_agent_id: str,
+        responder_agent_id: str,
+        requested_capabilities: list[str],
+    ) -> LocalSession:
+        self._evict_terminated()
+
+        if len(self._sessions) >= self._MAX_SESSIONS:
+            raise RuntimeError(
+                f"Local session store full ({self._MAX_SESSIONS}) — cannot create new session"
+            )
+
+        active_for_initiator = self.count_active_for_agent(initiator_agent_id)
+        if active_for_initiator >= self._active_cap_per_agent:
+            raise LocalAgentSessionCapExceeded(
+                agent_id=initiator_agent_id,
+                current=active_for_initiator,
+                cap=self._active_cap_per_agent,
+            )
+
+        session_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        session = LocalSession(
+            session_id=session_id,
+            initiator_agent_id=initiator_agent_id,
+            responder_agent_id=responder_agent_id,
+            requested_capabilities=list(requested_capabilities),
+            created_at=now,
+            expires_at=now + self._ttl,
+        )
+        self._sessions[session_id] = session
+        return session
+
+    def get(self, session_id: str) -> LocalSession | None:
+        session = self._sessions.get(session_id)
+        if session and session.is_expired() and session.status != SessionStatus.closed:
+            session.status = SessionStatus.closed
+            if session.close_reason is None:
+                session.close_reason = SessionCloseReason.ttl_expired
+        return session
+
+    def activate(self, session_id: str) -> LocalSession | None:
+        session = self.get(session_id)
+        if session and session.status == SessionStatus.pending:
+            session.status = SessionStatus.active
+            session.touch()
+        return session
+
+    def reject(self, session_id: str) -> LocalSession | None:
+        session = self.get(session_id)
+        if session and session.status == SessionStatus.pending:
+            session.status = SessionStatus.denied
+            session.close_reason = SessionCloseReason.rejected
+        return session
+
+    def close(
+        self,
+        session_id: str,
+        reason: SessionCloseReason = SessionCloseReason.normal,
+    ) -> LocalSession | None:
+        session = self._sessions.get(session_id)
+        if session and session.status != SessionStatus.closed:
+            session.status = SessionStatus.closed
+            if session.close_reason is None:
+                session.close_reason = reason
+        return session
+
+    def find_stale(
+        self,
+        idle_timeout_seconds: int = LOCAL_SESSION_IDLE_TIMEOUT_SECONDS,
+    ) -> list[tuple[LocalSession, SessionCloseReason]]:
+        out: list[tuple[LocalSession, SessionCloseReason]] = []
+        for s in self._sessions.values():
+            if s.status in (SessionStatus.closed, SessionStatus.denied):
+                continue
+            if s.is_expired():
+                out.append((s, SessionCloseReason.ttl_expired))
+            elif s.is_idle(idle_timeout_seconds):
+                out.append((s, SessionCloseReason.idle_timeout))
+        return out
+
+    def list_for_agent(self, agent_id: str) -> list[LocalSession]:
+        return [s for s in self._sessions.values() if s.involves(agent_id)]
+
+    def restore(self, session: LocalSession) -> None:
+        """Insert a session reconstructed from persistence (startup path)."""
+        self._sessions[session.session_id] = session
+
+    @property
+    def hard_ttl(self) -> timedelta:
+        return self._ttl

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -99,6 +99,19 @@ async def lifespan(app: FastAPI):
     else:
         _log.warning("No broker_url configured — egress endpoints will return 503")
 
+    # ADR-001 Phase 3a — local session store (intra-org mini-broker).
+    # Instantiated regardless of the feature flag so the DB schema is always
+    # readable; the egress router only dispatches into it when the flag is on
+    # and the routing decision returns "intra".
+    from mcp_proxy.local.persistence import restore_sessions
+    from mcp_proxy.local.session import LocalSessionStore
+    local_store = LocalSessionStore()
+    try:
+        await restore_sessions(local_store)
+    except Exception as exc:
+        _log.warning("Failed to restore local sessions from DB: %s", exc)
+    app.state.local_session_store = local_store
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
@@ -107,8 +120,9 @@ async def lifespan(app: FastAPI):
     yield
 
     # Cleanup
-    if hasattr(app.state, "broker_bridge"):
-        await app.state.broker_bridge.shutdown()
+    bridge = getattr(app.state, "broker_bridge", None)
+    if bridge is not None:
+        await bridge.shutdown()
     if _jwks_client:
         await _jwks_client.close()
     await dispose_db()

--- a/tests/test_proxy_local_sessions.py
+++ b/tests/test_proxy_local_sessions.py
@@ -18,7 +18,6 @@ from mcp_proxy.local.models import SessionCloseReason, SessionStatus
 from mcp_proxy.local.persistence import restore_sessions, save_session
 from mcp_proxy.local.session import (
     LocalAgentSessionCapExceeded,
-    LocalSession,
     LocalSessionStore,
 )
 

--- a/tests/test_proxy_local_sessions.py
+++ b/tests/test_proxy_local_sessions.py
@@ -1,0 +1,324 @@
+"""ADR-001 Phase 3a — local session lifecycle in the proxy.
+
+Covers:
+  - LocalSessionStore: create, activate, reject, close, find_stale, cap
+  - persistence: save + restore round-trip on local_sessions table
+  - egress router interception when PROXY_INTRA_ORG=on and target is intra
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.local.models import SessionCloseReason, SessionStatus
+from mcp_proxy.local.persistence import restore_sessions, save_session
+from mcp_proxy.local.session import (
+    LocalAgentSessionCapExceeded,
+    LocalSession,
+    LocalSessionStore,
+)
+
+
+# ── LocalSessionStore unit tests ────────────────────────────────────
+
+def test_create_and_get():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", ["cap.read"])
+    assert s.status == SessionStatus.pending
+    assert s.initiator_agent_id == "alice"
+    assert s.responder_agent_id == "bob"
+    assert store.get(s.session_id) is s
+
+
+def test_activate_pending_to_active():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    activated = store.activate(s.session_id)
+    assert activated.status == SessionStatus.active
+
+
+def test_activate_closed_is_noop():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    store.close(s.session_id)
+    result = store.activate(s.session_id)
+    assert result.status == SessionStatus.closed
+
+
+def test_reject_sets_denied_with_reason():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    store.reject(s.session_id)
+    assert s.status == SessionStatus.denied
+    assert s.close_reason == SessionCloseReason.rejected
+
+
+def test_close_default_reason_is_normal():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    store.close(s.session_id)
+    assert s.status == SessionStatus.closed
+    assert s.close_reason == SessionCloseReason.normal
+
+
+def test_close_preserves_first_reason():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    store.close(s.session_id, SessionCloseReason.policy_revoked)
+    store.close(s.session_id, SessionCloseReason.normal)
+    assert s.close_reason == SessionCloseReason.policy_revoked
+
+
+def test_cap_enforced_on_active_sessions():
+    store = LocalSessionStore(active_cap_per_agent=2)
+    s1 = store.create("alice", "bob", [])
+    s2 = store.create("alice", "carol", [])
+    store.activate(s1.session_id)
+    store.activate(s2.session_id)
+    with pytest.raises(LocalAgentSessionCapExceeded) as exc:
+        store.create("alice", "dave", [])
+    assert exc.value.current == 2
+    assert exc.value.cap == 2
+
+
+def test_cap_does_not_count_pending_or_closed():
+    store = LocalSessionStore(active_cap_per_agent=1)
+    s1 = store.create("alice", "bob", [])  # pending
+    store.create("alice", "carol", [])     # also pending — fine
+    store.activate(s1.session_id)          # 1 active (at cap)
+    store.close(s1.session_id)             # 0 active again
+    store.create("alice", "dave", [])      # allowed
+
+
+def test_list_for_agent_matches_both_roles():
+    store = LocalSessionStore()
+    s1 = store.create("alice", "bob", [])
+    s2 = store.create("bob", "alice", [])
+    s3 = store.create("carol", "dave", [])
+    alice_sessions = {s.session_id for s in store.list_for_agent("alice")}
+    assert alice_sessions == {s1.session_id, s2.session_id}
+    assert s3.session_id not in alice_sessions
+
+
+def test_find_stale_flags_idle_active_sessions():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    store.activate(s.session_id)
+    # Force last_activity_at into the past.
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(seconds=3600)
+    stale = store.find_stale(idle_timeout_seconds=60)
+    assert any(
+        sid == s.session_id and reason == SessionCloseReason.idle_timeout
+        for (sess, reason) in stale
+        for sid in [sess.session_id]
+    )
+
+
+def test_find_stale_flags_ttl_expired():
+    store = LocalSessionStore(session_ttl_minutes=1)
+    s = store.create("alice", "bob", [])
+    s.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    stale = store.find_stale()
+    assert any(
+        reason == SessionCloseReason.ttl_expired for (_s, reason) in stale
+    )
+
+
+def test_get_flips_expired_to_closed():
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    s.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    fetched = store.get(s.session_id)
+    assert fetched.status == SessionStatus.closed
+    assert fetched.close_reason == SessionCloseReason.ttl_expired
+
+
+# ── Persistence round-trip ──────────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    await init_db(url)
+    yield url
+    await dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_save_and_restore_roundtrip(proxy_db):
+    store1 = LocalSessionStore()
+    s = store1.create("alice", "bob", ["cap.read"])
+    store1.activate(s.session_id)
+    await save_session(s)
+
+    store2 = LocalSessionStore()
+    restored = await restore_sessions(store2)
+    assert restored == 1
+    s2 = store2.get(s.session_id)
+    assert s2 is not None
+    assert s2.initiator_agent_id == "alice"
+    assert s2.responder_agent_id == "bob"
+    assert s2.status == SessionStatus.active
+
+
+@pytest.mark.asyncio
+async def test_restore_skips_closed_sessions(proxy_db):
+    store1 = LocalSessionStore()
+    s_active = store1.create("alice", "bob", [])
+    store1.activate(s_active.session_id)
+    s_closed = store1.create("alice", "carol", [])
+    store1.close(s_closed.session_id)
+    await save_session(s_active)
+    await save_session(s_closed)
+
+    store2 = LocalSessionStore()
+    restored = await restore_sessions(store2)
+    assert restored == 1
+    assert store2.get(s_active.session_id) is not None
+    assert store2.get(s_closed.session_id) is None
+
+
+# ── Egress router interception ──────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    # Settings singleton is lru_cache'd — flush between tests
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    # Force the lifespan to run by using the ASGI transport.
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision_internal_agent(agent_id: str = "sender-bot") -> str:
+    """Create an internal agent with API key and return the raw key."""
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+    raw_key = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=["cap.read"],
+        api_key_hash=hash_api_key(raw_key),
+    )
+    return raw_key
+
+
+@pytest.mark.asyncio
+async def test_router_opens_local_session_for_intra_target(proxy_app):
+    app, client = proxy_app
+    api_key = await _provision_internal_agent("sender-bot")
+
+    resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": api_key},
+        json={
+            "target_agent_id": "acme::peer-bot",
+            "target_org_id": "acme",
+            "capabilities": ["cap.read"],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    session_id = resp.json()["session_id"]
+
+    store: LocalSessionStore = app.state.local_session_store
+    session = store.get(session_id)
+    assert session is not None
+    assert session.status == SessionStatus.pending
+    assert session.responder_agent_id == "acme::peer-bot"
+
+
+@pytest.mark.asyncio
+async def test_router_accept_close_round_trip(proxy_app):
+    app, client = proxy_app
+    initiator_key = await _provision_internal_agent("sender-bot")
+    responder_key = await _provision_internal_agent("peer-bot")
+
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": initiator_key},
+        json={
+            "target_agent_id": "peer-bot",
+            "target_org_id": "acme",
+            "capabilities": [],
+        },
+    )
+    session_id = open_resp.json()["session_id"]
+
+    accept_resp = await client.post(
+        f"/v1/egress/sessions/{session_id}/accept",
+        headers={"X-API-Key": responder_key},
+    )
+    assert accept_resp.status_code == 200, accept_resp.text
+
+    store: LocalSessionStore = app.state.local_session_store
+    assert store.get(session_id).status == SessionStatus.active
+
+    close_resp = await client.post(
+        f"/v1/egress/sessions/{session_id}/close",
+        headers={"X-API-Key": initiator_key},
+    )
+    assert close_resp.status_code == 200, close_resp.text
+    assert store.get(session_id).status == SessionStatus.closed
+
+
+@pytest.mark.asyncio
+async def test_accept_rejects_non_responder(proxy_app):
+    app, client = proxy_app
+    initiator_key = await _provision_internal_agent("sender-bot")
+    await _provision_internal_agent("peer-bot")
+    stranger_key = await _provision_internal_agent("stranger-bot")
+
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": initiator_key},
+        json={"target_agent_id": "peer-bot", "target_org_id": "acme", "capabilities": []},
+    )
+    session_id = open_resp.json()["session_id"]
+
+    resp = await client.post(
+        f"/v1/egress/sessions/{session_id}/accept",
+        headers={"X-API-Key": stranger_key},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_list_sessions_returns_local_only_without_broker(proxy_app):
+    app, client = proxy_app
+    api_key = await _provision_internal_agent("sender-bot")
+
+    # Explicitly clear the broker bridge so list_sessions falls back to local.
+    app.state.broker_bridge = None
+
+    await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": api_key},
+        json={"target_agent_id": "peer-bot", "target_org_id": "acme", "capabilities": []},
+    )
+
+    resp = await client.get("/v1/egress/sessions", headers={"X-API-Key": api_key})
+    assert resp.status_code == 200
+    sessions = resp.json()["sessions"]
+    assert len(sessions) == 1
+    assert sessions[0]["scope"] == "local"

--- a/tests/test_proxy_local_sessions.py
+++ b/tests/test_proxy_local_sessions.py
@@ -7,7 +7,6 @@ Covers:
 """
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 
 import pytest


### PR DESCRIPTION
## Summary

First slice of the M3-twin mini-broker (issue #53). When \`PROXY_INTRA_ORG=true\` and the target resolves to this proxy's \`(trust_domain, org)\`, session open/accept/close are handled in-process against the \`local_sessions\` table — **no round-trip to the broker** for intra-org traffic. Cross-org is unchanged; flag-off deployments see zero behavioral change.

Part of #53 (Phase 3 tracking). This is slice 1 of 4 (3a session / 3b WS server / 3c messages / 3d sweeper).

## Files
- \`mcp_proxy/local/\` new subpackage for the local mini-broker
  - \`session.py\` — \`LocalSession\` + \`LocalSessionStore\` (simplified single-org port of \`app/broker/session.py\`)
  - \`persistence.py\` — UPSERT/restore against \`local_sessions\` table
  - \`models.py\` — \`SessionStatus\` + \`SessionCloseReason\` enums
- \`mcp_proxy/egress/router.py\` — intercept session endpoints when \`_should_route_intra()\` is true; merged local+broker listing
- \`mcp_proxy/main.py\` — lifespan wiring + tolerant shutdown when broker absent
- \`tests/test_proxy_local_sessions.py\` — 18 tests

## Design notes
- **Single-org simplification**: local_sessions schema has no \`org_id\` (intra by definition), no \`capabilities\` (kept in-memory), no \`expires_at\` (reconstructed from \`created_at + HARD_TTL\` on restore). Keeps Phase 3a free of new migrations.
- **Session open routing**: \`_should_route_intra()\` prefers the explicit \`target_org_id\` when provided (session-open case); for other paths falls back to the SPIFFE-driven \`decide_route()\` from Phase 2.
- **List merging**: \`GET /v1/egress/sessions\` now returns local + broker sessions with a \`scope: local\` discriminator. Broker failure degrades to local-only rather than 502.

## Test plan
- [x] \`pytest tests/test_proxy_local_sessions.py\` — 18/18 green (store behavior, persistence round-trip, router interception)
- [x] Full suite (no e2e): 575 passed, 5 skipped, **0 regressions**
- [x] \`./demo_network/smoke.sh full\` — PASS (flag default off)
- [ ] CI: helm-test, demo_network smoke matrix, test (3.11), security, DCO

## Out of scope (next slices)
- Proxy WS server for realtime push (3b, ~2gg)
- Message queue + ack + delivery decision on \`local_messages\` (3c, ~2gg)
- Local sweeper for idle/TTL expire (3d, ~1gg)

Refs \`imp/adr_001_intra_org_routing.md\` §5 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)