### PR TITLE
feat(connector+proxy): MCP resource registration via Connector (ADR-009 sandbox PR 1/4)

### DIFF
--- a/cullis_connector/templates/mcp.html
+++ b/cullis_connector/templates/mcp.html
@@ -1,0 +1,105 @@
+{% extends "base.html" %}
+{% block title %}MCP Resources{% endblock %}
+{% block content %}
+
+<section class="panel">
+    <div class="panel-eyebrow">MCP Resources</div>
+    <h1 class="panel-title">Register an MCP server</h1>
+    <p style="color: var(--text-muted); margin: 8px 0 18px;">
+        These resources are registered on the Mastio at
+        <strong>{{ site_host }}</strong> for agent
+        <strong>{{ agent_id }}</strong>. Admin secret stays in memory only
+        and is cleared on Connector restart.
+    </p>
+
+    {% if error %}
+    <div class="error-banner">⚠ {{ error.replace('+', ' ') }}</div>
+    {% endif %}
+
+    {% if not admin_secret_set %}
+    <form method="post" action="/mcp/admin-secret" class="form">
+        <label for="admin_secret" class="form-label">Mastio admin secret</label>
+        <input type="password" id="admin_secret" name="admin_secret" required
+               placeholder="e.g. demo-proxy-admin-a" autocomplete="off">
+        <p class="form-hint">Required to call the Mastio admin API. Not persisted.</p>
+        <button type="submit" class="btn primary">Unlock admin mode</button>
+    </form>
+
+    {% else %}
+
+    <div class="admin-status">
+        <span class="status-dot online"></span>
+        <span>Admin mode unlocked</span>
+        <form method="post" action="/mcp/admin-secret/clear" style="display:inline;margin-left:12px;">
+            <button type="submit" class="btn ghost small">Lock</button>
+        </form>
+    </div>
+
+    <form method="post" action="/mcp/register" class="form">
+        <label for="name" class="form-label">Resource name</label>
+        <input type="text" id="name" name="name" required
+               pattern="[A-Za-z0-9._-]+" placeholder="e.g. catalog">
+
+        <label for="endpoint_url" class="form-label">Endpoint URL</label>
+        <input type="url" id="endpoint_url" name="endpoint_url" required
+               placeholder="http://mcp-catalog:9300/">
+
+        <label for="description" class="form-label">Description (optional)</label>
+        <input type="text" id="description" name="description"
+               placeholder="Product catalog MCP">
+
+        <label for="required_capability" class="form-label">Required capability (optional)</label>
+        <input type="text" id="required_capability" name="required_capability"
+               placeholder="catalog.read">
+
+        <button type="submit" class="btn primary">Register</button>
+    </form>
+
+    {% if resources_error %}
+    <div class="error-banner">⚠ {{ resources_error }}</div>
+    {% endif %}
+
+    {% if resources %}
+    <h2 class="panel-subtitle">Registered resources</h2>
+    <table class="mcp-list">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Endpoint</th>
+                <th>Org</th>
+                <th>Enabled</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for r in resources %}
+            <tr>
+                <td><strong>{{ r.name }}</strong>{% if r.description %}<br><span style="color:var(--text-muted);font-size:0.85em">{{ r.description }}</span>{% endif %}</td>
+                <td><code>{{ r.endpoint_url }}</code></td>
+                <td>{{ r.org_id or "—" }}</td>
+                <td>{{ "✓" if r.enabled else "—" }}</td>
+                <td style="white-space:nowrap;">
+                    <form method="post" action="/mcp/{{ r.resource_id }}/bind-self" style="display:inline;">
+                        <button type="submit" class="btn ghost small" title="Bind this Connector's agent">Bind me</button>
+                    </form>
+                    <form method="post" action="/mcp/{{ r.resource_id }}/delete" style="display:inline;">
+                        <button type="submit" class="btn danger small"
+                                onclick="return confirm('Delete {{ r.name }}?')">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% else %}
+    <p style="color:var(--text-muted);margin-top:16px;">No resources registered yet.</p>
+    {% endif %}
+
+    {% endif %}
+</section>
+
+<p style="text-align:center;margin-top:16px;">
+    <a href="/connected" style="color:var(--text-muted);">← Back to identity</a>
+</p>
+
+{% endblock %}

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -90,10 +90,23 @@ class _Pending:
 
 _pending: _Pending | None = None
 
+# ── MCP registration session state (ADR-009 sandbox) ─────────────────────
+#
+# Admin secret required to call the Mastio /v1/admin/mcp-resources API.
+# Kept in process memory only — never persisted. The user re-enters it on
+# each Connector restart. Prevents shoulder-surfing post-quit.
+
+_mastio_admin_secret: str | None = None
+
 
 def _clear_pending() -> None:
     global _pending
     _pending = None
+
+
+def _set_admin_secret(secret: str | None) -> None:
+    global _mastio_admin_secret
+    _mastio_admin_secret = secret or None
 
 
 # ── App factory ──────────────────────────────────────────────────────────
@@ -422,6 +435,169 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             },
             status_code=400,
         )
+
+    # ── MCP resource registration (ADR-009 sandbox) ──────────────────────
+
+    def _mastio_client() -> httpx.Client:
+        identity = load_identity(config.config_dir)
+        base = identity.metadata.site_url.rstrip("/")
+        return httpx.Client(
+            base_url=base, verify=config.verify_tls, timeout=10.0,
+        )
+
+    def _mcp_admin_headers() -> dict[str, str]:
+        if not _mastio_admin_secret:
+            raise RuntimeError("admin secret not set")
+        return {"X-Admin-Secret": _mastio_admin_secret}
+
+    @app.get("/mcp", response_class=HTMLResponse)
+    def mcp_get(request: Request, error: str | None = None) -> Response:
+        """MCP resource registration screen (Connector-side admin UI).
+
+        Gated on identity existing — this is a post-enrollment admin flow.
+        If no admin secret is in session, render a prompt form first.
+        """
+        if not has_identity(config.config_dir):
+            return RedirectResponse("/setup", status_code=303)
+
+        identity = load_identity(config.config_dir)
+        meta = identity.metadata
+        site_host = _host_of(meta.site_url)
+
+        resources: list[dict[str, Any]] = []
+        resources_error: str | None = None
+        if _mastio_admin_secret:
+            try:
+                with _mastio_client() as c:
+                    r = c.get(
+                        "/v1/admin/mcp-resources",
+                        headers=_mcp_admin_headers(),
+                    )
+                    if r.status_code == 403:
+                        resources_error = "admin secret rejected (403)"
+                    else:
+                        r.raise_for_status()
+                        resources = r.json()
+            except Exception as exc:
+                resources_error = f"failed to fetch: {exc}"
+
+        return templates.TemplateResponse(
+            request,
+            "mcp.html",
+            {
+                "connector_status": "online",
+                "connector_status_label": "Online",
+                "agent_id": meta.agent_id or "(unassigned)",
+                "site_host": site_host,
+                "admin_secret_set": _mastio_admin_secret is not None,
+                "resources": resources,
+                "resources_error": resources_error,
+                "error": error,
+            },
+        )
+
+    @app.post("/mcp/admin-secret")
+    def mcp_set_admin_secret(admin_secret: str = Form(...)) -> Response:
+        _set_admin_secret(admin_secret.strip())
+        return RedirectResponse("/mcp", status_code=303)
+
+    @app.post("/mcp/admin-secret/clear")
+    def mcp_clear_admin_secret() -> Response:
+        _set_admin_secret(None)
+        return RedirectResponse("/mcp", status_code=303)
+
+    @app.post("/mcp/register")
+    def mcp_register(
+        name: str = Form(...),
+        endpoint_url: str = Form(...),
+        description: str = Form(""),
+        required_capability: str = Form(""),
+    ) -> Response:
+        if not _mastio_admin_secret:
+            return RedirectResponse(
+                "/mcp?error=" + "admin+secret+not+set", status_code=303,
+            )
+        identity = load_identity(config.config_dir)
+        body: dict[str, Any] = {
+            "name": name.strip(),
+            "endpoint_url": endpoint_url.strip(),
+            "auth_type": "none",
+            "enabled": True,
+        }
+        if description.strip():
+            body["description"] = description.strip()
+        if required_capability.strip():
+            body["required_capability"] = required_capability.strip()
+        # The Mastio scopes resources per-org; pull it from the enrolled
+        # agent_id prefix (``org::agent``).
+        agent_id = identity.metadata.agent_id or ""
+        if "::" in agent_id:
+            body["org_id"] = agent_id.split("::", 1)[0]
+
+        try:
+            with _mastio_client() as c:
+                r = c.post(
+                    "/v1/admin/mcp-resources",
+                    headers=_mcp_admin_headers(),
+                    json=body,
+                )
+                if r.status_code == 403:
+                    return RedirectResponse(
+                        "/mcp?error=admin+secret+rejected", status_code=303,
+                    )
+                if r.status_code == 409:
+                    return RedirectResponse(
+                        "/mcp?error=name+already+exists", status_code=303,
+                    )
+                if not r.is_success:
+                    return RedirectResponse(
+                        "/mcp?error=" + f"registration+failed+({r.status_code})",
+                        status_code=303,
+                    )
+        except Exception as exc:
+            _log.warning("mcp_register failed: %s", exc)
+            return RedirectResponse("/mcp?error=network+error", status_code=303)
+
+        return RedirectResponse("/mcp", status_code=303)
+
+    @app.post("/mcp/{resource_id}/delete")
+    def mcp_delete(resource_id: str) -> Response:
+        if not _mastio_admin_secret:
+            return RedirectResponse("/mcp", status_code=303)
+        try:
+            with _mastio_client() as c:
+                c.delete(
+                    f"/v1/admin/mcp-resources/{resource_id}",
+                    headers=_mcp_admin_headers(),
+                )
+        except Exception as exc:
+            _log.warning("mcp_delete failed: %s", exc)
+        return RedirectResponse("/mcp", status_code=303)
+
+    @app.post("/mcp/{resource_id}/bind-self")
+    def mcp_bind_self(resource_id: str) -> Response:
+        """Bind the currently-enrolled agent to this resource."""
+        if not _mastio_admin_secret:
+            return RedirectResponse("/mcp", status_code=303)
+        identity = load_identity(config.config_dir)
+        agent_id = identity.metadata.agent_id
+        if not agent_id:
+            return RedirectResponse(
+                "/mcp?error=agent_id+unknown", status_code=303,
+            )
+        try:
+            with _mastio_client() as c:
+                r = c.post(
+                    "/v1/admin/mcp-resources/bindings",
+                    headers=_mcp_admin_headers(),
+                    json={"agent_id": agent_id, "resource_id": resource_id},
+                )
+                if r.status_code == 409:
+                    # idempotent from the UX standpoint
+                    pass
+        except Exception as exc:
+            _log.warning("mcp_bind_self failed: %s", exc)
+        return RedirectResponse("/mcp", status_code=303)
 
     return app
 

--- a/mcp_proxy/admin/mcp_resources.py
+++ b/mcp_proxy/admin/mcp_resources.py
@@ -1,0 +1,376 @@
+"""Proxy admin JSON API for MCP resources + bindings.
+
+Complements ``mcp_proxy/dashboard/mcp_resources.py`` (HTML form-based).
+The Connector Desktop uses these endpoints to let users register MCP
+servers and bind agents without leaving the Connector UI — same flow
+the enrollment screen already provides for agents (ADR-009 sandbox).
+
+Auth: ``X-Admin-Secret`` — same contract as ``/v1/admin/mastio-pubkey``.
+Callers pass the Mastio admin secret in-process; the Connector prompts
+for it the first time and keeps it in memory (not on disk).
+"""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_db, log_audit
+from mcp_proxy.tools.resource_loader import reload_resources
+
+
+_log = logging.getLogger("mcp_proxy.admin.mcp_resources")
+
+router = APIRouter(prefix="/v1/admin/mcp-resources", tags=["admin"])
+
+
+_ALLOWED_AUTH_TYPES = {"none", "bearer", "api_key", "mtls"}
+_NAME_RE = re.compile(r"^[a-zA-Z0-9\-_\.]+$")
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _validate_name(name: str) -> str:
+    name = name.strip()
+    if not name or not _NAME_RE.match(name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="name: letters, digits, dash, underscore, dot only",
+        )
+    if len(name) > 64:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="name: max 64 chars",
+        )
+    return name
+
+
+def _validate_endpoint_url(url: str) -> str:
+    url = url.strip()
+    if not url or not (url.startswith("http://") or url.startswith("https://")):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="endpoint_url must start with http:// or https://",
+        )
+    return url
+
+
+def _validate_auth_type(auth_type: str) -> str:
+    auth_type = auth_type.strip() or "none"
+    if auth_type not in _ALLOWED_AUTH_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"auth_type: must be one of {sorted(_ALLOWED_AUTH_TYPES)}",
+        )
+    return auth_type
+
+
+# ── Resources ───────────────────────────────────────────────────────────
+
+class MCPResourceCreate(BaseModel):
+    name: str
+    endpoint_url: str
+    description: str | None = None
+    auth_type: str = "none"
+    auth_secret_ref: str | None = None
+    required_capability: str | None = None
+    allowed_domains: list[str] = Field(default_factory=list)
+    org_id: str | None = None
+    enabled: bool = True
+
+
+class MCPResourceOut(BaseModel):
+    resource_id: str
+    name: str
+    endpoint_url: str
+    description: str | None
+    auth_type: str
+    required_capability: str | None
+    enabled: bool
+    org_id: str | None
+    created_at: str
+
+
+@router.get(
+    "",
+    response_model=list[MCPResourceOut],
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_resources():
+    """Return MCP resources registered on this proxy."""
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                """
+                SELECT resource_id, name, endpoint_url, description, auth_type,
+                       required_capability, enabled, org_id, created_at
+                  FROM local_mcp_resources
+                 ORDER BY created_at DESC
+                """
+            )
+        )).mappings().all()
+    return [
+        MCPResourceOut(
+            resource_id=r["resource_id"],
+            name=r["name"],
+            endpoint_url=r["endpoint_url"],
+            description=r["description"],
+            auth_type=r["auth_type"],
+            required_capability=r["required_capability"],
+            enabled=bool(r["enabled"]),
+            org_id=r["org_id"],
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+
+
+@router.post(
+    "",
+    response_model=MCPResourceOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def create_resource(body: MCPResourceCreate):
+    name = _validate_name(body.name)
+    endpoint_url = _validate_endpoint_url(body.endpoint_url)
+    auth_type = _validate_auth_type(body.auth_type)
+    resource_id = str(uuid.uuid4())
+    ts = _iso_now()
+
+    try:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_mcp_resources (
+                        resource_id, org_id, name, description, endpoint_url,
+                        auth_type, auth_secret_ref, required_capability,
+                        allowed_domains, enabled, created_at, updated_at
+                    ) VALUES (
+                        :rid, :org, :name, :description, :endpoint_url,
+                        :auth_type, :auth_secret_ref, :required_capability,
+                        :allowed_domains, :enabled, :ts, :ts
+                    )
+                    """
+                ),
+                {
+                    "rid": resource_id,
+                    "org": body.org_id,
+                    "name": name,
+                    "description": body.description,
+                    "endpoint_url": endpoint_url,
+                    "auth_type": auth_type,
+                    "auth_secret_ref": body.auth_secret_ref,
+                    "required_capability": body.required_capability,
+                    "allowed_domains": json.dumps(
+                        body.allowed_domains, separators=(",", ":"), sort_keys=True,
+                    ),
+                    "enabled": 1 if body.enabled else 0,
+                    "ts": ts,
+                },
+            )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"resource name '{name}' already exists in this org",
+        ) from exc
+
+    try:
+        await reload_resources()
+    except Exception as exc:  # defensive
+        _log.warning("reload_resources failed after create: %s", exc)
+
+    await log_audit(
+        agent_id="admin",
+        action="mcp_resource.create",
+        status="success",
+        detail=f"api=json resource_id={resource_id} name={name}",
+    )
+
+    return MCPResourceOut(
+        resource_id=resource_id,
+        name=name,
+        endpoint_url=endpoint_url,
+        description=body.description,
+        auth_type=auth_type,
+        required_capability=body.required_capability,
+        enabled=body.enabled,
+        org_id=body.org_id,
+        created_at=ts,
+    )
+
+
+@router.delete(
+    "/{resource_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def delete_resource(resource_id: str):
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT resource_id FROM local_mcp_resources WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )).first()
+        if row is None:
+            raise HTTPException(status_code=404, detail="resource not found")
+
+        # Cascade bindings (no physical FK on local_* tables).
+        await conn.execute(
+            text("DELETE FROM local_agent_resource_bindings WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )
+        await conn.execute(
+            text("DELETE FROM local_mcp_resources WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )
+
+    try:
+        await reload_resources()
+    except Exception as exc:
+        _log.warning("reload_resources failed after delete: %s", exc)
+
+    await log_audit(
+        agent_id="admin",
+        action="mcp_resource.delete",
+        status="success",
+        detail=f"api=json resource_id={resource_id}",
+    )
+
+
+# ── Bindings ────────────────────────────────────────────────────────────
+
+class MCPBindingCreate(BaseModel):
+    agent_id: str
+    resource_id: str
+
+
+class MCPBindingOut(BaseModel):
+    binding_id: str
+    agent_id: str
+    resource_id: str
+    org_id: str | None
+    granted_at: str
+    revoked_at: str | None
+
+
+@router.post(
+    "/bindings",
+    response_model=MCPBindingOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def create_binding(body: MCPBindingCreate):
+    agent_id = body.agent_id.strip()
+    resource_id = body.resource_id.strip()
+    if not agent_id or not resource_id:
+        raise HTTPException(
+            status_code=400, detail="agent_id and resource_id are required",
+        )
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT org_id FROM local_mcp_resources WHERE resource_id = :rid"),
+            {"rid": resource_id},
+        )).first()
+        if row is None:
+            raise HTTPException(status_code=404, detail="resource not found")
+        org_id = row[0]
+
+        binding_id = str(uuid.uuid4())
+        ts = _iso_now()
+        try:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_agent_resource_bindings (
+                        binding_id, agent_id, resource_id, org_id,
+                        granted_by, granted_at, revoked_at
+                    ) VALUES (
+                        :bid, :aid, :rid, :org,
+                        'admin', :ts, NULL
+                    )
+                    """
+                ),
+                {
+                    "bid": binding_id,
+                    "aid": agent_id,
+                    "rid": resource_id,
+                    "org": org_id,
+                    "ts": ts,
+                },
+            )
+        except IntegrityError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="binding already exists for this agent+resource pair",
+            ) from exc
+
+    await log_audit(
+        agent_id="admin",
+        action="mcp_binding.create",
+        status="success",
+        detail=f"api=json binding_id={binding_id} agent={agent_id} resource={resource_id}",
+    )
+
+    return MCPBindingOut(
+        binding_id=binding_id,
+        agent_id=agent_id,
+        resource_id=resource_id,
+        org_id=org_id,
+        granted_at=ts,
+        revoked_at=None,
+    )
+
+
+@router.delete(
+    "/bindings/{binding_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def revoke_binding(binding_id: str):
+    """Soft-delete: set ``revoked_at`` to the current timestamp."""
+    ts = _iso_now()
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                UPDATE local_agent_resource_bindings
+                   SET revoked_at = :ts
+                 WHERE binding_id = :bid AND revoked_at IS NULL
+                """
+            ),
+            {"bid": binding_id, "ts": ts},
+        )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=404, detail="binding not found or already revoked",
+            )
+    await log_audit(
+        agent_id="admin",
+        action="mcp_binding.revoke",
+        status="success",
+        detail=f"api=json binding_id={binding_id}",
+    )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -492,6 +492,10 @@ app.include_router(sign_assertion_router)
 from mcp_proxy.admin.info import router as admin_info_router
 app.include_router(admin_info_router)
 
+# ADR-009 sandbox — Connector JSON API for MCP resources + bindings.
+from mcp_proxy.admin.mcp_resources import router as admin_mcp_resources_router
+app.include_router(admin_mcp_resources_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/registry/agents/{id}/public-key
 # would otherwise fall into the `/v1/registry/*` forward prefix and never

--- a/tests/connector/test_web_mcp.py
+++ b/tests/connector/test_web_mcp.py
@@ -1,0 +1,215 @@
+"""Connector dashboard MCP resource registration screen (ADR-009 sandbox).
+
+Drives the Connector FastAPI app against a mocked Mastio (httpx
+MockTransport) so the web-layer tests don't need a real broker.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity.store import IdentityBundle, IdentityMetadata
+from cullis_connector.web import build_app
+
+
+@pytest.fixture
+def connector_dir(tmp_path):
+    d = tmp_path / "connector"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture
+def connector_client(connector_dir, monkeypatch):
+    """Boot a Connector app with a fake enrolled identity, no disk writes."""
+    meta = IdentityMetadata(
+        agent_id="demo-org::alice",
+        capabilities=["oneshot.message"],
+        site_url="http://mastio.test",
+        issued_at=_dt.datetime.now(_dt.timezone.utc).isoformat(),
+    )
+    bundle = IdentityBundle(
+        private_key=None,
+        cert=None,
+        cert_pem="-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        ca_chain_pem=None,
+        metadata=meta,
+    )
+    import cullis_connector.web as _web
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+    monkeypatch.setattr(_web, "load_identity", lambda _: bundle)
+    _web._set_admin_secret(None)
+
+    cfg = ConnectorConfig(
+        config_dir=connector_dir,
+        site_url="http://mastio.test",
+        verify_tls=False,
+    )
+    app = build_app(cfg)
+    return TestClient(app)
+
+
+def _mount_mastio(monkeypatch, handler):
+    """Patch httpx.Client inside web.py so every call goes to ``handler``."""
+    import cullis_connector.web as _web
+
+    original = _web.httpx.Client
+
+    def _factory(*args, **kwargs):
+        kwargs.setdefault("transport", httpx.MockTransport(handler))
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(_web.httpx, "Client", _factory)
+
+
+# ── admin secret gating ────────────────────────────────────────────────
+
+def test_mcp_screen_prompts_for_admin_secret(connector_client):
+    r = connector_client.get("/mcp")
+    assert r.status_code == 200
+    assert "Mastio admin secret" in r.text
+
+
+def test_mcp_screen_shows_unlocked_after_secret_set(connector_client, monkeypatch):
+    captured_requests: list[httpx.Request] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        captured_requests.append(req)
+        if req.url.path == "/v1/admin/mcp-resources" and req.method == "GET":
+            return httpx.Response(200, json=[])
+        return httpx.Response(404)
+
+    _mount_mastio(monkeypatch, _handler)
+
+    r = connector_client.post(
+        "/mcp/admin-secret",
+        data={"admin_secret": "demo-proxy-admin"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    r = connector_client.get("/mcp")
+    assert r.status_code == 200
+    assert "Admin mode unlocked" in r.text
+    assert any(
+        "x-admin-secret" in dict(req.headers)
+        for req in captured_requests
+    )
+
+
+# ── register resource ──────────────────────────────────────────────────
+
+def test_register_resource_round_trip(connector_client, monkeypatch):
+    recorded: list[tuple[str, dict]] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and req.url.path == "/v1/admin/mcp-resources":
+            body = json.loads(req.content)
+            recorded.append(("POST", body))
+            return httpx.Response(
+                201,
+                json={
+                    "resource_id": "fake-uuid-1",
+                    "name": body["name"],
+                    "endpoint_url": body["endpoint_url"],
+                    "description": body.get("description"),
+                    "auth_type": "none",
+                    "required_capability": body.get("required_capability"),
+                    "enabled": True,
+                    "org_id": body.get("org_id"),
+                    "created_at": "2026-04-17T00:00:00+00:00",
+                },
+            )
+        if req.method == "GET" and req.url.path == "/v1/admin/mcp-resources":
+            return httpx.Response(200, json=[])
+        return httpx.Response(404)
+
+    _mount_mastio(monkeypatch, _handler)
+
+    connector_client.post(
+        "/mcp/admin-secret", data={"admin_secret": "demo"},
+    )
+    r = connector_client.post(
+        "/mcp/register",
+        data={
+            "name": "catalog",
+            "endpoint_url": "http://mcp-catalog:9300/",
+            "description": "Catalog",
+            "required_capability": "",
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+
+    assert recorded, "POST to Mastio was not issued"
+    _, body = recorded[0]
+    assert body["name"] == "catalog"
+    assert body["endpoint_url"] == "http://mcp-catalog:9300/"
+    # agent_id is demo-org::alice so org_id derives as "demo-org"
+    assert body.get("org_id") == "demo-org"
+
+
+def test_register_without_admin_secret_redirects_with_error(
+    connector_client, monkeypatch,
+):
+    r = connector_client.post(
+        "/mcp/register",
+        data={"name": "x", "endpoint_url": "http://x/"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    assert "error=admin" in r.headers["location"]
+
+
+def test_register_forwards_409_conflict(connector_client, monkeypatch):
+    def _handler(req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and req.url.path == "/v1/admin/mcp-resources":
+            return httpx.Response(409, json={"detail": "exists"})
+        return httpx.Response(200, json=[])
+
+    _mount_mastio(monkeypatch, _handler)
+    connector_client.post("/mcp/admin-secret", data={"admin_secret": "demo"})
+    r = connector_client.post(
+        "/mcp/register",
+        data={"name": "dup", "endpoint_url": "http://x/"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    assert "already+exists" in r.headers["location"]
+
+
+# ── bind-self ─────────────────────────────────────────────────────────
+
+def test_bind_self_sends_agent_id(connector_client, monkeypatch):
+    recorded: list[dict] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        if (req.method == "POST"
+                and req.url.path == "/v1/admin/mcp-resources/bindings"):
+            recorded.append(json.loads(req.content))
+            return httpx.Response(
+                201,
+                json={
+                    "binding_id": "b1",
+                    "agent_id": json.loads(req.content)["agent_id"],
+                    "resource_id": json.loads(req.content)["resource_id"],
+                    "org_id": "demo-org",
+                    "granted_at": "now",
+                    "revoked_at": None,
+                },
+            )
+        return httpx.Response(200, json=[])
+
+    _mount_mastio(monkeypatch, _handler)
+    connector_client.post("/mcp/admin-secret", data={"admin_secret": "demo"})
+    r = connector_client.post(
+        "/mcp/fake-uuid-1/bind-self", follow_redirects=False,
+    )
+    assert r.status_code == 303
+    assert recorded
+    assert recorded[0]["agent_id"] == "demo-org::alice"
+    assert recorded[0]["resource_id"] == "fake-uuid-1"

--- a/tests/test_proxy_admin_mcp_resources.py
+++ b/tests/test_proxy_admin_mcp_resources.py
@@ -1,0 +1,225 @@
+"""Proxy /v1/admin/mcp-resources JSON API — CRUD + bindings.
+
+Covers the Connector-facing API that complements the HTML form admin.
+Auth is X-Admin-Secret (Connector prompts for it on-demand).
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _admin_headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── resources CRUD ─────────────────────────────────────────────────────
+
+async def test_create_list_delete_resource(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-crud")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+
+            # create
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={
+                    "name": "catalog",
+                    "endpoint_url": "http://mcp-catalog:9300/",
+                    "description": "Catalog MCP",
+                    "auth_type": "none",
+                    "org_id": "mcp-crud",
+                    "enabled": True,
+                },
+            )
+            assert r.status_code == 201, r.text
+            resource_id = r.json()["resource_id"]
+
+            # list
+            r = await cli.get("/v1/admin/mcp-resources", headers=h)
+            assert r.status_code == 200
+            names = [x["name"] for x in r.json()]
+            assert "catalog" in names
+
+            # delete
+            r = await cli.delete(
+                f"/v1/admin/mcp-resources/{resource_id}", headers=h,
+            )
+            assert r.status_code == 204
+
+            r = await cli.get("/v1/admin/mcp-resources", headers=h)
+            assert r.status_code == 200
+            assert all(x["name"] != "catalog" for x in r.json())
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_rejects_invalid(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-invalid")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+
+            # name with spaces
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={"name": "bad name", "endpoint_url": "http://x/"},
+            )
+            assert r.status_code == 400
+
+            # non-http endpoint
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={"name": "valid", "endpoint_url": "ftp://x/"},
+            )
+            assert r.status_code == 400
+
+            # bad auth_type
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={
+                    "name": "valid",
+                    "endpoint_url": "http://x/",
+                    "auth_type": "psk",
+                },
+            )
+            assert r.status_code == 400
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_conflict_on_duplicate(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-dup")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+            body = {
+                "name": "catalog",
+                "endpoint_url": "http://x/",
+                "org_id": "mcp-dup",
+            }
+            r = await cli.post("/v1/admin/mcp-resources", headers=h, json=body)
+            assert r.status_code == 201
+            r = await cli.post("/v1/admin/mcp-resources", headers=h, json=body)
+            assert r.status_code == 409
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── auth ───────────────────────────────────────────────────────────────
+
+async def test_requires_admin_secret(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-auth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            # missing header
+            r = await cli.get("/v1/admin/mcp-resources")
+            assert r.status_code == 422
+            # wrong secret
+            r = await cli.get(
+                "/v1/admin/mcp-resources",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+            assert r.status_code == 403
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── bindings ───────────────────────────────────────────────────────────
+
+async def test_binding_lifecycle(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-bind")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={
+                    "name": "catalog",
+                    "endpoint_url": "http://x/",
+                    "org_id": "mcp-bind",
+                },
+            )
+            rid = r.json()["resource_id"]
+
+            # bind agent
+            r = await cli.post(
+                "/v1/admin/mcp-resources/bindings",
+                headers=h,
+                json={"agent_id": "mcp-bind::alice", "resource_id": rid},
+            )
+            assert r.status_code == 201, r.text
+            bid = r.json()["binding_id"]
+
+            # duplicate → 409
+            r = await cli.post(
+                "/v1/admin/mcp-resources/bindings",
+                headers=h,
+                json={"agent_id": "mcp-bind::alice", "resource_id": rid},
+            )
+            assert r.status_code == 409
+
+            # revoke
+            r = await cli.delete(
+                f"/v1/admin/mcp-resources/bindings/{bid}", headers=h,
+            )
+            assert r.status_code == 204
+
+            # revoke again → 404
+            r = await cli.delete(
+                f"/v1/admin/mcp-resources/bindings/{bid}", headers=h,
+            )
+            assert r.status_code == 404
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_binding_unknown_resource(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-bind-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+            r = await cli.post(
+                "/v1/admin/mcp-resources/bindings",
+                headers=h,
+                json={"agent_id": "x::a", "resource_id": "does-not-exist"},
+            )
+            assert r.status_code == 404
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()


### PR DESCRIPTION
First PR of the enterprise sandbox restructure. Closes the gap "MCP registration only via Mastio HTML dashboard" by adding a JSON API + a new Connector Desktop screen.

## Summary

- **Mastio JSON API** \`/v1/admin/mcp-resources\` (list/create/delete + bindings create/revoke). Auth \`X-Admin-Secret\`. Same validation as the HTML form.
- **Connector Desktop** grows a \`/mcp\` admin screen:
  - prompts for the Mastio admin secret (kept in memory only, cleared on restart)
  - register a new MCP resource (name, endpoint, description, capability)
  - list registered resources + one-click "Bind me" to bind the enrolled agent
  - delete resources
- **org_id derivation**: Connector uses the prefix of its \`agent_id\` (\`org::agent\`) so the user doesn't need to type the org.

## Next PRs in the stack

- PR 2/4 — \`CullisClient.from_connector()\` SDK helper + \`/downloads\` page on the Mastio
- PR 3/4 — enterprise_sandbox split into \`up\` (half-ready) / \`full\` (all-ready) + compose.full.yml
- PR 4/4 — scenario drivers (\`demo.sh oneshot-*\`, \`mcp-*\`) + guided markdown walkthrough (\`demo.sh guide\`)

## Test plan

- [x] \`pytest tests/test_proxy_admin_mcp_resources.py\` — 6/6 (CRUD, validation, 409, auth)
- [x] \`pytest tests/connector/test_web_mcp.py\` — 6/6 (admin secret gating, round-trip, org derivation, bind-self)
- [x] Full suite: 1078 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS
- [x] Mental ruff F541/F401/F841 check