### PR TITLE
fix(sdk): use 'spiffe' package, not 'pyspiffe'

### DIFF
--- a/cullis_sdk/spiffe.py
+++ b/cullis_sdk/spiffe.py
@@ -10,8 +10,8 @@ Requires the optional ``[spiffe]`` extra::
     pip install cullis-agent-sdk[spiffe]
 
 Design notes:
-- Thin wrapper over ``pyspiffe`` — all heavy lifting (gRPC, rotation streams)
-  is upstream. We only expose what the SDK needs: fetch a single SVID and
+- Thin wrapper over the ``spiffe`` package (py-spiffe) — all heavy lifting
+  (gRPC, rotation streams) is upstream. We only expose what the SDK needs: fetch a single SVID and
   return PEM bundles.
 - The enterprise operator decides the SPIFFE ID → Cullis agent_id mapping.
   See ``parse_spiffe_id()`` for the default convention.
@@ -61,9 +61,7 @@ def fetch_x509_svid(socket_path: str | None = None) -> SpiffeSvid:
             returns no SVID for this workload.
     """
     try:
-        from pyspiffe.workloadapi.default_workload_api_client import (
-            DefaultWorkloadApiClient,
-        )
+        from spiffe import WorkloadApiClient
     except ImportError as e:  # pragma: no cover — tested via monkeypatch
         raise ImportError(_INSTALL_HINT) from e
 
@@ -77,18 +75,25 @@ def fetch_x509_svid(socket_path: str | None = None) -> SpiffeSvid:
     if not endpoint.startswith("unix://"):
         endpoint = f"unix://{endpoint}"
 
-    client = DefaultWorkloadApiClient(spiffe_socket_path=endpoint)
+    # WorkloadApiClient reads SPIFFE_ENDPOINT_SOCKET from env; override it
+    # locally so callers can pass socket_path explicitly.
+    old = os.environ.get("SPIFFE_ENDPOINT_SOCKET")
+    os.environ["SPIFFE_ENDPOINT_SOCKET"] = endpoint
     try:
-        svid = client.fetch_x509_svid()
-        bundle_set = client.fetch_x509_bundles()
+        with WorkloadApiClient() as client:
+            svid = client.fetch_x509_svid()
+            bundle_set = client.fetch_x509_bundles()
     finally:
-        client.close()
+        if old is None:
+            os.environ.pop("SPIFFE_ENDPOINT_SOCKET", None)
+        else:
+            os.environ["SPIFFE_ENDPOINT_SOCKET"] = old
 
     return _to_pem_bundle(svid, bundle_set)
 
 
 def _to_pem_bundle(svid, bundle_set) -> SpiffeSvid:
-    """Convert pyspiffe objects into our PEM-based SpiffeSvid.
+    """Convert py-spiffe objects into our PEM-based SpiffeSvid.
 
     Kept as a separate function so tests can exercise the conversion without
     a real Workload API socket.
@@ -106,7 +111,7 @@ def _to_pem_bundle(svid, bundle_set) -> SpiffeSvid:
 
     spiffe_id = str(svid.spiffe_id)
     trust_domain = svid.spiffe_id.trust_domain
-    bundle = bundle_set.get_x509_bundle_for_trust_domain(trust_domain)
+    bundle = bundle_set.get_bundle_for_trust_domain(trust_domain)
     bundle_pem = "\n".join(
         c.public_bytes(serialization.Encoding.PEM).decode()
         for c in bundle.x509_authorities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ connector = [
     "PyYAML>=6.0",
 ]
 spiffe = [
-    "pyspiffe>=0.1.2",
+    "spiffe>=0.2.0",
 ]
 
 [project.scripts]

--- a/tests/test_sdk_spiffe.py
+++ b/tests/test_sdk_spiffe.py
@@ -75,7 +75,7 @@ class _FakeBundle:
 class _FakeBundleSet:
     bundle: _FakeBundle
 
-    def get_x509_bundle_for_trust_domain(self, td):
+    def get_bundle_for_trust_domain(self, td):
         return self.bundle
 
 
@@ -150,8 +150,8 @@ def test_fetch_x509_svid_without_extra_raises_importerror():
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name.startswith("pyspiffe"):
-            raise ImportError("no pyspiffe")
+        if name == "spiffe" or name.startswith("spiffe."):
+            raise ImportError("no spiffe")
         return real_import(name, *args, **kwargs)
 
     with patch("builtins.__import__", side_effect=fake_import):
@@ -161,10 +161,10 @@ def test_fetch_x509_svid_without_extra_raises_importerror():
 
 def test_fetch_x509_svid_without_socket_raises():
     """Missing socket + no env var → clear RuntimeError."""
-    # Need pyspiffe importable for the ImportError check to pass; if not
+    # Need spiffe importable for the ImportError check to pass; if not
     # installed in the dev env, this test is equivalent to the ImportError
     # path above. Skip cleanly when missing.
-    pytest.importorskip("pyspiffe")
+    pytest.importorskip("spiffe")
     import os
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("SPIFFE_ENDPOINT_SOCKET", None)


### PR DESCRIPTION
PR #90 declared a non-existent dep `pyspiffe>=0.1.2`. The actual published package on PyPI is `spiffe` (the [HewlettPackard/py-spiffe](https://github.com/HewlettPackard/py-spiffe) project, current 0.2.x).

Caught while wiring SPIRE into the enterprise sandbox — the agent container build failed with `Could not find a version that satisfies the requirement pyspiffe>=0.1.2`.

Also fixes the bundle accessor name: the `X509BundleSet` method is `get_bundle_for_trust_domain`, not `get_x509_bundle_for_trust_domain`.

## Changes

- `pyproject.toml`: `pyspiffe>=0.1.2` → `spiffe>=0.2.0`
- `cullis_sdk/spiffe.py`: import + bundle method renamed; uses `WorkloadApiClient` context manager (the supported API)
- `tests/test_sdk_spiffe.py`: rename mock methods + import-blocking pattern accordingly

No behavior change for users without the `[spiffe]` extra.

## Test plan

- [x] Unit tests: 8 pass + 1 skip (skip is the live-socket case, expected without `spiffe` installed)
- [x] Verified live in sandbox: SDK now successfully fetches X.509-SVID from a SPIRE agent's Workload API socket