### PR TITLE
feat(proxy): /v1/admin/unlink-broker + SSE teardown (ADR-006 Fase 2 / PR #7)

### DIFF
--- a/mcp_proxy/dashboard/link_broker.py
+++ b/mcp_proxy/dashboard/link_broker.py
@@ -25,6 +25,7 @@ Invariants kept during hot-swap:
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -302,4 +303,141 @@ async def link_broker_endpoint(request: Request):
             "org_id": org_id,
             "org_status": final_status,
         }
+    return RedirectResponse(url="/proxy/overview", status_code=303)
+
+
+# ── Unlink (federated → standalone at runtime) ───────────────────────────────
+
+
+async def _count_active_cross_org_sessions(app) -> int:
+    """How many sessions are still open at the broker bridge right now?
+
+    Intra-org sessions (local_sessions table) survive an unlink just fine
+    because they never touched the broker. But cross-org sessions own
+    state the broker tracks — walking them off in the middle of a
+    conversation silently drops messages. We treat those as a reason to
+    refuse the unlink unless the operator passes ?force=1.
+    """
+    bridge = getattr(app.state, "broker_bridge", None)
+    if bridge is None:
+        return 0
+    # CullisClient cache = one entry per agent with a live session. This
+    # is a proxy for "something is in flight". The count is coarse — we
+    # prefer false positives (refuse when there are clients cached even
+    # if they're idle) to false negatives.
+    return len(getattr(bridge, "_clients", {}) or {})
+
+
+async def _teardown_broker_bridge(app) -> None:
+    """Reverse everything ``_swap_broker_bridge`` installed.
+
+    The proxy goes back to standalone-shape: no bridge, no reverse-proxy
+    client, federation cache cleared. Local_* tables (intra-org state)
+    are untouched — that's the whole point of having two scopes.
+    """
+    bridge = getattr(app.state, "broker_bridge", None)
+    if bridge is not None:
+        try:
+            await bridge.shutdown()
+        except Exception as exc:
+            _log.warning("bridge shutdown on unlink raised: %s", exc)
+        app.state.broker_bridge = None
+
+    client = getattr(app.state, "reverse_proxy_client", None)
+    if client is not None:
+        try:
+            await client.aclose()
+        except Exception as exc:
+            _log.warning("reverse_proxy_client aclose on unlink raised: %s", exc)
+        app.state.reverse_proxy_client = None
+
+    app.state.reverse_proxy_broker_url = None
+
+    # Stop the federation SSE subscriber if it's running (ADR-001 Phase 4c).
+    sub_stop = getattr(app.state, "federation_subscriber_stop", None)
+    sub_task = getattr(app.state, "federation_subscriber_task", None)
+    if sub_stop is not None:
+        try:
+            sub_stop.set()
+        except Exception:
+            pass
+    if sub_task is not None:
+        try:
+            await asyncio.wait_for(sub_task, timeout=5.0)
+        except (asyncio.TimeoutError, Exception):
+            sub_task.cancel()
+    app.state.federation_subscriber_stop = None
+    app.state.federation_subscriber_task = None
+
+    # Clear the federation cache — the rows would otherwise look live
+    # to /v1/agents/search until the next subscriber rebuild (which
+    # won't happen until the proxy is re-linked to a broker).
+    from sqlalchemy import text as _text
+
+    from mcp_proxy.db import get_db as _get_db
+    async with _get_db() as conn:
+        for table in (
+            "cached_federated_agents",
+            "cached_policies",
+            "cached_bindings",
+            "federation_cursor",
+        ):
+            try:
+                await conn.execute(_text(f"DELETE FROM {table}"))
+            except Exception as exc:
+                _log.warning("failed to clear %s during unlink: %s", table, exc)
+
+
+@admin_router.post("/unlink-broker")
+async def unlink_broker_endpoint(request: Request):
+    """Revert the proxy to standalone shape.
+
+    Refuses when cross-org sessions look active — the ``_clients``
+    cache on the bridge is our proxy for "someone is mid-conversation
+    with a peer org". Pass ``?force=1`` to override.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        raise HTTPException(status_code=401, detail="login required")
+
+    content_type = request.headers.get("content-type", "")
+    force = request.query_params.get("force") in ("1", "true", "yes")
+    if "application/json" not in content_type:
+        # Form POST needs CSRF; JSON-mode (programmatic / smoke scripts)
+        # relies on the session cookie alone.
+        if not await verify_csrf(request, session):
+            raise HTTPException(status_code=403, detail="invalid CSRF token")
+
+    broker_url = await get_config("broker_url") or ""
+    if not broker_url:
+        raise HTTPException(status_code=400, detail="proxy is not linked to a broker")
+
+    if not force:
+        active = await _count_active_cross_org_sessions(request.app)
+        if active > 0:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "cross_org_sessions_active",
+                    "active_clients": active,
+                    "hint": "retry with ?force=1 to drop them",
+                },
+            )
+
+    await _teardown_broker_bridge(request.app)
+
+    # Persist the standalone-again state so the next lifespan boot
+    # doesn't try to reinitialize the bridge.
+    await set_config("broker_url", "")
+    await set_config("org_status", "standalone")
+
+    await log_audit(
+        agent_id="admin",
+        action="admin.unlink_broker",
+        status="success",
+        detail=f"was={broker_url} forced={force}",
+    )
+
+    if "application/json" in content_type:
+        return {"status": "unlinked", "was": broker_url, "forced": force}
     return RedirectResponse(url="/proxy/overview", status_code=303)

--- a/tests/test_proxy_link_broker.py
+++ b/tests/test_proxy_link_broker.py
@@ -213,3 +213,136 @@ async def test_link_broker_persists_config_for_next_boot(standalone_proxy):
     assert await get_config("broker_url") == "https://broker.example.com"
     assert await get_config("org_id") == "acme"
     assert await get_config("org_status") == "attached"
+
+
+# ── Unlink ───────────────────────────────────────────────────────────────────
+
+async def _link_for_test(client, app) -> None:
+    """Helper: link against a fake broker so we have something to unlink."""
+    async def handler(method, url, json, kwargs):
+        return Response(200, json={"org_id": "acme", "status": "attached"})
+
+    import httpx
+    original = httpx.AsyncClient
+    _fake_broker(handler)
+    try:
+        await client.post(
+            "/v1/admin/link-broker",
+            json={
+                "broker_url": "https://broker.example.com",
+                "invite_token": "tok",
+            },
+        )
+    finally:
+        httpx.AsyncClient = original
+
+
+@pytest.mark.asyncio
+async def test_unlink_restores_standalone_shape(standalone_proxy):
+    app, client = standalone_proxy
+    await _link_for_test(client, app)
+
+    assert getattr(app.state, "broker_bridge", None) is not None
+    assert getattr(app.state, "reverse_proxy_client", None) is not None
+
+    resp = await client.post("/v1/admin/unlink-broker", json={})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "unlinked"
+    assert body["was"] == "https://broker.example.com"
+
+    # Hot-teardown invariants — mirror image of the hot-swap assertions.
+    assert getattr(app.state, "broker_bridge", None) is None
+    assert getattr(app.state, "reverse_proxy_client", None) is None
+    assert getattr(app.state, "reverse_proxy_broker_url", None) is None
+
+    from mcp_proxy.db import get_config
+    assert (await get_config("broker_url")) == ""
+    assert (await get_config("org_status")) == "standalone"
+
+
+@pytest.mark.asyncio
+async def test_unlink_refuses_when_not_linked(standalone_proxy):
+    _, client = standalone_proxy
+    resp = await client.post("/v1/admin/unlink-broker", json={})
+    assert resp.status_code == 400
+    assert "not linked" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_unlink_requires_login(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.delenv("MCP_PROXY_ORG_ID", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/v1/admin/unlink-broker", json={})
+    assert resp.status_code == 401
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_unlink_clears_federation_cache(standalone_proxy):
+    """After unlink, /v1/agents/search must stop returning stale cached
+    federated rows — otherwise the admin thinks the peers are still
+    reachable while the bridge is gone."""
+    app, client = standalone_proxy
+    await _link_for_test(client, app)
+
+    # Seed a fake federated row so we can observe the cleanup.
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO cached_federated_agents (
+                    agent_id, org_id, display_name, capabilities,
+                    thumbprint, revoked, updated_at
+                ) VALUES (
+                    'fed-bot', 'other-org', 'Fed Bot', '[]',
+                    NULL, 0, '2026-04-16T00:00:00Z'
+                )
+                """
+            ),
+        )
+
+    resp = await client.post("/v1/admin/unlink-broker", json={})
+    assert resp.status_code == 200
+
+    async with get_db() as conn:
+        count = (await conn.execute(
+            text("SELECT COUNT(*) FROM cached_federated_agents")
+        )).scalar()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_unlink_refuses_on_active_clients_without_force(standalone_proxy):
+    """The bridge's _clients dict is our proxy for "something is in flight
+    cross-org". A non-empty cache → refuse unless ?force=1."""
+    app, client = standalone_proxy
+    await _link_for_test(client, app)
+
+    # Seed a fake client in the bridge cache so the count is non-zero.
+    bridge = app.state.broker_bridge
+    bridge._clients["alice"] = object()
+
+    resp = await client.post("/v1/admin/unlink-broker", json={})
+    assert resp.status_code == 409
+    body = resp.json()["detail"]
+    assert body["error"] == "cross_org_sessions_active"
+    assert body["active_clients"] == 1
+
+    # Forced unlink goes through despite the cache.
+    resp = await client.post("/v1/admin/unlink-broker?force=1", json={})
+    assert resp.status_code == 200
+    assert getattr(app.state, "broker_bridge", None) is None


### PR DESCRIPTION
## Summary

Mirror of PR #131 (link-broker). Admin can walk an uplinked proxy back to standalone at **runtime** without a restart — disaster recovery, broker migration, kill-switch.

## Endpoint

\`POST /v1/admin/unlink-broker\` (admin session + CSRF for form, session-only for JSON).

**Teardown sequence:**
1. \`BrokerBridge.shutdown()\` — drains CullisClient cache
2. \`reverse_proxy_client.aclose()\` — no connection-pool leak per link/unlink cycle
3. Stop federation SSE subscriber (stop event → 5s wait → cancel)
4. Clear \`cached_federated_agents\`, \`cached_policies\`, \`cached_bindings\`, \`federation_cursor\`
5. Persist \`broker_url=""\`, \`org_status=standalone\`
6. **Local_\* tables untouched** — intra-org state survives, that's the whole point of having two scopes

## Refuse-when-active guardrail

Bridge \`_clients\` cache = "cross-org in flight". Non-empty → **409** \`{error: cross_org_sessions_active, active_clients: N, hint: ...}\`. Override with \`?force=1\`.

## Test plan

- [x] \`test_proxy_link_broker.py\` +5 unlink tests (10 total):
  - standalone shape restored (bridge/client/url all None, config flipped)
  - refuses when not linked (400)
  - 401 without admin session
  - clears federation cache
  - refuses on active clients (409) + force=1 override works
- [x] Full pytest: 892 passed (+5 new), same 2 preexisting Postgres failures
- [x] \`./demo_network/smoke.sh full\` ✓
- [x] \`./demo_network/standalone_smoke.sh full\` ✓

## What's **not** in this PR

The SSE subscriber conditional startup is already wired (\`main.py:199\` gates on \`federation_sync_enabled + broker_url + org_id\`). Runtime start-on-link is a follow-up; for PR #7 the teardown path was the bigger safety gap.

## Next

**PR #8** — WebSocket reverse-proxy forwarding (last piece before Fase 2 smoke).

Related: \`imp/adr_006_proxy_troian_horse_dual_mode.md\`