### PR TITLE
feat(proxy): ADR-001 Phase 3c — local message queue + ack + push-vs-queue

### DIFF
--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -8,6 +8,7 @@ All endpoints require X-API-Key authentication (via get_agent_from_api_key).
 import logging
 import time
 import uuid
+from datetime import datetime, timezone
 
 import httpx
 
@@ -18,6 +19,7 @@ from mcp_proxy.auth.api_key import get_agent_from_api_key
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
 from mcp_proxy.egress.routing import decide_route
+from mcp_proxy.local import message_queue as local_queue
 from mcp_proxy.local.models import SessionCloseReason
 from mcp_proxy.local.persistence import save_session as save_local_session
 from mcp_proxy.local.session import (
@@ -64,6 +66,10 @@ class SendMessageRequest(BaseModel):
     session_id: str
     payload: dict
     recipient_agent_id: str
+    # ADR-001 Phase 3c — at-least-once fields (mirror broker M3 SDK params).
+    # Optional; omitting them keeps pre-3c client behavior.
+    ttl_seconds: int = Field(default=local_queue.DEFAULT_TTL_SECONDS, ge=10, le=3600)
+    idempotency_key: str | None = None
 
 
 class DiscoverRequest(BaseModel):
@@ -354,12 +360,87 @@ async def send_message(
     request: Request,
     agent: InternalAgent = Depends(get_agent_from_api_key),
 ):
-    """Send E2E encrypted message via broker."""
+    """Send an E2E-encrypted message.
+
+    ADR-001 Phase 3c: when `body.session_id` refers to a local session,
+    the message is enqueued on `local_messages` and pushed over the
+    recipient's local WS if connected. Otherwise the request falls
+    through to the broker bridge exactly like before.
+    """
     _validate_session_id(body.session_id)
-    bridge = _get_bridge(request)
     request_id = str(uuid.uuid4())
     t0 = time.monotonic()
 
+    local_store = _get_local_store(request)
+    local_session = local_store.get(body.session_id) if local_store else None
+    if local_session is not None:
+        if not local_session.involves(agent.agent_id):
+            raise HTTPException(status_code=403, detail="not a participant")
+        if agent.agent_id == local_session.initiator_agent_id:
+            recipient = local_session.responder_agent_id
+        else:
+            recipient = local_session.initiator_agent_id
+
+        # Ciphertext is already E2E-encrypted by the SDK. The proxy stores
+        # it opaquely and never needs to decrypt on the local path.
+        import json as _json
+        payload_cipher = _json.dumps(body.payload, separators=(",", ":"))
+
+        try:
+            msg_id, inserted = await local_queue.enqueue(
+                session_id=body.session_id,
+                sender_agent_id=agent.agent_id,
+                recipient_agent_id=recipient,
+                payload_ciphertext=payload_cipher,
+                ttl_seconds=body.ttl_seconds,
+                idempotency_key=body.idempotency_key,
+            )
+        except Exception as exc:
+            logger.error("Local enqueue failed for %s: %s", agent.agent_id, exc)
+            raise HTTPException(status_code=500, detail="enqueue_failed") from exc
+
+        local_session.touch()
+        await save_local_session(local_session)
+
+        # Push-vs-queue: if the recipient is connected, deliver immediately.
+        # Even when we push, the row stays pending until the recipient ack's
+        # so a crash between send_json and ack does not drop the message.
+        ws_manager = getattr(request.app.state, "local_ws_manager", None)
+        pushed = False
+        if ws_manager is not None and ws_manager.is_connected(recipient):
+            pushed = await ws_manager.send_to_agent(
+                recipient,
+                {
+                    "type": "new_message",
+                    "session_id": body.session_id,
+                    "msg_id": msg_id,
+                    "sender_agent_id": agent.agent_id,
+                    "payload": body.payload,
+                    "enqueued_at": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+
+        duration_ms = (time.monotonic() - t0) * 1000
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_send_local",
+            status="success",
+            detail=(
+                f"session={body.session_id} recipient={recipient} "
+                f"msg_id={msg_id} inserted={inserted} pushed={pushed}"
+            ),
+            request_id=request_id,
+            duration_ms=duration_ms,
+        )
+        return {
+            "status": "sent",
+            "session_id": body.session_id,
+            "msg_id": msg_id,
+            "delivered_via": "ws" if pushed else "queue",
+            "duplicate": not inserted,
+        }
+
+    bridge = _get_bridge(request)
     try:
         await bridge.send_message(
             agent.agent_id,
@@ -406,8 +487,38 @@ async def poll_messages(
     after: int = -1,
     agent: InternalAgent = Depends(get_agent_from_api_key),
 ):
-    """Poll for messages in a session."""
+    """Poll for messages in a session (local or broker).
+
+    Local path returns pending messages for the caller; the caller must
+    still hit the ack endpoint before we flip them to `delivered`. That
+    keeps at-least-once semantics even when clients prefer REST polling
+    over the WebSocket push.
+    """
     _validate_session_id(session_id)
+
+    local_store = _get_local_store(request)
+    local_session = local_store.get(session_id) if local_store else None
+    if local_session is not None:
+        if not local_session.involves(agent.agent_id):
+            raise HTTPException(status_code=403, detail="not a participant")
+        local_session.touch()
+        await save_local_session(local_session)
+        pending = await local_queue.fetch_pending_for_recipient(agent.agent_id)
+        # Only messages that belong to this session — the queue is global
+        # per recipient but the caller asked for a specific session.
+        msgs = [m for m in pending if m.session_id == session_id]
+        payload = [
+            {
+                "msg_id": m.msg_id,
+                "session_id": m.session_id,
+                "sender_agent_id": m.sender_agent_id,
+                "payload_ciphertext": m.payload_ciphertext,
+                "enqueued_at": m.enqueued_at.isoformat() if m.enqueued_at else None,
+            }
+            for m in msgs
+        ]
+        return {"messages": payload, "count": len(payload), "scope": "local"}
+
     bridge = _get_bridge(request)
     try:
         messages = await bridge.poll_messages(agent.agent_id, session_id, after)
@@ -421,6 +532,40 @@ async def poll_messages(
             ) from exc
         logger.error("Failed to poll messages for %s: %s", agent.agent_id, exc)
         raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+
+
+@router.post("/sessions/{session_id}/messages/{msg_id}/ack")
+async def ack_message(
+    session_id: str,
+    msg_id: str,
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_api_key),
+):
+    """Acknowledge delivery of a queued local message (ADR-001 Phase 3c).
+
+    Only applies to local sessions. Cross-org ack stays implicit via the
+    broker's M3 ack endpoint. Returns 404 when the msg_id doesn't exist,
+    is already delivered, or belongs to another recipient (same shape
+    across all three to avoid enumeration).
+    """
+    _validate_session_id(session_id)
+    local_store = _get_local_store(request)
+    local_session = local_store.get(session_id) if local_store else None
+    if local_session is None:
+        raise HTTPException(status_code=404, detail="session_not_local")
+    if not local_session.involves(agent.agent_id):
+        raise HTTPException(status_code=403, detail="not a participant")
+
+    ok = await local_queue.mark_delivered(msg_id, agent.agent_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="message_not_found")
+    await log_audit(
+        agent_id=agent.agent_id,
+        action="egress_ack_local",
+        status="success",
+        detail=f"session={session_id} msg_id={msg_id}",
+    )
+    return {"status": "acked", "msg_id": msg_id}
 
 
 @router.post("/discover")

--- a/mcp_proxy/local/message_queue.py
+++ b/mcp_proxy/local/message_queue.py
@@ -1,0 +1,293 @@
+"""Local message queue — ADR-001 Phase 3c.
+
+Twin of `app/broker/message_queue.py` targeting the proxy-local
+`local_messages` table. Same public behavior: at-least-once delivery
+with TTL + idempotency, drained on recipient WS reconnect.
+
+Schema differences vs the broker queue (kept intentionally lean for
+single-org proxy use):
+  - `status` is a TEXT enum ('pending' | 'delivered' | 'expired')
+    instead of an int for readability at the SQL prompt.
+  - No `seq` or `attempts` columns — delivery order is by enqueued_at
+    and a retry counter isn't needed for the simpler single-process
+    delivery path.
+  - No DB-level UNIQUE constraint on (recipient, idempotency_key) —
+    single-process proxy, app-level dedupe is sufficient. When proxy
+    HA lands (Redis + Postgres), the migration will add the unique
+    index and this module will switch to ON CONFLICT DO NOTHING.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+
+_log = logging.getLogger("mcp_proxy.local.message_queue")
+
+
+STATUS_PENDING = "pending"
+STATUS_DELIVERED = "delivered"
+STATUS_EXPIRED = "expired"
+
+DEFAULT_TTL_SECONDS = 300  # mirror broker M3 default
+
+
+@dataclass
+class QueuedLocalMessage:
+    msg_id: str
+    session_id: str
+    sender_agent_id: str
+    recipient_agent_id: str
+    payload_ciphertext: str
+    idempotency_key: str | None
+    enqueued_at: datetime
+    expires_at: datetime | None
+
+
+@dataclass
+class ExpiredLocalMessageNotice:
+    msg_id: str
+    session_id: str
+    sender_agent_id: str
+    recipient_agent_id: str
+
+
+def _iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _parse(raw: str | None) -> datetime | None:
+    if raw is None:
+        return None
+    dt = datetime.fromisoformat(raw)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+async def enqueue(
+    *,
+    session_id: str,
+    sender_agent_id: str,
+    recipient_agent_id: str,
+    payload_ciphertext: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    idempotency_key: str | None = None,
+) -> tuple[str, bool]:
+    """Persist a message awaiting ack.
+
+    Returns `(msg_id, inserted)` — when `inserted` is False the caller
+    is looking at a replay that collided with an existing row via the
+    idempotency key; the returned msg_id is the canonical one. Without
+    an idempotency key, every call is a fresh insert.
+    """
+    async with get_db() as conn:
+        if idempotency_key is not None:
+            existing = await conn.execute(
+                text(
+                    """
+                    SELECT msg_id FROM local_messages
+                     WHERE recipient_agent_id = :recipient
+                       AND idempotency_key = :ikey
+                    """
+                ),
+                {"recipient": recipient_agent_id, "ikey": idempotency_key},
+            )
+            row = existing.first()
+            if row is not None:
+                return row[0], False
+
+        msg_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc)
+        expires = now + timedelta(seconds=ttl_seconds)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_messages
+                    (msg_id, session_id, sender_agent_id, recipient_agent_id,
+                     payload_ciphertext, idempotency_key, status, enqueued_at,
+                     delivered_at, expires_at)
+                VALUES
+                    (:msg_id, :session_id, :sender, :recipient,
+                     :payload, :ikey, :status, :enqueued_at,
+                     NULL, :expires_at)
+                """
+            ),
+            {
+                "msg_id": msg_id,
+                "session_id": session_id,
+                "sender": sender_agent_id,
+                "recipient": recipient_agent_id,
+                "payload": payload_ciphertext,
+                "ikey": idempotency_key,
+                "status": STATUS_PENDING,
+                "enqueued_at": _iso(now),
+                "expires_at": _iso(expires),
+            },
+        )
+        return msg_id, True
+
+
+async def fetch_pending_for_recipient(
+    recipient_agent_id: str,
+    *,
+    limit: int = 500,
+) -> list[QueuedLocalMessage]:
+    """Return pending messages ordered by enqueue time. Pure read."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT msg_id, session_id, sender_agent_id, recipient_agent_id,
+                       payload_ciphertext, idempotency_key, enqueued_at, expires_at
+                  FROM local_messages
+                 WHERE recipient_agent_id = :recipient
+                   AND status = :status
+                 ORDER BY enqueued_at ASC
+                 LIMIT :limit
+                """
+            ),
+            {
+                "recipient": recipient_agent_id,
+                "status": STATUS_PENDING,
+                "limit": limit,
+            },
+        )
+        out: list[QueuedLocalMessage] = []
+        for row in result.mappings():
+            out.append(
+                QueuedLocalMessage(
+                    msg_id=row["msg_id"],
+                    session_id=row["session_id"],
+                    sender_agent_id=row["sender_agent_id"],
+                    recipient_agent_id=row["recipient_agent_id"],
+                    payload_ciphertext=row["payload_ciphertext"],
+                    idempotency_key=row["idempotency_key"],
+                    enqueued_at=_parse(row["enqueued_at"]),
+                    expires_at=_parse(row["expires_at"]),
+                )
+            )
+        return out
+
+
+async def mark_delivered(msg_id: str, recipient_agent_id: str) -> bool:
+    """Flip a pending row to `delivered`. Scoped by recipient so one agent
+    can't ack another agent's queue entry. Returns True on success."""
+    async with get_db() as conn:
+        now_iso = _iso(datetime.now(timezone.utc))
+        result = await conn.execute(
+            text(
+                """
+                UPDATE local_messages
+                   SET status = :delivered,
+                       delivered_at = :now
+                 WHERE msg_id = :msg_id
+                   AND recipient_agent_id = :recipient
+                   AND status = :pending
+                """
+            ),
+            {
+                "delivered": STATUS_DELIVERED,
+                "now": now_iso,
+                "msg_id": msg_id,
+                "recipient": recipient_agent_id,
+                "pending": STATUS_PENDING,
+            },
+        )
+        return (result.rowcount or 0) > 0
+
+
+async def fetch_for_session(
+    session_id: str,
+    after_iso: str | None = None,
+    *,
+    limit: int = 500,
+) -> list[QueuedLocalMessage]:
+    """Read messages visible to session participants. Includes both
+    pending and delivered rows so the legacy REST poll path (pre-WS
+    clients) observes a stable history."""
+    async with get_db() as conn:
+        params: dict = {"session_id": session_id, "limit": limit}
+        where = "session_id = :session_id"
+        if after_iso is not None:
+            where += " AND enqueued_at > :after_iso"
+            params["after_iso"] = after_iso
+        result = await conn.execute(
+            text(
+                f"""
+                SELECT msg_id, session_id, sender_agent_id, recipient_agent_id,
+                       payload_ciphertext, idempotency_key, enqueued_at, expires_at
+                  FROM local_messages
+                 WHERE {where}
+                 ORDER BY enqueued_at ASC
+                 LIMIT :limit
+                """
+            ),
+            params,
+        )
+        return [
+            QueuedLocalMessage(
+                msg_id=row["msg_id"],
+                session_id=row["session_id"],
+                sender_agent_id=row["sender_agent_id"],
+                recipient_agent_id=row["recipient_agent_id"],
+                payload_ciphertext=row["payload_ciphertext"],
+                idempotency_key=row["idempotency_key"],
+                enqueued_at=_parse(row["enqueued_at"]),
+                expires_at=_parse(row["expires_at"]),
+            )
+            for row in result.mappings()
+        ]
+
+
+async def sweep_expired(
+    *, limit: int = 1000
+) -> list[ExpiredLocalMessageNotice]:
+    """Flip TTL-expired pending rows to status=expired and return the
+    set so callers can notify senders. Used by the Phase 3d sweeper."""
+    async with get_db() as conn:
+        now_iso = _iso(datetime.now(timezone.utc))
+        result = await conn.execute(
+            text(
+                """
+                SELECT msg_id, session_id, sender_agent_id, recipient_agent_id
+                  FROM local_messages
+                 WHERE status = :pending
+                   AND expires_at IS NOT NULL
+                   AND expires_at < :now
+                 LIMIT :limit
+                """
+            ),
+            {"pending": STATUS_PENDING, "now": now_iso, "limit": limit},
+        )
+        notices = [
+            ExpiredLocalMessageNotice(
+                msg_id=row["msg_id"],
+                session_id=row["session_id"],
+                sender_agent_id=row["sender_agent_id"],
+                recipient_agent_id=row["recipient_agent_id"],
+            )
+            for row in result.mappings()
+        ]
+        if not notices:
+            return []
+        await conn.execute(
+            text(
+                """
+                UPDATE local_messages
+                   SET status = :expired
+                 WHERE status = :pending
+                   AND expires_at IS NOT NULL
+                   AND expires_at < :now
+                """
+            ),
+            {"expired": STATUS_EXPIRED, "pending": STATUS_PENDING, "now": now_iso},
+        )
+        return notices

--- a/mcp_proxy/local/ws_router.py
+++ b/mcp_proxy/local/ws_router.py
@@ -14,6 +14,7 @@ is internal-facing (loopback or LAN); if logs capture URLs, redact the
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Query, WebSocket
@@ -68,8 +69,17 @@ async def local_ws(
         # ADR-001 Phase 3c — drain any messages that were enqueued while
         # this agent was offline. Each replay carries queued:true so the
         # SDK can skip duplicate business handlers if the flow is idempotent.
+        # Guarded with a timeout so a slow DB can't stall the WS accept
+        # indefinitely — pending rows remain in the queue for the next
+        # reconnect.
         try:
-            pending = await local_queue.fetch_pending_for_recipient(agent_id)
+            pending = await asyncio.wait_for(
+                local_queue.fetch_pending_for_recipient(agent_id),
+                timeout=5.0,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Local queue drain timed out for %s", agent_id)
+            pending = []
         except Exception as exc:
             logger.warning("Local queue drain failed for %s: %s", agent_id, exc)
             pending = []

--- a/mcp_proxy/local/ws_router.py
+++ b/mcp_proxy/local/ws_router.py
@@ -20,6 +20,7 @@ from fastapi import APIRouter, Query, WebSocket
 from starlette.websockets import WebSocketDisconnect, WebSocketState
 
 from mcp_proxy.db import get_agent_by_key_hash
+from mcp_proxy.local import message_queue as local_queue
 from mcp_proxy.local.ws_manager import LocalConnectionManager
 
 logger = logging.getLogger("mcp_proxy.local.ws_router")
@@ -63,6 +64,34 @@ async def local_ws(
 
     try:
         await websocket.send_json({"type": "connected", "agent_id": agent_id})
+
+        # ADR-001 Phase 3c — drain any messages that were enqueued while
+        # this agent was offline. Each replay carries queued:true so the
+        # SDK can skip duplicate business handlers if the flow is idempotent.
+        try:
+            pending = await local_queue.fetch_pending_for_recipient(agent_id)
+        except Exception as exc:
+            logger.warning("Local queue drain failed for %s: %s", agent_id, exc)
+            pending = []
+        for msg in pending:
+            import json as _json
+            try:
+                payload = _json.loads(msg.payload_ciphertext)
+            except Exception:
+                payload = msg.payload_ciphertext
+            await websocket.send_json(
+                {
+                    "type": "new_message",
+                    "session_id": msg.session_id,
+                    "msg_id": msg.msg_id,
+                    "sender_agent_id": msg.sender_agent_id,
+                    "payload": payload,
+                    "enqueued_at": msg.enqueued_at.isoformat()
+                    if msg.enqueued_at else None,
+                    "queued": True,
+                }
+            )
+
         while True:
             # Treat any inbound frame as a keepalive. Phase 3c may add
             # client-initiated ack frames here.

--- a/tests/test_proxy_local_messages.py
+++ b/tests/test_proxy_local_messages.py
@@ -1,0 +1,304 @@
+"""ADR-001 Phase 3c — local message queue + ack + push-vs-queue.
+
+Covers:
+  - message_queue.enqueue / fetch_pending / mark_delivered / sweep_expired
+  - idempotency key dedupe
+  - /send intra path enqueues + pushes when WS connected
+  - /messages/{id} intra returns pending rows
+  - /sessions/{id}/messages/{msg_id}/ack flips status
+  - /send intra path with no WS connection stays queued
+  - drain on /v1/local/ws reconnect replays pending
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from starlette.testclient import TestClient
+
+from mcp_proxy.local import message_queue as local_queue
+
+
+# ── Unit — message_queue ────────────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    from mcp_proxy.db import dispose_db, init_db
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    await init_db(url)
+    yield url
+    await dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_and_fetch(proxy_db):
+    msg_id, inserted = await local_queue.enqueue(
+        session_id="s1",
+        sender_agent_id="alice",
+        recipient_agent_id="bob",
+        payload_ciphertext="hello",
+    )
+    assert inserted is True
+    pending = await local_queue.fetch_pending_for_recipient("bob")
+    assert len(pending) == 1
+    assert pending[0].msg_id == msg_id
+    assert pending[0].sender_agent_id == "alice"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_key_dedupes(proxy_db):
+    msg_id_1, inserted_1 = await local_queue.enqueue(
+        session_id="s1", sender_agent_id="alice",
+        recipient_agent_id="bob", payload_ciphertext="x",
+        idempotency_key="k-1",
+    )
+    msg_id_2, inserted_2 = await local_queue.enqueue(
+        session_id="s1", sender_agent_id="alice",
+        recipient_agent_id="bob", payload_ciphertext="x",
+        idempotency_key="k-1",
+    )
+    assert inserted_1 is True
+    assert inserted_2 is False
+    assert msg_id_1 == msg_id_2
+    pending = await local_queue.fetch_pending_for_recipient("bob")
+    assert len(pending) == 1
+
+
+@pytest.mark.asyncio
+async def test_mark_delivered_flips_status(proxy_db):
+    msg_id, _ = await local_queue.enqueue(
+        session_id="s1", sender_agent_id="alice",
+        recipient_agent_id="bob", payload_ciphertext="x",
+    )
+    ok = await local_queue.mark_delivered(msg_id, "bob")
+    assert ok is True
+    pending = await local_queue.fetch_pending_for_recipient("bob")
+    assert pending == []
+
+
+@pytest.mark.asyncio
+async def test_mark_delivered_rejects_other_recipient(proxy_db):
+    msg_id, _ = await local_queue.enqueue(
+        session_id="s1", sender_agent_id="alice",
+        recipient_agent_id="bob", payload_ciphertext="x",
+    )
+    ok = await local_queue.mark_delivered(msg_id, "carol")
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_mark_delivered_idempotent(proxy_db):
+    msg_id, _ = await local_queue.enqueue(
+        session_id="s1", sender_agent_id="alice",
+        recipient_agent_id="bob", payload_ciphertext="x",
+    )
+    assert await local_queue.mark_delivered(msg_id, "bob") is True
+    assert await local_queue.mark_delivered(msg_id, "bob") is False
+
+
+@pytest.mark.asyncio
+async def test_sweep_expired_flips_rows(proxy_db):
+    msg_id, _ = await local_queue.enqueue(
+        session_id="s1", sender_agent_id="alice",
+        recipient_agent_id="bob", payload_ciphertext="x",
+        ttl_seconds=10,
+    )
+    # Force expiry via direct UPDATE — avoids sleeping in unit test.
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    past = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE local_messages SET expires_at=:p WHERE msg_id=:m"),
+            {"p": past, "m": msg_id},
+        )
+    notices = await local_queue.sweep_expired()
+    assert len(notices) == 1
+    assert notices[0].msg_id == msg_id
+    assert await local_queue.fetch_pending_for_recipient("bob") == []
+
+
+# ── Integration — router /send + /messages + /ack + WS drain ────────
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision(agent_id: str) -> str:
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+    raw = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=[],
+        api_key_hash=hash_api_key(raw),
+    )
+    return raw
+
+
+async def _open_local_session(client: AsyncClient, initiator_key: str, responder: str) -> str:
+    resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": initiator_key},
+        json={
+            "target_agent_id": responder,
+            "target_org_id": "acme",
+            "capabilities": [],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["session_id"]
+
+
+@pytest.mark.asyncio
+async def test_send_intra_enqueues_and_polls(proxy_app):
+    _, client = proxy_app
+    initiator_key = await _provision("alice")
+    responder_key = await _provision("bob")
+    session_id = await _open_local_session(client, initiator_key, "bob")
+
+    send = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": initiator_key},
+        json={
+            "session_id": session_id,
+            "payload": {"greet": "hi"},
+            "recipient_agent_id": "bob",
+        },
+    )
+    assert send.status_code == 200, send.text
+    body = send.json()
+    assert body["status"] == "sent"
+    assert body["delivered_via"] == "queue"
+    assert body["duplicate"] is False
+    msg_id = body["msg_id"]
+
+    poll = await client.get(
+        f"/v1/egress/messages/{session_id}",
+        headers={"X-API-Key": responder_key},
+    )
+    assert poll.status_code == 200
+    data = poll.json()
+    assert data["count"] == 1
+    assert data["scope"] == "local"
+    assert data["messages"][0]["msg_id"] == msg_id
+
+
+@pytest.mark.asyncio
+async def test_ack_removes_message_from_pending(proxy_app):
+    _, client = proxy_app
+    initiator_key = await _provision("alice")
+    responder_key = await _provision("bob")
+    session_id = await _open_local_session(client, initiator_key, "bob")
+
+    send = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": initiator_key},
+        json={"session_id": session_id, "payload": {"x": 1}, "recipient_agent_id": "bob"},
+    )
+    msg_id = send.json()["msg_id"]
+
+    ack = await client.post(
+        f"/v1/egress/sessions/{session_id}/messages/{msg_id}/ack",
+        headers={"X-API-Key": responder_key},
+    )
+    assert ack.status_code == 200
+
+    poll = await client.get(
+        f"/v1/egress/messages/{session_id}",
+        headers={"X-API-Key": responder_key},
+    )
+    assert poll.json()["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_ack_rejects_stranger(proxy_app):
+    _, client = proxy_app
+    initiator_key = await _provision("alice")
+    await _provision("bob")
+    stranger_key = await _provision("eve")
+    session_id = await _open_local_session(client, initiator_key, "bob")
+
+    send = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": initiator_key},
+        json={"session_id": session_id, "payload": {}, "recipient_agent_id": "bob"},
+    )
+    msg_id = send.json()["msg_id"]
+
+    resp = await client.post(
+        f"/v1/egress/sessions/{session_id}/messages/{msg_id}/ack",
+        headers={"X-API-Key": stranger_key},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_send_idempotency_key_marks_duplicate(proxy_app):
+    _, client = proxy_app
+    initiator_key = await _provision("alice")
+    await _provision("bob")
+    session_id = await _open_local_session(client, initiator_key, "bob")
+
+    body = {
+        "session_id": session_id,
+        "payload": {"x": 1},
+        "recipient_agent_id": "bob",
+        "idempotency_key": "order-42",
+    }
+    first = await client.post("/v1/egress/send", headers={"X-API-Key": initiator_key}, json=body)
+    second = await client.post("/v1/egress/send", headers={"X-API-Key": initiator_key}, json=body)
+    assert first.json()["duplicate"] is False
+    assert second.json()["duplicate"] is True
+    assert first.json()["msg_id"] == second.json()["msg_id"]
+
+
+@pytest.mark.asyncio
+async def test_ws_drain_delivers_pending(proxy_app):
+    app, client = proxy_app
+    initiator_key = await _provision("alice")
+    responder_key = await _provision("bob")
+    session_id = await _open_local_session(client, initiator_key, "bob")
+
+    await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": initiator_key},
+        json={"session_id": session_id, "payload": {"n": 1}, "recipient_agent_id": "bob"},
+    )
+    await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": initiator_key},
+        json={"session_id": session_id, "payload": {"n": 2}, "recipient_agent_id": "bob"},
+    )
+
+    tc = TestClient(app, raise_server_exceptions=True)
+    with tc.websocket_connect(f"/v1/local/ws?api_key={responder_key}") as ws:
+        welcome = ws.receive_json()
+        assert welcome["type"] == "connected"
+        first = ws.receive_json()
+        second = ws.receive_json()
+        assert first["queued"] is True
+        assert second["queued"] is True
+        payloads = sorted([first["payload"]["n"], second["payload"]["n"]])
+        assert payloads == [1, 2]


### PR DESCRIPTION
## Summary

Third slice of the M3-twin mini-broker (#53). Intra-org messages are now delivered locally in the proxy with **at-least-once semantics, TTL expiry, idempotency dedupe, and push-vs-queue routing** that mirror the broker's M3 stack.

No behavior change when \`PROXY_INTRA_ORG=false\` (default) or when the session lives on the broker — cross-org path is untouched.

## What it does
- \`POST /v1/egress/send\` for a local session → enqueue on \`local_messages\` + push via local WS if recipient connected; otherwise stays pending for drain on reconnect
- \`GET /v1/egress/messages/{session_id}\` for a local session → pending rows scoped to the caller (read-only, client must still ack)
- \`POST /v1/egress/sessions/{id}/messages/{msg_id}/ack\` new endpoint → flips status to \`delivered\`
- WS \`/v1/local/ws\` on connect → drains pending with \`queued:true\` flag on each frame

## Files
- \`mcp_proxy/local/message_queue.py\` — enqueue / fetch_pending / mark_delivered / fetch_for_session / sweep_expired (used by Phase 3d sweeper)
- \`mcp_proxy/egress/router.py\` — \`/send\` + \`/messages\` + new \`/ack\` endpoints, gated on local session
- \`mcp_proxy/local/ws_router.py\` — drain hook on connect
- \`tests/test_proxy_local_messages.py\` — 11 tests

## SDK params
\`SendMessageRequest\` adds \`ttl_seconds\` (10..3600 default 300) and \`idempotency_key\` (optional) — mirrors broker M3 so existing cross-org clients aren't affected.

## Test plan
- [x] \`pytest tests/test_proxy_local_messages.py\` — 11/11 green (including E2E WS drain)
- [x] Full suite: **595 passed, 5 skipped, 0 regressions**
- [x] \`./demo_network/smoke.sh full\` — PASS
- [ ] CI: helm-test, demo_network smoke matrix, test (3.11), security, DCO

## Out of scope (next)
- SDK routing \`CULLIS_SDK_INTRA_LOCAL_WS\` — follow-up PR
- Sweeper task (idle session + TTL expire in a lifespan loop) — Phase 3d

🤖 Generated with [Claude Code](https://claude.com/claude-code)