### PR TITLE
feat(sdk): CullisClient.from_connector() loads enrolled identity (ADR-009 sandbox PR 2/4)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -268,6 +268,85 @@ class CullisClient:
             raise RuntimeError("Not enrolled — use from_enrollment() or set proxy credentials")
         return {"X-API-Key": self._proxy_api_key, "Content-Type": "application/json"}
 
+    @classmethod
+    def from_connector(
+        cls,
+        config_dir: str | Path | None = None,
+        *,
+        timeout: float = 10.0,
+    ) -> CullisClient:
+        """Build a client from an enrolled Connector Desktop identity on disk.
+
+        Reads ``~/.cullis/identity/`` (or a custom ``config_dir``) and
+        returns a client pre-configured with the Mastio URL, agent_id,
+        and API key. Call :meth:`login_via_proxy` afterwards to obtain a
+        broker access token.
+
+        Layout expected (written by the Connector at enrollment time):
+
+            <config_dir>/identity/agent.crt       ← agent cert (PEM)
+            <config_dir>/identity/agent.key       ← agent key (PEM)
+            <config_dir>/identity/metadata.json   ← agent_id, site_url, ...
+            <config_dir>/identity/api_key         ← API key plaintext
+
+        Raises ``FileNotFoundError`` if the identity hasn't been enrolled
+        yet (user should open the Connector dashboard first).
+        """
+        import json as _json
+        if config_dir is None:
+            config_dir = Path.home() / ".cullis"
+        else:
+            config_dir = Path(config_dir)
+
+        identity_dir = config_dir / "identity"
+        metadata_path = identity_dir / "metadata.json"
+        api_key_path = identity_dir / "api_key"
+
+        if not metadata_path.exists():
+            raise FileNotFoundError(
+                f"Connector identity not found at {identity_dir}. "
+                "Open the Connector dashboard and complete enrollment first."
+            )
+        if not api_key_path.exists():
+            raise FileNotFoundError(
+                f"Connector api_key missing at {api_key_path}. "
+                "Re-run enrollment through the Connector dashboard."
+            )
+
+        metadata = _json.loads(metadata_path.read_text())
+        agent_id = metadata.get("agent_id")
+        site_url = metadata.get("site_url")
+        if not agent_id or not site_url:
+            raise RuntimeError(
+                f"metadata.json at {metadata_path} is missing agent_id or site_url"
+            )
+
+        api_key = api_key_path.read_text().strip()
+        org_id = agent_id.split("::", 1)[0] if "::" in agent_id else ""
+
+        # verify_tls is not explicitly stored by the Connector — default to
+        # True for https sites, False for http (developer / sandbox).
+        verify_tls = site_url.startswith("https://")
+
+        instance = cls.__new__(cls)
+        instance.base = site_url.rstrip("/")
+        instance._verify_tls = verify_tls
+        instance._http = httpx.Client(timeout=timeout, verify=verify_tls)
+        instance.token = None
+        instance._label = agent_id
+        instance._signing_key_pem = None
+        instance._pubkey_cache = {}
+        instance._client_seq = {}
+        instance._dpop_privkey = None
+        instance._dpop_pubkey_jwk = None
+        instance._dpop_nonce = None
+        instance._proxy_api_key = api_key
+        instance._proxy_agent_id = agent_id
+        instance._proxy_org_id = org_id
+
+        log("sdk", f"Loaded Connector identity {agent_id} from {identity_dir}")
+        return instance
+
     # ── SPIFFE Workload API bootstrap ───────────────────────────────
 
     @classmethod

--- a/tests/test_sdk_from_connector.py
+++ b/tests/test_sdk_from_connector.py
@@ -1,0 +1,92 @@
+"""SDK CullisClient.from_connector() — loads identity from Connector dir.
+
+Matches the layout written by ``cullis_connector.identity.store.save_identity``:
+    <config_dir>/identity/agent.crt
+    <config_dir>/identity/agent.key
+    <config_dir>/identity/metadata.json
+    <config_dir>/identity/api_key
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cullis_sdk.client import CullisClient
+
+
+def _write_identity(
+    tmp_path: Path,
+    *,
+    agent_id: str = "demo-org::alice",
+    site_url: str = "http://mastio.test",
+    api_key: str = "sk_local_test_deadbeef",
+    cert_pem: str = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+    key_pem: str = "-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+) -> Path:
+    identity_dir = tmp_path / "identity"
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    (identity_dir / "agent.crt").write_text(cert_pem)
+    (identity_dir / "agent.key").write_text(key_pem)
+    (identity_dir / "metadata.json").write_text(json.dumps({
+        "agent_id": agent_id,
+        "capabilities": ["oneshot.message"],
+        "site_url": site_url,
+        "issued_at": "2026-04-17T00:00:00+00:00",
+    }))
+    (identity_dir / "api_key").write_text(api_key)
+    return tmp_path
+
+
+def test_from_connector_loads_identity(tmp_path):
+    cfg = _write_identity(tmp_path)
+    client = CullisClient.from_connector(config_dir=cfg)
+
+    assert client.base == "http://mastio.test"
+    assert client._proxy_agent_id == "demo-org::alice"
+    assert client._proxy_org_id == "demo-org"
+    assert client._proxy_api_key == "sk_local_test_deadbeef"
+    assert client._verify_tls is False  # http → verify_tls defaults off
+    assert client.token is None  # login_via_proxy not invoked yet
+
+
+def test_from_connector_https_defaults_verify_tls_true(tmp_path):
+    cfg = _write_identity(tmp_path, site_url="https://mastio.test")
+    client = CullisClient.from_connector(config_dir=cfg)
+    assert client._verify_tls is True
+
+
+def test_from_connector_missing_identity_dir(tmp_path):
+    with pytest.raises(FileNotFoundError, match="identity not found"):
+        CullisClient.from_connector(config_dir=tmp_path)
+
+
+def test_from_connector_missing_api_key(tmp_path):
+    cfg = _write_identity(tmp_path)
+    (cfg / "identity" / "api_key").unlink()
+    with pytest.raises(FileNotFoundError, match="api_key missing"):
+        CullisClient.from_connector(config_dir=cfg)
+
+
+def test_from_connector_malformed_metadata(tmp_path):
+    cfg = _write_identity(tmp_path)
+    (cfg / "identity" / "metadata.json").write_text(json.dumps({
+        "capabilities": [],
+    }))
+    with pytest.raises(RuntimeError, match="agent_id or site_url"):
+        CullisClient.from_connector(config_dir=cfg)
+
+
+def test_from_connector_trims_api_key_whitespace(tmp_path):
+    cfg = _write_identity(tmp_path, api_key="sk_local_test_abcdef\n")
+    client = CullisClient.from_connector(config_dir=cfg)
+    assert client._proxy_api_key == "sk_local_test_abcdef"
+
+
+def test_from_connector_agent_without_org_prefix(tmp_path):
+    """Legacy metadata where agent_id isn't ``org::name`` — org_id blank."""
+    cfg = _write_identity(tmp_path, agent_id="legacy-agent-no-prefix")
+    client = CullisClient.from_connector(config_dir=cfg)
+    assert client._proxy_agent_id == "legacy-agent-no-prefix"
+    assert client._proxy_org_id == ""


### PR DESCRIPTION
Second PR of the sandbox restructure. One-liner for devs writing agents on a laptop after enrolling through the Connector Desktop.

## Summary

- **SDK** \`CullisClient.from_connector(config_dir=None)\` reads \`~/.cullis/identity/{agent.crt, agent.key, metadata.json, api_key}\`, derives org_id from the \`org::agent\` prefix, picks sensible verify_tls default (https→on, http→off for sandbox), and returns a client ready for \`login_via_proxy\`.
- Raises \`FileNotFoundError\` with actionable hints when identity or api_key are missing.

## Gap that wasn't there

The \`/downloads\` page on the Mastio (\`mcp_proxy/dashboard/downloads.py\`) **already exists** and is wired — no change needed. The ricognizione initial report flagged this as a gap but the router is in main.

## Next in the stack

- PR 3/4 — \`enterprise_sandbox\` compose split \`up\`/\`full\` + bootstrap scope
- PR 4/4 — scenario drivers + guided markdown walkthrough

## Test plan

- [x] \`pytest tests/test_sdk_from_connector.py\` — 7/7 (happy, https/http defaults, missing identity/api_key, malformed metadata, whitespace trim, legacy agent_id)
- [x] Full suite (ex ts_interop local-stale): 1119 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS

## Local test note

\`test_ts_interop.py\` fails locally when Node.js runs a stale TS SDK build (pre-PR #157 fix). CI builds fresh — these failures are not regressions.