### PR TITLE
feat(court): POST /v1/federation/publish-agent (ADR-010 Phase 1)

### DIFF
--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -1,0 +1,258 @@
+"""ADR-010 — Court federation endpoint for Mastio-pushed agent records.
+
+Mastio is authoritative for its own org's agents and publishes the ones it
+decides to federate via ``POST /v1/federation/publish-agent``. The Court
+keeps the pushed records as a cache for cross-org routing and public-key
+lookup; it no longer accepts direct writes from callers wielding only
+``org_secret`` (legacy ``POST /v1/registry/agents`` — see Phase 6 cleanup).
+
+Auth: ADR-009 counter-signature over the raw request body. The Court
+verifies the signature against ``organizations.mastio_pubkey`` pinned
+at onboarding. No other auth is accepted — a Mastio whose pubkey is
+not pinned cannot federate agents.
+
+Cert chain: the payload's ``cert_pem`` must chain to the org's CA
+(the same cert stored in ``organizations.ca_certificate``). We reuse
+the validation that ``app/auth/x509_verifier.verify_client_assertion``
+performs at login-time, minus the JWT/SPIFFE signing bits.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
+from cryptography.hazmat.primitives import hashes
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_countersig
+from app.db.database import get_db
+from app.db.audit import log_event
+from app.registry.org_store import get_org_by_id
+from app.registry.store import (
+    AgentRecord, get_agent_by_id, register_agent, update_agent_cert,
+    compute_cert_thumbprint,
+)
+
+
+_log = logging.getLogger("agent_trust.federation")
+
+router = APIRouter(prefix="/v1/federation", tags=["federation"])
+
+
+class PublishAgentRequest(BaseModel):
+    agent_id: str = Field(..., pattern=r"^[a-z0-9][a-z0-9._-]{0,127}::[a-zA-Z0-9._-]{1,64}$")
+    cert_pem: str
+    capabilities: list[str] = Field(default_factory=list)
+    display_name: str = Field("", max_length=256)
+    revoked: bool = False
+
+
+class PublishAgentResponse(BaseModel):
+    agent_id: str
+    org_id: str
+    status: str  # "created" | "updated" | "revoked"
+    cert_thumbprint: str
+
+
+def _verify_cert_chain(cert_pem: str, org_ca_pem: str) -> x509.Certificate:
+    """Return the parsed leaf cert after confirming it's signed by the org CA.
+
+    Mirrors the chain-check step of ``verify_client_assertion`` — we
+    don't need the full SPIFFE / DPoP / JWT verification here, only the
+    proof that the agent cert was issued by the org the Mastio claims.
+    """
+    try:
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"cert_pem: malformed PEM ({exc})",
+        ) from exc
+
+    try:
+        ca_cert = x509.load_pem_x509_certificate(org_ca_pem.encode())
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="stored org CA is unreadable",
+        ) from exc
+
+    ca_pub = ca_cert.public_key()
+    try:
+        if isinstance(ca_pub, rsa.RSAPublicKey):
+            ca_pub.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                cert.signature_hash_algorithm,
+            )
+        elif isinstance(ca_pub, ec.EllipticCurvePublicKey):
+            ca_pub.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                ec.ECDSA(cert.signature_hash_algorithm),
+            )
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="unsupported org CA key type",
+            )
+    except InvalidSignature:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="cert_pem is not signed by the organization's CA",
+        )
+
+    return cert
+
+
+@router.post(
+    "/publish-agent",
+    response_model=PublishAgentResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def publish_agent(
+    request: Request,
+    body: PublishAgentRequest,
+    mastio_signature: str | None = Header(
+        default=None, alias=COUNTERSIG_HEADER,
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> PublishAgentResponse:
+    """Mastio pushes an agent to the Court (register, update cert, or revoke).
+
+    - Auth: X-Cullis-Mastio-Signature over the raw JSON body.
+    - The body's ``agent_id`` prefix must match the mastio's pinned org
+      (so Mastio X can't publish agents in Mastio Y's namespace).
+    - The ``cert_pem`` must be signed by the org's CA.
+    """
+    # 1. Derive org_id from agent_id prefix and look up the mastio pubkey.
+    org_id = body.agent_id.split("::", 1)[0]
+    org = await get_org_by_id(db, org_id)
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="organization not found",
+        )
+    if not org.mastio_pubkey:
+        await log_event(
+            db, "federation.publish_rejected", "denied",
+            org_id=org_id,
+            details={"reason": "mastio_pubkey_not_pinned",
+                     "agent_id": body.agent_id},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "organization has no pinned mastio_pubkey — onboarding "
+                "incomplete. Admin must PATCH "
+                "/v1/admin/orgs/{id}/mastio-pubkey first."
+            ),
+        )
+    if not org.ca_certificate:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="organization has no CA attached — cannot validate agent cert",
+        )
+
+    # 2. Verify counter-signature over the raw body bytes.
+    raw = await request.body()
+    try:
+        verify_mastio_countersig(
+            client_assertion=raw.decode(),
+            signature_b64=mastio_signature,
+            mastio_pubkey_pem=org.mastio_pubkey,
+        )
+    except HTTPException:
+        await log_event(
+            db, "federation.publish_rejected", "denied",
+            org_id=org_id,
+            details={"reason": "countersig_invalid",
+                     "agent_id": body.agent_id},
+        )
+        raise
+
+    # 3. Validate the agent cert chains to the org CA (unless we're only
+    #    recording a revocation — a revoked agent's cert chain doesn't
+    #    need to re-verify since the row already exists).
+    existing = await get_agent_by_id(db, body.agent_id)
+
+    cert: x509.Certificate | None = None
+    if not body.revoked:
+        cert = _verify_cert_chain(body.cert_pem, org.ca_certificate)
+
+    # 4. Revocation path: update the existing row and audit.
+    if body.revoked:
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="agent not found — cannot revoke",
+            )
+        existing.is_active = False
+        await db.commit()
+        await log_event(
+            db, "federation.agent_revoked", "ok",
+            org_id=org_id, agent_id=body.agent_id,
+            details={"source": "federated_push"},
+        )
+        return PublishAgentResponse(
+            agent_id=body.agent_id,
+            org_id=org_id,
+            status="revoked",
+            cert_thumbprint=existing.cert_thumbprint or "",
+        )
+
+    # 5. Upsert path.
+    thumbprint = compute_cert_thumbprint(body.cert_pem)
+    if existing is None:
+        new_record = await register_agent(
+            db,
+            agent_id=body.agent_id,
+            org_id=org_id,
+            display_name=body.display_name or body.agent_id.split("::", 1)[1],
+            capabilities=body.capabilities,
+            metadata={"source": "federated_push"},
+        )
+        # Pin the cert right away so the first /auth/token doesn't create
+        # a pinning mismatch.
+        await update_agent_cert(
+            db, agent_id=new_record.agent_id,
+            cert_pem=body.cert_pem, thumbprint=thumbprint,
+        )
+        await log_event(
+            db, "federation.agent_published", "ok",
+            org_id=org_id, agent_id=body.agent_id,
+            details={"status": "created", "thumbprint": thumbprint},
+        )
+        return PublishAgentResponse(
+            agent_id=body.agent_id,
+            org_id=org_id,
+            status="created",
+            cert_thumbprint=thumbprint,
+        )
+
+    # Existing → update cert + capabilities + reactivate.
+    existing.capabilities_json = json.dumps(body.capabilities)
+    existing.display_name = body.display_name or existing.display_name
+    existing.is_active = True
+    await db.commit()
+    await update_agent_cert(
+        db, agent_id=body.agent_id,
+        cert_pem=body.cert_pem, thumbprint=thumbprint,
+    )
+    await log_event(
+        db, "federation.agent_published", "ok",
+        org_id=org_id, agent_id=body.agent_id,
+        details={"status": "updated", "thumbprint": thumbprint},
+    )
+    return PublishAgentResponse(
+        agent_id=body.agent_id,
+        org_id=org_id,
+        status="updated",
+        cert_thumbprint=thumbprint,
+    )

--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -24,7 +24,6 @@ import logging
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
-from cryptography.hazmat.primitives import hashes
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -34,7 +33,7 @@ from app.db.database import get_db
 from app.db.audit import log_event
 from app.registry.org_store import get_org_by_id
 from app.registry.store import (
-    AgentRecord, get_agent_by_id, register_agent, update_agent_cert,
+    get_agent_by_id, register_agent, update_agent_cert,
     compute_cert_thumbprint,
 )
 
@@ -182,9 +181,8 @@ async def publish_agent(
     #    need to re-verify since the row already exists).
     existing = await get_agent_by_id(db, body.agent_id)
 
-    cert: x509.Certificate | None = None
     if not body.revoked:
-        cert = _verify_cert_chain(body.cert_pem, org.ca_certificate)
+        _verify_cert_chain(body.cert_pem, org.ca_certificate)
 
     # 4. Revocation path: update the existing row and audit.
     if body.revoked:

--- a/app/main.py
+++ b/app/main.py
@@ -371,6 +371,11 @@ if settings.a2a_adapter:
 
 app.include_router(v1)
 
+# ADR-010 Phase 1 — Mastio-sovereign registry. Federation router has its
+# own full /v1/federation prefix so register it at the app level.
+from app.federation.publish import router as federation_router
+app.include_router(federation_router)
+
 # ── Static files ─────────────────────────────────────────────────────────────
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 

--- a/tests/test_federation_publish.py
+++ b/tests/test_federation_publish.py
@@ -1,0 +1,290 @@
+"""ADR-010 Phase 1 — Court /v1/federation/publish-agent endpoint.
+
+The Mastio is authoritative for its org's agent registry and publishes
+federated agents to the Court. Auth is the ADR-009 counter-signature
+over the raw request body.
+
+Covers:
+  - Happy path: pubkey pinned + counter-sig valid + cert chain valid →
+    creates agent row on the Court
+  - Re-publish updates capabilities + cert + reactivates
+  - Revoke marks existing agent is_active=False
+  - Missing counter-sig → 403
+  - Wrong counter-sig key → 403
+  - agent_id prefix mismatch with org → 400 (via pydantic pattern) or
+    404 when the org doesn't exist
+  - cert_pem not signed by org CA → 400
+  - Org without pinned mastio_pubkey → 403
+  - Unknown org → 404
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+
+from tests.cert_factory import make_agent_cert, get_org_ca_pem
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.mastio_strict]
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+def _gen_mastio_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _sign(priv: ec.EllipticCurvePrivateKey, data: bytes) -> str:
+    sig = priv.sign(data, ec.ECDSA(hashes.SHA256()))
+    return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+async def _onboard_org_with_mastio(
+    client: AsyncClient,
+    org_id: str,
+    mastio_pubkey_pem: str,
+) -> None:
+    """Create an org on the Court (via admin) + attach its CA + pin
+    the mastio pubkey. Skips the attach-ca invite dance by writing
+    directly through admin-only endpoints available to the test."""
+    org_secret = f"{org_id}-secret"
+    r = await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    assert r.status_code in (201, 409), r.text
+    ca_pem = get_org_ca_pem(org_id)
+    r = await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    assert r.status_code in (200, 201), r.text
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import update_org_mastio_pubkey
+    async with AsyncSessionLocal() as db:
+        await update_org_mastio_pubkey(db, org_id, mastio_pubkey_pem)
+
+
+def _make_agent_cert_pem(agent_id: str, org_id: str) -> str:
+    key, cert = make_agent_cert(agent_id, org_id)
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+async def _fetch_agent_row(agent_id: str):
+    from app.db.database import AsyncSessionLocal
+    from app.registry.store import get_agent_by_id
+    async with AsyncSessionLocal() as db:
+        return await get_agent_by_id(db, agent_id)
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+async def test_publish_creates_agent(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-create"
+    agent_id = f"{org_id}::alice"
+    await _onboard_org_with_mastio(client, org_id, pub)
+    cert_pem = _make_agent_cert_pem(agent_id, org_id)
+
+    body = {
+        "agent_id": agent_id,
+        "cert_pem": cert_pem,
+        "capabilities": ["order.read"],
+        "display_name": "Alice",
+    }
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-agent",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["agent_id"] == agent_id
+    assert data["status"] == "created"
+    assert data["cert_thumbprint"]
+
+    row = await _fetch_agent_row(agent_id)
+    assert row is not None
+    assert row.is_active is True
+
+
+async def test_republish_updates_capabilities(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-update"
+    agent_id = f"{org_id}::bob"
+    await _onboard_org_with_mastio(client, org_id, pub)
+    cert_pem = _make_agent_cert_pem(agent_id, org_id)
+
+    async def _push(caps: list[str]) -> dict:
+        body = {
+            "agent_id": agent_id, "cert_pem": cert_pem,
+            "capabilities": caps, "display_name": "Bob",
+        }
+        raw = json.dumps(body).encode()
+        r = await client.post(
+            "/v1/federation/publish-agent",
+            content=raw,
+            headers={"Content-Type": "application/json",
+                     "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+        )
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    first = await _push(["order.read"])
+    assert first["status"] == "created"
+    second = await _push(["order.read", "order.write"])
+    assert second["status"] == "updated"
+
+    row = await _fetch_agent_row(agent_id)
+    caps = json.loads(row.capabilities_json)
+    assert "order.write" in caps
+
+
+async def test_revoke_marks_agent_inactive(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-revoke"
+    agent_id = f"{org_id}::carol"
+    await _onboard_org_with_mastio(client, org_id, pub)
+    cert_pem = _make_agent_cert_pem(agent_id, org_id)
+
+    # Create first.
+    body = {
+        "agent_id": agent_id, "cert_pem": cert_pem,
+        "capabilities": [], "display_name": "Carol",
+    }
+    raw = json.dumps(body).encode()
+    await client.post(
+        "/v1/federation/publish-agent", content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+
+    # Revoke.
+    body["revoked"] = True
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-agent", content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "revoked"
+
+    row = await _fetch_agent_row(agent_id)
+    assert row.is_active is False
+
+
+# ── auth failures ──────────────────────────────────────────────────────
+
+async def test_missing_countersig_header(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-nosig"
+    await _onboard_org_with_mastio(client, org_id, pub)
+    body = {
+        "agent_id": f"{org_id}::x", "cert_pem": _make_agent_cert_pem(f"{org_id}::x", org_id),
+        "capabilities": [],
+    }
+    r = await client.post(
+        "/v1/federation/publish-agent", json=body,
+    )
+    assert r.status_code == 403
+    assert "mastio counter" in r.text.lower() or "signature" in r.text.lower()
+
+
+async def test_wrong_countersig_key(client: AsyncClient):
+    _, pinned_pub = _gen_mastio_keypair()
+    attacker_priv, _ = _gen_mastio_keypair()
+    org_id = "fed-badkey"
+    agent_id = f"{org_id}::eve"
+    await _onboard_org_with_mastio(client, org_id, pinned_pub)
+    cert_pem = _make_agent_cert_pem(agent_id, org_id)
+    body = {"agent_id": agent_id, "cert_pem": cert_pem, "capabilities": []}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-agent", content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(attacker_priv, raw)},
+    )
+    assert r.status_code == 403
+    assert "verification" in r.text.lower() or "counter-sig" in r.text.lower()
+
+
+async def test_org_without_pinned_pubkey(client: AsyncClient):
+    priv, _ = _gen_mastio_keypair()
+    org_id = "fed-no-pubkey"
+    # Onboard without pinning.
+    org_secret = f"{org_id}-secret"
+    await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": get_org_ca_pem(org_id)},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+
+    agent_id = f"{org_id}::dave"
+    body = {
+        "agent_id": agent_id,
+        "cert_pem": _make_agent_cert_pem(agent_id, org_id),
+        "capabilities": [],
+    }
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-agent", content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 403
+    assert "mastio_pubkey" in r.text.lower()
+
+
+async def test_unknown_org(client: AsyncClient):
+    priv, _ = _gen_mastio_keypair()
+    body = {
+        "agent_id": "ghost::nobody",
+        "cert_pem": "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        "capabilities": [],
+    }
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-agent", content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 404
+
+
+async def test_cert_not_signed_by_org_ca(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-wrongca"
+    agent_id = f"{org_id}::frank"
+    await _onboard_org_with_mastio(client, org_id, pub)
+    # Use a cert from a DIFFERENT org's CA.
+    cert_pem_wrong = _make_agent_cert_pem("other-org::frank", "other-org")
+    body = {
+        "agent_id": agent_id, "cert_pem": cert_pem_wrong, "capabilities": [],
+    }
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-agent", content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 400
+    assert "not signed" in r.text.lower() or "signature" in r.text.lower()

--- a/tests/test_federation_publish.py
+++ b/tests/test_federation_publish.py
@@ -23,7 +23,6 @@ import base64
 import json
 
 import pytest
-from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from httpx import AsyncClient


### PR DESCRIPTION
First PR of **ADR-010 — Mastio-sovereign registry**.

Inverts the registry ownership model: the Mastio is authoritative for its org's agents, the Court becomes a cache of *federated* agents that Mastios push. This PR adds the Court-side endpoint. Phase 2+ teach the Mastio to push to it and deprecate the legacy \`org_secret\`-based path.

Full rationale: [\`imp/adr_010_mastio_sovereign_registry.md\`](imp/adr_010_mastio_sovereign_registry.md).

## Summary

- **\`POST /v1/federation/publish-agent\`** (\`app/federation/publish.py\`, new)
  - Body: \`agent_id\` (\`{org}::{name}\`), \`cert_pem\`, \`capabilities\`, \`display_name\`, \`revoked\`
  - Auth: ADR-009 counter-signature over the raw JSON body (\`X-Cullis-Mastio-Signature\`)
  - Validates the agent cert chains to the pinned org CA (RSA + EC supported)
  - Upserts \`agents\` + pins cert thumbprint; revoke flips \`is_active\`.
- Legacy \`POST /v1/registry/agents\` (\`org_secret\` auth) is untouched — Phase 6 deprecates it.

## Threat model

Everything that runs at login / messaging time is unchanged: the 15+ checks in \`verify_client_assertion\`, DPoP, E2E, policy dual-allow, binding. What changes is **who writes the row** on the Court: no more \`org_secret\` on this path, only a Mastio whose pubkey is pinned can federate. The admin-rogue bypass that \`org_secret\` leak enabled is closed here — symmetrically to ADR-009 for \`/auth/token\`.

## Test plan

- [x] \`pytest tests/test_federation_publish.py\` — 8/8: create, re-publish update, revoke, missing/wrong countersig → 403, unpinned org → 403, unknown org → 404, cert from different org CA → 400
- [x] Full suite (ex ts_interop/postgres local-stale): 1182 pass
- [x] \`./demo_network/smoke.sh full\` — PASS

## Next in the stack

- Phase 2 — Mastio authoritative registry (\`internal_agents.federated\` + admin API)
- Phase 3 — Federation push loop
- Phase 4 — Bootstrap sandbox rewrite
- Phase 5 — Dashboard polish
- Phase 6 — Cleanup legacy + drop \`local_agents\` doppione