### PR TITLE
fix(proxy): add missing authlib dep (PR #87 regression)

### DIFF
--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -15,3 +15,4 @@ jinja2>=3.1.0
 starlette>=0.40.0,<1.0.0
 sse-starlette>=2.0,<3.0
 python-multipart>=0.0.20
+authlib>=1.3.0


### PR DESCRIPTION
## Summary
- PR #87 added `mcp_proxy/dashboard/oidc.py` which imports `from authlib.jose import ...`
- The top-level `requirements.txt` already has `authlib>=1.3.0`
- But `mcp_proxy/requirements-proxy.txt` (used to build the proxy image) was missing it
- Any call to `GET /proxy/oidc/start` returned HTTP 500 with `ModuleNotFoundError: No module named 'authlib'` at runtime
- Caught during enterprise_sandbox shake-out

## Test plan
- [x] authlib now present in `mcp_proxy/requirements-proxy.txt`
- [x] Verified by rebuilding proxy image and re-running `GET /proxy/oidc/start` → now returns 303 redirect to IdP
- [ ] CI green