### PR TITLE
feat(connector): Phase 3 — send_to_agent, await_response, get_audit_trail + audit API (#65)

### DIFF
--- a/cullis_connector/tools/__init__.py
+++ b/cullis_connector/tools/__init__.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cullis_connector.tools import diagnostic, discovery, session
+from cullis_connector.tools import diagnostic, discovery, high_level, session
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -25,6 +25,7 @@ def register_all(mcp: "FastMCP") -> None:
     diagnostic.register(mcp)
     discovery.register(mcp)
     session.register(mcp)
+    high_level.register(mcp)
 
 
 __all__ = ["register_all"]

--- a/cullis_connector/tools/high_level.py
+++ b/cullis_connector/tools/high_level.py
@@ -1,0 +1,298 @@
+"""High-level wrapper tools layered on top of the session primitives.
+
+These three tools exist because driving an LLM through the explicit
+open/send/poll/close dance is noisy and error-prone. The primitives in
+``cullis_connector.tools.session`` are kept for power users and
+debugging; these wrappers are the ones most agents should reach for.
+
+* ``send_to_agent``    — one-shot open + send + optionally await + close
+* ``await_response``   — poll a specific session for replies (does NOT
+                         mutate the global ``active_session`` state)
+* ``get_audit_trail``  — pull the server-side audit trail for a session
+
+Design notes
+------------
+
+Unlike the primitives, ``send_to_agent`` and ``await_response`` do not
+read from ``state.active_session`` for their core operation. They take
+explicit session/peer identifiers so the LLM can fire-and-forget
+exchanges without worrying about stomping on an ongoing conversation.
+
+``get_audit_trail`` uses the Connector's enrolled proxy credentials
+(``X-API-Key`` emitted at enrollment) to hit the Site's audit read API.
+If the client was built without a proxy API key (legacy broker-only
+flow), the tool returns a clear error message rather than crashing.
+"""
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+import httpx
+
+from cullis_connector._logging import get_logger
+from cullis_connector.state import get_state
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+_log = get_logger("tools.high_level")
+
+# Shared tunables — kept small-but-not-tiny so humans running the tool
+# from an LLM chat still see reasonable latency ceilings.
+_ACCEPT_POLL_INTERVAL_S = 2.0
+_ACCEPT_TIMEOUT_S = 15.0
+_RESPONSE_POLL_INTERVAL_S = 2.0
+
+
+def _require_client():
+    state = get_state()
+    if state.client is None or state.client.token is None:
+        raise RuntimeError("Not connected. Use the connect tool first.")
+    return state.client
+
+
+def _wait_for_active(client, session_id: str, timeout_s: float) -> bool:
+    """Poll list_sessions until ``session_id`` becomes active or the
+    timeout elapses. Returns True on success, False on timeout."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        sessions = client.list_sessions()
+        match = next((s for s in sessions if s.session_id == session_id), None)
+        if match and match.status == "active":
+            return True
+        time.sleep(_ACCEPT_POLL_INTERVAL_S)
+    return False
+
+
+def _format_audit_entries(entries: list[dict]) -> str:
+    if not entries:
+        return "No audit entries for this session."
+    lines = []
+    for entry in entries:
+        ts = entry.get("timestamp", "?")
+        agent = entry.get("agent_id", "?")
+        action = entry.get("action", "?")
+        tool = entry.get("tool_name")
+        stat = entry.get("status", "?")
+        detail = entry.get("detail")
+        dur = entry.get("duration_ms")
+
+        parts = [f"[{ts}]", agent, action]
+        if tool:
+            parts.append(f"tool={tool}")
+        parts.append(f"status={stat}")
+        if dur is not None:
+            parts.append(f"{dur:.1f}ms")
+        if detail:
+            parts.append(f"— {detail}")
+        lines.append(" ".join(parts))
+    return "\n".join(lines)
+
+
+def register(mcp: "FastMCP") -> None:
+    """Register high-level wrapper tools on the given FastMCP instance."""
+
+    @mcp.tool()
+    def send_to_agent(
+        target_agent_id: str,
+        target_org_id: str,
+        capability: str,
+        message: str,
+        await_response: bool = True,
+        timeout_s: int = 30,
+    ) -> str:
+        """Open a session, send a message, optionally wait for the first
+        reply, and close. One-shot high-level wrapper for simple exchanges.
+
+        Args:
+            target_agent_id: Peer agent ID (e.g. ``chipfactory::sales``).
+            target_org_id:   Peer organization ID.
+            capability:      Single capability scoped to this session.
+            message:         Plain-text payload to send.
+            await_response:  If True (default), block for ``timeout_s`` waiting
+                             for the first inbound message before closing.
+            timeout_s:       Seconds to wait for the peer's first reply.
+
+        Returns a human-readable summary with the session_id and (if
+        await_response is True) the first response payload.
+        """
+        state = get_state()
+        try:
+            client = _require_client()
+        except RuntimeError as exc:
+            return f"Not connected: {exc}"
+
+        caps = [capability] if capability else []
+
+        # 1. Open the session.
+        try:
+            session_id = client.open_session(target_agent_id, target_org_id, caps)
+        except Exception as exc:  # noqa: BLE001
+            return f"Failed to open session: {exc}"
+
+        # 2. Wait for peer to accept. If they don't accept inside the
+        # acceptance window, close the session and return a clean error
+        # instead of dangling the pending session forever.
+        if not _wait_for_active(client, session_id, _ACCEPT_TIMEOUT_S):
+            try:
+                client.close_session(session_id)
+            except Exception:  # noqa: BLE001
+                pass
+            return (
+                f"Peer {target_agent_id} did not accept session "
+                f"{session_id[:12]}... within {int(_ACCEPT_TIMEOUT_S)}s."
+            )
+
+        # 3. Send the message.
+        try:
+            client.send(
+                session_id,
+                state.agent_id,
+                {"type": "message", "text": message},
+                recipient_agent_id=target_agent_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            try:
+                client.close_session(session_id)
+            except Exception:  # noqa: BLE001
+                pass
+            return f"Failed to send message on session {session_id[:12]}...: {exc}"
+
+        # 4. Optionally wait for the first inbound reply.
+        reply_summary = ""
+        if await_response:
+            deadline = time.monotonic() + max(1, int(timeout_s))
+            replies: list = []
+            while time.monotonic() < deadline:
+                try:
+                    messages = client.poll(session_id)
+                except Exception as exc:  # noqa: BLE001
+                    reply_summary = f"poll error: {exc}"
+                    break
+                if messages:
+                    replies = messages
+                    break
+                time.sleep(_RESPONSE_POLL_INTERVAL_S)
+            if replies:
+                chunks = []
+                for m in replies:
+                    text_val = m.payload.get("text", json.dumps(m.payload))
+                    chunks.append(f"[{m.sender_agent_id}]: {text_val}")
+                reply_summary = "\n".join(chunks)
+            elif not reply_summary:
+                reply_summary = f"No reply within {int(timeout_s)}s."
+
+        # 5. Close — always close, regardless of reply.
+        try:
+            client.close_session(session_id)
+        except Exception as exc:  # noqa: BLE001
+            _log.warning(
+                "send_to_agent: close_session failed",
+                extra={"session_id": session_id, "error": str(exc)},
+            )
+
+        header = f"Session {session_id[:12]}... exchange complete with {target_agent_id}."
+        if reply_summary:
+            return f"{header}\n{reply_summary}"
+        return header
+
+    @mcp.tool()
+    def await_response(session_id: str, timeout_s: int = 30) -> str:
+        """Poll a specific session for new incoming messages until one
+        arrives or the timeout elapses. Does NOT change the active_session
+        state — useful for checking on a background session without
+        disturbing the current conversation.
+
+        Args:
+            session_id: Full session ID to poll.
+            timeout_s:  Maximum seconds to wait.
+        """
+        try:
+            client = _require_client()
+        except RuntimeError as exc:
+            return f"Not connected: {exc}"
+
+        deadline = time.monotonic() + max(1, int(timeout_s))
+        while time.monotonic() < deadline:
+            try:
+                messages = client.poll(session_id)
+            except Exception as exc:  # noqa: BLE001
+                return f"Failed to poll session {session_id[:12]}...: {exc}"
+            if messages:
+                lines = []
+                for m in messages:
+                    text_val = m.payload.get("text", json.dumps(m.payload))
+                    lines.append(f"[{m.sender_agent_id}]: {text_val}")
+                return "\n".join(lines)
+            time.sleep(_RESPONSE_POLL_INTERVAL_S)
+
+        return f"No response within {int(timeout_s)}s."
+
+    @mcp.tool()
+    def get_audit_trail(session_id: str) -> str:
+        """Fetch the audit trail for a session from the Site. Returns
+        timestamps, actions, and status for each step — useful for
+        debugging failed exchanges or producing a compliance summary.
+
+        Args:
+            session_id: Session ID to audit.
+        """
+        state = get_state()
+        cfg = state.config
+        if cfg is None or not cfg.site_url:
+            return (
+                "Site URL is not configured. Pass --site-url or set "
+                "CULLIS_SITE_URL before starting the connector."
+            )
+
+        try:
+            client = _require_client()
+        except RuntimeError as exc:
+            return f"Not connected: {exc}"
+
+        try:
+            headers = client.proxy_headers()
+        except RuntimeError as exc:
+            return (
+                "Audit fetch requires proxy enrollment (API key) but the "
+                f"current client has none: {exc}"
+            )
+
+        url = f"{cfg.site_url}/v1/audit/session/{session_id}"
+        try:
+            resp = httpx.get(
+                url,
+                headers=headers,
+                verify=cfg.verify_tls,
+                timeout=cfg.request_timeout_s,
+            )
+        except httpx.HTTPError as exc:
+            return f"Site unreachable at {cfg.site_url}: {exc}"
+
+        if resp.status_code == 404:
+            return f"No audit trail found for session {session_id[:12]}..."
+        if resp.status_code == 403:
+            return (
+                f"Not authorized to read audit for session {session_id[:12]}..."
+                " (you must be a peer of the session)."
+            )
+        if resp.status_code != 200:
+            return (
+                f"Audit API error HTTP {resp.status_code} at {url}: "
+                f"{resp.text[:200]}"
+            )
+
+        try:
+            entries = resp.json()
+        except json.JSONDecodeError:
+            return f"Audit API returned non-JSON body: {resp.text[:200]}"
+        if not isinstance(entries, list):
+            return f"Audit API returned unexpected shape: {type(entries).__name__}"
+
+        header = (
+            f"Audit trail for session {session_id[:12]}... "
+            f"({len(entries)} entries):"
+        )
+        return header + "\n" + _format_audit_entries(entries)

--- a/mcp_proxy/audit/__init__.py
+++ b/mcp_proxy/audit/__init__.py
@@ -1,0 +1,7 @@
+"""Audit API router — per-session JSON audit trail reads for Connector tools.
+
+The dashboard already renders audit rows as HTML at ``/proxy/audit``.
+This module exposes a narrower, machine-readable surface scoped to a
+single session_id so an agent can pull its own audit trail at runtime
+(e.g. from the ``get_audit_trail`` MCP tool in the Cullis Connector).
+"""

--- a/mcp_proxy/audit/router.py
+++ b/mcp_proxy/audit/router.py
@@ -1,0 +1,139 @@
+"""FastAPI router exposing per-session audit trail reads to authenticated agents.
+
+Endpoint:
+
+    GET /v1/audit/session/{session_id}
+
+Authentication: ``X-API-Key`` (same internal-agent scheme used for egress).
+
+Authorization (MVP): the caller may read the audit trail for a session
+only if the ``audit_log`` table contains at least one entry with
+``agent_id = caller_agent_id`` AND ``request_id = session_id``. In
+practice every session the agent participated in (open/send/accept/
+close/poll…) writes such a row, so this is a reasonable proxy for
+"was this agent a peer of the session". It is intentionally not
+bulletproof — a full per-session ACL store is future work.
+
+Response shape: ``list[AuditEntry]`` ordered by timestamp ascending,
+capped at 500 entries per response to bound DoS surface.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import text
+
+from mcp_proxy.auth.api_key import get_agent_from_api_key
+from mcp_proxy.db import get_db
+from mcp_proxy.models import InternalAgent
+
+logger = logging.getLogger("mcp_proxy")
+
+router = APIRouter(tags=["audit"])
+
+# Cap responses so a single authenticated agent can't force the proxy to
+# serialize unbounded rows. 500 comfortably covers any realistic session.
+_MAX_ENTRIES = 500
+
+
+class AuditEntry(BaseModel):
+    """One immutable row from ``audit_log``, scoped to a single session."""
+
+    timestamp: str
+    agent_id: str
+    action: str
+    tool_name: str | None = None
+    status: str
+    detail: str | None = None
+    duration_ms: float | None = None
+
+
+def _row_to_entry(row: Any) -> AuditEntry:
+    duration_raw = row["duration_ms"]
+    duration: float | None
+    if duration_raw is None or duration_raw == "":
+        duration = None
+    else:
+        try:
+            duration = float(duration_raw)
+        except (TypeError, ValueError):
+            duration = None
+    return AuditEntry(
+        timestamp=row["timestamp"],
+        agent_id=row["agent_id"],
+        action=row["action"],
+        tool_name=row["tool_name"],
+        status=row["status"],
+        detail=row["detail"],
+        duration_ms=duration,
+    )
+
+
+@router.get(
+    "/v1/audit/session/{session_id}",
+    response_model=list[AuditEntry],
+)
+async def get_session_audit(
+    session_id: str,
+    agent: InternalAgent = Depends(get_agent_from_api_key),
+) -> list[AuditEntry]:
+    """Return the audit trail for ``session_id`` if the caller is a peer.
+
+    * 200 with ``[]`` is never returned for a legitimate caller on a real
+      session — the caller's own open/send/etc. entries always exist.
+    * 403 is returned when no row links the caller to the session.
+    * 404 is returned when the session_id has no audit entries at all.
+    """
+    async with get_db() as conn:
+        # Authorization probe: is the caller a peer of this session?
+        probe = await conn.execute(
+            text(
+                "SELECT 1 FROM audit_log "
+                "WHERE request_id = :sid AND agent_id = :aid "
+                "LIMIT 1"
+            ),
+            {"sid": session_id, "aid": agent.agent_id},
+        )
+        own_row = probe.first()
+
+        # Does the session exist at all (any agent)?
+        any_probe = await conn.execute(
+            text(
+                "SELECT 1 FROM audit_log WHERE request_id = :sid LIMIT 1"
+            ),
+            {"sid": session_id},
+        )
+        any_row = any_probe.first()
+
+        if any_row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No audit entries for the given session_id",
+            )
+        if own_row is None:
+            logger.warning(
+                "audit_read_forbidden agent=%s session=%s",
+                agent.agent_id, session_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Caller is not a peer of this session",
+            )
+
+        result = await conn.execute(
+            text(
+                "SELECT timestamp, agent_id, action, tool_name, status, "
+                "detail, duration_ms "
+                "FROM audit_log "
+                "WHERE request_id = :sid "
+                "ORDER BY timestamp ASC, id ASC "
+                "LIMIT :lim"
+            ),
+            {"sid": session_id, "lim": _MAX_ENTRIES},
+        )
+        rows = result.mappings().all()
+
+    return [_row_to_entry(r) for r in rows]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -350,6 +350,9 @@ app.include_router(local_ws_router)
 from mcp_proxy.enrollment.router import router as enrollment_router
 app.include_router(enrollment_router)
 
+from mcp_proxy.audit.router import router as audit_router
+app.include_router(audit_router)
+
 from mcp_proxy.dashboard.router import router as dashboard_router
 app.include_router(dashboard_router)
 

--- a/tests/connector/test_high_level_tools.py
+++ b/tests/connector/test_high_level_tools.py
@@ -1,0 +1,378 @@
+"""Unit tests for the Connector Phase 3 high-level tools.
+
+The three tools (``send_to_agent``, ``await_response``, ``get_audit_trail``)
+are tested through a ``_FakeFastMCP`` harness that captures the registered
+callables, then invoked with a mocked ``CullisClient`` and stubbed
+``httpx.get`` to avoid real network I/O.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.state import get_state, reset_state
+from cullis_connector.tools import high_level
+from cullis_sdk.types import InboxMessage, SessionInfo
+
+
+class _FakeFastMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self):
+        def decorator(fn):
+            self.tools[fn.__name__] = fn
+            return fn
+
+        return decorator
+
+
+class _FakeClient:
+    """Stand-in for ``cullis_sdk.CullisClient`` with canned responses.
+
+    The mock is intentionally permissive — tests poke attributes directly
+    rather than driving a full state machine. Each call is recorded for
+    assertion.
+    """
+
+    def __init__(self) -> None:
+        self.token = "fake-token"
+        self.opened: list[tuple[str, str, list[str]]] = []
+        self.sent: list[dict] = []
+        self.closed: list[str] = []
+        self.polled: list[str] = []
+
+        self._next_session_id = "sess-abc-1234567890"
+        self._open_raises: Exception | None = None
+        self._send_raises: Exception | None = None
+        self._sessions_queue: list[list[SessionInfo]] = []
+        self._poll_queue: list[list[InboxMessage]] = []
+        self._proxy_api_key = "sk_local_alice_deadbeef"
+        self._proxy_headers_raises: Exception | None = None
+
+    # ── Sessions ──────────────────────────────────────────────────
+    def open_session(self, target: str, org: str, caps: list[str]) -> str:
+        if self._open_raises is not None:
+            raise self._open_raises
+        self.opened.append((target, org, caps))
+        return self._next_session_id
+
+    def close_session(self, session_id: str) -> None:
+        self.closed.append(session_id)
+
+    def list_sessions(self, status: str | None = None) -> list[SessionInfo]:
+        if self._sessions_queue:
+            return self._sessions_queue.pop(0)
+        return []
+
+    def send(self, session_id: str, sender: str, payload: dict,
+             recipient_agent_id: str) -> None:
+        if self._send_raises is not None:
+            raise self._send_raises
+        self.sent.append({
+            "session_id": session_id,
+            "sender": sender,
+            "payload": payload,
+            "recipient": recipient_agent_id,
+        })
+
+    def poll(self, session_id: str) -> list[InboxMessage]:
+        self.polled.append(session_id)
+        if self._poll_queue:
+            return self._poll_queue.pop(0)
+        return []
+
+    def proxy_headers(self) -> dict:
+        if self._proxy_headers_raises is not None:
+            raise self._proxy_headers_raises
+        return {"X-API-Key": self._proxy_api_key, "Content-Type": "application/json"}
+
+
+def _active_session(client: _FakeClient, target: str) -> SessionInfo:
+    return SessionInfo(
+        session_id=client._next_session_id,
+        status="active",
+        initiator_agent_id="acme::alice",
+        target_agent_id=target,
+        initiator_org_id="acme",
+        target_org_id="chipfactory",
+    )
+
+
+def _pending_session(client: _FakeClient, target: str) -> SessionInfo:
+    s = _active_session(client, target)
+    s.status = "pending"
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state(tmp_path: Path, monkeypatch):
+    reset_state()
+    state = get_state()
+    state.config = ConnectorConfig(
+        site_url="https://site.test",
+        config_dir=tmp_path,
+        verify_tls=True,
+        request_timeout_s=2.0,
+    )
+    state.agent_id = "acme::alice"
+    # Avoid real sleeping in polling loops — unit tests shouldn't wait.
+    monkeypatch.setattr(high_level.time, "sleep", lambda _s: None)
+    # Shrink accept timeout for the "peer never accepts" path.
+    monkeypatch.setattr(high_level, "_ACCEPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(high_level, "_ACCEPT_POLL_INTERVAL_S", 0.01)
+    monkeypatch.setattr(high_level, "_RESPONSE_POLL_INTERVAL_S", 0.01)
+    yield
+    reset_state()
+
+
+@pytest.fixture
+def tools():
+    mcp = _FakeFastMCP()
+    high_level.register(mcp)
+    return mcp.tools
+
+
+@pytest.fixture
+def client():
+    c = _FakeClient()
+    get_state().client = c  # type: ignore[assignment]
+    return c
+
+
+# ── send_to_agent ────────────────────────────────────────────────────────
+
+
+def test_send_to_agent_full_exchange_with_reply(tools, client):
+    # First list_sessions call: session is active.
+    client._sessions_queue = [[_active_session(client, "chipfactory::sales")]]
+    # First poll returns a reply.
+    client._poll_queue = [[
+        InboxMessage(
+            seq=1,
+            sender_agent_id="chipfactory::sales",
+            payload={"text": "ack received"},
+        ),
+    ]]
+
+    result = tools["send_to_agent"](
+        target_agent_id="chipfactory::sales",
+        target_org_id="chipfactory",
+        capability="order.write",
+        message="please quote 500 wafers",
+        await_response=True,
+        timeout_s=2,
+    )
+
+    assert "exchange complete" in result
+    assert "chipfactory::sales" in result
+    assert "ack received" in result
+    assert len(client.opened) == 1
+    assert client.opened[0][0] == "chipfactory::sales"
+    assert client.opened[0][2] == ["order.write"]
+    assert len(client.sent) == 1
+    assert client.sent[0]["recipient"] == "chipfactory::sales"
+    assert client.closed == [client._next_session_id]
+
+
+def test_send_to_agent_peer_never_accepts(tools, client):
+    # list_sessions always returns pending → timeout path.
+    client._sessions_queue = [
+        [_pending_session(client, "chipfactory::sales")]
+        for _ in range(10)
+    ]
+
+    result = tools["send_to_agent"](
+        target_agent_id="chipfactory::sales",
+        target_org_id="chipfactory",
+        capability="chat",
+        message="hi",
+        await_response=False,
+    )
+    assert "did not accept" in result.lower()
+    # Session should still be closed to avoid dangling pending.
+    assert client.closed == [client._next_session_id]
+    assert client.sent == []  # Never sent because accept never happened.
+
+
+def test_send_to_agent_open_error_is_reported(tools, client):
+    client._open_raises = RuntimeError("broker unreachable")
+    result = tools["send_to_agent"](
+        target_agent_id="x::y",
+        target_org_id="x",
+        capability="chat",
+        message="hello",
+    )
+    assert "failed to open" in result.lower()
+    assert "broker unreachable" in result
+    assert client.sent == []
+    assert client.closed == []
+
+
+def test_send_to_agent_without_await_returns_immediately(tools, client):
+    client._sessions_queue = [[_active_session(client, "x::y")]]
+    result = tools["send_to_agent"](
+        target_agent_id="x::y",
+        target_org_id="x",
+        capability="chat",
+        message="hi",
+        await_response=False,
+        timeout_s=30,
+    )
+    assert "exchange complete" in result
+    assert client.polled == []  # No polling when await_response is False.
+    assert client.closed == [client._next_session_id]
+
+
+def test_send_to_agent_not_connected(tools):
+    # No client on state → clean error, not a crash.
+    result = tools["send_to_agent"](
+        target_agent_id="x::y",
+        target_org_id="x",
+        capability="chat",
+        message="hi",
+    )
+    assert "not connected" in result.lower()
+
+
+# ── await_response ───────────────────────────────────────────────────────
+
+
+def test_await_response_returns_messages(tools, client):
+    client._poll_queue = [[
+        InboxMessage(seq=1, sender_agent_id="peer::bob", payload={"text": "hi"}),
+    ]]
+    result = tools["await_response"]("sess-xyz", timeout_s=2)
+    assert "[peer::bob]: hi" == result
+    assert client.polled == ["sess-xyz"]
+    # await_response must NOT touch active_session.
+    assert get_state().active_session is None
+
+
+def test_await_response_timeout(tools, client):
+    # Empty queue — every poll returns no messages.
+    result = tools["await_response"]("sess-zzz", timeout_s=1)
+    assert "no response within" in result.lower()
+
+
+def test_await_response_poll_error(tools, client):
+    class Boom(Exception):
+        pass
+
+    def _boom(_sid):
+        raise Boom("kaboom")
+
+    client.poll = _boom  # type: ignore[assignment]
+    result = tools["await_response"]("sess-err", timeout_s=1)
+    assert "failed to poll" in result.lower()
+    assert "kaboom" in result
+
+
+# ── get_audit_trail ──────────────────────────────────────────────────────
+
+
+def _audit_entry(**kw):
+    base = {
+        "timestamp": "2026-04-14T12:00:01+00:00",
+        "agent_id": "acme::alice",
+        "action": "session.open",
+        "tool_name": "open_session",
+        "status": "ok",
+        "detail": None,
+        "duration_ms": 12.5,
+    }
+    base.update(kw)
+    return base
+
+
+def test_get_audit_trail_formats_entries(tools, client, monkeypatch):
+    captured: dict[str, Any] = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured["headers"] = kwargs.get("headers")
+        return httpx.Response(
+            status_code=200,
+            json=[
+                _audit_entry(),
+                _audit_entry(
+                    timestamp="2026-04-14T12:00:02+00:00",
+                    action="session.send",
+                    tool_name="send_message",
+                    detail="to peer",
+                    duration_ms=7.0,
+                ),
+            ],
+        )
+
+    monkeypatch.setattr(high_level.httpx, "get", fake_get)
+    result = tools["get_audit_trail"]("sess-abc-1234567890")
+    assert "Audit trail for session" in result
+    assert "session.open" in result
+    assert "session.send" in result
+    assert "to peer" in result
+    assert captured["url"] == (
+        "https://site.test/v1/audit/session/sess-abc-1234567890"
+    )
+    assert captured["headers"]["X-API-Key"] == client._proxy_api_key
+
+
+def test_get_audit_trail_404(tools, client, monkeypatch):
+    monkeypatch.setattr(
+        high_level.httpx,
+        "get",
+        lambda url, **kw: httpx.Response(status_code=404, json={"detail": "nope"}),
+    )
+    result = tools["get_audit_trail"]("sess-missing")
+    assert "no audit trail" in result.lower()
+
+
+def test_get_audit_trail_403(tools, client, monkeypatch):
+    monkeypatch.setattr(
+        high_level.httpx,
+        "get",
+        lambda url, **kw: httpx.Response(status_code=403, json={"detail": "nope"}),
+    )
+    result = tools["get_audit_trail"]("sess-foreign")
+    assert "not authorized" in result.lower()
+
+
+def test_get_audit_trail_missing_proxy_api_key(tools, client, monkeypatch):
+    client._proxy_headers_raises = RuntimeError("no proxy key")
+    result = tools["get_audit_trail"]("sess-abc")
+    assert "proxy enrollment" in result.lower()
+
+
+def test_get_audit_trail_site_unreachable(tools, client, monkeypatch):
+    def boom(url, **kw):
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(high_level.httpx, "get", boom)
+    result = tools["get_audit_trail"]("sess-abc")
+    assert "unreachable" in result.lower()
+
+
+def test_get_audit_trail_non_json(tools, client, monkeypatch):
+    monkeypatch.setattr(
+        high_level.httpx,
+        "get",
+        lambda url, **kw: httpx.Response(status_code=200, text="not json"),
+    )
+    result = tools["get_audit_trail"]("sess-abc")
+    assert "non-json" in result.lower()
+
+
+def test_get_audit_trail_no_site_url(tools):
+    get_state().config = ConnectorConfig(site_url="")
+    result = tools["get_audit_trail"]("sess-abc")
+    assert "site url is not configured" in result.lower()
+
+
+def test_get_audit_trail_not_connected(tools):
+    # state has config but no client.
+    result = tools["get_audit_trail"]("sess-abc")
+    assert "not connected" in result.lower()

--- a/tests/connector/test_server_assembly.py
+++ b/tests/connector/test_server_assembly.py
@@ -39,6 +39,9 @@ def test_build_server_registers_tools_and_sets_state(tmp_path: Path):
         "close_session",
         "list_sessions",
         "select_session",
+        "send_to_agent",
+        "await_response",
+        "get_audit_trail",
     }
     # Legacy `connect` tool removed in Phase 2b — identity now loaded from
     # ~/.cullis/identity/ populated by `cullis-connector enroll`.

--- a/tests/test_audit_api.py
+++ b/tests/test_audit_api.py
@@ -1,0 +1,218 @@
+"""Tests for the Connector audit API — ``GET /v1/audit/session/{session_id}``.
+
+Covers:
+  * 200 + ordering when the caller is a peer of the session
+  * 403 when the caller has no entries linking them to the session
+  * 404 when no entries exist for the session_id at all
+  * 401 when the X-API-Key header is missing
+  * Response cap at _MAX_ENTRIES (smoke, not a full stress test)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from mcp_proxy.audit.router import _MAX_ENTRIES
+from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+from mcp_proxy.db import create_agent, dispose_db, get_db, init_db, log_audit
+
+
+_SESSION_A = "sess-aaaa-1111"
+_SESSION_B = "sess-bbbb-2222"
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "audit.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}"
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def seeded_agents(proxy_app):
+    """Register two agents and seed audit rows for two sessions.
+
+    Layout:
+      * agent_alice → participated in _SESSION_A (two entries, increasing ts)
+      * agent_bob   → participated in _SESSION_B (one entry)
+      * _SESSION_A also has one row from a ``system`` actor to exercise the
+        non-caller ``agent_id`` path
+    """
+    alice_key = generate_api_key("alice")
+    bob_key = generate_api_key("bob")
+    await create_agent(
+        agent_id="alice",
+        display_name="Alice",
+        capabilities=["chat"],
+        api_key_hash=hash_api_key(alice_key),
+    )
+    await create_agent(
+        agent_id="bob",
+        display_name="Bob",
+        capabilities=["chat"],
+        api_key_hash=hash_api_key(bob_key),
+    )
+
+    base = datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Helper: log then manually overwrite the timestamp so we can test
+    # ordering without sleeping.
+    async def _seed(ts, agent_id, action, request_id, *, tool=None, detail=None,
+                    duration=None, status="ok"):
+        await log_audit(
+            agent_id=agent_id,
+            action=action,
+            status=status,
+            tool_name=tool,
+            detail=detail,
+            request_id=request_id,
+            duration_ms=duration,
+        )
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE audit_log SET timestamp = :ts "
+                    "WHERE id = (SELECT MAX(id) FROM audit_log)"
+                ),
+                {"ts": ts.isoformat()},
+            )
+
+    await _seed(base + timedelta(seconds=1), "alice", "session.open",
+                _SESSION_A, tool="open_session", duration=12.5)
+    await _seed(base + timedelta(seconds=2), "system", "policy.evaluate",
+                _SESSION_A, detail="allow", duration=3.0)
+    await _seed(base + timedelta(seconds=3), "alice", "session.send",
+                _SESSION_A, tool="send_message", duration=7.0)
+    await _seed(base + timedelta(seconds=1), "bob", "session.open",
+                _SESSION_B, tool="open_session", duration=11.0)
+
+    return {"alice_key": alice_key, "bob_key": bob_key}
+
+
+@pytest.mark.asyncio
+async def test_audit_returns_entries_for_peer(proxy_app, seeded_agents):
+    _, client = proxy_app
+    headers = {"X-API-Key": seeded_agents["alice_key"]}
+    resp = await client.get(
+        f"/v1/audit/session/{_SESSION_A}", headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    entries = resp.json()
+    # 3 rows for session A (two alice + one system).
+    assert len(entries) == 3
+    # Ordering is ascending by timestamp.
+    ts_list = [e["timestamp"] for e in entries]
+    assert ts_list == sorted(ts_list)
+    # Schema sanity.
+    first = entries[0]
+    assert first["agent_id"] == "alice"
+    assert first["action"] == "session.open"
+    assert first["tool_name"] == "open_session"
+    assert first["status"] == "ok"
+    assert first["duration_ms"] == pytest.approx(12.5)
+
+
+@pytest.mark.asyncio
+async def test_audit_forbids_non_peer(proxy_app, seeded_agents):
+    _, client = proxy_app
+    # bob never touched session A → 403.
+    headers = {"X-API-Key": seeded_agents["bob_key"]}
+    resp = await client.get(
+        f"/v1/audit/session/{_SESSION_A}", headers=headers,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_audit_404_on_unknown_session(proxy_app, seeded_agents):
+    _, client = proxy_app
+    headers = {"X-API-Key": seeded_agents["alice_key"]}
+    resp = await client.get(
+        "/v1/audit/session/sess-does-not-exist", headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_audit_requires_api_key(proxy_app, seeded_agents):
+    _, client = proxy_app
+    resp = await client.get(f"/v1/audit/session/{_SESSION_A}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_audit_rejects_bad_api_key(proxy_app, seeded_agents):
+    _, client = proxy_app
+    resp = await client.get(
+        f"/v1/audit/session/{_SESSION_A}",
+        headers={"X-API-Key": "sk_local_nobody_deadbeef"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_audit_caps_response_length(tmp_path, monkeypatch):
+    """Insert more than _MAX_ENTRIES rows for a single session and confirm
+    the response is capped. Uses a fresh DB to avoid coupling to the other
+    seeded fixtures."""
+    db_file = tmp_path / "audit_cap.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+
+    try:
+        agent_key = generate_api_key("capper")
+        await create_agent(
+            agent_id="capper",
+            display_name="Capper",
+            capabilities=["chat"],
+            api_key_hash=hash_api_key(agent_key),
+        )
+        sid = "sess-cap-9999"
+        insert_count = _MAX_ENTRIES + 25
+        for i in range(insert_count):
+            await log_audit(
+                agent_id="capper",
+                action=f"action.{i}",
+                status="ok",
+                request_id=sid,
+            )
+
+        from mcp_proxy.main import app
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            async with app.router.lifespan_context(app):
+                resp = await client.get(
+                    f"/v1/audit/session/{sid}",
+                    headers={"X-API-Key": agent_key},
+                )
+        assert resp.status_code == 200, resp.text
+        entries = resp.json()
+        assert len(entries) == _MAX_ENTRIES
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Closes the Cullis Connector **Phase 3** scope (issue #65): the three
missing high-level MCP tools plus the server-side JSON audit endpoint
they rely on.

- **Server (`mcp_proxy/audit/`)** — new router with
  `GET /v1/audit/session/{session_id}`, `X-API-Key` auth (same scheme
  as egress), peer-only authorization (caller must have ≥1 `audit_log`
  row linking them to the session), 403 / 404 / 401 on the expected
  failure paths, response capped at 500 entries ordered by timestamp
  asc.
- **Connector (`cullis_connector/tools/high_level.py`)** — three new
  MCP tools layered on top of the existing session primitives:
  - `send_to_agent` — one-shot open → wait-active → send → optional
    poll → close, with clean errors on open failure / accept timeout /
    send failure
  - `await_response(session_id, timeout_s)` — polls a specific session
    without mutating `state.active_session`
  - `get_audit_trail(session_id)` — GETs the new audit endpoint via
    `client.proxy_headers()`, formats each entry as a readable line
- **Tests**
  - `tests/test_audit_api.py` (6 tests): peer / non-peer / unknown /
    missing-key / bad-key / response-cap
  - `tests/connector/test_high_level_tools.py` (17 tests): happy path +
    every error branch for each tool
  - `tests/connector/test_server_assembly.py`: registered-tool set
    extended with the three new names
- **Design decisions**
  - `mcp_proxy/audit/` is a new package (not a single file) to mirror
    `mcp_proxy/enrollment/` and leave room for future endpoints
    (per-org feed, streaming tail).
  - New file `tools/high_level.py` rather than extending `session.py`
    to keep primitives ↔ wrappers separated.

## What's left (follow-up)

- The audit endpoint returns **proxy-local** entries only. The per-org
  hash-chained cross-org audit (PR #77) lives on the broker and is not
  joined here — a future slice can add that once the broker exposes a
  per-session read API with agent-level auth.
- Authorization is an **MVP heuristic** ("caller has a row for this
  session"). A proper per-session ACL store is future work.

## Test plan

- [x] `pytest tests/test_audit_api.py tests/connector/test_high_level_tools.py tests/connector/test_server_assembly.py` → 23/23 pass
- [x] `pytest tests/ --ignore=tests/test_postgres_integration.py` → 681 passed, 14 skipped (postgres integration requires a running Postgres, pre-existing on main)
- [x] `./demo_network/smoke.sh full` → PASS (round-trip nonce, A4 dashboard persistence, A7 audit hash chain intact)
- [x] `python3 -m pyflakes` clean on all new/changed files
- [x] DCO signoff on the commit