### PR TITLE
ADR-008 Phase 1 / PR #2 — cross-org sessionless one-shot via broker

### DIFF
--- a/alembic/versions/b7c8d9e0f1a2_add_broker_oneshot_queue.py
+++ b/alembic/versions/b7c8d9e0f1a2_add_broker_oneshot_queue.py
@@ -1,0 +1,91 @@
+"""add broker one-shot queue (ADR-008 Phase 1 / PR #2)
+
+Revision ID: b7c8d9e0f1a2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-04-16 20:00:00.000000
+
+Introduces the broker-side durable queue for cross-org sessionless
+one-shot messaging. A sender proxy forwards a one-shot envelope to
+``POST /broker/oneshot/forward``; the broker inserts a row here and
+holds it until the recipient proxy drains it via
+``GET /broker/oneshot/inbox`` + ``POST /broker/oneshot/{id}/ack``.
+
+Dedup is scoped to ``(sender_agent_id, correlation_id)`` so sender-side
+retries collapse without the recipient ever seeing a duplicate. The
+``nonce`` column is also globally unique as a defence-in-depth guard
+against signature replay across correlation ids.
+
+Rows are TTL-expired by ``app/broker/session_sweeper.py`` (flip
+``delivery_status`` 0 → 2) and pruned by a future retention job.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+# This migration also merges two pre-existing heads:
+#   - f6a7b8c9d0e1 (audit chain per-org, linea principale)
+#   - a1b2c3d4e5f7 (org trust_domain)
+# both were independently in main before this PR.
+revision: str = "b7c8d9e0f1a2"
+down_revision: Union[str, Sequence[str], None] = (
+    "f6a7b8c9d0e1",
+    "a1b2c3d4e5f7",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "broker_oneshot_messages",
+        sa.Column("msg_id", sa.String(length=64), primary_key=True),
+        sa.Column("correlation_id", sa.String(length=128), nullable=False),
+        sa.Column(
+            "reply_to_correlation_id", sa.String(length=128), nullable=True,
+        ),
+        sa.Column("sender_agent_id", sa.String(length=256), nullable=False),
+        sa.Column("sender_org_id", sa.String(length=128), nullable=False),
+        sa.Column("recipient_agent_id", sa.String(length=256), nullable=False),
+        sa.Column("recipient_org_id", sa.String(length=128), nullable=False),
+        sa.Column("envelope_json", sa.Text(), nullable=False),
+        sa.Column("nonce", sa.String(length=128), nullable=False),
+        sa.Column(
+            "enqueued_at", sa.DateTime(timezone=True), nullable=False,
+        ),
+        sa.Column(
+            "ttl_expires_at", sa.DateTime(timezone=True), nullable=False,
+        ),
+        sa.Column(
+            "delivery_status",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "delivered_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.UniqueConstraint(
+            "sender_agent_id", "correlation_id",
+            name="uq_oneshot_sender_corr",
+        ),
+        sa.UniqueConstraint("nonce", name="uq_oneshot_nonce"),
+    )
+    op.create_index(
+        "ix_oneshot_recipient_pending", "broker_oneshot_messages",
+        ["recipient_agent_id", "delivery_status"], unique=False,
+    )
+    op.create_index(
+        "ix_oneshot_ttl", "broker_oneshot_messages",
+        ["ttl_expires_at"], unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oneshot_ttl", table_name="broker_oneshot_messages")
+    op.drop_index(
+        "ix_oneshot_recipient_pending", table_name="broker_oneshot_messages",
+    )
+    op.drop_table("broker_oneshot_messages")

--- a/app/broker/db_models.py
+++ b/app/broker/db_models.py
@@ -96,6 +96,57 @@ class ProxyMessageQueueRecord(Base):
     expired_at          = Column(DateTime(timezone=True), nullable=True)
 
 
+class BrokerOneShotMessageRecord(Base):
+    """ADR-008 Phase 1 PR #2 — cross-org sessionless one-shot queue.
+
+    A sender proxy forwards a one-shot envelope via
+    ``POST /broker/oneshot/forward``; the row stays here until the
+    recipient's proxy pulls it through ``GET /broker/oneshot/inbox``
+    and acks delivery via ``POST /broker/oneshot/{msg_id}/ack``.
+
+    ``delivery_status`` values mirror ``ProxyMessageQueueRecord``:
+      0 = pending   — enqueued, recipient has not yet ack'd
+      1 = delivered — recipient proxy ack'd, eligible for pruning
+      2 = expired   — TTL passed before ack (sweeper-driven)
+
+    Dedup is scoped ``(sender_agent_id, correlation_id)`` so a sender
+    retry collapses without the recipient ever observing a duplicate.
+    """
+
+    __tablename__ = "broker_oneshot_messages"
+    __table_args__ = (
+        UniqueConstraint(
+            "sender_agent_id", "correlation_id",
+            name="uq_oneshot_sender_corr",
+        ),
+        UniqueConstraint("nonce", name="uq_oneshot_nonce"),
+        Index(
+            "ix_oneshot_recipient_pending",
+            "recipient_agent_id", "delivery_status",
+        ),
+        Index("ix_oneshot_ttl", "ttl_expires_at"),
+    )
+
+    msg_id                   = Column(String(64), primary_key=True)
+    correlation_id           = Column(String(128), nullable=False)
+    reply_to_correlation_id  = Column(String(128), nullable=True)
+    sender_agent_id          = Column(String(256), nullable=False)
+    sender_org_id            = Column(String(128), nullable=False)
+    recipient_agent_id       = Column(String(256), nullable=False)
+    recipient_org_id         = Column(String(128), nullable=False)
+    envelope_json            = Column(Text, nullable=False)
+    nonce                    = Column(String(128), nullable=False)
+    enqueued_at              = Column(
+        DateTime(timezone=True), nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    ttl_expires_at           = Column(DateTime(timezone=True), nullable=False)
+    delivery_status          = Column(
+        SmallInteger, nullable=False, default=0,
+    )
+    delivered_at             = Column(DateTime(timezone=True), nullable=True)
+
+
 class RfqRecord(Base):
     __tablename__ = "rfq_requests"
 

--- a/app/broker/oneshot_router.py
+++ b/app/broker/oneshot_router.py
@@ -1,0 +1,462 @@
+"""Broker router for cross-org sessionless one-shot messages (ADR-008 Phase 1 / PR #2).
+
+Endpoints:
+
+  POST /broker/oneshot/forward          — sender proxy enqueues a one-shot
+  GET  /broker/oneshot/inbox            — recipient proxy drains pending
+  POST /broker/oneshot/{msg_id}/ack     — recipient proxy acks delivery
+
+The sender's proxy authenticates to the broker as the sender agent
+(same DPoP + JWT as session endpoints), signs the envelope with the
+agent's private key using ``session_id="oneshot:<correlation_id>"``
+for domain separation, and forwards it here. The broker verifies the
+signature, applies policy (as a synthetic session with capabilities
+``["oneshot.message"]``), and persists the row until the recipient
+proxy pulls and acks it.
+
+Dedup is scoped to ``(sender_agent_id, correlation_id)`` so sender
+retries collapse to the same row; the recipient never sees a duplicate.
+Offline recipients are backstopped by a TTL sweeper that flips
+``delivery_status`` 0 → 2 (expired).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import get_current_agent
+from app.auth.message_signer import verify_message_signature
+from app.auth.models import TokenPayload
+from app.broker.db_models import BrokerOneShotMessageRecord
+from app.broker.ws_manager import ws_manager
+from app.db.audit import log_event, log_event_cross_org
+from app.db.database import get_db
+from app.policy.backend import evaluate_session_policy
+from app.rate_limit.limiter import rate_limiter
+from app.registry.binding_store import get_approved_binding
+from app.registry.org_store import get_org_by_id
+from app.registry.store import get_agent_by_id
+
+_log = logging.getLogger("agent_trust")
+
+router = APIRouter(prefix="/broker/oneshot", tags=["broker-oneshot"])
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+_ONESHOT_CAPABILITY = "oneshot.message"
+
+
+# ── Schemas ────────────────────────────────────────────────────────────
+
+class ForwardOneShotRequest(BaseModel):
+    recipient_agent_id: str = Field(
+        ..., description="Bare agent_id of the recipient (not SPIFFE form).",
+    )
+    correlation_id: str = Field(
+        ..., description="Sender-generated UUID; unique per sender.",
+    )
+    reply_to_correlation_id: str | None = Field(
+        None,
+        description="correlation_id of the message this one is a reply to.",
+    )
+    payload: dict = Field(..., description="Plaintext application body.")
+    signature: str = Field(
+        ...,
+        description="RSA-PSS/ECDSA signature over the canonical plaintext "
+                    "with session_id='oneshot:<correlation_id>' (domain separation).",
+    )
+    nonce: str = Field(..., description="Globally-unique nonce for this envelope.")
+    timestamp: int = Field(..., description="Unix timestamp seconds.")
+    mode: Literal["mtls-only"] = Field(
+        "mtls-only",
+        description="Phase 1 supports mtls-only; E2E envelope lands in Phase 2.",
+    )
+    ttl_seconds: int = Field(
+        300, ge=10, le=3600,
+        description="Broker-side TTL for offline recipients.",
+    )
+
+
+class ForwardOneShotResponse(BaseModel):
+    msg_id: str
+    duplicate: bool
+
+
+class InboxOneShotItem(BaseModel):
+    msg_id: str
+    correlation_id: str
+    reply_to_correlation_id: str | None
+    sender_agent_id: str
+    sender_org_id: str
+    envelope_json: str
+    nonce: str
+    enqueued_at: str
+    ttl_expires_at: str
+
+
+class InboxOneShotResponse(BaseModel):
+    messages: list[InboxOneShotItem]
+    count: int
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _iso(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _build_envelope_json(body: ForwardOneShotRequest) -> str:
+    """Serialize the envelope exactly the shape the proxy's one-shot
+    router expects when it lazy-mirrors into ``local_messages``.
+    """
+    envelope = {
+        "mode": body.mode,
+        "payload": body.payload,
+        "signature": body.signature,
+        "nonce": body.nonce,
+        "timestamp": body.timestamp,
+        "correlation_id": body.correlation_id,
+        "reply_to": body.reply_to_correlation_id,
+    }
+    return json.dumps(envelope, separators=(",", ":"), sort_keys=True)
+
+
+# ── POST /broker/oneshot/forward ───────────────────────────────────────
+
+@router.post(
+    "/forward",
+    response_model=ForwardOneShotResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def forward_oneshot(
+    body: ForwardOneShotRequest,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> ForwardOneShotResponse:
+    """Enqueue a sessionless one-shot for the recipient's proxy to drain.
+
+    Returns 202 with ``{msg_id, duplicate}``. ``duplicate=true`` means a
+    prior send with the same ``(sender_agent_id, correlation_id)`` is
+    already queued — the returned ``msg_id`` points to that row.
+    """
+    await rate_limiter.check(current_agent.agent_id, "broker.oneshot")
+
+    # Correlation id format — sender generates a UUID; reject arbitrary
+    # strings so log_event details + dedup behave predictably.
+    if not _UUID_RE.match(body.correlation_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="correlation_id must be a UUID",
+        )
+
+    # ── Resolve recipient ─────────────────────────────────────────────
+    recipient = await get_agent_by_id(db, body.recipient_agent_id)
+    if recipient is None or not recipient.is_active:
+        await log_event(
+            db, "broker.oneshot_denied", "denied",
+            agent_id=current_agent.agent_id, org_id=current_agent.org,
+            details={
+                "recipient": body.recipient_agent_id,
+                "correlation_id": body.correlation_id,
+                "reason": "recipient_not_found",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Recipient agent not found or inactive",
+        )
+
+    if recipient.agent_id == current_agent.agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You cannot send a one-shot to yourself",
+        )
+
+    # ── Recipient binding ─────────────────────────────────────────────
+    recipient_binding = await get_approved_binding(
+        db, recipient.org_id, recipient.agent_id,
+    )
+    if recipient_binding is None:
+        await log_event(
+            db, "broker.oneshot_denied", "denied",
+            agent_id=current_agent.agent_id, org_id=current_agent.org,
+            details={
+                "recipient": recipient.agent_id,
+                "correlation_id": body.correlation_id,
+                "reason": "recipient_binding_missing",
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Recipient has no approved binding",
+        )
+
+    # ── Policy (synthetic session with oneshot.message capability) ────
+    initiator_org = await get_org_by_id(db, current_agent.org)
+    target_org = await get_org_by_id(db, recipient.org_id)
+
+    pdp_decision = await evaluate_session_policy(
+        initiator_org_id=current_agent.org,
+        initiator_webhook_url=initiator_org.webhook_url if initiator_org else None,
+        target_org_id=recipient.org_id,
+        target_webhook_url=target_org.webhook_url if target_org else None,
+        initiator_agent_id=current_agent.agent_id,
+        target_agent_id=recipient.agent_id,
+        capabilities=[_ONESHOT_CAPABILITY],
+    )
+    if not pdp_decision.allowed:
+        await log_event(
+            db, "broker.oneshot_denied", "denied",
+            agent_id=current_agent.agent_id, org_id=current_agent.org,
+            details={
+                "recipient": recipient.agent_id,
+                "correlation_id": body.correlation_id,
+                "reason": pdp_decision.reason,
+                "denied_by": pdp_decision.org_id,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Policy: {pdp_decision.reason}",
+        )
+
+    # ── Freshness ─────────────────────────────────────────────────────
+    now_dt = datetime.now(timezone.utc)
+    now_ts = int(now_dt.timestamp())
+    if abs(now_ts - body.timestamp) > 60:
+        await log_event(
+            db, "broker.oneshot_denied", "denied",
+            agent_id=current_agent.agent_id, org_id=current_agent.org,
+            details={
+                "correlation_id": body.correlation_id,
+                "reason": "timestamp_out_of_window",
+                "ts": body.timestamp,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Timestamp outside freshness window — possible replay",
+        )
+
+    # ── Verify signature ──────────────────────────────────────────────
+    sender_rec = await get_agent_by_id(db, current_agent.agent_id)
+    if sender_rec is None or not sender_rec.cert_pem:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sender certificate not available — log in before sending",
+        )
+    verify_message_signature(
+        sender_rec.cert_pem,
+        body.signature,
+        f"oneshot:{body.correlation_id}",
+        current_agent.agent_id,
+        body.nonce,
+        body.timestamp,
+        body.payload,
+        client_seq=0,
+    )
+
+    # ── Dedup + insert ────────────────────────────────────────────────
+    envelope_json = _build_envelope_json(body)
+    ttl_expires_at = now_dt + timedelta(seconds=body.ttl_seconds)
+
+    existing = (
+        await db.execute(
+            select(BrokerOneShotMessageRecord).where(
+                BrokerOneShotMessageRecord.sender_agent_id
+                == current_agent.agent_id,
+                BrokerOneShotMessageRecord.correlation_id
+                == body.correlation_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return ForwardOneShotResponse(msg_id=existing.msg_id, duplicate=True)
+
+    msg_id = str(uuid.uuid4())
+    row = BrokerOneShotMessageRecord(
+        msg_id=msg_id,
+        correlation_id=body.correlation_id,
+        reply_to_correlation_id=body.reply_to_correlation_id,
+        sender_agent_id=current_agent.agent_id,
+        sender_org_id=current_agent.org,
+        recipient_agent_id=recipient.agent_id,
+        recipient_org_id=recipient.org_id,
+        envelope_json=envelope_json,
+        nonce=body.nonce,
+        enqueued_at=now_dt,
+        ttl_expires_at=ttl_expires_at,
+        delivery_status=0,
+    )
+    db.add(row)
+    try:
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        # Race: sender retried while the first insert was in-flight. Look
+        # up the winning row so both calls return the same msg_id.
+        winner = (
+            await db.execute(
+                select(BrokerOneShotMessageRecord).where(
+                    BrokerOneShotMessageRecord.sender_agent_id
+                    == current_agent.agent_id,
+                    BrokerOneShotMessageRecord.correlation_id
+                    == body.correlation_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if winner is None:
+            raise
+        return ForwardOneShotResponse(msg_id=winner.msg_id, duplicate=True)
+
+    # ── Cross-org audit dual-write ────────────────────────────────────
+    await log_event_cross_org(
+        db, "broker.oneshot_forwarded", "ok",
+        org_a=current_agent.org, org_b=recipient.org_id,
+        agent_id=current_agent.agent_id,
+        details={
+            "msg_id": msg_id,
+            "correlation_id": body.correlation_id,
+            "reply_to_correlation_id": body.reply_to_correlation_id,
+            "recipient_agent_id": recipient.agent_id,
+            "nonce": body.nonce,
+        },
+    )
+
+    # ── Best-effort nudge if recipient is WS-connected ────────────────
+    try:
+        if ws_manager.is_connected(recipient.agent_id):
+            await ws_manager.send_to_agent(
+                recipient.agent_id,
+                {
+                    "type": "oneshot_pending",
+                    "msg_id": msg_id,
+                    "correlation_id": body.correlation_id,
+                },
+            )
+    except Exception:  # noqa: BLE001 — nudge is advisory
+        _log.debug(
+            "oneshot_pending notify failed for %s (msg %s)",
+            recipient.agent_id, msg_id,
+        )
+
+    return ForwardOneShotResponse(msg_id=msg_id, duplicate=False)
+
+
+# ── GET /broker/oneshot/inbox ──────────────────────────────────────────
+
+@router.get("/inbox", response_model=InboxOneShotResponse)
+async def poll_oneshot_inbox(
+    limit: int = 500,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> InboxOneShotResponse:
+    """Return pending one-shot messages addressed to the caller.
+
+    The response does NOT flip delivery_status — the recipient acks
+    separately after successfully mirroring the envelope locally, so a
+    crash between drain and mirror is safe to retry.
+    """
+    await rate_limiter.check(current_agent.agent_id, "broker.oneshot_inbox")
+
+    limit = max(1, min(limit, 500))
+    rows = (
+        await db.execute(
+            select(BrokerOneShotMessageRecord)
+            .where(
+                BrokerOneShotMessageRecord.recipient_agent_id
+                == current_agent.agent_id,
+                BrokerOneShotMessageRecord.delivery_status == 0,
+            )
+            .order_by(BrokerOneShotMessageRecord.enqueued_at.asc())
+            .limit(limit)
+        )
+    ).scalars().all()
+
+    return InboxOneShotResponse(
+        messages=[
+            InboxOneShotItem(
+                msg_id=r.msg_id,
+                correlation_id=r.correlation_id,
+                reply_to_correlation_id=r.reply_to_correlation_id,
+                sender_agent_id=r.sender_agent_id,
+                sender_org_id=r.sender_org_id,
+                envelope_json=r.envelope_json,
+                nonce=r.nonce,
+                enqueued_at=_iso(r.enqueued_at),
+                ttl_expires_at=_iso(r.ttl_expires_at),
+            )
+            for r in rows
+        ],
+        count=len(rows),
+    )
+
+
+# ── POST /broker/oneshot/{msg_id}/ack ──────────────────────────────────
+
+@router.post(
+    "/{msg_id}/ack",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def ack_oneshot(
+    msg_id: str,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Flip the row to delivered. 404 if not found for this recipient,
+    409 if already in a terminal state.
+    """
+    if not _UUID_RE.match(msg_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="msg_id must be a UUID",
+        )
+
+    now_dt = datetime.now(timezone.utc)
+    result = await db.execute(
+        update(BrokerOneShotMessageRecord)
+        .where(
+            BrokerOneShotMessageRecord.msg_id == msg_id,
+            BrokerOneShotMessageRecord.recipient_agent_id
+            == current_agent.agent_id,
+            BrokerOneShotMessageRecord.delivery_status == 0,
+        )
+        .values(delivery_status=1, delivered_at=now_dt)
+    )
+    await db.commit()
+    if result.rowcount and result.rowcount > 0:
+        return
+
+    existing = (
+        await db.execute(
+            select(BrokerOneShotMessageRecord.delivery_status).where(
+                BrokerOneShotMessageRecord.msg_id == msg_id,
+                BrokerOneShotMessageRecord.recipient_agent_id
+                == current_agent.agent_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="One-shot message not found for this recipient",
+        )
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="One-shot already in a terminal state",
+    )

--- a/app/broker/session_sweeper.py
+++ b/app/broker/session_sweeper.py
@@ -120,6 +120,52 @@ async def _sweep_message_queue() -> int:
     return len(notices)
 
 
+async def _sweep_oneshot_queue() -> int:
+    """Expire TTL-lapsed cross-org one-shots (ADR-008 Phase 1 PR #2).
+
+    Flips ``delivery_status`` from 0 (pending) to 2 (expired) on rows
+    whose ``ttl_expires_at`` has passed. Pure DB sweep — no WS nudge,
+    since the one-shot sender already fire-and-forgot the envelope and
+    relies on reply semantics rather than per-message ack notifications.
+    """
+    if os.environ.get("CULLIS_DISABLE_QUEUE_OPS") == "1":
+        return 0
+
+    try:
+        from datetime import datetime, timezone
+        from sqlalchemy import update
+        from app.broker.db_models import BrokerOneShotMessageRecord
+        from app.db.database import AsyncSessionLocal
+    except Exception:
+        return 0
+
+    try:
+        async with AsyncSessionLocal() as db:
+            now_dt = datetime.now(timezone.utc)
+            result = await asyncio.wait_for(
+                db.execute(
+                    update(BrokerOneShotMessageRecord)
+                    .where(
+                        BrokerOneShotMessageRecord.delivery_status == 0,
+                        BrokerOneShotMessageRecord.ttl_expires_at < now_dt,
+                    )
+                    .values(delivery_status=2)
+                ),
+                timeout=5.0,
+            )
+            await db.commit()
+    except asyncio.TimeoutError:
+        _log.warning(
+            "sweeper: one-shot queue sweep exceeded 5s — skipping this cycle"
+        )
+        return 0
+    except Exception:
+        _log.exception("sweeper: one-shot queue sweep failed")
+        return 0
+
+    return int(result.rowcount or 0) if result is not None else 0
+
+
 async def _persist_closed(session: Session) -> None:
     """Persist the close to the DB. Isolated so failures don't kill the sweep."""
     try:
@@ -176,6 +222,9 @@ async def sweep_once(
 
     # M3.6 — also sweep TTL-expired queued messages (independent of session close).
     await _sweep_message_queue()
+
+    # ADR-008 Phase 1 PR #2 — expire stale broker-side one-shots.
+    await _sweep_oneshot_queue()
 
     SESSION_SWEEPER_CYCLES_COUNTER.add(1, {"closed": str(closed)})
     return closed

--- a/app/main.py
+++ b/app/main.py
@@ -358,6 +358,10 @@ v1.include_router(admin_router)
 from app.broker.federation_router import router as federation_router
 v1.include_router(federation_router)
 
+# ADR-008 Phase 1 PR #2 — cross-org sessionless one-shot forwarding.
+from app.broker.oneshot_router import router as oneshot_router
+v1.include_router(oneshot_router)
+
 # ADR-002 Phase 2a — A2A protocol adapter (read-only AgentCard + directory).
 # Gated on settings.a2a_adapter (default False) so existing deployments
 # see no surface change.

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -758,16 +758,15 @@ class CullisClient:
         transport = decision["transport"]
         target_agent_id = decision["target_agent_id"]
 
-        if transport != "mtls-only":
+        if transport not in ("mtls-only", "envelope"):
             raise NotImplementedError(
-                "cross-org one-shot is not wired in this revision — "
-                "Phase 2 adds broker-forwarded envelopes"
+                f"one-shot transport '{transport}' not supported"
             )
 
         if not self._signing_key_pem:
             raise RuntimeError(
-                "mtls-only transport requires a signing key — initialize "
-                "the client via login() or from_spiffe_workload_api()"
+                "one-shot send requires a signing key — initialize the "
+                "client via login() or from_spiffe_workload_api()"
             )
 
         corr_id = correlation_id or str(uuid.uuid4())
@@ -793,7 +792,7 @@ class CullisClient:
             "payload": payload,
             "correlation_id": corr_id,
             "reply_to": reply_to,
-            "mode": "mtls-only",
+            "mode": transport,
             "signature": signature,
             "nonce": nonce,
             "timestamp": timestamp,
@@ -838,6 +837,68 @@ class CullisClient:
         )
         resp.raise_for_status()
         return resp.json().get("messages", [])
+
+    # ── Broker one-shot forwarding (used by proxy BrokerBridge) ────
+
+    def forward_oneshot(
+        self,
+        *,
+        recipient_agent_id: str,
+        correlation_id: str,
+        reply_to_correlation_id: str | None,
+        payload: dict,
+        nonce: str,
+        timestamp: int,
+        signature: str,
+        ttl_seconds: int = 300,
+    ) -> dict:
+        """Forward a one-shot envelope to the broker's cross-org queue.
+
+        Used by the sender proxy's ``BrokerBridge`` after it has already
+        verified the local policy. The proxy signs the canonical payload
+        with ``session_id='oneshot:<correlation_id>'`` on the sender's
+        key before calling this; the broker re-verifies and persists.
+        """
+        body = {
+            "recipient_agent_id": recipient_agent_id,
+            "correlation_id": correlation_id,
+            "reply_to_correlation_id": reply_to_correlation_id,
+            "payload": payload,
+            "signature": signature,
+            "nonce": nonce,
+            "timestamp": timestamp,
+            "mode": "mtls-only",
+            "ttl_seconds": ttl_seconds,
+        }
+        resp = self._authed_request(
+            "POST", "/v1/broker/oneshot/forward", json=body,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def poll_oneshot_inbox(self) -> list[dict]:
+        """Drain pending cross-org one-shots addressed to this agent.
+
+        The broker does NOT flip delivery status on read — the caller
+        acks via :meth:`ack_oneshot` once the row has been mirrored
+        locally. Returns the raw row dicts (see broker
+        ``InboxOneShotItem``).
+        """
+        resp = self._authed_request("GET", "/v1/broker/oneshot/inbox")
+        resp.raise_for_status()
+        return resp.json().get("messages", [])
+
+    def ack_oneshot(self, msg_id: str) -> bool:
+        """Mark a broker one-shot row as delivered. Returns False on 404/409."""
+        resp = self._authed_request(
+            "POST", f"/v1/broker/oneshot/{msg_id}/ack",
+        )
+        if resp.status_code == 204:
+            return True
+        if resp.status_code in (404, 409):
+            return False
+        resp.raise_for_status()
+        return False
 
     def ack_via_proxy(self, session_id: str, msg_id: str) -> bool:
         """Acknowledge a local-queue message to the proxy (at-least-once)."""

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -260,6 +260,86 @@ class BrokerBridge:
                 return [_agent_info_to_dict(a) for a in agents]
             raise
 
+    # ── One-shot (ADR-008 Phase 1 PR #2) ────────────────────────────
+
+    async def send_oneshot(
+        self,
+        agent_id: str,
+        *,
+        recipient_agent_id: str,
+        correlation_id: str,
+        reply_to_correlation_id: str | None,
+        payload: dict,
+        nonce: str,
+        timestamp: int,
+        signature: str,
+        ttl_seconds: int = 300,
+    ) -> dict:
+        """Forward a sessionless one-shot through the broker.
+
+        Returns the broker's response body — ``{msg_id, duplicate}``.
+        Uses the same auth-error retry pattern as session operations.
+        """
+        client = await self.get_client(agent_id)
+        try:
+            return await asyncio.to_thread(
+                client.forward_oneshot,
+                recipient_agent_id=recipient_agent_id,
+                correlation_id=correlation_id,
+                reply_to_correlation_id=reply_to_correlation_id,
+                payload=payload,
+                nonce=nonce,
+                timestamp=timestamp,
+                signature=signature,
+                ttl_seconds=ttl_seconds,
+            )
+        except Exception as exc:
+            if _is_auth_error(exc):
+                logger.warning(
+                    "Auth error for %s, re-authenticating: %s", agent_id, exc,
+                )
+                client = await self._evict_and_retry(agent_id)
+                return await asyncio.to_thread(
+                    client.forward_oneshot,
+                    recipient_agent_id=recipient_agent_id,
+                    correlation_id=correlation_id,
+                    reply_to_correlation_id=reply_to_correlation_id,
+                    payload=payload,
+                    nonce=nonce,
+                    timestamp=timestamp,
+                    signature=signature,
+                    ttl_seconds=ttl_seconds,
+                )
+            raise
+
+    async def poll_oneshot_inbox(self, agent_id: str) -> list[dict]:
+        """Drain pending cross-org one-shots from the broker for ``agent_id``."""
+        client = await self.get_client(agent_id)
+        try:
+            return await asyncio.to_thread(client.poll_oneshot_inbox)
+        except Exception as exc:
+            if _is_auth_error(exc):
+                logger.warning(
+                    "Auth error for %s, re-authenticating: %s", agent_id, exc,
+                )
+                client = await self._evict_and_retry(agent_id)
+                return await asyncio.to_thread(client.poll_oneshot_inbox)
+            raise
+
+    async def ack_oneshot(self, agent_id: str, msg_id: str) -> bool:
+        """Ack a broker-side one-shot row as delivered."""
+        client = await self.get_client(agent_id)
+        try:
+            return await asyncio.to_thread(client.ack_oneshot, msg_id)
+        except Exception as exc:
+            if _is_auth_error(exc):
+                logger.warning(
+                    "Auth error for %s, re-authenticating: %s", agent_id, exc,
+                )
+                client = await self._evict_and_retry(agent_id)
+                return await asyncio.to_thread(client.ack_oneshot, msg_id)
+            raise
+
     # ── Shutdown ────────────────────────────────────────────────────
 
     async def shutdown(self) -> None:

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -172,19 +172,6 @@ async def send_oneshot(
         "mode": body.mode,
     }
 
-    if path == "cross":
-        await append_local_audit(
-            event_type="oneshot_denied",
-            result="error",
-            agent_id=agent.agent_id,
-            org_id=local_org,
-            details={**audit_details, "reason": "cross_org_not_implemented"},
-        )
-        raise HTTPException(
-            status_code=501,
-            detail="Cross-org one-shot messaging not implemented (Phase 2).",
-        )
-
     # Policy: evaluate the payload the same way session /send does.
     decision = await evaluate_local_message(
         org_id=local_org,
@@ -201,6 +188,78 @@ async def send_oneshot(
         raise HTTPException(
             status_code=403,
             detail=f"Policy: {decision.reason or 'message blocked'}",
+        )
+
+    if path == "cross":
+        bridge = getattr(request.app.state, "broker_bridge", None)
+        if bridge is None:
+            await append_local_audit(
+                event_type="oneshot_denied",
+                result="error",
+                agent_id=agent.agent_id,
+                org_id=local_org,
+                details={**audit_details, "reason": "broker_bridge_unavailable"},
+            )
+            raise HTTPException(
+                status_code=503,
+                detail="Broker uplink not configured — cross-org one-shot unavailable",
+            )
+
+        # The broker stores agent_id in "{org}::{agent}" form (same as
+        # open_session). Translate SPIFFE URIs to that canonical shape;
+        # pass the "::" form through unchanged.
+        if body.recipient_id.startswith("spiffe://"):
+            from mcp_proxy.spiffe import parse_spiffe
+            _, rec_org, rec_bare = parse_spiffe(body.recipient_id)
+            broker_recipient_id = f"{rec_org}::{rec_bare}"
+        else:
+            broker_recipient_id = body.recipient_id
+
+        try:
+            result = await bridge.send_oneshot(
+                agent.agent_id,
+                recipient_agent_id=broker_recipient_id,
+                correlation_id=corr_id,
+                reply_to_correlation_id=body.reply_to,
+                payload=body.payload,
+                nonce=body.nonce or "",
+                timestamp=body.timestamp or 0,
+                signature=body.signature or "",
+                ttl_seconds=body.ttl_seconds,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            await append_local_audit(
+                event_type="oneshot_denied",
+                result="error",
+                agent_id=agent.agent_id,
+                org_id=local_org,
+                details={**audit_details, "reason": f"broker_forward_failed: {exc}"},
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=f"Broker forward failed: {exc}",
+            ) from exc
+
+        broker_msg_id = result.get("msg_id", "")
+        duplicate = bool(result.get("duplicate", False))
+        await append_local_audit(
+            event_type="oneshot_sent",
+            result="ok",
+            agent_id=agent.agent_id,
+            org_id=local_org,
+            details={
+                **audit_details,
+                "msg_id": broker_msg_id,
+                "duplicate": duplicate,
+                "broker_forwarded": True,
+            },
+        )
+        return SendOneShotResponse(
+            correlation_id=corr_id,
+            msg_id=broker_msg_id,
+            status="duplicate" if duplicate else "enqueued",
         )
 
     # Recipient must match the internal_agents.agent_id format the
@@ -278,7 +337,63 @@ async def receive_oneshot_inbox(
     then narrows to ``is_oneshot = 1``. Session messages stay on
     ``/v1/egress/messages/{session_id}`` — keeping the two surfaces
     disjoint simplifies callers' mental model.
+
+    ADR-008 Phase 1 PR #2: before reading locally, drain any cross-org
+    one-shots pending on the broker side for this agent, mirror each
+    into ``local_messages`` (lazy materialization), and ack back to the
+    broker. The mirror step is idempotent thanks to
+    ``idempotency_key = f"oneshot:<corr>"``.
     """
+    settings = get_settings()
+    local_org = settings.org_id or ""
+
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is not None:
+        try:
+            remote_inbox = await bridge.poll_oneshot_inbox(agent.agent_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("broker one-shot poll failed: %s", exc)
+            remote_inbox = []
+
+        for r in remote_inbox:
+            try:
+                _, inserted = await local_queue.enqueue_oneshot(
+                    sender_agent_id=r["sender_agent_id"],
+                    recipient_agent_id=agent.agent_id,
+                    correlation_id=r["correlation_id"],
+                    reply_to_correlation_id=r.get("reply_to_correlation_id"),
+                    payload_ciphertext=r["envelope_json"],
+                    ttl_seconds=300,
+                )
+            except Exception:
+                logger.exception(
+                    "failed to mirror broker one-shot msg_id=%s",
+                    r.get("msg_id"),
+                )
+                continue
+
+            try:
+                await bridge.ack_oneshot(agent.agent_id, r["msg_id"])
+            except Exception:
+                logger.exception(
+                    "broker one-shot ack failed for msg_id=%s", r.get("msg_id"),
+                )
+
+            if inserted:
+                await append_local_audit(
+                    event_type="oneshot_delivered",
+                    result="ok",
+                    agent_id=agent.agent_id,
+                    org_id=local_org,
+                    details={
+                        "msg_id": r.get("msg_id"),
+                        "correlation_id": r.get("correlation_id"),
+                        "sender_agent_id": r.get("sender_agent_id"),
+                        "sender_org_id": r.get("sender_org_id"),
+                        "cross_org": True,
+                    },
+                )
+
     all_pending = await local_queue.fetch_pending_for_recipient(
         agent.agent_id,
     )

--- a/tests/test_oneshot_cross.py
+++ b/tests/test_oneshot_cross.py
@@ -1,0 +1,416 @@
+"""ADR-008 Phase 1 PR #2 — cross-org sessionless one-shot via broker.
+
+Exercises the broker endpoints ``/v1/broker/oneshot/{forward,inbox,<id>/ack}``
+end-to-end: forward + inbox + ack + dedup + tampered signature + TTL
+sweep + audit dual-write.
+
+The proxy-side ``oneshot.py`` flip (501 → broker.send_oneshot) stays
+covered by the live smoke stack — unit-testing it in-process requires
+mounting a full fake broker on top of the proxy's ASGI, which the
+smoke flow already does.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from cullis_sdk.crypto.message_signer import sign_message
+from tests.cert_factory import DPoPHelper, get_agent_key_pem, get_org_ca_pem
+from tests.conftest import ADMIN_HEADERS, TestSessionLocal
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+async def _register_and_login(
+    client: AsyncClient, dpop: DPoPHelper, agent_id: str, org_id: str,
+) -> str:
+    """Register org + CA + agent + approved binding, then obtain a token."""
+    org_secret = org_id + "-secret"
+
+    await client.post(
+        "/v1/registry/orgs",
+        json={
+            "org_id": org_id, "display_name": org_id, "secret": org_secret,
+        },
+        headers=ADMIN_HEADERS,
+    )
+    ca_pem = get_org_ca_pem(org_id)
+    await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    await client.post(
+        "/v1/registry/agents",
+        json={
+            "agent_id": agent_id, "org_id": org_id,
+            "display_name": agent_id,
+            "capabilities": ["oneshot.message"],
+        },
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    resp = await client.post(
+        "/v1/registry/bindings",
+        json={
+            "org_id": org_id, "agent_id": agent_id,
+            "scope": ["oneshot.message"],
+        },
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = resp.json()["id"]
+    await client.post(
+        f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    return await dpop.get_token(client, agent_id, org_id)
+
+
+def _build_forward_body(
+    sender_agent_id: str,
+    sender_org_id: str,
+    recipient_agent_id: str,
+    payload: dict,
+    *,
+    correlation_id: str | None = None,
+    reply_to: str | None = None,
+    timestamp: int | None = None,
+    tamper_signature: bool = False,
+) -> tuple[dict, str, str]:
+    """Return (body, correlation_id, nonce)."""
+    corr = correlation_id or str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time()) if timestamp is None else timestamp
+    key_pem = get_agent_key_pem(sender_agent_id, sender_org_id)
+    sig = sign_message(
+        key_pem,
+        f"oneshot:{corr}",
+        sender_agent_id,
+        nonce,
+        ts,
+        payload,
+        client_seq=0,
+    )
+    if tamper_signature:
+        sig = sig[:-4] + ("AAAA" if not sig.endswith("AAAA") else "BBBB")
+    body = {
+        "recipient_agent_id": recipient_agent_id,
+        "correlation_id": corr,
+        "reply_to_correlation_id": reply_to,
+        "payload": payload,
+        "signature": sig,
+        "nonce": nonce,
+        "timestamp": ts,
+        "mode": "mtls-only",
+        "ttl_seconds": 300,
+    }
+    return body, corr, nonce
+
+
+@pytest.fixture(autouse=True)
+def _mock_oneshot_pdp():
+    """Bypass PDP webhook calls in the one-shot router.
+
+    The shared ``mock_pdp_webhook`` autouse fixture patches the symbol
+    imported by ``app.broker.router``; the one-shot router imports its
+    own reference that we have to patch separately. Individual tests
+    override this with a deny mock when they need to exercise policy.
+    """
+    from app.policy.webhook import WebhookDecision
+
+    allow = WebhookDecision(allowed=True, reason="mocked allow", org_id="broker")
+    with patch(
+        "app.broker.oneshot_router.evaluate_session_policy",
+        new=AsyncMock(return_value=allow),
+    ):
+        yield
+
+
+# ── Tests ──────────────────────────────────────────────────────────────
+
+async def test_cross_org_happy_path(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme1::alice", "acme1")
+    token_b = await _register_and_login(client, dpop_b, "globex1::bob", "globex1")
+
+    body, corr, _ = _build_forward_body(
+        "acme1::alice", "acme1", "globex1::bob", {"msg": "quote?"},
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward",
+        json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 202, r.text
+    data = r.json()
+    assert data["duplicate"] is False
+    msg_id = data["msg_id"]
+
+    r2 = await client.get(
+        "/v1/broker/oneshot/inbox",
+        headers=dpop_b.headers("GET", "/v1/broker/oneshot/inbox", token_b),
+    )
+    assert r2.status_code == 200
+    inbox = r2.json()
+    assert inbox["count"] == 1
+    msg = inbox["messages"][0]
+    assert msg["correlation_id"] == corr
+    assert msg["sender_agent_id"] == "acme1::alice"
+    assert msg["sender_org_id"] == "acme1"
+    assert msg["msg_id"] == msg_id
+    envelope = json.loads(msg["envelope_json"])
+    assert envelope["payload"] == {"msg": "quote?"}
+    assert envelope["mode"] == "mtls-only"
+
+
+async def test_duplicate_correlation_returns_same_msg_id(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme2::alice", "acme2")
+    await _register_and_login(client, dpop_b, "globex2::bob", "globex2")
+
+    corr = str(uuid.uuid4())
+    body1, _, _ = _build_forward_body(
+        "acme2::alice", "acme2", "globex2::bob", {"n": 1},
+        correlation_id=corr,
+    )
+    body2, _, _ = _build_forward_body(
+        "acme2::alice", "acme2", "globex2::bob", {"n": 2},
+        correlation_id=corr,  # same corr, different payload/nonce
+    )
+
+    r1 = await client.post(
+        "/v1/broker/oneshot/forward", json=body1,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r1.status_code == 202
+    r2 = await client.post(
+        "/v1/broker/oneshot/forward", json=body2,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r2.status_code == 202
+    assert r2.json()["duplicate"] is True
+    assert r1.json()["msg_id"] == r2.json()["msg_id"]
+
+
+async def test_ack_flips_status_and_inbox_empties(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme3::alice", "acme3")
+    token_b = await _register_and_login(client, dpop_b, "globex3::bob", "globex3")
+
+    body, _, _ = _build_forward_body(
+        "acme3::alice", "acme3", "globex3::bob", {"msg": "ack me"},
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    msg_id = r.json()["msg_id"]
+
+    r_ack = await client.post(
+        f"/v1/broker/oneshot/{msg_id}/ack",
+        headers=dpop_b.headers(
+            "POST", f"/v1/broker/oneshot/{msg_id}/ack", token_b,
+        ),
+    )
+    assert r_ack.status_code == 204
+
+    r_inbox = await client.get(
+        "/v1/broker/oneshot/inbox",
+        headers=dpop_b.headers("GET", "/v1/broker/oneshot/inbox", token_b),
+    )
+    assert r_inbox.json()["count"] == 0
+
+
+async def test_ack_second_call_returns_409(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme4::alice", "acme4")
+    token_b = await _register_and_login(client, dpop_b, "globex4::bob", "globex4")
+
+    body, _, _ = _build_forward_body(
+        "acme4::alice", "acme4", "globex4::bob", {"msg": "x"},
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    msg_id = r.json()["msg_id"]
+    path = f"/v1/broker/oneshot/{msg_id}/ack"
+    first = await client.post(path, headers=dpop_b.headers("POST", path, token_b))
+    assert first.status_code == 204
+    second = await client.post(path, headers=dpop_b.headers("POST", path, token_b))
+    assert second.status_code == 409
+
+
+async def test_ack_by_wrong_agent_returns_404(client: AsyncClient):
+    dpop_a, dpop_b, dpop_c = DPoPHelper(), DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme5::alice", "acme5")
+    await _register_and_login(client, dpop_b, "globex5::bob", "globex5")
+    token_c = await _register_and_login(client, dpop_c, "globex5::charlie", "globex5")
+
+    body, _, _ = _build_forward_body(
+        "acme5::alice", "acme5", "globex5::bob", {"msg": "for-bob"},
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    msg_id = r.json()["msg_id"]
+    path = f"/v1/broker/oneshot/{msg_id}/ack"
+    r_ack = await client.post(path, headers=dpop_c.headers("POST", path, token_c))
+    assert r_ack.status_code == 404
+
+
+async def test_forward_rejects_tampered_signature(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme6::alice", "acme6")
+    await _register_and_login(client, dpop_b, "globex6::bob", "globex6")
+
+    body, _, _ = _build_forward_body(
+        "acme6::alice", "acme6", "globex6::bob", {"x": 1},
+        tamper_signature=True,
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 401
+
+
+async def test_forward_rejects_stale_timestamp(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme7::alice", "acme7")
+    await _register_and_login(client, dpop_b, "globex7::bob", "globex7")
+
+    body, _, _ = _build_forward_body(
+        "acme7::alice", "acme7", "globex7::bob", {"x": 1},
+        timestamp=int(time.time()) - 3600,
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 409
+
+
+async def test_forward_unknown_recipient_returns_404(client: AsyncClient):
+    dpop_a = DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme8::alice", "acme8")
+
+    body, _, _ = _build_forward_body(
+        "acme8::alice", "acme8", "ghost::agent", {"x": 1},
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 404
+
+
+async def test_forward_denied_by_policy(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme9::alice", "acme9")
+    await _register_and_login(client, dpop_b, "globex9::bob", "globex9")
+
+    from app.policy.webhook import WebhookDecision
+
+    deny = WebhookDecision(allowed=False, reason="test deny", org_id="globex9")
+    body, _, _ = _build_forward_body(
+        "acme9::alice", "acme9", "globex9::bob", {"x": 1},
+    )
+    with patch(
+        "app.broker.oneshot_router.evaluate_session_policy",
+        new=AsyncMock(return_value=deny),
+    ):
+        r = await client.post(
+            "/v1/broker/oneshot/forward", json=body,
+            headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+        )
+    assert r.status_code == 403
+    assert "test deny" in r.text
+
+
+async def test_audit_dual_write_on_forward(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "acme10::alice", "acme10")
+    await _register_and_login(client, dpop_b, "globex10::bob", "globex10")
+
+    body, corr, _ = _build_forward_body(
+        "acme10::alice", "acme10", "globex10::bob", {"ping": True},
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 202
+
+    from app.db.audit import AuditLog
+
+    async with TestSessionLocal() as db:
+        all_rows = (
+            await db.execute(
+                select(AuditLog).where(
+                    AuditLog.event_type == "broker.oneshot_forwarded"
+                )
+            )
+        ).scalars().all()
+    # In-memory StaticPool keeps prior tests' audit rows — filter to our corr.
+    rows = [r for r in all_rows if corr in (r.details or "")]
+    assert len(rows) == 2
+    orgs = sorted(r.org_id for r in rows)
+    assert orgs == ["acme10", "globex10"]
+    peer_map = {r.org_id: r.peer_org_id for r in rows}
+    assert peer_map["acme10"] == "globex10"
+    assert peer_map["globex10"] == "acme10"
+    for row in rows:
+        assert row.peer_row_hash is not None
+
+
+async def test_sweeper_expires_ttl_rows(client: AsyncClient, monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    from app.broker.db_models import BrokerOneShotMessageRecord
+    from app.broker.session_sweeper import _sweep_oneshot_queue
+
+    # conftest sets CULLIS_DISABLE_QUEUE_OPS=1 for the shared suite; clear
+    # it here so the sweep actually runs against the in-memory DB.
+    monkeypatch.delenv("CULLIS_DISABLE_QUEUE_OPS", raising=False)
+
+    now_dt = datetime.now(timezone.utc)
+    async with TestSessionLocal() as db:
+        row = BrokerOneShotMessageRecord(
+            msg_id=str(uuid.uuid4()),
+            correlation_id=str(uuid.uuid4()),
+            reply_to_correlation_id=None,
+            sender_agent_id="acme11::alice",
+            sender_org_id="acme11",
+            recipient_agent_id="globex11::bob",
+            recipient_org_id="globex11",
+            envelope_json="{}",
+            nonce=str(uuid.uuid4()),
+            enqueued_at=now_dt - timedelta(seconds=600),
+            ttl_expires_at=now_dt - timedelta(seconds=1),
+            delivery_status=0,
+        )
+        db.add(row)
+        await db.commit()
+        msg_id = row.msg_id
+
+    await _sweep_oneshot_queue()
+
+    async with TestSessionLocal() as db:
+        status_after = (
+            await db.execute(
+                select(BrokerOneShotMessageRecord.delivery_status).where(
+                    BrokerOneShotMessageRecord.msg_id == msg_id
+                )
+            )
+        ).scalar_one()
+    assert status_after == 2

--- a/tests/test_oneshot_intra.py
+++ b/tests/test_oneshot_intra.py
@@ -298,7 +298,15 @@ async def test_duplicate_correlation_id_idempotent(proxy_app):
 
 
 @pytest.mark.asyncio
-async def test_cross_org_returns_501(proxy_app):
+async def test_cross_org_without_broker_returns_503(proxy_app):
+    """When the proxy has no broker uplink configured (as in this fixture),
+    a cross-org send should fail fast with 503.
+
+    ADR-008 Phase 1 PR #2 replaced the hardcoded 501 with a live broker
+    forward path; 501 no longer applies. A deployment that never wires
+    the bridge surfaces the gap as 503 ("broker uplink not configured").
+    Cross-org happy path is covered in tests/test_oneshot_cross.py.
+    """
     _, client = proxy_app
     alice_key, alice_cert, alice_priv = await _provision_agent("alice")
     await _provision_local_target("alice", alice_cert)
@@ -314,8 +322,8 @@ async def test_cross_org_returns_501(proxy_app):
         headers={"X-API-Key": alice_key},
         json=body,
     )
-    assert r.status_code == 501
-    assert "not implemented" in r.text.lower()
+    assert r.status_code == 503
+    assert "broker" in r.text.lower()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes the cross-org gap of ADR-008 Phase 1 — `POST /v1/egress/message/send` now forwards via a new broker endpoint + durable queue, and `GET /v1/egress/message/inbox` lazy-mirrors pending broker rows before serving locally. Follows `imp/adr_008_phase1_pr2_plan.md` (D1–D8).

- **Broker**: `/v1/broker/oneshot/{forward,inbox,<id>/ack}` with signature verification (`oneshot:<corr>` domain), synthetic-session policy (`oneshot.message`), dedup on `(sender_agent_id, correlation_id)`, cross-org audit dual-write, TTL sweeper pass.
- **Proxy**: 501 → broker forward on `cross` route; lazy-mirror + ack on inbox poll; full audit trail (`oneshot_sent`, `oneshot_delivered`).
- **SDK**: `forward_oneshot`/`poll_oneshot_inbox`/`ack_oneshot` broker low-level + `send_oneshot` now accepts `envelope` transport.
- **Migration**: `broker_oneshot_messages` + indexes. Also merges the two pre-existing heads (`f6a7b8c9d0e1` + `a1b2c3d4e5f7`) that had diverged in main.

## Test plan

- [x] `pytest tests/test_oneshot_cross.py` — 11 new cases (happy path, dedup, ack, wrong recipient, tampered signature, stale timestamp, unknown recipient, policy deny, audit dual-write, TTL sweep) all green
- [x] `pytest tests/test_oneshot_intra.py` — regression green; the prior `test_cross_org_returns_501` replaced with `test_cross_org_without_broker_returns_503` (the 501 no longer applies)
- [x] `pytest tests/` — 1014 pass, 2 unrelated postgres-Bearer pre-existing fails
- [x] `./demo_network/smoke.sh full` — A1/A4/A7/A8 all PASS
- [x] `alembic heads` — single head `b7c8d9e0f1a2`