### PR TITLE
feat(sandbox): scope-aware bootstrap + compose profiles for tiered demo (ADR-009 sandbox PR 3/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,16 +34,18 @@ scripts/demo/.checker.log
 
 # Local-only: notes, drafts, root demo dir, CLI tools.
 # `/demo/` is anchored to the repo root so it does NOT match `scripts/demo/`.
+# File globs here are rooted with `/` so they only match the repo root —
+# `enterprise_sandbox/bootstrap/bootstrap.py` (etc.) stays tracked.
 imp/
 /demo/
 drafts/
-admin.py
-bootstrap.py
-join.py
-join_agent.py
-policy.py
-revoke.py
-generate_demo_certs.py
+/admin.py
+/bootstrap.py
+/join.py
+/join_agent.py
+/policy.py
+/revoke.py
+/generate_demo_certs.py
 # generate_certs.py is INTENTIONALLY tracked — it is a runtime dependency
 # of both deploy_broker.sh and deploy_demo.sh (they invoke it on a fresh
 # clone to bootstrap the broker CA).

--- a/enterprise_sandbox/bootstrap/bootstrap.py
+++ b/enterprise_sandbox/bootstrap/bootstrap.py
@@ -1,0 +1,631 @@
+"""Enterprise sandbox bootstrap: 2 orgs, 3 agents, 2 MCP servers, verbose ANSI output."""
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import secrets
+import sys
+import time
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.x509.oid import NameOID
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+BROKER_URL   = os.environ.get("BROKER_URL", "http://broker:8000")
+ADMIN_SECRET = os.environ["ADMIN_SECRET"]
+STATE        = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
+DONE_FLAG    = STATE / "bootstrap.done"
+PKI_KEY_TYPE = os.environ.get("PKI_KEY_TYPE", "ec").strip().lower()
+TRUST_DOMAIN_SUFFIX = os.environ.get("TRUST_DOMAIN_SUFFIX", ".test")
+
+# ADR-009 sandbox — scope=up leaves org A (Acme Corp) **unregistered on the
+# Court**: Mastio A is still booted standalone (CA generated locally, volume
+# seeded) so the user can walk through the guided onboarding. scope=full
+# registers both orgs + all agents + MCP resources for scenario replay.
+SCOPE = os.environ.get("BOOTSTRAP_SCOPE", "full").strip().lower()
+if SCOPE not in ("up", "full"):
+    print(f"invalid BOOTSTRAP_SCOPE={SCOPE!r} — falling back to 'full'")
+    SCOPE = "full"
+
+# ---------------------------------------------------------------------------
+# ANSI helpers
+# ---------------------------------------------------------------------------
+RESET  = "\033[0m"
+BOLD   = "\033[1m"
+GREEN  = "\033[32m"
+YELLOW = "\033[33m"
+RED    = "\033[31m"
+CYAN   = "\033[36m"
+GRAY   = "\033[90m"
+
+
+def _header(phase: int, title: str) -> None:
+    line = f"═══ PHASE {phase} — {title} "
+    print(f"\n{BOLD}{CYAN}{line}{'═' * max(0, 60 - len(line))}{RESET}\n", flush=True)
+
+
+def _ok(msg: str) -> None:
+    print(f"  {GREEN}✓{RESET} {msg}", flush=True)
+
+
+def _warn(msg: str) -> None:
+    print(f"  {YELLOW}⚠{RESET} {msg}", flush=True)
+
+
+def _fail(msg: str) -> None:
+    print(f"  {RED}✗{RESET} {msg}", flush=True)
+
+
+def _info(msg: str) -> None:
+    print(f"  {GRAY}…{RESET} {msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Org / Agent definitions
+# ---------------------------------------------------------------------------
+ORGS = [
+    {"org_id": "orga", "display_name": "Organization A", "flow": "join"},
+    {"org_id": "orgb", "display_name": "Organization B", "flow": "attach"},
+]
+
+AGENTS = [
+    {
+        "agent_id": "orga::agent-a",
+        "org_id": "orga",
+        "capabilities": ["order.read", "order.write", "oneshot.message", "sandbox.read"],
+    },
+    {
+        "agent_id": "orga::byoca-bot",
+        "org_id": "orga",
+        "capabilities": ["order.read", "oneshot.message", "sandbox.read"],
+        "persist_extra": True,  # byoca-a container reads certs from state
+    },
+    {
+        "agent_id": "orgb::agent-b",
+        "org_id": "orgb",
+        "capabilities": ["order.read", "order.write", "oneshot.message", "sandbox.read"],
+    },
+]
+
+PEERS = {
+    "orga::agent-a":   ["orgb::agent-b", "orga::byoca-bot"],
+    "orga::byoca-bot":  ["orgb::agent-b", "orga::agent-a"],
+    "orgb::agent-b":   ["orga::agent-a", "orga::byoca-bot"],
+}
+
+# ---------------------------------------------------------------------------
+# PKI helpers
+# ---------------------------------------------------------------------------
+
+def _gen_key():
+    """Generate a private key of the configured type."""
+    if PKI_KEY_TYPE == "ec":
+        return ec.generate_private_key(ec.SECP256R1())
+    if PKI_KEY_TYPE == "rsa":
+        return rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    raise SystemExit(f"bootstrap: unsupported PKI_KEY_TYPE={PKI_KEY_TYPE!r}")
+
+
+def _thumbprint(cert: x509.Certificate) -> str:
+    """SHA-256 thumbprint, first 16 hex chars."""
+    return cert.fingerprint(hashes.SHA256()).hex()[:16]
+
+
+def _serial_hex(cert: x509.Certificate) -> str:
+    return format(cert.serial_number, "x")
+
+
+def _trust_domain(org_id: str) -> str:
+    return f"{org_id}{TRUST_DOMAIN_SUFFIX}"
+
+
+def _spiffe_id(org_id: str, agent_name: str) -> str:
+    return f"spiffe://{_trust_domain(org_id)}/{org_id}/{agent_name}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Wait for broker
+# ---------------------------------------------------------------------------
+
+def _wait_broker(client: httpx.Client, timeout_s: float = 120.0) -> None:
+    _header(1, "Waiting for Court (broker)")
+    _info(f"polling {BROKER_URL}/health (timeout {timeout_s:.0f}s)")
+    start = time.monotonic()
+    last_exc: Exception | None = None
+    while time.monotonic() - start < timeout_s:
+        try:
+            r = client.get(f"{BROKER_URL}/health")
+            if r.status_code == 200:
+                elapsed = time.monotonic() - start
+                _ok(f"GET /health → 200 OK  ({elapsed:.1f}s)")
+                return
+        except Exception as exc:
+            last_exc = exc
+        time.sleep(1)
+    _fail(f"broker not healthy after {timeout_s:.0f}s — last error: {last_exc}")
+    raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Generate Org CAs
+# ---------------------------------------------------------------------------
+
+def _gen_org_ca(org_id: str) -> tuple[x509.Certificate, bytes, bytes]:
+    """Generate a self-signed org CA. Returns (cert_obj, cert_pem, key_pem)."""
+    key = _gen_key()
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id} CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, key_cert_sign=True, crl_sign=True,
+                content_commitment=False, key_encipherment=False,
+                data_encipherment=False, key_agreement=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return cert, cert_pem, key_pem
+
+
+def _persist_org(org_id: str, display_name: str, cert_pem: bytes,
+                 key_pem: bytes, org_secret: str) -> None:
+    d = STATE / org_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "ca.pem").write_bytes(cert_pem)
+    (d / "ca-key.pem").write_bytes(key_pem)
+    (d / "org_secret").write_text(org_secret)
+    (d / "display_name").write_text(display_name)
+    for p in d.iterdir():
+        p.chmod(0o644)
+
+
+def phase_2_generate_cas() -> dict[str, dict]:
+    """Returns {org_id: {cert, cert_pem, key_pem, org_secret, display_name}}."""
+    _header(2, "Generate Org CAs")
+    orgs_data: dict[str, dict] = {}
+    for org in ORGS:
+        oid = org["org_id"]
+        cert, cert_pem, key_pem = _gen_org_ca(oid)
+        org_secret = secrets.token_urlsafe(32)
+        _persist_org(oid, org["display_name"], cert_pem, key_pem, org_secret)
+        cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+        _ok(f"org_id={BOLD}{oid}{RESET}  key={PKI_KEY_TYPE.upper()}  CN={cn}")
+        _ok(f"serial={GRAY}{_serial_hex(cert)}{RESET}  thumbprint={CYAN}{_thumbprint(cert)}{RESET}")
+        _ok(f"persisted → {STATE / oid}/")
+        orgs_data[oid] = {
+            "cert": cert, "cert_pem": cert_pem, "key_pem": key_pem,
+            "org_secret": org_secret, "display_name": org["display_name"],
+        }
+    return orgs_data
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Register orgs on broker
+# ---------------------------------------------------------------------------
+
+def _admin_headers() -> dict[str, str]:
+    return {"x-admin-secret": ADMIN_SECRET}
+
+
+def _org_headers(org_id: str, org_secret: str) -> dict[str, str]:
+    return {"x-org-id": org_id, "x-org-secret": org_secret}
+
+
+def _log_http(method: str, path: str, r: httpx.Response) -> None:
+    status = r.status_code
+    reason = r.reason_phrase or ""
+    color = GREEN if 200 <= status < 300 else (YELLOW if status < 400 else RED)
+    _ok(f"{method} {path} → {color}{status} {reason}{RESET}")
+
+
+def _onboard_via_join(client: httpx.Client, org_id: str, display_name: str,
+                      cert_pem: bytes, org_secret: str) -> None:
+    # Create invite
+    r = client.post(
+        f"{BROKER_URL}/v1/admin/invites",
+        json={"label": f"sandbox-{org_id}", "ttl_hours": 1},
+        headers=_admin_headers(),
+    )
+    r.raise_for_status()
+    token = r.json()["token"]
+    _log_http("POST", "/v1/admin/invites", r)
+
+    # Join
+    r = client.post(f"{BROKER_URL}/v1/onboarding/join", json={
+        "org_id": org_id,
+        "display_name": display_name,
+        "secret": org_secret,
+        "ca_certificate": cert_pem.decode(),
+        "contact_email": f"admin@{org_id}.test",
+        "invite_token": token,
+        "trust_domain": _trust_domain(org_id),
+    })
+    if r.status_code == 409:
+        _warn(f"{org_id} already registered — skipping join")
+        return
+    if r.status_code not in (200, 201, 202):
+        _fail(f"join failed: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _log_http("POST", "/v1/onboarding/join", r)
+
+    # Admin approve
+    r = client.post(
+        f"{BROKER_URL}/v1/admin/orgs/{org_id}/approve",
+        headers=_admin_headers(),
+    )
+    if r.status_code not in (200, 409):
+        r.raise_for_status()
+    _log_http("POST", f"/v1/admin/orgs/{org_id}/approve", r)
+    _ok(f"{BOLD}{org_id}{RESET} active via join flow")
+
+
+def _onboard_via_attach(client: httpx.Client, org_id: str, display_name: str,
+                        cert_pem: bytes, org_secret: str) -> None:
+    # Admin creates org (409 = already exists → skip to attach)
+    r = client.post(f"{BROKER_URL}/v1/registry/orgs", json={
+        "org_id": org_id,
+        "display_name": display_name,
+        "secret": "placeholder-will-be-rotated",
+    }, headers=_admin_headers())
+    if r.status_code == 409:
+        _warn(f"{org_id} already registered — skipping attach")
+        return
+    r.raise_for_status()
+    _log_http("POST", "/v1/registry/orgs", r)
+
+    # Admin generates attach invite
+    r = client.post(
+        f"{BROKER_URL}/v1/admin/orgs/{org_id}/attach-invite",
+        json={"label": f"sandbox-attach-{org_id}", "ttl_hours": 1},
+        headers=_admin_headers(),
+    )
+    r.raise_for_status()
+    token = r.json()["token"]
+    _log_http("POST", f"/v1/admin/orgs/{org_id}/attach-invite", r)
+
+    # Attach CA + rotate secret
+    r = client.post(f"{BROKER_URL}/v1/onboarding/attach", json={
+        "ca_certificate": cert_pem.decode(),
+        "invite_token": token,
+        "secret": org_secret,
+        "trust_domain": _trust_domain(org_id),
+    })
+    if r.status_code not in (200, 201, 202):
+        _fail(f"attach failed: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _log_http("POST", "/v1/onboarding/attach", r)
+    _ok(f"{BOLD}{org_id}{RESET} active via attach flow")
+
+
+def phase_3_register_orgs(client: httpx.Client, orgs_data: dict[str, dict]) -> None:
+    # ADR-009 sandbox — scope=up registers only ``orgb``. ``orga`` is left
+    # unregistered so the user can walk through the guided Court-side
+    # onboarding (see GUIDE.md, step 1). Mastio A is still booted with the
+    # locally-generated Org CA so the dashboard is reachable.
+    target_orgs = [o for o in ORGS if SCOPE == "full" or o["org_id"] != "orga"]
+
+    _header(3, f"Register orgs on broker (scope={SCOPE})")
+    if SCOPE == "up":
+        _info("scope=up → registering only orgb; orga left for user onboarding")
+
+    for org in target_orgs:
+        oid = org["org_id"]
+        d = orgs_data[oid]
+        _info(f"registering {BOLD}{oid}{RESET} via {org['flow']} flow")
+        if org["flow"] == "join":
+            _onboard_via_join(client, oid, d["display_name"],
+                              d["cert_pem"], d["org_secret"])
+        elif org["flow"] == "attach":
+            _onboard_via_attach(client, oid, d["display_name"],
+                                d["cert_pem"], d["org_secret"])
+        else:
+            raise SystemExit(f"unknown flow: {org['flow']}")
+
+    # Verify
+    r = client.get(f"{BROKER_URL}/v1/registry/orgs", headers=_admin_headers())
+    r.raise_for_status()
+    active_ids = {o["org_id"] for o in r.json() if o.get("status") == "active"}
+    expected = {o["org_id"] for o in target_orgs}
+    missing = expected - active_ids
+    if missing:
+        _fail(f"orgs not active: {missing}")
+        raise SystemExit(1)
+    _ok(f"verified {len(expected)} orgs active on broker")
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Register agents
+# ---------------------------------------------------------------------------
+
+def _gen_agent_cert(agent_id: str, org_id: str,
+                    ca_cert_pem: bytes, ca_key_pem: bytes) -> tuple[x509.Certificate, bytes, bytes]:
+    """Issue agent cert signed by org CA with SPIFFE SAN."""
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem)
+    ca_key = load_pem_private_key(ca_key_pem, password=None)
+    key = _gen_key()
+    _, agent_name = agent_id.split("::", 1)
+    spiffe = _spiffe_id(org_id, agent_name)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe),
+            ]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return cert, cert_pem, key_pem
+
+
+def _provision_agent(client: httpx.Client, agent_def: dict,
+                     orgs_data: dict[str, dict]) -> dict:
+    """Register one agent + binding; returns metadata dict."""
+    agent_id = agent_def["agent_id"]
+    org_id = agent_def["org_id"]
+    caps = agent_def["capabilities"]
+    _, agent_name = agent_id.split("::", 1)
+    spiffe = _spiffe_id(org_id, agent_name)
+
+    od = orgs_data[org_id]
+    org_secret = od["org_secret"]
+    headers = _org_headers(org_id, org_secret)
+
+    # 1. Issue cert
+    cert, cert_pem, key_pem = _gen_agent_cert(
+        agent_id, org_id, od["cert_pem"], od["key_pem"],
+    )
+
+    # Persist cert/key for the agent
+    agent_dir = STATE / org_id / "agents" / agent_name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.pem").write_bytes(cert_pem)
+    (agent_dir / "agent-key.pem").write_bytes(key_pem)
+    (agent_dir / "agent.pem").chmod(0o644)
+    (agent_dir / "agent-key.pem").chmod(0o644)
+
+    _ok(f"agent_id={BOLD}{agent_id}{RESET}  SPIFFE={CYAN}{spiffe}{RESET}")
+    _ok(f"cert serial={GRAY}{_serial_hex(cert)}{RESET}  thumbprint={CYAN}{_thumbprint(cert)}{RESET}  key={PKI_KEY_TYPE.upper()}")
+
+    # 2. Register agent
+    r = client.post(
+        f"{BROKER_URL}/v1/registry/agents",
+        json={
+            "agent_id": agent_id,
+            "org_id": org_id,
+            "display_name": f"{od['display_name']} {agent_name}",
+            "capabilities": caps,
+            "description": f"enterprise sandbox {agent_name}",
+        },
+        headers=headers,
+    )
+    if r.status_code not in (200, 201, 409):
+        _fail(f"register agent {agent_id}: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _log_http("POST", "/v1/registry/agents", r)
+
+    # 3. Create binding
+    r = client.post(
+        f"{BROKER_URL}/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": caps},
+        headers=headers,
+    )
+    if r.status_code == 201:
+        binding_id = r.json()["id"]
+    elif r.status_code == 409:
+        r2 = client.get(
+            f"{BROKER_URL}/v1/registry/bindings",
+            params={"org_id": org_id},
+            headers=headers,
+        )
+        r2.raise_for_status()
+        binding_id = next(b["id"] for b in r2.json() if b.get("agent_id") == agent_id)
+    else:
+        _fail(f"binding create {agent_id}: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _log_http("POST", "/v1/registry/bindings", r)
+
+    # 4. Approve binding
+    r = client.post(
+        f"{BROKER_URL}/v1/registry/bindings/{binding_id}/approve",
+        headers=headers,
+    )
+    if r.status_code != 200:
+        _fail(f"binding approve {agent_id}: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _ok(f"binding {GRAY}{binding_id}{RESET}  scope={caps}")
+
+    # Extra persist for byoca-bot
+    if agent_def.get("persist_extra"):
+        _ok(f"persisted cert+key → {agent_dir}/")
+
+    return {
+        "agent_id": agent_id,
+        "org_id": org_id,
+        "spiffe_id": spiffe,
+        "capabilities": caps,
+        "cert_serial": _serial_hex(cert),
+        "cert_thumbprint": _thumbprint(cert),
+    }
+
+
+def phase_4_register_agents(client: httpx.Client, orgs_data: dict[str, dict]) -> list[dict]:
+    # ADR-009 sandbox — scope=up enrolls only orgb agents. orga agents are
+    # deferred to the guided walkthrough.
+    targets = [a for a in AGENTS if SCOPE == "full" or a["org_id"] != "orga"]
+    _header(4, f"Register agents (scope={SCOPE})")
+    if SCOPE == "up":
+        _info("scope=up → enrolling only orgb agents")
+    results = []
+    for agent_def in targets:
+        _info(f"provisioning {BOLD}{agent_def['agent_id']}{RESET}")
+        meta = _provision_agent(client, agent_def, orgs_data)
+        results.append(meta)
+        print(flush=True)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Session policies
+# ---------------------------------------------------------------------------
+
+def phase_5_session_policies(client: httpx.Client, orgs_data: dict[str, dict]) -> None:
+    target_orgs = [o for o in ORGS if SCOPE == "full" or o["org_id"] != "orga"]
+    _header(5, f"Create session policies (scope={SCOPE})")
+    for org in target_orgs:
+        oid = org["org_id"]
+        od = orgs_data[oid]
+        policy_id = f"{oid}::session-allow-all"
+        headers = _org_headers(oid, od["org_secret"])
+        r = client.post(
+            f"{BROKER_URL}/v1/policy/rules",
+            json={
+                "policy_id": policy_id,
+                "org_id": oid,
+                "policy_type": "session",
+                "rules": {
+                    "effect": "allow",
+                    "conditions": {"target_org_id": [], "capabilities": []},
+                },
+            },
+            headers=headers,
+        )
+        if r.status_code not in (200, 201, 409):
+            _fail(f"policy create {policy_id}: {r.status_code} {r.text}")
+            raise SystemExit(1)
+        _log_http("POST", "/v1/policy/rules", r)
+        _ok(f"policy_id={BOLD}{policy_id}{RESET}  effect={GREEN}allow{RESET}")
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — peers.json
+# ---------------------------------------------------------------------------
+
+def phase_6_peers_json() -> None:
+    _header(6, "Generate peers.json")
+    path = STATE / "peers.json"
+    path.write_text(json.dumps(PEERS, indent=2))
+    path.chmod(0o644)
+    for agent_id, peers in PEERS.items():
+        _ok(f"{agent_id} → {peers}")
+    _ok(f"written → {path}")
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — Summary
+# ---------------------------------------------------------------------------
+
+def phase_7_summary(agents_meta: list[dict]) -> None:
+    _header(7, "Summary")
+
+    # Org table
+    print(f"  {BOLD}{'ORG ID':<12} {'DISPLAY NAME':<22} {'FLOW':<8}{RESET}", flush=True)
+    print(f"  {'─' * 12} {'─' * 22} {'─' * 8}", flush=True)
+    for org in ORGS:
+        print(f"  {GREEN}{org['org_id']:<12}{RESET} {org['display_name']:<22} {org['flow']:<8}", flush=True)
+    print(flush=True)
+
+    # Agent table
+    print(f"  {BOLD}{'AGENT ID':<22} {'SPIFFE ID':<42} {'THUMBPRINT':<18} {'CAPABILITIES'}{RESET}", flush=True)
+    print(f"  {'─' * 22} {'─' * 42} {'─' * 18} {'─' * 30}", flush=True)
+    for m in agents_meta:
+        caps_str = ", ".join(m["capabilities"])
+        print(
+            f"  {GREEN}{m['agent_id']:<22}{RESET} "
+            f"{CYAN}{m['spiffe_id']:<42}{RESET} "
+            f"{GRAY}{m['cert_thumbprint']:<18}{RESET} "
+            f"{caps_str}",
+            flush=True,
+        )
+    print(flush=True)
+
+    DONE_FLAG.touch()
+    _ok(f"bootstrap.done → {DONE_FLAG}")
+    print(f"\n  {BOLD}{GREEN}Bootstrap complete.{RESET}\n", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    STATE.mkdir(parents=True, exist_ok=True)
+    if DONE_FLAG.exists():
+        DONE_FLAG.unlink()
+
+    with httpx.Client(verify=False, timeout=30.0) as client:
+        # Phase 1
+        _wait_broker(client)
+
+        # Phase 2
+        orgs_data = phase_2_generate_cas()
+
+        # Phase 3
+        phase_3_register_orgs(client, orgs_data)
+
+        # Phase 4
+        agents_meta = phase_4_register_agents(client, orgs_data)
+
+        # Phase 5
+        phase_5_session_policies(client, orgs_data)
+
+    # Phase 6
+    phase_6_peers_json()
+
+    # Phase 7
+    phase_7_summary(agents_meta)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enterprise_sandbox/bootstrap/bootstrap_mastio.py
+++ b/enterprise_sandbox/bootstrap/bootstrap_mastio.py
@@ -27,9 +27,16 @@ import httpx
 BROKER_URL   = os.environ.get("BROKER_URL", "http://broker:8000")
 ADMIN_SECRET = os.environ["ADMIN_SECRET"]
 
+# ADR-009 sandbox — scope=up has only orgb on the Court. Patching orga
+# would fail with 404 because the bootstrap container skipped its
+# registration. scope=full pins both.
+SCOPE = os.environ.get("BOOTSTRAP_SCOPE", "full").strip().lower()
+if SCOPE not in ("up", "full"):
+    SCOPE = "full"
+
 # Per-org proxy URL + proxy admin secret. Sandbox uses the broker's
 # admin secret for simplicity — in prod each proxy carries its own.
-PROXIES = [
+_ALL_PROXIES = [
     {
         "org_id":       "orga",
         "proxy_url":    os.environ.get("PROXY_A_URL", "http://proxy-a:9100"),
@@ -40,6 +47,9 @@ PROXIES = [
         "proxy_url":    os.environ.get("PROXY_B_URL", "http://proxy-b:9200"),
         "admin_secret": os.environ.get("PROXY_B_ADMIN_SECRET", ADMIN_SECRET),
     },
+]
+PROXIES = [
+    p for p in _ALL_PROXIES if SCOPE == "full" or p["org_id"] != "orga"
 ]
 
 RESET = "\033[0m"

--- a/enterprise_sandbox/demo.sh
+++ b/enterprise_sandbox/demo.sh
@@ -1,63 +1,88 @@
 #!/usr/bin/env bash
+# Cullis Enterprise Sandbox — 3-mode driver (ADR-009 sandbox restructure).
+#
+#   demo.sh up        Tier 1: Court + Org B complete + Mastio A standalone
+#                              (user completes Org A via the guided flow)
+#   demo.sh full      Tier 2: everything wired — two orgs, three agents,
+#                              two MCP servers, scenarios ready to replay
+#   demo.sh down      Teardown (containers + volumes)
+#   demo.sh status    List running services
+#   demo.sh logs [S]  Tail compose logs
+#   demo.sh dashboard Print dashboard URLs
+#   demo.sh help      This message
+#
 set -euo pipefail
-
 cd "$(dirname "$0")"
 
-# ANSI
 BOLD='\033[1m'
 GREEN='\033[32m'
 CYAN='\033[36m'
+YELLOW='\033[33m'
 RESET='\033[0m'
 
 _header() { echo -e "\n${BOLD}${CYAN}═══ $1 ═══${RESET}\n"; }
+_ok()     { echo -e "  ${GREEN}✓${RESET} $1"; }
+_note()   { echo -e "  ${YELLOW}•${RESET} $1"; }
+
+_print_dashboards() {
+    _header "Dashboard URLs"
+    echo -e "  ${GREEN}Court (broker)${RESET}      http://localhost:8000/dashboard/login"
+    echo -e "                       admin / sandbox-admin-secret-change-me"
+    echo -e "  ${GREEN}Mastio A (proxy-a)${RESET}  http://localhost:9100/proxy"
+    echo -e "                       admin secret: sandbox-proxy-admin-a"
+    echo -e "  ${GREEN}Mastio B (proxy-b)${RESET}  http://localhost:9200/proxy"
+    echo -e "                       admin secret: sandbox-proxy-admin-b"
+    echo -e "  ${GREEN}Keycloak A${RESET}          http://localhost:8180 (alice / alice-sandbox)"
+    echo -e "  ${GREEN}Keycloak B${RESET}          http://localhost:8280 (bob / bob-sandbox)"
+}
 
 case "${1:-help}" in
   up)
-    _header "Enterprise Sandbox — Starting"
-    echo "Building and starting all services..."
+    _header "Enterprise Sandbox — Tier 1 (you onboard Org A)"
+    _note "Org B (Globex Inc) is fully wired."
+    _note "Org A (Acme Corp) has Mastio A running in standalone mode but"
+    _note "is NOT registered on the Court — you will do that from the guide."
+    export BOOTSTRAP_SCOPE=up
     docker compose build --quiet
     docker compose up -d --wait
-    echo ""
     _header "Services Running"
     docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+    _print_dashboards
     echo ""
-    _header "Dashboard URLs"
-    echo -e "  ${GREEN}Court (broker)${RESET}     http://localhost:8000/dashboard/login"
-    echo -e "                      admin / sandbox-admin-secret-change-me"
-    echo -e "  ${GREEN}Mastio A (proxy-a)${RESET} http://localhost:9100/proxy"
-    echo -e "                      admin secret: sandbox-proxy-admin-a"
-    echo -e "  ${GREEN}Mastio B (proxy-b)${RESET} http://localhost:9200/proxy"
-    echo -e "                      admin secret: sandbox-proxy-admin-b"
-    echo -e "  ${GREEN}Keycloak A${RESET}         http://localhost:8180  (alice / alice-sandbox)"
-    echo -e "  ${GREEN}Keycloak B${RESET}         http://localhost:8280  (bob / bob-sandbox)"
+    _ok "Sandbox ready. Run ${BOLD}demo.sh help${RESET} to see commands."
+    ;;
+
+  full)
+    _header "Enterprise Sandbox — Tier 2 (everything wired)"
+    _note "Both orgs registered, three agents enrolled, two MCP servers online."
+    export BOOTSTRAP_SCOPE=full
+    docker compose --profile full build --quiet
+    docker compose --profile full up -d --wait
+    _header "Services Running"
+    docker compose --profile full ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+    _print_dashboards
     echo ""
-    echo -e "Bootstrap logs:  docker compose -f enterprise_sandbox/docker-compose.yml logs bootstrap"
-    echo -e "Agent logs:      docker compose -f enterprise_sandbox/docker-compose.yml logs agent-a agent-b byoca-a"
+    _ok "Full sandbox ready."
     ;;
 
   down)
     _header "Enterprise Sandbox — Teardown"
-    docker compose down -v --remove-orphans
-    echo -e "${GREEN}✓ sandbox down${RESET}"
+    docker compose --profile full down -v --remove-orphans
+    _ok "sandbox down"
     ;;
 
   status)
     _header "Enterprise Sandbox — Status"
-    docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
+    docker compose --profile full ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
     ;;
 
   logs)
     shift
-    docker compose logs "${@:---tail=50}"
+    docker compose --profile full logs "${@:---tail=50}"
     ;;
 
   dashboard)
-    _header "Dashboard URLs"
-    echo -e "  Court (broker)     http://localhost:8000/dashboard/login"
-    echo -e "  Mastio A (proxy-a) http://localhost:9100/proxy"
-    echo -e "  Mastio B (proxy-b) http://localhost:9200/proxy"
-    echo -e "  Keycloak A         http://localhost:8180"
-    echo -e "  Keycloak B         http://localhost:8280"
+    _print_dashboards
     ;;
 
   bootstrap-logs)
@@ -65,16 +90,20 @@ case "${1:-help}" in
     ;;
 
   help|*)
-    echo "Usage: demo.sh <command>"
-    echo ""
-    echo "Lifecycle:"
-    echo "  up              Build + start all services, show dashboard URLs"
-    echo "  down            Teardown (remove containers + volumes)"
-    echo "  status          Show running services"
-    echo "  logs [service]  Show logs (default: last 50 lines)"
-    echo ""
-    echo "Info:"
-    echo "  dashboard       Print dashboard URLs"
-    echo "  bootstrap-logs  Show bootstrap verbose output"
+    cat <<EOF
+Usage: demo.sh <command>
+
+Lifecycle:
+  up              Tier 1 — Court + Org B wired + Mastio A standalone.
+                  Org A is left for you to onboard via the guided flow.
+  full            Tier 2 — both orgs + all agents + MCP servers wired.
+  down            Stop everything + drop volumes.
+
+Inspection:
+  status          List services + health.
+  logs [svc]      Tail compose logs (default: --tail=50).
+  dashboard       Print dashboard URLs + admin secrets.
+  bootstrap-logs  Replay the verbose Phase 1-7 bootstrap output.
+EOF
     ;;
 esac

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -180,10 +180,14 @@ services:
       broker:
         condition: service_healthy
     environment:
-      BROKER_URL:   "http://broker:8000"
-      ADMIN_SECRET: "sandbox-admin-secret-change-me"
-      STATE_DIR:    /state
-      POSTGRES_DSN: "postgresql://atn:atn-sandbox@postgres:5432/agent_trust"
+      BROKER_URL:       "http://broker:8000"
+      ADMIN_SECRET:     "sandbox-admin-secret-change-me"
+      STATE_DIR:        /state
+      POSTGRES_DSN:     "postgresql://atn:atn-sandbox@postgres:5432/agent_trust"
+      # ADR-009 sandbox: BOOTSTRAP_SCOPE=up (default) keeps orga unregistered
+      # on the Court so the user walks through it in the guided flow;
+      # demo.sh full exports BOOTSTRAP_SCOPE=full.
+      BOOTSTRAP_SCOPE:  "${BOOTSTRAP_SCOPE:-up}"
       # Per PR #88 the broker no longer has per-org OIDC login — OIDC is
       # configured per-proxy via proxy-init below. Bootstrap just creates
       # the orgs on the broker and writes CA/secret to /state.
@@ -336,6 +340,10 @@ services:
       start_period: 15s
 
   agent-a:
+    # ADR-009 sandbox — orga workloads only start in ``full`` mode; with
+    # the default ``demo.sh up`` the user bootstraps orga themselves
+    # via the guided walkthrough.
+    profiles: ["full"]
     build:
       context: ..
       dockerfile: enterprise_sandbox/agent/Dockerfile
@@ -375,6 +383,7 @@ services:
   # mode: same org, one trust_domain, different agents pick different
   # auth methods.
   byoca-a:
+    profiles: ["full"]
     build:
       context: ..
       dockerfile: enterprise_sandbox/agent/Dockerfile
@@ -569,6 +578,7 @@ services:
   # ── MCP servers (ADR-007) ──────────────────────────────────────────────────
 
   mcp-catalog:
+    profiles: ["full"]
     build:
       context: ./mcp-catalog
       dockerfile: ../mcp-server.Dockerfile
@@ -613,5 +623,8 @@ services:
       PROXY_A_ADMIN_SECRET:  "sandbox-proxy-admin-a"
       PROXY_B_URL:           "http://proxy-b:9200"
       PROXY_B_ADMIN_SECRET:  "sandbox-proxy-admin-b"
+      # Must match bootstrap's scope — in ``up`` only orgb is patched;
+      # orga doesn't exist on the Court yet.
+      BOOTSTRAP_SCOPE:       "${BOOTSTRAP_SCOPE:-up}"
     networks: [public-wan]
     restart: "no"


### PR DESCRIPTION
Third PR of the sandbox restructure — splits the enterprise sandbox into two tiered experiences.

## Summary

- **\`demo.sh up\`** (Tier 1, new default): Court + Org B (Globex Inc) fully wired + Mastio A (Acme Corp) **standalone, unregistered on the Court**. The user will complete the Org A onboarding through the guided flow in PR 4/4.
- **\`demo.sh full\`** (Tier 2): everything wired — both orgs, three agents, two MCP servers. Same footprint as the previous \`demo.sh up\`.
- **Mechanism**: native \`docker compose profiles: ["full"]\` on \`agent-a\`, \`byoca-a\`, \`mcp-catalog\` + \`BOOTSTRAP_SCOPE=up|full\` env var read by \`bootstrap.py\` and \`bootstrap_mastio.py\`.

## Bug fix (incidental but load-bearing)

\`.gitignore\` had an unanchored \`bootstrap.py\` rule — every \`bootstrap.py\` anywhere in the tree was silently ignored. \`enterprise_sandbox/bootstrap/bootstrap.py\` had never been committed → fresh CI clones couldn't build the sandbox image. Rule anchored with \`/\`; the real sandbox bootstrap is now in git.

## Next in the stack

- PR 4/4 — scenario drivers (\`demo.sh oneshot-a-to-b\`, \`mcp-a-to-b\`, …) + \`demo.sh guide\` markdown walkthrough + host-agent example

## Test plan

- [x] \`docker compose config --services\` → 20 services (Org A workloads absent)
- [x] \`docker compose --profile full config --services\` → 23 services (agent-a, byoca-a, mcp-catalog added)
- [x] Full pytest suite (ex ts_interop/postgres local-stale): 1119 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS
- [ ] Manual shake-out of \`./enterprise_sandbox/demo.sh up\` + \`full\` — to be done after merge (sandbox is not a CI gate)