### PR TITLE
feat(sandbox+proxy): ADR-004 PR B — sandbox proxy-only topology

### DIFF
--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -93,11 +93,11 @@ services:
       KMS_BACKEND: "local"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
-      # Used by DPoP htu validation. Agents on the docker network reach the
-      # broker via "http://broker:8000", so that's what their proofs claim.
-      # OIDC browser flow now lives on the proxies (PR #88) so this URL no
-      # longer needs to match a browser-typed host.
-      BROKER_PUBLIC_URL: "http://broker:8000"
+      # ADR-004 PR B — proxy-only topology. Agents now reach the broker
+      # through proxy-{a,b}, so their DPoP proofs claim htu=http://proxy-X:9100/...
+      # Leaving BROKER_PUBLIC_URL empty makes build_htu fall back to the
+      # request's Host header, which the proxy preserves on forward. That
+      # keeps htu validation in lock-step with whatever proxy the SDK hit.
       DATABASE_URL: "postgresql+asyncpg://atn:atn-sandbox@postgres:5432/agent_trust"
       REDIS_URL: "redis://redis:6379"
       POLICY_BACKEND: "webhook"
@@ -336,7 +336,7 @@ services:
       broker:
         condition: service_healthy
     environment:
-      BROKER_URL: "http://broker:8000"
+      BROKER_URL: "http://proxy-a:9100"
       ORG_ID: "orga"
       AGENT_NAME: "agent-a"
       SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
@@ -344,7 +344,10 @@ services:
     volumes:
       - spire-a-agent-socket:/run/spire/sockets:ro
       - bootstrap-state:/state:ro
-    networks: [orga-internal, public-wan]
+    # ADR-004 PR B — proxy-only topology. agent-a reaches the broker
+    # exclusively via proxy-a on orga-internal. public-wan is detached so
+    # B4.8 can assert no direct TCP path to broker:8000 exists.
+    networks: [orga-internal]
     # Share PID namespace with spire-agent-a so the SPIRE unix WorkloadAttestor
     # can see this process via /proc/{pid}/exe and attest the unix:uid:1000
     # selector. Without this, attestation fails with "could not resolve
@@ -372,7 +375,7 @@ services:
       broker:
         condition: service_healthy
     environment:
-      BROKER_URL: "http://broker:8000"
+      BROKER_URL: "http://proxy-a:9100"
       ORG_ID: "orga"
       AGENT_NAME: "byoca-bot"
       AGENT_AUTH: "byoca"
@@ -381,7 +384,8 @@ services:
       PEERS_FILE: "/state/peers.json"
     volumes:
       - bootstrap-state:/state:ro
-    networks: [orga-internal, public-wan]
+    # ADR-004 PR B — proxy-only: byoca-a talks to proxy-a, not broker.
+    networks: [orga-internal]
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "test", "-f", "/tmp/ready"]
@@ -528,7 +532,7 @@ services:
       broker:
         condition: service_healthy
     environment:
-      BROKER_URL: "http://broker:8000"
+      BROKER_URL: "http://proxy-b:9100"
       ORG_ID: "orgb"
       AGENT_NAME: "agent-b"
       SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
@@ -536,7 +540,8 @@ services:
     volumes:
       - spire-b-agent-socket:/run/spire/sockets:ro
       - bootstrap-state:/state:ro
-    networks: [orgb-internal, public-wan]
+    # ADR-004 PR B — proxy-only topology. agent-b reaches broker via proxy-b.
+    networks: [orgb-internal]
     pid: "service:spire-agent-b"
     restart: unless-stopped
     healthcheck:

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -316,6 +316,35 @@ else
     done
 fi
 
+# B4.8 — ADR-004: proxy-only topology.
+#
+# Each agent container is detached from public-wan, so there is no network
+# path from the agent to broker:8000. A direct TCP connect attempt must fail
+# (DNS resolution or connect timeout). This proves that the successful B4.4
+# / B4.5 / B4.6 auth flows and B4.7 A2A round-trip all travel through the
+# proxy reverse-proxy, not directly to the broker.
+B48_PROBE='
+import socket, sys
+s = socket.socket()
+s.settimeout(2)
+try:
+    s.connect(("broker", 8000))
+    # Connected — the proxy-only invariant is broken.
+    sys.exit(0)
+except Exception:
+    sys.exit(1)
+'
+B48_FAIL=0
+for c in agent-a byoca-a agent-b; do
+    if docker compose exec -T "$c" python -c "$B48_PROBE" 2>/dev/null; then
+        fail "B4.8 $c reached broker:8000 directly (LEAK — public-wan still attached?)"
+        B48_FAIL=1
+    fi
+done
+if [[ $B48_FAIL -eq 0 ]]; then
+    pass "B4.8 proxy-only — agent-a, byoca-a, agent-b cannot reach broker:8000 directly"
+fi
+
 echo ""
 echo "[smoke] PASS=$PASS  FAIL=$FAIL  SKIP=$SKIP"
 [[ $FAIL -eq 0 ]]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -304,8 +304,12 @@ async def security_headers(request: Request, call_next):
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
     response.headers["Cache-Control"] = "no-store"
 
-    # DPoP-Nonce on API responses only (not on dashboard/health routes)
-    _no_dpop_nonce = ("/proxy/", "/health", "/healthz", "/readyz")
+    # DPoP-Nonce on API responses only (not on dashboard/health routes, and
+    # not on ADR-004 reverse-proxied paths — those carry the broker's own
+    # DPoP-Nonce header verbatim; overriding it here would break the SDK's
+    # use_dpop_nonce retry loop).
+    from mcp_proxy.reverse_proxy import FORWARDED_PREFIXES as _RP_PREFIXES
+    _no_dpop_nonce = ("/proxy/", "/health", "/healthz", "/readyz") + _RP_PREFIXES
     if not any(request.url.path.startswith(p) for p in _no_dpop_nonce):
         from mcp_proxy.auth.dpop import get_current_dpop_nonce
         response.headers["DPoP-Nonce"] = get_current_dpop_nonce()

--- a/mcp_proxy/reverse_proxy/forwarder.py
+++ b/mcp_proxy/reverse_proxy/forwarder.py
@@ -76,6 +76,22 @@ async def _forward(request: Request, broker_url: str, client: httpx.AsyncClient)
     body = await request.body()
     headers = _filter_request_headers(request.headers.raw)
 
+    # Propagate the caller's IP so the broker's rate limiter can distinguish
+    # per-agent load instead of collapsing every agent of an org onto the
+    # single proxy IP. Broker must trust the proxy (FORWARDED_ALLOW_IPS) for
+    # this to count — same contract as any L7 load balancer.
+    client_host = request.client.host if request.client else None
+    if client_host:
+        existing = headers.get("x-forwarded-for")
+        headers["x-forwarded-for"] = (
+            f"{existing}, {client_host}" if existing else client_host
+        )
+        headers.setdefault("x-forwarded-proto", request.url.scheme)
+        if not headers.get("x-forwarded-host"):
+            host = request.headers.get("host")
+            if host:
+                headers["x-forwarded-host"] = host
+
     try:
         upstream = await client.request(
             request.method,


### PR DESCRIPTION
Ref Epic #106 — **PR B**. Stacked on PR #108 (merged).

## Summary

- `agent-a`, `byoca-a`, `agent-b` now point `BROKER_URL` at their local proxy (`proxy-a:9100` / `proxy-b:9100`) instead of the broker.
- Agents detached from `public-wan`: no network path from an agent container to `broker:8000` exists.
- New smoke assertion **B4.8**: each agent tries to TCP-connect to `broker:8000` and must fail. With B4.4-B4.7 still passing, every successful auth + A2A round-trip in the sandbox now provably traverses the reverse-proxy wired up in PR A.
- Two reverse-proxy fixes the sandbox migration uncovered:
  - Skip `security_headers` DPoP-Nonce injection on ADR-004 prefixes — the broker's own nonce was being overwritten, breaking the SDK's `use_dpop_nonce` retry.
  - Propagate `X-Forwarded-For/-Host/-Proto` so the broker rate limiter sees the real agent IP instead of collapsing every agent of an org onto the single proxy IP.
- Dropped `BROKER_PUBLIC_URL` from the sandbox broker env so `build_htu` falls back to the preserved Host header (ADR-004 §2.3 strategy (a)).

## Test plan

- [x] `enterprise_sandbox/smoke.sh` — 24/24 PASS (including new B4.8)
- [x] `pytest tests/` — 764 pass (same 2 pre-existing Postgres failures as `main`)
- [x] `./demo_network/smoke.sh full` — PASS

## Scope

Strictly sandbox migration + forwarder fixes that blocked it. Out of scope:
- `demo_network` migration + SDK deprecation warning → PR C
- `/v1/auth/sign-assertion` + BrokerBridge refactor → PR D