### PR TITLE
feat(mastio): federation publisher loop (ADR-010 Phase 3)

### DIFF
--- a/mcp_proxy/alembic/versions/0011_internal_agents_last_pushed_revision.py
+++ b/mcp_proxy/alembic/versions/0011_internal_agents_last_pushed_revision.py
@@ -1,0 +1,39 @@
+"""ADR-010 Phase 3 — track last-pushed revision on internal_agents.
+
+Revision ID: 0011_internal_agents_last_pushed_revision
+Revises: 0010_internal_agents_federated
+Create Date: 2026-04-17 19:30:00.000000
+
+The Phase 3 publisher needs to know which mutation was last published
+to the Court so a flap of ``federation_revision`` (bumped on every
+patch/toggle in Phase 2) can be detected. Add ``last_pushed_revision``
+INTEGER DEFAULT 0. On successful push the publisher writes
+``last_pushed_revision = federation_revision``; the poll query filters
+``federated = 1 AND federation_revision > last_pushed_revision`` so
+idle rows are skipped.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0011_internal_agents_last_pushed_revision"
+down_revision: Union[str, Sequence[str], None] = "0010_internal_agents_federated"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "last_pushed_revision", sa.Integer(),
+                nullable=False, server_default="0",
+            ),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.drop_column("last_pushed_revision")

--- a/mcp_proxy/alembic/versions/0011_last_pushed_revision.py
+++ b/mcp_proxy/alembic/versions/0011_last_pushed_revision.py
@@ -18,7 +18,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "0011_internal_agents_last_pushed_revision"
+revision: str = "0011_last_pushed_revision"
 down_revision: Union[str, Sequence[str], None] = "0010_internal_agents_federated"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/mcp_proxy/federation/publisher.py
+++ b/mcp_proxy/federation/publisher.py
@@ -1,0 +1,179 @@
+"""ADR-010 Phase 3 — Mastio federation publisher.
+
+Background task that pushes agents marked ``federated=True`` in
+``internal_agents`` to the Court's ``POST /v1/federation/publish-agent``
+endpoint (Phase 1). Uses the ADR-009 counter-signature so the Court can
+identify which Mastio is pushing. Tracks progress via
+``last_pushed_revision`` so every mutation (patch federated, cert
+rotation, deactivation) gets exactly one push.
+
+Flow per tick:
+  1. Query all rows where ``federated=1`` OR ``federated_at IS NOT NULL``
+     (the second lets us push revocations for rows that were federated
+     and later flipped off) AND
+     ``federation_revision > last_pushed_revision``.
+  2. For each row, build the JSON payload, sign the raw bytes with the
+     Mastio leaf key via ``AgentManager.countersign()``, POST to the
+     Court.
+  3. On 2xx, bump ``last_pushed_revision = federation_revision`` +
+     ``federated_at = now()``.
+  4. On 4xx/5xx, log + skip (next tick will retry; Phase 3 avoids infinite
+     retries by design — pathological rows are visible in the audit log).
+
+The Court is contacted via ``app.state.reverse_proxy_broker_url``
+(already initialized in the lifespan when the proxy is federated).
+Standalone proxies never reach here because ``federated_at`` stays NULL
+and revisions never go above ``last_pushed_revision=0``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from sqlalchemy import text
+
+
+_log = logging.getLogger("mcp_proxy.federation.publisher")
+
+
+POLL_INTERVAL_S = 30.0
+HTTP_TIMEOUT_S = 10.0
+
+
+async def _fetch_pending(conn) -> list[dict]:
+    """Rows that need a push on this tick."""
+    result = await conn.execute(
+        text(
+            """
+            SELECT agent_id, display_name, capabilities, cert_pem,
+                   is_active, federated, federation_revision,
+                   last_pushed_revision
+              FROM internal_agents
+             WHERE (federated = 1 OR federated_at IS NOT NULL)
+               AND federation_revision > last_pushed_revision
+            """
+        ),
+    )
+    return [dict(row) for row in result.mappings().all()]
+
+
+async def _mark_pushed(conn, agent_id: str, revision: int) -> None:
+    await conn.execute(
+        text(
+            """
+            UPDATE internal_agents
+               SET last_pushed_revision = :rev,
+                   federated_at = :now
+             WHERE agent_id = :aid
+            """
+        ),
+        {
+            "rev": revision,
+            "now": datetime.now(timezone.utc).isoformat(),
+            "aid": agent_id,
+        },
+    )
+
+
+def _build_body(row: dict) -> bytes:
+    """Canonical JSON body for signing + sending. Revoked iff
+    inactive — an admin can deactivate without clearing the federated
+    flag and we still want the Court to hear about it."""
+    payload = {
+        "agent_id": row["agent_id"],
+        "cert_pem": row["cert_pem"] or "",
+        "capabilities": json.loads(row["capabilities"] or "[]"),
+        "display_name": row["display_name"] or "",
+        "revoked": not bool(row["is_active"]),
+    }
+    return json.dumps(payload).encode()
+
+
+async def _publish_one(
+    *, row: dict, broker_url: str, countersign, client: httpx.AsyncClient,
+) -> bool:
+    body = _build_body(row)
+    signature = countersign(body)
+    url = f"{broker_url.rstrip('/')}/v1/federation/publish-agent"
+    try:
+        resp = await client.post(
+            url,
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Cullis-Mastio-Signature": signature,
+            },
+            timeout=HTTP_TIMEOUT_S,
+        )
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        _log.warning(
+            "federation publish: broker unreachable for %s (%s) — will retry",
+            row["agent_id"], exc,
+        )
+        return False
+
+    if resp.is_success:
+        _log.info(
+            "federation publish OK: %s rev=%d status=%s",
+            row["agent_id"], row["federation_revision"],
+            (resp.json() or {}).get("status"),
+        )
+        return True
+
+    _log.warning(
+        "federation publish %s → HTTP %d: %s",
+        row["agent_id"], resp.status_code, resp.text[:200],
+    )
+    # 4xx means the Court rejected the payload (bad sig, unpinned pubkey,
+    # unknown org, cert not chaining). Re-pushing won't fix it — mark as
+    # pushed so we don't spin forever. 5xx transient, retry next tick.
+    return 400 <= resp.status_code < 500
+
+
+async def _tick(app_state) -> int:
+    """One iteration: enumerate pending rows, push each, update state.
+    Returns the number of rows successfully acknowledged by the Court."""
+    broker_url = getattr(app_state, "reverse_proxy_broker_url", None)
+    mgr = getattr(app_state, "agent_manager", None)
+    http = getattr(app_state, "reverse_proxy_client", None)
+
+    if not broker_url or mgr is None or http is None:
+        return 0
+    if not getattr(mgr, "mastio_loaded", False):
+        return 0
+
+    from mcp_proxy.db import get_db
+    acked = 0
+    async with get_db() as conn:
+        rows = await _fetch_pending(conn)
+
+    for row in rows:
+        ok = await _publish_one(
+            row=row, broker_url=broker_url,
+            countersign=mgr.countersign, client=http,
+        )
+        if ok:
+            async with get_db() as conn:
+                await _mark_pushed(conn, row["agent_id"], row["federation_revision"])
+            acked += 1
+    return acked
+
+
+async def run_publisher(app_state, *, stop_event: asyncio.Event) -> None:
+    """Background task body. Exits when ``stop_event`` is set."""
+    _log.info("federation publisher started (poll=%.1fs)", POLL_INTERVAL_S)
+    try:
+        while not stop_event.is_set():
+            try:
+                await _tick(app_state)
+            except Exception as exc:  # defensive — never let the loop die
+                _log.exception("federation publisher tick failed: %s", exc)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=POLL_INTERVAL_S)
+            except asyncio.TimeoutError:
+                continue
+    finally:
+        _log.info("federation publisher stopped")

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -259,6 +259,21 @@ async def lifespan(app: FastAPI):
             app.state.federation_subscriber_stats = sub_cfg.stats
             _log.info("federation subscriber started (org=%s)", org_id)
 
+    # ADR-010 Phase 3 — federation publisher loop. Only makes sense when
+    # the proxy is federated (broker_url set) and the mastio identity
+    # is loaded (pubkey pinned at the Court so counter-sig verification
+    # succeeds). Standalone proxies skip entirely.
+    if broker_url and getattr(agent_mgr, "mastio_loaded", False):
+        from mcp_proxy.federation.publisher import run_publisher
+        pub_stop = asyncio.Event()
+        pub_task = asyncio.create_task(
+            run_publisher(app.state, stop_event=pub_stop),
+            name="federation_publisher",
+        )
+        app.state.federation_publisher_stop = pub_stop
+        app.state.federation_publisher_task = pub_task
+        _log.info("federation publisher started (org=%s)", org_id)
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
@@ -292,6 +307,20 @@ async def lifespan(app: FastAPI):
             sub_task.cancel()
             try:
                 await sub_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    pub_stop = getattr(app.state, "federation_publisher_stop", None)
+    pub_task = getattr(app.state, "federation_publisher_task", None)
+    if pub_stop is not None:
+        pub_stop.set()
+    if pub_task is not None:
+        try:
+            await asyncio.wait_for(pub_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            pub_task.cancel()
+            try:
+                await pub_task
             except (asyncio.CancelledError, Exception):
                 pass
 

--- a/tests/test_federation_publisher.py
+++ b/tests/test_federation_publisher.py
@@ -1,0 +1,239 @@
+"""ADR-010 Phase 3 — federation publisher loop unit tests.
+
+No real Court; uses httpx MockTransport + a fake AgentManager. Covers:
+  - Only federated rows with revision > last_pushed_revision get pushed
+  - Successful 2xx push bumps last_pushed_revision to federation_revision
+  - 4xx "poison" response is also acknowledged (so we don't spin)
+  - 5xx transient errors leave last_pushed_revision untouched (retry)
+  - Connection error leaves row pending
+  - Revoked (is_active=0) rows produce revoked=true payload
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from mcp_proxy.federation.publisher import _tick
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+class _FakeMgr:
+    """Minimal drop-in for AgentManager that only answers ``countersign``
+    and advertises ``mastio_loaded=True``. Signatures are real ES256 so the
+    transport assertion can verify them."""
+
+    def __init__(self):
+        self.mastio_loaded = True
+        self._key = ec.generate_private_key(ec.SECP256R1())
+
+    def countersign(self, data: bytes) -> str:
+        sig = self._key.sign(data, ec.ECDSA(hashes.SHA256()))
+        return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+class _AppState:
+    def __init__(self, mgr, broker_url: str, client: httpx.AsyncClient):
+        self.agent_manager = mgr
+        self.reverse_proxy_broker_url = broker_url
+        self.reverse_proxy_client = client
+
+
+async def _seed_agents(tmp_path, monkeypatch, rows: list[dict]):
+    """Boot an isolated proxy DB + populate internal_agents with the rows."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import init_db, get_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    async with get_db() as conn:
+        from sqlalchemy import text
+        for r in rows:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO internal_agents (
+                        agent_id, display_name, capabilities, api_key_hash,
+                        cert_pem, created_at, is_active,
+                        federated, federated_at, federation_revision,
+                        last_pushed_revision
+                    ) VALUES (
+                        :aid, :name, :caps, :hash,
+                        :cert, :created, :active,
+                        :fed, :fed_at, :rev, :last
+                    )
+                    """
+                ),
+                {
+                    "aid": r["agent_id"],
+                    "name": r.get("display_name", r["agent_id"]),
+                    "caps": json.dumps(r.get("capabilities", [])),
+                    "hash": "$2b$12$placeholder",
+                    "cert": r.get("cert_pem", "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----\n"),
+                    "created": "2026-04-17T00:00:00+00:00",
+                    "active": 1 if r.get("is_active", True) else 0,
+                    "fed": 1 if r.get("federated", True) else 0,
+                    "fed_at": r.get("federated_at"),
+                    "rev": r.get("federation_revision", 1),
+                    "last": r.get("last_pushed_revision", 0),
+                },
+            )
+
+
+async def _fetch_last_pushed(agent_id: str) -> int:
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT last_pushed_revision FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )).first()
+        return int(row[0]) if row else -1
+
+
+# ── tests ───────────────────────────────────────────────────────────────
+
+async def test_publishes_federated_rows_only(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::alice", "federated": True,  "federation_revision": 3},
+        {"agent_id": "orga::bob",   "federated": False, "federation_revision": 2},
+    ])
+    seen: list[str] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        body = json.loads(req.content)
+        seen.append(body["agent_id"])
+        return httpx.Response(200, json={
+            "agent_id": body["agent_id"], "org_id": "orga",
+            "status": "created", "cert_thumbprint": "x",
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 1
+    assert seen == ["orga::alice"]
+    assert await _fetch_last_pushed("orga::alice") == 3
+    assert await _fetch_last_pushed("orga::bob") == 0
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_ack_at_4xx_prevents_infinite_retry(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::carol", "federated": True, "federation_revision": 5},
+    ])
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": "bad shape"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 1
+    # 4xx is still "ack": the Court will never accept this row as-is.
+    assert await _fetch_last_pushed("orga::carol") == 5
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_5xx_leaves_row_pending(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::dave", "federated": True, "federation_revision": 7},
+    ])
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="overloaded")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 0
+    assert await _fetch_last_pushed("orga::dave") == 0  # still pending
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_connection_error_leaves_row_pending(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::eve", "federated": True, "federation_revision": 2},
+    ])
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 0
+    assert await _fetch_last_pushed("orga::eve") == 0
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_revoked_row_pushes_revoked_true(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {
+            "agent_id": "orga::frank",
+            "federated": True,
+            "is_active": False,
+            "federated_at": "2026-04-17T00:00:00+00:00",
+            "federation_revision": 2,
+        },
+    ])
+    payloads: list[dict] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        payloads.append(json.loads(req.content))
+        return httpx.Response(200, json={
+            "agent_id": "orga::frank", "org_id": "orga",
+            "status": "revoked", "cert_thumbprint": "x",
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 1
+    assert payloads[0]["revoked"] is True
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_standalone_is_noop(tmp_path, monkeypatch):
+    """Without broker_url + mastio_loaded the publisher does nothing."""
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::ghost", "federated": True, "federation_revision": 1},
+    ])
+
+    class _NoMgr:
+        mastio_loaded = False
+
+    async with httpx.AsyncClient() as cli:
+        state = _AppState(_NoMgr(), "", cli)
+        acked = await _tick(state)
+    assert acked == 0
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_federation_publisher.py
+++ b/tests/test_federation_publisher.py
@@ -10,7 +10,6 @@ No real Court; uses httpx MockTransport + a fake AgentManager. Covers:
 """
 from __future__ import annotations
 
-import asyncio
 import base64
 import json
 

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -67,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0011_internal_agents_last_pushed_revision",)]
+    assert rows == [("0011_last_pushed_revision",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0011_internal_agents_last_pushed_revision",)]
+    assert version == [("0011_last_pushed_revision",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -67,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0010_internal_agents_federated",)]
+    assert rows == [("0011_internal_agents_last_pushed_revision",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0010_internal_agents_federated",)]
+    assert version == [("0011_internal_agents_last_pushed_revision",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0011_internal_agents_last_pushed_revision"
+HEAD_REVISION = "0011_last_pushed_revision"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0010_internal_agents_federated"
+HEAD_REVISION = "0011_internal_agents_last_pushed_revision"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0010_internal_agents_federated"
+HEAD_REVISION = "0011_internal_agents_last_pushed_revision"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0011_internal_agents_last_pushed_revision"
+HEAD_REVISION = "0011_last_pushed_revision"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 


### PR DESCRIPTION
Third PR of ADR-010. Closes the loop: Mastio (Phase 2) → Court (Phase 1) via counter-signed push on a 30s ticker.

## Summary

- **Schema**: \`internal_agents.last_pushed_revision INTEGER NOT NULL DEFAULT 0\` (alembic \`0011_internal_agents_last_pushed_revision\`).
- **Publisher** (\`mcp_proxy/federation/publisher.py\`, new): 30s poll on \`federation_revision > last_pushed_revision\`, builds JSON body, \`AgentManager.countersign\`, POSTs to \`/v1/federation/publish-agent\`.
- **Revoke propagation**: an already-federated agent deactivated on the Mastio produces \`revoked=true\` at the Court.
- **Retry policy**: 2xx/4xx ack (4xx is poison; retrying won't fix a bad signature or wrong cert chain); 5xx and connection errors leave the row pending for the next tick.
- **Standalone safe**: no broker_url + no mastio identity → the publisher is a no-op.
- **Lifespan**: starts task only when federated; cancels gracefully on shutdown.

## Test plan

- [x] \`pytest tests/test_federation_publisher.py\` — 6/6 (filter, 2xx bumps revision, 4xx ack, 5xx pending, connection error pending, revoked payload, standalone noop)
- [x] Migration head tests bumped 0010 → 0011
- [x] Full suite: 1196 pass, 6 skipped
- [x] \`./demo_network/smoke.sh full\` — PASS

## Next in the stack

- Phase 4 — Bootstrap sandbox rewrite (stop calling the Court directly, use \`/v1/admin/agents\` on the Mastio)
- Phase 5 — Dashboard polish
- Phase 6 — Deprecate legacy \`POST /v1/registry/agents\` + drop \`local_agents\` doppione