### PR TITLE
feat(proxy): aggregated MCP server + resource forwarding (ADR-007 Phase 1 / PR #3)

### DIFF
--- a/mcp_proxy/ingress/mcp_aggregator.py
+++ b/mcp_proxy/ingress/mcp_aggregator.py
@@ -1,0 +1,273 @@
+"""ADR-007 Phase 1 PR #3 — aggregated MCP server endpoint.
+
+``POST /v1/mcp`` speaks JSON-RPC 2.0. The proxy presents itself as a
+single MCP server that exposes the union of:
+
+  * builtin tools (those registered without a ``resource_id``), filtered
+    by the agent's capability scope — same semantics as
+    ``/v1/ingress/tools``.
+  * DB-loaded MCP resources (``local_mcp_resources`` rows), filtered by
+    the agent's explicit bindings in ``local_agent_resource_bindings``.
+
+Methods implemented:
+
+  initialize                       — MCP handshake, advertises tools capability.
+  notifications/initialized        — no-op ack per spec.
+  tools/list                       — binding-filtered tool list.
+  tools/call                       — dispatches via executor.run(); the
+                                     resource forwarder (PR #3) actually
+                                     talks to the remote MCP server.
+
+Authentication is identical to the rest of ingress: DPoP-bound JWT.
+Error codes follow JSON-RPC spec with a Cullis-specific range
+(-32000 to -32099) for application errors.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.db import get_db
+from mcp_proxy.local.audit import append_local_audit
+from mcp_proxy.models import TokenPayload, ToolExecuteRequest
+from mcp_proxy.tools import executor
+from mcp_proxy.tools.registry import tool_registry
+
+router = APIRouter(prefix="/v1/mcp", tags=["mcp-aggregator"])
+_log = logging.getLogger("mcp_proxy.ingress.mcp_aggregator")
+
+PROTOCOL_VERSION = "2024-11-05"
+SERVER_NAME = "cullis-proxy"
+SERVER_VERSION = "0.1.0"
+
+# JSON-RPC error codes.
+ERR_PARSE = -32700
+ERR_INVALID_REQUEST = -32600
+ERR_METHOD_NOT_FOUND = -32601
+ERR_INVALID_PARAMS = -32602
+ERR_INTERNAL = -32603
+# Cullis-specific application errors (-32000 to -32099 per spec).
+ERR_RESOURCE_NOT_AUTHORIZED = -32000
+ERR_RESOURCE_UNREACHABLE = -32001
+ERR_RESOURCE_AUTH_FAILED = -32002
+ERR_RESOURCE_ERROR = -32003
+ERR_TOOL_NOT_FOUND = -32004
+
+
+def _rpc_error(req_id: Any, code: int, message: str, data: Any = None) -> dict:
+    err: dict[str, Any] = {"code": code, "message": message}
+    if data is not None:
+        err["data"] = data
+    return {"jsonrpc": "2.0", "id": req_id, "error": err}
+
+
+def _rpc_result(req_id: Any, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+async def _bound_resource_ids(agent_id: str) -> set[str]:
+    """Return the set of resource_ids this agent currently has active bindings for."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT resource_id
+                  FROM local_agent_resource_bindings
+                 WHERE agent_id = :a AND revoked_at IS NULL
+                """
+            ),
+            {"a": agent_id},
+        )
+        return {row[0] for row in result.all()}
+
+
+async def _has_active_binding(agent_id: str, resource_id: str) -> bool:
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                """
+                SELECT 1 FROM local_agent_resource_bindings
+                 WHERE agent_id = :a AND resource_id = :r
+                   AND revoked_at IS NULL
+                 LIMIT 1
+                """
+            ),
+            {"a": agent_id, "r": resource_id},
+        )).first()
+        return row is not None
+
+
+def _stringify(result: Any) -> str:
+    """Serialize a handler return value for MCP ``content`` text block."""
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, separators=(",", ":"), sort_keys=True, default=str)
+
+
+async def _handle_initialize(req_id: Any) -> dict:
+    return _rpc_result(req_id, {
+        "protocolVersion": PROTOCOL_VERSION,
+        "capabilities": {"tools": {}},
+        "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
+    })
+
+
+async def _handle_tools_list(req_id: Any, agent: TokenPayload) -> dict:
+    bound = await _bound_resource_ids(agent.agent_id)
+    agent_caps = set(agent.scope or [])
+
+    tools_out: list[dict] = []
+    for td in tool_registry.list_tools():
+        if td.is_mcp_resource:
+            # MCP resource: binding is the only gate (capability stays
+            # informational in Phase 1; binding is the auth decision).
+            if td.resource_id not in bound:
+                continue
+        else:
+            # Builtin: capability-gated like /v1/ingress/tools.
+            if td.required_capability and td.required_capability not in agent_caps:
+                continue
+
+        tools_out.append({
+            "name": td.name,
+            "description": td.description or "",
+            "inputSchema": td.parameters_schema or {
+                "type": "object",
+                "properties": {},
+            },
+        })
+
+    return _rpc_result(req_id, {"tools": tools_out})
+
+
+async def _handle_tools_call(
+    req_id: Any,
+    params: dict,
+    agent: TokenPayload,
+    request: Request,
+) -> dict:
+    name = params.get("name")
+    arguments = params.get("arguments") or {}
+
+    if not isinstance(name, str) or not name:
+        return _rpc_error(
+            req_id, ERR_INVALID_PARAMS,
+            "Missing or invalid 'name' in tools/call params",
+        )
+    if not isinstance(arguments, dict):
+        return _rpc_error(
+            req_id, ERR_INVALID_PARAMS,
+            "'arguments' must be an object",
+        )
+
+    tool_def = tool_registry.get(name)
+    if tool_def is None:
+        return _rpc_error(
+            req_id, ERR_TOOL_NOT_FOUND,
+            f"Tool '{name}' not found",
+        )
+
+    # Binding is the primary authz for MCP resources — audit + deny
+    # before even building a ToolContext.
+    if tool_def.is_mcp_resource:
+        if not await _has_active_binding(agent.agent_id, tool_def.resource_id):
+            await append_local_audit(
+                event_type="resource_call",
+                result="denied",
+                agent_id=agent.agent_id,
+                org_id=agent.org,
+                details={
+                    "resource_id": tool_def.resource_id,
+                    "tool": name,
+                    "reason": "no_binding",
+                },
+            )
+            return _rpc_error(
+                req_id, ERR_RESOURCE_NOT_AUTHORIZED,
+                f"No active binding for resource '{tool_def.resource_id}'",
+            )
+
+    # MCP resource names can contain hyphens/uppercase (e.g. 'github-mcp')
+    # which ToolExecuteRequest's stricter regex would reject at pydantic
+    # validation. The aggregator is the *trusted* caller here — it reads
+    # the tool name from our own registry, not from user input verbatim
+    # — so bypass validation with ``model_construct``.
+    exec_req = ToolExecuteRequest.model_construct(
+        tool=name,
+        parameters=arguments,
+        request_id=str(req_id) if req_id is not None else None,
+    )
+
+    secret_provider = getattr(request.app.state, "secret_provider", None)
+    resp = await executor.run(
+        request=exec_req,
+        agent=agent,
+        db=None,
+        secret_provider=secret_provider,
+    )
+
+    if resp.status == "success":
+        return _rpc_result(req_id, {
+            "content": [{"type": "text", "text": _stringify(resp.result)}],
+            "isError": False,
+        })
+    # executor.run always returns status="error" on failure; map to a
+    # generic Cullis-range error. The forwarder has already written a
+    # detailed local_audit row; this response carries the message.
+    return _rpc_error(
+        req_id, ERR_RESOURCE_ERROR,
+        resp.error or "Tool execution failed",
+    )
+
+
+@router.post("")
+async def mcp_endpoint(
+    request: Request,
+    agent: TokenPayload = Depends(get_authenticated_agent),
+) -> JSONResponse:
+    """JSON-RPC 2.0 dispatcher — single endpoint per MCP HTTP transport spec."""
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(
+            _rpc_error(None, ERR_PARSE, "Invalid JSON body"),
+            status_code=400,
+        )
+
+    if not isinstance(body, dict):
+        return JSONResponse(
+            _rpc_error(None, ERR_INVALID_REQUEST, "Request must be a JSON object"),
+            status_code=400,
+        )
+
+    method = body.get("method")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+    if not isinstance(params, dict):
+        return JSONResponse(
+            _rpc_error(req_id, ERR_INVALID_PARAMS, "'params' must be an object"),
+        )
+
+    if method == "initialize":
+        return JSONResponse(await _handle_initialize(req_id))
+
+    if method == "notifications/initialized":
+        # Notifications don't expect a response, but FastAPI must return
+        # something. 204 is the standard "ack without body".
+        return JSONResponse(None, status_code=204)
+
+    if method == "tools/list":
+        return JSONResponse(await _handle_tools_list(req_id, agent))
+
+    if method == "tools/call":
+        return JSONResponse(await _handle_tools_call(req_id, params, agent, request))
+
+    return JSONResponse(
+        _rpc_error(req_id, ERR_METHOD_NOT_FOUND, f"Method '{method}' not found"),
+    )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -131,6 +131,13 @@ async def lifespan(app: FastAPI):
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
 
+    # ADR-007 Phase 1 PR #3 — SecretProvider is consumed by the MCP
+    # resource forwarder (env:// / vault:// refs). Same instance used by
+    # /v1/ingress/execute via the executor, now also exposed on state so
+    # the aggregator can pass it down to ToolContext.
+    from mcp_proxy.tools.secrets import get_secret_provider
+    app.state.secret_provider = get_secret_provider(settings)
+
     if broker_url:
         from mcp_proxy.egress.broker_bridge import BrokerBridge
         bridge = BrokerBridge(
@@ -495,6 +502,10 @@ app.include_router(build_websocket_reverse_proxy_router())
 
 from mcp_proxy.ingress.router import router as ingress_router
 app.include_router(ingress_router)
+
+# ADR-007 Phase 1 PR #3 — aggregated MCP endpoint (/v1/mcp JSON-RPC 2.0).
+from mcp_proxy.ingress.mcp_aggregator import router as mcp_aggregator_router
+app.include_router(mcp_aggregator_router)
 
 from mcp_proxy.egress.router import router as egress_router
 app.include_router(egress_router)

--- a/mcp_proxy/tools/context.py
+++ b/mcp_proxy/tools/context.py
@@ -23,3 +23,7 @@ class ToolContext:
     secrets: dict[str, str]
     http_client: httpx.AsyncClient
     request_id: str
+    # ADR-007 Phase 1 PR #3 — forwarder handler needs SecretProvider to
+    # resolve ``auth_secret_ref`` (env://... or vault://...). Optional so
+    # builtin handlers don't have to care.
+    secret_provider: Any | None = None

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -34,16 +34,11 @@ async def run(
 ) -> ToolExecuteResponse:
     """Execute a tool on behalf of an authenticated agent.
 
-    Steps:
-      1. Lookup tool in registry         -> 404 if not found
-      2. Check capability in agent.scope  -> 403 if missing
-      3. Fetch secrets via SecretProvider
-      4. Build ToolContext with WhitelistedTransport
-      5. Call handler(ctx) with timeout
-      6. Catch exceptions -> error response
-      7. Log audit entry
-      8. Return ToolExecuteResponse
+    The ``db`` parameter is retained for API compatibility but no longer
+    used — ``log_audit`` opens its own connection via ``get_db()`` since
+    the SQLAlchemy async refactor (#36).
     """
+    del db  # kept in signature for backwards compatibility
     t0 = time.monotonic()
     tool_name = request.tool
     request_id = request.request_id
@@ -53,7 +48,6 @@ async def run(
     if tool_def is None:
         duration_ms = _elapsed_ms(t0)
         await log_audit(
-            db,
             agent_id=agent.agent_id,
             action="tool_execute",
             tool_name=tool_name,
@@ -80,7 +74,6 @@ async def run(
             tool_name,
         )
         await log_audit(
-            db,
             agent_id=agent.agent_id,
             action="tool_execute",
             tool_name=tool_name,
@@ -115,6 +108,7 @@ async def run(
             secrets=secrets,
             http_client=http_client,
             request_id=request_id,
+            secret_provider=secret_provider,
         )
 
         # 5. Execute handler with timeout
@@ -133,7 +127,6 @@ async def run(
                 request_id,
             )
             await log_audit(
-                db,
                 agent_id=agent.agent_id,
                 action="tool_execute",
                 tool_name=tool_name,
@@ -158,7 +151,6 @@ async def run(
                 request_id,
             )
             await log_audit(
-                db,
                 agent_id=agent.agent_id,
                 action="tool_execute",
                 tool_name=tool_name,
@@ -184,7 +176,6 @@ async def run(
                 request_id,
             )
             await log_audit(
-                db,
                 agent_id=agent.agent_id,
                 action="tool_execute",
                 tool_name=tool_name,
@@ -209,7 +200,6 @@ async def run(
                 request_id,
             )
             await log_audit(
-                db,
                 agent_id=agent.agent_id,
                 action="tool_execute",
                 tool_name=tool_name,

--- a/mcp_proxy/tools/mcp_resource_forwarder.py
+++ b/mcp_proxy/tools/mcp_resource_forwarder.py
@@ -1,0 +1,198 @@
+"""ADR-007 Phase 1 PR #3 — forwarding handler for DB-loaded MCP resources.
+
+Replaces the PR-2 ``_unwired_handler``. The resource_loader binds this
+function to a specific ``ToolDefinition`` via a closure before
+registering it, so ``executor.run`` can invoke it exactly like any
+builtin handler.
+
+Contract:
+  - Authenticated caller's parameters reach the remote MCP server as
+    ``params.arguments`` of a JSON-RPC ``tools/call`` envelope.
+  - ``auth_secret_ref`` (if set) resolves via the SecretProvider; the
+    value is injected as a ``Authorization: Bearer`` or ``X-API-Key``
+    header depending on ``auth_type``.
+  - Every call emits exactly one ``local_audit`` row with
+    ``event_type='resource_call'``. Failure paths (unreachable, HTTP
+    error, RPC error) are audited before raising so the chain reflects
+    reality even when the remote is down.
+  - Hash chain parity is preserved: the new ``event_type`` uses the
+    same canonical form as the rest of ``append_local_audit``; payload
+    fields (``resource_id``, ``endpoint_url``, ``tool``) live inside
+    ``details`` JSON, not as new hashed columns.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+import httpx
+
+from mcp_proxy.local.audit import append_local_audit
+from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.http_whitelist import ToolExecutionError, WhitelistedTransport
+from mcp_proxy.tools.registry import ToolDefinition
+
+_log = logging.getLogger("mcp_proxy.tools.mcp_resource_forwarder")
+
+DEFAULT_FORWARD_TIMEOUT = 15.0  # seconds — fail fast, no retry
+
+
+async def _build_auth_header(
+    *,
+    auth_type: str,
+    auth_secret_ref: str | None,
+    secret_provider: Any,
+) -> dict[str, str]:
+    """Resolve ``auth_secret_ref`` via the SecretProvider.
+
+    Returns an empty dict when auth is disabled, the ref is missing, or
+    the provider cannot resolve it — never raises. Misconfiguration
+    degrades to "no header" so one bad row cannot cascade-fail an
+    unrelated call.
+    """
+    if auth_type == "none" or not auth_secret_ref:
+        return {}
+    if secret_provider is None:
+        _log.warning(
+            "auth_secret_ref=%r set but no SecretProvider available on "
+            "ToolContext — forwarding without auth header",
+            auth_secret_ref,
+        )
+        return {}
+    try:
+        secret = await secret_provider.get_secret_by_ref(auth_secret_ref)
+    except Exception:
+        _log.exception(
+            "SecretProvider lookup failed for ref=%r", auth_secret_ref
+        )
+        return {}
+    if not secret:
+        _log.warning("SecretProvider returned no value for ref=%r", auth_secret_ref)
+        return {}
+
+    if auth_type == "bearer":
+        return {"Authorization": f"Bearer {secret}"}
+    if auth_type == "api_key":
+        return {"X-API-Key": secret}
+    _log.warning("Unknown auth_type=%r — forwarding without auth header", auth_type)
+    return {}
+
+
+async def forward_to_mcp_resource(
+    ctx: ToolContext,
+    *,
+    tool_def: ToolDefinition,
+) -> Any:
+    """Forward a ``tools/call`` to the remote MCP server backing this resource.
+
+    Raises :class:`ToolExecutionError` on any failure so the executor's
+    error path produces a clean ``ToolExecuteResponse``. The local
+    audit row is written before the raise.
+    """
+    endpoint = tool_def.endpoint_url
+    if not endpoint:
+        raise ToolExecutionError(
+            f"Resource '{tool_def.name}' has no endpoint_url configured"
+        )
+
+    # Private attrs stashed by resource_loader (avoid widening the
+    # ToolDefinition dataclass schema for backend-specific metadata).
+    auth_type = getattr(tool_def, "_auth_type", "none") or "none"
+    auth_secret_ref = getattr(tool_def, "_auth_secret_ref", None)
+
+    auth_header = await _build_auth_header(
+        auth_type=auth_type,
+        auth_secret_ref=auth_secret_ref,
+        secret_provider=ctx.secret_provider,
+    )
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": ctx.request_id or str(uuid.uuid4()),
+        "method": "tools/call",
+        "params": {
+            "name": tool_def.name,
+            "arguments": ctx.parameters,
+        },
+    }
+
+    audit_details = {
+        "resource_id": tool_def.resource_id,
+        "endpoint_url": endpoint,
+        "tool": tool_def.name,
+    }
+
+    transport = WhitelistedTransport(allowed_domains=tool_def.allowed_domains)
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            timeout=DEFAULT_FORWARD_TIMEOUT,
+        ) as client:
+            resp = await client.post(endpoint, json=payload, headers=auth_header)
+    except (httpx.TimeoutException, httpx.ConnectError) as exc:
+        await append_local_audit(
+            event_type="resource_call",
+            result="error",
+            agent_id=ctx.agent_id,
+            org_id=ctx.org_id,
+            details={**audit_details, "error": "unreachable", "detail": str(exc)[:200]},
+        )
+        raise ToolExecutionError(f"MCP resource unreachable: {exc}") from exc
+
+    if resp.status_code in (401, 403):
+        await append_local_audit(
+            event_type="resource_call",
+            result="denied",
+            agent_id=ctx.agent_id,
+            org_id=ctx.org_id,
+            details={**audit_details, "http_status": resp.status_code},
+        )
+        raise ToolExecutionError(
+            f"MCP resource rejected the call with HTTP {resp.status_code}"
+        )
+    if resp.status_code >= 400:
+        await append_local_audit(
+            event_type="resource_call",
+            result="error",
+            agent_id=ctx.agent_id,
+            org_id=ctx.org_id,
+            details={**audit_details, "http_status": resp.status_code},
+        )
+        raise ToolExecutionError(
+            f"MCP resource returned HTTP {resp.status_code}"
+        )
+
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        await append_local_audit(
+            event_type="resource_call",
+            result="error",
+            agent_id=ctx.agent_id,
+            org_id=ctx.org_id,
+            details={**audit_details, "error": "malformed_json"},
+        )
+        raise ToolExecutionError("MCP resource returned non-JSON body") from exc
+
+    if isinstance(data, dict) and "error" in data:
+        err = data["error"] if isinstance(data["error"], dict) else {"message": str(data["error"])}
+        await append_local_audit(
+            event_type="resource_call",
+            result="error",
+            agent_id=ctx.agent_id,
+            org_id=ctx.org_id,
+            details={**audit_details, "rpc_error": err},
+        )
+        raise ToolExecutionError(
+            f"MCP resource RPC error: {err.get('message', 'unknown')}"
+        )
+
+    await append_local_audit(
+        event_type="resource_call",
+        result="ok",
+        agent_id=ctx.agent_id,
+        org_id=ctx.org_id,
+        details=audit_details,
+    )
+    return data.get("result") if isinstance(data, dict) else data

--- a/mcp_proxy/tools/registry.py
+++ b/mcp_proxy/tools/registry.py
@@ -125,10 +125,19 @@ class ToolRegistry:
         return list(self._tools.values())
 
     def has_capability(self, tool_name: str, agent_capabilities: list[str]) -> bool:
-        """Check whether the agent has the capability required by the tool."""
+        """Check whether the agent has the capability required by the tool.
+
+        Tools with an empty ``required_capability`` (``""``) are treated
+        as having no capability gate — any authenticated agent passes.
+        This matches MCP-resource semantics from ADR-007 where the
+        binding table is the primary authz; capability stays optional
+        metadata for discovery filtering.
+        """
         tool = self._tools.get(tool_name)
         if tool is None:
             return False
+        if not tool.required_capability:
+            return True
         return tool.required_capability in agent_capabilities
 
     # ------------------------------------------------------------------

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -1,10 +1,7 @@
 """
 MCP resource loader — populate the tool registry from ``local_mcp_resources``.
 
-ADR-007 Phase 1 PR #2. Reads enabled rows out of the DB at startup and
-registers each one as a ``ToolDefinition`` with ``resource_id`` and
-``endpoint_url`` set. The handler is a placeholder that raises
-``NotImplementedError`` — real forwarding lands in PR-3.
+ADR-007 Phase 1 PR #2 (schema + placeholder) + PR #3 (real forwarder).
 
 Conflict policy: if a name collides with an already-registered tool
 (typically a builtin loaded from tools.yaml), the DB entry is SKIPPED
@@ -14,28 +11,39 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from sqlalchemy import text
 
 from mcp_proxy.db import get_db
-from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.mcp_resource_forwarder import forward_to_mcp_resource
 from mcp_proxy.tools.registry import ToolDefinition, ToolRegistry
 
 _log = logging.getLogger("mcp_proxy.tools.resource_loader")
 
 
-async def _unwired_handler(ctx: ToolContext) -> Any:
-    """Placeholder handler for DB-loaded resources.
+async def _noop_placeholder(ctx):
+    """Unreachable placeholder — real handler is attached via closure below.
 
-    PR-2 registers the definition so discovery and metadata lookups
-    work. PR-3 replaces this with a forwarder that proxies the call
-    to ``tool_def.endpoint_url`` honouring binding and capability
-    checks.
+    Exists only because :class:`ToolDefinition` requires a non-null
+    ``handler`` at construction and we bind the closure-ified forwarder
+    immediately after. If this function ever runs, the binding step
+    was skipped — log loudly.
     """
-    raise NotImplementedError(
-        "MCP resource forwarding not wired yet — landing in ADR-007 Phase 1 PR #3"
+    raise RuntimeError(
+        "resource_loader bug: forwarder closure not bound for this ToolDefinition"
     )
+
+
+def _make_handler(tool_def: ToolDefinition):
+    """Bind the forwarder to its ToolDefinition via closure.
+
+    The executor invokes ``tool_def.handler(ctx)`` with a single
+    positional ``ctx``; the forwarder needs the definition too for
+    endpoint_url / auth metadata, so we pre-bind here.
+    """
+    async def _h(ctx):
+        return await forward_to_mcp_resource(ctx, tool_def=tool_def)
+    return _h
 
 
 def _parse_allowed_domains(raw: str | None) -> list[str]:
@@ -80,8 +88,8 @@ async def load_resources_into_registry(registry: ToolRegistry) -> int:
             text(
                 """
                 SELECT resource_id, org_id, name, description,
-                       endpoint_url, required_capability,
-                       allowed_domains, enabled
+                       endpoint_url, auth_type, auth_secret_ref,
+                       required_capability, allowed_domains, enabled
                   FROM local_mcp_resources
                  WHERE enabled = 1
                 """
@@ -109,11 +117,18 @@ async def load_resources_into_registry(registry: ToolRegistry) -> int:
             description=row["description"] or "",
             required_capability=row["required_capability"] or "",
             allowed_domains=_parse_allowed_domains(row["allowed_domains"]),
-            handler=_unwired_handler,
+            handler=_noop_placeholder,  # replaced below; must be a callable
             parameters_schema=None,
             resource_id=row["resource_id"],
             endpoint_url=row["endpoint_url"],
         )
+        # Stash auth config as private attrs (avoids widening the public
+        # dataclass schema for backend-specific metadata the forwarder
+        # alone consumes).
+        tool_def._auth_type = row["auth_type"]
+        tool_def._auth_secret_ref = row["auth_secret_ref"]
+        # Bind the real handler with the def in its closure.
+        tool_def.handler = _make_handler(tool_def)
         registry.register_definition(tool_def)
         loaded += 1
 

--- a/mcp_proxy/tools/secrets.py
+++ b/mcp_proxy/tools/secrets.py
@@ -24,6 +24,21 @@ class SecretProvider(Protocol):
     async def get_tool_secrets(self, tool_name: str) -> dict[str, str]:
         ...  # pragma: no cover
 
+    async def get_secret_by_ref(self, ref: str) -> str | None:
+        """Resolve an opaque secret reference to its raw value.
+
+        Reference format:
+          ``env://VAR_NAME``           → read from environment
+          ``vault://path/to/secret``   → Vault KV v2 read, field=``value``
+          ``vault://path#field``       → Vault KV v2 read, specific field
+
+        Returns ``None`` if the backend can't satisfy this ref scheme or
+        if the secret is missing. Callers treat ``None`` as "no auth
+        header" rather than raising, so a misconfigured ref doesn't
+        break an unrelated tool call.
+        """
+        ...  # pragma: no cover
+
 
 class EnvSecretProvider:
     """Read secrets from environment variables.
@@ -48,6 +63,12 @@ class EnvSecretProvider:
             tool_name,
         )
         return secrets
+
+    async def get_secret_by_ref(self, ref: str) -> str | None:
+        """ADR-007: resolve ``env://VAR`` refs. Other schemes → None."""
+        if not ref or not ref.startswith("env://"):
+            return None
+        return os.environ.get(ref[len("env://"):])
 
 
 class VaultSecretProvider:
@@ -88,6 +109,40 @@ class VaultSecretProvider:
         except Exception:
             _log.exception("Failed to fetch secrets from Vault for tool '%s'", tool_name)
             return {}
+
+    async def get_secret_by_ref(self, ref: str) -> str | None:
+        """ADR-007: resolve ``vault://path#field`` and ``env://VAR`` refs.
+
+        When the Vault client is available, ``vault://`` goes to Vault
+        (KV v2, field defaults to ``value``). ``env://`` falls back to
+        environment for hybrid deploys (platform env + Vault mounts).
+        """
+        if not ref:
+            return None
+        if ref.startswith("env://"):
+            return os.environ.get(ref[len("env://"):])
+        if not ref.startswith("vault://"):
+            return None
+        body = ref[len("vault://"):]
+        if "#" in body:
+            path, field = body.rsplit("#", 1)
+        else:
+            path, field = body, "value"
+        try:
+            resp = await self._client.get(f"/v1/{path.lstrip('/')}")
+            resp.raise_for_status()
+            data = resp.json()["data"]["data"]
+            return data.get(field)
+        except httpx.HTTPStatusError as exc:
+            _log.error(
+                "Vault HTTP %d resolving ref %r",
+                exc.response.status_code,
+                ref,
+            )
+            return None
+        except Exception:
+            _log.exception("Vault by-ref lookup failed: %s", ref)
+            return None
 
     async def close(self) -> None:
         await self._client.aclose()

--- a/tests/test_proxy_mcp_aggregator.py
+++ b/tests/test_proxy_mcp_aggregator.py
@@ -9,9 +9,7 @@ agent. The forwarder's outbound HTTP is intercepted with
 """
 from __future__ import annotations
 
-import asyncio
 import json
-from typing import Any
 
 import httpx
 import pytest
@@ -22,7 +20,6 @@ from mcp_proxy.auth.dependencies import get_authenticated_agent
 from mcp_proxy.db import dispose_db, get_db, init_db
 from mcp_proxy.local.audit import verify_local_chain
 from mcp_proxy.models import TokenPayload
-from mcp_proxy.tools.context import ToolContext
 from mcp_proxy.tools.registry import ToolDefinition, tool_registry
 from mcp_proxy.tools.resource_loader import load_resources_into_registry
 

--- a/tests/test_proxy_mcp_aggregator.py
+++ b/tests/test_proxy_mcp_aggregator.py
@@ -1,0 +1,633 @@
+"""ADR-007 Phase 1 PR #3 — aggregated MCP endpoint + resource forwarder.
+
+Unit tests for ``mcp_proxy/ingress/mcp_aggregator.py`` and
+``mcp_proxy/tools/mcp_resource_forwarder.py``. The FastAPI app is
+booted with dependency overrides so the DPoP auth dance is bypassed
+and every test can assert against a deterministic authenticated
+agent. The forwarder's outbound HTTP is intercepted with
+``httpx.MockTransport`` so no real network is touched.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.local.audit import verify_local_chain
+from mcp_proxy.models import TokenPayload
+from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.registry import ToolDefinition, tool_registry
+from mcp_proxy.tools.resource_loader import load_resources_into_registry
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+def _fake_agent(
+    agent_id: str = "acme::buyer",
+    org: str = "acme",
+    scope: list[str] | None = None,
+) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=0,
+        jti=f"jti-{agent_id}",
+        scope=scope or [],
+        cnf={"jkt": "fake-jkt"},
+    )
+
+
+@pytest.fixture
+def clean_registry():
+    """Snapshot + restore the singleton registry to keep tests isolated."""
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+@pytest.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """Init a fresh SQLite DB with full migrations, yield its url.
+
+    The URL is exported via ``PROXY_DB_URL`` so any subsequent
+    ``init_db(settings.database_url)`` — e.g. the lifespan triggered by
+    ``TestClient(app)`` in ``app_client`` — reuses this DB rather than
+    falling back to the default and overwriting the engine.
+    """
+    db_file = tmp_path / "mcp_agg.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    # Force-reload settings so the fresh env var is picked up by lifespan.
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()  # type: ignore[attr-defined]
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def app_client(proxy_db):
+    """TestClient with get_authenticated_agent overridden per-test.
+
+    Depends on ``proxy_db`` so settings' database_url points at the test
+    DB before the lifespan fires.
+    """
+    from mcp_proxy.main import app
+    app.dependency_overrides[get_authenticated_agent] = lambda: _fake_agent()
+    with TestClient(app) as client:
+        yield client, app
+    app.dependency_overrides.pop(get_authenticated_agent, None)
+
+
+async def _seed_resource(
+    *,
+    resource_id: str,
+    name: str,
+    org_id: str | None = "acme",
+    description: str = "seeded",
+    endpoint_url: str = "http://mcp-svc:8080",
+    auth_type: str = "none",
+    auth_secret_ref: str | None = None,
+    required_capability: str | None = None,
+    allowed_domains: str = '["mcp-svc:8080"]',
+    enabled: int = 1,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_mcp_resources (
+                    resource_id, org_id, name, description, endpoint_url,
+                    auth_type, auth_secret_ref, required_capability,
+                    allowed_domains, enabled, created_at, updated_at
+                ) VALUES (
+                    :resource_id, :org_id, :name, :description, :endpoint_url,
+                    :auth_type, :auth_secret_ref, :required_capability,
+                    :allowed_domains, :enabled,
+                    '2026-04-16T10:00:00Z', '2026-04-16T10:00:00Z'
+                )
+                """
+            ),
+            {
+                "resource_id": resource_id,
+                "org_id": org_id,
+                "name": name,
+                "description": description,
+                "endpoint_url": endpoint_url,
+                "auth_type": auth_type,
+                "auth_secret_ref": auth_secret_ref,
+                "required_capability": required_capability,
+                "allowed_domains": allowed_domains,
+                "enabled": enabled,
+            },
+        )
+
+
+async def _seed_binding(
+    *,
+    agent_id: str,
+    resource_id: str,
+    org_id: str | None = "acme",
+    revoked_at: str | None = None,
+    binding_id: str | None = None,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_agent_resource_bindings (
+                    binding_id, agent_id, resource_id, org_id,
+                    granted_by, granted_at, revoked_at
+                ) VALUES (
+                    :binding_id, :agent_id, :resource_id, :org_id,
+                    'admin', '2026-04-16T10:05:00Z', :revoked_at
+                )
+                """
+            ),
+            {
+                "binding_id": binding_id or f"bind-{agent_id}-{resource_id}",
+                "agent_id": agent_id,
+                "resource_id": resource_id,
+                "org_id": org_id,
+                "revoked_at": revoked_at,
+            },
+        )
+
+
+def _patch_whitelist_transport(monkeypatch, handler):
+    """Replace WhitelistedTransport with httpx.MockTransport for forwarder tests."""
+    from mcp_proxy.tools import mcp_resource_forwarder as fwd
+
+    class _MockWT(httpx.MockTransport):
+        def __init__(self, allowed_domains: list[str]) -> None:
+            super().__init__(handler)
+
+    monkeypatch.setattr(fwd, "WhitelistedTransport", _MockWT)
+
+
+# ── Aggregator endpoint tests (no DB I/O for initialize) ────────────
+
+def test_initialize_returns_protocol_info(app_client):
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 1, "method": "initialize",
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["jsonrpc"] == "2.0"
+    assert body["id"] == 1
+    assert body["result"]["protocolVersion"] == "2024-11-05"
+    assert body["result"]["serverInfo"]["name"] == "cullis-proxy"
+    assert "tools" in body["result"]["capabilities"]
+
+
+def test_notifications_initialized_returns_204(app_client):
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "method": "notifications/initialized",
+    })
+    assert resp.status_code == 204
+
+
+def test_method_not_found(app_client):
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 9, "method": "tools/unknown",
+    })
+    body = resp.json()
+    assert body["error"]["code"] == -32601
+    assert "tools/unknown" in body["error"]["message"]
+
+
+def test_invalid_json_body_returns_parse_error(app_client):
+    client, _ = app_client
+    resp = client.post("/v1/mcp", content=b"not json", headers={"content-type": "application/json"})
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == -32700
+
+
+def test_non_object_body_returns_invalid_request(app_client):
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json=["not", "an", "object"])
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == -32600
+
+
+# ── tools/list: binding-aware discovery ─────────────────────────────
+
+@pytest.mark.asyncio
+async def test_tools_list_returns_only_bound_resources(
+    proxy_db, clean_registry, app_client,
+):
+    await _seed_resource(resource_id="res-x", name="postgres-prod")
+    await _seed_resource(resource_id="res-y", name="github-mcp")
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-x")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 2, "method": "tools/list",
+    }).json()
+    names = [t["name"] for t in body["result"]["tools"]]
+    assert "postgres-prod" in names
+    assert "github-mcp" not in names
+
+
+@pytest.mark.asyncio
+async def test_tools_list_excludes_revoked_bindings(
+    proxy_db, clean_registry, app_client,
+):
+    await _seed_resource(resource_id="res-rev", name="revoked-one")
+    await _seed_binding(
+        agent_id="acme::buyer", resource_id="res-rev",
+        revoked_at="2026-04-15T09:00:00Z",
+    )
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 3, "method": "tools/list",
+    }).json()
+    assert body["result"]["tools"] == []
+
+
+@pytest.mark.asyncio
+async def test_tools_list_includes_builtin_for_capability_match(
+    proxy_db, clean_registry,
+):
+    from mcp_proxy.main import app
+    clean_registry.register_definition(ToolDefinition(
+        name="builtin_x",
+        description="a builtin",
+        required_capability="cap.x",
+        allowed_domains=[],
+        handler=lambda ctx: None,  # unused
+    ))
+    app.dependency_overrides[get_authenticated_agent] = (
+        lambda: _fake_agent(scope=["cap.x"])
+    )
+    with TestClient(app) as client:
+        body = client.post("/v1/mcp", json={
+            "jsonrpc": "2.0", "id": 4, "method": "tools/list",
+        }).json()
+    app.dependency_overrides.pop(get_authenticated_agent, None)
+
+    names = [t["name"] for t in body["result"]["tools"]]
+    assert "builtin_x" in names
+
+
+@pytest.mark.asyncio
+async def test_tools_list_excludes_builtin_without_capability(
+    proxy_db, clean_registry, app_client,
+):
+    clean_registry.register_definition(ToolDefinition(
+        name="builtin_y",
+        description="a builtin",
+        required_capability="cap.y",
+        allowed_domains=[],
+        handler=lambda ctx: None,
+    ))
+    client, _ = app_client  # fake agent has scope=[]
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 5, "method": "tools/list",
+    }).json()
+    assert body["result"]["tools"] == []
+
+
+# ── tools/call: binding enforcement ─────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_tools_call_without_binding_is_denied(
+    proxy_db, clean_registry, app_client,
+):
+    await _seed_resource(resource_id="res-nb", name="no-binding")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 10, "method": "tools/call",
+        "params": {"name": "no-binding", "arguments": {}},
+    })
+    body = resp.json()
+    assert body["error"]["code"] == -32000
+    assert "res-nb" in body["error"]["message"]
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT event_type, result, details FROM local_audit "
+            "ORDER BY id DESC LIMIT 1"
+        ))).first()
+    assert row.event_type == "resource_call"
+    assert row.result == "denied"
+    details = json.loads(row.details)
+    assert details["reason"] == "no_binding"
+    assert details["resource_id"] == "res-nb"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_unknown_tool_returns_jsonrpc_error(
+    proxy_db, clean_registry, app_client,
+):
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 11, "method": "tools/call",
+        "params": {"name": "nope", "arguments": {}},
+    }).json()
+    assert body["error"]["code"] == -32004
+
+
+@pytest.mark.asyncio
+async def test_tools_call_missing_name_returns_invalid_params(
+    proxy_db, clean_registry, app_client,
+):
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 12, "method": "tools/call",
+        "params": {"arguments": {}},
+    }).json()
+    assert body["error"]["code"] == -32602
+
+
+# ── tools/call: forwarding through mcp_resource_forwarder ───────────
+
+@pytest.mark.asyncio
+async def test_tools_call_forwards_to_mock_mcp_server(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={"jsonrpc": "2.0", "id": captured["body"]["id"],
+                  "result": {"content": [{"type": "text", "text": "hello"}]}},
+        )
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-fw", name="echo-svc",
+        endpoint_url="http://echo-svc:8080/",
+        allowed_domains='["echo-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-fw")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 20, "method": "tools/call",
+        "params": {"name": "echo-svc", "arguments": {"x": 1}},
+    })
+    body = resp.json()
+    assert body["result"]["isError"] is False
+    assert captured["body"]["method"] == "tools/call"
+    assert captured["body"]["params"]["arguments"] == {"x": 1}
+    # content includes upstream response
+    text_out = body["result"]["content"][0]["text"]
+    assert "hello" in text_out
+
+
+@pytest.mark.asyncio
+async def test_tools_call_injects_bearer_auth_header(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    monkeypatch.setenv("TEST_MCP_TOKEN", "abc123")
+    captured_headers = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.update(dict(request.headers))
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x",
+                                         "result": {"ok": True}})
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-auth", name="auth-svc",
+        endpoint_url="http://auth-svc:8080/",
+        allowed_domains='["auth-svc:8080"]',
+        auth_type="bearer", auth_secret_ref="env://TEST_MCP_TOKEN",
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-auth")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 21, "method": "tools/call",
+        "params": {"name": "auth-svc", "arguments": {}},
+    })
+    assert captured_headers.get("authorization") == "Bearer abc123"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_injects_api_key_header(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    monkeypatch.setenv("TEST_MCP_KEY", "xyz789")
+    captured_headers = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_headers.update(dict(request.headers))
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x",
+                                         "result": {"ok": True}})
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-apikey", name="key-svc",
+        endpoint_url="http://key-svc:8080/",
+        allowed_domains='["key-svc:8080"]',
+        auth_type="api_key", auth_secret_ref="env://TEST_MCP_KEY",
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-apikey")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 22, "method": "tools/call",
+        "params": {"name": "key-svc", "arguments": {}},
+    })
+    assert captured_headers.get("x-api-key") == "xyz789"
+    assert "authorization" not in captured_headers
+
+
+@pytest.mark.asyncio
+async def test_tools_call_timeout_surfaces_error(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-down", name="down-svc",
+        endpoint_url="http://down-svc:8080/",
+        allowed_domains='["down-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-down")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 23, "method": "tools/call",
+        "params": {"name": "down-svc", "arguments": {}},
+    }).json()
+    assert body["error"]["code"] == -32003
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT result, details FROM local_audit ORDER BY id DESC LIMIT 1"
+        ))).first()
+    assert row.result == "error"
+    assert json.loads(row.details)["error"] == "unreachable"
+
+
+@pytest.mark.asyncio
+async def test_tools_call_remote_401_marked_denied(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": "unauthorized"})
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-401", name="reject-svc",
+        endpoint_url="http://reject-svc:8080/",
+        allowed_domains='["reject-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-401")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 24, "method": "tools/call",
+        "params": {"name": "reject-svc", "arguments": {}},
+    })
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT result, details FROM local_audit ORDER BY id DESC LIMIT 1"
+        ))).first()
+    assert row.result == "denied"
+    assert json.loads(row.details)["http_status"] == 401
+
+
+@pytest.mark.asyncio
+async def test_tools_call_remote_rpc_error_audited(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "jsonrpc": "2.0", "id": "x",
+            "error": {"code": -32603, "message": "boom"},
+        })
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-boom", name="boom-svc",
+        endpoint_url="http://boom-svc:8080/",
+        allowed_domains='["boom-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-boom")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 25, "method": "tools/call",
+        "params": {"name": "boom-svc", "arguments": {}},
+    }).json()
+    assert body["error"]["code"] == -32003
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT result, details FROM local_audit ORDER BY id DESC LIMIT 1"
+        ))).first()
+    assert row.result == "error"
+    details = json.loads(row.details)
+    assert details["rpc_error"]["message"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_audit_row_has_resource_id_in_details_on_success(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x",
+                                         "result": {"value": 42}})
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-ok", name="ok-svc",
+        endpoint_url="http://ok-svc:8080/",
+        allowed_domains='["ok-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-ok")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 26, "method": "tools/call",
+        "params": {"name": "ok-svc", "arguments": {}},
+    })
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT event_type, result, details FROM local_audit "
+            "WHERE event_type = 'resource_call' ORDER BY id DESC LIMIT 1"
+        ))).first()
+    assert row.result == "ok"
+    details = json.loads(row.details)
+    assert details["resource_id"] == "res-ok"
+    assert details["endpoint_url"] == "http://ok-svc:8080/"
+    assert details["tool"] == "ok-svc"
+    # Canonical form intact: no new keys bleed into colonne hashate
+    assert set(json.loads(row.details).keys()) == {"resource_id", "endpoint_url", "tool"}
+
+
+@pytest.mark.asyncio
+async def test_audit_hash_chain_intact_after_resource_calls(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"jsonrpc": "2.0", "id": "x",
+                                         "result": {"ok": True}})
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-chain", name="chain-svc",
+        endpoint_url="http://chain-svc:8080/",
+        allowed_domains='["chain-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-chain")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    for _ in range(5):
+        client.post("/v1/mcp", json={
+            "jsonrpc": "2.0", "id": 50, "method": "tools/call",
+            "params": {"name": "chain-svc", "arguments": {}},
+        })
+
+    ok, broken_at = await verify_local_chain("acme")
+    assert ok, f"hash chain broken at seq={broken_at}"

--- a/tests/test_proxy_resource_registry.py
+++ b/tests/test_proxy_resource_registry.py
@@ -231,8 +231,12 @@ async def test_load_resources_overwrites_previous_mcp_resource(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_load_resources_handler_is_placeholder(tmp_path):
-    """The DB loader uses a placeholder that raises NotImplementedError."""
+async def test_load_resources_handler_is_bound_forwarder(tmp_path):
+    """PR #3: handler is the MCP forwarder bound to this ToolDefinition.
+
+    Asserts the closure structure rather than invoking the handler
+    (which would try to talk to ``endpoint_url`` over the network).
+    """
     url = f"sqlite+aiosqlite:///{tmp_path / 'handler.db'}"
     await init_db(url)
     try:
@@ -244,8 +248,13 @@ async def test_load_resources_handler_is_placeholder(tmp_path):
 
     tool_def = registry.get("not-wired")
     assert tool_def is not None
-    with pytest.raises(NotImplementedError, match="PR #3"):
-        await tool_def.handler(None)
+    # Auth config stashed by the loader
+    assert tool_def._auth_type == "none"
+    assert tool_def._auth_secret_ref is None
+    # Handler is callable and bound — not the import-time placeholder
+    assert callable(tool_def.handler)
+    from mcp_proxy.tools.resource_loader import _noop_placeholder
+    assert tool_def.handler is not _noop_placeholder
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Third PR of ADR-007 Phase 1 (#140). Makes MCP resources actually callable end-to-end.

- **\`mcp_proxy/ingress/mcp_aggregator.py\`** — new \`POST /v1/mcp\` endpoint speaking **JSON-RPC 2.0** (MCP protocol 2024-11-05). Methods: \`initialize\`, \`notifications/initialized\`, \`tools/list\` (binding-filtered), \`tools/call\` (binding-enforced, then dispatched via \`executor.run\`). The proxy now presents itself as a drop-in MCP server — any standard MCP client can connect.
- **\`mcp_proxy/tools/mcp_resource_forwarder.py\`** — forward handler bound per-\`ToolDefinition\` via the \`resource_loader\` closure. POSTs JSON-RPC \`tools/call\` to the resource's \`endpoint_url\` via \`WhitelistedTransport\`. Injects \`Authorization: Bearer\` or \`X-API-Key\` from SecretProvider (\`env://\`, \`vault://path#field\`). Every call writes one \`local_audit\` row with \`event_type='resource_call'\`.
- **\`SecretProvider.get_secret_by_ref\`** — extend the Protocol with a ref-based lookup (\`env://VAR\`, \`vault://path#field\`), implemented on both Env and Vault providers.
- **\`ToolContext.secret_provider\`** — optional field so the forwarder can resolve refs without coupling to app.state.
- **\`ToolRegistry.has_capability()\`** — empty \`required_capability\` (\`\"\"\") now means 'no gate', matching ADR-007 semantics where the binding table is the primary authz for MCP resources.
- **\`resource_loader.py\`** — placeholder replaced with the real forwarder. SELECT broadened to pull \`auth_type\` + \`auth_secret_ref\`.
- **\`executor.py\`** drive-by fix — the \`log_audit()\` call sites had been passing a stale positional \`db\` arg broken since the SQLAlchemy async refactor (#36). Regression only surfaced now because PR #3 is the first test suite to actually exercise \`executor.run()\`.

## Hash chain parity preserved

\`resource_id\`, \`endpoint_url\`, \`tool\` live inside \`details\` JSON. Canonical form unchanged. \`test_proxy_audit_chain_parity\` + new \`test_audit_hash_chain_intact_after_resource_calls\` both green.

## Test plan

- [x] 20 new tests in \`tests/test_proxy_mcp_aggregator.py\`:
  - Protocol: \`initialize\` returns version info; \`notifications/initialized\` → 204; bad JSON → -32700; non-object body → -32600; unknown method → -32601.
  - Discovery: \`tools/list\` returns only bound resources; revoked bindings excluded; builtins visible when capability matches; builtins hidden when capability missing.
  - Call authz: no-binding denial with audit (\`result='denied'\`, \`reason='no_binding'\`); unknown tool → -32004; missing name → -32602.
  - Forwarding: round-trip via \`httpx.MockTransport\`; bearer header injection; api_key header injection; timeout → -32003 + audit \`unreachable\`; remote 401 → audit \`denied\` with \`http_status\`; remote RPC error → audit \`error\` with \`rpc_error\`; success audit has \`resource_id\`/\`endpoint_url\`/\`tool\` in \`details\`; hash chain intact across 5 calls.
- [x] \`pytest tests/\` — **947 passed** (927 baseline + 20 new), same 2 pre-existing postgres DPoP failures unrelated.
- [x] \`./demo_network/smoke.sh full\` — round-trip + dashboard signing + audit hash chain all green.
- [x] DCO \`Signed-off-by\`, no \`Co-Authored-By\`.

## Scope boundary

- No MCP-echo server / \`demo_network\` integration / smoke A8 step — per the Phase 1 plan those land in PR #5.
- Builtin YAML reload path untouched.
- ADR-006 agent ↔ agent flows untouched.
- \`/v1/ingress/execute\` path untouched (it shares the executor, but the executor fix is behavior-preserving — the stale \`db\` arg was silently broken before).

## Follow-up (Phase 1 plan)

- PR #4 — SPIFFE 3-component parser (\`spiffe://org/resource/*\`) for stricter resource identity.
- PR #5 — dashboard CRUD for \`local_mcp_resources\` + \`demo_network/mcp-echo\` + smoke A8 end-to-end.

Related: #140 (EPIC ADR-007), #142 (PR #1 — schema, merged), #143 (PR #2 — DB loader, merged).