### PR TITLE
feat(proxy): intra-org policy eval + hash-chained local audit (ADR-006 Fase 1 / PR #2)

### DIFF
--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -21,6 +21,7 @@ from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
 from mcp_proxy.egress.routing import decide_route
 from mcp_proxy.local import message_queue as local_queue
+from mcp_proxy.local.audit import append_local_audit
 from mcp_proxy.local.models import SessionCloseReason
 from mcp_proxy.local.persistence import save_session as save_local_session
 from mcp_proxy.local.session import (
@@ -29,6 +30,7 @@ from mcp_proxy.local.session import (
     LocalSessionStore,
 )
 from mcp_proxy.models import InternalAgent
+from mcp_proxy.policy.local_eval import evaluate_local_message
 
 logger = logging.getLogger("mcp_proxy.egress.router")
 
@@ -226,6 +228,17 @@ async def open_session(
                 request_id=request_id,
                 duration_ms=duration_ms,
             )
+            await append_local_audit(
+                event_type="session_opened",
+                agent_id=agent.agent_id,
+                session_id=session.session_id,
+                org_id=get_settings().org_id,
+                details={
+                    "target_agent_id": body.target_agent_id,
+                    "target_org_id": body.target_org_id,
+                    "capabilities": body.capabilities,
+                },
+            )
             return OpenSessionResponse(session_id=session.session_id, status="opened")
         except LocalAgentSessionCapExceeded as exc:
             await log_audit(
@@ -325,6 +338,12 @@ async def accept_session(
                     status="success",
                     detail=f"session={session_id}",
                 )
+                await append_local_audit(
+                    event_type="session_accepted",
+                    agent_id=agent.agent_id,
+                    session_id=session_id,
+                    org_id=get_settings().org_id,
+                )
                 return {"status": "accepted", "session_id": session_id}
 
     bridge = _get_bridge(request)
@@ -373,6 +392,13 @@ async def close_session(
                     action="egress_session_close_local",
                     status="success",
                     detail=f"session={session_id}",
+                )
+                await append_local_audit(
+                    event_type="session_closed",
+                    agent_id=agent.agent_id,
+                    session_id=session_id,
+                    org_id=get_settings().org_id,
+                    details={"reason": "normal"},
                 )
                 return {"status": "closed", "session_id": session_id}
 
@@ -426,6 +452,44 @@ async def send_message(
             recipient = local_session.target_agent_id
         else:
             recipient = local_session.initiator_agent_id
+
+        # ADR-006 Fase 1 — intra-org policy evaluation. Rules live in
+        # local_policies and match the broker JSON schema
+        # (max_payload_size_bytes, required_fields, blocked_fields, deny).
+        # Envelope mode stores content as opaque ciphertext, so field-level
+        # rules only bite on mtls-only payloads; size-on-wire still applies.
+        settings = get_settings()
+        verdict = await evaluate_local_message(
+            org_id=settings.org_id, payload=body.payload,
+        )
+        if not verdict.allowed:
+            await append_local_audit(
+                event_type="message_denied",
+                result="denied",
+                agent_id=agent.agent_id,
+                session_id=body.session_id,
+                org_id=settings.org_id,
+                details={
+                    "reason": verdict.reason,
+                    "policy_id": verdict.policy_id,
+                    "recipient": recipient,
+                },
+            )
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_send_local_denied",
+                status="denied",
+                detail=f"policy={verdict.policy_id} reason={verdict.reason}",
+                request_id=request_id,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "policy_denied",
+                    "reason": verdict.reason,
+                    "policy_id": verdict.policy_id,
+                },
+            )
 
         # ADR-001 §10 — mtls-only path: sender signs plaintext, proxy verifies
         # the signature before enqueueing. The stored blob carries mode +
@@ -533,6 +597,19 @@ async def send_message(
             ),
             request_id=request_id,
             duration_ms=duration_ms,
+        )
+        await append_local_audit(
+            event_type="message_sent",
+            agent_id=agent.agent_id,
+            session_id=body.session_id,
+            org_id=get_settings().org_id,
+            details={
+                "recipient": recipient,
+                "msg_id": msg_id,
+                "mode": body.mode,
+                "duplicate": not inserted,
+                "delivered_via": "ws" if pushed else "queue",
+            },
         )
         return {
             "status": "sent",
@@ -694,6 +771,13 @@ async def ack_message(
         action="egress_ack_local",
         status="success",
         detail=f"session={session_id} msg_id={msg_id}",
+    )
+    await append_local_audit(
+        event_type="message_delivered",
+        agent_id=agent.agent_id,
+        session_id=session_id,
+        org_id=get_settings().org_id,
+        details={"msg_id": msg_id},
     )
     return {"status": "acked", "msg_id": msg_id}
 

--- a/mcp_proxy/local/audit.py
+++ b/mcp_proxy/local/audit.py
@@ -1,0 +1,216 @@
+"""Append-only local audit chain writer (ADR-006 Fase 1 / PR #2).
+
+Twin of ``app/db/audit.py`` targeting the proxy's ``local_audit`` table.
+The canonical hash form is byte-for-byte identical to the broker's
+(``mcp_proxy.local.audit_chain.compute_entry_hash``), so a row written
+here can be exported and verified on the broker side without schema
+translation.
+
+Design notes:
+  - Per-org asyncio.Lock guarantees atomicity for "read last head +
+    insert new" without blocking writes to other orgs. Top-level guard
+    protects the lock dict.
+  - SQL stays in raw ``text()`` form to match the rest of
+    ``mcp_proxy.local.*`` (the proxy uses SQLAlchemy Core via
+    AsyncConnection, not ORM sessions).
+  - ``details`` is a free-form JSON string. Caller serializes (so
+    sensitive dicts can be redacted before this boundary).
+  - ``SYSTEM_ORG`` is the fallback when an event has no natural tenant
+    — bootstrap, first-boot CA generation, etc. Same sentinel the
+    broker uses, so exports merge cleanly.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+from mcp_proxy.local.audit_chain import SYSTEM_ORG, compute_entry_hash
+
+_log = logging.getLogger("mcp_proxy.local.audit")
+
+_org_locks: dict[str, asyncio.Lock] = {}
+_locks_guard = asyncio.Lock()
+
+
+async def _get_org_lock(org_id: str) -> asyncio.Lock:
+    if org_id in _org_locks:
+        return _org_locks[org_id]
+    async with _locks_guard:
+        if org_id not in _org_locks:
+            _org_locks[org_id] = asyncio.Lock()
+        return _org_locks[org_id]
+
+
+def _iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+async def append_local_audit(
+    *,
+    event_type: str,
+    result: str = "ok",
+    agent_id: str | None = None,
+    session_id: str | None = None,
+    org_id: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Append one row to ``local_audit``, chained per org.
+
+    Returns a summary dict (``{id, chain_seq, entry_hash, previous_hash}``)
+    mostly for tests and for upstream structured logging; callers are
+    expected to fire-and-forget in the happy path.
+    """
+    chain_org = org_id or SYSTEM_ORG
+    details_json = json.dumps(details, separators=(",", ":"), sort_keys=True) if details else None
+    lock = await _get_org_lock(chain_org)
+
+    async with lock, get_db() as conn:
+        # 1. Fetch current head for this org (entry_hash + chain_seq).
+        head = (await conn.execute(
+            text(
+                """
+                SELECT entry_hash, chain_seq FROM local_audit
+                 WHERE org_id = :org_id AND chain_seq IS NOT NULL
+                 ORDER BY chain_seq DESC
+                 LIMIT 1
+                """
+            ),
+            {"org_id": chain_org},
+        )).first()
+        previous_hash = head[0] if head else None
+        last_seq = head[1] if head else 0
+        new_seq = last_seq + 1
+
+        # 2. Insert with placeholder entry_hash; database auto-assigns id.
+        now = datetime.now(timezone.utc)
+        ts_iso = _iso(now)
+        insert_result = await conn.execute(
+            text(
+                """
+                INSERT INTO local_audit (
+                    timestamp, event_type, agent_id, session_id, org_id,
+                    details, result, previous_hash, chain_seq,
+                    peer_org_id, peer_row_hash, entry_hash
+                ) VALUES (
+                    :timestamp, :event_type, :agent_id, :session_id, :org_id,
+                    :details, :result, :previous_hash, :chain_seq,
+                    NULL, NULL, :placeholder
+                )
+                """
+            ),
+            {
+                "timestamp": ts_iso,
+                "event_type": event_type,
+                "agent_id": agent_id,
+                "session_id": session_id,
+                "org_id": chain_org,
+                "details": details_json,
+                "result": result,
+                "previous_hash": previous_hash,
+                "chain_seq": new_seq,
+                "placeholder": "",
+            },
+        )
+        # Postgres returns lastrowid on some drivers; for portability we
+        # query back by (org_id, chain_seq) which is unique by construction.
+        row_id = insert_result.lastrowid
+        if row_id is None:
+            id_row = (await conn.execute(
+                text(
+                    "SELECT id FROM local_audit WHERE org_id = :org_id "
+                    "AND chain_seq = :chain_seq"
+                ),
+                {"org_id": chain_org, "chain_seq": new_seq},
+            )).first()
+            row_id = id_row[0]
+
+        # 3. Compute the hash now that we know the row id.
+        entry_hash = compute_entry_hash(
+            entry_id=row_id,
+            timestamp=now,
+            event_type=event_type,
+            agent_id=agent_id,
+            session_id=session_id,
+            org_id=chain_org,
+            result=result,
+            details=details_json,
+            previous_hash=previous_hash,
+            chain_seq=new_seq,
+            peer_org_id=None,
+        )
+
+        # 4. Back-fill the hash. The row is immutable from here on.
+        await conn.execute(
+            text("UPDATE local_audit SET entry_hash = :h WHERE id = :id"),
+            {"h": entry_hash, "id": row_id},
+        )
+
+    return {
+        "id": row_id,
+        "chain_seq": new_seq,
+        "entry_hash": entry_hash,
+        "previous_hash": previous_hash,
+    }
+
+
+async def verify_local_chain(org_id: str) -> tuple[bool, str | None]:
+    """Recompute every row's entry_hash from canonical inputs and compare.
+
+    Returns ``(True, None)`` when the chain is intact; ``(False, reason)``
+    with the first divergent row's description when tampering is found.
+    Meant for CLI / dashboard "verify" buttons, not the hot path.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT id, timestamp, event_type, agent_id, session_id,
+                       org_id, details, result, previous_hash, chain_seq,
+                       peer_org_id, entry_hash
+                  FROM local_audit
+                 WHERE org_id = :org_id AND chain_seq IS NOT NULL
+                 ORDER BY chain_seq ASC
+                """
+            ),
+            {"org_id": org_id},
+        )
+        expected_prev: str | None = None
+        for row in result.mappings():
+            ts_raw = row["timestamp"]
+            ts = datetime.fromisoformat(ts_raw) if isinstance(ts_raw, str) else ts_raw
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            if row["previous_hash"] != expected_prev:
+                return False, (
+                    f"row chain_seq={row['chain_seq']} previous_hash mismatch: "
+                    f"expected {expected_prev!r}, got {row['previous_hash']!r}"
+                )
+            expected = compute_entry_hash(
+                entry_id=row["id"],
+                timestamp=ts,
+                event_type=row["event_type"],
+                agent_id=row["agent_id"],
+                session_id=row["session_id"],
+                org_id=row["org_id"],
+                result=row["result"],
+                details=row["details"],
+                previous_hash=row["previous_hash"],
+                chain_seq=row["chain_seq"],
+                peer_org_id=row["peer_org_id"],
+            )
+            if expected != row["entry_hash"]:
+                return False, (
+                    f"row id={row['id']} chain_seq={row['chain_seq']} "
+                    f"entry_hash mismatch: expected {expected}, got "
+                    f"{row['entry_hash']}"
+                )
+            expected_prev = row["entry_hash"]
+    return True, None

--- a/mcp_proxy/policy/local_eval.py
+++ b/mcp_proxy/policy/local_eval.py
@@ -1,0 +1,131 @@
+"""Local policy evaluation for intra-org messages (ADR-006 Fase 1 / PR #2).
+
+The proxy reads its own ``local_policies`` table — populated by the
+admin through the dashboard — and evaluates each outbound intra-org
+message against the matching rules. The rule JSON format matches the
+broker's ``app/policy/engine.py`` message rules so a policy authored
+in either place behaves identically:
+
+    {
+      "effect": "allow" | "deny",
+      "conditions": {
+        "max_payload_size_bytes": <int>,   // optional
+        "required_fields": [<str>, ...],   // optional
+        "blocked_fields":  [<str>, ...]    // optional
+      }
+    }
+
+Default is **allow** when no rule matches — same semantics as the broker
+for messages (sessions are default-deny; messages are default-allow).
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+
+_log = logging.getLogger("mcp_proxy.policy.local_eval")
+
+
+@dataclass(frozen=True)
+class LocalPolicyDecision:
+    allowed: bool
+    reason: str
+    policy_id: str | None = None
+
+
+async def _load_message_policies(org_id: str) -> list[tuple[str, dict[str, Any]]]:
+    """Return ``[(policy_id, rules)]`` for active message-type policies of an org."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT policy_id, rules_json FROM local_policies
+                 WHERE enabled = 1
+                   AND (policy_type = 'message' OR policy_type IS NULL)
+                   AND (org_id = :org_id OR org_id IS NULL)
+                """
+            ),
+            {"org_id": org_id},
+        )
+        out: list[tuple[str, dict[str, Any]]] = []
+        for row in result.mappings():
+            try:
+                rules = json.loads(row["rules_json"])
+            except (ValueError, TypeError):
+                _log.warning("Skipping local policy %s — invalid rules_json", row["policy_id"])
+                continue
+            if not isinstance(rules, dict):
+                continue
+            out.append((row["policy_id"], rules))
+        return out
+
+
+def _evaluate_rules(
+    rules: dict[str, Any],
+    payload: dict[str, Any],
+    payload_json: str,
+    policy_id: str,
+) -> LocalPolicyDecision | None:
+    """Apply a single rule to a payload. ``None`` means "no verdict, try next"."""
+    conditions = rules.get("conditions") or {}
+    effect = rules.get("effect", "allow")
+
+    max_size = conditions.get("max_payload_size_bytes")
+    if max_size is not None and len(payload_json.encode()) > max_size:
+        return LocalPolicyDecision(
+            allowed=False,
+            reason=f"payload too large: {len(payload_json.encode())}B > {max_size}B",
+            policy_id=policy_id,
+        )
+
+    required: list[str] = conditions.get("required_fields") or []
+    missing = [f for f in required if f not in payload]
+    if missing:
+        return LocalPolicyDecision(
+            allowed=False,
+            reason=f"required fields missing: {missing}",
+            policy_id=policy_id,
+        )
+
+    blocked: list[str] = conditions.get("blocked_fields") or []
+    present_blocked = [f for f in blocked if f in payload]
+    if present_blocked:
+        return LocalPolicyDecision(
+            allowed=False,
+            reason=f"blocked fields present: {present_blocked}",
+            policy_id=policy_id,
+        )
+
+    if effect == "deny":
+        return LocalPolicyDecision(
+            allowed=False,
+            reason="explicitly denied by policy",
+            policy_id=policy_id,
+        )
+
+    return None
+
+
+async def evaluate_local_message(
+    *,
+    org_id: str,
+    payload: dict[str, Any],
+) -> LocalPolicyDecision:
+    """Check a payload against the org's intra-org message policies."""
+    policies = await _load_message_policies(org_id)
+    if not policies:
+        return LocalPolicyDecision(allowed=True, reason="no local message policy — default allow")
+
+    payload_json = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    for policy_id, rules in policies:
+        verdict = _evaluate_rules(rules, payload, payload_json, policy_id)
+        if verdict is not None:
+            return verdict
+
+    return LocalPolicyDecision(allowed=True, reason="no rule violated — default allow")

--- a/tests/test_proxy_local_audit_chain.py
+++ b/tests/test_proxy_local_audit_chain.py
@@ -1,0 +1,112 @@
+"""ADR-006 Fase 1 / PR #2 — proxy writes hash-chained entries to local_audit.
+
+Verifies:
+  - append_local_audit inserts rows with byte-compatible entry_hash
+    (matching mcp_proxy.local.audit_chain.compute_entry_hash)
+  - chain_seq is monotonic per org; each row's previous_hash matches
+    the prior row's entry_hash
+  - verify_local_chain returns (True, None) on clean data and
+    (False, <reason>) after tampering
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.local.audit import append_local_audit, verify_local_chain
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path):
+    db_file = tmp_path / "audit.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    yield
+    await dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_first_append_is_genesis(fresh_db):
+    entry = await append_local_audit(
+        event_type="session_opened",
+        org_id="acme",
+        agent_id="alice",
+        session_id="s1",
+    )
+    assert entry["chain_seq"] == 1
+    assert entry["previous_hash"] is None
+    assert len(entry["entry_hash"]) == 64  # SHA-256 hex
+
+
+@pytest.mark.asyncio
+async def test_second_append_chains_to_first(fresh_db):
+    first = await append_local_audit(event_type="session_opened", org_id="acme")
+    second = await append_local_audit(
+        event_type="message_sent",
+        org_id="acme",
+        details={"msg_id": "m1"},
+    )
+    assert second["chain_seq"] == 2
+    assert second["previous_hash"] == first["entry_hash"]
+
+
+@pytest.mark.asyncio
+async def test_per_org_chains_are_independent(fresh_db):
+    acme1 = await append_local_audit(event_type="session_opened", org_id="acme")
+    contoso1 = await append_local_audit(event_type="session_opened", org_id="contoso")
+    acme2 = await append_local_audit(event_type="session_closed", org_id="acme")
+    assert acme1["chain_seq"] == 1
+    assert contoso1["chain_seq"] == 1
+    assert acme2["chain_seq"] == 2
+    assert acme2["previous_hash"] == acme1["entry_hash"]
+
+
+@pytest.mark.asyncio
+async def test_verify_local_chain_intact(fresh_db):
+    for i in range(5):
+        await append_local_audit(
+            event_type="message_sent",
+            org_id="acme",
+            agent_id=f"alice-{i}",
+            details={"seq": i},
+        )
+    ok, reason = await verify_local_chain("acme")
+    assert ok is True
+    assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_verify_local_chain_detects_tampering(fresh_db):
+    await append_local_audit(event_type="session_opened", org_id="acme")
+    await append_local_audit(event_type="message_sent", org_id="acme")
+    # Tamper: rewrite details on the second row so the stored entry_hash
+    # no longer matches the canonical recomputation.
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE local_audit SET details = :d WHERE chain_seq = 2"),
+            {"d": '{"forged":true}'},
+        )
+    ok, reason = await verify_local_chain("acme")
+    assert ok is False
+    assert reason is not None
+    assert "entry_hash mismatch" in reason
+
+
+@pytest.mark.asyncio
+async def test_concurrent_appends_keep_chain_monotonic(fresh_db):
+    import asyncio
+
+    # 20 concurrent appends must still produce a strictly increasing
+    # chain_seq with no duplicates and no gaps.
+    results = await asyncio.gather(
+        *[
+            append_local_audit(event_type="message_sent", org_id="acme", details={"i": i})
+            for i in range(20)
+        ]
+    )
+    seqs = sorted(r["chain_seq"] for r in results)
+    assert seqs == list(range(1, 21))
+    ok, reason = await verify_local_chain("acme")
+    assert ok is True, reason

--- a/tests/test_proxy_local_policy.py
+++ b/tests/test_proxy_local_policy.py
@@ -1,0 +1,329 @@
+"""ADR-006 Fase 1 / PR #2 — intra-org policy evaluation at the proxy.
+
+Covers the policy engine in isolation plus its wiring into
+POST /v1/egress/send when a local session matches the message.
+Rule format mirrors the broker's message-policy schema so a JSON rule
+authored once can be re-used on either side.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.policy.local_eval import evaluate_local_message
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path):
+    db_file = tmp_path / "policy.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    yield
+    await dispose_db()
+
+
+async def _insert_policy(
+    policy_id: str,
+    org_id: str,
+    rules: dict,
+    *,
+    policy_type: str = "message",
+    enabled: int = 1,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_policies (
+                    policy_id, org_id, policy_type, name, scope,
+                    rules_json, enabled, created_at, updated_at
+                ) VALUES (
+                    :pid, :org, :ptype, :name, 'intra',
+                    :rules, :enabled, '2026-04-16T00:00:00Z', '2026-04-16T00:00:00Z'
+                )
+                """
+            ),
+            {
+                "pid": policy_id,
+                "org": org_id,
+                "ptype": policy_type,
+                "name": policy_id,
+                "rules": json.dumps(rules),
+                "enabled": enabled,
+            },
+        )
+
+
+# ── unit: evaluate_local_message ────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_no_policies_defaults_to_allow(fresh_db):
+    verdict = await evaluate_local_message(org_id="acme", payload={"x": 1})
+    assert verdict.allowed is True
+    assert "default allow" in verdict.reason
+
+
+@pytest.mark.asyncio
+async def test_max_payload_size_denies(fresh_db):
+    await _insert_policy(
+        "p1", "acme",
+        {"effect": "allow", "conditions": {"max_payload_size_bytes": 5}},
+    )
+    verdict = await evaluate_local_message(org_id="acme", payload={"very": "long"})
+    assert verdict.allowed is False
+    assert "too large" in verdict.reason
+    assert verdict.policy_id == "p1"
+
+
+@pytest.mark.asyncio
+async def test_required_fields_denies_when_missing(fresh_db):
+    await _insert_policy(
+        "p_req", "acme",
+        {"effect": "allow", "conditions": {"required_fields": ["user_id"]}},
+    )
+    verdict = await evaluate_local_message(org_id="acme", payload={"x": 1})
+    assert verdict.allowed is False
+    assert "required fields missing" in verdict.reason
+
+
+@pytest.mark.asyncio
+async def test_blocked_fields_denies(fresh_db):
+    await _insert_policy(
+        "p_blk", "acme",
+        {"effect": "allow", "conditions": {"blocked_fields": ["admin_override"]}},
+    )
+    verdict = await evaluate_local_message(
+        org_id="acme", payload={"user_id": "u1", "admin_override": True},
+    )
+    assert verdict.allowed is False
+    assert "blocked fields" in verdict.reason
+
+
+@pytest.mark.asyncio
+async def test_disabled_policies_skipped(fresh_db):
+    await _insert_policy(
+        "p_off", "acme",
+        {"effect": "deny", "conditions": {}},
+        enabled=0,
+    )
+    verdict = await evaluate_local_message(org_id="acme", payload={})
+    assert verdict.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_other_org_policies_ignored(fresh_db):
+    await _insert_policy(
+        "p_other", "contoso",
+        {"effect": "deny", "conditions": {}},
+    )
+    verdict = await evaluate_local_message(org_id="acme", payload={})
+    assert verdict.allowed is True
+
+
+@pytest.mark.asyncio
+async def test_org_null_policy_applies_to_any_org(fresh_db):
+    """NULL org_id acts as a global default rule — useful for baseline
+    guardrails that should bite regardless of org_id config."""
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_policies (
+                    policy_id, org_id, policy_type, name, scope,
+                    rules_json, enabled, created_at, updated_at
+                ) VALUES (
+                    'global', NULL, 'message', 'global', 'intra',
+                    :rules, 1, '2026-04-16T00:00:00Z', '2026-04-16T00:00:00Z'
+                )
+                """
+            ),
+            {"rules": json.dumps(
+                {"effect": "deny", "conditions": {"blocked_fields": ["secret"]}}
+            )},
+        )
+    verdict = await evaluate_local_message(org_id="acme", payload={"secret": "x"})
+    assert verdict.allowed is False
+
+
+# ── integration: wired into /v1/egress/send ─────────────────────────
+
+@pytest_asyncio.fixture
+async def standalone_proxy(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("PROXY_INTRA_ORG", raising=False)
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_BROKER_JWKS_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision_agent(agent_id: str) -> str:
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+
+    raw = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=["cap.read"],
+        api_key_hash=hash_api_key(raw),
+    )
+    return raw
+
+
+@pytest.mark.asyncio
+async def test_send_blocked_by_policy_returns_403_and_logs_denial(standalone_proxy):
+    app, client = standalone_proxy
+    alice = await _provision_agent("alice-bot")
+    bob = await _provision_agent("bob-bot")
+
+    # Install a policy that blocks payloads carrying "admin_override".
+    await _insert_policy(
+        "p_guardrail", "acme",
+        {"effect": "allow", "conditions": {"blocked_fields": ["admin_override"]}},
+    )
+
+    # Open + accept a session so send reaches the local path.
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": alice},
+        json={"target_agent_id": "bob-bot", "target_org_id": "acme", "capabilities": []},
+    )
+    session_id = open_resp.json()["session_id"]
+    await client.post(
+        f"/v1/egress/sessions/{session_id}/accept",
+        headers={"X-API-Key": bob},
+    )
+
+    # Forbidden payload
+    send = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": alice},
+        json={
+            "session_id": session_id,
+            "payload": {"hello": "bob", "admin_override": True},
+            "recipient_agent_id": "bob-bot",
+            "mode": "envelope",
+        },
+    )
+    assert send.status_code == 403, send.text
+    body = send.json()["detail"]
+    assert body["error"] == "policy_denied"
+    assert body["policy_id"] == "p_guardrail"
+
+    # Allowed payload goes through.
+    allowed = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": alice},
+        json={
+            "session_id": session_id,
+            "payload": {"hello": "bob"},
+            "recipient_agent_id": "bob-bot",
+            "mode": "envelope",
+        },
+    )
+    assert allowed.status_code == 200, allowed.text
+
+    # The denial and the successful send both show up in local_audit.
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT event_type FROM local_audit "
+                "WHERE org_id = 'acme' ORDER BY chain_seq ASC"
+            )
+        )).all()
+    kinds = [r[0] for r in rows]
+    assert "message_denied" in kinds
+    assert "message_sent" in kinds
+    assert kinds.count("session_opened") == 1
+    assert kinds.count("session_accepted") == 1
+
+
+@pytest.mark.asyncio
+async def test_local_audit_chain_integrity_after_full_roundtrip(standalone_proxy):
+    _, client = standalone_proxy
+    alice = await _provision_agent("alice-bot")
+    bob = await _provision_agent("bob-bot")
+
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": alice},
+        json={"target_agent_id": "bob-bot", "target_org_id": "acme", "capabilities": []},
+    )
+    session_id = open_resp.json()["session_id"]
+    await client.post(
+        f"/v1/egress/sessions/{session_id}/accept",
+        headers={"X-API-Key": bob},
+    )
+    send = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": alice},
+        json={
+            "session_id": session_id,
+            "payload": {"hi": 1},
+            "recipient_agent_id": "bob-bot",
+            "mode": "envelope",
+        },
+    )
+    msg_id = send.json()["msg_id"]
+    await client.post(
+        f"/v1/egress/sessions/{session_id}/messages/{msg_id}/ack",
+        headers={"X-API-Key": bob},
+    )
+    await client.post(
+        f"/v1/egress/sessions/{session_id}/close",
+        headers={"X-API-Key": alice},
+    )
+
+    from mcp_proxy.local.audit import verify_local_chain
+    ok, reason = await verify_local_chain("acme")
+    assert ok is True, reason
+
+
+@pytest.mark.asyncio
+async def test_default_allow_when_no_policies(standalone_proxy):
+    _, client = standalone_proxy
+    alice = await _provision_agent("alice-bot")
+    bob = await _provision_agent("bob-bot")
+
+    # No policies inserted — send must succeed.
+    open_resp = await client.post(
+        "/v1/egress/sessions",
+        headers={"X-API-Key": alice},
+        json={"target_agent_id": "bob-bot", "target_org_id": "acme", "capabilities": []},
+    )
+    session_id = open_resp.json()["session_id"]
+    await client.post(
+        f"/v1/egress/sessions/{session_id}/accept",
+        headers={"X-API-Key": bob},
+    )
+    send = await client.post(
+        "/v1/egress/send",
+        headers={"X-API-Key": alice},
+        json={
+            "session_id": session_id,
+            "payload": {"x": "y"},
+            "recipient_agent_id": "bob-bot",
+            "mode": "envelope",
+        },
+    )
+    assert send.status_code == 200, send.text


### PR DESCRIPTION
## Summary

Two capabilities land on the proxy-as-mini-broker:

### 1. Intra-org message policy evaluation at \`/v1/egress/send\`

Rules live in \`local_policies\` (SQL today; dashboard UI in follow-up PR #2b so this stays small). Rule JSON matches the broker's message-policy schema byte-for-byte:

\`\`\`json
{ "effect": "allow"|"deny",
  "conditions": {
    "max_payload_size_bytes": <int>,
    "required_fields": [<str>, ...],
    "blocked_fields":  [<str>, ...]
  } }
\`\`\`

Default **allow** when no rule matches (same semantics as broker). \`NULL org_id\` = global baseline rule. A denial returns **403** with \`{error, reason, policy_id}\`.

### 2. Per-org hash-chained local audit

\`mcp_proxy/local/audit.py::append_local_audit\` writes one row to \`local_audit\`, chained per org via asyncio.Lock. Canonical hash form is **byte-for-byte identical** to broker (\`compute_entry_hash\` from #124), so rows exported by the proxy verify on the broker side without schema translation.

\`verify_local_chain(org_id)\` recomputes every row's \`entry_hash\` from canonical inputs and returns \`(False, reason)\` on the first divergent row.

**Wired into egress router events**: \`session_opened\`, \`session_accepted\`, \`session_closed\`, \`message_sent\`, \`message_denied\`, \`message_delivered\`. Denials go on the chain with \`result="denied"\` — audit reflects attempted + refused, not only success.

## Test plan

- [x] \`test_proxy_local_audit_chain.py\` (6/6): genesis, chain continuity, per-org isolation, verify_local_chain clean/tampered, 20-way concurrent append monotonic
- [x] \`test_proxy_local_policy.py\` (10/10): unit (no-policies, max_size, required, blocked, disabled, other-org, NULL-org) + integration (denial via /v1/egress/send 403, end-to-end chain integrity, default-allow)
- [x] Full pytest: 820 passed (+16 new), same 2 preexisting Postgres failures
- [x] \`./demo_network/smoke.sh full\` ✓

## Why

ADR-006 Fase 1, PR #2 of 4. After this the proxy has policy enforcement + forensic-grade audit chain without any broker uplink — missing piece before the "Trojan Horse" smoke becomes a compelling demo.

Stacked work ahead (not in this PR): **#2b** dashboard UI CRUD on \`local_policies\`; **#3** discovery + pubkey proxy-served; **#4** end-to-end standalone smoke in demo_network.

Related: \`imp/adr_006_proxy_troian_horse_dual_mode.md\`, prior commits fb2bd59 (#124 Fase 0), 74a9eb6 (#125 Fase 1 session E2E).