### PR TITLE
feat(proxy+sdk): ADR-004 PR D — /v1/auth/sign-assertion + SDK login_via_proxy

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -318,6 +318,66 @@ class CullisClient:
                 f"[{agent_id}] Login failed (HTTP {e.response.status_code}): {e.response.text}"
             ) from e
 
+    def login_via_proxy(self) -> None:
+        """ADR-004 §2.4 — authenticate an enrolled agent via the local proxy.
+
+        The cert + key stay on the proxy; this call asks the proxy to mint a
+        short-lived client_assertion signed on the agent's behalf, then hands
+        that assertion to the broker's ``/v1/auth/token`` (via the
+        reverse-proxy) to receive a DPoP-bound access token.
+
+        Requires :attr:`_proxy_api_key` and :attr:`_proxy_agent_id` to be set —
+        typically via :meth:`from_enrollment`. After a successful call,
+        :attr:`token` holds the broker access token and all subsequent
+        ``_authed_request`` / ``discover`` / ``open_session`` / ``send`` calls
+        work exactly like a cert-based login.
+        """
+        api_key = getattr(self, "_proxy_api_key", None)
+        agent_id = getattr(self, "_proxy_agent_id", None)
+        if not api_key or not agent_id:
+            raise RuntimeError(
+                "login_via_proxy() requires proxy enrollment — "
+                "use CullisClient.from_enrollment() first",
+            )
+        self._label = agent_id
+
+        try:
+            sign_resp = self._http.post(
+                f"{self.base}/v1/auth/sign-assertion",
+                headers={"X-API-Key": api_key},
+            )
+            sign_resp.raise_for_status()
+            self._update_nonce(sign_resp)
+            assertion = sign_resp.json()["client_assertion"]
+
+            self._dpop_privkey, self._dpop_pubkey_jwk = generate_dpop_keypair()
+            token_url = f"{self.base}/v1/auth/token"
+
+            dpop_proof = self._dpop_proof("POST", token_url, access_token=None)
+            resp = self._http.post(
+                token_url,
+                json={"client_assertion": assertion},
+                headers={"DPoP": dpop_proof},
+            )
+            if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
+                self._update_nonce(resp)
+                dpop_proof = self._dpop_proof("POST", token_url, access_token=None)
+                resp = self._http.post(
+                    token_url,
+                    json={"client_assertion": assertion},
+                    headers={"DPoP": dpop_proof},
+                )
+            resp.raise_for_status()
+            self._update_nonce(resp)
+            self.token = resp.json()["access_token"]
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise ConnectionError(f"[{agent_id}] Proxy unreachable: {e}") from e
+        except httpx.HTTPStatusError as e:
+            raise PermissionError(
+                f"[{agent_id}] login_via_proxy failed "
+                f"(HTTP {e.response.status_code}): {e.response.text}"
+            ) from e
+
     # ── Registry ────────────────────────────────────────────────────
 
     def register(self, agent_id: str, org_id: str, display_name: str,

--- a/mcp_proxy/auth/sign_assertion.py
+++ b/mcp_proxy/auth/sign_assertion.py
@@ -1,0 +1,77 @@
+"""ADR-004 §2.4 — proxy-side signing of broker client_assertion JWTs.
+
+An agent enrolled via the proxy doesn't have its x509 key material locally
+(it sits server-side, in Vault or in the proxy_config fallback). To obtain a
+DPoP token from the broker via the reverse-proxy, it calls this endpoint
+with its X-API-Key, and the proxy returns a freshly-minted client_assertion
+signed with the agent's certificate.
+
+The SDK then posts that assertion to ``/v1/auth/token`` (reverse-proxied),
+gets back a DPoP-bound access token, and from that point on it behaves
+exactly like any SPIFFE/BYOCA agent — the broker never knows whether the
+assertion was signed on-device or on the proxy.
+
+This replaces the BrokerBridge impersonation path for enrolled agents.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+
+from cullis_sdk.auth import build_client_assertion
+from mcp_proxy.auth.api_key import InternalAgent, get_agent_from_api_key
+
+_log = logging.getLogger("mcp_proxy.auth.sign_assertion")
+
+router = APIRouter(tags=["auth"])
+
+
+class SignAssertionResponse(BaseModel):
+    """Response payload — just the signed JWT."""
+
+    client_assertion: str
+    agent_id: str
+
+
+@router.post(
+    "/v1/auth/sign-assertion",
+    response_model=SignAssertionResponse,
+    summary="Sign a broker client_assertion on behalf of an enrolled agent",
+)
+async def sign_assertion(
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_api_key),
+) -> SignAssertionResponse:
+    """Return a fresh x509 client_assertion JWT for the authenticated agent.
+
+    The SDK posts this JWT to ``/v1/auth/token`` (via the reverse-proxy) to
+    obtain a DPoP-bound access token from the broker. The key never leaves
+    the proxy: only the short-lived signed assertion does (exp ≤ 5 min).
+    """
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is None or bridge._agent_manager is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized (no broker uplink)",
+        )
+
+    try:
+        cert_pem, key_pem = await bridge._agent_manager.get_agent_credentials(
+            agent.agent_id,
+        )
+    except ValueError as exc:
+        _log.warning(
+            "sign-assertion: credentials unavailable for %s: %s",
+            agent.agent_id, exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="agent credentials not available on proxy",
+        ) from exc
+
+    assertion, _alg = build_client_assertion(agent.agent_id, cert_pem, key_pem)
+    return SignAssertionResponse(
+        client_assertion=assertion, agent_id=agent.agent_id,
+    )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -406,6 +406,11 @@ async def pdp_health():
     return {"status": "ok", "mode": "built-in"}
 
 
+# ADR-004 PR D — proxy-native /v1/auth/sign-assertion. Must precede the
+# reverse-proxy catch-all so the sign endpoint wins route matching.
+from mcp_proxy.auth.sign_assertion import router as sign_assertion_router
+app.include_router(sign_assertion_router)
+
 # ADR-004 PR A — reverse-proxy router for /v1/broker/*, /v1/auth/*,
 # /v1/registry/*. Registered before local handlers so the proxy owns these
 # paths by default; local endpoints live under /v1/egress/* and /v1/ingress/*.

--- a/tests/test_proxy_sign_assertion.py
+++ b/tests/test_proxy_sign_assertion.py
@@ -1,0 +1,158 @@
+"""ADR-004 PR D — /v1/auth/sign-assertion endpoint.
+
+The proxy signs a broker client_assertion JWT on behalf of an enrolled
+agent so the SDK can call /v1/auth/token (via the reverse-proxy) without
+needing the cert+key locally.
+"""
+from __future__ import annotations
+
+import uuid
+
+import jwt as jose_jwt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    """Proxy ASGI app with an initialized BrokerBridge + AgentManager."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.example")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision_agent_with_cert(app, agent_id: str) -> tuple[str, str]:
+    """Provision an enrolled agent: Org CA + cert issued + key stored.
+
+    Returns (api_key, cert_pem).
+    """
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+    from datetime import datetime, timedelta, timezone
+
+    # Generate Org CA
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "acme CA")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_subject).issuer_name(ca_subject)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(hours=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    ca_key_pem = ca_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    ca_cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    from mcp_proxy.db import set_config
+    await set_config("org_ca_key", ca_key_pem)
+    await set_config("org_ca_cert", ca_cert_pem)
+
+    mgr = app.state.broker_bridge._agent_manager
+    await mgr.load_org_ca(ca_key_pem, ca_cert_pem)
+
+    cert_pem, key_pem = mgr._generate_agent_cert(agent_id.split("::", 1)[-1])
+
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+    raw = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=["cap.read"],
+        api_key_hash=hash_api_key(raw),
+        cert_pem=cert_pem,
+    )
+    await set_config(f"agent_key:{agent_id}", key_pem)
+    return raw, cert_pem
+
+
+@pytest.mark.asyncio
+async def test_sign_assertion_returns_jwt(proxy_app):
+    app, client = proxy_app
+    api_key, cert_pem = await _provision_agent_with_cert(app, "acme::enrolled-bot")
+
+    resp = await client.post(
+        "/v1/auth/sign-assertion",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "acme::enrolled-bot"
+    assertion = body["client_assertion"]
+    assert assertion.count(".") == 2
+
+    claims = jose_jwt.decode(assertion, options={"verify_signature": False})
+    assert claims["sub"] == "acme::enrolled-bot"
+    assert claims["iss"] == "acme::enrolled-bot"
+    assert claims["aud"] == "agent-trust-broker"
+    assert "jti" in claims and len(claims["jti"]) > 0
+    assert claims["exp"] > claims["iat"]
+
+    header = jose_jwt.get_unverified_header(assertion)
+    assert header.get("x5c"), "assertion must carry the agent cert in x5c"
+
+
+@pytest.mark.asyncio
+async def test_sign_assertion_requires_api_key(proxy_app):
+    _, client = proxy_app
+    resp = await client.post("/v1/auth/sign-assertion")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sign_assertion_not_reverse_proxied(proxy_app):
+    """Route precedence — /v1/auth/sign-assertion must NOT hit the reverse proxy."""
+    _, client = proxy_app
+    resp = await client.post(
+        "/v1/auth/sign-assertion",
+        headers={"X-API-Key": "sk_local_bogus_" + uuid.uuid4().hex},
+    )
+    # 401 from the API-key dependency — not 502/504 from upstream, not a
+    # broker-looking response. The reverse-proxy would yield something very
+    # different (x-cullis-role set by the forwarder override).
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sign_assertion_agent_missing_credentials(proxy_app):
+    app, client = proxy_app
+    # Provision an agent WITHOUT calling the provisioning helper — just
+    # an API key, no cert+key. The endpoint must fail gracefully.
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+    raw = generate_api_key("ghost-bot")
+    await create_agent(
+        agent_id="ghost-bot",
+        display_name="ghost-bot",
+        capabilities=[],
+        api_key_hash=hash_api_key(raw),
+    )
+    resp = await client.post(
+        "/v1/auth/sign-assertion",
+        headers={"X-API-Key": raw},
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
Ref Epic #106 — **PR D** (final).

## Summary

Closes the ADR-004 loop for enrolled agents — the ones whose x509 key material stays in Vault / proxy_config on the proxy and never touches the agent box.

- **\`POST /v1/auth/sign-assertion\`** on the proxy. X-API-Key auth, returns \`{ client_assertion, agent_id }\` signed with the agent's cert (x5c embedded). Registered before the reverse-proxy catch-all so route matching lands here.
- **\`CullisClient.login_via_proxy()\`** — uses \`from_enrollment()\`-stored API key + agent_id, calls sign-assertion, then \`/v1/auth/token\` (via the reverse-proxy) with the returned assertion. After the call the client behaves identically to cert-based login: \`self.token\` is set, \`_authed_request\` works for every broker endpoint.
- Key never leaves the proxy. Assertions are short-lived (≤ 5 min).

## Test plan

- [x] \`pytest tests/test_proxy_sign_assertion.py\` — 4/4 PASS
  - signed JWT with correct claims + x5c header
  - 401 without X-API-Key
  - route precedence: sign-assertion wins over the reverse-proxy catch-all
  - 404 when an agent has an API key but no cert+key
- [x] \`pytest tests/\` — 768 pass (same 2 pre-existing Postgres failures as \`main\`)
- [x] \`./demo_network/smoke.sh full\` — PASS

## Scope

BrokerBridge impersonation code path is left untouched here — it's now a dead path for ADR-004 enrolled agents. Removing it is pure cleanup and will land as a follow-up issue once no callers remain.

Out of scope: WebSocket reverse-proxy (ADR-004 §5 Q2), mutual TLS agent→proxy (§5 Q3).