### PR TITLE
feat(proxy): dashboard CRUD for MCP resources + bindings (ADR-007 Phase 1 / PR #5a)

### DIFF
--- a/mcp_proxy/dashboard/mcp_resources.py
+++ b/mcp_proxy/dashboard/mcp_resources.py
@@ -1,0 +1,541 @@
+"""Dashboard CRUD for ADR-007 Phase 1 — local_mcp_resources + bindings.
+
+Admin UI for the two tables deployed by PR #1 (schema) and populated
+at startup by PR #2 (loader). Any mutation here triggers
+``reload_resources()`` so the aggregated MCP endpoint (PR #3) reflects
+the new state without a proxy restart.
+
+Kept in a dedicated module — not merged into ``dashboard/router.py`` —
+matching the policies_local.py (PR #136) layout for patch-fighting.
+Wired in ``main.py`` via ``include_router``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+import re
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import get_db, log_audit
+from mcp_proxy.spiffe import InvalidRecipient, build_resource_spiffe
+from mcp_proxy.tools.registry import tool_registry
+from mcp_proxy.tools.resource_loader import reload_resources
+
+_log = logging.getLogger("mcp_proxy.dashboard.mcp_resources")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+router = APIRouter(prefix="/proxy/mcp-resources", tags=["dashboard-mcp-resources"])
+
+_ALLOWED_AUTH_TYPES = {"none", "bearer", "api_key", "mtls"}
+# Matches mcp_proxy.spiffe._PATH_COMPONENT_RE so a resource name always
+# round-trips through build_resource_spiffe / parse_resource_spiffe.
+_NAME_RE = re.compile(r"^[a-zA-Z0-9\-_\.]+$")
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        "active": "mcp_resources",
+        **kwargs,
+    }
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_allowed_domains(raw: str) -> list[str]:
+    raw = raw.strip()
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"invalid allowed_domains JSON: {exc}",
+        ) from exc
+    if not isinstance(parsed, list):
+        raise HTTPException(
+            status_code=400,
+            detail="allowed_domains must be a JSON array",
+        )
+    return [str(d) for d in parsed]
+
+
+def _validate_endpoint_url(url: str) -> str:
+    url = url.strip()
+    if not url.startswith(("http://", "https://")):
+        raise HTTPException(
+            status_code=400,
+            detail="endpoint_url must start with http:// or https://",
+        )
+    return url
+
+
+def _validate_name(name: str) -> str:
+    name = name.strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    if not _NAME_RE.match(name):
+        raise HTTPException(
+            status_code=400,
+            detail="name must match [a-zA-Z0-9._-]+",
+        )
+    return name
+
+
+def _validate_auth_type(auth_type: str) -> str:
+    if auth_type not in _ALLOWED_AUTH_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"auth_type must be one of {sorted(_ALLOWED_AUTH_TYPES)}",
+        )
+    return auth_type
+
+
+async def _list_resources(trust_domain: str) -> list[dict]:
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                """
+                SELECT r.resource_id, r.org_id, r.name, r.description,
+                       r.endpoint_url, r.auth_type, r.auth_secret_ref,
+                       r.required_capability, r.allowed_domains, r.enabled,
+                       r.created_at, r.updated_at,
+                       COALESCE(SUM(CASE WHEN b.revoked_at IS NULL THEN 1 ELSE 0 END), 0) AS active_count,
+                       COUNT(b.binding_id) AS total_count
+                  FROM local_mcp_resources r
+                  LEFT JOIN local_agent_resource_bindings b
+                    ON b.resource_id = r.resource_id
+                 GROUP BY r.resource_id
+                 ORDER BY r.created_at DESC
+                """
+            )
+        )).mappings().all()
+
+    out: list[dict] = []
+    for r in rows:
+        entry = dict(r)
+        try:
+            entry["spiffe_uri"] = build_resource_spiffe(
+                trust_domain=trust_domain,
+                org=entry["org_id"] or "",
+                resource_name=entry["name"],
+            )
+        except InvalidRecipient:
+            entry["spiffe_uri"] = None
+        out.append(entry)
+    return out
+
+
+async def _list_bindings_by_resource() -> dict[str, list[dict]]:
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                """
+                SELECT binding_id, agent_id, resource_id, org_id,
+                       granted_by, granted_at, revoked_at
+                  FROM local_agent_resource_bindings
+                 ORDER BY granted_at DESC
+                """
+            )
+        )).mappings().all()
+    grouped: dict[str, list[dict]] = {}
+    for r in rows:
+        grouped.setdefault(r["resource_id"], []).append(dict(r))
+    return grouped
+
+
+async def _list_bindable_agents() -> list[dict]:
+    """UNION of internal_agents + local_agents active, for the binding dropdown."""
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                """
+                SELECT agent_id, display_name, 'internal' AS source
+                  FROM internal_agents WHERE is_active = 1
+                UNION ALL
+                SELECT agent_id, display_name, 'local' AS source
+                  FROM local_agents WHERE is_active = 1
+                 ORDER BY agent_id
+                """
+            )
+        )).mappings().all()
+    return [dict(r) for r in rows]
+
+
+async def _reload_registry_safe() -> None:
+    try:
+        await reload_resources(tool_registry)
+    except Exception:
+        _log.exception("Failed to hot-reload MCP resources registry")
+
+
+# ── Pages ────────────────────────────────────────────────────────────
+
+@router.get("", response_class=HTMLResponse)
+async def resources_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    settings = get_settings()
+    resources = await _list_resources(settings.trust_domain)
+    bindings_by_rid = await _list_bindings_by_resource()
+    bindable = await _list_bindable_agents()
+
+    return templates.TemplateResponse("mcp_resources.html", _ctx(
+        request, session,
+        resources=resources,
+        bindings_by_rid=bindings_by_rid,
+        bindable_agents=bindable,
+        default_org_id=settings.org_id or "",
+        trust_domain=settings.trust_domain,
+    ))
+
+
+@router.post("/create")
+async def resources_create(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    name = _validate_name(str(form.get("name", "")))
+    description = str(form.get("description", "")).strip() or None
+    endpoint_url = _validate_endpoint_url(str(form.get("endpoint_url", "")))
+    auth_type = _validate_auth_type(str(form.get("auth_type", "none")).strip())
+    auth_secret_ref = str(form.get("auth_secret_ref", "")).strip() or None
+    required_capability = str(form.get("required_capability", "")).strip() or None
+    allowed_domains = _parse_allowed_domains(str(form.get("allowed_domains", "")))
+    org_id = str(form.get("org_id", "")).strip() or None
+    enabled = 1 if form.get("enabled") in ("1", "true", "on") else 0
+
+    resource_id = str(uuid.uuid4())
+    ts = _iso_now()
+    try:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_mcp_resources (
+                        resource_id, org_id, name, description, endpoint_url,
+                        auth_type, auth_secret_ref, required_capability,
+                        allowed_domains, enabled, created_at, updated_at
+                    ) VALUES (
+                        :rid, :org, :name, :description, :endpoint_url,
+                        :auth_type, :auth_secret_ref, :required_capability,
+                        :allowed_domains, :enabled, :ts, :ts
+                    )
+                    """
+                ),
+                {
+                    "rid": resource_id,
+                    "org": org_id,
+                    "name": name,
+                    "description": description,
+                    "endpoint_url": endpoint_url,
+                    "auth_type": auth_type,
+                    "auth_secret_ref": auth_secret_ref,
+                    "required_capability": required_capability,
+                    "allowed_domains": json.dumps(
+                        allowed_domains, separators=(",", ":"), sort_keys=True,
+                    ),
+                    "enabled": enabled,
+                    "ts": ts,
+                },
+            )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=f"resource name '{name}' already exists in this org",
+        ) from exc
+
+    await _reload_registry_safe()
+    await log_audit(
+        agent_id="admin",
+        action="mcp_resource.create",
+        status="success",
+        detail=f"resource_id={resource_id} name={name} enabled={enabled}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+@router.post("/{resource_id}/update")
+async def resources_update(resource_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    description = str(form.get("description", "")).strip() or None
+    endpoint_url = _validate_endpoint_url(str(form.get("endpoint_url", "")))
+    auth_type = _validate_auth_type(str(form.get("auth_type", "none")).strip())
+    auth_secret_ref = str(form.get("auth_secret_ref", "")).strip() or None
+    required_capability = str(form.get("required_capability", "")).strip() or None
+    allowed_domains = _parse_allowed_domains(str(form.get("allowed_domains", "")))
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                UPDATE local_mcp_resources
+                   SET description = :description,
+                       endpoint_url = :endpoint_url,
+                       auth_type = :auth_type,
+                       auth_secret_ref = :auth_secret_ref,
+                       required_capability = :required_capability,
+                       allowed_domains = :allowed_domains,
+                       updated_at = :ts
+                 WHERE resource_id = :rid
+                """
+            ),
+            {
+                "rid": resource_id,
+                "description": description,
+                "endpoint_url": endpoint_url,
+                "auth_type": auth_type,
+                "auth_secret_ref": auth_secret_ref,
+                "required_capability": required_capability,
+                "allowed_domains": json.dumps(
+                    allowed_domains, separators=(",", ":"), sort_keys=True,
+                ),
+                "ts": _iso_now(),
+            },
+        )
+
+    await _reload_registry_safe()
+    await log_audit(
+        agent_id="admin",
+        action="mcp_resource.update",
+        status="success",
+        detail=f"resource_id={resource_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+@router.post("/{resource_id}/toggle")
+async def resources_toggle(resource_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                UPDATE local_mcp_resources
+                   SET enabled = CASE enabled WHEN 1 THEN 0 ELSE 1 END,
+                       updated_at = :ts
+                 WHERE resource_id = :rid
+                """
+            ),
+            {"rid": resource_id, "ts": _iso_now()},
+        )
+
+    await _reload_registry_safe()
+    await log_audit(
+        agent_id="admin",
+        action="mcp_resource.toggle",
+        status="success",
+        detail=f"resource_id={resource_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+@router.post("/{resource_id}/delete")
+async def resources_delete(resource_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        # Cascade bindings first (no physical FK on local_* tables).
+        await conn.execute(
+            text("DELETE FROM local_agent_resource_bindings WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )
+        await conn.execute(
+            text("DELETE FROM local_mcp_resources WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )
+
+    await _reload_registry_safe()
+    await log_audit(
+        agent_id="admin",
+        action="mcp_resource.delete",
+        status="success",
+        detail=f"resource_id={resource_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+# ── Bindings ─────────────────────────────────────────────────────────
+
+@router.post("/bindings/create")
+async def bindings_create(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    agent_id = str(form.get("agent_id", "")).strip()
+    resource_id = str(form.get("resource_id", "")).strip()
+    if not agent_id or not resource_id:
+        raise HTTPException(
+            status_code=400,
+            detail="agent_id and resource_id are required",
+        )
+
+    # Look up the resource's org_id so the binding row denormalizes it.
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT org_id FROM local_mcp_resources WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )).first()
+        if row is None:
+            raise HTTPException(status_code=404, detail="resource not found")
+        org_id = row[0]
+
+        binding_id = str(uuid.uuid4())
+        try:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_agent_resource_bindings (
+                        binding_id, agent_id, resource_id, org_id,
+                        granted_by, granted_at, revoked_at
+                    ) VALUES (
+                        :bid, :aid, :rid, :org,
+                        'admin', :ts, NULL
+                    )
+                    """
+                ),
+                {
+                    "bid": binding_id,
+                    "aid": agent_id,
+                    "rid": resource_id,
+                    "org": org_id,
+                    "ts": _iso_now(),
+                },
+            )
+        except IntegrityError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="binding already exists for this agent+resource pair",
+            ) from exc
+
+    await log_audit(
+        agent_id="admin",
+        action="mcp_binding.create",
+        status="success",
+        detail=f"binding_id={binding_id} agent={agent_id} resource={resource_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+@router.post("/bindings/{binding_id}/revoke")
+async def bindings_revoke(binding_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                UPDATE local_agent_resource_bindings
+                   SET revoked_at = :ts
+                 WHERE binding_id = :bid
+                """
+            ),
+            {"bid": binding_id, "ts": _iso_now()},
+        )
+    await log_audit(
+        agent_id="admin",
+        action="mcp_binding.revoke",
+        status="success",
+        detail=f"binding_id={binding_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+@router.post("/bindings/{binding_id}/reapprove")
+async def bindings_reapprove(binding_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                UPDATE local_agent_resource_bindings
+                   SET revoked_at = NULL
+                 WHERE binding_id = :bid
+                """
+            ),
+            {"bid": binding_id},
+        )
+    await log_audit(
+        agent_id="admin",
+        action="mcp_binding.reapprove",
+        status="success",
+        detail=f"binding_id={binding_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)
+
+
+@router.post("/bindings/{binding_id}/delete")
+async def bindings_delete(binding_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    async with get_db() as conn:
+        await conn.execute(
+            text("DELETE FROM local_agent_resource_bindings WHERE binding_id = :bid"),
+            {"bid": binding_id},
+        )
+    await log_audit(
+        agent_id="admin",
+        action="mcp_binding.delete",
+        status="success",
+        detail=f"binding_id={binding_id}",
+    )
+    return RedirectResponse(url="/proxy/mcp-resources", status_code=303)

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -61,6 +61,11 @@
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z"/></svg>
                 Tools
             </a>
+            <a href="/proxy/mcp-resources"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'mcp_resources' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg>
+                MCP Resources
+            </a>
             <a href="/proxy/pki"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'pki' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill="currentColor" stroke="none"/></svg>

--- a/mcp_proxy/dashboard/templates/mcp_resources.html
+++ b/mcp_proxy/dashboard/templates/mcp_resources.html
@@ -1,0 +1,285 @@
+{% extends "base.html" %}
+{% block title %}MCP Resources{% endblock %}
+{% block header_title %}MCP Resources (ADR-007){% endblock %}
+{% block content %}
+<div class="max-w-6xl space-y-6">
+
+    <div class="p-4 bg-surface-900/60 border border-gray-800/60 rounded text-sm text-gray-400">
+        External MCP servers the proxy forwards to, gated by explicit agent bindings.
+        Resources appear in <code>/v1/mcp tools/list</code> only for agents with an
+        active binding. SPIFFE URIs use the 3-component form
+        <code>spiffe://&lt;td&gt;/&lt;org&gt;/mcp/&lt;name&gt;</code>.
+    </div>
+
+    <!-- Create resource form -->
+    <details class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
+        <summary class="text-sm uppercase tracking-[0.2em] text-gray-400 cursor-pointer">New MCP resource</summary>
+        <form method="post" action="/proxy/mcp-resources/create" class="mt-4 space-y-4">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Name</label>
+                    <input type="text" name="name" required placeholder="postgres-prod"
+                           class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white focus:border-accent-400 focus:outline-none">
+                </div>
+                <div>
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">
+                        Org scope (leave blank for global)
+                    </label>
+                    <input type="text" name="org_id" value="{{ default_org_id }}" placeholder="acme"
+                           class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white">
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Description</label>
+                    <input type="text" name="description" placeholder="Primary Postgres MCP server"
+                           class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white">
+                </div>
+                <div class="md:col-span-2">
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Endpoint URL</label>
+                    <input type="url" name="endpoint_url" required placeholder="http://postgres-mcp:8080/"
+                           class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white"
+                           style="font-family: 'JetBrains Mono', monospace;">
+                </div>
+                <div>
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Auth type</label>
+                    <select name="auth_type" class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white">
+                        <option value="none" selected>none</option>
+                        <option value="bearer">bearer</option>
+                        <option value="api_key">api_key</option>
+                        <option value="mtls">mtls (Phase 3)</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">
+                        Auth secret ref <span class="text-gray-600">(reference, not the secret)</span>
+                    </label>
+                    <input type="text" name="auth_secret_ref" placeholder="env://GITHUB_MCP_TOKEN or vault://path#field"
+                           class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white"
+                           style="font-family: 'JetBrains Mono', monospace;">
+                </div>
+                <div>
+                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Required capability</label>
+                    <input type="text" name="required_capability" placeholder="sql.read (optional)"
+                           class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white">
+                </div>
+                <div class="flex items-center gap-2 mt-6">
+                    <input type="checkbox" name="enabled" id="enabled-new" value="1" checked
+                           class="w-4 h-4 bg-surface-950 border-gray-700">
+                    <label for="enabled-new" class="text-xs text-gray-400 uppercase tracking-wider">Enabled</label>
+                </div>
+            </div>
+            <div>
+                <label class="block text-xs text-gray-500 uppercase tracking-wider mb-2">Allowed domains (JSON array)</label>
+                <textarea name="allowed_domains" rows="2"
+                          class="w-full px-3 py-2 bg-surface-950 border border-gray-700 rounded text-white"
+                          style="font-family: 'JetBrains Mono', monospace;"
+                          placeholder='["postgres-mcp:8080"]'>[]</textarea>
+            </div>
+            <button type="submit"
+                    class="px-4 py-2 bg-accent-500/20 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/30 uppercase tracking-wider text-sm font-medium">
+                Create resource
+            </button>
+        </form>
+    </details>
+
+    <!-- Resource list -->
+    <div class="p-6 bg-surface-900/60 border border-gray-800/60 rounded-lg">
+        <h3 class="text-sm uppercase tracking-[0.2em] text-gray-400 mb-4">
+            Resources ({{ resources|length }})
+        </h3>
+        {% if not resources %}
+        <p class="text-sm text-gray-500">No MCP resources yet. Use the form above to create one.</p>
+        {% else %}
+        <table class="w-full text-sm">
+            <thead>
+                <tr class="text-[10px] text-gray-500 uppercase tracking-wider text-left">
+                    <th class="py-2">Name</th>
+                    <th>SPIFFE</th>
+                    <th>Endpoint</th>
+                    <th>Auth</th>
+                    <th>Capability</th>
+                    <th class="text-center">Bindings</th>
+                    <th class="text-center">Enabled</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for r in resources %}
+                <tr class="border-t border-gray-800/60">
+                    <td class="py-3 text-white">{{ r.name }}</td>
+                    <td>
+                        {% if r.spiffe_uri %}
+                        <code class="text-xs text-gray-400" style="font-family: 'JetBrains Mono', monospace;">{{ r.spiffe_uri }}</code>
+                        {% else %}
+                        <span class="text-gray-600">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="text-gray-400 text-xs" style="font-family: 'JetBrains Mono', monospace;">{{ r.endpoint_url }}</td>
+                    <td class="text-gray-400">{{ r.auth_type }}</td>
+                    <td class="text-gray-400">{{ r.required_capability or "—" }}</td>
+                    <td class="text-center text-gray-400">
+                        {{ r.active_count }} / {{ r.total_count }}
+                    </td>
+                    <td class="text-center">
+                        <form method="post" action="/proxy/mcp-resources/{{ r.resource_id }}/toggle" class="inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit" class="text-xs {% if r.enabled %}text-emerald-400{% else %}text-gray-500{% endif %} hover:underline">
+                                {% if r.enabled %}ON{% else %}OFF{% endif %}
+                            </button>
+                        </form>
+                    </td>
+                    <td class="flex gap-3">
+                        <details class="inline">
+                            <summary class="text-accent-400 cursor-pointer text-xs">edit</summary>
+                            <form method="post" action="/proxy/mcp-resources/{{ r.resource_id }}/update"
+                                  class="mt-3 p-4 bg-surface-950 border border-gray-800 rounded space-y-3">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <div>
+                                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Description</label>
+                                    <input type="text" name="description" value="{{ r.description or '' }}"
+                                           class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm">
+                                </div>
+                                <div>
+                                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Endpoint URL</label>
+                                    <input type="url" name="endpoint_url" required value="{{ r.endpoint_url }}"
+                                           class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                                           style="font-family: 'JetBrains Mono', monospace;">
+                                </div>
+                                <div class="grid grid-cols-2 gap-3">
+                                    <div>
+                                        <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Auth type</label>
+                                        <select name="auth_type" class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm">
+                                            {% for opt in ["none","bearer","api_key","mtls"] %}
+                                            <option value="{{ opt }}" {% if r.auth_type == opt %}selected{% endif %}>{{ opt }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    <div>
+                                        <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Auth secret ref</label>
+                                        <input type="text" name="auth_secret_ref" value="{{ r.auth_secret_ref or '' }}"
+                                               class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                                               style="font-family: 'JetBrains Mono', monospace;">
+                                    </div>
+                                </div>
+                                <div>
+                                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Required capability</label>
+                                    <input type="text" name="required_capability" value="{{ r.required_capability or '' }}"
+                                           class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm">
+                                </div>
+                                <div>
+                                    <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Allowed domains</label>
+                                    <textarea name="allowed_domains" rows="2"
+                                              class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                                              style="font-family: 'JetBrains Mono', monospace;">{{ r.allowed_domains }}</textarea>
+                                </div>
+                                <button type="submit"
+                                        class="px-3 py-1 bg-accent-500/20 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/30 text-xs uppercase tracking-wider">
+                                    Save
+                                </button>
+                            </form>
+                        </details>
+                        <form method="post" action="/proxy/mcp-resources/{{ r.resource_id }}/delete" class="inline"
+                              onsubmit="return confirm('Delete {{ r.name }}? Also removes {{ r.total_count }} binding(s).')">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit" class="text-xs text-red-400 hover:underline">delete</button>
+                        </form>
+                    </td>
+                </tr>
+
+                <!-- Bindings sub-row -->
+                <tr class="border-t border-gray-800/30 bg-surface-950/40">
+                    <td colspan="8" class="py-3 px-6">
+                        <details>
+                            <summary class="text-accent-400 cursor-pointer text-xs uppercase tracking-wider">
+                                Bindings for {{ r.name }} ({{ r.active_count }} active / {{ r.total_count }} total)
+                            </summary>
+                            <div class="mt-3 space-y-3">
+                                <!-- New binding form -->
+                                <form method="post" action="/proxy/mcp-resources/bindings/create"
+                                      class="flex items-end gap-2">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                    <input type="hidden" name="resource_id" value="{{ r.resource_id }}">
+                                    <div class="flex-1">
+                                        <label class="block text-xs text-gray-500 uppercase tracking-wider mb-1">Agent</label>
+                                        <select name="agent_id" required
+                                                class="w-full px-2 py-1 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                                                {% if not bindable_agents %}disabled{% endif %}>
+                                            {% if not bindable_agents %}
+                                            <option>No active agents — create one in /proxy/agents first</option>
+                                            {% else %}
+                                            {% for a in bindable_agents %}
+                                            <option value="{{ a.agent_id }}">{{ a.display_name }} ({{ a.agent_id }}) [{{ a.source }}]</option>
+                                            {% endfor %}
+                                            {% endif %}
+                                        </select>
+                                    </div>
+                                    <button type="submit"
+                                            class="px-3 py-1 bg-emerald-500/20 text-emerald-400 border border-emerald-400/30 rounded hover:bg-emerald-500/30 text-xs uppercase tracking-wider"
+                                            {% if not bindable_agents %}disabled{% endif %}>
+                                        Grant
+                                    </button>
+                                </form>
+
+                                <!-- Existing bindings -->
+                                {% set bindings = bindings_by_rid.get(r.resource_id, []) %}
+                                {% if bindings %}
+                                <table class="w-full text-xs">
+                                    <thead>
+                                        <tr class="text-[10px] text-gray-500 uppercase tracking-wider text-left">
+                                            <th class="py-1">Agent</th>
+                                            <th>Granted</th>
+                                            <th>Granted at</th>
+                                            <th>Status</th>
+                                            <th></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {% for b in bindings %}
+                                        <tr class="border-t border-gray-800/40">
+                                            <td class="py-2 text-gray-300" style="font-family: 'JetBrains Mono', monospace;">{{ b.agent_id }}</td>
+                                            <td class="text-gray-500">{{ b.granted_by }}</td>
+                                            <td class="text-gray-500">{{ b.granted_at }}</td>
+                                            <td>
+                                                {% if b.revoked_at %}
+                                                <span class="text-gray-500">revoked {{ b.revoked_at }}</span>
+                                                {% else %}
+                                                <span class="text-emerald-400">active</span>
+                                                {% endif %}
+                                            </td>
+                                            <td class="flex gap-3">
+                                                {% if b.revoked_at %}
+                                                <form method="post" action="/proxy/mcp-resources/bindings/{{ b.binding_id }}/reapprove" class="inline">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                                    <button type="submit" class="text-emerald-400 hover:underline">re-approve</button>
+                                                </form>
+                                                {% else %}
+                                                <form method="post" action="/proxy/mcp-resources/bindings/{{ b.binding_id }}/revoke" class="inline">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                                    <button type="submit" class="text-amber-400 hover:underline">revoke</button>
+                                                </form>
+                                                {% endif %}
+                                                <form method="post" action="/proxy/mcp-resources/bindings/{{ b.binding_id }}/delete" class="inline"
+                                                      onsubmit="return confirm('Delete binding permanently?')">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                                    <button type="submit" class="text-red-400 hover:underline">delete</button>
+                                                </form>
+                                            </td>
+                                        </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                                {% else %}
+                                <p class="text-xs text-gray-500">No bindings yet. Grant one above.</p>
+                                {% endif %}
+                            </div>
+                        </details>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -538,6 +538,10 @@ app.include_router(link_broker_admin_router)
 from mcp_proxy.dashboard.policies_local import router as local_policies_router
 app.include_router(local_policies_router)
 
+# ADR-007 Phase 1 PR #5a — dashboard CRUD for MCP resources + bindings.
+from mcp_proxy.dashboard.mcp_resources import router as mcp_resources_dashboard_router
+app.include_router(mcp_resources_dashboard_router)
+
 from mcp_proxy.dashboard.downloads import router as downloads_router
 app.include_router(downloads_router)
 

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -21,6 +21,25 @@ from mcp_proxy.tools.registry import ToolDefinition, ToolRegistry
 _log = logging.getLogger("mcp_proxy.tools.resource_loader")
 
 
+async def reload_resources(registry: ToolRegistry) -> int:
+    """Drop every MCP-resource ToolDefinition and reload from the DB.
+
+    Called by the dashboard CRUD after any mutation to
+    ``local_mcp_resources`` so the live registry reflects the new state
+    without a proxy restart. Builtin tools (``is_mcp_resource is False``)
+    are untouched.
+
+    Returns the count of resources re-registered.
+    """
+    stale = [
+        name for name, td in registry._tools.items()
+        if td.is_mcp_resource
+    ]
+    for name in stale:
+        registry._tools.pop(name, None)
+    return await load_resources_into_registry(registry)
+
+
 async def _noop_placeholder(ctx):
     """Unreachable placeholder — real handler is attached via closure below.
 

--- a/tests/test_proxy_dashboard_mcp_resources.py
+++ b/tests/test_proxy_dashboard_mcp_resources.py
@@ -1,0 +1,493 @@
+"""ADR-007 Phase 1 PR #5a — dashboard CRUD for MCP resources + bindings.
+
+Exercises the admin UI at /proxy/mcp-resources: list, create/update/
+toggle/delete resources, binding create/revoke/reapprove/delete, and
+the hot-reload of the tool_registry after any mutation.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield client
+    get_settings.cache_clear()
+
+
+async def _csrf(client) -> str:
+    page = await client.get("/proxy/mcp-resources")
+    assert page.status_code == 200, page.text
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token not found"
+    return m.group(1)
+
+
+async def _create_resource(
+    client,
+    *,
+    name: str,
+    endpoint_url: str = "http://mcp-svc:8080/",
+    auth_type: str = "none",
+    org_id: str = "acme",
+    enabled: str = "1",
+    allowed_domains: str = '["mcp-svc:8080"]',
+    required_capability: str = "",
+    auth_secret_ref: str = "",
+    description: str = "",
+) -> str:
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mcp-resources/create",
+        data={
+            "csrf_token": csrf,
+            "name": name,
+            "description": description,
+            "endpoint_url": endpoint_url,
+            "auth_type": auth_type,
+            "auth_secret_ref": auth_secret_ref,
+            "required_capability": required_capability,
+            "allowed_domains": allowed_domains,
+            "org_id": org_id,
+            "enabled": enabled,
+        },
+        follow_redirects=False,
+    )
+    return resp
+
+
+async def _resource_id(name: str) -> str:
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        rid = (await conn.execute(
+            text("SELECT resource_id FROM local_mcp_resources WHERE name = :n"),
+            {"n": name},
+        )).scalar()
+    assert rid is not None, f"resource '{name}' not in DB"
+    return rid
+
+
+async def _seed_local_agent(agent_id: str, display: str = "Agent") -> None:
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_agents (
+                    agent_id, display_name, capabilities, scope,
+                    created_at, is_active
+                ) VALUES (
+                    :aid, :disp, '[]', 'local',
+                    '2026-04-16T10:00:00Z', 1
+                )
+                """
+            ),
+            {"aid": agent_id, "disp": display},
+        )
+
+
+# ── List + render ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_page_renders_empty(proxy_logged_in):
+    page = await proxy_logged_in.get("/proxy/mcp-resources")
+    assert page.status_code == 200
+    assert "MCP Resources" in page.text
+    assert "No MCP resources yet" in page.text
+
+
+# ── Resource create ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_resource_persists(proxy_logged_in):
+    resp = await _create_resource(
+        proxy_logged_in, name="github-mcp",
+        endpoint_url="https://api.example.com/mcp",
+        auth_type="bearer", auth_secret_ref="env://GH_TOKEN",
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT name, endpoint_url, auth_type, auth_secret_ref, enabled "
+                 "FROM local_mcp_resources WHERE name='github-mcp'")
+        )).mappings().first()
+    assert row is not None
+    assert row["endpoint_url"] == "https://api.example.com/mcp"
+    assert row["auth_type"] == "bearer"
+    assert row["auth_secret_ref"] == "env://GH_TOKEN"
+    assert row["enabled"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_name(proxy_logged_in):
+    resp = await _create_resource(proxy_logged_in, name="bad name!!")
+    assert resp.status_code == 400
+    assert "must match" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_allowed_domains(proxy_logged_in):
+    resp = await _create_resource(
+        proxy_logged_in, name="bad-dom",
+        allowed_domains="not-json",
+    )
+    assert resp.status_code == 400
+    assert "allowed_domains" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_endpoint(proxy_logged_in):
+    resp = await _create_resource(
+        proxy_logged_in, name="bad-endpoint",
+        endpoint_url="ftp://oops",
+    )
+    assert resp.status_code == 400
+    assert "endpoint_url" in resp.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_create_duplicate_returns_409(proxy_logged_in):
+    r1 = await _create_resource(proxy_logged_in, name="dup")
+    assert r1.status_code == 303
+    r2 = await _create_resource(proxy_logged_in, name="dup")
+    assert r2.status_code == 409
+    assert "already exists" in r2.text.lower()
+
+
+# ── Resource update / toggle / delete ───────────────────────────────
+
+@pytest.mark.asyncio
+async def test_update_changes_fields(proxy_logged_in):
+    await _create_resource(proxy_logged_in, name="edit-me")
+    rid = await _resource_id("edit-me")
+
+    csrf = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        f"/proxy/mcp-resources/{rid}/update",
+        data={
+            "csrf_token": csrf,
+            "description": "updated",
+            "endpoint_url": "https://new.example.com/mcp",
+            "auth_type": "api_key",
+            "auth_secret_ref": "env://NEW",
+            "required_capability": "x.read",
+            "allowed_domains": '["new.example.com"]',
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT description, endpoint_url, auth_type, required_capability "
+                 "FROM local_mcp_resources WHERE resource_id = :r"),
+            {"r": rid},
+        )).mappings().first()
+    assert row["description"] == "updated"
+    assert row["endpoint_url"] == "https://new.example.com/mcp"
+    assert row["auth_type"] == "api_key"
+    assert row["required_capability"] == "x.read"
+
+
+@pytest.mark.asyncio
+async def test_toggle_flips_enabled(proxy_logged_in):
+    await _create_resource(proxy_logged_in, name="toggle-me")
+    rid = await _resource_id("toggle-me")
+
+    csrf = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        f"/proxy/mcp-resources/{rid}/toggle",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        enabled = (await conn.execute(
+            text("SELECT enabled FROM local_mcp_resources WHERE resource_id = :r"),
+            {"r": rid},
+        )).scalar()
+    assert enabled == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_resource_and_cascade_bindings(proxy_logged_in):
+    await _seed_local_agent("acme::buyer")
+    await _create_resource(proxy_logged_in, name="with-bindings")
+    rid = await _resource_id("with-bindings")
+
+    # Create one binding for the resource.
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::buyer", "resource_id": rid},
+        follow_redirects=False,
+    )
+
+    csrf = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        f"/proxy/mcp-resources/{rid}/delete",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        r_count = (await conn.execute(
+            text("SELECT COUNT(*) FROM local_mcp_resources WHERE resource_id = :r"),
+            {"r": rid},
+        )).scalar()
+        b_count = (await conn.execute(
+            text("SELECT COUNT(*) FROM local_agent_resource_bindings WHERE resource_id = :r"),
+            {"r": rid},
+        )).scalar()
+    assert r_count == 0
+    assert b_count == 0
+
+
+# ── SPIFFE rendering ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_spiffe_uri_shown_on_list(proxy_logged_in):
+    await _create_resource(proxy_logged_in, name="pg-svc")
+    page = await proxy_logged_in.get("/proxy/mcp-resources")
+    assert "spiffe://test.local/acme/mcp/pg-svc" in page.text
+
+
+# ── Bindings ────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_binding_persists(proxy_logged_in):
+    await _seed_local_agent("acme::buyer")
+    await _create_resource(proxy_logged_in, name="res1")
+    rid = await _resource_id("res1")
+
+    csrf = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::buyer", "resource_id": rid},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT agent_id, granted_by, revoked_at "
+                 "FROM local_agent_resource_bindings WHERE resource_id = :r"),
+            {"r": rid},
+        )).mappings().first()
+    assert row["agent_id"] == "acme::buyer"
+    assert row["granted_by"] == "admin"
+    assert row["revoked_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_binding_duplicate_returns_409(proxy_logged_in):
+    await _seed_local_agent("acme::buyer")
+    await _create_resource(proxy_logged_in, name="dup-bind")
+    rid = await _resource_id("dup-bind")
+
+    csrf = await _csrf(proxy_logged_in)
+    r1 = await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::buyer", "resource_id": rid},
+        follow_redirects=False,
+    )
+    assert r1.status_code == 303
+
+    csrf = await _csrf(proxy_logged_in)
+    r2 = await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::buyer", "resource_id": rid},
+        follow_redirects=False,
+    )
+    assert r2.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_revoke_and_reapprove_binding(proxy_logged_in):
+    await _seed_local_agent("acme::buyer")
+    await _create_resource(proxy_logged_in, name="rev-bind")
+    rid = await _resource_id("rev-bind")
+
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::buyer", "resource_id": rid},
+        follow_redirects=False,
+    )
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        bid = (await conn.execute(
+            text("SELECT binding_id FROM local_agent_resource_bindings "
+                 "WHERE resource_id = :r"),
+            {"r": rid},
+        )).scalar()
+
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        f"/proxy/mcp-resources/bindings/{bid}/revoke",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    async with get_db() as conn:
+        rev = (await conn.execute(
+            text("SELECT revoked_at FROM local_agent_resource_bindings "
+                 "WHERE binding_id = :b"),
+            {"b": bid},
+        )).scalar()
+    assert rev is not None
+
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        f"/proxy/mcp-resources/bindings/{bid}/reapprove",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    async with get_db() as conn:
+        rev = (await conn.execute(
+            text("SELECT revoked_at FROM local_agent_resource_bindings "
+                 "WHERE binding_id = :b"),
+            {"b": bid},
+        )).scalar()
+    assert rev is None
+
+
+@pytest.mark.asyncio
+async def test_list_shows_binding_counts(proxy_logged_in):
+    await _seed_local_agent("acme::buyer")
+    await _seed_local_agent("acme::seller")
+    await _create_resource(proxy_logged_in, name="counts")
+    rid = await _resource_id("counts")
+
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::buyer", "resource_id": rid},
+        follow_redirects=False,
+    )
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/mcp-resources/bindings/create",
+        data={"csrf_token": csrf, "agent_id": "acme::seller", "resource_id": rid},
+        follow_redirects=False,
+    )
+    # Revoke one so active=1, total=2.
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        bid = (await conn.execute(
+            text(
+                "SELECT binding_id FROM local_agent_resource_bindings "
+                "WHERE resource_id = :r AND agent_id = 'acme::buyer'"
+            ),
+            {"r": rid},
+        )).scalar()
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        f"/proxy/mcp-resources/bindings/{bid}/revoke",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+
+    page = await proxy_logged_in.get("/proxy/mcp-resources")
+    assert "1 / 2" in page.text
+
+
+# ── Registry hot-reload ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_registry_reloaded_on_create(proxy_logged_in):
+    from mcp_proxy.tools.registry import tool_registry
+    await _create_resource(proxy_logged_in, name="hotload")
+    td = tool_registry.get("hotload")
+    assert td is not None
+    assert td.is_mcp_resource is True
+
+
+@pytest.mark.asyncio
+async def test_registry_reloaded_on_delete(proxy_logged_in):
+    from mcp_proxy.tools.registry import tool_registry
+    await _create_resource(proxy_logged_in, name="goneload")
+    rid = await _resource_id("goneload")
+    assert tool_registry.get("goneload") is not None
+
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        f"/proxy/mcp-resources/{rid}/delete",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert tool_registry.get("goneload") is None
+
+
+# ── Auth guards ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_requires_login(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/proxy/mcp-resources", follow_redirects=False)
+            assert resp.status_code == 303
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_csrf_enforced_on_create(proxy_logged_in):
+    resp = await proxy_logged_in.post(
+        "/proxy/mcp-resources/create",
+        data={
+            "csrf_token": "bogus",
+            "name": "no-csrf",
+            "endpoint_url": "http://x:80/",
+            "auth_type": "none",
+            "allowed_domains": "[]",
+            "org_id": "acme",
+            "enabled": "1",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Fifth PR of ADR-007 Phase 1 (#140), split into **PR-5a (this, UI-only)** and PR-5b (demo_network + smoke A8, coming next). Admin UI at \`/proxy/mcp-resources\` for the tables from PR #1 — no more hand-written SQL to register resources or grant bindings.

### What you can do now

- Create / edit / toggle-enabled / delete **MCP resources** with full metadata (endpoint, auth_type, auth_secret_ref, required_capability, allowed_domains).
- Grant / revoke / re-approve / delete **agent↔resource bindings** inline per resource.
- See the resource's canonical SPIFFE URI (via \`build_resource_spiffe\` from PR #4).
- See active/total binding counts at a glance.
- The binding agent dropdown is the **UNION of \`internal_agents\` + \`local_agents\` active** — covers both federated and standalone deploys.

### Hot-reload

Every mutation calls \`reload_resources(tool_registry)\` — a new helper that drops only \`is_mcp_resource\` entries and reloads from DB. \`/v1/mcp tools/list\` reflects the new state without a proxy restart. Builtins are untouched; reload failures log + continue so a dashboard action never breaks a running agent.

### Validation

- \`name\` must match \`[a-zA-Z0-9._-]+\` (round-trip safe through \`build_resource_spiffe\`).
- \`endpoint_url\` must start with \`http://\` or \`https://\`.
- \`auth_type\` ∈ {\`none\`, \`bearer\`, \`api_key\`, \`mtls\`}.
- \`allowed_domains\` must be a JSON array.
- UNIQUE \`(org_id, name)\` on resources and \`(agent_id, resource_id)\` on bindings surface as **409 Conflict** (graceful error, not 500).
- Delete cascades bindings in the same transaction (no FK on \`local_*\` tables).

## Test plan

- [x] 18 new tests in \`tests/test_proxy_dashboard_mcp_resources.py\`:
  - Rendering: empty list, SPIFFE URI shown, binding counts \`1 / 2\`.
  - Create: persists, name regex, allowed_domains JSON, endpoint_url scheme, duplicate → 409.
  - Update: all fields, \`updated_at\` touched.
  - Toggle: flips \`enabled\`.
  - Delete: removes resource + cascade bindings.
  - Bindings: create persists, duplicate 409, revoke sets \`revoked_at\`, reapprove clears it.
  - Registry: hot-reload on create, cleared on delete.
  - Auth: \`/proxy/mcp-resources\` 303 to login; CSRF enforced on \`/create\`.
- [x] \`pytest tests/\` — **985 passed** (967 baseline + 18 new), same 2 pre-existing postgres DPoP failures unrelated.
- [x] \`./demo_network/smoke.sh full\` — round-trip + dashboard signing + audit hash chain all green.
- [x] DCO \`Signed-off-by\`, no \`Co-Authored-By\`.

## Scope boundary

- **No change** to \`/v1/mcp\` aggregator, forwarder, audit canonical form.
- **No change** to \`demo_network\`, \`sender\`, \`smoke.sh\` — those land in PR-5b.
- Routing, policy engine, ADR-006 flows untouched.

## Follow-up

- PR-5b — \`demo_network/mcp-echo\` fake MCP server + proxy-init seed + smoke A8 end-to-end assertion. Closes ADR-007 Phase 1.
- Phase 2 next: policy \`resource\` type, Vault-backed secrets, rate limiting per resource.

Related: #140 (EPIC), #142 / #143 / #144 / #145 (PRs #1–#4 merged).