### PR TITLE
feat(proxy): align local_* schema with broker (ADR-006 Fase 0)

### DIFF
--- a/mcp_proxy/alembic/versions/0005_schema_parity_with_broker.py
+++ b/mcp_proxy/alembic/versions/0005_schema_parity_with_broker.py
@@ -1,0 +1,296 @@
+"""Schema parity local_*↔broker — ADR-006 Fase 0.
+
+Revision ID: 0005_schema_parity_with_broker
+Revises: 0004_add_federation_cache
+Create Date: 2026-04-16
+
+Brings the local_* tables in line with the broker equivalents so the proxy
+can operate as a standalone mini-broker (ADR-006 Fase 1) while remaining
+byte-compatible with the broker for future export / audit merge.
+
+Divergences closed here (see imp/adr_006_proxy_troian_horse_dual_mode.md §A):
+
+  local_agents   : + org_id, cert_thumbprint, metadata_json
+  local_sessions : rename responder→target, + initiator_org_id,
+                   target_org_id, requested_capabilities, expires_at,
+                   closed_at
+  local_messages : + seq, nonce (unique), signature, attempts,
+                   expired_at; rename status→delivery_status (integer
+                   enum 0/1/2 matching ProxyMessageQueueRecord)
+  local_policies : + org_id, policy_type
+  local_audit    : rename action→event_type, actor_agent_id→agent_id,
+                   detail_json→details, prev_hash→previous_hash,
+                   row_hash→entry_hash; + session_id, org_id, result,
+                   chain_seq, peer_org_id, peer_row_hash
+
+The hash-chain ``compute_entry_hash`` helper lives in
+``mcp_proxy/local/audit_chain.py``; its canonical form matches
+``app/db/audit.py:compute_entry_hash`` byte-for-byte so rows are portable.
+
+Live proxies have no production data in local_* (enforced in 0002 comment:
+"Phase 1 only deploys the schema — no application code reads from or writes
+to these tables yet"). The migration uses ``batch_alter_table`` for SQLite
+compatibility.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0005_schema_parity_with_broker"
+down_revision: Union[str, Sequence[str], None] = "0004_add_federation_cache"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ── local_agents ────────────────────────────────────────────────────────
+    with op.batch_alter_table("local_agents") as batch_op:
+        batch_op.add_column(sa.Column("org_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("cert_thumbprint", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column("metadata_json", sa.Text(), nullable=False, server_default="{}")
+        )
+    op.create_index("idx_local_agents_org", "local_agents", ["org_id"])
+    op.create_index(
+        "idx_local_agents_thumbprint", "local_agents", ["cert_thumbprint"]
+    )
+
+    # ── local_sessions ──────────────────────────────────────────────────────
+    # Existing index references the old column name; drop it before rename.
+    op.drop_index("idx_local_sessions_responder", table_name="local_sessions")
+    with op.batch_alter_table("local_sessions") as batch_op:
+        batch_op.alter_column(
+            "responder_agent_id",
+            new_column_name="target_agent_id",
+            existing_type=sa.Text(),
+            existing_nullable=False,
+        )
+        batch_op.add_column(sa.Column("initiator_org_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("target_org_id", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "requested_capabilities",
+                sa.Text(),
+                nullable=False,
+                server_default="[]",
+            )
+        )
+        batch_op.add_column(sa.Column("expires_at", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("closed_at", sa.Text(), nullable=True))
+    op.create_index("idx_local_sessions_target", "local_sessions", ["target_agent_id"])
+    op.create_index(
+        "idx_local_sessions_initiator_org", "local_sessions", ["initiator_org_id"]
+    )
+    op.create_index(
+        "idx_local_sessions_target_org", "local_sessions", ["target_org_id"]
+    )
+
+    # ── local_messages ──────────────────────────────────────────────────────
+    # Rename legacy ``status`` (text: queued|delivered|expired) to
+    # ``delivery_status`` with integer enum semantics matching the broker's
+    # ProxyMessageQueueRecord (0=pending, 1=delivered, 2=expired).
+    op.drop_index(
+        "idx_local_messages_recipient_status", table_name="local_messages"
+    )
+    with op.batch_alter_table("local_messages") as batch_op:
+        batch_op.alter_column(
+            "status",
+            new_column_name="delivery_status",
+            existing_type=sa.Text(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+            postgresql_using="CASE status "
+            "WHEN 'delivered' THEN 1 "
+            "WHEN 'expired' THEN 2 "
+            "ELSE 0 END",
+            server_default="0",
+        )
+        batch_op.add_column(sa.Column("seq", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("nonce", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("signature", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default="0")
+        )
+        batch_op.add_column(sa.Column("expired_at", sa.Text(), nullable=True))
+        batch_op.create_unique_constraint(
+            "uq_local_messages_session_seq", ["session_id", "seq"]
+        )
+        batch_op.create_unique_constraint("uq_local_messages_nonce", ["nonce"])
+    op.create_index(
+        "idx_local_messages_recipient_delivery_status",
+        "local_messages",
+        ["recipient_agent_id", "delivery_status"],
+    )
+
+    # ── local_policies ──────────────────────────────────────────────────────
+    with op.batch_alter_table("local_policies") as batch_op:
+        batch_op.add_column(sa.Column("org_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("policy_type", sa.Text(), nullable=True))
+    op.create_index("idx_local_policies_org", "local_policies", ["org_id"])
+    op.create_index(
+        "idx_local_policies_type", "local_policies", ["policy_type"]
+    )
+
+    # ── local_audit ─────────────────────────────────────────────────────────
+    # Align column names with broker app/db/audit.py::AuditLog so that
+    # compute_entry_hash (canonical form) is byte-compatible.
+    op.drop_index("idx_local_audit_actor", table_name="local_audit")
+    with op.batch_alter_table("local_audit") as batch_op:
+        batch_op.alter_column(
+            "action",
+            new_column_name="event_type",
+            existing_type=sa.Text(),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            "actor_agent_id",
+            new_column_name="agent_id",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "detail_json",
+            new_column_name="details",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "prev_hash",
+            new_column_name="previous_hash",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "row_hash",
+            new_column_name="entry_hash",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.drop_column("subject")
+        batch_op.add_column(sa.Column("session_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("org_id", sa.Text(), nullable=True))
+        batch_op.add_column(
+            sa.Column("result", sa.Text(), nullable=False, server_default="ok")
+        )
+        batch_op.add_column(sa.Column("chain_seq", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("peer_org_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("peer_row_hash", sa.Text(), nullable=True))
+    op.create_index("idx_local_audit_event_type", "local_audit", ["event_type"])
+    op.create_index("idx_local_audit_agent", "local_audit", ["agent_id"])
+    op.create_index("idx_local_audit_session", "local_audit", ["session_id"])
+    op.create_index("idx_local_audit_org", "local_audit", ["org_id"])
+    op.create_index("idx_local_audit_peer_org", "local_audit", ["peer_org_id"])
+
+
+def downgrade() -> None:
+    # ── local_audit ─────────────────────────────────────────────────────────
+    op.drop_index("idx_local_audit_peer_org", table_name="local_audit")
+    op.drop_index("idx_local_audit_org", table_name="local_audit")
+    op.drop_index("idx_local_audit_session", table_name="local_audit")
+    op.drop_index("idx_local_audit_agent", table_name="local_audit")
+    op.drop_index("idx_local_audit_event_type", table_name="local_audit")
+    with op.batch_alter_table("local_audit") as batch_op:
+        batch_op.drop_column("peer_row_hash")
+        batch_op.drop_column("peer_org_id")
+        batch_op.drop_column("chain_seq")
+        batch_op.drop_column("result")
+        batch_op.drop_column("org_id")
+        batch_op.drop_column("session_id")
+        batch_op.add_column(sa.Column("subject", sa.Text(), nullable=True))
+        batch_op.alter_column(
+            "entry_hash",
+            new_column_name="row_hash",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "previous_hash",
+            new_column_name="prev_hash",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "details",
+            new_column_name="detail_json",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "agent_id",
+            new_column_name="actor_agent_id",
+            existing_type=sa.Text(),
+            existing_nullable=True,
+        )
+        batch_op.alter_column(
+            "event_type",
+            new_column_name="action",
+            existing_type=sa.Text(),
+            existing_nullable=False,
+        )
+    op.create_index("idx_local_audit_actor", "local_audit", ["actor_agent_id"])
+
+    # ── local_policies ──────────────────────────────────────────────────────
+    op.drop_index("idx_local_policies_type", table_name="local_policies")
+    op.drop_index("idx_local_policies_org", table_name="local_policies")
+    with op.batch_alter_table("local_policies") as batch_op:
+        batch_op.drop_column("policy_type")
+        batch_op.drop_column("org_id")
+
+    # ── local_messages ──────────────────────────────────────────────────────
+    op.drop_index(
+        "idx_local_messages_recipient_delivery_status", table_name="local_messages"
+    )
+    with op.batch_alter_table("local_messages") as batch_op:
+        batch_op.drop_constraint("uq_local_messages_nonce", type_="unique")
+        batch_op.drop_constraint("uq_local_messages_session_seq", type_="unique")
+        batch_op.drop_column("expired_at")
+        batch_op.drop_column("attempts")
+        batch_op.drop_column("signature")
+        batch_op.drop_column("nonce")
+        batch_op.drop_column("seq")
+        batch_op.alter_column(
+            "delivery_status",
+            new_column_name="status",
+            existing_type=sa.SmallInteger(),
+            type_=sa.Text(),
+            existing_nullable=False,
+            postgresql_using="CASE delivery_status "
+            "WHEN 1 THEN 'delivered' "
+            "WHEN 2 THEN 'expired' "
+            "ELSE 'queued' END",
+            server_default=None,
+        )
+    op.create_index(
+        "idx_local_messages_recipient_status",
+        "local_messages",
+        ["recipient_agent_id", "status"],
+    )
+
+    # ── local_sessions ──────────────────────────────────────────────────────
+    op.drop_index("idx_local_sessions_target_org", table_name="local_sessions")
+    op.drop_index("idx_local_sessions_initiator_org", table_name="local_sessions")
+    op.drop_index("idx_local_sessions_target", table_name="local_sessions")
+    with op.batch_alter_table("local_sessions") as batch_op:
+        batch_op.drop_column("closed_at")
+        batch_op.drop_column("expires_at")
+        batch_op.drop_column("requested_capabilities")
+        batch_op.drop_column("target_org_id")
+        batch_op.drop_column("initiator_org_id")
+        batch_op.alter_column(
+            "target_agent_id",
+            new_column_name="responder_agent_id",
+            existing_type=sa.Text(),
+            existing_nullable=False,
+        )
+    op.create_index(
+        "idx_local_sessions_responder", "local_sessions", ["responder_agent_id"]
+    )
+
+    # ── local_agents ────────────────────────────────────────────────────────
+    op.drop_index("idx_local_agents_thumbprint", table_name="local_agents")
+    op.drop_index("idx_local_agents_org", table_name="local_agents")
+    with op.batch_alter_table("local_agents") as batch_op:
+        batch_op.drop_column("metadata_json")
+        batch_op.drop_column("cert_thumbprint")
+        batch_op.drop_column("org_id")

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -20,8 +20,10 @@ from sqlalchemy import (
     Index,
     Integer,
     MetaData,
+    SmallInteger,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import declarative_base
 
@@ -122,57 +124,91 @@ class PendingEnrollment(Base):
 
 
 class LocalAgent(Base):
-    """Agents with scope=local. Owned by the proxy, broker never sees them."""
+    """Agents with scope=local. Owned by the proxy, broker never sees them.
+
+    Schema aligned with broker ``registry.agents`` (ADR-006 Fase 0) so a row
+    can be exported / promoted to federated visibility without field mapping.
+    """
     __tablename__ = "local_agents"
 
     agent_id = Column(Text, primary_key=True)
+    org_id = Column(Text, nullable=True)
     display_name = Column(Text, nullable=False)
     capabilities = Column(Text, nullable=False, server_default="[]")  # JSON array
     cert_pem = Column(Text, nullable=True)
+    cert_thumbprint = Column(Text, nullable=True)
     api_key_hash = Column(Text, nullable=True)
     scope = Column(Text, nullable=False, server_default="local")  # reserved: "local" | "federated-cache"
+    metadata_json = Column(Text, nullable=False, server_default="{}")
     created_at = Column(Text, nullable=False)
     is_active = Column(Integer, nullable=False, server_default="1")
 
+    __table_args__ = (
+        Index("idx_local_agents_org", "org_id"),
+        Index("idx_local_agents_thumbprint", "cert_thumbprint"),
+    )
+
 
 class LocalSession(Base):
-    """Intra-org sessions. Phase 4 wires routing; Phase 1 schema-only."""
+    """Intra-org sessions. Column names match broker ``sessions`` table."""
     __tablename__ = "local_sessions"
 
     session_id = Column(Text, primary_key=True)
     initiator_agent_id = Column(Text, nullable=False)
-    responder_agent_id = Column(Text, nullable=False)
+    initiator_org_id = Column(Text, nullable=True)
+    target_agent_id = Column(Text, nullable=False)
+    target_org_id = Column(Text, nullable=True)
     status = Column(Text, nullable=False)  # pending | active | closed
+    requested_capabilities = Column(Text, nullable=False, server_default="[]")
     created_at = Column(Text, nullable=False)
+    expires_at = Column(Text, nullable=True)
+    closed_at = Column(Text, nullable=True)
     last_activity_at = Column(Text, nullable=True)
     close_reason = Column(Text, nullable=True)
 
     __table_args__ = (
         Index("idx_local_sessions_initiator", "initiator_agent_id"),
-        Index("idx_local_sessions_responder", "responder_agent_id"),
+        Index("idx_local_sessions_target", "target_agent_id"),
         Index("idx_local_sessions_status", "status"),
+        Index("idx_local_sessions_initiator_org", "initiator_org_id"),
+        Index("idx_local_sessions_target_org", "target_org_id"),
     )
 
 
 class LocalMessage(Base):
-    """M3-twin queue for intra-org messages (Phase 4)."""
+    """M3-twin queue for intra-org messages.
+
+    ``delivery_status`` mirrors broker ``ProxyMessageQueueRecord``:
+    0 = pending, 1 = delivered, 2 = expired.
+    """
     __tablename__ = "local_messages"
 
     msg_id = Column(Text, primary_key=True)
     session_id = Column(Text, nullable=False)
+    seq = Column(Integer, nullable=True)
     sender_agent_id = Column(Text, nullable=False)
     recipient_agent_id = Column(Text, nullable=False)
     payload_ciphertext = Column(Text, nullable=False)
+    nonce = Column(Text, nullable=True)
+    signature = Column(Text, nullable=True)
     idempotency_key = Column(Text, nullable=True)
-    status = Column(Text, nullable=False)  # queued | delivered | expired
+    delivery_status = Column(SmallInteger, nullable=False, server_default="0")
+    attempts = Column(Integer, nullable=False, server_default="0")
     enqueued_at = Column(Text, nullable=False)
     delivered_at = Column(Text, nullable=True)
+    expired_at = Column(Text, nullable=True)
     expires_at = Column(Text, nullable=True)
 
     __table_args__ = (
         Index("idx_local_messages_session", "session_id"),
-        Index("idx_local_messages_recipient_status", "recipient_agent_id", "status"),
+        Index(
+            "idx_local_messages_recipient_delivery_status",
+            "recipient_agent_id",
+            "delivery_status",
+        ),
         Index("idx_local_messages_idempotency", "idempotency_key"),
+        UniqueConstraint("session_id", "seq", name="uq_local_messages_session_seq"),
+        UniqueConstraint("nonce", name="uq_local_messages_nonce"),
     )
 
 
@@ -181,6 +217,8 @@ class LocalPolicy(Base):
     __tablename__ = "local_policies"
 
     policy_id = Column(Text, primary_key=True)
+    org_id = Column(Text, nullable=True)
+    policy_type = Column(Text, nullable=True)  # session | message
     name = Column(Text, nullable=False)
     scope = Column(Text, nullable=False, server_default="intra")  # reserved: "intra" | "egress"
     rules_json = Column(Text, nullable=False, server_default="{}")
@@ -188,26 +226,43 @@ class LocalPolicy(Base):
     created_at = Column(Text, nullable=False)
     updated_at = Column(Text, nullable=False)
 
+    __table_args__ = (
+        Index("idx_local_policies_org", "org_id"),
+        Index("idx_local_policies_type", "policy_type"),
+    )
+
 
 class LocalAudit(Base):
     """Append-only, hash-chained intra-org audit log.
 
-    Hash chain (computed Phase 4): row_hash = SHA-256(prev_hash || canonical_json(row)).
-    Phase 1 defines the columns; chain enforcement happens later with a DB
-    trigger / application-level guard.
+    Column names and hash canonical form match broker ``app/db/audit.py``
+    (``AuditLog`` + ``compute_entry_hash``). Rows are byte-for-byte
+    portable: export on the proxy and verify on the broker without schema
+    translation. Cross-org dual-write columns (``peer_org_id``,
+    ``peer_row_hash``) are present for schema parity — the proxy never
+    dual-writes in standalone mode, they stay NULL.
     """
     __tablename__ = "local_audit"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     timestamp = Column(Text, nullable=False)
-    actor_agent_id = Column(Text, nullable=True)
-    action = Column(Text, nullable=False)
-    subject = Column(Text, nullable=True)
-    detail_json = Column(Text, nullable=True)
-    prev_hash = Column(Text, nullable=True)
-    row_hash = Column(Text, nullable=True)
+    event_type = Column(Text, nullable=False)
+    agent_id = Column(Text, nullable=True)
+    session_id = Column(Text, nullable=True)
+    org_id = Column(Text, nullable=True)
+    details = Column(Text, nullable=True)
+    result = Column(Text, nullable=False, server_default="ok")
+    entry_hash = Column(Text, nullable=True)
+    previous_hash = Column(Text, nullable=True)
+    chain_seq = Column(Integer, nullable=True)
+    peer_org_id = Column(Text, nullable=True)
+    peer_row_hash = Column(Text, nullable=True)
 
     __table_args__ = (
         Index("idx_local_audit_timestamp", "timestamp"),
-        Index("idx_local_audit_actor", "actor_agent_id"),
+        Index("idx_local_audit_event_type", "event_type"),
+        Index("idx_local_audit_agent", "agent_id"),
+        Index("idx_local_audit_session", "session_id"),
+        Index("idx_local_audit_org", "org_id"),
+        Index("idx_local_audit_peer_org", "peer_org_id"),
     )

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -161,7 +161,7 @@ def _local_session_to_dict(session: LocalSession) -> dict:
     return {
         "session_id": session.session_id,
         "initiator_agent_id": session.initiator_agent_id,
-        "target_agent_id": session.responder_agent_id,
+        "target_agent_id": session.target_agent_id,
         "status": session.status.value,
         "requested_capabilities": list(session.requested_capabilities),
         "created_at": session.created_at.isoformat(),
@@ -197,7 +197,7 @@ async def open_session(
         try:
             session = local_store.create(
                 initiator_agent_id=agent.agent_id,
-                responder_agent_id=body.target_agent_id,
+                target_agent_id=body.target_agent_id,
                 requested_capabilities=body.capabilities,
             )
             await save_local_session(session)
@@ -299,8 +299,8 @@ async def accept_session(
         async with local_store._lock:
             session = local_store.get(session_id)
             if session is not None:
-                if session.responder_agent_id != agent.agent_id:
-                    raise HTTPException(status_code=403, detail="not the responder")
+                if session.target_agent_id != agent.agent_id:
+                    raise HTTPException(status_code=403, detail="not the target")
                 session = local_store.activate(session_id)
                 await save_local_session(session)
                 await log_audit(
@@ -407,7 +407,7 @@ async def send_message(
         if not local_session.involves(agent.agent_id):
             raise HTTPException(status_code=403, detail="not a participant")
         if agent.agent_id == local_session.initiator_agent_id:
-            recipient = local_session.responder_agent_id
+            recipient = local_session.target_agent_id
         else:
             recipient = local_session.initiator_agent_id
 

--- a/mcp_proxy/local/audit_chain.py
+++ b/mcp_proxy/local/audit_chain.py
@@ -1,0 +1,53 @@
+"""Per-org hash-chain primitives for the proxy's ``local_audit`` table.
+
+The canonical form is **byte-for-byte identical** to the broker's
+``app/db/audit.py::compute_entry_hash`` so rows written by the proxy can be
+exported and verified on the broker side without schema translation.
+
+Broker code is intentionally not imported: ``mcp_proxy`` and ``app`` share
+no Python packages (see db_models.py module docstring). Any divergence
+between the two implementations is a federation-breaking bug and must be
+caught by ``tests/test_proxy_audit_chain_parity.py``, which imports both
+and asserts equality on a large randomized input set.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+
+# Sentinel org for audit events that have no natural tenant (system-level,
+# bootstrap, etc.). Matches broker ``app.db.audit.SYSTEM_ORG`` so exports
+# merge cleanly.
+SYSTEM_ORG = "__system__"
+
+
+def compute_entry_hash(
+    entry_id: int,
+    timestamp: datetime,
+    event_type: str,
+    agent_id: str | None,
+    session_id: str | None,
+    org_id: str | None,
+    result: str,
+    details: str | None,
+    previous_hash: str | None,
+    chain_seq: int | None = None,
+    peer_org_id: str | None = None,
+) -> str:
+    """SHA-256 of the canonical audit-entry serialization.
+
+    When ``chain_seq`` is ``None`` the format matches the pre-per-org
+    broker format (legacy rows, globally chained). For new rows (per-org
+    chain) ``chain_seq`` and ``peer_org_id`` are appended so neither can
+    be rewritten without detection.
+    """
+    base = (
+        f"{entry_id}|{timestamp.isoformat()}|{event_type}|"
+        f"{agent_id or ''}|{session_id or ''}|{org_id or ''}|"
+        f"{result}|{details or ''}|{previous_hash or 'genesis'}"
+    )
+    if chain_seq is None:
+        canonical = base
+    else:
+        canonical = f"{base}|seq={chain_seq}|peer={peer_org_id or ''}"
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/mcp_proxy/local/message_queue.py
+++ b/mcp_proxy/local/message_queue.py
@@ -4,13 +4,13 @@ Twin of `app/broker/message_queue.py` targeting the proxy-local
 `local_messages` table. Same public behavior: at-least-once delivery
 with TTL + idempotency, drained on recipient WS reconnect.
 
-Schema differences vs the broker queue (kept intentionally lean for
-single-org proxy use):
-  - `status` is a TEXT enum ('pending' | 'delivered' | 'expired')
-    instead of an int for readability at the SQL prompt.
-  - No `seq` or `attempts` columns — delivery order is by enqueued_at
-    and a retry counter isn't needed for the simpler single-process
-    delivery path.
+Schema aligned with broker ``ProxyMessageQueueRecord`` as of ADR-006 Fase 0
+— ``delivery_status`` is a SMALLINT enum (0=pending, 1=delivered, 2=expired)
+matching ``app/broker/db_models.py``, so a row exported from the proxy is
+byte-compatible with the broker durable queue.
+
+Remaining intentional deltas vs the broker queue (kept lean for single-org
+proxy use):
   - No DB-level UNIQUE constraint on (recipient, idempotency_key) —
     single-process proxy, app-level dedupe is sufficient. When proxy
     HA lands (Redis + Postgres), the migration will add the unique
@@ -30,9 +30,10 @@ from mcp_proxy.db import get_db
 _log = logging.getLogger("mcp_proxy.local.message_queue")
 
 
-STATUS_PENDING = "pending"
-STATUS_DELIVERED = "delivered"
-STATUS_EXPIRED = "expired"
+# SMALLINT values aligned with broker ProxyMessageQueueRecord.delivery_status.
+STATUS_PENDING = 0
+STATUS_DELIVERED = 1
+STATUS_EXPIRED = 2
 
 DEFAULT_TTL_SECONDS = 300  # mirror broker M3 default
 
@@ -112,12 +113,12 @@ async def enqueue(
                 """
                 INSERT INTO local_messages
                     (msg_id, session_id, sender_agent_id, recipient_agent_id,
-                     payload_ciphertext, idempotency_key, status, enqueued_at,
-                     delivered_at, expires_at)
+                     payload_ciphertext, idempotency_key, delivery_status,
+                     enqueued_at, delivered_at, expires_at)
                 VALUES
                     (:msg_id, :session_id, :sender, :recipient,
-                     :payload, :ikey, :status, :enqueued_at,
-                     NULL, :expires_at)
+                     :payload, :ikey, :delivery_status,
+                     :enqueued_at, NULL, :expires_at)
                 """
             ),
             {
@@ -127,7 +128,7 @@ async def enqueue(
                 "recipient": recipient_agent_id,
                 "payload": payload_ciphertext,
                 "ikey": idempotency_key,
-                "status": STATUS_PENDING,
+                "delivery_status": STATUS_PENDING,
                 "enqueued_at": _iso(now),
                 "expires_at": _iso(expires),
             },
@@ -149,14 +150,14 @@ async def fetch_pending_for_recipient(
                        payload_ciphertext, idempotency_key, enqueued_at, expires_at
                   FROM local_messages
                  WHERE recipient_agent_id = :recipient
-                   AND status = :status
+                   AND delivery_status = :delivery_status
                  ORDER BY enqueued_at ASC
                  LIMIT :limit
                 """
             ),
             {
                 "recipient": recipient_agent_id,
-                "status": STATUS_PENDING,
+                "delivery_status": STATUS_PENDING,
                 "limit": limit,
             },
         )
@@ -186,11 +187,11 @@ async def mark_delivered(msg_id: str, recipient_agent_id: str) -> bool:
             text(
                 """
                 UPDATE local_messages
-                   SET status = :delivered,
+                   SET delivery_status = :delivered,
                        delivered_at = :now
                  WHERE msg_id = :msg_id
                    AND recipient_agent_id = :recipient
-                   AND status = :pending
+                   AND delivery_status = :pending
                 """
             ),
             {
@@ -250,8 +251,8 @@ async def fetch_for_session(
 async def sweep_expired(
     *, limit: int = 1000
 ) -> list[ExpiredLocalMessageNotice]:
-    """Flip TTL-expired pending rows to status=expired and return the
-    set so callers can notify senders. Used by the Phase 3d sweeper."""
+    """Flip TTL-expired pending rows to delivery_status=expired and return
+    the set so callers can notify senders. Used by the Phase 3d sweeper."""
     async with get_db() as conn:
         now_iso = _iso(datetime.now(timezone.utc))
         result = await conn.execute(
@@ -259,7 +260,7 @@ async def sweep_expired(
                 """
                 SELECT msg_id, session_id, sender_agent_id, recipient_agent_id
                   FROM local_messages
-                 WHERE status = :pending
+                 WHERE delivery_status = :pending
                    AND expires_at IS NOT NULL
                    AND expires_at < :now
                  LIMIT :limit
@@ -282,8 +283,8 @@ async def sweep_expired(
             text(
                 """
                 UPDATE local_messages
-                   SET status = :expired
-                 WHERE status = :pending
+                   SET delivery_status = :expired
+                 WHERE delivery_status = :pending
                    AND expires_at IS NOT NULL
                    AND expires_at < :now
                 """

--- a/mcp_proxy/local/persistence.py
+++ b/mcp_proxy/local/persistence.py
@@ -2,7 +2,7 @@
 non-terminal rows at startup so the in-memory store survives restarts.
 
 Schema (alembic 0002_local_tables.py): session_id, initiator_agent_id,
-responder_agent_id, status, created_at, last_activity_at, close_reason.
+target_agent_id, status, created_at, last_activity_at, close_reason.
 Capabilities and expires_at are NOT persisted — they're reconstructed
 in-memory (see LocalSession / LocalSessionStore).
 """
@@ -44,10 +44,10 @@ async def save_session(session: LocalSession) -> None:
             text(
                 """
                 INSERT INTO local_sessions
-                    (session_id, initiator_agent_id, responder_agent_id,
+                    (session_id, initiator_agent_id, target_agent_id,
                      status, created_at, last_activity_at, close_reason)
                 VALUES
-                    (:session_id, :initiator_agent_id, :responder_agent_id,
+                    (:session_id, :initiator_agent_id, :target_agent_id,
                      :status, :created_at, :last_activity_at, :close_reason)
                 ON CONFLICT(session_id) DO UPDATE SET
                     status = excluded.status,
@@ -58,7 +58,7 @@ async def save_session(session: LocalSession) -> None:
             {
                 "session_id": session.session_id,
                 "initiator_agent_id": session.initiator_agent_id,
-                "responder_agent_id": session.responder_agent_id,
+                "target_agent_id": session.target_agent_id,
                 "status": session.status.value,
                 "created_at": _iso(session.created_at),
                 "last_activity_at": _iso(session.last_activity_at),
@@ -80,7 +80,7 @@ async def restore_sessions(store: LocalSessionStore) -> int:
         result = await conn.execute(
             text(
                 """
-                SELECT session_id, initiator_agent_id, responder_agent_id,
+                SELECT session_id, initiator_agent_id, target_agent_id,
                        status, created_at, last_activity_at, close_reason
                   FROM local_sessions
                  WHERE status IN ('pending', 'active')
@@ -98,7 +98,7 @@ async def restore_sessions(store: LocalSessionStore) -> int:
         session = LocalSession(
             session_id=row["session_id"],
             initiator_agent_id=row["initiator_agent_id"],
-            responder_agent_id=row["responder_agent_id"],
+            target_agent_id=row["target_agent_id"],
             requested_capabilities=[],
             status=SessionStatus(row["status"]),
             created_at=created_at,

--- a/mcp_proxy/local/session.py
+++ b/mcp_proxy/local/session.py
@@ -52,7 +52,7 @@ LOCAL_SESSION_CAP_ACTIVE_PER_AGENT = _env_int("PROXY_LOCAL_SESSION_CAP_ACTIVE_PE
 class LocalSession:
     session_id: str
     initiator_agent_id: str
-    responder_agent_id: str
+    target_agent_id: str
     requested_capabilities: list[str]
     status: SessionStatus = SessionStatus.pending
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
@@ -75,7 +75,7 @@ class LocalSession:
         self.last_activity_at = datetime.now(timezone.utc)
 
     def involves(self, agent_id: str) -> bool:
-        return agent_id in (self.initiator_agent_id, self.responder_agent_id)
+        return agent_id in (self.initiator_agent_id, self.target_agent_id)
 
 
 class LocalAgentSessionCapExceeded(Exception):
@@ -137,7 +137,7 @@ class LocalSessionStore:
     def create(
         self,
         initiator_agent_id: str,
-        responder_agent_id: str,
+        target_agent_id: str,
         requested_capabilities: list[str],
     ) -> LocalSession:
         self._evict_terminated()
@@ -160,7 +160,7 @@ class LocalSessionStore:
         session = LocalSession(
             session_id=session_id,
             initiator_agent_id=initiator_agent_id,
-            responder_agent_id=responder_agent_id,
+            target_agent_id=target_agent_id,
             requested_capabilities=list(requested_capabilities),
             created_at=now,
             expires_at=now + self._ttl,

--- a/mcp_proxy/local/sweeper.py
+++ b/mcp_proxy/local/sweeper.py
@@ -74,7 +74,7 @@ async def sweep_once(
                 "session_id": session.session_id,
                 "reason": reason.value,
             }
-            for agent_id in (session.initiator_agent_id, session.responder_agent_id):
+            for agent_id in (session.initiator_agent_id, session.target_agent_id):
                 try:
                     await ws_manager.send_to_agent(agent_id, payload)
                 except Exception as exc:

--- a/tests/test_proxy_audit_chain_parity.py
+++ b/tests/test_proxy_audit_chain_parity.py
@@ -1,0 +1,103 @@
+"""Byte-for-byte parity between proxy and broker hash-chain canonical form.
+
+ADR-006 Fase 0: ``mcp_proxy.local.audit_chain.compute_entry_hash`` must
+produce the exact same SHA-256 digest as ``app.db.audit.compute_entry_hash``
+for identical inputs. If this test ever fails, proxy audit rows become
+non-portable to the broker — federation-breaking.
+
+The randomized input set spans legacy (chain_seq=None) and per-org rows,
+NULL and non-NULL details/peer_org_id, and edge-case strings.
+"""
+from __future__ import annotations
+
+import random
+import string
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.db.audit import compute_entry_hash as broker_compute
+from mcp_proxy.local.audit_chain import compute_entry_hash as proxy_compute
+
+
+def _rand_str(rng: random.Random, n: int) -> str:
+    return "".join(rng.choices(string.ascii_letters + string.digits + "|{}\"':", k=n))
+
+
+@pytest.mark.parametrize("seed", list(range(16)))
+def test_hash_parity_randomized(seed: int):
+    rng = random.Random(seed)
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(
+        seconds=rng.randint(0, 3600 * 24 * 90)
+    )
+    kwargs = dict(
+        entry_id=rng.randint(1, 10_000),
+        timestamp=ts,
+        event_type=_rand_str(rng, 16),
+        agent_id=_rand_str(rng, 24) if rng.random() > 0.3 else None,
+        session_id=_rand_str(rng, 20) if rng.random() > 0.3 else None,
+        org_id=_rand_str(rng, 12) if rng.random() > 0.2 else None,
+        result=rng.choice(["ok", "denied", "error"]),
+        details=_rand_str(rng, 80) if rng.random() > 0.4 else None,
+        previous_hash=_rand_str(rng, 64) if rng.random() > 0.5 else None,
+        chain_seq=rng.randint(1, 1000) if rng.random() > 0.5 else None,
+        peer_org_id=_rand_str(rng, 12) if rng.random() > 0.7 else None,
+    )
+    assert proxy_compute(**kwargs) == broker_compute(**kwargs)
+
+
+def test_genesis_row_matches_broker():
+    ts = datetime(2026, 4, 16, 10, 30, tzinfo=timezone.utc)
+    args = dict(
+        entry_id=1,
+        timestamp=ts,
+        event_type="session_open",
+        agent_id="acme::buyer",
+        session_id="sess-001",
+        org_id="acme",
+        result="ok",
+        details='{"capabilities":["kyc.read"]}',
+        previous_hash=None,
+        chain_seq=1,
+        peer_org_id=None,
+    )
+    assert proxy_compute(**args) == broker_compute(**args)
+
+
+def test_legacy_row_shape_identical():
+    """chain_seq=None path must still match (grandfathered legacy rows)."""
+    ts = datetime(2025, 12, 31, 23, 59, tzinfo=timezone.utc)
+    args = dict(
+        entry_id=42,
+        timestamp=ts,
+        event_type="legacy_event",
+        agent_id=None,
+        session_id=None,
+        org_id=None,
+        result="ok",
+        details=None,
+        previous_hash=None,
+        chain_seq=None,
+    )
+    assert proxy_compute(**args) == broker_compute(**args)
+
+
+def test_peer_org_id_binds_into_hash():
+    """peer_org_id difference must change the digest (dual-write audit)."""
+    ts = datetime(2026, 4, 16, tzinfo=timezone.utc)
+    base = dict(
+        entry_id=7,
+        timestamp=ts,
+        event_type="cross_org_session",
+        agent_id="acme::buyer",
+        session_id="sess-x",
+        org_id="acme",
+        result="ok",
+        details="x",
+        previous_hash="0" * 64,
+        chain_seq=5,
+    )
+    h1 = proxy_compute(**base, peer_org_id="contoso")
+    h2 = proxy_compute(**base, peer_org_id="otherco")
+    h3 = proxy_compute(**base, peer_org_id=None)
+    assert h1 != h2 != h3

--- a/tests/test_proxy_local_sessions.py
+++ b/tests/test_proxy_local_sessions.py
@@ -29,7 +29,7 @@ def test_create_and_get():
     s = store.create("alice", "bob", ["cap.read"])
     assert s.status == SessionStatus.pending
     assert s.initiator_agent_id == "alice"
-    assert s.responder_agent_id == "bob"
+    assert s.target_agent_id == "bob"
     assert store.get(s.session_id) is s
 
 
@@ -162,7 +162,7 @@ async def test_save_and_restore_roundtrip(proxy_db):
     s2 = store2.get(s.session_id)
     assert s2 is not None
     assert s2.initiator_agent_id == "alice"
-    assert s2.responder_agent_id == "bob"
+    assert s2.target_agent_id == "bob"
     assert s2.status == SessionStatus.active
 
 
@@ -244,7 +244,7 @@ async def test_router_opens_local_session_for_intra_target(proxy_app):
     session = store.get(session_id)
     assert session is not None
     assert session.status == SessionStatus.pending
-    assert session.responder_agent_id == "acme::peer-bot"
+    assert session.target_agent_id == "acme::peer-bot"
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -65,7 +65,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0004_add_federation_cache",)]
+    assert rows == [("0005_schema_parity_with_broker",)]
 
 
 @pytest.mark.asyncio
@@ -125,7 +125,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0004_add_federation_cache",)]
+    assert version == [("0005_schema_parity_with_broker",)]
 
 
 @pytest.mark.asyncio
@@ -181,6 +181,75 @@ async def test_proxy_db_url_env_overrides_settings(monkeypatch, tmp_path):
 
     settings = ProxySettings()
     assert settings.database_url.endswith("override.db")
+
+
+def _column_names_sqlite(path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    finally:
+        conn.close()
+    return {r[1] for r in rows}
+
+
+@pytest.mark.asyncio
+async def test_schema_parity_with_broker_columns_present(tmp_path):
+    """ADR-006 Fase 0: local_* tables must carry broker-parity columns."""
+    db_file = tmp_path / "parity.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    path = str(db_file)
+
+    agents_cols = _column_names_sqlite(path, "local_agents")
+    assert {"org_id", "cert_thumbprint", "metadata_json"}.issubset(agents_cols)
+
+    sessions_cols = _column_names_sqlite(path, "local_sessions")
+    assert {
+        "target_agent_id",
+        "initiator_org_id",
+        "target_org_id",
+        "requested_capabilities",
+        "expires_at",
+        "closed_at",
+    }.issubset(sessions_cols)
+    assert "responder_agent_id" not in sessions_cols
+
+    messages_cols = _column_names_sqlite(path, "local_messages")
+    assert {
+        "seq",
+        "nonce",
+        "signature",
+        "attempts",
+        "expired_at",
+        "delivery_status",
+    }.issubset(messages_cols)
+    assert "status" not in messages_cols
+
+    policies_cols = _column_names_sqlite(path, "local_policies")
+    assert {"org_id", "policy_type"}.issubset(policies_cols)
+
+    audit_cols = _column_names_sqlite(path, "local_audit")
+    assert {
+        "event_type",
+        "agent_id",
+        "session_id",
+        "org_id",
+        "details",
+        "result",
+        "entry_hash",
+        "previous_hash",
+        "chain_seq",
+        "peer_org_id",
+        "peer_row_hash",
+    }.issubset(audit_cols)
+    assert "action" not in audit_cols
+    assert "actor_agent_id" not in audit_cols
+    assert "row_hash" not in audit_cols
+    assert "prev_hash" not in audit_cols
+    assert "detail_json" not in audit_cols
+    assert "subject" not in audit_cols
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Summary

First PR of the ADR-006 Trojan Horse roadmap — Fase 0 **schema parity** between the proxy's `local_*` tables and their broker equivalents. Done now, before any customer has production data in `local_*`, so it's a free rename instead of a costly migration later.

**What changes in the schema:**

- `local_agents` — `+ org_id, cert_thumbprint, metadata_json`
- `local_sessions` — rename `responder_agent_id → target_agent_id`, `+ initiator_org_id, target_org_id, requested_capabilities, expires_at, closed_at`
- `local_messages` — `+ seq, nonce (unique), signature, attempts, expired_at`; rename `status → delivery_status` with SMALLINT enum (0=pending, 1=delivered, 2=expired) matching `ProxyMessageQueueRecord`
- `local_policies` — `+ org_id, policy_type`
- `local_audit` — rename `action → event_type`, `actor_agent_id → agent_id`, `detail_json → details`, `prev_hash → previous_hash`, `row_hash → entry_hash`; `+ session_id, org_id, result, chain_seq, peer_org_id, peer_row_hash`

**Hash-chain helper** — `mcp_proxy/local/audit_chain.py::compute_entry_hash` is byte-for-byte identical to `app/db/audit.py::compute_entry_hash`. A randomized parity test asserts equality across 16+ seeds and edge cases; any future divergence (silent federation-export breaker) fails CI immediately.

**App-level renames** — `LocalSession.responder_agent_id → target_agent_id` propagated through `session.py`, `persistence.py`, `sweeper.py`, `egress/router.py`. `message_queue.py` switches to SMALLINT status constants.

## Test plan

- [x] `pytest tests/test_proxy_audit_chain_parity.py` — 19/19 pass
- [x] `pytest tests/test_proxy_migrations.py` — 4/4 pass (fresh, legacy stamp+upgrade, seed-only proxy_config, new column-parity assertion)
- [x] `pytest tests/test_proxy_local_sessions.py` `tests/test_proxy_local_messages.py` `tests/test_proxy_local_sweeper.py` `tests/test_proxy_mtls_only_send.py` — 50+/50+ pass
- [x] `pytest tests/` full suite — 799 passed, 6 skipped (2 pre-existing postgres integration failures unrelated to this PR)
- [x] `./demo_network/smoke.sh full` — round-trip A7 hash chain intact across 34 entries ✓
- [ ] CI green across all workflows

## Why now

ADR-006 defines the proxy dual-mode: **standalone mini-broker** (go-to-market land) + **federated uplink** (upsell expand). Phase 0 is the non-negotiable prerequisite: once customers ship with the standalone proxy, every schema rename becomes a data migration nightmare. Doing it now is free.

Related ADR: `imp/adr_006_proxy_troian_horse_dual_mode.md`