### PR TITLE
feat(proxy+sdk): ADR-004 PR A — reverse-proxy middleware

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -59,6 +59,13 @@ class CullisClient:
         self._dpop_pubkey_jwk: dict | None = None
         self._dpop_nonce: str | None = None
 
+        # ADR-004 — last-seen server role (proxy|broker|None) from
+        # the `x-cullis-role` response header. The SDK's base URL can
+        # point either to a proxy (reverse-proxying to a broker) or to
+        # a broker directly; responses self-identify so tooling can
+        # detect which role is in front of it without a config change.
+        self.server_role: str | None = None
+
     def __enter__(self) -> CullisClient:
         return self
 
@@ -83,6 +90,9 @@ class CullisClient:
         nonce = response.headers.get("dpop-nonce")
         if nonce:
             self._dpop_nonce = nonce
+        role = response.headers.get("x-cullis-role")
+        if role:
+            self.server_role = role
 
     def _headers(self, method: str, path: str) -> dict:
         if not self.token:

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -80,6 +80,18 @@ async def lifespan(app: FastAPI):
     from mcp_proxy.db import get_config
     broker_url = await get_config("broker_url") or settings.broker_url
     org_id = await get_config("org_id") or settings.org_id
+
+    # ADR-004 PR A — reverse-proxy httpx client. One shared AsyncClient so the
+    # forwarder re-uses HTTP/2 connections across requests. The broker URL is
+    # pinned on app.state so tests can override it before lifespan.
+    import httpx as _httpx
+    app.state.reverse_proxy_broker_url = broker_url
+    app.state.reverse_proxy_client = _httpx.AsyncClient(
+        timeout=30.0,
+        verify=settings.broker_verify_tls,
+        follow_redirects=False,
+    )
+
     if broker_url:
         from mcp_proxy.egress.agent_manager import AgentManager
         from mcp_proxy.egress.broker_bridge import BrokerBridge
@@ -218,6 +230,9 @@ async def lifespan(app: FastAPI):
     bridge = getattr(app.state, "broker_bridge", None)
     if bridge is not None:
         await bridge.shutdown()
+    rp_client = getattr(app.state, "reverse_proxy_client", None)
+    if rp_client is not None:
+        await rp_client.aclose()
     if _jwks_client:
         await _jwks_client.close()
     await dispose_db()
@@ -386,6 +401,12 @@ async def pdp_health():
     """PDP health check."""
     return {"status": "ok", "mode": "built-in"}
 
+
+# ADR-004 PR A — reverse-proxy router for /v1/broker/*, /v1/auth/*,
+# /v1/registry/*. Registered before local handlers so the proxy owns these
+# paths by default; local endpoints live under /v1/egress/* and /v1/ingress/*.
+from mcp_proxy.reverse_proxy import build_reverse_proxy_router
+app.include_router(build_reverse_proxy_router())
 
 from mcp_proxy.ingress.router import router as ingress_router
 app.include_router(ingress_router)

--- a/mcp_proxy/reverse_proxy/__init__.py
+++ b/mcp_proxy/reverse_proxy/__init__.py
@@ -1,0 +1,15 @@
+"""ADR-004 reverse-proxy middleware.
+
+Forwards /v1/broker/*, /v1/auth/*, /v1/registry/* to the configured broker,
+preserving method, path, body, and auth-relevant headers (DPoP, Authorization,
+client_assertion x5c). Host header from the inbound request is propagated so
+the broker's DPoP htu validator sees the URL the SDK actually used.
+
+WebSocket upgrade forwarding is not implemented here — see ADR-004 §5 Q2.
+"""
+from mcp_proxy.reverse_proxy.forwarder import (
+    FORWARDED_PREFIXES,
+    build_reverse_proxy_router,
+)
+
+__all__ = ["FORWARDED_PREFIXES", "build_reverse_proxy_router"]

--- a/mcp_proxy/reverse_proxy/forwarder.py
+++ b/mcp_proxy/reverse_proxy/forwarder.py
@@ -1,0 +1,144 @@
+"""HTTP reverse-proxy forwarder for ADR-004 PR A.
+
+The SDK always connects to the proxy (never direct to broker). For operations
+that conceptually belong to the broker — auth token, sessions, registry — the
+proxy forwards the request as-is to the configured broker URL.
+
+Invariants:
+- Method / path / query / body pass through unchanged.
+- Authorization and DPoP headers pass through unchanged (the broker does the
+  actual verification — the proxy is transparent at the auth layer).
+- Host header from the inbound request is forwarded. The broker's DPoP htu
+  validator uses request.url (derived from Host); the SDK computed htu from
+  its own base URL, so they line up.
+- Hop-by-hop headers (RFC 7230 §6.1) are stripped.
+- Responses are returned verbatim with an extra `x-cullis-role: proxy` header
+  so SDKs can detect whether they are talking to a proxy or directly to the
+  broker.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Iterable
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, Response
+
+_log = logging.getLogger("mcp_proxy.reverse_proxy")
+
+FORWARDED_PREFIXES: tuple[str, ...] = (
+    "/v1/broker",
+    "/v1/auth",
+    "/v1/registry",
+)
+
+_HOP_BY_HOP = frozenset(
+    h.lower()
+    for h in (
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+        # content-length is recomputed by httpx / starlette from the body.
+        "content-length",
+    )
+)
+
+
+def _filter_request_headers(headers: Iterable[tuple[bytes, bytes]]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name, value in headers:
+        lname = name.decode("latin-1").lower()
+        if lname in _HOP_BY_HOP:
+            continue
+        out[lname] = value.decode("latin-1")
+    return out
+
+
+def _filter_response_headers(resp: httpx.Response) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for name, value in resp.headers.items():
+        if name.lower() in _HOP_BY_HOP:
+            continue
+        out[name] = value
+    return out
+
+
+async def _forward(request: Request, broker_url: str, client: httpx.AsyncClient) -> Response:
+    target = broker_url.rstrip("/") + request.url.path
+    if request.url.query:
+        target = f"{target}?{request.url.query}"
+
+    body = await request.body()
+    headers = _filter_request_headers(request.headers.raw)
+
+    try:
+        upstream = await client.request(
+            request.method,
+            target,
+            content=body if body else None,
+            headers=headers,
+        )
+    except httpx.ConnectError as exc:
+        _log.warning("reverse-proxy: broker unreachable (%s): %s", target, exc)
+        raise HTTPException(status_code=502, detail="broker unreachable") from exc
+    except httpx.TimeoutException as exc:
+        _log.warning("reverse-proxy: broker timeout (%s): %s", target, exc)
+        raise HTTPException(status_code=504, detail="broker timeout") from exc
+
+    out_headers = _filter_response_headers(upstream)
+    out_headers["x-cullis-role"] = "proxy"
+
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=out_headers,
+        media_type=upstream.headers.get("content-type"),
+    )
+
+
+def build_reverse_proxy_router() -> APIRouter:
+    """Return an APIRouter that forwards the ADR-004 prefixes to the broker.
+
+    The handler reads broker URL and httpx client from ``request.app.state`` so
+    tests can monkey-patch either one and so the same router works regardless
+    of the lifespan-initialized values.
+    """
+    router = APIRouter(tags=["reverse-proxy"])
+
+    methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"]
+
+    async def _handler(request: Request) -> Response:
+        broker_url: str | None = getattr(request.app.state, "reverse_proxy_broker_url", None)
+        client: httpx.AsyncClient | None = getattr(
+            request.app.state, "reverse_proxy_client", None,
+        )
+        if not broker_url or client is None:
+            raise HTTPException(
+                status_code=503,
+                detail="reverse proxy not configured (broker_url missing)",
+            )
+        return await _forward(request, broker_url, client)
+
+    for prefix in FORWARDED_PREFIXES:
+        router.add_api_route(
+            f"{prefix}/{{path:path}}",
+            _handler,
+            methods=methods,
+            include_in_schema=False,
+        )
+        # Also match the bare prefix (no trailing segment) — FastAPI's `path:path`
+        # placeholder requires at least an empty segment, which matches ``/v1/auth/``
+        # but not ``/v1/auth``. Both are valid URLs, so register the bare form too.
+        router.add_api_route(
+            prefix,
+            _handler,
+            methods=methods,
+            include_in_schema=False,
+        )
+
+    return router

--- a/tests/test_proxy_reverse_forwarding.py
+++ b/tests/test_proxy_reverse_forwarding.py
@@ -6,12 +6,10 @@ x5c) and Host preserved, so the broker's DPoP ``htu`` check still passes.
 """
 from __future__ import annotations
 
-import base64
 import uuid
 
 import pytest
 import pytest_asyncio
-from cryptography.hazmat.primitives import serialization
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app as broker_app  # ensures conftest side-effects load

--- a/tests/test_proxy_reverse_forwarding.py
+++ b/tests/test_proxy_reverse_forwarding.py
@@ -1,0 +1,177 @@
+"""ADR-004 PR A — proxy reverse-proxy forwarding for /v1/broker, /v1/auth, /v1/registry.
+
+Verifies that the SDK can hit the proxy at ``http://proxy`` and the request is
+transparently forwarded to the broker with auth headers (DPoP, client_assertion
+x5c) and Host preserved, so the broker's DPoP ``htu`` check still passes.
+"""
+from __future__ import annotations
+
+import base64
+import uuid
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app as broker_app  # ensures conftest side-effects load
+from tests.cert_factory import get_org_ca_pem, make_assertion
+from tests.conftest import ADMIN_HEADERS
+
+
+# The proxy forwards to this address; the same ASGI transport answers both the
+# proxy's lifespan check and the broker calls, so we can keep the URL arbitrary.
+BROKER_TARGET = "http://broker-test"
+
+
+@pytest_asyncio.fixture
+async def proxy_forwarding(tmp_path, monkeypatch):
+    """Spin up the proxy app wired to forward /v1/* to the in-memory broker app."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    # Any value — we overwrite app.state.reverse_proxy_client below anyway.
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", BROKER_TARGET)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app as proxy_app
+
+    async with proxy_app.router.lifespan_context(proxy_app):
+        # Point the proxy's reverse-proxy httpx client at the in-memory broker.
+        broker_client = AsyncClient(
+            transport=ASGITransport(app=broker_app),
+            base_url=BROKER_TARGET,
+        )
+        proxy_app.state.reverse_proxy_client = broker_client
+        proxy_app.state.reverse_proxy_broker_url = BROKER_TARGET
+
+        proxy_transport = ASGITransport(app=proxy_app)
+        async with AsyncClient(transport=proxy_transport, base_url="http://test") as c:
+            try:
+                yield proxy_app, c
+            finally:
+                await broker_client.aclose()
+    get_settings.cache_clear()
+
+
+async def _register_agent_on_broker(agent_id: str, org_id: str) -> None:
+    """Provision org + CA + agent + approved binding directly on the broker app."""
+    # Use a short-lived AsyncClient straight to the broker so we don't pollute
+    # the proxy forwarding path during setup.
+    async with AsyncClient(
+        transport=ASGITransport(app=broker_app), base_url="http://test",
+    ) as broker:
+        org_secret = org_id + "-secret"
+        await broker.post(
+            "/v1/registry/orgs",
+            json={"org_id": org_id, "display_name": org_id, "secret": org_secret},
+            headers=ADMIN_HEADERS,
+        )
+        await broker.post(
+            f"/v1/registry/orgs/{org_id}/certificate",
+            json={"ca_certificate": get_org_ca_pem(org_id)},
+            headers={"x-org-id": org_id, "x-org-secret": org_secret},
+        )
+        await broker.post(
+            "/v1/registry/agents",
+            json={
+                "agent_id": agent_id, "org_id": org_id,
+                "display_name": agent_id, "capabilities": ["test.read"],
+            },
+            headers={"x-org-id": org_id, "x-org-secret": org_secret},
+        )
+        resp = await broker.post(
+            "/v1/registry/bindings",
+            json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},
+            headers={"x-org-id": org_id, "x-org-secret": org_secret},
+        )
+        binding_id = resp.json()["id"]
+        await broker.post(
+            f"/v1/registry/bindings/{binding_id}/approve",
+            headers={"x-org-id": org_id, "x-org-secret": org_secret},
+        )
+
+
+@pytest.mark.asyncio
+async def test_auth_token_via_proxy(proxy_forwarding, dpop):
+    """Agent auth via proxy: DPoP htu and x5c both propagate so broker accepts."""
+    _, client = proxy_forwarding
+
+    org_id = f"rp-org-{uuid.uuid4().hex[:6]}"
+    agent_id = f"{org_id}::agent-1"
+    await _register_agent_on_broker(agent_id, org_id)
+
+    # Prime the DPoP nonce via the proxy (health endpoint lives on the proxy
+    # itself, so prime directly from the broker to match the DPoP helper).
+    async with AsyncClient(
+        transport=ASGITransport(app=broker_app), base_url="http://test",
+    ) as broker:
+        prime = await broker.get("/health")
+        dpop._update_nonce(prime)
+
+    assertion = make_assertion(agent_id, org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof},
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["token_type"] == "DPoP"
+    assert body["access_token"]
+    # The proxy tags every reverse-proxied response so SDKs can detect role.
+    assert resp.headers.get("x-cullis-role") == "proxy"
+
+
+@pytest.mark.asyncio
+async def test_dpop_nonce_header_propagates(proxy_forwarding, dpop):
+    """Broker-issued DPoP-Nonce header must survive reverse-proxy forwarding."""
+    _, client = proxy_forwarding
+
+    org_id = f"rp-nonce-{uuid.uuid4().hex[:6]}"
+    agent_id = f"{org_id}::agent-1"
+    await _register_agent_on_broker(agent_id, org_id)
+
+    # Send a proof without a nonce — the broker replies 401 use_dpop_nonce
+    # with a fresh DPoP-Nonce header. The proxy must forward that header
+    # verbatim so the SDK can retry with it.
+    dpop._nonce = None
+    assertion = make_assertion(agent_id, org_id)
+    proof_no_nonce = dpop.proof("POST", "/v1/auth/token", nonce=None)
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof_no_nonce},
+    )
+    assert resp.status_code == 401
+    assert "use_dpop_nonce" in resp.text
+    assert resp.headers.get("dpop-nonce"), "proxy dropped DPoP-Nonce header"
+    assert resp.headers.get("x-cullis-role") == "proxy"
+
+
+@pytest.mark.asyncio
+async def test_reverse_proxy_tags_role_header(proxy_forwarding):
+    """Any reverse-proxied response must carry x-cullis-role=proxy."""
+    _, client = proxy_forwarding
+
+    # /v1/registry/agents/search without DPoP returns 401 from the broker; we
+    # only need to verify the proxy tagged the response and forwarded the path.
+    resp = await client.get("/v1/registry/agents/search?pattern=*")
+    assert resp.status_code in (401, 422), resp.text
+    assert resp.headers.get("x-cullis-role") == "proxy"
+
+
+@pytest.mark.asyncio
+async def test_reverse_proxy_503_when_broker_url_unset(proxy_forwarding):
+    """With no broker_url configured, the reverse proxy short-circuits 503."""
+    proxy_app, client = proxy_forwarding
+    proxy_app.state.reverse_proxy_broker_url = None
+
+    resp = await client.post("/v1/auth/token", json={})
+    assert resp.status_code == 503, resp.text


### PR DESCRIPTION
Ref Epic #106 — **PR A**.

## Summary

- New module `mcp_proxy/reverse_proxy/` registers a FastAPI catch-all for `/v1/broker/*`, `/v1/auth/*`, `/v1/registry/*` and forwards to the configured broker via a shared `httpx.AsyncClient`.
- Method / path / query / body and all auth-relevant headers (`Authorization`, `DPoP`, `Host`, `client_assertion` x5c carried in the body) pass through unchanged. Hop-by-hop headers are stripped per RFC 7230 §6.1.
- Every reverse-proxied response carries `x-cullis-role: proxy`.
- `CullisClient` records the server role on `self.server_role` (updated from the header alongside the DPoP nonce). No API change: a proxy URL can be passed as `broker_url` today.
- Broker stays invariant — it continues to see the agent's real identity and run the full auth pipeline. DPoP `htu` lines up because the proxy preserves the inbound `Host` header (ADR-004 §2.3 strategy (a), "trasparenza totale").

## Test plan

- [x] `pytest tests/test_proxy_reverse_forwarding.py` — 4/4 green
  - auth-via-proxy round-trip (x5c + DPoP + htu all align, response tagged `x-cullis-role: proxy`)
  - `DPoP-Nonce` header propagates through the proxy verbatim
  - any reverse-proxied response carries the role tag
  - 503 when `reverse_proxy_broker_url` is unset
- [x] `pytest tests/` — 764 passed (2 pre-existing Postgres integration failures, unrelated — same on `main`)
- [x] `./demo_network/smoke.sh full` — PASS (round-trip + dashboard survival + audit hash chain)

## Scope

Strictly the moving parts for PR A. Out of scope:
- Sandbox / demo_network migration to `proxy_url` as base → PR B/C
- `/v1/auth/sign-assertion` endpoint + BrokerBridge refactor → PR D
- WebSocket reverse-proxy → ADR-004 §5 Q2 follow-up