### PR TITLE
feat(adr-009): post-proxy-boot mastio_pubkey pinning (Phase 2 / PR 2b)

### DIFF
--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -497,6 +497,41 @@ async def approve_org(
             "message": f"Organization '{org_id}' approved."}
 
 
+class MastioPubkeyPatch(BaseModel):
+    mastio_pubkey: str | None = Field(None, max_length=1024)
+
+
+@admin_router.patch("/orgs/{org_id}/mastio-pubkey",
+                    dependencies=[Depends(_require_admin)])
+async def patch_org_mastio_pubkey(
+    org_id: str,
+    body: MastioPubkeyPatch,
+    db: AsyncSession = Depends(get_db),
+):
+    """ADR-009 Phase 2 — pin or clear the mastio ES256 counter-signature
+    pubkey for an existing org. Enables the counter-sig enforcement flow
+    post-proxy-boot (when the proxy generates its mastio identity after
+    the broker onboarding has already completed).
+
+    Body ``{mastio_pubkey: null}`` clears the column → reverts to legacy.
+    """
+    org = await get_org_by_id(db, org_id)
+    if org is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    _validate_mastio_pubkey(body.mastio_pubkey)
+    await update_org_mastio_pubkey(db, org_id, body.mastio_pubkey)
+    await log_event(
+        db, "admin.mastio_pubkey_patched", "ok",
+        org_id=org_id,
+        details={"cleared": body.mastio_pubkey is None},
+    )
+    return {
+        "org_id": org_id,
+        "mastio_pubkey_set": body.mastio_pubkey is not None,
+    }
+
+
 @admin_router.post("/orgs/{org_id}/reject",
                    dependencies=[Depends(_require_admin)])
 async def reject_org(

--- a/enterprise_sandbox/bootstrap/Dockerfile
+++ b/enterprise_sandbox/bootstrap/Dockerfile
@@ -4,5 +4,6 @@ RUN pip install --no-cache-dir httpx==0.27.2 cryptography==43.0.1 asyncpg==0.29.
 
 WORKDIR /app
 COPY bootstrap.py /app/bootstrap.py
+COPY bootstrap_mastio.py /app/bootstrap_mastio.py
 
 ENTRYPOINT ["python", "/app/bootstrap.py"]

--- a/enterprise_sandbox/bootstrap/bootstrap_mastio.py
+++ b/enterprise_sandbox/bootstrap/bootstrap_mastio.py
@@ -1,0 +1,146 @@
+"""ADR-009 Phase 2 — pin each proxy's mastio_pubkey on the Court.
+
+Runs **after** the proxies have booted and generated their Mastio CA +
+leaf identity (lifespan hook in ``mcp_proxy/main.py``). The main
+bootstrap container ran before the proxies, so it couldn't know the
+mastio pubkey yet — this is a second-phase one-shot that closes that
+loop, enabling the Court's counter-signature enforcement on every
+subsequent ``/v1/auth/token`` call.
+
+Flow per proxy:
+  1. poll ``GET /v1/admin/mastio-pubkey`` on the proxy (with X-Admin-Secret)
+     until it returns a non-null PEM (first boot may still be finalizing)
+  2. ``PATCH /v1/admin/orgs/{org_id}/mastio-pubkey`` on the Court with
+     the PEM — pin it under the admin secret.
+
+Idempotent: re-running the container just re-PATCHes the same pubkey.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import httpx
+
+
+BROKER_URL   = os.environ.get("BROKER_URL", "http://broker:8000")
+ADMIN_SECRET = os.environ["ADMIN_SECRET"]
+
+# Per-org proxy URL + proxy admin secret. Sandbox uses the broker's
+# admin secret for simplicity — in prod each proxy carries its own.
+PROXIES = [
+    {
+        "org_id":       "orga",
+        "proxy_url":    os.environ.get("PROXY_A_URL", "http://proxy-a:9100"),
+        "admin_secret": os.environ.get("PROXY_A_ADMIN_SECRET", ADMIN_SECRET),
+    },
+    {
+        "org_id":       "orgb",
+        "proxy_url":    os.environ.get("PROXY_B_URL", "http://proxy-b:9200"),
+        "admin_secret": os.environ.get("PROXY_B_ADMIN_SECRET", ADMIN_SECRET),
+    },
+]
+
+RESET = "\033[0m"
+BOLD  = "\033[1m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED   = "\033[31m"
+CYAN  = "\033[36m"
+GRAY  = "\033[90m"
+
+
+def _log(sym: str, color: str, msg: str) -> None:
+    print(f"  {color}{sym}{RESET} {msg}", flush=True)
+
+
+def _ok(msg: str) -> None:
+    _log("✓", GREEN, msg)
+
+
+def _warn(msg: str) -> None:
+    _log("⚠", YELLOW, msg)
+
+
+def _fail(msg: str) -> None:
+    _log("✗", RED, msg)
+
+
+def _info(msg: str) -> None:
+    _log("…", GRAY, msg)
+
+
+def _fetch_mastio_pubkey(
+    client: httpx.Client, proxy_url: str, admin_secret: str,
+    timeout_s: float = 120.0,
+) -> str:
+    """Poll the proxy until mastio_pubkey is populated. Fails with
+    ``SystemExit`` if the deadline elapses."""
+    deadline = time.monotonic() + timeout_s
+    last_err = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            r = client.get(
+                f"{proxy_url}/v1/admin/mastio-pubkey",
+                headers={"X-Admin-Secret": admin_secret},
+                timeout=5.0,
+            )
+            if r.status_code == 200:
+                pem = r.json().get("mastio_pubkey")
+                if pem:
+                    return pem
+                last_err = "mastio_pubkey still null (first boot finalizing)"
+            else:
+                last_err = f"HTTP {r.status_code}: {r.text[:120]}"
+        except httpx.TransportError as exc:
+            last_err = f"connection: {exc}"
+        time.sleep(1.0)
+    _fail(f"timeout fetching mastio_pubkey from {proxy_url} — last: {last_err}")
+    raise SystemExit(1)
+
+
+def _pin_on_court(
+    client: httpx.Client, org_id: str, pem: str,
+) -> None:
+    r = client.patch(
+        f"{BROKER_URL}/v1/admin/orgs/{org_id}/mastio-pubkey",
+        headers={"X-Admin-Secret": ADMIN_SECRET},
+        json={"mastio_pubkey": pem},
+        timeout=10.0,
+    )
+    if r.status_code != 200:
+        _fail(
+            f"court PATCH failed for {org_id}: "
+            f"HTTP {r.status_code} {r.text[:200]}",
+        )
+        raise SystemExit(1)
+
+
+def main() -> int:
+    print(
+        f"\n{BOLD}{CYAN}═══ ADR-009 Phase 2 — pin mastio_pubkey on Court "
+        f"{'═' * 10}{RESET}\n",
+        flush=True,
+    )
+    with httpx.Client(timeout=10.0) as client:
+        for cfg in PROXIES:
+            org_id = cfg["org_id"]
+            _info(f"fetching mastio_pubkey from {BOLD}{cfg['proxy_url']}{RESET}")
+            pem = _fetch_mastio_pubkey(
+                client, cfg["proxy_url"], cfg["admin_secret"],
+            )
+            preview = pem.split("\n")[1][:40] if "\n" in pem else pem[:40]
+            _ok(f"{org_id}: pubkey fetched ({preview}…)")
+
+            _info(f"pinning on Court for {BOLD}{org_id}{RESET}")
+            _pin_on_court(client, org_id, pem)
+            _ok(f"{org_id}: mastio_pubkey pinned — counter-sig enforcement active")
+
+    print(f"\n{BOLD}{GREEN}✓ ADR-009 mastio identities pinned on Court{RESET}\n",
+          flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -593,3 +593,25 @@ services:
       interval: 5s
       timeout: 3s
       retries: 10
+
+  # ── ADR-009 Phase 2 — pin mastio_pubkey on Court post-proxy-boot ──────────
+
+  bootstrap-mastio:
+    build: ./bootstrap
+    depends_on:
+      broker:
+        condition: service_healthy
+      proxy-a:
+        condition: service_healthy
+      proxy-b:
+        condition: service_healthy
+    command: ["python", "/app/bootstrap_mastio.py"]
+    environment:
+      BROKER_URL:            "http://broker:8000"
+      ADMIN_SECRET:          "sandbox-admin-secret-change-me"
+      PROXY_A_URL:           "http://proxy-a:9100"
+      PROXY_A_ADMIN_SECRET:  "sandbox-proxy-admin-a"
+      PROXY_B_URL:           "http://proxy-b:9200"
+      PROXY_B_ADMIN_SECRET:  "sandbox-proxy-admin-b"
+    networks: [public-wan]
+    restart: "no"

--- a/tests/test_adr009_phase2_patch_mastio_pubkey.py
+++ b/tests/test_adr009_phase2_patch_mastio_pubkey.py
@@ -1,0 +1,148 @@
+"""ADR-009 Phase 2 PR 2b — Court admin endpoint for pinning the mastio
+public key on an existing org (post-proxy-boot flow).
+
+Covers:
+  - PATCH /v1/admin/orgs/{id}/mastio-pubkey under admin secret pins a
+    valid EC P-256 PEM
+  - Clear with body {mastio_pubkey: null} reverts to legacy
+  - Non-P-256 key rejected (400)
+  - Malformed PEM rejected (400)
+  - Missing admin secret → 403
+  - Unknown org → 404
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from app.config import get_settings
+from tests.cert_factory import get_org_ca_pem
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN_SECRET = get_settings().admin_secret
+
+
+def _gen_p256_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _gen_rsa_pem() -> str:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+async def _create_org(client: AsyncClient, org_id: str) -> None:
+    """Create an org with CA — mirror the onboarding flow used by sandbox."""
+    invite = await client.post(
+        "/v1/admin/invites",
+        json={"label": org_id, "ttl_hours": 1},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    token = invite.json()["token"]
+    await client.post("/v1/onboarding/join", json={
+        "org_id": org_id,
+        "display_name": org_id,
+        "secret": f"{org_id}-secret",
+        "ca_certificate": get_org_ca_pem(org_id),
+        "invite_token": token,
+    })
+
+
+async def _fetch_pubkey(org_id: str) -> str | None:
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import get_org_by_id
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        return org.mastio_pubkey if org else None
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+async def test_patch_pins_mastio_pubkey(client: AsyncClient):
+    await _create_org(client, "patch-ok")
+    pem = _gen_p256_pem()
+    r = await client.patch(
+        "/v1/admin/orgs/patch-ok/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": pem},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["org_id"] == "patch-ok"
+    assert body["mastio_pubkey_set"] is True
+    assert await _fetch_pubkey("patch-ok") == pem
+
+
+async def test_patch_clear_reverts_to_legacy(client: AsyncClient):
+    await _create_org(client, "patch-clear")
+    pem = _gen_p256_pem()
+    await client.patch(
+        "/v1/admin/orgs/patch-clear/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": pem},
+    )
+    r = await client.patch(
+        "/v1/admin/orgs/patch-clear/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": None},
+    )
+    assert r.status_code == 200
+    assert r.json()["mastio_pubkey_set"] is False
+    assert await _fetch_pubkey("patch-clear") is None
+
+
+# ── validation ─────────────────────────────────────────────────────────
+
+async def test_patch_rejects_rsa(client: AsyncClient):
+    await _create_org(client, "patch-rsa")
+    r = await client.patch(
+        "/v1/admin/orgs/patch-rsa/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": _gen_rsa_pem()},
+    )
+    assert r.status_code == 400
+    assert "P-256" in r.json()["detail"]
+
+
+async def test_patch_rejects_malformed_pem(client: AsyncClient):
+    await _create_org(client, "patch-bad")
+    r = await client.patch(
+        "/v1/admin/orgs/patch-bad/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={
+            "mastio_pubkey":
+                "-----BEGIN PUBLIC KEY-----\nnot-base64\n-----END PUBLIC KEY-----\n",
+        },
+    )
+    assert r.status_code == 400
+
+
+# ── auth ───────────────────────────────────────────────────────────────
+
+async def test_patch_requires_admin_secret(client: AsyncClient):
+    await _create_org(client, "patch-auth")
+    r = await client.patch(
+        "/v1/admin/orgs/patch-auth/mastio-pubkey",
+        headers={"x-admin-secret": "wrong"},
+        json={"mastio_pubkey": _gen_p256_pem()},
+    )
+    assert r.status_code == 403
+
+
+async def test_patch_unknown_org_returns_404(client: AsyncClient):
+    r = await client.patch(
+        "/v1/admin/orgs/does-not-exist/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": _gen_p256_pem()},
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
Second PR of ADR-009 Phase 2 — **closes the sandbox loop**.

Phase 2 PR 2a (#158) wired the proxy signing path. This PR adds the final leg: after the proxies boot and generate their Mastio CA + leaf (PR 1a lifespan hook), a new sandbox one-shot fetches the mastio pubkey and pins it on the Court via a new admin endpoint. From that point on the Court enforces the counter-signature for every \`/v1/auth/token\` call for that org.

## Summary

- **Court**: new \`PATCH /v1/admin/orgs/{org_id}/mastio-pubkey\` (admin secret). Validates PEM + EC P-256 curve, clears on \`null\`, audits.
- **Sandbox**: \`bootstrap/bootstrap_mastio.py\` polls \`/v1/admin/mastio-pubkey\` on each proxy (up to 120s) then PATCHes the Court. Idempotent.
- **docker-compose**: new \`bootstrap-mastio\` service with \`depends_on\` on both proxies' \`service_healthy\` + broker.

## Phase 2 status

With this PR, Phase 1 + Phase 2 chain is complete end-to-end in the sandbox:
1. Bootstrap registers orgs on Court (no mastio_pubkey yet)
2. proxy-init writes Org CA to proxy_config
3. proxy-a/b boot, generate Mastio CA + leaf
4. bootstrap-mastio fetches + pins on Court
5. Every subsequent agent login is counter-sig-enforced

## Test plan

- [x] \`pytest tests/test_adr009_phase2_patch_mastio_pubkey.py\` — 6/6 (happy pin, clear, RSA reject, malformed PEM, auth 403, unknown org 404)
- [x] Full suite: 1052 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS all scenarios
- [ ] Manual sandbox smoke: \`./enterprise_sandbox/demo.sh up\` — to be run after merge (enterprise sandbox is not a CI gate)