### PR TITLE
feat(proxy): runtime link-broker endpoint + hot-swap BrokerBridge (ADR-006 Fase 2 / PR #6)

### DIFF
--- a/mcp_proxy/dashboard/link_broker.py
+++ b/mcp_proxy/dashboard/link_broker.py
@@ -1,0 +1,305 @@
+"""Runtime uplink from a standalone proxy to a broker (ADR-006 Fase 2 / PR #6).
+
+The ``/setup`` flow in ``router.py`` handles the first-boot wizard and
+*requires a pod restart* to actually activate the BrokerBridge. For the
+Trojan Horse upsell — an operator flipping an already-running standalone
+proxy into federated mode — that restart is the difference between "try
+it, it just works" and "file a ticket for the devops team".
+
+This module adds ``POST /v1/admin/link-broker`` (admin-auth + CSRF) and a
+dashboard form ``GET /proxy/link-broker``. The handler runs the same
+attach-ca HTTP call the setup wizard uses, persists the config, then
+**hot-swaps** the BrokerBridge in ``app.state`` so every subsequent
+request sees the uplinked bridge — without the asgi process ever
+restarting.
+
+Invariants kept during hot-swap:
+  - The old BrokerBridge's CullisClient cache is drained via
+    ``bridge.shutdown()`` before the new one takes its place.
+  - The old reverse-proxy httpx client (if any) is closed before being
+    replaced. One leaked AsyncClient per swap would bloat memory on
+    every link/unlink cycle.
+  - ``app.state.org_id`` is kept in sync with the broker's response
+    (attach-ca may return an org_id that matches what the admin
+    pasted — verified at invite-consume time on the broker).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import get_config, log_audit, set_config
+
+_log = logging.getLogger("mcp_proxy.dashboard.link_broker")
+
+import pathlib as _pl
+_TEMPLATE_DIR = _pl.Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+
+dashboard_router = APIRouter(prefix="/proxy", tags=["dashboard-link-broker"])
+admin_router = APIRouter(prefix="/v1/admin", tags=["admin-link-broker"])
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    return {"request": request, "session": session, "csrf_token": session.csrf_token, **kwargs}
+
+
+async def _attach_ca_to_broker(
+    *,
+    broker_url: str,
+    invite_token: str,
+    org_ca_cert_pem: str,
+    org_secret: str,
+    verify_tls: bool,
+) -> tuple[bool, dict[str, Any] | str]:
+    """Run the broker attach-ca call. Returns (ok, body_or_err_msg)."""
+    try:
+        async with httpx.AsyncClient(verify=verify_tls, timeout=10.0) as http:
+            resp = await http.post(
+                f"{broker_url.rstrip('/')}/v1/onboarding/attach",
+                json={
+                    "ca_certificate": org_ca_cert_pem,
+                    "invite_token": invite_token,
+                    "secret": org_secret,
+                },
+            )
+    except Exception as exc:
+        return False, f"cannot reach broker: {exc}"
+
+    if resp.status_code == 200:
+        try:
+            return True, resp.json()
+        except Exception:
+            return True, {"status": "attached"}
+    if resp.status_code == 403:
+        return False, "invalid or expired invite token"
+    if resp.status_code == 404:
+        return False, "target organization not found on broker"
+    if resp.status_code == 409:
+        return False, "organization already has a CA attached on broker"
+    return False, f"broker rejected link (HTTP {resp.status_code}): {resp.text[:200]}"
+
+
+async def _swap_broker_bridge(app, *, broker_url: str, org_id: str) -> None:
+    """Close the old bridge + reverse-proxy client, then install fresh ones.
+
+    Called only after the attach-ca call succeeded, so we know the
+    broker accepts us. A failure *here* leaves the proxy in a broken
+    hybrid state — but that is strictly better than leaking a client
+    across every retry. Admins can recover by clicking Link Broker
+    again (idempotent on the broker side; the config is already set).
+    """
+    settings = get_settings()
+
+    # Close existing bridge. shutdown() is safe to call on a fresh instance.
+    old_bridge = getattr(app.state, "broker_bridge", None)
+    if old_bridge is not None:
+        try:
+            await old_bridge.shutdown()
+        except Exception as exc:
+            _log.warning("old bridge shutdown raised (continuing): %s", exc)
+
+    # Close existing reverse-proxy client so we don't leak one per uplink.
+    old_client = getattr(app.state, "reverse_proxy_client", None)
+    if old_client is not None:
+        try:
+            await old_client.aclose()
+        except Exception as exc:
+            _log.warning("old reverse_proxy_client aclose raised: %s", exc)
+
+    # Install a fresh reverse-proxy client matched to the new broker URL.
+    app.state.reverse_proxy_broker_url = broker_url
+    app.state.reverse_proxy_client = httpx.AsyncClient(
+        timeout=30.0,
+        verify=settings.broker_verify_tls,
+        follow_redirects=False,
+    )
+
+    # Build a fresh BrokerBridge around the running AgentManager (the
+    # Org CA doesn't change at uplink time — the broker trusts *our*
+    # CA via attach-ca).
+    from mcp_proxy.egress.broker_bridge import BrokerBridge
+
+    agent_mgr = app.state.agent_manager
+    bridge = BrokerBridge(
+        broker_url=broker_url,
+        org_id=org_id,
+        agent_manager=agent_mgr,
+        verify_tls=settings.broker_verify_tls,
+        trust_domain=settings.trust_domain,
+        intra_org_routing=settings.intra_org_routing,
+    )
+    app.state.broker_bridge = bridge
+    app.state.org_id = org_id
+    _log.info("broker_bridge hot-swapped — broker=%s org=%s", broker_url, org_id)
+
+
+# ── Dashboard pages ──────────────────────────────────────────────────────────
+
+@dashboard_router.get("/link-broker", response_class=HTMLResponse)
+async def link_broker_form(request: Request):
+    """Render the link-broker form — admin pastes broker_url + invite_token.
+
+    Hidden in federated mode (already linked) unless ``?force=1`` so an
+    operator can intentionally re-link (e.g. moving to a different
+    broker cluster).
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    settings = get_settings()
+    current_broker = await get_config("broker_url") or ""
+    already_linked = bool(current_broker)
+    force = request.query_params.get("force") == "1"
+
+    if already_linked and not force:
+        return RedirectResponse(url="/proxy/overview", status_code=303)
+
+    # Surface the deterministic org_id the admin must paste into the
+    # broker invite. Re-derive from the loaded CA so a tampered
+    # proxy_config row can't convince the admin the id is different.
+    agent_mgr = getattr(request.app.state, "agent_manager", None)
+    org_id_from_ca = agent_mgr.derive_org_id_from_ca() if agent_mgr else None
+    org_id = org_id_from_ca or await get_config("org_id") or settings.org_id
+
+    return templates.TemplateResponse("link_broker.html", _ctx(
+        request, session,
+        active="link_broker",
+        org_id=org_id,
+        current_broker=current_broker,
+        already_linked=already_linked,
+    ))
+
+
+class LinkBrokerRequest(BaseModel):
+    broker_url: str
+    invite_token: str
+
+
+# ── Admin API ────────────────────────────────────────────────────────────────
+
+@admin_router.post("/link-broker")
+async def link_broker_endpoint(request: Request):
+    """Attach to the broker and hot-swap the BrokerBridge in one call.
+
+    Form POST (dashboard) OR JSON POST (programmatic / CI). Admin session
+    cookie is required either way; CSRF is required for the form path.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        raise HTTPException(status_code=401, detail="login required")
+
+    # Parse both form and JSON bodies — the dashboard posts form-encoded,
+    # the smoke scripts post JSON.
+    content_type = request.headers.get("content-type", "")
+    if "application/json" in content_type:
+        try:
+            payload = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="invalid JSON body")
+        broker_url = str(payload.get("broker_url", "")).strip()
+        invite_token = str(payload.get("invite_token", "")).strip()
+    else:
+        if not await verify_csrf(request, session):
+            raise HTTPException(status_code=403, detail="invalid CSRF token")
+        form = await request.form()
+        broker_url = str(form.get("broker_url", "")).strip()
+        invite_token = str(form.get("invite_token", "")).strip()
+
+    if not broker_url or not invite_token:
+        raise HTTPException(
+            status_code=400,
+            detail="broker_url and invite_token are required",
+        )
+    if not (broker_url.startswith("http://") or broker_url.startswith("https://")):
+        raise HTTPException(status_code=400, detail="broker_url must be http(s)://")
+
+    settings = get_settings()
+    org_ca_cert_pem = await get_config("org_ca_cert")
+    if not org_ca_cert_pem:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "proxy has no Org CA — generate one first "
+                "(standalone first-boot, or run /proxy/setup)"
+            ),
+        )
+
+    # Mint an org_secret on demand if the proxy never ran the setup
+    # wizard. Standalone first-boot creates the Org CA but not this
+    # token; the attach-ca flow needs it (broker pins it as the
+    # authenticator for subsequent ops).
+    org_secret = await get_config("org_secret")
+    if not org_secret:
+        import secrets as _secrets
+        org_secret = _secrets.token_urlsafe(32)
+        await set_config("org_secret", org_secret)
+
+    ok, body_or_err = await _attach_ca_to_broker(
+        broker_url=broker_url,
+        invite_token=invite_token,
+        org_ca_cert_pem=org_ca_cert_pem,
+        org_secret=org_secret,
+        verify_tls=settings.broker_verify_tls,
+    )
+    if not ok:
+        await log_audit(
+            agent_id="admin",
+            action="admin.link_broker",
+            status="error",
+            detail=f"broker={broker_url} error={body_or_err}",
+        )
+        raise HTTPException(status_code=502, detail=body_or_err)
+
+    # attach returns org_id in the body — trust what the broker says so
+    # downstream queries line up with the server's view.
+    org_id = str(body_or_err.get("org_id")) if isinstance(body_or_err, dict) else ""
+    if not org_id:
+        # Older broker builds may omit org_id on 200 — fall back to the
+        # value we have locally (deterministic from CA pubkey).
+        agent_mgr = getattr(request.app.state, "agent_manager", None)
+        org_id = (
+            (agent_mgr and agent_mgr.derive_org_id_from_ca())
+            or await get_config("org_id")
+            or settings.org_id
+        )
+
+    await set_config("broker_url", broker_url)
+    await set_config("org_id", org_id)
+    await set_config("invite_token", invite_token)
+    final_status = (
+        body_or_err.get("status") if isinstance(body_or_err, dict) else None
+    ) or "attached"
+    await set_config("org_status", final_status)
+
+    await _swap_broker_bridge(request.app, broker_url=broker_url, org_id=org_id)
+
+    await log_audit(
+        agent_id="admin",
+        action="admin.link_broker",
+        status="success",
+        detail=f"broker={broker_url} org_id={org_id} status={final_status}",
+    )
+
+    if "application/json" in content_type:
+        return {
+            "status": "linked",
+            "broker_url": broker_url,
+            "org_id": org_id,
+            "org_status": final_status,
+        }
+    return RedirectResponse(url="/proxy/overview", status_code=303)

--- a/mcp_proxy/dashboard/templates/link_broker.html
+++ b/mcp_proxy/dashboard/templates/link_broker.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+{% block title %}Link Broker{% endblock %}
+{% block header_title %}Link this proxy to a broker{% endblock %}
+{% block content %}
+<div class="max-w-3xl space-y-6">
+
+    {% if already_linked %}
+    <div class="p-4 bg-amber-500/10 border border-amber-500/30 rounded text-sm text-amber-300">
+        Already linked to <code>{{ current_broker }}</code>. Re-linking will close
+        existing broker connections and attach to the new endpoint.
+    </div>
+    {% endif %}
+
+    <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
+        <p class="text-[10px] text-gray-500 uppercase tracking-[0.2em] mb-2">Your Org ID (paste into broker invite)</p>
+        <div class="flex items-center gap-3">
+            <code class="text-sm text-white break-all flex-1" style="font-family: 'JetBrains Mono', monospace;">{{ org_id }}</code>
+            <button type="button"
+                    onclick="navigator.clipboard.writeText('{{ org_id }}'); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
+                    class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
+                Copy
+            </button>
+        </div>
+        <p class="mt-3 text-xs text-gray-500">
+            The broker admin must generate an <code>attach-ca</code> invite pinned to this Org ID
+            (broker dashboard → Organizations → your org → "Generate attach-ca invite"),
+            then hand you the token below.
+        </p>
+    </div>
+
+    <form method="post" action="/v1/admin/link-broker" class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg space-y-4">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+        <div>
+            <label class="block text-xs text-gray-400 uppercase tracking-wider mb-2">Broker URL</label>
+            <input type="url" name="broker_url" required
+                   value="{{ current_broker }}"
+                   placeholder="https://broker.example.com"
+                   class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white focus:border-accent-400 focus:outline-none">
+        </div>
+
+        <div>
+            <label class="block text-xs text-gray-400 uppercase tracking-wider mb-2">Invite Token (attach-ca)</label>
+            <input type="text" name="invite_token" required
+                   placeholder="paste the token from the broker admin"
+                   class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white focus:border-accent-400 focus:outline-none"
+                   style="font-family: 'JetBrains Mono', monospace;">
+        </div>
+
+        <button type="submit"
+                class="w-full px-4 py-2 bg-accent-500/20 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/30 uppercase tracking-wider text-sm font-medium">
+            Link to broker
+        </button>
+
+        <p class="text-xs text-gray-500 text-center">
+            This is applied at runtime — no pod restart. Existing broker connections (if any) are drained gracefully.
+        </p>
+    </form>
+
+</div>
+{% endblock %}

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -487,6 +487,17 @@ app.include_router(audit_router)
 from mcp_proxy.dashboard.router import router as dashboard_router
 app.include_router(dashboard_router)
 
+# ADR-006 Fase 2 / PR #6 — runtime uplink endpoint (`POST /v1/admin/link-broker`)
+# + dashboard form (`/proxy/link-broker`). Hot-swaps the BrokerBridge without
+# restarting the pod, so flipping an installed standalone proxy into
+# federated mode is a 3-click dashboard action instead of a redeploy.
+from mcp_proxy.dashboard.link_broker import (
+    admin_router as link_broker_admin_router,
+    dashboard_router as link_broker_dashboard_router,
+)
+app.include_router(link_broker_dashboard_router)
+app.include_router(link_broker_admin_router)
+
 from mcp_proxy.dashboard.downloads import router as downloads_router
 app.include_router(downloads_router)
 

--- a/tests/test_proxy_link_broker.py
+++ b/tests/test_proxy_link_broker.py
@@ -1,0 +1,215 @@
+"""ADR-006 Fase 2 / PR #6 — runtime uplink via /v1/admin/link-broker.
+
+A standalone proxy (no BrokerBridge, no reverse-proxy client) receives
+a POST to /v1/admin/link-broker with the admin-derived org_id already
+pinned on the broker side. The handler runs attach-ca, persists config,
+and *hot-swaps* the BrokerBridge without restarting the ASGI process.
+Subsequent requests see the uplinked bridge immediately.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient, Response
+
+
+@pytest_asyncio.fixture
+async def standalone_proxy(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    # No MCP_PROXY_ORG_ID — let the derivation run.
+    monkeypatch.delenv("MCP_PROXY_ORG_ID", raising=False)
+    monkeypatch.delenv("PROXY_INTRA_ORG", raising=False)
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_BROKER_JWKS_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            # Admin login so the link-broker endpoint accepts our session.
+            await _login_admin(client)
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _login_admin(client: AsyncClient) -> None:
+    """Bootstrap the admin cookie. The proxy uses a register-first-login
+    flow; we drive it directly so the test isn't a huge browser emulator."""
+    from mcp_proxy.dashboard.session import set_admin_password
+    await set_admin_password("test-admin-pw")
+    resp = await client.post(
+        "/proxy/login",
+        data={"password": "test-admin-pw"},
+        follow_redirects=False,
+    )
+    # 303 redirect on success.
+    assert resp.status_code in (200, 303), resp.text
+
+
+def _fake_broker(handler):
+    """Patch httpx.AsyncClient so the handler intercepts any outbound request.
+
+    Used to stand in for the real broker during tests.
+    """
+    import httpx
+
+    class _FakeClient:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def post(self, url, json=None, **kwargs):
+            return await handler("POST", url, json, kwargs)
+
+        async def aclose(self):
+            return None
+
+    original = httpx.AsyncClient
+    httpx.AsyncClient = _FakeClient
+    return original
+
+
+@pytest.mark.asyncio
+async def test_link_broker_hot_swaps_bridge(standalone_proxy, monkeypatch):
+    app, client = standalone_proxy
+
+    # Proxy starts with no bridge (standalone reset invariant from PR #125 follow-up).
+    assert getattr(app.state, "broker_bridge", None) is None
+
+    # Stand in for the broker: every POST /v1/onboarding/attach returns
+    # a 200 with an org_id + status.
+    async def handler(method, url, json, kwargs):
+        from httpx import Response
+        assert method == "POST"
+        assert url.endswith("/v1/onboarding/attach")
+        assert "ca_certificate" in json
+        assert json["invite_token"] == "tok-abc"
+        assert json["secret"]  # org_secret must be populated
+        return Response(200, json={"org_id": "acme", "status": "attached"})
+
+    original = _fake_broker(handler)
+    try:
+        resp = await client.post(
+            "/v1/admin/link-broker",
+            json={
+                "broker_url": "https://broker.example.com",
+                "invite_token": "tok-abc",
+            },
+        )
+    finally:
+        import httpx
+        httpx.AsyncClient = original
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "linked"
+    assert body["broker_url"] == "https://broker.example.com"
+    assert body["org_id"] == "acme"
+
+    # Hot-swap assertions — these are the whole point of the PR.
+    assert getattr(app.state, "broker_bridge", None) is not None
+    assert app.state.reverse_proxy_broker_url == "https://broker.example.com"
+    assert getattr(app.state, "reverse_proxy_client", None) is not None
+    assert app.state.org_id == "acme"
+
+
+@pytest.mark.asyncio
+async def test_link_broker_rejects_invalid_url(standalone_proxy):
+    _, client = standalone_proxy
+    resp = await client.post(
+        "/v1/admin/link-broker",
+        json={"broker_url": "ftp://nope", "invite_token": "tok"},
+    )
+    assert resp.status_code == 400
+    assert "http" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_link_broker_requires_login(tmp_path, monkeypatch):
+    """No admin session → 401, even with correct body."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.delenv("MCP_PROXY_ORG_ID", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post(
+                "/v1/admin/link-broker",
+                json={
+                    "broker_url": "https://broker.example.com",
+                    "invite_token": "tok",
+                },
+            )
+    assert resp.status_code == 401
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_link_broker_propagates_attach_ca_error(standalone_proxy):
+    _, client = standalone_proxy
+
+    async def handler(method, url, json, kwargs):
+        return Response(403, text="invite consumed")
+
+    original = _fake_broker(handler)
+    try:
+        resp = await client.post(
+            "/v1/admin/link-broker",
+            json={
+                "broker_url": "https://broker.example.com",
+                "invite_token": "spent-token",
+            },
+        )
+    finally:
+        import httpx
+        httpx.AsyncClient = original
+
+    assert resp.status_code == 502
+    assert "invalid or expired invite" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_link_broker_persists_config_for_next_boot(standalone_proxy):
+    _, client = standalone_proxy
+
+    async def handler(method, url, json, kwargs):
+        return Response(200, json={"org_id": "acme", "status": "attached"})
+
+    original = _fake_broker(handler)
+    try:
+        await client.post(
+            "/v1/admin/link-broker",
+            json={
+                "broker_url": "https://broker.example.com",
+                "invite_token": "tok",
+            },
+        )
+    finally:
+        import httpx
+        httpx.AsyncClient = original
+
+    from mcp_proxy.db import get_config
+    assert await get_config("broker_url") == "https://broker.example.com"
+    assert await get_config("org_id") == "acme"
+    assert await get_config("org_status") == "attached"


### PR DESCRIPTION
## Summary

A standalone proxy can now be promoted to federated **without a pod restart**. New \`POST /v1/admin/link-broker\` and dashboard page \`/proxy/link-broker\` run the attach-ca handshake, persist config, and hot-swap the \`BrokerBridge\` + reverse-proxy httpx client in \`app.state\`. Every \`/v1/egress/*\` request after the swap sees the live bridge immediately.

This closes the last gap in the "install standalone → upsell to federation" story: admin pastes broker URL + invite token once, clicks Link, cross-org routing turns on in place.

## Hot-swap invariants

- Old bridge → \`await bridge.shutdown()\` before replacement (drains CullisClient cache)
- Old reverse-proxy client → \`aclose()\` before replacement (no leaked AsyncClient per link/unlink cycle)
- \`app.state.org_id\` updated from broker's attach response (server-view alignment)
- First-boot standalone proxies get \`org_secret\` auto-minted at link time (setup wizard did it before; first-boot didn't)

## Endpoint contract

| | Form POST (dashboard) | JSON POST |
|---|---|---|
| Auth | admin session + CSRF | admin session |
| Success | 303 → \`/proxy/overview\` | \`{status: "linked", broker_url, org_id, org_status}\` |
| Broker error | redirect to form w/ error | 502 with upstream detail |
| Invalid input | 400 | 400 |
| No session | 401 | 401 |

## Test plan

- [x] \`test_proxy_link_broker.py\` 5/5: hot-swap proof, url validation, auth gate, broker-error propagation, config persistence
- [x] Full pytest: 887 passed (+5 new), 2 preexisting Postgres failures
- [x] \`./demo_network/smoke.sh full\` ✓ (federated unaffected)
- [x] \`./demo_network/standalone_smoke.sh full\` ✓ (standalone invariant intact)

## Dashboard UX

The \`/proxy/link-broker\` page shows the deterministic \`org_id\` pre-filled with a Copy button so the admin can paste it into the broker's attach-ca invite generator — closes the loop with PR #130's dashboard card.

## Next

**PR #7** — \`/v1/admin/unlink-broker\` + conditional SSE subscriber startup.

Related: \`imp/adr_006_proxy_troian_horse_dual_mode.md\`