### PR TITLE
fix(sandbox): seed internal_agents so Mastio dashboard shows SPIRE/BYOCA agents

### DIFF
--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -245,6 +245,12 @@ services:
       # ``request.url`` for DPoP htu reconstruction — matches the agent's
       # signed htu in both cases instead of pinning one.
       # MCP_PROXY_PROXY_PUBLIC_URL: unset
+      # Pull the Court's agent registry into ``cached_federated_agents``
+      # on a timer so the Mastio dashboard shows the SPIRE/BYOCA agents
+      # that authenticate directly against the Court — otherwise the
+      # "Agents" table looks empty in the sandbox (they were never
+      # enrolled through the Connector flow).
+      PROXY_FEDERATION_SYNC:       "true"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
@@ -467,6 +473,7 @@ services:
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
       # See proxy-a comment above — unset so DPoP htu falls back to request.url.
       # MCP_PROXY_PROXY_PUBLIC_URL: unset
+      PROXY_FEDERATION_SYNC:       "true"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"

--- a/enterprise_sandbox/proxy-init/seed.py
+++ b/enterprise_sandbox/proxy-init/seed.py
@@ -180,10 +180,77 @@ async def _seed_mcp_resources(db_url: str, org_id: str) -> None:
         await engine.dispose()
 
 
+async def _seed_internal_agents(db_url: str, org_id: str) -> None:
+    """Populate ``internal_agents`` so the Mastio dashboard shows the
+    SPIRE/BYOCA workloads that live in this org.
+
+    Production agents hit the Mastio via the Connector enrollment flow,
+    which writes an ``api_key_hash`` row here. Sandbox SPIRE/BYOCA
+    agents bypass the Connector — they authenticate to the Court
+    directly through the reverse-proxy with their own cert — so their
+    ``internal_agents`` row stays empty and the Mastio dashboard looks
+    broken. Seed them from ``/state/{org}/{agent_name}.pem`` (persisted
+    by bootstrap phase 4) so the dashboard matches the reality of
+    who lives on this org.
+    """
+    state = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
+    agents_dir = state / org_id / "agents"
+    if not agents_dir.exists():
+        return
+
+    now = datetime.now(timezone.utc).isoformat()
+    engine = create_async_engine(db_url)
+    try:
+        # Bootstrap writes ``{org}/agents/{agent}/agent.pem`` per phase 4.
+        for agent_subdir in sorted(p for p in agents_dir.iterdir() if p.is_dir()):
+            cert_path = agent_subdir / "agent.pem"
+            if not cert_path.exists():
+                continue
+            agent_name = agent_subdir.name
+            agent_id = f"{org_id}::{agent_name}"
+            cert_pem = cert_path.read_text()
+            async with engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO internal_agents (
+                            agent_id, display_name, capabilities,
+                            api_key_hash, cert_pem, created_at, is_active
+                        ) VALUES (
+                            :aid, :name, :caps, :hash, :cert, :now, 1
+                        )
+                        ON CONFLICT (agent_id) DO UPDATE SET
+                            cert_pem   = EXCLUDED.cert_pem,
+                            is_active  = 1
+                        """
+                    ),
+                    {
+                        "aid": agent_id,
+                        "name": agent_name,
+                        "caps": json.dumps([]),
+                        # Unreachable bcrypt hash — these agents don't use
+                        # API keys (they auth via cert through the
+                        # reverse-proxy). Column is NOT NULL so we still
+                        # store a placeholder that no plaintext can match.
+                        "hash": "$2b$12$sandbox.placeholder.no.api.key.enrolled."
+                                "aaaaaaaaaaaaaaaaaaaaaaa",
+                        "cert": cert_pem,
+                        "now": now,
+                    },
+                )
+            print(
+                f"proxy-init: seeded internal_agents row for {agent_id}",
+                flush=True,
+            )
+    finally:
+        await engine.dispose()
+
+
 async def _async_main(db_url: str, org_id: str) -> int:
     await _seed_proxy_config(db_url, org_id)
     if os.environ.get("SEED_MCP_RESOURCES") == "1":
         await _seed_mcp_resources(db_url, org_id)
+    await _seed_internal_agents(db_url, org_id)
     return 0
 
 


### PR DESCRIPTION
Manual shake-out surfaced the frustration: \`demo.sh full\` completes, Court shows "3 agents, 2 orgs", but Mastio A / Mastio B dashboards look empty.

## Why

The Mastio dashboard reads two tables:
- \`internal_agents\` — agents enrolled via the Connector Desktop flow
- \`cached_federated_agents\` — pulled by the federation subscriber

In the enterprise sandbox the agents authenticate to the Court **directly** through the reverse-proxy with their SPIRE / BYOCA cert. They never hit the Connector, so \`internal_agents\` stays empty. And federation_sync needs an externally-registered subscriber factory we don't wire in the sandbox.

## Fix

\`proxy-init/seed.py\` grows \`_seed_internal_agents()\` that reads each agent's cert from \`/state/{org}/agents/{name}/agent.pem\` (bootstrap phase 4 path) and inserts an \`internal_agents\` row. \`api_key_hash\` is NOT NULL so we seed an unreachable bcrypt stub — no plaintext can match it.

docker-compose also flips on \`PROXY_FEDERATION_SYNC=true\` for both proxies. No-op today (no subscriber factory wired), but documented so a follow-up can swap in a real subscriber without touching compose.

## Verified locally

\`\`\`
proxy-a-init: seeded internal_agents row for orga::agent-a
proxy-a-init: seeded internal_agents row for orga::byoca-bot
proxy-b-init: seeded internal_agents row for orgb::agent-b
\`\`\`

Regression: \`oneshot-b-to-a\` + \`mcp-inventory\` still green end-to-end.

## Test plan

- [x] \`demo.sh down && demo.sh full\` → 2 agent rows in Mastio A DB, 1 in Mastio B
- [x] \`demo.sh oneshot-b-to-a\` → cross-org E2E round-trip succeeds
- [x] \`demo.sh mcp-inventory\` → MCP tool call returns real data