### PR TITLE
feat(proxy): ADR-001 Phase 4c — rebuild-cache CLI + lifespan wiring

### DIFF
--- a/mcp_proxy/cli/__init__.py
+++ b/mcp_proxy/cli/__init__.py
@@ -1,0 +1,97 @@
+"""cullis-proxy CLI — operational commands for the proxy.
+
+Entry point: `python -m mcp_proxy.cli <subcommand>`.
+
+Subcommands:
+  rebuild-cache    Drop and re-fetch the federation cache from the broker.
+
+Each subcommand is a thin async wrapper around helpers that live next
+to the runtime code (e.g. mcp_proxy.sync.cache_admin) so the CLI itself
+stays trivial and the operational logic stays unit-testable.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.sync.cache_admin import drop_federation_cache
+
+_log = logging.getLogger("mcp_proxy.cli")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cullis-proxy",
+        description="Operational CLI for the Cullis MCP Proxy.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    rebuild = sub.add_parser(
+        "rebuild-cache",
+        help="Drop the federation cache so the subscriber re-fetches "
+        "every event on next start. Safe to run on a live proxy: the "
+        "subscriber will replay from seq=0 and converge in seconds.",
+    )
+    rebuild.add_argument(
+        "--yes", action="store_true",
+        help="Skip the interactive confirmation prompt.",
+    )
+
+    return parser
+
+
+async def _cmd_rebuild_cache(args: argparse.Namespace) -> int:
+    if not args.yes:
+        # Reading from stdin keeps the prompt out of the test path —
+        # tests always pass --yes. Operators see a clear warning.
+        sys.stderr.write(
+            "This will DROP all rows in cached_federated_agents, "
+            "cached_policies, cached_bindings, and reset the federation "
+            "cursor for this proxy. The subscriber will refetch from "
+            "the broker on next connection.\n"
+            "Continue? [y/N]: "
+        )
+        sys.stderr.flush()
+        ans = sys.stdin.readline().strip().lower()
+        if ans not in ("y", "yes"):
+            sys.stderr.write("aborted\n")
+            return 1
+
+    settings = get_settings()
+    await init_db(settings.database_url)
+    try:
+        counts = await drop_federation_cache()
+    finally:
+        await dispose_db()
+
+    sys.stdout.write(
+        f"federation cache dropped: "
+        f"agents={counts['agents']}, "
+        f"policies={counts['policies']}, "
+        f"bindings={counts['bindings']}, "
+        f"cursor_rows={counts['cursor']}\n"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "rebuild-cache":
+        return asyncio.run(_cmd_rebuild_cache(args))
+
+    parser.print_help(sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -77,6 +77,12 @@ class ProxySettings(BaseSettings):
     trust_domain: str = "cullis.local"
     intra_org_routing: bool = False
 
+    # ADR-001 Phase 4c — Federation cache subscriber.
+    # When enabled, a long-lived task tails the broker's federation
+    # event stream and mirrors agent / policy / binding state into
+    # local cache tables. Default off — flip via PROXY_FEDERATION_SYNC.
+    federation_sync_enabled: bool = False
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")
@@ -92,6 +98,11 @@ class ProxySettings(BaseSettings):
         flag = os.environ.get("PROXY_INTRA_ORG")
         if flag is not None:
             self.intra_org_routing = flag.lower() in ("1", "true", "yes", "on")
+        sync_flag = os.environ.get("PROXY_FEDERATION_SYNC")
+        if sync_flag is not None:
+            self.federation_sync_enabled = sync_flag.lower() in (
+                "1", "true", "yes", "on",
+            )
         return self
 
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -141,6 +141,41 @@ async def lifespan(app: FastAPI):
         app.state.local_sweeper_stop = stop_event
         app.state.local_sweeper_task = sweeper_task
 
+    # Phase 4c — federation SSE subscriber. Wires the Phase 4b cache
+    # to the live broker stream. Off by default; flip via
+    # PROXY_FEDERATION_SYNC=true. The auth surface (DPoP / mTLS / SPIFFE)
+    # is delegated to an externally-provided client factory set on
+    # `app.state.federation_subscriber_factory`. Wiring an actual
+    # credential is a follow-up — keeping the factory injectable lets
+    # deployments pick the auth flavor without forking this module.
+    if settings.federation_sync_enabled and broker_url and org_id:
+        factory = getattr(app.state, "federation_subscriber_factory", None)
+        if factory is None:
+            _log.warning(
+                "PROXY_FEDERATION_SYNC=on but no "
+                "federation_subscriber_factory registered on app.state "
+                "— subscriber not started. Set one before app startup.",
+            )
+        else:
+            from mcp_proxy.sync.subscriber import (
+                SubscriberConfig,
+                run_subscriber,
+            )
+            sub_cfg = SubscriberConfig(
+                broker_url=broker_url,
+                org_id=org_id,
+                client_factory=factory,
+            )
+            sub_stop = asyncio.Event()
+            sub_task = asyncio.create_task(
+                run_subscriber(sub_cfg, stop_event=sub_stop),
+                name="federation_subscriber",
+            )
+            app.state.federation_subscriber_stop = sub_stop
+            app.state.federation_subscriber_task = sub_task
+            app.state.federation_subscriber_stats = sub_cfg.stats
+            _log.info("federation subscriber started (org=%s)", org_id)
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
@@ -160,6 +195,20 @@ async def lifespan(app: FastAPI):
             sweeper_task.cancel()
             try:
                 await sweeper_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    sub_stop = getattr(app.state, "federation_subscriber_stop", None)
+    sub_task = getattr(app.state, "federation_subscriber_task", None)
+    if sub_stop is not None:
+        sub_stop.set()
+    if sub_task is not None:
+        try:
+            await asyncio.wait_for(sub_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            sub_task.cancel()
+            try:
+                await sub_task
             except (asyncio.CancelledError, Exception):
                 pass
 

--- a/mcp_proxy/sync/cache_admin.py
+++ b/mcp_proxy/sync/cache_admin.py
@@ -1,0 +1,39 @@
+"""Operational helpers for the federation cache (ADR-001 Phase 4c).
+
+Kept in `sync/` rather than `cli/` so unit tests can exercise the
+truncate logic without touching argparse.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+
+
+async def drop_federation_cache() -> dict[str, int]:
+    """Truncate the four federation cache tables and return the per-table
+    row counts that were removed.
+
+    Safe to call on a live proxy: the subscriber will reopen its SSE
+    connection (or hit the next reconnect tick), see cursor=0, and
+    re-apply the full broker history. While the cache is empty,
+    intra-org decisions that consult it will see "agent unknown" and
+    behave as the proxy did before Phase 4 — the broker remains
+    authoritative for any decision the cache was only accelerating.
+    """
+    counts: dict[str, int] = {}
+    async with get_db() as conn:
+        # Order matters only for foreign-key consistency, of which we
+        # have none; alphabetize for determinism.
+        for table, key in (
+            ("cached_federated_agents", "agents"),
+            ("cached_policies", "policies"),
+            ("cached_bindings", "bindings"),
+            ("federation_cursor", "cursor"),
+        ):
+            n = (
+                await conn.execute(text(f"SELECT COUNT(*) FROM {table}"))
+            ).scalar_one()
+            await conn.execute(text(f"DELETE FROM {table}"))
+            counts[key] = int(n)
+    return counts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ connector = [
 
 [project.scripts]
 cullis-connector = "cullis_connector.cli:main"
+cullis-proxy = "mcp_proxy.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["cullis_sdk", "cullis_connector"]

--- a/tests/test_proxy_cli_rebuild_cache.py
+++ b/tests/test_proxy_cli_rebuild_cache.py
@@ -1,0 +1,124 @@
+"""ADR-001 Phase 4c — `cullis-proxy rebuild-cache` CLI tests."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.cli import main as cli_main
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.sync.cache_admin import drop_federation_cache
+from mcp_proxy.sync.handlers import (
+    EVENT_AGENT_REGISTERED,
+    EVENT_BINDING_GRANTED,
+    EVENT_POLICY_UPDATED,
+    apply_event,
+)
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    # Settings is lru_cache'd — flush so the rebuild-cache command
+    # reads the test database URL, not the dev default.
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield url
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+# ── drop_federation_cache helper ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_drop_federation_cache_returns_counts(proxy_db):
+    async with get_db() as conn:
+        await apply_event(
+            conn, org_id="acme", seq=1,
+            event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "acme::a", "capabilities": []},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=2,
+            event_type=EVENT_AGENT_REGISTERED,
+            payload={"agent_id": "acme::b", "capabilities": []},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=3,
+            event_type=EVENT_POLICY_UPDATED,
+            payload={"policy_id": "p1", "policy_type": "session"},
+        )
+        await apply_event(
+            conn, org_id="acme", seq=4,
+            event_type=EVENT_BINDING_GRANTED,
+            payload={"binding_id": 9, "agent_id": "acme::a", "scope": []},
+        )
+
+    counts = await drop_federation_cache()
+    assert counts == {"agents": 2, "policies": 1, "bindings": 1, "cursor": 1}
+
+    async with get_db() as conn:
+        for table in (
+            "cached_federated_agents", "cached_policies",
+            "cached_bindings", "federation_cursor",
+        ):
+            n = (await conn.execute(text(f"SELECT COUNT(*) FROM {table}"))).scalar_one()
+            assert n == 0, f"{table} not empty after drop"
+
+
+@pytest.mark.asyncio
+async def test_drop_federation_cache_on_empty_db_is_noop(proxy_db):
+    counts = await drop_federation_cache()
+    assert counts == {"agents": 0, "policies": 0, "bindings": 0, "cursor": 0}
+
+
+# ── CLI integration ────────────────────────────────────────────────
+
+
+def test_cli_rebuild_cache_with_yes_flag(proxy_db, capsys):
+    """Invoke `cullis-proxy rebuild-cache --yes` end-to-end and assert
+    the human-readable summary line lands on stdout."""
+    # Pre-seed via async helper so the CLI has rows to drop.
+    async def _seed():
+        async with get_db() as conn:
+            await apply_event(
+                conn, org_id="acme", seq=1,
+                event_type=EVENT_AGENT_REGISTERED,
+                payload={"agent_id": "acme::seed", "capabilities": []},
+            )
+    asyncio.run(_seed())
+
+    rc = cli_main(["rebuild-cache", "--yes"])
+    assert rc == 0
+
+    captured = capsys.readouterr()
+    assert "federation cache dropped" in captured.out
+    assert "agents=1" in captured.out
+
+
+def test_cli_rebuild_cache_aborts_without_yes(proxy_db, monkeypatch, capsys):
+    """Without `--yes`, the CLI prompts on stderr and aborts on a `n`
+    answer. We pipe `n\\n` into stdin to confirm the abort path."""
+    import io
+    monkeypatch.setattr("sys.stdin", io.StringIO("n\n"))
+    rc = cli_main(["rebuild-cache"])
+    assert rc == 1
+
+    err = capsys.readouterr().err
+    assert "Continue?" in err
+    assert "aborted" in err
+
+
+def test_cli_no_subcommand_prints_help(capsys):
+    """Bare `cullis-proxy` invocation must show help, not crash."""
+    with pytest.raises(SystemExit) as exc:
+        cli_main([])
+    # argparse exits with 2 when required subcommand is missing.
+    assert exc.value.code == 2


### PR DESCRIPTION
## Summary
- New `cullis-proxy` console script (entry point in `pyproject.toml`) with `rebuild-cache` subcommand. Truncates the four federation cache tables; subscriber replays from seq=0 on next connect.
- `mcp_proxy/sync/cache_admin.py` — `drop_federation_cache()` helper kept out of argparse for unit testing.
- Lifespan wiring (gated by `PROXY_FEDERATION_SYNC=true` + `broker_url` + `org_id`): spawns the Phase 4b subscriber as a background task, cleans it up on shutdown next to the local sweeper.
- Auth surface delegated to an externally-provided callable on `app.state.federation_subscriber_factory`. Keeps the wiring DPoP/mTLS/SPIFFE-agnostic. A clear warning is logged when the flag is on but no factory is registered (no crash).

**Closes Phase 4 of ADR-001** (PR #83 + #85 + this).

## Test plan
- [x] `pytest tests/test_proxy_cli_rebuild_cache.py` — 5/5 (drop helper with/without rows, `--yes` path, interactive abort, bare-invocation help)
- [x] Full suite parallel: 733 passed, 5 skipped
- [x] `./demo_network/smoke.sh full` passes