### PR TITLE
ci: parallelize tests with pytest-xdist (~8x speedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: requirements.txt
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -32,14 +34,6 @@ jobs:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: sdk-ts/package-lock.json
-
-      - name: Cache pip
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |
@@ -70,7 +64,7 @@ jobs:
           OTEL_ENABLED: "false"
           DATABASE_URL: "sqlite+aiosqlite://"
         run: |
-          pytest tests/ -v --tb=short --ignore=tests/test_postgres_integration.py
+          pytest tests/ --tb=short --ignore=tests/test_postgres_integration.py
 
   security:
     runs-on: ubuntu-latest

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,4 +12,4 @@ markers =
     timeout: per-test timeout in seconds (requires pytest-timeout)
 
 # Skip the e2e marker by default. The unit suite still runs everything else.
-addopts = -m "not e2e"
+addopts = -m "not e2e" -n auto --dist=loadfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,7 @@ opentelemetry-exporter-prometheus>=0.46b0
 prometheus-client>=0.20.0
 pytest>=8.3.4
 pytest-asyncio>=0.25.2
+pytest-xdist>=3.6.0
+pytest-split>=0.9.0
 mcp>=1.0
 PyYAML>=6.0

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -27,11 +27,14 @@ async def test_metrics_endpoint_does_not_require_auth(client: AsyncClient):
 
 async def test_metrics_endpoint_when_enabled(client: AsyncClient, monkeypatch):
     """When PROMETHEUS_ENABLED=true, /metrics returns the Prometheus text format."""
-    from app.config import get_settings
+    import app.main
 
-    # Patch the cached settings to enable Prometheus for this test only.
-    s = get_settings()
-    monkeypatch.setattr(s, "prometheus_enabled", True)
+    # Patch both the lru_cached settings *and* the module-level reference in
+    # app.main. If another test has called `get_settings.cache_clear()` earlier
+    # on this worker, `get_settings()` now returns a fresh instance while
+    # `app.main.settings` still references the original — the /metrics route
+    # reads from the latter, so we must flip the flag there too.
+    monkeypatch.setattr(app.main.settings, "prometheus_enabled", True)
 
     resp = await client.get("/metrics")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add `pytest-xdist` + `pytest-split` to requirements; default pytest to `-n auto --dist=loadfile`
- `loadfile` keeps each test file on a single worker so stateful modules (`test_e2e` steps, `test_rfq`) don't race on shared state
- Switch CI to `setup-python`'s native pip cache, drop `-v` from pytest invocation

## Numbers
- Local (Ryzen 7, 16c, 624 tests): **5:27 → 0:38** (~8.6×)
- GitHub runner (4 vCPU): expected **~1:30–2:00** vs 7:34 baseline — this PR's own CI run is the measurement

## Test plan
- [x] Local `pytest tests/` green (624 passed, 5 skipped, 38s)
- [x] Verified `-n auto` alone breaks 4 tests; `--dist=loadfile` fixes all
- [ ] GitHub Actions CI green on this PR, confirm wall-clock improvement