### PR TITLE
feat(proxy): dashboard CRUD for intra-org policies (ADR-006 PR #2b follow-up)

### DIFF
--- a/mcp_proxy/dashboard/policies_local.py
+++ b/mcp_proxy/dashboard/policies_local.py
@@ -1,0 +1,202 @@
+"""Dashboard CRUD for ADR-006 intra-org policies (follow-up to PR #126).
+
+The policy *engine* shipped in #126 reads from ``local_policies`` at
+every ``/v1/egress/send``; the table's been populated by raw SQL
+since then. This module adds the admin UI for that table so operators
+aren't writing INSERTs by hand.
+
+Kept in a separate file (not merged into ``dashboard/router.py``) so
+this PR doesn't collide with unrelated dashboard work from parallel
+agents. Wired in ``main.py`` via ``include_router`` with prefix
+``/proxy/local-policies``.
+
+Rule JSON matches the broker's message-rule schema (ADR-006 §5 /
+#126 commit body) so a policy authored here behaves identically to
+one on the broker side.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import text
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import get_db, log_audit
+
+_log = logging.getLogger("mcp_proxy.dashboard.policies_local")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+router = APIRouter(prefix="/proxy/local-policies", tags=["dashboard-local-policies"])
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        "active": "local_policies",
+        **kwargs,
+    }
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _list_rows() -> list[dict]:
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT policy_id, org_id, policy_type, name, scope,
+                       rules_json, enabled, created_at, updated_at
+                  FROM local_policies
+                 ORDER BY created_at DESC
+                """
+            ),
+        )
+        return [dict(r) for r in result.mappings()]
+
+
+# ── Pages ────────────────────────────────────────────────────────────
+
+@router.get("", response_class=HTMLResponse)
+async def policies_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    rows = await _list_rows()
+    settings = get_settings()
+    return templates.TemplateResponse("policies_local.html", _ctx(
+        request, session,
+        policies=rows,
+        default_org_id=settings.org_id or "",
+    ))
+
+
+@router.post("/create")
+async def policies_create(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    name = str(form.get("name", "")).strip()
+    org_id = str(form.get("org_id", "")).strip() or None
+    policy_type = str(form.get("policy_type", "message")).strip()
+    rules_raw = str(form.get("rules_json", "")).strip()
+    enabled = 1 if form.get("enabled") in ("1", "true", "on") else 0
+
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    if policy_type not in ("message", "session"):
+        raise HTTPException(status_code=400, detail="policy_type must be message|session")
+    try:
+        parsed = json.loads(rules_raw) if rules_raw else {}
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"invalid rules_json: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=400, detail="rules_json must be an object")
+
+    policy_id = str(uuid.uuid4())
+    ts = _iso_now()
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_policies (
+                    policy_id, org_id, policy_type, name, scope,
+                    rules_json, enabled, created_at, updated_at
+                ) VALUES (
+                    :pid, :org, :ptype, :name, 'intra',
+                    :rules, :enabled, :ts, :ts
+                )
+                """
+            ),
+            {
+                "pid": policy_id,
+                "org": org_id,
+                "ptype": policy_type,
+                "name": name,
+                "rules": json.dumps(parsed, separators=(",", ":"), sort_keys=True),
+                "enabled": enabled,
+                "ts": ts,
+            },
+        )
+
+    await log_audit(
+        agent_id="admin",
+        action="local_policy.create",
+        status="success",
+        detail=f"policy_id={policy_id} name={name} enabled={enabled}",
+    )
+    return RedirectResponse(url="/proxy/local-policies", status_code=303)
+
+
+@router.post("/{policy_id}/toggle")
+async def policies_toggle(policy_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        # Flip enabled in one statement so concurrent admins don't race.
+        await conn.execute(
+            text(
+                """
+                UPDATE local_policies
+                   SET enabled = CASE enabled WHEN 1 THEN 0 ELSE 1 END,
+                       updated_at = :ts
+                 WHERE policy_id = :pid
+                """
+            ),
+            {"pid": policy_id, "ts": _iso_now()},
+        )
+    await log_audit(
+        agent_id="admin",
+        action="local_policy.toggle",
+        status="success",
+        detail=f"policy_id={policy_id}",
+    )
+    return RedirectResponse(url="/proxy/local-policies", status_code=303)
+
+
+@router.post("/{policy_id}/delete")
+async def policies_delete(policy_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        await conn.execute(
+            text("DELETE FROM local_policies WHERE policy_id = :pid"),
+            {"pid": policy_id},
+        )
+    await log_audit(
+        agent_id="admin",
+        action="local_policy.delete",
+        status="success",
+        detail=f"policy_id={policy_id}",
+    )
+    return RedirectResponse(url="/proxy/local-policies", status_code=303)

--- a/mcp_proxy/dashboard/templates/policies_local.html
+++ b/mcp_proxy/dashboard/templates/policies_local.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+{% block title %}Local Policies{% endblock %}
+{% block header_title %}Intra-org Policies (ADR-006){% endblock %}
+{% block content %}
+<div class="max-w-5xl space-y-6">
+
+    <div class="p-4 bg-surface-900/60 border border-gray-800/60 rounded text-sm text-gray-400">
+        Rules evaluated by the proxy on every intra-org <code>/v1/egress/send</code>.
+        JSON schema matches the broker's message-rule format — a policy authored
+        here behaves identically to one on the broker side.
+    </div>
+
+    <!-- Create form -->
+    <form method="post" action="/proxy/local-policies/create"
+          class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg space-y-4">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <h3 class="text-sm uppercase tracking-[0.2em] text-gray-400">New policy</h3>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Name</label>
+                <input type="text" name="name" required placeholder="block-secrets"
+                       class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white focus:border-accent-400 focus:outline-none">
+            </div>
+            <div>
+                <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Policy type</label>
+                <select name="policy_type"
+                        class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white">
+                    <option value="message" selected>message</option>
+                    <option value="session">session</option>
+                </select>
+            </div>
+            <div>
+                <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">
+                    Org scope (leave blank for global)
+                </label>
+                <input type="text" name="org_id" value="{{ default_org_id }}" placeholder="acme"
+                       class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white">
+            </div>
+            <div class="flex items-center gap-2 mt-6">
+                <input type="checkbox" name="enabled" id="enabled" value="1" checked
+                       class="w-4 h-4 bg-surface-950 border-gray-700">
+                <label for="enabled" class="text-xs text-gray-400 uppercase tracking-wider">Enabled</label>
+            </div>
+        </div>
+
+        <div>
+            <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Rules JSON</label>
+            <textarea name="rules_json" rows="6" required
+                      class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white"
+                      style="font-family: 'JetBrains Mono', monospace;"
+                      placeholder='{"effect":"allow","conditions":{"blocked_fields":["admin_override"],"max_payload_size_bytes":65536}}'>{
+  "effect": "allow",
+  "conditions": {
+    "blocked_fields": ["admin_override"],
+    "max_payload_size_bytes": 65536
+  }
+}</textarea>
+        </div>
+
+        <button type="submit"
+                class="px-4 py-2 bg-accent-500/20 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/30 uppercase tracking-wider text-sm font-medium">
+            Create policy
+        </button>
+    </form>
+
+    <!-- List -->
+    <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
+        <h3 class="text-sm uppercase tracking-[0.2em] text-gray-400 mb-4">
+            Active policies ({{ policies|length }})
+        </h3>
+        {% if not policies %}
+        <p class="text-sm text-gray-500">No local policies yet. Intra-org send is default-allow.</p>
+        {% else %}
+        <table class="w-full text-sm">
+            <thead>
+                <tr class="text-[10px] text-gray-500 uppercase tracking-wider text-left">
+                    <th class="py-2">Name</th>
+                    <th>Type</th>
+                    <th>Org</th>
+                    <th>Rules</th>
+                    <th class="text-center">Enabled</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for p in policies %}
+                <tr class="border-t border-gray-800/60">
+                    <td class="py-3 text-white">{{ p.name }}</td>
+                    <td class="text-gray-400">{{ p.policy_type or "—" }}</td>
+                    <td class="text-gray-400">{{ p.org_id or "global" }}</td>
+                    <td>
+                        <details>
+                            <summary class="text-accent-400 cursor-pointer text-xs">view</summary>
+                            <pre class="mt-2 p-2 bg-surface-950 text-xs text-gray-300 rounded overflow-auto" style="font-family: 'JetBrains Mono', monospace;">{{ p.rules_json }}</pre>
+                        </details>
+                    </td>
+                    <td class="text-center">
+                        <form method="post" action="/proxy/local-policies/{{ p.policy_id }}/toggle" class="inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit" class="text-xs {% if p.enabled %}text-emerald-400{% else %}text-gray-500{% endif %} hover:underline">
+                                {% if p.enabled %}ON{% else %}OFF{% endif %}
+                            </button>
+                        </form>
+                    </td>
+                    <td>
+                        <form method="post" action="/proxy/local-policies/{{ p.policy_id }}/delete" class="inline"
+                              onsubmit="return confirm('Delete policy {{ p.name }}?')">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit" class="text-xs text-red-400 hover:underline">delete</button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -272,18 +272,6 @@ async def lifespan(app: FastAPI):
     if _jwks_client:
         await _jwks_client.close()
     await dispose_db()
-
-    # Isolation hygiene: ``app`` is a module-level singleton that
-    # survives across test lifespans. Leaving a shutdown BrokerBridge +
-    # a closed reverse-proxy client attached to ``app.state`` poisons
-    # the next lifespan's setup — a federated test after a standalone
-    # one could see broker_bridge still None because the next startup
-    # short-circuits before reassigning. Clear the three
-    # standalone/federated-shape handles only; agent_manager outlives
-    # lifespan for other tests that assert on it post-teardown.
-    app.state.broker_bridge = None
-    app.state.reverse_proxy_client = None
-    app.state.reverse_proxy_broker_url = None
     _log.info("MCP Proxy shutdown complete")
 
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -272,6 +272,17 @@ async def lifespan(app: FastAPI):
     if _jwks_client:
         await _jwks_client.close()
     await dispose_db()
+
+    # Isolation hygiene: ``app`` is a module-level singleton that
+    # survives across test lifespans. Leaving shutdown bridges + disposed
+    # clients attached to ``app.state`` poisons the next lifespan's
+    # setup — a federated test after a standalone one could see
+    # broker_bridge still None because the next startup short-circuits
+    # before reassigning. Clear the handles explicitly.
+    app.state.broker_bridge = None
+    app.state.reverse_proxy_client = None
+    app.state.reverse_proxy_broker_url = None
+    app.state.agent_manager = None
     _log.info("MCP Proxy shutdown complete")
 
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -274,15 +274,16 @@ async def lifespan(app: FastAPI):
     await dispose_db()
 
     # Isolation hygiene: ``app`` is a module-level singleton that
-    # survives across test lifespans. Leaving shutdown bridges + disposed
-    # clients attached to ``app.state`` poisons the next lifespan's
-    # setup — a federated test after a standalone one could see
-    # broker_bridge still None because the next startup short-circuits
-    # before reassigning. Clear the handles explicitly.
+    # survives across test lifespans. Leaving a shutdown BrokerBridge +
+    # a closed reverse-proxy client attached to ``app.state`` poisons
+    # the next lifespan's setup — a federated test after a standalone
+    # one could see broker_bridge still None because the next startup
+    # short-circuits before reassigning. Clear the three
+    # standalone/federated-shape handles only; agent_manager outlives
+    # lifespan for other tests that assert on it post-teardown.
     app.state.broker_bridge = None
     app.state.reverse_proxy_client = None
     app.state.reverse_proxy_broker_url = None
-    app.state.agent_manager = None
     _log.info("MCP Proxy shutdown complete")
 
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -505,6 +505,11 @@ from mcp_proxy.dashboard.link_broker import (
 app.include_router(link_broker_dashboard_router)
 app.include_router(link_broker_admin_router)
 
+# ADR-006 PR #2b — dashboard CRUD for intra-org policies. The engine
+# landed in #126; this gives operators a UI instead of raw SQL.
+from mcp_proxy.dashboard.policies_local import router as local_policies_router
+app.include_router(local_policies_router)
+
 from mcp_proxy.dashboard.downloads import router as downloads_router
 app.include_router(downloads_router)
 

--- a/tests/test_proxy_local_policies_ui.py
+++ b/tests/test_proxy_local_policies_ui.py
@@ -1,0 +1,200 @@
+"""ADR-006 PR #2b — dashboard CRUD for local_policies.
+
+The policy engine shipped in #126; this suite covers the admin UI
+that replaces raw SQL inserts: create, toggle, delete, and the
+list/read path.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post("/proxy/login",
+                              data={"password": "test-password-1234"},
+                              follow_redirects=False)
+            yield client
+    get_settings.cache_clear()
+
+
+async def _csrf_from_list(client) -> str:
+    page = await client.get("/proxy/local-policies")
+    assert page.status_code == 200, page.text
+    import re
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token not found on page"
+    return m.group(1)
+
+
+@pytest.mark.asyncio
+async def test_list_page_renders_empty(proxy_logged_in):
+    page = await proxy_logged_in.get("/proxy/local-policies")
+    assert page.status_code == 200
+    assert "Intra-org Policies" in page.text
+    assert "No local policies yet" in page.text
+
+
+@pytest.mark.asyncio
+async def test_create_persists_and_shows_on_list(proxy_logged_in):
+    csrf = await _csrf_from_list(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        "/proxy/local-policies/create",
+        data={
+            "csrf_token": csrf,
+            "name": "block-secrets",
+            "policy_type": "message",
+            "org_id": "acme",
+            "enabled": "1",
+            "rules_json": json.dumps({
+                "effect": "allow",
+                "conditions": {"blocked_fields": ["admin_override"]},
+            }),
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    # Row must be queryable + active by the policy engine.
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT name, org_id, enabled, policy_type, rules_json "
+                 "FROM local_policies WHERE name = 'block-secrets'")
+        )).mappings().first()
+    assert row is not None
+    assert row["enabled"] == 1
+    assert row["org_id"] == "acme"
+    assert row["policy_type"] == "message"
+    assert "admin_override" in row["rules_json"]
+
+    page = await proxy_logged_in.get("/proxy/local-policies")
+    assert "block-secrets" in page.text
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_json(proxy_logged_in):
+    csrf = await _csrf_from_list(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        "/proxy/local-policies/create",
+        data={
+            "csrf_token": csrf,
+            "name": "bad",
+            "policy_type": "message",
+            "rules_json": "{not json",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "invalid rules_json" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_toggle_flips_enabled(proxy_logged_in):
+    csrf = await _csrf_from_list(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/local-policies/create",
+        data={
+            "csrf_token": csrf, "name": "p1", "policy_type": "message",
+            "enabled": "1",
+            "rules_json": json.dumps({"effect": "allow", "conditions": {}}),
+        },
+        follow_redirects=False,
+    )
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        pid = (await conn.execute(
+            text("SELECT policy_id FROM local_policies WHERE name='p1'")
+        )).scalar()
+
+    csrf = await _csrf_from_list(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        f"/proxy/local-policies/{pid}/toggle",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    async with get_db() as conn:
+        enabled = (await conn.execute(
+            text("SELECT enabled FROM local_policies WHERE policy_id=:pid"),
+            {"pid": pid},
+        )).scalar()
+    assert enabled == 0  # flipped off
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_row(proxy_logged_in):
+    csrf = await _csrf_from_list(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/local-policies/create",
+        data={
+            "csrf_token": csrf, "name": "to-delete", "policy_type": "message",
+            "rules_json": json.dumps({"effect": "allow", "conditions": {}}),
+        },
+        follow_redirects=False,
+    )
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        pid = (await conn.execute(
+            text("SELECT policy_id FROM local_policies WHERE name='to-delete'")
+        )).scalar()
+
+    csrf = await _csrf_from_list(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        f"/proxy/local-policies/{pid}/delete",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    async with get_db() as conn:
+        count = (await conn.execute(
+            text("SELECT COUNT(*) FROM local_policies WHERE policy_id=:pid"),
+            {"pid": pid},
+        )).scalar()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_requires_login(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/proxy/local-policies",
+                                    follow_redirects=False)
+            # Not logged in → redirect to login.
+            assert resp.status_code == 303
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary

The policy **engine** landed in #126; this PR adds the admin **UI** for the \`local_policies\` table.

- \`GET /proxy/local-policies\` list + create form
- \`POST /proxy/local-policies/create\` insert
- \`POST /proxy/local-policies/{id}/toggle\` flip enabled
- \`POST /proxy/local-policies/{id}/delete\` remove

Rule JSON matches broker message-rule format. Global rule (org_id=NULL) supported.

## Wiring

New module \`mcp_proxy/dashboard/policies_local.py\` — separate APIRouter included from main.py. Kept out of \`dashboard/router.py\` to avoid collisions with parallel dashboard work. Admin session + CSRF gated.

## Test plan

- [x] 6/6 UI tests: empty state, create+list, invalid JSON 400, toggle atomic, delete, unauth redirect
- [x] Full pytest 910 passed (+6), 2 preexisting Postgres failures
- [x] \`./demo_network/smoke.sh full\` + \`./standalone_smoke.sh full\` ✓

## Closes ADR-006 follow-up

Last roadmap item after the 10 merged PRs completing Fase 0-2. Full create → enforce → audit cycle now usable from dashboard.