### PR TITLE
ADR-008 Phase 1 / PR #3 — cross-org E2E envelope + SDK ergonomics

### DIFF
--- a/app/broker/oneshot_router.py
+++ b/app/broker/oneshot_router.py
@@ -80,9 +80,12 @@ class ForwardOneShotRequest(BaseModel):
     )
     nonce: str = Field(..., description="Globally-unique nonce for this envelope.")
     timestamp: int = Field(..., description="Unix timestamp seconds.")
-    mode: Literal["mtls-only"] = Field(
+    mode: Literal["mtls-only", "envelope"] = Field(
         "mtls-only",
-        description="Phase 1 supports mtls-only; E2E envelope lands in Phase 2.",
+        description="mtls-only: payload is plaintext dict; envelope: payload "
+                    "is a cipher_blob the broker never decrypts. Signature "
+                    "is verified on whichever form is present (outer signature "
+                    "for envelope mode).",
     )
     ttl_seconds: int = Field(
         300, ge=10, le=3600,

--- a/app/broker/oneshot_router.py
+++ b/app/broker/oneshot_router.py
@@ -87,6 +87,12 @@ class ForwardOneShotRequest(BaseModel):
                     "is verified on whichever form is present (outer signature "
                     "for envelope mode).",
     )
+    capabilities: list[str] = Field(
+        default_factory=list,
+        description="Requested capabilities — verified against both sender "
+                    "and recipient binding scopes. Empty list falls back to "
+                    "the sentinel 'oneshot.message'.",
+    )
     ttl_seconds: int = Field(
         300, ge=10, le=3600,
         description="Broker-side TTL for offline recipients.",
@@ -209,7 +215,62 @@ async def forward_oneshot(
             detail="Recipient has no approved binding",
         )
 
-    # ── Policy (synthetic session with oneshot.message capability) ────
+    # ── Capability scope check (mirrors session scope verification) ──
+    effective_caps = body.capabilities or [_ONESHOT_CAPABILITY]
+    from app.config import get_settings as _get_settings
+    _settings = _get_settings()
+    if _settings.policy_enforcement:
+        initiator_scope = set(current_agent.scope)
+        target_scope = set(recipient_binding.scope)
+        target_caps = set(recipient.capabilities)
+        for cap in effective_caps:
+            if cap not in initiator_scope:
+                await log_event(
+                    db, "broker.oneshot_denied", "denied",
+                    agent_id=current_agent.agent_id,
+                    org_id=current_agent.org,
+                    details={
+                        "correlation_id": body.correlation_id,
+                        "cap": cap,
+                        "reason": "capability_not_in_sender_scope",
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Capability '{cap}' not authorized in your scope",
+                )
+            if cap not in target_scope:
+                await log_event(
+                    db, "broker.oneshot_denied", "denied",
+                    agent_id=current_agent.agent_id,
+                    org_id=current_agent.org,
+                    details={
+                        "correlation_id": body.correlation_id,
+                        "cap": cap,
+                        "reason": "capability_not_in_recipient_scope",
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=f"Capability '{cap}' not authorized in the recipient's scope",
+                )
+            if cap not in target_caps:
+                await log_event(
+                    db, "broker.oneshot_denied", "denied",
+                    agent_id=current_agent.agent_id,
+                    org_id=current_agent.org,
+                    details={
+                        "correlation_id": body.correlation_id,
+                        "cap": cap,
+                        "reason": "recipient_does_not_advertise_capability",
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Recipient does not advertise capability '{cap}'",
+                )
+
+    # ── PDP policy ────────────────────────────────────────────────────
     initiator_org = await get_org_by_id(db, current_agent.org)
     target_org = await get_org_by_id(db, recipient.org_id)
 
@@ -220,7 +281,7 @@ async def forward_oneshot(
         target_webhook_url=target_org.webhook_url if target_org else None,
         initiator_agent_id=current_agent.agent_id,
         target_agent_id=recipient.agent_id,
-        capabilities=[_ONESHOT_CAPABILITY],
+        capabilities=effective_caps,
     )
     if not pdp_decision.allowed:
         await log_event(

--- a/app/broker/oneshot_router.py
+++ b/app/broker/oneshot_router.py
@@ -190,6 +190,8 @@ async def forward_oneshot(
             detail="Recipient agent not found or inactive",
         )
 
+    await rate_limiter.check(body.recipient_agent_id, "broker.oneshot_inbound")
+
     if recipient.agent_id == current_agent.agent_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -399,6 +401,7 @@ async def forward_oneshot(
             "reply_to_correlation_id": body.reply_to_correlation_id,
             "recipient_agent_id": recipient.agent_id,
             "nonce": body.nonce,
+            "mode": body.mode,
         },
     )
 

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -736,9 +736,10 @@ class CullisClient:
     ) -> dict:
         """Send a sessionless one-shot message via the local proxy.
 
-        Intra-org only in this revision — cross-org recipients raise
-        ``NotImplementedError`` (the proxy returns 501; Phase 2 wires
-        the broker forwarder).
+        Intra-org resolves to ``mtls-only`` (signed plaintext); cross-org
+        resolves to ``envelope`` (AES-256-GCM + RSA-OAEP/ECDH key wrap,
+        signed outer by the sender, inner signature carried inside the
+        cipher_blob for recipient non-repudiation).
 
         ``correlation_id`` defaults to a new UUID; pass the original
         request's correlation_id plus ``reply_to`` to send a reply.
@@ -777,7 +778,7 @@ class CullisClient:
         # Domain separation: signature binding substitutes the session_id
         # slot with 'oneshot:<correlation_id>' so a session signature
         # cannot be replayed as a one-shot signature and vice versa.
-        signature = sign_message(
+        inner_signature = sign_message(
             self._signing_key_pem,
             f"oneshot:{corr_id}",
             sender_agent_id,
@@ -787,13 +788,42 @@ class CullisClient:
             client_seq=0,
         )
 
+        if transport == "envelope":
+            # ADR-008 Phase 1 PR #3 — cross-org: encrypt with recipient pubkey.
+            # The broker sees only the cipher_blob and verifies the outer
+            # signature. The recipient decrypts and verifies the inner
+            # signature for non-repudiation.
+            recipient_pubkey = decision.get("target_cert_pem")
+            if not recipient_pubkey:
+                raise RuntimeError(
+                    "cross-org one-shot requires a recipient public key — "
+                    "proxy /resolve did not return target_cert_pem"
+                )
+            cipher_blob = encrypt_for_agent(
+                recipient_pubkey, payload, inner_signature,
+                f"oneshot:{corr_id}", sender_agent_id, client_seq=0,
+            )
+            wire_payload: dict[str, Any] = cipher_blob
+            wire_signature = sign_message(
+                self._signing_key_pem,
+                f"oneshot:{corr_id}",
+                sender_agent_id,
+                nonce,
+                timestamp,
+                cipher_blob,
+                client_seq=0,
+            )
+        else:
+            wire_payload = payload
+            wire_signature = inner_signature
+
         body: dict[str, Any] = {
             "recipient_id": target_agent_id,
-            "payload": payload,
+            "payload": wire_payload,
             "correlation_id": corr_id,
             "reply_to": reply_to,
             "mode": transport,
-            "signature": signature,
+            "signature": wire_signature,
             "nonce": nonce,
             "timestamp": timestamp,
             "ttl_seconds": ttl_seconds,
@@ -837,6 +867,107 @@ class CullisClient:
         )
         resp.raise_for_status()
         return resp.json().get("messages", [])
+
+    def decrypt_oneshot(self, inbox_row: dict) -> dict:
+        """Decrypt a one-shot envelope row returned by :meth:`receive_oneshot`.
+
+        For ``mtls-only`` rows the payload is already plaintext —
+        returned as-is with ``sender_verified=False`` (the mTLS transport
+        already guaranteed sender identity at proxy-to-proxy level).
+
+        For ``envelope`` rows: AES-GCM decrypt with the caller's private
+        key, then verify the inner signature against the sender's cert
+        from the broker registry. Raises ``ValueError`` on decrypt or
+        signature failure.
+
+        Returns ``{"payload": <plaintext_dict>, "sender_verified": bool,
+        "mode": "mtls-only" | "envelope"}``.
+        """
+        import json as _json
+        from cullis_sdk.crypto.e2e import verify_inner_signature
+
+        envelope = _json.loads(inbox_row["payload_ciphertext"])
+        mode = envelope.get("mode", "mtls-only")
+        sender = inbox_row["sender_agent_id"]
+        corr = inbox_row["correlation_id"]
+
+        if mode == "mtls-only":
+            return {
+                "payload": envelope.get("payload", {}),
+                "sender_verified": False,
+                "mode": mode,
+            }
+
+        if not self._signing_key_pem:
+            raise RuntimeError(
+                "envelope decrypt requires a private signing key — "
+                "initialize the client via login() or from_spiffe_workload_api()"
+            )
+
+        cipher_blob = envelope["payload"]
+        plaintext, inner_sig = decrypt_from_agent(
+            self._signing_key_pem, cipher_blob,
+            f"oneshot:{corr}", sender, client_seq=0,
+        )
+
+        sender_cert_pem = self.get_agent_public_key(sender)
+        verify_inner_signature(
+            sender_cert_pem, inner_sig,
+            f"oneshot:{corr}", sender,
+            envelope["nonce"], envelope["timestamp"], plaintext,
+            client_seq=0,
+        )
+        return {
+            "payload": plaintext,
+            "sender_verified": True,
+            "mode": mode,
+        }
+
+    def send_oneshot_and_wait(
+        self,
+        recipient_id: str,
+        payload: dict,
+        *,
+        timeout: float = 30.0,
+        poll_interval: float = 1.0,
+        ttl_seconds: int = 300,
+    ) -> dict:
+        """Request-response convenience: send a one-shot, block until a
+        reply tagged with the same ``correlation_id`` is in the caller's
+        inbox, or ``TimeoutError`` after ``timeout`` seconds.
+
+        Returns ``{"correlation_id", "msg_id", "reply_to", "reply",
+        "sender", "mode", "sender_verified"}``. ``reply`` is the
+        decrypted + signature-verified plaintext for envelope mode, or
+        the passthrough payload for mtls-only.
+        """
+        import json as _json
+
+        sent = self.send_oneshot(
+            recipient_id, payload, ttl_seconds=ttl_seconds,
+        )
+        corr = sent["correlation_id"]
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            inbox = self.receive_oneshot()
+            for row in inbox:
+                envelope = _json.loads(row["payload_ciphertext"])
+                if envelope.get("reply_to") != corr:
+                    continue
+                decoded = self.decrypt_oneshot(row)
+                return {
+                    "correlation_id": row["correlation_id"],
+                    "msg_id": row["msg_id"],
+                    "reply_to": corr,
+                    "reply": decoded["payload"],
+                    "sender": row["sender_agent_id"],
+                    "mode": decoded["mode"],
+                    "sender_verified": decoded["sender_verified"],
+                }
+            time.sleep(poll_interval)
+        raise TimeoutError(
+            f"no reply for correlation_id={corr} within {timeout:.1f}s"
+        )
 
     # ── Broker one-shot forwarding (used by proxy BrokerBridge) ────
 

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -733,6 +733,7 @@ class CullisClient:
         correlation_id: str | None = None,
         reply_to: str | None = None,
         ttl_seconds: int = 300,
+        capabilities: list[str] | None = None,
     ) -> dict:
         """Send a sessionless one-shot message via the local proxy.
 
@@ -827,6 +828,7 @@ class CullisClient:
             "nonce": nonce,
             "timestamp": timestamp,
             "ttl_seconds": ttl_seconds,
+            "capabilities": capabilities or [],
         }
         resp = self._http.post(
             f"{self.base}/v1/egress/message/send",
@@ -982,6 +984,7 @@ class CullisClient:
         timestamp: int,
         signature: str,
         ttl_seconds: int = 300,
+        capabilities: list[str] | None = None,
     ) -> dict:
         """Forward a one-shot envelope to the broker's cross-org queue.
 
@@ -1000,6 +1003,7 @@ class CullisClient:
             "timestamp": timestamp,
             "mode": "mtls-only",
             "ttl_seconds": ttl_seconds,
+            "capabilities": capabilities or [],
         }
         resp = self._authed_request(
             "POST", "/v1/broker/oneshot/forward", json=body,

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -260,6 +260,32 @@ class BrokerBridge:
                 return [_agent_info_to_dict(a) for a in agents]
             raise
 
+    # ── Peer discovery (ADR-008 Phase 1 PR #3) ──────────────────────
+
+    async def get_peer_public_key(
+        self, agent_id: str, peer_agent_id: str,
+    ) -> str:
+        """Fetch a peer agent's current public key from the broker.
+
+        ``agent_id`` is this proxy's caller (used to pick the authenticated
+        CullisClient); ``peer_agent_id`` is the broker-side key to query.
+        """
+        client = await self.get_client(agent_id)
+        try:
+            return await asyncio.to_thread(
+                client.get_agent_public_key, peer_agent_id,
+            )
+        except Exception as exc:
+            if _is_auth_error(exc):
+                logger.warning(
+                    "Auth error for %s, re-authenticating: %s", agent_id, exc,
+                )
+                client = await self._evict_and_retry(agent_id)
+                return await asyncio.to_thread(
+                    client.get_agent_public_key, peer_agent_id,
+                )
+            raise
+
     # ── One-shot (ADR-008 Phase 1 PR #2) ────────────────────────────
 
     async def send_oneshot(

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -300,42 +300,34 @@ class BrokerBridge:
         timestamp: int,
         signature: str,
         ttl_seconds: int = 300,
+        capabilities: list[str] | None = None,
     ) -> dict:
         """Forward a sessionless one-shot through the broker.
 
         Returns the broker's response body — ``{msg_id, duplicate}``.
         Uses the same auth-error retry pattern as session operations.
         """
+        kw = dict(
+            recipient_agent_id=recipient_agent_id,
+            correlation_id=correlation_id,
+            reply_to_correlation_id=reply_to_correlation_id,
+            payload=payload,
+            nonce=nonce,
+            timestamp=timestamp,
+            signature=signature,
+            ttl_seconds=ttl_seconds,
+            capabilities=capabilities or [],
+        )
         client = await self.get_client(agent_id)
         try:
-            return await asyncio.to_thread(
-                client.forward_oneshot,
-                recipient_agent_id=recipient_agent_id,
-                correlation_id=correlation_id,
-                reply_to_correlation_id=reply_to_correlation_id,
-                payload=payload,
-                nonce=nonce,
-                timestamp=timestamp,
-                signature=signature,
-                ttl_seconds=ttl_seconds,
-            )
+            return await asyncio.to_thread(client.forward_oneshot, **kw)
         except Exception as exc:
             if _is_auth_error(exc):
                 logger.warning(
                     "Auth error for %s, re-authenticating: %s", agent_id, exc,
                 )
                 client = await self._evict_and_retry(agent_id)
-                return await asyncio.to_thread(
-                    client.forward_oneshot,
-                    recipient_agent_id=recipient_agent_id,
-                    correlation_id=correlation_id,
-                    reply_to_correlation_id=reply_to_correlation_id,
-                    payload=payload,
-                    nonce=nonce,
-                    timestamp=timestamp,
-                    signature=signature,
-                    ttl_seconds=ttl_seconds,
-                )
+                return await asyncio.to_thread(client.forward_oneshot, **kw)
             raise
 
     async def poll_oneshot_inbox(self, agent_id: str) -> list[dict]:

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -79,6 +79,12 @@ class SendOneShotRequest(BaseModel):
         None,
         description="Unix timestamp seconds. Server enforces freshness.",
     )
+    capabilities: list[str] = Field(
+        default_factory=list,
+        description="Requested capabilities verified against both parties' "
+                    "binding scopes at the broker. Empty list falls back to "
+                    "the sentinel 'oneshot.message'.",
+    )
     ttl_seconds: int = Field(
         300,
         ge=10,
@@ -226,6 +232,7 @@ async def send_oneshot(
                 timestamp=body.timestamp or 0,
                 signature=body.signature or "",
                 ttl_seconds=body.ttl_seconds,
+                capabilities=body.capabilities,
             )
         except HTTPException:
             raise

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -858,6 +858,28 @@ async def resolve_recipient(
             target_cert_pem=target_cert_pem,
         )
 
+    # ADR-008 Phase 1 PR #3 — best-effort peer public key for envelope
+    # encryption cross-org. If the broker uplink is present but the fetch
+    # fails, fail the resolve (502) so the sender doesn't silently fall
+    # back to plaintext. If no bridge is configured at all the proxy is
+    # intra-only and callers that actually try to send will still get
+    # the legacy behaviour at /v1/egress/send.
+    target_cert_pem: str | None = None
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is not None:
+        broker_peer_id = f"{target_org}::{target_agent}"
+        try:
+            target_cert_pem = await bridge.get_peer_public_key(
+                agent.agent_id, broker_peer_id,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"unable to resolve peer public key: {exc}",
+            ) from exc
+
     return ResolveResponse(
         path="cross-org",
         target_agent_id=target_agent,
@@ -865,7 +887,7 @@ async def resolve_recipient(
         target_spiffe=target_spiffe,
         transport="envelope",
         egress_inspection=settings.egress_inspection_enabled,
-        target_cert_pem=None,
+        target_cert_pem=target_cert_pem,
     )
 
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -154,6 +154,7 @@ async def lifespan(app: FastAPI):
             broker_url, org_id, settings.trust_domain, settings.intra_org_routing,
         )
     else:
+        app.state.broker_bridge = None
         _log.warning("No broker_url configured — egress endpoints will return 503")
 
     # ADR-001 Phase 3a — local session store (intra-org mini-broker).

--- a/tests/test_oneshot_cross.py
+++ b/tests/test_oneshot_cross.py
@@ -84,6 +84,7 @@ def _build_forward_body(
     reply_to: str | None = None,
     timestamp: int | None = None,
     tamper_signature: bool = False,
+    capabilities: list[str] | None = None,
 ) -> tuple[dict, str, str]:
     """Return (body, correlation_id, nonce)."""
     corr = correlation_id or str(uuid.uuid4())
@@ -111,6 +112,7 @@ def _build_forward_body(
         "timestamp": ts,
         "mode": "mtls-only",
         "ttl_seconds": 300,
+        "capabilities": capabilities or [],
     }
     return body, corr, nonce
 
@@ -414,3 +416,129 @@ async def test_sweeper_expires_ttl_rows(client: AsyncClient, monkeypatch):
             )
         ).scalar_one()
     assert status_after == 2
+
+
+# ── Capability scope checks ──────────────────────────────────────────
+
+
+async def _register_and_login_with_caps(
+    client: AsyncClient, dpop: DPoPHelper, agent_id: str, org_id: str,
+    caps: list[str],
+) -> str:
+    """Like _register_and_login but lets the caller choose capabilities."""
+    org_secret = org_id + "-secret"
+    await client.post(
+        "/v1/registry/orgs",
+        json={"org_id": org_id, "display_name": org_id, "secret": org_secret},
+        headers=ADMIN_HEADERS,
+    )
+    ca_pem = get_org_ca_pem(org_id)
+    await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    await client.post(
+        "/v1/registry/agents",
+        json={
+            "agent_id": agent_id, "org_id": org_id,
+            "display_name": agent_id, "capabilities": caps,
+        },
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    resp = await client.post(
+        "/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": caps},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = resp.json()["id"]
+    await client.post(
+        f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    return await dpop.get_token(client, agent_id, org_id)
+
+
+async def test_capability_in_scope_accepted(client: AsyncClient):
+    """Both sender and recipient have 'order.read' in scope → 202."""
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login_with_caps(
+        client, dpop_a, "cap1::alice", "cap1", ["order.read", "oneshot.message"],
+    )
+    await _register_and_login_with_caps(
+        client, dpop_b, "capt1::bob", "capt1", ["order.read", "oneshot.message"],
+    )
+    body, _, _ = _build_forward_body(
+        "cap1::alice", "cap1", "capt1::bob", {"x": 1},
+        capabilities=["order.read"],
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 202, r.text
+
+
+async def test_capability_not_in_sender_scope_rejected(client: AsyncClient):
+    """Sender binding lacks 'kyc.write' → 403."""
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login_with_caps(
+        client, dpop_a, "cap2::alice", "cap2", ["order.read"],
+    )
+    await _register_and_login_with_caps(
+        client, dpop_b, "capt2::bob", "capt2", ["order.read", "kyc.write"],
+    )
+    body, _, _ = _build_forward_body(
+        "cap2::alice", "cap2", "capt2::bob", {"x": 1},
+        capabilities=["kyc.write"],
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 403
+    assert "kyc.write" in r.text
+    assert "your scope" in r.text.lower()
+
+
+async def test_capability_not_in_recipient_scope_rejected(client: AsyncClient):
+    """Recipient binding lacks 'kyc.write' → 403."""
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login_with_caps(
+        client, dpop_a, "cap3::alice", "cap3", ["order.read", "kyc.write"],
+    )
+    await _register_and_login_with_caps(
+        client, dpop_b, "capt3::bob", "capt3", ["order.read"],
+    )
+    body, _, _ = _build_forward_body(
+        "cap3::alice", "cap3", "capt3::bob", {"x": 1},
+        capabilities=["kyc.write"],
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 403
+    assert "kyc.write" in r.text
+    assert "recipient" in r.text.lower()
+
+
+async def test_empty_capabilities_falls_back_to_sentinel(client: AsyncClient):
+    """Empty capabilities list uses sentinel 'oneshot.message' → still works
+    when both sides have it in their binding scope (or policy enforcement off).
+    """
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(
+        client, dpop_a, "cap4::alice", "cap4",
+    )
+    await _register_and_login(client, dpop_b, "capt4::bob", "capt4")
+
+    body, _, _ = _build_forward_body(
+        "cap4::alice", "cap4", "capt4::bob", {"x": 1},
+        capabilities=[],
+    )
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 202

--- a/tests/test_oneshot_cross_envelope.py
+++ b/tests/test_oneshot_cross_envelope.py
@@ -1,0 +1,649 @@
+"""ADR-008 Phase 1 PR #3 — cross-org envelope E2E + SDK req/resp helper.
+
+Three groups:
+
+A. Broker accepts ``mode=envelope`` with opaque cipher_blob payload.
+B. SDK crypto roundtrip — encrypt_for_agent + decrypt_oneshot + inner
+   signature verification + AAD binding.
+C. ``send_oneshot_and_wait`` contract via mocked proxy HTTP.
+
+End-to-end proxy↔broker↔proxy via ASGI transport is already covered by
+``demo_network/smoke.sh``; unit-testing the full path in-process would
+require mounting a fake broker on top of the proxy app. These tests
+focus on the correctness gates that unit testing is best at.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from cullis_sdk.client import CullisClient
+from cullis_sdk.crypto.e2e import (
+    decrypt_from_agent,
+    encrypt_for_agent,
+    verify_inner_signature,
+)
+from cullis_sdk.crypto.message_signer import sign_message
+from tests.cert_factory import (
+    DPoPHelper,
+    get_agent_key_pem,
+    get_agent_pubkey_pem,
+    get_org_ca_pem,
+)
+from tests.conftest import ADMIN_HEADERS
+from tests.test_oneshot_cross import (  # reuse helpers from PR #2 suite
+    _register_and_login,
+    _mock_oneshot_pdp,  # noqa — autouse fixture re-exported for patch scope
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def _make_cipher_blob(
+    *,
+    recipient_pubkey_pem: str,
+    correlation_id: str,
+    sender_agent_id: str,
+    sender_key_pem: str,
+    payload: dict,
+    nonce: str,
+    timestamp: int,
+) -> tuple[dict, str, str]:
+    """Return (cipher_blob, inner_signature, outer_signature)."""
+    inner_sig = sign_message(
+        sender_key_pem,
+        f"oneshot:{correlation_id}",
+        sender_agent_id,
+        nonce,
+        timestamp,
+        payload,
+        client_seq=0,
+    )
+    cipher_blob = encrypt_for_agent(
+        recipient_pubkey_pem, payload, inner_sig,
+        f"oneshot:{correlation_id}", sender_agent_id, client_seq=0,
+    )
+    outer_sig = sign_message(
+        sender_key_pem,
+        f"oneshot:{correlation_id}",
+        sender_agent_id,
+        nonce,
+        timestamp,
+        cipher_blob,
+        client_seq=0,
+    )
+    return cipher_blob, inner_sig, outer_sig
+
+
+# ── Group A — broker accepts envelope mode ────────────────────────────
+
+async def test_broker_accepts_envelope_mode(client: AsyncClient):
+    """Broker stores an envelope cipher_blob as opaque payload and serves
+    it back unchanged through /inbox."""
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(
+        client, dpop_a, "env1::alice", "env1",
+    )
+    token_b = await _register_and_login(
+        client, dpop_b, "envt1::bob", "envt1",
+    )
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("env1::alice", "env1")
+    bob_pubkey = get_agent_pubkey_pem("envt1::bob", "envt1")
+
+    cipher_blob, _inner, outer_sig = _make_cipher_blob(
+        recipient_pubkey_pem=bob_pubkey,
+        correlation_id=corr,
+        sender_agent_id="env1::alice",
+        sender_key_pem=alice_priv,
+        payload={"msg": "confidential"},
+        nonce=nonce,
+        timestamp=ts,
+    )
+
+    body = {
+        "recipient_agent_id": "envt1::bob",
+        "correlation_id": corr,
+        "reply_to_correlation_id": None,
+        "payload": cipher_blob,
+        "signature": outer_sig,
+        "nonce": nonce,
+        "timestamp": ts,
+        "mode": "envelope",
+        "ttl_seconds": 300,
+    }
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers(
+            "POST", "/v1/broker/oneshot/forward", token_a,
+        ),
+    )
+    assert r.status_code == 202, r.text
+
+    r2 = await client.get(
+        "/v1/broker/oneshot/inbox",
+        headers=dpop_b.headers("GET", "/v1/broker/oneshot/inbox", token_b),
+    )
+    assert r2.status_code == 200
+    inbox = r2.json()["messages"]
+    assert len(inbox) == 1
+    returned_envelope = json.loads(inbox[0]["envelope_json"])
+    assert returned_envelope["mode"] == "envelope"
+    # Broker faithfully echoes the opaque cipher_blob.
+    assert returned_envelope["payload"] == cipher_blob
+
+
+async def test_broker_rejects_tampered_outer_signature_envelope(
+    client: AsyncClient,
+):
+    """Outer signature still verified even when payload is opaque."""
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(
+        client, dpop_a, "env2::alice", "env2",
+    )
+    await _register_and_login(client, dpop_b, "envt2::bob", "envt2")
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("env2::alice", "env2")
+    bob_pubkey = get_agent_pubkey_pem("envt2::bob", "envt2")
+
+    cipher_blob, _i, outer_sig = _make_cipher_blob(
+        recipient_pubkey_pem=bob_pubkey,
+        correlation_id=corr,
+        sender_agent_id="env2::alice",
+        sender_key_pem=alice_priv,
+        payload={"x": 1},
+        nonce=nonce,
+        timestamp=ts,
+    )
+    # Flip a byte in the b64url signature
+    bad_sig = outer_sig[:-4] + ("AAAA" if not outer_sig.endswith("AAAA") else "BBBB")
+
+    body = {
+        "recipient_agent_id": "envt2::bob",
+        "correlation_id": corr,
+        "reply_to_correlation_id": None,
+        "payload": cipher_blob,
+        "signature": bad_sig,
+        "nonce": nonce,
+        "timestamp": ts,
+        "mode": "envelope",
+        "ttl_seconds": 300,
+    }
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers(
+            "POST", "/v1/broker/oneshot/forward", token_a,
+        ),
+    )
+    assert r.status_code == 401
+
+
+# ── Group B — SDK crypto roundtrip ─────────────────────────────────────
+
+async def test_sdk_decrypt_oneshot_envelope_roundtrip(client: AsyncClient):
+    """encrypt_for_agent + decrypt_oneshot returns matching plaintext and
+    verifies inner signature against the broker registry cert."""
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    await _register_and_login(client, dpop_a, "env3::alice", "env3")
+    token_b = await _register_and_login(client, dpop_b, "envt3::bob", "envt3")
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("env3::alice", "env3")
+    bob_priv = get_agent_key_pem("envt3::bob", "envt3")
+    bob_pubkey = get_agent_pubkey_pem("envt3::bob", "envt3")
+
+    payload = {"quote": 42, "currency": "EUR"}
+    cipher_blob, inner_sig, _outer = _make_cipher_blob(
+        recipient_pubkey_pem=bob_pubkey,
+        correlation_id=corr,
+        sender_agent_id="env3::alice",
+        sender_key_pem=alice_priv,
+        payload=payload,
+        nonce=nonce,
+        timestamp=ts,
+    )
+
+    envelope_json = json.dumps({
+        "mode": "envelope",
+        "payload": cipher_blob,
+        "signature": _outer,
+        "nonce": nonce,
+        "timestamp": ts,
+        "correlation_id": corr,
+        "reply_to": None,
+    }, separators=(",", ":"), sort_keys=True)
+    inbox_row = {
+        "msg_id": str(uuid.uuid4()),
+        "correlation_id": corr,
+        "reply_to": None,
+        "sender_agent_id": "env3::alice",
+        "payload_ciphertext": envelope_json,
+        "idempotency_key": f"oneshot:{corr}",
+        "enqueued_at": "2026-04-16T00:00:00+00:00",
+        "expires_at": None,
+    }
+
+    # Construct a Bob client, swap its HTTP stack to talk to the broker ASGI.
+    bob_client = CullisClient("http://test", verify_tls=False)
+    bob_client._signing_key_pem = bob_priv
+    # Pre-seed pubkey cache so decrypt_oneshot doesn't need a live broker.
+    alice_cert_pem = _alice_cert_pem = _get_alice_cert_pem = None
+    from tests.cert_factory import make_agent_cert
+    from cryptography.hazmat.primitives import serialization
+    _, alice_cert = make_agent_cert("env3::alice", "env3")
+    alice_cert_pem = alice_cert.public_bytes(
+        serialization.Encoding.PEM,
+    ).decode()
+    bob_client._pubkey_cache["env3::alice"] = (alice_cert_pem, time.time())
+
+    decoded = bob_client.decrypt_oneshot(inbox_row)
+    assert decoded["mode"] == "envelope"
+    assert decoded["sender_verified"] is True
+    assert decoded["payload"] == payload
+    bob_client.close()
+
+
+async def test_sdk_decrypt_rejects_tampered_inner_signature(
+    client: AsyncClient,
+):
+    """Swap inner_sig inside the cipher_blob → verify_inner_signature raises.
+
+    We exercise this at the crypto helper level directly: build a valid
+    cipher_blob, decrypt to get plaintext + inner_sig, flip a byte,
+    call verify_inner_signature → ValueError.
+    """
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("env4::alice", "env4")
+    bob_priv = get_agent_key_pem("envt4::bob", "envt4")
+    bob_pubkey = get_agent_pubkey_pem("envt4::bob", "envt4")
+    from tests.cert_factory import make_agent_cert
+    from cryptography.hazmat.primitives import serialization
+    _, alice_cert = make_agent_cert("env4::alice", "env4")
+    alice_cert_pem = alice_cert.public_bytes(
+        serialization.Encoding.PEM,
+    ).decode()
+
+    cipher_blob, inner_sig, _outer = _make_cipher_blob(
+        recipient_pubkey_pem=bob_pubkey,
+        correlation_id=corr,
+        sender_agent_id="env4::alice",
+        sender_key_pem=alice_priv,
+        payload={"ok": True},
+        nonce=nonce,
+        timestamp=ts,
+    )
+    plaintext, _ = decrypt_from_agent(
+        bob_priv, cipher_blob, f"oneshot:{corr}", "env4::alice", client_seq=0,
+    )
+
+    tampered = inner_sig[:-4] + ("AAAA" if not inner_sig.endswith("AAAA") else "BBBB")
+    with pytest.raises(ValueError):
+        verify_inner_signature(
+            alice_cert_pem, tampered,
+            f"oneshot:{corr}", "env4::alice", nonce, ts, plaintext,
+            client_seq=0,
+        )
+
+
+async def test_aad_binding_rejects_wrong_correlation_id(
+    client: AsyncClient,
+):
+    """AAD = ``oneshot:<corr>|sender|0`` pins the cipher_blob to that
+    correlation_id. Decrypting with a different corr must fail.
+    """
+    corr_real = str(uuid.uuid4())
+    corr_attacker = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("env5::alice", "env5")
+    bob_priv = get_agent_key_pem("envt5::bob", "envt5")
+    bob_pubkey = get_agent_pubkey_pem("envt5::bob", "envt5")
+
+    cipher_blob, _i, _o = _make_cipher_blob(
+        recipient_pubkey_pem=bob_pubkey,
+        correlation_id=corr_real,
+        sender_agent_id="env5::alice",
+        sender_key_pem=alice_priv,
+        payload={"secret": True},
+        nonce=nonce,
+        timestamp=ts,
+    )
+
+    # Try to decrypt the blob under a wrong AAD (different corr)
+    with pytest.raises(Exception):
+        decrypt_from_agent(
+            bob_priv, cipher_blob,
+            f"oneshot:{corr_attacker}", "env5::alice", client_seq=0,
+        )
+
+
+async def test_broker_cannot_decrypt_envelope(client: AsyncClient):
+    """Decrypting a cipher_blob with a non-recipient key must fail."""
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("env6::alice", "env6")
+    bob_pubkey = get_agent_pubkey_pem("envt6::bob", "envt6")
+    # Use alice's own priv to simulate an attacker with broker-equivalent powers
+    attacker_priv = alice_priv
+
+    cipher_blob, _i, _o = _make_cipher_blob(
+        recipient_pubkey_pem=bob_pubkey,
+        correlation_id=corr,
+        sender_agent_id="env6::alice",
+        sender_key_pem=alice_priv,
+        payload={"secret": True},
+        nonce=nonce,
+        timestamp=ts,
+    )
+    with pytest.raises(Exception):
+        decrypt_from_agent(
+            attacker_priv, cipher_blob,
+            f"oneshot:{corr}", "env6::alice", client_seq=0,
+        )
+
+
+# ── Group C — send_oneshot_and_wait contract ─────────────────────────
+
+def test_send_oneshot_and_wait_returns_reply():
+    """Mock the proxy HTTP surface: /resolve + /message/send + /inbox.
+    The helper should loop polling until a row with matching reply_to
+    appears, then return the decrypted plaintext.
+    """
+    alice_priv = get_agent_key_pem("env7::alice", "env7")
+    bob_priv = get_agent_key_pem("envt7::bob", "envt7")
+    bob_pubkey = get_agent_pubkey_pem("envt7::bob", "envt7")
+    from tests.cert_factory import make_agent_cert
+    from cryptography.hazmat.primitives import serialization
+    _, bob_cert = make_agent_cert("envt7::bob", "envt7")
+    bob_cert_pem = bob_cert.public_bytes(serialization.Encoding.PEM).decode()
+
+    # Client posing as Alice (sender). send_oneshot_and_wait will:
+    #   1. POST /resolve
+    #   2. POST /message/send
+    #   3. loop GET /inbox until it sees a row with reply_to=corr
+    alice = CullisClient("http://mock-proxy", verify_tls=False)
+    alice._signing_key_pem = alice_priv
+    alice._proxy_api_key = "fake-api-key"
+    alice._proxy_agent_id = "env7::alice"
+    alice._proxy_org_id = "env7"
+
+    # Seed Alice's pubkey cache so decrypt_oneshot finds Bob's cert when
+    # verifying his inner signature on the reply.
+    alice._pubkey_cache["envt7::bob"] = (bob_cert_pem, time.time())
+
+    # Pre-compute Bob's reply ciphertext + outer envelope.
+    #   Alice sends: payload={"q": "price?"}, corr=C
+    #   Bob replies: payload={"a": 100}, reply_to=C, new corr=C2
+    def _build_reply_row(request_corr: str) -> dict:
+        reply_corr = str(uuid.uuid4())
+        reply_nonce = str(uuid.uuid4())
+        reply_ts = int(time.time())
+        # Alice's pubkey to encrypt toward her
+        alice_pubkey = get_agent_pubkey_pem("env7::alice", "env7")
+        reply_plain = {"a": 100}
+        inner = sign_message(
+            bob_priv, f"oneshot:{reply_corr}", "envt7::bob",
+            reply_nonce, reply_ts, reply_plain, client_seq=0,
+        )
+        cipher = encrypt_for_agent(
+            alice_pubkey, reply_plain, inner,
+            f"oneshot:{reply_corr}", "envt7::bob", client_seq=0,
+        )
+        outer = sign_message(
+            bob_priv, f"oneshot:{reply_corr}", "envt7::bob",
+            reply_nonce, reply_ts, cipher, client_seq=0,
+        )
+        env = {
+            "mode": "envelope",
+            "payload": cipher,
+            "signature": outer,
+            "nonce": reply_nonce,
+            "timestamp": reply_ts,
+            "correlation_id": reply_corr,
+            "reply_to": request_corr,
+        }
+        return {
+            "msg_id": str(uuid.uuid4()),
+            "correlation_id": reply_corr,
+            "reply_to": request_corr,
+            "sender_agent_id": "envt7::bob",
+            "payload_ciphertext": json.dumps(env, separators=(",", ":"), sort_keys=True),
+            "idempotency_key": f"oneshot:{reply_corr}",
+            "enqueued_at": "2026-04-16T00:00:00+00:00",
+            "expires_at": None,
+        }
+
+    captured: dict[str, str] = {}
+
+    def _fake_post(url: str, *args, **kwargs):
+        body = kwargs.get("json", {})
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.headers = {}
+        if url.endswith("/v1/egress/resolve"):
+            resp.json.return_value = {
+                "path": "cross-org",
+                "target_agent_id": "envt7::bob",
+                "target_org_id": "envt7",
+                "target_spiffe": None,
+                "transport": "envelope",
+                "egress_inspection": False,
+                "target_cert_pem": bob_pubkey,
+            }
+            return resp
+        if url.endswith("/v1/egress/message/send"):
+            captured["corr"] = body["correlation_id"]
+            resp.json.return_value = {
+                "correlation_id": body["correlation_id"],
+                "msg_id": str(uuid.uuid4()),
+                "status": "enqueued",
+            }
+            return resp
+        raise AssertionError(f"unexpected POST: {url}")
+
+    call_count = {"inbox": 0}
+    reply_row_container: dict[str, dict] = {}
+
+    def _fake_get(url: str, *args, **kwargs):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.headers = {}
+        if url.endswith("/v1/egress/message/inbox"):
+            call_count["inbox"] += 1
+            # Return the reply only on the second poll so we exercise
+            # the loop.
+            if call_count["inbox"] >= 2:
+                if "row" not in reply_row_container:
+                    reply_row_container["row"] = _build_reply_row(
+                        captured["corr"],
+                    )
+                resp.json.return_value = {
+                    "messages": [reply_row_container["row"]], "count": 1,
+                }
+            else:
+                resp.json.return_value = {"messages": [], "count": 0}
+            return resp
+        raise AssertionError(f"unexpected GET: {url}")
+
+    alice._http = MagicMock()
+    alice._http.post.side_effect = _fake_post
+    alice._http.get.side_effect = _fake_get
+
+    result = alice.send_oneshot_and_wait(
+        "envt7::bob", {"q": "price?"},
+        timeout=5.0, poll_interval=0.1,
+    )
+
+    assert result["reply"] == {"a": 100}
+    assert result["sender"] == "envt7::bob"
+    assert result["mode"] == "envelope"
+    assert result["sender_verified"] is True
+    assert call_count["inbox"] >= 2
+
+
+def test_send_oneshot_and_wait_timeout():
+    """No matching reply within timeout → TimeoutError."""
+    alice_priv = get_agent_key_pem("env8::alice", "env8")
+    bob_pubkey = get_agent_pubkey_pem("envt8::bob", "envt8")
+
+    alice = CullisClient("http://mock-proxy", verify_tls=False)
+    alice._signing_key_pem = alice_priv
+    alice._proxy_api_key = "fake-api-key"
+    alice._proxy_agent_id = "env8::alice"
+
+    def _fake_post(url: str, *args, **kwargs):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.headers = {}
+        if url.endswith("/v1/egress/resolve"):
+            resp.json.return_value = {
+                "path": "cross-org",
+                "target_agent_id": "envt8::bob",
+                "target_org_id": "envt8",
+                "target_spiffe": None,
+                "transport": "envelope",
+                "egress_inspection": False,
+                "target_cert_pem": bob_pubkey,
+            }
+            return resp
+        if url.endswith("/v1/egress/message/send"):
+            body = kwargs.get("json", {})
+            resp.json.return_value = {
+                "correlation_id": body["correlation_id"],
+                "msg_id": str(uuid.uuid4()),
+                "status": "enqueued",
+            }
+            return resp
+        raise AssertionError(url)
+
+    def _fake_get(url: str, *args, **kwargs):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.headers = {}
+        resp.json.return_value = {"messages": [], "count": 0}
+        return resp
+
+    alice._http = MagicMock()
+    alice._http.post.side_effect = _fake_post
+    alice._http.get.side_effect = _fake_get
+
+    with pytest.raises(TimeoutError):
+        alice.send_oneshot_and_wait(
+            "envt8::bob", {"q": "?"},
+            timeout=0.5, poll_interval=0.1,
+        )
+
+
+# ── Group D — /resolve populates target_cert_pem cross-org ───────────
+
+async def test_proxy_resolve_populates_target_cert_pem_cross_org(tmp_path, monkeypatch):
+    """Proxy /resolve hits BrokerBridge.get_peer_public_key on cross-org."""
+    from httpx import ASGITransport as _ASGIT, AsyncClient as _AC
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+
+    db_file = tmp_path / "resolve.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "resolveorg")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    fake_bridge = MagicMock()
+    fake_bridge.get_peer_public_key = AsyncMock(return_value="-----FAKE CERT-----")
+    fake_bridge.shutdown = AsyncMock()
+    app.state.broker_bridge = fake_bridge
+
+    transport = _ASGIT(app=app)
+    async with _AC(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            raw = generate_api_key("alice")
+            await create_agent(
+                agent_id="alice",
+                display_name="alice",
+                capabilities=["oneshot.message"],
+                api_key_hash=hash_api_key(raw),
+                cert_pem="-----X-----",
+            )
+            r = await cli.post(
+                "/v1/egress/resolve",
+                headers={"X-API-Key": raw},
+                json={"recipient_id": "other::bob"},
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["path"] == "cross-org"
+            assert body["transport"] == "envelope"
+            assert body["target_cert_pem"] == "-----FAKE CERT-----"
+            fake_bridge.get_peer_public_key.assert_awaited_once_with(
+                "alice", "other::bob",
+            )
+    get_settings.cache_clear()
+
+
+async def test_proxy_resolve_fails_closed_on_bridge_error(tmp_path, monkeypatch):
+    """If BrokerBridge.get_peer_public_key raises, /resolve returns 502."""
+    from httpx import ASGITransport as _ASGIT, AsyncClient as _AC
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+
+    db_file = tmp_path / "resolve_fail.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "resolvefailorg")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    fake_bridge = MagicMock()
+    fake_bridge.get_peer_public_key = AsyncMock(
+        side_effect=RuntimeError("broker down"),
+    )
+    fake_bridge.shutdown = AsyncMock()
+    app.state.broker_bridge = fake_bridge
+
+    transport = _ASGIT(app=app)
+    async with _AC(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            raw = generate_api_key("alice")
+            await create_agent(
+                agent_id="alice",
+                display_name="alice",
+                capabilities=["oneshot.message"],
+                api_key_hash=hash_api_key(raw),
+                cert_pem="-----X-----",
+            )
+            r = await cli.post(
+                "/v1/egress/resolve",
+                headers={"X-API-Key": raw},
+                json={"recipient_id": "other::bob"},
+            )
+    assert r.status_code == 502
+    assert "peer public key" in r.text.lower()
+    get_settings.cache_clear()

--- a/tests/test_oneshot_cross_envelope.py
+++ b/tests/test_oneshot_cross_envelope.py
@@ -17,11 +17,10 @@ from __future__ import annotations
 import json
 import time
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
 
 from cullis_sdk.client import CullisClient
 from cullis_sdk.crypto.e2e import (
@@ -34,9 +33,7 @@ from tests.cert_factory import (
     DPoPHelper,
     get_agent_key_pem,
     get_agent_pubkey_pem,
-    get_org_ca_pem,
 )
-from tests.conftest import ADMIN_HEADERS
 from tests.test_oneshot_cross import (  # reuse helpers from PR #2 suite
     _register_and_login,
     _mock_oneshot_pdp,  # noqa — autouse fixture re-exported for patch scope
@@ -200,7 +197,7 @@ async def test_sdk_decrypt_oneshot_envelope_roundtrip(client: AsyncClient):
     verifies inner signature against the broker registry cert."""
     dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
     await _register_and_login(client, dpop_a, "env3::alice", "env3")
-    token_b = await _register_and_login(client, dpop_b, "envt3::bob", "envt3")
+    await _register_and_login(client, dpop_b, "envt3::bob", "envt3")
 
     corr = str(uuid.uuid4())
     nonce = str(uuid.uuid4())

--- a/tests/test_oneshot_cross_envelope.py
+++ b/tests/test_oneshot_cross_envelope.py
@@ -573,11 +573,11 @@ async def test_proxy_resolve_populates_target_cert_pem_cross_org(tmp_path, monke
     fake_bridge = MagicMock()
     fake_bridge.get_peer_public_key = AsyncMock(return_value="-----FAKE CERT-----")
     fake_bridge.shutdown = AsyncMock()
-    app.state.broker_bridge = fake_bridge
 
     transport = _ASGIT(app=app)
     async with _AC(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            app.state.broker_bridge = fake_bridge
             raw = generate_api_key("alice")
             await create_agent(
                 agent_id="alice",
@@ -623,11 +623,11 @@ async def test_proxy_resolve_fails_closed_on_bridge_error(tmp_path, monkeypatch)
         side_effect=RuntimeError("broker down"),
     )
     fake_bridge.shutdown = AsyncMock()
-    app.state.broker_bridge = fake_bridge
 
     transport = _ASGIT(app=app)
     async with _AC(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            app.state.broker_bridge = fake_bridge
             raw = generate_api_key("alice")
             await create_agent(
                 agent_id="alice",


### PR DESCRIPTION
## Summary

Completes ADR-008 Phase 1 with zero-knowledge cross-org encryption and SDK convenience helpers.

- **E2E envelope cross-org**: sender SDK encrypts (AES-256-GCM + RSA-OAEP/ECDH) with recipient pubkey fetched via proxy `/resolve` → broker bridge → `/v1/registry/agents/{id}/public-key`. Broker verifies outer signature on opaque cipher_blob; inner signature (non-repudiation) verified by recipient after decrypt. AAD = `oneshot:<corr>|sender|0` prevents cross-session replay.
- **`decrypt_oneshot(inbox_row)`**: auto-decrypts + inner-sig verifies envelope rows; passthrough for mtls-only intra-org.
- **`send_oneshot_and_wait(recipient, payload, timeout=30)`**: sync req/resp — sends one-shot, polls inbox until `reply_to=<corr>` appears or timeout.
- **Proxy /resolve**: populates `target_cert_pem` for cross-org via `BrokerBridge.get_peer_public_key`. Gracefully returns `null` if no bridge configured (intra-only deploy); fail-closed 502 if bridge present but fetch errors.
- **Broker**: `ForwardOneShotRequest.mode` now accepts `"envelope"` — signature verification works on cipher_blob dict the same way (deterministic JSON canonical form).

## Test plan

- [x] `tests/test_oneshot_cross_envelope.py` — 10 new tests all green (envelope roundtrip, tampered inner sig, AAD binding, broker can't decrypt, outer sig, `send_oneshot_and_wait` happy + timeout, `/resolve` cert population + fail-closed)
- [x] `tests/test_oneshot_intra.py` + `test_oneshot_cross.py` + `test_proxy_resolve.py` — all regression green
- [x] `pytest tests/` — 1024 pass, 2 unrelated postgres-Bearer pre-existing fails
- [x] `./demo_network/smoke.sh full` — A1/A4/A7/A8 PASS