### PR TITLE
fix(config): reject ADMIN_SECRET default at Settings construction (F-B-5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,14 @@ jobs:
     # the pytest conftest.py that seeds a test secret, so set it
     # job-wide so every step that constructs Settings has a non-default
     # value available.
+    #
+    # The value MUST match the ``ADMIN_HEADERS`` literal hard-coded in
+    # ``tests/conftest.py`` — the conftest uses ``os.environ.setdefault``
+    # so a CI-supplied value wins, and ``ADMIN_HEADERS`` is a plain
+    # string. Mismatch → every admin-authed test 403s against
+    # ``/v1/admin/*`` and so on.
     env:
-      ADMIN_SECRET: "ci-non-default-admin-secret-for-ci-runs"
+      ADMIN_SECRET: "test-secret-not-default"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,14 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11"]
+    # Audit F-B-5: Settings() now refuses the insecure default
+    # ADMIN_SECRET at construction time. Alembic imports app.db.database
+    # (which calls get_settings() at module load) without going through
+    # the pytest conftest.py that seeds a test secret, so set it
+    # job-wide so every step that constructs Settings has a non-default
+    # value available.
+    env:
+      ADMIN_SECRET: "ci-non-default-admin-secret-for-ci-runs"
 
     steps:
       - uses: actions/checkout@v4

--- a/app/config.py
+++ b/app/config.py
@@ -1,8 +1,15 @@
 import logging
 import pathlib
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 from functools import lru_cache
+
+
+# Defined before the ``Settings`` class so the model validator below
+# can reference it without a forward-reference trick.
+_INSECURE_DEFAULT_SECRET = "change-me-in-production"
+_INSECURE_VAULT_TOKEN = "dev-root-token"
 
 
 class Settings(BaseSettings):
@@ -117,9 +124,35 @@ class Settings(BaseSettings):
         env_file = ".env"
         extra = "ignore"
 
+    @model_validator(mode="after")
+    def _reject_insecure_default_admin_secret(self):
+        """Audit F-B-5: refuse to construct ``Settings`` with the default
+        ``ADMIN_SECRET`` at all — in dev or prod.
 
-_INSECURE_DEFAULT_SECRET = "change-me-in-production"
-_INSECURE_VAULT_TOKEN = "dev-root-token"
+        Previously the rejection lived only in ``validate_config``, which
+        is called at ``app.main`` lifespan. Subprocess callers (scripts,
+        test harnesses, custom entrypoints) that built ``Settings()``
+        without running ``validate_config`` got happy settings, served
+        ``/registry/orgs/*`` admin endpoints, and accepted the well-known
+        default string as a credential. The header path is
+        ``hmac.compare_digest(x_admin_secret, settings.admin_secret)`` —
+        trivial to forge once you know the secret is still the default.
+
+        Moving the refusal to construction-time is the authoritative
+        gate. ``validate_config`` keeps the same check as
+        defense-in-depth for code paths that mutate the field
+        post-construction.
+        """
+        if self.admin_secret == _INSECURE_DEFAULT_SECRET:
+            raise ValueError(
+                "ADMIN_SECRET is the insecure default "
+                f"'{_INSECURE_DEFAULT_SECRET}' — set ADMIN_SECRET in your "
+                ".env or environment before starting the broker "
+                "(audit F-B-5)."
+            )
+        return self
+
+
 _startup_logger = logging.getLogger("agent_trust.startup")
 
 

--- a/tests/test_secrets_hardening.py
+++ b/tests/test_secrets_hardening.py
@@ -253,3 +253,59 @@ def test_proxy_validate_config_dev_without_redis_no_warning(monkeypatch):
     proxy_validate_config(settings)
     messages = " ".join(warnings)
     assert "F-B-12" not in messages
+
+
+# ── F-B-5: reject ADMIN_SECRET default at Settings construction ────
+#
+# Previously the rejection lived only in validate_config, so a caller
+# that built ``Settings()`` without running validate_config (subprocess
+# tests, scripts, custom entrypoints) got happy settings carrying the
+# well-known insecure default — which ``_require_admin`` then accepted
+# via ``hmac.compare_digest``. Moving the refusal to a model_validator
+# makes every ``Settings()`` instance fail fast.
+
+def test_settings_rejects_insecure_default_admin_secret(monkeypatch):
+    """The default literal ``change-me-in-production`` must not be
+    accepted — ``Settings()`` raises at construction time, before
+    any lifespan hook (``validate_config``) is ever invoked."""
+    from app.config import _INSECURE_DEFAULT_SECRET
+    from pydantic import ValidationError
+
+    monkeypatch.setenv("ADMIN_SECRET", _INSECURE_DEFAULT_SECRET)
+    with pytest.raises(ValidationError) as excinfo:
+        Settings()
+    # Error message names the env var so operators know how to fix it.
+    assert "ADMIN_SECRET" in str(excinfo.value)
+    assert "F-B-5" in str(excinfo.value)
+
+
+def test_settings_rejects_default_even_when_kwarg_forced():
+    """Explicit kwarg override must also raise — not just .env reads.
+    Guards against a test harness that passes the default through
+    unintentionally."""
+    from app.config import _INSECURE_DEFAULT_SECRET
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        Settings(admin_secret=_INSECURE_DEFAULT_SECRET)
+
+
+def test_settings_accepts_any_non_default_admin_secret():
+    """Sanity: any string other than the sentinel is fine."""
+    settings = Settings(admin_secret="some-other-admin-secret-value")
+    assert settings.admin_secret == "some-other-admin-secret-value"
+
+
+def test_settings_rejects_default_regardless_of_environment(monkeypatch):
+    """The refusal is environment-independent. Dev mode does not unlock
+    the default — tests that genuinely need it must supply a
+    non-default value (the conftest autouses
+    ``ADMIN_SECRET=test-secret-not-default``)."""
+    from app.config import _INSECURE_DEFAULT_SECRET
+    from pydantic import ValidationError
+
+    monkeypatch.setenv("ADMIN_SECRET", _INSECURE_DEFAULT_SECRET)
+    for env in ("development", "production"):
+        monkeypatch.setenv("ENVIRONMENT", env)
+        with pytest.raises(ValidationError):
+            Settings()


### PR DESCRIPTION
## Summary

- Move the rejection of the default \`ADMIN_SECRET\` (\`change-me-in-production\`) from \`validate_config\` to a pydantic \`@model_validator\` on \`Settings\`. The broker now fails at construction time — before any lifespan hook, router, or subprocess bypass.
- Works regardless of environment: dev and prod both refuse. Tests that supply a non-default secret (every current caller) are unaffected.
- \`validate_config\` keeps the same checks as defense-in-depth for the rare case of post-construction mutation.

Closes audit finding **F-B-5** (High, \`imp/audit_2026_04_17/phase1_B_authz.md:240\`).

## The bypass

Before this PR the rejection lived only in \`validate_config\`, invoked from \`app/main.py\` lifespan. Any code path that constructed \`Settings()\` without going through \`validate_config\` got happy settings with the default in place:

- subprocess callers (one-off scripts, migration helpers)
- custom entrypoints that skip or mock the lifespan
- test harnesses that import \`Settings\` outside the broker app

The header auth path is \`hmac.compare_digest(x_admin_secret, settings.admin_secret)\` on every admin router (\`/registry/orgs\`, \`/onboarding\`, \`/policy\`). An attacker who knows the broker is still on the default — the literal string is a public sentinel — could then mint org records, push bindings, etc., with no further credential.

## The fix

\`\`\`python
@model_validator(mode=\"after\")
def _reject_insecure_default_admin_secret(self):
    if self.admin_secret == _INSECURE_DEFAULT_SECRET:
        raise ValueError(
            \"ADMIN_SECRET is the insecure default '\"
            f\"{_INSECURE_DEFAULT_SECRET}' — set ADMIN_SECRET in your \"
            \".env or environment before starting the broker \"
            \"(audit F-B-5).\"
        )
    return self
\`\`\`

pydantic wraps the \`ValueError\` in a \`ValidationError\` and raises it from \`Settings()\`. The \`@lru_cache get_settings()\` never gets to cache a bad value.

\`_INSECURE_DEFAULT_SECRET\` is lifted above the class definition so the validator can reference it as a module-level constant. \`_INSECURE_VAULT_TOKEN\` follows for consistency.

\`validate_config\` keeps the two identical-looking checks (prod branch at line 148 and dev branch at line 183 — each for its own environment). They are now defense-in-depth against post-construction mutation (BaseSettings is not frozen by default); a comment explains the duplication.

## Tests (4 new cases)

\`tests/test_secrets_hardening.py\`:

- \`test_settings_rejects_insecure_default_admin_secret\` — env \`ADMIN_SECRET\` set to the sentinel → \`Settings()\` raises \`ValidationError\` whose message carries both \`ADMIN_SECRET\` and \`F-B-5\` so operators can find the fix.
- \`test_settings_rejects_default_even_when_kwarg_forced\` — explicit kwarg with the sentinel also raises. Guards against a test harness passing the default through unintentionally.
- \`test_settings_accepts_any_non_default_admin_secret\` — sanity: any other string works.
- \`test_settings_rejects_default_regardless_of_environment\` — same refusal fires in both \`development\` and \`production\`. Dev mode does not unlock the default.

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1246 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_secrets_hardening.py -q\` — 18 passed (4 new + 14 pre-existing).
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.
- [x] Existing tests that build \`Settings(admin_secret=...)\` explicitly (test_secrets_hardening etc.) all supply non-default values — no fixture change needed.

## Follow-ups (out of scope, separate issues)

- **F-B-5 (b)**: \`admin_secret_version\` column + per-secret timestamps so an operator can rotate without a fresh deploy.
- **F-B-5 (c)**: hash \`ADMIN_SECRET\` on disk with bcrypt and compare against the hash rather than a raw string — the same shape as dashboard password hashing.