### PR TITLE
fix(proxy): enforce TLS verification on broker and Vault calls

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -31,6 +31,12 @@ class ProxySettings(BaseSettings):
     vault_addr: str = ""
     vault_token: str = ""
     vault_secret_prefix: str = "secret/data/mcp-proxy/tools"
+    # Verify Vault TLS cert (disable only for dev / self-signed sandbox).
+    # When ``vault_ca_cert_path`` is set, it takes precedence: httpx will use
+    # the file as the CA bundle and ignore ``vault_verify_tls``. Mirrors the
+    # broker-side pattern in ``app/kms/vault.py``.
+    vault_verify_tls: bool = True
+    vault_ca_cert_path: str = ""
 
     # Tools
     tools_config_path: str = "tools.yaml"
@@ -193,6 +199,27 @@ def validate_config(settings: ProxySettings) -> None:
                 )
                 raise SystemExit(1)
 
+            if not settings.broker_verify_tls:
+                _log.critical(
+                    "MCP_PROXY_BROKER_VERIFY_TLS is false in production. "
+                    "Re-enable TLS verification for the broker uplink "
+                    "(audit F-E-01)."
+                )
+                raise SystemExit(1)
+
+        # Vault TLS verification is enforced whenever a Vault backend is
+        # configured in production, regardless of standalone mode (the
+        # standalone proxy may still use Vault to hold agent private keys).
+        if settings.secret_backend == "vault" and not settings.vault_verify_tls:
+            _log.critical(
+                "MCP_PROXY_VAULT_VERIFY_TLS is false in production with "
+                "secret_backend=vault. Re-enable TLS verification for Vault "
+                "(audit F-E-02). Pin a private CA via "
+                "MCP_PROXY_VAULT_CA_CERT_PATH instead if you need to trust a "
+                "self-signed Vault cert."
+            )
+            raise SystemExit(1)
+
     # Warnings for any environment
     if settings.admin_secret == _INSECURE_DEFAULT_SECRET:
         _log.warning(
@@ -217,3 +244,27 @@ def validate_config(settings: ProxySettings) -> None:
 def get_settings() -> ProxySettings:
     """Return cached ProxySettings singleton."""
     return ProxySettings()
+
+
+def broker_tls_verify(settings: ProxySettings) -> bool | str:
+    """Return the ``verify=`` value to use for broker-directed httpx calls.
+
+    Mirrors the broker-side pattern in ``app/kms/vault.py``: a CA path wins
+    over the boolean flag, otherwise the flag decides. Callers should pass
+    the result straight into ``httpx.AsyncClient(verify=...)``.
+    """
+    # Proxy has no dedicated broker CA path today; expose the hook anyway
+    # so upgrades can pin a private CA without touching every call site.
+    ca_path = getattr(settings, "broker_ca_cert_path", "") or ""
+    return ca_path if ca_path else settings.broker_verify_tls
+
+
+def vault_tls_verify(settings: ProxySettings) -> bool | str:
+    """Return the ``verify=`` value to use for Vault-directed httpx calls.
+
+    If ``vault_ca_cert_path`` is set, httpx uses that file as the CA bundle;
+    otherwise the boolean ``vault_verify_tls`` flag decides. Never returns
+    ``False`` silently — operators who need to ignore TLS must set the flag
+    explicitly (and production rejects that in :func:`validate_config`).
+    """
+    return settings.vault_ca_cert_path or settings.vault_verify_tls

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -107,8 +107,11 @@ def generate_org_ca(org_id: str) -> tuple[str, str]:
 async def _test_vault_connectivity(vault_addr: str, vault_token: str) -> tuple[bool, str]:
     """Test Vault connectivity. Returns (success, message)."""
     import httpx
+    from mcp_proxy.config import get_settings, vault_tls_verify
     try:
-        async with httpx.AsyncClient(verify=False, timeout=5.0) as client:
+        async with httpx.AsyncClient(
+            verify=vault_tls_verify(get_settings()), timeout=5.0,
+        ) as client:
             resp = await client.get(
                 f"{vault_addr.rstrip('/')}/v1/sys/health",
                 headers={"X-Vault-Token": vault_token},
@@ -126,9 +129,12 @@ async def _test_vault_connectivity(vault_addr: str, vault_token: str) -> tuple[b
 async def _store_ca_key_in_vault(vault_addr: str, vault_token: str, org_id: str, key_pem: str) -> None:
     """Store Org CA private key in Vault."""
     import httpx
+    from mcp_proxy.config import get_settings, vault_tls_verify
     path = f"secret/data/mcp-proxy/{org_id}/org-ca"
     url = f"{vault_addr.rstrip('/')}/v1/{path}"
-    async with httpx.AsyncClient(verify=False, timeout=5.0) as client:
+    async with httpx.AsyncClient(
+        verify=vault_tls_verify(get_settings()), timeout=5.0,
+    ) as client:
         resp = await client.post(
             url,
             json={"data": {"key_pem": key_pem}},
@@ -358,7 +364,10 @@ async def org_status(request: Request):
         )
 
     try:
-        async with httpx.AsyncClient(verify=False, timeout=5.0) as http:
+        from mcp_proxy.config import get_settings, broker_tls_verify
+        async with httpx.AsyncClient(
+            verify=broker_tls_verify(get_settings()), timeout=5.0,
+        ) as http:
             resp = await http.get(
                 f"{broker_url}/v1/registry/orgs/me",
                 headers={"X-Org-Id": org_id, "X-Org-Secret": org_secret},
@@ -490,7 +499,10 @@ async def setup_submit(request: Request):
     inspect_err: str | None = None
     if broker_url and invite_token:
         try:
-            async with httpx.AsyncClient(verify=False, timeout=10.0) as http:
+            from mcp_proxy.config import broker_tls_verify
+            async with httpx.AsyncClient(
+                verify=broker_tls_verify(_get_settings()), timeout=10.0,
+            ) as http:
                 r = await http.post(
                     f"{broker_url}/v1/onboarding/invite/inspect",
                     json={"invite_token": invite_token},
@@ -673,7 +685,10 @@ async def setup_submit(request: Request):
 
     error_msg: str | None = None
     try:
-        async with httpx.AsyncClient(verify=False, timeout=10.0) as http:
+        from mcp_proxy.config import get_settings as _s, broker_tls_verify
+        async with httpx.AsyncClient(
+            verify=broker_tls_verify(_s()), timeout=10.0,
+        ) as http:
             if invite_type == "attach-ca":
                 # Existing org on broker (pre-registered by admin), we just
                 # attach the CA and claim the org by rotating its secret.
@@ -832,7 +847,10 @@ async def _refresh_org_status_from_broker() -> str:
         return cached
 
     try:
-        async with httpx.AsyncClient(verify=False, timeout=3.0) as http:
+        from mcp_proxy.config import get_settings as _s, broker_tls_verify
+        async with httpx.AsyncClient(
+            verify=broker_tls_verify(_s()), timeout=3.0,
+        ) as http:
             resp = await http.get(
                 f"{broker_url}/v1/registry/orgs/me",
                 headers={"X-Org-Id": org_id, "X-Org-Secret": org_secret},
@@ -1017,7 +1035,10 @@ async def agents_create(request: Request):
     if broker_url and org_id_cfg and org_secret:
         headers = {"X-Org-Id": org_id_cfg, "X-Org-Secret": org_secret}
         try:
-            async with httpx.AsyncClient(verify=False, timeout=10.0) as http:
+            from mcp_proxy.config import broker_tls_verify
+            async with httpx.AsyncClient(
+                verify=broker_tls_verify(get_settings()), timeout=10.0,
+            ) as http:
                 # 1. Register agent
                 await http.post(f"{broker_url}/v1/registry/agents", json={
                     "agent_id": agent_id,
@@ -1281,7 +1302,10 @@ async def agent_delete(request: Request, agent_id: str):
     org_secret = await get_config("org_secret")
     if broker_url and org_id and org_secret:
         try:
-            async with httpx.AsyncClient(verify=False, timeout=5.0) as http:
+            from mcp_proxy.config import get_settings as _s, broker_tls_verify
+            async with httpx.AsyncClient(
+                verify=broker_tls_verify(_s()), timeout=5.0,
+            ) as http:
                 await http.delete(
                     f"{broker_url}/v1/registry/agents/{agent_id}",
                     headers={"X-Org-Id": org_id, "X-Org-Secret": org_secret},
@@ -1801,8 +1825,11 @@ async def vault_page(request: Request):
     vault_key_count = 0
     if vault_addr and vault_token:
         import httpx
+        from mcp_proxy.config import get_settings as _s, vault_tls_verify
         try:
-            async with httpx.AsyncClient(verify=False, timeout=5.0) as client:
+            async with httpx.AsyncClient(
+                verify=vault_tls_verify(_s()), timeout=5.0,
+            ) as client:
                 resp = await client.get(
                     f"{vault_addr.rstrip('/')}/v1/sys/health",
                     headers={"X-Vault-Token": vault_token},
@@ -1943,6 +1970,9 @@ async def vault_migrate_keys(request: Request):
         raise HTTPException(status_code=502, detail=f"Vault unreachable: {msg}")
 
     import httpx
+    from mcp_proxy.config import get_settings as _s, vault_tls_verify
+
+    _vault_verify = vault_tls_verify(_s())
 
     # Find all agent keys stored in proxy_config (agent_key:* pattern)
     from sqlalchemy import text
@@ -1960,7 +1990,7 @@ async def vault_migrate_keys(request: Request):
         path = f"secret/data/mcp-proxy/agents/{agent_id}"
         url = f"{vault_addr.rstrip('/')}/v1/{path}"
         try:
-            async with httpx.AsyncClient(verify=False, timeout=5.0) as client:
+            async with httpx.AsyncClient(verify=_vault_verify, timeout=5.0) as client:
                 resp = await client.post(
                     url,
                     json={"data": {"key_pem": key_pem}},

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -23,7 +23,7 @@ from cryptography.x509 import (
 from cryptography.x509.oid import NameOID
 
 from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
-from mcp_proxy.config import get_settings
+from mcp_proxy.config import broker_tls_verify, get_settings, vault_tls_verify
 from mcp_proxy.db import (
     create_agent as db_create_agent,
     deactivate_agent as db_deactivate_agent,
@@ -426,7 +426,9 @@ class AgentManager:
         settings = get_settings()
         if settings.broker_url:
             try:
-                async with httpx.AsyncClient(verify=False, timeout=5.0) as http:
+                async with httpx.AsyncClient(
+                    verify=broker_tls_verify(settings), timeout=5.0,
+                ) as http:
                     resp = await http.delete(
                         f"{settings.broker_url}/v1/registry/agents/{agent_id}",
                         headers={
@@ -673,7 +675,9 @@ class AgentManager:
         path = f"{settings.vault_secret_prefix}/agents/{agent_id}"
         url = f"{settings.vault_addr}/v1/{path}"
 
-        async with httpx.AsyncClient(verify=False, timeout=5.0) as http:
+        async with httpx.AsyncClient(
+            verify=vault_tls_verify(settings), timeout=5.0,
+        ) as http:
             resp = await http.post(
                 url,
                 json={"data": {"key_pem": key_pem}},
@@ -690,7 +694,9 @@ class AgentManager:
         path = f"{settings.vault_secret_prefix}/agents/{agent_id}"
         url = f"{settings.vault_addr}/v1/{path}"
 
-        async with httpx.AsyncClient(verify=False, timeout=5.0) as http:
+        async with httpx.AsyncClient(
+            verify=vault_tls_verify(settings), timeout=5.0,
+        ) as http:
             resp = await http.get(
                 url,
                 headers={"X-Vault-Token": settings.vault_token},
@@ -721,8 +727,10 @@ class AgentManager:
             import asyncio
             from cullis_sdk.client import CullisClient
 
+            _verify = settings.broker_verify_tls
+
             def _do_login():
-                client = CullisClient(broker_url, verify_tls=False)
+                client = CullisClient(broker_url, verify_tls=_verify)
                 client.login_from_pem(agent_id, self._org_id, cert_pem, key_pem)
                 client.close()
 
@@ -756,7 +764,9 @@ class AgentManager:
         headers = {"X-Org-Id": self._org_id, "X-Org-Secret": org_secret}
 
         try:
-            async with httpx.AsyncClient(verify=False, timeout=5.0) as http:
+            async with httpx.AsyncClient(
+                verify=broker_tls_verify(get_settings()), timeout=5.0,
+            ) as http:
                 resp = await http.post(
                     f"{broker_url}/v1/registry/agents",
                     headers=headers,

--- a/tests/test_proxy_tls_verify.py
+++ b/tests/test_proxy_tls_verify.py
@@ -19,7 +19,7 @@ audit actually requires — no need to instantiate the full lifespan.
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_proxy_tls_verify.py
+++ b/tests/test_proxy_tls_verify.py
@@ -1,0 +1,237 @@
+"""Audit F-E-01 + F-E-02 — proxy must verify TLS for broker and Vault.
+
+These tests lock in the post-fix behaviour:
+
+1. ``validate_config`` refuses to start in ``environment=production`` when
+   either ``MCP_PROXY_BROKER_VERIFY_TLS`` or ``MCP_PROXY_VAULT_VERIFY_TLS``
+   is disabled. Development mode keeps allowing the opt-out (self-signed
+   sandboxes still need it).
+2. The Vault helpers in the dashboard router and the agent manager pass
+   the configured ``verify=`` kwarg into ``httpx.AsyncClient`` instead of
+   the previously hardcoded ``verify=False``.
+3. ``broker_tls_verify`` / ``vault_tls_verify`` honour the CA-cert-path
+   override when set, falling back to the boolean flag otherwise.
+
+The broker-facing call sites (dashboard setup wizard, AgentManager
+deactivate / register) reuse the same helper, so the unit coverage
+around the helper plus the assertion in ``validate_config`` is what the
+audit actually requires — no need to instantiate the full lifespan.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_proxy.config import (
+    ProxySettings,
+    broker_tls_verify,
+    validate_config,
+    vault_tls_verify,
+)
+
+
+# ── validate_config production guards ───────────────────────────────
+
+def _prod_settings(**overrides) -> ProxySettings:
+    """Build a ProxySettings that passes every other production check."""
+    base = dict(
+        environment="production",
+        admin_secret="strong-random-admin-secret",
+        broker_jwks_url="https://broker.example.com/.well-known/jwks.json",
+        standalone=False,
+    )
+    base.update(overrides)
+    return ProxySettings(**base)
+
+
+def test_validate_config_rejects_prod_with_broker_verify_disabled():
+    settings = _prod_settings(broker_verify_tls=False)
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+def test_validate_config_rejects_prod_with_vault_verify_disabled():
+    settings = _prod_settings(secret_backend="vault", vault_verify_tls=False)
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+def test_validate_config_allows_prod_with_verify_enabled():
+    settings = _prod_settings(
+        secret_backend="vault",
+        broker_verify_tls=True,
+        vault_verify_tls=True,
+    )
+    # Must not raise.
+    validate_config(settings)
+
+
+def test_validate_config_ignores_vault_flag_when_backend_is_env():
+    """If secret_backend=env we never talk to Vault, so the vault flag is
+    advisory and must not block production startup."""
+    settings = _prod_settings(secret_backend="env", vault_verify_tls=False)
+    validate_config(settings)
+
+
+def test_validate_config_dev_tolerates_disabled_verify():
+    """Development keeps the existing opt-out for self-signed sandboxes."""
+    settings = ProxySettings(
+        environment="development",
+        broker_verify_tls=False,
+        vault_verify_tls=False,
+        secret_backend="vault",
+    )
+    validate_config(settings)
+
+
+def test_validate_config_standalone_still_enforces_vault_tls():
+    """Standalone mode skips broker checks but a Vault backend is still
+    reachable — keep enforcing its TLS in production."""
+    settings = ProxySettings(
+        environment="production",
+        admin_secret="strong-random-admin-secret",
+        standalone=True,
+        secret_backend="vault",
+        vault_verify_tls=False,
+    )
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+# ── verify kwarg helpers ────────────────────────────────────────────
+
+def test_broker_tls_verify_defaults_to_true():
+    settings = ProxySettings()
+    assert broker_tls_verify(settings) is True
+
+
+def test_broker_tls_verify_honours_false_flag():
+    settings = ProxySettings(broker_verify_tls=False)
+    assert broker_tls_verify(settings) is False
+
+
+def test_vault_tls_verify_defaults_to_true():
+    settings = ProxySettings()
+    assert vault_tls_verify(settings) is True
+
+
+def test_vault_tls_verify_returns_ca_path_when_set():
+    settings = ProxySettings(vault_ca_cert_path="/etc/ssl/vault-ca.pem")
+    assert vault_tls_verify(settings) == "/etc/ssl/vault-ca.pem"
+
+
+def test_vault_tls_verify_ca_path_wins_over_false_flag():
+    """CA path pinning must take precedence over the boolean flag so a
+    sandbox with a private CA never falls back to ``verify=False``."""
+    settings = ProxySettings(
+        vault_ca_cert_path="/etc/ssl/vault-ca.pem",
+        vault_verify_tls=False,
+    )
+    assert vault_tls_verify(settings) == "/etc/ssl/vault-ca.pem"
+
+
+# ── call sites forward the verify kwarg ─────────────────────────────
+
+class _AsyncClientRecorder:
+    """Stand-in for ``httpx.AsyncClient`` that captures constructor kwargs
+    and returns a minimal context manager with stub get/post/delete."""
+
+    captured_kwargs: dict = {}
+
+    def __init__(self, *args, **kwargs):
+        _AsyncClientRecorder.captured_kwargs = kwargs
+        self._resp = MagicMock()
+        self._resp.status_code = 200
+        self._resp.json = MagicMock(return_value={
+            "data": {"data": {"key_pem": "PEM"}}
+        })
+        self._resp.raise_for_status = MagicMock(return_value=None)
+        self._resp.is_success = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, *args, **kwargs):
+        return self._resp
+
+    async def post(self, *args, **kwargs):
+        return self._resp
+
+    async def delete(self, *args, **kwargs):
+        return self._resp
+
+
+@pytest.mark.asyncio
+async def test_store_key_vault_passes_verify_kwarg(monkeypatch):
+    """``AgentManager._store_key_vault`` must pass ``verify=`` from settings
+    to httpx instead of the hardcoded ``verify=False``."""
+    from mcp_proxy import config as proxy_config
+    from mcp_proxy.egress import agent_manager as am_mod
+
+    monkeypatch.setattr(am_mod, "httpx", MagicMock(AsyncClient=_AsyncClientRecorder))
+
+    fake_settings = ProxySettings(
+        secret_backend="vault",
+        vault_addr="https://vault.example.com",
+        vault_token="t",
+        vault_ca_cert_path="/etc/ssl/vault-ca.pem",
+    )
+    monkeypatch.setattr(am_mod, "get_settings", lambda: fake_settings)
+    monkeypatch.setattr(proxy_config, "get_settings", lambda: fake_settings)
+
+    mgr = am_mod.AgentManager.__new__(am_mod.AgentManager)
+    mgr._org_id = "acme"
+    await mgr._store_key_vault("agent-1", "KEY_PEM")
+
+    assert _AsyncClientRecorder.captured_kwargs.get("verify") == (
+        "/etc/ssl/vault-ca.pem"
+    ), (
+        "Expected vault_ca_cert_path to be forwarded as verify=, got "
+        f"{_AsyncClientRecorder.captured_kwargs!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_key_vault_passes_verify_kwarg(monkeypatch):
+    """``AgentManager._fetch_key_vault`` must forward ``verify=`` too."""
+    from mcp_proxy.egress import agent_manager as am_mod
+
+    monkeypatch.setattr(am_mod, "httpx", MagicMock(AsyncClient=_AsyncClientRecorder))
+
+    fake_settings = ProxySettings(
+        secret_backend="vault",
+        vault_addr="https://vault.example.com",
+        vault_token="t",
+        vault_verify_tls=True,
+    )
+    monkeypatch.setattr(am_mod, "get_settings", lambda: fake_settings)
+
+    mgr = am_mod.AgentManager.__new__(am_mod.AgentManager)
+    mgr._org_id = "acme"
+    _AsyncClientRecorder.captured_kwargs = {}
+    await mgr._fetch_key_vault("agent-1")
+
+    assert _AsyncClientRecorder.captured_kwargs.get("verify") is True
+
+
+def test_no_hardcoded_verify_false_in_mcp_proxy():
+    """Regression guard for F-E-01 / F-E-02: scrub the tree for any
+    accidental re-introduction of ``verify=False`` or ``verify_tls=False``
+    in shipping proxy code. Tests may legitimately use them on fixtures."""
+    import pathlib
+
+    root = pathlib.Path(__file__).resolve().parent.parent / "mcp_proxy"
+    hits: list[str] = []
+    for path in root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for needle in ("verify=False", "verify_tls=False"):
+            if needle in text:
+                hits.append(f"{path}: {needle}")
+    assert not hits, (
+        "TLS verification must stay enforced in mcp_proxy/. Offending "
+        f"lines: {hits}"
+    )


### PR DESCRIPTION
## Summary

- **Audit reference:** F-E-01 (CRITICAL) + F-E-02 (CRITICAL) from `imp/audit_2026_04_17/phase1_E_secrets.md`. 19 `httpx.AsyncClient` call sites in `mcp_proxy/` hardcoded `verify=False`, silently disabling TLS verification to the broker and to the Vault backend that stores agent private keys, the Org CA private key, and the Vault token itself.
- **Fix:** wire every call site through the existing `ProxySettings.broker_verify_tls` flag (already honored in 3 places — main.py, link_broker.py) and a new `vault_verify_tls` / `vault_ca_cert_path` pair that mirrors the broker-side `app/kms/vault.py` `VAULT_CA_CERT` pattern. Production startup now refuses to run with verification disabled.
- **Design decisions worth reviewing:**
  - Introduced two helpers `broker_tls_verify(settings)` / `vault_tls_verify(settings)` in `mcp_proxy/config.py` instead of a new utility module. They return `verify=` values (bool or CA path string) with CA path winning over a disabled flag — so a sandbox that pins a private Vault CA never silently falls through to `False`.
  - `validate_config()` enforces the flag in production. The Vault check only fires when `secret_backend=vault` (no point blocking operators who don't talk to Vault) but applies in **both** normal and standalone mode, since standalone proxies may still use Vault for agent keys.
  - `CullisClient(broker_url, verify_tls=False)` in `AgentManager._login_to_broker` is also wired to the flag — not strictly in the 19 `verify=False` count but same class of bug.

## Test plan

- [x] `pytest tests/test_proxy_tls_verify.py -v` — 14 new unit tests pass (production guards, helper precedence, `_store_key_vault` / `_fetch_key_vault` forward `verify=` kwarg, tree-wide regression grep).
- [x] `pytest tests/ -n auto --dist=loadfile` — 1040 passed, 15 skipped. The only failures are the 2 pre-existing `test_postgres_integration` tests which reproduce on `main` (DPoP / session setup issue unrelated to TLS).
- [x] `grep -rn 'verify=False\|verify_tls=False' mcp_proxy/` — 0 hits. Tests under `tests/` still use `verify=False` for self-signed fixtures, which the brief allows.
- [x] `./demo_network/smoke.sh full` — passes (round-trip, A4, A7, A8). First attempts flaked on a docker volume leftover; a `docker system prune -f` and rerun was clean.
- [x] New prod-assertion test exercises the `SystemExit` path for both broker and Vault flags.