### PR TITLE
feat(mastio): authoritative agent registry + admin API (ADR-010 Phase 2)

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -1,0 +1,341 @@
+"""ADR-010 Phase 2 — Mastio-side authoritative agent registry admin API.
+
+This is the endpoint a Mastio admin (or automation like the sandbox
+bootstrap after Phase 4) calls to register an agent **on the Mastio**.
+Crucially, registering here does **not** automatically publish to the
+Court — the ``federated`` flag controls that. Setting ``federated=true``
+(either at create or via PATCH) enqueues a push that the federation
+publisher loop (Phase 3) will carry to the Court via ADR-009
+counter-signed ``POST /v1/federation/publish-agent``.
+
+Auth: ``X-Admin-Secret`` (same contract as ``/v1/admin/mastio-pubkey``
+and the MCP resources admin API). These operations are in-house admin
+surface — the Connector dashboard can use the ADR-009 session flow,
+scripts just pass the admin secret.
+
+Register vs update:
+- POST  ``/v1/admin/agents``                   — create new agent row
+                                                (emits cert signed by
+                                                Agent CA / Org CA and
+                                                API key if enrolling)
+- PATCH ``/v1/admin/agents/{id}/federated``    — flip the federate flag
+- DELETE ``/v1/admin/agents/{id}``             — deactivate (revoke-at-
+                                                Court follows if the
+                                                agent was federated).
+
+Cert issuance reuses ``AgentManager._generate_agent_cert`` so the
+chain stays Org CA → Agent CA → leaf (or Org CA → leaf in the
+pre-Agent-CA sandbox). No new PKI logic here.
+"""
+from __future__ import annotations
+
+import bcrypt
+import hmac
+import json
+import logging
+import secrets
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_db, log_audit
+
+
+_log = logging.getLogger("mcp_proxy.admin.agents")
+
+router = APIRouter(prefix="/v1/admin/agents", tags=["admin"])
+
+
+# ── auth ────────────────────────────────────────────────────────────────
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+# ── models ──────────────────────────────────────────────────────────────
+
+class AgentCreateRequest(BaseModel):
+    # Short name only; the mastio scopes it to its own org_id.
+    agent_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    display_name: str = Field("", max_length=256)
+    capabilities: list[str] = Field(default_factory=list)
+    federated: bool = False
+
+
+class AgentCreateResponse(BaseModel):
+    agent_id: str
+    display_name: str
+    capabilities: list[str]
+    federated: bool
+    api_key: str  # plaintext — shown exactly once
+    cert_pem: str
+
+
+class AgentOut(BaseModel):
+    agent_id: str
+    display_name: str
+    capabilities: list[str]
+    federated: bool
+    federated_at: str | None
+    federation_revision: int
+    is_active: bool
+    created_at: str
+
+
+class FederatedPatch(BaseModel):
+    federated: bool
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+def _api_key_for(agent_name: str) -> str:
+    """Cryptographically-strong local API key. 32 random hex chars + prefix
+    so it's recognizable in logs and can be revoked without re-scanning."""
+    return f"sk_local_{agent_name}_{secrets.token_hex(16)}"
+
+
+def _bcrypt_hash(raw: str) -> str:
+    return bcrypt.hashpw(raw.encode(), bcrypt.gensalt(rounds=12)).decode()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _require_agent_mgr(request: Request):
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None or not getattr(mgr, "ca_loaded", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized — Org CA not loaded",
+        )
+    return mgr
+
+
+# ── endpoints ───────────────────────────────────────────────────────────
+
+@router.post(
+    "",
+    response_model=AgentCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def create_agent(
+    body: AgentCreateRequest,
+    request: Request,
+) -> AgentCreateResponse:
+    """Register a new agent on the Mastio.
+
+    Emits an Org-CA-signed x509 cert + a local API key. Writes the row
+    to ``internal_agents`` with ``federated`` set per the request. The
+    Phase 3 publisher picks it up if federated=True.
+    """
+    mgr = await _require_agent_mgr(request)
+    agent_name = body.agent_name
+    agent_id = f"{mgr.org_id}::{agent_name}"
+
+    # Mint cert + key via the same path the Connector enrollment uses.
+    cert_pem, key_pem = mgr._generate_agent_cert(agent_name)
+
+    # Persist the private key. Store in Vault if configured, otherwise
+    # fall back to proxy_config (same pattern as AgentManager.create_agent).
+    try:
+        await mgr._store_key_vault(agent_id, key_pem)
+    except Exception as exc:
+        from mcp_proxy.db import set_config
+        _log.info("Vault unavailable for %s (%s) — stashing key in proxy_config",
+                  agent_id, exc)
+        await set_config(f"agent_key:{agent_id}", key_pem)
+
+    api_key = _api_key_for(agent_name)
+    api_key_hash = _bcrypt_hash(api_key)
+
+    ts = _now_iso()
+    try:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO internal_agents (
+                        agent_id, display_name, capabilities, api_key_hash,
+                        cert_pem, created_at, is_active,
+                        federated, federated_at, federation_revision
+                    ) VALUES (
+                        :aid, :name, :caps, :hash,
+                        :cert, :now, 1,
+                        :federated, NULL, 1
+                    )
+                    """
+                ),
+                {
+                    "aid": agent_id,
+                    "name": body.display_name or agent_name,
+                    "caps": json.dumps(body.capabilities),
+                    "hash": api_key_hash,
+                    "cert": cert_pem,
+                    "now": ts,
+                    "federated": 1 if body.federated else 0,
+                },
+            )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"agent {agent_id!r} already registered",
+        ) from exc
+
+    await log_audit(
+        agent_id="admin",
+        action="agent.create",
+        status="success",
+        detail=f"agent_id={agent_id} federated={body.federated}",
+    )
+
+    return AgentCreateResponse(
+        agent_id=agent_id,
+        display_name=body.display_name or agent_name,
+        capabilities=body.capabilities,
+        federated=body.federated,
+        api_key=api_key,
+        cert_pem=cert_pem,
+    )
+
+
+@router.get(
+    "",
+    response_model=list[AgentOut],
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_agents_endpoint() -> list[AgentOut]:
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                """
+                SELECT agent_id, display_name, capabilities, is_active,
+                       federated, federated_at, federation_revision,
+                       created_at
+                  FROM internal_agents
+                 ORDER BY created_at DESC
+                """
+            )
+        )).mappings().all()
+    return [
+        AgentOut(
+            agent_id=r["agent_id"],
+            display_name=r["display_name"],
+            capabilities=json.loads(r["capabilities"] or "[]"),
+            federated=bool(r["federated"]),
+            federated_at=str(r["federated_at"]) if r["federated_at"] else None,
+            federation_revision=int(r["federation_revision"]),
+            is_active=bool(r["is_active"]),
+            created_at=str(r["created_at"]),
+        )
+        for r in rows
+    ]
+
+
+@router.patch(
+    "/{agent_id}/federated",
+    response_model=AgentOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def patch_federated(agent_id: str, body: FederatedPatch) -> AgentOut:
+    """Toggle the federate flag. Phase 3 publisher will pick up the
+    change on its next pass and PUT/revoke the agent at the Court."""
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT 1 FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )).first()
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="agent not found",
+            )
+
+        await conn.execute(
+            text(
+                """
+                UPDATE internal_agents
+                   SET federated = :fed,
+                       federation_revision = federation_revision + 1
+                 WHERE agent_id = :aid
+                """
+            ),
+            {"fed": 1 if body.federated else 0, "aid": agent_id},
+        )
+
+        updated = (await conn.execute(
+            text(
+                """
+                SELECT agent_id, display_name, capabilities, is_active,
+                       federated, federated_at, federation_revision, created_at
+                  FROM internal_agents WHERE agent_id = :aid
+                """
+            ),
+            {"aid": agent_id},
+        )).mappings().first()
+
+    await log_audit(
+        agent_id="admin",
+        action="agent.federated_patched",
+        status="success",
+        detail=f"agent_id={agent_id} federated={body.federated}",
+    )
+
+    return AgentOut(
+        agent_id=updated["agent_id"],
+        display_name=updated["display_name"],
+        capabilities=json.loads(updated["capabilities"] or "[]"),
+        federated=bool(updated["federated"]),
+        federated_at=str(updated["federated_at"]) if updated["federated_at"] else None,
+        federation_revision=int(updated["federation_revision"]),
+        is_active=bool(updated["is_active"]),
+        created_at=str(updated["created_at"]),
+    )
+
+
+@router.delete(
+    "/{agent_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def deactivate_agent_endpoint(agent_id: str):
+    """Soft-delete: ``is_active=0``. If the agent was federated, Phase 3
+    publisher will follow up with a revoke push to the Court."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                UPDATE internal_agents
+                   SET is_active = 0,
+                       federation_revision = federation_revision + 1
+                 WHERE agent_id = :aid AND is_active = 1
+                """
+            ),
+            {"aid": agent_id},
+        )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="agent not found or already inactive",
+            )
+
+    await log_audit(
+        agent_id="admin",
+        action="agent.deactivated",
+        status="success",
+        detail=f"agent_id={agent_id}",
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mcp_proxy/alembic/versions/0010_internal_agents_federated.py
+++ b/mcp_proxy/alembic/versions/0010_internal_agents_federated.py
@@ -1,0 +1,54 @@
+"""ADR-010 Phase 2 — internal_agents.federated flag.
+
+Revision ID: 0010_internal_agents_federated
+Revises: 0009_audit_chain_unique_seq
+Create Date: 2026-04-17 17:00:00.000000
+
+Adds three columns to ``internal_agents`` so the Mastio can mark agents
+as federated (published to the Court) and track the push state:
+
+  federated            BOOL NOT NULL DEFAULT 0
+  federated_at         TIMESTAMP NULL
+  federation_revision  INTEGER NOT NULL DEFAULT 0
+
+Default ``federated=0`` matches ADR-010 D1 "opt-in, admin flips the
+flag to expose". ``federation_revision`` is bumped on every mutation
+(cert rotate, caps change, etc.) so the publisher loop (Phase 3) can
+tell whether the row needs a re-push.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0010_internal_agents_federated"
+down_revision: Union[str, Sequence[str], None] = "0009_audit_chain_unique_seq"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "federated", sa.Boolean(),
+                nullable=False, server_default=sa.false(),
+            ),
+        )
+        batch_op.add_column(
+            sa.Column("federated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "federation_revision", sa.Integer(),
+                nullable=False, server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.drop_column("federation_revision")
+        batch_op.drop_column("federated_at")
+        batch_op.drop_column("federated")

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -496,6 +496,10 @@ app.include_router(admin_info_router)
 from mcp_proxy.admin.mcp_resources import router as admin_mcp_resources_router
 app.include_router(admin_mcp_resources_router)
 
+# ADR-010 Phase 2 — Mastio-authoritative agent registry admin API.
+from mcp_proxy.admin.agents import router as admin_agents_router
+app.include_router(admin_agents_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/registry/agents/{id}/public-key
 # would otherwise fall into the `/v1/registry/*` forward prefix and never
@@ -561,7 +565,6 @@ app.include_router(link_broker_admin_router)
 from mcp_proxy.dashboard.policies_local import router as local_policies_router
 app.include_router(local_policies_router)
 
-# ADR-007 Phase 1 PR #5a — dashboard CRUD for MCP resources + bindings.
 from mcp_proxy.dashboard.mcp_resources import router as mcp_resources_dashboard_router
 app.include_router(mcp_resources_dashboard_router)
 

--- a/tests/test_admin_agents.py
+++ b/tests/test_admin_agents.py
@@ -1,0 +1,197 @@
+"""ADR-010 Phase 2 — Mastio ``/v1/admin/agents`` admin API.
+
+Covers:
+  - POST creates agent + emits api_key + cert
+  - POST with federated=true writes the flag
+  - GET list returns all agents with federated info
+  - PATCH flip federated bumps ``federation_revision``
+  - DELETE soft-deletes (is_active=0)
+  - Auth: missing / wrong ``X-Admin-Secret`` rejected
+  - Duplicate agent_name → 409
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── create ─────────────────────────────────────────────────────────────
+
+async def test_create_agent_emits_key_and_cert(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-create")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/agents",
+                headers=h,
+                json={
+                    "agent_name": "alice",
+                    "display_name": "Alice the explorer",
+                    "capabilities": ["order.read"],
+                    "federated": False,
+                },
+            )
+            assert r.status_code == 201, r.text
+            data = r.json()
+            assert data["agent_id"] == "aa-create::alice"
+            assert data["capabilities"] == ["order.read"]
+            assert data["federated"] is False
+            assert data["api_key"].startswith("sk_local_alice_")
+            assert "BEGIN CERTIFICATE" in data["cert_pem"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_with_federated_flag(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-fed")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/agents", headers=h,
+                json={"agent_name": "bob", "federated": True},
+            )
+            assert r.status_code == 201
+            assert r.json()["federated"] is True
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_duplicate_returns_409(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-dup")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            body = {"agent_name": "charlie"}
+            r1 = await cli.post("/v1/admin/agents", headers=h, json=body)
+            assert r1.status_code == 201
+            r2 = await cli.post("/v1/admin/agents", headers=h, json=body)
+            assert r2.status_code == 409
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── list / patch / delete ──────────────────────────────────────────────
+
+async def test_list_shows_federated_info(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-list")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post("/v1/admin/agents", headers=h,
+                           json={"agent_name": "dave", "federated": False})
+            await cli.post("/v1/admin/agents", headers=h,
+                           json={"agent_name": "eve", "federated": True})
+            r = await cli.get("/v1/admin/agents", headers=h)
+            assert r.status_code == 200
+            rows = r.json()
+            by_name = {row["agent_id"]: row for row in rows}
+            assert by_name["aa-list::dave"]["federated"] is False
+            assert by_name["aa-list::eve"]["federated"] is True
+            assert all(row["federation_revision"] >= 1 for row in rows)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_patch_federated_bumps_revision(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-patch")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post("/v1/admin/agents", headers=h,
+                           json={"agent_name": "frank", "federated": False})
+            r = await cli.patch(
+                "/v1/admin/agents/aa-patch::frank/federated",
+                headers=h, json={"federated": True},
+            )
+            assert r.status_code == 200
+            body = r.json()
+            assert body["federated"] is True
+            assert body["federation_revision"] >= 2
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_patch_unknown_agent_returns_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-p404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.patch(
+                "/v1/admin/agents/aa-p404::ghost/federated",
+                headers=h, json={"federated": True},
+            )
+            assert r.status_code == 404
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_delete_deactivates(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-del")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post("/v1/admin/agents", headers=h,
+                           json={"agent_name": "gina"})
+            r = await cli.delete(
+                "/v1/admin/agents/aa-del::gina", headers=h,
+            )
+            assert r.status_code == 204
+            # Second delete should 404 (already inactive).
+            r2 = await cli.delete(
+                "/v1/admin/agents/aa-del::gina", headers=h,
+            )
+            assert r2.status_code == 404
+            # list still shows the row with is_active=false.
+            rl = await cli.get("/v1/admin/agents", headers=h)
+            row = next(r for r in rl.json() if r["agent_id"] == "aa-del::gina")
+            assert row["is_active"] is False
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── auth ───────────────────────────────────────────────────────────────
+
+async def test_auth_required(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-auth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get("/v1/admin/agents")
+            assert r.status_code == 422  # header missing
+            r = await cli.get(
+                "/v1/admin/agents",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+            assert r.status_code == 403
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -67,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0009_audit_chain_unique_seq",)]
+    assert rows == [("0010_internal_agents_federated",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0009_audit_chain_unique_seq",)]
+    assert version == [("0010_internal_agents_federated",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0009_audit_chain_unique_seq"
+HEAD_REVISION = "0010_internal_agents_federated"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0009_audit_chain_unique_seq"
+HEAD_REVISION = "0010_internal_agents_federated"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 


### PR DESCRIPTION
Second PR of ADR-010. Gives the Mastio a real authoritative registry for its org's agents and the admin API to manage it; the Court becomes a downstream cache of the ones marked \`federated=true\`.

Phase 3 (publisher loop) will read \`federated\` + \`federation_revision\` and push to the Phase 1 endpoint (#184).

## Summary

- **Schema** (alembic \`0010_internal_agents_federated\`):
  - \`internal_agents.federated BOOL NOT NULL DEFAULT 0\`
  - \`internal_agents.federated_at TIMESTAMP NULL\`
  - \`internal_agents.federation_revision INTEGER NOT NULL DEFAULT 0\` (bumped on every mutation so Phase 3 can tell whether a re-push is due)

- **API** (\`mcp_proxy/admin/agents.py\`, new):
  - \`POST   /v1/admin/agents\` — create agent, emit API key + Org-CA-signed cert. \`federated\` optional.
  - \`GET    /v1/admin/agents\` — list + federated state
  - \`PATCH  /v1/admin/agents/{id}/federated\` — toggle the flag (bumps revision)
  - \`DELETE /v1/admin/agents/{id}\` — soft-delete (is_active=0)

- **Auth**: \`X-Admin-Secret\` (same contract as \`/v1/admin/mastio-pubkey\` and \`/v1/admin/mcp-resources\`). Cert issuance reuses \`AgentManager._generate_agent_cert\` so the PKI chain is unchanged.

## Test plan

- [x] \`pytest tests/test_admin_agents.py\` — 8/8 (create, federated flag, duplicate 409, list with federation info, patch bump revision, 404 on unknown agent, delete idempotent, auth)
- [x] \`tests/test_proxy_migrations.py\` head updated 0009 → 0010
- [x] Full suite serial (-n 0): 1190 pass, 6 skipped
- [ ] Full suite parallel (-n auto): 24 fails unrelated (dashboard mcp_resources tests — flaky in parallel + loadfile, pass in serial and at -n 2; tracking separately)

## Note on -n auto flakiness

Some proxy dashboard tests pass at -n 2 or -n 0 but fail at -n auto. Not introduced by this PR (re-run on main shows the same pattern), and the test bodies themselves pass in isolation. Will investigate separately — does not block Phase 2 correctness.