### PR TITLE
fix(ci): Windows cygpath + Docker /dist mkdir (rc3 follow-up)

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -33,6 +33,7 @@ COPY . /src
 
 RUN python -m pip install --upgrade pip build \
  && bash packaging/pypi/build.sh \
+ && mkdir -p /dist \
  && mv dist/cullis_connector-*.whl /dist/
 
 # ── Stage 2: runtime ────────────────────────────────────────────────────

--- a/packaging/pyinstaller/build.sh
+++ b/packaging/pyinstaller/build.sh
@@ -79,8 +79,13 @@ fi
 # PyInstaller's --add-data wants different separators per OS. The modern
 # release accepts both but we hedge anyway: ':' on POSIX, ';' on Windows.
 DATA_SEP=":"
+ADD_DATA_ROOT="${REPO_ROOT}"
 if [[ "${PLATFORM}" == "windows" ]]; then
   DATA_SEP=";"
+  # Git Bash represents Windows paths as /d/a/... which PyInstaller can't
+  # resolve as filesystem paths — it treats them as missing and aborts.
+  # cygpath -w converts them back to native D:\a\... form.
+  ADD_DATA_ROOT="$(cygpath -w "${REPO_ROOT}")"
 fi
 
 # `cullis_connector.__main__` is the documented module entry point;
@@ -102,8 +107,8 @@ pyinstaller \
   --workpath "build/pyinstaller" \
   --specpath "build/pyinstaller" \
   ${STRIP_FLAG} \
-  --add-data "${REPO_ROOT}/cullis_connector/templates${DATA_SEP}cullis_connector/templates" \
-  --add-data "${REPO_ROOT}/cullis_connector/static${DATA_SEP}cullis_connector/static" \
+  --add-data "${ADD_DATA_ROOT}/cullis_connector/templates${DATA_SEP}cullis_connector/templates" \
+  --add-data "${ADD_DATA_ROOT}/cullis_connector/static${DATA_SEP}cullis_connector/static" \
   --collect-submodules cullis_connector \
   --collect-submodules mcp \
   --collect-submodules fastapi \


### PR DESCRIPTION
## Summary

rc3 landed Linux + macOS binaries. Two micro-fixes close the last gaps:

| Job | Error | Fix |
|---|---|---|
| Build binary (windows-latest) | \`Unable to find '\\d\\a\\cullis\\...\\templates'\` | Git Bash posix paths (\`/d/a/...\`) are invalid on Windows PyInstaller. Convert \`REPO_ROOT\` with \`cygpath -w\` on Windows so \`--add-data\` receives native \`D:\\a\\...\` paths. |
| Build & push Docker image | \`mv: cannot move ... to '/dist/': Not a directory\` | Builder stage never created \`/dist\`. Added \`mkdir -p /dist\` before the move. |

## Test plan

- [ ] CI green on this PR
- [ ] After merge, tag \`connector-v0.2.0-rc4\` — expect all 6 jobs green → Release page with 3 zips + wheel + Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)