### PR TITLE
feat(sdk): SPIFFE Workload API authentication

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -195,6 +195,56 @@ class CullisClient:
             raise RuntimeError("Not enrolled — use from_enrollment() or set proxy credentials")
         return {"X-API-Key": self._proxy_api_key, "Content-Type": "application/json"}
 
+    # ── SPIFFE Workload API bootstrap ───────────────────────────────
+
+    @classmethod
+    def from_spiffe_workload_api(
+        cls,
+        broker_url: str,
+        *,
+        org_id: str,
+        socket_path: str | None = None,
+        agent_id: str | None = None,
+        verify_tls: bool = True,
+        timeout: float = 10.0,
+    ) -> CullisClient:
+        """Bootstrap a broker-connected client using a SPIFFE X.509-SVID.
+
+        Fetches the workload's SVID from the local SPIFFE Workload API
+        (typically a SPIRE agent Unix socket), then authenticates to the
+        broker using that certificate. Requires the ``[spiffe]`` extra.
+
+        The Org CA must be configured as the SPIRE server's UpstreamAuthority
+        so that SVIDs chain to a root the broker trusts.
+
+        Args:
+            broker_url: Cullis broker base URL.
+            org_id: Cullis org identifier (the broker's view of the org).
+            socket_path: Workload API socket. Defaults to
+                ``SPIFFE_ENDPOINT_SOCKET`` env var.
+            agent_id: Override the default SPIFFE ID → agent_id mapping.
+                If None, uses ``{org_id}::{last_spiffe_path_segment}``.
+            verify_tls: Whether to verify the broker's TLS cert.
+            timeout: HTTP timeout in seconds.
+
+        Example::
+
+            client = CullisClient.from_spiffe_workload_api(
+                "https://broker.cullis.test",
+                org_id="orga",
+                socket_path="/tmp/spire-agent/public/api.sock",
+            )
+        """
+        from cullis_sdk.spiffe import fetch_x509_svid, default_agent_id
+
+        svid = fetch_x509_svid(socket_path)
+        resolved_agent_id = agent_id or default_agent_id(svid.spiffe_id, org_id)
+
+        instance = cls(broker_url, verify_tls=verify_tls, timeout=timeout)
+        instance.login_from_pem(resolved_agent_id, org_id, svid.cert_pem, svid.key_pem)
+        log(f"Authenticated {resolved_agent_id} via SPIFFE ({svid.spiffe_id})")
+        return instance
+
     # ── Broker authentication ──────────────────────────────────────
 
     def login(self, agent_id: str, org_id: str, cert_path: str, key_path: str) -> None:

--- a/cullis_sdk/spiffe.py
+++ b/cullis_sdk/spiffe.py
@@ -1,0 +1,153 @@
+"""
+SPIFFE Workload API integration for Cullis SDK.
+
+Lets Cullis agents fetch their X.509-SVID identity from a local SPIRE agent
+(or any SPIFFE Workload API provider) over a Unix domain socket, instead of
+reading cert/key from disk.
+
+Requires the optional ``[spiffe]`` extra::
+
+    pip install cullis-agent-sdk[spiffe]
+
+Design notes:
+- Thin wrapper over ``pyspiffe`` — all heavy lifting (gRPC, rotation streams)
+  is upstream. We only expose what the SDK needs: fetch a single SVID and
+  return PEM bundles.
+- The enterprise operator decides the SPIFFE ID → Cullis agent_id mapping.
+  See ``parse_spiffe_id()`` for the default convention.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from cryptography.hazmat.primitives import serialization
+
+if TYPE_CHECKING:
+    from cryptography.x509 import Certificate
+
+
+_INSTALL_HINT = (
+    "SPIFFE support requires the optional dependency. Install with:\n"
+    "    pip install cullis-agent-sdk[spiffe]"
+)
+
+
+@dataclass
+class SpiffeSvid:
+    """An X.509-SVID fetched from the Workload API."""
+
+    spiffe_id: str
+    cert_pem: str
+    key_pem: str
+    trust_bundle_pem: str
+
+
+def fetch_x509_svid(socket_path: str | None = None) -> SpiffeSvid:
+    """Fetch a single X.509-SVID from the local Workload API.
+
+    Args:
+        socket_path: Path to the Workload API Unix socket. If ``None``, falls
+            back to the ``SPIFFE_ENDPOINT_SOCKET`` environment variable
+            (the SPIFFE standard convention).
+
+    Returns:
+        SpiffeSvid with the PEM cert, key, trust bundle, and the SPIFFE ID URI.
+
+    Raises:
+        ImportError: if the ``[spiffe]`` extra is not installed.
+        RuntimeError: if no socket path is provided or the Workload API
+            returns no SVID for this workload.
+    """
+    try:
+        from pyspiffe.workloadapi.default_workload_api_client import (
+            DefaultWorkloadApiClient,
+        )
+    except ImportError as e:  # pragma: no cover — tested via monkeypatch
+        raise ImportError(_INSTALL_HINT) from e
+
+    endpoint = socket_path or os.environ.get("SPIFFE_ENDPOINT_SOCKET")
+    if not endpoint:
+        raise RuntimeError(
+            "No Workload API socket provided. Pass socket_path=... or set "
+            "SPIFFE_ENDPOINT_SOCKET environment variable."
+        )
+
+    if not endpoint.startswith("unix://"):
+        endpoint = f"unix://{endpoint}"
+
+    client = DefaultWorkloadApiClient(spiffe_socket_path=endpoint)
+    try:
+        svid = client.fetch_x509_svid()
+        bundle_set = client.fetch_x509_bundles()
+    finally:
+        client.close()
+
+    return _to_pem_bundle(svid, bundle_set)
+
+
+def _to_pem_bundle(svid, bundle_set) -> SpiffeSvid:
+    """Convert pyspiffe objects into our PEM-based SpiffeSvid.
+
+    Kept as a separate function so tests can exercise the conversion without
+    a real Workload API socket.
+    """
+    leaf: Certificate = svid.cert_chain[0]
+    cert_pem_parts = [
+        c.public_bytes(serialization.Encoding.PEM).decode()
+        for c in svid.cert_chain
+    ]
+    key_pem = svid.private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+    spiffe_id = str(svid.spiffe_id)
+    trust_domain = svid.spiffe_id.trust_domain
+    bundle = bundle_set.get_x509_bundle_for_trust_domain(trust_domain)
+    bundle_pem = "\n".join(
+        c.public_bytes(serialization.Encoding.PEM).decode()
+        for c in bundle.x509_authorities
+    )
+
+    del leaf  # only used for type narrowing above
+    return SpiffeSvid(
+        spiffe_id=spiffe_id,
+        cert_pem="".join(cert_pem_parts),
+        key_pem=key_pem,
+        trust_bundle_pem=bundle_pem,
+    )
+
+
+def parse_spiffe_id(spiffe_id: str) -> tuple[str, str]:
+    """Split a SPIFFE ID URI into (trust_domain, path).
+
+    Example:
+        >>> parse_spiffe_id("spiffe://orga.sandbox/agents/agent-a")
+        ('orga.sandbox', 'agents/agent-a')
+    """
+    if not spiffe_id.startswith("spiffe://"):
+        raise ValueError(f"Not a SPIFFE ID URI: {spiffe_id!r}")
+    rest = spiffe_id[len("spiffe://"):]
+    if "/" not in rest:
+        raise ValueError(f"SPIFFE ID has no path: {spiffe_id!r}")
+    td, path = rest.split("/", 1)
+    return td, path
+
+
+def default_agent_id(spiffe_id: str, org_id: str) -> str:
+    """Default SPIFFE ID → Cullis agent_id mapping.
+
+    Takes the *last* path segment as the agent short name and prefixes it
+    with ``org_id::``. Operators with a different naming convention can
+    parse ``spiffe_id`` themselves and build the agent_id manually.
+
+    Example:
+        spiffe://orga.sandbox/agent-a   → orga::agent-a
+        spiffe://orga.sandbox/prod/api  → orga::api
+    """
+    _, path = parse_spiffe_id(spiffe_id)
+    name = path.rsplit("/", 1)[-1]
+    return f"{org_id}::{name}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ connector = [
     "mcp>=1.0",
     "PyYAML>=6.0",
 ]
+spiffe = [
+    "pyspiffe>=0.1.2",
+]
 
 [project.scripts]
 cullis-connector = "cullis_connector.cli:main"

--- a/tests/test_sdk_spiffe.py
+++ b/tests/test_sdk_spiffe.py
@@ -1,0 +1,172 @@
+"""Unit tests for cullis_sdk.spiffe — SPIFFE Workload API integration."""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from unittest.mock import patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from cullis_sdk.spiffe import (
+    SpiffeSvid,
+    _to_pem_bundle,
+    default_agent_id,
+    fetch_x509_svid,
+    parse_spiffe_id,
+)
+
+
+# ── Helpers: build a fake SVID that mimics pyspiffe's object shape ──
+
+def _mint_cert(subject_cn: str, spiffe_uri: str) -> tuple[x509.Certificate, ec.EllipticCurvePrivateKey]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_cn)]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "fake-ca")]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_uri)]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return cert, key
+
+
+@dataclass
+class _FakeTrustDomain:
+    name: str
+
+    def __str__(self) -> str:
+        return self.name
+
+
+@dataclass
+class _FakeSpiffeId:
+    uri: str
+    trust_domain: _FakeTrustDomain
+
+    def __str__(self) -> str:
+        return self.uri
+
+
+@dataclass
+class _FakeSvid:
+    spiffe_id: _FakeSpiffeId
+    cert_chain: list
+    private_key: object
+
+
+@dataclass
+class _FakeBundle:
+    x509_authorities: list
+
+
+@dataclass
+class _FakeBundleSet:
+    bundle: _FakeBundle
+
+    def get_x509_bundle_for_trust_domain(self, td):
+        return self.bundle
+
+
+# ── parse_spiffe_id ──────────────────────────────────────────────────
+
+def test_parse_spiffe_id_simple():
+    assert parse_spiffe_id("spiffe://orga.sandbox/agent-a") == (
+        "orga.sandbox", "agent-a",
+    )
+
+
+def test_parse_spiffe_id_nested_path():
+    assert parse_spiffe_id("spiffe://orga.sandbox/prod/api") == (
+        "orga.sandbox", "prod/api",
+    )
+
+
+def test_parse_spiffe_id_rejects_non_spiffe():
+    with pytest.raises(ValueError, match="Not a SPIFFE ID"):
+        parse_spiffe_id("https://example.com/foo")
+
+
+def test_parse_spiffe_id_rejects_missing_path():
+    with pytest.raises(ValueError, match="no path"):
+        parse_spiffe_id("spiffe://orga.sandbox")
+
+
+# ── default_agent_id ─────────────────────────────────────────────────
+
+def test_default_agent_id_uses_last_segment():
+    assert default_agent_id("spiffe://orga.sandbox/agent-a", "orga") == "orga::agent-a"
+
+
+def test_default_agent_id_strips_intermediate_path():
+    assert default_agent_id("spiffe://orga.sandbox/prod/api", "orga") == "orga::api"
+
+
+# ── _to_pem_bundle ───────────────────────────────────────────────────
+
+def test_to_pem_bundle_roundtrip():
+    leaf, key = _mint_cert("agent-a", "spiffe://orga.sandbox/agent-a")
+    root, _ = _mint_cert("fake-ca", "spiffe://orga.sandbox")
+    td = _FakeTrustDomain("orga.sandbox")
+    svid = _FakeSvid(
+        spiffe_id=_FakeSpiffeId("spiffe://orga.sandbox/agent-a", td),
+        cert_chain=[leaf],
+        private_key=key,
+    )
+    bundle_set = _FakeBundleSet(_FakeBundle([root]))
+
+    result = _to_pem_bundle(svid, bundle_set)
+
+    assert isinstance(result, SpiffeSvid)
+    assert result.spiffe_id == "spiffe://orga.sandbox/agent-a"
+    assert "BEGIN CERTIFICATE" in result.cert_pem
+    assert "BEGIN PRIVATE KEY" in result.key_pem
+    assert "BEGIN CERTIFICATE" in result.trust_bundle_pem
+    # Key re-parses cleanly
+    serialization.load_pem_private_key(result.key_pem.encode(), password=None)
+    # Cert re-parses cleanly
+    parsed = x509.load_pem_x509_certificate(result.cert_pem.encode())
+    san = parsed.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    uris = [str(u) for u in san.value.get_values_for_type(x509.UniformResourceIdentifier)]
+    assert "spiffe://orga.sandbox/agent-a" in uris
+
+
+# ── fetch_x509_svid — ImportError path ───────────────────────────────
+
+def test_fetch_x509_svid_without_extra_raises_importerror():
+    """If pyspiffe isn't installed, the error must be actionable."""
+    import builtins
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("pyspiffe"):
+            raise ImportError("no pyspiffe")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(ImportError, match=r"pip install cullis-agent-sdk\[spiffe\]"):
+            fetch_x509_svid("/tmp/bogus.sock")
+
+
+def test_fetch_x509_svid_without_socket_raises():
+    """Missing socket + no env var → clear RuntimeError."""
+    # Need pyspiffe importable for the ImportError check to pass; if not
+    # installed in the dev env, this test is equivalent to the ImportError
+    # path above. Skip cleanly when missing.
+    pytest.importorskip("pyspiffe")
+    import os
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("SPIFFE_ENDPOINT_SOCKET", None)
+        with pytest.raises(RuntimeError, match="No Workload API socket"):
+            fetch_x509_svid(None)


### PR DESCRIPTION
## Summary

First mile of Blocco 4 sandbox integration — makes the SDK consume SPIFFE-issued X.509-SVIDs natively, so Cullis agents can live in enterprises that already run SPIRE without bolting on a separate cert distribution mechanism.

- New optional dependency: `pip install cullis-agent-sdk[spiffe]` (pulls `pyspiffe`, which brings `grpcio`)
- New `cullis_sdk/spiffe.py` — thin wrapper exposing `fetch_x509_svid(socket_path)`
- New factory `CullisClient.from_spiffe_workload_api(broker_url, org_id, socket_path=...)`
- Default SPIFFE ID → Cullis `agent_id` mapping: `{org_id}::{last_path_segment}`, overridable
- Base SDK install unchanged — `from_spiffe_workload_api()` raises `ImportError` with a clear install hint if the extra isn't present

## Architectural note

This PR only lets the SDK *consume* SVIDs. For the end-to-end flow to work against a Cullis broker, the enterprise operator must configure SPIRE with `UpstreamAuthority` = Cullis Org CA, so issued SVIDs chain to a root the broker already trusts. Agent *registration* in the broker is unchanged — SPIFFE only replaces the cert-distribution step.

Sandbox wiring (SPIRE server+agent, registration entries, smoke assertions) is the next PR and lives on `feat/enterprise-sandbox`.

## Test plan

- [x] 9 unit tests, `tests/test_sdk_spiffe.py` — mocks pyspiffe objects so the suite doesn't need a live Workload API socket
- [x] Full pytest suite: 733 passed, 2 pre-existing postgres-integration failures unrelated to this change
- [ ] End-to-end validation via sandbox Blocco 4 (follow-up PR)