### PR TITLE
feat(sandbox): mixed-mode BYOCA + SPIRE agents — smoke 22/0/0

### DIFF
--- a/enterprise_sandbox/agent/agent.py
+++ b/enterprise_sandbox/agent/agent.py
@@ -1,19 +1,18 @@
-"""Sandbox demo agent — fetches SVID from SPIRE Workload API and authenticates to broker.
+"""Sandbox demo agent — authenticates to broker via SPIFFE or classic BYOCA.
 
 Env:
     BROKER_URL                e.g. http://broker:8000
     ORG_ID                    e.g. orga
-    AGENT_NAME                e.g. agent-a (short name, becomes {ORG_ID}::{AGENT_NAME})
-    SPIFFE_ENDPOINT_SOCKET    path to SPIRE Workload API socket
-    AGENT_MODE                'responder' (default) or 'initiator'
+    AGENT_NAME                short name (becomes {ORG_ID}::{AGENT_NAME})
+    AGENT_AUTH                'spire' (default) or 'byoca'
+    SPIFFE_ENDPOINT_SOCKET    path to SPIRE Workload API socket (spire mode only)
+    CERT_PATH, KEY_PATH       PEM paths for classic BYOCA cert (byoca mode only)
 
-Blocco 4a scope: prove SPIFFE auth works end-to-end.
-  - fetch SVID
-  - login to broker
-  - drop a ready-marker file (/tmp/ready) for smoke to detect
-  - stay alive
+Scope: prove both auth paths work end-to-end against the same broker and
+that a classic BYOCA agent can live next to a SPIRE SVID agent inside
+the same org (ADR-003 §2.6 mixed mode).
 
-Cross-org messaging lives in Blocco 4c.
+Cross-org messaging lives in a follow-up (Blocco 4c, issue #96).
 """
 from __future__ import annotations
 
@@ -47,37 +46,65 @@ def wait_for_http(url: str, timeout: float = 60.0) -> bool:
     return False
 
 
+def _auth_spire(broker: str, org_id: str) -> CullisClient:
+    socket = os.environ.get(
+        "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock"
+    )
+    raw = socket.removeprefix("unix://") if socket.startswith("unix://") else socket
+    if not wait_for_socket(raw, timeout=60):
+        raise RuntimeError(f"socket {raw} not available after 60s")
+    return CullisClient.from_spiffe_workload_api(
+        broker, org_id=org_id, socket_path=socket,
+    )
+
+
+def _auth_byoca(broker: str, org_id: str, agent_id: str) -> CullisClient:
+    cert_path = os.environ["CERT_PATH"]
+    key_path = os.environ["KEY_PATH"]
+    # Wait for bootstrap to publish the cert on the shared volume.
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        if pathlib.Path(cert_path).exists() and pathlib.Path(key_path).exists():
+            break
+        time.sleep(0.5)
+    else:
+        raise RuntimeError(f"BYOCA cert/key not found at {cert_path} / {key_path}")
+    cert_pem = pathlib.Path(cert_path).read_text()
+    key_pem = pathlib.Path(key_path).read_text()
+    client = CullisClient(broker)
+    client.login_from_pem(agent_id, org_id, cert_pem, key_pem)
+    return client
+
+
 def main() -> int:
     broker = os.environ["BROKER_URL"].rstrip("/")
     org_id = os.environ["ORG_ID"]
     name = os.environ["AGENT_NAME"]
-    socket = os.environ.get(
-        "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock"
-    )
+    auth_mode = os.environ.get("AGENT_AUTH", "spire").lower()
     agent_id = f"{org_id}::{name}"
-
-    # Wait for Workload API socket (spire-agent may still be starting)
-    raw = socket.removeprefix("unix://") if socket.startswith("unix://") else socket
-    if not wait_for_socket(raw, timeout=60):
-        print(f"[{agent_id}] FAIL: socket {raw} not available after 60s",
-              file=sys.stderr, flush=True)
-        return 1
 
     # Wait for broker (we start in parallel with it)
     if not wait_for_http(f"{broker}/health", timeout=60):
         print(f"[{agent_id}] FAIL: broker {broker} not reachable", file=sys.stderr, flush=True)
         return 1
 
-    # Authenticate via SPIFFE — this is the whole point of the demo
     try:
-        client = CullisClient.from_spiffe_workload_api(
-            broker, org_id=org_id, socket_path=socket,
-        )
+        if auth_mode == "spire":
+            client = _auth_spire(broker, org_id)
+            auth_label = "SPIFFE"
+        elif auth_mode == "byoca":
+            client = _auth_byoca(broker, org_id, agent_id)
+            auth_label = "BYOCA"
+        else:
+            print(f"[{agent_id}] FAIL: unknown AGENT_AUTH={auth_mode!r}",
+                  file=sys.stderr, flush=True)
+            return 2
     except Exception as e:
-        print(f"[{agent_id}] FAIL: SPIFFE auth: {e!r}", file=sys.stderr, flush=True)
+        print(f"[{agent_id}] FAIL: {auth_mode} auth: {e!r}",
+              file=sys.stderr, flush=True)
         return 2
 
-    print(f"[{agent_id}] SPIFFE auth OK — token={client.token[:24] if client.token else None}...",
+    print(f"[{agent_id}] {auth_label} auth OK — token={client.token[:24] if client.token else None}...",
           flush=True)
 
     # Ready-marker: smoke reads this to assert success without parsing logs.

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -356,6 +356,37 @@ services:
       retries: 20
       start_period: 20s
 
+  # Classic BYOCA agent living side-by-side with the SPIRE workload in
+  # Org A — exercises the CN/O auth branch and proves ADR-003 §2.6 mixed
+  # mode: same org, one trust_domain, different agents pick different
+  # auth methods.
+  byoca-a:
+    build:
+      context: ..
+      dockerfile: enterprise_sandbox/agent/Dockerfile
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+      broker:
+        condition: service_healthy
+    environment:
+      BROKER_URL: "http://broker:8000"
+      ORG_ID: "orga"
+      AGENT_NAME: "byoca-bot"
+      AGENT_AUTH: "byoca"
+      CERT_PATH: "/state/orga/agents/byoca-bot/agent.pem"
+      KEY_PATH:  "/state/orga/agents/byoca-bot/agent-key.pem"
+    volumes:
+      - bootstrap-state:/state:ro
+    networks: [orga-internal, public-wan]
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "test", "-f", "/tmp/ready"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+      start_period: 20s
+
   # ── Org B proxy ────────────────────────────────────────────────────────────
 
   proxy-b-init:

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -264,6 +264,18 @@ else
     fail "B4.5 agent-b SPIFFE auth"
 fi
 
+# B4.6 — classic BYOCA agent (byoca-bot) coexists with the SPIRE workload
+# in Org A (ADR-003 §2.6 mixed mode). Login uses a CN/O cert signed
+# directly by the Org CA — hits the classic code path with thumbprint
+# pinning active — while agent-a in the same org goes through the SPIFFE
+# SVID path with pinning skipped. Same broker, same org, different auth
+# branches resolving to different agent_ids.
+if docker compose ps byoca-a --format json | grep -q '"Health":"healthy"'; then
+    pass "B4.6 byoca-a classic auth OK (mixed mode alongside SPIRE in orga)"
+else
+    fail "B4.6 byoca-a classic auth"
+fi
+
 echo ""
 echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Milestone on the path to full A2A messaging (issue #96). Adds a classic BYOCA agent (\`byoca-bot\`) alongside the existing SPIRE workload (\`agent-a\`) in Org A, authenticating through the classic CN/O branch of the broker verifier with thumbprint pinning active — while \`agent-a\` keeps going through the SPIFFE SVID branch with pinning skipped. End-to-end proof of ADR-003 §2.6 mixed mode.

- \`agent/agent.py\`: \`AGENT_AUTH\` env selects between SPIRE Workload API and \`login_from_pem\` on a BYOCA cert loaded from the shared bootstrap volume
- \`docker-compose.yml\`: \`byoca-a\` service reusing the same agent Dockerfile, no SPIRE dependencies, cert+key mounted read-only
- \`smoke.sh\`: new \`B4.6\` asserts \`byoca-a\` healthy → **smoke 22/0/0**

Local-only \`bootstrap.py\` (gitignored) generates the classic cert (\`CN=orga::byoca-bot\`, \`O=orga\`, signed by the Org CA) and registers it with an approved binding on the broker.

## Follow-up (not in this PR)

Full 3-agent A2A message round-trip (\`spire-a ↔ byoca-a ↔ spire-b\` each way, 6 messages total) → PR #105. Will extend \`agent.py\` to open sessions and send/receive nonces, adding B4.7 for delivery.

## Test plan

- [x] \`./down.sh && ./up.sh && ./smoke.sh\` → 22 PASS, 0 FAIL, 0 SKIP
- [x] broker logs show one SPIFFE login (agent-a) and one classic login (byoca-bot) from Org A
- [x] broker \`audit_log\` contains two distinct \`auth.token_issued\` events with different agent_ids, both under \`org_id=orga\`