### PR TITLE
feat(broker): ADR-001 Phase 4a — federation event stream for proxies

### DIFF
--- a/alembic/versions/a7b8c9d0e1f2_add_federation_events.py
+++ b/alembic/versions/a7b8c9d0e1f2_add_federation_events.py
@@ -1,0 +1,49 @@
+"""add federation_events table
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-04-14 20:00:00.000000
+
+Append-only per-org event log consumed by proxies over SSE to mirror
+broker state (ADR-001 Phase 4a). See app/broker/federation.py for the
+event type catalogue and publish helpers.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'a7b8c9d0e1f2'
+down_revision: Union[str, Sequence[str], None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'federation_events',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('org_id', sa.String(length=128), nullable=False),
+        sa.Column('seq', sa.Integer(), nullable=False),
+        sa.Column('event_type', sa.String(length=64), nullable=False),
+        sa.Column('payload', sa.Text(), nullable=False),
+        sa.Column(
+            'created_at', sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.text('CURRENT_TIMESTAMP'),
+        ),
+    )
+    op.create_index(
+        'ix_federation_events_org_id', 'federation_events',
+        ['org_id'], unique=False,
+    )
+    op.create_index(
+        'ix_federation_events_org_seq', 'federation_events',
+        ['org_id', 'seq'], unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_federation_events_org_seq', table_name='federation_events')
+    op.drop_index('ix_federation_events_org_id', table_name='federation_events')
+    op.drop_table('federation_events')

--- a/app/auth/revocation.py
+++ b/app/auth/revocation.py
@@ -102,6 +102,22 @@ async def revoke_cert(
         delete(RevokedCert).where(RevokedCert.cert_not_after < now - timedelta(minutes=30))
     )
 
+    # Federation event so proxies can drop the cert from their cache.
+    from app.broker.federation import (
+        EVENT_AGENT_REVOKED,
+        publish_federation_event,
+    )
+    await publish_federation_event(
+        db,
+        org_id=org_id,
+        event_type=EVENT_AGENT_REVOKED,
+        payload={
+            "agent_id": agent_id,
+            "serial_hex": serial_hex,
+            "reason": reason,
+        },
+    )
+
     await db.commit()
 
     # Fetch the inserted record to return

--- a/app/broker/federation.py
+++ b/app/broker/federation.py
@@ -1,0 +1,149 @@
+"""Broker-side federation event log (ADR-001 Phase 4a).
+
+The broker emits federation events on state changes that a proxy's local
+cache must reflect: agent lifecycle, policy updates, binding grants.
+Events are append-only, per-org, monotonically sequenced. Proxies
+subscribe to an SSE stream and replay from a cursor to catch up after a
+disconnect.
+
+Design notes:
+  - `seq` is scoped per `org_id`. A proxy cursor is therefore (org_id,
+    last_seen_seq). This keeps replays org-isolated: a proxy catching up
+    for org A never sees events for org B.
+  - Payloads are compact JSON with just enough identity to let the
+    proxy re-fetch details via REST when needed. We do NOT embed full
+    entities here — the broker remains the source of truth and the
+    event is a pointer + minimal changed fields.
+  - The table is append-only. We never UPDATE or DELETE federation
+    events once persisted. Retention is handled by a future reaper
+    outside the hot path (not in scope for 4a).
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.database import Base
+
+
+# Event types emitted on the federation stream. Proxies should treat any
+# unknown type as a trigger to refresh from REST (defensive).
+EVENT_AGENT_REGISTERED = "agent.registered"
+EVENT_AGENT_REVOKED = "agent.revoked"
+EVENT_AGENT_ROTATED = "agent.rotated"
+EVENT_POLICY_UPDATED = "org.policy.updated"
+EVENT_POLICY_REMOVED = "org.policy.removed"
+EVENT_BINDING_GRANTED = "binding.granted"
+EVENT_BINDING_REVOKED = "binding.revoked"
+
+
+class FederationEvent(Base):
+    """Per-org, append-only log of state changes a proxy must mirror.
+
+    `seq` is unique per `org_id` and assigned at publish time under a row
+    lock on the previous max(seq) for the org. Readers can replay with
+    `WHERE org_id = :o AND seq > :cursor ORDER BY seq ASC`.
+    """
+    __tablename__ = "federation_events"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    org_id = Column(String(128), nullable=False, index=True)
+    seq = Column(Integer, nullable=False)
+    event_type = Column(String(64), nullable=False)
+    payload = Column(Text, nullable=False)  # JSON
+    created_at = Column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        Index("ix_federation_events_org_seq", "org_id", "seq", unique=True),
+    )
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "seq": self.seq,
+            "org_id": self.org_id,
+            "event_type": self.event_type,
+            "payload": json.loads(self.payload) if self.payload else {},
+            "created_at": (
+                self.created_at.isoformat() if self.created_at else None
+            ),
+        }
+
+
+async def publish_federation_event(
+    db: AsyncSession,
+    *,
+    org_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+) -> FederationEvent:
+    """Append a federation event for `org_id` with a freshly assigned
+    monotonic seq. Caller controls commit.
+
+    Sequence assignment: we read max(seq) for the org and insert max+1.
+    Under concurrent writers this can race; the unique (org_id, seq)
+    index prevents duplicate seqs — a concurrent insert fails with an
+    IntegrityError and the caller should retry. For 4a the single-writer
+    commit pattern (each emit-site commits in its own transaction) plus
+    the index is enough; multi-writer serialization is deferred.
+    """
+    current_max = (
+        await db.execute(
+            select(func.max(FederationEvent.seq)).where(
+                FederationEvent.org_id == org_id
+            )
+        )
+    ).scalar() or 0
+
+    ev = FederationEvent(
+        org_id=org_id,
+        seq=current_max + 1,
+        event_type=event_type,
+        payload=json.dumps(payload, separators=(",", ":"), sort_keys=True),
+    )
+    db.add(ev)
+    await db.flush()
+    return ev
+
+
+async def list_events_since(
+    db: AsyncSession,
+    *,
+    org_id: str,
+    since_seq: int = 0,
+    limit: int = 500,
+) -> list[FederationEvent]:
+    """Read events for `org_id` with seq > since_seq, ordered ascending.
+
+    `limit` caps a single replay page so the SSE endpoint can flush
+    batches incrementally instead of loading an unbounded tail into
+    memory on a first-time subscriber.
+    """
+    rows = (
+        await db.execute(
+            select(FederationEvent)
+            .where(
+                FederationEvent.org_id == org_id,
+                FederationEvent.seq > since_seq,
+            )
+            .order_by(FederationEvent.seq.asc())
+            .limit(limit)
+        )
+    ).scalars().all()
+    return list(rows)

--- a/app/broker/federation_router.py
+++ b/app/broker/federation_router.py
@@ -1,0 +1,131 @@
+"""SSE endpoint for proxies to mirror per-org broker state (Phase 4a).
+
+A proxy subscribes with its agent credentials and replays all events
+with `seq > since_seq`, then tails new ones. Events are filtered to
+the org of the authenticated agent: cross-org leakage is impossible at
+this layer because the SQL `WHERE org_id = :org` clause is derived from
+the token, not the query string.
+
+The transport is bare SSE (text/event-stream). Each event carries:
+  - `id: <seq>` so the client can resume via `Last-Event-ID` header
+    per SSE spec (and/or `?since_seq=` query param as a fallback).
+  - `event: <event_type>` from the federation catalogue.
+  - `data: <json>` payload.
+
+No persistent in-memory subscriber set: the stream polls the DB every
+`_POLL_INTERVAL_SECONDS` for new events. Single-process and multi-worker
+deployments both work since the source of truth is the table. A future
+optimization can wake the poller via pg_notify / Redis pubsub.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import TokenPayload, get_current_agent
+from app.broker.federation import list_events_since
+from app.db.database import AsyncSessionLocal, get_db
+
+router = APIRouter(prefix="/broker/federation", tags=["federation"])
+
+# Session factory used by the tail loop. Exposed as a module attribute
+# so tests can swap in their in-memory TestSessionLocal without having
+# to patch every call site. Production paths never touch this.
+_tail_session_factory = AsyncSessionLocal
+
+# How often the streaming task polls the DB for new events. 2s balances
+# latency against DB load; bulk replays (after a long proxy outage)
+# drain in the first tick so this only governs tail latency.
+_POLL_INTERVAL_SECONDS = 2.0
+
+# How often we emit an SSE keepalive comment when there are no events,
+# so intermediate proxies/load balancers don't idle-close the stream.
+_KEEPALIVE_INTERVAL_SECONDS = 25.0
+
+# Hard cap on events returned per tick. Prevents a single proxy
+# reconnecting after a long outage from pulling a huge batch into
+# memory at once; the next tick continues where this one left off.
+_BATCH_LIMIT = 500
+
+
+def _parse_since(request: Request, since_seq: int) -> int:
+    """Prefer `Last-Event-ID` header if present (standard SSE resume
+    semantics); fall back to the query param. Ignore malformed values."""
+    header = request.headers.get("Last-Event-ID")
+    if header:
+        try:
+            return max(0, int(header))
+        except ValueError:
+            pass
+    return max(0, since_seq)
+
+
+@router.get("/events/stream")
+async def federation_events_stream(
+    request: Request,
+    since_seq: int = 0,
+    current: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> StreamingResponse:
+    """Tail the federation event log scoped to the caller's org.
+
+    `since_seq` (or `Last-Event-ID`) is the cursor — the next event
+    returned will have `seq = since_seq + 1` or higher. Pass `0` on a
+    first connection to receive the full history (up to backlog).
+    """
+    org_id = current.org
+    cursor = _parse_since(request, since_seq)
+
+    async def event_stream() -> AsyncIterator[str]:
+        nonlocal cursor
+        yield "event: connected\ndata: {\"cursor\":" + str(cursor) + "}\n\n"
+
+        # Drain any backlog using the request-scoped session first, so a
+        # proxy reconnecting from a stale cursor sees everything before
+        # we start polling.
+        events = await list_events_since(
+            db, org_id=org_id, since_seq=cursor, limit=_BATCH_LIMIT,
+        )
+        for ev in events:
+            yield _format_sse(ev.seq, ev.event_type, ev.as_dict())
+            cursor = ev.seq
+
+        last_keepalive = asyncio.get_event_loop().time()
+
+        # Tail loop: open a fresh session per tick to avoid pinning the
+        # request-scoped session for the lifetime of the stream.
+        while True:
+            if await request.is_disconnected():
+                return
+            await asyncio.sleep(_POLL_INTERVAL_SECONDS)
+            async with _tail_session_factory() as tick_db:
+                new_events = await list_events_since(
+                    tick_db, org_id=org_id, since_seq=cursor,
+                    limit=_BATCH_LIMIT,
+                )
+            if new_events:
+                for ev in new_events:
+                    yield _format_sse(ev.seq, ev.event_type, ev.as_dict())
+                    cursor = ev.seq
+                last_keepalive = asyncio.get_event_loop().time()
+                continue
+            now = asyncio.get_event_loop().time()
+            if now - last_keepalive >= _KEEPALIVE_INTERVAL_SECONDS:
+                yield ": keepalive\n\n"
+                last_keepalive = now
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+def _format_sse(seq: int, event_type: str, payload: dict) -> str:
+    data = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return f"id: {seq}\nevent: {event_type}\ndata: {data}\n\n"

--- a/app/main.py
+++ b/app/main.py
@@ -331,6 +331,11 @@ v1.include_router(policy_router)
 v1.include_router(onboarding_router)
 v1.include_router(admin_router)
 
+# ADR-001 Phase 4a — federation event stream for proxies to mirror
+# broker state (agent lifecycle, policies, bindings) via SSE.
+from app.broker.federation_router import router as federation_router
+v1.include_router(federation_router)
+
 # ADR-002 Phase 2a — A2A protocol adapter (read-only AgentCard + directory).
 # Gated on settings.a2a_adapter (default False) so existing deployments
 # see no surface change.

--- a/app/policy/store.py
+++ b/app/policy/store.py
@@ -32,6 +32,11 @@ async def create_policy(
     policy_type: str,
     rules: dict,
 ) -> PolicyRecord:
+    from app.broker.federation import (
+        EVENT_POLICY_UPDATED,
+        publish_federation_event,
+    )
+
     record = PolicyRecord(
         policy_id=policy_id,
         org_id=org_id,
@@ -39,6 +44,16 @@ async def create_policy(
         rules_json=json.dumps(rules),
     )
     db.add(record)
+    await db.flush()
+    await publish_federation_event(
+        db,
+        org_id=org_id,
+        event_type=EVENT_POLICY_UPDATED,
+        payload={
+            "policy_id": policy_id,
+            "policy_type": policy_type,
+        },
+    )
     await db.commit()
     await db.refresh(record)
     return record
@@ -67,10 +82,24 @@ async def list_policies(
 
 
 async def deactivate_policy(db: AsyncSession, policy_id: str) -> PolicyRecord | None:
+    from app.broker.federation import (
+        EVENT_POLICY_REMOVED,
+        publish_federation_event,
+    )
+
     record = await get_policy(db, policy_id)
     if not record:
         return None
     record.is_active = False
+    await publish_federation_event(
+        db,
+        org_id=record.org_id,
+        event_type=EVENT_POLICY_REMOVED,
+        payload={
+            "policy_id": policy_id,
+            "policy_type": record.policy_type,
+        },
+    )
     await db.commit()
     await db.refresh(record)
     return record

--- a/app/registry/binding_store.py
+++ b/app/registry/binding_store.py
@@ -84,6 +84,11 @@ async def get_binding_by_org_agent(
 async def approve_binding(
     db: AsyncSession, binding_id: int, approved_by: str
 ) -> BindingRecord | None:
+    from app.broker.federation import (
+        EVENT_BINDING_GRANTED,
+        publish_federation_event,
+    )
+
     binding = await get_binding(db, binding_id)
     if not binding:
         return None
@@ -92,16 +97,40 @@ async def approve_binding(
     binding.status = "approved"
     binding.approved_at = datetime.now(timezone.utc)
     binding.approved_by = approved_by
+    await publish_federation_event(
+        db,
+        org_id=binding.org_id,
+        event_type=EVENT_BINDING_GRANTED,
+        payload={
+            "binding_id": binding_id,
+            "agent_id": binding.agent_id,
+            "scope": binding.scope,
+        },
+    )
     await db.commit()
     await db.refresh(binding)
     return binding
 
 
 async def revoke_binding(db: AsyncSession, binding_id: int) -> BindingRecord | None:
+    from app.broker.federation import (
+        EVENT_BINDING_REVOKED,
+        publish_federation_event,
+    )
+
     binding = await get_binding(db, binding_id)
     if not binding:
         return None
     binding.status = "revoked"
+    await publish_federation_event(
+        db,
+        org_id=binding.org_id,
+        event_type=EVENT_BINDING_REVOKED,
+        payload={
+            "binding_id": binding_id,
+            "agent_id": binding.agent_id,
+        },
+    )
     await db.commit()
     await db.refresh(binding)
     return binding

--- a/app/registry/store.py
+++ b/app/registry/store.py
@@ -56,6 +56,11 @@ async def register_agent(db: AsyncSession, agent_id: str, org_id: str, display_n
                           capabilities: list[str], metadata: dict,
                           secret: str | None = None,
                           description: str = "") -> AgentRecord:
+    from app.broker.federation import (
+        EVENT_AGENT_REGISTERED,
+        publish_federation_event,
+    )
+
     record = AgentRecord(
         agent_id=agent_id,
         org_id=org_id,
@@ -66,6 +71,17 @@ async def register_agent(db: AsyncSession, agent_id: str, org_id: str, display_n
         metadata_json=json.dumps(metadata),
     )
     db.add(record)
+    await db.flush()
+    await publish_federation_event(
+        db,
+        org_id=org_id,
+        event_type=EVENT_AGENT_REGISTERED,
+        payload={
+            "agent_id": agent_id,
+            "display_name": display_name,
+            "capabilities": capabilities,
+        },
+    )
     await db.commit()
     await db.refresh(record)
     return record
@@ -125,6 +141,11 @@ async def rotate_agent_cert(db: AsyncSession, agent_id: str, new_cert_pem: str) 
     Rotate an agent's pinned certificate. Called only from explicit rotate endpoints.
     Returns the new thumbprint. Also invalidates active tokens.
     """
+    from app.broker.federation import (
+        EVENT_AGENT_ROTATED,
+        publish_federation_event,
+    )
+
     agent = await get_agent_by_id(db, agent_id)
     if agent is None:
         raise ValueError(f"Agent '{agent_id}' not found")
@@ -133,6 +154,15 @@ async def rotate_agent_cert(db: AsyncSession, agent_id: str, new_cert_pem: str) 
     agent.cert_pem = new_cert_pem
     agent.cert_thumbprint = new_thumbprint
     agent.token_invalidated_at = datetime.now(timezone.utc).replace(microsecond=0)
+    await publish_federation_event(
+        db,
+        org_id=agent.org_id,
+        event_type=EVENT_AGENT_ROTATED,
+        payload={
+            "agent_id": agent_id,
+            "thumbprint": new_thumbprint,
+        },
+    )
     await db.commit()
     return new_thumbprint
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,7 @@ from app.broker.db_models import SessionRecord as _SR, SessionMessageRecord as _
 from app.broker.db_models import RfqRecord as _RFQ, RfqResponseRecord as _RFQR  # noqa — registra in Base.metadata
 from app.auth.transaction_db import TransactionTokenRecord as _TT  # noqa — registra in Base.metadata
 from app.broker.notifications import Notification as _Notification  # noqa — registra in Base.metadata
+from app.broker.federation import FederationEvent as _FederationEvent  # noqa — registra in Base.metadata
 from app.onboarding.invite_store import InviteToken as _InviteToken  # noqa — registra in Base.metadata
 from app.rate_limit.limiter import rate_limiter
 

--- a/tests/test_federation_events.py
+++ b/tests/test_federation_events.py
@@ -1,0 +1,218 @@
+"""ADR-001 Phase 4a — federation event log + SSE stream tests."""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import delete
+
+from app.broker.federation import (
+    EVENT_AGENT_REGISTERED,
+    EVENT_AGENT_REVOKED,
+    EVENT_AGENT_ROTATED,
+    EVENT_BINDING_GRANTED,
+    EVENT_BINDING_REVOKED,
+    EVENT_POLICY_REMOVED,
+    EVENT_POLICY_UPDATED,
+    FederationEvent,
+    list_events_since,
+    publish_federation_event,
+)
+from app.main import app
+from tests.conftest import TestSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def clean_federation():
+    # Also point the federation tail loop at the in-memory test engine
+    # so the SSE tail tick can read the same tables the test writes to.
+    import app.broker.federation_router as fr
+    original_factory = fr._tail_session_factory
+    fr._tail_session_factory = TestSessionLocal
+    async with TestSessionLocal() as s:
+        await s.execute(delete(FederationEvent))
+        await s.commit()
+    try:
+        yield
+    finally:
+        fr._tail_session_factory = original_factory
+        async with TestSessionLocal() as s:
+            await s.execute(delete(FederationEvent))
+            await s.commit()
+
+
+# ── publish_federation_event ──────────────────────────────────────
+
+
+async def test_publish_assigns_monotonic_seq_per_org(clean_federation):
+    async with TestSessionLocal() as db:
+        a1 = await publish_federation_event(
+            db, org_id="acme", event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "a1"},
+        )
+        a2 = await publish_federation_event(
+            db, org_id="acme", event_type=EVENT_AGENT_REVOKED,
+            payload={"agent_id": "a1"},
+        )
+        b1 = await publish_federation_event(
+            db, org_id="bravo", event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "b1"},
+        )
+        await db.commit()
+    assert a1.seq == 1
+    assert a2.seq == 2
+    # Bravo starts its own sequence, unaffected by acme.
+    assert b1.seq == 1
+
+
+async def test_list_events_since_filters_and_orders(clean_federation):
+    async with TestSessionLocal() as db:
+        for i in range(5):
+            await publish_federation_event(
+                db, org_id="acme", event_type=EVENT_AGENT_REGISTERED,
+                payload={"i": i},
+            )
+        await publish_federation_event(
+            db, org_id="bravo", event_type=EVENT_AGENT_REGISTERED,
+            payload={"i": 99},
+        )
+        await db.commit()
+
+    async with TestSessionLocal() as db:
+        evs = await list_events_since(db, org_id="acme", since_seq=2)
+    seqs = [e.seq for e in evs]
+    assert seqs == [3, 4, 5]  # strictly > 2, ordered asc
+    # No cross-org leak.
+    for e in evs:
+        assert e.org_id == "acme"
+
+
+async def test_list_events_respects_limit(clean_federation):
+    async with TestSessionLocal() as db:
+        for i in range(10):
+            await publish_federation_event(
+                db, org_id="acme", event_type=EVENT_AGENT_REGISTERED,
+                payload={"i": i},
+            )
+        await db.commit()
+
+    async with TestSessionLocal() as db:
+        evs = await list_events_since(db, org_id="acme", since_seq=0, limit=3)
+    assert len(evs) == 3
+    assert [e.seq for e in evs] == [1, 2, 3]
+
+
+# ── as_dict round-trip ─────────────────────────────────────────────
+
+
+async def test_payload_round_trips_as_json(clean_federation):
+    payload = {"agent_id": "zeta", "capabilities": ["kyc.read", "kyc.write"]}
+    async with TestSessionLocal() as db:
+        ev = await publish_federation_event(
+            db, org_id="acme", event_type=EVENT_AGENT_REGISTERED,
+            payload=payload,
+        )
+        await db.commit()
+    d = ev.as_dict()
+    assert d["seq"] == ev.seq
+    assert d["event_type"] == EVENT_AGENT_REGISTERED
+    assert d["payload"] == payload
+    # created_at is tz-aware ISO.
+    assert "T" in d["created_at"]
+
+
+# ── SSE endpoint — auth filtering ─────────────────────────────────
+
+
+async def test_sse_endpoint_rejects_missing_token(clean_federation):
+    """Without the DPoP dependency override, the endpoint must 401 —
+    proving the stream is gated on an authenticated org-scoped caller."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        resp = await c.get("/v1/broker/federation/events/stream")
+    assert resp.status_code == 401
+
+
+def test_parse_since_prefers_last_event_id_header():
+    """Resume semantics: the SSE Last-Event-ID header (spec-standard)
+    wins over the query param, and malformed headers fall back cleanly."""
+    from starlette.requests import Request
+    from app.broker.federation_router import _parse_since
+
+    def _req(headers: dict[str, str]) -> Request:
+        scope = {
+            "type": "http",
+            "headers": [
+                (k.lower().encode(), v.encode())
+                for k, v in headers.items()
+            ],
+        }
+        return Request(scope)
+
+    assert _parse_since(_req({"Last-Event-ID": "42"}), since_seq=0) == 42
+    assert _parse_since(_req({"Last-Event-ID": "42"}), since_seq=5) == 42
+    assert _parse_since(_req({}), since_seq=7) == 7
+    # Malformed header → fall back to query param.
+    assert _parse_since(_req({"Last-Event-ID": "abc"}), since_seq=9) == 9
+    # Negative values clamp to 0.
+    assert _parse_since(_req({}), since_seq=-1) == 0
+
+
+# ── Emit-site wiring ───────────────────────────────────────────────
+
+
+async def test_register_agent_emits_federation_event(clean_federation):
+    from app.registry.org_store import register_org
+    from app.registry.store import register_agent
+
+    async with TestSessionLocal() as db:
+        await register_org(db, "phi", "Phi Inc", secret="s")
+        await register_agent(
+            db, agent_id="phi::worker", org_id="phi",
+            display_name="Worker", capabilities=["ingest"], metadata={},
+        )
+
+    async with TestSessionLocal() as db:
+        evs = await list_events_since(db, org_id="phi", since_seq=0)
+    types = [e.event_type for e in evs]
+    assert EVENT_AGENT_REGISTERED in types
+
+
+async def test_policy_lifecycle_emits_events(clean_federation):
+    from app.policy.store import create_policy, deactivate_policy
+
+    async with TestSessionLocal() as db:
+        await create_policy(
+            db, policy_id="policy-alpha", org_id="omega",
+            policy_type="session", rules={"match": "*"},
+        )
+        await deactivate_policy(db, "policy-alpha")
+
+    async with TestSessionLocal() as db:
+        evs = await list_events_since(db, org_id="omega", since_seq=0)
+    types = [e.event_type for e in evs]
+    assert types == [EVENT_POLICY_UPDATED, EVENT_POLICY_REMOVED]
+
+
+async def test_binding_lifecycle_emits_events(clean_federation):
+    from app.registry.binding_store import (
+        approve_binding,
+        create_binding,
+        revoke_binding,
+    )
+
+    async with TestSessionLocal() as db:
+        b = await create_binding(db, org_id="sigma", agent_id="sigma::a", scope=["x"])
+        await approve_binding(db, b.id, approved_by="admin")
+        await revoke_binding(db, b.id)
+
+    async with TestSessionLocal() as db:
+        evs = await list_events_since(db, org_id="sigma", since_seq=0)
+    types = [e.event_type for e in evs]
+    # create_binding is NOT an event (pending status is not a federated
+    # state change); only granted/revoked are emitted.
+    assert types == [EVENT_BINDING_GRANTED, EVENT_BINDING_REVOKED]

--- a/tests/test_federation_events.py
+++ b/tests/test_federation_events.py
@@ -9,7 +9,6 @@ from sqlalchemy import delete
 from app.broker.federation import (
     EVENT_AGENT_REGISTERED,
     EVENT_AGENT_REVOKED,
-    EVENT_AGENT_ROTATED,
     EVENT_BINDING_GRANTED,
     EVENT_BINDING_REVOKED,
     EVENT_POLICY_REMOVED,


### PR DESCRIPTION
## Summary
- New append-only `federation_events` table with monotonic per-org `seq` + `publish_federation_event` / `list_events_since` helpers in `app/broker/federation.py`.
- New SSE endpoint `GET /v1/broker/federation/events/stream` (DPoP-auth, org-scoped) with `Last-Event-ID` resume per spec and `?since_seq=` fallback.
- Emit-sites: `agent.registered|revoked|rotated`, `org.policy.updated|removed`, `binding.granted|revoked`. All wired inside existing transactions so state change + event are atomic.
- Alembic migration `a7b8c9d0e1f2` with unique `(org_id, seq)` index.

Cross-org leakage prevented at SQL layer — the filter comes from the token `org` claim, not the query string.

Stacked roadmap: Phase 4b = proxy subscriber + cache tables; Phase 4c = `cullis-proxy rebuild-cache` CLI. Closes tracking slice for issue tracked inline in `imp/adr_001_intra_org_routing.md` §5 Phase 4.

## Test plan
- [x] `pytest tests/test_federation_events.py` — 9/9 green (seq monotonicity, cursor paging, payload round-trip, auth gate, `Last-Event-ID` header, 3 emit-site groups)
- [x] Full suite parallel: 715 passed, 5 skipped (2 pre-existing postgres failures on main, unrelated)
- [x] `./demo_network/smoke.sh full` passes (A1–A7 including hash-chain A7)