### PR TITLE
feat(adr-009): strict requires_proxy flag (Phase 3)

### DIFF
--- a/alembic/versions/h8c9d0e1f2a3_add_org_requires_proxy.py
+++ b/alembic/versions/h8c9d0e1f2a3_add_org_requires_proxy.py
@@ -1,0 +1,45 @@
+"""add org.requires_proxy for ADR-009 Phase 3 strict enforcement
+
+Revision ID: h8c9d0e1f2a3
+Revises: g7b8c9d0e1f2
+Create Date: 2026-04-17 11:50:00.000000
+
+Adds a non-nullable ``requires_proxy`` BOOLEAN column (default FALSE) to
+``organizations``. When set, /v1/auth/token for that org rejects any
+request that doesn't carry a valid X-Cullis-Mastio-Signature — even if
+mastio_pubkey is somehow null. Closes the last legacy path: an org can
+now explicitly declare "no agent may bypass the mastio".
+
+Default FALSE preserves backward compatibility — every existing org
+keeps the soft enforcement introduced in Phase 1 (enforce only if
+mastio_pubkey is pinned). Phase 4 will migrate appropriate orgs to
+TRUE and remove the legacy soft path entirely.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'h8c9d0e1f2a3'
+down_revision: Union[str, Sequence[str], None] = 'g7b8c9d0e1f2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        'organizations',
+        sa.Column(
+            'requires_proxy',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('organizations', 'requires_proxy')

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -61,26 +61,44 @@ async def issue_token(
         span.set_attribute("agent.id", agent_id)
         span.set_attribute("org.id", org_id)
 
-        # ── ADR-009 Phase 1 — mastio counter-signature ───────────────────────
-        # If the org has pinned a mastio public key at onboarding, every
-        # login for that org must carry an ES256 signature over the raw
-        # client_assertion. NULL column = legacy mode (skipped).
+        # ── ADR-009 Phase 1/3 — mastio counter-signature ─────────────────────
+        # Phase 1 soft: org with pinned mastio_pubkey must carry a valid
+        # X-Cullis-Mastio-Signature; NULL pubkey was legacy-allowed.
+        # Phase 3 strict: when requires_proxy=true the org refuses the login
+        # even if mastio_pubkey is somehow NULL — prevents the legacy path
+        # from being a bypass after the org has declared "proxy-only".
         org_record = await get_org_by_id(db, org_id)
-        if org_record is not None and org_record.mastio_pubkey:
-            try:
-                verify_mastio_countersig(
-                    client_assertion=body.client_assertion,
-                    signature_b64=mastio_signature,
-                    mastio_pubkey_pem=org_record.mastio_pubkey,
-                )
-            except HTTPException:
-                AUTH_DENY_COUNTER.add(1, {"reason": "mastio_countersig"})
+        if org_record is not None:
+            if org_record.requires_proxy and not org_record.mastio_pubkey:
+                AUTH_DENY_COUNTER.add(1, {"reason": "requires_proxy_no_pubkey"})
                 await log_event(
                     db, "auth.token_request", "denied",
                     agent_id=agent_id, org_id=org_id,
-                    details={"reason": "mastio_countersig_missing_or_invalid"},
+                    details={"reason": "requires_proxy_true_but_no_mastio_pubkey"},
                 )
-                raise
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=(
+                        "organization requires proxy-mediated login but no "
+                        "mastio_pubkey is pinned — admin must pin the key "
+                        "before enabling requires_proxy"
+                    ),
+                )
+            if org_record.mastio_pubkey:
+                try:
+                    verify_mastio_countersig(
+                        client_assertion=body.client_assertion,
+                        signature_b64=mastio_signature,
+                        mastio_pubkey_pem=org_record.mastio_pubkey,
+                    )
+                except HTTPException:
+                    AUTH_DENY_COUNTER.add(1, {"reason": "mastio_countersig"})
+                    await log_event(
+                        db, "auth.token_request", "denied",
+                        agent_id=agent_id, org_id=org_id,
+                        details={"reason": "mastio_countersig_missing_or_invalid"},
+                    )
+                    raise
 
         # ── Agent checks ─────────────────────────────────────────────────────
         agent = await get_agent_by_id(db, agent_id)

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -27,6 +27,7 @@ from app.registry.org_store import (
     register_org,
     update_org_ca_cert,
     update_org_mastio_pubkey,
+    update_org_requires_proxy,
     update_org_secret,
     update_org_trust_domain,
     update_org_webhook,
@@ -501,6 +502,48 @@ class MastioPubkeyPatch(BaseModel):
     mastio_pubkey: str | None = Field(None, max_length=1024)
 
 
+class RequiresProxyPatch(BaseModel):
+    requires_proxy: bool
+
+
+@admin_router.patch("/orgs/{org_id}/requires-proxy",
+                    dependencies=[Depends(_require_admin)])
+async def patch_org_requires_proxy(
+    org_id: str,
+    body: RequiresProxyPatch,
+    db: AsyncSession = Depends(get_db),
+):
+    """ADR-009 Phase 3 — flip the strict-enforcement flag on an org.
+
+    When ``requires_proxy=true`` and ``mastio_pubkey`` is NULL the org
+    rejects the request as misconfigured (see /v1/auth/token). Admin
+    must pin a mastio_pubkey first, then flip this flag, to close the
+    legacy (NULL-pubkey) bypass.
+    """
+    org = await get_org_by_id(db, org_id)
+    if org is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    # Safety: refuse to enable when no pubkey is pinned, so the admin can't
+    # lock themselves out of /auth/token for this org.
+    if body.requires_proxy and not org.mastio_pubkey:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail=(
+                "cannot enable requires_proxy while mastio_pubkey is unpinned — "
+                "PATCH /v1/admin/orgs/{id}/mastio-pubkey first"
+            ),
+        )
+
+    await update_org_requires_proxy(db, org_id, body.requires_proxy)
+    await log_event(
+        db, "admin.requires_proxy_patched", "ok",
+        org_id=org_id,
+        details={"requires_proxy": body.requires_proxy},
+    )
+    return {"org_id": org_id, "requires_proxy": body.requires_proxy}
+
+
 @admin_router.patch("/orgs/{org_id}/mastio-pubkey",
                     dependencies=[Depends(_require_admin)])
 async def patch_org_mastio_pubkey(
@@ -518,6 +561,17 @@ async def patch_org_mastio_pubkey(
     org = await get_org_by_id(db, org_id)
     if org is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    # Safety — don't strip the pubkey while the strict flag is on, it
+    # would lock every agent of this org out of /auth/token.
+    if body.mastio_pubkey is None and org.requires_proxy:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail=(
+                "cannot clear mastio_pubkey while requires_proxy is true — "
+                "disable requires_proxy first"
+            ),
+        )
 
     _validate_mastio_pubkey(body.mastio_pubkey)
     await update_org_mastio_pubkey(db, org_id, body.mastio_pubkey)

--- a/app/registry/org_store.py
+++ b/app/registry/org_store.py
@@ -18,6 +18,7 @@ by any code path. The helpers that used to read/write it were removed.
 import json
 import bcrypt
 from datetime import datetime, timezone
+import sqlalchemy as sa
 from sqlalchemy import Column, String, DateTime, Text, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -46,9 +47,16 @@ class OrganizationRecord(Base):
     trust_domain = Column(String(256), nullable=True, unique=True, index=True)
     # ADR-009 Phase 1 — mastio/proxy ES256 public key (PEM). When set, the
     # Court enforces an ``X-Cullis-Mastio-Signature`` counter-signature on
-    # auth requests for this org. NULL keeps legacy (agent-direct) behavior
-    # until Phase 3 makes it mandatory.
+    # auth requests for this org. NULL keeps legacy (agent-direct) behavior.
     mastio_pubkey = Column(Text, nullable=True)
+    # ADR-009 Phase 3 — strict enforcement flag. When TRUE, /v1/auth/token
+    # rejects ANY request missing a valid counter-sig — even if
+    # mastio_pubkey is somehow null (misconfiguration). Closes the last
+    # legacy path. FALSE preserves Phase 1 soft enforcement (enforce only
+    # if pubkey is pinned). Default FALSE keeps pre-ADR-009 orgs working.
+    requires_proxy = Column(
+        sa.Boolean, nullable=False, default=False, server_default=sa.false(),
+    )
 
     def verify_secret(self, plain: str) -> bool:
         return bcrypt.checkpw(plain.encode(), self.secret_hash.encode())
@@ -82,6 +90,7 @@ async def register_org(
     status: str = "active",
     trust_domain: str | None = None,
     mastio_pubkey: str | None = None,
+    requires_proxy: bool = False,
 ) -> OrganizationRecord:
     record = OrganizationRecord(
         org_id=org_id,
@@ -92,6 +101,7 @@ async def register_org(
         status=status,
         trust_domain=trust_domain,
         mastio_pubkey=mastio_pubkey,
+        requires_proxy=requires_proxy,
     )
     db.add(record)
     await db.commit()
@@ -168,6 +178,21 @@ async def update_org_mastio_pubkey(
     if record is None:
         return None
     record.mastio_pubkey = mastio_pubkey
+    await db.commit()
+    await db.refresh(record)
+    return record
+
+
+async def update_org_requires_proxy(
+    db: AsyncSession,
+    org_id: str,
+    requires_proxy: bool,
+) -> OrganizationRecord | None:
+    """Flip the ADR-009 Phase 3 strict-enforcement flag on an org."""
+    record = await get_org_by_id(db, org_id)
+    if record is None:
+        return None
+    record.requires_proxy = requires_proxy
     await db.commit()
     await db.refresh(record)
     return record

--- a/tests/test_adr009_phase3_requires_proxy.py
+++ b/tests/test_adr009_phase3_requires_proxy.py
@@ -1,0 +1,208 @@
+"""ADR-009 Phase 3 — strict enforcement flag ``requires_proxy``.
+
+Covers:
+  - PATCH /v1/admin/orgs/{id}/requires-proxy flips the flag (needs admin)
+  - Enabling requires_proxy without mastio_pubkey → 409 (safety)
+  - Clearing mastio_pubkey while requires_proxy=true → 409 (safety)
+  - /v1/auth/token with requires_proxy=true and NULL pubkey → 403
+    (bogus DB state — defensive path exists)
+  - /v1/auth/token with requires_proxy=true + pinned pubkey works like
+    Phase 1 (valid countersig → 200, missing → 403)
+  - Legacy org (requires_proxy=false, pubkey NULL) still works without
+    any header
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+
+from tests.cert_factory import make_assertion, get_org_ca_pem
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = pytest.mark.asyncio
+
+
+def _gen_mastio() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub
+
+
+def _sign(priv: ec.EllipticCurvePrivateKey, data: bytes) -> str:
+    s = priv.sign(data, ec.ECDSA(hashes.SHA256()))
+    return base64.urlsafe_b64encode(s).rstrip(b"=").decode()
+
+
+async def _prime_nonce(client: AsyncClient, dpop) -> None:
+    resp = await client.get("/health")
+    dpop._update_nonce(resp)
+
+
+async def _full_register(
+    client: AsyncClient,
+    agent_id: str,
+    org_id: str,
+    *,
+    mastio_pubkey: str | None = None,
+    requires_proxy: bool = False,
+) -> None:
+    """Register org + agent + binding. Directly mutate the ADR-009 columns
+    after the basic flow to avoid coupling with public onboarding endpoints."""
+    org_secret = org_id + "-secret"
+    await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": get_org_ca_pem(org_id)},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    await client.post("/v1/registry/agents", json={
+        "agent_id": agent_id,
+        "org_id": org_id,
+        "display_name": f"Test {agent_id}",
+        "capabilities": ["test.read"],
+    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    r = await client.post("/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = r.json()["id"]
+    await client.post(
+        f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import (
+        update_org_mastio_pubkey, update_org_requires_proxy,
+    )
+    async with AsyncSessionLocal() as db:
+        if mastio_pubkey is not None:
+            await update_org_mastio_pubkey(db, org_id, mastio_pubkey)
+        if requires_proxy:
+            await update_org_requires_proxy(db, org_id, True)
+
+
+# ── PATCH /requires-proxy ──────────────────────────────────────────────
+
+async def test_patch_requires_proxy_requires_pubkey_first(client: AsyncClient):
+    """Enabling requires_proxy without a pinned pubkey → 409 safety check."""
+    from app.config import get_settings
+    admin = get_settings().admin_secret
+    await _full_register(client, "rp-noup::a", "rp-noup")
+
+    r = await client.patch(
+        "/v1/admin/orgs/rp-noup/requires-proxy",
+        headers={"x-admin-secret": admin},
+        json={"requires_proxy": True},
+    )
+    assert r.status_code == 409
+    assert "mastio_pubkey" in r.json()["detail"]
+
+
+async def test_patch_requires_proxy_ok_when_pubkey_pinned(client: AsyncClient):
+    from app.config import get_settings
+    admin = get_settings().admin_secret
+    _, pub = _gen_mastio()
+    await _full_register(
+        client, "rp-ok::a", "rp-ok", mastio_pubkey=pub,
+    )
+
+    r = await client.patch(
+        "/v1/admin/orgs/rp-ok/requires-proxy",
+        headers={"x-admin-secret": admin},
+        json={"requires_proxy": True},
+    )
+    assert r.status_code == 200
+    assert r.json()["requires_proxy"] is True
+
+
+async def test_patch_cannot_clear_pubkey_while_strict(client: AsyncClient):
+    """Clearing mastio_pubkey with requires_proxy=true → 409."""
+    from app.config import get_settings
+    admin = get_settings().admin_secret
+    _, pub = _gen_mastio()
+    await _full_register(
+        client, "rp-lock::a", "rp-lock",
+        mastio_pubkey=pub, requires_proxy=True,
+    )
+
+    r = await client.patch(
+        "/v1/admin/orgs/rp-lock/mastio-pubkey",
+        headers={"x-admin-secret": admin},
+        json={"mastio_pubkey": None},
+    )
+    assert r.status_code == 409
+    assert "requires_proxy" in r.json()["detail"]
+
+
+# ── /auth/token behavior ───────────────────────────────────────────────
+
+async def test_token_strict_with_valid_countersig(client: AsyncClient, dpop):
+    await _prime_nonce(client, dpop)
+    priv, pub = _gen_mastio()
+    org_id = "rp-auth-ok"
+    agent_id = f"{org_id}::bot"
+    await _full_register(
+        client, agent_id, org_id,
+        mastio_pubkey=pub, requires_proxy=True,
+    )
+    assertion = make_assertion(agent_id, org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+    sig = _sign(priv, assertion.encode())
+
+    r = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={
+            "DPoP": dpop_proof,
+            "X-Cullis-Mastio-Signature": sig,
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+async def test_token_strict_denies_missing_header(client: AsyncClient, dpop):
+    await _prime_nonce(client, dpop)
+    _, pub = _gen_mastio()
+    org_id = "rp-auth-miss"
+    agent_id = f"{org_id}::bot"
+    await _full_register(
+        client, agent_id, org_id,
+        mastio_pubkey=pub, requires_proxy=True,
+    )
+    assertion = make_assertion(agent_id, org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+
+    r = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof},
+    )
+    assert r.status_code == 403
+
+
+async def test_token_legacy_still_works_when_flag_off(client: AsyncClient, dpop):
+    await _prime_nonce(client, dpop)
+    org_id = "rp-legacy"
+    agent_id = f"{org_id}::bot"
+    # requires_proxy default False, no pubkey — legacy path
+    await _full_register(client, agent_id, org_id)
+
+    assertion = make_assertion(agent_id, org_id)
+    dpop_proof = dpop.proof("POST", "/v1/auth/token")
+
+    r = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop_proof},
+    )
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
Phase 3 of ADR-009 — **closes the last legacy bypass path**.

Phase 1+2 introduced soft enforcement: an org without a pinned \`mastio_pubkey\` still let logins through without any counter-sig. Phase 3 adds an opt-in strict flag so an org can declare "no agent may bypass the mastio" without leaving the soft path as an escape hatch.

## Summary

- **Schema**: \`organizations.requires_proxy\` BOOLEAN NOT NULL DEFAULT FALSE (alembic \`h8c9d0e1f2a3\`).
- **Court**: \`/v1/auth/token\` refuses with 403 when \`requires_proxy=true\` but \`mastio_pubkey=NULL\` (defensive — see below). The pinned-pubkey branch continues to run the Phase 1 soft enforcement.
- **Admin**: \`PATCH /v1/admin/orgs/{id}/requires-proxy\` flips the flag. Safety 409 refuses to enable without a pubkey pinned, and the mastio-pubkey PATCH refuses to clear while the flag is on — admins can't lock themselves out.

## Rollout

1. Pin \`mastio_pubkey\` (Phase 1/2)
2. Verify login works under counter-sig
3. Flip \`requires_proxy=true\` → legacy bypass closed

## Test plan

- [x] \`pytest tests/test_adr009_phase3_requires_proxy.py\` — 6/6 (safety 409s, strict /auth/token with/without countersig, legacy unchanged)
- [x] Full suite: 1058 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS
- [x] \`.venv/bin/alembic heads\` — single head