### PR TITLE
feat(sandbox): A2A messaging 3-agent round-trip — smoke 23/0/0

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -11,7 +11,10 @@ from app.auth.dpop import verify_dpop_proof, build_htu
 from app.config import get_settings
 from app.db.database import get_db
 from app.db.audit import log_event
-from app.registry.store import get_agent_by_id, update_agent_cert, invalidate_agent_tokens
+from app.registry.store import (
+    get_agent_by_id, update_agent_cert, refresh_agent_cert_svid,
+    invalidate_agent_tokens,
+)
 from app.registry.binding_store import get_approved_binding
 from app.rate_limit.limiter import rate_limiter
 from app.telemetry import tracer
@@ -89,11 +92,17 @@ async def issue_token(
                 detail="No approved binding for this agent and organization",
             )
 
-        # ── Certificate thumbprint pinning (anti Rogue CA) ───────────────────
-        # Skipped in SPIFFE mode: SPIRE rotates SVIDs every ~1h so the
-        # thumbprint changes constantly; identity is already bound by the
-        # chain walk + SPIFFE URI match (see ADR-003 §2.3).
-        if not svid_mode:
+        # ── Certificate storage ──────────────────────────────────────────────
+        # Classic BYOCA: enforce thumbprint pinning (anti Rogue CA).
+        # SPIFFE mode: overwrite the stored cert on every login — SPIRE
+        # rotates SVIDs on a short schedule, so pinning would reject every
+        # rotation. Identity in SPIFFE mode is bound by the chain walk +
+        # SPIFFE URI match instead (ADR-003 §2.3). The cert_pem still needs
+        # to be current on the server side so outbound-message signature
+        # verification in the broker can locate it.
+        if svid_mode:
+            await refresh_agent_cert_svid(db, agent_id, cert_pem, cert_thumbprint)
+        elif not svid_mode:
             pinned_ok = await update_agent_cert(db, agent_id, cert_pem, cert_thumbprint)
             if not pinned_ok:
                 from app.telemetry_metrics import CERT_PINNING_MISMATCH_COUNTER

--- a/app/registry/store.py
+++ b/app/registry/store.py
@@ -136,6 +136,37 @@ async def update_agent_cert(db: AsyncSession, agent_id: str, cert_pem: str,
     return False
 
 
+async def refresh_agent_cert_svid(
+    db: AsyncSession, agent_id: str, cert_pem: str, thumbprint: str,
+) -> bool:
+    """
+    Refresh the agent's stored cert without enforcing thumbprint pinning.
+
+    Used when the caller authenticated in SPIFFE/SVID mode: the leaf cert
+    rotates on a short schedule (SPIRE default ~1h), so pinning would
+    reject every second login. Identity is still bound by the chain walk
+    and the SPIFFE URI match — see ADR-003 §2.3. The broker still needs a
+    current cert_pem to verify outbound message signatures, so we overwrite
+    it on every SPIFFE-mode token issuance.
+
+    Returns True on success, False if the agent record is missing.
+    """
+    from app.auth.revocation import check_cert_not_revoked
+    from cryptography import x509 as _x509
+
+    cert_obj = _x509.load_pem_x509_certificate(cert_pem.encode())
+    serial_hex = format(cert_obj.serial_number, 'x')
+    await check_cert_not_revoked(db, serial_hex)
+
+    agent = await get_agent_by_id(db, agent_id)
+    if agent is None:
+        return False
+    agent.cert_pem = cert_pem
+    agent.cert_thumbprint = thumbprint
+    await db.commit()
+    return True
+
+
 async def rotate_agent_cert(db: AsyncSession, agent_id: str, new_cert_pem: str) -> str:
     """
     Rotate an agent's pinned certificate. Called only from explicit rotate endpoints.

--- a/enterprise_sandbox/agent/agent.py
+++ b/enterprise_sandbox/agent/agent.py
@@ -1,27 +1,50 @@
-"""Sandbox demo agent — authenticates to broker via SPIFFE or classic BYOCA.
+"""Sandbox demo agent — SPIFFE or BYOCA auth + A2A messaging round-trip.
+
+Each agent authenticates to the broker, opens a session with every peer
+listed in ``/state/peers.json``, and sends a single nonce payload. In
+parallel it auto-accepts inbound sessions (so peers can send to it) and
+polls every active session for messages, accumulating received nonces
+to ``/tmp/received.json`` for the smoke suite to inspect.
 
 Env:
     BROKER_URL                e.g. http://broker:8000
     ORG_ID                    e.g. orga
     AGENT_NAME                short name (becomes {ORG_ID}::{AGENT_NAME})
     AGENT_AUTH                'spire' (default) or 'byoca'
-    SPIFFE_ENDPOINT_SOCKET    path to SPIRE Workload API socket (spire mode only)
-    CERT_PATH, KEY_PATH       PEM paths for classic BYOCA cert (byoca mode only)
-
-Scope: prove both auth paths work end-to-end against the same broker and
-that a classic BYOCA agent can live next to a SPIRE SVID agent inside
-the same org (ADR-003 §2.6 mixed mode).
-
-Cross-org messaging lives in a follow-up (Blocco 4c, issue #96).
+    SPIFFE_ENDPOINT_SOCKET    spire mode only
+    CERT_PATH, KEY_PATH       byoca mode only
+    PEERS_FILE                /state/peers.json (written by bootstrap)
 """
 from __future__ import annotations
 
+import json
 import os
 import pathlib
 import sys
+import threading
 import time
+import uuid
 
 from cullis_sdk import CullisClient
+
+
+RECEIVED_FILE = pathlib.Path("/tmp/received.json")
+_received_lock = threading.Lock()
+_received_nonces: list[str] = []
+
+
+def _persist_received() -> None:
+    with _received_lock:
+        data = {"nonces": list(_received_nonces)}
+    tmp = RECEIVED_FILE.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data))
+    tmp.rename(RECEIVED_FILE)
+
+
+def _record(nonce: str) -> None:
+    with _received_lock:
+        _received_nonces.append(nonce)
+    _persist_received()
 
 
 def wait_for_socket(path: str, timeout: float = 60.0) -> bool:
@@ -61,7 +84,6 @@ def _auth_spire(broker: str, org_id: str) -> CullisClient:
 def _auth_byoca(broker: str, org_id: str, agent_id: str) -> CullisClient:
     cert_path = os.environ["CERT_PATH"]
     key_path = os.environ["KEY_PATH"]
-    # Wait for bootstrap to publish the cert on the shared volume.
     deadline = time.monotonic() + 60
     while time.monotonic() < deadline:
         if pathlib.Path(cert_path).exists() and pathlib.Path(key_path).exists():
@@ -76,16 +98,100 @@ def _auth_byoca(broker: str, org_id: str, agent_id: str) -> CullisClient:
     return client
 
 
+def _auto_accept_loop(client: CullisClient, self_id: str) -> None:
+    """Accept every pending session targeting this agent."""
+    seen: set[str] = set()
+    while True:
+        try:
+            sessions = client.list_sessions(status="pending")
+            for s in sessions:
+                if s.target_agent_id == self_id and s.session_id not in seen:
+                    try:
+                        client.accept_session(s.session_id)
+                        seen.add(s.session_id)
+                        print(f"[{self_id}] accepted session {s.session_id[:8]} "
+                              f"from {s.initiator_agent_id}", flush=True)
+                    except Exception as exc:
+                        print(f"[{self_id}] accept {s.session_id[:8]} failed: {exc!r}",
+                              flush=True)
+        except Exception as exc:
+            print(f"[{self_id}] list_sessions(pending) failed: {exc!r}", flush=True)
+        time.sleep(1)
+
+
+def _receive_loop(client: CullisClient, self_id: str) -> None:
+    """Poll every active session and record any nonce payloads."""
+    cursors: dict[str, int] = {}
+    while True:
+        try:
+            sessions = client.list_sessions(status="active")
+            for s in sessions:
+                sid = s.session_id
+                after = cursors.get(sid, -1)
+                try:
+                    msgs = client.poll(sid, after=after, poll_interval=0)
+                except Exception as exc:
+                    print(f"[{self_id}] poll {sid[:8]} failed: {exc!r}", flush=True)
+                    continue
+                for m in msgs:
+                    if isinstance(m.payload, dict) and "nonce" in m.payload:
+                        _record(m.payload["nonce"])
+                        print(f"[{self_id}] received nonce from {m.sender_agent_id}: "
+                              f"{m.payload['nonce']}", flush=True)
+                    cursors[sid] = max(cursors.get(sid, -1), m.seq)
+        except Exception as exc:
+            print(f"[{self_id}] list_sessions(active) failed: {exc!r}", flush=True)
+        time.sleep(1)
+
+
+def _send_to_peers(client: CullisClient, self_id: str, peers: list[str]) -> None:
+    """Open a session to each peer and send one nonce, retrying until the
+    session transitions from pending → active (peer accepts)."""
+    for peer_id in peers:
+        peer_org, _ = peer_id.split("::", 1)
+        try:
+            # target_agent_id is the full "{org}::{name}" form — broker's
+            # lookup is keyed on that, not on the short name.
+            session_id = client.open_session(
+                target_agent_id=peer_id,
+                target_org_id=peer_org,
+                capabilities=["sandbox.read"],
+            )
+        except Exception as exc:
+            print(f"[{self_id}] open_session {peer_id} failed: {exc!r}", flush=True)
+            continue
+        print(f"[{self_id}] session {session_id[:8]} opened → {peer_id}", flush=True)
+
+        nonce = f"{self_id}->{peer_id}:{uuid.uuid4().hex[:8]}"
+        for attempt in range(90):  # up to 90s for peer auto-accept
+            try:
+                client.send(
+                    session_id=session_id,
+                    sender_agent_id=self_id,
+                    payload={"nonce": nonce},
+                    recipient_agent_id=peer_id,
+                )
+                print(f"[{self_id}] sent nonce to {peer_id}", flush=True)
+                break
+            except Exception as exc:
+                if attempt < 89:
+                    time.sleep(1)
+                else:
+                    print(f"[{self_id}] send to {peer_id} giving up: {exc!r}",
+                          flush=True)
+
+
 def main() -> int:
     broker = os.environ["BROKER_URL"].rstrip("/")
     org_id = os.environ["ORG_ID"]
     name = os.environ["AGENT_NAME"]
     auth_mode = os.environ.get("AGENT_AUTH", "spire").lower()
-    agent_id = f"{org_id}::{name}"
+    peers_file = os.environ.get("PEERS_FILE", "/state/peers.json")
+    self_id = f"{org_id}::{name}"
 
-    # Wait for broker (we start in parallel with it)
     if not wait_for_http(f"{broker}/health", timeout=60):
-        print(f"[{agent_id}] FAIL: broker {broker} not reachable", file=sys.stderr, flush=True)
+        print(f"[{self_id}] FAIL: broker {broker} not reachable",
+              file=sys.stderr, flush=True)
         return 1
 
     try:
@@ -93,25 +199,51 @@ def main() -> int:
             client = _auth_spire(broker, org_id)
             auth_label = "SPIFFE"
         elif auth_mode == "byoca":
-            client = _auth_byoca(broker, org_id, agent_id)
+            client = _auth_byoca(broker, org_id, self_id)
             auth_label = "BYOCA"
         else:
-            print(f"[{agent_id}] FAIL: unknown AGENT_AUTH={auth_mode!r}",
+            print(f"[{self_id}] FAIL: unknown AGENT_AUTH={auth_mode!r}",
                   file=sys.stderr, flush=True)
             return 2
-    except Exception as e:
-        print(f"[{agent_id}] FAIL: {auth_mode} auth: {e!r}",
+    except Exception as exc:
+        print(f"[{self_id}] FAIL: {auth_mode} auth: {exc!r}",
               file=sys.stderr, flush=True)
         return 2
 
-    print(f"[{agent_id}] {auth_label} auth OK — token={client.token[:24] if client.token else None}...",
-          flush=True)
+    print(f"[{self_id}] {auth_label} auth OK — "
+          f"token={client.token[:24] if client.token else None}...", flush=True)
+    pathlib.Path("/tmp/ready").write_text(self_id + "\n")
+    _persist_received()  # initialize empty /tmp/received.json
 
-    # Ready-marker: smoke reads this to assert success without parsing logs.
-    pathlib.Path("/tmp/ready").write_text(agent_id + "\n")
+    # Load peer list written by bootstrap.
+    deadline = time.monotonic() + 30
+    while time.monotonic() < deadline:
+        if pathlib.Path(peers_file).exists():
+            break
+        time.sleep(0.5)
+    try:
+        topology = json.loads(pathlib.Path(peers_file).read_text())
+        peers = topology.get(self_id, [])
+    except Exception as exc:
+        print(f"[{self_id}] WARN: peers file unreadable ({exc!r}), no sends",
+              flush=True)
+        peers = []
+    print(f"[{self_id}] peers: {peers}", flush=True)
 
-    # Keep alive (long-running responder). Token refresh via SVID rotation
-    # is a later concern — SDK currently does not auto-rotate.
+    threading.Thread(
+        target=_auto_accept_loop, args=(client, self_id), daemon=True,
+    ).start()
+    threading.Thread(
+        target=_receive_loop, args=(client, self_id), daemon=True,
+    ).start()
+
+    # Give peer containers a head start so their auto_accept loop is running
+    # when we open sessions toward them.
+    time.sleep(5)
+    if peers:
+        _send_to_peers(client, self_id, peers)
+
+    # Keep the process alive — daemons handle accept + receive in background.
     while True:
         time.sleep(30)
 

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -340,8 +340,10 @@ services:
       ORG_ID: "orga"
       AGENT_NAME: "agent-a"
       SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
+      PEERS_FILE: "/state/peers.json"
     volumes:
       - spire-a-agent-socket:/run/spire/sockets:ro
+      - bootstrap-state:/state:ro
     networks: [orga-internal, public-wan]
     # Share PID namespace with spire-agent-a so the SPIRE unix WorkloadAttestor
     # can see this process via /proc/{pid}/exe and attest the unix:uid:1000
@@ -376,6 +378,7 @@ services:
       AGENT_AUTH: "byoca"
       CERT_PATH: "/state/orga/agents/byoca-bot/agent.pem"
       KEY_PATH:  "/state/orga/agents/byoca-bot/agent-key.pem"
+      PEERS_FILE: "/state/peers.json"
     volumes:
       - bootstrap-state:/state:ro
     networks: [orga-internal, public-wan]
@@ -529,8 +532,10 @@ services:
       ORG_ID: "orgb"
       AGENT_NAME: "agent-b"
       SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
+      PEERS_FILE: "/state/peers.json"
     volumes:
       - spire-b-agent-socket:/run/spire/sockets:ro
+      - bootstrap-state:/state:ro
     networks: [orgb-internal, public-wan]
     pid: "service:spire-agent-b"
     restart: unless-stopped

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -276,6 +276,46 @@ else
     fail "B4.6 byoca-a classic auth"
 fi
 
+# B4.7 — full 3-agent A2A round-trip. Each agent opens a session with each
+# of the other two and sends one nonce payload. Every recipient's
+# /tmp/received.json accumulates the nonces. When the topology has
+# settled each agent has received exactly 2 nonces (one per peer).
+# This exercises: session open, peer auto-accept, broker routing,
+# E2E encryption, message signing, cross-org + intra-org both via broker,
+# mixed authentication (SPIRE leaf and classic leaf coexist).
+check_received() {
+    local container="$1" expected_from_a="$2" expected_from_b="$3"
+    docker compose exec -T "$container" python -c "
+import json, sys
+d = json.load(open('/tmp/received.json'))
+nonces = d['nonces']
+# Look for prefix '$expected_from_a->' and '$expected_from_b->' (at least one each)
+got_a = any(n.startswith('$expected_from_a->') for n in nonces)
+got_b = any(n.startswith('$expected_from_b->') for n in nonces)
+sys.exit(0 if (got_a and got_b) else 1)
+" 2>/dev/null
+}
+delivery_ok=true
+for i in $(seq 1 60); do
+    if check_received agent-a   "orga::byoca-bot" "orgb::agent-b" \
+       && check_received byoca-a "orga::agent-a"   "orgb::agent-b" \
+       && check_received agent-b  "orga::agent-a"   "orga::byoca-bot"; then
+        delivery_ok=true
+        break
+    fi
+    delivery_ok=false
+    sleep 1
+done
+if $delivery_ok; then
+    pass "B4.7 A2A messaging — each agent received nonces from both peers (cross-org + intra-org, mixed auth)"
+else
+    fail "B4.7 A2A messaging (not all 6 nonces delivered within 60s)"
+    for c in agent-a byoca-a agent-b; do
+        echo "  --- $c /tmp/received.json ---"
+        docker compose exec -T "$c" cat /tmp/received.json 2>/dev/null || echo "  (unreachable)"
+    done
+fi
+
 echo ""
 echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
 [[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes issue #96. Completes the A2A story started by #104: every agent in the sandbox (\`spire-a\`, \`spire-b\`, \`byoca-bot\`) opens a session with each peer and sends one signed+encrypted nonce, in parallel auto-accepting inbound sessions and polling every active session. The smoke asserts each recipient eventually holds both expected nonces.

End-to-end proof of:
- Session open / accept / send / poll across three agents
- **Cross-org routing** (orga ↔ orgb via shared broker)
- **Intra-org routing** (\`orga::agent-a\` ↔ \`orga::byoca-bot\` via broker)
- **Mixed-mode auth** interoperating: SPIRE SVID leaf ↔ classic CN/O cert
- E2E encryption + dual-signature + policy engine default-allow

## Changes

- \`enterprise_sandbox/agent/agent.py\`: rewritten as multi-peer dual-role initiator+responder. Background threads auto-accept pending sessions, poll all active sessions, accumulate received nonces into \`/tmp/received.json\`. \`AGENT_AUTH\` selects spire vs byoca.
- \`enterprise_sandbox/docker-compose.yml\`: all three agent services mount \`bootstrap-state\` read-only; \`PEERS_FILE=/state/peers.json\`.
- \`enterprise_sandbox/smoke.sh\`: new B4.7 polls the three containers' \`/tmp/received.json\` for up to 60s. **Target 23/0/0** (was 22/0/0).

Local-only \`bootstrap.py\` (gitignored) writes the \`/state/peers.json\` topology.

### Incidental broker fix (strictly required)

- \`app/registry/store.py\`: new \`refresh_agent_cert_svid\` — overwrites stored cert without enforcing thumbprint pinning. Companion to PR #101's pinning-skip-in-SVID-mode change.
- \`app/auth/router.py\`: SVID-mode token issuance calls the new helper instead of skipping cert storage entirely.

Without this, \`cert_pem\` stays NULL for every SPIFFE-authenticated agent and outbound message signature verification at \`/v1/broker/sessions/{id}/messages\` returns 401 \"Agent certificate not found\". Same carve-out rationale as the SDK \`log()\` fix in #102.

## What's NOT covered (explicit limits)

This PR uses \`client.send()\` against the broker for every message (intra-org too). The ADR-001 \`/v1/egress/send\` mtls-only local path (PR #100) is **not** exercised end-to-end in this smoke — the unit test \`tests/test_intra_org_round_trip.py\` covers it at the HTTP layer. Wiring agent.py to use proxy enrollment + \`send_via_proxy\` for intra-org is a separate follow-up.

## Test plan

- [x] \`./down.sh && ./up.sh && ./smoke.sh\` → 23 PASS, 0 FAIL, 0 SKIP
- [x] \`pytest tests/test_auth.py tests/test_auth_svid.py tests/test_auth_chain.py -n auto\` → 32/32 (no regression on pinning / SVID paths)
- [x] broker audit log shows auth.token_issued × 3 + 6 session-related events under both orgs