### PR TITLE
fix(ci): unblock connector release workflow (rc1 failed)

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -74,7 +74,11 @@ jobs:
         run: python -m pip install --upgrade pip build
 
       - name: Build wheel + sdist
-        run: python -m build --outdir dist/ packaging/pypi
+        # Uses the staging helper so README_PKG.md, LICENSE, NOTICE, and
+        # the connector source tree are copied into packaging/pypi/ before
+        # hatchling runs — the raw `python -m build packaging/pypi/`
+        # invocation skips staging and fails on the missing README_PKG.md.
+        run: bash packaging/pypi/build.sh
 
       - name: Smoke test wheel
         run: |

--- a/packaging/pyinstaller/build.sh
+++ b/packaging/pyinstaller/build.sh
@@ -64,9 +64,12 @@ echo "==> Building ${BIN_NAME} on ${PLATFORM}/${ARCH}"
 # surprising contributors who already manage their own.
 python -m pip install --upgrade pip pyinstaller >&2
 python -m pip install --upgrade \
-    "mcp>=1.0" "httpx>=0.24.0" "cryptography>=41.0.0" "PyYAML>=6.0" \
+    "mcp[cli]>=1.0" "httpx>=0.24.0" "cryptography>=41.0.0" "PyYAML>=6.0" \
     "bcrypt>=4.0" \
     "fastapi>=0.110" "uvicorn[standard]>=0.27" "jinja2>=3.1" "python-multipart>=0.0.9" >&2
+# mcp[cli] pulls in typer — required by `--collect-submodules mcp` below
+# because mcp.cli raises ImportError at module-load time when typer is
+# absent, which aborts PyInstaller's submodule scan.
 
 STRIP_FLAG=""
 if [[ "${PLATFORM}" == "linux" ]]; then

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -58,9 +58,16 @@ dependencies = [
     "httpx>=0.24.0",
     "cryptography>=41.0.0",
     "PyYAML>=6.0",
+    "bcrypt>=4.0",
 ]
 
 [project.optional-dependencies]
+dashboard = [
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.27",
+    "jinja2>=3.1",
+    "python-multipart>=0.0.9",
+]
 dev = [
     "pytest>=8.0",
     "ruff>=0.4",
@@ -86,6 +93,13 @@ cullis-connector = "cullis_connector.cli:main"
 include = [
     "cullis_connector/**/*.py",
     "cullis_connector/**/*.md",
+    # Dashboard runtime assets — Jinja2Templates + StaticFiles both read
+    # these off disk relative to cullis_connector/__file__, so the wheel
+    # must ship them or the dashboard subcommand ImportError's on launch.
+    "cullis_connector/templates/*.html",
+    "cullis_connector/static/*.css",
+    "cullis_connector/static/*.js",
+    "cullis_connector/static/*.svg",
     "cullis_connector/py.typed",
     "LICENSE",
     "LICENSE-APACHE-2.0",


### PR DESCRIPTION
## Summary

Tag \`connector-v0.2.0-rc1\` produced three failed jobs. This PR fixes all three:

| Job | Error | Fix |
|---|---|---|
| Build Python distributions | \`OSError: Readme file does not exist: README_PKG.md\` | Call \`bash packaging/pypi/build.sh\` (staging helper) instead of \`python -m build\` directly |
| Build binary (all 3 OS) | \`ModuleNotFoundError: No module named 'typer'\` during \`--collect-submodules mcp\` | Install \`mcp[cli]>=1.0\` so typer is present during PyInstaller's scan |
| (silent gap) | Dashboard templates + static not in wheel | Added \`*.html / *.css / *.js / *.svg\` to hatch include globs |

Also: mirrored the \`dashboard\` optional-dependencies entry in \`packaging/pypi/pyproject.toml\` so \`pip install 'cullis-connector[dashboard]'\` works from PyPI, matching the root pyproject.

## Verification

Ran \`packaging/pypi/build.sh\` locally — wheel now builds cleanly and \`zipfile.ZipFile\` confirms the 4 templates + 3 static assets are packaged:

\`\`\`
cullis_connector/templates/base.html
cullis_connector/templates/connected.html
cullis_connector/templates/setup.html
cullis_connector/templates/waiting.html
cullis_connector/static/favicon.svg
cullis_connector/static/htmx.min.js
cullis_connector/static/style.css
\`\`\`

PyInstaller part only testable in CI (NixOS can't run stock PyInstaller bootloaders).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, delete tag \`connector-v0.2.0-rc1\` and retag on the new main → release-connector workflow produces 3 zips + Python dist + Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)