### PR TITLE
feat(proxy+connector): device-code enrollment passes api_key_hash end-to-end

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -23,6 +23,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import os
+import secrets
+
+import bcrypt
 import httpx
 from cryptography import x509
 
@@ -33,6 +37,21 @@ from cullis_connector.identity import (
     save_identity,
 )
 from cullis_connector.identity.store import IdentityMetadata, load_identity
+
+
+_API_KEY_PREFIX = "sk_local_"
+
+
+def _generate_api_key() -> str:
+    """Mirror of mcp_proxy.auth.api_key.generate_api_key — same format
+    (``sk_local_<label>_<32-hex>``) so the server accepts the resulting hash
+    with its existing ``verify_api_key`` helper."""
+    label = os.environ.get("HOSTNAME", "connector").replace(" ", "-")[:32]
+    return f"{_API_KEY_PREFIX}{label}_{secrets.token_hex(16)}"
+
+
+def _bcrypt_hash(raw: str) -> str:
+    return bcrypt.hashpw(raw.encode(), bcrypt.gensalt()).decode()
 
 _log = logging.getLogger("cullis_connector.enrollment")
 
@@ -79,10 +98,18 @@ def enroll(
     private_key = generate_keypair()
     pubkey_pem = public_key_to_pem(private_key.public_key()).decode()
 
+    # Generate an X-API-Key locally. The raw key never leaves this process
+    # until we persist it to disk post-approval. The server receives only
+    # the bcrypt hash and copies it into internal_agents.api_key_hash on
+    # approve() so /v1/egress/* auth works from day one.
+    api_key_raw = _generate_api_key()
+    api_key_hash = _bcrypt_hash(api_key_raw)
+
     start_resp = _start(
         site_url=site_url,
         pubkey_pem=pubkey_pem,
         requester=requester,
+        api_key_hash=api_key_hash,
         verify_tls=verify_tls,
         timeout_s=request_timeout_s,
     )
@@ -139,6 +166,7 @@ def enroll(
         private_key=private_key,
         ca_chain_pem=None,  # Phase 2c will fetch the CA chain from the Site.
         metadata=metadata,
+        api_key=api_key_raw,
     )
 
     print(
@@ -158,6 +186,7 @@ def _start(
     site_url: str,
     pubkey_pem: str,
     requester: RequesterInfo,
+    api_key_hash: str | None,
     verify_tls: bool,
     timeout_s: float,
 ) -> dict[str, Any]:
@@ -170,6 +199,8 @@ def _start(
         body["reason"] = requester.reason
     if requester.device_info:
         body["device_info"] = requester.device_info
+    if api_key_hash:
+        body["api_key_hash"] = api_key_hash
 
     try:
         response = httpx.post(

--- a/cullis_connector/identity/store.py
+++ b/cullis_connector/identity/store.py
@@ -29,6 +29,7 @@ CERT_FILENAME = "agent.crt"
 KEY_FILENAME = "agent.key"
 CA_CHAIN_FILENAME = "ca-chain.pem"
 METADATA_FILENAME = "metadata.json"
+API_KEY_FILENAME = "api_key"
 
 
 class IdentityNotFound(Exception):
@@ -89,11 +90,13 @@ def save_identity(
     private_key: PrivateKeyTypes,
     ca_chain_pem: str | None,
     metadata: IdentityMetadata,
+    api_key: str | None = None,
 ) -> None:
     """Persist the full identity bundle atomically per-file.
 
-    The private key is written with ``chmod 600``; the public cert and
-    metadata stay world-readable (they contain no secret material).
+    The private key and api_key file are written with ``chmod 600``; the
+    public cert and metadata stay world-readable (they contain no secret
+    material).
     """
     identity_dir = _identity_dir(config_dir)
     identity_dir.mkdir(parents=True, exist_ok=True)
@@ -124,6 +127,16 @@ def save_identity(
         json.dumps(metadata.to_dict(), indent=2).encode(),
         mode=0o644,
     )
+
+    # The X-API-Key (if provided) is written as a newline-terminated plain
+    # text file at 0600 — same treatment as the private key. Scripts read
+    # it with `.read_text().strip()` to get the raw sk_local_... value.
+    if api_key:
+        _write_atomic(
+            identity_dir / API_KEY_FILENAME,
+            (api_key + "\n").encode(),
+            mode=0o600,
+        )
 
 
 def load_identity(config_dir: Path) -> IdentityBundle:

--- a/mcp_proxy/alembic/versions/0006_enrollment_api_key_hash.py
+++ b/mcp_proxy/alembic/versions/0006_enrollment_api_key_hash.py
@@ -1,0 +1,34 @@
+"""Add api_key_hash column to pending_enrollments — #122 follow-up.
+
+Revision ID: 0006_enrollment_api_key_hash
+Revises: 0005_schema_parity_with_broker
+Create Date: 2026-04-16
+
+The connector now generates its own X-API-Key locally at enroll-start
+time, hashes it (bcrypt) and sends the hash with the enrollment
+request. The server stores the hash here; on approve() it copies it
+into internal_agents.api_key_hash so the device-code-approved agent
+has a usable API key from day one — without the server ever seeing
+the raw key.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006_enrollment_api_key_hash"
+down_revision: Union[str, Sequence[str], None] = "0005_schema_parity_with_broker"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("pending_enrollments") as batch_op:
+        batch_op.add_column(
+            sa.Column("api_key_hash", sa.Text(), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("pending_enrollments") as batch_op:
+        batch_op.drop_column("api_key_hash")

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -100,6 +100,7 @@ async def start_enrollment(
                 requester_email=payload.requester_email,
                 reason=payload.reason,
                 device_info=payload.device_info,
+                api_key_hash=payload.api_key_hash,
             )
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -36,6 +36,19 @@ class EnrollmentStartRequest(BaseModel):
             " Not used for auth — helps admin decide and appears in audit."
         ),
     )
+    api_key_hash: str | None = Field(
+        None,
+        min_length=20,
+        max_length=200,
+        description=(
+            "bcrypt hash of the X-API-Key the Connector generated locally."
+            " The raw key never leaves the requester's machine. On approve,"
+            " this hash is copied to internal_agents.api_key_hash so the"
+            " Connector can authenticate to /v1/egress/* immediately."
+            " Optional for backward compat — omitting it makes the server"
+            " generate its own key during approval (legacy behaviour)."
+        ),
+    )
 
 
 class EnrollmentStartResponse(BaseModel):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -130,11 +130,19 @@ async def start_enrollment(
     requester_email: str,
     reason: str | None,
     device_info: str | None,
+    api_key_hash: str | None = None,
 ) -> StartedEnrollment:
     """Create a new pending enrollment.
 
     The session_id is a 128-bit URL-safe random token — unguessable so only
     the client that started the flow can poll it.
+
+    ``api_key_hash`` is the bcrypt hash of an X-API-Key that the connector
+    generated locally (the raw key never leaves the requester's machine).
+    If provided, it gets stored now and copied to internal_agents on
+    approve() so the connector can authenticate to /v1/egress/* from day
+    one. Legacy connectors that don't send this still work — the server
+    generates its own key in approve() for backward compatibility.
     """
     fingerprint = _pubkey_fingerprint(pubkey_pem)
     session_id = secrets.token_urlsafe(24)
@@ -146,11 +154,11 @@ async def start_enrollment(
             """INSERT INTO pending_enrollments (
                 session_id, pubkey_pem, pubkey_fingerprint,
                 requester_name, requester_email, reason, device_info,
-                status, created_at, expires_at
+                status, created_at, expires_at, api_key_hash
             ) VALUES (
                 :sid, :pk, :fp,
                 :name, :email, :reason, :device,
-                'pending', :created, :expires
+                'pending', :created, :expires, :keyhash
             )"""
         ),
         {
@@ -163,6 +171,7 @@ async def start_enrollment(
             "device": device_info,
             "created": _iso(now),
             "expires": _iso(expires_at),
+            "keyhash": api_key_hash,
         },
     )
     return StartedEnrollment(session_id=session_id, expires_at=expires_at)
@@ -228,14 +237,16 @@ async def approve(
 
     # Register the approved agent in the main internal_agents registry so it
     # shows up in the dashboard and can authenticate via X-API-Key against
-    # /v1/egress/*. The connector does not use the API key (it authenticates
-    # via cert + DPoP), but it is surfaced on the dashboard for admin rotation
-    # and optional SDK paths. Without this step a device-code enrollment left
-    # the agent invisible in the UI — see the history of this function.
+    # /v1/egress/*. If the connector supplied its own api_key_hash at start
+    # (see 0005 migration), reuse it — the server never sees the raw key.
+    # Legacy connectors that didn't send one get a server-generated hash
+    # here (backward-compatible with pre-#123 clients).
     from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
 
-    raw_api_key = generate_api_key(agent_id)
-    api_key_hash = hash_api_key(raw_api_key)
+    api_key_hash = record.get("api_key_hash")
+    if not api_key_hash:
+        raw_api_key = generate_api_key(agent_id)
+        api_key_hash = hash_api_key(raw_api_key)
     existing = await conn.execute(
         text("SELECT 1 FROM internal_agents WHERE agent_id = :aid"),
         {"aid": agent_id},

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -242,6 +242,63 @@ async def test_approve_signs_cert_and_marks_approved(db_engine):
 
 
 @pytest.mark.asyncio
+async def test_start_enrollment_accepts_connector_provided_api_key_hash(db_engine):
+    """Connector-provided api_key_hash flows through start → approve → internal_agents.
+
+    End-to-end: connector generates a raw key locally, hashes it, submits
+    the hash with /v1/enrollment/start. After approve(), the hash shows up
+    verbatim in internal_agents.api_key_hash so the SAME raw key (which
+    only the connector has) authenticates to /v1/egress/*.
+    """
+    import bcrypt
+    from sqlalchemy import text as _text
+    from mcp_proxy.auth.api_key import verify_api_key
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    raw_key = "sk_local_connector_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    submitted_hash = bcrypt.hashpw(raw_key.encode(), bcrypt.gensalt()).decode()
+
+    pubkey = _rsa_pubkey_pem()
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="A",
+            requester_email="a@x.com",
+            reason=None,
+            device_info=None,
+            api_key_hash=submitted_hash,
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="conn-bot",
+            capabilities=["test.read"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            _text("SELECT api_key_hash FROM internal_agents WHERE agent_id = 'conn-bot'"),
+        )).mappings().first()
+
+    assert row is not None
+    assert row["api_key_hash"] == submitted_hash, (
+        "approve() must reuse the connector-provided hash rather than "
+        "generating a new one"
+    )
+    # And the raw key the connector kept locally verifies against it.
+    assert verify_api_key(raw_key, row["api_key_hash"]) is True
+
+
+@pytest.mark.asyncio
 async def test_approve_registers_agent_in_internal_registry(db_engine):
     """Device-code approval must also land in internal_agents + audit_log.
 

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -65,7 +65,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0005_schema_parity_with_broker",)]
+    assert rows == [("0006_enrollment_api_key_hash",)]
 
 
 @pytest.mark.asyncio
@@ -125,7 +125,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0005_schema_parity_with_broker",)]
+    assert version == [("0006_enrollment_api_key_hash",)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #122. Fixes the rc2 smoke symptom: the connector got a valid cert but could not call \`/v1/egress/*\` because the raw API key was server-generated and never returned.

## Change

- **Connector** generates its X-API-Key locally at enroll-start (\`sk_local_{hostname}_{32-hex}\`), bcrypt-hashes it, includes the hash in \`POST /v1/enrollment/start\`.
- **Server** stores the hash in \`pending_enrollments.api_key_hash\` (new column, Alembic 0005). On approve(), copies it into \`internal_agents.api_key_hash\`.
- **Connector** persists the raw key to \`{config_dir}/identity/api_key\` (chmod 0600) alongside cert + key on approval.

**Server never sees the raw key.** Legacy connectors without the field still work — server generates its own key in that case.

## Test plan

- [x] New unit: submitted hash survives start → approve → verbatim in \`internal_agents.api_key_hash\`; \`verify_api_key()\` accepts the corresponding raw.
- [x] Migration test updated — head = 0005.
- [x] \`pytest tests/\` — 780 pass (same 2 preexisting PG failures).

## After merge

- Cut \`proxy-v0.1.0-rc3\`.
- Re-enroll from VM — raw key now in \`~/.cullis/identity/api_key\`.
- Run the updated \`imp/agent_ollama.py\` daemon + \`imp/send_oneshot.py\` injector without copying keys from the dashboard.

## Follow-up (not in this PR)

- Dashboard "Rotate key" for agents enrolled via device-code.
- "Three flussi → 1" onboarding refactor the user wants (converge dashboard-create / device-code / from_enrollment into a single invite-token flow).