### PR TITLE
feat(proxy): MCP_PROXY_STANDALONE flag — explicit no-broker mode

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -49,7 +49,18 @@ class ProxySettings(BaseSettings):
     admin_secret: str = "change-me-in-production"
     dashboard_signing_key: str = ""
 
-    # Broker uplink (for egress)
+    # Standalone mode — ship the proxy as a product on its own, without a
+    # Cullis broker in front of it. When true:
+    #   - BrokerBridge and the reverse-proxy httpx client are not initialized.
+    #   - /readyz skips the JWKS cache check (there is no broker to fetch from).
+    #   - validate_config() does not require BROKER_JWKS_URL in production.
+    #   - Dashboard responses carry x-cullis-mode: standalone.
+    # Intra-org flows (enrollment, /v1/egress/*, local sessions, Guardian)
+    # keep working unchanged. Federation can be turned on later by flipping
+    # this to false and setting broker_url/broker_jwks_url.
+    standalone: bool = False
+
+    # Broker uplink (for egress) — ignored in standalone mode.
     broker_url: str = ""
     broker_verify_tls: bool = True  # verify broker TLS cert (disable only for dev)
     org_id: str = ""
@@ -128,6 +139,11 @@ class ProxySettings(BaseSettings):
             self.egress_inspection_enabled = egress_flag.lower() in (
                 "1", "true", "yes", "on",
             )
+        standalone_flag = os.environ.get("MCP_PROXY_STANDALONE")
+        if standalone_flag is not None:
+            self.standalone = standalone_flag.lower() in (
+                "1", "true", "yes", "on",
+            )
         return self
 
 
@@ -147,19 +163,25 @@ def validate_config(settings: ProxySettings) -> None:
             )
             raise SystemExit(1)
 
-        if not settings.broker_jwks_url:
-            _log.critical(
-                "BROKER_JWKS_URL is empty in production. "
-                "Set MCP_PROXY_BROKER_JWKS_URL to the broker JWKS endpoint."
-            )
-            raise SystemExit(1)
+        # JWKS is only required when the proxy fronts a broker. Standalone
+        # deploys (no broker) have no JWKS endpoint to fetch from; enforcing
+        # it would block the intended ship-on-its-own mode.
+        if not settings.standalone:
+            if not settings.broker_jwks_url:
+                _log.critical(
+                    "BROKER_JWKS_URL is empty in production. "
+                    "Set MCP_PROXY_BROKER_JWKS_URL to the broker JWKS "
+                    "endpoint, or set MCP_PROXY_STANDALONE=true to run "
+                    "without a broker."
+                )
+                raise SystemExit(1)
 
-        if settings.broker_jwks_url.startswith("http://"):
-            _log.critical(
-                "BROKER_JWKS_URL uses plain HTTP ('%s') in production. "
-                "Use HTTPS for JWKS endpoint.", settings.broker_jwks_url
-            )
-            raise SystemExit(1)
+            if settings.broker_jwks_url.startswith("http://"):
+                _log.critical(
+                    "BROKER_JWKS_URL uses plain HTTP ('%s') in production. "
+                    "Use HTTPS for JWKS endpoint.", settings.broker_jwks_url
+                )
+                raise SystemExit(1)
 
     # Warnings for any environment
     if settings.admin_secret == _INSECURE_DEFAULT_SECRET:

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -76,21 +76,30 @@ async def lifespan(app: FastAPI):
     from mcp_proxy.auth.dpop import generate_dpop_nonce
     generate_dpop_nonce()
 
-    # 5. Initialize BrokerBridge for egress (if broker_url configured)
+    # 5. Initialize BrokerBridge for egress (if broker_url configured and
+    # the proxy is not in standalone mode). Standalone deploys skip broker
+    # uplink entirely — the reverse-proxy catch-all will 503 on any
+    # federation-bound path, and /readyz won't fail on JWKS staleness.
     from mcp_proxy.db import get_config
-    broker_url = await get_config("broker_url") or settings.broker_url
-    org_id = await get_config("org_id") or settings.org_id
+    if settings.standalone:
+        broker_url = ""
+        org_id = settings.org_id
+        app.state.reverse_proxy_broker_url = None
+        app.state.reverse_proxy_client = None
+        _log.info("Standalone mode — broker uplink skipped.")
+    else:
+        broker_url = await get_config("broker_url") or settings.broker_url
+        org_id = await get_config("org_id") or settings.org_id
 
-    # ADR-004 PR A — reverse-proxy httpx client. One shared AsyncClient so the
-    # forwarder re-uses HTTP/2 connections across requests. The broker URL is
-    # pinned on app.state so tests can override it before lifespan.
-    import httpx as _httpx
-    app.state.reverse_proxy_broker_url = broker_url
-    app.state.reverse_proxy_client = _httpx.AsyncClient(
-        timeout=30.0,
-        verify=settings.broker_verify_tls,
-        follow_redirects=False,
-    )
+        # ADR-004 PR A — reverse-proxy httpx client. One shared AsyncClient
+        # so the forwarder re-uses HTTP/2 connections across requests.
+        import httpx as _httpx
+        app.state.reverse_proxy_broker_url = broker_url
+        app.state.reverse_proxy_client = _httpx.AsyncClient(
+            timeout=30.0,
+            verify=settings.broker_verify_tls,
+            follow_redirects=False,
+        )
 
     if broker_url:
         from mcp_proxy.egress.agent_manager import AgentManager
@@ -297,6 +306,12 @@ if _cors_origins:
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
     response = await call_next(request)
+    # Let operators tell at a glance whether this proxy is running
+    # standalone or fronting a Cullis broker.
+    response.headers.setdefault(
+        "x-cullis-mode",
+        "standalone" if get_settings().standalone else "federation",
+    )
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
@@ -474,6 +489,11 @@ async def readyz():
         return JSONResponse(
             {"status": "not_ready", "checks": checks}, status_code=503,
         )
+
+    # Standalone deploys have no broker, so no JWKS to check — skip.
+    if get_settings().standalone:
+        checks["jwks_cache"] = "standalone"
+        return {"status": "ready", "checks": checks}
 
     # JWKS cache freshness — distinguish "never fetched" from "stale".
     # A proxy that has never talked to the broker (e.g. first boot in

--- a/tests/test_proxy_standalone.py
+++ b/tests/test_proxy_standalone.py
@@ -1,0 +1,97 @@
+"""#114 — MCP_PROXY_STANDALONE flag.
+
+Standalone deploy skips broker uplink entirely: no BrokerBridge, no
+reverse-proxy httpx client, /readyz does not fail on missing JWKS, and
+the reverse-proxy catch-all returns 503 since there is nothing to
+forward to.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def standalone_proxy(tmp_path, monkeypatch):
+    """Proxy ASGI app booted with MCP_PROXY_STANDALONE=true and no broker_url."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_BROKER_JWKS_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_standalone_lifespan_skips_broker_bridge(standalone_proxy):
+    app, _ = standalone_proxy
+    assert getattr(app.state, "broker_bridge", None) is None, (
+        "BrokerBridge must not initialize in standalone mode"
+    )
+    assert getattr(app.state, "reverse_proxy_broker_url", None) is None
+    assert getattr(app.state, "reverse_proxy_client", None) is None
+
+
+@pytest.mark.asyncio
+async def test_standalone_readyz_is_ready_without_jwks(standalone_proxy):
+    _, client = standalone_proxy
+    resp = await client.get("/readyz")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "ready"
+    assert body["checks"]["jwks_cache"] == "standalone"
+
+
+@pytest.mark.asyncio
+async def test_standalone_reverse_proxy_returns_503(standalone_proxy):
+    """With no broker uplink, /v1/auth/token has nowhere to forward to."""
+    _, client = standalone_proxy
+    resp = await client.post("/v1/auth/token", json={})
+    assert resp.status_code == 503
+    assert "reverse proxy not configured" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_standalone_mode_header_on_health(standalone_proxy):
+    _, client = standalone_proxy
+    resp = await client.get("/health")
+    assert resp.headers.get("x-cullis-mode") == "standalone"
+
+
+@pytest.mark.asyncio
+async def test_federation_mode_default_header(tmp_path, monkeypatch):
+    """Default boot (no STANDALONE) advertises federation mode."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_STANDALONE", raising=False)
+    # Give it a broker URL so BrokerBridge spins up cleanly.
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.example")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/health")
+            assert resp.headers.get("x-cullis-mode") == "federation"
+    get_settings.cache_clear()


### PR DESCRIPTION
Ref Epic #112 — **#114**.

## Summary

Today the proxy silently skips broker-bridge init when \`broker_url\` is empty. That's a side-effect, not a contract. This promotes it to an explicit switch so operators shipping the proxy on its own have a clean, audited mode.

\`MCP_PROXY_STANDALONE=true\` →
- \`BrokerBridge\` + reverse-proxy \`httpx.AsyncClient\` not initialized.
- \`/v1/broker/*\`, \`/v1/auth/*\`, \`/v1/registry/*\` → 503 (honest: nothing to forward to).
- \`/readyz\` skips the JWKS cache check; reports \`jwks_cache: "standalone"\`.
- Production validator does **not** require \`BROKER_JWKS_URL\`. Error message points at both options if someone misconfigures.
- Every response carries \`x-cullis-mode: standalone|federation\`.

Intra-org flows (enrollment, \`/v1/egress/*\`, local sessions, Guardian hook, OIDC dashboard) unchanged. Federation can be turned on later by flipping the flag.

## Test plan

- [x] \`pytest tests/test_proxy_standalone.py\` — 5/5 PASS
  - standalone lifespan skips BrokerBridge
  - \`/readyz\` returns 200 without JWKS
  - reverse-proxy catch-all returns 503
  - \`x-cullis-mode: standalone\` header in standalone mode
  - \`x-cullis-mode: federation\` header by default
- [x] \`pytest tests/\` — 773 pass (+5, same 2 pre-existing Postgres failures)