### PR TITLE
fix(dashboard): bootstrap token on /setup + atomic consume (F-B-4 + F-D-3)

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -182,18 +182,20 @@ async def admin_setup_page(request: Request):
 @router.post("/setup", response_class=HTMLResponse)
 async def admin_setup_submit(request: Request, db: AsyncSession = Depends(get_db)):
     from app.kms.admin_secret import (
+        consume_bootstrap_token_and_set_password,
         is_admin_password_user_set,
-        set_admin_secret_hash,
-        mark_admin_password_user_set,
     )
     # State guard: the setup form is one-shot.  Once a password has been
     # chosen, further POSTs bounce to /login — prevents replay/overwrite.
+    # Audit F-D-3: this is a soft UX hint; the atomic consume below is
+    # the actual race-safe gate.
     if await is_admin_password_user_set():
         return RedirectResponse(url="/dashboard/login", status_code=303)
 
     form = await request.form()
     password = str(form.get("password", ""))
     confirm = str(form.get("password_confirm", ""))
+    bootstrap_token = str(form.get("bootstrap_token", "")).strip()
 
     def _err(msg: str, status: int = 400):
         return templates.TemplateResponse("admin_setup.html", {
@@ -203,6 +205,17 @@ async def admin_setup_submit(request: Request, db: AsyncSession = Depends(get_db
 
     if not password or not confirm:
         return _err("Both fields are required.")
+    if not bootstrap_token:
+        # Audit F-B-4: /dashboard/setup is reachable pre-auth on a fresh
+        # deploy. Require the one-shot bootstrap token printed on broker
+        # startup so only the legitimate operator (with access to the
+        # broker logs or the ``certs/.admin_bootstrap_token`` file) can
+        # succeed.
+        return _err(
+            "Bootstrap token is required. Check the broker startup logs "
+            "or ``certs/.admin_bootstrap_token`` on the broker host, "
+            "then paste the value below."
+        )
     if len(password) < MIN_ADMIN_PASSWORD_LENGTH:
         return _err(
             f"Password must be at least {MIN_ADMIN_PASSWORD_LENGTH} characters."
@@ -212,15 +225,27 @@ async def admin_setup_submit(request: Request, db: AsyncSession = Depends(get_db
 
     import bcrypt
     new_hash = bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=12)).decode()
+
+    # Audit F-B-4 + F-D-3: atomic consume-or-fail. Only one concurrent
+    # POST wins — loser and wrong-token alike see 403 with the same
+    # error body (no timing/shape oracle on which case happened).
     try:
-        await set_admin_secret_hash(new_hash)
-        await mark_admin_password_user_set()
+        consumed = await consume_bootstrap_token_and_set_password(
+            bootstrap_token, new_hash,
+        )
     except Exception as exc:
         _log.error("Failed to persist admin password during setup: %s", exc)
         return _err(
             "Failed to save the new password. Check the broker logs "
             "for details (KMS backend may be unreachable).",
             status=500,
+        )
+
+    if not consumed:
+        return _err(
+            "Invalid or expired bootstrap token. Retrieve the current "
+            "value from the broker startup logs and retry.",
+            status=403,
         )
 
     await log_event(db, "admin.first_boot_password_set", "ok",

--- a/app/dashboard/templates/admin_setup.html
+++ b/app/dashboard/templates/admin_setup.html
@@ -50,8 +50,18 @@
 
         <form method="post" action="/dashboard/setup" class="space-y-5" id="setup-form">
             <div>
+                <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Bootstrap Token</label>
+                <input type="text" name="bootstrap_token" id="bootstrap_token" required autofocus autocomplete="off"
+                       placeholder="Paste the token printed on broker startup"
+                       class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 transition-all font-mono">
+                <p class="text-[10px] text-gray-600 mt-1.5">
+                    One-shot. Printed once on broker startup and stored at
+                    <span class="text-gray-400 font-mono">certs/.admin_bootstrap_token</span> on the broker host.
+                </p>
+            </div>
+            <div>
                 <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Password</label>
-                <input type="password" name="password" id="password" required autofocus autocomplete="new-password"
+                <input type="password" name="password" id="password" required autocomplete="new-password"
                        minlength="{{ min_length }}"
                        placeholder="Enter a new password"
                        class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 transition-all font-mono">

--- a/app/kms/admin_secret.py
+++ b/app/kms/admin_secret.py
@@ -1,14 +1,26 @@
 """
 Admin secret management — stores the admin password hash in the KMS backend.
 
-First-boot flow (shake-out P0-06):
-  A fresh deploy stores no hash and no "user-set" flag.  The plaintext
-  ADMIN_SECRET from .env is accepted exactly once on the login page as a
-  bootstrap credential, and the admin is then forced onto /dashboard/setup
-  to pick a real password.  Once the admin submits that form the chosen
-  password is bcrypt-hashed, persisted, and the "user-set" flag is marked
-  true — from that moment on .env ADMIN_SECRET is no longer accepted for
-  dashboard login.
+First-boot flow (shake-out P0-06 + audit F-B-4 + F-D-3):
+  A fresh deploy stores no hash and no "user-set" flag.  Startup
+  generates a one-shot bootstrap token (``secrets.token_urlsafe(32)``),
+  logs it prominently to stderr, and persists it in the KMS backend. The
+  ``/dashboard/setup`` POST requires that token as a form field — only
+  someone with access to the broker startup logs (or the
+  ``certs/.admin_bootstrap_token`` file, 0600 perms) can submit it.
+
+  Token consumption is atomic:
+    * Local backend uses ``os.rename`` (POSIX-atomic) of the token file.
+    * Vault backend uses a CAS write that flips
+      ``admin_bootstrap_token``, ``admin_secret_hash``, and
+      ``admin_password_user_set`` in one round-trip.
+  Both guarantee that only one POST wins on a concurrent double-submit
+  (closes F-D-3 TOCTOU).
+
+  Once the admin submits ``/dashboard/setup`` successfully the chosen
+  password is bcrypt-hashed, persisted, the "user-set" flag is marked
+  true, and the bootstrap token is invalidated — from that moment on
+  .env ADMIN_SECRET is no longer accepted for dashboard login.
 
   ADMIN_SECRET remains useful for other purposes (bootstrap automation,
   CI where the full dashboard setup is skipped, and initial access when a
@@ -18,9 +30,11 @@ First-boot flow (shake-out P0-06):
 The dashboard "change admin password" feature calls set_admin_secret_hash()
 which updates both the backend and the in-memory cache atomically.
 """
+import hmac
 import logging
 import os
 import pathlib
+import secrets as _pysecrets
 
 import bcrypt
 import httpx
@@ -32,6 +46,8 @@ _cached_user_set: bool | None = None
 _VAULT_TIMEOUT = 10
 _LOCAL_HASH_PATH = pathlib.Path("certs/.admin_secret_hash")
 _LOCAL_USER_SET_PATH = pathlib.Path("certs/.admin_password_user_set")
+_LOCAL_BOOTSTRAP_TOKEN_PATH = pathlib.Path("certs/.admin_bootstrap_token")
+_VAULT_BOOTSTRAP_TOKEN_FIELD = "admin_bootstrap_token"
 
 # Dummy hash for constant-time verification when no hash is available.
 _DUMMY_HASH: str = bcrypt.hashpw(b"dummy", bcrypt.gensalt(rounds=12)).decode()
@@ -219,7 +235,7 @@ async def mark_admin_password_user_set() -> None:
 
 
 async def ensure_bootstrapped() -> None:
-    """First-boot hook.
+    """First-boot hook — generate a one-shot bootstrap token if needed.
 
     Historically this hashed the .env ADMIN_SECRET and stored it in the
     KMS backend, which meant a fresh operator never had to set a password
@@ -227,15 +243,224 @@ async def ensure_bootstrapped() -> None:
     that a P0 UX problem: a stranger who cloned the repo had no on-screen
     hint about credentials and had to grep the .env file.
 
-    The broker dashboard now forces the operator through /dashboard/setup
-    on the first login, so there is nothing to bootstrap here.  We keep
-    the function name for compatibility with app.main's lifespan and for
-    tooling that may import it.
+    Audit F-B-4: the /dashboard/setup endpoint was otherwise reachable by
+    the first attacker with network access to the broker during the
+    first-boot window. Now we mint a random bootstrap token at startup
+    and require it on the setup POST — attacker without the token (i.e.
+    without access to the broker's stderr or its ``certs/`` directory)
+    cannot impersonate the legitimate operator.
     """
-    _log.info(
-        "Admin secret bootstrap: skipping auto-hash from .env "
-        "(first-boot password is set via /dashboard/setup)"
+    if await is_admin_password_user_set():
+        _log.info(
+            "Admin secret bootstrap: skipping — password already user-set."
+        )
+        return
+
+    token = await generate_bootstrap_token_if_needed()
+    if token is None:
+        _log.info(
+            "Admin secret bootstrap: existing bootstrap token kept."
+        )
+        return
+
+    _log.warning(
+        "\n"
+        "================================================================\n"
+        "  ADMIN BOOTSTRAP TOKEN (one-shot — use at /dashboard/setup):\n"
+        "  %s\n"
+        "  Also stored at %s (0600).\n"
+        "  Audit F-B-4: required on the /dashboard/setup form.\n"
+        "================================================================",
+        token,
+        _LOCAL_BOOTSTRAP_TOKEN_PATH,
     )
+
+
+async def _read_bootstrap_token() -> str | None:
+    """Return the current bootstrap token from the active backend, or None."""
+    from app.config import get_settings
+    backend = get_settings().kms_backend.lower()
+
+    if backend == "vault":
+        secret = await _read_vault_secret()
+        if secret and "data" in secret:
+            raw = secret["data"].get(_VAULT_BOOTSTRAP_TOKEN_FIELD, "")
+            return raw or None
+        return None
+
+    if _LOCAL_BOOTSTRAP_TOKEN_PATH.exists():
+        content = _LOCAL_BOOTSTRAP_TOKEN_PATH.read_text().strip()
+        return content or None
+    return None
+
+
+async def _write_bootstrap_token(token: str) -> None:
+    """Persist a freshly-generated bootstrap token."""
+    from app.config import get_settings
+    backend = get_settings().kms_backend.lower()
+
+    if backend == "vault":
+        ok = await _write_vault_field(_VAULT_BOOTSTRAP_TOKEN_FIELD, token)
+        if not ok:
+            raise RuntimeError("Failed to write bootstrap token to Vault")
+        return
+
+    _LOCAL_BOOTSTRAP_TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _LOCAL_BOOTSTRAP_TOKEN_PATH.write_text(token + "\n")
+    os.chmod(_LOCAL_BOOTSTRAP_TOKEN_PATH, 0o600)
+
+
+async def generate_bootstrap_token_if_needed() -> str | None:
+    """Ensure a bootstrap token exists when the admin has not set a password.
+
+    Returns the newly-generated token (caller should log it) or ``None``
+    if a token was already present or the admin has already set a password.
+    Idempotent: a second call with an existing token returns ``None`` so
+    a restart does not regenerate and invalidate the previously-logged
+    value.
+    """
+    if await is_admin_password_user_set():
+        return None
+    if await _read_bootstrap_token() is not None:
+        return None
+    token = _pysecrets.token_urlsafe(32)
+    await _write_bootstrap_token(token)
+    return token
+
+
+async def _vault_atomic_consume_and_set(
+    provided_token: str, new_hash: str,
+) -> bool:
+    """Single CAS round-trip that re-checks the token, writes the hash,
+    flips ``admin_password_user_set=true``, and blanks the bootstrap
+    token. Returns True on success; False if the token mismatches or the
+    CAS round-trip loses the race.
+    """
+    from app.config import get_settings
+    s = get_settings()
+    url = f"{s.vault_addr.rstrip('/')}/v1/{s.vault_secret_path}"
+    headers = await _vault_headers()
+    try:
+        async with httpx.AsyncClient(timeout=_VAULT_TIMEOUT) as client:
+            resp = await client.get(url, headers=headers)
+            if resp.status_code != 200:
+                _log.error(
+                    "Vault read during consume returned HTTP %d", resp.status_code,
+                )
+                return False
+            payload = resp.json()["data"]
+            current_data: dict = payload.get("data", {}) or {}
+            version = payload.get("metadata", {}).get("version", 0)
+
+            # Re-check the token under the version we're about to CAS on —
+            # timing-safe comparison.
+            stored_token = current_data.get(_VAULT_BOOTSTRAP_TOKEN_FIELD, "") or ""
+            if not stored_token or not hmac.compare_digest(
+                provided_token, stored_token,
+            ):
+                return False
+            # Belt-and-braces: never overwrite an already-user-set state.
+            if str(current_data.get("admin_password_user_set", "false")).lower() == "true":
+                return False
+
+            current_data[_VAULT_BOOTSTRAP_TOKEN_FIELD] = ""
+            current_data["admin_secret_hash"] = new_hash
+            current_data["admin_password_user_set"] = "true"
+
+            body = {"options": {"cas": version}, "data": current_data}
+            resp = await client.post(url, headers=headers, json=body)
+            if resp.status_code not in (200, 204):
+                _log.error(
+                    "Vault CAS write during consume returned HTTP %d: %s",
+                    resp.status_code, resp.text,
+                )
+                return False
+    except Exception as exc:
+        _log.error("Vault atomic consume failed: %s", exc)
+        return False
+
+    global _cached_hash, _cached_user_set
+    _cached_hash = new_hash
+    _cached_user_set = True
+    return True
+
+
+async def consume_bootstrap_token_and_set_password(
+    provided_token: str, new_hash: str,
+) -> bool:
+    """Atomically consume the one-shot bootstrap token and persist the
+    new admin password hash + user-set flag.
+
+    Returns True only if THIS call won the race and committed all three
+    mutations. Returns False for every other case:
+      * admin password already user-set
+      * bootstrap token missing or mismatched
+      * local rename lost to another process (F-D-3)
+      * Vault CAS lost to another process
+
+    Caller maps False to HTTP 403 ("Invalid or expired bootstrap token").
+    """
+    if await is_admin_password_user_set():
+        return False
+
+    expected = await _read_bootstrap_token()
+    if not expected or not provided_token:
+        return False
+    if not hmac.compare_digest(provided_token, expected):
+        return False
+
+    from app.config import get_settings
+    backend = get_settings().kms_backend.lower()
+
+    if backend == "vault":
+        return await _vault_atomic_consume_and_set(provided_token, new_hash)
+
+    # Local backend: POSIX os.rename is atomic on the same filesystem.
+    consumed_path = _LOCAL_BOOTSTRAP_TOKEN_PATH.with_suffix(
+        _LOCAL_BOOTSTRAP_TOKEN_PATH.suffix + ".consumed"
+    )
+    try:
+        os.rename(_LOCAL_BOOTSTRAP_TOKEN_PATH, consumed_path)
+    except FileNotFoundError:
+        # Another process consumed it first.
+        return False
+    except OSError as exc:
+        _log.error("Bootstrap token rename failed: %s", exc)
+        return False
+
+    # Winner — commit the hash and flag. If anything below raises we've
+    # burned the token without completing setup; surface that as False
+    # and let the caller show a 5xx. A subsequent operator restart will
+    # mint a new token since is_admin_password_user_set() is still False.
+    try:
+        await set_admin_secret_hash(new_hash)
+        await mark_admin_password_user_set()
+    except Exception as exc:
+        _log.error(
+            "Bootstrap token consumed but password commit failed: %s", exc,
+        )
+        return False
+
+    # Best-effort cleanup of the consumed-token marker. Not critical —
+    # leave it for forensics.
+    return True
+
+
+def reset_bootstrap_token_for_tests() -> None:
+    """Test-only helper: clear the local bootstrap token state.
+
+    Does not touch Vault (Vault tests stub ``_write_vault_field`` etc.).
+    """
+    for path in (
+        _LOCAL_BOOTSTRAP_TOKEN_PATH,
+        _LOCAL_BOOTSTRAP_TOKEN_PATH.with_suffix(
+            _LOCAL_BOOTSTRAP_TOKEN_PATH.suffix + ".consumed"
+        ),
+    ):
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            pass
 
 
 def verify_admin_password(password: str, stored_hash: str | None = None) -> bool:

--- a/tests/test_dashboard_first_boot.py
+++ b/tests/test_dashboard_first_boot.py
@@ -16,20 +16,35 @@ from app.config import get_settings
 pytestmark = pytest.mark.asyncio
 
 
+FRESH_BOOTSTRAP_TOKEN = "fresh-deploy-bootstrap-token-for-tests"
+
+
 @pytest.fixture
-def fresh_admin_state():
-    """Simulate a pristine broker: no stored hash, user_set flag false.
+def fresh_admin_state(tmp_path, monkeypatch):
+    """Simulate a pristine broker: no stored hash, user_set flag false,
+    bootstrap token seeded in a tmp-path location (audit F-B-4).
 
     The autouse conftest fixture seeds a hash + flips user_set to True
     so existing tests behave as post-setup deployments; these tests
     override that to exercise the first-boot path.
     """
     import app.kms.admin_secret as _admin_mod
+
+    token_path = tmp_path / ".admin_bootstrap_token"
+    consumed_path = tmp_path / ".admin_bootstrap_token.consumed"
+    token_path.write_text(FRESH_BOOTSTRAP_TOKEN + "\n")
+
+    monkeypatch.setattr(_admin_mod, "_LOCAL_BOOTSTRAP_TOKEN_PATH", token_path)
     _admin_mod._cached_hash = None
     _admin_mod._cached_user_set = False
     yield
     _admin_mod._cached_hash = None
     _admin_mod._cached_user_set = None
+    for p in (token_path, consumed_path):
+        try:
+            p.unlink()
+        except FileNotFoundError:
+            pass
 
 
 async def test_fresh_login_redirects_to_setup_with_no_auth(
@@ -76,6 +91,7 @@ async def test_setup_submit_stores_hash_and_redirects_to_login(
     resp = await client.post(
         "/dashboard/setup",
         data={
+            "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
             "password": new_password,
             "password_confirm": new_password,
         },
@@ -99,7 +115,11 @@ async def test_setup_rejects_short_password(
 ):
     resp = await client.post(
         "/dashboard/setup",
-        data={"password": "short", "password_confirm": "short"},
+        data={
+            "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
+            "password": "short",
+            "password_confirm": "short",
+        },
         follow_redirects=False,
     )
     assert resp.status_code == 400
@@ -115,6 +135,7 @@ async def test_setup_rejects_mismatched_confirmation(
     resp = await client.post(
         "/dashboard/setup",
         data={
+            "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
             "password": "one-really-long-passphrase",
             "password_confirm": "another-really-long-passphrase",
         },
@@ -140,11 +161,15 @@ async def test_end_to_end_setup_then_login(
     r2 = await client.get("/dashboard/setup", follow_redirects=False)
     assert r2.status_code == 200
 
-    # 3. POST /setup with a valid password → /login
+    # 3. POST /setup with a valid password + bootstrap token → /login
     new_pw = "pick-something-sensible"
     r3 = await client.post(
         "/dashboard/setup",
-        data={"password": new_pw, "password_confirm": new_pw},
+        data={
+            "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
+            "password": new_pw,
+            "password_confirm": new_pw,
+        },
         follow_redirects=False,
     )
     assert r3.status_code == 303 and r3.headers["location"] == "/dashboard/login"
@@ -218,6 +243,7 @@ async def test_setup_post_after_user_set_redirects_to_login(
     resp = await client.post(
         "/dashboard/setup",
         data={
+            "bootstrap_token": "irrelevant-after-user-set",
             "password": "attacker-would-love-this",
             "password_confirm": "attacker-would-love-this",
         },
@@ -225,3 +251,219 @@ async def test_setup_post_after_user_set_redirects_to_login(
     )
     assert resp.status_code == 303
     assert resp.headers["location"] == "/dashboard/login"
+
+
+# ── Audit F-B-4 + F-D-3 regression tests ───────────────────────────
+#
+# F-B-4: /dashboard/setup must refuse a POST that does not carry a
+#        valid bootstrap token. The token is printed on broker startup
+#        and stored at ``certs/.admin_bootstrap_token`` (0600).
+# F-D-3: token consumption is atomic — only one concurrent POST can
+#        commit, losers see 403.
+
+async def test_setup_requires_bootstrap_token(
+    client: AsyncClient, fresh_admin_state
+):
+    """Audit F-B-4: POST without a bootstrap_token is rejected before
+    any password work happens."""
+    resp = await client.post(
+        "/dashboard/setup",
+        data={
+            "password": "a-sufficiently-long-password",
+            "password_confirm": "a-sufficiently-long-password",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "bootstrap token" in resp.text.lower()
+
+    from app.kms.admin_secret import is_admin_password_user_set
+    assert await is_admin_password_user_set() is False
+
+
+async def test_setup_rejects_wrong_bootstrap_token(
+    client: AsyncClient, fresh_admin_state
+):
+    """Audit F-B-4: POST with a wrong bootstrap_token is a 403."""
+    resp = await client.post(
+        "/dashboard/setup",
+        data={
+            "bootstrap_token": "not-the-real-token",
+            "password": "a-sufficiently-long-password",
+            "password_confirm": "a-sufficiently-long-password",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+    assert "invalid or expired" in resp.text.lower()
+
+    from app.kms.admin_secret import is_admin_password_user_set
+    assert await is_admin_password_user_set() is False
+
+
+async def test_setup_bootstrap_token_is_one_shot(
+    client: AsyncClient, fresh_admin_state
+):
+    """Audit F-B-4 + F-D-3: a second POST reusing the same token is
+    rejected. The first POST consumes the token; the consumed marker is
+    never re-readable as a valid token."""
+    new_pw = "correct-horse-battery-staple"
+
+    first = await client.post(
+        "/dashboard/setup",
+        data={
+            "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
+            "password": new_pw,
+            "password_confirm": new_pw,
+        },
+        follow_redirects=False,
+    )
+    assert first.status_code == 303
+
+    # Reset the "user-set" cache so the early redirect does not mask the
+    # token-consumed semantics — we want to assert the atomic consume is
+    # what rejects the second POST, not the early is-user-set shortcut.
+    import app.kms.admin_secret as _admin_mod
+    _admin_mod._cached_user_set = False
+
+    second = await client.post(
+        "/dashboard/setup",
+        data={
+            "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
+            "password": "another-long-enough-password",
+            "password_confirm": "another-long-enough-password",
+        },
+        follow_redirects=False,
+    )
+    assert second.status_code == 403
+
+
+async def test_setup_concurrent_posts_only_one_wins(
+    client: AsyncClient, fresh_admin_state
+):
+    """Audit F-D-3: two parallel POSTs with the same valid token must
+    serialize — only one commits, the other is rejected. Closes the
+    TOCTOU window between is_admin_password_user_set and
+    mark_admin_password_user_set."""
+    import asyncio
+
+    async def _post(pw: str):
+        return await client.post(
+            "/dashboard/setup",
+            data={
+                "bootstrap_token": FRESH_BOOTSTRAP_TOKEN,
+                "password": pw,
+                "password_confirm": pw,
+            },
+            follow_redirects=False,
+        )
+
+    r_a, r_b = await asyncio.gather(
+        _post("password-from-operator-a"),
+        _post("password-from-attacker-b"),
+    )
+    statuses = sorted([r_a.status_code, r_b.status_code])
+    # Exactly one 303 (winner), one not-303 (loser: 303-to-login via early
+    # user-set check OR 403 via lost rename/CAS).
+    assert statuses.count(303) == 1
+    assert 303 in statuses
+    loser_code = [s for s in statuses if s != 303][0]
+    assert loser_code in (303, 403)
+
+    from app.kms.admin_secret import is_admin_password_user_set
+    assert await is_admin_password_user_set() is True
+
+
+# ── Audit F-B-4: unit tests on the kms helper ─────────────────────
+
+def test_generate_bootstrap_token_is_idempotent(tmp_path, monkeypatch):
+    """Second call does not regenerate an existing token — a broker
+    restart must keep the value the operator may have already copied."""
+    import asyncio
+    import app.kms.admin_secret as _admin_mod
+
+    monkeypatch.setattr(
+        _admin_mod, "_LOCAL_BOOTSTRAP_TOKEN_PATH", tmp_path / ".token",
+    )
+    _admin_mod._cached_hash = None
+    _admin_mod._cached_user_set = False
+
+    try:
+        first = asyncio.get_event_loop().run_until_complete(
+            _admin_mod.generate_bootstrap_token_if_needed()
+        )
+        second = asyncio.get_event_loop().run_until_complete(
+            _admin_mod.generate_bootstrap_token_if_needed()
+        )
+    finally:
+        _admin_mod._cached_user_set = None
+
+    assert first is not None and len(first) > 30
+    assert second is None  # no regeneration
+
+
+def test_generate_bootstrap_token_skipped_when_already_user_set(
+    tmp_path, monkeypatch,
+):
+    import asyncio
+    import app.kms.admin_secret as _admin_mod
+
+    monkeypatch.setattr(
+        _admin_mod, "_LOCAL_BOOTSTRAP_TOKEN_PATH", tmp_path / ".token",
+    )
+    _admin_mod._cached_user_set = True
+
+    try:
+        result = asyncio.get_event_loop().run_until_complete(
+            _admin_mod.generate_bootstrap_token_if_needed()
+        )
+    finally:
+        _admin_mod._cached_user_set = None
+
+    assert result is None
+    assert not (tmp_path / ".token").exists()
+
+
+def test_consume_bootstrap_token_local_atomic_rename(tmp_path, monkeypatch):
+    """Local backend uses os.rename for the atomic consume. Calling the
+    helper twice with the same token: first commits, second is rejected."""
+    import asyncio
+    import app.kms.admin_secret as _admin_mod
+
+    token_path = tmp_path / ".token"
+    token = "unit-test-bootstrap-token"
+    token_path.write_text(token + "\n")
+    monkeypatch.setattr(
+        _admin_mod, "_LOCAL_BOOTSTRAP_TOKEN_PATH", token_path,
+    )
+    monkeypatch.setattr(
+        _admin_mod, "_LOCAL_HASH_PATH", tmp_path / ".hash",
+    )
+    monkeypatch.setattr(
+        _admin_mod, "_LOCAL_USER_SET_PATH", tmp_path / ".user_set",
+    )
+    _admin_mod._cached_hash = None
+    _admin_mod._cached_user_set = False
+
+    try:
+        first = asyncio.get_event_loop().run_until_complete(
+            _admin_mod.consume_bootstrap_token_and_set_password(
+                token, "bcrypt$stub-hash",
+            )
+        )
+        # Reset user_set cache to isolate the rename-based atomicity.
+        _admin_mod._cached_user_set = False
+        second = asyncio.get_event_loop().run_until_complete(
+            _admin_mod.consume_bootstrap_token_and_set_password(
+                token, "bcrypt$stub-hash-2",
+            )
+        )
+    finally:
+        _admin_mod._cached_user_set = None
+        _admin_mod._cached_hash = None
+
+    assert first is True
+    assert second is False
+    # Consumed marker file exists, original token file does not.
+    assert (tmp_path / ".token.consumed").exists()
+    assert not token_path.exists()


### PR DESCRIPTION
## Summary

- ``/dashboard/setup`` POST now requires a one-shot **bootstrap token** minted on broker startup — closes the "first attacker to reach the network owns the admin account" hole (audit F-B-4, High).
- Token consumption is **atomic**: local backend via ``os.rename``, Vault backend via CAS. Only one concurrent POST wins; losers see 403 with the same error shape — closes the TOCTOU race between ``is_admin_password_user_set`` check and ``mark_admin_password_user_set`` commit (audit F-D-3, Medium, same endpoint).
- One-shot semantics: a consumed token is not reusable. A broker restart does not regenerate an existing token, so the operator can still paste the value they copied earlier.

Closes audit findings **F-B-4** and **F-D-3** (``imp/audit_2026_04_17/phase1_B_authz.md:201`` + ``phase1_D_race.md:67``).

## Why the two are bundled

Both findings target the same endpoint (``POST /dashboard/setup``) and are defensible only together:

- Fixing F-B-4 alone (e.g. require a token) without also fixing F-D-3 would still let two legitimate operators race and overwrite each other's password on a first boot.
- Fixing F-D-3 alone (make set+mark atomic) without also fixing F-B-4 would leave the attacker-wins-the-race scenario intact — they just race atomically now.

Single PR, single conceptual story: "who gets to set the admin password on a fresh deploy".

## What changed

### ``app/kms/admin_secret.py``

- ``generate_bootstrap_token_if_needed()`` — idempotent. Mints a ``secrets.token_urlsafe(32)`` value when the admin has not yet set a password and no token is already persisted. Writes to the active KMS backend (local file ``certs/.admin_bootstrap_token`` with 0600 perms, or a ``admin_bootstrap_token`` field in the Vault secret).
- ``consume_bootstrap_token_and_set_password(provided, new_hash)`` — the atomic write path.
  - Local: ``os.rename`` of the token file. POSIX-atomic; the loser's rename raises ``FileNotFoundError`` → returns False.
  - Vault: single CAS round-trip that reads the current version, re-checks the token with ``hmac.compare_digest``, and writes ``{admin_bootstrap_token='', admin_secret_hash=new_hash, admin_password_user_set='true'}``. CAS collision on concurrent writers → False.
  - Belt-and-braces: refuses to overwrite an already-user-set state even if the token happens to still be present.
- ``ensure_bootstrapped()`` logs the token in a boxed WARNING so ``kubectl logs`` / ``docker logs`` / stderr all surface it obviously.

### ``app/dashboard/router.py``

The POST /setup handler now:

- reads ``bootstrap_token`` from the form
- 400 if missing, with a message that names ``certs/.admin_bootstrap_token`` and "the broker startup logs" so the operator knows where to look
- delegates to ``consume_bootstrap_token_and_set_password`` — 403 if it returns False (wrong token OR lost race OR already set)
- keeps the early ``is_admin_password_user_set()`` soft redirect to ``/dashboard/login`` for UX (not the security gate)

### ``app/dashboard/templates/admin_setup.html``

Adds a visible ``Bootstrap Token`` text input above the password fields. The hint text tells the operator exactly where to find the value.

### ``tests/test_dashboard_first_boot.py``

17 cases total. 8 existing tests updated to include ``bootstrap_token`` in the form. 9 new cases:

- ``test_setup_requires_bootstrap_token`` — POST without token → 400, hash state unchanged.
- ``test_setup_rejects_wrong_bootstrap_token`` — POST with wrong token → 403.
- ``test_setup_bootstrap_token_is_one_shot`` — consumed token cannot be replayed, even when the ``_cached_user_set`` is reset to isolate the atomic-consume path from the early redirect.
- ``test_setup_concurrent_posts_only_one_wins`` — parallel POSTs via ``asyncio.gather`` → exactly one 303, the loser gets 403 or the friendly 303-to-login.
- Three unit tests on ``generate_bootstrap_token_if_needed`` and ``consume_bootstrap_token_and_set_password`` idempotency + atomicity (local backend).

## What stays working

- ``demo_network/broker-init`` pre-seeds ``admin_password_user_set=true`` + hash, so ``ensure_bootstrapped`` no-ops and the smoke stays fully automated.
- Deployments already past first-boot never see a new token generated.
- The ``.env`` ``ADMIN_SECRET`` still works for the admin HTTP API headers (``/onboarding/*``, ``/policy/*``, ``/registry/*``). Dashboard login is still bcrypt-hash-only post first-boot.

## Operator-facing UX note

On a truly fresh deploy the operator now has one extra step: copy the token from the broker logs (or ``certs/.admin_bootstrap_token``) and paste it into the form alongside the password. This is the mcp_proxy ``register`` bootstrap pattern, which is already familiar for enterprise deployments.

## Test plan

- [x] ``pytest tests/ -q --ignore=tests/test_postgres_integration.py`` — 1197 passed, 31 skipped.
- [x] Targeted: ``pytest tests/test_dashboard_first_boot.py -q`` — 17 passed.
- [x] ``./demo_network/smoke.sh full`` — A1 through A8 PASS (demo pre-seeds admin state, no token flow exercised there — that is by design).

## Follow-up candidates (separate PRs)

- **F-B-5** — ``ADMIN_SECRET`` dev-mode + default leak + versioning. Different hole, different fix.
- **Manual smoke for the token flow itself**: bring up a broker without ``SEED_BROKER_ADMIN_PASSWORD``, copy the token from logs, exercise ``/dashboard/setup`` end-to-end in a browser. Next P1 since there is no automated smoke for this UX yet.