### PR TITLE
feat(proxy): load MCP resources from DB into tool registry (ADR-007 Phase 1 / PR #2)

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -163,6 +163,23 @@ async def lifespan(app: FastAPI):
         _log.warning("Failed to restore local sessions from DB: %s", exc)
     app.state.local_session_store = local_store
 
+    # ADR-007 Phase 1 PR #2 — load MCP resources from local_mcp_resources
+    # into the tool registry. Discovery and forwarding land in PR #3;
+    # here we only populate the registry so subsequent PRs can rely on
+    # the data being present at startup. Failures degrade soft — the
+    # proxy still serves builtin tools if the DB read blows up.
+    from mcp_proxy.tools.registry import tool_registry
+    from mcp_proxy.tools.resource_loader import load_resources_into_registry
+    try:
+        loaded = await load_resources_into_registry(tool_registry)
+        _log.info("MCP resource registry populated (count=%d)", loaded)
+    except Exception as exc:
+        _log.warning(
+            "Failed to load MCP resources from DB — continuing with "
+            "builtin tools only: %s",
+            exc,
+        )
+
     # Phase 3b — local WS manager. Phase 3c will plug this into message
     # delivery (push-vs-queue decision). Today the endpoint accepts
     # connections so SDKs can start depending on it behind the same

--- a/mcp_proxy/tools/registry.py
+++ b/mcp_proxy/tools/registry.py
@@ -29,6 +29,16 @@ class ToolDefinition:
     allowed_domains: list[str]
     handler: Callable[[ToolContext], Awaitable[Any]]
     parameters_schema: dict | None = None
+    # ADR-007 Phase 1 — MCP resource metadata. Populated when the entry
+    # was loaded from ``local_mcp_resources`` instead of the builtin YAML.
+    # PR-3 reads these to forward calls; builtins keep both as None.
+    resource_id: str | None = None
+    endpoint_url: str | None = None
+
+    @property
+    def is_mcp_resource(self) -> bool:
+        """True when this definition backs an external MCP resource."""
+        return self.resource_id is not None
 
 
 class ToolRegistry:
@@ -78,6 +88,29 @@ class ToolRegistry:
             return fn
 
         return decorator
+
+    def register_definition(self, tool_def: ToolDefinition) -> None:
+        """Register a pre-built ToolDefinition.
+
+        Used by the DB resource loader (ADR-007) which constructs the
+        definition from a ``local_mcp_resources`` row. Unlike the
+        ``@register`` decorator (which wraps a handler function), this
+        path accepts the full object so callers can attach a placeholder
+        handler until PR-3 wires real forwarding.
+
+        Last-writer-wins with a warning — same semantics as ``register``.
+        """
+        if tool_def.name in self._tools:
+            _log.warning(
+                "Tool '%s' registered twice — overwriting", tool_def.name
+            )
+        self._tools[tool_def.name] = tool_def
+        _log.info(
+            "Registered tool '%s' (capability=%s, resource_id=%s)",
+            tool_def.name,
+            tool_def.required_capability,
+            tool_def.resource_id,
+        )
 
     # ------------------------------------------------------------------
     # Lookup

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -1,0 +1,125 @@
+"""
+MCP resource loader — populate the tool registry from ``local_mcp_resources``.
+
+ADR-007 Phase 1 PR #2. Reads enabled rows out of the DB at startup and
+registers each one as a ``ToolDefinition`` with ``resource_id`` and
+``endpoint_url`` set. The handler is a placeholder that raises
+``NotImplementedError`` — real forwarding lands in PR-3.
+
+Conflict policy: if a name collides with an already-registered tool
+(typically a builtin loaded from tools.yaml), the DB entry is SKIPPED
+with a warning. Builtin YAML wins — rationale in ADR-007 issue #140.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.registry import ToolDefinition, ToolRegistry
+
+_log = logging.getLogger("mcp_proxy.tools.resource_loader")
+
+
+async def _unwired_handler(ctx: ToolContext) -> Any:
+    """Placeholder handler for DB-loaded resources.
+
+    PR-2 registers the definition so discovery and metadata lookups
+    work. PR-3 replaces this with a forwarder that proxies the call
+    to ``tool_def.endpoint_url`` honouring binding and capability
+    checks.
+    """
+    raise NotImplementedError(
+        "MCP resource forwarding not wired yet — landing in ADR-007 Phase 1 PR #3"
+    )
+
+
+def _parse_allowed_domains(raw: str | None) -> list[str]:
+    """Decode the JSON-encoded allowed_domains column.
+
+    Schema stores a JSON array text (``"[]"`` default). Malformed
+    payload degrades to an empty whitelist so a single bad row cannot
+    break startup — defense in depth; ``WhitelistedTransport`` still
+    validates at call-time.
+    """
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        _log.warning("allowed_domains not valid JSON: %r — using []", raw)
+        return []
+    if not isinstance(parsed, list):
+        _log.warning(
+            "allowed_domains is not a JSON list: %r — using []", raw
+        )
+        return []
+    return [str(d) for d in parsed]
+
+
+async def load_resources_into_registry(registry: ToolRegistry) -> int:
+    """Load every enabled row from ``local_mcp_resources`` into ``registry``.
+
+    Returns the count of resources actually registered; rows skipped
+    because of a name collision with a builtin are not counted.
+
+    Must be called AFTER ``init_db`` has completed (Alembic upgrade head
+    is responsible for creating the table). Safe to call multiple times:
+    re-registering a resource the loader already knows about updates the
+    existing entry (last-writer-wins).
+    """
+    loaded = 0
+    skipped_conflict = 0
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT resource_id, org_id, name, description,
+                       endpoint_url, required_capability,
+                       allowed_domains, enabled
+                  FROM local_mcp_resources
+                 WHERE enabled = 1
+                """
+            )
+        )
+        rows = list(result.mappings())
+
+    for row in rows:
+        name = row["name"]
+
+        existing = registry.get(name)
+        if existing is not None and not existing.is_mcp_resource:
+            _log.warning(
+                "Resource '%s' (resource_id=%s) collides with builtin "
+                "tool — DB entry skipped. Rename the DB resource to "
+                "resolve.",
+                name,
+                row["resource_id"],
+            )
+            skipped_conflict += 1
+            continue
+
+        tool_def = ToolDefinition(
+            name=name,
+            description=row["description"] or "",
+            required_capability=row["required_capability"] or "",
+            allowed_domains=_parse_allowed_domains(row["allowed_domains"]),
+            handler=_unwired_handler,
+            parameters_schema=None,
+            resource_id=row["resource_id"],
+            endpoint_url=row["endpoint_url"],
+        )
+        registry.register_definition(tool_def)
+        loaded += 1
+
+    _log.info(
+        "MCP resource loader: %d loaded, %d skipped (conflict with builtin)",
+        loaded,
+        skipped_conflict,
+    )
+    return loaded

--- a/tests/test_proxy_resource_registry.py
+++ b/tests/test_proxy_resource_registry.py
@@ -1,0 +1,285 @@
+"""ADR-007 Phase 1 PR #2 — MCP resource loader into the tool registry.
+
+Pure unit tests for ``load_resources_into_registry``: seed rows into
+``local_mcp_resources`` via SQLAlchemy, invoke the loader against a
+fresh ToolRegistry, assert the resulting entries carry the right
+``resource_id`` / ``endpoint_url`` and honour the conflict policy
+against builtin-style pre-registered tools.
+
+Migration tests (schema correctness) are owned by
+tests/test_proxy_migrations_adr007.py — this file does NOT re-assert
+table shape.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.registry import ToolDefinition, ToolRegistry
+from mcp_proxy.tools.resource_loader import load_resources_into_registry
+
+
+async def _seed_resource(
+    *,
+    resource_id: str,
+    name: str,
+    org_id: str | None = "acme",
+    description: str | None = "seeded",
+    endpoint_url: str = "http://mcp-svc:8080",
+    required_capability: str | None = "cap.read",
+    allowed_domains: str = '["mcp-svc:8080"]',
+    enabled: int = 1,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_mcp_resources (
+                    resource_id, org_id, name, description, endpoint_url,
+                    auth_type, auth_secret_ref, required_capability,
+                    allowed_domains, enabled, created_at, updated_at
+                ) VALUES (
+                    :resource_id, :org_id, :name, :description, :endpoint_url,
+                    'none', NULL, :required_capability,
+                    :allowed_domains, :enabled,
+                    '2026-04-16T10:00:00Z', '2026-04-16T10:00:00Z'
+                )
+                """
+            ),
+            {
+                "resource_id": resource_id,
+                "org_id": org_id,
+                "name": name,
+                "description": description,
+                "endpoint_url": endpoint_url,
+                "required_capability": required_capability,
+                "allowed_domains": allowed_domains,
+                "enabled": enabled,
+            },
+        )
+
+
+async def _builtin_handler(ctx: ToolContext) -> dict:
+    return {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_resource_definition_has_new_fields():
+    """ToolDefinition accepts resource_id + endpoint_url with sane defaults."""
+    d = ToolDefinition(
+        name="t",
+        description="",
+        required_capability="",
+        allowed_domains=[],
+        handler=_builtin_handler,
+    )
+    assert d.resource_id is None
+    assert d.endpoint_url is None
+    assert d.is_mcp_resource is False
+
+    d2 = ToolDefinition(
+        name="r",
+        description="",
+        required_capability="",
+        allowed_domains=[],
+        handler=_builtin_handler,
+        resource_id="res-1",
+        endpoint_url="http://svc",
+    )
+    assert d2.is_mcp_resource is True
+
+
+@pytest.mark.asyncio
+async def test_load_resources_empty_db(tmp_path):
+    """No rows in local_mcp_resources → loader returns 0, registry empty."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'empty.db'}"
+    await init_db(url)
+    try:
+        registry = ToolRegistry()
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert loaded == 0
+    assert len(registry) == 0
+
+
+@pytest.mark.asyncio
+async def test_load_resources_populates_registry(tmp_path):
+    """Two enabled rows → two registry entries with resource_id set."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'two.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(
+            resource_id="res-a", name="postgres-prod",
+            required_capability="sql.read",
+        )
+        await _seed_resource(
+            resource_id="res-b", name="github-mcp",
+            endpoint_url="http://github-mcp:9000",
+            required_capability="repo.read",
+            allowed_domains='["github-mcp:9000"]',
+        )
+
+        registry = ToolRegistry()
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert loaded == 2
+    assert len(registry) == 2
+
+    pg = registry.get("postgres-prod")
+    assert pg is not None
+    assert pg.resource_id == "res-a"
+    assert pg.endpoint_url == "http://mcp-svc:8080"
+    assert pg.required_capability == "sql.read"
+    assert pg.allowed_domains == ["mcp-svc:8080"]
+    assert pg.is_mcp_resource is True
+
+    gh = registry.get("github-mcp")
+    assert gh is not None
+    assert gh.resource_id == "res-b"
+    assert gh.endpoint_url == "http://github-mcp:9000"
+
+
+@pytest.mark.asyncio
+async def test_load_resources_skip_disabled(tmp_path):
+    """One enabled + one disabled → only enabled one lands in registry."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'dis.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(resource_id="on", name="live")
+        await _seed_resource(resource_id="off", name="hidden", enabled=0)
+
+        registry = ToolRegistry()
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert loaded == 1
+    assert registry.get("live") is not None
+    assert registry.get("hidden") is None
+
+
+@pytest.mark.asyncio
+async def test_load_resources_conflict_with_builtin_skips_db(tmp_path):
+    """Name collision with pre-registered builtin → DB row skipped.
+
+    Asserts the conflict policy documented in PR-2: builtins win so a
+    bad dashboard entry can't silently shadow a prod tool.
+    """
+    url = f"sqlite+aiosqlite:///{tmp_path / 'conflict.db'}"
+    await init_db(url)
+    try:
+        registry = ToolRegistry()
+        registry.register_definition(
+            ToolDefinition(
+                name="shared",
+                description="builtin version",
+                required_capability="builtin.cap",
+                allowed_domains=[],
+                handler=_builtin_handler,
+            )
+        )
+
+        await _seed_resource(
+            resource_id="res-dup", name="shared",
+            description="db version",
+            required_capability="db.cap",
+        )
+
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert loaded == 0
+    existing = registry.get("shared")
+    assert existing is not None
+    assert existing.description == "builtin version"
+    assert existing.required_capability == "builtin.cap"
+    assert existing.is_mcp_resource is False
+
+
+@pytest.mark.asyncio
+async def test_load_resources_overwrites_previous_mcp_resource(tmp_path):
+    """Second load-from-DB for the same name overwrites (reload semantics)."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'reload.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(
+            resource_id="res-evolve", name="evolve",
+            description="v1",
+        )
+        registry = ToolRegistry()
+        await load_resources_into_registry(registry)
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE local_mcp_resources SET description = 'v2' "
+                    "WHERE resource_id = 'res-evolve'"
+                )
+            )
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert loaded == 1
+    assert registry.get("evolve").description == "v2"
+
+
+@pytest.mark.asyncio
+async def test_load_resources_handler_is_placeholder(tmp_path):
+    """The DB loader uses a placeholder that raises NotImplementedError."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'handler.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(resource_id="res-nh", name="not-wired")
+        registry = ToolRegistry()
+        await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    tool_def = registry.get("not-wired")
+    assert tool_def is not None
+    with pytest.raises(NotImplementedError, match="PR #3"):
+        await tool_def.handler(None)
+
+
+@pytest.mark.asyncio
+async def test_load_resources_empty_allowed_domains(tmp_path):
+    """Non-JSON allowed_domains → empty whitelist, no crash."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'dom.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(
+            resource_id="res-bad-json", name="bad",
+            allowed_domains='not-json',
+        )
+        registry = ToolRegistry()
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert loaded == 1
+    assert registry.get("bad").allowed_domains == []
+
+
+@pytest.mark.asyncio
+async def test_load_resources_null_required_capability(tmp_path):
+    """NULL required_capability → empty string in the registry."""
+    url = f"sqlite+aiosqlite:///{tmp_path / 'cap.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(
+            resource_id="res-nocap", name="anon",
+            required_capability=None,
+        )
+        registry = ToolRegistry()
+        await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+
+    assert registry.get("anon").required_capability == ""


### PR DESCRIPTION
## Summary

Second PR of ADR-007 Phase 1 (#140). Builds on the schema foundation from PR #142 (merged as commit \`7390198\`) and wires the existing tool registry to surface \`local_mcp_resources\` rows as \`ToolDefinition\` entries at proxy startup. **No new HTTP endpoint, no handler forwarding** — those land in PR #3.

### What changes

- **\`ToolDefinition\`**: two optional fields (\`resource_id\`, \`endpoint_url\`) plus an \`is_mcp_resource\` property. Builtins keep both \`None\` → zero behavior change for YAML-loaded tools.
- **\`ToolRegistry.register_definition()\`**: low-level entry point that accepts a pre-built \`ToolDefinition\`. The decorator-based \`register()\` only wraps callables; the DB loader needs to attach a placeholder handler, so this is the clean API.
- **\`mcp_proxy/tools/resource_loader.py\`** (new): \`load_resources_into_registry()\` reads enabled rows from \`local_mcp_resources\`, maps columns onto \`ToolDefinition\`, and registers them. Placeholder handler raises \`NotImplementedError(\"... PR #3\")\` so an accidental call surfaces a loud signal.
- **Conflict policy — DB loses, builtin wins**: if a DB row's \`name\` collides with an already-registered builtin, the DB entry is skipped with a warning. Rationale: \`tools.yaml\` is code-reviewed, dashboard entries are runtime data; a misconfiguration in the dashboard must not silently shadow a prod tool.
- **\`main.py\` lifespan**: invoke loader after \`restore_sessions\`. Wrapped in try/except so a DB read failure degrades soft — builtin tools still serve.

### Test plan

- [x] 9 new tests in \`tests/test_proxy_resource_registry.py\`: dataclass defaults + \`is_mcp_resource\`, empty DB, two-row populate, skip-disabled, builtin-vs-DB collision skip, reload overwrite, placeholder handler raises, malformed \`allowed_domains\` JSON, NULL \`required_capability\`.
- [x] \`pytest tests/\` — **927 passed** (918 baseline + 9 new), same 2 pre-existing postgres DPoP failures unrelated to this PR (confirmed on main).
- [x] \`./demo_network/smoke.sh full\` — round-trip PASS, dashboard signing key persistence PASS, audit hash chain PASS (34 entries).
- [x] DCO \`Signed-off-by\` present, no \`Co-Authored-By\` attribution.
- [x] Import smoke: \`python -c \"import mcp_proxy.main\"\` — no circular import or module-load regression.

### Scope boundary

- No new HTTP endpoint; no handler forwarding — next PR.
- Builtin YAML loading path (dashboard \`/proxy/tools/reload\`) unchanged.
- Audit, policy, routing, discovery endpoints untouched.
- \`smoke.sh\` unchanged (no new endpoint to exercise).

### Follow-up (PR #3)

- Replace \`_unwired_handler\` with the forwarder (whitelisted HTTP transport to \`endpoint_url\`).
- Wire aggregated MCP server endpoint (\`tools/list\` + \`tools/call\` filtered by \`local_agent_resource_bindings\`).
- Add smoke step that seeds a fake MCP server and exercises a call end-to-end.

Related: #140 (EPIC ADR-007), #142 (PR #1 — schema).