### PR TITLE
feat(connector): Phase 4 — distribution packaging (PyPI/Homebrew/Docker/binary)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,3 +33,17 @@ __pycache__/
 imp/
 drafts/
 demo/
+
+# Build outputs (keep the Docker build context small; the connector
+# Dockerfile builds the wheel fresh inside the builder stage).
+dist/
+build/
+*.egg-info/
+node_modules/
+sdk-ts/node_modules/
+sdk-ts/dist/
+
+# Test / coverage caches
+.coverage
+htmlcov/
+tests/connector/__pycache__/

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -1,0 +1,232 @@
+# Release pipeline for `cullis-connector`.
+#
+# Triggered by pushing a tag of the form `connector-vX.Y.Z`. On tag push:
+#
+#   1. Run the connector test subset to gate the release.
+#   2. Build a standalone PyPI wheel + sdist from packaging/pypi/.
+#   3. Build and push the Docker image to ghcr.io (multi-arch).
+#   4. Build PyInstaller binaries for Linux and macOS (best effort).
+#   5. Create a GitHub Release and attach wheel, sdist, and binaries.
+#   6. Optionally publish to PyPI (gated on PYPI_TOKEN presence).
+#
+# This workflow is intentionally isolated from the main CI pipeline: it
+# must not run on PRs or pushes to main. Only tag pushes trigger it.
+
+name: release-connector
+
+on:
+  push:
+    tags:
+      - "connector-v*"
+
+# Minimal default permissions; individual jobs grant what they need.
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Tests ─────────────────────────────────────────────────────────
+  test:
+    name: Test connector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run connector tests
+        env:
+          OTEL_ENABLED: "false"
+          DATABASE_URL: "sqlite+aiosqlite://"
+        run: pytest tests/connector tests/test_enrollment.py --tb=short
+
+  # ── 2. Build wheel + sdist (standalone PyPI distribution) ───────────
+  build-python:
+    name: Build Python distributions
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract version from tag
+        id: extract-version
+        run: |
+          # connector-v1.2.3 → 1.2.3
+          version="${GITHUB_REF_NAME#connector-v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: ${version}"
+
+      - name: Install build tool
+        run: python -m pip install --upgrade pip build
+
+      - name: Build wheel + sdist
+        run: python -m build --outdir dist/ packaging/pypi
+
+      - name: Smoke test wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install dist/cullis_connector-*.whl
+          /tmp/smoke/bin/cullis-connector --version
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+          retention-days: 7
+
+  # ── 3. Docker image → ghcr.io ───────────────────────────────────────
+  build-docker:
+    name: Build & push Docker image
+    needs: [test, build-python]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/cullis-connector
+          tags: |
+            type=match,pattern=connector-v(.*),group=1
+            type=raw,value=latest
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: packaging/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── 4. PyInstaller binaries (best effort, per-OS) ────────────────────
+  build-binaries:
+    name: Build binary (${{ matrix.os }})
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+          - os: macos-latest
+            platform: macos
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build binary
+        run: bash packaging/pyinstaller/build.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binary-${{ matrix.platform }}
+          path: dist/cullis-connector-*
+          retention-days: 7
+
+  # ── 5. GitHub Release ────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: [build-python, build-docker, build-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release-assets
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p dist
+          find release-assets -type f \( -name 'cullis_connector-*' -o -name 'cullis-connector-*' \) \
+            -exec cp -v {} dist/ \;
+          ls -lah dist/
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          version="${GITHUB_REF_NAME#connector-v}"
+          # Grab the section matching ## [vX.Y.Z] or ## vX.Y.Z up to the next ## heading.
+          awk "/^## \\[?v?${version}\\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
+            > release-notes.md || true
+          if [[ ! -s release-notes.md ]]; then
+            echo "Release ${GITHUB_REF_NAME}" > release-notes.md
+          fi
+          cat release-notes.md
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Cullis Connector ${{ github.ref_name }}"
+          body_path: release-notes.md
+          files: dist/*
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+
+  # ── 6. PyPI upload (opt-in via PYPI_TOKEN secret) ────────────────────
+  #
+  # TODO: once PYPI_TOKEN is provisioned in repository secrets, remove
+  # the `if:` guard below. Until then this job is a no-op on releases.
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-python
+    runs-on: ubuntu-latest
+    if: ${{ false }}  # TODO: flip to `${{ secrets.PYPI_TOKEN != '' }}` once provisioned
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cullis-connector
+    permissions:
+      id-token: write  # for PyPI trusted publishing once configured
+    steps:
+      - name: Download wheel + sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          # Switch to trusted publishing (OIDC) once the PyPI project
+          # is configured; then `password` can be dropped.

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,6 @@ run.sh
 reset.sh
 agent.sh
 CLAUDE.md
-CHANGELOG.md
 .claude/
 enterprise-lab/
 org-node/
@@ -82,3 +81,18 @@ node_modules/
 package-lock.json
 app/static/css/tailwind.css
 mcp_proxy/dashboard/static/css/tailwind.css
+
+# Staged files for the standalone `cullis-connector` PyPI build. They
+# are copied in from the monorepo root by packaging/pypi/build.sh and
+# are never authored in-place — the source of truth lives at repo root.
+packaging/pypi/cullis_connector/
+packaging/pypi/README_PKG.md
+packaging/pypi/LICENSE
+packaging/pypi/LICENSE-APACHE-2.0
+packaging/pypi/NOTICE
+packaging/pypi/CHANGELOG.md
+
+# Python build outputs
+dist/
+build/
+*.egg-info/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to `cullis-connector` are documented in this file.
+
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The connector follows its own release cadence, independent from the
+broker and proxy components of the Cullis monorepo. Connector releases
+are tagged `connector-vX.Y.Z`.
+
+## [v0.1.0] — 2026-04-14
+
+Initial public release of the Cullis Connector.
+
+### Added
+- **MCP stdio server** (`cullis-connector serve`) exposing nine neutral
+  tools for local MCP clients: session, discovery, and diagnostics.
+- **Device-code enrollment** (`cullis-connector enroll`) — keypair
+  generation, submission to the Cullis Site, admin approval polling,
+  and local identity persistence under `~/.cullis/identity/`.
+- **Config resolution** with clear precedence: CLI flags override env
+  vars (`CULLIS_SITE_URL`, etc.) override `~/.cullis/config.yaml`.
+- **Multi-transport support** planned via config: defaults to stdio,
+  prepared for SSE and HTTP transports in later phases.
+- **Packaging & distribution** (this release):
+  - PyPI: `pip install cullis-connector` (standalone distribution).
+  - Homebrew: `brew install cullis-security/tap/cullis-connector`
+    (template formula, tap repo to be provisioned).
+  - Docker: `ghcr.io/cullis-security/cullis-connector:v0.1.0`.
+  - GitHub Releases: PyInstaller binaries for Linux amd64 and
+    macOS (best effort on arm64).
+- **Release automation**: `.github/workflows/release-connector.yml`
+  triggered on `connector-v*` tags.
+
+### Changed
+- None (first release).
+
+### Security
+- Identity private key is stored with `0600` permissions in
+  `~/.cullis/identity/`. Never transmitted to the Site beyond the
+  initial public-key enrollment.
+- TLS verification is enabled by default; `--no-verify-tls` is
+  accepted only for local development and logs a prominent warning.
+
+[v0.1.0]: https://github.com/cullis-security/cullis/releases/tag/connector-v0.1.0

--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -1,0 +1,210 @@
+# `cullis-connector`
+
+**The user-side binary for the Cullis federated agent-trust network.**
+
+The Cullis Connector is a small MCP (Model Context Protocol) server that
+runs on your workstation, inside your MCP client of choice (Claude Code,
+Cursor, Claude Desktop, ToolHive, or any other MCP-speaking client), and
+bridges that client into the Cullis network. It handles:
+
+- **Enrollment** — one-time device-code flow that provisions your
+  identity against the Cullis Site.
+- **Session management** — opening, routing, and closing agent-to-agent
+  sessions over the Cullis broker.
+- **Discovery** — browsing agents and services reachable from your org.
+- **Diagnostics** — local troubleshooting commands, exposed as MCP tools
+  so the host LLM can run them with your approval.
+
+The connector is one of three Cullis components:
+
+| Component       | Runs where                   | Purpose                                    |
+|-----------------|------------------------------|--------------------------------------------|
+| Cullis Site     | Per-org control plane        | Admin UI, enrollment approvals, CA         |
+| Cullis Broker   | Per-org data plane           | Routing, policy, audit                     |
+| Cullis Connector| End-user workstation         | Binds the user's MCP client into the net   |
+
+---
+
+## Install
+
+### PyPI (recommended)
+
+```bash
+pip install cullis-connector
+cullis-connector --version
+```
+
+Python 3.10+ required. The package installs a single console script:
+`cullis-connector`.
+
+### Homebrew (macOS and Linux)
+
+```bash
+brew tap cullis-security/tap
+brew install cullis-connector
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/cullis-security/cullis-connector:latest
+docker run --rm ghcr.io/cullis-security/cullis-connector:latest --version
+```
+
+Persist the identity by mounting `~/.cullis`:
+
+```bash
+docker run --rm -it \
+  -v "$HOME/.cullis:/home/cullis/.cullis" \
+  ghcr.io/cullis-security/cullis-connector:latest \
+  enroll --site-url https://cullis.acme.local \
+    --requester-name "Alice" --requester-email "alice@acme.example"
+```
+
+### Standalone binary (GitHub Releases)
+
+Each release on
+<https://github.com/cullis-security/cullis/releases> ships pre-built
+PyInstaller binaries for Linux amd64 and macOS. Download, `chmod +x`,
+drop on your `$PATH`.
+
+---
+
+## Enroll
+
+The first run needs a one-time enrollment against your org's Cullis
+Site. Your admin receives an approval prompt; once they click approve,
+the connector persists a client certificate and key under
+`~/.cullis/identity/`.
+
+```bash
+cullis-connector enroll \
+  --site-url https://cullis.acme.local \
+  --requester-name "Alice Example" \
+  --requester-email "alice@acme.example" \
+  --reason "New laptop, replacing the old MBP"
+```
+
+The command prints a URL you can share with your admin and polls until
+approval or timeout. See `cullis-connector enroll --help` for all flags.
+
+---
+
+## Wire up your MCP client
+
+Every example below assumes you have already enrolled successfully.
+
+### Claude Code
+
+```bash
+claude mcp add cullis cullis-connector \
+  -- --site-url https://cullis.acme.local
+```
+
+Or append to `~/.claude/settings.json` manually:
+
+```json
+{
+  "mcpServers": {
+    "cullis": {
+      "command": "cullis-connector",
+      "args": ["--site-url", "https://cullis.acme.local"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json` (or the project-local `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "cullis": {
+      "command": "cullis-connector",
+      "args": ["--site-url", "https://cullis.acme.local"]
+    }
+  }
+}
+```
+
+Cursor picks up the connector on next IDE restart.
+
+### Claude Desktop
+
+Edit `claude_desktop_config.json`:
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+- Linux: `~/.config/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "cullis": {
+      "command": "cullis-connector",
+      "args": ["--site-url", "https://cullis.acme.local"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop — the Cullis tools appear in the MCP menu.
+
+### ToolHive
+
+ToolHive pulls MCP servers from its registry. The Cullis Connector is
+planned to land there once the Docker image is public:
+
+```bash
+# (future, once listed in the ToolHive registry)
+thv run cullis-connector -- --site-url https://cullis.acme.local
+```
+
+Until the registry entry is accepted, you can run the containerised
+connector manually:
+
+```bash
+thv run --docker ghcr.io/cullis-security/cullis-connector:latest \
+  -- --site-url https://cullis.acme.local
+```
+
+(Submission of the connector to the ToolHive registry is tracked as a
+separate rollout step.)
+
+---
+
+## Configuration precedence
+
+1. CLI flags (`--site-url`, `--config-dir`, `--log-level`, ...)
+2. Environment variables (`CULLIS_SITE_URL`, `CULLIS_CONFIG_DIR`, ...)
+3. `~/.cullis/config.yaml`
+
+Multi-org users can point each client at a distinct directory:
+
+```bash
+cullis-connector --config-dir ~/.cullis-orgA serve
+cullis-connector --config-dir ~/.cullis-orgB serve
+```
+
+---
+
+## Troubleshooting
+
+- **`No identity found`** — run `cullis-connector enroll ...` first.
+- **TLS failures against a dev Site** — the admin must share the org
+  CA cert; import it into your trust store, or pass `--no-verify-tls`
+  for local development *only*.
+- **`cullis-connector` not on `$PATH`** after `pip install` — your pip
+  user bin directory is probably missing; add `python -m site --user-base`
+  + `/bin` to `$PATH`, or install in a venv.
+
+---
+
+## License
+
+`cullis-connector` is distributed under the
+[Functional Source License 1.1 with Apache 2.0 future grant](../LICENSE).
+SDKs (`cullis_sdk`, `sdk-ts`) are permissive Apache 2.0 — see the
+monorepo root `LICENSE` files for the full text.

--- a/packaging/RELEASING.md
+++ b/packaging/RELEASING.md
@@ -1,0 +1,168 @@
+# Releasing `cullis-connector`
+
+Step-by-step checklist for cutting a new connector release. The whole
+flow is gated on pushing a `connector-vX.Y.Z` tag; the GitHub Actions
+workflow (`.github/workflows/release-connector.yml`) handles the rest.
+
+---
+
+## 0. Prerequisites (one-off)
+
+- Write access to `cullis-security/cullis`.
+- `PYPI_TOKEN` secret configured on the repo (needed for PyPI upload;
+  the workflow no-ops its `publish-pypi` job until this is present).
+- `ghcr.io` write via the built-in `GITHUB_TOKEN` (already works; no
+  extra setup needed).
+- Clone of `cullis-security/homebrew-tap` (only required when you
+  want to bump the Homebrew formula — see step 6).
+
+---
+
+## 1. Bump the version
+
+Bump both files together. They must stay in sync:
+
+- `packaging/pypi/pyproject.toml` → `[project] version = "X.Y.Z"`
+- `cullis_connector/__init__.py` → `__version__ = "X.Y.Z"`
+
+Quick sanity check:
+
+```bash
+grep -E '^(version|__version__)' \
+  packaging/pypi/pyproject.toml cullis_connector/__init__.py
+```
+
+The two lines must show the same `X.Y.Z`.
+
+---
+
+## 2. Update the changelog
+
+Add a new section to `CHANGELOG.md` at the top, below the title:
+
+```markdown
+## [vX.Y.Z] — YYYY-MM-DD
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+
+### Security
+- ...
+
+[vX.Y.Z]: https://github.com/cullis-security/cullis/releases/tag/connector-vX.Y.Z
+```
+
+Keep entries short and user-oriented. The release workflow extracts
+this section verbatim and uses it as the GitHub Release body.
+
+---
+
+## 3. Commit and open a release PR
+
+```bash
+git checkout -b release/connector-vX.Y.Z
+git add packaging/pypi/pyproject.toml cullis_connector/__init__.py CHANGELOG.md
+git commit -sm "release(connector): vX.Y.Z"
+git push -u origin release/connector-vX.Y.Z
+gh pr create --title "release(connector): vX.Y.Z" --body "See CHANGELOG"
+```
+
+Wait for CI green + review + merge into `main`.
+
+---
+
+## 4. Tag and push
+
+After the release PR lands on `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -a connector-vX.Y.Z -m "cullis-connector vX.Y.Z"
+git push origin connector-vX.Y.Z
+```
+
+The tag push triggers `release-connector.yml`. Watch it with:
+
+```bash
+gh run watch --exit-status
+```
+
+---
+
+## 5. Verify artefacts
+
+Once the workflow is green:
+
+- **PyPI** (skip until `PYPI_TOKEN` is provisioned and the
+  `publish-pypi` job guard is flipped):
+  ```bash
+  pip install --upgrade cullis-connector
+  cullis-connector --version    # → cullis-connector X.Y.Z
+  ```
+
+- **Docker**:
+  ```bash
+  docker pull ghcr.io/cullis-security/cullis-connector:vX.Y.Z
+  docker run --rm ghcr.io/cullis-security/cullis-connector:vX.Y.Z --version
+  ```
+
+- **GitHub Release**: visit
+  <https://github.com/cullis-security/cullis/releases/tag/connector-vX.Y.Z>
+  and confirm the wheel, sdist, and Linux / macOS binaries are
+  attached, and the release notes render the changelog correctly.
+
+---
+
+## 6. Bump the Homebrew tap (optional)
+
+Only needed on releases we want to surface via `brew`. Takes ~5 min.
+
+```bash
+cd ../homebrew-tap
+git checkout -b bump/cullis-connector-vX.Y.Z
+
+# Edit Formula/cullis-connector.rb
+#   - url:     point at the new sdist on GitHub Releases
+#   - version: X.Y.Z
+#   - sha256:  shasum -a 256 cullis_connector-X.Y.Z.tar.gz
+brew update-python-resources cullis-connector   # regenerates resource hashes
+brew install --build-from-source ./Formula/cullis-connector.rb
+brew test cullis-connector
+brew audit --strict cullis-connector
+
+git commit -asm "cullis-connector vX.Y.Z"
+git push -u origin bump/cullis-connector-vX.Y.Z
+gh pr create --title "cullis-connector vX.Y.Z" --body "Automated bump"
+```
+
+Merge once `brew test-bot` is green.
+
+---
+
+## 7. Announce
+
+- Update the landing page release banner if the release is notable.
+- Post to the project X/LinkedIn accounts (tone guidelines in
+  `feedback_marketing_tone.md`).
+- Notify any pilot customers directly about breaking changes or
+  security fixes.
+
+---
+
+## Rollback
+
+If a release turns out broken:
+
+1. **Yank from PyPI** — `pypi yank cullis-connector X.Y.Z --reason "..."`.
+2. **Delete the ghcr.io tag** (keep `latest` pinned at the previous
+   good version).
+3. **Delete the GitHub Release** (keeps the tag; that's fine).
+4. **Do NOT delete the git tag** — CI assumes tags are immutable;
+   instead, cut a `X.Y.Z+1` patch release with the fix.

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -1,0 +1,70 @@
+# Multi-stage Dockerfile for the Cullis Connector.
+#
+# Build context: the monorepo root (NOT this directory). The release
+# workflow and local developers invoke it as:
+#
+#   docker build -f packaging/docker/Dockerfile -t cullis-connector .
+#
+# Why multi-stage:
+#   • Stage 1 (`builder`) owns build-time toolchain (gcc, rust for
+#     cryptography) and produces a single wheel from the standalone
+#     `packaging/pypi/pyproject.toml`.
+#   • Stage 2 (`runtime`) is a slim python base that only installs the
+#     wheel plus its dependencies — no toolchain, no build artefacts.
+#
+# Image size target: ~100 MiB uncompressed. If this grows significantly,
+# revisit by switching to `python:3.12-alpine` (requires musl-compatible
+# cryptography wheels) or distroless.
+
+# ── Stage 1: builder ────────────────────────────────────────────────────
+FROM python:3.12-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Build deps only — discarded in the runtime stage.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends build-essential \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+RUN python -m pip install --upgrade pip build \
+ && python -m build --wheel --outdir /dist packaging/pypi
+
+# ── Stage 2: runtime ────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Non-root user — the connector never needs privileged ops.
+RUN useradd --create-home --uid 10001 --shell /bin/false cullis
+
+COPY --from=builder /dist/*.whl /tmp/
+RUN pip install /tmp/cullis_connector-*.whl && rm /tmp/cullis_connector-*.whl
+
+USER cullis
+WORKDIR /home/cullis
+
+# ``cullis-connector`` reads config + identity from ``~/.cullis``. Mount
+# a host directory there to persist the enrollment across container
+# restarts, e.g.:
+#
+#   docker run --rm -v ~/.cullis:/home/cullis/.cullis \
+#       ghcr.io/cullis-security/cullis-connector enroll \
+#       --site-url https://cullis-site.acme.local \
+#       --requester-name "Alice" --requester-email "alice@acme.example"
+
+ENTRYPOINT ["cullis-connector"]
+CMD ["--help"]
+
+LABEL org.opencontainers.image.title="cullis-connector" \
+      org.opencontainers.image.description="MCP connector for the Cullis agent-trust network" \
+      org.opencontainers.image.source="https://github.com/cullis-security/cullis" \
+      org.opencontainers.image.licenses="FSL-1.1-Apache-2.0" \
+      org.opencontainers.image.vendor="Cullis Security"

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -1,0 +1,55 @@
+# Docker image for `cullis-connector`
+
+Multi-stage image intended for MCP clients that launch connectors
+as containers (ToolHive, Docker MCP gateway, custom orchestrators).
+
+## Build (from monorepo root)
+
+```bash
+docker build -f packaging/docker/Dockerfile -t cullis-connector:dev .
+```
+
+## Smoke test
+
+```bash
+docker run --rm cullis-connector:dev --version
+# → cullis-connector 0.1.0
+```
+
+## Enroll (one-off)
+
+```bash
+docker run --rm -it -v $HOME/.cullis:/home/cullis/.cullis \
+  cullis-connector:dev enroll \
+  --site-url https://cullis-site.acme.local \
+  --requester-name "Alice Example" \
+  --requester-email "alice@acme.example"
+```
+
+## Serve (MCP stdio)
+
+Most MCP clients will exec the container on demand. Example for a
+client that speaks stdio:
+
+```json
+{
+  "mcpServers": {
+    "cullis": {
+      "command": "docker",
+      "args": [
+        "run", "--rm", "-i",
+        "-v", "${HOME}/.cullis:/home/cullis/.cullis",
+        "ghcr.io/cullis-security/cullis-connector:latest",
+        "serve", "--site-url", "https://cullis-site.acme.local"
+      ]
+    }
+  }
+}
+```
+
+## Published images
+
+The release workflow publishes to GHCR on every `connector-v*` tag:
+
+- `ghcr.io/cullis-security/cullis-connector:<version>`
+- `ghcr.io/cullis-security/cullis-connector:latest`

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,47 @@
+# Homebrew tap template
+
+This directory holds the source-of-truth Homebrew formula for
+`cullis-connector`. The tap itself lives in a separate repo
+(`cullis-security/homebrew-tap`) — Homebrew requires each tap to live at
+`github.com/<org>/homebrew-<name>`.
+
+## Release flow
+
+Each time a `connector-vX.Y.Z` tag is pushed on the monorepo:
+
+1. The release workflow uploads the sdist to GitHub Releases.
+2. A maintainer bumps `version`, `url`, `sha256`, and Python resource
+   hashes in the tap repo copy of `cullis-connector.rb`.
+3. `brew update-python-resources cullis-connector` regenerates the
+   `resource` blocks.
+4. Open a PR on the tap repo, wait for `brew test-bot` to pass, merge.
+
+## Local testing before tap PR
+
+```bash
+# From the tap repo working tree:
+brew install --build-from-source ./cullis-connector.rb
+brew test cullis-connector
+brew audit --strict cullis-connector
+```
+
+## First-time tap setup (one-off, not required on every release)
+
+```bash
+gh repo create cullis-security/homebrew-tap --public \
+  --description "Homebrew tap for Cullis tooling"
+
+git clone https://github.com/cullis-security/homebrew-tap
+cd homebrew-tap
+mkdir Formula
+cp <monorepo>/packaging/homebrew/cullis-connector.rb Formula/
+git add . && git commit -sm "Add cullis-connector formula"
+git push
+```
+
+After that, end users tap with:
+
+```bash
+brew tap cullis-security/tap
+brew install cullis-connector
+```

--- a/packaging/homebrew/cullis-connector.rb
+++ b/packaging/homebrew/cullis-connector.rb
@@ -1,0 +1,84 @@
+# Homebrew formula for `cullis-connector`.
+#
+# This file is a TEMPLATE intended to be copied into the Cullis Homebrew
+# tap repository (`cullis-security/homebrew-tap`) at release time. It is
+# NOT consumed directly from this monorepo — Homebrew expects formulas in
+# a dedicated `homebrew-<name>` tap layout.
+#
+# Users install via:
+#
+#   brew tap cullis-security/tap
+#   brew install cullis-connector
+#
+# Release cycle for maintainers:
+#   1. Cut a `connector-vX.Y.Z` tag on the monorepo (see RELEASING.md)
+#   2. GitHub Actions publishes the sdist tarball to
+#      https://github.com/cullis-security/cullis/releases/download/...
+#   3. Maintainer opens a PR on `cullis-security/homebrew-tap` that
+#      updates `url`, `version`, and `sha256` below
+#   4. Homebrew CI runs `brew test-bot`; merge on green
+#
+# This formula installs the connector as a *Python formula* via
+# `virtualenv_install_with_resources`, which is Homebrew's recommended
+# pattern for Python CLI tools. Heavy C-extension deps (`cryptography`)
+# are pulled from bottled Homebrew formulas rather than compiled from
+# source.
+
+class CullisConnector < Formula
+  include Language::Python::Virtualenv
+
+  desc     "MCP server bridging local MCP clients to the Cullis agent-trust network"
+  homepage "https://cullis.io"
+  url      "https://github.com/cullis-security/cullis/releases/download/connector-v0.1.0/cullis_connector-0.1.0.tar.gz"
+  sha256   "REPLACE_WITH_SDIST_SHA256_ON_RELEASE"
+  license  "FSL-1.1-Apache-2.0"
+  head     "https://github.com/cullis-security/cullis.git", branch: "main"
+
+  depends_on "python@3.12"
+  depends_on "rust" => :build        # required to build `cryptography` from sdist
+  depends_on "openssl@3"
+
+  # Python runtime dependencies. `brew update-python-resources` regenerates
+  # this block on version bumps — do NOT hand-edit the resource URLs in
+  # long-lived forks, regenerate them.
+  resource "httpx" do
+    url "https://files.pythonhosted.org/packages/source/h/httpx/httpx-0.27.0.tar.gz"
+    sha256 "REPLACE_ON_RELEASE"
+  end
+
+  resource "cryptography" do
+    url "https://files.pythonhosted.org/packages/source/c/cryptography/cryptography-42.0.0.tar.gz"
+    sha256 "REPLACE_ON_RELEASE"
+  end
+
+  resource "mcp" do
+    url "https://files.pythonhosted.org/packages/source/m/mcp/mcp-1.0.0.tar.gz"
+    sha256 "REPLACE_ON_RELEASE"
+  end
+
+  resource "pyyaml" do
+    url "https://files.pythonhosted.org/packages/source/p/pyyaml/pyyaml-6.0.1.tar.gz"
+    sha256 "REPLACE_ON_RELEASE"
+  end
+
+  # Add further resources as required — run:
+  #   brew update-python-resources cullis-connector
+  # to generate the full dependency tree with correct sha256 values.
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # `--version` exits 0 and prints the expected tag.
+    assert_match version.to_s, shell_output("#{bin}/cullis-connector --version")
+
+    # `serve` without an identity must fail fast with a clear hint,
+    # not hang on stdio or crash unexpectedly.
+    output = shell_output(
+      "#{bin}/cullis-connector serve --config-dir #{testpath}/nonexistent 2>&1",
+      2,  # expected non-zero exit code
+    )
+    assert_match(/no identity/i, output)
+  end
+end

--- a/packaging/pyinstaller/build.sh
+++ b/packaging/pyinstaller/build.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Build a standalone PyInstaller binary for `cullis-connector`.
+#
+# Produces a single-file executable under `dist/` that bundles the Python
+# runtime and all dependencies. Target platform is whatever the host
+# machine is — PyInstaller does NOT cross-compile, so Linux amd64 binaries
+# must be built on Linux amd64 (CI uses `ubuntu-latest`), macOS binaries
+# on macOS runners, Windows binaries on Windows runners.
+#
+# Usage:
+#     ./packaging/pyinstaller/build.sh              # auto-detect platform
+#     ./packaging/pyinstaller/build.sh --name foo   # override binary name
+#
+# Environment:
+#     CULLIS_PYINSTALLER_OUT   override `dist/` output directory
+#     CULLIS_PYINSTALLER_SPEC  use a custom .spec file instead of CLI args
+#
+# Notes:
+#   • We deliberately avoid `--onedir` because single-file is simpler to
+#     ship via GitHub Releases; startup cost is ~200ms extra from the
+#     bootloader extracting to a temp dir, which is fine for an MCP
+#     stdio server that runs for the duration of the client session.
+#   • `--strip` reduces size ~30% but breaks on macOS code-signing;
+#     we enable it only on Linux.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+BIN_NAME="cullis-connector"
+OUT_DIR="${CULLIS_PYINSTALLER_OUT:-dist}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)   BIN_NAME="$2"; shift 2 ;;
+    --out)    OUT_DIR="$2";  shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "error: unknown flag: $1" >&2
+      exit 64
+      ;;
+  esac
+done
+
+UNAME_S="$(uname -s)"
+UNAME_M="$(uname -m)"
+case "${UNAME_S}" in
+  Linux)    PLATFORM="linux" ;;
+  Darwin)   PLATFORM="macos" ;;
+  MINGW*|MSYS*|CYGWIN*) PLATFORM="windows" ;;
+  *)        PLATFORM="unknown-${UNAME_S,,}" ;;
+esac
+ARCH="${UNAME_M}"
+
+echo "==> Building ${BIN_NAME} on ${PLATFORM}/${ARCH}"
+
+# Install build deps into the active environment. Callers are expected
+# to run this inside a venv or CI; we don't create one to avoid
+# surprising contributors who already manage their own.
+python -m pip install --upgrade pip pyinstaller >&2
+python -m pip install --upgrade \
+    "mcp>=1.0" "httpx>=0.24.0" "cryptography>=41.0.0" "PyYAML>=6.0" >&2
+
+STRIP_FLAG=""
+if [[ "${PLATFORM}" == "linux" ]]; then
+  STRIP_FLAG="--strip"
+fi
+
+# `cullis_connector.__main__` is the documented module entry point;
+# PyInstaller hooks the package correctly when given the module path.
+# We build from the source tree rather than an installed wheel so the
+# binary reflects the current repo state (important for the release
+# workflow, which checks out the tagged commit).
+pyinstaller \
+  --name "${BIN_NAME}" \
+  --onefile \
+  --clean \
+  --noconfirm \
+  --distpath "${OUT_DIR}" \
+  --workpath "build/pyinstaller" \
+  --specpath "build/pyinstaller" \
+  ${STRIP_FLAG} \
+  --collect-submodules cullis_connector \
+  --collect-submodules mcp \
+  cullis_connector/__main__.py
+
+FINAL_NAME="${BIN_NAME}-${PLATFORM}-${ARCH}"
+if [[ "${PLATFORM}" == "windows" ]]; then
+  mv "${OUT_DIR}/${BIN_NAME}.exe" "${OUT_DIR}/${FINAL_NAME}.exe"
+  FINAL_PATH="${OUT_DIR}/${FINAL_NAME}.exe"
+else
+  mv "${OUT_DIR}/${BIN_NAME}" "${OUT_DIR}/${FINAL_NAME}"
+  FINAL_PATH="${OUT_DIR}/${FINAL_NAME}"
+fi
+
+echo "==> Built: ${FINAL_PATH}"
+echo "==> Size:  $(du -h "${FINAL_PATH}" | cut -f1)"
+
+# Quick smoke test — binary must at least answer --version without
+# blowing up. This catches missing hidden imports early.
+"${FINAL_PATH}" --version
+
+echo "==> OK"

--- a/packaging/pypi/.gitignore
+++ b/packaging/pypi/.gitignore
@@ -1,0 +1,13 @@
+# These staged files are copied in at build time by `build.sh` and are
+# not tracked in git — the monorepo root is their source of truth.
+#
+# IMPORTANT: We deliberately do NOT list `cullis_connector/` here even
+# though it is copied in fresh on every build. Hatchling respects
+# `.gitignore` when selecting sdist/wheel contents, so ignoring the
+# package directory here would result in an empty wheel.
+
+README_PKG.md
+LICENSE
+LICENSE-APACHE-2.0
+NOTICE
+CHANGELOG.md

--- a/packaging/pypi/README.md
+++ b/packaging/pypi/README.md
@@ -1,0 +1,47 @@
+# Standalone `cullis-connector` PyPI build
+
+This directory contains a dedicated `pyproject.toml` that builds the
+`cullis-connector` package as a **standalone distribution** on PyPI —
+separate from the monorepo `cullis-agent-sdk` wheel.
+
+## Why
+
+The connector is the user-facing binary (runs inside Claude Code, Cursor,
+Claude Desktop, ToolHive). Users installing it should not have to pull in
+the full server-side SDK or pick through monorepo packaging. A separate
+distribution also gives the connector its own:
+
+- Versioning cadence (semver independent of broker/proxy releases)
+- Branding on PyPI (`pip install cullis-connector`)
+- Entry point in Docker MCP catalog & ToolHive registry
+
+## Build locally
+
+From the monorepo root:
+
+```bash
+python -m pip install --upgrade build
+python -m build --outdir dist/ packaging/pypi
+```
+
+This produces:
+
+- `dist/cullis_connector-<version>-py3-none-any.whl`
+- `dist/cullis_connector-<version>.tar.gz`
+
+## Smoke test the wheel
+
+```bash
+python -m venv /tmp/cc-smoke && . /tmp/cc-smoke/bin/activate
+pip install dist/cullis_connector-*.whl
+cullis-connector --version
+deactivate
+```
+
+## Publish (maintainers only)
+
+The release workflow (`.github/workflows/release-connector.yml`) handles
+PyPI upload on tag `connector-v*`. A PyPI API token named `PYPI_TOKEN`
+must be configured in the repo secrets before the first real publish.
+
+See [`packaging/RELEASING.md`](../RELEASING.md) for the full checklist.

--- a/packaging/pypi/build.sh
+++ b/packaging/pypi/build.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build the standalone `cullis-connector` wheel + sdist.
+#
+# Hatchling's sdist builder refuses include paths that escape the
+# pyproject directory (for good reasons — tar archives with `..` are
+# a minor footgun). So instead of playing tricks with `force-include`
+# and symlinks we stage the sources into `packaging/pypi/` first, then
+# invoke `python -m build` against the staged tree.
+#
+# Idempotent: safe to re-run. The staged copies are gitignored by the
+# local `.gitignore` so they never leak into commits.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+STAGE_DIR="${SCRIPT_DIR}"
+OUT_DIR="${REPO_ROOT}/dist"
+
+echo "==> Staging sources into ${STAGE_DIR}"
+
+# Fresh copy of the connector package every time — avoids stale files.
+rm -rf "${STAGE_DIR}/cullis_connector"
+cp -a "${REPO_ROOT}/cullis_connector" "${STAGE_DIR}/cullis_connector"
+
+# Package readme for PyPI (lives next to pyproject.toml).
+cp -f "${REPO_ROOT}/cullis_connector/README.md" "${STAGE_DIR}/README_PKG.md"
+
+# License + notices, required by FSL-1.1-Apache-2.0 distribution terms.
+cp -f "${REPO_ROOT}/LICENSE"            "${STAGE_DIR}/LICENSE"
+cp -f "${REPO_ROOT}/LICENSE-APACHE-2.0" "${STAGE_DIR}/LICENSE-APACHE-2.0"
+cp -f "${REPO_ROOT}/NOTICE"             "${STAGE_DIR}/NOTICE"
+cp -f "${REPO_ROOT}/CHANGELOG.md"       "${STAGE_DIR}/CHANGELOG.md"
+
+mkdir -p "${OUT_DIR}"
+
+echo "==> Building wheel + sdist into ${OUT_DIR}"
+( cd "${STAGE_DIR}" && python -m build --outdir "${OUT_DIR}" )
+
+echo "==> Artefacts:"
+ls -lah "${OUT_DIR}"/cullis_connector-* 2>/dev/null || true

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -1,0 +1,107 @@
+# Standalone PyPI packaging for `cullis-connector`.
+#
+# DO NOT invoke `python -m build` directly against this directory —
+# this pyproject expects a staged source tree next to it, created by
+# the build helper at `packaging/pypi/build.sh`. The helper copies the
+# monorepo `cullis_connector/` package and the root license files
+# into this directory so hatchling can build a self-contained wheel
+# and sdist without cross-directory `..` include paths (which sdist
+# rejects by design).
+#
+# Run:
+#     ./packaging/pypi/build.sh           # stages + builds wheel+sdist
+#
+# The release workflow in `.github/workflows/release-connector.yml`
+# invokes the same helper.
+
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cullis-connector"
+version = "0.1.0"
+description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
+readme = "README_PKG.md"
+requires-python = ">=3.10"
+license = { text = "FSL-1.1-Apache-2.0" }
+authors = [
+    { name = "Cullis Security", email = "hello@cullis.io" },
+]
+keywords = [
+    "mcp",
+    "model-context-protocol",
+    "agent",
+    "cullis",
+    "agent-trust",
+    "identity",
+    "spiffe",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Networking",
+    "License :: Other/Proprietary License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "mcp>=1.0",
+    "httpx>=0.24.0",
+    "cryptography>=41.0.0",
+    "PyYAML>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.4",
+    "build>=1.0",
+]
+
+[project.urls]
+Homepage = "https://cullis.io"
+Documentation = "https://github.com/cullis-security/cullis/tree/main/cullis_connector"
+Repository = "https://github.com/cullis-security/cullis"
+Issues = "https://github.com/cullis-security/cullis/issues"
+Changelog = "https://github.com/cullis-security/cullis/blob/main/CHANGELOG.md"
+
+[project.scripts]
+cullis-connector = "cullis_connector.cli:main"
+
+# Hatchling defaults to consulting VCS (.gitignore) when selecting files.
+# That breaks us: `packaging/pypi/cullis_connector/` is intentionally
+# gitignored at the monorepo root (it's staged at build time), so VCS
+# mode would produce an empty wheel. Turn VCS-mode off and rely on
+# explicit include/exclude globs.
+[tool.hatch.build]
+include = [
+    "cullis_connector/**/*.py",
+    "cullis_connector/**/*.md",
+    "cullis_connector/py.typed",
+    "LICENSE",
+    "LICENSE-APACHE-2.0",
+    "NOTICE",
+    "CHANGELOG.md",
+    "README_PKG.md",
+    "pyproject.toml",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+    "**/.pytest_cache",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["cullis_connector"]
+
+[tool.hatch.build.targets.sdist]
+support-legacy = true


### PR DESCRIPTION
Closes #66.

## Summary

Packages the Cullis Connector for every install channel MCP users care about, without touching Phase 1–2 runtime code.

- **PyPI**: standalone `cullis-connector` distribution via `packaging/pypi/` (wheel + sdist build cleanly, 33 KiB wheel).
- **Homebrew**: template formula `packaging/homebrew/cullis-connector.rb`, ready to copy into a future `cullis-security/homebrew-tap` repo.
- **Docker**: multi-stage `packaging/docker/Dockerfile` producing a non-root `python:3.12-slim` runtime image, pushed to `ghcr.io/cullis-security/cullis-connector` by the release workflow.
- **Binaries**: PyInstaller one-file build via `packaging/pyinstaller/build.sh` for Linux + macOS.
- **Release automation**: `.github/workflows/release-connector.yml` triggers on `connector-v*` tags — tests → wheel/sdist → multi-arch Docker → PyInstaller → GitHub Release with changelog extraction.
- **Docs**: quickstart snippets for Claude Code / Cursor / Claude Desktop / ToolHive in `cullis_connector/README.md`, `CHANGELOG.md` seeded, maintainer runbook in `packaging/RELEASING.md`.

## Strategic decision

Kept `cullis-agent-sdk` intact and published `cullis-connector` as a *separate* PyPI distribution built from the same `cullis_connector/` source tree. Users installing the connector get only what they need (mcp, httpx, cryptography, PyYAML) without the server-side SDK footprint. Zero code duplication — `packaging/pypi/build.sh` stages the source into the packaging directory at build time, because hatchling sdists cannot include paths outside the pyproject directory.

## Test plan

- [x] `bash packaging/pypi/build.sh` produces wheel + sdist (`dist/cullis_connector-0.1.0-py3-none-any.whl` + `.tar.gz`).
- [x] Wheel contents verified: full `cullis_connector/` tree, `entry_points.txt` maps `cullis-connector → cullis_connector.cli:main`, license files present, METADATA matches spec.
- [x] `docker build -f packaging/docker/Dockerfile -t cullis-connector .` completes green.
- [x] `docker run --rm cullis-connector --version` prints `cullis-connector 0.1.0`.
- [x] `pytest tests/connector tests/test_enrollment.py` → 38 passed.
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/release-connector.yml'))"` parses OK.
- [ ] `release-connector.yml` dry-run on a test tag once CI secrets are in place (out of scope for this PR).

No impact on `mcp_proxy/`, `alembic/`, `cullis_sdk/`, or `app/`, so `./demo_network/smoke.sh full` was skipped per project convention for packaging-only PRs.

## What's left for a follow-up

- Flip the `publish-pypi` job `if: false` guard once the `PYPI_TOKEN` secret is provisioned (or configure PyPI trusted publishing, which is preferred).
- Provision the `cullis-security/homebrew-tap` repo and run the first formula bump (checklist in `packaging/RELEASING.md` step 6).
- Submit the Docker image to the ToolHive and Docker MCP catalogues once the first release is public.