### PR TITLE
feat(audit): wire TSA worker into lifespan + add rfc3161-client dep

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -204,6 +204,15 @@ async def lifespan(app: FastAPI):
         name="cullis-session-sweeper",
     )
 
+    # Audit TSA worker: periodically anchor per-org chain heads to an
+    # external RFC 3161 TSA. Opt-in via `audit_tsa_enabled` so default
+    # deployments don't call out to the network.
+    tsa_task = None
+    tsa_stop = None
+    if getattr(settings, "audit_tsa_enabled", False):
+        from app.audit.tsa_worker import start_worker_task
+        tsa_task, tsa_stop = start_worker_task(settings)
+
     yield
 
     # ── Drain phase ──────────────────────────────────────────────────────────
@@ -234,6 +243,15 @@ async def lifespan(app: FastAPI):
         await sweeper_task
     except (asyncio.CancelledError, Exception):
         pass
+
+    # Stop the TSA worker cleanly if it was started.
+    if tsa_task is not None and tsa_stop is not None:
+        tsa_stop.set()
+        tsa_task.cancel()
+        try:
+            await tsa_task
+        except (asyncio.CancelledError, Exception):
+            pass
 
     await ws_manager.shutdown()
     await close_redis()

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,7 @@ pytest-xdist>=3.6.0
 pytest-split>=0.9.0
 mcp>=1.0
 PyYAML>=6.0
+# RFC 3161 TSA client for audit chain anchoring (opt-in via
+# audit_tsa_backend=rfc3161). The broker boots without this dep when
+# the default mock backend is used; import is lazy in app/audit/tsa_client.py.
+rfc3161-client>=1.0.3

--- a/tests/test_audit_tsa.py
+++ b/tests/test_audit_tsa.py
@@ -168,6 +168,29 @@ class _BrokenTsa(TsaClient):
         return False
 
 
+async def test_start_worker_task_returns_cancellable_task(clean_audit):
+    """Lifespan wiring: start_worker_task must return (task, stop_event)
+    and stop cleanly when the event is set, without leaking a running
+    loop. This mirrors how app.main.lifespan drives shutdown."""
+    import asyncio
+    from app.audit.tsa_worker import start_worker_task
+
+    class _S:
+        audit_tsa_backend = "mock"
+        audit_tsa_url = "mock://x"
+        audit_tsa_interval_seconds = 3600  # long — we'll cancel via event
+
+    task, stop = start_worker_task(_S())
+    try:
+        # Let the first tick run (empty DB → no anchors, returns fast).
+        await asyncio.sleep(0.05)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+    finally:
+        if not task.done():
+            task.cancel()
+
+
 async def test_worker_continues_when_tsa_fails(clean_audit):
     """TSA backend failure must not corrupt the chain nor raise out
     of the worker. Next tick retries."""


### PR DESCRIPTION
## Summary
- Start `audit.tsa_worker.start_worker_task` in FastAPI lifespan when `audit_tsa_enabled=True`; cancel cleanly on shutdown.
- Add `rfc3161-client>=1.0.3` to `requirements.txt` so the rfc3161 backend works when operators opt-in (import stays lazy — zero cost when mock backend is used).
- Add `test_start_worker_task_returns_cancellable_task` covering the lifespan start/stop contract.

Closes the non-blocking follow-ups called out in PR #80 / issue #75.

## Test plan
- [x] `pytest tests/test_audit_tsa.py tests/test_audit_export_tsa.py tests/test_audit_chain.py` — 32/32 green
- [x] Full suite: 685 passed (2 pre-existing postgres failures unrelated, same on main)
- [x] `python -c "from app.main import app"` boots clean with flag default-off