### PR TITLE
ci: release-proxy workflow — publish ghcr.io/cullis-security/mcp-proxy

### DIFF
--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -1,0 +1,170 @@
+# Release pipeline for `mcp-proxy`.
+#
+# Triggered by pushing a tag of the form `proxy-vX.Y.Z`. On tag push:
+#
+#   1. Run the proxy test subset to gate the release.
+#   2. Build and push the multi-arch Docker image to ghcr.io.
+#   3. Create a GitHub Release with a changelog excerpt.
+#
+# The proxy is a runtime, not a library — no wheel / sdist / PyPI upload.
+# This workflow is isolated from the main CI pipeline: only tag pushes
+# trigger it.
+
+name: release-proxy
+
+on:
+  push:
+    tags:
+      - "proxy-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Tests ─────────────────────────────────────────────────────────
+  test:
+    name: Test proxy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run proxy test subset
+        env:
+          OTEL_ENABLED: "false"
+          DATABASE_URL: "sqlite+aiosqlite://"
+        run: |
+          pytest \
+            tests/test_proxy_reverse_forwarding.py \
+            tests/test_proxy_sign_assertion.py \
+            tests/test_proxy_resolve.py \
+            tests/test_proxy_routing.py \
+            tests/test_proxy_local_sessions.py \
+            tests/test_proxy_local_messages.py \
+            tests/test_proxy_local_sweeper.py \
+            tests/test_proxy_local_ws.py \
+            tests/test_proxy_mtls_only_send.py \
+            tests/test_proxy_migrations.py \
+            tests/test_proxy_dashboard_oidc.py \
+            tests/test_proxy_federation_sync.py \
+            tests/test_enrollment.py \
+            --tb=short
+
+  # ── 2. Extract version ───────────────────────────────────────────────
+  version:
+    name: Extract version
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        run: |
+          # proxy-v1.2.3 → 1.2.3
+          version="${GITHUB_REF_NAME#proxy-v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing mcp-proxy: ${version}"
+
+  # ── 3. Docker image → ghcr.io ───────────────────────────────────────
+  build-docker:
+    name: Build & push Docker image
+    needs: [test, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/mcp-proxy
+          tags: |
+            type=match,pattern=proxy-v(.*),group=1
+            type=match,pattern=proxy-v(\d+\.\d+)\..*,group=1
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
+          labels: |
+            org.opencontainers.image.title=Cullis MCP Proxy
+            org.opencontainers.image.description=Standalone org-level gateway for AI agents
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.version.outputs.version }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: mcp_proxy/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── 4. GitHub Release ────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: [build-docker, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          version="${{ needs.version.outputs.version }}"
+          # Grab the section matching ## [vX.Y.Z] or ## vX.Y.Z, up to the next ## heading.
+          if [[ -f CHANGELOG.md ]]; then
+            awk "/^## \\[?v?${version}\\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
+              > release-notes.md || true
+          fi
+          if [[ ! -s release-notes.md ]]; then
+            cat > release-notes.md <<NOTES
+          Release ${GITHUB_REF_NAME}
+
+          Docker image: \`ghcr.io/${{ github.repository_owner }}/mcp-proxy:${version}\`
+
+          \`\`\`bash
+          docker run -d --name cullis-proxy -p 9100:9100 \\
+            -e MCP_PROXY_ORG_ID=acme \\
+            -e MCP_PROXY_PROXY_PUBLIC_URL=https://cullis.acme.internal \\
+            -v cullis-proxy-data:/data \\
+            ghcr.io/${{ github.repository_owner }}/mcp-proxy:${version}
+          \`\`\`
+          NOTES
+          fi
+          cat release-notes.md
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Cullis MCP Proxy ${{ github.ref_name }}"
+          body_path: release-notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}


### PR DESCRIPTION
Ref Epic #112 — **#113**.

## Summary

New workflow \`.github/workflows/release-proxy.yml\` triggered on \`proxy-vX.Y.Z\` tags. Runs the proxy test subset, builds a multi-arch (linux/amd64 + linux/arm64) image, publishes to \`ghcr.io/cullis-security/mcp-proxy\`, and creates a GitHub Release with a changelog excerpt (falls back to a Docker-run snippet when CHANGELOG.md has no matching heading).

Cloned from \`release-connector.yml\`, minus the PyPI/wheel/PyInstaller bits — the proxy is a runtime, not a library.

## First release

Once merged, cutting the first proxy release looks like:

\`\`\`bash
git tag -a proxy-v0.1.0-rc1 -m "Cullis MCP Proxy 0.1.0-rc1"
git push origin proxy-v0.1.0-rc1
\`\`\`

The workflow pushes \`ghcr.io/cullis-security/mcp-proxy:0.1.0-rc1\` + \`0.1\` (the \`latest\` tag is kept off pre-releases).

## Test plan

- [x] \`python -c \"import yaml; yaml.safe_load(open('.github/workflows/release-proxy.yml'))\"\` — valid syntax.
- [x] Triggers are tag-only (\`on: push: tags: [proxy-v*]\`), so the workflow does not fire on this PR.
- [ ] Post-merge: cut a \`proxy-v0.0.1-smoke\` tag to validate the workflow end-to-end before the real 0.1.0 release.

## Scope

Out of scope — tracked in the epic:
- Helm chart OCI publishing (#116)
- \`MCP_PROXY_STANDALONE\` config flag (#114)
- First-boot Org CA self-generation (#115)