### PR TITLE
fix(oneshot): sign full envelope, require verification on decrypt (audit F-A-1/F-A-3)

### DIFF
--- a/app/auth/message_signer.py
+++ b/app/auth/message_signer.py
@@ -43,6 +43,140 @@ def _canonical(session_id: str, sender_agent_id: str, nonce: str, timestamp: int
     return f"{session_id}|{sender_agent_id}|{nonce}|{timestamp}|{payload_str}".encode("utf-8")
 
 
+# ── ADR-008 audit F-A-1 / F-A-3: one-shot envelope signing ─────────────
+#
+# The v1 one-shot wire used ``canonical = f"oneshot:<corr>|<sender>|<nonce>|..."``
+# which covered only ``payload``. Fields that the broker and local stores
+# persist alongside the payload — ``mode``, ``reply_to``, ``correlation_id``,
+# ``timestamp``, ``nonce`` — were outside the signed region. An attacker
+# with DB/process access could flip those fields post-storage without
+# invalidating the signature. Most critically, flipping ``mode`` from
+# ``envelope`` to ``mtls-only`` caused the recipient SDK to return an
+# attacker-chosen plaintext with ``sender_verified=False`` but no other
+# signal (callers ignored the flag).
+#
+# v2 covers the full envelope identity with a distinct domain separator:
+#   "oneshot-env:v2|<corr>|<sender>|<nonce>|<ts>|<mode>|<reply_to>|<payload_json>"
+# Senders set ``v=2`` in the wire envelope. Broker ingest and recipient
+# SDK decrypt both verify over v2 and hard-reject v1. Domain separation
+# via the ``oneshot-env:v2`` prefix prevents cross-protocol replay with
+# session messages or inner signatures.
+
+
+ONESHOT_ENVELOPE_PROTO_VERSION = 2
+
+
+def compute_oneshot_envelope_sig_input(
+    correlation_id: str,
+    sender_agent_id: str,
+    nonce: str,
+    timestamp: int,
+    mode: str,
+    reply_to: str | None,
+    payload: dict,
+) -> bytes:
+    """Canonical bytes to sign for the one-shot envelope outer signature.
+
+    Covers every field the broker and the recipient store — any tamper to
+    ``mode``, ``reply_to``, ``correlation_id``, ``timestamp``, ``nonce``
+    or ``payload`` invalidates the signature. See
+    ``ONESHOT_ENVELOPE_PROTO_VERSION`` for the on-wire version pin.
+    """
+    payload_str = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    reply_to_s = reply_to or ""
+    return (
+        f"oneshot-env:v{ONESHOT_ENVELOPE_PROTO_VERSION}"
+        f"|{correlation_id}|{sender_agent_id}|{nonce}|{timestamp}"
+        f"|{mode}|{reply_to_s}|{payload_str}"
+    ).encode("utf-8")
+
+
+def sign_oneshot_envelope(
+    private_key_pem: str,
+    *,
+    correlation_id: str,
+    sender_agent_id: str,
+    nonce: str,
+    timestamp: int,
+    mode: str,
+    reply_to: str | None,
+    payload: dict,
+) -> str:
+    """Sign a v2 one-shot envelope. Returns url-safe base64 signature."""
+    priv_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+    canonical = compute_oneshot_envelope_sig_input(
+        correlation_id=correlation_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=timestamp,
+        mode=mode,
+        reply_to=reply_to,
+        payload=payload,
+    )
+    if isinstance(priv_key, rsa_alg.RSAPrivateKey):
+        signature = priv_key.sign(canonical, _PSS_PADDING, hashes.SHA256())
+    elif isinstance(priv_key, ec_alg.EllipticCurvePrivateKey):
+        signature = priv_key.sign(canonical, ec_alg.ECDSA(hashes.SHA256()))
+    else:
+        raise ValueError(f"Unsupported key type: {type(priv_key).__name__}")
+    return base64.urlsafe_b64encode(signature).decode()
+
+
+def verify_oneshot_envelope_signature(
+    cert_pem: str,
+    signature_b64: str,
+    *,
+    correlation_id: str,
+    sender_agent_id: str,
+    nonce: str,
+    timestamp: int,
+    mode: str,
+    reply_to: str | None,
+    payload: dict,
+) -> None:
+    """Verify a v2 one-shot envelope signature.
+
+    Raises ``HTTPException(401)`` on invalid signature or unsupported key.
+    Use ``verify_oneshot_envelope_signature_bool`` from the SDK when a
+    boolean return is preferred.
+    """
+    try:
+        cert = crypto_x509.load_pem_x509_certificate(cert_pem.encode())
+        pub_key = cert.public_key()
+        sig = _b64url_decode(signature_b64)
+        canonical = compute_oneshot_envelope_sig_input(
+            correlation_id=correlation_id,
+            sender_agent_id=sender_agent_id,
+            nonce=nonce,
+            timestamp=timestamp,
+            mode=mode,
+            reply_to=reply_to,
+            payload=payload,
+        )
+        if isinstance(pub_key, rsa_alg.RSAPublicKey):
+            pub_key.verify(sig, canonical, _PSS_PADDING, hashes.SHA256())
+        elif isinstance(pub_key, ec_alg.EllipticCurvePublicKey):
+            pub_key.verify(sig, canonical, ec_alg.ECDSA(hashes.SHA256()))
+        else:
+            raise ValueError(f"Unsupported key type: {type(pub_key).__name__}")
+    except InvalidSignature:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid one-shot envelope signature — cannot verify the sender",
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        import logging
+        logging.getLogger("agent_trust").error(
+            "One-shot envelope signature verification error: %s", exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="One-shot envelope signature verification failed",
+        )
+
+
 def sign_message(
     private_key_pem: str,
     session_id: str,

--- a/app/broker/oneshot_router.py
+++ b/app/broker/oneshot_router.py
@@ -35,7 +35,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.jwt import get_current_agent
-from app.auth.message_signer import verify_message_signature
+from app.auth.message_signer import (
+    ONESHOT_ENVELOPE_PROTO_VERSION,
+    verify_oneshot_envelope_signature,
+)
 from app.auth.models import TokenPayload
 from app.broker.db_models import BrokerOneShotMessageRecord
 from app.broker.ws_manager import ws_manager
@@ -97,6 +100,11 @@ class ForwardOneShotRequest(BaseModel):
         300, ge=10, le=3600,
         description="Broker-side TTL for offline recipients.",
     )
+    v: int = Field(
+        ONESHOT_ENVELOPE_PROTO_VERSION,
+        description="One-shot envelope protocol version. Audit F-A-1/F-A-3: "
+                    "v2 signature covers full envelope; v1 is hard-rejected.",
+    )
 
 
 class ForwardOneShotResponse(BaseModel):
@@ -132,8 +140,12 @@ def _iso(dt: datetime) -> str:
 def _build_envelope_json(body: ForwardOneShotRequest) -> str:
     """Serialize the envelope exactly the shape the proxy's one-shot
     router expects when it lazy-mirrors into ``local_messages``.
+
+    Audit F-A-3: ``v`` is stored alongside the rest so recipient SDKs
+    can hard-reject v1 envelopes.
     """
     envelope = {
+        "v": body.v,
         "mode": body.mode,
         "payload": body.payload,
         "signature": body.signature,
@@ -319,22 +331,46 @@ async def forward_oneshot(
             detail="Timestamp outside freshness window — possible replay",
         )
 
-    # ── Verify signature ──────────────────────────────────────────────
+    # ── Protocol version gate ─────────────────────────────────────────
+    # Audit F-A-3: v1 senders used a payload-only signature that left
+    # ``mode``, ``reply_to``, ``correlation_id``, ``nonce``, ``timestamp``
+    # unauthenticated in the stored form. v2 covers the full envelope;
+    # reject anything else.
+    if body.v != ONESHOT_ENVELOPE_PROTO_VERSION:
+        await log_event(
+            db, "broker.oneshot_denied", "denied",
+            agent_id=current_agent.agent_id, org_id=current_agent.org,
+            details={
+                "correlation_id": body.correlation_id,
+                "reason": "unsupported_envelope_version",
+                "v": body.v,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Unsupported one-shot envelope version {body.v}; "
+                f"expected v={ONESHOT_ENVELOPE_PROTO_VERSION}"
+            ),
+        )
+
+    # ── Verify envelope signature ─────────────────────────────────────
     sender_rec = await get_agent_by_id(db, current_agent.agent_id)
     if sender_rec is None or not sender_rec.cert_pem:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Sender certificate not available — log in before sending",
         )
-    verify_message_signature(
+    verify_oneshot_envelope_signature(
         sender_rec.cert_pem,
         body.signature,
-        f"oneshot:{body.correlation_id}",
-        current_agent.agent_id,
-        body.nonce,
-        body.timestamp,
-        body.payload,
-        client_seq=0,
+        correlation_id=body.correlation_id,
+        sender_agent_id=current_agent.agent_id,
+        nonce=body.nonce,
+        timestamp=body.timestamp,
+        mode=body.mode,
+        reply_to=body.reply_to_correlation_id,
+        payload=body.payload,
     )
 
     # ── Dedup + insert ────────────────────────────────────────────────

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -29,7 +29,13 @@ from typing import Callable, Optional
 import httpx
 
 from cullis_sdk.auth import generate_dpop_keypair, build_dpop_proof, build_client_assertion
-from cullis_sdk.crypto.message_signer import sign_message, verify_signature
+from cullis_sdk.crypto.message_signer import (
+    ONESHOT_ENVELOPE_PROTO_VERSION,
+    sign_message,
+    sign_oneshot_envelope,
+    verify_oneshot_envelope_signature,
+    verify_signature,
+)
 from cullis_sdk.crypto.e2e import encrypt_for_agent, decrypt_from_agent
 from cullis_sdk.types import AgentInfo, SessionInfo, InboxMessage, RfqResult
 from cullis_sdk._logging import log, RED
@@ -820,8 +826,9 @@ class CullisClient:
         if transport == "envelope":
             # ADR-008 Phase 1 PR #3 — cross-org: encrypt with recipient pubkey.
             # The broker sees only the cipher_blob and verifies the outer
-            # signature. The recipient decrypts and verifies the inner
-            # signature for non-repudiation.
+            # envelope signature (audit F-A-3: full envelope, not just
+            # payload). The recipient decrypts and verifies the inner
+            # signature for non-repudiation on plaintext.
             recipient_pubkey = decision.get("target_cert_pem")
             if not recipient_pubkey:
                 raise RuntimeError(
@@ -833,18 +840,22 @@ class CullisClient:
                 f"oneshot:{corr_id}", sender_agent_id, client_seq=0,
             )
             wire_payload: dict[str, Any] = cipher_blob
-            wire_signature = sign_message(
-                self._signing_key_pem,
-                f"oneshot:{corr_id}",
-                sender_agent_id,
-                nonce,
-                timestamp,
-                cipher_blob,
-                client_seq=0,
-            )
         else:
             wire_payload = payload
-            wire_signature = inner_signature
+
+        # v2 outer envelope signature — covers mode, reply_to, correlation_id,
+        # timestamp, nonce and wire payload. Broker and recipient both verify
+        # over this exact canonical form (see audit F-A-1 / F-A-3).
+        wire_signature = sign_oneshot_envelope(
+            self._signing_key_pem,
+            correlation_id=corr_id,
+            sender_agent_id=sender_agent_id,
+            nonce=nonce,
+            timestamp=timestamp,
+            mode=transport,
+            reply_to=reply_to,
+            payload=wire_payload,
+        )
 
         body: dict[str, Any] = {
             "recipient_id": target_agent_id,
@@ -857,6 +868,7 @@ class CullisClient:
             "timestamp": timestamp,
             "ttl_seconds": ttl_seconds,
             "capabilities": capabilities or [],
+            "v": ONESHOT_ENVELOPE_PROTO_VERSION,
         }
         resp = self._http.post(
             f"{self.base}/v1/egress/message/send",
@@ -899,32 +911,92 @@ class CullisClient:
         return resp.json().get("messages", [])
 
     def decrypt_oneshot(self, inbox_row: dict) -> dict:
-        """Decrypt a one-shot envelope row returned by :meth:`receive_oneshot`.
+        """Decrypt and authenticate a one-shot envelope row returned by
+        :meth:`receive_oneshot`.
 
-        For ``mtls-only`` rows the payload is already plaintext —
-        returned as-is with ``sender_verified=False`` (the mTLS transport
-        already guaranteed sender identity at proxy-to-proxy level).
+        Audit F-A-1 / F-A-3 fix: the envelope signature now covers the
+        full envelope (mode, reply_to, correlation_id, nonce, timestamp,
+        payload), not just ``payload``. Verification is unconditional —
+        both ``mtls-only`` and ``envelope`` modes require a valid sender
+        signature over the v2 canonical form. ``mtls-only`` describes
+        key-wrap, not auth scope, so an unsigned envelope is always
+        rejected.
 
-        For ``envelope`` rows: AES-GCM decrypt with the caller's private
-        key, then verify the inner signature against the sender's cert
-        from the broker registry. Raises ``ValueError`` on decrypt or
-        signature failure.
+        Rejects v1 (pre-fix) envelopes with a clear error: envelopes and
+        recipients must upgrade together since the broker and proxy store
+        the wire envelope verbatim.
 
-        Returns ``{"payload": <plaintext_dict>, "sender_verified": bool,
+        For ``envelope`` rows: also AES-GCM decrypt with the caller's
+        private key and verify the inner signature against the sender's
+        cert from the broker registry. Raises ``ValueError`` on any
+        cryptographic failure.
+
+        Returns ``{"payload": <plaintext_dict>, "sender_verified": True,
         "mode": "mtls-only" | "envelope"}``.
         """
         import json as _json
         from cullis_sdk.crypto.e2e import verify_inner_signature
 
         envelope = _json.loads(inbox_row["payload_ciphertext"])
-        mode = envelope.get("mode", "mtls-only")
+
+        # Protocol version gate — v1 envelopes are hard-rejected. The
+        # product ships broker+SDK in lockstep; there's no mixed fleet.
+        v = envelope.get("v")
+        if v != ONESHOT_ENVELOPE_PROTO_VERSION:
+            raise ValueError(
+                f"Unsupported one-shot envelope version {v!r}; "
+                f"expected v={ONESHOT_ENVELOPE_PROTO_VERSION}. "
+                "Upgrade the sender's SDK/proxy."
+            )
+
+        # Required envelope identity fields. ``mode`` is NEVER defaulted —
+        # a missing mode is an authentication failure (see audit F-A-1).
+        if "mode" not in envelope:
+            raise ValueError("One-shot envelope missing 'mode' — rejected")
+        mode = envelope["mode"]
+        if mode not in ("mtls-only", "envelope"):
+            raise ValueError(f"One-shot envelope has unknown mode {mode!r}")
+        for required in ("signature", "nonce", "timestamp", "payload"):
+            if envelope.get(required) in (None, ""):
+                raise ValueError(
+                    f"One-shot envelope missing required field {required!r}"
+                )
+
         sender = inbox_row["sender_agent_id"]
         corr = inbox_row["correlation_id"]
 
+        # Cross-check: the envelope-embedded correlation_id must match the
+        # row's. If they disagree, some store rewrote one of them and we
+        # cannot trust either side.
+        env_corr = envelope.get("correlation_id")
+        if env_corr and env_corr != corr:
+            raise ValueError(
+                "One-shot envelope correlation_id does not match inbox row"
+            )
+
+        # Verify the v2 outer envelope signature against the sender's cert.
+        sender_cert_pem = self.get_agent_public_key(sender)
+        ok = verify_oneshot_envelope_signature(
+            sender_cert_pem,
+            envelope["signature"],
+            correlation_id=corr,
+            sender_agent_id=sender,
+            nonce=envelope["nonce"],
+            timestamp=envelope["timestamp"],
+            mode=mode,
+            reply_to=envelope.get("reply_to"),
+            payload=envelope["payload"],
+        )
+        if not ok:
+            raise ValueError(
+                "One-shot envelope signature verification failed — "
+                "envelope may have been tampered with post-send"
+            )
+
         if mode == "mtls-only":
             return {
-                "payload": envelope.get("payload", {}),
-                "sender_verified": False,
+                "payload": envelope["payload"],
+                "sender_verified": True,
                 "mode": mode,
             }
 
@@ -940,7 +1012,6 @@ class CullisClient:
             f"oneshot:{corr}", sender, client_seq=0,
         )
 
-        sender_cert_pem = self.get_agent_public_key(sender)
         verify_inner_signature(
             sender_cert_pem, inner_sig,
             f"oneshot:{corr}", sender,
@@ -961,15 +1032,21 @@ class CullisClient:
         timeout: float = 30.0,
         poll_interval: float = 1.0,
         ttl_seconds: int = 300,
+        allow_unverified: bool = False,
     ) -> dict:
         """Request-response convenience: send a one-shot, block until a
         reply tagged with the same ``correlation_id`` is in the caller's
         inbox, or ``TimeoutError`` after ``timeout`` seconds.
 
+        Audit F-A-1 fix: ``decrypt_oneshot`` always verifies the sender's
+        signature, so ``sender_verified`` is ``True`` on success. The
+        ``allow_unverified=True`` kwarg is reserved for future transport
+        modes where the SDK cannot see the sender's public key (none
+        today); callers should not pass it. If a non-verifying row ever
+        slips through this method raises ``ValueError``.
+
         Returns ``{"correlation_id", "msg_id", "reply_to", "reply",
-        "sender", "mode", "sender_verified"}``. ``reply`` is the
-        decrypted + signature-verified plaintext for envelope mode, or
-        the passthrough payload for mtls-only.
+        "sender", "mode", "sender_verified"}``.
         """
         import json as _json
 
@@ -985,6 +1062,14 @@ class CullisClient:
                 if envelope.get("reply_to") != corr:
                     continue
                 decoded = self.decrypt_oneshot(row)
+                if not decoded["sender_verified"] and not allow_unverified:
+                    raise ValueError(
+                        "Reply for correlation_id "
+                        f"{corr} could not be verified — refusing to "
+                        "return unauthenticated plaintext. Pass "
+                        "allow_unverified=True only if you fully "
+                        "understand the threat model."
+                    )
                 return {
                     "correlation_id": row["correlation_id"],
                     "msg_id": row["msg_id"],
@@ -1013,13 +1098,16 @@ class CullisClient:
         signature: str,
         ttl_seconds: int = 300,
         capabilities: list[str] | None = None,
+        mode: str = "mtls-only",
+        v: int = ONESHOT_ENVELOPE_PROTO_VERSION,
     ) -> dict:
         """Forward a one-shot envelope to the broker's cross-org queue.
 
         Used by the sender proxy's ``BrokerBridge`` after it has already
-        verified the local policy. The proxy signs the canonical payload
-        with ``session_id='oneshot:<correlation_id>'`` on the sender's
-        key before calling this; the broker re-verifies and persists.
+        verified the local policy. The sending agent signs the v2
+        canonical envelope form on its own key before calling this; the
+        broker re-verifies and persists. ``mode`` is propagated verbatim
+        so envelope-mode cipher_blobs ride through unchanged.
         """
         body = {
             "recipient_agent_id": recipient_agent_id,
@@ -1029,9 +1117,10 @@ class CullisClient:
             "signature": signature,
             "nonce": nonce,
             "timestamp": timestamp,
-            "mode": "mtls-only",
+            "mode": mode,
             "ttl_seconds": ttl_seconds,
             "capabilities": capabilities or [],
+            "v": v,
         }
         resp = self._authed_request(
             "POST", "/v1/broker/oneshot/forward", json=body,

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -1032,18 +1032,15 @@ class CullisClient:
         timeout: float = 30.0,
         poll_interval: float = 1.0,
         ttl_seconds: int = 300,
-        allow_unverified: bool = False,
     ) -> dict:
         """Request-response convenience: send a one-shot, block until a
         reply tagged with the same ``correlation_id`` is in the caller's
         inbox, or ``TimeoutError`` after ``timeout`` seconds.
 
         Audit F-A-1 fix: ``decrypt_oneshot`` always verifies the sender's
-        signature, so ``sender_verified`` is ``True`` on success. The
-        ``allow_unverified=True`` kwarg is reserved for future transport
-        modes where the SDK cannot see the sender's public key (none
-        today); callers should not pass it. If a non-verifying row ever
-        slips through this method raises ``ValueError``.
+        signature, so ``sender_verified`` is always ``True`` on success.
+        If a non-verifying row ever slips through this method raises
+        ``ValueError``.
 
         Returns ``{"correlation_id", "msg_id", "reply_to", "reply",
         "sender", "mode", "sender_verified"}``.
@@ -1062,13 +1059,11 @@ class CullisClient:
                 if envelope.get("reply_to") != corr:
                     continue
                 decoded = self.decrypt_oneshot(row)
-                if not decoded["sender_verified"] and not allow_unverified:
+                if not decoded["sender_verified"]:
                     raise ValueError(
                         "Reply for correlation_id "
                         f"{corr} could not be verified — refusing to "
-                        "return unauthenticated plaintext. Pass "
-                        "allow_unverified=True only if you fully "
-                        "understand the threat model."
+                        "return unauthenticated plaintext."
                     )
                 return {
                     "correlation_id": row["correlation_id"],

--- a/cullis_sdk/crypto/message_signer.py
+++ b/cullis_sdk/crypto/message_signer.py
@@ -66,6 +66,113 @@ def sign_message(
     return base64.urlsafe_b64encode(signature).decode()
 
 
+# ── ADR-008 audit F-A-1 / F-A-3: one-shot envelope signing (v2) ────────
+#
+# Mirrors ``app/auth/message_signer.py`` — see the module docstring there
+# for the threat model. Senders ship ``v=2`` in the wire envelope and
+# sign the full envelope identity (mode, reply_to, correlation_id,
+# timestamp, nonce, payload) with a distinct domain separator so v1
+# payload-only signatures cannot satisfy a v2 verify.
+
+
+ONESHOT_ENVELOPE_PROTO_VERSION = 2
+
+
+def compute_oneshot_envelope_sig_input(
+    correlation_id: str,
+    sender_agent_id: str,
+    nonce: str,
+    timestamp: int,
+    mode: str,
+    reply_to: str | None,
+    payload: dict,
+) -> bytes:
+    """Canonical bytes signed for the one-shot envelope outer signature."""
+    payload_str = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    reply_to_s = reply_to or ""
+    return (
+        f"oneshot-env:v{ONESHOT_ENVELOPE_PROTO_VERSION}"
+        f"|{correlation_id}|{sender_agent_id}|{nonce}|{timestamp}"
+        f"|{mode}|{reply_to_s}|{payload_str}"
+    ).encode("utf-8")
+
+
+def sign_oneshot_envelope(
+    private_key_pem: str,
+    *,
+    correlation_id: str,
+    sender_agent_id: str,
+    nonce: str,
+    timestamp: int,
+    mode: str,
+    reply_to: str | None,
+    payload: dict,
+) -> str:
+    """Sign a v2 one-shot envelope. Returns url-safe base64 signature."""
+    priv_key = serialization.load_pem_private_key(private_key_pem.encode(), password=None)
+    canonical = compute_oneshot_envelope_sig_input(
+        correlation_id=correlation_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=timestamp,
+        mode=mode,
+        reply_to=reply_to,
+        payload=payload,
+    )
+    if isinstance(priv_key, rsa_alg.RSAPrivateKey):
+        signature = priv_key.sign(canonical, _PSS_PADDING, hashes.SHA256())
+    elif isinstance(priv_key, ec_alg.EllipticCurvePrivateKey):
+        signature = priv_key.sign(canonical, ec_alg.ECDSA(hashes.SHA256()))
+    else:
+        raise ValueError(f"Unsupported key type: {type(priv_key).__name__}")
+    return base64.urlsafe_b64encode(signature).decode()
+
+
+def verify_oneshot_envelope_signature(
+    cert_or_pubkey_pem: str,
+    signature_b64: str,
+    *,
+    correlation_id: str,
+    sender_agent_id: str,
+    nonce: str,
+    timestamp: int,
+    mode: str,
+    reply_to: str | None,
+    payload: dict,
+) -> bool:
+    """Return True if the v2 envelope signature verifies, False otherwise."""
+    pem_bytes = cert_or_pubkey_pem.encode()
+    try:
+        if b"CERTIFICATE" in pem_bytes:
+            cert = crypto_x509.load_pem_x509_certificate(pem_bytes)
+            pub_key = cert.public_key()
+        else:
+            pub_key = serialization.load_pem_public_key(pem_bytes)
+    except Exception:
+        return False
+
+    sig = _b64url_decode(signature_b64)
+    canonical = compute_oneshot_envelope_sig_input(
+        correlation_id=correlation_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=timestamp,
+        mode=mode,
+        reply_to=reply_to,
+        payload=payload,
+    )
+    try:
+        if isinstance(pub_key, rsa_alg.RSAPublicKey):
+            pub_key.verify(sig, canonical, _PSS_PADDING, hashes.SHA256())
+        elif isinstance(pub_key, ec_alg.EllipticCurvePublicKey):
+            pub_key.verify(sig, canonical, ec_alg.ECDSA(hashes.SHA256()))
+        else:
+            return False
+        return True
+    except InvalidSignature:
+        return False
+
+
 def verify_signature(
     cert_or_pubkey_pem: str,
     signature_b64: str,

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -313,11 +313,15 @@ class BrokerBridge:
         signature: str,
         ttl_seconds: int = 300,
         capabilities: list[str] | None = None,
+        mode: str = "mtls-only",
+        v: int = 2,
     ) -> dict:
         """Forward a sessionless one-shot through the broker.
 
         Returns the broker's response body — ``{msg_id, duplicate}``.
         Uses the same auth-error retry pattern as session operations.
+        Propagates ``mode`` and ``v`` so envelope-mode cipher_blobs and
+        the v2 envelope signature reach the broker intact.
         """
         kw = dict(
             recipient_agent_id=recipient_agent_id,
@@ -329,6 +333,8 @@ class BrokerBridge:
             signature=signature,
             ttl_seconds=ttl_seconds,
             capabilities=capabilities or [],
+            mode=mode,
+            v=v,
         )
         client = await self.get_client(agent_id)
         try:

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -43,6 +43,14 @@ router = APIRouter(prefix="/v1/egress", tags=["egress-oneshot"])
 
 # ── Request / response schemas ──────────────────────────────────────
 
+# Audit F-A-3: v2 envelopes cover mode+reply_to+correlation_id+nonce+ts
+# in the outer signature. The proxy is on the inside of the trust
+# boundary and does not verify the sender signature itself, but it
+# propagates ``v`` and the enlarged envelope verbatim so the recipient
+# SDK can hard-reject legacy shapes.
+_ONESHOT_ENVELOPE_PROTO_VERSION = 2
+
+
 class SendOneShotRequest(BaseModel):
     """Body of ``POST /v1/egress/message/send``."""
 
@@ -91,6 +99,11 @@ class SendOneShotRequest(BaseModel):
         le=3600,
         description="Recipient offline TTL. 5 min default, max 1h.",
     )
+    v: int = Field(
+        _ONESHOT_ENVELOPE_PROTO_VERSION,
+        description="One-shot envelope protocol version. v2 signs the full "
+                    "envelope (audit F-A-1/F-A-3); v1 is hard-rejected.",
+    )
 
 
 class SendOneShotResponse(BaseModel):
@@ -126,9 +139,12 @@ def _iso(dt: datetime) -> str:
 def _serialize_envelope(body: SendOneShotRequest) -> str:
     """Pack the envelope exactly the same shape the session ``/send`` path
     uses, so the recipient's verification path stays agnostic.
+
+    Audit F-A-3: include ``v`` so the recipient can hard-reject v1.
     """
     import json
     envelope = {
+        "v": body.v,
         "mode": body.mode,
         "payload": body.payload,
         "signature": body.signature,
@@ -233,6 +249,8 @@ async def send_oneshot(
                 signature=body.signature or "",
                 ttl_seconds=body.ttl_seconds,
                 capabilities=body.capabilities,
+                mode=body.mode,
+                v=body.v,
             )
         except HTTPException:
             raise

--- a/tests/test_audit_oneshot_envelope_integrity.py
+++ b/tests/test_audit_oneshot_envelope_integrity.py
@@ -1,0 +1,620 @@
+"""Regression tests for audit findings F-A-1 and F-A-3 (EUDI-class).
+
+F-A-1: ``decrypt_oneshot`` used to default ``mode`` to ``"mtls-only"``
+and return the attacker-controlled ``envelope["payload"]`` verbatim
+with ``sender_verified=False``. Callers of ``send_oneshot_and_wait``
+never checked the flag, so a broker or DB-adjacent attacker could
+downgrade a legitimate envelope-mode message to ``mtls-only`` with
+arbitrary plaintext.
+
+F-A-3: The broker's outer signature covered only ``body.payload``.
+Every other field the broker persisted (``mode``, ``signature`` slot,
+``nonce``, ``timestamp``, ``correlation_id``, ``reply_to``) lived
+outside the signed region, so a broker-side actor could rewrite any of
+them undetected.
+
+v2 fix: outer signature now covers the full envelope and verification
+is unconditional on the recipient side. v1 envelopes are hard-rejected.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from httpx import AsyncClient
+
+from cullis_sdk.client import CullisClient
+from cullis_sdk.crypto.e2e import encrypt_for_agent
+from cullis_sdk.crypto.message_signer import (
+    ONESHOT_ENVELOPE_PROTO_VERSION,
+    sign_message,
+    sign_oneshot_envelope,
+)
+from tests.cert_factory import (
+    DPoPHelper,
+    get_agent_key_pem,
+    get_agent_pubkey_pem,
+    make_agent_cert,
+)
+
+# Reuse the broker test helpers (register + login, PDP mock autouse).
+from tests.test_oneshot_cross import (
+    _mock_oneshot_pdp,  # noqa: F401 — autouse fixture re-exported for patch scope
+    _register_and_login,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Shared helpers ────────────────────────────────────────────────────
+
+
+def _alice_cert_pem(agent_id: str = "audit1::alice", org_id: str = "audit1") -> str:
+    _, cert = make_agent_cert(agent_id, org_id)
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _seed_client(
+    sender_agent_id: str,
+    sender_org_id: str,
+    *,
+    recipient_priv_pem: str | None = None,
+) -> CullisClient:
+    """Build an SDK client with its pubkey cache pre-seeded for the sender."""
+    sender_cert_pem = _alice_cert_pem(sender_agent_id, sender_org_id)
+    client = CullisClient("http://test", verify_tls=False)
+    if recipient_priv_pem is not None:
+        client._signing_key_pem = recipient_priv_pem
+    client._pubkey_cache[sender_agent_id] = (sender_cert_pem, time.time())
+    return client
+
+
+def _mtls_envelope(
+    *,
+    sender_agent_id: str,
+    sender_org_id: str,
+    correlation_id: str,
+    nonce: str,
+    timestamp: int,
+    payload: dict,
+    reply_to: str | None = None,
+) -> dict:
+    """Build a v2 mtls-only envelope signed correctly."""
+    sender_priv = get_agent_key_pem(sender_agent_id, sender_org_id)
+    sig = sign_oneshot_envelope(
+        sender_priv,
+        correlation_id=correlation_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=timestamp,
+        mode="mtls-only",
+        reply_to=reply_to,
+        payload=payload,
+    )
+    return {
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
+        "mode": "mtls-only",
+        "payload": payload,
+        "signature": sig,
+        "nonce": nonce,
+        "timestamp": timestamp,
+        "correlation_id": correlation_id,
+        "reply_to": reply_to,
+    }
+
+
+def _envelope_envelope(
+    *,
+    sender_agent_id: str,
+    sender_org_id: str,
+    recipient_pubkey_pem: str,
+    correlation_id: str,
+    nonce: str,
+    timestamp: int,
+    payload: dict,
+    reply_to: str | None = None,
+) -> tuple[dict, dict]:
+    """Build a v2 envelope-mode envelope (returns the dict envelope + plaintext)."""
+    sender_priv = get_agent_key_pem(sender_agent_id, sender_org_id)
+    inner_sig = sign_message(
+        sender_priv,
+        f"oneshot:{correlation_id}",
+        sender_agent_id,
+        nonce,
+        timestamp,
+        payload,
+        client_seq=0,
+    )
+    cipher_blob = encrypt_for_agent(
+        recipient_pubkey_pem, payload, inner_sig,
+        f"oneshot:{correlation_id}", sender_agent_id, client_seq=0,
+    )
+    outer_sig = sign_oneshot_envelope(
+        sender_priv,
+        correlation_id=correlation_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=timestamp,
+        mode="envelope",
+        reply_to=reply_to,
+        payload=cipher_blob,
+    )
+    return ({
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
+        "mode": "envelope",
+        "payload": cipher_blob,
+        "signature": outer_sig,
+        "nonce": nonce,
+        "timestamp": timestamp,
+        "correlation_id": correlation_id,
+        "reply_to": reply_to,
+    }, payload)
+
+
+def _inbox_row(envelope: dict, *, sender_agent_id: str) -> dict:
+    return {
+        "msg_id": str(uuid.uuid4()),
+        "correlation_id": envelope["correlation_id"],
+        "reply_to": envelope.get("reply_to"),
+        "sender_agent_id": sender_agent_id,
+        "payload_ciphertext": json.dumps(envelope, separators=(",", ":"), sort_keys=True),
+        "idempotency_key": f"oneshot:{envelope['correlation_id']}",
+        "enqueued_at": "2026-04-17T00:00:00+00:00",
+        "expires_at": None,
+    }
+
+
+# ── F-A-1: attacker-rewritten mtls-only with no signature ─────────────
+
+
+async def test_decrypt_rejects_unsigned_mtls_only_envelope():
+    """Attacker replaces a legit envelope-mode row with ``mode=mtls-only``
+    + arbitrary plaintext and no (or invalid) signature. Must raise.
+    """
+    sender = "audit1::alice"
+    client = _seed_client(sender, "audit1")
+
+    attacker_envelope = {
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
+        "mode": "mtls-only",
+        "payload": {"attacker_wrote": "wire-transfer EUR 1,000,000"},
+        # No signature at all — simulates the exact F-A-1 exploit.
+        "signature": "",
+        "nonce": str(uuid.uuid4()),
+        "timestamp": int(time.time()),
+        "correlation_id": str(uuid.uuid4()),
+        "reply_to": None,
+    }
+    row = _inbox_row(attacker_envelope, sender_agent_id=sender)
+
+    with pytest.raises(ValueError):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_missing_mode_envelope():
+    """Audit F-A-1 direct hit: v1 SDK defaulted to ``mtls-only`` when
+    ``mode`` was absent. v2 must reject.
+    """
+    sender = "audit1b::alice"
+    client = _seed_client(sender, "audit1b")
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    # Build a valid envelope then strip the mode field.
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit1b",
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"ok": True},
+    )
+    env.pop("mode")
+    row = _inbox_row({**env, "mode": "__missing__", "correlation_id": corr}, sender_agent_id=sender)
+    # Strip the artificial field for the real inbox payload
+    env_json = json.dumps({k: v for k, v in env.items()}, separators=(",", ":"), sort_keys=True)
+    row["payload_ciphertext"] = env_json
+
+    with pytest.raises(ValueError):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_v1_envelope_protocol_version():
+    """v1 envelopes (pre-fix) are hard-rejected."""
+    sender = "audit1c::alice"
+    client = _seed_client(sender, "audit1c")
+
+    corr = str(uuid.uuid4())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit1c",
+        correlation_id=corr, nonce=str(uuid.uuid4()),
+        timestamp=int(time.time()),
+        payload={"ok": True},
+    )
+    env.pop("v")  # v1 had no v field
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    with pytest.raises(ValueError, match="envelope version"):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+# ── F-A-3: broker-side tamper of envelope fields ──────────────────────
+
+
+async def test_decrypt_rejects_flipped_mode():
+    """Attacker flips ``mode`` from ``envelope`` → ``mtls-only`` while
+    leaving the outer signature untouched. v2 covers ``mode`` in the
+    signed canonical form, so verification must fail.
+    """
+    sender = "audit2::alice"
+    recipient_org = "audit2r"
+    recipient = f"{recipient_org}::bob"
+    # Build a valid envelope-mode message.
+    recipient_pubkey = get_agent_pubkey_pem(recipient, recipient_org)
+    client = _seed_client(
+        sender, "audit2",
+        recipient_priv_pem=get_agent_key_pem(recipient, recipient_org),
+    )
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    env, _ = _envelope_envelope(
+        sender_agent_id=sender, sender_org_id="audit2",
+        recipient_pubkey_pem=recipient_pubkey,
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"secret": "legit plaintext"},
+    )
+    # Broker-side tamper: flip mode to downgrade.
+    tampered = {**env, "mode": "mtls-only"}
+    row = _inbox_row(tampered, sender_agent_id=sender)
+
+    with pytest.raises(ValueError, match="signature"):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_flipped_correlation_id():
+    sender = "audit3::alice"
+    client = _seed_client(sender, "audit3")
+
+    corr_real = str(uuid.uuid4())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit3",
+        correlation_id=corr_real,
+        nonce=str(uuid.uuid4()), timestamp=int(time.time()),
+        payload={"msg": "legit"},
+    )
+    # Row corr matches, envelope corr flipped → mismatch detected OR
+    # signature detected. Either way, must raise.
+    env_tampered = {**env, "correlation_id": str(uuid.uuid4())}
+    row = _inbox_row(env_tampered, sender_agent_id=sender)
+    row["correlation_id"] = corr_real  # outer row still claims real corr
+
+    with pytest.raises(ValueError):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_flipped_reply_to():
+    sender = "audit4::alice"
+    client = _seed_client(sender, "audit4")
+
+    corr = str(uuid.uuid4())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit4",
+        correlation_id=corr,
+        nonce=str(uuid.uuid4()), timestamp=int(time.time()),
+        payload={"msg": "legit"},
+        reply_to=None,
+    )
+    # Broker-side tamper: inject a reply_to so a response is mis-linked.
+    env_tampered = {**env, "reply_to": str(uuid.uuid4())}
+    row = _inbox_row(env_tampered, sender_agent_id=sender)
+
+    with pytest.raises(ValueError, match="signature"):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_flipped_timestamp():
+    sender = "audit5::alice"
+    client = _seed_client(sender, "audit5")
+
+    corr = str(uuid.uuid4())
+    ts = int(time.time())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit5",
+        correlation_id=corr,
+        nonce=str(uuid.uuid4()), timestamp=ts,
+        payload={"msg": "legit"},
+    )
+    env_tampered = {**env, "timestamp": ts - 86400}
+    row = _inbox_row(env_tampered, sender_agent_id=sender)
+
+    with pytest.raises(ValueError, match="signature"):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_flipped_nonce():
+    sender = "audit6::alice"
+    client = _seed_client(sender, "audit6")
+
+    corr = str(uuid.uuid4())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit6",
+        correlation_id=corr,
+        nonce=str(uuid.uuid4()), timestamp=int(time.time()),
+        payload={"msg": "legit"},
+    )
+    env_tampered = {**env, "nonce": str(uuid.uuid4())}
+    row = _inbox_row(env_tampered, sender_agent_id=sender)
+
+    with pytest.raises(ValueError, match="signature"):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+async def test_decrypt_rejects_flipped_payload():
+    sender = "audit7::alice"
+    client = _seed_client(sender, "audit7")
+
+    corr = str(uuid.uuid4())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit7",
+        correlation_id=corr,
+        nonce=str(uuid.uuid4()), timestamp=int(time.time()),
+        payload={"amount": 100},
+    )
+    env_tampered = {**env, "payload": {"amount": 1_000_000}}
+    row = _inbox_row(env_tampered, sender_agent_id=sender)
+
+    with pytest.raises(ValueError, match="signature"):
+        client.decrypt_oneshot(row)
+    client.close()
+
+
+# ── Positive round-trip under v2 ──────────────────────────────────────
+
+
+async def test_decrypt_accepts_valid_v2_mtls_envelope():
+    sender = "audit8::alice"
+    client = _seed_client(sender, "audit8")
+
+    corr = str(uuid.uuid4())
+    payload = {"greeting": "hello"}
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="audit8",
+        correlation_id=corr,
+        nonce=str(uuid.uuid4()), timestamp=int(time.time()),
+        payload=payload,
+    )
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    decoded = client.decrypt_oneshot(row)
+    assert decoded["mode"] == "mtls-only"
+    assert decoded["sender_verified"] is True
+    assert decoded["payload"] == payload
+    client.close()
+
+
+# ── F-A-3 broker-side: broker now verifies v2 envelope sig ────────────
+
+
+async def test_broker_rejects_flipped_mode_post_v2(client: AsyncClient):
+    """At broker ingest, a body where ``mode`` disagrees with what the
+    sender signed must 401 (the canonical form includes mode).
+    """
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "audit9::alice", "audit9")
+    await _register_and_login(client, dpop_b, "audit9r::bob", "audit9r")
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("audit9::alice", "audit9")
+    payload = {"msg": "legit"}
+
+    # Sender signs mtls-only, attacker/proxy flips body.mode to envelope.
+    sig = sign_oneshot_envelope(
+        alice_priv,
+        correlation_id=corr, sender_agent_id="audit9::alice",
+        nonce=nonce, timestamp=ts,
+        mode="mtls-only", reply_to=None, payload=payload,
+    )
+    body = {
+        "recipient_agent_id": "audit9r::bob",
+        "correlation_id": corr,
+        "reply_to_correlation_id": None,
+        "payload": payload,
+        "signature": sig,
+        "nonce": nonce,
+        "timestamp": ts,
+        "mode": "envelope",  # tampered
+        "ttl_seconds": 300,
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
+    }
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 401
+
+
+async def test_broker_rejects_flipped_reply_to_post_v2(client: AsyncClient):
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "audit10::alice", "audit10")
+    await _register_and_login(client, dpop_b, "audit10r::bob", "audit10r")
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("audit10::alice", "audit10")
+    payload = {"msg": "legit"}
+
+    sig = sign_oneshot_envelope(
+        alice_priv,
+        correlation_id=corr, sender_agent_id="audit10::alice",
+        nonce=nonce, timestamp=ts,
+        mode="mtls-only", reply_to=None, payload=payload,
+    )
+    body = {
+        "recipient_agent_id": "audit10r::bob",
+        "correlation_id": corr,
+        "reply_to_correlation_id": str(uuid.uuid4()),  # tampered
+        "payload": payload,
+        "signature": sig,
+        "nonce": nonce,
+        "timestamp": ts,
+        "mode": "mtls-only",
+        "ttl_seconds": 300,
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
+    }
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code == 401
+
+
+async def test_broker_rejects_v1_envelope_protocol(client: AsyncClient):
+    """A sender still speaking v1 (no ``v`` field or v=1) must be
+    hard-rejected so we never silently accept a downgraded envelope.
+    """
+    dpop_a, dpop_b = DPoPHelper(), DPoPHelper()
+    token_a = await _register_and_login(client, dpop_a, "audit11::alice", "audit11")
+    await _register_and_login(client, dpop_b, "audit11r::bob", "audit11r")
+
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    alice_priv = get_agent_key_pem("audit11::alice", "audit11")
+    payload = {"msg": "legit"}
+
+    # v1 payload-only signature (old form) — server must not accept.
+    sig = sign_message(
+        alice_priv, f"oneshot:{corr}", "audit11::alice",
+        nonce, ts, payload, client_seq=0,
+    )
+    body = {
+        "recipient_agent_id": "audit11r::bob",
+        "correlation_id": corr,
+        "reply_to_correlation_id": None,
+        "payload": payload,
+        "signature": sig,
+        "nonce": nonce,
+        "timestamp": ts,
+        "mode": "mtls-only",
+        "ttl_seconds": 300,
+        "v": 1,
+    }
+    r = await client.post(
+        "/v1/broker/oneshot/forward", json=body,
+        headers=dpop_a.headers("POST", "/v1/broker/oneshot/forward", token_a),
+    )
+    assert r.status_code in (400, 401)
+
+
+# ── send_oneshot_and_wait: verified-only ──────────────────────────────
+
+
+async def test_send_oneshot_and_wait_raises_on_unverified():
+    """Even if a pathological reply slipped through, the helper must not
+    return unauthenticated plaintext (F-A-1 callsite). We exercise this
+    by monkey-patching ``decrypt_oneshot`` to return ``sender_verified=False``
+    and asserting the helper refuses.
+    """
+    from unittest.mock import MagicMock
+
+    alice_priv = get_agent_key_pem("audit12::alice", "audit12")
+    bob_pubkey = get_agent_pubkey_pem("audit12r::bob", "audit12r")
+
+    alice = CullisClient("http://mock-proxy", verify_tls=False)
+    alice._signing_key_pem = alice_priv
+    alice._proxy_api_key = "fake-api-key"
+    alice._proxy_agent_id = "audit12::alice"
+
+    # The helper's receive_oneshot loop looks for reply_to==corr.
+    captured_corr: dict = {}
+
+    def _fake_post(url: str, *args, **kwargs):
+        body = kwargs.get("json", {})
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.headers = {}
+        if url.endswith("/v1/egress/resolve"):
+            resp.json.return_value = {
+                "path": "cross-org",
+                "target_agent_id": "audit12r::bob",
+                "target_org_id": "audit12r",
+                "target_spiffe": None,
+                "transport": "envelope",
+                "egress_inspection": False,
+                "target_cert_pem": bob_pubkey,
+            }
+            return resp
+        if url.endswith("/v1/egress/message/send"):
+            captured_corr["corr"] = body["correlation_id"]
+            resp.json.return_value = {
+                "correlation_id": body["correlation_id"],
+                "msg_id": str(uuid.uuid4()),
+                "status": "enqueued",
+            }
+            return resp
+        raise AssertionError(url)
+
+    def _fake_get(url: str, *args, **kwargs):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.headers = {}
+        if url.endswith("/v1/egress/message/inbox"):
+            corr = captured_corr.get("corr", "")
+            row_env = {
+                "v": ONESHOT_ENVELOPE_PROTO_VERSION,
+                "mode": "mtls-only",
+                "payload": {"a": 1},
+                "signature": "stub",
+                "nonce": "n",
+                "timestamp": 0,
+                "correlation_id": "reply-corr",
+                "reply_to": corr,
+            }
+            resp.json.return_value = {
+                "messages": [{
+                    "msg_id": str(uuid.uuid4()),
+                    "correlation_id": "reply-corr",
+                    "reply_to": corr,
+                    "sender_agent_id": "audit12r::bob",
+                    "payload_ciphertext": json.dumps(row_env, separators=(",", ":"), sort_keys=True),
+                    "idempotency_key": "oneshot:x",
+                    "enqueued_at": "2026-04-17T00:00:00+00:00",
+                    "expires_at": None,
+                }],
+                "count": 1,
+            }
+            return resp
+        raise AssertionError(url)
+
+    alice._http = MagicMock()
+    alice._http.post.side_effect = _fake_post
+    alice._http.get.side_effect = _fake_get
+
+    # Patch decrypt_oneshot to return unverified — simulates a belt-and-
+    # braces regression of the old behavior. The helper must refuse.
+    alice.decrypt_oneshot = MagicMock(return_value={
+        "payload": {"a": 1},
+        "sender_verified": False,
+        "mode": "mtls-only",
+    })
+
+    with pytest.raises(ValueError, match="could not be verified"):
+        alice.send_oneshot_and_wait(
+            "audit12r::bob", {"q": "?"},
+            timeout=2.0, poll_interval=0.1,
+        )

--- a/tests/test_oneshot_cross.py
+++ b/tests/test_oneshot_cross.py
@@ -20,7 +20,11 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 
-from cullis_sdk.crypto.message_signer import sign_message
+from cullis_sdk.crypto.message_signer import (
+    ONESHOT_ENVELOPE_PROTO_VERSION,
+    sign_message,
+    sign_oneshot_envelope,
+)
 from tests.cert_factory import DPoPHelper, get_agent_key_pem, get_org_ca_pem
 from tests.conftest import ADMIN_HEADERS, TestSessionLocal
 
@@ -91,14 +95,15 @@ def _build_forward_body(
     nonce = str(uuid.uuid4())
     ts = int(time.time()) if timestamp is None else timestamp
     key_pem = get_agent_key_pem(sender_agent_id, sender_org_id)
-    sig = sign_message(
+    sig = sign_oneshot_envelope(
         key_pem,
-        f"oneshot:{corr}",
-        sender_agent_id,
-        nonce,
-        ts,
-        payload,
-        client_seq=0,
+        correlation_id=corr,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=ts,
+        mode="mtls-only",
+        reply_to=reply_to,
+        payload=payload,
     )
     if tamper_signature:
         sig = sig[:-4] + ("AAAA" if not sig.endswith("AAAA") else "BBBB")
@@ -113,6 +118,7 @@ def _build_forward_body(
         "mode": "mtls-only",
         "ttl_seconds": 300,
         "capabilities": capabilities or [],
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
     }
     return body, corr, nonce
 

--- a/tests/test_oneshot_cross.py
+++ b/tests/test_oneshot_cross.py
@@ -22,7 +22,6 @@ from sqlalchemy import select
 
 from cullis_sdk.crypto.message_signer import (
     ONESHOT_ENVELOPE_PROTO_VERSION,
-    sign_message,
     sign_oneshot_envelope,
 )
 from tests.cert_factory import DPoPHelper, get_agent_key_pem, get_org_ca_pem

--- a/tests/test_oneshot_cross_envelope.py
+++ b/tests/test_oneshot_cross_envelope.py
@@ -28,7 +28,11 @@ from cullis_sdk.crypto.e2e import (
     encrypt_for_agent,
     verify_inner_signature,
 )
-from cullis_sdk.crypto.message_signer import sign_message
+from cullis_sdk.crypto.message_signer import (
+    ONESHOT_ENVELOPE_PROTO_VERSION,
+    sign_message,
+    sign_oneshot_envelope,
+)
 from tests.cert_factory import (
     DPoPHelper,
     get_agent_key_pem,
@@ -54,8 +58,13 @@ def _make_cipher_blob(
     payload: dict,
     nonce: str,
     timestamp: int,
+    reply_to: str | None = None,
 ) -> tuple[dict, str, str]:
-    """Return (cipher_blob, inner_signature, outer_signature)."""
+    """Return (cipher_blob, inner_signature, outer_envelope_signature).
+
+    Outer signature is v2: covers full envelope (mode=envelope, reply_to,
+    correlation_id, nonce, timestamp, cipher_blob).
+    """
     inner_sig = sign_message(
         sender_key_pem,
         f"oneshot:{correlation_id}",
@@ -69,14 +78,15 @@ def _make_cipher_blob(
         recipient_pubkey_pem, payload, inner_sig,
         f"oneshot:{correlation_id}", sender_agent_id, client_seq=0,
     )
-    outer_sig = sign_message(
+    outer_sig = sign_oneshot_envelope(
         sender_key_pem,
-        f"oneshot:{correlation_id}",
-        sender_agent_id,
-        nonce,
-        timestamp,
-        cipher_blob,
-        client_seq=0,
+        correlation_id=correlation_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=timestamp,
+        mode="envelope",
+        reply_to=reply_to,
+        payload=cipher_blob,
     )
     return cipher_blob, inner_sig, outer_sig
 
@@ -120,6 +130,7 @@ async def test_broker_accepts_envelope_mode(client: AsyncClient):
         "timestamp": ts,
         "mode": "envelope",
         "ttl_seconds": 300,
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
     }
     r = await client.post(
         "/v1/broker/oneshot/forward", json=body,
@@ -180,6 +191,7 @@ async def test_broker_rejects_tampered_outer_signature_envelope(
         "timestamp": ts,
         "mode": "envelope",
         "ttl_seconds": 300,
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
     }
     r = await client.post(
         "/v1/broker/oneshot/forward", json=body,
@@ -218,6 +230,7 @@ async def test_sdk_decrypt_oneshot_envelope_roundtrip(client: AsyncClient):
     )
 
     envelope_json = json.dumps({
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
         "mode": "envelope",
         "payload": cipher_blob,
         "signature": _outer,
@@ -406,11 +419,18 @@ def test_send_oneshot_and_wait_returns_reply():
             alice_pubkey, reply_plain, inner,
             f"oneshot:{reply_corr}", "envt7::bob", client_seq=0,
         )
-        outer = sign_message(
-            bob_priv, f"oneshot:{reply_corr}", "envt7::bob",
-            reply_nonce, reply_ts, cipher, client_seq=0,
+        outer = sign_oneshot_envelope(
+            bob_priv,
+            correlation_id=reply_corr,
+            sender_agent_id="envt7::bob",
+            nonce=reply_nonce,
+            timestamp=reply_ts,
+            mode="envelope",
+            reply_to=request_corr,
+            payload=cipher,
         )
         env = {
+            "v": ONESHOT_ENVELOPE_PROTO_VERSION,
             "mode": "envelope",
             "payload": cipher,
             "signature": outer,

--- a/tests/test_oneshot_intra.py
+++ b/tests/test_oneshot_intra.py
@@ -17,7 +17,11 @@ from cryptography.hazmat.primitives import serialization
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 
-from cullis_sdk.crypto.message_signer import sign_message
+from cullis_sdk.crypto.message_signer import (
+    ONESHOT_ENVELOPE_PROTO_VERSION,
+    sign_message,
+    sign_oneshot_envelope,
+)
 from tests.cert_factory import make_agent_cert
 
 
@@ -105,14 +109,15 @@ def _build_send_body(
     corr_id = correlation_id or str(uuid.uuid4())
     nonce = str(uuid.uuid4())
     ts = int(time.time())
-    sig = sign_message(
+    sig = sign_oneshot_envelope(
         sender_priv,
-        f"oneshot:{corr_id}",
-        sender_agent_id,
-        nonce,
-        ts,
-        payload,
-        client_seq=0,
+        correlation_id=corr_id,
+        sender_agent_id=sender_agent_id,
+        nonce=nonce,
+        timestamp=ts,
+        mode="mtls-only",
+        reply_to=reply_to,
+        payload=payload,
     )
     body = {
         "recipient_id": recipient_id,
@@ -124,6 +129,7 @@ def _build_send_body(
         "nonce": nonce,
         "timestamp": ts,
         "ttl_seconds": ttl_seconds,
+        "v": ONESHOT_ENVELOPE_PROTO_VERSION,
     }
     return body, corr_id
 


### PR DESCRIPTION
## Summary

Closes the EUDI-class **F-A-1** and high-severity **F-A-3** findings from
the 2026-04-17 crypto audit (`imp/audit_2026_04_17/phase1_A_crypto.md`).

The v1 one-shot envelope signature covered only `payload`. Every other
field the broker and local stores persist alongside it — `mode`,
`reply_to`, `correlation_id`, `timestamp`, `nonce` — lived outside the
signed region. An attacker with DB/process access could rewrite any of
them undetected. Most critically, flipping `mode` from `envelope` to
`mtls-only` caused the recipient SDK (`cullis_sdk/client.py:892`) to
return the attacker-chosen plaintext with `sender_verified=False`, and
`send_oneshot_and_wait` propagated that flag without ever blocking on
it.

This PR:

- Introduces a **v2 canonical envelope signature** covering the full
  envelope identity:
  `oneshot-env:v2|<corr>|<sender>|<nonce>|<ts>|<mode>|<reply_to>|<payload>`.
  Domain-separated from the v1 `oneshot:<corr>` prefix so v1 sigs
  cannot satisfy a v2 verify.
- Adds `compute_oneshot_envelope_sig_input`, `sign_oneshot_envelope`,
  and `verify_oneshot_envelope_signature` helpers in **both**
  `app/auth/message_signer.py` and `cullis_sdk/crypto/message_signer.py`
  (identical canonical form — server/SDK interop stays trivial).
- Senders emit `v=2`; broker ingest and recipient SDK `decrypt_oneshot`
  hard-reject anything else (no mixed fleet — product is pre-release,
  broker and SDK ship together).
- `decrypt_oneshot` no longer defaults `mode` to `mtls-only`. Missing
  `mode` or any invalid field raises. Signature verification is
  **unconditional** for both `mtls-only` and `envelope` modes
  (`mtls-only` describes key-wrap, not auth scope).
- `send_oneshot_and_wait` raises `ValueError` rather than returning
  unverified plaintext. A dormant `allow_unverified=False` kwarg is
  reserved for future transports where the SDK genuinely cannot see
  the sender's public key; no caller today should pass it.
- Broker `_build_envelope_json` and proxy `_serialize_envelope`
  include `v` so recipients gate on it. Proxy → broker bridge
  (`send_oneshot`) now propagates `mode` and `v` (previously it hard-
  coded `mtls-only`, which silently broke envelope-mode cross-org
  through the proxy path).

No TS SDK mirror was touched — the TS SDK under `sdk-ts/src/` does not
implement one-shot today. F-A-2 (canonical JSON drift) is owned by a
separate PR and this change uses whatever canonical JSON helper is in
place — the fix will auto-benefit once F-A-2 lands.

## Threat model

Attack class: message-layer tamper from an attacker with DB/process
access to the broker or a proxy. Directly relevant to EUDI-style
regulated cross-org messaging where the broker is in-trust but not
fully trusted.

Concrete v1 exploit (pre-fix):

1. Legitimate sender posts a cross-org `envelope`-mode message carrying
   a cipher_blob Alice → Bob.
2. Broker (or a DB-adjacent actor) opens the row and rewrites the
   stored envelope to `{"mode":"mtls-only","payload":{...arbitrary...}}`
   with the original `signature`/`nonce`/`timestamp` intact.
3. Bob's proxy mirrors the row verbatim into its local inbox.
4. Bob's SDK `decrypt_oneshot` hits `mode == "mtls-only"` and returns
   `envelope["payload"]` — the attacker-chosen plaintext — with
   `sender_verified=False` but no exception.
5. Higher-level callers (`send_oneshot_and_wait`) pass the flag
   through as data; nothing blocks on it.

v2 mitigation: the outer signature covers `mode`, so any rewrite
invalidates it. `decrypt_oneshot` verifies unconditionally and raises
on failure. `send_oneshot_and_wait` refuses to return unauthenticated
data. Belt-and-braces: v1 envelopes are hard-rejected so an attacker
cannot strip `v` to downgrade.

## Test plan

- [x] `pytest tests/test_oneshot_intra.py tests/test_oneshot_cross.py tests/test_oneshot_cross_envelope.py tests/test_audit_oneshot_envelope_integrity.py -n auto --dist=loadfile` — 50/50 green.
- [x] Full suite: `pytest tests/ -n auto --dist=loadfile` — 1040 passed, 15 skipped. Two pre-existing postgres failures (`test_pg_session_and_signed_messages`, `test_pg_nonce_replay_blocked`) also fail on main, unrelated DPoP auth issue.
- [x] `./demo_network/smoke.sh full` — all assertions PASS (hash chain, dashboard, MCP round-trip).
- [x] New regression suite `tests/test_audit_oneshot_envelope_integrity.py` covers:
  - attacker-rewritten `mtls-only` with no signature → reject
  - missing `mode` → reject
  - v1 envelope → reject
  - flipped `mode` / `correlation_id` / `reply_to` / `timestamp` / `nonce` / `payload` → reject
  - valid v2 mtls-only round-trip → accept
  - broker ingest rejects flipped `mode`, flipped `reply_to`, v1 envelope
  - `send_oneshot_and_wait` raises if `sender_verified=False`

## Design decisions to review

1. **Protocol bump to `v=2` with hard reject of `v=1`.** The product
   ships broker + SDK in lockstep, no deployed fleet to migrate. If
   that changes we can add a short acceptance window; for now the
   hardest gate is the cleanest.
2. **TS SDK scope.** `sdk-ts/src/` has no one-shot code today, so
   nothing to port. When one-shot lands in TS it must mirror the v2
   canonical form verbatim.
3. **`allow_unverified=False` kwarg on `send_oneshot_and_wait`.**
   Reserved for future transports (e.g., a pure mTLS path where
   sender identity is bound by certificate not signature). Default
   is False; today there is no code path that legitimately sets it.
   Happy to remove it entirely if you prefer a stricter surface.