### PR TITLE
feat(audit): per-org hash chain + cross-org dual-write (Slice 1 of #75)

### DIFF
--- a/alembic/versions/f6a7b8c9d0e1_audit_chain_per_org.py
+++ b/alembic/versions/f6a7b8c9d0e1_audit_chain_per_org.py
@@ -1,0 +1,91 @@
+"""audit chain per-org + TSA anchors
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-04-14 17:00:00.000000
+
+Converts the audit_log hash chain from a single global chain into
+independent per-org chains. Existing rows are grandfathered: they keep
+their globally-chained `previous_hash` and are treated as "legacy"
+(chain_seq IS NULL) by verify_chain. New rows get a monotonic
+`chain_seq` scoped per org_id and `previous_hash` referencing the last
+entry for the same org.
+
+Cross-org events can be stored as two rows (one per involved org)
+sharing the same payload hash via the new peer_org_id / peer_row_hash
+columns, so a dispute verifier can cross-reference both orgs' exports.
+
+Also introduces `audit_tsa_anchors` for RFC 3161 timestamping of
+per-org chain heads, wired by a later migration / PR 2.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, Sequence[str], None] = 'e5f6a7b8c9d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Per-org chain ordering; NULL = legacy row (pre-per-org migration).
+    op.add_column(
+        'audit_log',
+        sa.Column('chain_seq', sa.Integer(), nullable=True),
+    )
+    # Cross-org linkage: when an event is dual-written to two chains, the
+    # companion row's org_id + entry_hash go here so verifiers can confirm
+    # both sides agree.
+    op.add_column(
+        'audit_log',
+        sa.Column('peer_org_id', sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        'audit_log',
+        sa.Column('peer_row_hash', sa.String(length=64), nullable=True),
+    )
+    op.create_index(
+        'ix_audit_log_org_chain_seq', 'audit_log',
+        ['org_id', 'chain_seq'], unique=False,
+    )
+    op.create_index(
+        op.f('ix_audit_log_peer_org_id'), 'audit_log',
+        ['peer_org_id'], unique=False,
+    )
+
+    # RFC 3161 TimeStampToken anchors for per-org chain heads.
+    op.create_table(
+        'audit_tsa_anchors',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('org_id', sa.String(length=128), nullable=False),
+        sa.Column('chain_seq', sa.Integer(), nullable=False),
+        sa.Column('row_hash', sa.String(length=64), nullable=False),
+        sa.Column('tsa_token', sa.LargeBinary(), nullable=False),
+        sa.Column('tsa_url', sa.String(length=256), nullable=False),
+        sa.Column('tsa_cert_chain', sa.Text(), nullable=True),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.text('CURRENT_TIMESTAMP'),
+        ),
+        sa.UniqueConstraint('org_id', 'chain_seq', name='uq_tsa_anchor_org_seq'),
+    )
+    op.create_index(
+        op.f('ix_audit_tsa_anchors_org_id'), 'audit_tsa_anchors',
+        ['org_id'], unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_audit_tsa_anchors_org_id'), table_name='audit_tsa_anchors')
+    op.drop_table('audit_tsa_anchors')
+    op.drop_index(op.f('ix_audit_log_peer_org_id'), table_name='audit_log')
+    op.drop_index('ix_audit_log_org_chain_seq', table_name='audit_log')
+    op.drop_column('audit_log', 'peer_row_hash')
+    op.drop_column('audit_log', 'peer_org_id')
+    op.drop_column('audit_log', 'chain_seq')

--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -18,8 +18,6 @@ import asyncio
 import hashlib
 import json
 from datetime import datetime, timezone
-from typing import Any
-
 from sqlalchemy import Column, Integer, String, DateTime, Text, and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -1,8 +1,16 @@
 """
-Append-only audit log with cryptographic hash chain.
+Append-only audit log with per-org cryptographic hash chain.
 
-Every event is recorded with a SHA-256 hash that chains to the previous entry,
-making any tampering (insert, update, delete, reorder) detectable.
+Every event is recorded with a SHA-256 hash that chains to the previous
+entry **for the same org_id**, making tampering detectable per tenant.
+Cross-org events are dual-written: two rows, one per involved org,
+sharing the same payload hash + peer cross-references so a dispute
+verifier can cross-check both orgs' exports.
+
+Legacy rows (pre-per-org migration, chain_seq IS NULL) stay globally
+chained and are grandfathered by verify_chain — they remain
+tamper-evident under the original rules; only new rows use per-org
+chains.
 
 No row is ever modified or deleted (threat model: non-repudiation, SOC2).
 """
@@ -10,16 +18,33 @@ import asyncio
 import hashlib
 import json
 from datetime import datetime, timezone
+from typing import Any
 
-from sqlalchemy import Column, Integer, String, DateTime, Text, select
+from sqlalchemy import Column, Integer, String, DateTime, Text, and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import Base
 
-# Serializes audit log inserts to prevent hash chain bifurcation.
-# Two concurrent log_event() calls reading the same previous_hash before
-# either commits would fork the chain. This lock ensures sequential access.
-_audit_chain_lock = asyncio.Lock()
+# Sentinel org used for audit events that have no natural tenant
+# (system-level events, bootstrap, etc.). Isolates their chain from
+# real tenants so an export for a real org never mixes in system rows.
+SYSTEM_ORG = "__system__"
+
+# One lock per org_id guarantees that reads of "last entry for org X"
+# + insert of the next entry are atomic without blocking writes to
+# other orgs' chains. A top-level guard protects the dict itself.
+_org_locks: dict[str, asyncio.Lock] = {}
+_locks_guard = asyncio.Lock()
+
+
+async def _get_org_lock(org_id: str) -> asyncio.Lock:
+    """Return (or lazily create) the per-org append lock."""
+    if org_id in _org_locks:
+        return _org_locks[org_id]
+    async with _locks_guard:
+        if org_id not in _org_locks:
+            _org_locks[org_id] = asyncio.Lock()
+        return _org_locks[org_id]
 
 
 class AuditLog(Base):
@@ -35,6 +60,11 @@ class AuditLog(Base):
     result = Column(String(16), nullable=False)  # "ok" | "denied" | "error"
     entry_hash = Column(String(64), nullable=True, index=True)
     previous_hash = Column(String(64), nullable=True)
+    # Per-org chain ordering; NULL = legacy row (pre-per-org migration).
+    chain_seq = Column(Integer, nullable=True)
+    # Cross-org linkage: on dual-write these point to the companion row.
+    peer_org_id = Column(String(128), nullable=True, index=True)
+    peer_row_hash = Column(String(64), nullable=True)
 
 
 def compute_entry_hash(
@@ -47,17 +77,104 @@ def compute_entry_hash(
     result: str,
     details: str | None,
     previous_hash: str | None,
+    chain_seq: int | None = None,
+    peer_org_id: str | None = None,
 ) -> str:
     """Compute the SHA-256 hash of an audit log entry.
 
-    The canonical string is deterministic — any field change invalidates the hash.
+    The canonical string is deterministic — any field change invalidates
+    the hash. When `chain_seq` is None (legacy row) the hash format is
+    identical to the pre-per-org version so existing rows stay
+    verifiable against the original algorithm.
     """
-    canonical = (
+    base = (
         f"{entry_id}|{timestamp.isoformat()}|{event_type}|"
         f"{agent_id or ''}|{session_id or ''}|{org_id or ''}|"
         f"{result}|{details or ''}|{previous_hash or 'genesis'}"
     )
+    if chain_seq is None:
+        canonical = base
+    else:
+        # New rows bind chain_seq + peer_org_id into the hash so either
+        # field cannot be rewritten without detection.
+        canonical = f"{base}|seq={chain_seq}|peer={peer_org_id or ''}"
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def _last_per_org(db: AsyncSession, org_id: str) -> tuple[str | None, int]:
+    """Return (last_entry_hash, last_chain_seq) for the given org.
+
+    Looks up the most recent row with `chain_seq IS NOT NULL` for the
+    org (i.e. the last post-migration entry). Returns (None, 0) when the
+    org has no per-org entries yet — the first append becomes seq=1
+    with `previous_hash` tied to any legacy entry_hash (if present) or
+    NULL for brand-new orgs.
+    """
+    stmt = (
+        select(AuditLog.entry_hash, AuditLog.chain_seq)
+        .where(and_(AuditLog.org_id == org_id, AuditLog.chain_seq.is_not(None)))
+        .order_by(AuditLog.chain_seq.desc())
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).one_or_none()
+    if row is None:
+        # Fall back to the last legacy row for this org, so the per-org
+        # chain's genesis is hash-linked to the most recent legacy entry
+        # (if any) rather than starting cold. This preserves
+        # append-only continuity across the migration boundary.
+        legacy = await db.execute(
+            select(AuditLog.entry_hash)
+            .where(and_(AuditLog.org_id == org_id, AuditLog.chain_seq.is_(None)))
+            .order_by(AuditLog.id.desc())
+            .limit(1)
+        )
+        return (legacy.scalar_one_or_none(), 0)
+    return (row[0], row[1])
+
+
+async def _append_row(
+    db: AsyncSession,
+    *,
+    org_id: str,
+    event_type: str,
+    result: str,
+    agent_id: str | None,
+    session_id: str | None,
+    details_json: str | None,
+    peer_org_id: str | None,
+    peer_row_hash: str | None,
+) -> AuditLog:
+    """Insert one audit row in the org's chain. Caller must hold the
+    per-org lock and will commit. Does NOT commit itself."""
+    previous_hash, last_seq = await _last_per_org(db, org_id)
+    new_seq = last_seq + 1
+
+    entry = AuditLog(
+        event_type=event_type,
+        agent_id=agent_id,
+        session_id=session_id,
+        org_id=org_id,
+        details=details_json,
+        result=result,
+        previous_hash=previous_hash,
+        chain_seq=new_seq,
+        peer_org_id=peer_org_id,
+        peer_row_hash=peer_row_hash,
+    )
+    db.add(entry)
+    await db.flush()  # assigns auto-incremented id
+
+    ts = entry.timestamp
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    entry.entry_hash = compute_entry_hash(
+        entry.id, ts, event_type,
+        agent_id, session_id, org_id, result,
+        details_json, previous_hash,
+        chain_seq=new_seq,
+        peer_org_id=peer_org_id,
+    )
+    return entry
 
 
 async def log_event(
@@ -69,36 +186,26 @@ async def log_event(
     org_id: str | None = None,
     details: dict | None = None,
 ) -> AuditLog:
+    """Append a single entry to the caller's org chain.
+
+    For cross-org events that should appear on both orgs' chains, use
+    `log_event_cross_org` instead.
+    """
     details_json = json.dumps(details) if details else None
+    chain_org = org_id or SYSTEM_ORG
+    lock = await _get_org_lock(chain_org)
 
-    # Serialize chain access: read previous_hash + insert + commit must be
-    # atomic to prevent two coroutines forking the hash chain.
-    async with _audit_chain_lock:
-        last = await db.execute(
-            select(AuditLog.entry_hash).order_by(AuditLog.id.desc()).limit(1)
-        )
-        previous_hash = last.scalar_one_or_none()
-
-        entry = AuditLog(
+    async with lock:
+        entry = await _append_row(
+            db,
+            org_id=chain_org,
             event_type=event_type,
+            result=result,
             agent_id=agent_id,
             session_id=session_id,
-            org_id=org_id,
-            details=details_json,
-            result=result,
-            previous_hash=previous_hash,
-        )
-        db.add(entry)
-        await db.flush()  # assigns auto-incremented id
-
-        # Normalize timestamp for hash computation — SQLite may strip tzinfo on refresh
-        ts = entry.timestamp
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-        entry.entry_hash = compute_entry_hash(
-            entry.id, ts, event_type,
-            agent_id, session_id, org_id, result,
-            details_json, previous_hash,
+            details_json=details_json,
+            peer_org_id=None,
+            peer_row_hash=None,
         )
         await db.commit()
         await db.refresh(entry)
@@ -111,6 +218,84 @@ async def log_event(
         pass  # SSE failure must never break audit logging
 
     return entry
+
+
+async def log_event_cross_org(
+    db: AsyncSession,
+    event_type: str,
+    result: str,
+    org_a: str,
+    org_b: str,
+    *,
+    agent_id: str | None = None,
+    session_id: str | None = None,
+    details: dict | None = None,
+) -> tuple[AuditLog, AuditLog]:
+    """Append the same event to both org chains atomically.
+
+    Produces two rows, one per involved org, linked by `peer_org_id` +
+    `peer_row_hash`. Both rows share identical `details` / event_type /
+    result / session_id, so a dispute verifier can confirm both orgs
+    recorded the same fact. Returns (row_a, row_b) in the order the
+    args were passed — the append order itself is sorted(org_ids) to
+    prevent deadlocks under concurrent cross-org writes.
+    """
+    if org_a == org_b:
+        raise ValueError("cross-org append requires distinct org ids")
+
+    details_json = json.dumps(details) if details else None
+
+    # Deterministic lock order ⇒ no deadlocks when two coroutines race
+    # on the same pair in opposite directions.
+    first, second = sorted([org_a, org_b])
+    lock_first = await _get_org_lock(first)
+    lock_second = await _get_org_lock(second)
+
+    async with lock_first, lock_second:
+        row_first = await _append_row(
+            db,
+            org_id=first,
+            event_type=event_type,
+            result=result,
+            agent_id=agent_id,
+            session_id=session_id,
+            details_json=details_json,
+            peer_org_id=second,
+            peer_row_hash=None,  # filled in after row_second is hashed
+        )
+        row_second = await _append_row(
+            db,
+            org_id=second,
+            event_type=event_type,
+            result=result,
+            agent_id=agent_id,
+            session_id=session_id,
+            details_json=details_json,
+            peer_org_id=first,
+            peer_row_hash=row_first.entry_hash,
+        )
+        # Back-fill peer_row_hash on the first row now that the second
+        # row's hash exists. This closes the cross-reference ring.
+        # The entry_hash of row_first was computed with peer_row_hash=None,
+        # so we must recompute after setting the link — otherwise the
+        # stored entry_hash would mismatch on verify. To preserve
+        # immutability of entry_hash post-commit, we include peer_row_hash
+        # in the hash computation only via peer_org_id (not the hash
+        # itself); the peer_row_hash column is thus informational/reference
+        # data, not part of the signed content.
+        row_first.peer_row_hash = row_second.entry_hash
+        await db.commit()
+        await db.refresh(row_first)
+        await db.refresh(row_second)
+
+    try:
+        from app.dashboard.sse import sse_manager
+        await sse_manager.broadcast(event_type)
+    except Exception:
+        pass
+
+    # Return in caller's original (a, b) order.
+    return (row_first, row_second) if org_a == first else (row_second, row_first)
 
 
 async def query_audit_logs(
@@ -136,47 +321,117 @@ async def query_audit_logs(
     return list(result.scalars().all())
 
 
-async def verify_chain(db: AsyncSession) -> tuple[bool, int, int]:
-    """Walk the audit log and verify every hash in the chain.
+async def verify_chain(
+    db: AsyncSession,
+    org_id: str | None = None,
+) -> tuple[bool, int, int]:
+    """Verify the hash chain integrity.
 
-    Returns (is_valid, total_checked, first_broken_id).
-    first_broken_id is 0 if the chain is intact.
+    When `org_id` is None, verifies every org's chain + the residual
+    legacy global chain. When provided, limits the verification to that
+    org's per-org chain (legacy rows are skipped).
 
-    Increments AUDIT_CHAIN_VERIFY_FAILED_COUNTER on the first broken entry —
-    this metric drives the AuditChainBroken alert (severity: critical).
+    Returns (is_valid, total_checked, first_broken_id). first_broken_id
+    is 0 if the chain is intact.
+
+    Verification modes:
+      - Per-org rows (chain_seq IS NOT NULL): each row's previous_hash
+        must equal the entry_hash of the same org's row at chain_seq-1
+        (or the last legacy entry_hash for that org, for chain_seq=1).
+      - Legacy rows (chain_seq IS NULL): each row's previous_hash must
+        equal the entry_hash of the row globally preceding it by id —
+        this mirrors the pre-migration global-chain invariant.
     """
-    result = await db.execute(
-        select(AuditLog).order_by(AuditLog.id.asc())
-    )
-    entries = result.scalars().all()
+    from app.telemetry_metrics import AUDIT_CHAIN_VERIFY_FAILED_COUNTER
 
-    if not entries:
-        return (True, 0, 0)
-
-    expected_previous: str | None = None
-    for i, entry in enumerate(entries):
-        # Skip entries without hashes (pre-migration)
-        if entry.entry_hash is None:
-            continue
-
-        if entry.previous_hash != expected_previous:
-            from app.telemetry_metrics import AUDIT_CHAIN_VERIFY_FAILED_COUNTER
-            AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(1, {"reason": "previous_hash_mismatch"})
-            return (False, i, entry.id)
-
-        ts = entry.timestamp
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-        expected_hash = compute_entry_hash(
-            entry.id, ts, entry.event_type,
-            entry.agent_id, entry.session_id, entry.org_id,
-            entry.result, entry.details, entry.previous_hash,
+    # ── Per-org chains ─────────────────────────────────────────────
+    if org_id is not None:
+        orgs = [org_id]
+    else:
+        org_rows = await db.execute(
+            select(AuditLog.org_id)
+            .where(AuditLog.chain_seq.is_not(None))
+            .distinct()
         )
-        if entry.entry_hash != expected_hash:
-            from app.telemetry_metrics import AUDIT_CHAIN_VERIFY_FAILED_COUNTER
-            AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(1, {"reason": "entry_hash_mismatch"})
-            return (False, i, entry.id)
+        orgs = [r for r in org_rows.scalars().all() if r is not None]
 
-        expected_previous = entry.entry_hash
+    total_checked = 0
+    for o in orgs:
+        stmt = (
+            select(AuditLog)
+            .where(and_(AuditLog.org_id == o, AuditLog.chain_seq.is_not(None)))
+            .order_by(AuditLog.chain_seq.asc())
+        )
+        entries = (await db.execute(stmt)).scalars().all()
+        if not entries:
+            continue
+        # Genesis previous_hash = last legacy entry for this org (or None).
+        legacy_tail = await db.execute(
+            select(AuditLog.entry_hash)
+            .where(and_(AuditLog.org_id == o, AuditLog.chain_seq.is_(None)))
+            .order_by(AuditLog.id.desc())
+            .limit(1)
+        )
+        expected_previous = legacy_tail.scalar_one_or_none()
 
-    return (True, len(entries), 0)
+        for entry in entries:
+            if entry.previous_hash != expected_previous:
+                AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(
+                    1, {"reason": "previous_hash_mismatch", "scope": "per_org"}
+                )
+                return (False, total_checked, entry.id)
+
+            ts = entry.timestamp
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            expected_hash = compute_entry_hash(
+                entry.id, ts, entry.event_type,
+                entry.agent_id, entry.session_id, entry.org_id,
+                entry.result, entry.details, entry.previous_hash,
+                chain_seq=entry.chain_seq,
+                peer_org_id=entry.peer_org_id,
+            )
+            if entry.entry_hash != expected_hash:
+                AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(
+                    1, {"reason": "entry_hash_mismatch", "scope": "per_org"}
+                )
+                return (False, total_checked, entry.id)
+
+            expected_previous = entry.entry_hash
+            total_checked += 1
+
+    # ── Legacy global chain (only when org_id filter omitted) ──────
+    if org_id is None:
+        legacy_stmt = (
+            select(AuditLog)
+            .where(AuditLog.chain_seq.is_(None))
+            .order_by(AuditLog.id.asc())
+        )
+        legacy = (await db.execute(legacy_stmt)).scalars().all()
+        expected_previous = None
+        for entry in legacy:
+            if entry.entry_hash is None:
+                # pre-hash-chain row, predating even the legacy chain
+                continue
+            if entry.previous_hash != expected_previous:
+                AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(
+                    1, {"reason": "previous_hash_mismatch", "scope": "legacy"}
+                )
+                return (False, total_checked, entry.id)
+            ts = entry.timestamp
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            expected_hash = compute_entry_hash(
+                entry.id, ts, entry.event_type,
+                entry.agent_id, entry.session_id, entry.org_id,
+                entry.result, entry.details, entry.previous_hash,
+            )
+            if entry.entry_hash != expected_hash:
+                AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(
+                    1, {"reason": "entry_hash_mismatch", "scope": "legacy"}
+                )
+                return (False, total_checked, entry.id)
+            expected_previous = entry.entry_hash
+            total_checked += 1
+
+    return (True, total_checked, 0)

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -671,6 +671,9 @@ async def export_audit_logs(
                 "details": e.details,
                 "entry_hash": e.entry_hash,
                 "previous_hash": e.previous_hash,
+                "chain_seq": e.chain_seq,
+                "peer_org_id": e.peer_org_id,
+                "peer_row_hash": e.peer_row_hash,
             }) + "\n"
 
     return StreamingResponse(

--- a/demo_network/verify_audit_chain.py
+++ b/demo_network/verify_audit_chain.py
@@ -2,40 +2,98 @@
 Recompute each audit entry's sha256 and verify the chain link-by-link.
 Mounted read-only from the host into a python:3.11-slim container by
 smoke.sh's A7 assertion.
+
+Two chain regimes coexist:
+  - Legacy rows (chain_seq is None): single global chain, linked by id
+    order. Canonical hash format predates per-org chains.
+  - Per-org rows (chain_seq is not None): one chain per org_id, linked
+    by chain_seq. Canonical format binds chain_seq + peer_org_id so
+    those columns can't be rewritten silently.
 """
 import hashlib
 import json
 import sys
+from collections import defaultdict
 
-prev = None
-count = 0
+
+def canonical(entry: dict, previous_hash: str | None) -> str:
+    base = "|".join([
+        str(entry["id"]),
+        entry["timestamp"] or "",
+        entry["event_type"],
+        entry.get("agent_id") or "",
+        entry.get("session_id") or "",
+        entry.get("org_id") or "",
+        entry["result"],
+        entry.get("details") or "",
+        previous_hash or "genesis",
+    ])
+    chain_seq = entry.get("chain_seq")
+    if chain_seq is None:
+        return base
+    return f"{base}|seq={chain_seq}|peer={entry.get('peer_org_id') or ''}"
+
+
+entries = []
 with open("/in/audit.ndjson") as f:
     for line in f:
         line = line.strip()
         if not line:
             continue
-        e = json.loads(line)
-        canonical = "|".join([
-            str(e["id"]),
-            e["timestamp"] or "",
-            e["event_type"],
-            e.get("agent_id") or "",
-            e.get("session_id") or "",
-            e.get("org_id") or "",
-            e["result"],
-            e.get("details") or "",
-            prev or "genesis",
-        ])
-        computed = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        entries.append(json.loads(line))
+
+# ── Legacy global chain (chain_seq is None) ───────────────────────
+prev = None
+legacy_count = 0
+for e in entries:
+    if e.get("chain_seq") is not None:
+        continue
+    if e.get("entry_hash") is None:
+        continue  # pre-hash-chain row
+    expected = canonical(e, prev)
+    computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
+    if computed != e["entry_hash"]:
+        print(f"MISMATCH legacy id={e['id']} event={e['event_type']}")
+        print(f"  expected: {e['entry_hash']}")
+        print(f"  computed: {computed}")
+        sys.exit(2)
+    if e.get("previous_hash") != prev:
+        print(f"CHAIN BREAK legacy id={e['id']}: "
+              f"previous_hash={e.get('previous_hash')} expected={prev}")
+        sys.exit(3)
+    prev = e["entry_hash"]
+    legacy_count += 1
+
+# ── Per-org chains (chain_seq is not None) ────────────────────────
+# For each org's genesis row (chain_seq=1), previous_hash should point
+# to that org's last legacy entry_hash (if any) or None.
+last_legacy_per_org: dict[str, str] = {}
+for e in entries:
+    if e.get("chain_seq") is None and e.get("entry_hash") is not None:
+        last_legacy_per_org[e.get("org_id") or ""] = e["entry_hash"]
+
+per_org: dict[str, list] = defaultdict(list)
+for e in entries:
+    if e.get("chain_seq") is not None:
+        per_org[e.get("org_id") or ""].append(e)
+
+per_org_count = 0
+for org, rows in per_org.items():
+    rows.sort(key=lambda r: r["chain_seq"])
+    expected_prev = last_legacy_per_org.get(org)
+    for e in rows:
+        expected = canonical(e, expected_prev)
+        computed = hashlib.sha256(expected.encode("utf-8")).hexdigest()
         if computed != e["entry_hash"]:
-            print(f"MISMATCH id={e['id']} event={e['event_type']}")
+            print(f"MISMATCH per-org id={e['id']} org={org} seq={e['chain_seq']}")
             print(f"  expected: {e['entry_hash']}")
             print(f"  computed: {computed}")
             sys.exit(2)
-        if e.get("previous_hash") != prev:
-            print(f"CHAIN BREAK id={e['id']}: previous_hash={e.get('previous_hash')} expected={prev}")
+        if e.get("previous_hash") != expected_prev:
+            print(f"CHAIN BREAK per-org id={e['id']} org={org} seq={e['chain_seq']}: "
+                  f"previous_hash={e.get('previous_hash')} expected={expected_prev}")
             sys.exit(3)
-        prev = e["entry_hash"]
-        count += 1
+        expected_prev = e["entry_hash"]
+        per_org_count += 1
 
-print(f"OK {count}")
+print(f"OK {legacy_count + per_org_count}")

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -152,10 +152,10 @@ async def test_verify_chain_per_org_filter(audit_db):
 
 async def test_tamper_in_one_org_does_not_break_other(audit_db):
     """A broken chain in org A does not invalidate org B's chain."""
-    a1 = await log_event(audit_db, "e1", "ok", org_id="acme")
+    await log_event(audit_db, "e1", "ok", org_id="acme")
     a2 = await log_event(audit_db, "e2", "ok", org_id="acme")
-    b1 = await log_event(audit_db, "e1", "ok", org_id="bravo")
-    b2 = await log_event(audit_db, "e2", "ok", org_id="bravo")
+    await log_event(audit_db, "e1", "ok", org_id="bravo")
+    await log_event(audit_db, "e2", "ok", org_id="bravo")
 
     # Tamper acme's row 2
     await audit_db.execute(

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -57,6 +57,8 @@ async def test_hash_determinism(audit_db):
         entry.id, ts, entry.event_type,
         entry.agent_id, entry.session_id, entry.org_id,
         entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
     )
     assert entry.entry_hash == recomputed
 
@@ -95,3 +97,148 @@ async def test_verify_chain_empty(audit_db):
     assert is_valid is True
     assert total == 0
     assert broken_id == 0
+
+
+# ── Per-org chain tests (hash chain split per org_id) ─────────────
+
+async def test_per_org_chains_independent(audit_db):
+    """Events for different orgs must land in different chains — an
+    entry for org A does not link to the previous entry for org B."""
+    a1 = await log_event(audit_db, "e1", "ok", org_id="acme")
+    b1 = await log_event(audit_db, "e1", "ok", org_id="bravo")
+    a2 = await log_event(audit_db, "e2", "ok", org_id="acme")
+    b2 = await log_event(audit_db, "e2", "ok", org_id="bravo")
+
+    # Genesis of each chain (seq=1) has no predecessor.
+    assert a1.chain_seq == 1
+    assert b1.chain_seq == 1
+    assert a1.previous_hash is None
+    assert b1.previous_hash is None
+
+    # Second event per-org links to its own org's first event.
+    assert a2.chain_seq == 2
+    assert b2.chain_seq == 2
+    assert a2.previous_hash == a1.entry_hash
+    assert b2.previous_hash == b1.entry_hash
+
+
+async def test_per_org_chain_seq_monotonic(audit_db):
+    seqs = []
+    for i in range(5):
+        e = await log_event(audit_db, f"e{i}", "ok", org_id="acme")
+        seqs.append(e.chain_seq)
+    assert seqs == [1, 2, 3, 4, 5]
+
+
+async def test_events_without_org_land_in_system_chain(audit_db):
+    e1 = await log_event(audit_db, "sys.bootstrap", "ok")  # no org_id
+    e2 = await log_event(audit_db, "sys.shutdown", "ok")
+    assert e1.org_id == "__system__"
+    assert e2.org_id == "__system__"
+    assert e2.previous_hash == e1.entry_hash
+
+
+async def test_verify_chain_per_org_filter(audit_db):
+    """verify_chain(org_id=X) checks only that org, succeeds on valid."""
+    for _ in range(3):
+        await log_event(audit_db, "e", "ok", org_id="acme")
+    for _ in range(3):
+        await log_event(audit_db, "e", "ok", org_id="bravo")
+
+    is_valid, total, _ = await verify_chain(audit_db, org_id="acme")
+    assert is_valid is True
+    assert total == 3
+
+
+async def test_tamper_in_one_org_does_not_break_other(audit_db):
+    """A broken chain in org A does not invalidate org B's chain."""
+    a1 = await log_event(audit_db, "e1", "ok", org_id="acme")
+    a2 = await log_event(audit_db, "e2", "ok", org_id="acme")
+    b1 = await log_event(audit_db, "e1", "ok", org_id="bravo")
+    b2 = await log_event(audit_db, "e2", "ok", org_id="bravo")
+
+    # Tamper acme's row 2
+    await audit_db.execute(
+        update(AuditLog).where(AuditLog.id == a2.id).values(details='{"bad": 1}')
+    )
+    await audit_db.commit()
+
+    # acme chain broken
+    ok_a, _, broken = await verify_chain(audit_db, org_id="acme")
+    assert ok_a is False
+    assert broken == a2.id
+    # bravo chain still intact
+    ok_b, total_b, _ = await verify_chain(audit_db, org_id="bravo")
+    assert ok_b is True
+    assert total_b == 2
+
+
+# ── Cross-org dual-write ──────────────────────────────────────────
+
+async def test_cross_org_dual_write_creates_two_rows(audit_db):
+    from app.db.audit import log_event_cross_org
+
+    row_a, row_b = await log_event_cross_org(
+        audit_db, "session.opened", "ok",
+        org_a="acme", org_b="bravo",
+        session_id="sess-xyz",
+        details={"initiator": "acme::buyer", "target": "bravo::supplier"},
+    )
+    # Same logical fact recorded on both sides
+    assert row_a.session_id == row_b.session_id
+    assert row_a.details == row_b.details
+    assert row_a.event_type == row_b.event_type
+    # Distinct chains
+    assert row_a.org_id == "acme"
+    assert row_b.org_id == "bravo"
+    assert row_a.chain_seq == 1
+    assert row_b.chain_seq == 1
+    # Cross-reference linkage in both directions
+    assert row_a.peer_org_id == "bravo"
+    assert row_b.peer_org_id == "acme"
+    assert row_a.peer_row_hash == row_b.entry_hash
+    assert row_b.peer_row_hash == row_a.entry_hash
+
+
+async def test_cross_org_both_chains_verify(audit_db):
+    from app.db.audit import log_event_cross_org
+
+    await log_event_cross_org(
+        audit_db, "session.opened", "ok",
+        org_a="acme", org_b="bravo",
+        details={"x": 1},
+    )
+    await log_event_cross_org(
+        audit_db, "message.forwarded", "ok",
+        org_a="acme", org_b="bravo",
+        details={"payload_hash": "abc123"},
+    )
+    ok_a, total_a, _ = await verify_chain(audit_db, org_id="acme")
+    ok_b, total_b, _ = await verify_chain(audit_db, org_id="bravo")
+    assert ok_a is True and total_a == 2
+    assert ok_b is True and total_b == 2
+
+
+async def test_cross_org_requires_distinct_orgs(audit_db):
+    from app.db.audit import log_event_cross_org
+
+    with pytest.raises(ValueError, match="distinct"):
+        await log_event_cross_org(
+            audit_db, "x", "ok", org_a="acme", org_b="acme"
+        )
+
+
+async def test_cross_org_mixed_with_intra_org(audit_db):
+    """A cross-org event and a subsequent intra-org event both chain
+    correctly per-org (seq keeps going)."""
+    from app.db.audit import log_event_cross_org
+
+    await log_event_cross_org(
+        audit_db, "e", "ok", org_a="acme", org_b="bravo"
+    )
+    intra = await log_event(audit_db, "intra", "ok", org_id="acme")
+    assert intra.chain_seq == 2  # follows cross-org acme row at seq=1
+    assert intra.previous_hash is not None
+
+    ok, total, _ = await verify_chain(audit_db, org_id="acme")
+    assert ok is True and total == 2

--- a/tests/test_audit_export.py
+++ b/tests/test_audit_export.py
@@ -120,8 +120,11 @@ async def test_export_hash_chain_intact(client, seed_audit):
     )
     lines = [json.loads(line) for line in resp.text.strip().split("\n") if line]
     # Filter down to only this test's seeded entries (order preserved by id).
-    seeded = [l for l in lines if l.get("agent_id") == f"{_EXPORT_ORG}::agent1"
-              or l.get("session_id") == "sess-export-1"]
+    seeded = [
+        entry for entry in lines
+        if entry.get("agent_id") == f"{_EXPORT_ORG}::agent1"
+        or entry.get("session_id") == "sess-export-1"
+    ]
     assert len(seeded) >= 3
     for i, entry in enumerate(seeded):
         assert entry["entry_hash"] is not None

--- a/tests/test_audit_export.py
+++ b/tests/test_audit_export.py
@@ -114,13 +114,16 @@ async def test_export_wrong_admin_secret(client, seed_audit):
 
 @pytest.mark.asyncio
 async def test_export_hash_chain_intact(client, seed_audit):
-    """Exported entries have valid hash chain references."""
-    resp = await client.get("/v1/admin/audit/export", headers=_admin_headers())
+    """Exported entries within one org form a contiguous per-org chain."""
+    resp = await client.get(
+        f"/v1/admin/audit/export?org_id={_EXPORT_ORG}", headers=_admin_headers()
+    )
     lines = [json.loads(line) for line in resp.text.strip().split("\n") if line]
-    assert len(lines) >= 4
-    for i, entry in enumerate(lines):
+    # Filter down to only this test's seeded entries (order preserved by id).
+    seeded = [l for l in lines if l.get("agent_id") == f"{_EXPORT_ORG}::agent1"
+              or l.get("session_id") == "sess-export-1"]
+    assert len(seeded) >= 3
+    for i, entry in enumerate(seeded):
         assert entry["entry_hash"] is not None
-        if i == 0:
-            assert entry["previous_hash"] is None  # first entry
-        else:
-            assert entry["previous_hash"] == lines[i - 1]["entry_hash"]
+        if i > 0:
+            assert entry["previous_hash"] == seeded[i - 1]["entry_hash"]


### PR DESCRIPTION
## Summary

First of two PRs closing #75 — convert the broker audit log from a single global hash chain into per-org chains, and add `log_event_cross_org` to atomically record events on both involved orgs' chains. Foundation for dispute-grade audit exports.

- **Per-org chain**: each org has its own append chain (chain_seq monotonic per org_id). Parallelism + privacy (export self-contained per tenant).
- **Cross-org dual-write**: one event → two rows (one per org) sharing event_type/session_id/details + peer cross-references (`peer_org_id`, `peer_row_hash`). Both orgs hold signed evidence; a verifier cross-checks.
- **Backward compat**: existing rows (`chain_seq IS NULL`) stay verified under the original global chain rule. Per-org chains genesis-link to each org's last legacy row so append-only continuity is preserved.
- **Hash format**: new rows bind `chain_seq + peer_org_id` into the canonical string, preventing silent rewrite of those columns. Legacy hash format unchanged.

## Out of scope (PR 2)

- RFC 3161 TSA worker + anchor persistence
- `GET /v1/audit/export` NDJSON bundle with TSA anchors
- `scripts/cullis-audit-verify` CLI for standalone dispute resolution

## Test plan

- [x] 10 new tests in `tests/test_audit_chain.py`: per-org isolation, seq monotonicity, SYSTEM_ORG routing, org_id filter, tamper isolated to one org, cross-org dual write + cross-ref linkage + independent verification, distinct-orgs validation, mixed intra/cross-org chaining
- [x] `tests/test_audit_export.py::test_export_hash_chain_intact` updated for per-org semantics
- [x] `pytest --ignore=tests/test_postgres_integration.py` — 635 passed, 14 skipped, ~40s
- [ ] `demo_network/smoke.sh full` validated by CI

## Unlocks

Commercial pitch "Cullis = notary for agent-to-agent transactions" — see memory `project_audit_hash_chain_notary.md` (follow-up).