### PR TITLE
fix(proxy): propagate X-Forwarded-* on federated public-key fetch (P1)

### DIFF
--- a/enterprise_sandbox/scenarios/oneshot_cross_org.py
+++ b/enterprise_sandbox/scenarios/oneshot_cross_org.py
@@ -115,21 +115,39 @@ def main() -> int:
         return 1
     _ok(f"session_id={session_id}")
 
-    _step(3, "Cross-org handshake verified")
+    _info("waiting ~2s for the recipient's auto-accept loop to pick up the session")
+    time.sleep(2.5)
+
+    _step(3, "Send an end-to-end encrypted message")
+    nonce = uuid.uuid4().hex[:16]
+    payload = {
+        "nonce": nonce,
+        "hello": "cross-org message from the sandbox scenario driver",
+        "sender": sender,
+        "sent_at": time.time(),
+    }
+    _info(f"payload nonce = {nonce}")
+    try:
+        msg_id = client.send(
+            session_id=session_id,
+            sender_agent_id=sender,
+            payload=payload,
+            recipient_agent_id=target,
+        )
+    except Exception as exc:
+        _fail(f"send failed: {exc!r}")
+        return 1
+    _ok(f"message enqueued — msg_id={msg_id}")
+
+    _step(4, "Verify on the recipient side")
     _info(
-        "session_id is server-issued — the Court ran the full gate: "
-        "DPoP + ADR-009 counter-sig + both-org PDP allow + policy rule "
-        "+ capability binding. Any missing piece would have rejected it."
-    )
-    _info(
-        "Sending an encrypted message over this session exercises the "
-        "public-key lookup + E2E wrap; that path ships in a follow-up "
-        "(peer pubkey federated fetch needs an extra binding)."
+        f"grep the recipient's log — "
+        f"`demo.sh logs {target.split('::', 1)[1]} | grep {nonce}`"
     )
 
     print(
-        f"\n{BOLD}{GREEN}✓ cross-org session handshake succeeded "
-        f"({sender} → {target}){RESET}",
+        f"\n{BOLD}{GREEN}✓ cross-org session + envelope exercised "
+        f"end-to-end ({sender} → {target}, nonce={nonce}){RESET}",
         flush=True,
     )
     return 0

--- a/mcp_proxy/registry/public_key.py
+++ b/mcp_proxy/registry/public_key.py
@@ -95,7 +95,10 @@ async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
     # Broker enforces org isolation + binding auth on this endpoint, so we
     # must propagate the caller's Authorization / DPoP headers. Hop-by-hop
     # headers are dropped for the same reason the reverse-proxy forwarder
-    # drops them.
+    # drops them. Host is stripped separately so the broker's ``build_htu``
+    # can reconstruct the URL the SDK originally signed — otherwise the
+    # DPoP proof fails verification with 401 because the broker sees its
+    # own hostname in ``request.url`` while the proof carries the proxy's.
     _HOP = frozenset([
         "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
         "te", "trailer", "transfer-encoding", "upgrade", "content-length",
@@ -104,6 +107,21 @@ async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
     forward_headers = {
         k: v for k, v in request.headers.items() if k.lower() not in _HOP
     }
+    # Same X-Forwarded-* propagation the generic reverse-proxy does in
+    # mcp_proxy/reverse_proxy/forwarder.py — the broker's DPoP htu builder
+    # reads these to rebuild the URL the SDK signed. Without them the
+    # verification fails and the call 401s even though DPoP proof itself
+    # is structurally valid.
+    inbound_host = request.headers.get("host")
+    if inbound_host and "x-forwarded-host" not in {h.lower() for h in forward_headers}:
+        forward_headers["x-forwarded-host"] = inbound_host
+    forward_headers.setdefault("x-forwarded-proto", request.url.scheme)
+    client_host = request.client.host if request.client else None
+    if client_host:
+        existing = forward_headers.get("x-forwarded-for")
+        forward_headers["x-forwarded-for"] = (
+            f"{existing}, {client_host}" if existing else client_host
+        )
     try:
         upstream = await client.get(target, headers=forward_headers)
     except httpx.ConnectError as exc:


### PR DESCRIPTION
Resolves the P1 gap from the sandbox gap list — cross-org E2E encryption now works end-to-end.

## Bug

\`mcp_proxy/registry/public_key.py\` has a "local-first, federated-fallback" handler for \`GET /v1/registry/agents/{id}/public-key\`. When the agent is federated, the handler forwards to the broker — **without** X-Forwarded-Host/Proto/For headers. The broker's \`build_htu\` (\`app/auth/dpop.py\`) then rebuilds the URL from its own \`request.url\` instead of the proxy URL the SDK signed → DPoP verification mismatch → 401 on every federated pubkey lookup.

This blocked \`CullisClient.send\` cross-org because the SDK needs the peer pubkey to wrap the envelope.

## Fix

Mirror the X-Forwarded-* propagation the generic \`reverse_proxy/forwarder.py\` already does. Minimal change, same header set and precedence rules.

Kept the local-first handler (faster for intra-org lookups) rather than deleting it in favor of the reverse-proxy catch-all.

## Also in this PR

Re-enabled the \`send\` step in the scenario driver (was truncated in #175 while this bug was open) + 2.5s wait for the recipient's auto-accept loop. Without the wait the send would 409 because the session is still \`pending_accept\`.

## Verified locally — full round-trip

\`\`\`
▶ Step 2 — Open a cross-org session
  ✓ session_id=3d628496-7967-4d70-a477-57b60e5f0eb6
▶ Step 3 — Send an end-to-end encrypted message
  ✓ message enqueued — msg_id=...
✓ cross-org session + envelope exercised end-to-end
  (orgb::agent-b → orga::agent-a, nonce=ac7f37581b154a4d)

# recipient log:
agent-a-1  | [orga::agent-a] received nonce from orgb::agent-b: ac7f37581b154a4d
\`\`\`

## Next from the P0/P1/P2 list

P1 binding auto-provisioning turned out to be **not needed** — the 401 was pure forwarding bug, not binding. Moving to P2 scenarios MCP next.