### PR TITLE
feat(proxy): ADR-001 Phase 3d — local sweeper (closes Phase 3)

### DIFF
--- a/mcp_proxy/local/sweeper.py
+++ b/mcp_proxy/local/sweeper.py
@@ -1,0 +1,156 @@
+"""Local mini-broker sweeper — ADR-001 Phase 3d.
+
+Background task that periodically:
+  - Closes idle or TTL-expired local sessions (mirrors M1 broker-side).
+  - Flips TTL-expired pending local_messages rows to `expired` and
+    best-effort notifies senders via the local WS manager (mirrors M3.6).
+
+Lifecycle is owned by the FastAPI lifespan in `mcp_proxy/main.py`.
+Kept defensive: each step's failures are isolated so one broken piece
+doesn't stop the others from running.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from mcp_proxy.local import message_queue as local_queue
+from mcp_proxy.local.models import SessionStatus
+from mcp_proxy.local.persistence import save_session as save_local_session
+from mcp_proxy.local.session import (
+    LOCAL_SESSION_IDLE_TIMEOUT_SECONDS,
+    LocalSessionStore,
+)
+from mcp_proxy.local.ws_manager import LocalConnectionManager
+
+_log = logging.getLogger("mcp_proxy.local.sweeper")
+
+
+def _env_int(name: str, default: int, minimum: int = 1) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return max(minimum, int(raw))
+    except ValueError:
+        return default
+
+
+LOCAL_SWEEP_INTERVAL_SECONDS = _env_int("PROXY_LOCAL_SWEEP_INTERVAL_SECONDS", 30)
+
+
+async def sweep_once(
+    store: LocalSessionStore,
+    ws_manager: LocalConnectionManager | None = None,
+    *,
+    idle_timeout_seconds: int = LOCAL_SESSION_IDLE_TIMEOUT_SECONDS,
+) -> tuple[int, int]:
+    """One sweep pass. Returns `(sessions_closed, messages_expired)`.
+
+    Extracted so tests can exercise the logic deterministically without
+    spawning a loop.
+    """
+    # ── Sessions: close stale (idle or TTL-expired) ──────────────
+    stale = store.find_stale(idle_timeout_seconds=idle_timeout_seconds)
+    sessions_closed = 0
+    for session, reason in stale:
+        async with store._lock:
+            if session.status == SessionStatus.closed:
+                continue
+            store.close(session.session_id, reason)
+
+        try:
+            await save_local_session(session)
+        except Exception:
+            _log.exception(
+                "sweeper: failed to persist local session %s close",
+                session.session_id,
+            )
+
+        if ws_manager is not None:
+            payload = {
+                "type": "session_closed",
+                "session_id": session.session_id,
+                "reason": reason.value,
+            }
+            for agent_id in (session.initiator_agent_id, session.responder_agent_id):
+                try:
+                    await ws_manager.send_to_agent(agent_id, payload)
+                except Exception as exc:
+                    _log.debug(
+                        "session_closed notify failed for %s (session %s): %s",
+                        agent_id, session.session_id, exc,
+                    )
+
+        sessions_closed += 1
+        _log.info(
+            "local sweeper closed session %s (reason=%s)",
+            session.session_id, reason.value,
+        )
+
+    # ── Messages: expire TTL-lapsed pending rows ─────────────────
+    try:
+        notices = await asyncio.wait_for(local_queue.sweep_expired(), timeout=5.0)
+    except asyncio.TimeoutError:
+        _log.warning("local sweeper: message queue sweep exceeded 5s — skipping")
+        notices = []
+    except Exception:
+        _log.exception("local sweeper: message queue sweep failed")
+        notices = []
+
+    if ws_manager is not None:
+        for n in notices:
+            payload = {
+                "type": "message_expired",
+                "session_id": n.session_id,
+                "msg_id": n.msg_id,
+                "recipient_agent_id": n.recipient_agent_id,
+                "reason": "ttl",
+            }
+            try:
+                await ws_manager.send_to_agent(n.sender_agent_id, payload)
+            except Exception as exc:
+                _log.debug(
+                    "message_expired notify failed for sender %s (msg %s): %s",
+                    n.sender_agent_id, n.msg_id, exc,
+                )
+
+    return sessions_closed, len(notices)
+
+
+async def sweeper_loop(
+    store: LocalSessionStore,
+    ws_manager: LocalConnectionManager | None = None,
+    *,
+    interval_seconds: int = LOCAL_SWEEP_INTERVAL_SECONDS,
+    idle_timeout_seconds: int = LOCAL_SESSION_IDLE_TIMEOUT_SECONDS,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Run sweeps on a cadence until `stop_event` fires (or task cancel)."""
+    _log.info(
+        "local sweeper started (interval=%ds, idle_timeout=%ds)",
+        interval_seconds, idle_timeout_seconds,
+    )
+    while True:
+        try:
+            if stop_event is not None and stop_event.is_set():
+                break
+            await sweep_once(
+                store, ws_manager, idle_timeout_seconds=idle_timeout_seconds,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.exception("local sweeper cycle failed — continuing")
+
+        if stop_event is not None:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=interval_seconds)
+                break
+            except asyncio.TimeoutError:
+                continue
+        else:
+            await asyncio.sleep(interval_seconds)
+
+    _log.info("local sweeper stopped")

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -6,7 +6,9 @@ Standalone component with ZERO imports from app/.
 
 Lifespan: validate_config -> init_db -> JWKS fetch -> yield -> cleanup
 """
+import asyncio
 import logging
+import os
 import time
 from contextlib import asynccontextmanager
 
@@ -119,6 +121,26 @@ async def lifespan(app: FastAPI):
     # PROXY_INTRA_ORG flag.
     app.state.local_ws_manager = LocalConnectionManager()
 
+    # Phase 3d — sweeper. Closes idle/TTL-expired local sessions and
+    # expires pending messages whose TTL lapsed, best-effort notifying
+    # peers. Only spawned when PROXY_INTRA_ORG is on (otherwise no
+    # intra-org traffic ever lands in local_* tables, so there's
+    # nothing to sweep). Also explicitly skippable via
+    # PROXY_LOCAL_SWEEPER_DISABLED=1 for deterministic tests.
+    if settings.intra_org_routing and os.environ.get("PROXY_LOCAL_SWEEPER_DISABLED") != "1":
+        from mcp_proxy.local.sweeper import sweeper_loop as _local_sweeper_loop
+        stop_event = asyncio.Event()
+        sweeper_task = asyncio.create_task(
+            _local_sweeper_loop(
+                local_store,
+                app.state.local_ws_manager,
+                stop_event=stop_event,
+            ),
+            name="local_sweeper",
+        )
+        app.state.local_sweeper_stop = stop_event
+        app.state.local_sweeper_task = sweeper_task
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
@@ -127,6 +149,20 @@ async def lifespan(app: FastAPI):
     yield
 
     # Cleanup
+    stop_event = getattr(app.state, "local_sweeper_stop", None)
+    sweeper_task = getattr(app.state, "local_sweeper_task", None)
+    if stop_event is not None:
+        stop_event.set()
+    if sweeper_task is not None:
+        try:
+            await asyncio.wait_for(sweeper_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            sweeper_task.cancel()
+            try:
+                await sweeper_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
     ws_manager = getattr(app.state, "local_ws_manager", None)
     if ws_manager is not None:
         await ws_manager.shutdown()

--- a/tests/test_proxy_local_messages.py
+++ b/tests/test_proxy_local_messages.py
@@ -132,6 +132,7 @@ async def proxy_app(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
     monkeypatch.delenv("PROXY_DB_URL", raising=False)
     monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()

--- a/tests/test_proxy_local_sessions.py
+++ b/tests/test_proxy_local_sessions.py
@@ -192,6 +192,7 @@ async def proxy_app(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
     monkeypatch.delenv("PROXY_DB_URL", raising=False)
     monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
     # Settings singleton is lru_cache'd — flush between tests

--- a/tests/test_proxy_local_sweeper.py
+++ b/tests/test_proxy_local_sweeper.py
@@ -1,0 +1,169 @@
+"""ADR-001 Phase 3d — local mini-broker sweeper.
+
+Covers:
+  - sweep_once closes idle sessions + TTL-expired sessions
+  - sweep_once expires TTL-lapsed queue rows
+  - sweeper_loop respects stop_event and wakes out of sleep
+  - sweeper emits session_closed + message_expired on the WS manager
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.local import message_queue as local_queue
+from mcp_proxy.local.models import SessionCloseReason, SessionStatus
+from mcp_proxy.local.session import LocalSessionStore
+from mcp_proxy.local.sweeper import sweep_once, sweeper_loop
+from mcp_proxy.local.ws_manager import LocalConnectionManager
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    await init_db(url)
+    yield url
+    await dispose_db()
+
+
+class _FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send_json(self, data: dict) -> None:
+        self.sent.append(data)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_sweep_closes_idle_session(proxy_db):
+    store = LocalSessionStore()
+    s = store.create("alice", "bob", [])
+    store.activate(s.session_id)
+    # Force last_activity into the past.
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(seconds=3600)
+
+    closed, expired = await sweep_once(store, idle_timeout_seconds=60)
+    assert closed == 1
+    assert expired == 0
+    assert store.get(s.session_id).status == SessionStatus.closed
+    assert store.get(s.session_id).close_reason == SessionCloseReason.idle_timeout
+
+
+@pytest.mark.asyncio
+async def test_sweep_closes_ttl_expired_session(proxy_db):
+    store = LocalSessionStore(session_ttl_minutes=1)
+    s = store.create("alice", "bob", [])
+    s.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+    closed, _ = await sweep_once(store)
+    assert closed == 1
+    # store.get already flips expired sessions to closed before find_stale,
+    # so the sweeper may see them as already-closed and skip the transition.
+    # Either way, status is closed and the reason is ttl_expired.
+    sess = store.get(s.session_id)
+    assert sess.status == SessionStatus.closed
+    assert sess.close_reason == SessionCloseReason.ttl_expired
+
+
+@pytest.mark.asyncio
+async def test_sweep_expires_ttl_lapsed_messages(proxy_db):
+    store = LocalSessionStore()
+    msg_id, _ = await local_queue.enqueue(
+        session_id="s1",
+        sender_agent_id="alice",
+        recipient_agent_id="bob",
+        payload_ciphertext="x",
+        ttl_seconds=10,
+    )
+    past = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE local_messages SET expires_at=:p WHERE msg_id=:m"),
+            {"p": past, "m": msg_id},
+        )
+
+    _, expired = await sweep_once(store)
+    assert expired == 1
+    assert await local_queue.fetch_pending_for_recipient("bob") == []
+
+
+@pytest.mark.asyncio
+async def test_sweep_notifies_peers_on_session_close(proxy_db):
+    store = LocalSessionStore()
+    ws = LocalConnectionManager()
+    alice_ws, bob_ws = _FakeWS(), _FakeWS()
+    await ws.connect("alice", alice_ws)
+    await ws.connect("bob", bob_ws)
+
+    s = store.create("alice", "bob", [])
+    store.activate(s.session_id)
+    s.last_activity_at = datetime.now(timezone.utc) - timedelta(seconds=3600)
+
+    await sweep_once(store, ws, idle_timeout_seconds=60)
+
+    for recorded in (alice_ws.sent, bob_ws.sent):
+        assert any(
+            f.get("type") == "session_closed"
+            and f.get("session_id") == s.session_id
+            and f.get("reason") == SessionCloseReason.idle_timeout.value
+            for f in recorded
+        )
+
+
+@pytest.mark.asyncio
+async def test_sweep_notifies_sender_on_message_expiry(proxy_db):
+    store = LocalSessionStore()
+    ws = LocalConnectionManager()
+    alice_ws = _FakeWS()
+    await ws.connect("alice", alice_ws)
+
+    msg_id, _ = await local_queue.enqueue(
+        session_id="s1",
+        sender_agent_id="alice",
+        recipient_agent_id="bob",
+        payload_ciphertext="x",
+        ttl_seconds=10,
+    )
+    past = (datetime.now(timezone.utc) - timedelta(seconds=60)).isoformat()
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE local_messages SET expires_at=:p WHERE msg_id=:m"),
+            {"p": past, "m": msg_id},
+        )
+
+    await sweep_once(store, ws)
+
+    assert any(
+        f.get("type") == "message_expired"
+        and f.get("msg_id") == msg_id
+        and f.get("reason") == "ttl"
+        for f in alice_ws.sent
+    )
+
+
+@pytest.mark.asyncio
+async def test_sweeper_loop_stops_on_event(proxy_db):
+    store = LocalSessionStore()
+    stop_event = asyncio.Event()
+
+    task = asyncio.create_task(
+        sweeper_loop(store, interval_seconds=100, stop_event=stop_event),
+    )
+    # Give the loop one cycle to start.
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    # Should return without needing the full 100s interval thanks to
+    # asyncio.wait_for on stop_event.wait().
+    await asyncio.wait_for(task, timeout=5.0)
+    assert task.done()


### PR DESCRIPTION
## Summary

Final slice of ADR-001 Phase 3 (#53). Background task scans the local store + queue on a cadence:
- Closes idle + TTL-expired local sessions → \`session_closed\` frame to peers
- Expires TTL-lapsed pending \`local_messages\` → \`message_expired\` frame to sender

Gated on \`intra_org_routing\` — when the flag is off nothing lands in \`local_*\` tables, so nothing to sweep and no task is spawned. Keeps pre-Phase-3 test suites unchanged.

## Files
- \`mcp_proxy/local/sweeper.py\` — \`sweep_once\` (deterministic) + \`sweeper_loop\` (background, stop_event-driven)
- \`mcp_proxy/main.py\` — lifespan spawn + graceful shutdown (stop_event + 5s \`wait_for\` with cancel fallback)
- \`tests/test_proxy_local_sweeper.py\` — 6 tests

## Config
- \`PROXY_LOCAL_SWEEP_INTERVAL_SECONDS\` default 30
- \`PROXY_LOCAL_SESSION_IDLE_TIMEOUT_SECONDS\` default 600 (10 min)
- \`PROXY_LOCAL_SESSION_HARD_TTL_MINUTES\` default 60
- \`PROXY_LOCAL_SWEEPER_DISABLED=1\` — explicit off switch for tests

## Phase 3 status
- 3a local session lifecycle ✅ #54
- 3b proxy WS server ✅ #55
- 3c message queue + ack + push-vs-queue ✅ #60
- 3d sweeper ✅ **this PR**

Phase 3 is complete. Phase 4 (sync broker↔proxy) and Phase 5 (Guardian) remain.

## Test plan
- [x] \`pytest tests/test_proxy_local_sweeper.py\` — 6/6 green
- [x] Full suite: **601 passed, 5 skipped, 0 regressions**
- [x] \`./demo_network/smoke.sh full\` — PASS
- [ ] CI: helm-test, demo_network smoke matrix, test (3.11), security, DCO

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)