### PR TITLE
feat(proxy): ADR-001 Phase 3b — local WebSocket server for intra-org push

### DIFF
--- a/mcp_proxy/local/ws_manager.py
+++ b/mcp_proxy/local/ws_manager.py
@@ -1,0 +1,98 @@
+"""Local WebSocket connection manager — ADR-001 Phase 3b.
+
+Single-process in-memory registry of internal agents that are currently
+connected to the proxy's `/v1/local/ws` endpoint. Used by the local
+mini-broker (Phase 3c) to decide push-vs-queue for intra-org messages.
+
+Design simplifications vs `app/broker/ws_manager.py`:
+  - No Redis Pub/Sub: the proxy is a single-process component serving
+    one org, so cross-worker delivery isn't needed. HA story (multiple
+    proxy replicas behind a load balancer sharing state via Redis) can
+    be layered later without changing this interface.
+  - No per-org cap: agents already belong to the proxy's single org.
+
+Concurrency: `_lock` serialises connect/disconnect so a fast reconnect
+replaces the stale WS atomically (no TOCTOU).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Dict
+
+from fastapi import WebSocket
+
+logger = logging.getLogger("mcp_proxy.local.ws_manager")
+
+
+class LocalConnectionManager:
+    def __init__(self) -> None:
+        self._connections: Dict[str, WebSocket] = {}
+        self._lock = asyncio.Lock()
+        self._shut_down = False
+
+    async def connect(self, agent_id: str, websocket: WebSocket) -> None:
+        """Register a WebSocket for an agent. If the agent already has a
+        live connection, close it first so only the newest survives."""
+        async with self._lock:
+            existing = self._connections.pop(agent_id, None)
+            if existing is not None:
+                logger.warning(
+                    "Closing previous local WS for agent %s before reconnect",
+                    agent_id,
+                )
+                try:
+                    await existing.close(code=1000, reason="reconnect")
+                except Exception:
+                    pass
+            self._connections[agent_id] = websocket
+            logger.info("Agent %s connected to local WS", agent_id)
+
+    async def disconnect(
+        self,
+        agent_id: str,
+        *,
+        code: int = 1000,
+        reason: str = "",
+    ) -> None:
+        async with self._lock:
+            ws = self._connections.pop(agent_id, None)
+        if ws is None:
+            return
+        try:
+            await ws.close(code=code, reason=reason)
+        except Exception as exc:
+            logger.debug("Error closing local WS for %s: %s", agent_id, exc)
+        logger.info(
+            "Agent %s disconnected from local WS (code=%d reason=%s)",
+            agent_id, code, reason or "-",
+        )
+
+    async def send_to_agent(self, agent_id: str, data: dict) -> bool:
+        """Deliver a frame to the agent if connected. Returns True on
+        success, False when the agent is offline or the send failed
+        (connection will be evicted in that case)."""
+        ws = self._connections.get(agent_id)
+        if ws is None:
+            return False
+        try:
+            await ws.send_json(data)
+            return True
+        except Exception as exc:
+            logger.error("Local WS send failed for %s: %s — evicting", agent_id, exc)
+            await self.disconnect(agent_id, code=1011, reason="send_failed")
+            return False
+
+    def is_connected(self, agent_id: str) -> bool:
+        return agent_id in self._connections
+
+    def connected_agents(self) -> list[str]:
+        return list(self._connections)
+
+    async def shutdown(self) -> None:
+        """Close every connection. Idempotent."""
+        if self._shut_down:
+            return
+        self._shut_down = True
+        for agent_id in list(self._connections):
+            await self.disconnect(agent_id, code=1012, reason="proxy_restart")

--- a/mcp_proxy/local/ws_router.py
+++ b/mcp_proxy/local/ws_router.py
@@ -1,0 +1,85 @@
+"""WebSocket endpoint for intra-org push delivery — ADR-001 Phase 3b.
+
+An internal agent that wants real-time delivery of messages queued for
+it locally connects to `/v1/local/ws?api_key=<raw>`. We accept the
+socket, authenticate the key, register the connection in the
+`LocalConnectionManager`, and then idle in a read loop (inbound frames
+are treated as keepalive — there is nothing the client needs to send
+today). Phase 3c will push `new_message` frames over this socket.
+
+Auth via query param (not header) because JS WebSocket and many client
+libraries cannot set custom headers on the upgrade request. The proxy
+is internal-facing (loopback or LAN); if logs capture URLs, redact the
+`api_key` param at the logger level rather than punishing the protocol.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Query, WebSocket
+from starlette.websockets import WebSocketDisconnect, WebSocketState
+
+from mcp_proxy.db import get_agent_by_key_hash
+from mcp_proxy.local.ws_manager import LocalConnectionManager
+
+logger = logging.getLogger("mcp_proxy.local.ws_router")
+
+router = APIRouter(prefix="/v1/local", tags=["local"])
+
+
+# RFC 6455 application-level close codes — 4000-4999 are reserved for app use.
+_WS_CLOSE_UNAUTHORIZED = 4401
+_WS_CLOSE_INTERNAL_ERROR = 1011
+
+
+def _get_manager(app) -> LocalConnectionManager | None:
+    return getattr(app.state, "local_ws_manager", None)
+
+
+@router.websocket("/ws")
+async def local_ws(
+    websocket: WebSocket,
+    api_key: str = Query(default="", description="Internal agent API key"),
+) -> None:
+    """Agent-facing WebSocket for intra-org realtime push."""
+    manager = _get_manager(websocket.app)
+    if manager is None:
+        # Phase 3 not wired — refuse the upgrade before sending anything.
+        await websocket.close(code=_WS_CLOSE_INTERNAL_ERROR, reason="ws_not_ready")
+        return
+
+    if not api_key or not api_key.startswith("sk_local_"):
+        await websocket.close(code=_WS_CLOSE_UNAUTHORIZED, reason="missing_api_key")
+        return
+
+    agent_data = await get_agent_by_key_hash(api_key)
+    if agent_data is None:
+        await websocket.close(code=_WS_CLOSE_UNAUTHORIZED, reason="invalid_api_key")
+        return
+
+    agent_id = agent_data["agent_id"]
+    await websocket.accept()
+    await manager.connect(agent_id, websocket)
+
+    try:
+        await websocket.send_json({"type": "connected", "agent_id": agent_id})
+        while True:
+            # Treat any inbound frame as a keepalive. Phase 3c may add
+            # client-initiated ack frames here.
+            try:
+                await websocket.receive_text()
+            except WebSocketDisconnect:
+                break
+    except Exception as exc:
+        logger.warning("Local WS loop error for %s: %s", agent_id, exc)
+    finally:
+        # Only disconnect if the manager still owns this socket — the
+        # manager itself handles the race where a reconnect already
+        # replaced us.
+        if manager.is_connected(agent_id):
+            await manager.disconnect(agent_id)
+        if websocket.client_state != WebSocketState.DISCONNECTED:
+            try:
+                await websocket.close()
+            except Exception:
+                pass

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -105,12 +105,19 @@ async def lifespan(app: FastAPI):
     # and the routing decision returns "intra".
     from mcp_proxy.local.persistence import restore_sessions
     from mcp_proxy.local.session import LocalSessionStore
+    from mcp_proxy.local.ws_manager import LocalConnectionManager
     local_store = LocalSessionStore()
     try:
         await restore_sessions(local_store)
     except Exception as exc:
         _log.warning("Failed to restore local sessions from DB: %s", exc)
     app.state.local_session_store = local_store
+
+    # Phase 3b — local WS manager. Phase 3c will plug this into message
+    # delivery (push-vs-queue decision). Today the endpoint accepts
+    # connections so SDKs can start depending on it behind the same
+    # PROXY_INTRA_ORG flag.
+    app.state.local_ws_manager = LocalConnectionManager()
 
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
@@ -120,6 +127,9 @@ async def lifespan(app: FastAPI):
     yield
 
     # Cleanup
+    ws_manager = getattr(app.state, "local_ws_manager", None)
+    if ws_manager is not None:
+        await ws_manager.shutdown()
     bridge = getattr(app.state, "broker_bridge", None)
     if bridge is not None:
         await bridge.shutdown()
@@ -297,6 +307,9 @@ app.include_router(ingress_router)
 
 from mcp_proxy.egress.router import router as egress_router
 app.include_router(egress_router)
+
+from mcp_proxy.local.ws_router import router as local_ws_router
+app.include_router(local_ws_router)
 
 from mcp_proxy.dashboard.router import router as dashboard_router
 app.include_router(dashboard_router)

--- a/tests/test_proxy_local_ws.py
+++ b/tests/test_proxy_local_ws.py
@@ -1,0 +1,180 @@
+"""ADR-001 Phase 3b — proxy-side WebSocket server for intra-org push.
+
+Covers:
+  - LocalConnectionManager: connect/disconnect/send/reconnect
+  - /v1/local/ws handshake: missing key, invalid key, valid key
+  - Server-initiated push reaches the client
+  - Reconnect replaces the stale connection
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from mcp_proxy.local.ws_manager import LocalConnectionManager
+
+
+# ── LocalConnectionManager unit tests ───────────────────────────────
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+        self.closed: tuple[int, str] | None = None
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed = (code, reason)
+
+
+@pytest.mark.asyncio
+async def test_connect_and_send():
+    mgr = LocalConnectionManager()
+    ws = _FakeWS()
+    await mgr.connect("alice", ws)
+    assert mgr.is_connected("alice")
+    delivered = await mgr.send_to_agent("alice", {"type": "new_message"})
+    assert delivered is True
+    assert ws.sent == [{"type": "new_message"}]
+
+
+@pytest.mark.asyncio
+async def test_send_to_absent_agent_returns_false():
+    mgr = LocalConnectionManager()
+    assert await mgr.send_to_agent("nobody", {"type": "x"}) is False
+
+
+@pytest.mark.asyncio
+async def test_reconnect_evicts_previous_ws():
+    mgr = LocalConnectionManager()
+    old_ws = _FakeWS()
+    new_ws = _FakeWS()
+    await mgr.connect("alice", old_ws)
+    await mgr.connect("alice", new_ws)
+    assert old_ws.closed is not None
+    assert mgr.is_connected("alice")
+    await mgr.send_to_agent("alice", {"ok": True})
+    assert new_ws.sent == [{"ok": True}]
+    assert old_ws.sent == []
+
+
+@pytest.mark.asyncio
+async def test_disconnect_removes_and_closes():
+    mgr = LocalConnectionManager()
+    ws = _FakeWS()
+    await mgr.connect("alice", ws)
+    await mgr.disconnect("alice", code=1000, reason="bye")
+    assert not mgr.is_connected("alice")
+    assert ws.closed == (1000, "bye")
+
+
+@pytest.mark.asyncio
+async def test_send_failure_evicts_connection():
+    class _BrokenWS(_FakeWS):
+        async def send_json(self, data: dict) -> None:
+            raise RuntimeError("socket broken")
+
+    mgr = LocalConnectionManager()
+    ws = _BrokenWS()
+    await mgr.connect("alice", ws)
+    delivered = await mgr.send_to_agent("alice", {"x": 1})
+    assert delivered is False
+    assert not mgr.is_connected("alice")
+
+
+@pytest.mark.asyncio
+async def test_shutdown_closes_all():
+    mgr = LocalConnectionManager()
+    ws1, ws2 = _FakeWS(), _FakeWS()
+    await mgr.connect("alice", ws1)
+    await mgr.connect("bob", ws2)
+    await mgr.shutdown()
+    assert ws1.closed is not None
+    assert ws2.closed is not None
+    # Idempotent — calling again doesn't raise.
+    await mgr.shutdown()
+
+
+# ── /v1/local/ws endpoint integration ───────────────────────────────
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision(agent_id: str) -> str:
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+    raw = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=[],
+        api_key_hash=hash_api_key(raw),
+    )
+    return raw
+
+
+def _ws_client(app):
+    """TestClient gives a synchronous WebSocket helper that plays well with
+    Starlette's transport — easier than httpx for upgrade flows."""
+    return TestClient(app, raise_server_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_missing_api_key(proxy_app):
+    app, _ = proxy_app
+    client = _ws_client(app)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/v1/local/ws"):
+            pass
+    assert exc.value.code == 4401
+
+
+@pytest.mark.asyncio
+async def test_ws_rejects_invalid_api_key(proxy_app):
+    app, _ = proxy_app
+    client = _ws_client(app)
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/v1/local/ws?api_key=sk_local_fake_nope"):
+            pass
+    assert exc.value.code == 4401
+
+
+@pytest.mark.asyncio
+async def test_ws_accepts_valid_api_key_and_registers(proxy_app):
+    app, _ = proxy_app
+    raw = await _provision("alice")
+    client = _ws_client(app)
+
+    with client.websocket_connect(f"/v1/local/ws?api_key={raw}") as ws:
+        welcome = ws.receive_json()
+        assert welcome == {"type": "connected", "agent_id": "alice"}
+        assert app.state.local_ws_manager.is_connected("alice")
+
+    # After the context exits, the manager should have released the entry.
+    assert not app.state.local_ws_manager.is_connected("alice")
+
+
+# Note: server-initiated push end-to-end (manager.send_to_agent → frame
+# arriving at the TestClient websocket) is exercised by Phase 3c when a
+# real message delivery path drives it. The unit test
+# `test_connect_and_send` above already covers the manager half.


### PR DESCRIPTION
## Summary

Second slice of the M3-twin mini-broker (#53). Adds the proxy-side WebSocket endpoint that Phase 3c will use to push \`new_message\` frames with **realtime parity to the broker**.

- \`LocalConnectionManager\`: single-process, no Redis (proxy is single-org by design — HA can layer Redis later without breaking the interface)
- \`WS /v1/local/ws?api_key=<raw>\`: API-key auth via query param (WS upgrade can't carry custom headers cross-client); on accept, sends \`{type:connected}\` and idles in recv loop
- Lifespan wiring + graceful shutdown

No behavioral change for today's callers — nothing pushes over the socket yet. Phase 3c will plug it into the local message queue's push-vs-queue decision.

## Files
- \`mcp_proxy/local/ws_manager.py\` — LocalConnectionManager
- \`mcp_proxy/local/ws_router.py\` — WS endpoint + auth
- \`mcp_proxy/main.py\` — instantiate + register + graceful shutdown
- \`tests/test_proxy_local_ws.py\` — 9 cases (manager unit + handshake integration)

## Test plan
- [x] \`pytest tests/test_proxy_local_ws.py\` — 9/9 green
- [x] Full suite: 584 passed, 5 skipped, **0 regressions**
- [x] \`./demo_network/smoke.sh full\` — PASS
- [ ] CI: helm-test, demo_network smoke matrix, test (3.11), security, DCO

## Out of scope (3c / 3d)
- SDK-side WebSocket routing (proxy-local vs broker) — lands with 3c when there's something to route
- Server-initiated push end-to-end integration test — covered by 3c when real messages drive the manager
- Message queue enqueue/ack/drain — Phase 3c
- Sweeper — Phase 3d

🤖 Generated with [Claude Code](https://claude.com/claude-code)