### PR TITLE
feat(sandbox): MCP servers + demo wrapper + broker certs tmpfs

### DIFF
--- a/enterprise_sandbox/demo.sh
+++ b/enterprise_sandbox/demo.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# ANSI
+BOLD='\033[1m'
+GREEN='\033[32m'
+CYAN='\033[36m'
+RESET='\033[0m'
+
+_header() { echo -e "\n${BOLD}${CYAN}═══ $1 ═══${RESET}\n"; }
+
+case "${1:-help}" in
+  up)
+    _header "Enterprise Sandbox — Starting"
+    echo "Building and starting all services..."
+    docker compose build --quiet
+    docker compose up -d --wait
+    echo ""
+    _header "Services Running"
+    docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+    echo ""
+    _header "Dashboard URLs"
+    echo -e "  ${GREEN}Court (broker)${RESET}     http://localhost:8000/dashboard/login"
+    echo -e "                      admin / sandbox-admin-secret-change-me"
+    echo -e "  ${GREEN}Mastio A (proxy-a)${RESET} http://localhost:9100/proxy"
+    echo -e "                      admin secret: sandbox-proxy-admin-a"
+    echo -e "  ${GREEN}Mastio B (proxy-b)${RESET} http://localhost:9200/proxy"
+    echo -e "                      admin secret: sandbox-proxy-admin-b"
+    echo -e "  ${GREEN}Keycloak A${RESET}         http://localhost:8180  (alice / alice-sandbox)"
+    echo -e "  ${GREEN}Keycloak B${RESET}         http://localhost:8280  (bob / bob-sandbox)"
+    echo ""
+    echo -e "Bootstrap logs:  docker compose -f enterprise_sandbox/docker-compose.yml logs bootstrap"
+    echo -e "Agent logs:      docker compose -f enterprise_sandbox/docker-compose.yml logs agent-a agent-b byoca-a"
+    ;;
+
+  down)
+    _header "Enterprise Sandbox — Teardown"
+    docker compose down -v --remove-orphans
+    echo -e "${GREEN}✓ sandbox down${RESET}"
+    ;;
+
+  status)
+    _header "Enterprise Sandbox — Status"
+    docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+    ;;
+
+  logs)
+    shift
+    docker compose logs "${@:---tail=50}"
+    ;;
+
+  dashboard)
+    _header "Dashboard URLs"
+    echo -e "  Court (broker)     http://localhost:8000/dashboard/login"
+    echo -e "  Mastio A (proxy-a) http://localhost:9100/proxy"
+    echo -e "  Mastio B (proxy-b) http://localhost:9200/proxy"
+    echo -e "  Keycloak A         http://localhost:8180"
+    echo -e "  Keycloak B         http://localhost:8280"
+    ;;
+
+  bootstrap-logs)
+    docker compose logs bootstrap --no-log-prefix
+    ;;
+
+  help|*)
+    echo "Usage: demo.sh <command>"
+    echo ""
+    echo "Lifecycle:"
+    echo "  up              Build + start all services, show dashboard URLs"
+    echo "  down            Teardown (remove containers + volumes)"
+    echo "  status          Show running services"
+    echo "  logs [service]  Show logs (default: last 50 lines)"
+    echo ""
+    echo "Info:"
+    echo "  dashboard       Print dashboard URLs"
+    echo "  bootstrap-logs  Show bootstrap verbose output"
+    ;;
+esac

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -109,6 +109,8 @@ services:
       OTEL_ENABLED: "false"
       ENVIRONMENT: "development"
       FORWARDED_ALLOW_IPS: "172.16.0.0/12"
+    tmpfs:
+      - /app/certs:uid=999,gid=999
     volumes:
       - broker-ca:/broker-certs:ro
     entrypoint: ["sh", "-c"]
@@ -193,7 +195,9 @@ services:
   # ── Org A proxy ────────────────────────────────────────────────────────────
 
   proxy-a-init:
-    build: ./proxy-init
+    build:
+      context: ..
+      dockerfile: enterprise_sandbox/proxy-init/Dockerfile
     depends_on:
       bootstrap:
         condition: service_completed_successfully
@@ -206,9 +210,14 @@ services:
       OIDC_ISSUER_URL:     "http://keycloak-a:8180/realms/orga"
       OIDC_CLIENT_ID:      "cullis-proxy-dashboard"
       OIDC_CLIENT_SECRET:  "orga-oidc-client-secret-change-me"
+      SEED_MCP_RESOURCES:  "1"
+      SEED_MCP_0_NAME:     "catalog"
+      SEED_MCP_0_ENDPOINT: "http://mcp-catalog:9300/"
+      SEED_MCP_0_AGENTS:   "agent-a,byoca-bot"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-a-data:/data
+    networks: [orga-internal, public-wan]
     restart: "no"
 
   proxy-a:
@@ -397,7 +406,9 @@ services:
   # ── Org B proxy ────────────────────────────────────────────────────────────
 
   proxy-b-init:
-    build: ./proxy-init
+    build:
+      context: ..
+      dockerfile: enterprise_sandbox/proxy-init/Dockerfile
     depends_on:
       bootstrap:
         condition: service_completed_successfully
@@ -410,6 +421,10 @@ services:
       OIDC_ISSUER_URL:     "http://keycloak-b:8280/realms/orgb"
       OIDC_CLIENT_ID:      "cullis-proxy-dashboard"
       OIDC_CLIENT_SECRET:  "orgb-oidc-client-secret-change-me"
+      SEED_MCP_RESOURCES:  "1"
+      SEED_MCP_0_NAME:     "inventory"
+      SEED_MCP_0_ENDPOINT: "http://mcp-inventory:9400/"
+      SEED_MCP_0_AGENTS:   "agent-b"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-b-data:/data
@@ -550,3 +565,31 @@ services:
       timeout: 2s
       retries: 20
       start_period: 20s
+
+  # ── MCP servers (ADR-007) ──────────────────────────────────────────────────
+
+  mcp-catalog:
+    build:
+      context: ./mcp-catalog
+      dockerfile: ../mcp-server.Dockerfile
+    command: ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "9300"]
+    networks: [orga-internal]
+    expose: ["9300"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9300/healthz')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  mcp-inventory:
+    build:
+      context: ./mcp-inventory
+      dockerfile: ../mcp-server.Dockerfile
+    command: ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "9400"]
+    networks: [orgb-internal]
+    expose: ["9400"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9400/healthz')"]
+      interval: 5s
+      timeout: 3s
+      retries: 10

--- a/enterprise_sandbox/mcp-catalog/server.py
+++ b/enterprise_sandbox/mcp-catalog/server.py
@@ -1,0 +1,90 @@
+"""MCP server: product catalog lookup (enterprise sandbox demo).
+
+JSON-RPC 2.0 over POST / with a single tool `get_catalog`.
+GET /healthz for compose healthcheck.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="mcp-catalog", version="0.1.0")
+
+_PROTOCOL_VERSION = "2024-11-05"
+_TOOL = {
+    "name": "get_catalog",
+    "description": "Return product catalog for a category",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"category": {"type": "string"}},
+    },
+}
+
+_CATALOGS: dict[str, list[dict]] = {
+    "electronics": [
+        {"sku": "WIDGET-X", "name": "Widget X", "price": 42.00},
+        {"sku": "GADGET-Y", "name": "Gadget Y", "price": 99.50},
+    ],
+}
+_DEFAULT_CATALOG = [{"sku": "GENERIC-1", "name": "Generic Item", "price": 10.00}]
+
+
+def _rpc_result(req_id: Any, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _rpc_error(req_id: Any, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    return {"ok": True}
+
+
+@app.post("/")
+async def rpc(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(_rpc_error(None, -32700, "parse error"), status_code=400)
+
+    method = body.get("method")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+
+    print(
+        f"mcp-catalog: method={method!r} id={req_id!r} "
+        f"params={json.dumps(params, sort_keys=True)}",
+        flush=True,
+    )
+
+    if method == "initialize":
+        return JSONResponse(_rpc_result(req_id, {
+            "protocolVersion": _PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mcp-catalog", "version": "0.1.0"},
+        }))
+
+    if method == "notifications/initialized":
+        return JSONResponse(None, status_code=204)
+
+    if method == "tools/list":
+        return JSONResponse(_rpc_result(req_id, {"tools": [_TOOL]}))
+
+    if method == "tools/call":
+        name = params.get("name")
+        if name != "get_catalog":
+            return JSONResponse(_rpc_error(req_id, -32601, f"tool not found: {name}"))
+        args = params.get("arguments") or {}
+        category = args.get("category", "")
+        catalog = _CATALOGS.get(category, _DEFAULT_CATALOG)
+        return JSONResponse(_rpc_result(req_id, {
+            "content": [{"type": "text", "text": json.dumps(catalog)}],
+            "isError": False,
+        }))
+
+    return JSONResponse(_rpc_error(req_id, -32601, f"method not found: {method}"))

--- a/enterprise_sandbox/mcp-inventory/server.py
+++ b/enterprise_sandbox/mcp-inventory/server.py
@@ -1,0 +1,87 @@
+"""MCP server: stock availability check (enterprise sandbox demo).
+
+JSON-RPC 2.0 over POST / with a single tool `check_inventory`.
+GET /healthz for compose healthcheck.
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="mcp-inventory", version="0.1.0")
+
+_PROTOCOL_VERSION = "2024-11-05"
+_TOOL = {
+    "name": "check_inventory",
+    "description": "Check stock availability for a SKU",
+    "inputSchema": {
+        "type": "object",
+        "properties": {"sku": {"type": "string"}},
+    },
+}
+
+_STOCK: dict[str, dict] = {
+    "WIDGET-X": {"sku": "WIDGET-X", "in_stock": True, "quantity": 150, "warehouse": "EU-1"},
+    "GADGET-Y": {"sku": "GADGET-Y", "in_stock": True, "quantity": 23, "warehouse": "US-2"},
+}
+
+
+def _rpc_result(req_id: Any, result: Any) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _rpc_error(req_id: Any, code: int, message: str) -> dict:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+@app.get("/healthz")
+async def healthz() -> dict:
+    return {"ok": True}
+
+
+@app.post("/")
+async def rpc(request: Request) -> JSONResponse:
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse(_rpc_error(None, -32700, "parse error"), status_code=400)
+
+    method = body.get("method")
+    req_id = body.get("id")
+    params = body.get("params") or {}
+
+    print(
+        f"mcp-inventory: method={method!r} id={req_id!r} "
+        f"params={json.dumps(params, sort_keys=True)}",
+        flush=True,
+    )
+
+    if method == "initialize":
+        return JSONResponse(_rpc_result(req_id, {
+            "protocolVersion": _PROTOCOL_VERSION,
+            "capabilities": {"tools": {}},
+            "serverInfo": {"name": "mcp-inventory", "version": "0.1.0"},
+        }))
+
+    if method == "notifications/initialized":
+        return JSONResponse(None, status_code=204)
+
+    if method == "tools/list":
+        return JSONResponse(_rpc_result(req_id, {"tools": [_TOOL]}))
+
+    if method == "tools/call":
+        name = params.get("name")
+        if name != "check_inventory":
+            return JSONResponse(_rpc_error(req_id, -32601, f"tool not found: {name}"))
+        args = params.get("arguments") or {}
+        sku = args.get("sku", "")
+        stock = _STOCK.get(sku, {"sku": sku, "in_stock": False, "quantity": 0, "warehouse": None})
+        return JSONResponse(_rpc_result(req_id, {
+            "content": [{"type": "text", "text": json.dumps(stock)}],
+            "isError": False,
+        }))
+
+    return JSONResponse(_rpc_error(req_id, -32601, f"method not found: {method}"))

--- a/enterprise_sandbox/mcp-server.Dockerfile
+++ b/enterprise_sandbox/mcp-server.Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+RUN pip install --no-cache-dir fastapi==0.115.6 uvicorn==0.34.0
+WORKDIR /app
+COPY server.py /app/server.py
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "9300"]

--- a/enterprise_sandbox/proxy-init/Dockerfile
+++ b/enterprise_sandbox/proxy-init/Dockerfile
@@ -1,7 +1,13 @@
 FROM python:3.11-slim
 
-RUN pip install --no-cache-dir aiosqlite==0.20.0
+COPY enterprise_sandbox/proxy-init/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-COPY seed.py /usr/local/bin/seed.py
+WORKDIR /app
+COPY mcp_proxy/ /app/mcp_proxy/
+
+ENV PYTHONPATH=/app
+
+COPY enterprise_sandbox/proxy-init/seed.py /usr/local/bin/seed.py
 
 ENTRYPOINT ["python", "/usr/local/bin/seed.py"]

--- a/enterprise_sandbox/proxy-init/requirements.txt
+++ b/enterprise_sandbox/proxy-init/requirements.txt
@@ -1,0 +1,4 @@
+aiosqlite==0.20.0
+sqlalchemy>=2.0.36
+alembic>=1.18.0
+asyncpg>=0.30.0

--- a/enterprise_sandbox/proxy-init/seed.py
+++ b/enterprise_sandbox/proxy-init/seed.py
@@ -1,97 +1,210 @@
-"""
-Seed an MCP proxy's SQLite config DB so it boots pre-configured.
+"""Seed an MCP proxy's SQLite config DB for the enterprise sandbox.
 
-Normally the setup wizard in the proxy dashboard writes these rows after
-the admin pastes an invite token. For non-interactive smoke runs we just
-insert them directly, using the org CA + secret that bootstrap.py already
-generated on the shared /state volume.
+Runs Alembic migrations first (so ADR-007 tables exist), then seeds
+proxy_config rows + optional MCP resources with agent bindings.
 
 Env inputs:
-  ORG_ID          e.g. "demo-org-a"
-  BROKER_URL      e.g. "https://broker.cullis.test:8443"
-  PROXY_PUBLIC_URL e.g. "https://proxy-a.cullis.test:8443"
-  PROXY_DB_PATH   e.g. "/data/mcp_proxy.db"
-  STATE_DIR       e.g. "/state"
+  ORG_ID, BROKER_URL, PROXY_PUBLIC_URL, PROXY_DB_PATH, STATE_DIR
+  OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET  (optional)
+  POLICY_RULES                                           (optional JSON)
+
+  SEED_MCP_RESOURCES       "1" to enable MCP resource seeding
+  SEED_MCP_0_NAME          resource name, e.g. "catalog"
+  SEED_MCP_0_ENDPOINT      endpoint URL, e.g. "http://mcp-catalog:9300/"
+  SEED_MCP_0_AGENTS        comma-separated agent_ids to bind
 """
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import pathlib
 import sys
+import uuid
+from datetime import datetime, timezone
+from urllib.parse import urlparse
 
-import aiosqlite
+from alembic import command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
 
-_SCHEMA = """
-CREATE TABLE IF NOT EXISTS proxy_config (
-    key   TEXT PRIMARY KEY,
-    value TEXT NOT NULL
-);
-"""
+_ALEMBIC_INI = pathlib.Path("/app/mcp_proxy/alembic.ini")
 
-async def main() -> int:
-    org_id         = os.environ["ORG_ID"]
-    broker_url     = os.environ["BROKER_URL"]
-    proxy_public   = os.environ["PROXY_PUBLIC_URL"]
-    db_path        = os.environ.get("PROXY_DB_PATH", "/data/mcp_proxy.db")
-    state          = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
 
+def _run_alembic_upgrade(db_url: str) -> None:
+    cfg = AlembicConfig(str(_ALEMBIC_INI))
+    cfg.set_main_option("sqlalchemy.url", db_url)
+    command.upgrade(cfg, "head")
+
+
+async def _seed_proxy_config(db_url: str, org_id: str) -> None:
+    broker_url = os.environ["BROKER_URL"]
+    proxy_public = os.environ["PROXY_PUBLIC_URL"]
+    state = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
     org_dir = state / org_id
     ca_cert = (org_dir / "ca.pem").read_text()
-    ca_key  = (org_dir / "ca-key.pem").read_text()
-    secret  = (org_dir / "org_secret").read_text().strip()
+    ca_key = (org_dir / "ca-key.pem").read_text()
+    secret = (org_dir / "org_secret").read_text().strip()
     display = (org_dir / "display_name").read_text().strip()
+
+    rows = {
+        "broker_url":    broker_url,
+        "org_id":        org_id,
+        "org_secret":    secret,
+        "org_ca_cert":   ca_cert,
+        "org_ca_key":    ca_key,
+        "display_name":  display,
+        "contact_email": f"admin@{org_id}.test",
+        "webhook_url":   f"{proxy_public}/pdp/policy",
+        "org_status":    "active",
+    }
+    policy_rules = os.environ.get("POLICY_RULES", "").strip()
+    if policy_rules:
+        rows["policy_rules"] = policy_rules
+
+    oidc_issuer = os.environ.get("OIDC_ISSUER_URL", "").strip()
+    oidc_client = os.environ.get("OIDC_CLIENT_ID", "").strip()
+    oidc_secret = os.environ.get("OIDC_CLIENT_SECRET", "").strip()
+    if oidc_issuer and oidc_client:
+        rows["oidc_issuer_url"] = oidc_issuer
+        rows["oidc_client_id"] = oidc_client
+        if oidc_secret:
+            rows["oidc_client_secret"] = oidc_secret
+
+    engine = create_async_engine(db_url)
+    try:
+        async with engine.begin() as conn:
+            for k, v in rows.items():
+                await conn.execute(
+                    text(
+                        "INSERT INTO proxy_config (key, value) "
+                        "VALUES (:k, :v) "
+                        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value"
+                    ),
+                    {"k": k, "v": v},
+                )
+    finally:
+        await engine.dispose()
+    print(f"proxy-init: seeded proxy_config for {org_id}", flush=True)
+
+
+async def _seed_mcp_resources(db_url: str, org_id: str) -> None:
+    """Seed numbered MCP resources from SEED_MCP_N_* env vars."""
+    now = datetime.now(timezone.utc).isoformat()
+    engine = create_async_engine(db_url)
+    try:
+        idx = 0
+        while True:
+            name = os.environ.get(f"SEED_MCP_{idx}_NAME", "").strip()
+            endpoint = os.environ.get(f"SEED_MCP_{idx}_ENDPOINT", "").strip()
+            agents_csv = os.environ.get(f"SEED_MCP_{idx}_AGENTS", "").strip()
+            if not name or not endpoint:
+                break
+
+            host = urlparse(endpoint).hostname or name
+            allowed = json.dumps([host], separators=(",", ":"))
+
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO local_mcp_resources (
+                            resource_id, org_id, name, description, endpoint_url,
+                            auth_type, auth_secret_ref, required_capability,
+                            allowed_domains, enabled, created_at, updated_at
+                        ) VALUES (
+                            :rid, :org, :name, :desc, :endpoint,
+                            'none', NULL, NULL, :allowed, 1, :now, :now
+                        )
+                        ON CONFLICT (org_id, name) DO UPDATE SET
+                            endpoint_url    = EXCLUDED.endpoint_url,
+                            allowed_domains = EXCLUDED.allowed_domains,
+                            enabled         = 1,
+                            updated_at      = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "rid": str(uuid.uuid4()),
+                        "org": org_id,
+                        "name": name,
+                        "desc": f"Enterprise sandbox MCP server: {name}",
+                        "endpoint": endpoint,
+                        "allowed": allowed,
+                        "now": now,
+                    },
+                )
+                row = (await conn.execute(
+                    text(
+                        "SELECT resource_id FROM local_mcp_resources "
+                        "WHERE org_id = :org AND name = :name"
+                    ),
+                    {"org": org_id, "name": name},
+                )).first()
+                if row is None:
+                    raise RuntimeError(f"failed to locate resource {name}")
+                resource_id = row[0]
+
+                for agent_id in agents_csv.split(","):
+                    agent_id = agent_id.strip()
+                    if not agent_id:
+                        continue
+                    await conn.execute(
+                        text(
+                            """
+                            INSERT INTO local_agent_resource_bindings (
+                                binding_id, agent_id, resource_id, org_id,
+                                granted_by, granted_at, revoked_at
+                            ) VALUES (
+                                :bid, :aid, :rid, :org,
+                                'proxy-init-seed', :now, NULL
+                            )
+                            ON CONFLICT (agent_id, resource_id) DO UPDATE SET
+                                revoked_at = NULL
+                            """
+                        ),
+                        {
+                            "bid": str(uuid.uuid4()),
+                            "aid": agent_id,
+                            "rid": resource_id,
+                            "org": org_id,
+                            "now": now,
+                        },
+                    )
+                    print(
+                        f"proxy-init: bound MCP resource {name} → {agent_id}",
+                        flush=True,
+                    )
+            idx += 1
+    finally:
+        await engine.dispose()
+
+
+async def _async_main(db_url: str, org_id: str) -> int:
+    await _seed_proxy_config(db_url, org_id)
+    if os.environ.get("SEED_MCP_RESOURCES") == "1":
+        await _seed_mcp_resources(db_url, org_id)
+    return 0
+
+
+def main() -> int:
+    org_id = os.environ["ORG_ID"]
+    db_path = os.environ.get("PROXY_DB_PATH", "/data/mcp_proxy.db")
 
     db_file = pathlib.Path(db_path)
     db_file.parent.mkdir(parents=True, exist_ok=True)
 
-    async with aiosqlite.connect(str(db_file)) as db:
-        await db.execute("PRAGMA journal_mode=WAL")
-        await db.executescript(_SCHEMA)
+    db_url = os.environ.get("PROXY_DB_URL") or f"sqlite+aiosqlite:///{db_path}"
+    _run_alembic_upgrade(db_url)
 
-        rows = {
-            "broker_url":    broker_url,
-            "org_id":        org_id,
-            "org_secret":    secret,
-            "org_ca_cert":   ca_cert,
-            "org_ca_key":    ca_key,
-            "display_name":  display,
-            "contact_email": f"admin@{org_id}.test",
-            "webhook_url":   f"{proxy_public}/pdp/policy",
-            "org_status":    "active",
-        }
+    rc = asyncio.run(_async_main(db_url, org_id))
 
-        # Optional PDP policy rules — passed as JSON via POLICY_RULES env var
-        # so each proxy can have a different ruleset. Smoke configures
-        # proxy-b with a blocked_agents list so the DENY branch of the
-        # webhook path is exercised every run.
-        policy_rules = os.environ.get("POLICY_RULES", "").strip()
-        if policy_rules:
-            rows["policy_rules"] = policy_rules
+    if db_url.startswith("sqlite"):
+        db_file.chmod(0o666)
 
-        # Optional per-proxy OIDC config (PR #87) — if all three are set, the
-        # proxy dashboard enables SSO login via that IdP.
-        oidc_issuer = os.environ.get("OIDC_ISSUER_URL", "").strip()
-        oidc_client = os.environ.get("OIDC_CLIENT_ID", "").strip()
-        oidc_secret = os.environ.get("OIDC_CLIENT_SECRET", "").strip()
-        if oidc_issuer and oidc_client:
-            rows["oidc_issuer_url"] = oidc_issuer
-            rows["oidc_client_id"] = oidc_client
-            if oidc_secret:
-                rows["oidc_client_secret"] = oidc_secret
-        for k, v in rows.items():
-            await db.execute(
-                "INSERT INTO proxy_config (key, value) VALUES (?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-                (k, v),
-            )
-        await db.commit()
-
-    # Ensure proxyuser (uid varies but typically not root) can read the file.
-    db_file.chmod(0o666)
-    print(f"proxy-init: seeded {db_path} for {org_id} (keys: {', '.join(rows.keys())})")
-    return 0
+    print(f"proxy-init: done ({org_id})", flush=True)
+    return rc
 
 
 if __name__ == "__main__":
-    sys.exit(asyncio.run(main()))
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Commits the enterprise sandbox demo work built on top of the ADR-007 MCP aggregation groundwork.

- 2 MCP stub servers (mcp-catalog on orga:9300, mcp-inventory on orgb:9400) with FastMCP tool stubs, shared Dockerfile.
- `proxy-init` now runs Alembic migration at startup and seeds MCP resource bindings from `SEED_MCP_*` env vars; context moved to repo root so the image can reach `mcp_proxy/alembic`.
- `demo.sh` wrapper exposing `up/down/status/dashboard/logs`.
- docker-compose: broker `/app/certs` on tmpfs (uid 999), proxy-a-init on public-wan for bootstrap, 2 MCP services wired to per-org internal networks.

Landing pad for ADR-009 work — a clean `main` without sandbox deltas in the working tree.

## Test plan

- [ ] `./enterprise_sandbox/demo.sh up` brings up 22 services without errors
- [ ] `./enterprise_sandbox/demo.sh status` shows all services healthy
- [ ] Mastio A dashboard (https://localhost:9100) shows `catalog` MCP resource bound to `agent-a, byoca-bot`
- [ ] Mastio B dashboard (https://localhost:9200) shows `inventory` MCP resource bound to `agent-b`
- [ ] CI green on main checks (pytest, smoke, helm-test, DCO, security)