### PR TITLE
feat(proxy): ADR-001 Phase 4b — federation SSE subscriber + cache

### DIFF
--- a/mcp_proxy/alembic/versions/0004_add_federation_cache.py
+++ b/mcp_proxy/alembic/versions/0004_add_federation_cache.py
@@ -1,0 +1,76 @@
+"""Add federation cache tables — ADR-001 Phase 4b.
+
+Revision ID: 0004_add_federation_cache
+Revises: 0003_add_pending_enrollments
+Create Date: 2026-04-14
+
+Proxy-side read-only cache populated by the federation SSE subscriber.
+The broker is authoritative for agents/policies/bindings; these tables
+are a mirror that avoids a REST round-trip on every intra-org decision
+and can be dropped+rebuilt at any time via `cullis-proxy rebuild-cache`.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_add_federation_cache"
+down_revision: Union[str, Sequence[str], None] = "0003_add_pending_enrollments"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cached_federated_agents",
+        sa.Column("agent_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=True),
+        sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("thumbprint", sa.Text(), nullable=True),
+        sa.Column("revoked", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+    )
+    op.create_index(
+        "idx_cached_agents_org", "cached_federated_agents", ["org_id"],
+    )
+
+    op.create_table(
+        "cached_policies",
+        sa.Column("policy_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("policy_type", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+    )
+    op.create_index("idx_cached_policies_org", "cached_policies", ["org_id"])
+
+    op.create_table(
+        "cached_bindings",
+        sa.Column("binding_id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("agent_id", sa.Text(), nullable=False),
+        sa.Column("scope", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+    )
+    op.create_index("idx_cached_bindings_org", "cached_bindings", ["org_id"])
+    op.create_index("idx_cached_bindings_agent", "cached_bindings", ["agent_id"])
+
+    op.create_table(
+        "federation_cursor",
+        sa.Column("org_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("last_seq", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("federation_cursor")
+    op.drop_index("idx_cached_bindings_agent", table_name="cached_bindings")
+    op.drop_index("idx_cached_bindings_org", table_name="cached_bindings")
+    op.drop_table("cached_bindings")
+    op.drop_index("idx_cached_policies_org", table_name="cached_policies")
+    op.drop_table("cached_policies")
+    op.drop_index("idx_cached_agents_org", table_name="cached_federated_agents")
+    op.drop_table("cached_federated_agents")

--- a/mcp_proxy/sync/__init__.py
+++ b/mcp_proxy/sync/__init__.py
@@ -1,0 +1,2 @@
+"""Federation sync — proxy-side subscriber that mirrors broker state
+via the /v1/broker/federation/events/stream SSE channel (ADR-001 Phase 4b)."""

--- a/mcp_proxy/sync/handlers.py
+++ b/mcp_proxy/sync/handlers.py
@@ -1,0 +1,233 @@
+"""Dispatch federation event types to cache upserts/deletes.
+
+Each handler is an `async def h(conn, payload, ts)` that mutates the
+proxy cache under the caller's transaction. The `apply_event` function
+picks the right handler from the event type.
+
+Handlers intentionally do not re-raise on "row not found" (for removals
+and revocations), so the subscriber makes progress even when a proxy
+restored from backup misses intermediate state: the next event type
+that creates/updates the row recovers consistency.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+_log = logging.getLogger("mcp_proxy.sync.handlers")
+
+
+# Event type constants (mirror app/broker/federation.py so the subscriber
+# does not import from the broker package).
+EVENT_AGENT_REGISTERED = "agent.registered"
+EVENT_AGENT_REVOKED = "agent.revoked"
+EVENT_AGENT_ROTATED = "agent.rotated"
+EVENT_POLICY_UPDATED = "org.policy.updated"
+EVENT_POLICY_REMOVED = "org.policy.removed"
+EVENT_BINDING_GRANTED = "binding.granted"
+EVENT_BINDING_REVOKED = "binding.revoked"
+
+
+Handler = Callable[[AsyncConnection, str, dict[str, Any], str], Awaitable[None]]
+
+
+async def _agent_registered(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    await conn.execute(
+        text(
+            """INSERT INTO cached_federated_agents
+                 (agent_id, org_id, display_name, capabilities, revoked, updated_at)
+               VALUES (:agent_id, :org_id, :display_name, :capabilities, 0, :ts)
+               ON CONFLICT (agent_id) DO UPDATE SET
+                 org_id=excluded.org_id,
+                 display_name=excluded.display_name,
+                 capabilities=excluded.capabilities,
+                 revoked=0,
+                 updated_at=excluded.updated_at"""
+        ),
+        {
+            "agent_id": payload["agent_id"],
+            "org_id": org_id,
+            "display_name": payload.get("display_name"),
+            "capabilities": json.dumps(payload.get("capabilities", [])),
+            "ts": ts,
+        },
+    )
+
+
+async def _agent_revoked(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    # Revoked events carry only {agent_id, serial_hex, reason} — we may
+    # not have seen a prior register event (e.g. proxy enabled after
+    # the agent was registered long ago). UPSERT with revoked=1 so the
+    # cache reflects reality either way.
+    agent_id = payload.get("agent_id")
+    if not agent_id:
+        _log.debug("agent.revoked without agent_id — skipping")
+        return
+    await conn.execute(
+        text(
+            """INSERT INTO cached_federated_agents
+                 (agent_id, org_id, capabilities, revoked, updated_at)
+               VALUES (:agent_id, :org_id, '[]', 1, :ts)
+               ON CONFLICT (agent_id) DO UPDATE SET
+                 revoked=1,
+                 updated_at=excluded.updated_at"""
+        ),
+        {"agent_id": agent_id, "org_id": org_id, "ts": ts},
+    )
+
+
+async def _agent_rotated(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    await conn.execute(
+        text(
+            """UPDATE cached_federated_agents
+               SET thumbprint=:thumbprint, updated_at=:ts
+               WHERE agent_id=:agent_id"""
+        ),
+        {
+            "agent_id": payload["agent_id"],
+            "thumbprint": payload.get("thumbprint"),
+            "ts": ts,
+        },
+    )
+
+
+async def _policy_updated(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    await conn.execute(
+        text(
+            """INSERT INTO cached_policies
+                 (policy_id, org_id, policy_type, is_active, updated_at)
+               VALUES (:policy_id, :org_id, :policy_type, 1, :ts)
+               ON CONFLICT (policy_id) DO UPDATE SET
+                 policy_type=excluded.policy_type,
+                 is_active=1,
+                 updated_at=excluded.updated_at"""
+        ),
+        {
+            "policy_id": payload["policy_id"],
+            "org_id": org_id,
+            "policy_type": payload.get("policy_type"),
+            "ts": ts,
+        },
+    )
+
+
+async def _policy_removed(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    await conn.execute(
+        text(
+            """UPDATE cached_policies
+               SET is_active=0, updated_at=:ts
+               WHERE policy_id=:policy_id"""
+        ),
+        {"policy_id": payload["policy_id"], "ts": ts},
+    )
+
+
+async def _binding_granted(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    await conn.execute(
+        text(
+            """INSERT INTO cached_bindings
+                 (binding_id, org_id, agent_id, scope, status, updated_at)
+               VALUES (:binding_id, :org_id, :agent_id, :scope, 'approved', :ts)
+               ON CONFLICT (binding_id) DO UPDATE SET
+                 org_id=excluded.org_id,
+                 agent_id=excluded.agent_id,
+                 scope=excluded.scope,
+                 status='approved',
+                 updated_at=excluded.updated_at"""
+        ),
+        {
+            "binding_id": payload["binding_id"],
+            "org_id": org_id,
+            "agent_id": payload["agent_id"],
+            "scope": json.dumps(payload.get("scope", [])),
+            "ts": ts,
+        },
+    )
+
+
+async def _binding_revoked(
+    conn: AsyncConnection, org_id: str, payload: dict[str, Any], ts: str,
+) -> None:
+    await conn.execute(
+        text(
+            """UPDATE cached_bindings
+               SET status='revoked', updated_at=:ts
+               WHERE binding_id=:binding_id"""
+        ),
+        {"binding_id": payload["binding_id"], "ts": ts},
+    )
+
+
+_HANDLERS: dict[str, Handler] = {
+    EVENT_AGENT_REGISTERED: _agent_registered,
+    EVENT_AGENT_REVOKED: _agent_revoked,
+    EVENT_AGENT_ROTATED: _agent_rotated,
+    EVENT_POLICY_UPDATED: _policy_updated,
+    EVENT_POLICY_REMOVED: _policy_removed,
+    EVENT_BINDING_GRANTED: _binding_granted,
+    EVENT_BINDING_REVOKED: _binding_revoked,
+}
+
+
+async def apply_event(
+    conn: AsyncConnection,
+    *,
+    org_id: str,
+    seq: int,
+    event_type: str,
+    payload: dict[str, Any],
+) -> None:
+    """Apply a single federation event to the proxy cache and bump the
+    cursor. All writes go through the same transaction so a mid-apply
+    crash cannot leave the cache ahead of the cursor (or vice versa).
+    """
+    handler = _HANDLERS.get(event_type)
+    ts = datetime.now(timezone.utc).isoformat()
+    if handler is None:
+        # Unknown event type: log and advance the cursor anyway. A newer
+        # broker may introduce event types this proxy version doesn't
+        # handle; rather than wedging the subscriber, we skip and rely
+        # on the rebuild-cache fallback for full consistency.
+        _log.info("unknown federation event type %s — cursor advanced", event_type)
+    else:
+        await handler(conn, org_id, payload, ts)
+
+    await conn.execute(
+        text(
+            """INSERT INTO federation_cursor (org_id, last_seq, updated_at)
+               VALUES (:org_id, :seq, :ts)
+               ON CONFLICT (org_id) DO UPDATE SET
+                 last_seq=excluded.last_seq,
+                 updated_at=excluded.updated_at"""
+        ),
+        {"org_id": org_id, "seq": seq, "ts": ts},
+    )
+
+
+async def get_cursor(conn: AsyncConnection, org_id: str) -> int:
+    """Read last-applied seq for `org_id`, returning 0 if the subscriber
+    has never run before for this org."""
+    row = (
+        await conn.execute(
+            text("SELECT last_seq FROM federation_cursor WHERE org_id = :org_id"),
+            {"org_id": org_id},
+        )
+    ).first()
+    return int(row[0]) if row else 0

--- a/mcp_proxy/sync/subscriber.py
+++ b/mcp_proxy/sync/subscriber.py
@@ -1,0 +1,176 @@
+"""Federation SSE subscriber task (ADR-001 Phase 4b).
+
+Opens a long-lived `text/event-stream` connection to the broker's
+`/v1/broker/federation/events/stream` endpoint, applies each event to
+the proxy cache, and persists the cursor so a restart/reconnect resumes
+without replaying the full history.
+
+Reconnect strategy is exponential backoff with a ceiling, capped at a
+configurable maximum. Transient failures (network blip, broker reboot,
+token refresh) don't require human intervention.
+
+Auth is delegated to the caller: the subscriber takes a preconfigured
+`httpx.AsyncClient` (or async factory) plus a bearer-style headers dict.
+This keeps the subscriber agnostic to DPoP / mTLS / API-key choices —
+the wiring in `mcp_proxy/main.py` decides which credential flavor to
+use based on the deployment profile.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable
+
+import httpx
+
+from mcp_proxy.db import get_db
+from mcp_proxy.sync.handlers import apply_event, get_cursor
+
+_log = logging.getLogger("mcp_proxy.sync.subscriber")
+
+
+@dataclass
+class SubscriberConfig:
+    broker_url: str
+    org_id: str
+    # Factory so each reconnect gets a fresh client with fresh auth
+    # (DPoP proofs, SPIFFE cert, etc.). Returning an httpx.AsyncClient
+    # with appropriate base_url and headers is the caller's job.
+    client_factory: Callable[[], Awaitable[httpx.AsyncClient]]
+    initial_backoff_seconds: float = 1.0
+    max_backoff_seconds: float = 60.0
+    backoff_multiplier: float = 2.0
+    # If set, the subscriber stops after this many successful events —
+    # used by tests; None in production.
+    stop_after_events: int | None = None
+    # Observability counters; tests read these to assert behaviour
+    # without having to intercept log lines.
+    stats: "SubscriberStats" = field(default_factory=lambda: SubscriberStats())
+
+
+@dataclass
+class SubscriberStats:
+    connects: int = 0
+    reconnects: int = 0
+    events_applied: int = 0
+    last_applied_seq: int = 0
+    last_error: str | None = None
+
+
+async def run_subscriber(
+    cfg: SubscriberConfig,
+    *,
+    stop_event: asyncio.Event | None = None,
+) -> None:
+    """Main loop. Exits when `stop_event` is set or `stop_after_events`
+    is reached. Each reconnect reloads the cursor from the cache DB so
+    out-of-band rebuild-cache invocations are respected."""
+    backoff = cfg.initial_backoff_seconds
+    while stop_event is None or not stop_event.is_set():
+        try:
+            applied_this_session = await _run_once(cfg, stop_event=stop_event)
+            if cfg.stop_after_events is not None and \
+                    cfg.stats.events_applied >= cfg.stop_after_events:
+                return
+            if applied_this_session > 0:
+                backoff = cfg.initial_backoff_seconds
+        except Exception as exc:  # noqa: BLE001
+            cfg.stats.last_error = f"{type(exc).__name__}: {exc}"
+            cfg.stats.reconnects += 1
+            _log.warning(
+                "federation subscriber error: %s — reconnecting in %.1fs",
+                exc, backoff,
+            )
+        if stop_event is None:
+            await asyncio.sleep(backoff)
+        else:
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=backoff)
+                return
+            except asyncio.TimeoutError:
+                pass
+        backoff = min(backoff * cfg.backoff_multiplier, cfg.max_backoff_seconds)
+
+
+async def _run_once(
+    cfg: SubscriberConfig,
+    *,
+    stop_event: asyncio.Event | None,
+) -> int:
+    """Open one SSE stream, drain until it closes or we're asked to
+    stop. Returns the number of events applied during this attempt."""
+    async with get_db() as conn:
+        cursor = await get_cursor(conn, cfg.org_id)
+
+    client = await cfg.client_factory()
+    cfg.stats.connects += 1
+    applied = 0
+    try:
+        async with client.stream(
+            "GET",
+            f"{cfg.broker_url.rstrip('/')}/v1/broker/federation/events/stream",
+            headers={"Last-Event-ID": str(cursor)} if cursor else None,
+            timeout=httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0),
+        ) as resp:
+            resp.raise_for_status()
+            async for frame in _iter_sse_frames(resp):
+                if stop_event is not None and stop_event.is_set():
+                    return applied
+                seq = frame.get("id")
+                event_type = frame.get("event")
+                data = frame.get("data")
+                if seq is None or event_type is None or data is None:
+                    continue
+                if event_type == "connected":
+                    continue
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError:
+                    _log.warning("malformed SSE data frame — skipping")
+                    continue
+                seq_int = int(seq)
+                async with get_db() as conn:
+                    await apply_event(
+                        conn,
+                        org_id=cfg.org_id,
+                        seq=seq_int,
+                        event_type=event_type,
+                        payload=payload.get("payload", payload),
+                    )
+                cfg.stats.events_applied += 1
+                cfg.stats.last_applied_seq = seq_int
+                applied += 1
+                if cfg.stop_after_events is not None and \
+                        cfg.stats.events_applied >= cfg.stop_after_events:
+                    return applied
+    finally:
+        await client.aclose()
+    return applied
+
+
+async def _iter_sse_frames(resp: httpx.Response):
+    """Yield parsed SSE frames from `resp`. Each frame is a dict with
+    any of `id`, `event`, `data` fields set.
+
+    SSE wire format: consecutive lines of the form "field: value",
+    frames separated by a blank line. We ignore retry/comment lines.
+    """
+    current: dict[str, str] = {}
+    async for line in resp.aiter_lines():
+        if line == "":
+            if current:
+                yield current
+                current = {}
+            continue
+        if line.startswith(":"):
+            continue  # keepalive / comment
+        if ":" not in line:
+            continue
+        field_name, _, value = line.partition(":")
+        if value.startswith(" "):
+            value = value[1:]
+        current[field_name] = value
+    if current:
+        yield current

--- a/tests/test_proxy_federation_sync.py
+++ b/tests/test_proxy_federation_sync.py
@@ -1,0 +1,370 @@
+"""ADR-001 Phase 4b — proxy federation subscriber + cache handler tests.
+
+Two layers of coverage:
+
+1. Handler unit tests (synchronous apply_event against an in-memory
+   SQLite) — the fast, exhaustive layer.
+2. Subscriber integration test against a tiny in-process SSE server
+   built from Starlette + httpx ASGITransport — the reconnect-and-cursor
+   smoke. Heavy HTTP suites are not needed: the shape of the wire is
+   trivial and the handlers carry most of the logic risk.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from starlette.applications import Starlette
+from starlette.responses import StreamingResponse
+from starlette.routing import Route
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.sync.handlers import (
+    EVENT_AGENT_REGISTERED,
+    EVENT_AGENT_REVOKED,
+    EVENT_AGENT_ROTATED,
+    EVENT_BINDING_GRANTED,
+    EVENT_BINDING_REVOKED,
+    EVENT_POLICY_REMOVED,
+    EVENT_POLICY_UPDATED,
+    apply_event,
+    get_cursor,
+)
+from mcp_proxy.sync.subscriber import SubscriberConfig, run_subscriber
+
+
+# ── proxy_db fixture ───────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    await init_db(url)
+    yield url
+    await dispose_db()
+
+
+# ── Handler unit tests ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_registered_inserts_row(proxy_db):
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_AGENT_REGISTERED,
+            payload={
+                "agent_id": "acme::alice",
+                "display_name": "Alice",
+                "capabilities": ["cap.read"],
+            },
+        )
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT agent_id, org_id, display_name, capabilities, revoked "
+                 "FROM cached_federated_agents WHERE agent_id='acme::alice'")
+        )).first()
+    assert row is not None
+    assert row[0] == "acme::alice"
+    assert row[1] == "acme"
+    assert row[2] == "Alice"
+    assert json.loads(row[3]) == ["cap.read"]
+    assert row[4] == 0
+
+
+@pytest.mark.asyncio
+async def test_agent_registered_is_idempotent(proxy_db):
+    for _ in range(3):
+        async with get_db() as conn:
+            await apply_event(
+                conn, org_id="acme", seq=1,
+                event_type=EVENT_AGENT_REGISTERED,
+                payload={"agent_id": "acme::a", "capabilities": []},
+            )
+    async with get_db() as conn:
+        n = (await conn.execute(
+            text("SELECT COUNT(*) FROM cached_federated_agents")
+        )).scalar_one()
+    assert n == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_revoked_marks_revoked(proxy_db):
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "acme::b", "capabilities": []},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=2,
+            event_type=EVENT_AGENT_REVOKED,
+            payload={"agent_id": "acme::b", "reason": "compromised"},
+        )
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT revoked FROM cached_federated_agents WHERE agent_id='acme::b'")
+        )).first()
+    assert row[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_revoked_before_register_is_accepted(proxy_db):
+    """Proxy may join mid-stream and miss the original register event.
+    A bare revoke should still produce a cache row, so decisions using
+    the cache can safely treat 'unknown agent' as absent (not revoked
+    masquerading as present)."""
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_AGENT_REVOKED,
+            payload={"agent_id": "acme::ghost"},
+        )
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT revoked FROM cached_federated_agents WHERE agent_id='acme::ghost'")
+        )).first()
+    assert row is not None
+    assert row[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_agent_rotated_updates_thumbprint(proxy_db):
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "acme::c", "capabilities": []},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=2,
+            event_type=EVENT_AGENT_ROTATED,
+            payload={"agent_id": "acme::c", "thumbprint": "abcdef1234"},
+        )
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT thumbprint FROM cached_federated_agents WHERE agent_id='acme::c'")
+        )).first()
+    assert row[0] == "abcdef1234"
+
+
+@pytest.mark.asyncio
+async def test_policy_lifecycle(proxy_db):
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_POLICY_UPDATED,
+            payload={"policy_id": "p1", "policy_type": "session"},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=2,
+            event_type=EVENT_POLICY_REMOVED,
+            payload={"policy_id": "p1"},
+        )
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT is_active, policy_type FROM cached_policies WHERE policy_id='p1'")
+        )).first()
+    assert row[0] == 0
+    assert row[1] == "session"
+
+
+@pytest.mark.asyncio
+async def test_binding_lifecycle(proxy_db):
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_BINDING_GRANTED,
+            payload={"binding_id": 42, "agent_id": "acme::x", "scope": ["r"]},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=2,
+            event_type=EVENT_BINDING_REVOKED,
+            payload={"binding_id": 42, "agent_id": "acme::x"},
+        )
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT status, scope FROM cached_bindings WHERE binding_id=42")
+        )).first()
+    assert row[0] == "revoked"
+    assert json.loads(row[1]) == ["r"]
+
+
+@pytest.mark.asyncio
+async def test_cursor_advances_with_each_event(proxy_db):
+    async with get_db() as conn:
+        cur0 = await get_cursor(conn, "acme")
+        assert cur0 == 0
+
+        for i in range(1, 4):
+            await apply_event(
+                conn, org_id="acme", seq=i,
+                event_type=EVENT_AGENT_REGISTERED,
+                payload={"agent_id": f"acme::a{i}", "capabilities": []},
+            )
+
+        cur_final = await get_cursor(conn, "acme")
+    assert cur_final == 3
+
+
+@pytest.mark.asyncio
+async def test_unknown_event_advances_cursor_without_raising(proxy_db):
+    """Newer broker may emit event types this proxy version does not
+    know. Skipping gracefully keeps the subscriber from getting stuck."""
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=7,
+            event_type="agent.future-type",
+            payload={"some": "future"},
+        )
+        cur = await get_cursor(conn, "acme")
+    assert cur == 7
+
+
+# ── Subscriber integration ─────────────────────────────────────────
+
+
+def _make_sse_app(frames: list[str]):
+    """In-process SSE server that emits the given pre-formatted frames
+    then closes. Used to exercise the subscriber without a real broker."""
+    async def _stream(request):
+        async def _gen():
+            for frame in frames:
+                yield frame
+                await asyncio.sleep(0)  # cooperative
+        return StreamingResponse(_gen(), media_type="text/event-stream")
+    return Starlette(routes=[
+        Route("/v1/broker/federation/events/stream", _stream),
+    ])
+
+
+@pytest.mark.asyncio
+async def test_subscriber_applies_frames_and_updates_cursor(proxy_db):
+    frames = [
+        "event: connected\ndata: {\"cursor\":0}\n\n",
+        'id: 1\nevent: agent.registered\n'
+        'data: {"agent_id":"acme::svc","capabilities":["cap.a"]}\n\n',
+        'id: 2\nevent: org.policy.updated\n'
+        'data: {"policy_id":"policy-alpha","policy_type":"session"}\n\n',
+    ]
+    sse_app = _make_sse_app(frames)
+
+    async def _factory():
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=sse_app),
+            base_url="http://broker.test",
+        )
+
+    cfg = SubscriberConfig(
+        broker_url="http://broker.test",
+        org_id="acme",
+        client_factory=_factory,
+        initial_backoff_seconds=0.01,
+        max_backoff_seconds=0.01,
+        stop_after_events=2,
+    )
+    stop = asyncio.Event()
+    await asyncio.wait_for(
+        run_subscriber(cfg, stop_event=stop), timeout=5.0,
+    )
+
+    assert cfg.stats.events_applied == 2
+    assert cfg.stats.last_applied_seq == 2
+
+    async with get_db() as conn:
+        cur = await get_cursor(conn, "acme")
+        assert cur == 2
+        a = (await conn.execute(
+            text("SELECT agent_id FROM cached_federated_agents")
+        )).first()
+        assert a[0] == "acme::svc"
+        p = (await conn.execute(
+            text("SELECT policy_id, is_active FROM cached_policies")
+        )).first()
+        assert p[0] == "policy-alpha"
+        assert p[1] == 1
+
+
+@pytest.mark.asyncio
+async def test_subscriber_resumes_from_persisted_cursor(proxy_db):
+    # Pre-populate the cursor so the subscriber should send
+    # Last-Event-ID: 5 and skip everything <= 5.
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=5,
+            event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "acme::pre", "capabilities": []},
+        )
+
+    captured_headers: dict[str, str] = {}
+
+    async def _stream(request):
+        captured_headers.update(dict(request.headers))
+        async def _gen():
+            yield "event: connected\ndata: {\"cursor\":5}\n\n"
+            yield ('id: 6\nevent: agent.registered\n'
+                   'data: {"agent_id":"acme::new","capabilities":[]}\n\n')
+        return StreamingResponse(_gen(), media_type="text/event-stream")
+
+    sse_app = Starlette(routes=[
+        Route("/v1/broker/federation/events/stream", _stream),
+    ])
+
+    async def _factory():
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=sse_app),
+            base_url="http://broker.test",
+        )
+
+    cfg = SubscriberConfig(
+        broker_url="http://broker.test",
+        org_id="acme",
+        client_factory=_factory,
+        initial_backoff_seconds=0.01,
+        stop_after_events=1,
+    )
+    await asyncio.wait_for(run_subscriber(cfg), timeout=5.0)
+
+    # The subscriber MUST send the cursor so the broker skips the
+    # backlog the proxy has already applied.
+    assert captured_headers.get("last-event-id") == "5"
+    assert cfg.stats.last_applied_seq == 6
+
+
+@pytest.mark.asyncio
+async def test_subscriber_backs_off_on_connect_failure(proxy_db):
+    """If the client factory raises, the subscriber must retry with
+    backoff rather than crash the proxy lifespan."""
+    attempts = {"n": 0}
+
+    async def _factory():
+        attempts["n"] += 1
+        raise RuntimeError("broker unreachable")
+
+    cfg = SubscriberConfig(
+        broker_url="http://broker.test",
+        org_id="acme",
+        client_factory=_factory,
+        initial_backoff_seconds=0.01,
+        max_backoff_seconds=0.02,
+    )
+    stop = asyncio.Event()
+
+    async def _stop_soon():
+        await asyncio.sleep(0.08)
+        stop.set()
+
+    await asyncio.gather(
+        run_subscriber(cfg, stop_event=stop),
+        _stop_soon(),
+    )
+    assert attempts["n"] >= 2
+    assert cfg.stats.reconnects >= 1
+    assert "broker unreachable" in (cfg.stats.last_error or "")

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -27,6 +27,10 @@ EXPECTED_TABLES = {
     "local_policies",
     "local_audit",
     "pending_enrollments",
+    "cached_federated_agents",
+    "cached_policies",
+    "cached_bindings",
+    "federation_cursor",
     "alembic_version",
 }
 
@@ -61,7 +65,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0003_add_pending_enrollments",)]
+    assert rows == [("0004_add_federation_cache",)]
 
 
 @pytest.mark.asyncio
@@ -121,7 +125,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0003_add_pending_enrollments",)]
+    assert version == [("0004_add_federation_cache",)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- New Alembic migration `0004_add_federation_cache` introducing 3 cache tables (`cached_federated_agents`, `cached_policies`, `cached_bindings`) + a per-org `federation_cursor`.
- `mcp_proxy/sync/handlers.py` — `apply_event` dispatch for the 7 Phase 4a event types. Idempotent UPSERTs; cursor bump runs in the same transaction so cache and cursor cannot diverge mid-apply. Unknown event types advance the cursor without raising (newer broker won't wedge older proxy).
- `mcp_proxy/sync/subscriber.py` — long-lived task with exponential backoff + cursor-resume via SSE `Last-Event-ID`. Auth delegated to a `client_factory` callable (DPoP / mTLS / API-key agnostic).

Stacked on #83 (Phase 4a). Wiring into the proxy lifespan + `cullis-proxy rebuild-cache` CLI land in Phase 4c.

## Test plan
- [x] `pytest tests/test_proxy_federation_sync.py` — 12/12 (all 7 handlers incl. revoke-before-register edge case + unknown-event skip, cursor monotonicity, backlog drain, Last-Event-ID resume, connect-failure backoff)
- [x] `pytest tests/test_proxy_migrations.py` — head bumped to `0004_add_federation_cache`
- [x] Full suite parallel: 728 passed, 5 skipped (2 pre-existing postgres failures on main)
- [x] `./demo_network/smoke.sh full` passes