### PR TITLE
fix(sdk): harden TLS opt-out paths (audit follow-up post-EUDI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,42 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip-audit
+
+      - name: Ban insecure TLS opt-outs in production code
+        # Matches audit F-E-01/F-E-02 class: blanket `verify=False` or
+        # `rejectUnauthorized: false` buried in runtime code is how the
+        # EUDI wallet shipped a MITM-wide-open URLSession. Keep the
+        # guard so new code can't regress.
+        #
+        # Allow-list: tests/, enterprise_sandbox/ (dev-only), demo/,
+        # demo_network/ use self-signed fixtures deliberately. Any
+        # production surface (app/, mcp_proxy/, cullis_sdk/,
+        # cullis_connector/, agents/, sdk-ts/src/) must use the wired
+        # verify_tls flag.
+        run: |
+          set -e
+          # Regex intent: assignment only. Must NOT match the substrings
+          # inside docstrings/comments/error messages that legitimately
+          # *reference* the anti-pattern while explaining the fix.
+          py_hits=$(grep -rn --include='*.py' \
+            -E 'verify\s*=\s*False[\s,)]' \
+            app/ mcp_proxy/ cullis_sdk/ cullis_connector/ agents/ \
+            | grep -vE '^[^:]+:[0-9]+:\s*#' \
+            || true)
+          ts_hits=$(grep -rn --include='*.ts' --include='*.tsx' \
+            -E 'rejectUnauthorized\s*:\s*false|process\.env\.NODE_TLS_REJECT_UNAUTHORIZED\s*=' \
+            sdk-ts/src/ cullis_connector/ \
+            | grep -vE '^[^:]+:[0-9]+:\s*//' \
+            || true)
+          if [ -n "$py_hits" ] || [ -n "$ts_hits" ]; then
+            echo "::error::Insecure TLS opt-out detected in production code."
+            echo "$py_hits"
+            echo "$ts_hits"
+            echo ""
+            echo "Fix: wire the call through the existing verify flag"
+            echo "(e.g. ProxySettings.broker_verify_tls, CullisClient"
+            echo "verify_tls), or move the code into tests/ if it is a"
+            echo "test fixture. See imp/audit_2026_04_17/phase1_E_secrets.md"
+            echo "F-E-01/F-E-02 for the audit reference."
+            exit 1
+          fi

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -37,6 +37,47 @@ from cullis_sdk._logging import log, RED
 _PUBKEY_CACHE_TTL = 300  # seconds
 
 
+class InsecureTLSWarning(UserWarning):
+    """Raised when the SDK is configured to skip TLS verification.
+
+    Emitted once per call site; attackers on the network can forge the
+    broker's identity. Meant for dev against a local self-signed broker.
+    """
+
+
+def _check_insecure_tls(verify_tls: bool) -> None:
+    """Warn (and optionally refuse) when TLS verification is disabled.
+
+    Refuses outright when ``CULLIS_ENV=production`` and the caller has
+    NOT also opted in via ``CULLIS_SDK_ALLOW_INSECURE_TLS=1`` — two-key
+    rule so a production deploy can't silently ship with ``verify_tls
+    =False`` left in from a dev config.
+    """
+    if verify_tls:
+        return
+    import os
+    import warnings
+    if (
+        os.environ.get("CULLIS_ENV", "").lower() == "production"
+        and os.environ.get("CULLIS_SDK_ALLOW_INSECURE_TLS") != "1"
+    ):
+        raise ValueError(
+            "verify_tls=False is disabled in production. Provide a "
+            "trust store that covers the broker certificate (system CA "
+            "store or a custom httpx transport) rather than disabling "
+            "verification. Set CULLIS_SDK_ALLOW_INSECURE_TLS=1 only if "
+            "you fully own the network path and accept MITM exposure."
+        )
+    warnings.warn(
+        "CullisClient is constructed with verify_tls=False. TLS "
+        "certificate verification is disabled — any host on the "
+        "network can MITM the broker connection. Use only for local "
+        "dev against a self-signed broker.",
+        InsecureTLSWarning,
+        stacklevel=3,
+    )
+
+
 class CullisClient:
     """Client for the Cullis federated agent trust broker."""
 
@@ -47,6 +88,7 @@ class CullisClient:
         verify_tls: bool = True,
         timeout: float = 10.0,
     ) -> None:
+        _check_insecure_tls(verify_tls)
         self.base = broker_url.rstrip("/")
         self._verify_tls = verify_tls
         self._http = httpx.Client(timeout=timeout, verify=verify_tls)
@@ -167,6 +209,7 @@ class CullisClient:
             client = CullisClient.from_enrollment("https://proxy.example.com/v1/enroll/enroll_buyer_abc123")
             agents = client.discover(capabilities=["order.read"])
         """
+        _check_insecure_tls(verify_tls)
         http = httpx.Client(timeout=timeout, verify=verify_tls)
         try:
             resp = http.get(enroll_url)
@@ -1282,6 +1325,7 @@ class CullisClient:
         if webhook_url:
             body["webhook_url"] = webhook_url
 
+        _check_insecure_tls(verify_tls)
         with httpx.Client(verify=verify_tls) as client:
             resp = client.post(url, json=body)
             resp.raise_for_status()
@@ -1351,6 +1395,12 @@ class WebSocketConnection:
         ws_kwargs: dict = {"open_timeout": 5}
         if ws_url.startswith("wss://") and not self._client._verify_tls:
             ssl_ctx = _ssl.create_default_context()
+            # Python's ssl module raises ValueError if check_hostname=True
+            # is combined with verify_mode=CERT_NONE. The order below
+            # (clear check_hostname FIRST, then lower verify_mode) is
+            # required, not redundant. _check_insecure_tls in the client
+            # constructor already warned/refused; here we just mirror
+            # the HTTP-path opt-out to the WS path.
             ssl_ctx.check_hostname = False
             ssl_ctx.verify_mode = _ssl.CERT_NONE
             ws_kwargs["ssl"] = ssl_ctx

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -73,13 +73,16 @@ async function httpRequest(
   // Node 18+ supports AbortSignal.timeout
   fetchOptions.signal = AbortSignal.timeout(timeoutMs);
 
-  // Note: Node.js native fetch does not support disabling TLS verification
-  // directly. For self-signed certs, set NODE_TLS_REJECT_UNAUTHORIZED=0
-  // in the environment, or use a custom agent via undici.
-  if (!verifyTls && typeof process !== "undefined") {
-    // This is a hint for the user; the actual env var must be set externally
-    // or use the NODE_TLS_REJECT_UNAUTHORIZED workaround.
-  }
+  // NB: this SDK does NOT implement a scoped TLS-verify opt-out. The
+  // historical workaround (NODE_TLS_REJECT_UNAUTHORIZED=0) disables TLS
+  // verification for the ENTIRE Node process, which is unsafe. If you
+  // need to talk to a broker with a private/self-signed CA, add the CA
+  // to Node's trust store via NODE_EXTRA_CA_CERTS=/path/to/ca.pem —
+  // this is scoped to the process but keeps verification ON for every
+  // other connection. The `verifyTls` option is retained so callers can
+  // see the default and for future scoped-dispatcher support; setting
+  // it to `false` currently raises at BrokerClient construction time.
+  void verifyTls;
 
   const response = await fetch(fullUrl, fetchOptions);
   const text = await response.text();
@@ -119,6 +122,22 @@ export class BrokerClient {
     this.baseUrl = options.baseUrl.replace(/\/+$/, "");
     this.verifyTls = options.verifyTls ?? true;
     this.timeoutMs = options.timeoutMs ?? 10_000;
+
+    // This SDK does not implement a scoped TLS-verify opt-out (see
+    // note in httpRequest). Refuse rather than silently trust the
+    // network: the previous behavior accepted `verifyTls=false` and
+    // did nothing, which hid the problem from callers.
+    if (!this.verifyTls) {
+      throw new Error(
+        "verifyTls=false is not supported. Node's native fetch cannot " +
+        "disable TLS verification per-call, and the process-wide escape " +
+        "hatch NODE_TLS_REJECT_UNAUTHORIZED=0 is unsafe. For a broker " +
+        "with a private or self-signed CA, add the CA PEM to Node's " +
+        "trust store via NODE_EXTRA_CA_CERTS=/path/to/ca.pem — this is " +
+        "scoped to this process and keeps verification enabled for every " +
+        "other connection.",
+      );
+    }
   }
 
   // ── Authentication ───────────────────────────────────────────

--- a/tests/test_sdk_tls_hardening.py
+++ b/tests/test_sdk_tls_hardening.py
@@ -1,0 +1,101 @@
+"""Regression tests for the SDK TLS-verify opt-out guard.
+
+Audit follow-up (post PR #159 / F-E-01/F-E-02): make sure the Python
+SDK does not silently accept ``verify_tls=False`` in production and at
+least warns in development. TS SDK equivalent lives in
+``sdk-ts/src/client.ts`` (construction-time throw).
+"""
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from cullis_sdk.client import (
+    CullisClient,
+    InsecureTLSWarning,
+    _check_insecure_tls,
+)
+
+
+# ── Helper-level tests ───────────────────────────────────────────────
+
+def test_check_insecure_tls_is_noop_when_verify_true():
+    """Happy path: verify=True never warns, never raises."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail
+        _check_insecure_tls(True)
+
+
+def test_check_insecure_tls_warns_when_verify_false_in_dev(monkeypatch):
+    """Dev flow: verify=False is tolerated but must warn loudly."""
+    monkeypatch.delenv("CULLIS_ENV", raising=False)
+    monkeypatch.delenv("CULLIS_SDK_ALLOW_INSECURE_TLS", raising=False)
+    with pytest.warns(InsecureTLSWarning):
+        _check_insecure_tls(False)
+
+
+def test_check_insecure_tls_refuses_in_production(monkeypatch):
+    """Prod default: verify=False without explicit opt-in must raise."""
+    monkeypatch.setenv("CULLIS_ENV", "production")
+    monkeypatch.delenv("CULLIS_SDK_ALLOW_INSECURE_TLS", raising=False)
+    with pytest.raises(ValueError, match="production"):
+        _check_insecure_tls(False)
+
+
+def test_check_insecure_tls_respects_production_opt_in(monkeypatch):
+    """Two-key rule: admin can override the prod block but takes a warning."""
+    monkeypatch.setenv("CULLIS_ENV", "production")
+    monkeypatch.setenv("CULLIS_SDK_ALLOW_INSECURE_TLS", "1")
+    with pytest.warns(InsecureTLSWarning):
+        _check_insecure_tls(False)
+
+
+def test_check_insecure_tls_production_case_insensitive(monkeypatch):
+    """CULLIS_ENV matching must tolerate casing variations."""
+    monkeypatch.setenv("CULLIS_ENV", "Production")
+    monkeypatch.delenv("CULLIS_SDK_ALLOW_INSECURE_TLS", raising=False)
+    with pytest.raises(ValueError):
+        _check_insecure_tls(False)
+
+
+# ── Constructor-level tests ─────────────────────────────────────────
+
+def test_cullis_client_warns_on_verify_tls_false(monkeypatch):
+    """The main constructor must route through _check_insecure_tls."""
+    monkeypatch.delenv("CULLIS_ENV", raising=False)
+    with pytest.warns(InsecureTLSWarning):
+        CullisClient("https://dev.broker.local", verify_tls=False)
+
+
+def test_cullis_client_refuses_prod_without_opt_in(monkeypatch):
+    monkeypatch.setenv("CULLIS_ENV", "production")
+    monkeypatch.delenv("CULLIS_SDK_ALLOW_INSECURE_TLS", raising=False)
+    with pytest.raises(ValueError):
+        CullisClient("https://broker.example.com", verify_tls=False)
+
+
+def test_cullis_client_default_is_secure(monkeypatch):
+    """Default-constructed client must NOT trigger the guard."""
+    monkeypatch.delenv("CULLIS_ENV", raising=False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", InsecureTLSWarning)
+        client = CullisClient("https://broker.example.com")
+        assert client._verify_tls is True
+        client.close()
+
+
+def test_join_network_refuses_insecure_in_prod(monkeypatch):
+    """Network-onboarding helper shares the same guard."""
+    monkeypatch.setenv("CULLIS_ENV", "production")
+    monkeypatch.delenv("CULLIS_SDK_ALLOW_INSECURE_TLS", raising=False)
+    with pytest.raises(ValueError):
+        CullisClient.join_network(
+            broker_url="https://broker.example.com",
+            org_id="orga",
+            display_name="Org A",
+            secret="s",
+            ca_certificate="pem",
+            invite_token="invite",
+            verify_tls=False,
+        )


### PR DESCRIPTION
Follow-up to PR #159 closing the remaining SDK-side gap of audit F-E-01/F-E-02 after reviewing the EUDI wallet disclosure. See commit message and inline code comments for full rationale.

## Threat model vs EUDI

| | EUDI wallet | Cullis before | Cullis after |
|---|---|---|---|
| Default cert verification | OFF (accepts any cert) | ON | ON |
| Opt-out mechanism | Unconditional in delegate | Explicit `verify_tls=False` kwarg | Same, gated |
| Production refusal | None | None in SDK | Raises unless `CULLIS_SDK_ALLOW_INSECURE_TLS=1` |
| Dev warning | None | None | `InsecureTLSWarning` |
| Recommended workaround | "Add this delegate" | `NODE_TLS_REJECT_UNAUTHORIZED=0` (process-wide) | `NODE_EXTRA_CA_CERTS=/path/ca.pem` (scoped) |
| CI guard | None | None | Grep rejects new occurrences |

## What changed

- Python SDK: new `InsecureTLSWarning` + `_check_insecure_tls()`; two-key rule refuses prod unless `CULLIS_SDK_ALLOW_INSECURE_TLS=1`.
- TS SDK: `BrokerClient` constructor now throws with a message pointing to `NODE_EXTRA_CA_CERTS`. Previously `verifyTls:false` was silently ignored.
- CI: new step bans `verify=False` / `rejectUnauthorized:false` / `process.env.NODE_TLS_REJECT_UNAUTHORIZED=` in production code. Allow-list: `tests/`, `demo/`, `demo_network/`, `enterprise_sandbox/`.
- WS path in Python SDK got an explanatory comment — `check_hostname=False` before `CERT_NONE` is required by Python's ssl module, not redundant.

## Test plan

- [x] 9 new regression tests in `tests/test_sdk_tls_hardening.py`
- [x] Full suite 1072 passed, 15 skipped
- [x] `cd sdk-ts && npx tsc --noEmit` clean
- [x] ruff clean
- [x] `./demo_network/smoke.sh full` PASS
- [x] CI guard regex verified locally: 0 false positives