### PR TITLE
fix(mastio): Redis opt-in for DPoP JTI + rate limiter (F-B-12)

### DIFF
--- a/mcp_proxy/auth/api_key.py
+++ b/mcp_proxy/auth/api_key.py
@@ -2,16 +2,17 @@
 Internal API key authentication for egress (internal agents -> proxy -> broker).
 
 API key format: sk_local_{agent_name}_{32 random hex chars}
-Hashed with bcrypt for storage. Rate-limited per agent_id.
+Hashed with bcrypt for storage. Rate-limited per agent_id via the dual-backend
+limiter in ``mcp_proxy.auth.rate_limit`` (in-memory by default, Redis when
+``MCP_PROXY_REDIS_URL`` is configured — audit F-B-12).
 """
 import logging
 import os
-import time
-from collections import defaultdict
 
 import bcrypt
 from fastapi import HTTPException, Request, status
 
+from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_agent_by_key_hash
 from mcp_proxy.models import InternalAgent
@@ -43,36 +44,6 @@ def verify_api_key(key: str, stored_hash: str) -> bool:
         return bcrypt.checkpw(key.encode(), stored_hash.encode())
     except Exception:
         return False
-
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Rate limiting — sliding window per agent_id
-# ─────────────────────────────────────────────────────────────────────────────
-
-# agent_id -> list of request timestamps (monotonic)
-_rate_limit_windows: dict[str, list[float]] = defaultdict(list)
-
-
-def _check_rate_limit(agent_id: str) -> bool:
-    """Check if the agent is within the rate limit.
-
-    Returns True if allowed, False if rate-limited.
-    Uses a sliding window of 60 seconds.
-    """
-    settings = get_settings()
-    now = time.monotonic()
-    window_start = now - 60.0  # 1-minute sliding window
-
-    timestamps = _rate_limit_windows[agent_id]
-
-    # Remove expired entries
-    _rate_limit_windows[agent_id] = [t for t in timestamps if t > window_start]
-
-    if len(_rate_limit_windows[agent_id]) >= settings.rate_limit_per_minute:
-        return False
-
-    _rate_limit_windows[agent_id].append(now)
-    return True
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -114,8 +85,9 @@ async def get_agent_from_api_key(request: Request) -> InternalAgent:
 
     agent_id = agent_data["agent_id"]
 
-    # Rate limit check
-    if not _check_rate_limit(agent_id):
+    # Rate limit check (in-memory or Redis depending on availability).
+    settings = get_settings()
+    if not await get_agent_rate_limiter().check(agent_id, settings.rate_limit_per_minute):
         _log.warning("Rate limit exceeded for agent: %s", agent_id)
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,

--- a/mcp_proxy/auth/dpop.py
+++ b/mcp_proxy/auth/dpop.py
@@ -212,50 +212,12 @@ def _normalize_htu(url: str) -> str:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# In-memory JTI store (replay protection)
+# JTI store (replay protection) — delegated to dpop_jti_store module
 # ─────────────────────────────────────────────────────────────────────────────
-
-_DEFAULT_JTI_TTL = 300  # seconds
-_MAX_JTI_ENTRIES = 100_000
-
-
-class InMemoryDpopJtiStore:
-    """Async-safe in-memory JTI store with TTL and lazy eviction."""
-
-    def __init__(self) -> None:
-        self._store: dict[str, float] = {}  # jti -> expires_at (monotonic)
-        self._lock = asyncio.Lock()
-
-    async def consume_jti(self, jti: str, ttl_seconds: int = _DEFAULT_JTI_TTL) -> bool:
-        """Atomically check+register a JTI.
-
-        Returns True if newly consumed (first use).
-        Returns False if already seen (replay).
-        """
-        now = time.monotonic()
-        expires_at = now + ttl_seconds
-
-        async with self._lock:
-            # Lazy eviction when store grows large
-            if len(self._store) >= _MAX_JTI_ENTRIES:
-                expired = [k for k, v in self._store.items() if v < now]
-                for k in expired:
-                    del self._store[k]
-
-            # Also clean expired entries on normal path
-            if jti in self._store:
-                if self._store[jti] < now:
-                    # Expired entry — allow reuse
-                    del self._store[jti]
-                else:
-                    return False  # replay
-
-            self._store[jti] = expires_at
-            return True
-
-
-# Global singleton
-_jti_store = InMemoryDpopJtiStore()
+#
+# Previously this module defined its own InMemoryDpopJtiStore singleton. The
+# dual-backend factory lives in ``mcp_proxy.auth.dpop_jti_store`` so that
+# multi-worker deploys can share a Redis-backed store (audit F-B-12 / #182).
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -415,7 +377,8 @@ async def verify_dpop_proof(
             )
 
     # -- 13. Consume JTI atomically (only after all checks pass)
-    is_new = await _jti_store.consume_jti(jti)
+    from mcp_proxy.auth.dpop_jti_store import get_dpop_jti_store
+    is_new = await get_dpop_jti_store().consume_jti(jti)
     if not is_new:
         raise HTTPException(
             status.HTTP_401_UNAUTHORIZED, "DPoP proof replay detected"

--- a/mcp_proxy/auth/dpop_jti_store.py
+++ b/mcp_proxy/auth/dpop_jti_store.py
@@ -1,0 +1,135 @@
+"""
+DPoP JTI store — short-lived nonce tracking for DPoP proof replay protection.
+
+Two backends:
+  - InMemoryDpopJtiStore  — single-worker only (default when Redis is unavailable)
+  - RedisDpopJtiStore     — multi-worker safe via SET NX EX (atomic check+insert)
+
+The active backend is selected at startup by ``get_dpop_jti_store()``, which
+checks if Redis is available. ``dpop.verify_dpop_proof`` calls
+``consume_jti()`` — a single atomic operation that checks and registers
+the JTI in one step (no race window).
+
+TTL defaults to 300s (5 min): covers the proof iat acceptance window plus
+clock-skew slack.
+
+Ported from ``app/auth/dpop_jti_store.py`` (audit F-E-04). The Mastio
+(``mcp_proxy``) side of the same finding lived unguarded until this
+port — see issue #182 for context.
+"""
+import asyncio
+import logging
+import time
+from typing import Protocol
+
+_log = logging.getLogger("mcp_proxy")
+
+_DEFAULT_TTL = 300  # seconds
+
+
+class DpopJtiStore(Protocol):
+    """Interface for DPoP JTI stores."""
+
+    async def consume_jti(self, jti: str, ttl_seconds: int = _DEFAULT_TTL) -> bool:
+        """Atomically check if the JTI has been seen, and register it if not.
+
+        Returns True if newly consumed (first use).
+        Returns False if already seen (replay).
+        """
+        ...
+
+
+class InMemoryDpopJtiStore:
+    """Async-safe in-memory JTI store with TTL and lazy cleanup.
+
+    Not suitable for multi-worker deployments — each worker has its own
+    dict, which defeats replay protection across workers.
+    """
+
+    def __init__(self) -> None:
+        self._store: dict[str, float] = {}  # jti -> expires_at (monotonic)
+        self._lock = asyncio.Lock()
+
+    async def consume_jti(self, jti: str, ttl_seconds: int = _DEFAULT_TTL) -> bool:
+        now = time.monotonic()
+        expires_at = now + ttl_seconds
+
+        async with self._lock:
+            expired = [k for k, v in self._store.items() if v < now]
+            for k in expired:
+                del self._store[k]
+
+            if jti in self._store:
+                return False  # replay
+            self._store[jti] = expires_at
+            return True  # new
+
+
+class RedisDpopJtiStore:
+    """Redis-backed JTI store — multi-worker safe.
+
+    Uses SET NX EX for atomic check+insert with automatic TTL expiry.
+    """
+
+    _PREFIX = "mcp_proxy:dpop:jti:"
+
+    def __init__(self, redis_client) -> None:
+        self._redis = redis_client
+
+    async def consume_jti(self, jti: str, ttl_seconds: int = _DEFAULT_TTL) -> bool:
+        result = await self._redis.set(
+            f"{self._PREFIX}{jti}", "1", nx=True, ex=ttl_seconds,
+        )
+        return result is not None
+
+
+_store: DpopJtiStore | None = None
+
+
+def _init_store() -> DpopJtiStore:
+    """Select the best available backend.
+
+    Mastio has a legitimate single-instance production mode (single-tenant
+    intra-org, SQLite + in-memory) where Redis is unnecessary. That differs
+    from the multi-tenant broker (``app/``), which *always* requires Redis
+    in production. So the factory does not refuse in-memory in production —
+    it only logs a warning. ``validate_config`` surfaces the same warning
+    at startup.
+
+    Operators running Mastio multi-worker (HA) MUST set
+    ``MCP_PROXY_REDIS_URL``; otherwise each worker holds an independent
+    JTI dict and a captured DPoP proof can be replayed N× across workers
+    within the ``iat`` window (RFC 9449).
+    """
+    from mcp_proxy.redis.pool import get_redis
+    from mcp_proxy.config import get_settings
+
+    redis = get_redis()
+    if redis is not None:
+        _log.info("DPoP JTI store: Redis")
+        return RedisDpopJtiStore(redis)
+
+    if get_settings().environment == "production":
+        _log.warning(
+            "DPoP JTI store: Redis unavailable in production — using "
+            "in-memory. This is safe only for single-instance/single-worker "
+            "deployments. Multi-worker/HA deploys MUST set "
+            "MCP_PROXY_REDIS_URL (see audit F-B-12)."
+        )
+
+    _log.info("DPoP JTI store: in-memory")
+    return InMemoryDpopJtiStore()
+
+
+def get_dpop_jti_store() -> DpopJtiStore:
+    """Return the active JTI store, initializing on first call."""
+    global _store
+    if _store is None:
+        _store = _init_store()
+    return _store
+
+
+def reset_dpop_jti_store() -> None:
+    """Reset the store (used by tests to force re-initialization)."""
+    global _store
+    _store = None

--- a/mcp_proxy/auth/rate_limit.py
+++ b/mcp_proxy/auth/rate_limit.py
@@ -1,0 +1,143 @@
+"""
+Per-agent sliding-window rate limiter for the egress X-API-Key path.
+
+Two backends, chosen on first use based on Redis availability:
+  - InMemoryAgentRateLimiter — single-worker only, counters reset on restart.
+  - RedisAgentRateLimiter    — multi-worker safe, atomic Lua sliding window
+    over a Redis sorted set.
+
+The proxy's current rate-limit surface is narrow: one bucket per agent_id
+(``settings.rate_limit_per_minute``), enforced on ``get_agent_from_api_key``.
+This module keeps that shape; the broker's richer multi-bucket limiter
+(``app/rate_limit/limiter.py``) can be ported if more buckets appear.
+
+Mastio default (single-instance intra-org) runs with the in-memory backend.
+Deploying with multiple workers without Redis silently multiplies the
+advertised rate budget by N — ``validate_config`` now refuses that in
+production by requiring ``MCP_PROXY_REDIS_URL`` (audit F-B-12).
+"""
+import asyncio
+import logging
+import time
+import uuid
+from typing import Protocol
+
+_log = logging.getLogger("mcp_proxy")
+
+_WINDOW_SECONDS = 60.0
+
+
+class AgentRateLimiter(Protocol):
+    """Interface for per-agent sliding-window rate limiters."""
+
+    async def check(self, agent_id: str, max_per_minute: int) -> bool:
+        """Return True if the request is within budget, False if over the limit."""
+        ...
+
+
+class InMemoryAgentRateLimiter:
+    """Per-process sliding window limiter. Async-safe within one event loop."""
+
+    def __init__(self) -> None:
+        self._windows: dict[str, list[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def check(self, agent_id: str, max_per_minute: int) -> bool:
+        now = time.monotonic()
+        cutoff = now - _WINDOW_SECONDS
+
+        async with self._lock:
+            timestamps = [t for t in self._windows.get(agent_id, []) if t > cutoff]
+            if len(timestamps) >= max_per_minute:
+                self._windows[agent_id] = timestamps
+                return False
+            timestamps.append(now)
+            self._windows[agent_id] = timestamps
+            return True
+
+
+class RedisAgentRateLimiter:
+    """Redis sorted-set sliding window limiter.
+
+    Atomic via Lua: ZREMRANGEBYSCORE (evict stale) + ZCARD (count) + ZADD
+    (register) + EXPIRE, all in one script. The TOCTOU race between count
+    and register is closed server-side.
+    """
+
+    _PREFIX = "mcp_proxy:ratelimit:api_key:"
+    _LUA_SCRIPT = """
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local cutoff = tonumber(ARGV[2])
+local max_requests = tonumber(ARGV[3])
+local request_id = ARGV[4]
+local ttl = tonumber(ARGV[5])
+
+redis.call('ZREMRANGEBYSCORE', key, 0, cutoff)
+local count = redis.call('ZCARD', key)
+if count >= max_requests then
+    return 0
+end
+redis.call('ZADD', key, now, request_id)
+redis.call('EXPIRE', key, ttl)
+return 1
+"""
+
+    def __init__(self, redis_client) -> None:
+        self._redis = redis_client
+        self._lua_sha: str | None = None
+
+    async def check(self, agent_id: str, max_per_minute: int) -> bool:
+        now = time.time()
+        cutoff = now - _WINDOW_SECONDS
+        key = f"{self._PREFIX}{agent_id}"
+        request_id = uuid.uuid4().hex
+        ttl = int(_WINDOW_SECONDS) + 10
+
+        if self._lua_sha is None:
+            self._lua_sha = await self._redis.script_load(self._LUA_SCRIPT)
+
+        allowed = await self._redis.evalsha(
+            self._lua_sha, 1, key,
+            str(now), str(cutoff), str(max_per_minute), request_id, str(ttl),
+        )
+        return bool(allowed)
+
+
+_limiter: AgentRateLimiter | None = None
+
+
+def _init_limiter() -> AgentRateLimiter:
+    """Select the best available backend.
+
+    Unlike the JTI store we do not refuse in-memory in production: a
+    silent rate-limit bypass degrades DoS protection, not authentication.
+    ``validate_config`` already blocks prod startup when
+    ``MCP_PROXY_REDIS_URL`` is empty, so production with Redis
+    temporarily unreachable falls back to per-worker in-memory windows —
+    degraded ceiling but the system keeps serving. Log the condition
+    loudly so operators see it in alerts.
+    """
+    from mcp_proxy.redis.pool import get_redis
+
+    redis = get_redis()
+    if redis is not None:
+        _log.info("Agent API-key rate limiter: Redis")
+        return RedisAgentRateLimiter(redis)
+
+    _log.info("Agent API-key rate limiter: in-memory")
+    return InMemoryAgentRateLimiter()
+
+
+def get_agent_rate_limiter() -> AgentRateLimiter:
+    """Return the active rate limiter, initializing on first call."""
+    global _limiter
+    if _limiter is None:
+        _limiter = _init_limiter()
+    return _limiter
+
+
+def reset_agent_rate_limiter() -> None:
+    """Reset the limiter (used by tests to force re-initialization)."""
+    global _limiter
+    _limiter = None

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -85,6 +85,12 @@ class ProxySettings(BaseSettings):
     # Rate limiting
     rate_limit_per_minute: int = 60
 
+    # Redis — optional. Empty = in-memory JTI store + rate limiter (single-
+    # instance Mastio is fine without Redis). Multi-worker / HA deploys MUST
+    # set this so the DPoP JTI store is shared across workers (audit F-B-12).
+    # Accepts redis:// or rediss:// URLs.
+    redis_url: str = ""
+
     # ADR-001 Phase 2 — SPIFFE routing decision.
     # trust_domain is the SPIFFE trust domain this proxy serves (matched against
     # recipient SPIFFE IDs to decide intra vs cross-org). intra_org_routing is
@@ -246,6 +252,21 @@ def validate_config(settings: ProxySettings) -> None:
 
     if settings.allowed_origins.strip() == "*":
         _log.warning("ALLOWED_ORIGINS is '*' — CORS fully open.")
+
+    # Audit F-B-12 — Mastio keeps a DPoP JTI cache and per-agent rate
+    # limiter in process memory by default. Single-instance deployments
+    # (the current Mastio mainstream) work fine without Redis. Operators
+    # running Mastio multi-worker or multi-replica (HA) MUST set
+    # MCP_PROXY_REDIS_URL so the JTI store is shared — otherwise a
+    # captured DPoP proof can be replayed once per worker within the iat
+    # window, and the advertised per-agent rate budget multiplies by N.
+    if is_production and not settings.redis_url:
+        _log.warning(
+            "MCP_PROXY_REDIS_URL is empty in production. Safe for "
+            "single-instance Mastio; set MCP_PROXY_REDIS_URL before "
+            "scaling to multiple workers or replicas (audit F-B-12: "
+            "cross-worker DPoP replay + rate-limit budget multiplies)."
+        )
 
     if not settings.broker_jwks_url and not settings.jwks_override_path:
         _log.warning(

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -58,6 +58,15 @@ async def lifespan(app: FastAPI):
     # 2. Initialize database
     await init_db(settings.database_url)
 
+    # 2b. Initialize the shared Redis client (audit F-B-12).
+    # Empty REDIS_URL is a supported single-instance configuration —
+    # ``init_redis`` is a no-op, and callers (JTI store, rate limiter)
+    # fall back to in-memory. Operators running multi-worker/HA MUST
+    # configure ``MCP_PROXY_REDIS_URL``; ``validate_config`` warns when
+    # that condition is missed in production.
+    from mcp_proxy.redis.pool import init_redis
+    await init_redis(settings.redis_url)
+
     # 3. Initialize JWKS client (for external JWT validation)
     from mcp_proxy.auth.jwks_client import JWKSClient
     _jwks_client = JWKSClient(
@@ -306,6 +315,8 @@ async def lifespan(app: FastAPI):
         await rp_client.aclose()
     if _jwks_client:
         await _jwks_client.close()
+    from mcp_proxy.redis.pool import close_redis
+    await close_redis()
     await dispose_db()
     _log.info("MCP Proxy shutdown complete")
 

--- a/mcp_proxy/redis/pool.py
+++ b/mcp_proxy/redis/pool.py
@@ -1,0 +1,87 @@
+"""
+Redis connection pool — shared async client for the Mastio (mcp_proxy) process.
+
+Usage:
+    from mcp_proxy.redis.pool import get_redis
+
+    redis = get_redis()          # returns the shared client (or None if disabled)
+    if redis:
+        await redis.set("key", "value", ex=300)
+
+The pool is initialized at startup (main.py lifespan) and closed at shutdown.
+If MCP_PROXY_REDIS_URL is empty or the connection fails, Redis is disabled
+gracefully: callers get None and fall back to in-memory implementations.
+
+Mastio default (single-instance intra-org) does not require Redis. Operators
+who run Mastio with multiple workers or replicas MUST configure
+MCP_PROXY_REDIS_URL so that the DPoP JTI store and agent rate limiter share
+state across workers (RFC 9449 replay protection + advertised rate limits).
+``validate_config`` refuses production startup when REDIS_URL is empty.
+"""
+import logging
+
+import redis.asyncio as aioredis
+
+_log = logging.getLogger("mcp_proxy")
+
+_client: aioredis.Redis | None = None
+
+
+async def init_redis(redis_url: str) -> bool:
+    """Initialize the shared Redis async client.
+
+    Returns True if the connection succeeded, False otherwise.
+    """
+    global _client
+
+    if not redis_url:
+        _log.info("Redis disabled — MCP_PROXY_REDIS_URL is empty")
+        return False
+
+    try:
+        client = aioredis.from_url(
+            redis_url,
+            decode_responses=True,
+            socket_connect_timeout=5,
+            socket_timeout=5,
+        )
+        await client.ping()
+        _client = client
+        _log.info("Redis connected: %s", redis_url)
+        return True
+    except Exception as exc:
+        _log.warning(
+            "Redis connection failed (%s) — falling back to in-memory: %s",
+            redis_url,
+            exc,
+        )
+        _client = None
+        return False
+
+
+async def close_redis() -> None:
+    """Close the Redis connection pool. Safe to call even if Redis is disabled."""
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+        _log.info("Redis connection closed")
+
+
+def get_redis() -> aioredis.Redis | None:
+    """Return the shared Redis client, or None if Redis is disabled.
+
+    Callers must check for None and fall back to in-memory.
+    """
+    return _client
+
+
+def reset_redis_for_tests() -> None:
+    """Drop the module singleton without closing the connection.
+
+    Tests that monkeypatch ``get_redis`` want a clean slate on teardown;
+    async close from a sync test hook is brittle, so we just forget the
+    reference. Never call in production code.
+    """
+    global _client
+    _client = None

--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -16,3 +16,7 @@ starlette>=0.40.0,<1.0.0
 sse-starlette>=2.0,<3.0
 python-multipart>=0.0.20
 authlib>=1.3.0
+# Redis — optional at runtime (single-instance Mastio runs fine without
+# MCP_PROXY_REDIS_URL set), but the Python package must be present for
+# the import path in mcp_proxy.redis.pool to resolve (audit F-B-12).
+redis>=5.0.0

--- a/tests/test_mcp_proxy_jti_store.py
+++ b/tests/test_mcp_proxy_jti_store.py
@@ -1,0 +1,151 @@
+"""Tests for the Mastio (mcp_proxy) DPoP JTI store — audit F-B-12."""
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_proxy.auth import dpop_jti_store as jti_mod
+from mcp_proxy.redis import pool as redis_pool
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── InMemory backend ────────────────────────────────────────────────
+
+async def test_in_memory_first_use_allowed():
+    store = jti_mod.InMemoryDpopJtiStore()
+    assert await store.consume_jti("jti-1") is True
+
+
+async def test_in_memory_replay_rejected():
+    store = jti_mod.InMemoryDpopJtiStore()
+    assert await store.consume_jti("jti-1") is True
+    assert await store.consume_jti("jti-1") is False
+
+
+async def test_in_memory_distinct_jtis_coexist():
+    store = jti_mod.InMemoryDpopJtiStore()
+    assert await store.consume_jti("jti-1") is True
+    assert await store.consume_jti("jti-2") is True
+    # Neither may be replayed.
+    assert await store.consume_jti("jti-1") is False
+    assert await store.consume_jti("jti-2") is False
+
+
+async def test_in_memory_ttl_expiry_allows_reuse():
+    store = jti_mod.InMemoryDpopJtiStore()
+    assert await store.consume_jti("jti-expiring", ttl_seconds=1) is True
+    await asyncio.sleep(1.1)
+    # After TTL, the same jti is accepted again (matches broker behavior).
+    assert await store.consume_jti("jti-expiring", ttl_seconds=1) is True
+
+
+async def test_in_memory_concurrent_consume_serialized():
+    """Two concurrent consumes of the same jti: only one wins."""
+    store = jti_mod.InMemoryDpopJtiStore()
+
+    async def consume():
+        return await store.consume_jti("race-jti")
+
+    results = await asyncio.gather(consume(), consume())
+    assert sorted(results) == [False, True]
+
+
+# ── Redis backend (via AsyncMock) ───────────────────────────────────
+
+async def test_redis_first_use_returns_true_on_set_ok():
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    store = jti_mod.RedisDpopJtiStore(fake_redis)
+    assert await store.consume_jti("jti-1") is True
+    fake_redis.set.assert_awaited_once()
+    # Verify NX + EX usage.
+    call = fake_redis.set.await_args
+    assert call.kwargs["nx"] is True
+    assert call.kwargs["ex"] == jti_mod._DEFAULT_TTL
+
+
+async def test_redis_replay_returns_false_on_set_none():
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=None)
+    store = jti_mod.RedisDpopJtiStore(fake_redis)
+    assert await store.consume_jti("jti-replay") is False
+
+
+async def test_redis_key_prefix_namespaces_mastio():
+    """Keys live under 'mcp_proxy:dpop:jti:' so they don't collide with
+    the broker's 'dpop:jti:' namespace when both share a Redis instance."""
+    fake_redis = AsyncMock()
+    fake_redis.set = AsyncMock(return_value=True)
+    store = jti_mod.RedisDpopJtiStore(fake_redis)
+    await store.consume_jti("jti-x")
+    call = fake_redis.set.await_args
+    key = call.args[0]
+    assert key.startswith("mcp_proxy:dpop:jti:")
+    assert key.endswith("jti-x")
+
+
+# ── Factory: backend selection ──────────────────────────────────────
+
+async def test_factory_returns_in_memory_when_redis_none(monkeypatch):
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    jti_mod.reset_dpop_jti_store()
+    try:
+        store = jti_mod._init_store()
+        assert isinstance(store, jti_mod.InMemoryDpopJtiStore)
+    finally:
+        jti_mod.reset_dpop_jti_store()
+
+
+async def test_factory_returns_redis_when_available(monkeypatch):
+    fake_redis = AsyncMock()
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: fake_redis)
+    jti_mod.reset_dpop_jti_store()
+    try:
+        store = jti_mod._init_store()
+        assert isinstance(store, jti_mod.RedisDpopJtiStore)
+    finally:
+        jti_mod.reset_dpop_jti_store()
+
+
+async def test_factory_allows_in_memory_in_production_single_instance(monkeypatch, caplog):
+    """Audit F-B-12 — unlike the broker, Mastio supports a legitimate
+    single-instance production mode. The factory must NOT raise when
+    prod + no Redis; it logs a warning and returns in-memory so
+    single-worker deploys keep working."""
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    get_settings.cache_clear()
+
+    jti_mod.reset_dpop_jti_store()
+    try:
+        with caplog.at_level("WARNING", logger="mcp_proxy"):
+            store = jti_mod._init_store()
+        assert isinstance(store, jti_mod.InMemoryDpopJtiStore)
+        # Warning must be emitted so operators see the single-instance constraint.
+        assert any("single-instance" in rec.message for rec in caplog.records)
+    finally:
+        get_settings.cache_clear()
+        jti_mod.reset_dpop_jti_store()
+
+
+async def test_get_store_caches_across_calls(monkeypatch):
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    jti_mod.reset_dpop_jti_store()
+    try:
+        first = jti_mod.get_dpop_jti_store()
+        second = jti_mod.get_dpop_jti_store()
+        assert first is second
+    finally:
+        jti_mod.reset_dpop_jti_store()
+
+
+async def test_reset_forces_reinitialization(monkeypatch):
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    jti_mod.reset_dpop_jti_store()
+    first = jti_mod.get_dpop_jti_store()
+    jti_mod.reset_dpop_jti_store()
+    second = jti_mod.get_dpop_jti_store()
+    assert first is not second

--- a/tests/test_mcp_proxy_jti_store.py
+++ b/tests/test_mcp_proxy_jti_store.py
@@ -114,43 +114,34 @@ async def test_factory_allows_in_memory_in_production_single_instance(monkeypatc
     prod + no Redis; it logs a warning and returns in-memory so
     single-worker deploys keep working.
 
-    The ``mcp_proxy`` logger is configured with ``propagate=False``
-    (see ``mcp_proxy/logging_setup.py``), which makes pytest's ``caplog``
-    miss records on CI runners where logging is already set up. Capture
-    via a dedicated handler on the target logger instead.
+    Intercept ``_log.warning`` directly on the module under test —
+    pytest's caplog misses records on CI because the ``mcp_proxy``
+    logger is configured with ``propagate=False`` (see
+    ``mcp_proxy/logging_setup.py``). A module-level monkeypatch has no
+    dependency on logging framework behaviour.
     """
-    import logging
-
     from mcp_proxy.config import get_settings
 
     monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
     monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
     get_settings.cache_clear()
 
-    captured: list[logging.LogRecord] = []
+    warnings: list[str] = []
 
-    class _Collector(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record)
+    def _record(msg, *args, **kwargs):
+        warnings.append(str(msg) % args if args else str(msg))
 
-    handler = _Collector(level=logging.WARNING)
-    logger = logging.getLogger("mcp_proxy")
-    previous_level = logger.level
-    logger.addHandler(handler)
-    logger.setLevel(logging.WARNING)
+    monkeypatch.setattr(jti_mod._log, "warning", _record)
 
     jti_mod.reset_dpop_jti_store()
     try:
         store = jti_mod._init_store()
         assert isinstance(store, jti_mod.InMemoryDpopJtiStore)
         # Warning must be emitted so operators see the single-instance constraint.
-        messages = [r.getMessage() for r in captured]
-        assert any("single-instance" in msg for msg in messages), (
-            f"expected single-instance warning, got: {messages}"
+        assert any("single-instance" in msg for msg in warnings), (
+            f"expected single-instance warning, got: {warnings}"
         )
     finally:
-        logger.removeHandler(handler)
-        logger.setLevel(previous_level)
         get_settings.cache_clear()
         jti_mod.reset_dpop_jti_store()
 

--- a/tests/test_mcp_proxy_jti_store.py
+++ b/tests/test_mcp_proxy_jti_store.py
@@ -108,25 +108,49 @@ async def test_factory_returns_redis_when_available(monkeypatch):
         jti_mod.reset_dpop_jti_store()
 
 
-async def test_factory_allows_in_memory_in_production_single_instance(monkeypatch, caplog):
+async def test_factory_allows_in_memory_in_production_single_instance(monkeypatch):
     """Audit F-B-12 — unlike the broker, Mastio supports a legitimate
     single-instance production mode. The factory must NOT raise when
     prod + no Redis; it logs a warning and returns in-memory so
-    single-worker deploys keep working."""
+    single-worker deploys keep working.
+
+    The ``mcp_proxy`` logger is configured with ``propagate=False``
+    (see ``mcp_proxy/logging_setup.py``), which makes pytest's ``caplog``
+    miss records on CI runners where logging is already set up. Capture
+    via a dedicated handler on the target logger instead.
+    """
+    import logging
+
     from mcp_proxy.config import get_settings
 
     monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
     monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
     get_settings.cache_clear()
 
+    captured: list[logging.LogRecord] = []
+
+    class _Collector(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _Collector(level=logging.WARNING)
+    logger = logging.getLogger("mcp_proxy")
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+
     jti_mod.reset_dpop_jti_store()
     try:
-        with caplog.at_level("WARNING", logger="mcp_proxy"):
-            store = jti_mod._init_store()
+        store = jti_mod._init_store()
         assert isinstance(store, jti_mod.InMemoryDpopJtiStore)
         # Warning must be emitted so operators see the single-instance constraint.
-        assert any("single-instance" in rec.message for rec in caplog.records)
+        messages = [r.getMessage() for r in captured]
+        assert any("single-instance" in msg for msg in messages), (
+            f"expected single-instance warning, got: {messages}"
+        )
     finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
         get_settings.cache_clear()
         jti_mod.reset_dpop_jti_store()
 

--- a/tests/test_mcp_proxy_rate_limit.py
+++ b/tests/test_mcp_proxy_rate_limit.py
@@ -1,0 +1,148 @@
+"""Tests for the Mastio (mcp_proxy) per-agent API-key rate limiter — audit F-B-12."""
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mcp_proxy.auth import rate_limit as rl_mod
+from mcp_proxy.redis import pool as redis_pool
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── InMemory backend ────────────────────────────────────────────────
+
+async def test_in_memory_allows_under_limit():
+    limiter = rl_mod.InMemoryAgentRateLimiter()
+    for _ in range(3):
+        assert await limiter.check("agent-a", max_per_minute=5) is True
+
+
+async def test_in_memory_blocks_when_over_limit():
+    limiter = rl_mod.InMemoryAgentRateLimiter()
+    for _ in range(5):
+        assert await limiter.check("agent-a", max_per_minute=5) is True
+    # 6th request in the same window: blocked.
+    assert await limiter.check("agent-a", max_per_minute=5) is False
+
+
+async def test_in_memory_separate_agents_have_independent_budgets():
+    limiter = rl_mod.InMemoryAgentRateLimiter()
+    for _ in range(5):
+        assert await limiter.check("agent-a", max_per_minute=5) is True
+    # agent-b has its own window.
+    assert await limiter.check("agent-b", max_per_minute=5) is True
+
+
+async def test_in_memory_sliding_window_prunes_old_entries(monkeypatch):
+    """Old timestamps outside the 60s window must be evicted so the
+    agent regains budget over time."""
+    limiter = rl_mod.InMemoryAgentRateLimiter()
+
+    # Seed the window with a stale timestamp in the past.
+    stale_time = 0.0
+    fresh_time = 120.0  # two minutes later, outside the 60s window.
+
+    monkeypatch.setattr(rl_mod.time, "monotonic", lambda: stale_time)
+    for _ in range(5):
+        assert await limiter.check("agent-a", max_per_minute=5) is True
+    # Budget full at stale_time.
+    assert await limiter.check("agent-a", max_per_minute=5) is False
+
+    # Move time forward — all stale entries evicted.
+    monkeypatch.setattr(rl_mod.time, "monotonic", lambda: fresh_time)
+    assert await limiter.check("agent-a", max_per_minute=5) is True
+
+
+async def test_in_memory_concurrent_checks_serialized():
+    """Two concurrent checks under the limit both succeed, without racing
+    on the underlying dict."""
+    limiter = rl_mod.InMemoryAgentRateLimiter()
+
+    async def do_check():
+        return await limiter.check("race-agent", max_per_minute=10)
+
+    results = await asyncio.gather(*(do_check() for _ in range(10)))
+    assert all(results)
+    # 11th must be blocked.
+    assert await limiter.check("race-agent", max_per_minute=10) is False
+
+
+# ── Redis backend (via AsyncMock) ───────────────────────────────────
+
+async def test_redis_allowed_returns_true_on_lua_1():
+    fake_redis = AsyncMock()
+    fake_redis.script_load = AsyncMock(return_value="sha-abc")
+    fake_redis.evalsha = AsyncMock(return_value=1)
+    limiter = rl_mod.RedisAgentRateLimiter(fake_redis)
+    assert await limiter.check("agent-a", max_per_minute=60) is True
+    fake_redis.script_load.assert_awaited_once()
+    fake_redis.evalsha.assert_awaited_once()
+
+
+async def test_redis_blocked_returns_false_on_lua_0():
+    fake_redis = AsyncMock()
+    fake_redis.script_load = AsyncMock(return_value="sha-abc")
+    fake_redis.evalsha = AsyncMock(return_value=0)
+    limiter = rl_mod.RedisAgentRateLimiter(fake_redis)
+    assert await limiter.check("agent-a", max_per_minute=60) is False
+
+
+async def test_redis_reuses_loaded_lua_sha():
+    """script_load runs at most once per RedisAgentRateLimiter instance —
+    subsequent checks reuse the SHA via evalsha."""
+    fake_redis = AsyncMock()
+    fake_redis.script_load = AsyncMock(return_value="sha-abc")
+    fake_redis.evalsha = AsyncMock(return_value=1)
+    limiter = rl_mod.RedisAgentRateLimiter(fake_redis)
+    for _ in range(3):
+        await limiter.check("agent-a", max_per_minute=60)
+    fake_redis.script_load.assert_awaited_once()
+    assert fake_redis.evalsha.await_count == 3
+
+
+async def test_redis_key_prefix_namespaces_mastio():
+    fake_redis = AsyncMock()
+    fake_redis.script_load = AsyncMock(return_value="sha-abc")
+    fake_redis.evalsha = AsyncMock(return_value=1)
+    limiter = rl_mod.RedisAgentRateLimiter(fake_redis)
+    await limiter.check("agent-a", max_per_minute=60)
+    # args: script_sha, numkeys, key, now, cutoff, max, request_id, ttl
+    call_args = fake_redis.evalsha.await_args.args
+    key = call_args[2]
+    assert key.startswith("mcp_proxy:ratelimit:api_key:")
+    assert key.endswith("agent-a")
+
+
+# ── Factory ─────────────────────────────────────────────────────────
+
+async def test_factory_returns_in_memory_when_redis_none(monkeypatch):
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    rl_mod.reset_agent_rate_limiter()
+    try:
+        limiter = rl_mod._init_limiter()
+        assert isinstance(limiter, rl_mod.InMemoryAgentRateLimiter)
+    finally:
+        rl_mod.reset_agent_rate_limiter()
+
+
+async def test_factory_returns_redis_when_available(monkeypatch):
+    fake_redis = AsyncMock()
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: fake_redis)
+    rl_mod.reset_agent_rate_limiter()
+    try:
+        limiter = rl_mod._init_limiter()
+        assert isinstance(limiter, rl_mod.RedisAgentRateLimiter)
+    finally:
+        rl_mod.reset_agent_rate_limiter()
+
+
+async def test_get_limiter_caches_across_calls(monkeypatch):
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    rl_mod.reset_agent_rate_limiter()
+    try:
+        first = rl_mod.get_agent_rate_limiter()
+        second = rl_mod.get_agent_rate_limiter()
+        assert first is second
+    finally:
+        rl_mod.reset_agent_rate_limiter()

--- a/tests/test_secrets_hardening.py
+++ b/tests/test_secrets_hardening.py
@@ -207,68 +207,49 @@ def test_dpop_jti_init_uses_in_memory_in_development(monkeypatch):
 # multi-worker/HA must set it to avoid the cross-worker DPoP replay +
 # rate-limit budget multiplication.
 #
-# The proxy configures the "mcp_proxy" logger with ``propagate=False``
-# at startup (``mcp_proxy/logging_setup.py``), so pytest's caplog —
-# which attaches to root by default — does not see the records. Capture
-# via a dedicated handler on the target logger instead.
-
-import logging as _logging
-
-
-class _ListHandler(_logging.Handler):
-    def __init__(self):
-        super().__init__(level=_logging.WARNING)
-        self.records: list[_logging.LogRecord] = []
-
-    def emit(self, record: _logging.LogRecord) -> None:
-        self.records.append(record)
+# pytest's caplog and even a manually-attached handler on the
+# ``mcp_proxy`` logger miss the records on some CI runners (the
+# structured JSON logger in ``mcp_proxy/logging_setup.py`` sets
+# ``propagate=False``; downstream hierarchy + handler timing is
+# environment-sensitive). Intercept ``_log.warning`` directly on the
+# module under test — this is the tightest possible coupling and has no
+# dependency on logging framework behaviour.
 
 
-def _capture_mcp_proxy_warnings():
-    handler = _ListHandler()
-    logger = _logging.getLogger("mcp_proxy")
-    previous_level = logger.level
-    logger.addHandler(handler)
-    logger.setLevel(_logging.WARNING)
-    return handler, logger, previous_level
+def _patch_startup_warning(monkeypatch):
+    """Capture warnings emitted by ``mcp_proxy.config._log.warning``."""
+    import mcp_proxy.config as _config_mod
+    calls: list[str] = []
+
+    def _record(msg, *args, **kwargs):
+        calls.append(str(msg) % args if args else str(msg))
+
+    monkeypatch.setattr(_config_mod._log, "warning", _record)
+    return calls
 
 
-def _restore_mcp_proxy_logger(handler, logger, previous_level):
-    logger.removeHandler(handler)
-    logger.setLevel(previous_level)
-
-
-def test_proxy_validate_config_warns_on_prod_without_redis():
+def test_proxy_validate_config_warns_on_prod_without_redis(monkeypatch):
     settings = _prod_proxy_settings(redis_url="")
-    handler, logger, prev = _capture_mcp_proxy_warnings()
-    try:
-        # Must NOT raise — single-instance Mastio prod is supported.
-        proxy_validate_config(settings)
-    finally:
-        _restore_mcp_proxy_logger(handler, logger, prev)
-    messages = " ".join(r.getMessage() for r in handler.records)
+    warnings = _patch_startup_warning(monkeypatch)
+    # Must NOT raise — single-instance Mastio prod is supported.
+    proxy_validate_config(settings)
+    messages = " ".join(warnings)
     assert "MCP_PROXY_REDIS_URL" in messages
     assert "single-instance" in messages or "multi-worker" in messages
     assert "F-B-12" in messages
 
 
-def test_proxy_validate_config_prod_with_redis_no_warning():
+def test_proxy_validate_config_prod_with_redis_no_warning(monkeypatch):
     settings = _prod_proxy_settings(redis_url="redis://redis:6379/0")
-    handler, logger, prev = _capture_mcp_proxy_warnings()
-    try:
-        proxy_validate_config(settings)
-    finally:
-        _restore_mcp_proxy_logger(handler, logger, prev)
-    messages = " ".join(r.getMessage() for r in handler.records)
+    warnings = _patch_startup_warning(monkeypatch)
+    proxy_validate_config(settings)
+    messages = " ".join(warnings)
     assert "F-B-12" not in messages
 
 
-def test_proxy_validate_config_dev_without_redis_no_warning():
+def test_proxy_validate_config_dev_without_redis_no_warning(monkeypatch):
     settings = ProxySettings(environment="development", redis_url="")
-    handler, logger, prev = _capture_mcp_proxy_warnings()
-    try:
-        proxy_validate_config(settings)
-    finally:
-        _restore_mcp_proxy_logger(handler, logger, prev)
-    messages = " ".join(r.getMessage() for r in handler.records)
+    warnings = _patch_startup_warning(monkeypatch)
+    proxy_validate_config(settings)
+    messages = " ".join(warnings)
     assert "F-B-12" not in messages

--- a/tests/test_secrets_hardening.py
+++ b/tests/test_secrets_hardening.py
@@ -197,3 +197,38 @@ def test_dpop_jti_init_uses_in_memory_in_development(monkeypatch):
     finally:
         get_settings.cache_clear()
         jti_mod.reset_dpop_jti_store()
+
+
+# ── F-B-12: Mastio Redis warning (not a hard refusal) ──────────────
+#
+# Unlike the broker, Mastio has a legitimate single-instance production
+# mode (single-tenant intra-org). validate_config warns rather than
+# refusing when REDIS_URL is empty in production — operators deploying
+# multi-worker/HA must set it to avoid the cross-worker DPoP replay +
+# rate-limit budget multiplication.
+
+def test_proxy_validate_config_warns_on_prod_without_redis(caplog):
+    settings = _prod_proxy_settings(redis_url="")
+    with caplog.at_level("WARNING", logger="mcp_proxy"):
+        # Must NOT raise — single-instance Mastio prod is supported.
+        proxy_validate_config(settings)
+    messages = " ".join(rec.message for rec in caplog.records)
+    assert "MCP_PROXY_REDIS_URL" in messages
+    assert "single-instance" in messages or "multi-worker" in messages
+    assert "F-B-12" in messages
+
+
+def test_proxy_validate_config_prod_with_redis_no_warning(caplog):
+    settings = _prod_proxy_settings(redis_url="redis://redis:6379/0")
+    with caplog.at_level("WARNING", logger="mcp_proxy"):
+        proxy_validate_config(settings)
+    messages = " ".join(rec.message for rec in caplog.records)
+    assert "F-B-12" not in messages
+
+
+def test_proxy_validate_config_dev_without_redis_no_warning(caplog):
+    settings = ProxySettings(environment="development", redis_url="")
+    with caplog.at_level("WARNING", logger="mcp_proxy"):
+        proxy_validate_config(settings)
+    messages = " ".join(rec.message for rec in caplog.records)
+    assert "F-B-12" not in messages

--- a/tests/test_secrets_hardening.py
+++ b/tests/test_secrets_hardening.py
@@ -206,29 +206,69 @@ def test_dpop_jti_init_uses_in_memory_in_development(monkeypatch):
 # refusing when REDIS_URL is empty in production — operators deploying
 # multi-worker/HA must set it to avoid the cross-worker DPoP replay +
 # rate-limit budget multiplication.
+#
+# The proxy configures the "mcp_proxy" logger with ``propagate=False``
+# at startup (``mcp_proxy/logging_setup.py``), so pytest's caplog —
+# which attaches to root by default — does not see the records. Capture
+# via a dedicated handler on the target logger instead.
 
-def test_proxy_validate_config_warns_on_prod_without_redis(caplog):
+import logging as _logging
+
+
+class _ListHandler(_logging.Handler):
+    def __init__(self):
+        super().__init__(level=_logging.WARNING)
+        self.records: list[_logging.LogRecord] = []
+
+    def emit(self, record: _logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _capture_mcp_proxy_warnings():
+    handler = _ListHandler()
+    logger = _logging.getLogger("mcp_proxy")
+    previous_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(_logging.WARNING)
+    return handler, logger, previous_level
+
+
+def _restore_mcp_proxy_logger(handler, logger, previous_level):
+    logger.removeHandler(handler)
+    logger.setLevel(previous_level)
+
+
+def test_proxy_validate_config_warns_on_prod_without_redis():
     settings = _prod_proxy_settings(redis_url="")
-    with caplog.at_level("WARNING", logger="mcp_proxy"):
+    handler, logger, prev = _capture_mcp_proxy_warnings()
+    try:
         # Must NOT raise — single-instance Mastio prod is supported.
         proxy_validate_config(settings)
-    messages = " ".join(rec.message for rec in caplog.records)
+    finally:
+        _restore_mcp_proxy_logger(handler, logger, prev)
+    messages = " ".join(r.getMessage() for r in handler.records)
     assert "MCP_PROXY_REDIS_URL" in messages
     assert "single-instance" in messages or "multi-worker" in messages
     assert "F-B-12" in messages
 
 
-def test_proxy_validate_config_prod_with_redis_no_warning(caplog):
+def test_proxy_validate_config_prod_with_redis_no_warning():
     settings = _prod_proxy_settings(redis_url="redis://redis:6379/0")
-    with caplog.at_level("WARNING", logger="mcp_proxy"):
+    handler, logger, prev = _capture_mcp_proxy_warnings()
+    try:
         proxy_validate_config(settings)
-    messages = " ".join(rec.message for rec in caplog.records)
+    finally:
+        _restore_mcp_proxy_logger(handler, logger, prev)
+    messages = " ".join(r.getMessage() for r in handler.records)
     assert "F-B-12" not in messages
 
 
-def test_proxy_validate_config_dev_without_redis_no_warning(caplog):
+def test_proxy_validate_config_dev_without_redis_no_warning():
     settings = ProxySettings(environment="development", redis_url="")
-    with caplog.at_level("WARNING", logger="mcp_proxy"):
+    handler, logger, prev = _capture_mcp_proxy_warnings()
+    try:
         proxy_validate_config(settings)
-    messages = " ".join(rec.message for rec in caplog.records)
+    finally:
+        _restore_mcp_proxy_logger(handler, logger, prev)
+    messages = " ".join(r.getMessage() for r in handler.records)
     assert "F-B-12" not in messages


### PR DESCRIPTION
## Summary

- Mastio (`mcp_proxy/`) becomes Redis-aware for multi-worker safety: dual-backend factory for DPoP JTI store and per-agent rate limiter, matching the broker-side fix from PR #173.
- Single-instance Mastio is unchanged: empty `MCP_PROXY_REDIS_URL` keeps the in-memory backends. Mainstream deployment stays zero-config.
- Multi-worker / HA deploys set `MCP_PROXY_REDIS_URL` and get shared state across workers — closing the cross-worker DPoP replay and the per-worker rate-budget multiplication.

Closes #182 (F-B-12).

## Why

Mastio transitioned from egress-only proxy to intra-org mini-broker via ADR-006/007/008 but kept the single-process in-memory JTI store (`mcp_proxy/auth/dpop.py:222`) and rate limiter (`mcp_proxy/auth/api_key.py:53`). The broker fixed the equivalent class of issue on its side in PR #173 (F-E-04); the parallel surface on Mastio was overlooked.

Coordinated with the agent driving ADR-010 — scope is strictly `mcp_proxy/{redis,auth,config,main}` + tests; zero overlap with their federation work.

## Design note — warn vs refuse

The broker refuses production startup with empty `REDIS_URL` (always multi-tenant / multi-worker). Mastio legitimately runs single-instance in production per the intended ICP model. `validate_config` therefore emits a \`WARNING\` (not \`SystemExit\`) when prod + empty \`REDIS_URL\`. Operators deploying multi-worker/HA must set it; single-instance operators keep the lightweight path.

## What changed

New modules:
- \`mcp_proxy/redis/pool.py\` — shared asyncio client + graceful None fallback on empty URL or connection failure.
- \`mcp_proxy/auth/dpop_jti_store.py\` — Protocol + \`InMemoryDpopJtiStore\` + \`RedisDpopJtiStore\` (SET NX EX) + factory.
- \`mcp_proxy/auth/rate_limit.py\` — Protocol + \`InMemoryAgentRateLimiter\` + \`RedisAgentRateLimiter\` (sorted-set Lua, atomic) + factory.

Modified:
- \`mcp_proxy/auth/dpop.py\` — JTI consume delegated to \`get_dpop_jti_store()\`. Inline \`InMemoryDpopJtiStore\` + module singleton removed.
- \`mcp_proxy/auth/api_key.py\` — rate check delegated to \`get_agent_rate_limiter().check(agent_id, max)\`. Now async at the call site.
- \`mcp_proxy/config.py\` — \`redis_url: str = \"\"\` field + F-B-12 production warning when empty.
- \`mcp_proxy/main.py\` — \`init_redis(settings.redis_url)\` at lifespan startup; \`close_redis()\` at shutdown.
- \`mcp_proxy/requirements-proxy.txt\` — \`redis>=5.0.0\` (needed for \`import redis.asyncio\` to resolve; runtime behavior stays opt-in).

Tests:
- \`tests/test_mcp_proxy_jti_store.py\` — 12 cases covering InMemory + Redis (via AsyncMock) + factory selection + prod warning path + singleton caching.
- \`tests/test_mcp_proxy_rate_limit.py\` — 13 cases covering InMemory sliding window + Redis Lua SHA reuse + prefix + factory.
- \`tests/test_secrets_hardening.py\` — 3 cases for the new validate_config warning.

## Threat-model coverage

Scenarios this PR closes (when operator sets \`REDIS_URL\` in multi-worker/HA):
- DPoP proof captured once, replayed across N workers within the 300s iat window.
- Agent burning N× the advertised \`rate_limit_per_minute\` across workers before hitting the shared ceiling.
- State loss across Mastio restarts / rolling updates for the JTI window.

Out of scope (follow-ups):
- Other Mastio in-memory state that assumes single-process (ws_manager, message_queue, audit chain parity). Umbrella tracker suggested: \"Mastio HA readiness\".
- DPoP egress-bearer upgrade on the API-key path — that is #181 (F-B-11).

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1202 passed, 31 skipped.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS (join + attach-ca + x509 + cross-org messaging + audit chain + \`/v1/mcp\` forwarder).
- [x] Target unit tests isolated: \`pytest tests/test_mcp_proxy_jti_store.py tests/test_mcp_proxy_rate_limit.py tests/test_secrets_hardening.py\` — 39 passed.
- [x] Smoke proxy startup sanity check: build, \`docker compose up\`, proxies reach healthy with empty \`REDIS_URL\`.

## Open questions for reviewers

1. Keep the broker-style prod-refusal instead of the warning, at the cost of requiring a throwaway Redis for single-instance prod? I landed on the warning because the other agent on ADR-010 explicitly designed Mastio for single-instance-default. Flip if that trade-off is wrong.
2. Optional follow-up: promote the warning to \`SystemExit\` when \`UVICORN_WORKERS > 1\` is detected. Not included here to keep this PR tight.