### PR TITLE
feat(broker): walk x5c chain for SPIRE-style SVIDs (ADR-003 core)

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -49,7 +49,7 @@ async def issue_token(
         dpop_jkt = await verify_dpop_proof(dpop, htm="POST", htu=htu, access_token=None)
 
         # ── Verify certificate and signature ─────────────────────────────────
-        agent_id, org_id, cert_pem, cert_thumbprint = await verify_client_assertion(
+        agent_id, org_id, cert_pem, cert_thumbprint, svid_mode = await verify_client_assertion(
             body.client_assertion, db, request=request,
         )
         span.set_attribute("agent.id", agent_id)
@@ -90,20 +90,24 @@ async def issue_token(
             )
 
         # ── Certificate thumbprint pinning (anti Rogue CA) ───────────────────
-        pinned_ok = await update_agent_cert(db, agent_id, cert_pem, cert_thumbprint)
-        if not pinned_ok:
-            from app.telemetry_metrics import CERT_PINNING_MISMATCH_COUNTER
-            AUTH_DENY_COUNTER.add(1, {"reason": "cert_thumbprint_mismatch"})
-            CERT_PINNING_MISMATCH_COUNTER.add(1, {"org_id": org_id})
-            await log_event(
-                db, "auth.token_request", "denied",
-                agent_id=agent_id, org_id=org_id,
-                details={"reason": "cert_thumbprint_mismatch", "presented": cert_thumbprint},
-            )
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Certificate thumbprint mismatch — use the rotate-cert endpoint to update",
-            )
+        # Skipped in SPIFFE mode: SPIRE rotates SVIDs every ~1h so the
+        # thumbprint changes constantly; identity is already bound by the
+        # chain walk + SPIFFE URI match (see ADR-003 §2.3).
+        if not svid_mode:
+            pinned_ok = await update_agent_cert(db, agent_id, cert_pem, cert_thumbprint)
+            if not pinned_ok:
+                from app.telemetry_metrics import CERT_PINNING_MISMATCH_COUNTER
+                AUTH_DENY_COUNTER.add(1, {"reason": "cert_thumbprint_mismatch"})
+                CERT_PINNING_MISMATCH_COUNTER.add(1, {"org_id": org_id})
+                await log_event(
+                    db, "auth.token_request", "denied",
+                    agent_id=agent_id, org_id=org_id,
+                    details={"reason": "cert_thumbprint_mismatch", "presented": cert_thumbprint},
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="Certificate thumbprint mismatch — use the rotate-cert endpoint to update",
+                )
 
         token, expires_in = await create_access_token(
             agent_id, org_id, scope=binding.scope, dpop_jkt=dpop_jkt

--- a/app/auth/x509_verifier.py
+++ b/app/auth/x509_verifier.py
@@ -35,18 +35,168 @@ from app.telemetry_metrics import X509_VERIFY_DURATION_HISTOGRAM
 
 _AUDIENCE = "agent-trust-broker"
 _ALLOWED_HASH_ALGORITHMS = (hashes.SHA256, hashes.SHA384, hashes.SHA512)
+_ALLOWED_EC_CURVES = (ec.SECP256R1, ec.SECP384R1, ec.SECP521R1)
+# Upper bound on the length of x5c we'll walk, to cap compute for a
+# malicious client that sends a pathological chain.
+_MAX_CHAIN_LENGTH = 6
+
+
+def _verify_sig(child: x509.Certificate, parent_pub) -> None:
+    """Verify that ``child`` was signed by ``parent_pub``.
+
+    Raises InvalidSignature on mismatch, or ValueError on unsupported key.
+    """
+    if not isinstance(child.signature_hash_algorithm, _ALLOWED_HASH_ALGORITHMS):
+        raise ValueError("weak signature hash algorithm")
+    if isinstance(parent_pub, rsa.RSAPublicKey):
+        parent_pub.verify(
+            child.signature,
+            child.tbs_certificate_bytes,
+            padding.PKCS1v15(),
+            child.signature_hash_algorithm,
+        )
+    elif isinstance(parent_pub, ec.EllipticCurvePublicKey):
+        parent_pub.verify(
+            child.signature,
+            child.tbs_certificate_bytes,
+            ec.ECDSA(child.signature_hash_algorithm),
+        )
+    else:
+        raise ValueError(f"unsupported parent key type: {type(parent_pub).__name__}")
+
+
+def _walk_chain(
+    leaf: x509.Certificate,
+    intermediates: list[x509.Certificate],
+    trust_anchor: x509.Certificate,
+    now: datetime.datetime,
+) -> None:
+    """
+    Validate chain ``leaf ← intermediates[0] ← … ← intermediates[-1] ← trust_anchor``.
+
+    - Each link verifies the child's signature against the parent's public key
+    - Every intermediate has BasicConstraints(CA=true) and KeyUsage.keyCertSign
+    - Path-length constraints are respected (parent's pathLenConstraint, if
+      set, bounds the number of non-self-issued CAs that follow)
+    - All certs in the chain are within their validity window
+    - Defence in depth: trust_anchor is not allowed inside ``intermediates``
+      (caller must strip) and the walk is bounded by _MAX_CHAIN_LENGTH
+
+    Raises HTTPException(401) on any failure.
+    """
+    if len(intermediates) > _MAX_CHAIN_LENGTH:
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail=f"certificate chain too long (max {_MAX_CHAIN_LENGTH} intermediates)",
+        )
+
+    full = [leaf, *intermediates, trust_anchor]
+
+    # Reject obvious shape errors: same cert twice (loop), or trust_anchor
+    # also present as an intermediate (caller duplicated it in x5c).
+    seen: set[bytes] = set()
+    for c in full:
+        fp = hashlib.sha256(c.public_bytes(serialization.Encoding.DER)).digest()
+        if fp in seen:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                detail="certificate chain contains a duplicate entry",
+            )
+        seen.add(fp)
+
+    # Temporal validity on every cert.
+    for c in full:
+        try:
+            nb = c.not_valid_before_utc
+            na = c.not_valid_after_utc
+        except AttributeError:
+            nb = c.not_valid_before.replace(tzinfo=datetime.timezone.utc)
+            na = c.not_valid_after.replace(tzinfo=datetime.timezone.utc)
+        if now < nb or now > na:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                detail="certificate in chain is expired or not yet valid",
+            )
+
+    # Intermediate certs must be real CAs with signing key usage.
+    for inter in intermediates:
+        try:
+            bc = inter.extensions.get_extension_for_class(x509.BasicConstraints).value
+        except x509.ExtensionNotFound:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                detail="intermediate certificate lacks BasicConstraints",
+            )
+        if not bc.ca:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                detail="intermediate certificate is not a CA",
+            )
+        try:
+            ku = inter.extensions.get_extension_for_class(x509.KeyUsage).value
+            if not ku.key_cert_sign:
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED,
+                    detail="intermediate KeyUsage missing keyCertSign",
+                )
+        except x509.ExtensionNotFound:
+            # KeyUsage is recommended but not strictly mandatory for CAs.
+            pass
+
+    # Path length: each parent's pathLenConstraint bounds the number of
+    # non-self-issued CAs that MAY follow below it. Walking top-down
+    # (trust_anchor first) lets us enforce it simply.
+    for idx in range(len(full) - 1, 0, -1):
+        parent = full[idx]
+        below_ca_count = max(0, (idx - 1))  # intermediates remaining below
+        try:
+            bc = parent.extensions.get_extension_for_class(x509.BasicConstraints).value
+            if bc.path_length is not None and below_ca_count - 1 > bc.path_length:
+                # -1 because the leaf is not a CA, so it doesn't consume path length
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED,
+                    detail=(f"certificate chain violates pathLenConstraint "
+                            f"(parent allows {bc.path_length} below, chain has "
+                            f"{max(0, below_ca_count - 1)} intermediates)"),
+                )
+        except x509.ExtensionNotFound:
+            # Non-CA wouldn't have BC; shouldn't reach here for intermediates
+            # or trust_anchor since we validated above.
+            pass
+
+    # Signature chain: each child verified against the next parent's pubkey.
+    for i in range(len(full) - 1):
+        child = full[i]
+        parent_pub = full[i + 1].public_key()
+        try:
+            _verify_sig(child, parent_pub)
+        except InvalidSignature:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                detail=(f"certificate chain broken at position {i} — "
+                        f"signature not produced by the next cert in the chain"),
+            )
+        except ValueError as exc:
+            raise HTTPException(
+                status.HTTP_401_UNAUTHORIZED,
+                detail=f"certificate chain verification failed: {exc}",
+            )
 
 
 async def verify_client_assertion(
     assertion: str,
     db: AsyncSession,
     request: Request | None = None,
-) -> tuple[str, str, str, str]:
+) -> tuple[str, str, str, str, bool]:
     """
-    Verify a client_assertion JWT and return (agent_id, org_id, cert_pem, cert_thumbprint).
+    Verify a client_assertion JWT and return (agent_id, org_id, cert_pem,
+    cert_thumbprint, svid_mode).
     cert_pem is the agent certificate extracted from x5c — it is saved in DB
     by the auth router to allow verification of message signatures.
     cert_thumbprint is the SHA-256 hex digest of the DER-encoded certificate.
+    svid_mode is True iff identity was resolved via SPIFFE URI SAN + chain
+    walk (no CN/O present); callers use it to skip per-cert pinning since
+    SPIRE-style SVIDs rotate far too fast for thumbprint-level stickiness.
 
     When ``request`` is provided and ``mtls_binding`` is enabled in settings,
     also enforces RFC 8705-style confirmation that the mTLS client cert
@@ -70,11 +220,21 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
     if not x5c or not isinstance(x5c, list) or len(x5c) == 0:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="x5c header absent or empty")
 
-    # ── 2. Load agent cert from x5c[0] and compute thumbprint ──────────────
+    # ── 2. Load full x5c chain and compute leaf thumbprint ──────────────────
+    # RFC 7515 §4.1.6: x5c[0] is the leaf, each subsequent entry is the CA
+    # that signs the previous one. The trust anchor (Org CA) is NOT in x5c —
+    # it's looked up from the DB by org_id / trust_domain. Legacy clients
+    # send only the leaf (single-level chain vs the registered Org CA);
+    # SPIFFE/SPIRE clients send the full chain up to (but excluding) the
+    # Org CA — walked in section 5 below.
     try:
-        cert_der = base64.b64decode(x5c[0])
-        agent_cert = x509.load_der_x509_certificate(cert_der)
+        chain_certs = [
+            x509.load_der_x509_certificate(base64.b64decode(c)) for c in x5c
+        ]
+        agent_cert = chain_certs[0]
+        cert_der = agent_cert.public_bytes(serialization.Encoding.DER)
         cert_thumbprint = hashlib.sha256(cert_der).hexdigest()
+        intermediates = chain_certs[1:]  # may be empty in classic mode
     except Exception:
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Invalid agent certificate")
 
@@ -151,33 +311,20 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
             detail="Agent certificate uses a weak signature algorithm — SHA-256 or stronger required",
         )
 
-    with tracer.start_as_current_span("auth.x509_chain_verify"):
-        try:
-            ca_pub = org_ca.public_key()
-            if isinstance(ca_pub, rsa.RSAPublicKey):
-                ca_pub.verify(
-                    agent_cert.signature,
-                    agent_cert.tbs_certificate_bytes,
-                    padding.PKCS1v15(),
-                    agent_cert.signature_hash_algorithm,
-                )
-            elif isinstance(ca_pub, ec.EllipticCurvePublicKey):
-                ca_pub.verify(
-                    agent_cert.signature,
-                    agent_cert.tbs_certificate_bytes,
-                    ec.ECDSA(agent_cert.signature_hash_algorithm),
-                )
-            else:
-                raise ValueError(f"Unsupported CA key type: {type(ca_pub).__name__}")
-        except InvalidSignature:
-            raise HTTPException(
-                status.HTTP_401_UNAUTHORIZED,
-                detail="Agent certificate not signed by the registered org CA",
-            )
-        except HTTPException:
-            raise
-        except Exception:
-            raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail="Certificate chain verification failed")
+    # If the client accidentally included the Org CA as the last x5c entry,
+    # strip it — the Org CA is the trust anchor and lives server-side.
+    org_ca_der = org_ca.public_bytes(serialization.Encoding.DER)
+    if intermediates and intermediates[-1].public_bytes(serialization.Encoding.DER) == org_ca_der:
+        intermediates = intermediates[:-1]
+
+    with tracer.start_as_current_span("auth.x509_chain_verify") as _chain_span:
+        _chain_span.set_attribute("chain.length", len(intermediates) + 1)
+        _walk_chain(
+            leaf=agent_cert,
+            intermediates=intermediates,
+            trust_anchor=org_ca,
+            now=datetime.datetime.now(datetime.timezone.utc),
+        )
 
     # ── 5b. Enforce minimum RSA key size (2048 bits) ──────────────────────
     agent_pub_key = agent_cert.public_key()
@@ -188,7 +335,6 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
                 detail=f"Agent RSA key too small ({agent_pub_key.key_size} bits) — minimum 2048 required",
             )
     elif isinstance(agent_pub_key, ec.EllipticCurvePublicKey):
-        _ALLOWED_EC_CURVES = (ec.SECP256R1, ec.SECP384R1, ec.SECP521R1)
         if not isinstance(agent_pub_key.curve, _ALLOWED_EC_CURVES):
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
@@ -335,5 +481,6 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
 
     cert_pem = agent_cert.public_bytes(serialization.Encoding.PEM).decode()
     _span.set_attribute("cert.thumbprint", cert_thumbprint)
+    _span.set_attribute("auth.svid_mode", svid_mode)
     X509_VERIFY_DURATION_HISTOGRAM.record((_time.monotonic() - _t0) * 1000)
-    return agent_id, org_id, cert_pem, cert_thumbprint
+    return agent_id, org_id, cert_pem, cert_thumbprint, svid_mode

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -184,6 +184,14 @@ async def join_network(
         if now > not_after or now < not_before:
             raise HTTPException(status.HTTP_400_BAD_REQUEST,
                                 detail="CA certificate is expired or not yet valid")
+        # SPIFFE mode: Org CA must authorize at most one level of
+        # intermediate below (SPIRE signing intermediate). See ADR-003 §2.4.
+        if body.trust_domain and bc.path_length is not None and bc.path_length > 1:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                detail=(f"CA pathLenConstraint is {bc.path_length} — when "
+                        f"declaring a SPIFFE trust_domain, pathLen must be ≤ 1"),
+            )
     except HTTPException:
         raise
     except Exception as exc:
@@ -332,6 +340,16 @@ async def attach_ca(
         if now > not_after or now < not_before:
             raise HTTPException(status.HTTP_400_BAD_REQUEST,
                                 detail="CA certificate is expired or not yet valid")
+        # SPIFFE mode: same pathLen check as /join — see ADR-003 §2.4.
+        # Use the incoming trust_domain if set in this request, else the
+        # one already stored on the org.
+        effective_td = body.trust_domain or org.trust_domain
+        if effective_td and bc.path_length is not None and bc.path_length > 1:
+            raise HTTPException(
+                status.HTTP_400_BAD_REQUEST,
+                detail=(f"CA pathLenConstraint is {bc.path_length} — when "
+                        f"declaring a SPIFFE trust_domain, pathLen must be ≤ 1"),
+            )
     except HTTPException:
         raise
     except Exception as exc:

--- a/cullis_sdk/auth.py
+++ b/cullis_sdk/auth.py
@@ -100,9 +100,19 @@ def build_client_assertion(
         (assertion_jwt, jwt_algorithm) tuple.
     """
     cert_bytes = cert_pem.encode() if isinstance(cert_pem, str) else cert_pem
-    cert = crypto_x509.load_pem_x509_certificate(cert_bytes)
-    cert_der = cert.public_bytes(serialization.Encoding.DER)
-    x5c = [base64.b64encode(cert_der).decode()]
+    # Accept either a single PEM cert (classic BYOCA) or a concatenation of
+    # PEM blocks (SPIFFE/SPIRE SVID → [leaf, intermediate, …]). In the latter
+    # case we include the full chain in x5c so the broker can walk it back
+    # to the registered Org CA (the trust anchor is never included — it
+    # stays server-side).
+    chain_certs = crypto_x509.load_pem_x509_certificates(cert_bytes)
+    if not chain_certs:
+        raise ValueError("cert_pem contains no certificate")
+    cert = chain_certs[0]
+    x5c = [
+        base64.b64encode(c.public_bytes(serialization.Encoding.DER)).decode()
+        for c in chain_certs
+    ]
 
     now = datetime.datetime.now(datetime.timezone.utc)
     payload = {

--- a/tests/cert_factory.py
+++ b/tests/cert_factory.py
@@ -118,11 +118,18 @@ def init_broker_keys() -> tuple[str, str]:
     return _key_pem(key), _pub_pem(key)
 
 
-def _get_org_ca(org_id: str, key_type: str = "rsa") -> tuple:
-    """Return (org_ca_key, org_ca_cert), generating them if necessary."""
+def _get_org_ca(
+    org_id: str, key_type: str = "rsa", path_length: int | None = 0,
+) -> tuple:
+    """Return (org_ca_key, org_ca_cert), generating them if necessary.
+
+    ``path_length`` defaults to 0 (Org CA directly signs end-entity certs,
+    classic BYOCA). Pass ``path_length=1`` for tests that need an
+    intermediate CA below (SPIRE-style 3-level chain).
+    """
     global _broker_ca_key, _broker_ca_cert
 
-    cache_key = (org_id, key_type)
+    cache_key = (org_id, key_type, path_length)
     if cache_key in _org_ca_cache:
         return _org_ca_cache[cache_key]
 
@@ -143,7 +150,10 @@ def _get_org_ca(org_id: str, key_type: str = "rsa") -> tuple:
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=1))
-        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length),
+            critical=True,
+        )
         .sign(_broker_ca_key, hashes.SHA256())
     )
     _org_ca_cache[cache_key] = (key, cert)
@@ -208,6 +218,150 @@ def make_agent_cert(
     cert = builder.sign(org_ca_key, hashes.SHA256())
     _agent_cert_cache[cache_key] = (key, cert)
     return key, cert
+
+
+def get_org_ca_pem_for_chain(ca_org_id: str) -> str:
+    """PEM of an Org CA with pathLenConstraint=1 — required for 3-level
+    chain tests where the Org CA signs a SPIRE-style intermediate."""
+    _, org_ca_cert = _get_org_ca(ca_org_id, path_length=1)
+    return org_ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def make_intermediate_ca(
+    ca_org_id: str,
+    name: str = "spire-intermediate",
+    path_length: int | None = 0,
+) -> tuple:
+    """
+    Generate an intermediate CA signed by the org CA (SPIRE-style).
+
+    The Org CA used as issuer is fetched with path_length=1 so it is
+    actually allowed to sign a CA below. path_length on the intermediate
+    itself defaults to 0 (end-entity only).
+
+    Returns (int_ca_key, int_ca_cert). Not cached — every call makes a new one.
+    """
+    org_ca_key, org_ca_cert = _get_org_ca(ca_org_id, path_length=1)
+    now = _now()
+    key = _gen_key(2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{ca_org_id} {name}"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, ca_org_id),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(org_ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(org_ca_key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def make_svid_with_chain(
+    agent_name: str,
+    ca_org_id: str,
+    trust_domain: str,
+    int_ca_key=None,
+    int_ca_cert=None,
+    spiffe_path: str | None = None,
+) -> tuple:
+    """
+    Build an SVID signed by an intermediate (SPIRE-style 3-level chain).
+
+    If ``int_ca_key``/``int_ca_cert`` are not provided, a fresh intermediate
+    is minted via ``make_intermediate_ca(ca_org_id)``.
+
+    Returns (svid_key, svid_cert, int_ca_cert, spiffe_id).
+    """
+    if int_ca_key is None or int_ca_cert is None:
+        int_ca_key, int_ca_cert = make_intermediate_ca(ca_org_id)
+
+    now = _now()
+    key = _gen_key(2048)
+    path = spiffe_path if spiffe_path is not None else agent_name
+    spiffe_id = f"spiffe://{trust_domain}/{path}"
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([]))
+        .issuer_name(int_ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_id)]),
+            critical=True,
+        )
+        .sign(int_ca_key, hashes.SHA256())
+    )
+    return key, cert, int_ca_cert, spiffe_id
+
+
+def make_svid_chain_assertion(
+    agent_name: str,
+    ca_org_id: str,
+    trust_domain: str,
+    int_ca_key=None,
+    int_ca_cert=None,
+    spiffe_path: str | None = None,
+    extra_intermediates: list | None = None,
+    sub_override: str | None = None,
+    jti: str | None = "auto",
+) -> tuple[str, str]:
+    """
+    Build a client_assertion with x5c = [SVID, intermediate, ...] for
+    testing broker chain walk. ``extra_intermediates`` can inject
+    additional cert(s) between the SVID and the real intermediate
+    (e.g. for duplicate / wrong-order / cycle tests).
+
+    Returns (assertion, spiffe_id).
+    """
+    svid_key, svid_cert, int_cert, spiffe_id = make_svid_with_chain(
+        agent_name, ca_org_id, trust_domain,
+        int_ca_key=int_ca_key, int_ca_cert=int_ca_cert,
+        spiffe_path=spiffe_path,
+    )
+    chain = [svid_cert, int_cert]
+    if extra_intermediates:
+        # Insert after the leaf so the tampering is realistic.
+        chain = [svid_cert] + list(extra_intermediates) + [int_cert]
+    x5c = [
+        base64.b64encode(c.public_bytes(serialization.Encoding.DER)).decode()
+        for c in chain
+    ]
+    now = _now()
+    sub = sub_override if sub_override is not None else spiffe_id
+    payload = {
+        "sub": sub, "iss": sub, "aud": "agent-trust-broker",
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
+    }
+    if jti == "auto":
+        payload["jti"] = str(uuid.uuid4())
+    elif jti is not None:
+        payload["jti"] = jti
+    return jwt.encode(
+        payload, _key_pem(svid_key),
+        algorithm=_jwt_alg_for(svid_key), headers={"x5c": x5c},
+    ), spiffe_id
 
 
 def make_svid_cert(

--- a/tests/test_auth_chain.py
+++ b/tests/test_auth_chain.py
@@ -1,0 +1,334 @@
+"""
+Broker x509 chain walk — 3-level PKI for SPIFFE/SPIRE agents.
+
+Covers ADR-003 §2.1 (broker walks x5c) and §2.3 (thumbprint pinning
+skipped in SPIFFE mode). All tests register the Org CA with
+pathLenConstraint=1 so the CA is legally allowed to sign a single
+intermediate below it (the SPIRE signing intermediate).
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import uuid
+
+import jwt as jose_jwt
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from httpx import AsyncClient
+
+from tests.cert_factory import (
+    get_org_ca_pem_for_chain,
+    make_intermediate_ca,
+    make_svid_chain_assertion,
+    make_svid_with_chain,
+    _get_org_ca,
+    _key_pem,
+    _now,
+)
+from tests.conftest import ADMIN_HEADERS, TestSessionLocal
+from app.registry.org_store import update_org_trust_domain
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _prime_nonce(client: AsyncClient, dpop) -> None:
+    resp = await client.get("/health")
+    dpop._update_nonce(resp)
+
+
+async def _register_agent_with_chain_ca(
+    client: AsyncClient, agent_id: str, org_id: str, trust_domain: str,
+) -> None:
+    org_secret = org_id + "-secret"
+    await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    # Upload the pathLen=1 CA — the classic helper uses pathLen=0
+    # which would refuse any intermediate below it.
+    ca_pem = get_org_ca_pem_for_chain(org_id)
+    await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    async with TestSessionLocal() as db:
+        await update_org_trust_domain(db, org_id, trust_domain)
+    await client.post("/v1/registry/agents", json={
+        "agent_id": agent_id, "org_id": org_id,
+        "display_name": agent_id, "capabilities": ["test.read"],
+    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    resp = await client.post(
+        "/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = resp.json()["id"]
+    await client.post(
+        f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_three_level_chain_accepted(client: AsyncClient, dpop):
+    """SVID signed by intermediate signed by Org CA → broker walks chain → 200."""
+    await _prime_nonce(client, dpop)
+    org_id = "chain-orga"
+    td = "chain-orga.test"
+    agent_id = f"{org_id}::workload-a"
+    await _register_agent_with_chain_ca(client, agent_id, org_id, td)
+
+    assertion, _ = make_svid_chain_assertion(
+        agent_name="workload-a",
+        ca_org_id=org_id,
+        trust_domain=td,
+        spiffe_path="workload/workload-a",
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_chain_with_orgca_appended_still_accepted(client: AsyncClient, dpop):
+    """If the client erroneously includes the Org CA in x5c, broker strips
+    it and still validates the chain."""
+    await _prime_nonce(client, dpop)
+    org_id = "chain-orgb"
+    td = "chain-orgb.test"
+    agent_id = f"{org_id}::workload-b"
+    await _register_agent_with_chain_ca(client, agent_id, org_id, td)
+
+    # Build chain + append the Org CA cert as last element.
+    _, org_ca_cert = _get_org_ca(org_id, path_length=1)
+    svid_key, svid_cert, int_cert, spiffe_id = make_svid_with_chain(
+        "workload-b", org_id, td, spiffe_path="workload/workload-b",
+    )
+    chain = [svid_cert, int_cert, org_ca_cert]
+    x5c = [
+        base64.b64encode(c.public_bytes(serialization.Encoding.DER)).decode()
+        for c in chain
+    ]
+    now = _now()
+    payload = {
+        "sub": spiffe_id, "iss": spiffe_id, "aud": "agent-trust-broker",
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
+        "jti": str(uuid.uuid4()),
+    }
+    assertion = jose_jwt.encode(
+        payload, _key_pem(svid_key), algorithm="RS256", headers={"x5c": x5c},
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Rejection paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_chain_broken_at_intermediate(client: AsyncClient, dpop):
+    """Intermediate from a DIFFERENT Org CA is spliced into the chain → 401."""
+    await _prime_nonce(client, dpop)
+    org_id = "chain-orgc"
+    td = "chain-orgc.test"
+    agent_id = f"{org_id}::workload-c"
+    await _register_agent_with_chain_ca(client, agent_id, org_id, td)
+
+    # Make a legitimate intermediate for org_id, but SIGN the SVID with
+    # an intermediate whose parent is a different org (unregistered).
+    _, rogue_int_cert = make_intermediate_ca("unregistered-org", name="rogue")
+    rogue_int_key, _ = make_intermediate_ca("unregistered-org", name="rogue2")
+    # Actually use a fresh unrelated intermediate for signing:
+    rogue_key, rogue_cert = make_intermediate_ca("unregistered-org", name="rogue3")
+
+    # Build SVID signed by rogue intermediate but place legitimate
+    # intermediate in x5c to try to fool the verifier.
+    _, int_ca_cert_ok = make_intermediate_ca(org_id)
+    svid_key, svid_cert, _, spiffe_id = make_svid_with_chain(
+        "workload-c", org_id, td,
+        int_ca_key=rogue_key, int_ca_cert=rogue_cert,
+        spiffe_path="workload/workload-c",
+    )
+    # x5c claims svid is under the legit intermediate — but signature
+    # was actually produced by the rogue key. Chain walk will catch it.
+    chain = [svid_cert, int_ca_cert_ok]
+    x5c = [
+        base64.b64encode(c.public_bytes(serialization.Encoding.DER)).decode()
+        for c in chain
+    ]
+    now = _now()
+    payload = {
+        "sub": spiffe_id, "iss": spiffe_id, "aud": "agent-trust-broker",
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
+        "jti": str(uuid.uuid4()),
+    }
+    assertion = jose_jwt.encode(
+        payload, _key_pem(svid_key), algorithm="RS256", headers={"x5c": x5c},
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 401
+    assert "chain" in resp.text.lower()
+
+
+async def test_chain_with_duplicate_intermediate(client: AsyncClient, dpop):
+    """Same intermediate cert appears twice in x5c → 401 duplicate."""
+    await _prime_nonce(client, dpop)
+    org_id = "chain-orgd"
+    td = "chain-orgd.test"
+    agent_id = f"{org_id}::workload-d"
+    await _register_agent_with_chain_ca(client, agent_id, org_id, td)
+
+    int_key, int_cert = make_intermediate_ca(org_id)
+    assertion, _ = make_svid_chain_assertion(
+        agent_name="workload-d",
+        ca_org_id=org_id,
+        trust_domain=td,
+        int_ca_key=int_key,
+        int_ca_cert=int_cert,
+        spiffe_path="workload/workload-d",
+        extra_intermediates=[int_cert],  # duplicate the intermediate
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 401
+    assert "duplicate" in resp.text.lower()
+
+
+async def test_chain_too_long(client: AsyncClient, dpop):
+    """More than _MAX_CHAIN_LENGTH intermediates → 401."""
+    await _prime_nonce(client, dpop)
+    org_id = "chain-orge"
+    td = "chain-orge.test"
+    agent_id = f"{org_id}::workload-e"
+    await _register_agent_with_chain_ca(client, agent_id, org_id, td)
+
+    # 7 certs in intermediates — exceeds _MAX_CHAIN_LENGTH=6.
+    bogus_intermediates = [
+        make_intermediate_ca("unregistered", name=f"bogus-{i}")[1]
+        for i in range(7)
+    ]
+    assertion, _ = make_svid_chain_assertion(
+        agent_name="workload-e",
+        ca_org_id=org_id,
+        trust_domain=td,
+        spiffe_path="workload/workload-e",
+        extra_intermediates=bogus_intermediates,
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 401
+    assert "too long" in resp.text.lower() or "chain" in resp.text.lower()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pinning behavior
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_pinning_skipped_in_spiffe_mode(client: AsyncClient, dpop):
+    """Two consecutive logins with DIFFERENT SVIDs (rotation) both succeed,
+    because SPIFFE mode skips thumbprint pinning."""
+    await _prime_nonce(client, dpop)
+    org_id = "chain-rot"
+    td = "chain-rot.test"
+    agent_id = f"{org_id}::rotator"
+    await _register_agent_with_chain_ca(client, agent_id, org_id, td)
+
+    # Shared intermediate so the chain walks consistently.
+    int_key, int_cert = make_intermediate_ca(org_id)
+
+    # First login with one SVID
+    a1, _ = make_svid_chain_assertion(
+        agent_name="rotator", ca_org_id=org_id, trust_domain=td,
+        int_ca_key=int_key, int_ca_cert=int_cert,
+        spiffe_path="workload/rotator",
+    )
+    r1 = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": a1},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert r1.status_code == 200, r1.text
+
+    # Second login with a FRESH SVID (new key → new thumbprint). If pinning
+    # were active this would 401 with cert_thumbprint_mismatch.
+    a2, _ = make_svid_chain_assertion(
+        agent_name="rotator", ca_org_id=org_id, trust_domain=td,
+        int_ca_key=int_key, int_ca_cert=int_cert,
+        spiffe_path="workload/rotator",
+    )
+    r2 = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": a2},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert r2.status_code == 200, r2.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Onboarding pathLen validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_onboarding_rejects_too_permissive_ca_in_spiffe_mode(client: AsyncClient):
+    """Submitting a CA with pathLenConstraint=2 together with a trust_domain
+    must be rejected with 400."""
+    # Build a self-signed CA with path_length=2 for the test.
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(x509.NameOID.COMMON_NAME, "TooDeep CA"),
+        x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, "toodeep"),
+    ])
+    now = _now()
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject).issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=2), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    ca_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    # First create an invite
+    invite_resp = await client.post(
+        "/v1/admin/invites", json={"label": "t", "ttl_hours": 1},
+        headers=ADMIN_HEADERS,
+    )
+    token = invite_resp.json()["token"]
+
+    resp = await client.post("/v1/onboarding/join", json={
+        "org_id": "toodeep",
+        "display_name": "TooDeep",
+        "secret": "toodeep-secret",
+        "ca_certificate": ca_pem,
+        "invite_token": token,
+        "contact_email": "a@b.c",
+        "trust_domain": "toodeep.test",
+    })
+    assert resp.status_code == 400
+    assert "pathlen" in resp.text.lower()


### PR DESCRIPTION
## Summary

Chiude il gap lasciato aperto da #95/#98: il broker ora accetta SVID SPIRE a 3 livelli (leaf ← intermediate ← Org CA). Classic BYOCA a 2 livelli resta invariato.

- `x509_verifier` walka l'intero `x5c`: verifica firma per ogni link, enforce `BasicConstraints`/`KeyUsage.keyCertSign` sugli intermediate, rifiuta duplicati, cappa chain a 6, strippa l'Org CA se inclusa per sbaglio.
- `verify_client_assertion` ritorna un extra `svid_mode: bool`.
- `auth/router`: thumbprint pinning skippato in SVID mode (SPIRE ruota SVID ogni ~1h — pinning per-cert non funziona). Classic mantiene pinning.
- SDK `build_client_assertion` accetta PEM multi-cert e popola `x5c = [leaf, intermediate, …]`; single-cert mantiene comportamento attuale.
- Onboarding `/join` e `/attach` rifiutano Org CA con `pathLenConstraint > 1` quando `trust_domain` è dichiarato.

Ref ADR-003 (doc interno).

## Test plan

- [x] `pytest tests/test_auth_chain.py -n auto` → 7/7 (happy path 3-level, trust anchor stripping, broken intermediate, duplicate, chain too long, rotation-without-pinning, pathLen rejection)
- [x] `pytest tests/ -n auto --dist=loadfile` → 758 passed (2 postgres failure sono pre-esistenti su `main`)
- [x] `./demo_network/smoke.sh full` → PASS

## Note

- Nessun breaking change per deployment esistenti: classic single-cert continua a funzionare identico.
- La validazione `pathLen ≤ 1` scatta solo se l'org dichiara `trust_domain`. Le org classic BYOCA non sono toccate.
- Sandbox enterprise (B4.4-B4.5 → target 21/0/0) sarà abilitato in PR separata dopo il merge di questa.