### PR TITLE
feat(adr-009): mastio identity + mastio_pubkey pin at onboarding (Phase 1 / PR 1a)

### DIFF
--- a/alembic/versions/g7b8c9d0e1f2_add_org_mastio_pubkey.py
+++ b/alembic/versions/g7b8c9d0e1f2_add_org_mastio_pubkey.py
@@ -1,0 +1,37 @@
+"""add org.mastio_pubkey for ADR-009 counter-signature
+
+Revision ID: g7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-04-17 09:00:00.000000
+
+Adds a nullable ``mastio_pubkey`` column to ``organizations`` so the Court
+can pin the mastio/proxy ES256 public key at onboarding time. Runtime
+requests carry an ``X-Cullis-Mastio-Signature`` header counter-signed by
+the mastio; the Court verifies it against this pinned key when present.
+
+NULL means "legacy mode" — no counter-signature enforcement. ADR-009
+Phase 3 will make this column NOT NULL and the enforcement mandatory.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'g7b8c9d0e1f2'
+down_revision: Union[str, Sequence[str], None] = 'b7c8d9e0f1a2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'organizations',
+        sa.Column('mastio_pubkey', sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('organizations', 'mastio_pubkey')

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -26,6 +26,7 @@ from app.registry.org_store import (
     get_org_by_trust_domain,
     register_org,
     update_org_ca_cert,
+    update_org_mastio_pubkey,
     update_org_secret,
     update_org_trust_domain,
     update_org_webhook,
@@ -46,6 +47,33 @@ def _require_admin(x_admin_secret: str = Header(...)) -> None:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Invalid admin secret")
 
 
+def _validate_mastio_pubkey(pem: str | None) -> None:
+    """Ensure a submitted mastio pubkey is a parseable EC P-256 public key.
+
+    Accepts None (legacy orgs skip this entirely). ES256 — the only
+    algorithm the Court uses to verify counter-signatures in Phase 1 —
+    requires a P-256 key, so enforce the curve at pin time to fail fast.
+    """
+    if pem is None:
+        return
+    from cryptography.hazmat.primitives import serialization as _ser
+    from cryptography.hazmat.primitives.asymmetric import ec as _ec
+    try:
+        key = _ser.load_pem_public_key(pem.encode())
+    except Exception:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="mastio_pubkey: invalid PEM",
+        )
+    if not isinstance(key, _ec.EllipticCurvePublicKey) or not isinstance(
+        key.curve, _ec.SECP256R1,
+    ):
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="mastio_pubkey: must be an EC P-256 public key (ES256)",
+        )
+
+
 # ── Models ────────────────────────────────────────────────────────────────────
 
 class JoinRequest(BaseModel):
@@ -61,6 +89,11 @@ class JoinRequest(BaseModel):
         None, max_length=256,
         pattern=r"^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$",
     )
+    # ADR-009 Phase 1 — mastio (proxy) ES256 public key in PEM format.
+    # When set, the Court pins it and will require a matching counter-
+    # signature header on subsequent auth requests. NULL keeps legacy
+    # agent-direct behavior for this org until Phase 3.
+    mastio_pubkey: str | None = Field(None, max_length=1024)
 
 
 class JoinResponse(BaseModel):
@@ -152,6 +185,8 @@ async def join_network(
                 detail=f"trust_domain '{body.trust_domain}' already claimed by another org",
             )
 
+    _validate_mastio_pubkey(body.mastio_pubkey)
+
     org = await register_org(
         db,
         org_id=body.org_id,
@@ -160,6 +195,7 @@ async def join_network(
         metadata={"contact_email": body.contact_email},
         webhook_url=body.webhook_url,
         trust_domain=body.trust_domain,
+        mastio_pubkey=body.mastio_pubkey,
     )
     # Validate CA certificate before storing
     try:
@@ -231,6 +267,9 @@ class AttachCARequest(BaseModel):
         None, max_length=256,
         pattern=r"^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$",
     )
+    # ADR-009 Phase 1 — optional mastio (proxy) ES256 public key pinned at
+    # attach time. Same semantics as JoinRequest: NULL keeps legacy mode.
+    mastio_pubkey: str | None = Field(None, max_length=1024)
 
 
 class AttachCAResponse(BaseModel):
@@ -392,6 +431,8 @@ async def attach_ca(
                 )
             await update_org_trust_domain(db, org_id, body.trust_domain)
 
+    _validate_mastio_pubkey(body.mastio_pubkey)
+
     await update_org_ca_cert(db, org_id, body.ca_certificate)
     # The proxy now owns the org — rotate secret_hash to the proxy-chosen value.
     # The placeholder secret set by the broker admin at creation is discarded.
@@ -401,10 +442,14 @@ async def attach_ca(
     # configured (or keep None = default-deny).
     if body.webhook_url is not None:
         await update_org_webhook(db, org_id, body.webhook_url)
+    # ADR-009 Phase 1 — pin the mastio counter-sig pubkey if supplied.
+    if body.mastio_pubkey is not None:
+        await update_org_mastio_pubkey(db, org_id, body.mastio_pubkey)
     await log_event(db, "onboarding.ca_attached", "ok",
                     org_id=org_id,
                     details={"invite_id": invite.id, "secret_rotated": True,
-                             "webhook_updated": body.webhook_url is not None})
+                             "webhook_updated": body.webhook_url is not None,
+                             "mastio_pubkey_pinned": body.mastio_pubkey is not None})
 
     return AttachCAResponse(
         org_id=org_id,

--- a/app/registry/org_store.py
+++ b/app/registry/org_store.py
@@ -44,6 +44,11 @@ class OrganizationRecord(Base):
     # SPIFFE trust domain of the org, for SVID-only auth (no CN/O in cert).
     # Nullable so legacy orgs keep working via CN/O-based agent certs.
     trust_domain = Column(String(256), nullable=True, unique=True, index=True)
+    # ADR-009 Phase 1 — mastio/proxy ES256 public key (PEM). When set, the
+    # Court enforces an ``X-Cullis-Mastio-Signature`` counter-signature on
+    # auth requests for this org. NULL keeps legacy (agent-direct) behavior
+    # until Phase 3 makes it mandatory.
+    mastio_pubkey = Column(Text, nullable=True)
 
     def verify_secret(self, plain: str) -> bool:
         return bcrypt.checkpw(plain.encode(), self.secret_hash.encode())
@@ -76,6 +81,7 @@ async def register_org(
     webhook_url: str | None = None,
     status: str = "active",
     trust_domain: str | None = None,
+    mastio_pubkey: str | None = None,
 ) -> OrganizationRecord:
     record = OrganizationRecord(
         org_id=org_id,
@@ -85,6 +91,7 @@ async def register_org(
         webhook_url=webhook_url,
         status=status,
         trust_domain=trust_domain,
+        mastio_pubkey=mastio_pubkey,
     )
     db.add(record)
     await db.commit()
@@ -146,6 +153,21 @@ async def update_org_secret(
     if record is None:
         return None
     record.secret_hash = bcrypt.hashpw(new_secret.encode(), bcrypt.gensalt()).decode()
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+async def update_org_mastio_pubkey(
+    db: AsyncSession,
+    org_id: str,
+    mastio_pubkey: str | None,
+) -> OrganizationRecord | None:
+    """Pin or clear the mastio ES256 counter-signature public key (ADR-009)."""
+    record = await get_org_by_id(db, org_id)
+    if record is None:
+        return None
+    record.mastio_pubkey = mastio_pubkey
     await db.commit()
     await db.refresh(record)
     return record

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta, timezone
 import httpx
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.x509 import (
     SubjectAlternativeName,
     UniformResourceIdentifier,
@@ -35,6 +35,18 @@ from mcp_proxy.db import (
 logger = logging.getLogger("mcp_proxy.egress.agent_manager")
 
 
+def _priv_to_pem(key) -> str:
+    return key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _cert_to_pem(cert: x509.Certificate) -> str:
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
 class AgentManager:
     """Manages internal agent identity lifecycle.
 
@@ -48,6 +60,12 @@ class AgentManager:
         self._trust_domain = trust_domain
         self._org_ca_key: rsa.RSAPrivateKey | None = None
         self._org_ca_cert: x509.Certificate | None = None
+        # ADR-009 Phase 1 — Mastio CA (intermediate) + leaf identity.
+        # Generated lazily at boot via ``ensure_mastio_identity()``.
+        self._mastio_ca_key: ec.EllipticCurvePrivateKey | None = None
+        self._mastio_ca_cert: x509.Certificate | None = None
+        self._mastio_leaf_key: ec.EllipticCurvePrivateKey | None = None
+        self._mastio_leaf_cert: x509.Certificate | None = None
 
     # ── CA loading ──────────────────────────────────────────────────
 
@@ -426,6 +444,169 @@ class AgentManager:
                 logger.warning("Could not unregister %s from broker: %s", agent_id, exc)
 
         logger.info("Agent deactivated: %s", agent_id)
+
+    # ── Mastio identity (ADR-009 Phase 1) ───────────────────────────
+
+    @property
+    def mastio_loaded(self) -> bool:
+        return (
+            self._mastio_ca_cert is not None
+            and self._mastio_leaf_cert is not None
+            and self._mastio_leaf_key is not None
+        )
+
+    async def ensure_mastio_identity(self) -> None:
+        """Load or generate the Mastio CA + leaf identity (EC P-256 / ES256).
+
+        Persisted in ``proxy_config`` under keys ``mastio_ca_key``,
+        ``mastio_ca_cert``, ``mastio_leaf_key``, ``mastio_leaf_cert``. Idempotent:
+        if all four are already present, it loads them; otherwise it generates
+        a fresh intermediate CA signed by the Org CA (``pathLen=0`` — leaves
+        only) and a fresh leaf signed by the Mastio CA. Required before the
+        proxy can counter-sign Court requests.
+
+        Raises ``RuntimeError`` if the Org CA is not loaded — the caller must
+        gate on :attr:`ca_loaded`.
+        """
+        if not self.ca_loaded:
+            raise RuntimeError(
+                "Org CA not loaded — cannot issue Mastio intermediate CA",
+            )
+
+        ca_key_pem = await get_config("mastio_ca_key")
+        ca_cert_pem = await get_config("mastio_ca_cert")
+        leaf_key_pem = await get_config("mastio_leaf_key")
+        leaf_cert_pem = await get_config("mastio_leaf_cert")
+
+        if ca_key_pem and ca_cert_pem and leaf_key_pem and leaf_cert_pem:
+            self._mastio_ca_key = serialization.load_pem_private_key(
+                ca_key_pem.encode(), password=None,
+            )
+            self._mastio_ca_cert = x509.load_pem_x509_certificate(
+                ca_cert_pem.encode(),
+            )
+            self._mastio_leaf_key = serialization.load_pem_private_key(
+                leaf_key_pem.encode(), password=None,
+            )
+            self._mastio_leaf_cert = x509.load_pem_x509_certificate(
+                leaf_cert_pem.encode(),
+            )
+            logger.info("Mastio identity loaded from proxy_config")
+            return
+
+        await self._generate_mastio_identity()
+
+    async def _generate_mastio_identity(self) -> None:
+        """Mint a fresh Mastio CA (intermediate) + leaf cert, persist both."""
+        now = datetime.now(timezone.utc)
+
+        # Intermediate CA — EC P-256, pathLen=0 (cannot sign further CAs).
+        mastio_ca_key = ec.generate_private_key(ec.SECP256R1())
+        mastio_ca_subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} Mastio CA"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id),
+        ])
+        mastio_ca_cert = (
+            x509.CertificateBuilder()
+            .subject_name(mastio_ca_subject)
+            .issuer_name(self._org_ca_cert.subject)
+            .public_key(mastio_ca_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=5))
+            .not_valid_after(now + timedelta(days=3650))
+            .add_extension(
+                x509.BasicConstraints(ca=True, path_length=0),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=False,
+                    content_commitment=False,
+                    key_encipherment=False,
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=True,
+                    crl_sign=True,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(mastio_ca_key.public_key()),
+                critical=False,
+            )
+            .sign(self._org_ca_key, hashes.SHA256())
+        )
+
+        # Leaf — EC P-256, SAN SPIFFE URI under /proxy/{org}.
+        leaf_key = ec.generate_private_key(ec.SECP256R1())
+        proxy_spiffe = f"spiffe://{self._trust_domain}/proxy/{self._org_id}"
+        leaf_subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, f"proxy:{self._org_id}"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id),
+        ])
+        leaf_cert = (
+            x509.CertificateBuilder()
+            .subject_name(leaf_subject)
+            .issuer_name(mastio_ca_cert.subject)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=5))
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                SubjectAlternativeName([UniformResourceIdentifier(proxy_spiffe)]),
+                critical=False,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .sign(mastio_ca_key, hashes.SHA256())
+        )
+
+        # Persist.
+        await set_config("mastio_ca_key", _priv_to_pem(mastio_ca_key))
+        await set_config("mastio_ca_cert", _cert_to_pem(mastio_ca_cert))
+        await set_config("mastio_leaf_key", _priv_to_pem(leaf_key))
+        await set_config("mastio_leaf_cert", _cert_to_pem(leaf_cert))
+
+        self._mastio_ca_key = mastio_ca_key
+        self._mastio_ca_cert = mastio_ca_cert
+        self._mastio_leaf_key = leaf_key
+        self._mastio_leaf_cert = leaf_cert
+
+        logger.info(
+            "Mastio identity generated — CA=%s, leaf SAN=%s",
+            mastio_ca_subject, proxy_spiffe,
+        )
+
+    def get_mastio_credentials(self) -> tuple[str, str]:
+        """Return ``(leaf_cert_pem, leaf_key_pem)`` for counter-signing.
+
+        Raises ``RuntimeError`` if :meth:`ensure_mastio_identity` has not run.
+        """
+        if not self.mastio_loaded:
+            raise RuntimeError(
+                "Mastio identity not loaded — call ensure_mastio_identity() first",
+            )
+        return _cert_to_pem(self._mastio_leaf_cert), _priv_to_pem(self._mastio_leaf_key)
+
+    def get_mastio_pubkey_pem(self) -> str:
+        """Return the leaf EC P-256 public key in PEM format.
+
+        This is what gets pinned to the Court at onboarding (join/attach
+        ``mastio_pubkey``). The Court verifies the counter-signature header
+        against this key.
+        """
+        if not self.mastio_loaded:
+            raise RuntimeError(
+                "Mastio identity not loaded — call ensure_mastio_identity() first",
+            )
+        return self._mastio_leaf_cert.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
 
     # ── Credential retrieval ────────────────────────────────────────
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -128,6 +128,16 @@ async def lifespan(app: FastAPI):
         if derive:
             org_id = agent_mgr.org_id
 
+    # ADR-009 Phase 1 — derive/persist the Mastio CA + leaf so the proxy can
+    # counter-sign Court requests. Only possible once the Org CA is loaded;
+    # attached-CA deploys that haven't consumed the invite yet will pick this
+    # up on the next boot after attach.
+    if agent_mgr.ca_loaded:
+        try:
+            await agent_mgr.ensure_mastio_identity()
+        except Exception as exc:  # defensive — never block lifespan on this
+            _log.warning("Mastio identity bootstrap failed: %s", exc)
+
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
 

--- a/tests/test_adr009_phase1_mastio_pubkey.py
+++ b/tests/test_adr009_phase1_mastio_pubkey.py
@@ -1,0 +1,302 @@
+"""ADR-009 Phase 1 — onboarding pins mastio_pubkey, proxy AgentManager
+generates/loads the Mastio CA + leaf identity.
+
+Covers:
+  - /v1/onboarding/join accepts and pins a valid ES256 mastio_pubkey
+  - /v1/onboarding/join rejects malformed PEM and non-P-256 keys
+  - /v1/onboarding/attach pins mastio_pubkey when supplied
+  - Legacy org (no mastio_pubkey in payload) keeps column NULL
+  - AgentManager.ensure_mastio_identity is idempotent, persists, re-loads
+  - Mastio leaf cert chains back to the Org CA via the Mastio CA intermediate
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from app.config import get_settings
+from tests.cert_factory import get_org_ca_pem
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN_SECRET = get_settings().admin_secret
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+def _make_p256_pubkey_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _make_rsa_pubkey_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+async def _generate_invite(client: AsyncClient, label: str = "") -> str:
+    resp = await client.post(
+        "/v1/admin/invites",
+        json={"label": label, "ttl_hours": 72},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    assert resp.status_code == 201
+    return resp.json()["token"]
+
+
+async def _generate_attach_invite(
+    client: AsyncClient, org_id: str, label: str = "",
+) -> str:
+    resp = await client.post(
+        "/v1/admin/invites",
+        json={
+            "label": label,
+            "ttl_hours": 72,
+            "invite_type": "attach-ca",
+            "linked_org_id": org_id,
+        },
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    assert resp.status_code == 201
+    return resp.json()["token"]
+
+
+async def _fetch_mastio_pubkey(org_id: str) -> str | None:
+    """Direct DB peek — the router has no getter endpoint in Phase 1."""
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import get_org_by_id
+
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        assert org is not None, f"org {org_id} not found"
+        return org.mastio_pubkey
+
+
+# ── /join ──────────────────────────────────────────────────────────────
+
+async def test_join_pins_valid_mastio_pubkey(client: AsyncClient):
+    invite = await _generate_invite(client, "join-mastio")
+    pubkey_pem = _make_p256_pubkey_pem()
+    resp = await client.post(
+        "/v1/onboarding/join",
+        json={
+            "org_id": "join-mastio-ok",
+            "display_name": "Mastio OK",
+            "secret": "join-mastio-ok-secret",
+            "ca_certificate": get_org_ca_pem("join-mastio-ok"),
+            "invite_token": invite,
+            "mastio_pubkey": pubkey_pem,
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    stored = await _fetch_mastio_pubkey("join-mastio-ok")
+    assert stored == pubkey_pem
+
+
+async def test_join_without_mastio_pubkey_keeps_null(client: AsyncClient):
+    invite = await _generate_invite(client, "join-legacy")
+    resp = await client.post(
+        "/v1/onboarding/join",
+        json={
+            "org_id": "join-mastio-legacy",
+            "display_name": "Legacy",
+            "secret": "join-mastio-legacy-secret",
+            "ca_certificate": get_org_ca_pem("join-mastio-legacy"),
+            "invite_token": invite,
+        },
+    )
+    assert resp.status_code == 202, resp.text
+    assert await _fetch_mastio_pubkey("join-mastio-legacy") is None
+
+
+async def test_join_rejects_malformed_mastio_pubkey(client: AsyncClient):
+    invite = await _generate_invite(client, "join-bad")
+    resp = await client.post(
+        "/v1/onboarding/join",
+        json={
+            "org_id": "join-mastio-bad",
+            "display_name": "Bad PEM",
+            "secret": "x",
+            "ca_certificate": get_org_ca_pem("join-mastio-bad"),
+            "invite_token": invite,
+            "mastio_pubkey": "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----\n",
+        },
+    )
+    assert resp.status_code == 400
+    assert "mastio_pubkey" in resp.json()["detail"]
+
+
+async def test_join_rejects_non_p256_mastio_pubkey(client: AsyncClient):
+    invite = await _generate_invite(client, "join-rsa")
+    resp = await client.post(
+        "/v1/onboarding/join",
+        json={
+            "org_id": "join-mastio-rsa",
+            "display_name": "RSA rejected",
+            "secret": "x",
+            "ca_certificate": get_org_ca_pem("join-mastio-rsa"),
+            "invite_token": invite,
+            "mastio_pubkey": _make_rsa_pubkey_pem(),
+        },
+    )
+    assert resp.status_code == 400
+    assert "P-256" in resp.json()["detail"]
+
+
+# ── /attach ────────────────────────────────────────────────────────────
+
+async def test_attach_pins_mastio_pubkey(client: AsyncClient):
+    # Create an org shell with no CA yet, then attach via invite.
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import register_org
+
+    async with AsyncSessionLocal() as db:
+        await register_org(
+            db,
+            org_id="attach-mastio",
+            display_name="Attach Mastio",
+            secret="placeholder",
+        )
+
+    # Generate an attach-ca invite bound to this org.
+    resp_invite = await client.post(
+        "/v1/admin/orgs/attach-mastio/attach-invite",
+        json={"ttl_hours": 24},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    assert resp_invite.status_code == 201, resp_invite.text
+    attach_token = resp_invite.json()["token"]
+
+    pubkey_pem = _make_p256_pubkey_pem()
+    resp = await client.post(
+        "/v1/onboarding/attach",
+        json={
+            "ca_certificate": get_org_ca_pem("attach-mastio"),
+            "invite_token": attach_token,
+            "secret": "attach-mastio-new-secret",
+            "mastio_pubkey": pubkey_pem,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert await _fetch_mastio_pubkey("attach-mastio") == pubkey_pem
+
+
+# ── AgentManager mastio identity ───────────────────────────────────────
+
+async def test_agent_manager_generates_and_reloads_mastio(tmp_path, monkeypatch):
+    """ensure_mastio_identity generates on first call, reloads on second."""
+    db_file = tmp_path / "mgr.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "mgr-org")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+
+    from mcp_proxy.config import get_settings as _get_settings
+    _get_settings.cache_clear()
+
+    from mcp_proxy.db import init_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+    mgr = AgentManager(org_id="mgr-org", trust_domain="cullis.test")
+    await mgr.generate_org_ca()
+    assert mgr.ca_loaded
+
+    # First call — generates fresh.
+    await mgr.ensure_mastio_identity()
+    assert mgr.mastio_loaded
+    cert_pem, key_pem = mgr.get_mastio_credentials()
+    leaf = x509.load_pem_x509_certificate(cert_pem.encode())
+    first_serial = leaf.serial_number
+
+    # Second call — must re-load, not re-mint.
+    mgr2 = AgentManager(org_id="mgr-org", trust_domain="cullis.test")
+    await mgr2.load_org_ca_from_config()
+    await mgr2.ensure_mastio_identity()
+    cert_pem_2, _ = mgr2.get_mastio_credentials()
+    leaf2 = x509.load_pem_x509_certificate(cert_pem_2.encode())
+    assert leaf2.serial_number == first_serial
+
+    # Leaf pubkey export is EC P-256.
+    pub_pem = mgr.get_mastio_pubkey_pem()
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    assert isinstance(pub, ec.EllipticCurvePublicKey)
+    assert isinstance(pub.curve, ec.SECP256R1)
+
+    _get_settings.cache_clear()
+
+
+async def test_mastio_leaf_chains_to_org_ca(tmp_path, monkeypatch):
+    """The Mastio leaf's issuer matches the Mastio CA; Mastio CA is signed
+    by the Org CA. No external chain verifier — we check the names + the
+    Mastio CA sig with cryptography."""
+    db_file = tmp_path / "chain.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "chain-org")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+
+    from mcp_proxy.config import get_settings as _get_settings
+    _get_settings.cache_clear()
+
+    from mcp_proxy.db import init_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    from mcp_proxy.egress.agent_manager import AgentManager
+    from mcp_proxy.db import get_config
+
+    mgr = AgentManager(org_id="chain-org", trust_domain="cullis.test")
+    await mgr.generate_org_ca()
+    await mgr.ensure_mastio_identity()
+
+    leaf_pem, _ = mgr.get_mastio_credentials()
+    leaf = x509.load_pem_x509_certificate(leaf_pem.encode())
+
+    mastio_ca_pem = await get_config("mastio_ca_cert")
+    mastio_ca = x509.load_pem_x509_certificate(mastio_ca_pem.encode())
+
+    org_ca_pem = await get_config("org_ca_cert")
+    org_ca = x509.load_pem_x509_certificate(org_ca_pem.encode())
+
+    # Leaf issuer == Mastio CA subject.
+    assert leaf.issuer == mastio_ca.subject
+    # Mastio CA issuer == Org CA subject.
+    assert mastio_ca.issuer == org_ca.subject
+
+    # Mastio CA is a CA with pathLen=0.
+    bc = mastio_ca.extensions.get_extension_for_class(x509.BasicConstraints).value
+    assert bc.ca is True
+    assert bc.path_length == 0
+
+    # Verify the Org CA's signature over the Mastio CA.
+    org_ca.public_key().verify(
+        mastio_ca.signature,
+        mastio_ca.tbs_certificate_bytes,
+        padding=__import__(
+            "cryptography.hazmat.primitives.asymmetric.padding",
+            fromlist=["PKCS1v15"],
+        ).PKCS1v15(),
+        algorithm=mastio_ca.signature_hash_algorithm,
+    )
+
+    # Leaf SAN is spiffe://.../proxy/chain-org.
+    san = leaf.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    uris = list(san.get_values_for_type(x509.UniformResourceIdentifier))
+    assert "spiffe://cullis.test/proxy/chain-org" in uris
+
+    _get_settings.cache_clear()


### PR DESCRIPTION
First PR of ADR-009 Phase 1 — mandatory proxy gateway via mastio counter-signature.

Scope: proxy grows a 3-tier PKI (Org CA → Mastio CA → mastio leaf) and the Court grows a pinnable column for the mastio ES256 public key. Wire-level enforcement of the counter-signature ships in PR 1b.

## Summary

- **Proxy**: `AgentManager.ensure_mastio_identity()` mints-or-loads a Mastio CA (EC P-256, pathLen=0, signed by Org CA) plus an EC P-256 leaf with SAN `spiffe://{trust}/proxy/{org}`. Idempotent across restarts. Hooked into the lifespan after the Org CA load.
- **Court**: new `organizations.mastio_pubkey` column (Alembic `g7b8c9d0e1f2`, stacked on head `b7c8d9e0f1a2`). Nullable by design — Phase 3 will enforce NOT NULL after all orgs have rolled their proxy.
- **Onboarding**: `JoinRequest` and `AttachCARequest` accept an optional `mastio_pubkey` PEM. `_validate_mastio_pubkey()` rejects malformed PEM and non-P-256 keys with 400.

Wire-level verification of `X-Cullis-Mastio-Signature` on Court auth/runtime endpoints lands in **PR 1b**.

## Test plan

- [x] `pytest tests/ -n auto --dist=loadfile --ignore=tests/test_postgres_integration.py` — 1035 pass
- [x] `pytest tests/test_adr009_phase1_mastio_pubkey.py` — 7/7 pass
- [x] `./demo_network/smoke.sh full` — PASS (ec + rsa + rsa+postgres + standalone + A4/A7/A8)
- [x] `.venv/bin/alembic heads` — single head after merge