### PR TITLE
feat(proxy+sdk): ADR-001 §10 — receiver side, close intra-org loop

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -27,7 +27,7 @@ from typing import Any
 import httpx
 
 from cullis_sdk.auth import generate_dpop_keypair, build_dpop_proof, build_client_assertion
-from cullis_sdk.crypto.message_signer import sign_message
+from cullis_sdk.crypto.message_signer import sign_message, verify_signature
 from cullis_sdk.crypto.e2e import encrypt_for_agent, decrypt_from_agent
 from cullis_sdk.types import AgentInfo, SessionInfo, InboxMessage, RfqResult
 from cullis_sdk._logging import log, RED
@@ -568,6 +568,91 @@ class CullisClient:
         )
         resp.raise_for_status()
         return resp.json()
+
+    def receive_via_proxy(self, session_id: str) -> list[dict]:
+        """Poll the proxy for pending messages in ``session_id`` (ADR-001 §10).
+
+        Returns the verified plaintext payloads. For ``mtls-only`` frames the
+        signature is verified against the sender cert the proxy bundled in
+        the response; a frame that fails verification raises
+        ``ValueError`` rather than being silently dropped, so the caller
+        chooses whether to ack it, audit it, or abort.
+
+        Each returned dict has:
+          - ``msg_id`` (str)
+          - ``session_id`` (str)
+          - ``sender_agent_id`` (str)
+          - ``mode`` (``"mtls-only"`` | ``"envelope"``)
+          - ``payload`` (dict, plaintext — populated for mtls-only only)
+          - ``payload_ciphertext`` (str, populated for envelope only —
+            caller still decrypts with its own key)
+          - ``enqueued_at`` (ISO-8601)
+
+        ``envelope`` messages are handed back untouched; the existing
+        ``decrypt_from_agent`` helper remains the caller's responsibility
+        until the envelope-via-proxy pass-through lands in a follow-up.
+        """
+        headers = self.proxy_headers()
+        resp = self._http.get(
+            f"{self.base}/v1/egress/messages/{session_id}",
+            headers=headers,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        out: list[dict] = []
+        for m in data.get("messages", []):
+            if m.get("mode") == "mtls-only":
+                cert_pem = m.get("sender_cert_pem")
+                if not cert_pem:
+                    raise ValueError(
+                        f"msg {m.get('msg_id')}: mtls-only frame missing sender_cert_pem"
+                    )
+                ok = verify_signature(
+                    cert_pem,
+                    m["signature"],
+                    session_id,
+                    m["sender_agent_id"],
+                    m["nonce"],
+                    m["timestamp"],
+                    m["payload"],
+                    client_seq=m.get("sender_seq"),
+                )
+                if not ok:
+                    raise ValueError(
+                        f"msg {m.get('msg_id')}: signature verification failed"
+                    )
+                out.append({
+                    "msg_id": m["msg_id"],
+                    "session_id": m["session_id"],
+                    "sender_agent_id": m["sender_agent_id"],
+                    "mode": "mtls-only",
+                    "payload": m["payload"],
+                    "enqueued_at": m.get("enqueued_at"),
+                })
+            else:
+                out.append({
+                    "msg_id": m["msg_id"],
+                    "session_id": m["session_id"],
+                    "sender_agent_id": m["sender_agent_id"],
+                    "mode": "envelope",
+                    "payload_ciphertext": m.get("payload_ciphertext"),
+                    "enqueued_at": m.get("enqueued_at"),
+                })
+        return out
+
+    def ack_via_proxy(self, session_id: str, msg_id: str) -> bool:
+        """Acknowledge a local-queue message to the proxy (at-least-once)."""
+        resp = self._http.post(
+            f"{self.base}/v1/egress/sessions/{session_id}/messages/{msg_id}/ack",
+            headers=self.proxy_headers(),
+        )
+        if resp.status_code == 204:
+            return True
+        if resp.status_code in (404, 409):
+            return False
+        resp.raise_for_status()
+        return True
 
     def ack_message(self, session_id: str, msg_id: str) -> bool:
         """Acknowledge a queued offline message (M3.5).

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -457,6 +457,7 @@ async def send_message(
                     "nonce": body.nonce,
                     "timestamp": body.timestamp,
                     "sender_seq": body.sender_seq,
+                    "sender_cert_pem": agent.cert_pem,
                 },
                 separators=(",", ":"),
                 sort_keys=True,
@@ -502,6 +503,7 @@ async def send_message(
                 push_frame["nonce"] = body.nonce
                 push_frame["timestamp"] = body.timestamp
                 push_frame["sender_seq"] = body.sender_seq
+                push_frame["sender_cert_pem"] = agent.cert_pem
             pushed = await ws_manager.send_to_agent(recipient, push_frame)
 
         duration_ms = (time.monotonic() - t0) * 1000
@@ -600,16 +602,35 @@ async def poll_messages(
         # Only messages that belong to this session — the queue is global
         # per recipient but the caller asked for a specific session.
         msgs = [m for m in pending if m.session_id == session_id]
-        payload = [
-            {
+        import json as _json
+        payload = []
+        for m in msgs:
+            entry: dict = {
                 "msg_id": m.msg_id,
                 "session_id": m.session_id,
                 "sender_agent_id": m.sender_agent_id,
-                "payload_ciphertext": m.payload_ciphertext,
                 "enqueued_at": m.enqueued_at.isoformat() if m.enqueued_at else None,
             }
-            for m in msgs
-        ]
+            # mtls-only blobs are self-describing — parse out the signed
+            # plaintext + metadata so the recipient SDK can verify without
+            # guessing at wire shape. Legacy ciphertext stays opaque.
+            try:
+                parsed = _json.loads(m.payload_ciphertext)
+                if isinstance(parsed, dict) and parsed.get("mode") == "mtls-only":
+                    entry["mode"] = "mtls-only"
+                    entry["payload"] = parsed.get("payload")
+                    entry["signature"] = parsed.get("signature")
+                    entry["nonce"] = parsed.get("nonce")
+                    entry["timestamp"] = parsed.get("timestamp")
+                    entry["sender_seq"] = parsed.get("sender_seq")
+                    entry["sender_cert_pem"] = parsed.get("sender_cert_pem")
+                else:
+                    entry["mode"] = "envelope"
+                    entry["payload_ciphertext"] = m.payload_ciphertext
+            except (ValueError, TypeError):
+                entry["mode"] = "envelope"
+                entry["payload_ciphertext"] = m.payload_ciphertext
+            payload.append(entry)
         return {"messages": payload, "count": len(payload), "scope": "local"}
 
     bridge = _get_bridge(request)

--- a/tests/test_intra_org_round_trip.py
+++ b/tests/test_intra_org_round_trip.py
@@ -1,0 +1,255 @@
+"""ADR-001 §10 — full intra-org round-trip over mtls-only.
+
+Proves the loop closes: alice sends signed plaintext via the proxy,
+bob polls the proxy, the SDK verifies the signature, and bob's
+business layer sees the original payload.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from httpx import ASGITransport, AsyncClient
+
+from cullis_sdk.crypto.message_signer import sign_message, verify_signature
+from tests.cert_factory import make_agent_cert
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("PROXY_TRANSPORT_INTRA_ORG", "mtls-only")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision_agent(agent_id: str, org_id: str = "acme") -> tuple[str, str, str]:
+    """Return (api_key, cert_pem, priv_pem) for a newly provisioned agent."""
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+
+    key, cert = make_agent_cert(f"{org_id}::{agent_id}", org_id, key_type="ec")
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    priv_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+    raw = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=["cap.read"],
+        api_key_hash=hash_api_key(raw),
+        cert_pem=cert_pem,
+    )
+    return raw, cert_pem, priv_pem
+
+
+async def _provision_local_target(agent_id: str, cert_pem: str) -> None:
+    """Mirror the agent into local_agents so resolve can find its cert."""
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_agents "
+                "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
+                " scope, created_at, is_active) "
+                "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
+                " :api_key_hash, :scope, :created_at, :is_active)"
+            ),
+            {
+                "agent_id": agent_id,
+                "display_name": agent_id,
+                "capabilities": "[]",
+                "cert_pem": cert_pem,
+                "api_key_hash": None,
+                "scope": "local",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "is_active": 1,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_alice_to_bob_intra_org_full_round_trip(proxy_app):
+    """Alice signs → proxy verifies + enqueues → bob polls → SDK re-verifies."""
+    _, client = proxy_app
+
+    alice_key, alice_cert, alice_priv = await _provision_agent("alice")
+    bob_key, bob_cert, bob_priv = await _provision_agent("bob")
+    await _provision_local_target("bob", bob_cert)
+    await _provision_local_target("alice", alice_cert)
+
+    # 1. Alice opens a session targeting bob.
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": alice_key},
+        json={
+            "target_agent_id": "bob",
+            "target_org_id": "acme",
+            "capabilities": ["cap.read"],
+        },
+    )
+    assert open_resp.status_code == 200, open_resp.text
+    session_id = open_resp.json()["session_id"]
+
+    # 2. Alice resolves bob and learns the transport.
+    resolve = await client.post(
+        "/v1/egress/resolve",
+        headers={"X-API-Key": alice_key},
+        json={"recipient_id": "acme::bob"},
+    )
+    assert resolve.status_code == 200
+    decision = resolve.json()
+    assert decision["transport"] == "mtls-only"
+
+    # 3. Alice signs the plaintext and sends via the proxy.
+    payload = {"greeting": "hello bob", "n": 42}
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    sig = sign_message(alice_priv, session_id, "alice", nonce, ts, payload, client_seq=0)
+
+    send_resp = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": alice_key},
+        json={
+            "session_id": session_id,
+            "payload": payload,
+            "recipient_agent_id": "acme::bob",
+            "mode": "mtls-only",
+            "signature": sig,
+            "nonce": nonce,
+            "timestamp": ts,
+            "sender_seq": 0,
+        },
+    )
+    assert send_resp.status_code == 200, send_resp.text
+
+    # 4. Bob polls the proxy.
+    poll = await client.get(
+        f"/v1/egress/messages/{session_id}",
+        headers={"X-API-Key": bob_key},
+    )
+    assert poll.status_code == 200, poll.text
+    body = poll.json()
+    assert body["count"] == 1
+    frame = body["messages"][0]
+
+    # 5. Proxy returned a parsed mtls-only frame with sender cert bundled.
+    assert frame["mode"] == "mtls-only"
+    assert frame["sender_agent_id"] == "alice"
+    assert frame["sender_cert_pem"] is not None
+    assert frame["sender_cert_pem"] == alice_cert
+    assert frame["payload"] == payload
+
+    # 6. Bob's SDK would verify the signature using that cert — we inline the
+    # helper here to avoid constructing a full CullisClient with ASGI bridging.
+    ok = verify_signature(
+        frame["sender_cert_pem"],
+        frame["signature"],
+        frame["session_id"],
+        frame["sender_agent_id"],
+        frame["nonce"],
+        frame["timestamp"],
+        frame["payload"],
+        client_seq=frame["sender_seq"],
+    )
+    assert ok is True, "bob must be able to verify alice's signature"
+
+
+@pytest.mark.asyncio
+async def test_receiver_rejects_tampered_frame(proxy_app):
+    """If the stored blob gets tampered post-enqueue, SDK verify fails."""
+    _, client = proxy_app
+
+    alice_key, alice_cert, alice_priv = await _provision_agent("alice")
+    bob_key, bob_cert, _ = await _provision_agent("bob")
+    await _provision_local_target("bob", bob_cert)
+
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": alice_key},
+        json={
+            "target_agent_id": "bob",
+            "target_org_id": "acme",
+            "capabilities": [],
+        },
+    )
+    session_id = open_resp.json()["session_id"]
+
+    payload = {"text": "original"}
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    sig = sign_message(alice_priv, session_id, "alice", nonce, ts, payload, client_seq=0)
+
+    await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": alice_key},
+        json={
+            "session_id": session_id,
+            "payload": payload,
+            "recipient_agent_id": "acme::bob",
+            "mode": "mtls-only",
+            "signature": sig,
+            "nonce": nonce,
+            "timestamp": ts,
+            "sender_seq": 0,
+        },
+    )
+
+    # Tamper the stored blob directly in the DB — simulate proxy compromise.
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    import json as _json
+    async with get_db() as conn:
+        row = await conn.execute(
+            text("SELECT payload_ciphertext FROM local_messages WHERE session_id = :s"),
+            {"s": session_id},
+        )
+        stored = row.scalar_one()
+        parsed = _json.loads(stored)
+        parsed["payload"] = {"text": "tampered"}
+        await conn.execute(
+            text("UPDATE local_messages SET payload_ciphertext = :p WHERE session_id = :s"),
+            {"p": _json.dumps(parsed), "s": session_id},
+        )
+
+    # Bob polls — proxy returns the tampered frame, SDK-side verify must fail.
+    poll = await client.get(
+        f"/v1/egress/messages/{session_id}",
+        headers={"X-API-Key": bob_key},
+    )
+    frame = poll.json()["messages"][0]
+    ok = verify_signature(
+        frame["sender_cert_pem"],
+        frame["signature"],
+        frame["session_id"],
+        frame["sender_agent_id"],
+        frame["nonce"],
+        frame["timestamp"],
+        frame["payload"],
+        client_seq=frame["sender_seq"],
+    )
+    assert ok is False, "tampered payload must fail signature verification"


### PR DESCRIPTION
## Summary

Third slice of ADR-001 §10 (tracked in #91), stacked on #97. The sender path worked end-to-end but the receiver had no SDK method to pull and verify mtls-only frames, so the intra-org `agent → proxy → agent` loop was only half wired. This PR closes the loop.

## Changes

**Proxy (`mcp_proxy/`)**:
- `/v1/egress/messages/{session_id}` (poll) unpacks the self-describing mtls-only blob stored in `local_messages` and returns structured fields: `mode`, `payload`, `signature`, `nonce`, `timestamp`, `sender_seq`, `sender_cert_pem`. Legacy envelope blobs stay opaque under `payload_ciphertext`.
- WebSocket push frame now includes `sender_cert_pem` so WS consumers don't need a side fetch.
- Stored blob at send time now bundles `sender_cert_pem` — the cert travels with the message.

**SDK (`cullis_sdk/`)**:
- `CullisClient.receive_via_proxy(session_id)` — polls the proxy, verifies signatures against the bundled sender cert, raises `ValueError` on tamper.
- `CullisClient.ack_via_proxy(session_id, msg_id)` — closes the at-least-once loop via the proxy's ack endpoint.

## Test plan

- [x] `pytest tests/test_intra_org_round_trip.py` — 2/2 pass
  - Alice signs → proxy verifies + enqueues → Bob polls → SDK re-verifies against bundled cert → plaintext delivered
  - Post-enqueue DB tamper → recipient verification fails (detection)
- [x] Broader regression: 147 proxy/sdk tests pass, 2 skip, no failures
- [ ] CI green

## Invariants preserved

- Private key never leaves the agent (sender signs with own key, receiver verifies with bundled cert).
- Broker never sees plaintext (cross-org still rejected in mtls-only mode from previous PR).
- Tamper detection: any post-enqueue mutation of payload or signature invalidates verification at the recipient SDK.
- Backcompat: envelope messages flow unchanged — SDK returns them untouched with `payload_ciphertext` for the caller to decrypt.

## Stacked on

- #93 — foundation (resolve + flags)
- #97 — sender side (mtls-only + SDK send_via_proxy)

Merge order: #93 → #97 → this.

## What this unlocks

Intra-org routing is **closed** end-to-end in sign-only mode. Remaining work for "routing finito" (tracked in #91):
- Envelope-via-proxy (cross-org, agent-holds-keys pass-through)
- Removal of legacy direct-broker SDK path
- Guardian hook at the proxy (when Guardian module MVP lands)