### PR TITLE
fix(proxy): device-code enrollment must register the agent everywhere

### DIFF
--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -225,6 +225,56 @@ async def approve(
             "sid": session_id,
         },
     )
+
+    # Register the approved agent in the main internal_agents registry so it
+    # shows up in the dashboard and can authenticate via X-API-Key against
+    # /v1/egress/*. The connector does not use the API key (it authenticates
+    # via cert + DPoP), but it is surfaced on the dashboard for admin rotation
+    # and optional SDK paths. Without this step a device-code enrollment left
+    # the agent invisible in the UI — see the history of this function.
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+
+    raw_api_key = generate_api_key(agent_id)
+    api_key_hash = hash_api_key(raw_api_key)
+    existing = await conn.execute(
+        text("SELECT 1 FROM internal_agents WHERE agent_id = :aid"),
+        {"aid": agent_id},
+    )
+    if existing.first() is None:
+        await conn.execute(
+            text(
+                """INSERT INTO internal_agents
+                   (agent_id, display_name, capabilities, api_key_hash,
+                    cert_pem, created_at, is_active)
+                   VALUES (:aid, :dn, :caps, :hash, :cert, :created, 1)"""
+            ),
+            {
+                "aid": agent_id,
+                "dn": agent_id,
+                "caps": json.dumps(capabilities),
+                "hash": api_key_hash,
+                "cert": cert_pem,
+                "created": now,
+            },
+        )
+        await conn.execute(
+            text(
+                """INSERT INTO audit_log
+                   (timestamp, agent_id, action, status, detail)
+                   VALUES (:ts, :aid, 'agent.create', 'success', :detail)"""
+            ),
+            {
+                "ts": now,
+                "aid": agent_id,
+                "detail": json.dumps({
+                    "source": "device_code_enrollment",
+                    "session_id": session_id,
+                    "admin": admin_name,
+                    "capabilities": capabilities,
+                }),
+            },
+        )
+
     return await get_record(conn, session_id)
 
 

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -241,6 +241,64 @@ async def test_approve_signs_cert_and_marks_approved(db_engine):
     assert cert.public_key().public_numbers() == submitted_pub.public_numbers()
 
 
+@pytest.mark.asyncio
+async def test_approve_registers_agent_in_internal_registry(db_engine):
+    """Device-code approval must also land in internal_agents + audit_log.
+
+    Without this, the connector receives a valid cert but the agent is
+    invisible in the dashboard agents list — see the 2026-04-15 rc1 smoke
+    bug report.
+    """
+    from sqlalchemy import text as _text
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    pubkey = _rsa_pubkey_pem()
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="A",
+            requester_email="a@x.com",
+            reason=None,
+            device_info=None,
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="claude-bot",
+            capabilities=["test.read"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    # The agent must now be in internal_agents AND the audit_log.
+    async with get_db() as conn:
+        agents = (await conn.execute(
+            _text("SELECT agent_id, cert_pem, is_active FROM internal_agents"),
+        )).mappings().all()
+        audits = (await conn.execute(
+            _text(
+                "SELECT agent_id, action, status FROM audit_log "
+                "WHERE action = 'agent.create'",
+            ),
+        )).mappings().all()
+
+    assert len(agents) == 1, "device-code approval must insert one agent"
+    assert agents[0]["agent_id"] == "claude-bot"
+    assert bool(agents[0]["is_active"]) is True
+    assert agents[0]["cert_pem"], "cert_pem must be persisted on the agent row"
+
+    assert len(audits) == 1
+    assert audits[0]["agent_id"] == "claude-bot"
+    assert audits[0]["status"] == "success"
+
+
 # ── HTTP endpoint tests ────────────────────────────────────────────
 
 


### PR DESCRIPTION
Concrete bug caught in the 0.1.0-rc1 end-to-end smoke.

## Symptom

1. Admin approves a device-code enrollment from the dashboard Pending list.
2. Connector receives a valid signed cert and writes its identity file.
3. **Agents tab stays empty** — the approved agent is invisible in the registry.
4. No \`agent.create\` audit event is logged either.

## Root cause

\`service.approve()\` only updated \`pending_enrollments\` and signed the cert. It never inserted into \`internal_agents\`, which is the table the dashboard and the \`X-API-Key\` auth path read from.

## Fix

Within the same transaction, after marking the enrollment approved and signing the cert, insert the agent into \`internal_agents\` with:

- admin-chosen \`agent_id\`
- the freshly signed \`cert_pem\`
- capabilities from the approval payload
- a newly generated X-API-Key hash (raw key lives in DB hash form only — dashboard can rotate; connector does not need it because it authenticates via cert + DPoP)
- \`is_active = 1\`

And write an \`agent.create\` audit row so the event shows in the same audit UI as dashboard-created agents.

Idempotent on re-approval — if the agent_id row already exists the insert is skipped.

## Test plan

- [x] New \`test_approve_registers_agent_in_internal_registry\` asserts an \`internal_agents\` row + an \`agent.create\` audit entry are present after approve().
- [x] \`pytest tests/test_enrollment.py\` — 12/12 PASS
- [x] \`pytest tests/\` — 779 pass (+1, same 2 pre-existing Postgres failures)

## Follow-up

This is a patch, not the refactor. The broader onboarding UX work (the user's "3 flussi → 1" ask) stays open and will converge the dashboard "Create agent" path, the device-code path, and \`from_enrollment(url)\` into a single invite-token flow. Tracked separately — this PR just makes the existing device-code path not silently drop the agent.

Release-wise this should land before \`proxy-v0.1.0\` proper. I can cut \`proxy-v0.1.0-rc2\` once merged.