### PR TITLE
README: swap logo to cullis-mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
-  <img src="cullis-lockup.svg" alt="Cullis" width="480"><br>
-  <strong>Zero-trust identity and audit for AI agents.</strong><br>
+  <img src="cullis-mark.svg" alt="Cullis" width="120"><br><br>
+  <strong>Cullis — Zero-trust identity and audit for AI agents.</strong><br>
   Start air-gapped in your organization. Scale to cross-company federation without redeploy.
 </p>
 

--- a/cullis-mark.svg
+++ b/cullis-mark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" role="img" aria-label="Cullis">
+  <rect x="8" y="10" width="84" height="6" fill="#00e5c7"/>
+  <rect x="20" y="16" width="8" height="62" fill="#00e5c7"/>
+  <rect x="46" y="16" width="8" height="62" fill="#00e5c7"/>
+  <rect x="72" y="16" width="8" height="62" fill="#00e5c7"/>
+  <rect x="14" y="44" width="72" height="6" fill="#00e5c7"/>
+  <polygon points="14,78 34,78 24,96" fill="#00e5c7"/>
+  <polygon points="40,78 60,78 50,96" fill="#00e5c7"/>
+  <polygon points="66,78 86,78 76,96" fill="#00e5c7"/>
+</svg>


### PR DESCRIPTION
## Summary

Follow-up to #149 (auto-merge landed before these two commits caught up). Brings in the logo swap:

- **Add `cullis-mark.svg`** at repo root — new cyan mark used across the site and as favicon
- **Update README hero** to point `<img src>` at `cullis-mark.svg` (was `cullis-lockup.svg`), width 120 (mark is a square icon, not a wordmark)
- Tagline prepended with "Cullis —" so the brand name is visible next to the mark

## Files changed

`README.md` (2 lines) + new `cullis-mark.svg`. Zero runtime impact.