### PR TITLE
feat(sandbox): scenario drivers + guided walkthrough + host-agent example (ADR-009 sandbox PR 4/4)

### DIFF
--- a/cullis_sdk/examples/host_agent.py
+++ b/cullis_sdk/examples/host_agent.py
@@ -1,0 +1,58 @@
+"""Host-agent example — send a one-shot using the Connector identity.
+
+After enrolling an agent through the Connector Desktop (ADR-009 sandbox
+Step 3 of GUIDE.md), run this script from any shell:
+
+    CULLIS_TARGET_AGENT=orgb::agent-b python cullis_sdk/examples/host_agent.py
+
+The script loads the enrolled identity from ``~/.cullis/identity/``,
+authenticates through the local Mastio via ``login_via_proxy`` (which
+the SDK auto-counter-signs, see ADR-009 Phase 2), and sends a single
+one-shot envelope to the target.
+
+Env:
+    CULLIS_TARGET_AGENT    recipient (e.g. ``orgb::agent-b``)
+    CULLIS_CONFIG_DIR      override ``~/.cullis`` (optional)
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+import uuid
+
+from cullis_sdk import CullisClient
+
+
+def main() -> int:
+    target = os.environ.get("CULLIS_TARGET_AGENT")
+    if not target:
+        print("set CULLIS_TARGET_AGENT (e.g. orgb::agent-b)", file=sys.stderr)
+        return 2
+
+    config_dir = os.environ.get("CULLIS_CONFIG_DIR")
+    client = CullisClient.from_connector(config_dir=config_dir)
+    print(f"loaded identity from disk: agent_id={client._proxy_agent_id}")
+
+    client.login_via_proxy()
+    print("authenticated via local Mastio — broker token issued")
+
+    nonce = uuid.uuid4().hex[:12]
+    resp = client.send_oneshot(
+        recipient_id=target,
+        payload={
+            "hello": "from a host-side agent",
+            "nonce": nonce,
+            "sent_at": time.time(),
+        },
+        ttl_seconds=300,
+    )
+    print(
+        f"\u2713 one-shot sent to {target}  "
+        f"msg_id={resp.get('msg_id')}  nonce={nonce}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/enterprise_sandbox/GUIDE.md
+++ b/enterprise_sandbox/GUIDE.md
@@ -1,0 +1,214 @@
+# Onboard Org A into the Cullis sandbox
+
+You spun up the sandbox with `./demo.sh up`. Org B (Globex Inc) is
+fully wired — you can inspect it already. Org A (Acme Corp) has its
+Mastio running in **standalone** mode but is not yet registered on the
+Court. Walk through the four steps below to complete the onboarding
+end-to-end.
+
+Every command is copy-paste-ready with the exact values used by this
+sandbox — no placeholders. You'll see the same flow a real customer
+follows when joining a federated Cullis network for the first time.
+
+---
+
+## Step 1 · Attach Mastio A to the Court
+
+The Court is the shared broker. The Mastio is your org's gateway. The
+handshake between them is the **attach-ca** flow — admin side creates
+a single-use invite, proxy side redeems it with its CA and a secret
+of its choice.
+
+### 1a · Court admin creates the attach invite
+
+```bash
+curl -X POST http://localhost:8000/v1/admin/invites \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-Secret: sandbox-admin-secret-change-me" \
+  -d '{
+    "label": "acme-corp attach",
+    "ttl_hours": 1,
+    "invite_type": "attach-ca",
+    "linked_org_id": "orga"
+  }'
+```
+
+Output:
+
+```json
+{ "token": "inv_xxxxxxxxxxxx...", ... }
+```
+
+Copy the `token` — you'll paste it into the Mastio dashboard next.
+
+### 1b · Mastio A admin redeems it
+
+Open the Mastio A dashboard: <http://localhost:9100/proxy/link-broker>
+Log in with admin secret `sandbox-proxy-admin-a`.
+
+Fill the form:
+
+- Broker URL: `http://broker:8000` (the Court, reachable from the
+  Mastio container)
+- Invite token: the value from Step 1a
+
+Press **Link broker**. The dashboard will reload; Mastio A is now
+federated.
+
+Verify from the terminal:
+
+```bash
+curl -s http://localhost:8000/v1/registry/orgs \
+  -H "X-Admin-Secret: sandbox-admin-secret-change-me" | jq '.[] | {org_id, status}'
+```
+
+You should see both `orga` and `orgb` with `"status": "active"`.
+
+---
+
+## Step 2 · Pin the Mastio counter-signature public key
+
+ADR-009 requires every `/v1/auth/token` call to carry a
+`X-Cullis-Mastio-Signature` header. The Court pins the mastio's EC
+P-256 public key at onboarding; any subsequent login for that org
+must be counter-signed by the matching private key. This closes the
+"agent bypasses the proxy" gap.
+
+### 2a · Fetch the key from Mastio A
+
+```bash
+curl -s http://localhost:9100/v1/admin/mastio-pubkey \
+  -H "X-Admin-Secret: sandbox-proxy-admin-a"
+```
+
+Output:
+
+```json
+{ "mastio_pubkey": "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n", "org_id": "orga" }
+```
+
+### 2b · Pin it on the Court
+
+```bash
+MASTIO_PUBKEY=$(curl -s http://localhost:9100/v1/admin/mastio-pubkey \
+  -H "X-Admin-Secret: sandbox-proxy-admin-a" | jq -r .mastio_pubkey)
+
+curl -X PATCH http://localhost:8000/v1/admin/orgs/orga/mastio-pubkey \
+  -H "Content-Type: application/json" \
+  -H "X-Admin-Secret: sandbox-admin-secret-change-me" \
+  -d "$(jq -n --arg k "$MASTIO_PUBKEY" '{mastio_pubkey: $k}')"
+```
+
+Expected: `{"org_id":"orga","mastio_pubkey_set":true}`
+
+From this moment on the Court will refuse to emit a token for `orga`
+without a valid counter-signature.
+
+---
+
+## Step 3 · Install the Connector Desktop and enroll Alice
+
+The Connector Desktop is the end-user app. A developer on their
+laptop runs it to enroll an agent, then their Python code uses
+`CullisClient.from_connector()` to talk to the network.
+
+### 3a · Download and run
+
+Open <http://localhost:9100/downloads> from your host browser.
+Download the zip for your OS, unpack, run.
+
+The Connector opens a local dashboard on **<http://127.0.0.1:7777>**.
+
+### 3b · Enrollment session — user side
+
+On the Connector dashboard, paste:
+
+- **Mastio URL**: `http://localhost:9100`
+- **Requester name**: `alice`
+- **Reason**: `demo onboarding`
+
+Press **Start enrollment**. The Connector generates a fresh EC P-256
+keypair locally, POSTs the public key to the Mastio, and shows a
+"waiting for admin approval" screen.
+
+### 3c · Admin approves
+
+Open the Mastio A admin dashboard:
+<http://localhost:9100/proxy/enrollments>.
+Log in with `sandbox-proxy-admin-a`. You'll see Alice's pending row.
+
+Click **Approve**, fill:
+
+- `agent_id`: `orga::alice`
+- `capabilities`: `oneshot.message, order.read`
+- `groups`: `demo`
+
+Press **Approve**. Within 5s the Connector dashboard flips to
+"Connected" and writes the identity under `~/.cullis/identity/`.
+
+---
+
+## Step 4 · Register an MCP server + bind Alice
+
+Alice needs a capability to call — an MCP server. Use the Connector's
+admin mode (no separate dashboard login required).
+
+### 4a · Unlock admin mode in the Connector
+
+On the Connector dashboard, open the **MCP Resources** link in the
+sidebar. Paste the Mastio admin secret (`sandbox-proxy-admin-a`).
+
+### 4b · Register a resource
+
+Fill the form:
+
+- Name: `acme-catalog`
+- Endpoint: `http://mcp-catalog:9300/`
+- Description: `Acme Corp catalog`
+- Required capability: `order.read`
+
+Press **Register**. The Connector calls
+`POST /v1/admin/mcp-resources` on the Mastio.
+
+### 4c · Bind Alice to the resource
+
+From the resource list, click **Bind me** on the `acme-catalog` row.
+That issues `POST /v1/admin/mcp-resources/bindings` with Alice's
+`agent_id` + the new `resource_id`.
+
+---
+
+## Step 5 · Test end-to-end
+
+From your host (with the Connector still running and Alice enrolled),
+run the host-agent example:
+
+```bash
+CULLIS_TARGET_AGENT=orgb::agent-b python cullis_sdk/examples/host_agent.py
+```
+
+Expected output: `✓ one-shot sent to orgb::agent-b`.
+
+Then inspect Bob's inbox:
+
+```bash
+./demo.sh logs agent-b | tail -20 | grep received
+```
+
+You'll see Bob's agent printing the nonce Alice just sent.
+
+---
+
+## What happens if you run `demo.sh full` instead?
+
+Same endpoint, same certs, same counter-signature. All four steps
+above are done for you at bootstrap time, so you skip straight to
+scenarios:
+
+```bash
+./demo.sh oneshot-a-to-b
+./demo.sh oneshot-b-to-a
+```
+
+Use `up` when you want to *learn* the onboarding flow; use `full`
+when you want to *replay* scenarios without any setup.

--- a/enterprise_sandbox/agent/Dockerfile
+++ b/enterprise_sandbox/agent/Dockerfile
@@ -12,6 +12,10 @@ COPY cullis_connector/ /build/cullis_connector/
 RUN pip install --no-cache-dir "/build[spiffe]"
 
 COPY enterprise_sandbox/agent/agent.py /app/agent.py
+# ADR-009 sandbox PR 4 — ship the scenario drivers alongside the runtime
+# agent so `docker compose exec agent-X python /app/scenarios/…` works
+# without extra build or volume wiring.
+COPY enterprise_sandbox/scenarios/ /app/scenarios/
 
 # Match spire-server registration entry `unix:uid:1000`
 RUN groupadd -g 1000 agent && useradd -u 1000 -g 1000 -m -s /bin/sh agent

--- a/enterprise_sandbox/demo.sh
+++ b/enterprise_sandbox/demo.sh
@@ -89,6 +89,26 @@ case "${1:-help}" in
     docker compose logs bootstrap --no-log-prefix
     ;;
 
+  oneshot-a-to-b)
+    _header "Scenario — cross-org one-shot: orga::agent-a → orgb::agent-b"
+    docker compose exec -e TARGET_AGENT_ID=orgb::agent-b agent-a \
+      python /app/scenarios/oneshot_cross_org.py
+    ;;
+
+  oneshot-b-to-a)
+    _header "Scenario — cross-org one-shot: orgb::agent-b → orga::agent-a"
+    docker compose exec -e TARGET_AGENT_ID=orga::agent-a agent-b \
+      python /app/scenarios/oneshot_cross_org.py
+    ;;
+
+  guide)
+    if command -v less >/dev/null 2>&1; then
+      less -R GUIDE.md
+    else
+      cat GUIDE.md
+    fi
+    ;;
+
   help|*)
     cat <<EOF
 Usage: demo.sh <command>
@@ -104,6 +124,13 @@ Inspection:
   logs [svc]      Tail compose logs (default: --tail=50).
   dashboard       Print dashboard URLs + admin secrets.
   bootstrap-logs  Replay the verbose Phase 1-7 bootstrap output.
+
+Scenarios (require 'full' mode — orga workloads must be running):
+  oneshot-a-to-b  Cross-org one-shot from orga::agent-a to orgb::agent-b.
+  oneshot-b-to-a  Cross-org one-shot from orgb::agent-b to orga::agent-a.
+
+Guided onboarding (for 'up' mode — walks you through completing orga):
+  guide           Open the step-by-step Markdown walkthrough.
 EOF
     ;;
 esac

--- a/enterprise_sandbox/scenarios/oneshot_cross_org.py
+++ b/enterprise_sandbox/scenarios/oneshot_cross_org.py
@@ -1,0 +1,148 @@
+"""Sandbox scenario — cross-org one-shot messaging (ADR-008 envelope).
+
+Executed inside a running agent container with:
+    docker compose exec agent-X python /app/scenarios/oneshot_cross_org.py
+
+Reuses the agent's own auth path (SPIRE or BYOCA) so the output
+mirrors what a production deployment would look like — just with
+narrated, colorized steps the user can follow by eye.
+
+Env:
+    BROKER_URL         proxy reverse-proxy URL
+    ORG_ID             this agent's org
+    AGENT_NAME         this agent's short name
+    AGENT_AUTH         'spire' (default) | 'byoca'
+    TARGET_AGENT_ID    peer (e.g. orgb::agent-b) — required
+    SPIFFE_ENDPOINT_SOCKET  (spire mode only)
+    CERT_PATH, KEY_PATH     (byoca mode only)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from cullis_sdk import CullisClient
+
+
+RESET = "\033[0m"
+BOLD  = "\033[1m"
+GREEN = "\033[32m"
+CYAN  = "\033[36m"
+YELLOW = "\033[33m"
+GRAY  = "\033[90m"
+
+
+def _step(n: int, title: str) -> None:
+    print(f"\n{BOLD}{CYAN}▶ Step {n} — {title}{RESET}", flush=True)
+
+
+def _ok(msg: str) -> None:
+    print(f"  {GREEN}✓{RESET} {msg}", flush=True)
+
+
+def _info(msg: str) -> None:
+    print(f"  {GRAY}…{RESET} {msg}", flush=True)
+
+
+def _fail(msg: str) -> None:
+    print(f"  {YELLOW}✗{RESET} {msg}", flush=True)
+
+
+def _auth() -> CullisClient:
+    broker = os.environ["BROKER_URL"]
+    org_id = os.environ["ORG_ID"]
+    agent_name = os.environ["AGENT_NAME"]
+    mode = os.environ.get("AGENT_AUTH", "spire").lower()
+
+    if mode == "spire":
+        socket = os.environ.get(
+            "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock",
+        )
+        _info(f"authenticating via SPIRE workload API at {socket}")
+        return CullisClient.from_spiffe_workload_api(
+            broker, org_id=org_id, socket_path=socket,
+        )
+
+    if mode == "byoca":
+        cert = Path(os.environ["CERT_PATH"]).read_text()
+        key = Path(os.environ["KEY_PATH"]).read_text()
+        _info(f"authenticating via BYOCA (cert={os.environ['CERT_PATH']})")
+        client = CullisClient(broker, verify_tls=False)
+        client.login_from_pem(f"{org_id}::{agent_name}", org_id, cert, key)
+        return client
+
+    raise SystemExit(f"unknown AGENT_AUTH: {mode}")
+
+
+def main() -> int:
+    target = os.environ.get("TARGET_AGENT_ID")
+    if not target:
+        _fail("TARGET_AGENT_ID is required (e.g. orgb::agent-b)")
+        return 2
+
+    org_id = os.environ["ORG_ID"]
+    agent_name = os.environ["AGENT_NAME"]
+    sender = f"{org_id}::{agent_name}"
+
+    print(
+        f"\n{BOLD}═══ Cross-org one-shot — "
+        f"{sender} → {target} ═══{RESET}",
+        flush=True,
+    )
+
+    _step(1, "Authenticate through the local Mastio")
+    client = _auth()
+    _ok(f"logged in as {sender}")
+
+    _step(2, "Resolve the recipient path + envelope transport")
+    _info("the Mastio will call /v1/egress/resolve and return 'cross-org'")
+    _info("with 'envelope' transport (ADR-008 Phase 1 / PR #3)")
+
+    nonce = uuid.uuid4().hex[:16]
+    payload = {
+        "nonce": nonce,
+        "hello": "ADR-008 cross-org sessionless message",
+        "sender": sender,
+        "sent_at": time.time(),
+    }
+
+    _step(3, "Send the envelope one-shot")
+    _info(f"payload nonce = {nonce}")
+    try:
+        resp = client.send_oneshot(
+            recipient_id=target,
+            payload=payload,
+            ttl_seconds=300,
+        )
+    except Exception as exc:
+        _fail(f"send failed: {exc!r}")
+        return 1
+
+    _ok(f"enqueued — msg_id={resp.get('msg_id')}  status={resp.get('status')}")
+    _ok(f"correlation_id={resp.get('correlation_id')}")
+
+    _step(4, "Verify on the recipient side")
+    _info(
+        f"grep the recipient's log — "
+        f"`demo.sh logs {target.split('::', 1)[1]} | grep {nonce}`"
+    )
+    _info("the recipient agent's polling loop will decrypt + surface it")
+
+    print(
+        f"\n{BOLD}{GREEN}✓ one-shot path exercised end-to-end{RESET}",
+        flush=True,
+    )
+    print(
+        f"{GRAY}Run `demo.sh logs {target.split('::', 1)[1]}` "
+        f"to see the receiver's view.{RESET}\n",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Final PR of the sandbox restructure.** Turns the sandbox from a pile of containers into a guided tour a prospect can follow end-to-end.

## Summary

- **Scenarios**: \`enterprise_sandbox/scenarios/oneshot_cross_org.py\` drives ADR-008 cross-org one-shot with colorized step-by-step ANSI output. Shipped into the agent image so \`docker compose exec agent-X python /app/scenarios/...\` works without volume wiring.
- **demo.sh** gains \`oneshot-a-to-b\` / \`oneshot-b-to-a\` scenarios and a \`guide\` command that opens GUIDE.md in \`less -R\`.
- **GUIDE.md**: 5-step onboarding walkthrough (attach-ca → pin mastio pubkey → install Connector → enroll agent → register MCP + bind). Every command is copy-paste-ready with exact sandbox values.
- **Host-agent example** (\`cullis_sdk/examples/host_agent.py\`): minimal Python script using \`CullisClient.from_connector()\` + \`login_via_proxy()\` to send a one-shot from the host after enrollment.

## ADR-009 sandbox roadmap — closed

- [x] PR 1/4 — Connector MCP registration + Mastio JSON API (#167)
- [x] PR 2/4 — SDK \`from_connector()\` + downloads page (#168)
- [x] PR 3/4 — compose profiles + scope-aware bootstrap + gitignore fix (#170)
- [x] **PR 4/4 — scenarios + guide + host-agent, this PR**

After merge: \`./demo.sh up\` gives a prospect a half-configured playground where they complete Org A themselves via \`demo.sh guide\`; \`./demo.sh full\` gives design-partner reviewers the same stack already wired for scenario replay.

## Test plan

- [x] Full pytest suite (ex ts_interop/postgres local-stale): 1119 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS
- [ ] Manual shake-out: \`./enterprise_sandbox/demo.sh up\` + full walkthrough — to be done after merge (sandbox not a CI gate)