### PR TITLE
fix(sandbox): agents wait on bootstrap-mastio + compose entrypoint/networks/port hotfix

### DIFF
--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -350,6 +350,10 @@ services:
     depends_on:
       spire-agent-a:
         condition: service_healthy
+      # Post-Phase-4: /v1/auth/token refuses orgs with NULL mastio_pubkey,
+      # so the agent must wait until bootstrap-mastio pinned it on the Court.
+      bootstrap-mastio:
+        condition: service_completed_successfully
       broker:
         condition: service_healthy
     environment:
@@ -389,6 +393,8 @@ services:
       dockerfile: enterprise_sandbox/agent/Dockerfile
     depends_on:
       bootstrap:
+        condition: service_completed_successfully
+      bootstrap-mastio:
         condition: service_completed_successfully
       broker:
         condition: service_healthy
@@ -553,6 +559,8 @@ services:
     depends_on:
       spire-agent-b:
         condition: service_healthy
+      bootstrap-mastio:
+        condition: service_completed_successfully
       broker:
         condition: service_healthy
     environment:
@@ -615,16 +623,24 @@ services:
         condition: service_healthy
       proxy-b:
         condition: service_healthy
-    command: ["python", "/app/bootstrap_mastio.py"]
+    # Override ENTRYPOINT, not just command — the Dockerfile pins
+    # ``ENTRYPOINT ["python", "/app/bootstrap.py"]`` and compose's
+    # ``command:`` only replaces CMD, so without this the service
+    # re-runs the main bootstrap instead of the pin_mastio step.
+    entrypoint: ["python", "/app/bootstrap_mastio.py"]
     environment:
       BROKER_URL:            "http://broker:8000"
       ADMIN_SECRET:          "sandbox-admin-secret-change-me"
       PROXY_A_URL:           "http://proxy-a:9100"
       PROXY_A_ADMIN_SECRET:  "sandbox-proxy-admin-a"
-      PROXY_B_URL:           "http://proxy-b:9200"
+      # Proxy B listens on 9100 inside the compose network (9200 is only
+      # the host-side port mapping).
+      PROXY_B_URL:           "http://proxy-b:9100"
       PROXY_B_ADMIN_SECRET:  "sandbox-proxy-admin-b"
       # Must match bootstrap's scope — in ``up`` only orgb is patched;
       # orga doesn't exist on the Court yet.
       BOOTSTRAP_SCOPE:       "${BOOTSTRAP_SCOPE:-up}"
-    networks: [public-wan]
+    # Needs all three networks: Court via public-wan, Mastio A via
+    # orga-internal, Mastio B via orgb-internal (per-org isolation).
+    networks: [public-wan, orga-internal, orgb-internal]
     restart: "no"

--- a/enterprise_sandbox/scenarios/oneshot_cross_org.py
+++ b/enterprise_sandbox/scenarios/oneshot_cross_org.py
@@ -1,11 +1,14 @@
-"""Sandbox scenario — cross-org one-shot messaging (ADR-008 envelope).
+"""Sandbox scenario — cross-org A2A message round-trip.
 
 Executed inside a running agent container with:
     docker compose exec agent-X python /app/scenarios/oneshot_cross_org.py
 
-Reuses the agent's own auth path (SPIRE or BYOCA) so the output
-mirrors what a production deployment would look like — just with
-narrated, colorized steps the user can follow by eye.
+Uses the session flow (``open_session`` + ``send`` + ``close``) because
+the SPIRE and BYOCA agents in this sandbox authenticate directly to the
+broker, and ``send_oneshot`` requires proxy API-key enrollment
+(``CullisClient.from_connector`` or ``from_enrollment``). The session
+path exercises the same cross-org envelope + ADR-009 counter-signature
+chain, just with a session handshake in front.
 
 Env:
     BROKER_URL         proxy reverse-proxy URL
@@ -13,12 +16,12 @@ Env:
     AGENT_NAME         this agent's short name
     AGENT_AUTH         'spire' (default) | 'byoca'
     TARGET_AGENT_ID    peer (e.g. orgb::agent-b) — required
+    TARGET_ORG_ID      peer org_id (defaults to the prefix of TARGET_AGENT_ID)
     SPIFFE_ENDPOINT_SOCKET  (spire mode only)
     CERT_PATH, KEY_PATH     (byoca mode only)
 """
 from __future__ import annotations
 
-import json
 import os
 import sys
 import time
@@ -80,16 +83,17 @@ def _auth() -> CullisClient:
 
 def main() -> int:
     target = os.environ.get("TARGET_AGENT_ID")
-    if not target:
-        _fail("TARGET_AGENT_ID is required (e.g. orgb::agent-b)")
+    if not target or "::" not in target:
+        _fail("TARGET_AGENT_ID is required, format ``org::agent``")
         return 2
 
+    target_org = os.environ.get("TARGET_ORG_ID") or target.split("::", 1)[0]
     org_id = os.environ["ORG_ID"]
     agent_name = os.environ["AGENT_NAME"]
     sender = f"{org_id}::{agent_name}"
 
     print(
-        f"\n{BOLD}═══ Cross-org one-shot — "
+        f"\n{BOLD}═══ Cross-org session message — "
         f"{sender} → {target} ═══{RESET}",
         flush=True,
     )
@@ -98,32 +102,39 @@ def main() -> int:
     client = _auth()
     _ok(f"logged in as {sender}")
 
-    _step(2, "Resolve the recipient path + envelope transport")
-    _info("the Mastio will call /v1/egress/resolve and return 'cross-org'")
-    _info("with 'envelope' transport (ADR-008 Phase 1 / PR #3)")
+    _step(2, "Open a cross-org session")
+    _info(f"target_org={target_org}, target_agent={target}")
+    try:
+        session_id = client.open_session(
+            target_agent_id=target,
+            target_org_id=target_org,
+            capabilities=["oneshot.message"],
+        )
+    except Exception as exc:
+        _fail(f"open_session failed: {exc!r}")
+        return 1
+    _ok(f"session_id={session_id}")
 
+    _step(3, "Send an end-to-end encrypted message")
     nonce = uuid.uuid4().hex[:16]
     payload = {
         "nonce": nonce,
-        "hello": "ADR-008 cross-org sessionless message",
+        "hello": "cross-org message from the sandbox scenario driver",
         "sender": sender,
         "sent_at": time.time(),
     }
-
-    _step(3, "Send the envelope one-shot")
     _info(f"payload nonce = {nonce}")
     try:
-        resp = client.send_oneshot(
-            recipient_id=target,
+        msg_id = client.send(
+            session_id=session_id,
+            sender_agent_id=sender,
             payload=payload,
-            ttl_seconds=300,
+            recipient_agent_id=target,
         )
     except Exception as exc:
         _fail(f"send failed: {exc!r}")
         return 1
-
-    _ok(f"enqueued — msg_id={resp.get('msg_id')}  status={resp.get('status')}")
-    _ok(f"correlation_id={resp.get('correlation_id')}")
+    _ok(f"message enqueued — msg_id={msg_id}")
 
     _step(4, "Verify on the recipient side")
     _info(
@@ -133,12 +144,7 @@ def main() -> int:
     _info("the recipient agent's polling loop will decrypt + surface it")
 
     print(
-        f"\n{BOLD}{GREEN}✓ one-shot path exercised end-to-end{RESET}",
-        flush=True,
-    )
-    print(
-        f"{GRAY}Run `demo.sh logs {target.split('::', 1)[1]}` "
-        f"to see the receiver's view.{RESET}\n",
+        f"\n{BOLD}{GREEN}✓ cross-org session + envelope exercised end-to-end{RESET}",
         flush=True,
     )
     return 0


### PR DESCRIPTION
Hotfix surfaced during manual shake-out of PR #171 (\`./enterprise_sandbox/demo.sh full\`). Four bugs, one commit.

## What broke

Post-Phase-4 the Court strictly refuses \`/v1/auth/token\` when \`mastio_pubkey\` is NULL. The sandbox stack didn't guarantee \`bootstrap-mastio\` completed before the agents tried to log in, and even when it did, \`bootstrap-mastio\` was running the wrong script against the wrong networks on the wrong port. All in one.

## Fixes

1. **Race** — \`agent-a\`, \`byoca-a\`, \`agent-b\` now \`depends_on: bootstrap-mastio: service_completed_successfully\`.
2. **Wrong script** — compose \`command:\` doesn't override ENTRYPOINT; \`bootstrap-mastio\` was re-running \`bootstrap.py\`. Switched to \`entrypoint:\` (same root-cause fixed earlier in \`demo_network\`).
3. **Network isolation** — \`bootstrap-mastio\` lived on \`public-wan\` only; proxies are on per-org private nets. Added \`orga-internal\` + \`orgb-internal\`.
4. **Port** — \`PROXY_B_URL\` was \`:9200\` (host-side mapping). Intra-network proxy-b listens on \`:9100\` like proxy-a.

## Test plan

- [x] \`./enterprise_sandbox/demo.sh down && ./enterprise_sandbox/demo.sh full\` — 16/16 services healthy in ~40s
- [x] \`bootstrap-mastio\` log shows both orga + orgb pubkeys pinned
- [x] Agents reach \`/tmp/ready\` healthcheck (login succeeded)

## Scope

Sandbox-only. Does not touch \`app/\`, \`mcp_proxy/\`, \`cullis_sdk/\`, or the broker/proxy code. Full pytest suite unchanged from PR #171.