### PR TITLE
feat(sandbox): enterprise sandbox + Blocco 4a SPIRE/SPIFFE demo

### DIFF
--- a/cullis_sdk/spiffe.py
+++ b/cullis_sdk/spiffe.py
@@ -10,8 +10,8 @@ Requires the optional ``[spiffe]`` extra::
     pip install cullis-agent-sdk[spiffe]
 
 Design notes:
-- Thin wrapper over ``pyspiffe`` — all heavy lifting (gRPC, rotation streams)
-  is upstream. We only expose what the SDK needs: fetch a single SVID and
+- Thin wrapper over the ``spiffe`` package (py-spiffe) — all heavy lifting
+  (gRPC, rotation streams) is upstream. We only expose what the SDK needs: fetch a single SVID and
   return PEM bundles.
 - The enterprise operator decides the SPIFFE ID → Cullis agent_id mapping.
   See ``parse_spiffe_id()`` for the default convention.
@@ -61,9 +61,7 @@ def fetch_x509_svid(socket_path: str | None = None) -> SpiffeSvid:
             returns no SVID for this workload.
     """
     try:
-        from pyspiffe.workloadapi.default_workload_api_client import (
-            DefaultWorkloadApiClient,
-        )
+        from spiffe import WorkloadApiClient
     except ImportError as e:  # pragma: no cover — tested via monkeypatch
         raise ImportError(_INSTALL_HINT) from e
 
@@ -77,18 +75,25 @@ def fetch_x509_svid(socket_path: str | None = None) -> SpiffeSvid:
     if not endpoint.startswith("unix://"):
         endpoint = f"unix://{endpoint}"
 
-    client = DefaultWorkloadApiClient(spiffe_socket_path=endpoint)
+    # WorkloadApiClient reads SPIFFE_ENDPOINT_SOCKET from env; override it
+    # locally so callers can pass socket_path explicitly.
+    old = os.environ.get("SPIFFE_ENDPOINT_SOCKET")
+    os.environ["SPIFFE_ENDPOINT_SOCKET"] = endpoint
     try:
-        svid = client.fetch_x509_svid()
-        bundle_set = client.fetch_x509_bundles()
+        with WorkloadApiClient() as client:
+            svid = client.fetch_x509_svid()
+            bundle_set = client.fetch_x509_bundles()
     finally:
-        client.close()
+        if old is None:
+            os.environ.pop("SPIFFE_ENDPOINT_SOCKET", None)
+        else:
+            os.environ["SPIFFE_ENDPOINT_SOCKET"] = old
 
     return _to_pem_bundle(svid, bundle_set)
 
 
 def _to_pem_bundle(svid, bundle_set) -> SpiffeSvid:
-    """Convert pyspiffe objects into our PEM-based SpiffeSvid.
+    """Convert py-spiffe objects into our PEM-based SpiffeSvid.
 
     Kept as a separate function so tests can exercise the conversion without
     a real Workload API socket.
@@ -106,7 +111,7 @@ def _to_pem_bundle(svid, bundle_set) -> SpiffeSvid:
 
     spiffe_id = str(svid.spiffe_id)
     trust_domain = svid.spiffe_id.trust_domain
-    bundle = bundle_set.get_x509_bundle_for_trust_domain(trust_domain)
+    bundle = bundle_set.get_bundle_for_trust_domain(trust_domain)
     bundle_pem = "\n".join(
         c.public_bytes(serialization.Encoding.PEM).decode()
         for c in bundle.x509_authorities

--- a/enterprise_sandbox/README.md
+++ b/enterprise_sandbox/README.md
@@ -41,6 +41,22 @@ Modello federazione Cullis: **1 broker condiviso** + N org che attach-ano la pro
 
 Ogni proxy è attached a org-internal + public-wan (fa da bridge). IdP/Vault/SPIRE/agent chiusi dentro org-internal. Le 2 org non si vedono tra loro se non via broker.
 
+## Browser OIDC login (manuale)
+
+Aggiungi al tuo `/etc/hosts`:
+```
+127.0.0.1 keycloak-a keycloak-b
+```
+
+Poi browse:
+- Broker dashboard: http://localhost:8000/
+- Login via Keycloak-a (Org A): http://localhost:8000/dashboard/oidc/start?role=org&org_id=orga
+  - credenziali: `alice` / `alice-sandbox`
+- Login via Keycloak-b (Org B): http://localhost:8000/dashboard/oidc/start?role=org&org_id=orgb
+  - credenziali: `bob` / `bob-sandbox`
+- Keycloak admin-a: http://localhost:8180/ (admin / admin-sandbox)
+- Keycloak admin-b: http://localhost:8280/ (admin / admin-sandbox)
+
 ## File di riferimento
 
 - `imp/enterprise_sandbox_plan.md` — piano completo 6 blocchi

--- a/enterprise_sandbox/README.md
+++ b/enterprise_sandbox/README.md
@@ -24,20 +24,22 @@ Blocco corrente: **1 — Scheletro + 2 broker cross-org** (in progress)
 
 ## Topologia
 
+Modello federazione Cullis: **1 broker condiviso** + N org che attach-ano la propria CA. Il cross-org avviene via quel broker (zero-knowledge, vede solo ciphertext E2E).
+
 ```
 ┌──────────────── public-wan ────────────────┐
-│    broker-a                  broker-b      │
-└────┬────────────────────────────┬──────────┘
-     │                            │
-┌────┼── orga-internal ──┐   ┌────┼── orgb-internal ──┐
-│  proxy-a connector-a   │   │  proxy-b connector-b   │
-│  agent-a               │   │  agent-b               │
-│  keycloak-a vault-a    │   │  keycloak-b vault-b    │
-│  spire-a               │   │  spire-b               │
-└────────────────────────┘   └────────────────────────┘
+│              broker (shared)               │
+└────┬──────────────────────────┬────────────┘
+     │                          │
+┌────┼── orga-internal ──┐  ┌───┼── orgb-internal ──┐
+│  proxy-a  (bridge)     │  │  proxy-b  (bridge)   │
+│  connector-a agent-a   │  │  connector-b agent-b │
+│  keycloak-a vault-a    │  │  keycloak-b vault-b  │
+│  spire-a               │  │  spire-b             │
+└────────────────────────┘  └──────────────────────┘
 ```
 
-Solo i broker attraversano `public-wan`. Tutto il resto è chiuso nella org-internal.
+Ogni proxy è attached a org-internal + public-wan (fa da bridge). IdP/Vault/SPIRE/agent chiusi dentro org-internal. Le 2 org non si vedono tra loro se non via broker.
 
 ## File di riferimento
 

--- a/enterprise_sandbox/README.md
+++ b/enterprise_sandbox/README.md
@@ -1,0 +1,45 @@
+# Cullis Enterprise Sandbox
+
+Docker compose single-host con 2 org isolate, ognuna con stack enterprise finto (Keycloak IdP, Vault, SPIRE) + Cullis broker/proxy/connector/agent.
+
+**Scopo**: shake-out pre-customer-discovery + asset marketing "prova Cullis da solo".
+
+**Differenza da `demo_network/`**:
+- demo_network = 1 broker + 2 proxy (stessa org), pre-merge gate veloce
+- enterprise_sandbox = 2 org separate cross-org, Pattern C onboarding, IdP reale
+
+## Status
+
+🚧 **Work in progress** — vedi `imp/enterprise_sandbox_plan.md` per roadmap completa.
+
+Blocco corrente: **1 — Scheletro + 2 broker cross-org** (in progress)
+
+## Quickstart (target)
+
+```bash
+./up.sh         # ~90s cold start
+./smoke.sh      # ~60s, 10 assertion
+./down.sh
+```
+
+## Topologia
+
+```
+┌──────────────── public-wan ────────────────┐
+│    broker-a                  broker-b      │
+└────┬────────────────────────────┬──────────┘
+     │                            │
+┌────┼── orga-internal ──┐   ┌────┼── orgb-internal ──┐
+│  proxy-a connector-a   │   │  proxy-b connector-b   │
+│  agent-a               │   │  agent-b               │
+│  keycloak-a vault-a    │   │  keycloak-b vault-b    │
+│  spire-a               │   │  spire-b               │
+└────────────────────────┘   └────────────────────────┘
+```
+
+Solo i broker attraversano `public-wan`. Tutto il resto è chiuso nella org-internal.
+
+## File di riferimento
+
+- `imp/enterprise_sandbox_plan.md` — piano completo 6 blocchi
+- `demo_network/` — pattern base riutilizzato

--- a/enterprise_sandbox/agent/Dockerfile
+++ b/enterprise_sandbox/agent/Dockerfile
@@ -1,0 +1,21 @@
+# Demo Cullis agent — installs the SDK from the local repo (with [spiffe] extra)
+# and uses CullisClient.from_spiffe_workload_api() to authenticate.
+#
+# Build context must be the repo root (so pyproject.toml + cullis_sdk/ are visible).
+FROM python:3.11-slim
+
+# Install deps first for caching
+COPY pyproject.toml /build/pyproject.toml
+COPY cullis_sdk/ /build/cullis_sdk/
+COPY cullis_connector/ /build/cullis_connector/
+
+RUN pip install --no-cache-dir "/build[spiffe]"
+
+COPY enterprise_sandbox/agent/agent.py /app/agent.py
+
+# Match spire-server registration entry `unix:uid:1000`
+RUN groupadd -g 1000 agent && useradd -u 1000 -g 1000 -m -s /bin/sh agent
+USER 1000:1000
+
+WORKDIR /app
+ENTRYPOINT ["python", "/app/agent.py"]

--- a/enterprise_sandbox/agent/agent.py
+++ b/enterprise_sandbox/agent/agent.py
@@ -1,0 +1,93 @@
+"""Sandbox demo agent — fetches SVID from SPIRE Workload API and authenticates to broker.
+
+Env:
+    BROKER_URL                e.g. http://broker:8000
+    ORG_ID                    e.g. orga
+    AGENT_NAME                e.g. agent-a (short name, becomes {ORG_ID}::{AGENT_NAME})
+    SPIFFE_ENDPOINT_SOCKET    path to SPIRE Workload API socket
+    AGENT_MODE                'responder' (default) or 'initiator'
+
+Blocco 4a scope: prove SPIFFE auth works end-to-end.
+  - fetch SVID
+  - login to broker
+  - drop a ready-marker file (/tmp/ready) for smoke to detect
+  - stay alive
+
+Cross-org messaging lives in Blocco 4c.
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import time
+
+from cullis_sdk import CullisClient
+
+
+def wait_for_socket(path: str, timeout: float = 60.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if pathlib.Path(path).exists():
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def wait_for_http(url: str, timeout: float = 60.0) -> bool:
+    import urllib.request
+    import urllib.error
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=2)
+            return True
+        except (urllib.error.URLError, OSError):
+            time.sleep(1)
+    return False
+
+
+def main() -> int:
+    broker = os.environ["BROKER_URL"].rstrip("/")
+    org_id = os.environ["ORG_ID"]
+    name = os.environ["AGENT_NAME"]
+    socket = os.environ.get(
+        "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock"
+    )
+    agent_id = f"{org_id}::{name}"
+
+    # Wait for Workload API socket (spire-agent may still be starting)
+    raw = socket.removeprefix("unix://") if socket.startswith("unix://") else socket
+    if not wait_for_socket(raw, timeout=60):
+        print(f"[{agent_id}] FAIL: socket {raw} not available after 60s",
+              file=sys.stderr, flush=True)
+        return 1
+
+    # Wait for broker (we start in parallel with it)
+    if not wait_for_http(f"{broker}/health", timeout=60):
+        print(f"[{agent_id}] FAIL: broker {broker} not reachable", file=sys.stderr, flush=True)
+        return 1
+
+    # Authenticate via SPIFFE — this is the whole point of the demo
+    try:
+        client = CullisClient.from_spiffe_workload_api(
+            broker, org_id=org_id, socket_path=socket,
+        )
+    except Exception as e:
+        print(f"[{agent_id}] FAIL: SPIFFE auth: {e!r}", file=sys.stderr, flush=True)
+        return 2
+
+    print(f"[{agent_id}] SPIFFE auth OK — token={client.token[:24] if client.token else None}...",
+          flush=True)
+
+    # Ready-marker: smoke reads this to assert success without parsing logs.
+    pathlib.Path("/tmp/ready").write_text(agent_id + "\n")
+
+    # Keep alive (long-running responder). Token refresh via SVID rotation
+    # is a later concern — SDK currently does not auto-rotate.
+    while True:
+        time.sleep(30)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enterprise_sandbox/bootstrap/Dockerfile
+++ b/enterprise_sandbox/bootstrap/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-RUN pip install --no-cache-dir httpx==0.27.2 cryptography==43.0.1
+RUN pip install --no-cache-dir httpx==0.27.2 cryptography==43.0.1 asyncpg==0.29.0
 
 WORKDIR /app
 COPY bootstrap.py /app/bootstrap.py

--- a/enterprise_sandbox/bootstrap/Dockerfile
+++ b/enterprise_sandbox/bootstrap/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir httpx==0.27.2 cryptography==43.0.1
+
+WORKDIR /app
+COPY bootstrap.py /app/bootstrap.py
+
+ENTRYPOINT ["python", "/app/bootstrap.py"]

--- a/enterprise_sandbox/broker-ca-init/Dockerfile
+++ b/enterprise_sandbox/broker-ca-init/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.20
+RUN apk add --no-cache openssl bash
+COPY generate.sh /usr/local/bin/generate.sh
+RUN chmod +x /usr/local/bin/generate.sh
+ENTRYPOINT ["/usr/local/bin/generate.sh"]

--- a/enterprise_sandbox/broker-ca-init/generate.sh
+++ b/enterprise_sandbox/broker-ca-init/generate.sh
@@ -24,7 +24,10 @@ openssl req -x509 -new -nodes -key "$KEY" -sha256 -days 3650 \
     -out "$CERT"
 
 chmod 644 "$CERT"
-chmod 600 "$KEY"
+# Broker runs as non-root; local KMS derives encryption key from this PEM
+# and needs read access. World-readable is acceptable in sandbox since the
+# CA is ephemeral test material (not a real production key).
+chmod 644 "$KEY"
 
 echo "[broker-ca-init:$ORG_ID] generated broker CA"
 openssl x509 -in "$CERT" -noout -subject -dates

--- a/enterprise_sandbox/broker-ca-init/generate.sh
+++ b/enterprise_sandbox/broker-ca-init/generate.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Generates a per-org Broker CA (RSA-4096) used by Cullis to sign organization
+# subordinate CAs. One CA per org (orga/orgb). Idempotent: skip if valid cert
+# already present with >30d validity.
+set -euo pipefail
+
+ORG_ID="${ORG_ID:?ORG_ID env required}"
+OUT="${OUT_DIR:-/broker-certs}"
+mkdir -p "$OUT"
+
+CERT="$OUT/broker-ca.pem"
+KEY="$OUT/broker-ca-key.pem"
+
+if [[ -f "$CERT" && -f "$KEY" ]] && openssl x509 -in "$CERT" -noout -checkend $((30*24*3600)) >/dev/null 2>&1; then
+    echo "[broker-ca-init:$ORG_ID] existing CA valid, skipping"
+    exit 0
+fi
+
+umask 077
+
+openssl genrsa -out "$KEY" 4096 2>/dev/null
+openssl req -x509 -new -nodes -key "$KEY" -sha256 -days 3650 \
+    -subj "/CN=Cullis Broker CA ($ORG_ID)/O=$ORG_ID" \
+    -out "$CERT"
+
+chmod 644 "$CERT"
+chmod 600 "$KEY"
+
+echo "[broker-ca-init:$ORG_ID] generated broker CA"
+openssl x509 -in "$CERT" -noout -subject -dates

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -1,10 +1,14 @@
 # Cullis Enterprise Sandbox — compose topology
 #
-# Blocco 1: skeleton + 2 brokers cross-org.
+# Cullis federation model: 1 shared broker + N orgs that attach-ca.
+# Cross-org traffic flows: agent-a → proxy-a → broker → proxy-b → agent-b.
+# Broker does not talk to another broker (no broker federation today).
+#
+# Blocco 1: skeleton + shared broker reachable on public-wan.
 # - 3 networks: orga-internal, orgb-internal, public-wan
-# - Only brokers live on public-wan (simulates internet between orgs)
+# - broker on public-wan (+ its own DB/Redis on public-wan)
+# - org-internal networks are empty until Blocco 2 (proxy, agent, IdP)
 # - Local KMS (filesystem), HTTP only — TLS + Vault arrive in Blocco 2
-# - No proxy/IdP/SPIRE yet — added in Blocchi 2/3/4
 #
 # Plan: imp/enterprise_sandbox_plan.md
 
@@ -20,154 +24,86 @@ networks:
     driver: bridge
 
 volumes:
-  broker-ca-a:
-  broker-ca-b:
-  postgres-a-data:
-  postgres-b-data:
-
-# Anchors for DRY per-org configuration.
-x-broker-base: &broker-base
-  build:
-    context: ..
-    dockerfile: Dockerfile
-  environment: &broker-env-base
-    ADMIN_SECRET: "sandbox-admin-secret-change-me"
-    DASHBOARD_SIGNING_KEY: "sandbox-dashboard-signing-key-32chars-long"
-    KMS_BACKEND: "local"
-    POLICY_BACKEND: "webhook"
-    POLICY_ENFORCEMENT: "true"
-    POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: "true"
-    OTEL_ENABLED: "false"
-    ENVIRONMENT: "development"
-    FORWARDED_ALLOW_IPS: "172.16.0.0/12"
-  entrypoint: ["sh", "-c"]
-  command:
-    - |
-      exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips 172.16.0.0/12
-  expose: ["8000"]
-  healthcheck:
-    test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
-    interval: 5s
-    timeout: 3s
-    retries: 20
-    start_period: 15s
+  broker-ca:
+  postgres-data:
 
 services:
 
-  # ── Org A ──────────────────────────────────────────────────────────────────
-
-  broker-ca-init-a:
+  broker-ca-init:
     build: ./broker-ca-init
     environment:
-      ORG_ID: orga
+      ORG_ID: broker
     volumes:
-      - broker-ca-a:/broker-certs
-    networks: [orga-internal]
+      - broker-ca:/broker-certs
+    networks: [public-wan]
     restart: "no"
 
-  postgres-a:
+  postgres:
     image: postgres:16-alpine
     environment:
       POSTGRES_USER:     atn
       POSTGRES_PASSWORD: atn-sandbox
       POSTGRES_DB:       agent_trust
     volumes:
-      - postgres-a-data:/var/lib/postgresql/data
-    networks: [orga-internal]
+      - postgres-data:/var/lib/postgresql/data
+    networks: [public-wan]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U atn -d agent_trust"]
       interval: 3s
       timeout: 3s
       retries: 20
 
-  redis-a:
+  redis:
     image: redis:7-alpine
-    networks: [orga-internal]
+    networks: [public-wan]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 3s
       timeout: 2s
       retries: 20
 
-  broker-a:
-    <<: *broker-base
+  broker:
+    build:
+      context: ..
+      dockerfile: Dockerfile
     depends_on:
-      broker-ca-init-a:
+      broker-ca-init:
         condition: service_completed_successfully
-      postgres-a:
+      postgres:
         condition: service_healthy
-      redis-a:
+      redis:
         condition: service_healthy
     environment:
-      <<: *broker-env-base
+      ADMIN_SECRET: "sandbox-admin-secret-change-me"
+      DASHBOARD_SIGNING_KEY: "sandbox-dashboard-signing-key-32chars-long"
+      KMS_BACKEND: "local"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
-      BROKER_PUBLIC_URL: "http://broker-a:8000"
-      DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres-a:5432/agent_trust"
-      REDIS_URL: "redis://redis-a:6379"
-      TRUST_DOMAIN: "orga.test"
+      BROKER_PUBLIC_URL: "http://broker:8000"
+      DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres:5432/agent_trust"
+      REDIS_URL: "redis://redis:6379"
+      POLICY_BACKEND: "webhook"
+      POLICY_ENFORCEMENT: "true"
+      POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: "true"
+      # Federation broker: trust_domain neutral (not per-org). Orgs attach
+      # their own CA with their own trust_domain via the attach-ca flow.
+      TRUST_DOMAIN: "broker.sandbox"
+      OTEL_ENABLED: "false"
+      ENVIRONMENT: "development"
+      FORWARDED_ALLOW_IPS: "172.16.0.0/12"
     volumes:
-      - broker-ca-a:/broker-certs:ro
+      - broker-ca:/broker-certs:ro
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips 172.16.0.0/12
     networks:
-      orga-internal:
       public-wan:
-        aliases: [broker-a]
-
-  # ── Org B ──────────────────────────────────────────────────────────────────
-
-  broker-ca-init-b:
-    build: ./broker-ca-init
-    environment:
-      ORG_ID: orgb
-    volumes:
-      - broker-ca-b:/broker-certs
-    networks: [orgb-internal]
-    restart: "no"
-
-  postgres-b:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER:     atn
-      POSTGRES_PASSWORD: atn-sandbox
-      POSTGRES_DB:       agent_trust
-    volumes:
-      - postgres-b-data:/var/lib/postgresql/data
-    networks: [orgb-internal]
+        aliases: [broker]
+    expose: ["8000"]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U atn -d agent_trust"]
-      interval: 3s
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 5s
       timeout: 3s
       retries: 20
-
-  redis-b:
-    image: redis:7-alpine
-    networks: [orgb-internal]
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 3s
-      timeout: 2s
-      retries: 20
-
-  broker-b:
-    <<: *broker-base
-    depends_on:
-      broker-ca-init-b:
-        condition: service_completed_successfully
-      postgres-b:
-        condition: service_healthy
-      redis-b:
-        condition: service_healthy
-    environment:
-      <<: *broker-env-base
-      BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
-      BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
-      BROKER_PUBLIC_URL: "http://broker-b:8000"
-      DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres-b:5432/agent_trust"
-      REDIS_URL: "redis://redis-b:6379"
-      TRUST_DOMAIN: "orgb.test"
-    volumes:
-      - broker-ca-b:/broker-certs:ro
-    networks:
-      orgb-internal:
-      public-wan:
-        aliases: [broker-b]
+      start_period: 15s

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -111,6 +111,46 @@ services:
       retries: 20
       start_period: 15s
 
+  # ── Blocco 3: Keycloak IdP per org (OIDC) ──────────────────────────────────
+
+  keycloak-a:
+    image: quay.io/keycloak/keycloak:25.0
+    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin-sandbox
+      KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./keycloak-seed/realm-orga.json:/opt/keycloak/data/import/realm-orga.json:ro
+    networks:
+      public-wan:
+        aliases: [keycloak-a]
+    expose: ["8080"]
+    ports: ["8180:8080"]
+    # Keycloak image has no curl/wget and /bin/sh doesn't support /dev/tcp.
+    # Rely on start_period (~30s cold start) + bootstrap's own probe.
+
+  keycloak-b:
+    image: quay.io/keycloak/keycloak:25.0
+    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin-sandbox
+      KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME_STRICT: "false"
+      KC_HEALTH_ENABLED: "true"
+    volumes:
+      - ./keycloak-seed/realm-orgb.json:/opt/keycloak/data/import/realm-orgb.json:ro
+    networks:
+      public-wan:
+        aliases: [keycloak-b]
+    expose: ["8080"]
+    ports: ["8280:8080"]
+    # Keycloak image has no curl/wget and /bin/sh doesn't support /dev/tcp.
+    # Rely on start_period (~30s cold start) + bootstrap's own probe.
+
   # ── Blocco 2: bootstrap creates 2 orgs on shared broker ────────────────────
 
   bootstrap:
@@ -118,10 +158,21 @@ services:
     depends_on:
       broker:
         condition: service_healthy
+      keycloak-a:
+        condition: service_started
+      keycloak-b:
+        condition: service_started
     environment:
       BROKER_URL:   "http://broker:8000"
       ADMIN_SECRET: "sandbox-admin-secret-change-me"
       STATE_DIR:    /state
+      POSTGRES_DSN: "postgresql://atn:atn-sandbox@postgres:5432/agent_trust"
+      ORGA_OIDC_ISSUER: "http://keycloak-a:8080/realms/orga"
+      ORGA_OIDC_CLIENT_ID: "cullis-broker-dashboard"
+      ORGA_OIDC_CLIENT_SECRET: "orga-oidc-client-secret-change-me"
+      ORGB_OIDC_ISSUER: "http://keycloak-b:8080/realms/orgb"
+      ORGB_OIDC_CLIENT_ID: "cullis-broker-dashboard"
+      ORGB_OIDC_CLIENT_SECRET: "orgb-oidc-client-secret-change-me"
     volumes:
       - bootstrap-state:/state
     networks: [public-wan]

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -82,7 +82,11 @@ services:
       KMS_BACKEND: "local"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
-      BROKER_PUBLIC_URL: "http://broker:8000"
+      # Use host-visible URL so OIDC redirect_uri matches browser origin.
+      # Both "broker:8000" and "localhost:8000" are registered in Keycloak
+      # realm JSON, but broker generates redirect_uri from this value, so
+      # localhost keeps the browser round-trip consistent.
+      BROKER_PUBLIC_URL: "http://localhost:8000"
       DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres:5432/agent_trust"
       REDIS_URL: "redis://redis:6379"
       POLICY_BACKEND: "webhook"
@@ -104,6 +108,7 @@ services:
       public-wan:
         aliases: [broker]
     expose: ["8000"]
+    ports: ["8000:8000"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 5s
@@ -113,43 +118,46 @@ services:
 
   # ── Blocco 3: Keycloak IdP per org (OIDC) ──────────────────────────────────
 
+  # NB: Keycloak listens on 8180/8280 internally AND on host, so the URL is
+  # identical from browser and from docker network. Requires /etc/hosts entry
+  # on host: `127.0.0.1 keycloak-a keycloak-b`. Without that browser OIDC
+  # login breaks (iss mismatch). Smoke assertions bypass this (internal only).
+
   keycloak-a:
     image: quay.io/keycloak/keycloak:25.0
-    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    command: ["start-dev", "--import-realm", "--http-port=8180"]
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin-sandbox
       KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME: "http://keycloak-a:8180"
       KC_HOSTNAME_STRICT: "false"
-      KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
     volumes:
       - ./keycloak-seed/realm-orga.json:/opt/keycloak/data/import/realm-orga.json:ro
     networks:
       public-wan:
         aliases: [keycloak-a]
-    expose: ["8080"]
-    ports: ["8180:8080"]
-    # Keycloak image has no curl/wget and /bin/sh doesn't support /dev/tcp.
-    # Rely on start_period (~30s cold start) + bootstrap's own probe.
+    expose: ["8180"]
+    ports: ["8180:8180"]
 
   keycloak-b:
     image: quay.io/keycloak/keycloak:25.0
-    command: ["start-dev", "--import-realm", "--http-port=8080"]
+    command: ["start-dev", "--import-realm", "--http-port=8280"]
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin-sandbox
       KC_HTTP_ENABLED: "true"
+      KC_HOSTNAME: "http://keycloak-b:8280"
       KC_HOSTNAME_STRICT: "false"
-      KC_HEALTH_ENABLED: "true"
+      KC_HOSTNAME_STRICT_BACKCHANNEL: "false"
     volumes:
       - ./keycloak-seed/realm-orgb.json:/opt/keycloak/data/import/realm-orgb.json:ro
     networks:
       public-wan:
         aliases: [keycloak-b]
-    expose: ["8080"]
-    ports: ["8280:8080"]
-    # Keycloak image has no curl/wget and /bin/sh doesn't support /dev/tcp.
-    # Rely on start_period (~30s cold start) + bootstrap's own probe.
+    expose: ["8280"]
+    ports: ["8280:8280"]
 
   # ── Blocco 2: bootstrap creates 2 orgs on shared broker ────────────────────
 
@@ -167,10 +175,10 @@ services:
       ADMIN_SECRET: "sandbox-admin-secret-change-me"
       STATE_DIR:    /state
       POSTGRES_DSN: "postgresql://atn:atn-sandbox@postgres:5432/agent_trust"
-      ORGA_OIDC_ISSUER: "http://keycloak-a:8080/realms/orga"
+      ORGA_OIDC_ISSUER: "http://keycloak-a:8180/realms/orga"
       ORGA_OIDC_CLIENT_ID: "cullis-broker-dashboard"
       ORGA_OIDC_CLIENT_SECRET: "orga-oidc-client-secret-change-me"
-      ORGB_OIDC_ISSUER: "http://keycloak-b:8080/realms/orgb"
+      ORGB_OIDC_ISSUER: "http://keycloak-b:8280/realms/orgb"
       ORGB_OIDC_CLIENT_ID: "cullis-broker-dashboard"
       ORGB_OIDC_CLIENT_SECRET: "orgb-oidc-client-secret-change-me"
     volumes:

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -26,6 +26,9 @@ networks:
 volumes:
   broker-ca:
   postgres-data:
+  bootstrap-state:
+  proxy-a-data:
+  proxy-b-data:
 
 services:
 
@@ -107,3 +110,117 @@ services:
       timeout: 3s
       retries: 20
       start_period: 15s
+
+  # ── Blocco 2: bootstrap creates 2 orgs on shared broker ────────────────────
+
+  bootstrap:
+    build: ./bootstrap
+    depends_on:
+      broker:
+        condition: service_healthy
+    environment:
+      BROKER_URL:   "http://broker:8000"
+      ADMIN_SECRET: "sandbox-admin-secret-change-me"
+      STATE_DIR:    /state
+    volumes:
+      - bootstrap-state:/state
+    networks: [public-wan]
+    restart: "no"
+
+  # ── Org A proxy ────────────────────────────────────────────────────────────
+
+  proxy-a-init:
+    build: ./proxy-init
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    environment:
+      ORG_ID:           "orga"
+      BROKER_URL:       "http://broker:8000"
+      PROXY_PUBLIC_URL: "http://proxy-a:9100"
+      PROXY_DB_PATH:    /data/mcp_proxy.db
+      STATE_DIR:        /state
+    volumes:
+      - bootstrap-state:/state:ro
+      - proxy-a-data:/data
+    restart: "no"
+
+  proxy-a:
+    build:
+      context: ..
+      dockerfile: mcp_proxy/Dockerfile
+    depends_on:
+      proxy-a-init:
+        condition: service_completed_successfully
+    environment:
+      MCP_PROXY_BROKER_URL:        "http://broker:8000"
+      MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
+      MCP_PROXY_PROXY_PUBLIC_URL:  "http://proxy-a:9100"
+      MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
+      MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
+      MCP_PROXY_ORG_ID:            "orga"
+      MCP_PROXY_ALLOWED_ORIGINS:   "http://proxy-a:9100"
+      MCP_PROXY_ENVIRONMENT:       "development"
+    volumes:
+      - proxy-a-data:/data
+    networks:
+      orga-internal:
+        aliases: [proxy-a]
+      public-wan:
+        aliases: [proxy-a]
+    expose: ["9100"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  # ── Org B proxy ────────────────────────────────────────────────────────────
+
+  proxy-b-init:
+    build: ./proxy-init
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    environment:
+      ORG_ID:           "orgb"
+      BROKER_URL:       "http://broker:8000"
+      PROXY_PUBLIC_URL: "http://proxy-b:9100"
+      PROXY_DB_PATH:    /data/mcp_proxy.db
+      STATE_DIR:        /state
+    volumes:
+      - bootstrap-state:/state:ro
+      - proxy-b-data:/data
+    restart: "no"
+
+  proxy-b:
+    build:
+      context: ..
+      dockerfile: mcp_proxy/Dockerfile
+    depends_on:
+      proxy-b-init:
+        condition: service_completed_successfully
+    environment:
+      MCP_PROXY_BROKER_URL:        "http://broker:8000"
+      MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
+      MCP_PROXY_PROXY_PUBLIC_URL:  "http://proxy-b:9100"
+      MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
+      MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
+      MCP_PROXY_ORG_ID:            "orgb"
+      MCP_PROXY_ALLOWED_ORIGINS:   "http://proxy-b:9100"
+      MCP_PROXY_ENVIRONMENT:       "development"
+    volumes:
+      - proxy-b-data:/data
+    networks:
+      orgb-internal:
+        aliases: [proxy-b]
+      public-wan:
+        aliases: [proxy-b]
+    expose: ["9100"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -29,6 +29,17 @@ volumes:
   bootstrap-state:
   proxy-a-data:
   proxy-b-data:
+  # Blocco 4 — SPIRE stacks per org
+  spire-a-server-api:
+  spire-a-server-data:
+  spire-a-token:
+  spire-a-agent-socket:
+  spire-a-agent-data:
+  spire-b-server-api:
+  spire-b-server-data:
+  spire-b-token:
+  spire-b-agent-socket:
+  spire-b-agent-data:
 
 services:
 
@@ -82,11 +93,11 @@ services:
       KMS_BACKEND: "local"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
-      # Use host-visible URL so OIDC redirect_uri matches browser origin.
-      # Both "broker:8000" and "localhost:8000" are registered in Keycloak
-      # realm JSON, but broker generates redirect_uri from this value, so
-      # localhost keeps the browser round-trip consistent.
-      BROKER_PUBLIC_URL: "http://localhost:8000"
+      # Used by DPoP htu validation. Agents on the docker network reach the
+      # broker via "http://broker:8000", so that's what their proofs claim.
+      # OIDC browser flow now lives on the proxies (PR #88) so this URL no
+      # longer needs to match a browser-typed host.
+      BROKER_PUBLIC_URL: "http://broker:8000"
       DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres:5432/agent_trust"
       REDIS_URL: "redis://redis:6379"
       POLICY_BACKEND: "webhook"
@@ -232,6 +243,123 @@ services:
       retries: 20
       start_period: 10s
 
+  # ── Blocco 4 — SPIRE stack per Org A ──────────────────────────────────────
+  #
+  # Topology per org:
+  #   spire-server-X       long-running server, UpstreamAuthority=disk (Org CA)
+  #   spire-server-X-init  one-shot: token generate + entry create
+  #   spire-agent-X        long-running agent, connects with join token
+  #   agent-X              Python workload, fetches SVID via Workload API socket
+  #
+  # Org CA from /state/{org_id}/ca.pem (written by bootstrap, path_length=1).
+
+  spire-server-a:
+    image: ghcr.io/spiffe/spire-server:1.9.5
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    volumes:
+      - ./spire/server-a.conf:/run/spire/config/server.conf:ro
+      - bootstrap-state:/state:ro
+      - spire-a-server-api:/tmp/spire-server/private
+      - spire-a-server-data:/run/spire/data
+    command: ["-config", "/run/spire/config/server.conf"]
+    networks:
+      orga-internal:
+        aliases: [spire-server-a]
+    healthcheck:
+      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-socketPath", "/tmp/spire-server/private/api.sock"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  spire-server-a-init:
+    build: ./spire/init
+    depends_on:
+      spire-server-a:
+        condition: service_healthy
+    volumes:
+      - spire-a-server-api:/tmp/spire-server/private
+      - spire-a-token:/token
+    networks: [orga-internal]
+    command:
+      - |
+        set -e
+        SOCK=/tmp/spire-server/private/api.sock
+        if [ ! -s /token/join_token ]; then
+          TOKEN=$$(spire-server token generate \
+            -socketPath $$SOCK -ttl 3600 | grep '^Token:' | awk '{print $$NF}')
+          echo "$$TOKEN" > /token/join_token
+          spire-server entry create \
+            -socketPath $$SOCK \
+            -spiffeID spiffe://orga.test/agent-a \
+            -parentID "spiffe://orga.test/spire/agent/join_token/$$TOKEN" \
+            -selector unix:uid:1000
+          echo "spire-server-a-init: token + entry created"
+        else
+          echo "spire-server-a-init: already initialized"
+        fi
+    restart: "no"
+
+  spire-agent-a:
+    build: ./spire/agent-wrapper
+    depends_on:
+      spire-server-a-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./spire/agent-a.conf:/run/spire/config/agent.conf:ro
+      - spire-a-token:/token:ro
+      - spire-a-agent-socket:/run/spire/sockets
+      - spire-a-agent-data:/run/spire/data
+    command:
+      - |
+        TOKEN=$$(cat /token/join_token)
+        exec spire-agent run \
+          -config /run/spire/config/agent.conf \
+          -joinToken "$$TOKEN"
+    networks: [orga-internal]
+    healthcheck:
+      test: ["CMD", "spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
+
+  agent-a:
+    build:
+      context: ..
+      dockerfile: enterprise_sandbox/agent/Dockerfile
+    depends_on:
+      spire-agent-a:
+        condition: service_healthy
+      broker:
+        condition: service_healthy
+    environment:
+      BROKER_URL: "http://broker:8000"
+      ORG_ID: "orga"
+      AGENT_NAME: "agent-a"
+      SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
+    volumes:
+      - spire-a-agent-socket:/run/spire/sockets:ro
+    networks: [orga-internal, public-wan]
+    # Share PID namespace with spire-agent-a so the SPIRE unix WorkloadAttestor
+    # can see this process via /proc/{pid}/exe and attest the unix:uid:1000
+    # selector. Without this, attestation fails with "could not resolve
+    # caller information".
+    pid: "service:spire-agent-a"
+    # Container exits ~5s after start: the broker rejects SPIRE-issued SVIDs
+    # because they have no CN/O subject (only the SPIFFE URI in SAN). Once
+    # the broker grows SPIFFE-aware x509 auth, re-enable the healthcheck
+    # below and remove restart: "no". Tracked in a separate issue.
+    restart: "no"
+    # healthcheck:
+    #   test: ["CMD", "test", "-f", "/tmp/ready"]
+    #   interval: 3s
+    #   timeout: 2s
+    #   retries: 20
+    #   start_period: 20s
+
   # ── Org B proxy ────────────────────────────────────────────────────────────
 
   proxy-b-init:
@@ -284,3 +412,105 @@ services:
       timeout: 3s
       retries: 20
       start_period: 10s
+
+  # ── Blocco 4 — SPIRE stack per Org B ──────────────────────────────────────
+
+  spire-server-b:
+    image: ghcr.io/spiffe/spire-server:1.9.5
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    volumes:
+      - ./spire/server-b.conf:/run/spire/config/server.conf:ro
+      - bootstrap-state:/state:ro
+      - spire-b-server-api:/tmp/spire-server/private
+      - spire-b-server-data:/run/spire/data
+    command: ["-config", "/run/spire/config/server.conf"]
+    networks:
+      orgb-internal:
+        aliases: [spire-server-b]
+    healthcheck:
+      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-socketPath", "/tmp/spire-server/private/api.sock"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  spire-server-b-init:
+    build: ./spire/init
+    depends_on:
+      spire-server-b:
+        condition: service_healthy
+    volumes:
+      - spire-b-server-api:/tmp/spire-server/private
+      - spire-b-token:/token
+    networks: [orgb-internal]
+    command:
+      - |
+        set -e
+        SOCK=/tmp/spire-server/private/api.sock
+        if [ ! -s /token/join_token ]; then
+          TOKEN=$$(spire-server token generate \
+            -socketPath $$SOCK -ttl 3600 | grep '^Token:' | awk '{print $$NF}')
+          echo "$$TOKEN" > /token/join_token
+          spire-server entry create \
+            -socketPath $$SOCK \
+            -spiffeID spiffe://orgb.test/agent-b \
+            -parentID "spiffe://orgb.test/spire/agent/join_token/$$TOKEN" \
+            -selector unix:uid:1000
+          echo "spire-server-b-init: token + entry created"
+        else
+          echo "spire-server-b-init: already initialized"
+        fi
+    restart: "no"
+
+  spire-agent-b:
+    build: ./spire/agent-wrapper
+    depends_on:
+      spire-server-b-init:
+        condition: service_completed_successfully
+    volumes:
+      - ./spire/agent-b.conf:/run/spire/config/agent.conf:ro
+      - spire-b-token:/token:ro
+      - spire-b-agent-socket:/run/spire/sockets
+      - spire-b-agent-data:/run/spire/data
+    command:
+      - |
+        TOKEN=$$(cat /token/join_token)
+        exec spire-agent run \
+          -config /run/spire/config/agent.conf \
+          -joinToken "$$TOKEN"
+    networks: [orgb-internal]
+    healthcheck:
+      test: ["CMD", "spire-agent", "healthcheck", "-socketPath", "/run/spire/sockets/agent.sock"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
+
+  agent-b:
+    build:
+      context: ..
+      dockerfile: enterprise_sandbox/agent/Dockerfile
+    depends_on:
+      spire-agent-b:
+        condition: service_healthy
+      broker:
+        condition: service_healthy
+    environment:
+      BROKER_URL: "http://broker:8000"
+      ORG_ID: "orgb"
+      AGENT_NAME: "agent-b"
+      SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
+    volumes:
+      - spire-b-agent-socket:/run/spire/sockets:ro
+    networks: [orgb-internal, public-wan]
+    pid: "service:spire-agent-b"
+    # See agent-a comment — same broker SPIFFE-aware auth gap.
+    restart: "no"
+    # healthcheck:
+    #   test: ["CMD", "test", "-f", "/tmp/ready"]
+    #   interval: 3s
+    #   timeout: 2s
+    #   retries: 20
+    #   start_period: 20s

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -166,21 +166,14 @@ services:
     depends_on:
       broker:
         condition: service_healthy
-      keycloak-a:
-        condition: service_started
-      keycloak-b:
-        condition: service_started
     environment:
       BROKER_URL:   "http://broker:8000"
       ADMIN_SECRET: "sandbox-admin-secret-change-me"
       STATE_DIR:    /state
       POSTGRES_DSN: "postgresql://atn:atn-sandbox@postgres:5432/agent_trust"
-      ORGA_OIDC_ISSUER: "http://keycloak-a:8180/realms/orga"
-      ORGA_OIDC_CLIENT_ID: "cullis-broker-dashboard"
-      ORGA_OIDC_CLIENT_SECRET: "orga-oidc-client-secret-change-me"
-      ORGB_OIDC_ISSUER: "http://keycloak-b:8280/realms/orgb"
-      ORGB_OIDC_CLIENT_ID: "cullis-broker-dashboard"
-      ORGB_OIDC_CLIENT_SECRET: "orgb-oidc-client-secret-change-me"
+      # Per PR #88 the broker no longer has per-org OIDC login — OIDC is
+      # configured per-proxy via proxy-init below. Bootstrap just creates
+      # the orgs on the broker and writes CA/secret to /state.
     volumes:
       - bootstrap-state:/state
     networks: [public-wan]
@@ -194,11 +187,14 @@ services:
       bootstrap:
         condition: service_completed_successfully
     environment:
-      ORG_ID:           "orga"
-      BROKER_URL:       "http://broker:8000"
-      PROXY_PUBLIC_URL: "http://proxy-a:9100"
-      PROXY_DB_PATH:    /data/mcp_proxy.db
-      STATE_DIR:        /state
+      ORG_ID:              "orga"
+      BROKER_URL:          "http://broker:8000"
+      PROXY_PUBLIC_URL:    "http://localhost:9100"
+      PROXY_DB_PATH:       /data/mcp_proxy.db
+      STATE_DIR:           /state
+      OIDC_ISSUER_URL:     "http://keycloak-a:8180/realms/orga"
+      OIDC_CLIENT_ID:      "cullis-proxy-dashboard"
+      OIDC_CLIENT_SECRET:  "orga-oidc-client-secret-change-me"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-a-data:/data
@@ -214,11 +210,11 @@ services:
     environment:
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      MCP_PROXY_PROXY_PUBLIC_URL:  "http://proxy-a:9100"
+      MCP_PROXY_PROXY_PUBLIC_URL:  "http://localhost:9100"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
-      MCP_PROXY_ALLOWED_ORIGINS:   "http://proxy-a:9100"
+      MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9100"
       MCP_PROXY_ENVIRONMENT:       "development"
     volumes:
       - proxy-a-data:/data
@@ -228,6 +224,7 @@ services:
       public-wan:
         aliases: [proxy-a]
     expose: ["9100"]
+    ports: ["9100:9100"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
       interval: 5s
@@ -243,11 +240,14 @@ services:
       bootstrap:
         condition: service_completed_successfully
     environment:
-      ORG_ID:           "orgb"
-      BROKER_URL:       "http://broker:8000"
-      PROXY_PUBLIC_URL: "http://proxy-b:9100"
-      PROXY_DB_PATH:    /data/mcp_proxy.db
-      STATE_DIR:        /state
+      ORG_ID:              "orgb"
+      BROKER_URL:          "http://broker:8000"
+      PROXY_PUBLIC_URL:    "http://localhost:9200"
+      PROXY_DB_PATH:       /data/mcp_proxy.db
+      STATE_DIR:           /state
+      OIDC_ISSUER_URL:     "http://keycloak-b:8280/realms/orgb"
+      OIDC_CLIENT_ID:      "cullis-proxy-dashboard"
+      OIDC_CLIENT_SECRET:  "orgb-oidc-client-secret-change-me"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-b-data:/data
@@ -263,11 +263,11 @@ services:
     environment:
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      MCP_PROXY_PROXY_PUBLIC_URL:  "http://proxy-b:9100"
+      MCP_PROXY_PROXY_PUBLIC_URL:  "http://localhost:9200"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"
-      MCP_PROXY_ALLOWED_ORIGINS:   "http://proxy-b:9100"
+      MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9200"
       MCP_PROXY_ENVIRONMENT:       "development"
     volumes:
       - proxy-b-data:/data
@@ -277,6 +277,7 @@ services:
       public-wan:
         aliases: [proxy-b]
     expose: ["9100"]
+    ports: ["9200:9100"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
       interval: 5s

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -1,0 +1,29 @@
+# Cullis Enterprise Sandbox — compose topology
+#
+# Status: SCAFFOLD ONLY (Blocco 1 in progress)
+# Plan:   imp/enterprise_sandbox_plan.md
+#
+# Three networks:
+#   - orga-internal: contains all Org A services (IdP, Vault, SPIRE, proxy, connector, agent)
+#   - orgb-internal: mirror for Org B
+#   - public-wan:    only brokers live here; simulates internet between orgs
+
+networks:
+  orga-internal:
+    name: cullis-sandbox-orga
+    driver: bridge
+  orgb-internal:
+    name: cullis-sandbox-orgb
+    driver: bridge
+  public-wan:
+    name: cullis-sandbox-wan
+    driver: bridge
+
+# Services will be added incrementally per block.
+# Blocco 1: ca-init-{a,b}, postgres-{a,b}, redis-{a,b}, broker-{a,b}
+# Blocco 2: vault-{a,b}, proxy-{a,b}
+# Blocco 3: keycloak-{a,b}
+# Blocco 4: spire-server-{a,b}, spire-agent-{a,b}, connector-{a,b}, agent-{a,b}
+services: {}
+
+volumes: {}

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -1,12 +1,12 @@
 # Cullis Enterprise Sandbox — compose topology
 #
-# Status: SCAFFOLD ONLY (Blocco 1 in progress)
-# Plan:   imp/enterprise_sandbox_plan.md
+# Blocco 1: skeleton + 2 brokers cross-org.
+# - 3 networks: orga-internal, orgb-internal, public-wan
+# - Only brokers live on public-wan (simulates internet between orgs)
+# - Local KMS (filesystem), HTTP only — TLS + Vault arrive in Blocco 2
+# - No proxy/IdP/SPIRE yet — added in Blocchi 2/3/4
 #
-# Three networks:
-#   - orga-internal: contains all Org A services (IdP, Vault, SPIRE, proxy, connector, agent)
-#   - orgb-internal: mirror for Org B
-#   - public-wan:    only brokers live here; simulates internet between orgs
+# Plan: imp/enterprise_sandbox_plan.md
 
 networks:
   orga-internal:
@@ -19,11 +19,155 @@ networks:
     name: cullis-sandbox-wan
     driver: bridge
 
-# Services will be added incrementally per block.
-# Blocco 1: ca-init-{a,b}, postgres-{a,b}, redis-{a,b}, broker-{a,b}
-# Blocco 2: vault-{a,b}, proxy-{a,b}
-# Blocco 3: keycloak-{a,b}
-# Blocco 4: spire-server-{a,b}, spire-agent-{a,b}, connector-{a,b}, agent-{a,b}
-services: {}
+volumes:
+  broker-ca-a:
+  broker-ca-b:
+  postgres-a-data:
+  postgres-b-data:
 
-volumes: {}
+# Anchors for DRY per-org configuration.
+x-broker-base: &broker-base
+  build:
+    context: ..
+    dockerfile: Dockerfile
+  environment: &broker-env-base
+    ADMIN_SECRET: "sandbox-admin-secret-change-me"
+    DASHBOARD_SIGNING_KEY: "sandbox-dashboard-signing-key-32chars-long"
+    KMS_BACKEND: "local"
+    POLICY_BACKEND: "webhook"
+    POLICY_ENFORCEMENT: "true"
+    POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: "true"
+    OTEL_ENABLED: "false"
+    ENVIRONMENT: "development"
+    FORWARDED_ALLOW_IPS: "172.16.0.0/12"
+  entrypoint: ["sh", "-c"]
+  command:
+    - |
+      exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips 172.16.0.0/12
+  expose: ["8000"]
+  healthcheck:
+    test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+    interval: 5s
+    timeout: 3s
+    retries: 20
+    start_period: 15s
+
+services:
+
+  # ── Org A ──────────────────────────────────────────────────────────────────
+
+  broker-ca-init-a:
+    build: ./broker-ca-init
+    environment:
+      ORG_ID: orga
+    volumes:
+      - broker-ca-a:/broker-certs
+    networks: [orga-internal]
+    restart: "no"
+
+  postgres-a:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER:     atn
+      POSTGRES_PASSWORD: atn-sandbox
+      POSTGRES_DB:       agent_trust
+    volumes:
+      - postgres-a-data:/var/lib/postgresql/data
+    networks: [orga-internal]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atn -d agent_trust"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis-a:
+    image: redis:7-alpine
+    networks: [orga-internal]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+
+  broker-a:
+    <<: *broker-base
+    depends_on:
+      broker-ca-init-a:
+        condition: service_completed_successfully
+      postgres-a:
+        condition: service_healthy
+      redis-a:
+        condition: service_healthy
+    environment:
+      <<: *broker-env-base
+      BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
+      BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
+      BROKER_PUBLIC_URL: "http://broker-a:8000"
+      DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres-a:5432/agent_trust"
+      REDIS_URL: "redis://redis-a:6379"
+      TRUST_DOMAIN: "orga.test"
+    volumes:
+      - broker-ca-a:/broker-certs:ro
+    networks:
+      orga-internal:
+      public-wan:
+        aliases: [broker-a]
+
+  # ── Org B ──────────────────────────────────────────────────────────────────
+
+  broker-ca-init-b:
+    build: ./broker-ca-init
+    environment:
+      ORG_ID: orgb
+    volumes:
+      - broker-ca-b:/broker-certs
+    networks: [orgb-internal]
+    restart: "no"
+
+  postgres-b:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER:     atn
+      POSTGRES_PASSWORD: atn-sandbox
+      POSTGRES_DB:       agent_trust
+    volumes:
+      - postgres-b-data:/var/lib/postgresql/data
+    networks: [orgb-internal]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atn -d agent_trust"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis-b:
+    image: redis:7-alpine
+    networks: [orgb-internal]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+
+  broker-b:
+    <<: *broker-base
+    depends_on:
+      broker-ca-init-b:
+        condition: service_completed_successfully
+      postgres-b:
+        condition: service_healthy
+      redis-b:
+        condition: service_healthy
+    environment:
+      <<: *broker-env-base
+      BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
+      BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
+      BROKER_PUBLIC_URL: "http://broker-b:8000"
+      DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres-b:5432/agent_trust"
+      REDIS_URL: "redis://redis-b:6379"
+      TRUST_DOMAIN: "orgb.test"
+    volumes:
+      - broker-ca-b:/broker-certs:ro
+    networks:
+      orgb-internal:
+      public-wan:
+        aliases: [broker-b]

--- a/enterprise_sandbox/down.sh
+++ b/enterprise_sandbox/down.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Enterprise sandbox — down
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+docker compose down -v --remove-orphans

--- a/enterprise_sandbox/keycloak-seed/realm-orga.json
+++ b/enterprise_sandbox/keycloak-seed/realm-orga.json
@@ -1,0 +1,53 @@
+{
+  "realm": "orga",
+  "enabled": true,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "registrationAllowed": false,
+  "resetPasswordAllowed": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "users": [
+    {
+      "username": "alice",
+      "enabled": true,
+      "email": "alice@orga.test",
+      "emailVerified": true,
+      "firstName": "Alice",
+      "lastName": "Admin",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "alice-sandbox",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["default-roles-orga"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "cullis-broker-dashboard",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "orga-oidc-client-secret-change-me",
+      "redirectUris": [
+        "http://broker:8000/dashboard/oidc/callback",
+        "http://localhost:8000/dashboard/oidc/callback"
+      ],
+      "webOrigins": ["+"],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "implicitFlowEnabled": false,
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": ["email", "profile", "roles", "web-origins"]
+    }
+  ]
+}

--- a/enterprise_sandbox/keycloak-seed/realm-orga.json
+++ b/enterprise_sandbox/keycloak-seed/realm-orga.json
@@ -30,14 +30,14 @@
   ],
   "clients": [
     {
-      "clientId": "cullis-broker-dashboard",
+      "clientId": "cullis-proxy-dashboard",
       "enabled": true,
       "protocol": "openid-connect",
       "publicClient": false,
       "secret": "orga-oidc-client-secret-change-me",
       "redirectUris": [
-        "http://broker:8000/dashboard/oidc/callback",
-        "http://localhost:8000/dashboard/oidc/callback"
+        "http://localhost:9100/proxy/oidc/callback",
+        "http://proxy-a:9100/proxy/oidc/callback"
       ],
       "webOrigins": ["+"],
       "standardFlowEnabled": true,

--- a/enterprise_sandbox/keycloak-seed/realm-orgb.json
+++ b/enterprise_sandbox/keycloak-seed/realm-orgb.json
@@ -1,0 +1,53 @@
+{
+  "realm": "orgb",
+  "enabled": true,
+  "accessTokenLifespan": 300,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "registrationAllowed": false,
+  "resetPasswordAllowed": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "users": [
+    {
+      "username": "bob",
+      "enabled": true,
+      "email": "bob@orgb.test",
+      "emailVerified": true,
+      "firstName": "Bob",
+      "lastName": "Admin",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "bob-sandbox",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["default-roles-orgb"]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "cullis-broker-dashboard",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": false,
+      "secret": "orgb-oidc-client-secret-change-me",
+      "redirectUris": [
+        "http://broker:8000/dashboard/oidc/callback",
+        "http://localhost:8000/dashboard/oidc/callback"
+      ],
+      "webOrigins": ["+"],
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "implicitFlowEnabled": false,
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "defaultClientScopes": ["email", "profile", "roles", "web-origins"]
+    }
+  ]
+}

--- a/enterprise_sandbox/keycloak-seed/realm-orgb.json
+++ b/enterprise_sandbox/keycloak-seed/realm-orgb.json
@@ -30,14 +30,14 @@
   ],
   "clients": [
     {
-      "clientId": "cullis-broker-dashboard",
+      "clientId": "cullis-proxy-dashboard",
       "enabled": true,
       "protocol": "openid-connect",
       "publicClient": false,
       "secret": "orgb-oidc-client-secret-change-me",
       "redirectUris": [
-        "http://broker:8000/dashboard/oidc/callback",
-        "http://localhost:8000/dashboard/oidc/callback"
+        "http://localhost:9200/proxy/oidc/callback",
+        "http://proxy-b:9100/proxy/oidc/callback"
       ],
       "webOrigins": ["+"],
       "standardFlowEnabled": true,

--- a/enterprise_sandbox/proxy-init/Dockerfile
+++ b/enterprise_sandbox/proxy-init/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir aiosqlite==0.20.0
+
+COPY seed.py /usr/local/bin/seed.py
+
+ENTRYPOINT ["python", "/usr/local/bin/seed.py"]

--- a/enterprise_sandbox/proxy-init/seed.py
+++ b/enterprise_sandbox/proxy-init/seed.py
@@ -1,0 +1,86 @@
+"""
+Seed an MCP proxy's SQLite config DB so it boots pre-configured.
+
+Normally the setup wizard in the proxy dashboard writes these rows after
+the admin pastes an invite token. For non-interactive smoke runs we just
+insert them directly, using the org CA + secret that bootstrap.py already
+generated on the shared /state volume.
+
+Env inputs:
+  ORG_ID          e.g. "demo-org-a"
+  BROKER_URL      e.g. "https://broker.cullis.test:8443"
+  PROXY_PUBLIC_URL e.g. "https://proxy-a.cullis.test:8443"
+  PROXY_DB_PATH   e.g. "/data/mcp_proxy.db"
+  STATE_DIR       e.g. "/state"
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import pathlib
+import sys
+
+import aiosqlite
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS proxy_config (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+
+async def main() -> int:
+    org_id         = os.environ["ORG_ID"]
+    broker_url     = os.environ["BROKER_URL"]
+    proxy_public   = os.environ["PROXY_PUBLIC_URL"]
+    db_path        = os.environ.get("PROXY_DB_PATH", "/data/mcp_proxy.db")
+    state          = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
+
+    org_dir = state / org_id
+    ca_cert = (org_dir / "ca.pem").read_text()
+    ca_key  = (org_dir / "ca-key.pem").read_text()
+    secret  = (org_dir / "org_secret").read_text().strip()
+    display = (org_dir / "display_name").read_text().strip()
+
+    db_file = pathlib.Path(db_path)
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+
+    async with aiosqlite.connect(str(db_file)) as db:
+        await db.execute("PRAGMA journal_mode=WAL")
+        await db.executescript(_SCHEMA)
+
+        rows = {
+            "broker_url":    broker_url,
+            "org_id":        org_id,
+            "org_secret":    secret,
+            "org_ca_cert":   ca_cert,
+            "org_ca_key":    ca_key,
+            "display_name":  display,
+            "contact_email": f"admin@{org_id}.test",
+            "webhook_url":   f"{proxy_public}/pdp/policy",
+            "org_status":    "active",
+        }
+
+        # Optional PDP policy rules — passed as JSON via POLICY_RULES env var
+        # so each proxy can have a different ruleset. Smoke configures
+        # proxy-b with a blocked_agents list so the DENY branch of the
+        # webhook path is exercised every run.
+        policy_rules = os.environ.get("POLICY_RULES", "").strip()
+        if policy_rules:
+            rows["policy_rules"] = policy_rules
+        for k, v in rows.items():
+            await db.execute(
+                "INSERT INTO proxy_config (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+                (k, v),
+            )
+        await db.commit()
+
+    # Ensure proxyuser (uid varies but typically not root) can read the file.
+    db_file.chmod(0o666)
+    print(f"proxy-init: seeded {db_path} for {org_id} (keys: {', '.join(rows.keys())})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/enterprise_sandbox/proxy-init/seed.py
+++ b/enterprise_sandbox/proxy-init/seed.py
@@ -68,6 +68,17 @@ async def main() -> int:
         policy_rules = os.environ.get("POLICY_RULES", "").strip()
         if policy_rules:
             rows["policy_rules"] = policy_rules
+
+        # Optional per-proxy OIDC config (PR #87) — if all three are set, the
+        # proxy dashboard enables SSO login via that IdP.
+        oidc_issuer = os.environ.get("OIDC_ISSUER_URL", "").strip()
+        oidc_client = os.environ.get("OIDC_CLIENT_ID", "").strip()
+        oidc_secret = os.environ.get("OIDC_CLIENT_SECRET", "").strip()
+        if oidc_issuer and oidc_client:
+            rows["oidc_issuer_url"] = oidc_issuer
+            rows["oidc_client_id"] = oidc_client
+            if oidc_secret:
+                rows["oidc_client_secret"] = oidc_secret
         for k, v in rows.items():
             await db.execute(
                 "INSERT INTO proxy_config (key, value) VALUES (?, ?) "

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -78,7 +78,7 @@ echo "[smoke] Blocco 3 — Keycloak OIDC per org"
 # B3.1 — Keycloak-a OIDC discovery reachable from broker
 if docker exec enterprise_sandbox-broker-1 python -c "
 import urllib.request
-urllib.request.urlopen('http://keycloak-a:8080/realms/orga/.well-known/openid-configuration')
+urllib.request.urlopen('http://keycloak-a:8180/realms/orga/.well-known/openid-configuration')
 " 2>/dev/null; then
     pass "B3.1 keycloak-a realm 'orga' discovery OK"
 else
@@ -88,7 +88,7 @@ fi
 # B3.2 — Keycloak-b OIDC discovery reachable from broker
 if docker exec enterprise_sandbox-broker-1 python -c "
 import urllib.request
-urllib.request.urlopen('http://keycloak-b:8080/realms/orgb/.well-known/openid-configuration')
+urllib.request.urlopen('http://keycloak-b:8280/realms/orgb/.well-known/openid-configuration')
 " 2>/dev/null; then
     pass "B3.2 keycloak-b realm 'orgb' discovery OK"
 else
@@ -100,7 +100,7 @@ oidc_a=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -A
     "SELECT oidc_issuer_url FROM organizations WHERE org_id='orga';")
 oidc_b=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
     "SELECT oidc_issuer_url FROM organizations WHERE org_id='orgb';")
-if [[ "$oidc_a" == "http://keycloak-a:8080/realms/orga" && "$oidc_b" == "http://keycloak-b:8080/realms/orgb" ]]; then
+if [[ "$oidc_a" == "http://keycloak-a:8180/realms/orga" && "$oidc_b" == "http://keycloak-b:8280/realms/orgb" ]]; then
     pass "B3.3 per-org OIDC config wired in broker DB"
 else
     fail "B3.3 OIDC config wired (orga=$oidc_a orgb=$oidc_b)"
@@ -114,11 +114,11 @@ data = urllib.parse.urlencode({
     'client_secret':'orga-oidc-client-secret-change-me',
     'username':'alice','password':'alice-sandbox','scope':'openid email'
 }).encode()
-t = json.loads(urllib.request.urlopen('http://keycloak-a:8080/realms/orga/protocol/openid-connect/token', data=data).read())
+t = json.loads(urllib.request.urlopen('http://keycloak-a:8180/realms/orga/protocol/openid-connect/token', data=data).read())
 p = json.loads(base64.urlsafe_b64decode(t['id_token'].split('.')[1]+'==='))
 print(p['iss']+'|'+p['email'])
 " 2>/dev/null)
-if [[ "$b34" == "http://keycloak-a:8080/realms/orga|alice@orga.test" ]]; then
+if [[ "$b34" == "http://keycloak-a:8180/realms/orga|alice@orga.test" ]]; then
     pass "B3.4 alice@orga OIDC login → id_token valid"
 else
     fail "B3.4 alice OIDC login (got: $b34)"
@@ -132,12 +132,42 @@ data = urllib.parse.urlencode({
     'client_secret':'orga-oidc-client-secret-change-me',
     'username':'bob','password':'bob-sandbox','scope':'openid'
 }).encode()
-try: urllib.request.urlopen('http://keycloak-a:8080/realms/orga/protocol/openid-connect/token', data=data); exit(1)
+try: urllib.request.urlopen('http://keycloak-a:8180/realms/orga/protocol/openid-connect/token', data=data); exit(1)
 except Exception: exit(0)
 " 2>/dev/null; then
     pass "B3.5 tenant isolation (bob rejected by keycloak-a)"
 else
     fail "B3.5 tenant isolation (bob accepted by keycloak-a — LEAK)"
+fi
+
+# B3.6 — Full browser OIDC login flow (auth code + token exchange + session)
+browser_flow() {
+    local org_id="$1" kc="$2" port="$3" user="$4" pass="$5"
+    local cj; cj=$(mktemp)
+    local au lp fa cu rc dash
+    au=$(curl -s -o /dev/null -w "%{redirect_url}" -c "$cj" -b "$cj" \
+        "http://localhost:8000/dashboard/oidc/start?role=org&org_id=$org_id") || { rm -f "$cj"; return 1; }
+    lp=$(curl -s --resolve "$kc:$port:127.0.0.1" -c "$cj" -b "$cj" -L "$au") || { rm -f "$cj"; return 1; }
+    fa=$(echo "$lp" | grep -oE 'action="[^"]+"' | head -1 | sed 's/action="//;s/"$//;s/&amp;/\&/g')
+    [[ -n "$fa" ]] || { rm -f "$cj"; return 1; }
+    cu=$(curl -s -o /dev/null -w "%{redirect_url}" --resolve "$kc:$port:127.0.0.1" -c "$cj" -b "$cj" \
+        -d "username=$user&password=$pass&credentialId=" "$fa")
+    rc=$(curl -s -o /dev/null -w "%{http_code}" -c "$cj" -b "$cj" "$cu")
+    dash=$(curl -s -o /dev/null -w "%{http_code}" -c "$cj" -b "$cj" -L "http://localhost:8000/dashboard/")
+    rm -f "$cj"
+    [[ "$rc" == "303" && "$dash" == "200" ]]
+}
+
+if browser_flow orga keycloak-a 8180 alice alice-sandbox; then
+    pass "B3.6 alice@orga full browser OIDC login → broker dashboard"
+else
+    fail "B3.6 alice@orga browser OIDC login"
+fi
+
+if browser_flow orgb keycloak-b 8280 bob bob-sandbox; then
+    pass "B3.7 bob@orgb full browser OIDC login → broker dashboard"
+else
+    fail "B3.7 bob@orgb browser OIDC login"
 fi
 
 # Upcoming

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -13,47 +13,37 @@ pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
 fail() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
 skip() { echo "  ~ $1 (skipped: $2)"; SKIP=$((SKIP+1)); }
 
-echo "[smoke] Blocco 1 — topology + cross-org reachability"
+echo "[smoke] Blocco 1 — shared broker on public-wan"
 
-# B1.1 — all core services healthy
+# B1.1 — all services healthy
 if docker compose ps --format json | grep -q '"Health":"healthy"'; then
     pass "B1.1 services healthy"
 else
     fail "B1.1 services healthy"
 fi
 
-# B1.2 — broker-a reaches broker-b on public-wan
-if docker exec enterprise_sandbox-broker-a-1 \
-    python -c "import urllib.request; urllib.request.urlopen('http://broker-b:8000/health')" 2>/dev/null; then
-    pass "B1.2 broker-a → broker-b via public-wan"
+# B1.2 — broker reachable on public-wan
+if docker run --rm --network cullis-sandbox-wan \
+    curlimages/curl:8.10.1 -sf http://broker:8000/health >/dev/null 2>&1; then
+    pass "B1.2 broker reachable on public-wan"
 else
-    fail "B1.2 broker-a → broker-b via public-wan"
+    fail "B1.2 broker reachable on public-wan"
 fi
 
-# B1.3 — broker-b reaches broker-a on public-wan
-if docker exec enterprise_sandbox-broker-b-1 \
-    python -c "import urllib.request; urllib.request.urlopen('http://broker-a:8000/health')" 2>/dev/null; then
-    pass "B1.3 broker-b → broker-a via public-wan"
+# B1.3 — org-internal networks exist and are isolated from public-wan services
+# (container on orga-internal cannot reach broker, which is on public-wan only)
+if docker run --rm --network cullis-sandbox-orga \
+    curlimages/curl:8.10.1 -sf --max-time 3 http://broker:8000/health >/dev/null 2>&1; then
+    fail "B1.3 org-internal isolation (orga reached broker — LEAK)"
 else
-    fail "B1.3 broker-b → broker-a via public-wan"
-fi
-
-# B1.4 — network isolation: broker-a cannot reach postgres-b
-if docker exec enterprise_sandbox-broker-a-1 python -c "
-import socket; s = socket.socket(); s.settimeout(2)
-try: s.connect(('postgres-b', 5432)); exit(1)
-except Exception: exit(0)
-" 2>/dev/null; then
-    pass "B1.4 org network isolation (broker-a ⊥ postgres-b)"
-else
-    fail "B1.4 org network isolation"
+    pass "B1.3 org-internal isolated from public-wan (proxy will bridge in Blocco 2)"
 fi
 
 # Upcoming blocks
-skip "B2 Vault + Proxy"        "Blocco 2 not yet implemented"
-skip "B3 Keycloak OIDC"        "Blocco 3 not yet implemented"
-skip "B4 SPIRE + SVID agent"   "Blocco 4 not yet implemented"
-skip "B5 smoke 10 assertion"   "Blocco 5 not yet implemented"
+skip "B2 Vault + Proxies + attach-ca"  "Blocco 2 not yet implemented"
+skip "B3 Keycloak OIDC"                "Blocco 3 not yet implemented"
+skip "B4 SPIRE + SVID agent"           "Blocco 4 not yet implemented"
+skip "B5 smoke 10 assertion"           "Blocco 5 not yet implemented"
 
 echo ""
 echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -72,8 +72,75 @@ else
     fail "B2.5 proxy-a bridges to broker"
 fi
 
+echo ""
+echo "[smoke] Blocco 3 — Keycloak OIDC per org"
+
+# B3.1 — Keycloak-a OIDC discovery reachable from broker
+if docker exec enterprise_sandbox-broker-1 python -c "
+import urllib.request
+urllib.request.urlopen('http://keycloak-a:8080/realms/orga/.well-known/openid-configuration')
+" 2>/dev/null; then
+    pass "B3.1 keycloak-a realm 'orga' discovery OK"
+else
+    fail "B3.1 keycloak-a discovery"
+fi
+
+# B3.2 — Keycloak-b OIDC discovery reachable from broker
+if docker exec enterprise_sandbox-broker-1 python -c "
+import urllib.request
+urllib.request.urlopen('http://keycloak-b:8080/realms/orgb/.well-known/openid-configuration')
+" 2>/dev/null; then
+    pass "B3.2 keycloak-b realm 'orgb' discovery OK"
+else
+    fail "B3.2 keycloak-b discovery"
+fi
+
+# B3.3 — Per-org OIDC config wired in broker DB
+oidc_a=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
+    "SELECT oidc_issuer_url FROM organizations WHERE org_id='orga';")
+oidc_b=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
+    "SELECT oidc_issuer_url FROM organizations WHERE org_id='orgb';")
+if [[ "$oidc_a" == "http://keycloak-a:8080/realms/orga" && "$oidc_b" == "http://keycloak-b:8080/realms/orgb" ]]; then
+    pass "B3.3 per-org OIDC config wired in broker DB"
+else
+    fail "B3.3 OIDC config wired (orga=$oidc_a orgb=$oidc_b)"
+fi
+
+# B3.4 — End-to-end: alice@orga obtains id_token with correct issuer
+b34=$(docker exec enterprise_sandbox-broker-1 python -c "
+import urllib.request, urllib.parse, json, base64
+data = urllib.parse.urlencode({
+    'grant_type':'password','client_id':'cullis-broker-dashboard',
+    'client_secret':'orga-oidc-client-secret-change-me',
+    'username':'alice','password':'alice-sandbox','scope':'openid email'
+}).encode()
+t = json.loads(urllib.request.urlopen('http://keycloak-a:8080/realms/orga/protocol/openid-connect/token', data=data).read())
+p = json.loads(base64.urlsafe_b64decode(t['id_token'].split('.')[1]+'==='))
+print(p['iss']+'|'+p['email'])
+" 2>/dev/null)
+if [[ "$b34" == "http://keycloak-a:8080/realms/orga|alice@orga.test" ]]; then
+    pass "B3.4 alice@orga OIDC login → id_token valid"
+else
+    fail "B3.4 alice OIDC login (got: $b34)"
+fi
+
+# B3.5 — Tenant isolation: Keycloak-a does NOT have bob, Keycloak-b does NOT have alice
+if docker exec enterprise_sandbox-broker-1 python -c "
+import urllib.request, urllib.parse, json
+data = urllib.parse.urlencode({
+    'grant_type':'password','client_id':'cullis-broker-dashboard',
+    'client_secret':'orga-oidc-client-secret-change-me',
+    'username':'bob','password':'bob-sandbox','scope':'openid'
+}).encode()
+try: urllib.request.urlopen('http://keycloak-a:8080/realms/orga/protocol/openid-connect/token', data=data); exit(1)
+except Exception: exit(0)
+" 2>/dev/null; then
+    pass "B3.5 tenant isolation (bob rejected by keycloak-a)"
+else
+    fail "B3.5 tenant isolation (bob accepted by keycloak-a — LEAK)"
+fi
+
 # Upcoming
-skip "B3 Keycloak OIDC"              "Blocco 3 not yet implemented"
 skip "B4 SPIRE + SVID agent"         "Blocco 4 not yet implemented"
 skip "B5 full 10-assertion smoke"    "Blocco 5 not yet implemented"
 

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -15,14 +15,12 @@ skip() { echo "  ~ $1 (skipped: $2)"; SKIP=$((SKIP+1)); }
 
 echo "[smoke] Blocco 1 — shared broker on public-wan"
 
-# B1.1 — all services healthy
 if docker compose ps --format json | grep -q '"Health":"healthy"'; then
     pass "B1.1 services healthy"
 else
     fail "B1.1 services healthy"
 fi
 
-# B1.2 — broker reachable on public-wan
 if docker run --rm --network cullis-sandbox-wan \
     curlimages/curl:8.10.1 -sf http://broker:8000/health >/dev/null 2>&1; then
     pass "B1.2 broker reachable on public-wan"
@@ -30,20 +28,54 @@ else
     fail "B1.2 broker reachable on public-wan"
 fi
 
-# B1.3 — org-internal networks exist and are isolated from public-wan services
-# (container on orga-internal cannot reach broker, which is on public-wan only)
-if docker run --rm --network cullis-sandbox-orga \
-    curlimages/curl:8.10.1 -sf --max-time 3 http://broker:8000/health >/dev/null 2>&1; then
-    fail "B1.3 org-internal isolation (orga reached broker — LEAK)"
+echo ""
+echo "[smoke] Blocco 2 — proxies + attach-ca (2 orgs)"
+
+# B2.1 — 2 orgs registered and active on broker
+orgs=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
+    "SELECT org_id FROM organizations WHERE status='active' ORDER BY org_id;")
+if [[ "$orgs" == $'orga\norgb' ]]; then
+    pass "B2.1 orga + orgb active on broker"
 else
-    pass "B1.3 org-internal isolated from public-wan (proxy will bridge in Blocco 2)"
+    fail "B2.1 orgs active (got: $orgs)"
 fi
 
-# Upcoming blocks
-skip "B2 Vault + Proxies + attach-ca"  "Blocco 2 not yet implemented"
-skip "B3 Keycloak OIDC"                "Blocco 3 not yet implemented"
-skip "B4 SPIRE + SVID agent"           "Blocco 4 not yet implemented"
-skip "B5 smoke 10 assertion"           "Blocco 5 not yet implemented"
+# B2.2 — proxy-a reachable from orga-internal
+if docker run --rm --network cullis-sandbox-orga \
+    curlimages/curl:8.10.1 -sf http://proxy-a:9100/health >/dev/null 2>&1; then
+    pass "B2.2 proxy-a reachable from orga-internal"
+else
+    fail "B2.2 proxy-a reachable from orga-internal"
+fi
+
+# B2.3 — proxy-b reachable from orgb-internal
+if docker run --rm --network cullis-sandbox-orgb \
+    curlimages/curl:8.10.1 -sf http://proxy-b:9100/health >/dev/null 2>&1; then
+    pass "B2.3 proxy-b reachable from orgb-internal"
+else
+    fail "B2.3 proxy-b reachable from orgb-internal"
+fi
+
+# B2.4 — org isolation: orgb-internal cannot reach proxy-a directly
+if docker run --rm --network cullis-sandbox-orgb \
+    curlimages/curl:8.10.1 -sf --max-time 3 http://proxy-a:9100/health >/dev/null 2>&1; then
+    fail "B2.4 org isolation (orgb reached proxy-a directly — LEAK)"
+else
+    pass "B2.4 org isolation (orgb-internal ⊥ proxy-a direct access)"
+fi
+
+# B2.5 — proxy-a CAN reach broker via public-wan (bridge role)
+if docker exec enterprise_sandbox-proxy-a-1 \
+    python -c "import urllib.request; urllib.request.urlopen('http://broker:8000/health')" 2>/dev/null; then
+    pass "B2.5 proxy-a bridges orga-internal → broker (public-wan)"
+else
+    fail "B2.5 proxy-a bridges to broker"
+fi
+
+# Upcoming
+skip "B3 Keycloak OIDC"              "Blocco 3 not yet implemented"
+skip "B4 SPIRE + SVID agent"         "Blocco 4 not yet implemented"
+skip "B5 full 10-assertion smoke"    "Blocco 5 not yet implemented"
 
 echo ""
 echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -31,7 +31,6 @@ fi
 echo ""
 echo "[smoke] Blocco 2 — proxies + attach-ca (2 orgs)"
 
-# B2.1 — 2 orgs registered and active on broker
 orgs=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
     "SELECT org_id FROM organizations WHERE status='active' ORDER BY org_id;")
 if [[ "$orgs" == $'orga\norgb' ]]; then
@@ -40,7 +39,6 @@ else
     fail "B2.1 orgs active (got: $orgs)"
 fi
 
-# B2.2 — proxy-a reachable from orga-internal
 if docker run --rm --network cullis-sandbox-orga \
     curlimages/curl:8.10.1 -sf http://proxy-a:9100/health >/dev/null 2>&1; then
     pass "B2.2 proxy-a reachable from orga-internal"
@@ -48,7 +46,6 @@ else
     fail "B2.2 proxy-a reachable from orga-internal"
 fi
 
-# B2.3 — proxy-b reachable from orgb-internal
 if docker run --rm --network cullis-sandbox-orgb \
     curlimages/curl:8.10.1 -sf http://proxy-b:9100/health >/dev/null 2>&1; then
     pass "B2.3 proxy-b reachable from orgb-internal"
@@ -56,7 +53,6 @@ else
     fail "B2.3 proxy-b reachable from orgb-internal"
 fi
 
-# B2.4 — org isolation: orgb-internal cannot reach proxy-a directly
 if docker run --rm --network cullis-sandbox-orgb \
     curlimages/curl:8.10.1 -sf --max-time 3 http://proxy-a:9100/health >/dev/null 2>&1; then
     fail "B2.4 org isolation (orgb reached proxy-a directly — LEAK)"
@@ -64,53 +60,60 @@ else
     pass "B2.4 org isolation (orgb-internal ⊥ proxy-a direct access)"
 fi
 
-# B2.5 — proxy-a CAN reach broker via public-wan (bridge role)
-if docker exec enterprise_sandbox-proxy-a-1 \
-    python -c "import urllib.request; urllib.request.urlopen('http://broker:8000/health')" 2>/dev/null; then
-    pass "B2.5 proxy-a bridges orga-internal → broker (public-wan)"
-else
-    fail "B2.5 proxy-a bridges to broker"
-fi
-
 echo ""
-echo "[smoke] Blocco 3 — Keycloak OIDC per org"
+echo "[smoke] Blocco 3 — Keycloak OIDC per proxy (three-tier refactor)"
 
-# B3.1 — Keycloak-a OIDC discovery reachable from broker
+# B3.1 — Keycloak-a discovery reachable from broker network
 if docker exec enterprise_sandbox-broker-1 python -c "
 import urllib.request
 urllib.request.urlopen('http://keycloak-a:8180/realms/orga/.well-known/openid-configuration')
 " 2>/dev/null; then
-    pass "B3.1 keycloak-a realm 'orga' discovery OK"
+    pass "B3.1 keycloak-a realm 'orga' discovery OK (docker network)"
 else
     fail "B3.1 keycloak-a discovery"
 fi
 
-# B3.2 — Keycloak-b OIDC discovery reachable from broker
+# B3.2 — Keycloak-b discovery reachable from broker network
 if docker exec enterprise_sandbox-broker-1 python -c "
 import urllib.request
 urllib.request.urlopen('http://keycloak-b:8280/realms/orgb/.well-known/openid-configuration')
 " 2>/dev/null; then
-    pass "B3.2 keycloak-b realm 'orgb' discovery OK"
+    pass "B3.2 keycloak-b realm 'orgb' discovery OK (docker network)"
 else
     fail "B3.2 keycloak-b discovery"
 fi
 
-# B3.3 — Per-org OIDC config wired in broker DB
-oidc_a=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
-    "SELECT oidc_issuer_url FROM organizations WHERE org_id='orga';")
-oidc_b=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
-    "SELECT oidc_issuer_url FROM organizations WHERE org_id='orgb';")
+# B3.3 — OIDC config wired in proxy_config (not on broker)
+q_oidc() {
+    docker exec "$1" python -c "
+import sqlite3
+c = sqlite3.connect('/data/mcp_proxy.db')
+r = c.execute(\"SELECT value FROM proxy_config WHERE key='oidc_issuer_url'\").fetchone()
+print(r[0] if r else '')
+" 2>/dev/null
+}
+oidc_a=$(q_oidc enterprise_sandbox-proxy-a-1)
+oidc_b=$(q_oidc enterprise_sandbox-proxy-b-1)
 if [[ "$oidc_a" == "http://keycloak-a:8180/realms/orga" && "$oidc_b" == "http://keycloak-b:8280/realms/orgb" ]]; then
-    pass "B3.3 per-org OIDC config wired in broker DB"
+    pass "B3.3 per-proxy OIDC config (proxy_config table)"
 else
-    fail "B3.3 OIDC config wired (orga=$oidc_a orgb=$oidc_b)"
+    fail "B3.3 OIDC config per proxy (a=$oidc_a b=$oidc_b)"
 fi
 
-# B3.4 — End-to-end: alice@orga obtains id_token with correct issuer
-b34=$(docker exec enterprise_sandbox-broker-1 python -c "
+# B3.4 — Broker DB has NO per-org OIDC (columns still exist but unused)
+broker_oidc=$(docker exec enterprise_sandbox-postgres-1 psql -U atn -d agent_trust -Atc \
+    "SELECT COALESCE(oidc_issuer_url, 'NULL') FROM organizations ORDER BY org_id;" | tr '\n' ',')
+if [[ "$broker_oidc" == "NULL,NULL," ]]; then
+    pass "B3.4 broker has no org OIDC config (network-admin-only)"
+else
+    fail "B3.4 broker org OIDC should be NULL (got: $broker_oidc)"
+fi
+
+# B3.5 — alice@orga Keycloak direct grant (IdP tenant works standalone)
+b35=$(docker exec enterprise_sandbox-broker-1 python -c "
 import urllib.request, urllib.parse, json, base64
 data = urllib.parse.urlencode({
-    'grant_type':'password','client_id':'cullis-broker-dashboard',
+    'grant_type':'password','client_id':'cullis-proxy-dashboard',
     'client_secret':'orga-oidc-client-secret-change-me',
     'username':'alice','password':'alice-sandbox','scope':'openid email'
 }).encode()
@@ -118,56 +121,56 @@ t = json.loads(urllib.request.urlopen('http://keycloak-a:8180/realms/orga/protoc
 p = json.loads(base64.urlsafe_b64decode(t['id_token'].split('.')[1]+'==='))
 print(p['iss']+'|'+p['email'])
 " 2>/dev/null)
-if [[ "$b34" == "http://keycloak-a:8180/realms/orga|alice@orga.test" ]]; then
-    pass "B3.4 alice@orga OIDC login → id_token valid"
+if [[ "$b35" == "http://keycloak-a:8180/realms/orga|alice@orga.test" ]]; then
+    pass "B3.5 alice@orga OIDC token valid"
 else
-    fail "B3.4 alice OIDC login (got: $b34)"
+    fail "B3.5 alice OIDC (got: $b35)"
 fi
 
-# B3.5 — Tenant isolation: Keycloak-a does NOT have bob, Keycloak-b does NOT have alice
+# B3.6 — Tenant isolation: bob rejected by keycloak-a realm
 if docker exec enterprise_sandbox-broker-1 python -c "
-import urllib.request, urllib.parse, json
+import urllib.request, urllib.parse
 data = urllib.parse.urlencode({
-    'grant_type':'password','client_id':'cullis-broker-dashboard',
+    'grant_type':'password','client_id':'cullis-proxy-dashboard',
     'client_secret':'orga-oidc-client-secret-change-me',
     'username':'bob','password':'bob-sandbox','scope':'openid'
 }).encode()
 try: urllib.request.urlopen('http://keycloak-a:8180/realms/orga/protocol/openid-connect/token', data=data); exit(1)
 except Exception: exit(0)
 " 2>/dev/null; then
-    pass "B3.5 tenant isolation (bob rejected by keycloak-a)"
+    pass "B3.6 tenant isolation (bob rejected by keycloak-a)"
 else
-    fail "B3.5 tenant isolation (bob accepted by keycloak-a — LEAK)"
+    fail "B3.6 tenant isolation (bob accepted by keycloak-a — LEAK)"
 fi
 
-# B3.6 — Full browser OIDC login flow (auth code + token exchange + session)
+# B3.7 — Browser OIDC login flow via PROXY dashboard (not broker)
 browser_flow() {
-    local org_id="$1" kc="$2" port="$3" user="$4" pass="$5"
+    local proxy_port="$1" kc="$2" kc_port="$3" user="$4" pass="$5"
     local cj; cj=$(mktemp)
-    local au lp fa cu rc dash
+    local au lp fa cu rc
     au=$(curl -s -o /dev/null -w "%{redirect_url}" -c "$cj" -b "$cj" \
-        "http://localhost:8000/dashboard/oidc/start?role=org&org_id=$org_id") || { rm -f "$cj"; return 1; }
-    lp=$(curl -s --resolve "$kc:$port:127.0.0.1" -c "$cj" -b "$cj" -L "$au") || { rm -f "$cj"; return 1; }
+        "http://localhost:${proxy_port}/proxy/oidc/start") || { rm -f "$cj"; return 1; }
+    [[ -n "$au" ]] || { rm -f "$cj"; return 1; }
+    lp=$(curl -s --resolve "$kc:$kc_port:127.0.0.1" -c "$cj" -b "$cj" -L "$au")
     fa=$(echo "$lp" | grep -oE 'action="[^"]+"' | head -1 | sed 's/action="//;s/"$//;s/&amp;/\&/g')
     [[ -n "$fa" ]] || { rm -f "$cj"; return 1; }
-    cu=$(curl -s -o /dev/null -w "%{redirect_url}" --resolve "$kc:$port:127.0.0.1" -c "$cj" -b "$cj" \
+    cu=$(curl -s -o /dev/null -w "%{redirect_url}" --resolve "$kc:$kc_port:127.0.0.1" -c "$cj" -b "$cj" \
         -d "username=$user&password=$pass&credentialId=" "$fa")
     rc=$(curl -s -o /dev/null -w "%{http_code}" -c "$cj" -b "$cj" "$cu")
-    dash=$(curl -s -o /dev/null -w "%{http_code}" -c "$cj" -b "$cj" -L "http://localhost:8000/dashboard/")
     rm -f "$cj"
-    [[ "$rc" == "303" && "$dash" == "200" ]]
+    [[ "$rc" == "303" || "$rc" == "302" || "$rc" == "200" ]]
 }
 
-if browser_flow orga keycloak-a 8180 alice alice-sandbox; then
-    pass "B3.6 alice@orga full browser OIDC login → broker dashboard"
+if browser_flow 9100 keycloak-a 8180 alice alice-sandbox; then
+    pass "B3.7 alice@orga browser OIDC → proxy-a dashboard"
 else
-    fail "B3.6 alice@orga browser OIDC login"
+    fail "B3.7 alice@orga browser OIDC"
 fi
 
-if browser_flow orgb keycloak-b 8280 bob bob-sandbox; then
-    pass "B3.7 bob@orgb full browser OIDC login → broker dashboard"
+if browser_flow 9200 keycloak-b 8280 bob bob-sandbox; then
+    pass "B3.8 bob@orgb browser OIDC → proxy-b dashboard"
 else
-    fail "B3.7 bob@orgb browser OIDC login"
+    fail "B3.8 bob@orgb browser OIDC"
 fi
 
 # Upcoming

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -1,10 +1,60 @@
 #!/usr/bin/env bash
-# Enterprise sandbox — smoke test (stub)
-# Status: assertion scaffolded per block, implemented in Blocco 5
+# Enterprise sandbox — smoke test
+# Assertion list: imp/enterprise_sandbox_plan.md §smoke
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
-echo "[smoke] stub — assertion full list in imp/enterprise_sandbox_plan.md §smoke"
-echo "[smoke] implemented: 0/10"
-exit 0
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  ✓ $1"; PASS=$((PASS+1)); }
+fail() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+skip() { echo "  ~ $1 (skipped: $2)"; SKIP=$((SKIP+1)); }
+
+echo "[smoke] Blocco 1 — topology + cross-org reachability"
+
+# B1.1 — all core services healthy
+if docker compose ps --format json | grep -q '"Health":"healthy"'; then
+    pass "B1.1 services healthy"
+else
+    fail "B1.1 services healthy"
+fi
+
+# B1.2 — broker-a reaches broker-b on public-wan
+if docker exec enterprise_sandbox-broker-a-1 \
+    python -c "import urllib.request; urllib.request.urlopen('http://broker-b:8000/health')" 2>/dev/null; then
+    pass "B1.2 broker-a → broker-b via public-wan"
+else
+    fail "B1.2 broker-a → broker-b via public-wan"
+fi
+
+# B1.3 — broker-b reaches broker-a on public-wan
+if docker exec enterprise_sandbox-broker-b-1 \
+    python -c "import urllib.request; urllib.request.urlopen('http://broker-a:8000/health')" 2>/dev/null; then
+    pass "B1.3 broker-b → broker-a via public-wan"
+else
+    fail "B1.3 broker-b → broker-a via public-wan"
+fi
+
+# B1.4 — network isolation: broker-a cannot reach postgres-b
+if docker exec enterprise_sandbox-broker-a-1 python -c "
+import socket; s = socket.socket(); s.settimeout(2)
+try: s.connect(('postgres-b', 5432)); exit(1)
+except Exception: exit(0)
+" 2>/dev/null; then
+    pass "B1.4 org network isolation (broker-a ⊥ postgres-b)"
+else
+    fail "B1.4 org network isolation"
+fi
+
+# Upcoming blocks
+skip "B2 Vault + Proxy"        "Blocco 2 not yet implemented"
+skip "B3 Keycloak OIDC"        "Blocco 3 not yet implemented"
+skip "B4 SPIRE + SVID agent"   "Blocco 4 not yet implemented"
+skip "B5 smoke 10 assertion"   "Blocco 5 not yet implemented"
+
+echo ""
+echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
+[[ $FAIL -eq 0 ]]

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -209,9 +209,50 @@ else
     fail "B3.10 bob's cookie accepted by proxy-a (HTTP $cross_rc — LEAK)"
 fi
 
-# Upcoming
-skip "B4 SPIRE + SVID agent"         "Blocco 4 not yet implemented"
-skip "B5 full 10-assertion smoke"    "Blocco 5 not yet implemented"
+echo ""
+echo "[smoke] Blocco 4 — SPIRE stack + SPIFFE agent auth"
+
+# B4.1 — SPIRE servers up and healthy
+if docker compose ps spire-server-a --format json | grep -q '"Health":"healthy"' \
+   && docker compose ps spire-server-b --format json | grep -q '"Health":"healthy"'; then
+    pass "B4.1 spire-server-a + spire-server-b healthy"
+else
+    fail "B4.1 spire-server healthy"
+fi
+
+# B4.2 — Registration entries created (one per org).
+# spire-server image is distroless — no shell — but docker exec with the
+# absolute binary path bypasses PATH lookup and works anyway.
+entries_a=$(docker exec enterprise_sandbox-spire-server-a-1 \
+    /opt/spire/bin/spire-server entry show \
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null | \
+    grep -c "spiffe://orga.test/agent-a" || true)
+entries_b=$(docker exec enterprise_sandbox-spire-server-b-1 \
+    /opt/spire/bin/spire-server entry show \
+    -socketPath /tmp/spire-server/private/api.sock 2>/dev/null | \
+    grep -c "spiffe://orgb.test/agent-b" || true)
+if [[ "$entries_a" -ge 1 && "$entries_b" -ge 1 ]]; then
+    pass "B4.2 registration entries present (agent-a, agent-b)"
+else
+    fail "B4.2 registration entries (a=$entries_a b=$entries_b)"
+fi
+
+# B4.3 — SPIRE agents healthy (Workload API socket usable)
+if docker compose ps spire-agent-a --format json | grep -q '"Health":"healthy"' \
+   && docker compose ps spire-agent-b --format json | grep -q '"Health":"healthy"'; then
+    pass "B4.3 spire-agent-a + spire-agent-b healthy (Workload API ready)"
+else
+    fail "B4.3 spire-agent healthy"
+fi
+
+# B4.4 + B4.5 — End-to-end SPIFFE auth to broker is BLOCKED until the broker
+# learns to derive agent_id/org_id from a SPIFFE SAN URI when the cert lacks
+# CN/O (SPIRE-issued SVIDs do). Tracked separately — the SPIRE half (the
+# whole point of this Blocco) is verified by B4.1-3 above. Once the broker
+# work lands, agent-a/agent-b containers in compose will become healthy
+# without further sandbox changes.
+skip "B4.4 agent broker auth via SVID"   "blocked: broker needs SPIFFE-aware x509 verifier"
+skip "B4.5 cross-org session over SPIFFE" "blocked: same — see issue tracking SPIFFE-aware broker auth"
 
 echo ""
 echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Enterprise sandbox — smoke test (stub)
+# Status: assertion scaffolded per block, implemented in Blocco 5
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "[smoke] stub — assertion full list in imp/enterprise_sandbox_plan.md §smoke"
+echo "[smoke] implemented: 0/10"
+exit 0

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -173,6 +173,42 @@ else
     fail "B3.8 bob@orgb browser OIDC"
 fi
 
+# B3.9 — Unauthenticated access to proxy dashboard is blocked
+anon_rc=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9100/proxy/overview)
+if [[ "$anon_rc" == "303" || "$anon_rc" == "302" || "$anon_rc" == "401" || "$anon_rc" == "403" ]]; then
+    pass "B3.9 anonymous GET /proxy/overview blocked (HTTP $anon_rc)"
+else
+    fail "B3.9 anonymous access NOT blocked (HTTP $anon_rc — LEAK)"
+fi
+
+# B3.10 — Session isolation: bob's cookie must not grant access to proxy-a
+#
+# Full OIDC login for bob on proxy-b captures a session cookie, then we replay
+# that same cookie jar against proxy-a. Expected: 303/401/403 (bob's session
+# is bound to proxy-b's signing key + org; proxy-a must reject it).
+bob_login_and_try_other() {
+    local cj; cj=$(mktemp)
+    local au lp fa cu
+    au=$(curl -s -o /dev/null -w "%{redirect_url}" -c "$cj" -b "$cj" \
+        "http://localhost:9200/proxy/oidc/start") || { rm -f "$cj"; echo X; return; }
+    lp=$(curl -s --resolve "keycloak-b:8280:127.0.0.1" -c "$cj" -b "$cj" -L "$au")
+    fa=$(echo "$lp" | grep -oE 'action="[^"]+"' | head -1 | sed 's/action="//;s/"$//;s/&amp;/\&/g')
+    cu=$(curl -s -o /dev/null -w "%{redirect_url}" --resolve "keycloak-b:8280:127.0.0.1" -c "$cj" -b "$cj" \
+        -d "username=bob&password=bob-sandbox&credentialId=" "$fa")
+    curl -s -o /dev/null -c "$cj" -b "$cj" "$cu" >/dev/null   # seal bob session
+    # Replay bob's cookie jar against proxy-a (different port, different tenant)
+    local cross
+    cross=$(curl -s -o /dev/null -w "%{http_code}" -b "$cj" http://localhost:9100/proxy/overview)
+    rm -f "$cj"
+    echo "$cross"
+}
+cross_rc=$(bob_login_and_try_other)
+if [[ "$cross_rc" == "303" || "$cross_rc" == "302" || "$cross_rc" == "401" || "$cross_rc" == "403" ]]; then
+    pass "B3.10 bob's cookie rejected by proxy-a (HTTP $cross_rc — isolated)"
+else
+    fail "B3.10 bob's cookie accepted by proxy-a (HTTP $cross_rc — LEAK)"
+fi
+
 # Upcoming
 skip "B4 SPIRE + SVID agent"         "Blocco 4 not yet implemented"
 skip "B5 full 10-assertion smoke"    "Blocco 5 not yet implemented"

--- a/enterprise_sandbox/spire/agent-a.conf
+++ b/enterprise_sandbox/spire/agent-a.conf
@@ -1,0 +1,31 @@
+agent {
+  data_dir = "/run/spire/data"
+  log_level = "INFO"
+  server_address = "spire-server-a"
+  server_port = "8081"
+  socket_path = "/run/spire/sockets/agent.sock"
+  trust_domain = "orga.test"
+  # For the sandbox we let the agent accept the server's trust bundle on
+  # first connect (single-host demo, no OOB bundle distribution needed).
+  insecure_bootstrap = true
+}
+
+plugins {
+  NodeAttestor "join_token" {
+    plugin_data {}
+  }
+  KeyManager "memory" {
+    plugin_data {}
+  }
+  WorkloadAttestor "unix" {
+    plugin_data {}
+  }
+}
+
+health_checks {
+  listener_enabled = true
+  bind_address = "0.0.0.0"
+  bind_port = "8080"
+  live_path = "/live"
+  ready_path = "/ready"
+}

--- a/enterprise_sandbox/spire/agent-b.conf
+++ b/enterprise_sandbox/spire/agent-b.conf
@@ -1,0 +1,29 @@
+agent {
+  data_dir = "/run/spire/data"
+  log_level = "INFO"
+  server_address = "spire-server-b"
+  server_port = "8081"
+  socket_path = "/run/spire/sockets/agent.sock"
+  trust_domain = "orgb.test"
+  insecure_bootstrap = true
+}
+
+plugins {
+  NodeAttestor "join_token" {
+    plugin_data {}
+  }
+  KeyManager "memory" {
+    plugin_data {}
+  }
+  WorkloadAttestor "unix" {
+    plugin_data {}
+  }
+}
+
+health_checks {
+  listener_enabled = true
+  bind_address = "0.0.0.0"
+  bind_port = "8080"
+  live_path = "/live"
+  ready_path = "/ready"
+}

--- a/enterprise_sandbox/spire/agent-wrapper/Dockerfile
+++ b/enterprise_sandbox/spire/agent-wrapper/Dockerfile
@@ -1,0 +1,6 @@
+# Wrapper around the distroless spire-agent image so we get a shell
+# (needed to read the join-token file from a shared volume at start time).
+FROM ghcr.io/spiffe/spire-agent:1.9.5 AS bin
+FROM alpine:3.20
+COPY --from=bin /opt/spire/bin/spire-agent /usr/local/bin/spire-agent
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/enterprise_sandbox/spire/init/Dockerfile
+++ b/enterprise_sandbox/spire/init/Dockerfile
@@ -1,0 +1,9 @@
+# Tiny image to run `spire-server token generate` + `entry create` against
+# a sibling spire-server container. The official spire-server image is
+# distroless — no /bin/sh — so we copy the CLI into an alpine layer that
+# has a shell + awk.
+FROM ghcr.io/spiffe/spire-server:1.9.5 AS bin
+FROM alpine:3.20
+COPY --from=bin /opt/spire/bin/spire-server /usr/local/bin/spire-server
+RUN apk add --no-cache gawk
+ENTRYPOINT ["/bin/sh", "-c"]

--- a/enterprise_sandbox/spire/server-a.conf
+++ b/enterprise_sandbox/spire/server-a.conf
@@ -1,0 +1,39 @@
+server {
+  bind_address = "0.0.0.0"
+  bind_port = "8081"
+  trust_domain = "orga.test"
+  data_dir = "/run/spire/data"
+  log_level = "INFO"
+  ca_ttl = "24h"
+  default_x509_svid_ttl = "1h"
+}
+
+plugins {
+  DataStore "sql" {
+    plugin_data {
+      database_type = "sqlite3"
+      connection_string = "/run/spire/data/datastore.sqlite3"
+    }
+  }
+  NodeAttestor "join_token" {
+    plugin_data {}
+  }
+  KeyManager "memory" {
+    plugin_data {}
+  }
+  UpstreamAuthority "disk" {
+    plugin_data {
+      cert_file_path   = "/state/orga/ca.pem"
+      key_file_path    = "/state/orga/ca-key.pem"
+      bundle_file_path = "/state/orga/ca.pem"
+    }
+  }
+}
+
+health_checks {
+  listener_enabled = true
+  bind_address = "0.0.0.0"
+  bind_port = "8080"
+  live_path = "/live"
+  ready_path = "/ready"
+}

--- a/enterprise_sandbox/spire/server-b.conf
+++ b/enterprise_sandbox/spire/server-b.conf
@@ -1,0 +1,39 @@
+server {
+  bind_address = "0.0.0.0"
+  bind_port = "8081"
+  trust_domain = "orgb.test"
+  data_dir = "/run/spire/data"
+  log_level = "INFO"
+  ca_ttl = "24h"
+  default_x509_svid_ttl = "1h"
+}
+
+plugins {
+  DataStore "sql" {
+    plugin_data {
+      database_type = "sqlite3"
+      connection_string = "/run/spire/data/datastore.sqlite3"
+    }
+  }
+  NodeAttestor "join_token" {
+    plugin_data {}
+  }
+  KeyManager "memory" {
+    plugin_data {}
+  }
+  UpstreamAuthority "disk" {
+    plugin_data {
+      cert_file_path   = "/state/orgb/ca.pem"
+      key_file_path    = "/state/orgb/ca-key.pem"
+      bundle_file_path = "/state/orgb/ca.pem"
+    }
+  }
+}
+
+health_checks {
+  listener_enabled = true
+  bind_address = "0.0.0.0"
+  bind_port = "8080"
+  live_path = "/live"
+  ready_path = "/ready"
+}

--- a/enterprise_sandbox/up.sh
+++ b/enterprise_sandbox/up.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Enterprise sandbox — up
+# Status: stub, populated per block in imp/enterprise_sandbox_plan.md
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "[sandbox] docker compose config check"
+docker compose config >/dev/null
+
+echo "[sandbox] starting services"
+docker compose up -d --wait
+
+echo "[sandbox] status"
+docker compose ps

--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -15,3 +15,5 @@ jinja2>=3.1.0
 starlette>=0.40.0,<1.0.0
 sse-starlette>=2.0,<3.0
 python-multipart>=0.0.20
+authlib>=1.3.0
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ connector = [
     "PyYAML>=6.0",
 ]
 spiffe = [
-    "pyspiffe>=0.1.2",
+    "spiffe>=0.2.0",
 ]
 
 [project.scripts]

--- a/tests/test_sdk_spiffe.py
+++ b/tests/test_sdk_spiffe.py
@@ -75,7 +75,7 @@ class _FakeBundle:
 class _FakeBundleSet:
     bundle: _FakeBundle
 
-    def get_x509_bundle_for_trust_domain(self, td):
+    def get_bundle_for_trust_domain(self, td):
         return self.bundle
 
 
@@ -150,8 +150,8 @@ def test_fetch_x509_svid_without_extra_raises_importerror():
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name.startswith("pyspiffe"):
-            raise ImportError("no pyspiffe")
+        if name == "spiffe" or name.startswith("spiffe."):
+            raise ImportError("no spiffe")
         return real_import(name, *args, **kwargs)
 
     with patch("builtins.__import__", side_effect=fake_import):
@@ -161,10 +161,10 @@ def test_fetch_x509_svid_without_extra_raises_importerror():
 
 def test_fetch_x509_svid_without_socket_raises():
     """Missing socket + no env var → clear RuntimeError."""
-    # Need pyspiffe importable for the ImportError check to pass; if not
+    # Need spiffe importable for the ImportError check to pass; if not
     # installed in the dev env, this test is equivalent to the ImportError
     # path above. Skip cleanly when missing.
-    pytest.importorskip("pyspiffe")
+    pytest.importorskip("spiffe")
     import os
     with patch.dict(os.environ, {}, clear=False):
         os.environ.pop("SPIFFE_ENDPOINT_SOCKET", None)


### PR DESCRIPTION
First push of the \`feat/enterprise-sandbox\` branch to origin. This bundles every block of the enterprise sandbox developed in private worktree (B1 → B4a) into one PR for review.

## What this PR contains

| Block | Status | Smoke assertions |
|-------|--------|------------------|
| B1 — Skeleton + shared broker on public-wan | done | 2/2 |
| B2 — Per-org proxy + attach-ca | done | 4/4 |
| B3 — Keycloak OIDC per proxy (three-tier refactor) | done | 10/10 |
| B4a — SPIRE stack + SPIFFE workload demo | partial (see below) | 3/3 active, 2 skipped |

Total: **19 assertions PASS, 2 explicitly skipped, 0 fail** on \`./smoke.sh\`.

## Blocco 4a — what works, what's blocked

Working end-to-end:
- Per-org SPIRE server + agent (UpstreamAuthority = Org CA, generated by bootstrap)
- Registration entries minted (\`spiffe://orga.test/agent-a\`, \`spiffe://orgb.test/agent-b\`)
- Workload API socket reachable from demo agents (PID-namespace-shared)
- SDK \`from_spiffe_workload_api()\` (PR #90 + fix PR #92) successfully fetches an X.509-SVID

Blocked (smoke skipped, not failed):
- Agent → broker authentication via SVID. Real product gap: broker's x509 verifier requires \`CN\` + \`O\` in the cert subject, but SPIRE-issued SVIDs only carry the SPIFFE URI in SAN. End-to-end SPIFFE story closes once the broker grows SPIFFE-aware verification (tracked separately).

## Notable shake-out fixes

- bootstrap CA \`path_length\` 0 → 2 (SPIRE chains its own intermediate, depth 2 covers SPIRE's CA-rotation pair)
- \`BROKER_PUBLIC_URL\` switched from \`localhost:8000\` → \`broker:8000\` so DPoP \`htu\` validation matches what agents on the docker network actually send (browser OIDC moved to proxies after #87/#88)
- agent containers share \`pid: service:spire-agent-X\` so the SPIRE \`unix\` WorkloadAttestor can resolve callers via \`/proc\`
- spire-server image is distroless — added tiny alpine wrappers (\`spire/init/\`, \`spire/agent-wrapper/\`) for shell-based init
- \`spire-server token generate\` outputs \`Token: …\` plus a \`Warning: Missing SPIFFE ID.\` line — filter \`^Token:\` before awk

## Test plan

- [x] \`./up.sh && ./smoke.sh\` → 19 PASS, 2 SKIP (documented), 0 FAIL on a clean host
- [x] \`./down.sh\` → all volumes + networks removed cleanly
- [ ] CI: this branch hasn't run on CI yet — sandbox isn't part of the CI matrix today; the smoke is intended as a local shake-out tool

## Stacked behind

- Depends on PR #92 (\`fix/sdk-spiffe-package-name\`) for the agent container build to succeed.