### PR TITLE
feat(broker): A2A Phase 2b — SendMessage / GetTask / CancelTask

### DIFF
--- a/app/a2a/adapter.py
+++ b/app/a2a/adapter.py
@@ -1,0 +1,215 @@
+"""Bidirectional Cullis ⇄ A2A translation — ADR-002 Phase 2b.
+
+Pure mapping functions, no I/O. The router layer calls these to:
+
+  - wrap a Cullis envelope as an A2A `Message` (outbound)
+  - unwrap an A2A `Message` back to a Cullis envelope (inbound)
+  - project a Cullis session + its messages as an A2A `Task`
+  - normalize TaskState strings (hyphen↔underscore, unknown→failed)
+
+Per ADR-002 §2.2 the adapter holds the mapping contextId==taskId==session_id.
+Per §2.3 / spike Q1 the ciphertext rides as a single `DataPart`, with the
+mediaType marker in `metadata`, and Cullis-specific transport fields
+(nonce, signature, timestamp, client_seq, sender_agent_id) ride in
+`Message.metadata.cullis`.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from a2a.types import DataPart, Message, Part, Role, Task, TaskState, TaskStatus
+
+CULLIS_E2E_MEDIATYPE = "application/vnd.cullis.e2e+json"
+
+_CIPHER_FIELDS = ("ciphertext", "iv", "encrypted_key", "ephemeral_pubkey")
+_TRANSPORT_FIELDS = ("nonce", "timestamp", "signature", "client_seq", "sender_agent_id")
+
+_SESSION_STATE_MAP = {
+    "pending": TaskState.submitted,
+    "active": TaskState.working,
+    "denied": TaskState.rejected,
+}
+
+_CLOSE_REASON_MAP = {
+    "normal": TaskState.completed,
+    "rejected": TaskState.rejected,
+    "canceled": TaskState.canceled,  # surface A2A CancelTask explicitly
+    "idle_timeout": TaskState.failed,
+    "ttl_expired": TaskState.failed,
+    "peer_lost": TaskState.failed,
+    "policy_revoked": TaskState.failed,
+    "pending_timeout": TaskState.failed,
+}
+
+
+def normalize_task_state(raw: str | None) -> TaskState:
+    """Accept hyphen/underscore variants; map unknown or missing → failed.
+
+    Spike Q5: SDK wire form uses hyphens (`input-required`), protobuf
+    canonical form uses underscores (`input_required`). The adapter
+    accepts both at the boundary. The SDK's `unknown` value is treated
+    as `failed` so peers see a definite terminal state.
+    """
+    if not raw:
+        return TaskState.failed
+    normalized = raw.replace("_", "-").lower()
+    try:
+        state = TaskState(normalized)
+    except ValueError:
+        return TaskState.failed
+    if state == TaskState.unknown:
+        return TaskState.failed
+    return state
+
+
+def session_state_to_task_state(
+    status: str, close_reason: str | None = None
+) -> TaskState:
+    """Map Cullis SessionStatus (+close_reason if closed) to A2A TaskState."""
+    if status in _SESSION_STATE_MAP:
+        return _SESSION_STATE_MAP[status]
+    if status == "closed":
+        if close_reason is None:
+            return TaskState.completed
+        return _CLOSE_REASON_MAP.get(close_reason, TaskState.failed)
+    return TaskState.failed
+
+
+def cullis_envelope_to_a2a_message(
+    envelope: dict[str, Any],
+    *,
+    context_id: str,
+    task_id: str,
+    message_id: str,
+    role: Role = Role.agent,
+) -> Message:
+    """Wrap a Cullis envelope as an A2A Message.
+
+    `envelope` is expected in the broker's on-the-wire shape: a `payload`
+    dict holding the cipher blob (or cipher fields at top level, for
+    tests) plus the transport fields (nonce, timestamp, …). Anything we
+    can't classify is discarded — the envelope is reconstructable from
+    the fields we keep.
+    """
+    cipher: dict[str, Any]
+    if "payload" in envelope and isinstance(envelope["payload"], dict):
+        cipher = dict(envelope["payload"])
+    else:
+        cipher = {k: envelope[k] for k in _CIPHER_FIELDS if k in envelope}
+
+    part = DataPart(data=cipher, metadata={"mediaType": CULLIS_E2E_MEDIATYPE})
+
+    cullis_meta = {k: envelope[k] for k in _TRANSPORT_FIELDS if k in envelope}
+
+    return Message(
+        role=role,
+        parts=[Part(root=part)],
+        message_id=message_id,
+        context_id=context_id,
+        task_id=task_id,
+        metadata={"cullis": cullis_meta} if cullis_meta else None,
+    )
+
+
+def a2a_message_to_cullis_envelope(msg: Message) -> dict[str, Any]:
+    """Extract a Cullis envelope from an A2A Message.
+
+    Inverse of `cullis_envelope_to_a2a_message`. Finds the first
+    DataPart whose metadata declares the Cullis mediaType; lifts the
+    cipher into `payload` and copies transport fields back out of
+    `message.metadata.cullis`.
+
+    Raises ValueError when the message carries no Cullis DataPart.
+    """
+    cipher: dict[str, Any] | None = None
+    for part in msg.parts:
+        inner = part.root
+        if isinstance(inner, DataPart):
+            meta = inner.metadata or {}
+            if meta.get("mediaType") == CULLIS_E2E_MEDIATYPE:
+                cipher = dict(inner.data or {})
+                break
+    if cipher is None:
+        raise ValueError("a2a_message_missing_cullis_datapart")
+
+    envelope: dict[str, Any] = {"payload": cipher}
+    cullis_meta = {}
+    if msg.metadata and isinstance(msg.metadata, dict):
+        cullis_meta = msg.metadata.get("cullis") or {}
+    for k in _TRANSPORT_FIELDS:
+        if k in cullis_meta:
+            envelope[k] = cullis_meta[k]
+    return envelope
+
+
+def session_to_task(
+    session_record: Any,
+    messages: list[Any],
+    *,
+    history_length: int | None = None,
+) -> Task:
+    """Build an A2A Task view of a Cullis session.
+
+    ADR-002 §2.2: taskId == contextId == session_id. One Task per
+    session; multi-turn conversations append to `Task.history`. The
+    `history_length` hint mirrors A2A GetTask semantics: 0 → no history,
+    N → last N messages, None → full history.
+    """
+    state = session_state_to_task_state(
+        session_record.status, session_record.close_reason
+    )
+    ts = (
+        session_record.closed_at
+        or session_record.last_activity_at
+        or session_record.created_at
+    )
+
+    ordered = sorted(messages, key=lambda m: m.seq)
+    if history_length is not None:
+        ordered = [] if history_length <= 0 else ordered[-history_length:]
+
+    history: list[Message] = []
+    for m in ordered:
+        payload = m.payload if isinstance(m.payload, dict) else _loads(m.payload)
+        envelope: dict[str, Any] = {"payload": payload}
+        envelope["nonce"] = m.nonce
+        if m.timestamp is not None:
+            envelope["timestamp"] = int(m.timestamp.timestamp())
+        if m.signature is not None:
+            envelope["signature"] = m.signature
+        if m.client_seq is not None:
+            envelope["client_seq"] = m.client_seq
+        envelope["sender_agent_id"] = m.sender_agent_id
+        role = (
+            Role.user
+            if m.sender_agent_id == session_record.initiator_agent_id
+            else Role.agent
+        )
+        history.append(
+            cullis_envelope_to_a2a_message(
+                envelope,
+                context_id=session_record.session_id,
+                task_id=session_record.session_id,
+                message_id=f"{session_record.session_id}:{m.seq}",
+                role=role,
+            )
+        )
+
+    return Task(
+        id=session_record.session_id,
+        context_id=session_record.session_id,
+        status=TaskStatus(
+            state=state,
+            timestamp=ts.isoformat() if ts else None,
+        ),
+        history=history,
+    )
+
+
+def _loads(s: Any) -> dict[str, Any]:
+    try:
+        out = json.loads(s)
+        return out if isinstance(out, dict) else {"raw": out}
+    except (TypeError, ValueError):
+        return {"raw": s}

--- a/app/a2a/router.py
+++ b/app/a2a/router.py
@@ -1,36 +1,48 @@
-"""A2A protocol HTTP router — ADR-002 Phase 2a.
+"""A2A protocol HTTP router — ADR-002 Phase 2a + 2b.
 
-Two read-only endpoints:
-
+Phase 2a — read-only discovery:
   GET /v1/a2a/directory
-       List all agents the caller may discover, with their AgentCard URLs.
-       Filtered by capability/org if supplied.
-
   GET /v1/a2a/agents/{org_id}/{agent_id}/.well-known/agent.json
-       Return the AgentCard for one specific agent.
+  Both unauthenticated — discovery runs before credentials exist.
 
-Both are unauthenticated by design — A2A discovery is intentionally open
-(an A2A peer fetches the AgentCard *before* it has credentials). The
-listing respects Cullis' is_active flag so deactivated agents are not
-exposed. Cross-org visibility rules (binding approval, etc.) land in
-Phase 2b when authenticated A2A methods need them.
+Phase 2b — authenticated JSON-RPC surface:
+  POST /v1/a2a/rpc  (methods: message/send, tasks/get, tasks/cancel)
 
-Phase 2b will add SendMessage / GetTask / CancelTask. Phase 2c adds
-streaming + push notifications.
+The RPC endpoint authenticates via the standard Cullis token chain and
+reuses the broker's existing send/session logic — A2A Phase 2b is a
+translation layer, not a parallel implementation. Per ADR-002 §2.2 the
+A2A `contextId` and `taskId` are both the Cullis session_id. Phase 2b
+does NOT create sessions on first call: the caller must already be a
+participant of an existing Cullis session (session negotiation stays
+Cullis-native until Phase 3 ships the baseline-A2A bootstrap path).
+
+Phase 2c will add streaming + push notifications.
 """
 from __future__ import annotations
 
 import json
 import logging
-from typing import Optional
+from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.a2a.adapter import (
+    a2a_message_to_cullis_envelope,
+    session_to_task,
+)
 from app.a2a.agent_card import build_agent_card
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.broker.db_models import SessionMessageRecord, SessionRecord
+from app.broker.models import MessageEnvelope, SessionCloseReason, SessionStatus
+from app.broker.session import SessionStore, get_session_store
+from app.broker.persistence import save_session
 from app.config import get_settings
 from app.db.database import get_db
+from app.db.audit import log_event
 from app.registry.store import get_agent_by_id, list_agents
 
 logger = logging.getLogger("agent_trust.a2a")
@@ -128,3 +140,293 @@ async def agent_card(
             "Content-Type": "application/json",
         },
     )
+
+
+# ── Phase 2b — JSON-RPC surface ─────────────────────────────────────
+
+# JSON-RPC 2.0 error codes used by the A2A surface. The base -32xxx
+# range follows the JSON-RPC spec; the -32001..-32004 range is the
+# A2A-specific subset documented in the v0.3 spec.
+_JSONRPC_PARSE_ERROR = -32700
+_JSONRPC_INVALID_REQUEST = -32600
+_JSONRPC_METHOD_NOT_FOUND = -32601
+_JSONRPC_INVALID_PARAMS = -32602
+_JSONRPC_INTERNAL_ERROR = -32603
+_A2A_TASK_NOT_FOUND = -32001
+_A2A_TASK_NOT_CANCELABLE = -32002
+
+
+def _rpc_error(req_id: Any, code: int, message: str, *, status_code: int = 200):
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "jsonrpc": "2.0",
+            "id": req_id,
+            "error": {"code": code, "message": message},
+        },
+    )
+
+
+def _rpc_result(req_id: Any, result: dict):
+    return JSONResponse(
+        status_code=200,
+        content={"jsonrpc": "2.0", "id": req_id, "result": result},
+    )
+
+
+async def _load_session_or_error(
+    db: AsyncSession, session_id: str
+) -> SessionRecord | None:
+    stmt = select(SessionRecord).where(SessionRecord.session_id == session_id)
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    return row
+
+
+async def _load_session_messages(
+    db: AsyncSession, session_id: str
+) -> list[SessionMessageRecord]:
+    stmt = (
+        select(SessionMessageRecord)
+        .where(SessionMessageRecord.session_id == session_id)
+        .order_by(SessionMessageRecord.seq)
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+def _is_participant(session_row: SessionRecord, agent_id: str) -> bool:
+    return agent_id in (session_row.initiator_agent_id, session_row.target_agent_id)
+
+
+@router.post("/rpc")
+async def jsonrpc_dispatch(
+    request: Request,
+    payload: dict = Body(...),
+    current_agent: TokenPayload = Depends(get_current_agent),
+    store: SessionStore = Depends(get_session_store),
+    db: AsyncSession = Depends(get_db),
+):
+    """A2A v0.3 JSON-RPC entrypoint (ADR-002 Phase 2b).
+
+    Supported methods:
+      - message/send — post a Cullis envelope carried as an A2A Message
+        to an existing session; returns the updated Task
+      - tasks/get — fetch a Task (== Cullis session projection) with
+        optional historyLength truncation
+      - tasks/cancel — transition the underlying session to
+        closed/canceled; idempotent on already-canceled tasks
+
+    Session creation is NOT exposed here in 2b — A2A peers must join an
+    existing Cullis session negotiated via the native /v1/broker surface.
+    """
+    if not isinstance(payload, dict) or payload.get("jsonrpc") != "2.0":
+        return _rpc_error(
+            payload.get("id") if isinstance(payload, dict) else None,
+            _JSONRPC_INVALID_REQUEST,
+            "Invalid JSON-RPC 2.0 request",
+        )
+
+    req_id = payload.get("id")
+    method = payload.get("method")
+    params = payload.get("params") or {}
+    if not isinstance(params, dict):
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, "params must be an object")
+
+    if method == "message/send":
+        return await _rpc_message_send(
+            req_id, params, current_agent=current_agent, store=store, db=db
+        )
+    if method == "tasks/get":
+        return await _rpc_tasks_get(
+            req_id, params, current_agent=current_agent, db=db
+        )
+    if method == "tasks/cancel":
+        return await _rpc_tasks_cancel(
+            req_id, params, current_agent=current_agent, store=store, db=db
+        )
+
+    return _rpc_error(req_id, _JSONRPC_METHOD_NOT_FOUND, f"method not found: {method}")
+
+
+async def _rpc_message_send(
+    req_id: Any,
+    params: dict,
+    *,
+    current_agent: TokenPayload,
+    store: SessionStore,
+    db: AsyncSession,
+):
+    from a2a.types import Message
+
+    raw_message = params.get("message")
+    if not isinstance(raw_message, dict):
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, "params.message required")
+    try:
+        msg = Message.model_validate(raw_message)
+    except Exception as exc:  # pydantic validation
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, f"invalid Message: {exc}")
+
+    context_id = msg.context_id or msg.task_id
+    if not context_id:
+        return _rpc_error(
+            req_id,
+            _JSONRPC_INVALID_PARAMS,
+            "message.contextId (or taskId) is required — Phase 2b does not create sessions",
+        )
+
+    session_row = await _load_session_or_error(db, context_id)
+    if session_row is None:
+        return _rpc_error(req_id, _A2A_TASK_NOT_FOUND, "contextId/taskId not found")
+    if not _is_participant(session_row, current_agent.agent_id):
+        return _rpc_error(
+            req_id, _JSONRPC_INVALID_REQUEST, "caller is not a session participant"
+        )
+
+    try:
+        envelope_dict = a2a_message_to_cullis_envelope(msg)
+    except ValueError as exc:
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, str(exc))
+
+    # Build a Cullis MessageEnvelope the broker understands. Required
+    # transport fields (nonce, timestamp, signature) must be present in
+    # `message.metadata.cullis` — Phase 2b treats this as the contract
+    # for Cullis-aware A2A peers. Phase 3 ships the baseline path for
+    # pure-A2A peers via the cullis-trust/v1 extension negotiation.
+    missing = [
+        k for k in ("nonce", "timestamp", "signature", "sender_agent_id")
+        if k not in envelope_dict
+    ]
+    if missing:
+        return _rpc_error(
+            req_id,
+            _JSONRPC_INVALID_PARAMS,
+            f"message.metadata.cullis missing fields: {missing}",
+        )
+    try:
+        envelope = MessageEnvelope(
+            session_id=context_id,
+            sender_agent_id=envelope_dict["sender_agent_id"],
+            payload=envelope_dict["payload"],
+            nonce=envelope_dict["nonce"],
+            timestamp=int(envelope_dict["timestamp"]),
+            signature=envelope_dict["signature"],
+            client_seq=envelope_dict.get("client_seq"),
+        )
+    except Exception as exc:
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, f"envelope invalid: {exc}")
+
+    # Delegate to the broker's existing send_message handler — it owns
+    # signature verification, nonce dedup, policy + injection checks,
+    # persistence, and delivery (WS push or M3 queue). Calling it as a
+    # plain async function preserves all guarantees without duplicating
+    # ~270 lines of validation.
+    from app.broker.router import send_message as broker_send_message
+
+    try:
+        await broker_send_message(
+            session_id=context_id,
+            envelope=envelope,
+            ttl_seconds=300,
+            idempotency_key=None,
+            current_agent=current_agent,
+            store=store,
+            db=db,
+        )
+    except HTTPException as exc:
+        code = _JSONRPC_INVALID_REQUEST if exc.status_code < 500 else _JSONRPC_INTERNAL_ERROR
+        return _rpc_error(req_id, code, str(exc.detail))
+
+    # Reload + project the updated session as a Task
+    session_row = await _load_session_or_error(db, context_id)
+    messages = await _load_session_messages(db, context_id)
+    task = session_to_task(session_row, messages)
+
+    await log_event(
+        db, "a2a.message_send", "ok",
+        agent_id=current_agent.agent_id, session_id=context_id,
+        org_id=current_agent.org,
+        details={"method": "message/send"},
+    )
+
+    return _rpc_result(req_id, json.loads(task.model_dump_json()))
+
+
+async def _rpc_tasks_get(
+    req_id: Any, params: dict, *, current_agent: TokenPayload, db: AsyncSession
+):
+    task_id = params.get("id")
+    history_length = params.get("historyLength")
+    if not isinstance(task_id, str) or not task_id:
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, "params.id required")
+    if history_length is not None and not isinstance(history_length, int):
+        return _rpc_error(
+            req_id, _JSONRPC_INVALID_PARAMS, "historyLength must be an integer"
+        )
+
+    session_row = await _load_session_or_error(db, task_id)
+    if session_row is None:
+        return _rpc_error(req_id, _A2A_TASK_NOT_FOUND, "task not found")
+    if not _is_participant(session_row, current_agent.agent_id):
+        return _rpc_error(
+            req_id, _A2A_TASK_NOT_FOUND, "task not found"
+        )  # mask participation to avoid session enumeration
+
+    messages = await _load_session_messages(db, task_id)
+    task = session_to_task(session_row, messages, history_length=history_length)
+    return _rpc_result(req_id, json.loads(task.model_dump_json()))
+
+
+async def _rpc_tasks_cancel(
+    req_id: Any,
+    params: dict,
+    *,
+    current_agent: TokenPayload,
+    store: SessionStore,
+    db: AsyncSession,
+):
+    task_id = params.get("id")
+    if not isinstance(task_id, str) or not task_id:
+        return _rpc_error(req_id, _JSONRPC_INVALID_PARAMS, "params.id required")
+
+    session_row = await _load_session_or_error(db, task_id)
+    if session_row is None:
+        return _rpc_error(req_id, _A2A_TASK_NOT_FOUND, "task not found")
+    if not _is_participant(session_row, current_agent.agent_id):
+        return _rpc_error(req_id, _A2A_TASK_NOT_FOUND, "task not found")
+
+    # Idempotent: already-canceled returns the current state. Already
+    # closed with a different reason → TaskNotCancelable so peers know
+    # the session ended elsewhere.
+    if session_row.status == SessionStatus.closed.value:
+        if session_row.close_reason == SessionCloseReason.canceled.value:
+            messages = await _load_session_messages(db, task_id)
+            task = session_to_task(session_row, messages)
+            return _rpc_result(req_id, json.loads(task.model_dump_json()))
+        return _rpc_error(
+            req_id,
+            _A2A_TASK_NOT_CANCELABLE,
+            f"task already closed (reason={session_row.close_reason})",
+        )
+
+    async with store._lock:
+        in_mem = store.get(task_id)
+        if in_mem is not None:
+            store.close(task_id, SessionCloseReason.canceled)
+            await save_session(db, in_mem)
+        else:
+            # Session not in the in-memory store (e.g. rehydration gap);
+            # flip the DB row directly so the Task projection is correct.
+            session_row.status = SessionStatus.closed.value
+            session_row.close_reason = SessionCloseReason.canceled.value
+            await db.commit()
+
+    await log_event(
+        db, "a2a.task_cancel", "ok",
+        agent_id=current_agent.agent_id, session_id=task_id,
+        org_id=current_agent.org,
+        details={"method": "tasks/cancel"},
+    )
+
+    session_row = await _load_session_or_error(db, task_id)
+    messages = await _load_session_messages(db, task_id)
+    task = session_to_task(session_row, messages)
+    return _rpc_result(req_id, json.loads(task.model_dump_json()))

--- a/app/broker/models.py
+++ b/app/broker/models.py
@@ -29,6 +29,7 @@ class SessionCloseReason(str, Enum):
     policy_revoked = "policy_revoked"  # binding/policy revocation
     pending_timeout = "pending_timeout"  # accept not received within pending window
     rejected = "rejected"            # explicit reject() by target
+    canceled = "canceled"            # A2A tasks/cancel (ADR-002 Phase 2b)
 
 
 class SessionRequest(BaseModel):

--- a/tests/test_a2a_adapter.py
+++ b/tests/test_a2a_adapter.py
@@ -1,0 +1,253 @@
+"""ADR-002 Phase 2b — A2A adapter unit tests.
+
+Pure mapping, no HTTP / no DB. Verifies:
+  - envelope → Message → envelope round-trip
+  - mediaType lands in metadata (spike Q1)
+  - transport fields survive via Message.metadata.cullis
+  - session_to_task projects Cullis session into A2A Task
+  - historyLength 0/N/None truncation
+  - TaskState normalization: hyphen/underscore/unknown → canonical
+  - SessionStatus + close_reason → TaskState mapping
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from a2a.types import DataPart, Message, Role, TaskState
+
+from app.a2a.adapter import (
+    CULLIS_E2E_MEDIATYPE,
+    a2a_message_to_cullis_envelope,
+    cullis_envelope_to_a2a_message,
+    normalize_task_state,
+    session_state_to_task_state,
+    session_to_task,
+)
+
+
+# ── envelope ↔ Message ──────────────────────────────────────────────
+
+def _envelope():
+    return {
+        "payload": {
+            "ciphertext": "Y2lwaGVy",
+            "iv": "aXY=",
+            "encrypted_key": "a2V5",
+            "ephemeral_pubkey": "cGs=",
+        },
+        "nonce": "n-1",
+        "timestamp": 1_700_000_000,
+        "signature": "sig-xyz",
+        "client_seq": 3,
+        "sender_agent_id": "acme::alice",
+    }
+
+
+def test_envelope_to_message_places_mediatype_in_part_metadata():
+    msg = cullis_envelope_to_a2a_message(
+        _envelope(), context_id="c", task_id="c", message_id="m1"
+    )
+    inner = msg.parts[0].root
+    assert isinstance(inner, DataPart)
+    assert inner.data["ciphertext"] == "Y2lwaGVy"
+    assert (inner.metadata or {}).get("mediaType") == CULLIS_E2E_MEDIATYPE
+
+
+def test_envelope_to_message_carries_transport_fields_in_message_metadata():
+    msg = cullis_envelope_to_a2a_message(
+        _envelope(), context_id="c", task_id="c", message_id="m1"
+    )
+    cullis = (msg.metadata or {}).get("cullis") or {}
+    assert cullis["nonce"] == "n-1"
+    assert cullis["timestamp"] == 1_700_000_000
+    assert cullis["signature"] == "sig-xyz"
+    assert cullis["client_seq"] == 3
+    assert cullis["sender_agent_id"] == "acme::alice"
+
+
+def test_envelope_message_envelope_round_trip_via_json():
+    msg = cullis_envelope_to_a2a_message(
+        _envelope(), context_id="c", task_id="c", message_id="m1"
+    )
+    rt_msg = Message.model_validate_json(msg.model_dump_json())
+    rt_env = a2a_message_to_cullis_envelope(rt_msg)
+    assert rt_env["payload"]["ciphertext"] == "Y2lwaGVy"
+    assert rt_env["nonce"] == "n-1"
+    assert rt_env["timestamp"] == 1_700_000_000
+    assert rt_env["signature"] == "sig-xyz"
+    assert rt_env["client_seq"] == 3
+
+
+def test_a2a_message_without_cullis_datapart_raises():
+    from a2a.types import Part, TextPart
+
+    msg = Message(
+        role=Role.user,
+        parts=[Part(root=TextPart(text="hello"))],
+        message_id="m",
+        context_id="c",
+        task_id="c",
+    )
+    with pytest.raises(ValueError, match="cullis_datapart"):
+        a2a_message_to_cullis_envelope(msg)
+
+
+def test_envelope_to_message_accepts_role_user():
+    msg = cullis_envelope_to_a2a_message(
+        _envelope(), context_id="c", task_id="c", message_id="m", role=Role.user
+    )
+    assert msg.role == Role.user
+
+
+# ── TaskState normalization (spike Q5) ──────────────────────────────
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("submitted", TaskState.submitted),
+        ("working", TaskState.working),
+        ("input-required", TaskState.input_required),
+        ("input_required", TaskState.input_required),
+        ("auth-required", TaskState.auth_required),
+        ("auth_required", TaskState.auth_required),
+        ("completed", TaskState.completed),
+        ("canceled", TaskState.canceled),
+        ("failed", TaskState.failed),
+        ("rejected", TaskState.rejected),
+        ("unknown", TaskState.failed),  # unknown → failed
+        ("something-else", TaskState.failed),
+        ("", TaskState.failed),
+        (None, TaskState.failed),
+    ],
+)
+def test_normalize_task_state(raw, expected):
+    assert normalize_task_state(raw) == expected
+
+
+# ── SessionStatus → TaskState ───────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "status,reason,expected",
+    [
+        ("pending", None, TaskState.submitted),
+        ("active", None, TaskState.working),
+        ("denied", None, TaskState.rejected),
+        ("closed", "normal", TaskState.completed),
+        ("closed", "rejected", TaskState.rejected),
+        ("closed", "canceled", TaskState.canceled),
+        ("closed", "idle_timeout", TaskState.failed),
+        ("closed", "ttl_expired", TaskState.failed),
+        ("closed", "policy_revoked", TaskState.failed),
+        ("closed", "peer_lost", TaskState.failed),
+        ("closed", "pending_timeout", TaskState.failed),
+        ("closed", None, TaskState.completed),
+        ("closed", "unexpected", TaskState.failed),
+        ("weird", None, TaskState.failed),
+    ],
+)
+def test_session_state_to_task_state(status, reason, expected):
+    assert session_state_to_task_state(status, reason) == expected
+
+
+# ── session_to_task ─────────────────────────────────────────────────
+
+def _session(status="active", close_reason=None, closed_at=None):
+    return SimpleNamespace(
+        session_id="sess-123",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="beta::bob",
+        target_org_id="beta",
+        status=status,
+        close_reason=close_reason,
+        created_at=datetime(2026, 4, 14, 10, 0, tzinfo=timezone.utc),
+        last_activity_at=datetime(2026, 4, 14, 10, 5, tzinfo=timezone.utc),
+        closed_at=closed_at,
+    )
+
+
+def _message(seq, sender, nonce="n", client_seq=None):
+    return SimpleNamespace(
+        seq=seq,
+        sender_agent_id=sender,
+        payload={"ciphertext": f"ct-{seq}", "iv": "iv", "encrypted_key": "k"},
+        nonce=nonce,
+        timestamp=datetime(2026, 4, 14, 10, 0, seq, tzinfo=timezone.utc),
+        signature=f"sig-{seq}",
+        client_seq=client_seq,
+    )
+
+
+def test_session_to_task_basic_active():
+    sess = _session()
+    msgs = [_message(1, "acme::alice"), _message(2, "beta::bob")]
+    task = session_to_task(sess, msgs)
+
+    assert task.id == "sess-123"
+    assert task.context_id == "sess-123"
+    assert task.status.state == TaskState.working
+    assert len(task.history) == 2
+    assert task.history[0].role == Role.user  # initiator
+    assert task.history[1].role == Role.agent  # target
+    assert task.history[0].message_id == "sess-123:1"
+    # cipher survived
+    assert task.history[0].parts[0].root.data["ciphertext"] == "ct-1"
+
+
+def test_session_to_task_closed_maps_to_completed():
+    sess = _session(
+        status="closed",
+        close_reason="normal",
+        closed_at=datetime(2026, 4, 14, 11, 0, tzinfo=timezone.utc),
+    )
+    task = session_to_task(sess, [])
+    assert task.status.state == TaskState.completed
+
+
+def test_session_to_task_canceled():
+    sess = _session(
+        status="closed",
+        close_reason="canceled",
+        closed_at=datetime(2026, 4, 14, 11, 0, tzinfo=timezone.utc),
+    )
+    task = session_to_task(sess, [])
+    assert task.status.state == TaskState.canceled
+
+
+def test_session_to_task_history_length_zero_returns_empty():
+    sess = _session()
+    msgs = [_message(i, "acme::alice") for i in range(1, 4)]
+    task = session_to_task(sess, msgs, history_length=0)
+    assert task.history == []
+
+
+def test_session_to_task_history_length_truncates_to_last_n():
+    sess = _session()
+    msgs = [_message(i, "acme::alice", nonce=f"n-{i}") for i in range(1, 6)]
+    task = session_to_task(sess, msgs, history_length=2)
+    assert [m.message_id for m in task.history] == ["sess-123:4", "sess-123:5"]
+
+
+def test_session_to_task_history_preserves_order_regardless_of_input_order():
+    sess = _session()
+    msgs = [_message(3, "a", nonce="n3"), _message(1, "a", nonce="n1"), _message(2, "a", nonce="n2")]
+    task = session_to_task(sess, msgs)
+    assert [m.message_id for m in task.history] == [
+        "sess-123:1",
+        "sess-123:2",
+        "sess-123:3",
+    ]
+
+
+def test_session_to_task_serializable_via_json():
+    from a2a.types import Task
+
+    sess = _session()
+    msgs = [_message(1, "acme::alice")]
+    task = session_to_task(sess, msgs)
+    rt = Task.model_validate_json(task.model_dump_json())
+    assert rt.id == "sess-123"
+    assert rt.status.state == TaskState.working
+    assert len(rt.history) == 1

--- a/tests/test_a2a_rpc.py
+++ b/tests/test_a2a_rpc.py
@@ -1,0 +1,386 @@
+"""ADR-002 Phase 2b — A2A JSON-RPC endpoint end-to-end.
+
+Covers the three Phase 2b methods wired on /v1/a2a/rpc:
+  - message/send    — post a Cullis envelope via A2A Message, get Task back
+  - tasks/get       — fetch the Task view of an existing Cullis session
+  - tasks/cancel    — transition session → closed/canceled, idempotent
+
+Each test spins the app with A2A_ADAPTER=true, registers two orgs via the
+broker API, opens a Cullis session (pending → active), then drives the
+A2A RPC surface. We trust the underlying broker checks — signature,
+nonce dedup, policy — are covered by the broker's own test suite; the
+tests here verify the A2A translation layer + dispatch.
+"""
+from __future__ import annotations
+
+import uuid
+from importlib import reload
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from tests.cert_factory import DPoPHelper, make_encrypted_envelope
+from tests.conftest import ADMIN_HEADERS
+
+from app.a2a.adapter import CULLIS_E2E_MEDIATYPE
+from app.config import get_settings
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+def _reload_app_with_flag(monkeypatch, *, a2a_enabled: bool):
+    monkeypatch.setenv("A2A_ADAPTER", "true" if a2a_enabled else "false")
+    get_settings.cache_clear()
+    import app.main as _main
+    reload(_main)
+    return _main.app
+
+
+@pytest_asyncio.fixture
+async def a2a_app(monkeypatch):
+    app = _reload_app_with_flag(monkeypatch, a2a_enabled=True)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+    monkeypatch.setenv("A2A_ADAPTER", "false")
+    get_settings.cache_clear()
+    import app.main as _main
+    reload(_main)
+
+
+@pytest.fixture
+def dpop():
+    return DPoPHelper()
+
+
+async def _register_and_login(client: AsyncClient, dpop, agent_id: str, org_id: str) -> str:
+    """Same shape as tests/test_broker.py helper."""
+    from tests.cert_factory import get_org_ca_pem
+    org_secret = org_id + "-secret"
+    await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    ca_pem = get_org_ca_pem(org_id)
+    await client.post(f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    await client.post("/v1/registry/agents", json={
+        "agent_id": agent_id, "org_id": org_id,
+        "display_name": agent_id, "capabilities": ["kyc.read"],
+    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    resp = await client.post("/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": ["kyc.read"]},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = resp.json()["id"]
+    await client.post(f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    await client.post("/v1/policy/rules",
+        json={
+            "policy_id": f"{org_id}::session-allow-all",
+            "org_id": org_id,
+            "policy_type": "session",
+            "rules": {"effect": "allow", "conditions": {"target_org_id": [], "capabilities": []}},
+        },
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    return await dpop.get_token(client, agent_id, org_id)
+
+
+async def _open_active_session(client, dpop, tag: str) -> tuple[str, str, str, str, str]:
+    """Provision two agents, open and accept a Cullis session.
+
+    Returns (session_id, agent_a_id, org_a, agent_b_id, token_a).
+    """
+    org_a = f"{tag}-a"
+    org_b = f"{tag}-b"
+    a = f"{org_a}::alice"
+    b = f"{org_b}::bob"
+    token_a = await _register_and_login(client, dpop, a, org_a)
+    token_b = await _register_and_login(client, dpop, b, org_b)
+    resp = await client.post(
+        "/v1/broker/sessions",
+        json={
+            "target_agent_id": b,
+            "target_org_id": org_b,
+            "requested_capabilities": ["kyc.read"],
+        },
+        headers=dpop.headers("POST", "/v1/broker/sessions", token_a),
+    )
+    assert resp.status_code == 201, resp.text
+    session_id = resp.json()["session_id"]
+    accept_path = f"/v1/broker/sessions/{session_id}/accept"
+    resp = await client.post(accept_path, headers=dpop.headers("POST", accept_path, token_b))
+    assert resp.status_code == 200, resp.text
+    return session_id, a, org_a, b, token_a
+
+
+def _a2a_message(session_id: str, envelope: dict) -> dict:
+    """Wrap a Cullis MessageEnvelope as an A2A Message dict (what a
+    client would post in params.message)."""
+    return {
+        "kind": "message",
+        "messageId": str(uuid.uuid4()),
+        "contextId": session_id,
+        "taskId": session_id,
+        "role": "user",
+        "parts": [
+            {
+                "kind": "data",
+                "data": envelope["payload"],
+                "metadata": {"mediaType": CULLIS_E2E_MEDIATYPE},
+            }
+        ],
+        "metadata": {
+            "cullis": {
+                "nonce": envelope["nonce"],
+                "timestamp": envelope["timestamp"],
+                "signature": envelope["signature"],
+                "sender_agent_id": envelope["sender_agent_id"],
+            }
+        },
+    }
+
+
+# ── dispatch / shape tests ──────────────────────────────────────────
+
+async def test_rpc_requires_auth(a2a_app):
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get", "params": {"id": "x"}},
+    )
+    assert resp.status_code == 401
+
+
+async def test_rpc_unknown_method(a2a_app, dpop):
+    _, a, org_a, _, token = await _open_active_session(a2a_app, dpop, "rpc-unk")
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 2, "method": "bogus", "params": {}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32601
+
+
+async def test_rpc_invalid_jsonrpc_envelope(a2a_app, dpop):
+    _, _, _, _, token = await _open_active_session(a2a_app, dpop, "rpc-env")
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"method": "tasks/get"},  # missing jsonrpc
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32600
+
+
+async def test_rpc_flag_off_returns_404(monkeypatch, dpop):
+    app = _reload_app_with_flag(monkeypatch, a2a_enabled=False)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.post(
+            "/v1/a2a/rpc",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get", "params": {}},
+        )
+        assert resp.status_code == 404
+
+
+# ── message/send ────────────────────────────────────────────────────
+
+async def test_message_send_routes_to_active_session(a2a_app, dpop):
+    session_id, a, org_a, b, token_a = await _open_active_session(a2a_app, dpop, "send-ok")
+    nonce = str(uuid.uuid4())
+    envelope = make_encrypted_envelope(
+        a, org_a, b, org_a.replace("-a", "-b"), session_id, nonce, {"msg": "hello"}
+    )
+    rpc = {
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "message/send",
+        "params": {"message": _a2a_message(session_id, envelope)},
+    }
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc", json=rpc,
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "error" not in body, body
+    task = body["result"]
+    assert task["id"] == session_id
+    assert task["contextId"] == session_id
+    # A2A TaskState: active session → working
+    assert task["status"]["state"] == "working"
+    # The message we just sent is in history
+    assert len(task["history"]) == 1
+    assert task["history"][0]["contextId"] == session_id
+
+
+async def test_message_send_missing_context_id_rejected(a2a_app, dpop):
+    _, _, _, _, token = await _open_active_session(a2a_app, dpop, "send-noctx")
+    bad_msg = {
+        "kind": "message",
+        "messageId": "m1",
+        "role": "user",
+        "parts": [{"kind": "data", "data": {}, "metadata": {"mediaType": CULLIS_E2E_MEDIATYPE}}],
+    }
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "message/send",
+              "params": {"message": bad_msg}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32602
+
+
+async def test_message_send_unknown_context_id_returns_task_not_found(a2a_app, dpop):
+    _, _, _, _, token = await _open_active_session(a2a_app, dpop, "send-404")
+    bogus_id = "sess-does-not-exist-" + uuid.uuid4().hex
+    msg = _a2a_message(bogus_id, {
+        "payload": {"ciphertext": "x", "iv": "y", "encrypted_key": "z"},
+        "nonce": "n", "timestamp": 0, "signature": "s", "sender_agent_id": "x",
+    })
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "message/send",
+              "params": {"message": msg}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32001
+
+
+async def test_message_send_non_participant_forbidden(a2a_app, dpop):
+    session_id, a, org_a, b, _ = await _open_active_session(a2a_app, dpop, "send-nonp")
+    # Register a third agent not part of the session
+    outsider = "outsider-org::eve"
+    token_eve = await _register_and_login(a2a_app, dpop, outsider, "outsider-org")
+    envelope = make_encrypted_envelope(
+        outsider, "outsider-org", b, org_a.replace("-a", "-b"),
+        session_id, str(uuid.uuid4()), {"msg": "spy"},
+    )
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "message/send",
+              "params": {"message": _a2a_message(session_id, envelope)}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_eve),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32600  # invalid request, not a participant
+
+
+# ── tasks/get ───────────────────────────────────────────────────────
+
+async def test_tasks_get_returns_task_view(a2a_app, dpop):
+    session_id, *_, token_a = await _open_active_session(a2a_app, dpop, "get-ok")
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get",
+              "params": {"id": session_id}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+    )
+    body = resp.json()
+    assert "error" not in body, body
+    assert body["result"]["id"] == session_id
+    assert body["result"]["status"]["state"] == "working"
+
+
+async def test_tasks_get_history_length_truncates(a2a_app, dpop):
+    session_id, a, org_a, b, token_a = await _open_active_session(a2a_app, dpop, "get-trunc")
+    # Send 3 messages via the native broker path (faster than 3 RPC calls,
+    # same on-the-wire result because adapter reads from DB).
+    for _ in range(3):
+        nonce = str(uuid.uuid4())
+        env = make_encrypted_envelope(
+            a, org_a, b, org_a.replace("-a", "-b"),
+            session_id, nonce, {"n": nonce},
+        )
+        path = f"/v1/broker/sessions/{session_id}/messages"
+        r = await a2a_app.post(
+            path, json=env, headers=dpop.headers("POST", path, token_a),
+        )
+        assert r.status_code == 202
+
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get",
+              "params": {"id": session_id, "historyLength": 1}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+    )
+    task = resp.json()["result"]
+    assert len(task["history"]) == 1
+
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 2, "method": "tasks/get",
+              "params": {"id": session_id, "historyLength": 0}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+    )
+    task = resp.json()["result"]
+    assert task["history"] == []
+
+
+async def test_tasks_get_non_participant_gets_task_not_found(a2a_app, dpop):
+    session_id, *_ = await _open_active_session(a2a_app, dpop, "get-priv")
+    outsider_token = await _register_and_login(
+        a2a_app, dpop, "nosy-org::eve", "nosy-org",
+    )
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tasks/get",
+              "params": {"id": session_id}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", outsider_token),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32001  # masked as not-found
+
+
+# ── tasks/cancel ────────────────────────────────────────────────────
+
+async def test_tasks_cancel_transitions_to_canceled(a2a_app, dpop):
+    session_id, *_, token_a = await _open_active_session(a2a_app, dpop, "cancel-ok")
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tasks/cancel",
+              "params": {"id": session_id}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+    )
+    body = resp.json()
+    assert "error" not in body, body
+    assert body["result"]["status"]["state"] == "canceled"
+
+
+async def test_tasks_cancel_is_idempotent(a2a_app, dpop):
+    session_id, *_, token_a = await _open_active_session(a2a_app, dpop, "cancel-idem")
+    for call_id in (1, 2):
+        resp = await a2a_app.post(
+            "/v1/a2a/rpc",
+            json={"jsonrpc": "2.0", "id": call_id, "method": "tasks/cancel",
+                  "params": {"id": session_id}},
+            headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+        )
+        body = resp.json()
+        assert "error" not in body, body
+        assert body["result"]["status"]["state"] == "canceled"
+
+
+async def test_tasks_cancel_rejects_already_closed_with_other_reason(a2a_app, dpop):
+    session_id, *_, token_a = await _open_active_session(a2a_app, dpop, "cancel-blk")
+    # Close normally via Cullis-native path
+    path = f"/v1/broker/sessions/{session_id}/close"
+    r = await a2a_app.post(path, headers=dpop.headers("POST", path, token_a))
+    assert r.status_code == 200
+
+    resp = await a2a_app.post(
+        "/v1/a2a/rpc",
+        json={"jsonrpc": "2.0", "id": 1, "method": "tasks/cancel",
+              "params": {"id": session_id}},
+        headers=dpop.headers("POST", "/v1/a2a/rpc", token_a),
+    )
+    body = resp.json()
+    assert body["error"]["code"] == -32002  # TaskNotCancelable


### PR DESCRIPTION
## Summary

ADR-002 Phase 2b wires the three A2A JSON-RPC methods on top of the
existing Cullis broker, closing the gap between discovery (Phase 2a)
and security-extension wiring (Phase 3).

- `POST /v1/a2a/rpc` dispatches `message/send`, `tasks/get`, `tasks/cancel`
- `app/a2a/adapter.py` is the pure-mapping layer: Cullis envelope ⇄ A2A `Message`, Session → `Task`, TaskState normalization (hyphen↔underscore, `unknown`→`failed` per spike Q5)
- `message/send` delegates to the broker's existing `send_message` handler, preserving signature verification, nonce dedup, policy + injection checks, and M3 delivery — the A2A layer is a translator, not a parallel implementation
- `tasks/cancel` introduces `SessionCloseReason.canceled` so the projection surfaces `TaskState.canceled` cleanly; idempotent on already-canceled, returns `TaskNotCancelable` (-32002) when closed for another reason

Phase 2b does **not** create sessions on first call — `contextId` must match an existing Cullis session the caller participates in. Session bootstrap stays Cullis-native until Phase 3 ships the baseline-A2A path per ADR-002.

All endpoints gated on the existing `A2A_ADAPTER` flag.

## Test plan

- [x] `tests/test_a2a_adapter.py` — 40 unit tests (envelope round-trip, mediaType placement per spike Q1, state normalization, history truncation, session projection)
- [x] `tests/test_a2a_rpc.py` — 14 end-to-end tests (dispatch shape, auth, flag gating, all three methods on happy + error paths, idempotency, non-participant masking)
- [x] `pytest tests/ -n auto --dist=loadfile` — 669 passed, 14 skipped (~51s); 2 pre-existing Postgres-integration failures unrelated (need live Postgres)
- [ ] `demo_network/smoke.sh full` to be validated by CI