### PR TITLE
feat(proxy): SPIFFE 3-component parser for MCP resources (ADR-007 Phase 1 / PR #4)

### DIFF
--- a/mcp_proxy/spiffe.py
+++ b/mcp_proxy/spiffe.py
@@ -17,6 +17,14 @@ _SPIFFE_SCHEME = "spiffe"
 _TRUST_DOMAIN_RE = re.compile(r"^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$")
 _PATH_COMPONENT_RE = re.compile(r"^[a-zA-Z0-9\-_\.]+$")
 
+# ADR-007: supported ``resource_type`` path components for the 3-component
+# SPIFFE form ``spiffe://<td>/<org>/<resource_type>/<resource_name>``.
+# Phase 1 only ships "mcp" for DB-loaded MCP resources. Future phases may
+# add "llm" (LLM routing) or "saas" (SaaS connectors) — keep the set
+# explicit so ``parse_resource_spiffe`` refuses unknown types rather than
+# silently widening the namespace.
+_KNOWN_RESOURCE_TYPES: frozenset[str] = frozenset({"mcp"})
+
 
 class InvalidRecipient(ValueError):
     """Raised when a recipient identifier cannot be parsed."""
@@ -65,6 +73,90 @@ def parse_internal(internal_id: str) -> tuple[str, str]:
     if not org or not agent:
         raise InvalidRecipient(f"empty component in internal id: {internal_id!r}")
     return org, agent
+
+
+def parse_resource_spiffe(spiffe_id: str) -> tuple[str, str, str, str]:
+    """Parse a 3-component MCP-resource SPIFFE URI (ADR-007 Phase 1).
+
+    Expected shape: ``spiffe://<trust-domain>/<org>/<resource_type>/<resource_name>``
+    where ``resource_type`` is one of the entries in ``_KNOWN_RESOURCE_TYPES``
+    (today only ``"mcp"``).
+
+    Returns ``(trust_domain, org, resource_type, resource_name)``.
+
+    This function is intentionally **separate** from :func:`parse_spiffe`
+    so the existing agent-id path stays strict at 2 components and the
+    ADR-006 routing decision cannot accidentally consume a resource ID.
+    """
+    parsed = urlparse(spiffe_id)
+    if parsed.scheme != _SPIFFE_SCHEME:
+        raise InvalidRecipient(f"not a SPIFFE URI: {spiffe_id!r}")
+    trust_domain = parsed.netloc
+    if not trust_domain or not _TRUST_DOMAIN_RE.match(trust_domain):
+        raise InvalidRecipient(f"invalid trust domain: {trust_domain!r}")
+    if parsed.query or parsed.fragment:
+        raise InvalidRecipient("SPIFFE URI must not have query or fragment")
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) != 3:
+        raise InvalidRecipient(
+            "resource SPIFFE path must have 3 components "
+            f"(org/resource_type/resource_name), got {len(parts)}"
+        )
+    org, resource_type, resource_name = parts
+    if resource_type not in _KNOWN_RESOURCE_TYPES:
+        raise InvalidRecipient(
+            f"unknown resource_type {resource_type!r} "
+            f"(known: {sorted(_KNOWN_RESOURCE_TYPES)})"
+        )
+    for name, value in (
+        ("org", org),
+        ("resource_name", resource_name),
+    ):
+        if not value or not _PATH_COMPONENT_RE.match(value):
+            raise InvalidRecipient(f"invalid {name} component: {value!r}")
+    return trust_domain, org, resource_type, resource_name
+
+
+def is_resource_spiffe(spiffe_id: str) -> bool:
+    """Return ``True`` iff ``spiffe_id`` parses as a resource SPIFFE.
+
+    Non-raising counterpart of :func:`parse_resource_spiffe` — useful in
+    routing decisions that need to branch agent-vs-resource without a
+    try/except.
+    """
+    try:
+        parse_resource_spiffe(spiffe_id)
+    except (InvalidRecipient, ValueError):
+        return False
+    return True
+
+
+def build_resource_spiffe(
+    trust_domain: str,
+    org: str,
+    resource_name: str,
+    resource_type: str = "mcp",
+) -> str:
+    """Assemble a canonical resource SPIFFE URI.
+
+    Validates each component the same way :func:`parse_resource_spiffe`
+    does so a round-trip (``build`` then ``parse``) is guaranteed to
+    succeed or both halves raise on the same input.
+    """
+    if not _TRUST_DOMAIN_RE.match(trust_domain):
+        raise InvalidRecipient(f"invalid trust domain: {trust_domain!r}")
+    if resource_type not in _KNOWN_RESOURCE_TYPES:
+        raise InvalidRecipient(
+            f"unknown resource_type {resource_type!r} "
+            f"(known: {sorted(_KNOWN_RESOURCE_TYPES)})"
+        )
+    for name, value in (
+        ("org", org),
+        ("resource_name", resource_name),
+    ):
+        if not value or not _PATH_COMPONENT_RE.match(value):
+            raise InvalidRecipient(f"invalid {name} component: {value!r}")
+    return f"spiffe://{trust_domain}/{org}/{resource_type}/{resource_name}"
 
 
 def parse_recipient(recipient_id: str) -> tuple[str | None, str, str]:

--- a/tests/test_spiffe_resource_parsing.py
+++ b/tests/test_spiffe_resource_parsing.py
@@ -1,0 +1,150 @@
+"""ADR-007 Phase 1 PR #4 — SPIFFE 3-component parser for MCP resources.
+
+Covers the new ``parse_resource_spiffe``, ``is_resource_spiffe``, and
+``build_resource_spiffe`` helpers plus the regression guard that the
+existing 2-component ``parse_spiffe`` refuses 3-component input (so the
+ADR-006 routing decision can't accidentally consume a resource URI).
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.spiffe import (
+    InvalidRecipient,
+    build_resource_spiffe,
+    is_resource_spiffe,
+    parse_recipient,
+    parse_resource_spiffe,
+    parse_spiffe,
+)
+
+
+# ── Happy path ──────────────────────────────────────────────────────
+
+def test_parse_resource_spiffe_happy_path():
+    td, org, rtype, rname = parse_resource_spiffe(
+        "spiffe://cullis.test/acme/mcp/postgres-prod"
+    )
+    assert td == "cullis.test"
+    assert org == "acme"
+    assert rtype == "mcp"
+    assert rname == "postgres-prod"
+
+
+def test_parse_resource_spiffe_accepts_mixed_case_resource_name():
+    td, org, rtype, rname = parse_resource_spiffe(
+        "spiffe://cullis.test/acme/mcp/Postgres_Prod-01"
+    )
+    assert rname == "Postgres_Prod-01"
+
+
+def test_is_resource_spiffe_true_for_valid_resource_uri():
+    assert is_resource_spiffe("spiffe://cullis.test/acme/mcp/svc") is True
+
+
+def test_is_resource_spiffe_false_for_agent_uri():
+    assert is_resource_spiffe("spiffe://cullis.test/acme/buyer") is False
+
+
+def test_is_resource_spiffe_false_for_garbage():
+    assert is_resource_spiffe("not-a-spiffe-id") is False
+    assert is_resource_spiffe("") is False
+
+
+# ── Build round-trip ────────────────────────────────────────────────
+
+def test_build_resource_spiffe_round_trip():
+    uri = build_resource_spiffe("cullis.test", "acme", "echo")
+    assert uri == "spiffe://cullis.test/acme/mcp/echo"
+    td, org, rtype, rname = parse_resource_spiffe(uri)
+    assert (td, org, rtype, rname) == ("cullis.test", "acme", "mcp", "echo")
+
+
+def test_build_resource_spiffe_default_resource_type_is_mcp():
+    uri = build_resource_spiffe("example.org", "o", "r")
+    assert "/mcp/" in uri
+
+
+def test_build_resource_spiffe_rejects_invalid_trust_domain():
+    with pytest.raises(InvalidRecipient, match="trust domain"):
+        build_resource_spiffe("UPPERCASE-TLD", "acme", "x")
+
+
+def test_build_resource_spiffe_rejects_unknown_resource_type():
+    with pytest.raises(InvalidRecipient, match="unknown resource_type"):
+        build_resource_spiffe("cullis.test", "acme", "x", resource_type="llm")
+
+
+def test_build_resource_spiffe_rejects_empty_org():
+    with pytest.raises(InvalidRecipient, match="org"):
+        build_resource_spiffe("cullis.test", "", "x")
+
+
+def test_build_resource_spiffe_rejects_invalid_resource_name():
+    with pytest.raises(InvalidRecipient, match="resource_name"):
+        build_resource_spiffe("cullis.test", "acme", "bad name!")
+
+
+# ── Parse rejection paths ───────────────────────────────────────────
+
+def test_parse_resource_spiffe_rejects_non_spiffe_scheme():
+    with pytest.raises(InvalidRecipient, match="not a SPIFFE URI"):
+        parse_resource_spiffe("https://cullis.test/acme/mcp/x")
+
+
+def test_parse_resource_spiffe_rejects_missing_trust_domain():
+    with pytest.raises(InvalidRecipient, match="trust domain"):
+        parse_resource_spiffe("spiffe:///acme/mcp/x")
+
+
+def test_parse_resource_spiffe_rejects_two_components():
+    with pytest.raises(InvalidRecipient, match="3 components"):
+        parse_resource_spiffe("spiffe://cullis.test/acme/buyer")
+
+
+def test_parse_resource_spiffe_rejects_four_components():
+    with pytest.raises(InvalidRecipient, match="3 components"):
+        parse_resource_spiffe("spiffe://cullis.test/acme/mcp/svc/extra")
+
+
+def test_parse_resource_spiffe_rejects_unknown_resource_type():
+    with pytest.raises(InvalidRecipient, match="unknown resource_type"):
+        parse_resource_spiffe("spiffe://cullis.test/acme/llm/foo")
+
+
+def test_parse_resource_spiffe_rejects_query_or_fragment():
+    with pytest.raises(InvalidRecipient, match="query or fragment"):
+        parse_resource_spiffe("spiffe://cullis.test/acme/mcp/x?debug=1")
+    with pytest.raises(InvalidRecipient, match="query or fragment"):
+        parse_resource_spiffe("spiffe://cullis.test/acme/mcp/x#frag")
+
+
+# ── ADR-006 regression guard ────────────────────────────────────────
+
+def test_parse_spiffe_still_rejects_3_component_input():
+    """``parse_spiffe`` MUST stay strict at 2 components.
+
+    ADR-006 routing uses this parser for agent IDs; allowing it to
+    accept 3-component URIs would cause a resource SPIFFE to be
+    silently treated as an agent destination and route to the broker
+    bridge by mistake.
+    """
+    with pytest.raises(InvalidRecipient, match="2 components"):
+        parse_spiffe("spiffe://cullis.test/acme/mcp/svc")
+
+
+def test_parse_recipient_still_rejects_3_component_input():
+    """``parse_recipient`` should reject resource URIs too.
+
+    It dispatches to ``parse_spiffe`` for SPIFFE inputs, so the same
+    invariant holds. Guarantees egress routing code that calls
+    ``parse_recipient`` never confuses a resource for an agent.
+    """
+    with pytest.raises(InvalidRecipient, match="2 components"):
+        parse_recipient("spiffe://cullis.test/acme/mcp/svc")
+
+
+def test_parse_spiffe_still_parses_agent_id():
+    """Positive control — existing 2-component parsing untouched."""
+    td, org, agent = parse_spiffe("spiffe://cullis.test/acme/buyer")
+    assert (td, org, agent) == ("cullis.test", "acme", "buyer")


### PR DESCRIPTION
## Summary

Fourth PR of ADR-007 Phase 1 (#140). Introduces a dedicated parser for the resource-identity namespace (\`spiffe://<td>/<org>/<resource_type>/<name>\`) without touching the agent-identity parser used by ADR-006 routing.

### New helpers

- \`parse_resource_spiffe(spiffe_id)\` → \`(trust_domain, org, resource_type, resource_name)\`. Strict validation on each component. Unknown \`resource_type\` raises.
- \`is_resource_spiffe(spiffe_id)\` — non-raising probe for routing branches.
- \`build_resource_spiffe(trust_domain, org, resource_name, resource_type='mcp')\` — canonical builder that matches the parser 1:1.
- \`_KNOWN_RESOURCE_TYPES = frozenset({'mcp'})\` — explicit allowlist; Phase 1 ships only \`mcp\`. Future phases (\`llm\`, \`saas\`) widen the set.

### Regression guard

\`parse_spiffe\` and \`parse_recipient\` stay strict at 2 components. If a resource URI ever reaches them (e.g. a misrouted payload, or a future caller that forgets which parser to use) they raise \`InvalidRecipient\` instead of silently forwarding the message to the broker bridge as if it were an agent destination. Two explicit tests cover this.

## Test plan

- [x] 20 new tests in \`tests/test_spiffe_resource_parsing.py\`:
  - Happy path + mixed-case resource name
  - \`is_resource_spiffe\` true/false branches (agent URI, garbage, empty)
  - \`build_resource_spiffe\` round-trip + default type \`mcp\` + rejections (bad trust domain, unknown type, empty org, invalid resource name)
  - \`parse_resource_spiffe\` rejections (non-SPIFFE scheme, missing trust domain, 2 or 4 components, unknown type, query/fragment)
  - Regression guards: \`parse_spiffe\`, \`parse_recipient\` still reject 3-component; 2-component agent still parses
- [x] \`pytest tests/\` — **967 passed** (947 baseline + 20 new), same 2 pre-existing postgres DPoP failures unrelated.
- [x] \`./demo_network/smoke.sh full\` — round-trip + dashboard signing + audit hash chain all green.
- [x] DCO \`Signed-off-by\`, no \`Co-Authored-By\`.

## Scope boundary

- No callers wired to the new parser yet. The aggregator, forwarder, \`local_mcp_resources\` SELECT, and audit details do not yet emit \`spiffe://\` resource URIs — that wiring lands in PR #5 together with the dashboard + smoke integration.
- \`parse_spiffe\` / \`parse_recipient\` unchanged in behavior.
- No migration, no router, no storage change.

## Follow-up (Phase 1 plan)

- PR #5 — dashboard CRUD + \`demo_network/mcp-echo\` + smoke A8 + wire \`build_resource_spiffe\` into \`local_mcp_resources\` displays and audit \`details\`.

Related: #140 (EPIC ADR-007), #142 / #143 / #144 (PRs #1–#3, merged).