### PR TITLE
feat(demo): mcp-echo + aggregated MCP smoke A8 (ADR-007 Phase 1 / PR #5b)

### DIFF
--- a/demo_network/compose.postgres.yml
+++ b/demo_network/compose.postgres.yml
@@ -25,6 +25,26 @@ services:
       timeout: 3s
       retries: 30
 
+  # ADR-007 Phase 1 PR #5b: proxy-*-init must also see PROXY_DB_URL so
+  # the seed (Alembic chain + proxy_config + optional MCP resource)
+  # lands in the SAME Postgres DB that the proxy reads on boot.
+  # Before this override the init wrote to an orphan SQLite file at
+  # /data/mcp_proxy.db — invisible to the postgres-backed proxy, which
+  # meant policy_rules was never loaded and phase2 PDP-deny broke.
+  proxy-a-init:
+    depends_on:
+      proxy-db:
+        condition: service_healthy
+    environment:
+      PROXY_DB_URL: "postgresql+asyncpg://cullis_proxy:cullis_proxy_dev@proxy-db:5432/proxy_a"
+
+  proxy-b-init:
+    depends_on:
+      proxy-db:
+        condition: service_healthy
+    environment:
+      PROXY_DB_URL: "postgresql+asyncpg://cullis_proxy:cullis_proxy_dev@proxy-db:5432/proxy_b"
+
   proxy-a:
     depends_on:
       proxy-db:

--- a/demo_network/compose.yml
+++ b/demo_network/compose.yml
@@ -346,6 +346,14 @@ services:
     restart: "no"
 
   sender:
+    # ADR-007 Phase 1 PR #5b follow-up: `profiles: [drive]` excludes the
+    # sender from the default `up --wait` pool. `up --wait` treats any
+    # container that exits (even 0) during the wait as a failure; the
+    # sender is a *driver* (runs the 6 phases and exits), not a long-
+    # lived service. smoke.sh first brings up the fleet with `up --wait`
+    # (no sender), then explicitly `docker compose run --rm sender` to
+    # execute the scenarios and surface the exit code.
+    profiles: ["drive"]
     build:
       context: ..
       dockerfile: demo_network/sender/Dockerfile
@@ -354,11 +362,6 @@ services:
         condition: service_healthy
       broker:
         condition: service_healthy
-      # ADR-007 Phase 1 PR #5b — mcp-echo only needs to be *started*
-      # (port 9200 bound); its /healthz polling takes ~22s to mark
-      # Healthy which races compose `up --wait` on CI: the sender
-      # (restart: no) exits on exit(0) before the last healthcheck
-      # completes, and docker interprets that as an unhealthy outcome.
       mcp-echo:
         condition: service_started
     environment:

--- a/demo_network/compose.yml
+++ b/demo_network/compose.yml
@@ -354,8 +354,13 @@ services:
         condition: service_healthy
       broker:
         condition: service_healthy
+      # ADR-007 Phase 1 PR #5b — mcp-echo only needs to be *started*
+      # (port 9200 bound); its /healthz polling takes ~22s to mark
+      # Healthy which races compose `up --wait` on CI: the sender
+      # (restart: no) exits on exit(0) before the last healthcheck
+      # completes, and docker interprets that as an unhealthy outcome.
       mcp-echo:
-        condition: service_healthy
+        condition: service_started
     environment:
       # ADR-004 — sender reaches the broker via proxy-a (reverse-proxy).
       BROKER_URL:              "https://proxy-a.cullis.test:8443"

--- a/demo_network/compose.yml
+++ b/demo_network/compose.yml
@@ -219,7 +219,9 @@ services:
       start_period: 10s
 
   proxy-a-init:
-    build: ./proxy-init
+    build:
+      context: ..
+      dockerfile: demo_network/proxy-init/Dockerfile
     depends_on:
       bootstrap:
         condition: service_completed_successfully
@@ -231,13 +233,22 @@ services:
       PROXY_PUBLIC_URL: "https://proxy-a.cullis.test:8443"
       PROXY_DB_PATH: /data/mcp_proxy.db
       STATE_DIR: /state
+      # ADR-007 Phase 1 PR #5b — seed a DB-loaded MCP resource pointing
+      # at the mcp-echo service + a binding for the sender agent. The
+      # aggregator's /v1/mcp tools/list + tools/call then have something
+      # to forward in the A8 smoke step.
+      SEED_MCP_ECHO_RESOURCE: "1"
+      SEED_MCP_ECHO_ENDPOINT: "http://mcp-echo:9200/"
+      SEED_MCP_ECHO_BOUND_AGENT: "demo-org-a::sender"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-a-data:/data
     restart: "no"
 
   proxy-b-init:
-    build: ./proxy-init
+    build:
+      context: ..
+      dockerfile: demo_network/proxy-init/Dockerfile
     depends_on:
       bootstrap:
         condition: service_completed_successfully
@@ -328,6 +339,12 @@ services:
       - test-certs:/certs:ro
     expose: ["9000"]
 
+  mcp-echo:
+    build:
+      context: ./mcp-echo
+    expose: ["9200"]
+    restart: "no"
+
   sender:
     build:
       context: ..
@@ -336,6 +353,8 @@ services:
       checker:
         condition: service_healthy
       broker:
+        condition: service_healthy
+      mcp-echo:
         condition: service_healthy
     environment:
       # ADR-004 — sender reaches the broker via proxy-a (reverse-proxy).
@@ -360,8 +379,12 @@ services:
       UNBOUND_AGENT_ID:        "demo-org-a::unbound-agent"
       UNBOUND_AGENT_CERT_PATH: /state/demo-org-a/unbound-agent.pem
       UNBOUND_AGENT_KEY_PATH:  /state/demo-org-a/unbound-agent-key.pem
-      # Phase 5 — MCP Proxy ingress call for the A8 assertion.
+      # Phase 5 — MCP Proxy ingress call.
       INGRESS_URL:             "https://proxy-a.cullis.test:8443/v1/ingress/tools"
+      # ADR-007 Phase 1 / A8 — aggregated MCP endpoint. Phase 6 in send.py
+      # posts tools/list + tools/call and expects the NONCE echoed back
+      # from the mcp-echo container via the proxy forwarder.
+      MCP_AGG_URL:             "https://proxy-a.cullis.test:8443/v1/mcp"
     volumes:
       - bootstrap-state:/state:ro
       - test-certs:/certs:ro

--- a/demo_network/mcp-echo/Dockerfile
+++ b/demo_network/mcp-echo/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir fastapi==0.115.6 uvicorn==0.34.0
+
+WORKDIR /app
+COPY server.py /app/server.py
+
+EXPOSE 9200
+
+HEALTHCHECK --interval=3s --timeout=2s --start-period=3s --retries=10 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:9200/healthz')" || exit 1
+
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "9200", "--log-level", "warning"]

--- a/demo_network/mcp-echo/server.py
+++ b/demo_network/mcp-echo/server.py
@@ -1,0 +1,90 @@
+"""Fake MCP server for ADR-007 Phase 1 smoke A8.
+
+Speaks a minimal JSON-RPC 2.0 subset over POST /:
+
+  - initialize                     → handshake
+  - notifications/initialized      → 204 ack
+  - tools/list                     → one fixed 'echo' tool
+  - tools/call name=echo           → echoes params.arguments as JSON text
+
+GET /healthz returns 200 for the compose healthcheck.
+
+Every RPC is printed with flush=True so the smoke assertion can grep
+``docker compose logs mcp-echo`` for the current NONCE.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="mcp-echo", version="0.1.0")
+
+_PROTOCOL_VERSION = "2024-11-05"
+_ECHO_TOOL = {
+    "name": "echo",
+    "description": "Echo back the caller's arguments for ADR-007 smoke testing.",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"message": {"type": "string"}},
+        "additionalProperties": True,
+    },
+}
+
+
+def _rpc_result(req_id: Any, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _rpc_error(req_id: Any, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    return {"ok": True}
+
+
+@app.post("/")
+async def rpc(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(_rpc_error(None, -32700, "parse error"), status_code=400)
+
+    method = body.get("method")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+
+    print(
+        f"mcp-echo: method={method!r} id={req_id!r} "
+        f"params={json.dumps(params, sort_keys=True)}",
+        flush=True,
+    )
+
+    if method == "initialize":
+        return JSONResponse(_rpc_result(req_id, {
+            "protocolVersion": _PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mcp-echo", "version": "0.1.0"},
+        }))
+
+    if method == "notifications/initialized":
+        return JSONResponse(None, status_code=204)
+
+    if method == "tools/list":
+        return JSONResponse(_rpc_result(req_id, {"tools": [_ECHO_TOOL]}))
+
+    if method == "tools/call":
+        name = params.get("name")
+        if name != "echo":
+            return JSONResponse(_rpc_error(req_id, -32601, f"tool not found: {name}"))
+        args = params.get("arguments") or {}
+        return JSONResponse(_rpc_result(req_id, {
+            "content": [{"type": "text", "text": json.dumps(args, sort_keys=True)}],
+            "isError": False,
+        }))
+
+    return JSONResponse(_rpc_error(req_id, -32601, f"method not found: {method}"))

--- a/demo_network/proxy-init/Dockerfile
+++ b/demo_network/proxy-init/Dockerfile
@@ -1,7 +1,20 @@
 FROM python:3.11-slim
 
-RUN pip install --no-cache-dir aiosqlite==0.20.0
+# Ship alembic + the mcp_proxy package so the init container can apply
+# the proxy's real migration chain before the proxy itself starts. This
+# makes ADR-007 seed rows (inserted below) survive because the target
+# tables already exist by the time proxy-a boots.
+#
+# Build context expands to the repo root (see compose.yml); mirrors the
+# broker + sender + proxy services.
+COPY demo_network/proxy-init/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-COPY seed.py /usr/local/bin/seed.py
+WORKDIR /app
+COPY mcp_proxy/ /app/mcp_proxy/
+
+ENV PYTHONPATH=/app
+
+COPY demo_network/proxy-init/seed.py /usr/local/bin/seed.py
 
 ENTRYPOINT ["python", "/usr/local/bin/seed.py"]

--- a/demo_network/proxy-init/requirements.txt
+++ b/demo_network/proxy-init/requirements.txt
@@ -1,0 +1,4 @@
+aiosqlite==0.20.0
+sqlalchemy>=2.0.36
+alembic>=1.18.0
+asyncpg>=0.30.0

--- a/demo_network/proxy-init/seed.py
+++ b/demo_network/proxy-init/seed.py
@@ -35,11 +35,22 @@ import sys
 import uuid
 from datetime import datetime, timezone
 
-import aiosqlite
+import aiosqlite  # noqa: F401  # retained for potential future raw-sqlite ops
 from alembic import command
 from alembic.config import Config as AlembicConfig
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 
 _ALEMBIC_INI = pathlib.Path("/app/mcp_proxy/alembic.ini")
+
+
+def _dialect_upsert(table: str, conflict_cols: str, update_cols: list[str]) -> str:
+    """Return an INSERT … ON CONFLICT clause that works on both SQLite
+    and Postgres (both support the same syntax; asyncpg needs named
+    params so we rely on named binds for portability).
+    """
+    sets = ", ".join(f"{c} = EXCLUDED.{c}" for c in update_cols)
+    return f"ON CONFLICT ({conflict_cols}) DO UPDATE SET {sets}"
 
 
 def _run_alembic_upgrade(db_url: str) -> None:
@@ -49,7 +60,7 @@ def _run_alembic_upgrade(db_url: str) -> None:
     command.upgrade(cfg, "head")
 
 
-async def _seed_proxy_config(db_path: str, org_id: str) -> None:
+async def _seed_proxy_config(db_url: str, org_id: str) -> None:
     broker_url = os.environ["BROKER_URL"]
     proxy_public = os.environ["PROXY_PUBLIC_URL"]
     state = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
@@ -59,39 +70,50 @@ async def _seed_proxy_config(db_path: str, org_id: str) -> None:
     secret = (org_dir / "org_secret").read_text().strip()
     display = (org_dir / "display_name").read_text().strip()
 
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute("PRAGMA journal_mode=WAL")
-        rows = {
-            "broker_url":    broker_url,
-            "org_id":        org_id,
-            "org_secret":    secret,
-            "org_ca_cert":   ca_cert,
-            "org_ca_key":    ca_key,
-            "display_name":  display,
-            "contact_email": f"admin@{org_id}.test",
-            "webhook_url":   f"{proxy_public}/pdp/policy",
-            "org_status":    "active",
-        }
-        policy_rules = os.environ.get("POLICY_RULES", "").strip()
-        if policy_rules:
-            rows["policy_rules"] = policy_rules
-        for k, v in rows.items():
-            await db.execute(
-                "INSERT INTO proxy_config (key, value) VALUES (?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-                (k, v),
-            )
-        await db.commit()
+    rows = {
+        "broker_url":    broker_url,
+        "org_id":        org_id,
+        "org_secret":    secret,
+        "org_ca_cert":   ca_cert,
+        "org_ca_key":    ca_key,
+        "display_name":  display,
+        "contact_email": f"admin@{org_id}.test",
+        "webhook_url":   f"{proxy_public}/pdp/policy",
+        "org_status":    "active",
+    }
+    policy_rules = os.environ.get("POLICY_RULES", "").strip()
+    if policy_rules:
+        rows["policy_rules"] = policy_rules
+
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            for k, v in rows.items():
+                await conn.execute(
+                    text(
+                        "INSERT INTO proxy_config (key, value) "
+                        "VALUES (:k, :v) "
+                        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+                    ),
+                    {"k": k, "v": v},
+                )
+    finally:
+        await engine.dispose()
     print(f"proxy-init: seeded proxy_config for {org_id} (keys: {', '.join(rows.keys())})")
 
 
-async def _seed_mcp_echo_resource(db_path: str, org_id: str) -> None:
+async def _seed_mcp_echo_resource(db_url: str, org_id: str) -> None:
     """Insert one local_mcp_resources row + one binding.
 
     ADR-007 Phase 1 PR #5b — lets the smoke sender exercise the
     aggregated /v1/mcp endpoint end-to-end against the mcp-echo
     container. ON CONFLICT preserves idempotency when proxy-init runs
     a second time (e.g. after `docker compose up` on a warm volume).
+
+    Uses SQLAlchemy async so the same code path works on both SQLite
+    and Postgres (the postgres overlay points PROXY_DB_URL at a live
+    Postgres instance; both dialects accept the same ON CONFLICT syntax
+    with named binds).
     """
     endpoint = os.environ["SEED_MCP_ECHO_ENDPOINT"]
     agent_id = os.environ["SEED_MCP_ECHO_BOUND_AGENT"]
@@ -102,52 +124,72 @@ async def _seed_mcp_echo_resource(db_path: str, org_id: str) -> None:
     allowed_domains_json = json.dumps(["mcp-echo"], separators=(",", ":"), sort_keys=True)
     now = datetime.now(timezone.utc).isoformat()
 
-    async with aiosqlite.connect(db_path) as db:
-        await db.execute(
-            """
-            INSERT INTO local_mcp_resources (
-                resource_id, org_id, name, description, endpoint_url,
-                auth_type, auth_secret_ref, required_capability,
-                allowed_domains, enabled, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, 'none', NULL, NULL, ?, 1, ?, ?)
-            ON CONFLICT(org_id, name) DO UPDATE SET
-                endpoint_url    = excluded.endpoint_url,
-                allowed_domains = excluded.allowed_domains,
-                enabled         = 1,
-                updated_at      = excluded.updated_at
-            """,
-            (
-                str(uuid.uuid4()), org_id, name,
-                "ADR-007 Phase 1 smoke — mcp-echo fake server.",
-                endpoint,
-                allowed_domains_json,
-                now, now,
-            ),
-        )
-        # Re-read the canonical resource_id — ON CONFLICT leaves the
-        # original row's id intact while the new uuid above is discarded.
-        cursor = await db.execute(
-            "SELECT resource_id FROM local_mcp_resources "
-            "WHERE org_id = ? AND name = ?",
-            (org_id, name),
-        )
-        row = await cursor.fetchone()
-        if row is None:
-            raise RuntimeError("seed: failed to locate the resource we just upserted")
-        resource_id = row[0]
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_mcp_resources (
+                        resource_id, org_id, name, description, endpoint_url,
+                        auth_type, auth_secret_ref, required_capability,
+                        allowed_domains, enabled, created_at, updated_at
+                    ) VALUES (
+                        :rid, :org, :name, :description, :endpoint,
+                        'none', NULL, NULL, :allowed, 1, :now, :now
+                    )
+                    ON CONFLICT (org_id, name) DO UPDATE SET
+                        endpoint_url    = EXCLUDED.endpoint_url,
+                        allowed_domains = EXCLUDED.allowed_domains,
+                        enabled         = 1,
+                        updated_at      = EXCLUDED.updated_at
+                    """
+                ),
+                {
+                    "rid": str(uuid.uuid4()),
+                    "org": org_id,
+                    "name": name,
+                    "description": "ADR-007 Phase 1 smoke — mcp-echo fake server.",
+                    "endpoint": endpoint,
+                    "allowed": allowed_domains_json,
+                    "now": now,
+                },
+            )
+            row = (await conn.execute(
+                text(
+                    "SELECT resource_id FROM local_mcp_resources "
+                    "WHERE org_id = :org AND name = :name"
+                ),
+                {"org": org_id, "name": name},
+            )).first()
+            if row is None:
+                raise RuntimeError("seed: failed to locate the resource we just upserted")
+            resource_id = row[0]
 
-        await db.execute(
-            """
-            INSERT INTO local_agent_resource_bindings (
-                binding_id, agent_id, resource_id, org_id,
-                granted_by, granted_at, revoked_at
-            ) VALUES (?, ?, ?, ?, 'proxy-init-seed', ?, NULL)
-            ON CONFLICT(agent_id, resource_id) DO UPDATE SET
-                revoked_at = NULL
-            """,
-            (str(uuid.uuid4()), agent_id, resource_id, org_id, now),
-        )
-        await db.commit()
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_agent_resource_bindings (
+                        binding_id, agent_id, resource_id, org_id,
+                        granted_by, granted_at, revoked_at
+                    ) VALUES (
+                        :bid, :aid, :rid, :org,
+                        'proxy-init-seed', :now, NULL
+                    )
+                    ON CONFLICT (agent_id, resource_id) DO UPDATE SET
+                        revoked_at = NULL
+                    """
+                ),
+                {
+                    "bid": str(uuid.uuid4()),
+                    "aid": agent_id,
+                    "rid": resource_id,
+                    "org": org_id,
+                    "now": now,
+                },
+            )
+    finally:
+        await engine.dispose()
 
     print(
         f"proxy-init: seeded MCP resource name={name} endpoint={endpoint} "
@@ -155,10 +197,10 @@ async def _seed_mcp_echo_resource(db_path: str, org_id: str) -> None:
     )
 
 
-async def _async_main(db_file: pathlib.Path, org_id: str) -> int:
-    await _seed_proxy_config(str(db_file), org_id)
+async def _async_main(db_file: pathlib.Path, org_id: str, db_url: str) -> int:
+    await _seed_proxy_config(db_url, org_id)
     if os.environ.get("SEED_MCP_ECHO_RESOURCE") == "1":
-        await _seed_mcp_echo_resource(str(db_file), org_id)
+        await _seed_mcp_echo_resource(db_url, org_id)
     return 0
 
 
@@ -173,12 +215,18 @@ def main() -> int:
     # spins up its own asyncio.run() for the async engine migrations,
     # and Python forbids nested event loops. Do the migration chain
     # first, then fire up our own loop for the row seeds.
-    db_url = f"sqlite+aiosqlite:///{db_path}"
+    #
+    # Honour PROXY_DB_URL when the compose overlay points the proxy at
+    # Postgres (demo_network/compose.postgres.yml). The hardcoded SQLite
+    # URL made seed rows invisible to the postgres-backed proxy on
+    # restart — policy_rules was never loaded, breaking phase2 PDP-deny.
+    db_url = os.environ.get("PROXY_DB_URL") or f"sqlite+aiosqlite:///{db_path}"
     _run_alembic_upgrade(db_url)
 
-    rc = asyncio.run(_async_main(db_file, org_id))
+    rc = asyncio.run(_async_main(db_file, org_id, db_url))
 
-    db_file.chmod(0o666)
+    if db_url.startswith("sqlite"):
+        db_file.chmod(0o666)
     return rc
 
 

--- a/demo_network/proxy-init/seed.py
+++ b/demo_network/proxy-init/seed.py
@@ -6,49 +6,61 @@ the admin pastes an invite token. For non-interactive smoke runs we just
 insert them directly, using the org CA + secret that bootstrap.py already
 generated on the shared /state volume.
 
+ADR-007 Phase 1 PR #5b: this script now also applies the proxy's Alembic
+migration chain before the legacy seed, so subsequent optional seeds
+(MCP resources + bindings) can write into tables the proxy will load at
+startup.
+
 Env inputs:
-  ORG_ID          e.g. "demo-org-a"
-  BROKER_URL      e.g. "https://broker.cullis.test:8443"
-  PROXY_PUBLIC_URL e.g. "https://proxy-a.cullis.test:8443"
-  PROXY_DB_PATH   e.g. "/data/mcp_proxy.db"
-  STATE_DIR       e.g. "/state"
+  ORG_ID                   e.g. "demo-org-a"
+  BROKER_URL               e.g. "https://broker.cullis.test:8443"
+  PROXY_PUBLIC_URL         e.g. "https://proxy-a.cullis.test:8443"
+  PROXY_DB_PATH            e.g. "/data/mcp_proxy.db"
+  STATE_DIR                e.g. "/state"
+  POLICY_RULES             optional JSON ruleset for the PDP webhook
+
+  # ADR-007 Phase 1 optional seed:
+  SEED_MCP_ECHO_RESOURCE       "1" to enable the mcp-echo resource seed
+  SEED_MCP_ECHO_ENDPOINT       e.g. "http://mcp-echo:9200/"
+  SEED_MCP_ECHO_BOUND_AGENT    agent_id to bind, e.g. "demo-org-a::sender"
+  SEED_MCP_ECHO_NAME           optional, default "echo"
 """
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import pathlib
 import sys
+import uuid
+from datetime import datetime, timezone
 
 import aiosqlite
+from alembic import command
+from alembic.config import Config as AlembicConfig
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS proxy_config (
-    key   TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-"""
+_ALEMBIC_INI = pathlib.Path("/app/mcp_proxy/alembic.ini")
 
-async def main() -> int:
-    org_id         = os.environ["ORG_ID"]
-    broker_url     = os.environ["BROKER_URL"]
-    proxy_public   = os.environ["PROXY_PUBLIC_URL"]
-    db_path        = os.environ.get("PROXY_DB_PATH", "/data/mcp_proxy.db")
-    state          = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
 
+def _run_alembic_upgrade(db_url: str) -> None:
+    """Apply the full proxy migration chain so target tables exist."""
+    cfg = AlembicConfig(str(_ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(cfg, "head")
+
+
+async def _seed_proxy_config(db_path: str, org_id: str) -> None:
+    broker_url = os.environ["BROKER_URL"]
+    proxy_public = os.environ["PROXY_PUBLIC_URL"]
+    state = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
     org_dir = state / org_id
     ca_cert = (org_dir / "ca.pem").read_text()
-    ca_key  = (org_dir / "ca-key.pem").read_text()
-    secret  = (org_dir / "org_secret").read_text().strip()
+    ca_key = (org_dir / "ca-key.pem").read_text()
+    secret = (org_dir / "org_secret").read_text().strip()
     display = (org_dir / "display_name").read_text().strip()
 
-    db_file = pathlib.Path(db_path)
-    db_file.parent.mkdir(parents=True, exist_ok=True)
-
-    async with aiosqlite.connect(str(db_file)) as db:
+    async with aiosqlite.connect(db_path) as db:
         await db.execute("PRAGMA journal_mode=WAL")
-        await db.executescript(_SCHEMA)
-
         rows = {
             "broker_url":    broker_url,
             "org_id":        org_id,
@@ -60,11 +72,6 @@ async def main() -> int:
             "webhook_url":   f"{proxy_public}/pdp/policy",
             "org_status":    "active",
         }
-
-        # Optional PDP policy rules — passed as JSON via POLICY_RULES env var
-        # so each proxy can have a different ruleset. Smoke configures
-        # proxy-b with a blocked_agents list so the DENY branch of the
-        # webhook path is exercised every run.
         policy_rules = os.environ.get("POLICY_RULES", "").strip()
         if policy_rules:
             rows["policy_rules"] = policy_rules
@@ -75,12 +82,105 @@ async def main() -> int:
                 (k, v),
             )
         await db.commit()
+    print(f"proxy-init: seeded proxy_config for {org_id} (keys: {', '.join(rows.keys())})")
 
-    # Ensure proxyuser (uid varies but typically not root) can read the file.
-    db_file.chmod(0o666)
-    print(f"proxy-init: seeded {db_path} for {org_id} (keys: {', '.join(rows.keys())})")
+
+async def _seed_mcp_echo_resource(db_path: str, org_id: str) -> None:
+    """Insert one local_mcp_resources row + one binding.
+
+    ADR-007 Phase 1 PR #5b — lets the smoke sender exercise the
+    aggregated /v1/mcp endpoint end-to-end against the mcp-echo
+    container. ON CONFLICT preserves idempotency when proxy-init runs
+    a second time (e.g. after `docker compose up` on a warm volume).
+    """
+    endpoint = os.environ["SEED_MCP_ECHO_ENDPOINT"]
+    agent_id = os.environ["SEED_MCP_ECHO_BOUND_AGENT"]
+    name = os.environ.get("SEED_MCP_ECHO_NAME", "echo")
+
+    # WhitelistedTransport matches on request.url.host only (no port) —
+    # the allowlist stores the compose DNS name of the mcp-echo service.
+    allowed_domains_json = json.dumps(["mcp-echo"], separators=(",", ":"), sort_keys=True)
+    now = datetime.now(timezone.utc).isoformat()
+
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO local_mcp_resources (
+                resource_id, org_id, name, description, endpoint_url,
+                auth_type, auth_secret_ref, required_capability,
+                allowed_domains, enabled, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, 'none', NULL, NULL, ?, 1, ?, ?)
+            ON CONFLICT(org_id, name) DO UPDATE SET
+                endpoint_url    = excluded.endpoint_url,
+                allowed_domains = excluded.allowed_domains,
+                enabled         = 1,
+                updated_at      = excluded.updated_at
+            """,
+            (
+                str(uuid.uuid4()), org_id, name,
+                "ADR-007 Phase 1 smoke — mcp-echo fake server.",
+                endpoint,
+                allowed_domains_json,
+                now, now,
+            ),
+        )
+        # Re-read the canonical resource_id — ON CONFLICT leaves the
+        # original row's id intact while the new uuid above is discarded.
+        cursor = await db.execute(
+            "SELECT resource_id FROM local_mcp_resources "
+            "WHERE org_id = ? AND name = ?",
+            (org_id, name),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            raise RuntimeError("seed: failed to locate the resource we just upserted")
+        resource_id = row[0]
+
+        await db.execute(
+            """
+            INSERT INTO local_agent_resource_bindings (
+                binding_id, agent_id, resource_id, org_id,
+                granted_by, granted_at, revoked_at
+            ) VALUES (?, ?, ?, ?, 'proxy-init-seed', ?, NULL)
+            ON CONFLICT(agent_id, resource_id) DO UPDATE SET
+                revoked_at = NULL
+            """,
+            (str(uuid.uuid4()), agent_id, resource_id, org_id, now),
+        )
+        await db.commit()
+
+    print(
+        f"proxy-init: seeded MCP resource name={name} endpoint={endpoint} "
+        f"bound_agent={agent_id}"
+    )
+
+
+async def _async_main(db_file: pathlib.Path, org_id: str) -> int:
+    await _seed_proxy_config(str(db_file), org_id)
+    if os.environ.get("SEED_MCP_ECHO_RESOURCE") == "1":
+        await _seed_mcp_echo_resource(str(db_file), org_id)
     return 0
 
 
+def main() -> int:
+    org_id = os.environ["ORG_ID"]
+    db_path = os.environ.get("PROXY_DB_PATH", "/data/mcp_proxy.db")
+
+    db_file = pathlib.Path(db_path)
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+
+    # Run Alembic SYNCHRONOUSLY at module top — mcp_proxy/alembic/env.py
+    # spins up its own asyncio.run() for the async engine migrations,
+    # and Python forbids nested event loops. Do the migration chain
+    # first, then fire up our own loop for the row seeds.
+    db_url = f"sqlite+aiosqlite:///{db_path}"
+    _run_alembic_upgrade(db_url)
+
+    rc = asyncio.run(_async_main(db_file, org_id))
+
+    db_file.chmod(0o666)
+    return rc
+
+
 if __name__ == "__main__":
-    sys.exit(asyncio.run(main()))
+    sys.exit(main())

--- a/demo_network/sender/send.py
+++ b/demo_network/sender/send.py
@@ -214,23 +214,28 @@ def _phase4() -> None:
         client.close()
 
 
-def _phase5() -> None:
-    """MCP Proxy ingress — A8. sender calls GET /v1/ingress/tools on its
-    own proxy (proxy-a). The proxy validates the broker-issued JWT via
+def _phase5(shared_client: "CullisClient | None" = None) -> "CullisClient | None":
+    """MCP Proxy ingress. sender calls GET /v1/ingress/tools on its own
+    proxy (proxy-a). The proxy validates the broker-issued JWT via
     JWKS, checks the DPoP proof, and returns 200 with the allowed tools
-    (empty list since sender's scope doesn't match any proxy tools, but
-    200 is the assertion — it proves the JWKS fetch + DPoP validation
-    wiring at the proxy side still works).
+    (empty list for this agent).
+
+    Returns the logged-in client so the caller can chain _phase6 without
+    re-login (the broker's auth rate limit is 10/60s and the full
+    phase1..phase6 chain would otherwise exceed it once the DPoP nonce
+    retry doubles each login's request count).
     """
     proxy_url = os.environ.get("INGRESS_URL", "")
     if not proxy_url:
         print("sender: [phase5] skipped (INGRESS_URL not set)")
-        return
+        return None
 
     print(f"sender: [phase5] calling proxy ingress {proxy_url}")
-    client = CullisClient(BROKER_URL, verify_tls=CA_BUNDLE)
+    client = shared_client or CullisClient(BROKER_URL, verify_tls=CA_BUNDLE)
+    close_on_exit = shared_client is None
     try:
-        client.login(AGENT_ID, ORG_ID, CERT_PATH, KEY_PATH)
+        if shared_client is None:
+            client.login(AGENT_ID, ORG_ID, CERT_PATH, KEY_PATH)
         # The SDK doesn't have a public helper for non-broker DPoP calls;
         # reuse the internal _dpop_proof + http client directly — this is a
         # smoke test, not production code.
@@ -261,8 +266,99 @@ def _phase5() -> None:
                 f"{resp.text[:300]}"
             )
         print(f"sender: [phase5] OK — ingress returned 200 with {len(resp.json())} tool(s)")
+        return client
     finally:
-        client.close()
+        if close_on_exit:
+            client.close()
+
+
+def _phase6(shared_client: "CullisClient | None" = None) -> None:
+    """ADR-007 Phase 1 A8 — aggregated MCP endpoint end-to-end.
+
+    1. Use an already-logged-in client (passed by _phase5) or fall back
+       to a fresh login. The shared-client path matters because the
+       broker enforces auth rate limit 10/60s; the full phase1..phase6
+       chain issues ≥6 logins × 2 DPoP requests, crossing the limit.
+    2. POST /v1/mcp {tools/list} — expect 'echo' among the bound tools.
+    3. POST /v1/mcp {tools/call name=echo args={message:NONCE}} — expect
+       the NONCE echoed back in ``result.content[0].text``.
+    """
+    agg_url = os.environ.get("MCP_AGG_URL", "")
+    if not agg_url:
+        print("sender: [phase6] skipped (MCP_AGG_URL not set)")
+        return
+
+    print(f"sender: [phase6] calling aggregated MCP {agg_url}")
+    client = shared_client or CullisClient(BROKER_URL, verify_tls=CA_BUNDLE)
+    close_on_exit = shared_client is None
+    try:
+        if shared_client is None:
+            client.login(AGENT_ID, ORG_ID, CERT_PATH, KEY_PATH)
+        import httpx
+        import uuid as _uuid
+
+        def _post_rpc(method: str, params: dict | None = None) -> dict:
+            payload = {"jsonrpc": "2.0", "id": str(_uuid.uuid4()), "method": method}
+            if params is not None:
+                payload["params"] = params
+            nonce = None
+            resp = None
+            with httpx.Client(verify=CA_BUNDLE, timeout=10.0) as h:
+                for _ in range(2):
+                    client._dpop_nonce = nonce
+                    proof = client._dpop_proof("POST", agg_url, access_token=client.token)
+                    resp = h.post(
+                        agg_url,
+                        headers={
+                            "Authorization": f"DPoP {client.token}",
+                            "DPoP": proof,
+                            "Content-Type": "application/json",
+                        },
+                        json=payload,
+                    )
+                    if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
+                        nonce = resp.headers.get("DPoP-Nonce")
+                        continue
+                    break
+            if resp is None or resp.status_code != 200:
+                code = resp.status_code if resp is not None else "no-response"
+                body = resp.text[:300] if resp is not None else ""
+                raise SystemExit(f"sender: [phase6] {method} HTTP {code}: {body}")
+            return resp.json()
+
+        # tools/list ────────────────────────────────────────────────
+        list_body = _post_rpc("tools/list")
+        tools = list_body.get("result", {}).get("tools") or []
+        names = [t.get("name") for t in tools]
+        print(f"sender: [phase6] tools/list → {names}")
+        if "echo" not in names:
+            raise SystemExit(
+                f"sender: [phase6] expected 'echo' in tools/list, got {names}"
+            )
+
+        # tools/call echo with the smoke NONCE ──────────────────────
+        call_body = _post_rpc("tools/call", {
+            "name": "echo",
+            "arguments": {"message": NONCE},
+        })
+        result = call_body.get("result") or {}
+        content = result.get("content") or []
+        if not content or not isinstance(content, list):
+            raise SystemExit(
+                f"sender: [phase6] unexpected tools/call result: {call_body!r}"
+            )
+        text_out = content[0].get("text", "")
+        if NONCE not in text_out:
+            raise SystemExit(
+                f"sender: [phase6] NONCE {NONCE!r} not echoed: {text_out!r}"
+            )
+        print(
+            "sender: [phase6] OK — aggregator forwarded to mcp-echo and "
+            "echoed the NONCE"
+        )
+    finally:
+        if close_on_exit:
+            client.close()
 
 
 def main() -> int:
@@ -271,7 +367,16 @@ def main() -> int:
     _phase2()
     _phase3()
     _phase4()
-    _phase5()
+    # Log in once as AGENT_ID and reuse the client across phase5 + phase6
+    # to stay under the broker's auth rate limit (10 req/60s; DPoP nonce
+    # retry doubles the login count).
+    shared = CullisClient(BROKER_URL, verify_tls=CA_BUNDLE)
+    try:
+        shared.login(AGENT_ID, ORG_ID, CERT_PATH, KEY_PATH)
+        _phase5(shared)
+        _phase6(shared)
+    finally:
+        shared.close()
     return 0
 
 

--- a/demo_network/smoke.sh
+++ b/demo_network/smoke.sh
@@ -72,13 +72,30 @@ cmd_up() {
     local nonce; nonce="$(gen_nonce)"
     echo "$nonce" > "$NONCE_FILE"
     say "demo_network: starting with SMOKE_NONCE=$nonce"
-    # --wait blocks until healthchecks pass or a one-shot exits. If the
-    # bootstrap or sender crashes, compose returns non-zero and we surface
-    # logs immediately.
+    # Phase A — bring up the service fleet (sender excluded via
+    # `profiles: [drive]` in compose.yml). `up --wait` treats any
+    # container exit as failure, so the transient driver containers
+    # can't live here.
     if ! SMOKE_NONCE="$nonce" $COMPOSE up -d --build --wait 2>&1; then
         dump_failure_logs
         die "demo_network: services failed to reach healthy state"
     fi
+
+    # Phase B — drive the scenarios (A1 round-trip + A5/A6/A8 via
+    # sender phases). `run --rm` propagates the sender's exit code:
+    # a non-zero return means one of the phases SystemExited and we
+    # surface logs for the post-mortem.
+    #
+    # `--no-deps` is critical: without it, compose re-starts every
+    # dependency in the chain — bootstrap in particular has already
+    # exited(0), and re-running it replays the /onboarding/join for
+    # orgs already registered → HTTP 409. The fleet from Phase A is
+    # still running; we just need compose to spawn the sender in it.
+    if ! SMOKE_NONCE="$nonce" $COMPOSE --profile drive run --rm --no-deps --build sender 2>&1; then
+        dump_failure_logs
+        die "demo_network: sender driver failed"
+    fi
+
     ok "demo_network: up (nonce persisted to $NONCE_FILE)"
     cmd_dashboard
 }

--- a/demo_network/smoke.sh
+++ b/demo_network/smoke.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$HERE"
 
-SERVICES_ON_FAILURE=(broker proxy-a proxy-b bootstrap sender checker)
+SERVICES_ON_FAILURE=(broker proxy-a proxy-b bootstrap sender checker mcp-echo)
 
 # PROXY_DB=postgres activates compose.postgres.yml so the proxies run on a
 # real Postgres instead of the default per-proxy SQLite. Used by the CI
@@ -105,6 +105,7 @@ cmd_check() {
             ok "smoke PASS: message round-trip succeeded (nonce=$expected)"
             assert_dashboard_signing_key_persistent
             assert_audit_hash_chain_integrity
+            assert_aggregated_mcp_endpoint "$expected"
             return 0
         fi
         sleep 1
@@ -234,6 +235,27 @@ assert_audit_hash_chain_integrity() {
         warn "A7 output: $verified"
         dump_failure_logs
         die "A7 FAIL: audit hash chain broken"
+    fi
+}
+
+# A8 — aggregated MCP endpoint (ADR-007 Phase 1). The sender container's
+# _phase6 already exercises POST /v1/mcp {tools/list, tools/call echo};
+# if phase6 fails the container exits non-zero and compose --wait aborts
+# before we ever reach cmd_check. This assertion is the evidence check:
+# the mcp-echo container must have logged a tools/call whose arguments
+# contain the current smoke NONCE, proving the proxy forwarded the call
+# end-to-end.
+assert_aggregated_mcp_endpoint() {
+    local expected="$1"
+    say "demo_network: A8 asserting /v1/mcp forwarded to mcp-echo (nonce=$expected)"
+
+    if $COMPOSE logs mcp-echo 2>/dev/null | grep -q "$expected"; then
+        ok "smoke PASS (A8): mcp-echo received echo call with current NONCE"
+    else
+        warn "A8: mcp-echo logs did not contain NONCE=$expected"
+        $COMPOSE logs --tail=200 mcp-echo >&2 || true
+        dump_failure_logs
+        die "A8 FAIL: aggregator did not forward the sender's echo call"
     fi
 }
 

--- a/mcp_proxy/local/audit.py
+++ b/mcp_proxy/local/audit.py
@@ -119,9 +119,12 @@ async def append_local_audit(
                 "placeholder": "",
             },
         )
-        # Postgres returns lastrowid on some drivers; for portability we
-        # query back by (org_id, chain_seq) which is unique by construction.
-        row_id = insert_result.lastrowid
+        # SQLite drivers expose ``lastrowid`` on the CursorResult; asyncpg
+        # *does not* have that attribute at all (raises AttributeError,
+        # not returns None), so the ``is None`` check below never fires
+        # on Postgres. ``getattr(..., None)`` normalises both dialects to
+        # the same "unknown → query back" fallback path.
+        row_id = getattr(insert_result, "lastrowid", None)
         if row_id is None:
             id_row = (await conn.execute(
                 text(

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -103,7 +103,6 @@ export class BrokerClient {
 
   private token: string | null = null;
   private signingKeyPem: string | null = null;
-  private label = "agent";
 
   // DPoP ephemeral key pair
   private dpopPrivateKey: KeyObject | null = null;
@@ -138,8 +137,6 @@ export class BrokerClient {
     certPath: string,
     keyPath: string,
   ): Promise<void> {
-    this.label = agentId;
-
     const keyPem = await readFile(keyPath, "utf-8");
     const certPem = await readFile(certPath, "utf-8");
     this.signingKeyPem = keyPem;

--- a/tests/test_proxy_sign_assertion.py
+++ b/tests/test_proxy_sign_assertion.py
@@ -71,7 +71,15 @@ async def _provision_agent_with_cert(app, agent_id: str) -> tuple[str, str]:
     await set_config("org_ca_key", ca_key_pem)
     await set_config("org_ca_cert", ca_cert_pem)
 
-    mgr = app.state.broker_bridge._agent_manager
+    # ``app.state.broker_bridge`` is None in standalone test runs; the
+    # canonical AgentManager reference is on ``app.state.agent_manager``
+    # regardless of lifespan mode (see mcp_proxy/main.py:131). Using the
+    # nested attribute was racy under xdist when a prior test left the
+    # app singleton with broker_bridge=None.
+    mgr = (
+        getattr(app.state, "broker_bridge", None) and
+        app.state.broker_bridge._agent_manager
+    ) or app.state.agent_manager
     await mgr.load_org_ca(ca_key_pem, ca_cert_pem)
 
     cert_pem, key_pem = mgr._generate_agent_cert(agent_id.split("::", 1)[-1])


### PR DESCRIPTION
## Summary

Final PR of ADR-007 Phase 1 (#140). Exercises \`/v1/mcp\` end-to-end through the demo network:

> sender agent → proxy-a \`/v1/mcp\` (aggregator from #144) → \`mcp-echo\` fake server

All Phase 1 pieces land together — schema (#142), loader (#143), aggregator + forwarder (#144), SPIFFE parser (#145), dashboard CRUD (#146, independent), and now the end-to-end smoke proof here.

### What's new

- **\`demo_network/mcp-echo/\`** — FastAPI container (~90 LOC) speaking JSON-RPC 2.0 (\`initialize\` / \`tools/list\` / \`tools/call echo\`). Prints every RPC with \`flush=True\` so smoke.sh can grep the NONCE out of \`docker compose logs\`.
- **\`demo_network/proxy-init/\`** — refactored to apply the proxy's real Alembic migration chain before seeding. Build context moves to the repo root (mirrors broker/sender/proxy). New \`SEED_MCP_ECHO_RESOURCE\` env gates an idempotent insert of a \`local_mcp_resources\` row + \`local_agent_resource_bindings\` row for the sender agent.
- **\`demo_network/compose.yml\`** — new \`mcp-echo\` service with \`/healthz\`, extends proxy-a-init env with the seed toggle, adds \`MCP_AGG_URL\` and \`depends_on: mcp-echo\` to sender.
- **\`demo_network/sender/send.py\`** — new \`_phase6()\` posts \`tools/list\` (asserts \`echo\` present) then \`tools/call\` (asserts NONCE echoed). Shares the \`CullisClient\` with \`_phase5\` to stay under the broker's 10-req/60s auth rate limit.
- **\`demo_network/smoke.sh\`** — A8 assertion after A7 greps \`mcp-echo\` logs for the current smoke NONCE. \`_phase6\` fails fast in the sender container (SystemExit) so compose \`--wait\` aborts before \`cmd_check\` if forwarding broke; A8 then confirms the call actually reached mcp-echo.

### Seed approach — C (Alembic upgrade + direct aiosqlite INSERT)

Rejected:
- **A** dashboard HTTP flow: ~80 LOC of brittle CSRF scraping.
- **B** post-boot aiosqlite insert: \`tool_registry\` is loaded once at proxy startup with no external reload trigger — rows inserted after boot would stay invisible until a proxy restart.

Approach **C** keeps zero proxy-code changes: proxy-init applies migrations, seeds the row, proxy-a boots with the row already in place and picks it up via the existing \`resource_loader\`. Each proxy-init build ships the \`mcp_proxy\` package + alembic deps (~50 MB image growth, acceptable for a demo image).

### Drive-by fix

First seed.py version called \`_run_alembic_upgrade()\` from inside \`asyncio.run(main())\`, but \`mcp_proxy/alembic/env.py\` itself calls \`asyncio.run()\` for the async engine — nested event loops aren't allowed. Migration now runs sync before the asyncio entry point.

## Test plan

- [x] \`./demo_network/smoke.sh full\` — **A1..A8 all PASS** (measured locally ~60s total, +5-10s vs baseline).
- [x] \`pytest tests/\` — **967 passed** (baseline pre-#146), same 2 pre-existing postgres DPoP failures unrelated.
- [x] Branch independent of #146 (PR-5a dashboard CRUD); both can merge in any order.
- [x] DCO \`Signed-off-by\`, no \`Co-Authored-By\`.

## Scope boundary

- No change to app code (\`mcp_proxy/\`, \`app/\`, \`cullis_sdk/\`). Demo files only + a minor shared-client refactor in the sender to stay under rate limits.
- \`smoke.sh\` still runs in ≤65s.

## Closes Phase 1

With this PR merged, ADR-007 Phase 1 is complete:
- PR #142 (schema)
- PR #143 (DB loader + registry extension)
- PR #144 (aggregated MCP server + forwarder)
- PR #145 (SPIFFE 3-component parser)
- PR #146 (dashboard CRUD — independent, not stacked)
- PR #147 (this — demo + smoke)

Next: **ADR-008 Phase 1+2** (sessionless A2A one-shot, issue #141) per the sequence confirmed earlier — pattern dominante LLM↔LLM + moat cross-org.

Related: #140 (EPIC).