### PR TITLE
feat(adr-009): proxy login flow carries mastio counter-signature (Phase 2 / PR 2a)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -367,7 +367,16 @@ class CullisClient:
             )
             sign_resp.raise_for_status()
             self._update_nonce(sign_resp)
-            assertion = sign_resp.json()["client_assertion"]
+            sign_body = sign_resp.json()
+            assertion = sign_body["client_assertion"]
+
+            # ADR-009 Phase 2 — forward the proxy's counter-signature when
+            # the proxy returned one. The Court enforces it against
+            # organizations.mastio_pubkey; absence is fine for legacy orgs.
+            mastio_headers: dict[str, str] = {}
+            mastio_signature = sign_body.get("mastio_signature")
+            if mastio_signature:
+                mastio_headers["X-Cullis-Mastio-Signature"] = mastio_signature
 
             self._dpop_privkey, self._dpop_pubkey_jwk = generate_dpop_keypair()
             token_url = f"{self.base}/v1/auth/token"
@@ -376,7 +385,7 @@ class CullisClient:
             resp = self._http.post(
                 token_url,
                 json={"client_assertion": assertion},
-                headers={"DPoP": dpop_proof},
+                headers={"DPoP": dpop_proof, **mastio_headers},
             )
             if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
                 self._update_nonce(resp)
@@ -384,7 +393,7 @@ class CullisClient:
                 resp = self._http.post(
                     token_url,
                     json={"client_assertion": assertion},
-                    headers={"DPoP": dpop_proof},
+                    headers={"DPoP": dpop_proof, **mastio_headers},
                 )
             resp.raise_for_status()
             self._update_nonce(resp)

--- a/mcp_proxy/admin/info.py
+++ b/mcp_proxy/admin/info.py
@@ -1,0 +1,64 @@
+"""Proxy admin info endpoints (ADR-009 Phase 2).
+
+Machine-readable accessors for bootstrap / CI / sandbox automation. Auth
+uses the ``admin_secret`` shared between the proxy and its orchestrator,
+so there is no dashboard session involved — intended for calls from
+containers like ``enterprise_sandbox/bootstrap``.
+"""
+from __future__ import annotations
+
+import hmac
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel
+
+from mcp_proxy.config import get_settings
+
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+class MastioPubkeyResponse(BaseModel):
+    """ES256 mastio leaf pubkey, PEM-encoded. ``None`` when the proxy
+    hasn't loaded its mastio identity yet (pre-ADR-009 or Org CA not
+    attached). Bootstrap scripts must treat ``None`` as "skip pinning"
+    and retry once the proxy finishes first-boot."""
+
+    mastio_pubkey: str | None
+    org_id: str | None
+
+
+@router.get(
+    "/mastio-pubkey",
+    response_model=MastioPubkeyResponse,
+    dependencies=[Depends(_require_admin_secret)],
+    summary="Return the proxy's mastio ES256 public key in PEM format",
+)
+async def get_mastio_pubkey(request: Request) -> MastioPubkeyResponse:
+    """Return the mastio leaf pubkey pinned at onboarding.
+
+    Used by ``enterprise_sandbox/bootstrap/bootstrap.py`` to include the
+    key in its ``/v1/onboarding/join`` or ``/v1/onboarding/attach`` call
+    so the Court can enforce the ADR-009 counter-signature from then on.
+    """
+    mgr = getattr(request.app.state, "agent_manager", None)
+    org_id = getattr(request.app.state, "org_id", None)
+
+    if mgr is None or not getattr(mgr, "mastio_loaded", False):
+        return MastioPubkeyResponse(mastio_pubkey=None, org_id=org_id)
+
+    return MastioPubkeyResponse(
+        mastio_pubkey=mgr.get_mastio_pubkey_pem(),
+        org_id=org_id,
+    )

--- a/mcp_proxy/auth/sign_assertion.py
+++ b/mcp_proxy/auth/sign_assertion.py
@@ -29,10 +29,17 @@ router = APIRouter(tags=["auth"])
 
 
 class SignAssertionResponse(BaseModel):
-    """Response payload — just the signed JWT."""
+    """Response payload — the signed JWT plus the optional mastio
+    counter-signature that the SDK must forward as
+    ``X-Cullis-Mastio-Signature`` on ``/v1/auth/token`` (ADR-009 Phase 2).
+    When the proxy hasn't loaded its mastio identity yet (legacy deploys
+    pre-ADR-009), ``mastio_signature`` is ``None`` and the SDK skips the
+    header — matching the ``mastio_pubkey IS NULL`` legacy path server-side.
+    """
 
     client_assertion: str
     agent_id: str
+    mastio_signature: str | None = None
 
 
 @router.post(
@@ -76,6 +83,19 @@ async def sign_assertion(
         ) from exc
 
     assertion, _alg = build_client_assertion(agent.agent_id, cert_pem, key_pem)
+
+    # ADR-009 Phase 2 — counter-sign the assertion with the mastio leaf
+    # when the identity is available; otherwise leave None and the SDK will
+    # omit the header (legacy path).
+    mastio_signature: str | None = None
+    if getattr(mgr, "mastio_loaded", False):
+        try:
+            mastio_signature = mgr.countersign(assertion.encode())
+        except Exception as exc:
+            _log.warning("mastio countersign failed for %s: %s", agent.agent_id, exc)
+
     return SignAssertionResponse(
-        client_assertion=assertion, agent_id=agent.agent_id,
+        client_assertion=assertion,
+        agent_id=agent.agent_id,
+        mastio_signature=mastio_signature,
     )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -488,6 +488,10 @@ async def pdp_health():
 from mcp_proxy.auth.sign_assertion import router as sign_assertion_router
 app.include_router(sign_assertion_router)
 
+# ADR-009 Phase 2 — /v1/admin/mastio-pubkey for bootstrap automation.
+from mcp_proxy.admin.info import router as admin_info_router
+app.include_router(admin_info_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/registry/agents/{id}/public-key
 # would otherwise fall into the `/v1/registry/*` forward prefix and never

--- a/tests/test_adr009_phase2_proxy_login.py
+++ b/tests/test_adr009_phase2_proxy_login.py
@@ -1,0 +1,224 @@
+"""ADR-009 Phase 2 PR 2a — proxy end-to-end login flow carries the
+mastio counter-signature.
+
+Covers:
+  - /v1/auth/sign-assertion returns ``mastio_signature`` when the proxy
+    has loaded its mastio identity
+  - /v1/auth/sign-assertion returns ``mastio_signature=None`` when no
+    mastio identity is loaded (pre-ADR-009 / legacy)
+  - The signature is valid — verifiable against the mastio leaf pubkey
+  - /v1/admin/mastio-pubkey returns the PEM under X-Admin-Secret and
+    403s on wrong secret
+  - SDK login_via_proxy forwards mastio_signature into the /v1/auth/token
+    X-Cullis-Mastio-Signature header (MockTransport unit test)
+"""
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── /v1/auth/sign-assertion ────────────────────────────────────────────
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    """Shared fixture body — boot an in-process proxy app."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def test_sign_assertion_includes_mastio_signature(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sa-mastio")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            # Pre-register an agent so sign-assertion can resolve credentials.
+            from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+            from mcp_proxy.db import create_agent
+            from mcp_proxy.egress.agent_manager import AgentManager
+            mgr: AgentManager = app.state.agent_manager
+
+            # Issue an agent cert signed by the Org CA that the proxy just
+            # generated during first-boot.
+            cert_pem, key_pem = mgr._generate_agent_cert("alice")
+            raw = generate_api_key("alice")
+            await create_agent(
+                agent_id=f"sa-mastio::alice",
+                display_name="alice",
+                capabilities=["oneshot.message"],
+                api_key_hash=hash_api_key(raw),
+                cert_pem=cert_pem,
+            )
+            # Persist the private key so get_agent_credentials works.
+            from mcp_proxy.db import set_config
+            await set_config(f"agent_key:sa-mastio::alice", key_pem)
+
+            r = await cli.post(
+                "/v1/auth/sign-assertion",
+                headers={"X-API-Key": raw},
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["agent_id"] == "sa-mastio::alice"
+            assert body["client_assertion"]
+            assert body["mastio_signature"], "expected non-null mastio_signature"
+
+            # Verify the signature is valid against the pinned pubkey.
+            pubkey_pem = mgr.get_mastio_pubkey_pem()
+            pubkey = serialization.load_pem_public_key(pubkey_pem.encode())
+            sig = base64.urlsafe_b64decode(
+                body["mastio_signature"] + "=" * ((4 - len(body["mastio_signature"]) % 4) % 4)
+            )
+            pubkey.verify(
+                sig, body["client_assertion"].encode(),
+                ec.ECDSA(hashes.SHA256()),
+            )
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── /v1/admin/mastio-pubkey ────────────────────────────────────────────
+
+async def test_admin_mastio_pubkey_requires_admin_secret(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "adm-no-auth")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get("/v1/admin/mastio-pubkey")
+            assert r.status_code == 422  # missing required header
+            r2 = await cli.get(
+                "/v1/admin/mastio-pubkey",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+            assert r2.status_code == 403
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_admin_mastio_pubkey_returns_pem(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "adm-ok")
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.config import get_settings
+            admin_secret = get_settings().admin_secret
+
+            r = await cli.get(
+                "/v1/admin/mastio-pubkey",
+                headers={"X-Admin-Secret": admin_secret},
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["org_id"] == "adm-ok"
+            assert body["mastio_pubkey"]
+            key = serialization.load_pem_public_key(body["mastio_pubkey"].encode())
+            assert isinstance(key, ec.EllipticCurvePublicKey)
+            assert isinstance(key.curve, ec.SECP256R1)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── SDK login_via_proxy wiring ─────────────────────────────────────────
+
+def test_sdk_login_via_proxy_forwards_mastio_signature():
+    """login_via_proxy reads mastio_signature from /sign-assertion and sends
+    it as X-Cullis-Mastio-Signature on the /auth/token POST."""
+    from cullis_sdk.client import CullisClient
+
+    captured: dict[str, str] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/sign-assertion"):
+            return httpx.Response(
+                200,
+                json={
+                    "client_assertion": "FAKE-ASSERTION-JWT",
+                    "agent_id": "test-org::bot",
+                    "mastio_signature": "FAKE-MASTIO-SIG",
+                },
+                headers={"DPoP-Nonce": "test-nonce"},
+            )
+        # /auth/token
+        captured["mastio"] = request.headers.get("x-cullis-mastio-signature", "")
+        captured["dpop"] = request.headers.get("dpop", "")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "fake-token",
+                "token_type": "DPoP",
+                "expires_in": 900,
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+    client = CullisClient("http://proxy.test", verify_tls=False)
+    client._http = httpx.Client(transport=transport)
+    client._proxy_api_key = "sk_local_test_abcdef"
+    client._proxy_agent_id = "test-org::bot"
+
+    client.login_via_proxy()
+
+    assert captured["mastio"] == "FAKE-MASTIO-SIG"
+    assert captured["dpop"]  # DPoP proof was sent too
+    assert client.token == "fake-token"
+
+
+def test_sdk_login_via_proxy_skips_header_when_signature_missing():
+    """Legacy proxies (no mastio identity) return mastio_signature=None —
+    SDK must not send an empty header."""
+    from cullis_sdk.client import CullisClient
+
+    captured: dict[str, str | None] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/sign-assertion"):
+            return httpx.Response(
+                200,
+                json={
+                    "client_assertion": "FAKE-ASSERTION-JWT",
+                    "agent_id": "legacy::bot",
+                    "mastio_signature": None,
+                },
+            )
+        captured["mastio"] = request.headers.get("x-cullis-mastio-signature")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "fake-token",
+                "token_type": "DPoP",
+                "expires_in": 900,
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+    client = CullisClient("http://proxy.legacy", verify_tls=False)
+    client._http = httpx.Client(transport=transport)
+    client._proxy_api_key = "sk_local_test_xyz"
+    client._proxy_agent_id = "legacy::bot"
+
+    client.login_via_proxy()
+    assert captured.get("mastio") is None

--- a/tests/test_adr009_phase2_proxy_login.py
+++ b/tests/test_adr009_phase2_proxy_login.py
@@ -62,7 +62,7 @@ async def test_sign_assertion_includes_mastio_signature(tmp_path, monkeypatch):
             cert_pem, key_pem = mgr._generate_agent_cert("alice")
             raw = generate_api_key("alice")
             await create_agent(
-                agent_id=f"sa-mastio::alice",
+                agent_id="sa-mastio::alice",
                 display_name="alice",
                 capabilities=["oneshot.message"],
                 api_key_hash=hash_api_key(raw),
@@ -70,7 +70,7 @@ async def test_sign_assertion_includes_mastio_signature(tmp_path, monkeypatch):
             )
             # Persist the private key so get_agent_credentials works.
             from mcp_proxy.db import set_config
-            await set_config(f"agent_key:sa-mastio::alice", key_pem)
+            await set_config("agent_key:sa-mastio::alice", key_pem)
 
             r = await cli.post(
                 "/v1/auth/sign-assertion",


### PR DESCRIPTION
First PR of ADR-009 Phase 2 — **end-to-end login via proxy with mastio counter-sig**.

Builds on #155 (mastio identity) and #156 (Court enforcement). This PR closes the gap where \`/v1/auth/sign-assertion\` generated an agent client_assertion but didn't pair it with a mastio counter-sig — so \`login_via_proxy\` couldn't talk to an org with pinned \`mastio_pubkey\` without eating a 403.

## Summary

- **Proxy**: \`/v1/auth/sign-assertion\` now returns \`{client_assertion, mastio_signature}\`. Signature is \`None\` when the mastio identity isn't loaded (pre-ADR-009 / first-boot) — legacy-safe.
- **Proxy admin**: new \`GET /v1/admin/mastio-pubkey\` under \`X-Admin-Secret\` for bootstrap scripts (sandbox PR 2b). Returns PEM + org_id, or \`null\` PEM when first-boot hasn't completed.
- **SDK**: \`login_via_proxy\` forwards \`mastio_signature\` as \`X-Cullis-Mastio-Signature\` to \`/v1/auth/token\`. Absent signature → no header sent.

## Threat model

An agent enrolled at the proxy (API key) still cannot authenticate to the Court by itself — only the mastio holds the ES256 key that matches the pinned pubkey, and \`sign-assertion\` bundles both the agent-signed assertion and the mastio counter-sig. An attacker who hijacks the API key can't forge the counter-sig.

## Test plan

- [x] \`pytest tests/test_adr009_phase2_proxy_login.py\` — 5/5 (sign-assertion shape + crypto verify, admin endpoint auth + PEM, SDK MockTransport with/without signature)
- [x] Full suite: 1046 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS on all scenarios