### PR TITLE
fix(ci): zip via Python on all 3 OSes (no zip CLI on Windows)

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -183,9 +183,14 @@ jobs:
           # releases/latest/download/<this-name> and GitHub handles the
           # redirect, so admins sharing the link never have to update it
           # after a new tag.
-          ZIP_NAME="cullis-connector-${{ matrix.platform }}.zip"
-          ( cd "${STAGING}" && zip -r "../${ZIP_NAME}" . )
-          ls -lah "dist/${ZIP_NAME}"
+          #
+          # We zip via Python's shutil.make_archive instead of the `zip`
+          # CLI because windows-latest runners don't ship `zip` by default
+          # (only 7z and Compress-Archive), and Python is already on PATH
+          # here from the setup-python step.
+          ZIP_BASE="dist/cullis-connector-${{ matrix.platform }}"
+          python -c "import shutil; shutil.make_archive('${ZIP_BASE}', 'zip', '${STAGING}')"
+          ls -lah "${ZIP_BASE}.zip"
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary

rc4 closed Linux + macOS + Docker. Windows binary still fails at the zip step because \`windows-latest\` runners don't ship the unix \`zip\` utility — only 7z and PowerShell \`Compress-Archive\`.

Swap \`zip -r\` for \`python -c 'shutil.make_archive(...)'\` — same call works identically on all three OSes, no platform branching, Python is already on PATH from \`setup-python\`.

## Test plan

- [ ] CI green on this PR
- [ ] Tag \`connector-v0.2.0-rc5\` — expect all 6 release jobs green → Release page with 3 zips + wheel + Docker image

🤖 Generated with [Claude Code](https://claude.com/claude-code)