### PR TITLE
feat(dashboard): Phase 2c — admin pending enrollments UI

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1918,6 +1918,173 @@ async def vault_migrate_keys(request: Request):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Connector enrollments (Phase 2c — admin review UI)
+#
+# The JSON API lives under /v1/admin/enrollments/* (mcp_proxy.enrollment.router).
+# These routes render the HTML dashboard page and accept form-based POST
+# submissions so the approve/reject flow matches the prevailing form+CSRF
+# pattern used by the rest of the dashboard (agents/create, vault/save, etc).
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _resolve_agent_manager(request: Request):
+    """Return a usable AgentManager for enrollment approval.
+
+    Prefers ``app.state.agent_manager`` (set in tests), then the one
+    embedded in ``app.state.broker_bridge``, then falls back to
+    constructing one on the fly and loading the Org CA from config.
+    """
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is not None:
+        return mgr
+
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is not None:
+        embedded = getattr(bridge, "_agent_manager", None)
+        if embedded is not None:
+            return embedded
+
+    # Fallback: construct from config. ``load_org_ca_from_config`` is a
+    # no-op when no CA is stored; the enrollment service will then raise a
+    # clean 503 that we surface in the page.
+    from mcp_proxy.config import get_settings
+
+    settings = get_settings()
+    return AgentManager(org_id=settings.org_id, trust_domain=settings.trust_domain)
+
+
+@router.get("/enrollments", response_class=HTMLResponse)
+async def enrollments_page(request: Request):
+    """Admin-only list of pending Connector enrollment requests."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.db import get_db as _get_db
+    from mcp_proxy.enrollment import service as _enrollment_service
+
+    async with _get_db() as conn:
+        pending = await _enrollment_service.list_pending(conn)
+
+    flash = request.query_params.get("flash")
+    flash_kind = request.query_params.get("flash_kind", "success")
+    error = request.query_params.get("error")
+
+    return templates.TemplateResponse("enrollments.html", _ctx(
+        request, session,
+        active="enrollments",
+        pending=pending,
+        flash=flash,
+        flash_kind=flash_kind,
+        error=error,
+    ))
+
+
+@router.post("/enrollments/{session_id}/approve")
+async def enrollments_approve(request: Request, session_id: str):
+    """Form-based approve handler. Calls the service and redirects back."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import get_db as _get_db
+    from mcp_proxy.enrollment import service as _enrollment_service
+
+    form = await request.form()
+    agent_id = str(form.get("agent_id", "")).strip()
+    capabilities_raw = str(form.get("capabilities", "")).strip()
+    groups_raw = str(form.get("groups", "")).strip()
+
+    if not agent_id:
+        return RedirectResponse(
+            url="/proxy/enrollments?error=agent_id+is+required",
+            status_code=303,
+        )
+
+    capabilities = [c.strip() for c in capabilities_raw.split(",") if c.strip()]
+    groups = [g.strip() for g in groups_raw.split(",") if g.strip()]
+
+    agent_manager = _resolve_agent_manager(request)
+
+    try:
+        async with _get_db() as conn:
+            record = await _enrollment_service.approve(
+                conn,
+                session_id=session_id,
+                agent_id=agent_id,
+                capabilities=capabilities,
+                groups=groups,
+                admin_name=session.role or "admin",
+                agent_manager=agent_manager,
+            )
+    except _enrollment_service.EnrollmentError as exc:
+        from urllib.parse import quote
+        return RedirectResponse(
+            url=f"/proxy/enrollments?error={quote(str(exc))}",
+            status_code=303,
+        )
+
+    _log.info(
+        "enrollment_approved via dashboard: session=%s agent=%s admin=%s",
+        session_id, record.get("agent_id_assigned"), session.role,
+    )
+    from urllib.parse import quote
+    msg = f"Approved enrollment — agent {record.get('agent_id_assigned', agent_id)} issued"
+    return RedirectResponse(
+        url=f"/proxy/enrollments?flash={quote(msg)}",
+        status_code=303,
+    )
+
+
+@router.post("/enrollments/{session_id}/reject")
+async def enrollments_reject(request: Request, session_id: str):
+    """Form-based reject handler. Calls the service and redirects back."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import get_db as _get_db
+    from mcp_proxy.enrollment import service as _enrollment_service
+
+    form = await request.form()
+    reason = str(form.get("reason", "")).strip()
+    if not reason:
+        return RedirectResponse(
+            url="/proxy/enrollments?error=Rejection+reason+is+required",
+            status_code=303,
+        )
+
+    try:
+        async with _get_db() as conn:
+            await _enrollment_service.reject(
+                conn,
+                session_id=session_id,
+                reason=reason,
+                admin_name=session.role or "admin",
+            )
+    except _enrollment_service.EnrollmentError as exc:
+        from urllib.parse import quote
+        return RedirectResponse(
+            url=f"/proxy/enrollments?error={quote(str(exc))}",
+            status_code=303,
+        )
+
+    _log.info(
+        "enrollment_rejected via dashboard: session=%s admin=%s",
+        session_id, session.role,
+    )
+    return RedirectResponse(
+        url="/proxy/enrollments?flash=Enrollment+rejected&flash_kind=success",
+        status_code=303,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # HTMX badge fragments
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -1934,6 +2101,30 @@ async def badge_agents(request: Request):
     if active:
         return HTMLResponse(
             f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-teal-500/20 text-teal-400">{active}</span>'
+        )
+    return HTMLResponse("")
+
+
+@router.get("/badge/enrollments")
+async def badge_enrollments(request: Request):
+    """Return pending enrollment count badge fragment."""
+    session = get_session(request)
+    if not session.logged_in:
+        return HTMLResponse("")
+
+    from mcp_proxy.db import get_db as _get_db
+    from mcp_proxy.enrollment import service as _enrollment_service
+
+    try:
+        async with _get_db() as conn:
+            pending = await _enrollment_service.list_pending(conn)
+    except Exception:  # table may not exist in pre-migrated setups
+        return HTMLResponse("")
+
+    count = len(pending)
+    if count:
+        return HTMLResponse(
+            f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-amber-500/20 text-amber-400">{count}</span>'
         )
     return HTMLResponse("")
 

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -40,6 +40,12 @@
                 Agents
                 <span hx-get="/proxy/badge/agents" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
+            <a href="/proxy/enrollments"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'enrollments' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/></svg>
+                Enrollments
+                <span hx-get="/proxy/badge/enrollments" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+            </a>
             <a href="/proxy/network"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'network' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>

--- a/mcp_proxy/dashboard/templates/enrollments.html
+++ b/mcp_proxy/dashboard/templates/enrollments.html
@@ -1,0 +1,179 @@
+{% extends "base.html" %}
+{% block title %}Enrollments{% endblock %}
+{% block header_title %}Pending Enrollments{% endblock %}
+{% block content %}
+<div class="max-w-6xl">
+
+    {% if flash %}
+    <div class="mb-4 p-3 rounded text-sm border
+                {% if flash_kind == 'success' %}bg-emerald-500/10 border-emerald-500/20 text-emerald-400
+                {% else %}bg-amber-500/10 border-amber-500/20 text-amber-400{% endif %}">
+        {{ flash }}
+    </div>
+    {% endif %}
+
+    {% if error %}
+    <div class="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
+    {% endif %}
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Pending Enrollments</h2>
+            <p class="text-xs text-gray-600 mt-0.5">
+                {{ pending | length }} awaiting review
+                <span class="text-gray-700 mx-1">&middot;</span>
+                Connector device-code requests
+            </p>
+        </div>
+    </div>
+
+    <!-- Context banner -->
+    <div class="mb-6 p-4 bg-surface-900/60 border border-gray-800/50 rounded-lg text-xs text-gray-500 leading-relaxed">
+        Connector clients generate a keypair locally and submit the public key
+        plus self-declared identity. Approve a request to issue an Org-CA signed
+        certificate for the supplied public key and provision the agent in this
+        proxy. Rejection is permanent — the requester must start a new session.
+    </div>
+
+    <!-- Pending table -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Requester</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Pubkey SHA-256</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reason / Device</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Submitted</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Expires</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for req in pending %}
+                <tr class="table-row-hover transition-colors align-top">
+                    <td class="px-5 py-4">
+                        <div class="text-sm text-white">{{ req.requester_name }}</div>
+                        <div class="text-xs text-gray-500 font-mono">{{ req.requester_email }}</div>
+                    </td>
+                    <td class="px-5 py-4">
+                        <code class="text-[11px] font-mono text-accent-400 break-all"
+                              title="{{ req.pubkey_fingerprint }}">{{ req.pubkey_fingerprint[:24] }}&hellip;</code>
+                        <button type="button"
+                                onclick="copyToClipboard('{{ req.pubkey_fingerprint }}')"
+                                class="ml-1 text-[10px] text-gray-600 hover:text-gray-300 uppercase tracking-wider">copy</button>
+                    </td>
+                    <td class="px-5 py-4 max-w-xs">
+                        {% if req.reason %}
+                        <div class="text-xs text-gray-300 mb-1">{{ req.reason }}</div>
+                        {% else %}
+                        <div class="text-xs text-gray-700 italic mb-1">no reason provided</div>
+                        {% endif %}
+                        {% if req.device_info %}
+                        <div class="text-[10px] text-gray-600 font-mono break-all">{{ req.device_info }}</div>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">{{ req.created_at[:19] }}</td>
+                    <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">{{ req.expires_at[:19] }}</td>
+                    <td class="px-5 py-4 whitespace-nowrap">
+                        <button type="button"
+                                onclick="document.getElementById('approve-{{ req.session_id }}').classList.toggle('hidden'); document.getElementById('reject-{{ req.session_id }}').classList.add('hidden');"
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-emerald-600/60 text-emerald-400 rounded hover:bg-emerald-500/10 transition-colors">
+                            Approve
+                        </button>
+                        <button type="button"
+                                onclick="document.getElementById('reject-{{ req.session_id }}').classList.toggle('hidden'); document.getElementById('approve-{{ req.session_id }}').classList.add('hidden');"
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-red-600/60 text-red-400 rounded hover:bg-red-500/10 transition-colors ml-1">
+                            Reject
+                        </button>
+                    </td>
+                </tr>
+                <!-- Approve panel -->
+                <tr id="approve-{{ req.session_id }}" class="hidden bg-surface-950/60">
+                    <td colspan="6" class="px-5 py-4 border-t border-emerald-800/30">
+                        <form method="post" action="/proxy/enrollments/{{ req.session_id }}/approve" class="space-y-3">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <div class="text-xs text-emerald-400 uppercase tracking-wider font-semibold mb-2">
+                                Approve &mdash; {{ req.requester_name }}
+                            </div>
+                            <div class="grid grid-cols-3 gap-3">
+                                <div>
+                                    <label class="block text-[10px] font-medium text-gray-400 mb-1 uppercase tracking-wider">Agent ID</label>
+                                    <input type="text" name="agent_id" required
+                                           placeholder="agent-mrossi"
+                                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 font-mono">
+                                </div>
+                                <div>
+                                    <label class="block text-[10px] font-medium text-gray-400 mb-1 uppercase tracking-wider">Capabilities</label>
+                                    <input type="text" name="capabilities"
+                                           placeholder="procurement.read, erp.query"
+                                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 font-mono">
+                                </div>
+                                <div>
+                                    <label class="block text-[10px] font-medium text-gray-400 mb-1 uppercase tracking-wider">Groups</label>
+                                    <input type="text" name="groups"
+                                           placeholder="procurement, finance"
+                                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 font-mono">
+                                </div>
+                            </div>
+                            <p class="text-[10px] text-gray-600">Comma-separated. Assigned values are authoritative &mdash; requester input is informational only.</p>
+                            <div class="flex items-center gap-2 pt-1">
+                                <button type="submit"
+                                        class="px-4 py-1.5 text-[11px] font-semibold rounded transition-all"
+                                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;">
+                                    Issue Certificate
+                                </button>
+                                <button type="button"
+                                        onclick="document.getElementById('approve-{{ req.session_id }}').classList.add('hidden')"
+                                        class="px-3 py-1.5 text-[10px] text-gray-500 border border-gray-700 rounded hover:bg-gray-800 uppercase tracking-wider">
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </td>
+                </tr>
+                <!-- Reject panel -->
+                <tr id="reject-{{ req.session_id }}" class="hidden bg-surface-950/60">
+                    <td colspan="6" class="px-5 py-4 border-t border-red-800/30">
+                        <form method="post" action="/proxy/enrollments/{{ req.session_id }}/reject" class="space-y-3">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <div class="text-xs text-red-400 uppercase tracking-wider font-semibold mb-2">
+                                Reject &mdash; {{ req.requester_name }}
+                            </div>
+                            <div>
+                                <label class="block text-[10px] font-medium text-gray-400 mb-1 uppercase tracking-wider">Reason</label>
+                                <textarea name="reason" required rows="2"
+                                          placeholder="Not recognized as staff; no approval ticket on file."
+                                          class="w-full bg-surface-950 border border-gray-700/60 rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600"></textarea>
+                                <p class="text-[10px] text-gray-600 mt-1">Shown to the Connector client on next poll. Audit-logged.</p>
+                            </div>
+                            <div class="flex items-center gap-2 pt-1">
+                                <button type="submit"
+                                        class="px-4 py-1.5 text-[11px] font-semibold rounded transition-all bg-red-500/80 hover:bg-red-500 text-white uppercase tracking-wider"
+                                        style="font-family: 'Chakra Petch', sans-serif; letter-spacing: 0.05em;">
+                                    Reject
+                                </button>
+                                <button type="button"
+                                        onclick="document.getElementById('reject-{{ req.session_id }}').classList.add('hidden')"
+                                        class="px-3 py-1.5 text-[10px] text-gray-500 border border-gray-700 rounded hover:bg-gray-800 uppercase tracking-wider">
+                                    Cancel
+                                </button>
+                            </div>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not pending %}
+                <tr>
+                    <td colspan="6" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                        <p class="text-sm text-gray-600">No pending enrollments</p>
+                        <p class="text-xs text-gray-700 mt-1">Connector device-code requests will appear here awaiting your review.</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_enrollment_dashboard.py
+++ b/tests/test_enrollment_dashboard.py
@@ -1,0 +1,324 @@
+"""Phase 2c — admin dashboard pages for pending Connector enrollments.
+
+Covers the HTML routes under ``/proxy/enrollments``:
+
+  - GET redirects to /proxy/login when unauthenticated
+  - GET renders the list with one row per pending enrollment
+  - POST approve wires through the service layer (cert issued, status flipped)
+  - POST reject flips status and records the reason
+  - CSRF hidden field is mandatory on both mutating endpoints
+
+Complements ``tests/test_enrollment.py`` which exercises the JSON API.
+"""
+from __future__ import annotations
+
+import json as _json
+import time as _time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+def _ec_pubkey_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _generate_self_signed_ca(org_id: str) -> tuple[str, str]:
+    """Minimal self-signed CA. Returns (key_pem, cert_pem)."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id}-ca"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=30))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return key_pem, cert_pem
+
+
+def _admin_cookie(csrf_token: str = "test-csrf-token") -> tuple[str, str]:
+    """Mint a signed session cookie + matching CSRF token."""
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, _sign
+
+    payload = _json.dumps(
+        {"role": "admin", "csrf_token": csrf_token, "exp": int(_time.time()) + 3600}
+    )
+    return _COOKIE_NAME, _sign(payload)
+
+
+# ── Fixture: proxy app with CA-equipped AgentManager ────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            # Attach a CA-loaded AgentManager so approval can sign certs.
+            from mcp_proxy.egress.agent_manager import AgentManager
+
+            mgr = AgentManager(org_id="acme", trust_domain="cullis.local")
+            ca_key, ca_cert = _generate_self_signed_ca("acme")
+            await mgr.load_org_ca(ca_key, ca_cert)
+            app.state.agent_manager = mgr
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _start_enrollment(client: AsyncClient, name: str = "Mario Rossi") -> str:
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": _ec_pubkey_pem(),
+            "requester_name": name,
+            "requester_email": "mario@acme.com",
+            "reason": "Onboarding via dashboard test",
+            "device_info": '{"os":"linux","host":"laptop-01"}',
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["session_id"]
+
+
+# ── GET /proxy/enrollments ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_enrollments_requires_login(proxy_app):
+    _, client = proxy_app
+    resp = await client.get("/proxy/enrollments", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/proxy/login"
+
+
+@pytest.mark.asyncio
+async def test_get_enrollments_lists_pending(proxy_app):
+    _, client = proxy_app
+    session_id = await _start_enrollment(client, name="Mario Rossi")
+
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/enrollments")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Pending Enrollments" in body
+    assert "Mario Rossi" in body
+    assert "mario@acme.com" in body
+    # Form actions for both mutations are rendered per-row.
+    assert f"/proxy/enrollments/{session_id}/approve" in body
+    assert f"/proxy/enrollments/{session_id}/reject" in body
+    # CSRF hidden field is emitted.
+    assert 'name="csrf_token"' in body
+
+
+@pytest.mark.asyncio
+async def test_get_enrollments_empty_state(proxy_app):
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/enrollments")
+    assert resp.status_code == 200
+    assert "No pending enrollments" in resp.text
+
+
+# ── POST /proxy/enrollments/{id}/approve ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_approve_via_dashboard_issues_cert(proxy_app):
+    app, client = proxy_app
+    session_id = await _start_enrollment(client)
+
+    csrf = "dashboard-csrf-approve"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        f"/proxy/enrollments/{session_id}/approve",
+        data={
+            "csrf_token": csrf,
+            "agent_id": "agent-mrossi",
+            "capabilities": "procurement.read, erp.query",
+            "groups": "procurement",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+    assert "/proxy/enrollments" in resp.headers["location"]
+
+    # Verify the record flipped to approved and a cert was persisted.
+    from mcp_proxy.db import get_db
+    from mcp_proxy.enrollment import service
+
+    async with get_db() as conn:
+        record = await service.get_record(conn, session_id)
+    assert record["status"] == "approved"
+    assert record["agent_id_assigned"] == "agent-mrossi"
+    assert record["cert_pem"]
+    # Cert CN reflects org::agent_id binding (service-layer invariant).
+    cert = x509.load_pem_x509_certificate(record["cert_pem"].encode())
+    cns = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    assert cns[0].value == "acme::agent-mrossi"
+    # Capabilities persisted as JSON in assigned column.
+    caps = _json.loads(record["capabilities_assigned"])
+    assert caps == ["procurement.read", "erp.query"]
+
+
+@pytest.mark.asyncio
+async def test_approve_missing_csrf_is_403(proxy_app):
+    _, client = proxy_app
+    session_id = await _start_enrollment(client)
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        f"/proxy/enrollments/{session_id}/approve",
+        data={"agent_id": "agent-x"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_approve_missing_agent_id_redirects_with_error(proxy_app):
+    _, client = proxy_app
+    session_id = await _start_enrollment(client)
+
+    csrf = "dashboard-csrf-err"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        f"/proxy/enrollments/{session_id}/approve",
+        data={"csrf_token": csrf, "agent_id": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+
+
+# ── POST /proxy/enrollments/{id}/reject ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reject_via_dashboard_flips_status(proxy_app):
+    _, client = proxy_app
+    session_id = await _start_enrollment(client)
+
+    csrf = "dashboard-csrf-reject"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        f"/proxy/enrollments/{session_id}/reject",
+        data={"csrf_token": csrf, "reason": "No approval ticket on file."},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+
+    from mcp_proxy.db import get_db
+    from mcp_proxy.enrollment import service
+
+    async with get_db() as conn:
+        record = await service.get_record(conn, session_id)
+    assert record["status"] == "rejected"
+    assert record["rejection_reason"] == "No approval ticket on file."
+
+
+@pytest.mark.asyncio
+async def test_reject_missing_reason_redirects_with_error(proxy_app):
+    _, client = proxy_app
+    session_id = await _start_enrollment(client)
+    csrf = "dashboard-csrf-reject-empty"
+    cookie_name, cookie_value = _admin_cookie(csrf_token=csrf)
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        f"/proxy/enrollments/{session_id}/reject",
+        data={"csrf_token": csrf, "reason": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_reject_missing_csrf_is_403(proxy_app):
+    _, client = proxy_app
+    session_id = await _start_enrollment(client)
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.post(
+        f"/proxy/enrollments/{session_id}/reject",
+        data={"reason": "nope"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+# ── Nav badge ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_badge_enrollments_shows_count(proxy_app):
+    _, client = proxy_app
+    await _start_enrollment(client, name="A")
+    await _start_enrollment(client, name="B")
+
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/badge/enrollments")
+    assert resp.status_code == 200
+    assert ">2<" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_badge_enrollments_empty_when_unauth(proxy_app):
+    _, client = proxy_app
+    resp = await client.get("/proxy/badge/enrollments")
+    assert resp.status_code == 200
+    assert resp.text == ""


### PR DESCRIPTION
## Summary

- Adds the HTML admin surface for reviewing Connector device-code enrollment requests — admins can now approve/reject from the dashboard instead of curl.
- Together with #74 (Phase 2a server API) and #76 (Phase 2b client), this closes #64 end-to-end.
- New route `GET /proxy/enrollments` + form-based `POST /approve` and `/reject`, sidebar nav link, HTMX badge for pending count. JSON API under `/v1/admin/enrollments/*` is untouched.

## What's inside

- `mcp_proxy/dashboard/router.py`: `enrollments_page`, `enrollments_approve`, `enrollments_reject`, `badge_enrollments`. Form-based + CSRF hidden field — same idiom as `agents/create`, `vault/save`. AgentManager resolution: `app.state.agent_manager` → broker_bridge's embedded manager → config fallback.
- `mcp_proxy/dashboard/templates/enrollments.html`: table with requester name/email, truncated SHA-256 fingerprint (copy-to-clipboard), reason, device info, created/expires, inline Approve/Reject panels. Empty state with guidance.
- `mcp_proxy/dashboard/templates/base.html`: sidebar link between Agents and Network, with auto-refreshing badge counter.
- `tests/test_enrollment_dashboard.py`: 11 tests covering login guard, list rendering, empty state, approve happy path (cert CN check + caps persisted), approve validation (missing agent_id / CSRF), reject happy path + validation, badge behavior.

## Test plan

- [x] `pytest tests/test_enrollment_dashboard.py` — 11/11 pass
- [x] Full suite: `650 passed, 14 skipped` (only 2 failures are pre-existing `tests/test_postgres_integration.py` tests needing a real Postgres — verified they fail on `main` at the same commit before my changes)
- [x] `./demo_network/smoke.sh full` — PASS (round-trip + A4 + A7)
- [ ] Manual click-through: log in to proxy dashboard, start a Connector enrollment with `cullis-connector enroll`, verify the request appears in the list and approve/reject both flow cleanly.

## Scope

- No changes to `mcp_proxy/enrollment/`, `cullis_connector/`, `app/`, or any other area outside the dashboard package.
- Keeps the JSON admin API intact so SDK/automation use continues to work in parallel with the UI.

Closes #64.