### PR TITLE
feat(proxy): deterministic org_id + dashboard card (ADR-006 Fase 2 / PR #5)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -2229,12 +2229,25 @@ async def overview_page(request: Request):
     if isinstance(session, RedirectResponse):
         return session
 
+    from mcp_proxy.config import get_settings as _get_settings
     from mcp_proxy.db import get_config, list_agents
 
     org_id = await get_config("org_id") or ""
     display_name = await get_config("display_name") or ""
     broker_url = await get_config("broker_url") or ""
     org_status = await get_config("org_status") or ""
+
+    # ADR-006 §2.2 — show the deterministic org_id in standalone mode so
+    # the admin can paste it into a broker attach-ca invite without
+    # digging into the DB. In federated mode the uplink is already
+    # bound, so the card is hidden to avoid UI noise.
+    _settings = _get_settings()
+    standalone_mode = bool(_settings.standalone) and not broker_url
+    if standalone_mode and not org_id:
+        # The derivation runs at lifespan time, but an operator who
+        # boots with MCP_PROXY_ORG_ID set will have a non-derived value.
+        # Fall back to settings.org_id so the card always renders.
+        org_id = _settings.org_id
 
     # Federation subscriber live stats, if running
     fed_stats = getattr(request.app.state, "federation_subscriber_stats", None)
@@ -2275,6 +2288,7 @@ async def overview_page(request: Request):
         federated_orgs=federated_orgs,
         fed_stats=fed_stats,
         fed_running=fed_running,
+        standalone_mode=standalone_mode,
     ))
 
 

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -35,6 +35,25 @@
             <a href="/proxy/setup" class="underline hover:text-amber-300">Start the setup wizard &rarr;</a>
         </div>
         {% endif %}
+
+        {% if org_id and standalone_mode %}
+        <div class="mt-4 p-4 bg-surface-950/60 border border-gray-800/60 rounded">
+            <div class="flex items-center justify-between gap-3 mb-2">
+                <p class="text-[10px] text-gray-500 uppercase tracking-[0.2em]">Org ID (share with broker admin)</p>
+                <button type="button"
+                        onclick="navigator.clipboard.writeText('{{ org_id }}'); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
+                        class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
+                    Copy
+                </button>
+            </div>
+            <code class="block text-sm text-white break-all" style="font-family: 'JetBrains Mono', monospace;">{{ org_id }}</code>
+            <p class="mt-2 text-xs text-gray-500">
+                Deterministic — derived from this proxy's Org CA public key.
+                The broker admin pastes this into an <code>attach-ca</code> invite so
+                the uplink pins your identity across restarts (ADR-006 §2.2).
+            </p>
+        </div>
+        {% endif %}
     </div>
 
     <!-- Stats grid -->

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -7,6 +7,7 @@ Each internal agent gets:
   - A private key stored in Vault (or DB fallback)
   - A local API key (sk_local_{name}_{hex}) for authenticating to the proxy
 """
+import hashlib
 import json
 import logging
 from datetime import datetime, timedelta, timezone
@@ -74,7 +75,12 @@ class AgentManager:
         logger.warning("Org CA not found in proxy_config — agent cert issuance unavailable")
         return False
 
-    async def generate_org_ca(self, *, validity_days: int = 3650) -> None:
+    async def generate_org_ca(
+        self,
+        *,
+        validity_days: int = 3650,
+        derive_org_id: bool = False,
+    ) -> None:
         """Generate a fresh self-signed Org CA and persist it to proxy_config.
 
         Intended for standalone deploys (#115) where there is no broker to
@@ -83,6 +89,14 @@ class AgentManager:
         so a future SPIRE UpstreamAuthority can mint one intermediate
         underneath without re-rooting.
 
+        When ``derive_org_id`` is True, the proxy's ``org_id`` is derived
+        from the CA public key (``sha256(pubkey_DER).hex()[:16]``) and
+        persisted into ``proxy_config.org_id``. This is ADR-006 §2.2:
+        a deterministic identity that survives proxy restarts / redeploys
+        and that the broker's attach-ca flow can pin at invite-creation
+        time. Without it, the proxy would pick a random UUID and any
+        pre-shared ``linked_org_id`` would drift on the next boot.
+
         Safe to call only when no Org CA is already loaded — callers should
         gate on :attr:`ca_loaded` to avoid overwriting an attached CA.
         """
@@ -90,6 +104,16 @@ class AgentManager:
             raise RuntimeError("Org CA already loaded — refusing to overwrite")
 
         ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+        if derive_org_id:
+            pubkey_der = ca_key.public_key().public_bytes(
+                serialization.Encoding.DER,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            )
+            derived = hashlib.sha256(pubkey_der).hexdigest()[:16]
+            self._org_id = derived
+            await set_config("org_id", derived)
+            logger.info("Derived deterministic org_id=%s from Org CA public key", derived)
 
         subject = x509.Name([
             x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} CA"),
@@ -151,6 +175,28 @@ class AgentManager:
     @property
     def ca_loaded(self) -> bool:
         return self._org_ca_key is not None and self._org_ca_cert is not None
+
+    @property
+    def org_id(self) -> str:
+        return self._org_id
+
+    def derive_org_id_from_ca(self) -> str | None:
+        """SHA-256(pubkey DER)[:16] of the currently loaded Org CA.
+
+        Returns ``None`` if no CA is loaded. This is the value the admin
+        copies from the proxy dashboard into a broker attach-ca invite
+        (ADR-006 §2.2) — it doesn't read from ``proxy_config.org_id``,
+        it recomputes from the cert, so tampering with the config row
+        wouldn't let an attacker convince the broker the proxy is
+        a different org.
+        """
+        if self._org_ca_cert is None:
+            return None
+        pubkey_der = self._org_ca_cert.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        return hashlib.sha256(pubkey_der).hexdigest()[:16]
 
     # ── Certificate generation ──────────────────────────────────────
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -117,10 +117,19 @@ async def lifespan(app: FastAPI):
     # no CA has been attached (no attach-ca invite ever consumed) and no
     # broker is configured. Gated on standalone=true so federation deploys
     # keep the attach-ca flow unchanged.
+    #
+    # ADR-006 §2.2 — when the operator hasn't pinned an ``org_id`` via env
+    # or config, derive one deterministically from the CA public key. The
+    # admin then copies this value into the broker's attach-ca invite so
+    # future uplinks pin the same identity across proxy restarts.
     if settings.standalone and not agent_mgr.ca_loaded:
-        await agent_mgr.generate_org_ca()
+        derive = not org_id  # derive only when the operator didn't pick one
+        await agent_mgr.generate_org_ca(derive_org_id=derive)
+        if derive:
+            org_id = agent_mgr.org_id
 
     app.state.agent_manager = agent_mgr
+    app.state.org_id = org_id
 
     if broker_url:
         from mcp_proxy.egress.broker_bridge import BrokerBridge

--- a/tests/test_proxy_deterministic_org_id.py
+++ b/tests/test_proxy_deterministic_org_id.py
@@ -1,0 +1,102 @@
+"""ADR-006 §2.2 — deterministic org_id derived from Org CA public key.
+
+The proxy boots standalone, generates its self-signed CA, and the org_id
+comes out as sha256(pubkey_DER).hex()[:16]. Two consecutive boots with
+the same persisted CA must produce the same org_id. The overview
+dashboard exposes it so the admin can paste it into a broker attach-ca
+invite (the identity pin in ADR-006 §2.2).
+"""
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.x509 import load_pem_x509_certificate
+
+from mcp_proxy.db import dispose_db, get_config, init_db
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+async def _boot_fresh_db(tmp_path):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    return url
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path):
+    await _boot_fresh_db(tmp_path)
+    yield
+    await dispose_db()
+
+
+def _hash_pubkey(cert_pem: str) -> str:
+    cert = load_pem_x509_certificate(cert_pem.encode())
+    pubkey_der = cert.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(pubkey_der).hexdigest()[:16]
+
+
+@pytest.mark.asyncio
+async def test_derive_flag_sets_org_id_from_pubkey_hash(fresh_db):
+    mgr = AgentManager(org_id="", trust_domain="cullis.local")
+    await mgr.generate_org_ca(derive_org_id=True)
+
+    assert len(mgr.org_id) == 16
+    persisted = await get_config("org_id")
+    assert persisted == mgr.org_id
+
+    # The persisted value must match the hash recomputed from the stored CA.
+    ca_cert_pem = await get_config("org_ca_cert")
+    assert _hash_pubkey(ca_cert_pem) == mgr.org_id
+
+
+@pytest.mark.asyncio
+async def test_derive_off_preserves_operator_provided_org_id(fresh_db):
+    mgr = AgentManager(org_id="acme-prod", trust_domain="cullis.local")
+    await mgr.generate_org_ca(derive_org_id=False)
+
+    # Operator value wins — derive_org_id=False.
+    assert mgr.org_id == "acme-prod"
+    assert await get_config("org_id") is None  # not persisted through this path
+
+
+@pytest.mark.asyncio
+async def test_derive_org_id_from_ca_helper_matches_persisted(fresh_db):
+    mgr = AgentManager(org_id="", trust_domain="cullis.local")
+    await mgr.generate_org_ca(derive_org_id=True)
+
+    # Helper recomputes from the loaded cert — must match what we persisted.
+    assert mgr.derive_org_id_from_ca() == mgr.org_id
+
+
+@pytest.mark.asyncio
+async def test_derive_helper_returns_none_without_ca(fresh_db):
+    mgr = AgentManager(org_id="acme", trust_domain="cullis.local")
+    assert mgr.derive_org_id_from_ca() is None
+
+
+@pytest.mark.asyncio
+async def test_org_id_stable_across_reload(tmp_path):
+    """Restart simulation: generate CA, derive org_id, then reload a
+    fresh AgentManager from the same DB — org_id must stay the same."""
+    await _boot_fresh_db(tmp_path)
+
+    mgr1 = AgentManager(org_id="", trust_domain="cullis.local")
+    await mgr1.generate_org_ca(derive_org_id=True)
+    first = mgr1.org_id
+
+    # Simulate restart: new AgentManager reading CA from DB.
+    mgr2 = AgentManager(org_id="", trust_domain="cullis.local")
+    await mgr2.load_org_ca_from_config()
+    assert mgr2.derive_org_id_from_ca() == first
+
+    persisted = await get_config("org_id")
+    assert persisted == first
+
+    await dispose_db()


### PR DESCRIPTION
## Summary

Two changes that close the "identity pin" loop between standalone proxy and broker **before uplink** (ADR-006 §2.2):

### 1. Deterministic \`org_id\` derivation

\`AgentManager.generate_org_ca\` gains a \`derive_org_id\` flag. When set in the standalone first-boot path (and the operator didn't pin \`MCP_PROXY_ORG_ID\`), the Org CA is generated and \`org_id = sha256(CA_pubkey_DER).hex()[:16]\` is persisted to \`proxy_config.org_id\`.

- Survives restart / redeploy (same CA → same org_id)
- New helper \`derive_org_id_from_ca()\` recomputes from the loaded cert — anti-tampering for config row
- Operator override still wins: \`MCP_PROXY_ORG_ID=acme-prod\` skips derivation

### 2. Dashboard exposes the Org ID

\`/proxy/overview\` gains a Copy-to-clipboard card in standalone mode. Admin pastes this into a broker **attach-ca** invite. Broker pins \`linked_org_id\` on the invite; \`POST /onboarding/attach\` enforces the match (already wired at \`invite_store.py:117\`).

Card hidden in federated mode (binding already done, no UI noise).

## Test plan

- [x] \`test_proxy_deterministic_org_id.py\` 5/5: derivation sets org_id from hash; operator override wins; helper recomputes from cert; returns None before CA; org_id stable across AgentManager reload
- [x] Full pytest: 835 passed (+5 new), 2 preexisting Postgres failures
- [x] \`./demo_network/smoke.sh full\` ✓
- [x] \`./demo_network/standalone_smoke.sh full\` ✓

## What's **not** in this PR

Broker attach-ca UI was already complete (\`app/dashboard/templates/orgs.html:217\`): admin selects org, generates invite, \`linked_org_id\` auto-populated from URL. No broker changes needed.

## Next

**PR #6** — \`/v1/admin/link-broker\` endpoint + hot-swap of \`BrokerBridge\` so uplink becomes runtime, not restart-required.

Related: \`imp/adr_006_proxy_troian_horse_dual_mode.md\`