### PR TITLE
feat(proxy): add local_mcp_resources + bindings tables (ADR-007 Phase 1 / PR #1)

### DIFF
--- a/mcp_proxy/alembic/versions/0007_mcp_resources.py
+++ b/mcp_proxy/alembic/versions/0007_mcp_resources.py
@@ -1,0 +1,106 @@
+"""Local MCP resources + agent bindings — ADR-007 Phase 1 PR #1.
+
+Revision ID: 0007_mcp_resources
+Revises: 0006_enrollment_api_key_hash
+Create Date: 2026-04-16
+
+Schema-only addition for Local Resource Mediation (ADR-007). Deploys two
+tables that PR-3 will wire into the aggregated MCP server:
+
+  local_mcp_resources          : registry of external MCP services the
+                                 proxy is allowed to forward to.
+  local_agent_resource_bindings: explicit N:N grant table — only bound
+                                 agents see a resource in discovery and
+                                 may call it.
+
+Additive migration. No existing table touched, no handler reads from the
+new tables in this PR. Audit hash chain (local_audit columns and
+compute_entry_hash canonical form) is intentionally unchanged so that
+byte-parity with the broker — gate tests/test_proxy_audit_chain_parity.py
+— remains green by construction.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007_mcp_resources"
+down_revision: Union[str, Sequence[str], None] = "0006_enrollment_api_key_hash"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "local_mcp_resources",
+        sa.Column("resource_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("endpoint_url", sa.Text(), nullable=False),
+        sa.Column("auth_type", sa.Text(), nullable=False, server_default="none"),
+        sa.Column("auth_secret_ref", sa.Text(), nullable=True),
+        sa.Column("required_capability", sa.Text(), nullable=True),
+        sa.Column("allowed_domains", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("enabled", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.UniqueConstraint(
+            "org_id", "name", name="uq_local_mcp_resources_org_name"
+        ),
+    )
+    op.create_index(
+        "idx_local_mcp_resources_org_enabled",
+        "local_mcp_resources",
+        ["org_id", "enabled"],
+    )
+
+    op.create_table(
+        "local_agent_resource_bindings",
+        sa.Column("binding_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("agent_id", sa.Text(), nullable=False),
+        sa.Column("resource_id", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("granted_by", sa.Text(), nullable=False),
+        sa.Column("granted_at", sa.Text(), nullable=False),
+        sa.Column("revoked_at", sa.Text(), nullable=True),
+        sa.UniqueConstraint(
+            "agent_id", "resource_id",
+            name="uq_local_bindings_agent_resource",
+        ),
+    )
+    op.create_index(
+        "idx_local_bindings_agent_revoked",
+        "local_agent_resource_bindings",
+        ["agent_id", "revoked_at"],
+    )
+    op.create_index(
+        "idx_local_bindings_resource_revoked",
+        "local_agent_resource_bindings",
+        ["resource_id", "revoked_at"],
+    )
+    op.create_index(
+        "idx_local_bindings_org",
+        "local_agent_resource_bindings",
+        ["org_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_local_bindings_org", table_name="local_agent_resource_bindings"
+    )
+    op.drop_index(
+        "idx_local_bindings_resource_revoked",
+        table_name="local_agent_resource_bindings",
+    )
+    op.drop_index(
+        "idx_local_bindings_agent_revoked",
+        table_name="local_agent_resource_bindings",
+    )
+    op.drop_table("local_agent_resource_bindings")
+
+    op.drop_index(
+        "idx_local_mcp_resources_org_enabled", table_name="local_mcp_resources"
+    )
+    op.drop_table("local_mcp_resources")

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -266,3 +266,70 @@ class LocalAudit(Base):
         Index("idx_local_audit_org", "org_id"),
         Index("idx_local_audit_peer_org", "peer_org_id"),
     )
+
+
+# ── MCP Resources (ADR-007 Phase 1, unused until PR-3 wires routing) ─────────
+
+
+class LocalMCPResource(Base):
+    """Registry of MCP resources mediated by the proxy.
+
+    An MCP resource is an external service (postgres-mcp, github-mcp, ...)
+    that local agents may call through the proxy. The proxy enforces
+    binding + capability + egress-domain allowlists on each call.
+
+    ADR-007 Phase 1 PR #1 deploys schema only — no handler reads from this
+    table yet. PR-3 wires aggregated discovery and mediated forwarding.
+    """
+
+    __tablename__ = "local_mcp_resources"
+
+    resource_id = Column(Text, primary_key=True)
+    org_id = Column(Text, nullable=True)
+    name = Column(Text, nullable=False)
+    description = Column(Text, nullable=True)
+    endpoint_url = Column(Text, nullable=False)
+    auth_type = Column(Text, nullable=False, server_default="none")
+    auth_secret_ref = Column(Text, nullable=True)
+    required_capability = Column(Text, nullable=True)
+    allowed_domains = Column(Text, nullable=False, server_default="[]")
+    enabled = Column(Integer, nullable=False, server_default="1")
+    created_at = Column(Text, nullable=False)
+    updated_at = Column(Text, nullable=False)
+
+    __table_args__ = (
+        Index("idx_local_mcp_resources_org_enabled", "org_id", "enabled"),
+        UniqueConstraint(
+            "org_id", "name", name="uq_local_mcp_resources_org_name"
+        ),
+    )
+
+
+class LocalAgentResourceBinding(Base):
+    """Explicit N:N grant: which local agents may call which resources.
+
+    Revocation is soft (``revoked_at`` non-null). Regrant = UPDATE the
+    existing row back to ``revoked_at=NULL`` — the UNIQUE on
+    ``(agent_id, resource_id)`` enforces one logical binding per pair
+    without relying on partial indexes (SQLite/Postgres parity).
+    """
+
+    __tablename__ = "local_agent_resource_bindings"
+
+    binding_id = Column(Text, primary_key=True)
+    agent_id = Column(Text, nullable=False)
+    resource_id = Column(Text, nullable=False)
+    org_id = Column(Text, nullable=True)
+    granted_by = Column(Text, nullable=False)
+    granted_at = Column(Text, nullable=False)
+    revoked_at = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("idx_local_bindings_agent_revoked", "agent_id", "revoked_at"),
+        Index("idx_local_bindings_resource_revoked", "resource_id", "revoked_at"),
+        Index("idx_local_bindings_org", "org_id"),
+        UniqueConstraint(
+            "agent_id", "resource_id",
+            name="uq_local_bindings_agent_resource",
+        ),
+    )

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -26,6 +26,8 @@ EXPECTED_TABLES = {
     "local_messages",
     "local_policies",
     "local_audit",
+    "local_mcp_resources",
+    "local_agent_resource_bindings",
     "pending_enrollments",
     "cached_federated_agents",
     "cached_policies",
@@ -65,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0006_enrollment_api_key_hash",)]
+    assert rows == [("0007_mcp_resources",)]
 
 
 @pytest.mark.asyncio
@@ -125,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0006_enrollment_api_key_hash",)]
+    assert version == [("0007_mcp_resources",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -1,0 +1,311 @@
+"""Validate proxy Alembic migration 0007 — ADR-007 Phase 1 PR #1.
+
+Covers schema-only deployment of local_mcp_resources and
+local_agent_resource_bindings. Upgrade/downgrade idempotency and model
+round-trip via SQLAlchemy. Audit hash chain parity is NOT re-asserted
+here — that contract is owned by tests/test_proxy_audit_chain_parity.py
+which runs in the same suite and must stay green regardless.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import create_engine, insert, select
+from sqlalchemy.exc import IntegrityError
+
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
+
+HEAD_REVISION = "0007_mcp_resources"
+PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
+
+
+def _table_names(path: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def _index_names(path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name=?",
+            (table,),
+        ).fetchall()
+    finally:
+        conn.close()
+    return {r[0] for r in rows}
+
+
+def _alembic_cfg(url: str) -> AlembicConfig:
+    """Build an Alembic config that points at *url* (async driver required).
+
+    env.py wraps migrations in asyncio.run, so only async URLs work.
+    """
+    ini = Path(__file__).resolve().parents[1] / "mcp_proxy" / "alembic.ini"
+    cfg = AlembicConfig(str(ini))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_migration_0007_upgrade_creates_tables(tmp_path):
+    db_file = tmp_path / "0007_up.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+
+    await init_db(url)
+    await dispose_db()
+
+    tables = _table_names(str(db_file))
+    assert "local_mcp_resources" in tables
+    assert "local_agent_resource_bindings" in tables
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        version = conn.execute(
+            "SELECT version_num FROM alembic_version"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert version == (HEAD_REVISION,)
+
+
+@pytest.mark.asyncio
+async def test_migration_0007_creates_expected_indexes(tmp_path):
+    db_file = tmp_path / "0007_idx.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+    path = str(db_file)
+
+    res_idx = _index_names(path, "local_mcp_resources")
+    assert "idx_local_mcp_resources_org_enabled" in res_idx
+
+    # SQLite materializes named UNIQUE constraints inside the CREATE TABLE
+    # SQL (they surface as sqlite_autoindex_* in sqlite_master). Verify the
+    # constraint name by probing the schema SQL directly.
+    conn = sqlite3.connect(path)
+    try:
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE name='local_mcp_resources'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert "uq_local_mcp_resources_org_name" in sql
+    assert "UNIQUE" in sql.upper()
+
+    bind_idx = _index_names(path, "local_agent_resource_bindings")
+    assert "idx_local_bindings_agent_revoked" in bind_idx
+    assert "idx_local_bindings_resource_revoked" in bind_idx
+    assert "idx_local_bindings_org" in bind_idx
+
+
+def test_migration_0007_downgrade_removes_tables(tmp_path):
+    """env.py runs via asyncio — pass the async driver URL to Alembic."""
+    db_file = tmp_path / "0007_down.db"
+    async_url = f"sqlite+aiosqlite:///{db_file}"
+
+    cfg = _alembic_cfg(async_url)
+    command.upgrade(cfg, "head")
+
+    tables_up = _table_names(str(db_file))
+    assert "local_mcp_resources" in tables_up
+    assert "local_agent_resource_bindings" in tables_up
+
+    command.downgrade(cfg, PREVIOUS_REVISION)
+
+    tables_down = _table_names(str(db_file))
+    assert "local_mcp_resources" not in tables_down
+    assert "local_agent_resource_bindings" not in tables_down
+
+    # Previous schema intact.
+    assert "local_agents" in tables_down
+    assert "pending_enrollments" in tables_down
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        version = conn.execute(
+            "SELECT version_num FROM alembic_version"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert version == (PREVIOUS_REVISION,)
+
+
+@pytest.mark.asyncio
+async def test_local_mcp_resource_roundtrip(tmp_path):
+    db_file = tmp_path / "resource_rt.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                insert(LocalMCPResource).values(
+                    resource_id="res-001",
+                    org_id="acme",
+                    name="postgres-prod",
+                    description="Primary Postgres MCP",
+                    endpoint_url="http://postgres-mcp:8080",
+                    auth_type="bearer",
+                    auth_secret_ref="vault:kv/proxy/postgres",
+                    required_capability="sql.read",
+                    allowed_domains='["postgres-mcp:8080"]',
+                    created_at="2026-04-16T10:00:00Z",
+                    updated_at="2026-04-16T10:00:00Z",
+                )
+            )
+        with engine.connect() as conn:
+            rows = list(conn.execute(select(LocalMCPResource)))
+    finally:
+        engine.dispose()
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.resource_id == "res-001"
+    assert row.auth_type == "bearer"
+    assert row.enabled == 1
+    assert row.allowed_domains == '["postgres-mcp:8080"]'
+
+
+@pytest.mark.asyncio
+async def test_local_mcp_resource_defaults_applied(tmp_path):
+    db_file = tmp_path / "resource_def.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                insert(LocalMCPResource).values(
+                    resource_id="res-min",
+                    name="minimal",
+                    endpoint_url="http://svc:80",
+                    created_at="2026-04-16T10:00:00Z",
+                    updated_at="2026-04-16T10:00:00Z",
+                )
+            )
+        with engine.connect() as conn:
+            row = conn.execute(select(LocalMCPResource)).one()
+    finally:
+        engine.dispose()
+
+    assert row.auth_type == "none"
+    assert row.allowed_domains == "[]"
+    assert row.enabled == 1
+    assert row.org_id is None
+    assert row.required_capability is None
+
+
+@pytest.mark.asyncio
+async def test_local_agent_resource_binding_roundtrip(tmp_path):
+    db_file = tmp_path / "binding_rt.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                insert(LocalAgentResourceBinding).values(
+                    binding_id="bind-001",
+                    agent_id="acme::buyer",
+                    resource_id="res-001",
+                    org_id="acme",
+                    granted_by="admin@acme",
+                    granted_at="2026-04-16T10:05:00Z",
+                )
+            )
+        with engine.connect() as conn:
+            row = conn.execute(select(LocalAgentResourceBinding)).one()
+    finally:
+        engine.dispose()
+
+    assert row.binding_id == "bind-001"
+    assert row.revoked_at is None
+
+
+@pytest.mark.asyncio
+async def test_binding_unique_agent_resource_enforced(tmp_path):
+    """Two bindings for the same (agent_id, resource_id) are rejected."""
+    db_file = tmp_path / "binding_uq.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                insert(LocalAgentResourceBinding).values(
+                    binding_id="b1",
+                    agent_id="a",
+                    resource_id="r",
+                    granted_by="admin",
+                    granted_at="2026-04-16T10:00:00Z",
+                )
+            )
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    insert(LocalAgentResourceBinding).values(
+                        binding_id="b2",
+                        agent_id="a",
+                        resource_id="r",
+                        granted_by="admin",
+                        granted_at="2026-04-16T10:00:01Z",
+                    )
+                )
+    finally:
+        engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_resource_unique_org_name_enforced(tmp_path):
+    db_file = tmp_path / "resource_uq.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                insert(LocalMCPResource).values(
+                    resource_id="r1",
+                    org_id="acme",
+                    name="dup",
+                    endpoint_url="http://a",
+                    created_at="2026-04-16T10:00:00Z",
+                    updated_at="2026-04-16T10:00:00Z",
+                )
+            )
+        with pytest.raises(IntegrityError):
+            with engine.begin() as conn:
+                conn.execute(
+                    insert(LocalMCPResource).values(
+                        resource_id="r2",
+                        org_id="acme",
+                        name="dup",
+                        endpoint_url="http://b",
+                        created_at="2026-04-16T10:00:01Z",
+                        updated_at="2026-04-16T10:00:01Z",
+                    )
+                )
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary

Schema-only foundation for **Local Resource Mediation** (ADR-007, #140). Adds two new local tables to the proxy without touching any existing code path, handler, router, or schema — PR-3 of Phase 1 will wire them into the aggregated MCP server.

- \`local_mcp_resources\` — registry of external MCP services (postgres-mcp, github-mcp, ...) the proxy is allowed to forward to. Columns: endpoint_url, auth_type (none|bearer|api_key|mtls), auth_secret_ref (SecretProvider opaque ref), required_capability, allowed_domains (JSON array), enabled soft toggle.
- \`local_agent_resource_bindings\` — explicit N:N grant table. Only bound agents see a resource in discovery and may call it. Soft revoke via \`revoked_at\` nullable column; UNIQUE on \`(agent_id, resource_id)\` for SQLite/Postgres parity (no partial indexes).

Design decisions consolidated in #140 comment:
- Discovery model = **A2 explicit binding** + **B2 aggregated MCP server** (proxy exposes single MCP endpoint, drop-in client).
- Sessionless per definition (per-call audit, no session state).
- Audit hash chain canonical form untouched — \`resource_spiffe_id\` will go into \`details\` JSON in PR-3, never as a hashed column.

## Test plan

- [x] 7 new tests in \`tests/test_proxy_migrations_adr007.py\`: upgrade creates tables, expected indexes present, downgrade removes cleanly, model round-trip × 2, server defaults applied, UNIQUE enforced × 2.
- [x] \`tests/test_proxy_migrations.py\` updated: \`EXPECTED_TABLES\` adds 2 entries, head revision literals bumped from \`0006_enrollment_api_key_hash\` to \`0007_mcp_resources\` in 2 asserts.
- [x] \`pytest tests/\` — 918 passed, 2 pre-existing postgres DPoP failures unrelated to this PR (same failures on main).
- [x] \`tests/test_proxy_audit_chain_parity.py\` — green (byte-parity with broker preserved by construction; PR does not modify canonical form or local_audit).
- [x] Alembic CLI: \`alembic upgrade head\` → version \`0007_mcp_resources\`, both tables present. \`alembic downgrade -1\` → version \`0006_enrollment_api_key_hash\`, tables gone. Re-upgrade idempotent.
- [x] \`./demo_network/smoke.sh full\` — round-trip PASS, dashboard signing key persistence PASS, audit hash chain integrity PASS (34 entries).
- [x] DCO \`Signed-off-by\` present, no \`Co-Authored-By\` attribution.

## Scope boundary

- No handler, router, dashboard template, smoke step, or SDK change in this PR — schema only.
- ADR-006 agent ↔ agent flows unchanged; reverse-proxy and uplink paths not touched.
- Empty tables until PR-2 (registry extension) and PR-3 (MCP aggregation + forwarding) land.

Related: #140 (EPIC ADR-007).