### PR TITLE
feat(sandbox): bootstrap pushes agents via Mastio, not Court (ADR-010 Phase 4)

### DIFF
--- a/enterprise_sandbox/bootstrap/bootstrap.py
+++ b/enterprise_sandbox/bootstrap/bootstrap.py
@@ -488,57 +488,22 @@ def _provision_agent(client: httpx.Client, agent_def: dict,
     _ok(f"agent_id={BOLD}{agent_id}{RESET}  SPIFFE={CYAN}{spiffe}{RESET}")
     _ok(f"cert serial={GRAY}{_serial_hex(cert)}{RESET}  thumbprint={CYAN}{_thumbprint(cert)}{RESET}  key={PKI_KEY_TYPE.upper()}")
 
-    # 2. Register agent
-    r = client.post(
-        f"{BROKER_URL}/v1/registry/agents",
-        json={
-            "agent_id": agent_id,
-            "org_id": org_id,
-            "display_name": f"{od['display_name']} {agent_name}",
-            "capabilities": caps,
-            "description": f"enterprise sandbox {agent_name}",
-        },
-        headers=headers,
+    # ADR-010 Phase 4 — registry ownership inverted.
+    #
+    # Before: bootstrap POSTed ``/v1/registry/agents`` + binding on the
+    # Court directly, using ``org_secret`` for auth. That path bypassed
+    # the Mastio and left it blind to its own agents.
+    #
+    # After: bootstrap only mints the cert/key pair and parks them in
+    # ``/state/{org}/agents/{name}/`` (so the agent containers can mount
+    # them). The post-proxy-boot companion (``bootstrap_mastio.py``)
+    # reads the dir, calls ``/v1/admin/agents`` on the Mastio with
+    # ``federated=true``, and the Phase 3 publisher loop propagates
+    # the row to the Court on its next tick.
+    _info(f"cert persisted → /state/{org_id}/agents/{agent_name}/")
+    _info(
+        f"federation push deferred to bootstrap_mastio.py + publisher loop"
     )
-    if r.status_code not in (200, 201, 409):
-        _fail(f"register agent {agent_id}: {r.status_code} {r.text}")
-        raise SystemExit(1)
-    _log_http("POST", "/v1/registry/agents", r)
-
-    # 3. Create binding
-    r = client.post(
-        f"{BROKER_URL}/v1/registry/bindings",
-        json={"org_id": org_id, "agent_id": agent_id, "scope": caps},
-        headers=headers,
-    )
-    if r.status_code == 201:
-        binding_id = r.json()["id"]
-    elif r.status_code == 409:
-        r2 = client.get(
-            f"{BROKER_URL}/v1/registry/bindings",
-            params={"org_id": org_id},
-            headers=headers,
-        )
-        r2.raise_for_status()
-        binding_id = next(b["id"] for b in r2.json() if b.get("agent_id") == agent_id)
-    else:
-        _fail(f"binding create {agent_id}: {r.status_code} {r.text}")
-        raise SystemExit(1)
-    _log_http("POST", "/v1/registry/bindings", r)
-
-    # 4. Approve binding
-    r = client.post(
-        f"{BROKER_URL}/v1/registry/bindings/{binding_id}/approve",
-        headers=headers,
-    )
-    if r.status_code != 200:
-        _fail(f"binding approve {agent_id}: {r.status_code} {r.text}")
-        raise SystemExit(1)
-    _ok(f"binding {GRAY}{binding_id}{RESET}  scope={caps}")
-
-    # Extra persist for byoca-bot
-    if agent_def.get("persist_extra"):
-        _ok(f"persisted cert+key → {agent_dir}/")
 
     return {
         "agent_id": agent_id,

--- a/enterprise_sandbox/bootstrap/bootstrap_mastio.py
+++ b/enterprise_sandbox/bootstrap/bootstrap_mastio.py
@@ -1,19 +1,23 @@
-"""ADR-009 Phase 2 — pin each proxy's mastio_pubkey on the Court.
+"""Post-proxy-boot wiring: mastio_pubkey pin + agent seeding.
 
 Runs **after** the proxies have booted and generated their Mastio CA +
-leaf identity (lifespan hook in ``mcp_proxy/main.py``). The main
-bootstrap container ran before the proxies, so it couldn't know the
-mastio pubkey yet — this is a second-phase one-shot that closes that
-loop, enabling the Court's counter-signature enforcement on every
-subsequent ``/v1/auth/token`` call.
+leaf identity (lifespan hook in ``mcp_proxy/main.py``).
 
-Flow per proxy:
-  1. poll ``GET /v1/admin/mastio-pubkey`` on the proxy (with X-Admin-Secret)
-     until it returns a non-null PEM (first boot may still be finalizing)
-  2. ``PATCH /v1/admin/orgs/{org_id}/mastio-pubkey`` on the Court with
-     the PEM — pin it under the admin secret.
+Two responsibilities:
 
-Idempotent: re-running the container just re-PATCHes the same pubkey.
+1. **ADR-009 mastio pubkey pinning** (original job):
+   - poll ``GET /v1/admin/mastio-pubkey`` on each proxy until populated
+   - ``PATCH /v1/admin/orgs/{org_id}/mastio-pubkey`` on the Court
+
+2. **ADR-010 Phase 4 — Mastio-authoritative agent registry seeding**:
+   - for every agent the outer bootstrap minted a cert/key for under
+     ``/state/{org}/agents/{name}/``, ``POST /v1/admin/agents`` on the
+     owning Mastio with the pre-generated material and ``federated=true``
+   - the Phase 3 publisher loop picks the row up from
+     ``internal_agents`` and pushes it to the Court (no more direct
+     ``/v1/registry/agents`` call from bootstrap)
+
+Idempotent: the Mastio returns 409 on duplicates; we silently continue.
 """
 from __future__ import annotations
 
@@ -127,9 +131,58 @@ def _pin_on_court(
         raise SystemExit(1)
 
 
+def _seed_agents_on_mastio(
+    client: httpx.Client, proxy_url: str, admin_secret: str, org_id: str,
+) -> None:
+    """ADR-010 Phase 4 — register each /state/{org}/agents/* on the Mastio.
+
+    The outer bootstrap already generated agent cert/key pairs and wrote
+    them under ``/state/{org}/agents/{name}/agent.pem,agent-key.pem``.
+    We forward them to the Mastio's ``POST /v1/admin/agents`` with
+    ``federated=true``; the publisher loop then pushes to the Court.
+    """
+    import pathlib
+    agents_dir = pathlib.Path("/state") / org_id / "agents"
+    if not agents_dir.exists():
+        _info(f"{org_id}: no agents directory — skipping seed")
+        return
+
+    for entry in sorted(p for p in agents_dir.iterdir() if p.is_dir()):
+        name = entry.name
+        cert_path = entry / "agent.pem"
+        key_path = entry / "agent-key.pem"
+        if not cert_path.exists() or not key_path.exists():
+            _warn(f"{org_id}::{name}: missing agent.pem/agent-key.pem — skipping")
+            continue
+        cert_pem = cert_path.read_text()
+        key_pem = key_path.read_text()
+        r = client.post(
+            f"{proxy_url}/v1/admin/agents",
+            headers={"X-Admin-Secret": admin_secret},
+            json={
+                "agent_name": name,
+                "display_name": name,
+                "capabilities": [],  # assigned later by admin via PATCH
+                "federated": True,
+                "cert_pem": cert_pem,
+                "private_key_pem": key_pem,
+            },
+            timeout=10.0,
+        )
+        if r.status_code == 201:
+            _ok(f"{org_id}::{name}: seeded on Mastio (federated=True)")
+        elif r.status_code == 409:
+            _info(f"{org_id}::{name}: already on Mastio — skipping")
+        else:
+            _fail(
+                f"{org_id}::{name}: seed failed "
+                f"HTTP {r.status_code} {r.text[:200]}"
+            )
+
+
 def main() -> int:
     print(
-        f"\n{BOLD}{CYAN}═══ ADR-009 Phase 2 — pin mastio_pubkey on Court "
+        f"\n{BOLD}{CYAN}═══ Post-proxy-boot — mastio_pubkey + agent seeding "
         f"{'═' * 10}{RESET}\n",
         flush=True,
     )
@@ -147,8 +200,17 @@ def main() -> int:
             _pin_on_court(client, org_id, pem)
             _ok(f"{org_id}: mastio_pubkey pinned — counter-sig enforcement active")
 
-    print(f"\n{BOLD}{GREEN}✓ ADR-009 mastio identities pinned on Court{RESET}\n",
-          flush=True)
+            _info(f"seeding agents on Mastio {BOLD}{org_id}{RESET}")
+            _seed_agents_on_mastio(
+                client, cfg["proxy_url"], cfg["admin_secret"], org_id,
+            )
+
+    print(
+        f"\n{BOLD}{GREEN}"
+        f"✓ mastio identities pinned + agents seeded "
+        f"(publisher will propagate to Court){RESET}\n",
+        flush=True,
+    )
     return 0
 
 

--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -71,6 +71,14 @@ class AgentCreateRequest(BaseModel):
     display_name: str = Field("", max_length=256)
     capabilities: list[str] = Field(default_factory=list)
     federated: bool = False
+    # Optional pre-generated cert+key pair, used by the sandbox bootstrap
+    # that owns the same Org CA and wants to share the private key with
+    # an out-of-Mastio agent container via a volume mount. When both are
+    # provided the Mastio skips its own ``_generate_agent_cert`` call
+    # and stores the inbound material as-is (Org CA chain is still the
+    # trust anchor; re-emitting would invalidate the volume-shared key).
+    cert_pem: str | None = None
+    private_key_pem: str | None = None
 
 
 class AgentCreateResponse(BaseModel):
@@ -145,8 +153,20 @@ async def create_agent(
     agent_name = body.agent_name
     agent_id = f"{mgr.org_id}::{agent_name}"
 
-    # Mint cert + key via the same path the Connector enrollment uses.
-    cert_pem, key_pem = mgr._generate_agent_cert(agent_name)
+    # If both cert_pem + private_key_pem arrived in the body, trust the
+    # caller (e.g. the sandbox bootstrap that owns the same Org CA and
+    # has already shared the private key with an agent container over a
+    # volume mount). Otherwise mint a fresh pair via the Org CA.
+    if body.cert_pem and body.private_key_pem:
+        cert_pem = body.cert_pem
+        key_pem = body.private_key_pem
+    elif body.cert_pem or body.private_key_pem:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="cert_pem and private_key_pem must be provided together",
+        )
+    else:
+        cert_pem, key_pem = mgr._generate_agent_cert(agent_name)
 
     # Persist the private key. Store in Vault if configured, otherwise
     # fall back to proxy_config (same pattern as AgentManager.create_agent).

--- a/tests/test_admin_agents.py
+++ b/tests/test_admin_agents.py
@@ -65,6 +65,54 @@ async def test_create_agent_emits_key_and_cert(tmp_path, monkeypatch):
     get_settings.cache_clear()
 
 
+async def test_create_accepts_pre_generated_cert(tmp_path, monkeypatch):
+    """ADR-010 Phase 4 — bootstrap-style path: caller provides an already-
+    minted cert+key (signed by the same Org CA), Mastio stores them
+    verbatim instead of minting new ones."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-preout")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            # Mint externally, then re-submit via API.
+            cert_pem, key_pem = mgr._generate_agent_cert("ext-alice")
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/agents", headers=h,
+                json={
+                    "agent_name": "ext-alice",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                    "federated": True,
+                },
+            )
+            assert r.status_code == 201, r.text
+            # The returned cert_pem must be the exact bytes we submitted —
+            # proving the Mastio didn't re-mint.
+            assert r.json()["cert_pem"] == cert_pem
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_rejects_half_pre_generated_material(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "aa-half")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/agents", headers=h,
+                json={
+                    "agent_name": "half-bob",
+                    "cert_pem": "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----\n",
+                },
+            )
+            assert r.status_code == 400
+            assert "provided together" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
 async def test_create_with_federated_flag(tmp_path, monkeypatch):
     app = await _spin_proxy(tmp_path, monkeypatch, "aa-fed")
     transport = ASGITransport(app=app)


### PR DESCRIPTION
Fourth PR of ADR-010. Aligns the sandbox bootstrap with the new ownership model — no more direct Court calls to register agents; everything flows through the Mastio now.

## Before → After

\`\`\`
BEFORE: bootstrap → POST /v1/registry/agents (Court, org_secret)
                  → POST /v1/registry/bindings (Court, org_secret)
                  → POST /v1/registry/bindings/{id}/approve

AFTER:  bootstrap         → persist cert/key under /state/{org}/agents/{name}/
        bootstrap_mastio  → POST /v1/admin/agents (Mastio, X-Admin-Secret,
                           federated=true, cert_pem+private_key_pem included)
        publisher (Phase 3) → POST /v1/federation/publish-agent (Court,
                             counter-signed)
\`\`\`

The legacy \`/v1/registry/agents\` path still works for non-sandbox callers — Phase 6 deprecates it.

## Minor API bump

\`AgentCreateRequest\` gains optional \`cert_pem\` + \`private_key_pem\`. Supplying both makes the Mastio store the material verbatim instead of minting new ones — needed for the volume-shared cert/key pair the sandbox bootstrap uses to hand credentials to the agent containers.

## Test plan

- [x] \`pytest tests/test_admin_agents.py\` — 10/10 (plus +2 for pre-generated path)
- [x] Full suite serial: 1198 pass, 6 skipped
- [ ] Full suite parallel: 29 flakes (pre-existing across PRs, pass in isolation — tracking separately)
- [ ] Manual \`./enterprise_sandbox/demo.sh full\` shake-out — after merge

## Next

- Phase 5 — Dashboard polish (agent list view with federated column)
- Phase 6 — Deprecate legacy endpoint + drop \`local_agents\` doppione