### PR TITLE
feat(adr-009): mastio counter-signature enforcement on /auth/token (Phase 1 / PR 1b)

### DIFF
--- a/app/auth/mastio_countersig.py
+++ b/app/auth/mastio_countersig.py
@@ -1,0 +1,95 @@
+"""ADR-009 Phase 1 — mastio counter-signature verification.
+
+When an organization has pinned its mastio/proxy ES256 public key at
+onboarding (``organizations.mastio_pubkey``), the Court requires every
+``/v1/auth/token`` call for that org to carry an
+``X-Cullis-Mastio-Signature`` header. The header is the ES256 signature
+over the raw ``client_assertion`` JWT string (the exact bytes the agent
+submitted), base64url-encoded without padding.
+
+This proves the login flowed through the organization's mastio — an agent
+with a stolen or self-issued cert cannot bypass the gateway and authenticate
+to the Court directly, because only the mastio holds the pinned private key.
+
+Leaving ``mastio_pubkey`` NULL disables enforcement for that org, which is
+the legacy behavior used by orgs that have not yet been rolled onto the
+ADR-009 flow. Phase 3 flips this to NOT NULL.
+"""
+from __future__ import annotations
+
+import base64
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import HTTPException, status
+
+
+COUNTERSIG_HEADER = "X-Cullis-Mastio-Signature"
+
+
+def _b64url_decode_nopad(data: str) -> bytes:
+    """Decode base64url with or without padding (see feedback_base64url_nopad)."""
+    padding = "=" * ((4 - len(data) % 4) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+def verify_mastio_countersig(
+    *,
+    client_assertion: str,
+    signature_b64: str | None,
+    mastio_pubkey_pem: str,
+) -> None:
+    """Verify the mastio counter-signature or raise 403.
+
+    ``signature_b64`` is the header value as received; ``None`` means the
+    client didn't send it at all. ``mastio_pubkey_pem`` must be a pinned
+    EC P-256 SubjectPublicKeyInfo PEM (the format that onboarding accepts).
+    The signed message is the raw UTF-8 bytes of ``client_assertion`` —
+    the ``cryptography`` library applies SHA-256 internally as part of
+    ``ec.ECDSA(hashes.SHA256())``.
+    """
+    if signature_b64 is None or not signature_b64.strip():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "organization requires mastio counter-signature but the "
+                f"{COUNTERSIG_HEADER} header is missing"
+            ),
+        )
+
+    try:
+        pubkey = serialization.load_pem_public_key(mastio_pubkey_pem.encode())
+    except Exception as exc:
+        # Defensive: onboarding validates the PEM before pinning, so a
+        # malformed column means operator tampering. Fail closed.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="pinned mastio_pubkey is unreadable — contact the admin",
+        ) from exc
+
+    if not isinstance(pubkey, ec.EllipticCurvePublicKey) or not isinstance(
+        pubkey.curve, ec.SECP256R1,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="pinned mastio_pubkey is not EC P-256",
+        )
+
+    try:
+        signature = _b64url_decode_nopad(signature_b64.strip())
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"{COUNTERSIG_HEADER} is not valid base64url",
+        ) from exc
+
+    try:
+        pubkey.verify(
+            signature, client_assertion.encode(), ec.ECDSA(hashes.SHA256()),
+        )
+    except InvalidSignature:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="mastio counter-signature verification failed",
+        )

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -6,11 +6,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.models import TokenRequest, TokenResponse, TokenPayload
 from app.auth.jwt import create_access_token, get_current_agent
+from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_countersig
 from app.auth.x509_verifier import verify_client_assertion
 from app.auth.dpop import verify_dpop_proof, build_htu
 from app.config import get_settings
 from app.db.database import get_db
 from app.db.audit import log_event
+from app.registry.org_store import get_org_by_id
 from app.registry.store import (
     get_agent_by_id, update_agent_cert, refresh_agent_cert_svid,
     invalidate_agent_tokens,
@@ -28,6 +30,7 @@ async def issue_token(
     request: Request,
     body: TokenRequest,
     dpop: str = Header(alias="DPoP"),
+    mastio_signature: str | None = Header(default=None, alias=COUNTERSIG_HEADER),
     db: AsyncSession = Depends(get_db),
 ):
     """
@@ -57,6 +60,27 @@ async def issue_token(
         )
         span.set_attribute("agent.id", agent_id)
         span.set_attribute("org.id", org_id)
+
+        # ── ADR-009 Phase 1 — mastio counter-signature ───────────────────────
+        # If the org has pinned a mastio public key at onboarding, every
+        # login for that org must carry an ES256 signature over the raw
+        # client_assertion. NULL column = legacy mode (skipped).
+        org_record = await get_org_by_id(db, org_id)
+        if org_record is not None and org_record.mastio_pubkey:
+            try:
+                verify_mastio_countersig(
+                    client_assertion=body.client_assertion,
+                    signature_b64=mastio_signature,
+                    mastio_pubkey_pem=org_record.mastio_pubkey,
+                )
+            except HTTPException:
+                AUTH_DENY_COUNTER.add(1, {"reason": "mastio_countersig"})
+                await log_event(
+                    db, "auth.token_request", "denied",
+                    agent_id=agent_id, org_id=org_id,
+                    details={"reason": "mastio_countersig_missing_or_invalid"},
+                )
+                raise
 
         # ── Agent checks ─────────────────────────────────────────────────────
         agent = await get_agent_by_id(db, agent_id)

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -24,6 +24,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from typing import Callable, Optional
+
 import httpx
 
 from cullis_sdk.auth import generate_dpop_keypair, build_dpop_proof, build_client_assertion
@@ -269,19 +271,32 @@ class CullisClient:
 
     # ── Broker authentication ──────────────────────────────────────
 
-    def login(self, agent_id: str, org_id: str, cert_path: str, key_path: str) -> None:
+    def login(self, agent_id: str, org_id: str, cert_path: str, key_path: str,
+              *,
+              countersign_fn: Optional[Callable[[str], str]] = None) -> None:
         """Authenticate via x509 + DPoP, reading cert and key from file paths."""
         cert_pem = Path(cert_path).read_text()
         key_pem = Path(key_path).read_text()
-        self.login_from_pem(agent_id, org_id, cert_pem, key_pem)
+        self.login_from_pem(
+            agent_id, org_id, cert_pem, key_pem,
+            countersign_fn=countersign_fn,
+        )
 
     def login_from_pem(self, agent_id: str, org_id: str,
-                       cert_pem: str, key_pem: str) -> None:
+                       cert_pem: str, key_pem: str,
+                       *,
+                       countersign_fn: Optional[Callable[[str], str]] = None) -> None:
         """
         Authenticate via x509 + DPoP using PEM strings directly.
 
         Use this when loading credentials from a secret manager (Vault,
         AWS KMS, Azure Key Vault, etc.) instead of files on disk.
+
+        ADR-009 Phase 1 — ``countersign_fn`` is an optional callback invoked
+        with the raw client_assertion string; it must return a base64url
+        ES256 signature (no padding). The SDK forwards it as
+        ``X-Cullis-Mastio-Signature``. The mastio proxy is the typical
+        caller that wires this.
         """
         self._label = agent_id
         try:
@@ -292,11 +307,15 @@ class CullisClient:
             self._dpop_privkey, self._dpop_pubkey_jwk = generate_dpop_keypair()
             token_url = f"{self.base}/v1/auth/token"
 
+            extra_headers: dict[str, str] = {}
+            if countersign_fn is not None:
+                extra_headers["X-Cullis-Mastio-Signature"] = countersign_fn(assertion)
+
             dpop_proof = self._dpop_proof("POST", token_url, access_token=None)
             resp = self._http.post(
                 token_url,
                 json={"client_assertion": assertion},
-                headers={"DPoP": dpop_proof},
+                headers={"DPoP": dpop_proof, **extra_headers},
             )
 
             if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
@@ -305,7 +324,7 @@ class CullisClient:
                 resp = self._http.post(
                     token_url,
                     json={"client_assertion": assertion},
-                    headers={"DPoP": dpop_proof},
+                    headers={"DPoP": dpop_proof, **extra_headers},
                 )
 
             resp.raise_for_status()

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -608,6 +608,27 @@ class AgentManager:
             serialization.PublicFormat.SubjectPublicKeyInfo,
         ).decode()
 
+    def countersign(self, data: bytes) -> str:
+        """ES256 counter-signature over ``data``, base64url no-pad.
+
+        Used by ``BrokerBridge`` to attest every ``/v1/auth/token`` call as
+        proxied through this mastio. The signature goes into the
+        ``X-Cullis-Mastio-Signature`` header; the Court verifies it against
+        the PEM pinned at onboarding in ``organizations.mastio_pubkey``.
+
+        Raises ``RuntimeError`` if :meth:`ensure_mastio_identity` has not run.
+        """
+        import base64
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.hazmat.primitives.asymmetric import ec as _ec
+
+        if not self.mastio_loaded:
+            raise RuntimeError(
+                "Mastio identity not loaded — call ensure_mastio_identity() first",
+            )
+        sig = self._mastio_leaf_key.sign(data, _ec.ECDSA(hashes.SHA256()))
+        return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
     # ── Credential retrieval ────────────────────────────────────────
 
     async def get_agent_credentials(self, agent_id: str) -> tuple[str, str]:

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -50,10 +50,22 @@ class BrokerBridge:
         """Create and authenticate a new CullisClient for an agent."""
         cert_pem, key_pem = await self._agent_manager.get_agent_credentials(agent_id)
 
+        # ADR-009 Phase 1 — attest the login through the mastio identity.
+        # Only wired when the mastio identity is loaded; without it we let
+        # the login proceed unsigned (legacy orgs that haven't pinned a
+        # mastio_pubkey yet, or first-boot before ensure_mastio_identity()).
+        countersign_fn = None
+        if self._agent_manager.mastio_loaded:
+            mgr = self._agent_manager
+            countersign_fn = lambda assertion: mgr.countersign(assertion.encode())
+
         client = CullisClient(self._broker_url, verify_tls=self._verify_tls)
         # login_from_pem is synchronous in the SDK — run in thread to avoid blocking
         await asyncio.to_thread(
-            client.login_from_pem, agent_id, self._org_id, cert_pem, key_pem,
+            lambda: client.login_from_pem(
+                agent_id, self._org_id, cert_pem, key_pem,
+                countersign_fn=countersign_fn,
+            ),
         )
         logger.info("Authenticated CullisClient for agent: %s", agent_id)
         return client

--- a/tests/test_adr009_phase1_countersig.py
+++ b/tests/test_adr009_phase1_countersig.py
@@ -1,0 +1,250 @@
+"""ADR-009 Phase 1 PR 1b — Court enforces mastio counter-signature
+on /v1/auth/token when the org has pinned a mastio_pubkey.
+
+Covers:
+  - Valid counter-sig + pinned mastio_pubkey → 200
+  - Missing counter-sig header + pinned mastio_pubkey → 403
+  - Invalid counter-sig + pinned mastio_pubkey → 403
+  - Malformed base64 counter-sig → 403
+  - Legacy org (mastio_pubkey NULL) ignores any counter-sig → 200
+  - SDK client.login_from_pem wires the countersign_fn callback into
+    the X-Cullis-Mastio-Signature header end-to-end.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+
+from tests.cert_factory import make_assertion, get_org_ca_pem
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+def _gen_mastio_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _sign_countersig(priv: ec.EllipticCurvePrivateKey, data: bytes) -> str:
+    sig = priv.sign(data, ec.ECDSA(hashes.SHA256()))
+    return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+async def _prime_nonce(client: AsyncClient, dpop) -> None:
+    resp = await client.get("/health")
+    dpop._update_nonce(resp)
+
+
+async def _register_agent_with_mastio(
+    client: AsyncClient,
+    agent_id: str,
+    org_id: str,
+    mastio_pubkey_pem: str | None,
+) -> None:
+    """Mirror tests/test_auth.py::_register_agent and pin the mastio pubkey
+    directly on the org row if supplied."""
+    org_secret = org_id + "-secret"
+
+    await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+
+    ca_pem = get_org_ca_pem(org_id)
+    await client.post(f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+
+    await client.post("/v1/registry/agents", json={
+        "agent_id": agent_id,
+        "org_id": org_id,
+        "display_name": f"Test Agent {agent_id}",
+        "capabilities": ["test.read"],
+    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+
+    resp = await client.post("/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = resp.json()["id"]
+    await client.post(f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+
+    if mastio_pubkey_pem is not None:
+        from app.db.database import AsyncSessionLocal
+        from app.registry.org_store import update_org_mastio_pubkey
+
+        async with AsyncSessionLocal() as db:
+            await update_org_mastio_pubkey(db, org_id, mastio_pubkey_pem)
+
+
+# ── enforcement tests ──────────────────────────────────────────────────
+
+async def test_token_ok_with_valid_countersig(client: AsyncClient, dpop):
+    await _prime_nonce(client, dpop)
+    priv, pub_pem = _gen_mastio_keypair()
+    org_id = "cs-ok"
+    await _register_agent_with_mastio(client, f"{org_id}::alice", org_id, pub_pem)
+
+    assertion = make_assertion(f"{org_id}::alice", org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+    sig = _sign_countersig(priv, assertion.encode())
+
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={
+            "DPoP": dpop_proof,
+            "X-Cullis-Mastio-Signature": sig,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert "access_token" in resp.json()
+
+
+async def test_token_denied_missing_countersig(client: AsyncClient, dpop):
+    await _prime_nonce(client, dpop)
+    _, pub_pem = _gen_mastio_keypair()
+    org_id = "cs-missing"
+    await _register_agent_with_mastio(client, f"{org_id}::bob", org_id, pub_pem)
+
+    assertion = make_assertion(f"{org_id}::bob", org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof},
+    )
+    assert resp.status_code == 403
+    assert "mastio counter-signature" in resp.text or "X-Cullis-Mastio-Signature" in resp.text
+
+
+async def test_token_denied_wrong_countersig_key(client: AsyncClient, dpop):
+    """Signature with an unrelated EC key → 403."""
+    await _prime_nonce(client, dpop)
+    _, pinned_pub = _gen_mastio_keypair()
+    attacker_priv, _ = _gen_mastio_keypair()
+    org_id = "cs-wrong-key"
+    await _register_agent_with_mastio(
+        client, f"{org_id}::eve", org_id, pinned_pub,
+    )
+
+    assertion = make_assertion(f"{org_id}::eve", org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+    sig = _sign_countersig(attacker_priv, assertion.encode())
+
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof, "X-Cullis-Mastio-Signature": sig},
+    )
+    assert resp.status_code == 403
+    assert "verification failed" in resp.text
+
+
+async def test_token_denied_malformed_countersig(client: AsyncClient, dpop):
+    await _prime_nonce(client, dpop)
+    _, pub_pem = _gen_mastio_keypair()
+    org_id = "cs-malformed"
+    await _register_agent_with_mastio(
+        client, f"{org_id}::mallory", org_id, pub_pem,
+    )
+
+    assertion = make_assertion(f"{org_id}::mallory", org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={
+            "DPoP": dpop_proof,
+            "X-Cullis-Mastio-Signature": "!!!not-base64!!!",
+        },
+    )
+    assert resp.status_code == 403
+    assert "base64url" in resp.text or "verification" in resp.text
+
+
+async def test_token_legacy_org_ignores_countersig(client: AsyncClient, dpop):
+    """Org with mastio_pubkey NULL accepts login without any header."""
+    await _prime_nonce(client, dpop)
+    org_id = "cs-legacy"
+    await _register_agent_with_mastio(
+        client, f"{org_id}::charlie", org_id, mastio_pubkey_pem=None,
+    )
+
+    assertion = make_assertion(f"{org_id}::charlie", org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# ── SDK callback unit test ─────────────────────────────────────────────
+
+def test_sdk_login_calls_countersign_fn_with_assertion():
+    """CullisClient.login_from_pem invokes ``countersign_fn(assertion)``
+    and attaches the result as X-Cullis-Mastio-Signature on the POST.
+
+    Drives CullisClient against a mocked httpx transport so we don't need
+    a running broker — the broker-side enforcement is covered by the
+    tests above.
+    """
+    import httpx as _httpx
+    from cullis_sdk.client import CullisClient
+    from tests.cert_factory import make_agent_cert, _key_pem
+
+    captured_headers: dict[str, str] = {}
+
+    def _handler(request: _httpx.Request) -> _httpx.Response:
+        captured_headers.update(request.headers)
+        # Fake server nonce on the first round-trip.
+        return _httpx.Response(
+            200,
+            json={
+                "access_token": "fake-token",
+                "token_type": "DPoP",
+                "expires_in": 900,
+            },
+            headers={"DPoP-Nonce": "test-nonce"},
+        )
+
+    transport = _httpx.MockTransport(_handler)
+    client = CullisClient("http://test", verify_tls=False)
+    client._http = _httpx.Client(transport=transport)
+
+    key, cert = make_agent_cert("mock-org::sdk-bot", "mock-org")
+    from cryptography.hazmat.primitives import serialization as _ser
+    cert_pem = cert.public_bytes(_ser.Encoding.PEM).decode()
+    key_pem = _key_pem(key)
+
+    invocations: list[str] = []
+
+    def _sign(assertion_str: str) -> str:
+        invocations.append(assertion_str)
+        return "FAKE-SIG-BASE64URL"
+
+    client.login_from_pem(
+        "mock-org::sdk-bot", "mock-org", cert_pem, key_pem,
+        countersign_fn=_sign,
+    )
+
+    assert len(invocations) == 1
+    assert captured_headers.get("x-cullis-mastio-signature") == "FAKE-SIG-BASE64URL"


### PR DESCRIPTION
Second PR of ADR-009 Phase 1 — **closes the mastio bypass gap on login**.

Builds directly on PR #155 (mastio identity + \`organizations.mastio_pubkey\` pin).

## Summary

- **Court** now requires \`X-Cullis-Mastio-Signature\` on \`/v1/auth/token\` when the org row has a pinned \`mastio_pubkey\`. Missing / invalid / malformed-base64 → 403. NULL column → legacy passthrough (Phase 3 enforces NOT NULL).
- **Proxy** \`AgentManager.countersign()\` signs the raw \`client_assertion\` with the Mastio leaf key (ES256 over SHA-256, base64url no-pad). \`BrokerBridge\` wires it into every login.
- **SDK** \`CullisClient.login_from_pem(countersign_fn=...)\` — opt-in callback, default \`None\` preserves every existing caller.

### Threat model

An agent with a stolen or self-issued cert can no longer obtain a token by bypassing the mastio: only the proxy holds the ES256 private key that matches the pinned public key, so the 403 at \`/auth/token\` forces the login through the gateway. Runtime enforcement (proxy-mandatory for every request) ships in Phase 2/3.

## Test plan

- [x] \`pytest tests/test_adr009_phase1_countersig.py\` — 6/6 pass (valid sig, missing header, wrong key, malformed base64, legacy NULL, SDK callback wiring)
- [x] Full suite: 1041 pass, 6 skipped (postgres-gated)
- [x] \`./demo_network/smoke.sh full\` — PASS on all scenarios (ec / rsa / rsa+postgres / standalone)