### PR TITLE
feat(sandbox): intra-org MCP scenarios + 3 compose-config fixes (P2)

### DIFF
--- a/enterprise_sandbox/demo.sh
+++ b/enterprise_sandbox/demo.sh
@@ -101,6 +101,22 @@ case "${1:-help}" in
       python /app/scenarios/oneshot_cross_org.py
     ;;
 
+  mcp-catalog)
+    _header "Scenario — intra-org MCP call: orga::agent-a → get_catalog"
+    docker compose exec \
+      -e MCP_TOOL_NAME=get_catalog \
+      -e MCP_TOOL_ARGS='{"category":"electronics"}' \
+      agent-a python /app/scenarios/mcp_call_local.py
+    ;;
+
+  mcp-inventory)
+    _header "Scenario — intra-org MCP call: orgb::agent-b → check_inventory"
+    docker compose exec \
+      -e MCP_TOOL_NAME=check_inventory \
+      -e MCP_TOOL_ARGS='{"sku":"WIDGET-X"}' \
+      agent-b python /app/scenarios/mcp_call_local.py
+    ;;
+
   guide)
     if command -v less >/dev/null 2>&1; then
       less -R GUIDE.md
@@ -128,6 +144,8 @@ Inspection:
 Scenarios (require 'full' mode — orga workloads must be running):
   oneshot-a-to-b  Cross-org one-shot from orga::agent-a to orgb::agent-b.
   oneshot-b-to-a  Cross-org one-shot from orgb::agent-b to orga::agent-a.
+  mcp-catalog     Intra-org MCP call: orga::agent-a → mcp-catalog (get_catalog).
+  mcp-inventory   Intra-org MCP call: orgb::agent-b → mcp-inventory (check_inventory).
 
 Guided onboarding (for 'up' mode — walks you through completing orga):
   guide           Open the step-by-step Markdown walkthrough.

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -215,9 +215,14 @@ services:
       OIDC_CLIENT_ID:      "cullis-proxy-dashboard"
       OIDC_CLIENT_SECRET:  "orga-oidc-client-secret-change-me"
       SEED_MCP_RESOURCES:  "1"
-      SEED_MCP_0_NAME:     "catalog"
+      # The proxy aggregator maps 1 resource = 1 tool: the resource name
+      # is what the SDK calls ``tools/call`` with, and the proxy forwards
+      # verbatim to the MCP server. So the resource name must match the
+      # tool name the MCP server actually implements (``get_catalog``).
+      SEED_MCP_0_NAME:     "get_catalog"
       SEED_MCP_0_ENDPOINT: "http://mcp-catalog:9300/"
-      SEED_MCP_0_AGENTS:   "agent-a,byoca-bot"
+      # Binding.agent_id must match JWT agent_id exactly (``org::name``).
+      SEED_MCP_0_AGENTS:   "orga::agent-a,orga::byoca-bot"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-a-data:/data
@@ -234,7 +239,12 @@ services:
     environment:
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      MCP_PROXY_PROXY_PUBLIC_URL:  "http://localhost:9100"
+      # Intentionally unset: the sandbox serves the same proxy at two
+      # hostnames (``proxy-a`` intra-docker, ``localhost:9100`` from the
+      # host). Leaving ``proxy_public_url`` empty falls back to
+      # ``request.url`` for DPoP htu reconstruction — matches the agent's
+      # signed htu in both cases instead of pinning one.
+      # MCP_PROXY_PROXY_PUBLIC_URL: unset
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
@@ -437,9 +447,9 @@ services:
       OIDC_CLIENT_ID:      "cullis-proxy-dashboard"
       OIDC_CLIENT_SECRET:  "orgb-oidc-client-secret-change-me"
       SEED_MCP_RESOURCES:  "1"
-      SEED_MCP_0_NAME:     "inventory"
+      SEED_MCP_0_NAME:     "check_inventory"
       SEED_MCP_0_ENDPOINT: "http://mcp-inventory:9400/"
-      SEED_MCP_0_AGENTS:   "agent-b"
+      SEED_MCP_0_AGENTS:   "orgb::agent-b"
     volumes:
       - bootstrap-state:/state:ro
       - proxy-b-data:/data
@@ -455,7 +465,8 @@ services:
     environment:
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      MCP_PROXY_PROXY_PUBLIC_URL:  "http://localhost:9200"
+      # See proxy-a comment above — unset so DPoP htu falls back to request.url.
+      # MCP_PROXY_PROXY_PUBLIC_URL: unset
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"

--- a/enterprise_sandbox/scenarios/mcp_call_local.py
+++ b/enterprise_sandbox/scenarios/mcp_call_local.py
@@ -1,0 +1,176 @@
+"""Sandbox scenario — agent calls an MCP tool on its own org's MCP server.
+
+Executed inside a running agent container:
+    docker compose exec agent-X python /app/scenarios/mcp_call_local.py
+
+The proxy's aggregator at ``/v1/mcp`` exposes every MCP resource the
+agent is bound to (ADR-007 Phase 1). This driver drives one
+``tools/call`` JSON-RPC and surfaces the result. Intra-org only —
+cross-org MCP has to go through A2A message wrapping, out of scope
+for this walkthrough.
+
+Env:
+    BROKER_URL          proxy reverse-proxy URL (= the proxy the agent lives on)
+    ORG_ID              this agent's org
+    AGENT_NAME          this agent's short name
+    AGENT_AUTH          'spire' (default) | 'byoca'
+    MCP_TOOL_NAME       e.g. 'get_catalog' or 'check_inventory' — required
+    MCP_TOOL_ARGS       JSON-encoded arguments object (default: '{}')
+    SPIFFE_ENDPOINT_SOCKET  (spire mode only)
+    CERT_PATH, KEY_PATH     (byoca mode only)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from cullis_sdk import CullisClient
+
+
+RESET = "\033[0m"
+BOLD  = "\033[1m"
+GREEN = "\033[32m"
+CYAN  = "\033[36m"
+YELLOW = "\033[33m"
+GRAY  = "\033[90m"
+
+
+def _step(n: int, title: str) -> None:
+    print(f"\n{BOLD}{CYAN}▶ Step {n} — {title}{RESET}", flush=True)
+
+
+def _ok(msg: str) -> None:
+    print(f"  {GREEN}✓{RESET} {msg}", flush=True)
+
+
+def _info(msg: str) -> None:
+    print(f"  {GRAY}…{RESET} {msg}", flush=True)
+
+
+def _fail(msg: str) -> None:
+    print(f"  {YELLOW}✗{RESET} {msg}", flush=True)
+
+
+def _auth() -> CullisClient:
+    broker = os.environ["BROKER_URL"]
+    org_id = os.environ["ORG_ID"]
+    agent_name = os.environ["AGENT_NAME"]
+    mode = os.environ.get("AGENT_AUTH", "spire").lower()
+
+    if mode == "spire":
+        socket = os.environ.get(
+            "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock",
+        )
+        _info(f"authenticating via SPIRE workload API at {socket}")
+        return CullisClient.from_spiffe_workload_api(
+            broker, org_id=org_id, socket_path=socket,
+        )
+
+    if mode == "byoca":
+        cert = Path(os.environ["CERT_PATH"]).read_text()
+        key = Path(os.environ["KEY_PATH"]).read_text()
+        _info(f"authenticating via BYOCA (cert={os.environ['CERT_PATH']})")
+        client = CullisClient(broker, verify_tls=False)
+        client.login_from_pem(f"{org_id}::{agent_name}", org_id, cert, key)
+        return client
+
+    raise SystemExit(f"unknown AGENT_AUTH: {mode}")
+
+
+def _rpc(client: CullisClient, method: str, params: dict | None = None) -> dict:
+    """POST a single JSON-RPC request to the proxy's /v1/mcp aggregator.
+
+    Uses the SDK's internal ``_authed_request`` so DPoP nonce rotation
+    is handled automatically (the proxy issues ``use_dpop_nonce`` on the
+    first call of every new session — plain ``httpx.post`` would eat a
+    spurious 401 otherwise).
+    """
+    resp = client._authed_request(
+        "POST", "/v1/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": "1",
+            "method": method,
+            "params": params or {},
+        },
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main() -> int:
+    tool_name = os.environ.get("MCP_TOOL_NAME")
+    if not tool_name:
+        _fail("MCP_TOOL_NAME is required (e.g. get_catalog)")
+        return 2
+    try:
+        tool_args = json.loads(os.environ.get("MCP_TOOL_ARGS", "{}"))
+    except json.JSONDecodeError as exc:
+        _fail(f"MCP_TOOL_ARGS is not valid JSON: {exc}")
+        return 2
+
+    org_id = os.environ["ORG_ID"]
+    agent_name = os.environ["AGENT_NAME"]
+    sender = f"{org_id}::{agent_name}"
+
+    print(
+        f"\n{BOLD}═══ MCP tool call — {sender} → {tool_name}"
+        f"({json.dumps(tool_args)}) ═══{RESET}",
+        flush=True,
+    )
+
+    _step(1, "Authenticate through the local Mastio")
+    client = _auth()
+    _ok(f"logged in as {sender}")
+
+    _step(2, "Discover available tools (MCP tools/list)")
+    try:
+        listing = _rpc(client, "tools/list")
+    except Exception as exc:
+        _fail(f"tools/list failed: {exc!r}")
+        return 1
+    tools = (listing.get("result") or {}).get("tools") or []
+    _ok(f"{len(tools)} tool(s) visible to {sender} after binding filter")
+    for t in tools:
+        _info(f"  • {t.get('name')}")
+
+    if not any(t.get("name") == tool_name for t in tools):
+        _fail(
+            f"tool '{tool_name}' not visible — check the MCP resource "
+            f"binding for {sender}"
+        )
+        return 1
+
+    _step(3, f"Call {tool_name}")
+    _info(f"arguments = {json.dumps(tool_args)}")
+    try:
+        resp = _rpc(client, "tools/call", {
+            "name": tool_name, "arguments": tool_args,
+        })
+    except Exception as exc:
+        _fail(f"tools/call failed: {exc!r}")
+        return 1
+
+    if "error" in resp:
+        err = resp["error"]
+        _fail(f"server error {err.get('code')} — {err.get('message')}")
+        return 1
+
+    result = resp.get("result") or {}
+    content = result.get("content") or []
+    for entry in content:
+        text = entry.get("text", "")
+        _ok(f"response: {text}")
+
+    print(
+        f"\n{BOLD}{GREEN}✓ MCP aggregator exercised end-to-end "
+        f"(auth + tools/list + tools/call forwarded to the MCP server){RESET}",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds \`demo.sh mcp-catalog\` and \`demo.sh mcp-inventory\` — agents call their own org's MCP server through the proxy's \`/v1/mcp\` aggregator (ADR-007 Phase 1).

## End-to-end verified

\`\`\`
▶ Step 3 — Call check_inventory
  ✓ response: {"sku":"WIDGET-X","in_stock":true,"quantity":150,...}
\`\`\`

## Scope

Intra-org only. The proxy aggregator's \`tool_registry\` is local to each proxy — cross-org MCP calls need custom A2A session wrapping which is out of scope for the sandbox's first scenario.

## Compose fixes surfaced while wiring

Three configuration pitfalls the sandbox was hiding:

1. **\`MCP_PROXY_PROXY_PUBLIC_URL\` pinned to \`localhost:PORT\`** forced the proxy's DPoP \`htu\` rebuild to the host-side URL even for intra-compose calls signed as \`proxy-X:9100\` — 401 every time. Unset so \`build_htu\` falls back to \`request.url\`.

2. **\`SEED_MCP_0_AGENTS\` used short names** (\`agent-b\`) but the aggregator matches the fully-qualified JWT agent_id (\`orgb::agent-b\`). Seeded with \`org::name\` form now.

3. **Resource name == forwarded tool name** in the aggregator. Seeding \`inventory\` made the proxy call \`inventory\` on the MCP server, which implements \`check_inventory\`. Renamed the seeded resources to match tool names.

Each fix has an inline compose comment pointing at the exact mismatch rule, so the next user doesn't re-trip them.

## Remaining P2/P3

- P2 shake-out manuale GUIDE.md (follow along by hand, catch frictions)
- P3 README sandbox section