### PR TITLE
docs(readme): add enterprise sandbox section (P3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,37 @@ app](https://github.com/cullis-security/cullis/releases).
 
 ---
 
+## Enterprise sandbox
+
+A second, heavier demo with SPIRE, Keycloak, Vault, Postgres and the
+Connector Desktop. Two tiers:
+
+```bash
+./enterprise_sandbox/demo.sh up    # Court + Org B wired,
+                                   # Mastio A standalone — you onboard Org A
+./enterprise_sandbox/demo.sh full  # Both orgs + 3 agents + 2 MCP servers,
+                                   # scenarios ready to replay
+```
+
+Pick `up` if you want to *learn* the onboarding flow hand-on; pick
+`full` if you want to *replay* scenarios without any setup.
+
+Scenarios (full mode):
+
+```bash
+./enterprise_sandbox/demo.sh oneshot-a-to-b   # cross-org A2A message
+./enterprise_sandbox/demo.sh oneshot-b-to-a
+./enterprise_sandbox/demo.sh mcp-catalog      # intra-org MCP tool call
+./enterprise_sandbox/demo.sh mcp-inventory
+./enterprise_sandbox/demo.sh guide            # open the onboarding walkthrough
+```
+
+See [`enterprise_sandbox/GUIDE.md`](enterprise_sandbox/GUIDE.md) for the
+step-by-step Org A onboarding — attach-CA flow, mastio counter-signature
+pin (ADR-009), Connector Desktop enrollment, MCP resource registration.
+
+---
+
 ## Key features
 
 - **x509 PKI + SPIFFE per-agent identity** — each agent gets a cert


### PR DESCRIPTION
Closes the P3 task from the sandbox gap list. README had only the demo_network quickstart — add an "Enterprise sandbox" section right after it.

Covers:
- Two tiers (\`up\` = hands-on onboarding, \`full\` = scenario replay)
- 5 \`demo.sh\` scenario commands (\`oneshot-a-to-b\`, \`oneshot-b-to-a\`, \`mcp-catalog\`, \`mcp-inventory\`, \`guide\`)
- Pointer at \`enterprise_sandbox/GUIDE.md\` for hands-on Org A onboarding

## Sandbox gap list — all closed

- [x] P0 bootstrap idempotent (#176)
- [x] P1 public-key 401 forwarding (#177)
- [x] P2 MCP scenarios (#178)
- [x] P2 GUIDE.md shake-out (#179)
- [x] **P3 README section, this PR**

## Test plan

- [x] Docs-only, no code change
- [x] Full pytest suite (ex ts_interop/postgres local-stale): 1174 pass