### PR TITLE
fix(ci): --add-data absolute paths + Dockerfile staging (rc2 follow-up)

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -32,7 +32,8 @@ WORKDIR /src
 COPY . /src
 
 RUN python -m pip install --upgrade pip build \
- && python -m build --wheel --outdir /dist packaging/pypi
+ && bash packaging/pypi/build.sh \
+ && mv dist/cullis_connector-*.whl /dist/
 
 # ── Stage 2: runtime ────────────────────────────────────────────────────
 FROM python:3.12-slim AS runtime

--- a/packaging/pyinstaller/build.sh
+++ b/packaging/pyinstaller/build.sh
@@ -102,8 +102,8 @@ pyinstaller \
   --workpath "build/pyinstaller" \
   --specpath "build/pyinstaller" \
   ${STRIP_FLAG} \
-  --add-data "cullis_connector/templates${DATA_SEP}cullis_connector/templates" \
-  --add-data "cullis_connector/static${DATA_SEP}cullis_connector/static" \
+  --add-data "${REPO_ROOT}/cullis_connector/templates${DATA_SEP}cullis_connector/templates" \
+  --add-data "${REPO_ROOT}/cullis_connector/static${DATA_SEP}cullis_connector/static" \
   --collect-submodules cullis_connector \
   --collect-submodules mcp \
   --collect-submodules fastapi \


### PR DESCRIPTION
## Summary

rc2 moved the Python wheel build to green but exposed two remaining blockers:

| Job | Error | Fix |
|---|---|---|
| Build binary (all 3 OS) | \`Unable to find '.../build/pyinstaller/cullis_connector/templates' when adding binary and data files\` | Use \`\${REPO_ROOT}/cullis_connector/...\` absolute paths for \`--add-data\` (PyInstaller 6 resolves relative \`--add-data\` src against \`--specpath\`, not cwd) |
| Build & push Docker image | \`OSError: Readme file does not exist: README_PKG.md\` | Dockerfile still invokes \`python -m build packaging/pypi\` directly — swap for \`bash packaging/pypi/build.sh\` matching the workflow |

Tests unchanged. Not testable on NixOS — CI round-trip verifies.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, retag \`connector-v0.2.0-rc3\` → release-connector workflow produces zip Mac/Win/Linux + Docker image + Python wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)