### PR TITLE
feat(proxy): #115 standalone first-boot Org CA self-generation

### DIFF
--- a/mcp_proxy/auth/sign_assertion.py
+++ b/mcp_proxy/auth/sign_assertion.py
@@ -50,17 +50,21 @@ async def sign_assertion(
     obtain a DPoP-bound access token from the broker. The key never leaves
     the proxy: only the short-lived signed assertion does (exp ≤ 5 min).
     """
-    bridge = getattr(request.app.state, "broker_bridge", None)
-    if bridge is None or bridge._agent_manager is None:
+    # Prefer the canonical app.state.agent_manager (present in both
+    # standalone and federation mode). Fall back to the BrokerBridge's
+    # own reference for older boot paths.
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None:
+        bridge = getattr(request.app.state, "broker_bridge", None)
+        mgr = getattr(bridge, "_agent_manager", None) if bridge else None
+    if mgr is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="agent manager not initialized (no broker uplink)",
+            detail="agent manager not initialized",
         )
 
     try:
-        cert_pem, key_pem = await bridge._agent_manager.get_agent_credentials(
-            agent.agent_id,
-        )
+        cert_pem, key_pem = await mgr.get_agent_credentials(agent.agent_id)
     except ValueError as exc:
         _log.warning(
             "sign-assertion: credentials unavailable for %s: %s",

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -74,6 +74,80 @@ class AgentManager:
         logger.warning("Org CA not found in proxy_config — agent cert issuance unavailable")
         return False
 
+    async def generate_org_ca(self, *, validity_days: int = 3650) -> None:
+        """Generate a fresh self-signed Org CA and persist it to proxy_config.
+
+        Intended for standalone deploys (#115) where there is no broker to
+        run the attach-ca flow against. The CA is a long-lived root
+        (10 years by default); BasicConstraints(ca=True, path_length=1)
+        so a future SPIRE UpstreamAuthority can mint one intermediate
+        underneath without re-rooting.
+
+        Safe to call only when no Org CA is already loaded — callers should
+        gate on :attr:`ca_loaded` to avoid overwriting an attached CA.
+        """
+        if self.ca_loaded:
+            raise RuntimeError("Org CA already loaded — refusing to overwrite")
+
+        ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} CA"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id),
+        ])
+
+        now = datetime.now(timezone.utc)
+        ca_cert = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(subject)
+            .public_key(ca_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=5))
+            .not_valid_after(now + timedelta(days=validity_days))
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=1),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
+                critical=False,
+            )
+            .sign(ca_key, hashes.SHA256())
+        )
+
+        ca_key_pem = ca_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+        ca_cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+
+        await set_config("org_ca_key", ca_key_pem)
+        await set_config("org_ca_cert", ca_cert_pem)
+
+        self._org_ca_key = ca_key
+        self._org_ca_cert = ca_cert
+
+        logger.info(
+            "Self-signed Org CA generated (CN=%s, validity=%dd)",
+            f"{self._org_id} CA", validity_days,
+        )
+
     @property
     def ca_loaded(self) -> bool:
         return self._org_ca_key is not None and self._org_ca_cert is not None

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -76,11 +76,13 @@ async def lifespan(app: FastAPI):
     from mcp_proxy.auth.dpop import generate_dpop_nonce
     generate_dpop_nonce()
 
-    # 5. Initialize BrokerBridge for egress (if broker_url configured and
-    # the proxy is not in standalone mode). Standalone deploys skip broker
-    # uplink entirely — the reverse-proxy catch-all will 503 on any
-    # federation-bound path, and /readyz won't fail on JWKS staleness.
+    # 5. Initialize AgentManager + BrokerBridge.
+    # AgentManager is always needed (it owns the Org CA used to mint internal
+    # agent certs, regardless of whether the proxy federates with a broker).
+    # BrokerBridge + reverse-proxy client are only initialized when federating.
     from mcp_proxy.db import get_config
+    from mcp_proxy.egress.agent_manager import AgentManager
+
     if settings.standalone:
         broker_url = ""
         org_id = settings.org_id
@@ -101,11 +103,20 @@ async def lifespan(app: FastAPI):
             follow_redirects=False,
         )
 
+    agent_mgr = AgentManager(org_id=org_id, trust_domain=settings.trust_domain)
+    await agent_mgr.load_org_ca_from_config()
+
+    # #115 — standalone first-boot: generate a fresh self-signed Org CA when
+    # no CA has been attached (no attach-ca invite ever consumed) and no
+    # broker is configured. Gated on standalone=true so federation deploys
+    # keep the attach-ca flow unchanged.
+    if settings.standalone and not agent_mgr.ca_loaded:
+        await agent_mgr.generate_org_ca()
+
+    app.state.agent_manager = agent_mgr
+
     if broker_url:
-        from mcp_proxy.egress.agent_manager import AgentManager
         from mcp_proxy.egress.broker_bridge import BrokerBridge
-        agent_mgr = AgentManager(org_id=org_id, trust_domain=settings.trust_domain)
-        await agent_mgr.load_org_ca_from_config()
         bridge = BrokerBridge(
             broker_url=broker_url,
             org_id=org_id,

--- a/tests/test_proxy_standalone_ca.py
+++ b/tests/test_proxy_standalone_ca.py
@@ -1,0 +1,134 @@
+"""#115 — standalone first-boot Org CA self-generation.
+
+Booting the proxy in standalone mode with an empty DB should produce a
+fresh self-signed Org CA: persisted to proxy_config, loaded into the
+AgentManager, usable to mint agent certs. Federation mode keeps the
+existing attach-ca behaviour.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def standalone_proxy(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_standalone_generates_org_ca_on_first_boot(standalone_proxy):
+    app, _ = standalone_proxy
+    mgr = app.state.agent_manager
+    assert mgr.ca_loaded, "AgentManager must load the freshly-generated CA"
+    cert = mgr._org_ca_cert
+    subject_cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    assert subject_cn == "acme CA"
+    # Self-signed: issuer == subject
+    assert cert.issuer == cert.subject
+    # BasicConstraints(ca=True, path_length=1) — ADR-003 allows one intermediate
+    bc = cert.extensions.get_extension_for_class(x509.BasicConstraints).value
+    assert bc.ca is True
+    assert bc.path_length == 1
+
+
+@pytest.mark.asyncio
+async def test_standalone_ca_persisted_to_proxy_config(standalone_proxy):
+    _, _ = standalone_proxy
+    from mcp_proxy.db import get_config
+    ca_key_pem = await get_config("org_ca_key")
+    ca_cert_pem = await get_config("org_ca_cert")
+    assert ca_key_pem and "BEGIN PRIVATE KEY" in ca_key_pem
+    assert ca_cert_pem and "BEGIN CERTIFICATE" in ca_cert_pem
+    # Key is a valid RSA-2048
+    key = serialization.load_pem_private_key(ca_key_pem.encode(), password=None)
+    assert key.key_size == 2048
+
+
+@pytest.mark.asyncio
+async def test_standalone_ca_can_issue_agent_cert(standalone_proxy):
+    """The generated CA must be usable to mint internal agent certs."""
+    app, _ = standalone_proxy
+    mgr = app.state.agent_manager
+    cert_pem, key_pem = mgr._generate_agent_cert("bot-alpha")
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    # Signed by the freshly-generated Org CA
+    assert cert.issuer == mgr._org_ca_cert.subject
+    # Agent subject is {org}::{name}
+    cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+    assert cn == "acme::bot-alpha"
+
+
+@pytest.mark.asyncio
+async def test_standalone_ca_survives_restart(tmp_path, monkeypatch):
+    """Second boot must reuse the persisted CA instead of generating a new one."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    # First boot — generates CA.
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        first_cert_pem = app.state.agent_manager._org_ca_cert.public_bytes(
+            serialization.Encoding.PEM,
+        ).decode()
+
+    # Second boot — same DB, should reuse.
+    get_settings.cache_clear()
+    async with app.router.lifespan_context(app):
+        second_cert_pem = app.state.agent_manager._org_ca_cert.public_bytes(
+            serialization.Encoding.PEM,
+        ).decode()
+
+    assert first_cert_pem == second_cert_pem
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_federation_mode_no_autogeneration(tmp_path, monkeypatch):
+    """Federation deploys must NOT auto-generate a CA — attach-ca is the source of truth."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.delenv("MCP_PROXY_STANDALONE", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.example")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        mgr = app.state.agent_manager
+        # No attach-ca performed → CA not loaded, AND not auto-generated.
+        assert mgr.ca_loaded is False
+    get_settings.cache_clear()


### PR DESCRIPTION
Ref Epic #112 — **#115**. Closes the remaining gap for shippable standalone mode: the proxy now bootstraps its own Org CA on first boot when there's no broker to attach-ca from.

## Summary

- \`AgentManager.generate_org_ca()\` — fresh RSA-2048 self-signed root, CN=\`\${org_id} CA\`, 10y validity, \`BasicConstraints(ca=True, path_length=1)\`, \`KeyUsage(keyCertSign+crlSign)\`, SubjectKeyIdentifier. Persisted via the existing \`proxy_config.org_ca_{key,cert}\` keys so every read path works unchanged.
- Lifespan: \`AgentManager\` is now initialized in both modes (previously only when \`broker_url\` was set). Auto-generation is gated on \`standalone=true AND not ca_loaded\` — federation deploys keep attach-ca as the single source of truth.
- \`sign_assertion\` reads \`app.state.agent_manager\` directly (standalone has no \`BrokerBridge\`); falls back to the legacy path for backward compat.

Why \`path_length=1\`: leaves room for a SPIRE \`UpstreamAuthority\` intermediate below the Org CA without re-rooting later — aligns with ADR-003.

## Test plan

- [x] \`pytest tests/test_proxy_standalone_ca.py\` — 5/5 PASS
  - CA generated with expected fields (CN, self-signed, \`ca=True\`, \`path_length=1\`)
  - Persisted to \`proxy_config\`, RSA-2048
  - Mints internal agent certs (end-to-end \`_generate_agent_cert\` works)
  - Survives restart (second boot reuses same CA, doesn't regenerate)
  - Federation mode does NOT auto-generate
- [x] \`pytest tests/\` — 778 pass (+5, same 2 pre-existing Postgres failures)

## After this PR

Only #116 left in the epic — publish the Helm chart to OCI. After that the proxy ships as a standalone product end-to-end.