### PR TITLE
fix(registry): close /orgs/me enumeration + timing oracle (F-B-6)

### DIFF
--- a/app/registry/org_router.py
+++ b/app/registry/org_router.py
@@ -6,7 +6,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.db.database import get_db
-from app.registry.org_store import register_org, get_org_by_id, list_orgs, update_org_ca_cert
+from app.registry.org_store import (
+    get_org_by_id,
+    list_orgs,
+    register_org,
+    update_org_ca_cert,
+    verify_org_credentials,
+)
 
 router = APIRouter(prefix="/registry", tags=["registry"])
 
@@ -85,12 +91,20 @@ async def get_own_organization(
 ):
     """Organization self-status check. Uses org credentials, not admin secret.
     Returns org info including status (pending/active/rejected).
-    Used by MCP Proxy to poll for approval status."""
+    Used by MCP Proxy to poll for approval status.
+
+    Audit F-B-6: auth failures collapse to a single 403 whether the org
+    is missing or the secret is wrong, and bcrypt runs on both paths so
+    the two cases are indistinguishable by timing. Non-active orgs are
+    still allowed to authenticate here (and only here) so they can poll
+    their own lifecycle — ``active_only=False``.
+    """
     org = await get_org_by_id(db, x_org_id)
-    if not org:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
-    if not org.verify_secret(x_org_secret):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Invalid organization credentials")
+    if not verify_org_credentials(org, x_org_secret, active_only=False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid organization credentials",
+        )
     return OrgResponse(
         org_id=org.org_id,
         display_name=org.display_name,

--- a/app/registry/org_store.py
+++ b/app/registry/org_store.py
@@ -70,9 +70,21 @@ class OrganizationRecord(Base):
 _DUMMY_HASH: str = bcrypt.hashpw(b"dummy", bcrypt.gensalt(rounds=12)).decode()
 
 
-def verify_org_credentials(org: "OrganizationRecord | None", secret: str) -> bool:
-    """Verify org secret in constant time regardless of whether the org exists."""
-    if org is None or org.status != "active":
+def verify_org_credentials(
+    org: "OrganizationRecord | None",
+    secret: str,
+    active_only: bool = True,
+) -> bool:
+    """Verify org secret in constant time regardless of whether the org exists.
+
+    ``active_only=True`` (default) rejects any non-active org — the policy
+    for every authenticated API surface. ``active_only=False`` is for the
+    status-polling endpoint (``GET /registry/orgs/me``) where ``pending``
+    orgs legitimately need to authenticate to learn when they flip to
+    ``active``. In both modes, a missing org still hits the dummy hash so
+    the 403 path is constant-time (audit F-B-6).
+    """
+    if org is None or (active_only and org.status != "active"):
         # Always run bcrypt to prevent timing leaks
         bcrypt.checkpw(secret.encode(), _DUMMY_HASH.encode())
         return False

--- a/tests/test_fb6_orgs_me_no_enumeration.py
+++ b/tests/test_fb6_orgs_me_no_enumeration.py
@@ -1,0 +1,187 @@
+"""Audit F-B-6 — ``GET /v1/registry/orgs/me`` must not leak org existence.
+
+Before this fix the endpoint returned 404 on a missing org and 403 on
+wrong secret, differentiating the two cases by status code AND by
+response latency (no bcrypt on miss vs one bcrypt on hit).
+
+The fix reuses ``verify_org_credentials(org, secret, active_only=False)``
+from ``app/registry/org_store.py`` so both paths:
+  * respond with 403
+  * run bcrypt once (dummy hash on miss, real hash on hit)
+
+Non-active orgs (pending / rejected / suspended) are still allowed to
+authenticate on this specific endpoint because the MCP Proxy polls it
+during onboarding to learn when it becomes ``active`` — that is the
+only authenticated surface with ``active_only=False``.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _register_org(client: AsyncClient, org_id: str, secret: str) -> None:
+    resp = await client.post(
+        "/v1/registry/orgs",
+        json={"org_id": org_id, "display_name": org_id, "secret": secret},
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+# ── Primary regression: unified 403 response ───────────────────────
+
+async def test_orgs_me_missing_org_returns_403_not_404(client: AsyncClient):
+    resp = await client.get(
+        "/v1/registry/orgs/me",
+        headers={"x-org-id": "nonexistent-org", "x-org-secret": "whatever"},
+    )
+    assert resp.status_code == 403
+    # The body must NOT say "not found" or mention "Organization"
+    # existence — the 403 path is the unified response shape.
+    body = resp.json()
+    assert "not found" not in body.get("detail", "").lower()
+
+
+async def test_orgs_me_wrong_secret_returns_403(client: AsyncClient):
+    await _register_org(client, "fb6-org-a", "good-secret-fb6a")
+    resp = await client.get(
+        "/v1/registry/orgs/me",
+        headers={"x-org-id": "fb6-org-a", "x-org-secret": "wrong-secret"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_orgs_me_missing_vs_wrong_are_indistinguishable(client: AsyncClient):
+    """The response status AND detail body must be byte-identical between
+    'org not registered' and 'org registered but wrong secret' — that's
+    the whole point of F-B-6."""
+    await _register_org(client, "fb6-org-b", "good-secret-fb6b")
+
+    missing = await client.get(
+        "/v1/registry/orgs/me",
+        headers={"x-org-id": "definitely-not-here", "x-org-secret": "x"},
+    )
+    wrong_secret = await client.get(
+        "/v1/registry/orgs/me",
+        headers={"x-org-id": "fb6-org-b", "x-org-secret": "wrong"},
+    )
+
+    assert missing.status_code == wrong_secret.status_code == 403
+    assert missing.json() == wrong_secret.json()
+
+
+# ── Happy paths stay functional ────────────────────────────────────
+
+async def test_orgs_me_active_org_correct_secret_200(client: AsyncClient):
+    await _register_org(client, "fb6-org-c", "good-secret-fb6c")
+    resp = await client.get(
+        "/v1/registry/orgs/me",
+        headers={"x-org-id": "fb6-org-c", "x-org-secret": "good-secret-fb6c"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["org_id"] == "fb6-org-c"
+    assert body["status"] == "active"
+
+
+async def test_orgs_me_pending_org_can_poll_status(client: AsyncClient, db_session):
+    """A pending org must still authenticate on /me so the MCP Proxy
+    can poll for its approval. Regression guard on the active_only=False
+    decision path."""
+    from app.registry.org_store import OrganizationRecord, _DUMMY_HASH
+    import bcrypt
+    import json
+
+    secret = "pending-secret-fb6"
+    record = OrganizationRecord(
+        org_id="fb6-org-pending",
+        display_name="pending org",
+        secret_hash=bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=4)).decode(),
+        metadata_json=json.dumps({}),
+        status="pending",
+    )
+    db_session.add(record)
+    await db_session.commit()
+
+    resp = await client.get(
+        "/v1/registry/orgs/me",
+        headers={"x-org-id": "fb6-org-pending", "x-org-secret": secret},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"
+
+    # Sanity: unrelated dummy-hash import sanity-check (catches an accidental
+    # removal of the constant-time helper — if _DUMMY_HASH disappears the
+    # enumeration path reopens).
+    assert isinstance(_DUMMY_HASH, str) and _DUMMY_HASH.startswith("$2")
+
+
+# ── Timing oracle: bcrypt runs on both paths ───────────────────────
+
+async def test_orgs_me_bcrypt_runs_on_missing_org(client: AsyncClient):
+    """Closest deterministic proxy for the timing oracle: patch
+    ``bcrypt.checkpw`` and assert it was invoked even when the org does
+    not exist. Before the fix the 404 path short-circuited before any
+    bcrypt call, which is what made the timing side channel measurable.
+    """
+    # Patch at the module where the helper imports bcrypt from.
+    with patch("app.registry.org_store.bcrypt.checkpw", wraps=__import__("bcrypt").checkpw) as spy:
+        resp = await client.get(
+            "/v1/registry/orgs/me",
+            headers={"x-org-id": "very-definitely-missing", "x-org-secret": "x"},
+        )
+    assert resp.status_code == 403
+    # At least one bcrypt check happened for the missing-org branch.
+    assert spy.call_count >= 1
+
+
+async def test_orgs_me_bcrypt_runs_on_wrong_secret(client: AsyncClient):
+    await _register_org(client, "fb6-org-d", "good-secret-fb6d")
+    with patch("app.registry.org_store.bcrypt.checkpw", wraps=__import__("bcrypt").checkpw) as spy:
+        resp = await client.get(
+            "/v1/registry/orgs/me",
+            headers={"x-org-id": "fb6-org-d", "x-org-secret": "wrong"},
+        )
+    assert resp.status_code == 403
+    assert spy.call_count >= 1
+
+
+# ── Unit test on verify_org_credentials helper ──────────────────────
+
+def test_verify_org_credentials_active_only_false_accepts_pending():
+    """Unit guard on the new ``active_only=False`` contract."""
+    from app.registry.org_store import OrganizationRecord, verify_org_credentials
+    import bcrypt
+    import json
+
+    secret = "unit-test-secret"
+    org = OrganizationRecord(
+        org_id="unit",
+        display_name="unit",
+        secret_hash=bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=4)).decode(),
+        metadata_json=json.dumps({}),
+        status="pending",
+    )
+
+    assert verify_org_credentials(org, secret, active_only=False) is True
+    assert verify_org_credentials(org, "wrong", active_only=False) is False
+    # Default active_only=True still rejects pending.
+    assert verify_org_credentials(org, secret) is False
+
+
+def test_verify_org_credentials_missing_runs_bcrypt_even_when_active_only_false():
+    from app.registry.org_store import verify_org_credentials
+    with patch(
+        "app.registry.org_store.bcrypt.checkpw",
+        wraps=__import__("bcrypt").checkpw,
+    ) as spy:
+        result = verify_org_credentials(None, "any-secret", active_only=False)
+    assert result is False
+    assert spy.call_count == 1


### PR DESCRIPTION
## Summary

- \`GET /v1/registry/orgs/me\` no longer distinguishes missing-org from wrong-secret: both return the same 403 body.
- bcrypt runs on both branches, so the timing gap that leaked existence (instant 404 vs ~100 ms bcrypt) is gone.
- Non-active orgs (pending / rejected / suspended) keep their ability to authenticate on this one endpoint because that is the polling surface for \`status\` — implemented via a new \`active_only=False\` kwarg on \`verify_org_credentials\`.

Closes audit finding F-B-6 (High, \`imp/audit_2026_04_17/phase1_B_authz.md:280\`).

## The leak

Before this PR (\`app/registry/org_router.py:80-99\`):

\`\`\`python
org = await get_org_by_id(db, x_org_id)
if not org:
    raise HTTPException(404, \"Organization not found\")   # leaks: org does NOT exist
if not org.verify_secret(x_org_secret):
    raise HTTPException(403, \"Invalid organization credentials\")   # leaks: org DOES exist
return OrgResponse(...)
\`\`\`

Two leaks in one path:

1. **Status code**: 404 means \"org is not registered\"; 403 means \"registered but wrong secret\". An attacker can enumerate the org list by iterating candidate \`x-org-id\` values with any fixed wrong secret.
2. **Timing**: the 404 branch returns instantly; the 403 branch runs bcrypt (~100 ms). Even without looking at the status code, a timing measurement distinguishes the two cases.

Combined with the documented polling contract (\"Used by MCP Proxy to poll for approval status\") the endpoint is reachable pre-auth and the enumeration is cheap.

## Fix

\`\`\`python
org = await get_org_by_id(db, x_org_id)
if not verify_org_credentials(org, x_org_secret, active_only=False):
    raise HTTPException(403, \"Invalid organization credentials\")
return OrgResponse(...)
\`\`\`

\`verify_org_credentials\` (\`app/registry/org_store.py\`) was already doing dummy-bcrypt on miss for the other authenticated surfaces. Adding a \`active_only\` kwarg (default \`True\`, preserves existing caller semantics) lets the polling endpoint accept pending orgs without re-introducing the leak.

## What stays working

- \`pending\` org can still call \`/orgs/me\` and read its status → MCP Proxy bootstrap polling unaffected.
- Every other authenticated surface (auth/router, registry/router, binding_router) still uses the default \`active_only=True\` and keeps rejecting non-active orgs.
- Timing-constant 403 is the same shape as \`verify_org_credentials\` already gave the other call sites — no new pattern introduced.

## What does NOT change (out of scope)

- **F-B-7** (\`POST /orgs/{id}/certificate\`) is a Medium finding with the same pattern in the same file. Intentionally not in this PR — kept scope to one finding. Next PR candidate if the helper-reuse approach lands well here.
- **F-B-6 (3)**: the fact that \`status\` becomes visible once an attacker *has* the org secret is acknowledged and kept. Rejecting non-active orgs on \`/orgs/me\` would break the polling contract that the Mastio bootstrap depends on, and the precondition (already holding the secret) moves the attacker out of the 'pre-attack reconnaissance' class of exploit.

## Tests

\`tests/test_fb6_orgs_me_no_enumeration.py\` — 9 cases:

- \`test_orgs_me_missing_org_returns_403_not_404\` — the 404 regression guard.
- \`test_orgs_me_wrong_secret_returns_403\` — wrong-secret baseline.
- \`test_orgs_me_missing_vs_wrong_are_indistinguishable\` — status + body equality (the real F-B-6 invariant).
- \`test_orgs_me_active_org_correct_secret_200\` — happy path.
- \`test_orgs_me_pending_org_can_poll_status\` — pending polling still works (guards against over-zealous \`active_only=True\` backport).
- \`test_orgs_me_bcrypt_runs_on_missing_org\` + \`_wrong_secret\` — bcrypt.checkpw spy confirms the constant-time invariant.
- \`test_verify_org_credentials_active_only_false_accepts_pending\` + \`_missing_runs_bcrypt_even_when_active_only_false\` — unit tests on the helper.

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1191 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_fb6_orgs_me_no_enumeration.py -q\` — 9 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.

## Follow-up candidates (separate PRs)

- **F-B-7** — same pattern on \`POST /orgs/{id}/certificate\`.
- **F-B-8** — similar enumeration oracle on revoke-agent tokens.