### PR TITLE
feat(demo+proxy+broker): ADR-004 PR C — demo_network proxy-only + SDK deprecation warning

### DIFF
--- a/app/auth/dpop.py
+++ b/app/auth/dpop.py
@@ -163,14 +163,24 @@ def build_htu(request: Request, settings) -> str:
     Priority:
     1. settings.broker_public_url + request path  — explicit override, use in
        production behind a reverse proxy / load balancer.
-    2. Starlette-reconstructed URL — works when uvicorn is started with
-       --proxy-headers and --forwarded-allow-ips.
+    2. X-Forwarded-Host / X-Forwarded-Proto — ADR-004: agents reach the broker
+       via their local proxy, which sets these headers from the original Host
+       seen by the SDK. uvicorn's --proxy-headers handles X-Forwarded-Proto
+       and X-Forwarded-For but not Host, so the broker has to promote it
+       itself. FORWARDED_ALLOW_IPS is the trust boundary (same as uvicorn).
+    3. Starlette-reconstructed URL — works when no proxy is in the path.
 
     Query string and fragment are always stripped (RFC 9449 §4.3).
     """
     if settings.broker_public_url:
         base = settings.broker_public_url.rstrip("/")
         return _normalize_htu(base + request.url.path)
+
+    fwd_host = request.headers.get("x-forwarded-host")
+    if fwd_host:
+        fwd_proto = request.headers.get("x-forwarded-proto") or request.url.scheme
+        return _normalize_htu(f"{fwd_proto}://{fwd_host}{request.url.path}")
+
     return _normalize_htu(str(request.url))
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -308,6 +308,11 @@ else:
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
     response = await call_next(request)
+    # ADR-004 — broker self-identifies so SDKs connected directly can warn
+    # about the deprecated path. The proxy forwards this header unchanged
+    # (the reverse-proxy middleware overwrites it with "proxy", so a caller
+    # that sees "broker" is definitively talking to the broker directly).
+    response.headers.setdefault("x-cullis-role", "broker")
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -92,7 +92,19 @@ class CullisClient:
             self._dpop_nonce = nonce
         role = response.headers.get("x-cullis-role")
         if role:
+            previous = self.server_role
             self.server_role = role
+            if role == "broker" and previous != "broker":
+                import warnings
+                warnings.warn(
+                    "CullisClient is connected directly to the broker. "
+                    "ADR-004: agents should always reach the broker through "
+                    "their local proxy (set broker_url=<proxy_url>). Direct "
+                    "broker access is deprecated and will be removed in a "
+                    "future release.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
 
     def _headers(self, method: str, path: str) -> dict:
         if not self.token:

--- a/demo_network/compose.yml
+++ b/demo_network/compose.yml
@@ -174,7 +174,11 @@ services:
       DASHBOARD_SIGNING_KEY: "demo-dashboard-signing-key-32chars-long-enough"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
-      BROKER_PUBLIC_URL: "https://broker.cullis.test:8443"
+      # ADR-004 — agents reach the broker via proxy-{a,b}, whose DPoP proofs
+      # claim htu=https://proxy-X.cullis.test:8443/... Leaving BROKER_PUBLIC_URL
+      # empty lets build_htu fall back to the Host header, which the proxy
+      # preserves via X-Forwarded-Host on forward (uvicorn --proxy-headers).
+      # BROKER_PUBLIC_URL: "https://broker.cullis.test:8443"
       DATABASE_URL: "postgresql+asyncpg://atn:atn-smoke@postgres:5432/agent_trust"
       REDIS_URL: "redis://redis:6379"
       KMS_BACKEND: "vault"
@@ -221,7 +225,9 @@ services:
         condition: service_completed_successfully
     environment:
       ORG_ID: "demo-org-a"
-      BROKER_URL: "https://broker.cullis.test:8443"
+      # ADR-004 — reverse-proxy forwards directly to broker:8000 (no Traefik
+      # in between), so X-Forwarded-* survive to the broker.
+      BROKER_URL: "http://broker:8000"
       PROXY_PUBLIC_URL: "https://proxy-a.cullis.test:8443"
       PROXY_DB_PATH: /data/mcp_proxy.db
       STATE_DIR: /state
@@ -237,7 +243,8 @@ services:
         condition: service_completed_successfully
     environment:
       ORG_ID: "demo-org-b"
-      BROKER_URL: "https://broker.cullis.test:8443"
+      # ADR-004 — reverse-proxy → broker:8000 internal (no Traefik).
+      BROKER_URL: "http://broker:8000"
       PROXY_PUBLIC_URL: "https://proxy-b.cullis.test:8443"
       PROXY_DB_PATH: /data/mcp_proxy.db
       STATE_DIR: /state
@@ -258,8 +265,11 @@ services:
       proxy-a-init:
         condition: service_completed_successfully
     environment:
-      MCP_PROXY_BROKER_URL: "https://broker.cullis.test:8443"
-      MCP_PROXY_BROKER_JWKS_URL: "https://broker.cullis.test:8443/.well-known/jwks.json"
+      # ADR-004 — reverse-proxy forwards directly to broker:8000 (bypasses
+      # Traefik), so X-Forwarded-Host / -Proto survive to the broker's
+      # --proxy-headers htu reconstruction.
+      MCP_PROXY_BROKER_URL: "http://broker:8000"
+      MCP_PROXY_BROKER_JWKS_URL: "http://broker:8000/.well-known/jwks.json"
       MCP_PROXY_PROXY_PUBLIC_URL: "https://proxy-a.cullis.test:8443"
       MCP_PROXY_ADMIN_SECRET: "demo-proxy-admin-a"
       MCP_PROXY_DATABASE_URL: "sqlite+aiosqlite:////data/mcp_proxy.db"
@@ -281,8 +291,9 @@ services:
       proxy-b-init:
         condition: service_completed_successfully
     environment:
-      MCP_PROXY_BROKER_URL: "https://broker.cullis.test:8443"
-      MCP_PROXY_BROKER_JWKS_URL: "https://broker.cullis.test:8443/.well-known/jwks.json"
+      # ADR-004 — reverse-proxy → broker:8000 internal (no Traefik in between).
+      MCP_PROXY_BROKER_URL: "http://broker:8000"
+      MCP_PROXY_BROKER_JWKS_URL: "http://broker:8000/.well-known/jwks.json"
       MCP_PROXY_PROXY_PUBLIC_URL: "https://proxy-b.cullis.test:8443"
       MCP_PROXY_ADMIN_SECRET: "demo-proxy-admin-b"
       MCP_PROXY_DATABASE_URL: "sqlite+aiosqlite:////data/mcp_proxy.db"
@@ -304,7 +315,8 @@ services:
       bootstrap:
         condition: service_completed_successfully
     environment:
-      BROKER_URL:       "https://broker.cullis.test:8443"
+      # ADR-004 — checker reaches the broker via proxy-b (reverse-proxy).
+      BROKER_URL:       "https://proxy-b.cullis.test:8443"
       AGENT_ID:         "demo-org-b::checker"
       ORG_ID:           "demo-org-b"
       AGENT_CERT_PATH:  /state/demo-org-b/checker.pem
@@ -326,7 +338,8 @@ services:
       broker:
         condition: service_healthy
     environment:
-      BROKER_URL:              "https://broker.cullis.test:8443"
+      # ADR-004 — sender reaches the broker via proxy-a (reverse-proxy).
+      BROKER_URL:              "https://proxy-a.cullis.test:8443"
       AGENT_ID:                "demo-org-a::sender"
       ORG_ID:                  "demo-org-a"
       PEER_AGENT_ID:           "demo-org-b::checker"

--- a/mcp_proxy/reverse_proxy/forwarder.py
+++ b/mcp_proxy/reverse_proxy/forwarder.py
@@ -76,6 +76,21 @@ async def _forward(request: Request, broker_url: str, client: httpx.AsyncClient)
     body = await request.body()
     headers = _filter_request_headers(request.headers.raw)
 
+    # The broker's DPoP htu validator needs to reconstruct the URL the SDK
+    # used — but its Host reaches it via X-Forwarded-Host (uvicorn
+    # --proxy-headers honours it when the peer is in FORWARDED_ALLOW_IPS).
+    # The inbound Host header itself is discarded so shared ingress
+    # (Traefik, nginx) can't accidentally route the forwarded request back
+    # to the proxy's own vhost. httpx sets a fresh Host from broker_url.
+    inbound_host = headers.pop("host", None)
+    if inbound_host and not headers.get("x-forwarded-host"):
+        headers["x-forwarded-host"] = inbound_host
+    # If an upstream TLS terminator (Traefik, nginx) already set
+    # X-Forwarded-Proto=https, keep it — request.url.scheme here is "http"
+    # because the proxy listens on plain HTTP behind the terminator, and
+    # overwriting would cause the broker to reconstruct the wrong htu.
+    headers.setdefault("x-forwarded-proto", request.url.scheme)
+
     # Propagate the caller's IP so the broker's rate limiter can distinguish
     # per-agent load instead of collapsing every agent of an org onto the
     # single proxy IP. Broker must trust the proxy (FORWARDED_ALLOW_IPS) for
@@ -86,11 +101,6 @@ async def _forward(request: Request, broker_url: str, client: httpx.AsyncClient)
         headers["x-forwarded-for"] = (
             f"{existing}, {client_host}" if existing else client_host
         )
-        headers.setdefault("x-forwarded-proto", request.url.scheme)
-        if not headers.get("x-forwarded-host"):
-            host = request.headers.get("host")
-            if host:
-                headers["x-forwarded-host"] = host
 
     try:
         upstream = await client.request(

--- a/tests/test_proxy_reverse_forwarding.py
+++ b/tests/test_proxy_reverse_forwarding.py
@@ -17,9 +17,12 @@ from tests.cert_factory import get_org_ca_pem, make_assertion
 from tests.conftest import ADMIN_HEADERS
 
 
-# The proxy forwards to this address; the same ASGI transport answers both the
-# proxy's lifespan check and the broker calls, so we can keep the URL arbitrary.
-BROKER_TARGET = "http://broker-test"
+# SDK base + broker target share the same URL so scope["server"] and the
+# forwarded X-Forwarded-Host/Proto all reconstruct the same htu that the SDK
+# signed. uvicorn's --proxy-headers promotion of X-Forwarded-* is out of scope
+# under ASGITransport, so matching the URLs is the simplest way to keep the
+# DPoP htu comparison honest in-test.
+BROKER_TARGET = "http://test"
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
Ref Epic #106 — **PR C**.

## Summary

- **demo_network**: \`sender\` and \`checker\` point at their local proxy (\`proxy-a/b.cullis.test:8443\`) instead of the broker. Dropped \`BROKER_PUBLIC_URL\` on the broker. The proxy→broker hop uses \`http://broker:8000\` (internal, no Traefik) so \`X-Forwarded-*\` survive.
- **Reverse-proxy forwarder**: drops inbound \`Host\` (so shared ingress can't loop the request back), promotes it into \`X-Forwarded-Host\` when upstream hasn't set one, keeps upstream \`X-Forwarded-*\` (Traefik etc.).
- **Broker \`build_htu\`**: new priority-2 rule promotes \`X-Forwarded-Host\` + \`X-Forwarded-Proto\` to the htu. uvicorn \`--proxy-headers\` handles \`-For\`/\`-Proto\` but not \`-Host\`, so the broker has to do it itself; \`FORWARDED_ALLOW_IPS\` is the trust boundary.
- **Broker**: \`security_headers\` middleware emits \`x-cullis-role: broker\` on every response. The proxy overrides with \`proxy\` when forwarding, so a client that sees \`broker\` is definitively bypassing its proxy.
- **SDK**: \`CullisClient\` records \`self.server_role\` and raises \`DeprecationWarning\` on first observation of \`role=broker\` (ADR-004 Phase C — direct broker access is deprecated).

## Test plan

- [x] \`pytest tests/\` — 764 pass (same 2 pre-existing Postgres failures as \`main\`)
- [x] \`./demo_network/smoke.sh full\` — PASS (round-trip + dashboard survival + audit hash chain, now via proxy-only)
- [x] \`enterprise_sandbox/smoke.sh\` — 24/24 PASS including B4.8 (sanity check that broker \`build_htu\` change didn't regress PR B)

## Scope

Out of scope — deferred to PR D:
- \`/v1/auth/sign-assertion\` endpoint for BYOCA-enrolled agents (replaces BrokerBridge impersonation)
- BrokerBridge refactor to pure HTTP forwarder