### PR TITLE
ci+helm: #116 publish cullis-proxy chart as OCI on release

### DIFF
--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -124,10 +124,58 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-  # ── 4. GitHub Release ────────────────────────────────────────────────
+  # ── 4. Helm chart → ghcr.io/cullis-security/charts/cullis-proxy ──────
+  publish-helm:
+    name: Package & push Helm chart
+    needs: [build-docker, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: "v3.14.4"
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io \
+              --username "${{ github.actor }}" \
+              --password-stdin
+
+      - name: Override chart + app version from tag
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          # The tag is the source of truth; Chart.yaml's baked-in version
+          # is the floor for local development. Bump both in lockstep here
+          # so `helm install ... --version X.Y.Z` always matches the image.
+          sed -i "s/^version: .*/version: ${VERSION}/" deploy/helm/cullis-proxy/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" deploy/helm/cullis-proxy/Chart.yaml
+          head -15 deploy/helm/cullis-proxy/Chart.yaml
+
+      - name: Package chart
+        run: |
+          mkdir -p dist/charts
+          helm package deploy/helm/cullis-proxy --destination dist/charts
+          ls -lah dist/charts
+
+      - name: Push chart to OCI registry
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          helm push \
+            "dist/charts/cullis-proxy-${VERSION}.tgz" \
+            "oci://ghcr.io/${OWNER}/charts"
+
+  # ── 5. GitHub Release ────────────────────────────────────────────────
   release:
     name: Create GitHub Release
-    needs: [build-docker, version]
+    needs: [build-docker, publish-helm, version]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -148,13 +196,27 @@ jobs:
           Release ${GITHUB_REF_NAME}
 
           Docker image: \`ghcr.io/${{ github.repository_owner }}/mcp-proxy:${version}\`
+          Helm chart:   \`oci://ghcr.io/${{ github.repository_owner }}/charts/cullis-proxy:${version}\`
+
+          Standalone \`docker run\`:
 
           \`\`\`bash
           docker run -d --name cullis-proxy -p 9100:9100 \\
+            -e MCP_PROXY_STANDALONE=true \\
             -e MCP_PROXY_ORG_ID=acme \\
             -e MCP_PROXY_PROXY_PUBLIC_URL=https://cullis.acme.internal \\
             -v cullis-proxy-data:/data \\
             ghcr.io/${{ github.repository_owner }}/mcp-proxy:${version}
+          \`\`\`
+
+          Kubernetes:
+
+          \`\`\`bash
+          helm install cullis-proxy \\
+            oci://ghcr.io/${{ github.repository_owner }}/charts/cullis-proxy \\
+            --version ${version} \\
+            --set proxy.orgId=acme \\
+            --set proxy.proxyPublicUrl=https://cullis.acme.internal
           \`\`\`
           NOTES
           fi

--- a/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
@@ -9,6 +9,9 @@ data:
   MCP_PROXY_HOST: "0.0.0.0"
   MCP_PROXY_PORT: {{ .Values.proxy.containerPort | quote }}
 
+  # #114 — standalone mode toggles broker uplink off.
+  MCP_PROXY_STANDALONE: {{ .Values.proxy.standalone | default false | quote }}
+
   {{- if .Values.proxy.brokerUrl }}
   MCP_PROXY_BROKER_URL: {{ .Values.proxy.brokerUrl | quote }}
   {{- end }}

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -25,11 +25,19 @@ imagePullSecrets: []
 proxy:
   image:
     # -- Container image repository for the MCP proxy.
-    repository: ghcr.io/daenaihax/cullis-proxy
+    # Published by the release-proxy workflow on every `proxy-vX.Y.Z` tag.
+    repository: ghcr.io/cullis-security/mcp-proxy
     # -- Image tag. When empty the chart appVersion is used.
     tag: ""
     # -- Image pull policy.
     pullPolicy: IfNotPresent
+
+  # -- Standalone mode (#114). When true the proxy runs without a Cullis
+  # broker uplink — BrokerBridge is not initialized, reverse-proxy calls
+  # return 503, and the first boot auto-generates a self-signed Org CA
+  # (#115). Intra-org messaging, enrollment and the OIDC dashboard all
+  # keep working. Flip to `false` only when federating with a broker.
+  standalone: true
 
   # -- Static replica count. The proxy keeps state (SQLite, DPoP nonce,
   # JWKS cache) in-pod. Running >1 replica requires a RWX PVC backend
@@ -44,13 +52,15 @@ proxy:
   # -- Container port the proxy listens on. Matches the Dockerfile.
   containerPort: 9100
 
-  # -- Broker uplink URL. REQUIRED. In production MUST be HTTPS.
-  # The proxy calls this to join the org and bridge egress traffic.
+  # -- Broker uplink URL. Only required when `standalone: false`.
+  # In production MUST be HTTPS. The proxy calls this to join the org
+  # and bridge egress traffic.
   brokerUrl: ""
     # e.g. "https://broker.cullis.example.com"
 
-  # -- Broker JWKS endpoint used to validate broker-signed JWTs. REQUIRED
-  # in production (config.validate_config enforces HTTPS here).
+  # -- Broker JWKS endpoint used to validate broker-signed JWTs. Only
+  # required when `standalone: false` (config.validate_config enforces
+  # HTTPS here in production).
   brokerJwksUrl: ""
     # e.g. "https://broker.cullis.example.com/.well-known/jwks.json"
 


### PR DESCRIPTION
Ref Epic #112 — **#116** (final).

## Summary

Extends \`release-proxy.yml\` with a \`publish-helm\` job that runs after the image push:
- Overrides \`Chart.yaml\` \`version\` + \`appVersion\` from the git tag (\`proxy-v0.1.0\` → \`0.1.0\`).
- Packages and pushes \`cullis-proxy-\${version}.tgz\` to \`oci://ghcr.io/cullis-security/charts\`.

Chart changes:
- \`proxy.image.repository\` → \`ghcr.io/cullis-security/mcp-proxy\` (matches the image published by #113; was a stale pre-rename path).
- New default \`proxy.standalone: true\` — ships standalone by default.
- Broker uplink fields documented as optional when \`standalone=true\`.
- ConfigMap now emits \`MCP_PROXY_STANDALONE\` so the runtime picks up the mode straight from Helm values.

Release-notes fallback (for tags with no matching \`CHANGELOG.md\` section) now lists both a \`docker run\` and a \`helm install\` snippet pointing at the OCI registry.

## Acceptance

End-to-end from a fresh shell, post-merge:

\`\`\`bash
helm install cullis-proxy \\
  oci://ghcr.io/cullis-security/charts/cullis-proxy --version 0.1.0 \\
  --set proxy.orgId=acme --set proxy.proxyPublicUrl=https://cullis.acme.internal
\`\`\`

brings up the proxy in standalone mode with self-generated CA (from #115), \`readyz\` green, dashboard reachable on the ingress.

## Test plan

- [x] YAML syntax valid (\`python -c "yaml.safe_load(open('.github/workflows/release-proxy.yml'))"\`)
- [x] \`pytest tests/\` — 778 pass (unchanged, same 2 preexisting PG failures)
- [x] Chart lint runs on the existing \`helm-test\` workflow against this PR.
- [ ] Post-merge: cut \`proxy-v0.1.0-rc1\` and verify both image + chart land on ghcr.io.

## Epic closeout

This closes the 4-PR shippable-standalone epic (#112). After merge:
- Rewrite \`docs/mcp-proxy.md\` with only \`docker run\` + \`helm install\` entry points.
- Scaffold Docusaurus at \`docs.cullis.io\` with this doc as first page.