### PR TITLE
feat(enrollment): Connector Phase 2a — server-side enrollment API

### DIFF
--- a/mcp_proxy/alembic/versions/0003_add_pending_enrollments.py
+++ b/mcp_proxy/alembic/versions/0003_add_pending_enrollments.py
@@ -1,0 +1,69 @@
+"""Add pending_enrollments table — Connector Phase 2 (#64).
+
+Revision ID: 0003_add_pending_enrollments
+Revises: 0002_local_tables
+Create Date: 2026-04-14
+
+Tracks Cullis Connector enrollment requests between the moment a user-side
+Connector starts the device-code flow and the admin's approve/reject decision
+in the dashboard. Stores the client-supplied public key (private key never
+leaves the requester's machine), the requester's self-declared identity,
+and — once approved — the admin-assigned agent_id, capabilities, groups,
+and the resulting Org-CA-signed certificate.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0003_add_pending_enrollments"
+down_revision: Union[str, Sequence[str], None] = "0002_local_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pending_enrollments",
+        sa.Column("session_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("pubkey_pem", sa.Text(), nullable=False),
+        sa.Column("pubkey_fingerprint", sa.Text(), nullable=False),
+        sa.Column("requester_name", sa.Text(), nullable=False),
+        sa.Column("requester_email", sa.Text(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("device_info", sa.Text(), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="pending"),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("expires_at", sa.Text(), nullable=False),
+        sa.Column("decided_at", sa.Text(), nullable=True),
+        sa.Column("decided_by", sa.Text(), nullable=True),
+        sa.Column("agent_id_assigned", sa.Text(), nullable=True),
+        sa.Column(
+            "capabilities_assigned", sa.Text(), nullable=True, server_default="[]"
+        ),
+        sa.Column("groups_assigned", sa.Text(), nullable=True, server_default="[]"),
+        sa.Column("cert_pem", sa.Text(), nullable=True),
+        sa.Column("rejection_reason", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "idx_pending_enrollments_status", "pending_enrollments", ["status"]
+    )
+    op.create_index(
+        "idx_pending_enrollments_created_at", "pending_enrollments", ["created_at"]
+    )
+    op.create_index(
+        "idx_pending_enrollments_fingerprint",
+        "pending_enrollments",
+        ["pubkey_fingerprint"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_pending_enrollments_fingerprint", table_name="pending_enrollments"
+    )
+    op.drop_index(
+        "idx_pending_enrollments_created_at", table_name="pending_enrollments"
+    )
+    op.drop_index("idx_pending_enrollments_status", table_name="pending_enrollments")
+    op.drop_table("pending_enrollments")

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -71,6 +71,49 @@ class ProxyConfig(Base):
     value = Column(Text, nullable=False)
 
 
+class PendingEnrollment(Base):
+    """Connector enrollment requests awaiting admin decision.
+
+    Lifecycle: pending → approved (cert issued) | rejected | expired.
+    The requester supplies identity (name/email/reason) and a public key.
+    The admin chooses agent_id + capabilities + groups and signs the cert —
+    the requester never influences those values.
+    """
+    __tablename__ = "pending_enrollments"
+
+    session_id = Column(Text, primary_key=True)
+    pubkey_pem = Column(Text, nullable=False)
+    pubkey_fingerprint = Column(Text, nullable=False)  # SHA-256 hex of SubjectPublicKeyInfo DER
+    requester_name = Column(Text, nullable=False)
+    requester_email = Column(Text, nullable=False)
+    reason = Column(Text, nullable=True)
+    device_info = Column(Text, nullable=True)  # free-form JSON from SDK
+    status = Column(
+        Text, nullable=False, server_default="pending"
+    )  # pending | approved | rejected | expired
+    created_at = Column(Text, nullable=False)
+    expires_at = Column(Text, nullable=False)
+
+    # Filled on admin decision
+    decided_at = Column(Text, nullable=True)
+    decided_by = Column(Text, nullable=True)
+
+    # Approved: admin-assigned fields and resulting cert
+    agent_id_assigned = Column(Text, nullable=True)
+    capabilities_assigned = Column(Text, nullable=True, server_default="[]")
+    groups_assigned = Column(Text, nullable=True, server_default="[]")
+    cert_pem = Column(Text, nullable=True)
+
+    # Rejected
+    rejection_reason = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("idx_pending_enrollments_status", "status"),
+        Index("idx_pending_enrollments_created_at", "created_at"),
+        Index("idx_pending_enrollments_fingerprint", "pubkey_fingerprint"),
+    )
+
+
 # ── Local-* tables (ADR-001 Phase 1, unused until Phase 4) ───────────────────
 #
 # Minimal forward-compatible columns. Each table exists so that Phase 4 work

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -134,6 +134,55 @@ class AgentManager:
         logger.info("Generated x509 cert for %s (SAN %s)", agent_id, spiffe_uri)
         return cert_pem, key_pem
 
+    def sign_external_pubkey(self, *, pubkey_pem: str, agent_name: str) -> str:
+        """Sign an externally-generated public key with the Org CA.
+
+        Used by the Connector enrollment flow: the Connector keeps its
+        private key on the user's machine and only submits the public key,
+        the admin approves, and the proxy issues a cert bound to that key.
+
+        Raises ``RuntimeError`` if the Org CA is not loaded or the PEM is
+        malformed. Accepts any key type the ``cryptography`` library can
+        load (RSA, EC, Ed25519); the resulting cert signature is always
+        SHA-256 per the existing convention.
+        """
+        if not self.ca_loaded:
+            raise RuntimeError("Org CA not loaded — call load_org_ca() first")
+
+        public_key = serialization.load_pem_public_key(pubkey_pem.encode())
+
+        agent_id = f"{self._org_id}::{agent_name}"
+        spiffe_uri = f"spiffe://{self._trust_domain}/{self._org_id}/{agent_name}"
+
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id),
+        ])
+
+        now = datetime.now(timezone.utc)
+        cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(self._org_ca_cert.subject)
+            .public_key(public_key)
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now)
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                SubjectAlternativeName([
+                    UniformResourceIdentifier(spiffe_uri),
+                ]),
+                critical=False,
+            )
+            .sign(self._org_ca_key, hashes.SHA256())
+        )
+
+        cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+        logger.info(
+            "Signed external pubkey for %s (SAN %s)", agent_id, spiffe_uri
+        )
+        return cert_pem
+
     # ── Agent CRUD ──────────────────────────────────────────────────
 
     async def create_agent(

--- a/mcp_proxy/enrollment/__init__.py
+++ b/mcp_proxy/enrollment/__init__.py
@@ -1,0 +1,16 @@
+"""Connector enrollment — self-register + admin approve flow.
+
+Implements Pattern B from the three-tier architecture (see memory
+`project_three_tier_architecture.md`): a user-side Cullis Connector declares
+its identity (name/email/reason) and submits a public key; the admin then
+decides the internal agent_id, capabilities, and groups, and approves to
+trigger cert issuance signed by the Org CA.
+
+This package owns the server-side API only. The browser form rendered at
+``/enroll?session=...`` and the dashboard pending list live under
+``mcp_proxy.dashboard``.
+"""
+
+from mcp_proxy.enrollment.router import router
+
+__all__ = ["router"]

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -1,0 +1,238 @@
+"""FastAPI router for the Connector enrollment API.
+
+Two audiences share this router:
+
+* **Connector-side** (unauthenticated, keyed by an unguessable session_id):
+  - ``POST /v1/enrollment/start`` — start a pending request
+  - ``GET  /v1/enrollment/{session_id}/status`` — poll for decision
+
+* **Admin dashboard** (requires dashboard session + CSRF header):
+  - ``GET  /v1/admin/enrollments`` — list pending
+  - ``POST /v1/admin/enrollments/{session_id}/approve`` — approve
+  - ``POST /v1/admin/enrollments/{session_id}/reject`` — reject
+
+Identity on the Connector side is self-declared; the admin is the authority
+that decides what gets through. OIDC + SCIM layer on top later without
+changing this surface.
+"""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+)
+from mcp_proxy.db import get_db
+from mcp_proxy.enrollment import service
+from mcp_proxy.enrollment.schemas import (
+    EnrollmentApproveRequest,
+    EnrollmentRejectRequest,
+    EnrollmentStartRequest,
+    EnrollmentStartResponse,
+    EnrollmentStatusResponse,
+    PendingEnrollmentSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["enrollment"])
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _require_logged_in(request: Request) -> ProxyDashboardSession:
+    """Variant of ``require_login`` that raises HTTP 401 for JSON endpoints
+    instead of redirecting. The dashboard's existing HTML views continue to
+    use ``require_login`` (which redirects to ``/proxy/login``); our JSON
+    admin API shouldn't 303 an XHR."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return session
+
+
+def _verify_csrf_header(request: Request, session: ProxyDashboardSession) -> None:
+    """Check ``X-CSRF-Token`` header against the token bound to the session
+    cookie. Raises HTTP 403 on mismatch. Used for JSON mutations — the
+    form-based flow keeps using ``verify_csrf`` from the session module."""
+    token = request.headers.get("X-CSRF-Token", "")
+    if not session.csrf_token or not token:
+        raise HTTPException(status_code=403, detail="CSRF token missing")
+    if not hmac.compare_digest(token, session.csrf_token):
+        raise HTTPException(status_code=403, detail="CSRF token invalid")
+
+
+def _require_agent_manager(request: Request):
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None:
+        raise HTTPException(
+            status_code=503,
+            detail="agent_manager not initialized (complete broker setup first)",
+        )
+    return mgr
+
+
+# ── Connector-facing (unauthenticated, keyed by session_id) ──────────────
+
+
+@router.post(
+    "/v1/enrollment/start",
+    response_model=EnrollmentStartResponse,
+    status_code=201,
+)
+async def start_enrollment(
+    payload: EnrollmentStartRequest,
+    request: Request,
+) -> EnrollmentStartResponse:
+    try:
+        async with get_db() as conn:
+            started = await service.start_enrollment(
+                conn,
+                pubkey_pem=payload.pubkey_pem,
+                requester_name=payload.requester_name,
+                requester_email=payload.requester_email,
+                reason=payload.reason,
+                device_info=payload.device_info,
+            )
+    except service.EnrollmentError as exc:
+        raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
+
+    base = str(request.base_url).rstrip("/")
+    logger.info(
+        "enrollment_started",
+        extra={
+            "session_id": started.session_id,
+            "requester_email": payload.requester_email,
+        },
+    )
+    return EnrollmentStartResponse(
+        session_id=started.session_id,
+        status="pending",
+        poll_url=f"{base}/v1/enrollment/{started.session_id}/status",
+        enroll_url=f"{base}/enroll?session={started.session_id}",
+        poll_interval_s=service.POLL_INTERVAL_S,
+        expires_at=started.expires_at.isoformat(timespec="seconds"),
+    )
+
+
+@router.get(
+    "/v1/enrollment/{session_id}/status",
+    response_model=EnrollmentStatusResponse,
+)
+async def enrollment_status(session_id: str) -> EnrollmentStatusResponse:
+    try:
+        async with get_db() as conn:
+            record = await service.get_record(conn, session_id)
+    except service.EnrollmentError as exc:
+        raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
+
+    response = EnrollmentStatusResponse(
+        session_id=record["session_id"],
+        status=record["status"],  # type: ignore[arg-type]
+    )
+    if record["status"] == "approved":
+        response.agent_id = record["agent_id_assigned"]
+        response.cert_pem = record["cert_pem"]
+        caps_raw = record.get("capabilities_assigned") or "[]"
+        try:
+            response.capabilities = json.loads(caps_raw)
+        except json.JSONDecodeError:
+            response.capabilities = []
+    elif record["status"] == "rejected":
+        response.rejection_reason = record["rejection_reason"]
+    return response
+
+
+# ── Admin-facing (dashboard session required + CSRF) ─────────────────────
+
+
+@router.get(
+    "/v1/admin/enrollments",
+    response_model=list[PendingEnrollmentSummary],
+)
+async def admin_list_pending(request: Request) -> list[PendingEnrollmentSummary]:
+    _require_logged_in(request)
+    async with get_db() as conn:
+        rows = await service.list_pending(conn)
+    return [
+        PendingEnrollmentSummary(
+            session_id=r["session_id"],
+            requester_name=r["requester_name"],
+            requester_email=r["requester_email"],
+            reason=r.get("reason"),
+            device_info=r.get("device_info"),
+            pubkey_fingerprint=r["pubkey_fingerprint"],
+            created_at=r["created_at"],
+            expires_at=r["expires_at"],
+        )
+        for r in rows
+    ]
+
+
+@router.post("/v1/admin/enrollments/{session_id}/approve")
+async def admin_approve(
+    session_id: str,
+    payload: EnrollmentApproveRequest,
+    request: Request,
+) -> dict[str, str]:
+    session = _require_logged_in(request)
+    _verify_csrf_header(request, session)
+    agent_manager = _require_agent_manager(request)
+
+    try:
+        async with get_db() as conn:
+            record = await service.approve(
+                conn,
+                session_id=session_id,
+                agent_id=payload.agent_id,
+                capabilities=payload.capabilities,
+                groups=payload.groups,
+                admin_name=session.role or "admin",
+                agent_manager=agent_manager,
+            )
+    except service.EnrollmentError as exc:
+        raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
+
+    logger.info(
+        "enrollment_approved",
+        extra={
+            "session_id": session_id,
+            "agent_id": record["agent_id_assigned"],
+            "admin": session.role,
+        },
+    )
+    return {"status": "approved", "agent_id": record["agent_id_assigned"] or ""}
+
+
+@router.post("/v1/admin/enrollments/{session_id}/reject")
+async def admin_reject(
+    session_id: str,
+    payload: EnrollmentRejectRequest,
+    request: Request,
+) -> dict[str, str]:
+    session = _require_logged_in(request)
+    _verify_csrf_header(request, session)
+
+    try:
+        async with get_db() as conn:
+            await service.reject(
+                conn,
+                session_id=session_id,
+                reason=payload.reason,
+                admin_name=session.role or "admin",
+            )
+    except service.EnrollmentError as exc:
+        raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc
+
+    logger.info(
+        "enrollment_rejected",
+        extra={"session_id": session_id, "admin": session.role},
+    )
+    return {"status": "rejected"}

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -1,0 +1,83 @@
+"""Pydantic schemas for the enrollment API."""
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class EnrollmentStartRequest(BaseModel):
+    """Initial request from a Connector to begin enrollment.
+
+    The Connector generates its keypair locally, extracts the public key in
+    PEM, and submits it along with the self-declared identity. The private
+    key never leaves the caller's machine.
+    """
+
+    pubkey_pem: str = Field(..., min_length=100, max_length=8192)
+    requester_name: str = Field(..., min_length=1, max_length=200)
+    requester_email: str = Field(..., min_length=3, max_length=320)
+    reason: str | None = Field(None, max_length=1000)
+
+    @field_validator("requester_email")
+    @classmethod
+    def _validate_email(cls, value: str) -> str:
+        # Lightweight check — admin does the real vetting during approval.
+        # Keeps us off the ``email-validator`` dependency for a v1 MVP.
+        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", value):
+            raise ValueError("requester_email is not a valid email address")
+        return value
+    device_info: str | None = Field(
+        None,
+        max_length=500,
+        description=(
+            "Free-form device/client info (OS, hostname, Connector version)."
+            " Not used for auth — helps admin decide and appears in audit."
+        ),
+    )
+
+
+class EnrollmentStartResponse(BaseModel):
+    session_id: str
+    status: Literal["pending"]
+    poll_url: str
+    enroll_url: str
+    poll_interval_s: int
+    expires_at: str
+
+
+class EnrollmentStatusResponse(BaseModel):
+    session_id: str
+    status: Literal["pending", "approved", "rejected", "expired"]
+    # Populated only when status == "approved"
+    agent_id: str | None = None
+    cert_pem: str | None = None
+    capabilities: list[str] | None = None
+    # Populated only when status == "rejected"
+    rejection_reason: str | None = None
+
+
+class EnrollmentApproveRequest(BaseModel):
+    """Admin decision to approve a pending enrollment."""
+
+    agent_id: str = Field(..., min_length=1, max_length=200)
+    capabilities: list[str] = Field(default_factory=list)
+    groups: list[str] = Field(default_factory=list)
+
+
+class EnrollmentRejectRequest(BaseModel):
+    reason: str = Field(..., min_length=1, max_length=500)
+
+
+class PendingEnrollmentSummary(BaseModel):
+    """Single item in the admin list of pending enrollments."""
+
+    session_id: str
+    requester_name: str
+    requester_email: str
+    reason: str | None
+    device_info: str | None
+    pubkey_fingerprint: str
+    created_at: str
+    expires_at: str

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -1,0 +1,270 @@
+"""Business logic for the Connector enrollment flow.
+
+Thin helpers that take an ``AsyncConnection`` (the proxy's only DB primitive,
+see ``mcp_proxy.db.get_db``) and manipulate the ``pending_enrollments``
+table via raw SQL. Cert signing is delegated to :class:`AgentManager` so CA
+material stays owned by the module that already loads it from Vault/disk.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any
+
+from cryptography.hazmat.primitives import serialization
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+if TYPE_CHECKING:
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+
+ENROLLMENT_TTL = timedelta(minutes=30)
+POLL_INTERVAL_S = 5
+
+
+class EnrollmentError(Exception):
+    """Raised for user-facing enrollment failures. The router maps the
+    ``http_status`` to the HTTP response code (400/404/409/503)."""
+
+    def __init__(self, message: str, http_status: int = 400) -> None:
+        super().__init__(message)
+        self.http_status = http_status
+
+
+@dataclass
+class StartedEnrollment:
+    session_id: str
+    expires_at: datetime
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(ts: datetime) -> str:
+    return ts.isoformat(timespec="seconds")
+
+
+def _pubkey_fingerprint(pubkey_pem: str) -> str:
+    """SHA-256 of the DER SubjectPublicKeyInfo — matches standard CLI output.
+
+    Gives the admin a stable string to compare against what the Connector
+    prints locally on enrollment start.
+    """
+    try:
+        public_key = serialization.load_pem_public_key(pubkey_pem.encode())
+    except Exception as exc:
+        raise EnrollmentError(f"Invalid public key PEM: {exc}", http_status=400) from exc
+    der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(der).hexdigest()
+
+
+def _row_to_dict(row: Any) -> dict[str, Any]:
+    return dict(row)
+
+
+# ── Reads ────────────────────────────────────────────────────────────────
+
+
+async def get_record(conn: AsyncConnection, session_id: str) -> dict[str, Any]:
+    """Fetch a record. Lazily marks it expired when the TTL has lapsed."""
+    result = await conn.execute(
+        text("SELECT * FROM pending_enrollments WHERE session_id = :sid"),
+        {"sid": session_id},
+    )
+    row = result.mappings().first()
+    if row is None:
+        raise EnrollmentError("Enrollment session not found", http_status=404)
+    record = _row_to_dict(row)
+
+    if record["status"] == "pending":
+        expires_at = datetime.fromisoformat(record["expires_at"])
+        if expires_at < _now():
+            await conn.execute(
+                text(
+                    "UPDATE pending_enrollments SET status = 'expired' "
+                    "WHERE session_id = :sid"
+                ),
+                {"sid": session_id},
+            )
+            record["status"] = "expired"
+    return record
+
+
+async def list_pending(conn: AsyncConnection) -> list[dict[str, Any]]:
+    """Return pending records (newest first), flipping any whose TTL lapsed."""
+    now_iso = _iso(_now())
+    await conn.execute(
+        text(
+            "UPDATE pending_enrollments "
+            "SET status = 'expired' "
+            "WHERE status = 'pending' AND expires_at < :now"
+        ),
+        {"now": now_iso},
+    )
+    result = await conn.execute(
+        text(
+            "SELECT * FROM pending_enrollments "
+            "WHERE status = 'pending' "
+            "ORDER BY created_at DESC"
+        )
+    )
+    return [_row_to_dict(r) for r in result.mappings().all()]
+
+
+# ── Writes ───────────────────────────────────────────────────────────────
+
+
+async def start_enrollment(
+    conn: AsyncConnection,
+    *,
+    pubkey_pem: str,
+    requester_name: str,
+    requester_email: str,
+    reason: str | None,
+    device_info: str | None,
+) -> StartedEnrollment:
+    """Create a new pending enrollment.
+
+    The session_id is a 128-bit URL-safe random token — unguessable so only
+    the client that started the flow can poll it.
+    """
+    fingerprint = _pubkey_fingerprint(pubkey_pem)
+    session_id = secrets.token_urlsafe(24)
+    now = _now()
+    expires_at = now + ENROLLMENT_TTL
+
+    await conn.execute(
+        text(
+            """INSERT INTO pending_enrollments (
+                session_id, pubkey_pem, pubkey_fingerprint,
+                requester_name, requester_email, reason, device_info,
+                status, created_at, expires_at
+            ) VALUES (
+                :sid, :pk, :fp,
+                :name, :email, :reason, :device,
+                'pending', :created, :expires
+            )"""
+        ),
+        {
+            "sid": session_id,
+            "pk": pubkey_pem,
+            "fp": fingerprint,
+            "name": requester_name,
+            "email": requester_email,
+            "reason": reason,
+            "device": device_info,
+            "created": _iso(now),
+            "expires": _iso(expires_at),
+        },
+    )
+    return StartedEnrollment(session_id=session_id, expires_at=expires_at)
+
+
+async def approve(
+    conn: AsyncConnection,
+    *,
+    session_id: str,
+    agent_id: str,
+    capabilities: list[str],
+    groups: list[str],
+    admin_name: str,
+    agent_manager: "AgentManager",
+) -> dict[str, Any]:
+    """Approve a pending enrollment — admin decides agent_id/caps/groups.
+
+    The requester has no influence on these values; their only input was the
+    public key and the self-declared name/email/reason that the admin used
+    when deciding.
+    """
+    record = await get_record(conn, session_id)
+    if record["status"] != "pending":
+        raise EnrollmentError(
+            f"Cannot approve an enrollment in status '{record['status']}'",
+            http_status=409,
+        )
+
+    if not agent_manager.ca_loaded:
+        raise EnrollmentError(
+            "Org CA is not loaded — complete broker setup first.",
+            http_status=503,
+        )
+
+    cert_pem = agent_manager.sign_external_pubkey(
+        pubkey_pem=record["pubkey_pem"],
+        agent_name=agent_id,
+    )
+
+    now = _iso(_now())
+    await conn.execute(
+        text(
+            """UPDATE pending_enrollments
+               SET status = 'approved',
+                   decided_at = :decided,
+                   decided_by = :admin,
+                   agent_id_assigned = :agent_id,
+                   capabilities_assigned = :caps,
+                   groups_assigned = :groups,
+                   cert_pem = :cert
+               WHERE session_id = :sid"""
+        ),
+        {
+            "decided": now,
+            "admin": admin_name,
+            "agent_id": agent_id,
+            "caps": json.dumps(capabilities),
+            "groups": json.dumps(groups),
+            "cert": cert_pem,
+            "sid": session_id,
+        },
+    )
+    return await get_record(conn, session_id)
+
+
+async def reject(
+    conn: AsyncConnection,
+    *,
+    session_id: str,
+    reason: str,
+    admin_name: str,
+) -> dict[str, Any]:
+    record = await get_record(conn, session_id)
+    if record["status"] != "pending":
+        raise EnrollmentError(
+            f"Cannot reject an enrollment in status '{record['status']}'",
+            http_status=409,
+        )
+    now = _iso(_now())
+    await conn.execute(
+        text(
+            """UPDATE pending_enrollments
+               SET status = 'rejected',
+                   decided_at = :decided,
+                   decided_by = :admin,
+                   rejection_reason = :reason
+               WHERE session_id = :sid"""
+        ),
+        {"decided": now, "admin": admin_name, "reason": reason, "sid": session_id},
+    )
+    return await get_record(conn, session_id)
+
+
+async def sweep_expired(conn: AsyncConnection) -> int:
+    """Flip all pending records past their TTL to ``expired``. Returns count."""
+    now_iso = _iso(_now())
+    result = await conn.execute(
+        text(
+            "UPDATE pending_enrollments "
+            "SET status = 'expired' "
+            "WHERE status = 'pending' AND expires_at < :now"
+        ),
+        {"now": now_iso},
+    )
+    return int(result.rowcount or 0)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -347,6 +347,9 @@ app.include_router(egress_router)
 from mcp_proxy.local.ws_router import router as local_ws_router
 app.include_router(local_ws_router)
 
+from mcp_proxy.enrollment.router import router as enrollment_router
+app.include_router(enrollment_router)
+
 from mcp_proxy.dashboard.router import router as dashboard_router
 app.include_router(dashboard_router)
 

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -1,0 +1,378 @@
+"""Connector enrollment — server-side API + service layer (Phase 2, #64).
+
+Covers:
+  - service.start_enrollment / get_record / list_pending / approve / reject
+  - TTL lazy expiry and sweep
+  - HTTP endpoints: /v1/enrollment/start, /v1/enrollment/{id}/status
+  - Admin auth guard + CSRF header on /v1/admin/enrollments
+  - AgentManager.sign_external_pubkey: cert bound to supplied pubkey
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.enrollment import service
+from mcp_proxy.enrollment.service import EnrollmentError
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+
+def _rsa_pubkey_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _ec_pubkey_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+# ── Service layer tests (SQLite-backed, no HTTP) ───────────────────
+
+
+@pytest_asyncio.fixture
+async def db_engine(tmp_path, monkeypatch):
+    db_file = tmp_path / "enrollment.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_start_enrollment_persists_row(db_engine):
+    pubkey = _ec_pubkey_pem()
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="Mario Rossi",
+            requester_email="mario@acme.com",
+            reason="Procurement Q2 project",
+            device_info='{"os":"linux"}',
+        )
+    assert started.session_id
+    assert started.expires_at > datetime.now(timezone.utc)
+
+    async with get_db() as conn:
+        record = await service.get_record(conn, started.session_id)
+    assert record["requester_name"] == "Mario Rossi"
+    assert record["status"] == "pending"
+    assert len(record["pubkey_fingerprint"]) == 64  # sha256 hex
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_malformed_pubkey(db_engine):
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem="not a real pem",
+                requester_name="Mario",
+                requester_email="m@x.com",
+                reason=None,
+                device_info=None,
+            )
+    assert exc.value.http_status == 400
+
+
+@pytest.mark.asyncio
+async def test_get_record_not_found_raises_404(db_engine):
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.get_record(conn, "nonexistent")
+    assert exc.value.http_status == 404
+
+
+@pytest.mark.asyncio
+async def test_expired_record_flips_on_read(db_engine):
+    pubkey = _rsa_pubkey_pem()
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="N",
+            requester_email="n@x.com",
+            reason=None,
+            device_info=None,
+        )
+        # Manually backdate expiry — simulate TTL elapsed.
+        from sqlalchemy import text
+        past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat(
+            timespec="seconds"
+        )
+        await conn.execute(
+            text("UPDATE pending_enrollments SET expires_at = :t WHERE session_id = :s"),
+            {"t": past, "s": started.session_id},
+        )
+
+    async with get_db() as conn:
+        record = await service.get_record(conn, started.session_id)
+    assert record["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_list_pending_skips_expired(db_engine):
+    async with get_db() as conn:
+        alive = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Alive",
+            requester_email="alive@x.com",
+            reason=None,
+            device_info=None,
+        )
+        stale = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Stale",
+            requester_email="stale@x.com",
+            reason=None,
+            device_info=None,
+        )
+        from sqlalchemy import text
+        past = (datetime.now(timezone.utc) - timedelta(seconds=5)).isoformat(
+            timespec="seconds"
+        )
+        await conn.execute(
+            text("UPDATE pending_enrollments SET expires_at = :t WHERE session_id = :s"),
+            {"t": past, "s": stale.session_id},
+        )
+
+    async with get_db() as conn:
+        pending = await service.list_pending(conn)
+    ids = {r["session_id"] for r in pending}
+    assert alive.session_id in ids
+    assert stale.session_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_reject_sets_status_and_reason(db_engine):
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="R",
+            requester_email="r@x.com",
+            reason=None,
+            device_info=None,
+        )
+
+    async with get_db() as conn:
+        rejected = await service.reject(
+            conn,
+            session_id=started.session_id,
+            reason="Not recognized",
+            admin_name="admin",
+        )
+    assert rejected["status"] == "rejected"
+    assert rejected["rejection_reason"] == "Not recognized"
+
+    # Second reject must fail — can only act on pending.
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.reject(
+                conn,
+                session_id=started.session_id,
+                reason="again",
+                admin_name="admin",
+            )
+    assert exc.value.http_status == 409
+
+
+@pytest.mark.asyncio
+async def test_approve_signs_cert_and_marks_approved(db_engine):
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    pubkey = _rsa_pubkey_pem()
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="A",
+            requester_email="a@x.com",
+            reason=None,
+            device_info=None,
+        )
+
+    async with get_db() as conn:
+        record = await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="agent-mrossi",
+            capabilities=["procurement.read"],
+            groups=["procurement"],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    assert record["status"] == "approved"
+    assert record["agent_id_assigned"] == "agent-mrossi"
+    cert = x509.load_pem_x509_certificate(record["cert_pem"].encode())
+    # CN contains the admin-chosen agent_id.
+    cns = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+    assert cns[0].value == "acme::agent-mrossi"
+    # Cert binds to the *submitted* pubkey — requester keeps the private key.
+    submitted_pub = serialization.load_pem_public_key(pubkey.encode())
+    assert cert.public_key().public_numbers() == submitted_pub.public_numbers()
+
+
+# ── HTTP endpoint tests ────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}"
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_http_start_returns_201_and_poll_url(proxy_app):
+    _, client = proxy_app
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": _ec_pubkey_pem(),
+            "requester_name": "Mario",
+            "requester_email": "mario@acme.com",
+            "reason": "Onboarding",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "pending"
+    assert body["poll_url"].endswith(f"/v1/enrollment/{body['session_id']}/status")
+    assert body["poll_interval_s"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_http_status_pending_then_not_found(proxy_app):
+    _, client = proxy_app
+    start = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": _ec_pubkey_pem(),
+            "requester_name": "X",
+            "requester_email": "x@x.com",
+        },
+    )
+    session_id = start.json()["session_id"]
+
+    resp = await client.get(f"/v1/enrollment/{session_id}/status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+    missing = await client.get("/v1/enrollment/does-not-exist/status")
+    assert missing.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_http_admin_list_requires_auth(proxy_app):
+    _, client = proxy_app
+    resp = await client.get("/v1/admin/enrollments")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_http_admin_approve_requires_csrf(proxy_app):
+    app, client = proxy_app
+    # Mint a valid session cookie + csrf token via the session helper.
+    from mcp_proxy.dashboard.session import _sign, _COOKIE_NAME
+    import json as _json
+    import time as _time
+
+    csrf = "test-csrf-token-abc"
+    payload = _json.dumps(
+        {"role": "admin", "csrf_token": csrf, "exp": int(_time.time()) + 3600}
+    )
+    cookie = _sign(payload)
+    client.cookies.set(_COOKIE_NAME, cookie)
+
+    # Missing header → 403.
+    resp = await client.post(
+        "/v1/admin/enrollments/bogus/approve",
+        json={"agent_id": "x", "capabilities": [], "groups": []},
+    )
+    assert resp.status_code == 403
+
+    # Wrong header → 403.
+    resp = await client.post(
+        "/v1/admin/enrollments/bogus/approve",
+        headers={"X-CSRF-Token": "wrong"},
+        json={"agent_id": "x", "capabilities": [], "groups": []},
+    )
+    assert resp.status_code == 403
+
+
+# ── Test helpers ──────────────────────────────────────────────────
+
+
+def _generate_self_signed_ca(org_id: str) -> tuple[str, str]:
+    """Minimal self-signed CA for approve-path tests."""
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id}-ca"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=None), critical=True
+        )
+        .sign(key, __import__("cryptography").hazmat.primitives.hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return key_pem, cert_pem

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -26,6 +26,7 @@ EXPECTED_TABLES = {
     "local_messages",
     "local_policies",
     "local_audit",
+    "pending_enrollments",
     "alembic_version",
 }
 
@@ -60,7 +61,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0002_local_tables",)]
+    assert rows == [("0003_add_pending_enrollments",)]
 
 
 @pytest.mark.asyncio
@@ -120,7 +121,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0002_local_tables",)]
+    assert version == [("0003_add_pending_enrollments",)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Replaces #72 (closed accidentally during cleanup when branch was deleted before merge). Rebased clean on current main (which now includes A2A Phase 2b #71). No logical changes from the original PR — same commit content, just a new parent.

Part of #64 (Connector Phase 2 — server half; client device-code + identity storage land in a follow-up Phase 2b PR).

## Summary

Server-side API for the Cullis Connector enrollment flow (pattern B: Connector submits pubkey + self-declared identity, admin approves with an admin-chosen agent_id + capabilities + groups, proxy issues an Org-CA-signed cert).

- Alembic `0003_add_pending_enrollments` + `PendingEnrollment` ORM + indexes.
- `mcp_proxy/enrollment/` (schemas / service / router):
  - `POST /v1/enrollment/start` — unauthenticated, 128-bit URL-safe session_id.
  - `GET /v1/enrollment/{id}/status` — returns cert on `approved`.
  - `GET /v1/admin/enrollments` — admin-only, newest first, lazy TTL sweep.
  - `POST /v1/admin/enrollments/{id}/approve|reject` — dashboard cookie + `X-CSRF-Token` header.
- `AgentManager.sign_external_pubkey()` — signs any external PEM pubkey (RSA / EC / Ed25519) with the Org CA. Private key never leaves the Connector machine.
- 15 tests: service layer + HTTP + CSRF + cert binding assertion.

## Test plan

- [x] `pytest tests/test_enrollment.py tests/test_proxy_migrations.py` → 15 passed
- [x] `pytest tests/` full suite → 626 passed, 14 skipped
- [x] `./demo_network/smoke.sh full` → PASS (A1-A7 green, hash chain intact across 34 entries)
- [ ] CI must be green before merge.

## Out of scope (Phase 2b)

- HTML form under `/enroll?session=...`
- Dashboard "Pending Enrollments" admin page
- Client-side `cullis_connector/identity/` + device-code polling

Refs: EPIC #62, #64, memory `project_three_tier_architecture.md`.