### PR TITLE
feat(mastio): dashboard federate toggle (ADR-010 Phase 5)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1244,6 +1244,49 @@ CULLIS_BROKER_URL={broker_url}
     )
 
 
+@router.post("/agents/{agent_id:path}/federate")
+async def agent_toggle_federate(request: Request, agent_id: str):
+    """ADR-010 Phase 5 — flip ``internal_agents.federated`` from the
+    dashboard. Bumps ``federation_revision`` so the publisher
+    (Phase 3) picks up the change on its next tick and either pushes
+    (0→1) or revokes (1→0) on the Court."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import get_agent, get_db, log_audit
+    from sqlalchemy import text as _text
+
+    agent = await get_agent(agent_id)
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    new_flag = not bool(agent.get("federated"))
+    async with get_db() as conn:
+        await conn.execute(
+            _text(
+                """
+                UPDATE internal_agents
+                   SET federated = :fed,
+                       federation_revision = federation_revision + 1
+                 WHERE agent_id = :aid
+                """
+            ),
+            {"fed": 1 if new_flag else 0, "aid": agent_id},
+        )
+
+    await log_audit(
+        agent_id=agent_id,
+        action="agent.federated_patched",
+        status="success",
+        detail=f"source=dashboard federated={new_flag}",
+    )
+
+    return RedirectResponse(url="/proxy/agents", status_code=303)
+
+
 @router.post("/agents/{agent_id:path}/deactivate")
 async def agent_deactivate(request: Request, agent_id: str):
     session = require_login(request)

--- a/mcp_proxy/dashboard/templates/agents.html
+++ b/mcp_proxy/dashboard/templates/agents.html
@@ -136,6 +136,7 @@
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Capabilities</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Certificate</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider" title="ADR-010: whether this agent is published to the Court (visible cross-org)">Federated</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Created</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
                 </tr>
@@ -182,6 +183,27 @@
                         </span>
                         {% endif %}
                     </td>
+                    <td class="px-5 py-4">
+                        {% if agent.federated is defined and agent.federated %}
+                        <form method="post" action="/proxy/agents/{{ agent.agent_id }}/federate" class="inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit"
+                                    class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-accent-400/10 text-accent-400 uppercase tracking-wider border border-accent-400/20 hover:bg-accent-400/20 transition-colors"
+                                    title="Click to unpublish from the Court. Revision r{{ agent.federation_revision|default('?') }}.">
+                                <span class="w-1.5 h-1.5 rounded-full bg-accent-400"></span>Federated
+                            </button>
+                        </form>
+                        {% else %}
+                        <form method="post" action="/proxy/agents/{{ agent.agent_id }}/federate" class="inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit"
+                                    class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-700/30 text-gray-500 uppercase tracking-wider border border-gray-700/50 hover:bg-gray-700/60 hover:text-gray-300 transition-colors"
+                                    title="Click to publish this agent to the Court (becomes visible cross-org).">
+                                <span class="w-1.5 h-1.5 rounded-full bg-gray-600"></span>Local only
+                            </button>
+                        </form>
+                        {% endif %}
+                    </td>
                     <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">{{ agent.created_at[:19] }}</td>
                     <td class="px-5 py-4">
                         <a href="/proxy/agents/{{ agent.agent_id }}"
@@ -193,7 +215,7 @@
                 {% endfor %}
                 {% if not agents %}
                 <tr>
-                    <td colspan="7" class="px-5 py-16 text-center">
+                    <td colspan="8" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                         <p class="text-sm text-gray-600">No agents registered</p>
                         <p class="text-xs text-gray-700 mt-1">Create an agent to get started with the MCP Proxy.</p>

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -383,7 +383,7 @@ async def set_config(key: str, value: str) -> None:
 
 def _agent_row_to_dict(row: RowMapping) -> dict:
     """Convert a RowMapping to a plain dict with parsed capabilities."""
-    return {
+    out = {
         "agent_id": row["agent_id"],
         "display_name": row["display_name"],
         "capabilities": json.loads(row["capabilities"]),
@@ -392,3 +392,13 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
         "created_at": row["created_at"],
         "is_active": bool(row["is_active"]),
     }
+    # ADR-010 Phase 2/5 — federation flags are optional at read time
+    # because legacy rows predating migration 0010 won't have them
+    # (tests sometimes insert raw rows too).
+    for key in ("federated", "federated_at", "federation_revision",
+                "last_pushed_revision"):
+        if key in row.keys():
+            out[key] = (
+                bool(row[key]) if key == "federated" else row[key]
+            )
+    return out

--- a/tests/test_dashboard_agents_federated.py
+++ b/tests/test_dashboard_agents_federated.py
@@ -1,0 +1,192 @@
+"""ADR-010 Phase 5 — dashboard /proxy/agents/{id}/federate toggle.
+
+Covers:
+  - POST flips the flag 0 → 1 and bumps federation_revision
+  - Second POST flips back 1 → 0 and bumps the revision again
+  - Unknown agent → 404
+  - Login required (303 to /login without session)
+  - CSRF required (403 without token)
+"""
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin(tmp_path, monkeypatch, org_id: str = "pd-org"):
+    db_file = tmp_path / "p.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _seed_agent(
+    agent_id: str = "pd-org::alice", federated: bool = False,
+) -> None:
+    """Minimal row insert — bypasses the admin API so we can exercise
+    just the dashboard flip without the cert-mint machinery."""
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO internal_agents (
+                    agent_id, display_name, capabilities, api_key_hash,
+                    cert_pem, created_at, is_active,
+                    federated, federation_revision, last_pushed_revision
+                ) VALUES (
+                    :aid, :name, :caps, :hash,
+                    NULL, :now, 1,
+                    :fed, 1, 0
+                )
+                """
+            ),
+            {
+                "aid": agent_id,
+                "name": agent_id.split("::", 1)[-1],
+                "caps": json.dumps([]),
+                "hash": "$2b$12$placeholder",
+                "now": "2026-04-17T00:00:00+00:00",
+                "fed": 1 if federated else 0,
+            },
+        )
+
+
+async def _login(cli: AsyncClient) -> None:
+    """Set admin password directly + submit login form."""
+    from mcp_proxy.dashboard.session import set_admin_password
+    await set_admin_password("test-password-1234")
+    r = await cli.post(
+        "/proxy/login",
+        data={"password": "test-password-1234"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+
+
+async def _csrf(cli: AsyncClient) -> str:
+    """Scrape CSRF token from the agents page."""
+    r = await cli.get("/proxy/agents")
+    assert r.status_code == 200, r.text
+    m = re.search(r'name="csrf_token" value="([^"]+)"', r.text)
+    assert m, "csrf_token not found in /proxy/agents page"
+    return m.group(1)
+
+
+async def _fetch_flags(agent_id: str) -> dict:
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                """
+                SELECT federated, federation_revision
+                  FROM internal_agents WHERE agent_id = :aid
+                """
+            ),
+            {"aid": agent_id},
+        )).mappings().first()
+        return dict(row) if row else {}
+
+
+# ── tests ──────────────────────────────────────────────────────────────
+
+async def test_toggle_flips_and_bumps_revision(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _seed_agent()
+            await _login(cli)
+            csrf = await _csrf(cli)
+
+            r = await cli.post(
+                "/proxy/agents/pd-org::alice/federate",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303, r.text
+
+            state = await _fetch_flags("pd-org::alice")
+            assert bool(state["federated"]) is True
+            assert int(state["federation_revision"]) == 2
+
+            r = await cli.post(
+                "/proxy/agents/pd-org::alice/federate",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            state = await _fetch_flags("pd-org::alice")
+            assert bool(state["federated"]) is False
+            assert int(state["federation_revision"]) == 3
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_toggle_unknown_agent_returns_404(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/agents/pd-org::ghost/federate",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 404
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_toggle_requires_login(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _seed_agent()
+            # No login — should redirect to /proxy/login.
+            r = await cli.post(
+                "/proxy/agents/pd-org::alice/federate",
+                follow_redirects=False,
+            )
+            assert r.status_code in (302, 303, 401, 403)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_toggle_requires_csrf(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _seed_agent()
+            await _login(cli)
+            # No csrf_token in body.
+            r = await cli.post(
+                "/proxy/agents/pd-org::alice/federate",
+                follow_redirects=False,
+            )
+            assert r.status_code == 403
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary

ADR-010 Phase 5 — operators can now flip the `federated` flag from the Mastio dashboard instead of hand-crafting `curl` against the admin API.

- New **Federated** column in `/proxy/agents` (two states: *Local only* / *Federated*, with revision hover)
- `POST /proxy/agents/{agent_id}/federate` — CSRF-protected, bumps `federation_revision` so the publisher loop (Phase 3) picks up the change within 30s and pushes/revokes on the Court
- `_agent_row_to_dict` exposes `federated`, `federated_at`, `federation_revision`, `last_pushed_revision` (guarded — legacy rows without the columns still work)

## How it composes with earlier phases

| Phase | PR | What it does |
|---|---|---|
| 1 | #184 | Court `/v1/federation/publish-agent` endpoint + verification |
| 2 | #186 | `internal_agents.federated` + admin API |
| 3 | #188 | Publisher loop (Mastio → Court push every 30s) |
| 4 | #191 | Sandbox bootstrap uses admin API + `federated=true` |
| **5** | **this PR** | **Dashboard UI for flipping the flag** |

Flip flow: operator clicks the *Local only* pill → dashboard endpoint bumps `federation_revision` → within 30s, `run_publisher` notices `federation_revision > last_pushed_revision` → counter-signs and POSTs to `/v1/federation/publish-agent` on the Court → pill turns green on refresh.

## Test plan

- [x] `pytest tests/test_dashboard_agents_federated.py -n 0 -v` — 4/4 pass
    - flip 0→1→0 bumps revision 1→2→3
    - unknown agent → 404
    - no session → 303 to `/proxy/login`
    - no CSRF → 403
- [x] `pytest tests/test_admin_agents.py tests/test_dashboard_agents_federated.py tests/test_proxy_dashboard_mcp_resources.py -n 0` — 32/32 pass (no regression in neighbouring code paths)

Pre-existing failures in `tests/test_ts_interop.py` + `tests/test_postgres_integration.py` are unrelated (TS interop xdist flake + Postgres env-dependent); they occur on `main` today.