### PR TITLE
feat(federation): Mastio pushes fleet stats → Court dashboard shows them

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -696,6 +696,19 @@ async def orgs_list(request: Request, db: AsyncSession = Depends(get_db)):
     org_list = []
     for org in orgs:
         sealed = bool(getattr(org, "sealed", False))
+        # Mastio-pushed fleet stats land in metadata_json["stats"] via
+        # POST /v1/federation/publish-stats (ADR-010 Phase 3 companion).
+        # Orgs that haven't pushed yet (or predate the publisher) render
+        # as dashes — never blank — so the operator can spot missing
+        # telemetry without mistaking it for a zero-agent fleet.
+        mastio_stats = None
+        try:
+            meta = org.extra  # parses metadata_json
+            raw_stats = meta.get("stats") if isinstance(meta, dict) else None
+            if isinstance(raw_stats, dict):
+                mastio_stats = raw_stats
+        except (ValueError, TypeError):
+            pass
         org_list.append({
             "org_id": org.org_id,
             "display_name": org.display_name,
@@ -703,6 +716,7 @@ async def orgs_list(request: Request, db: AsyncSession = Depends(get_db)):
             "webhook_url": org.webhook_url,
             "ca_certificate": org.ca_certificate,
             "agent_count": agent_counts.get(org.org_id, 0),
+            "mastio_stats": mastio_stats,
             "sealed": sealed,
             "reauth_active": (
                 sealed and active_session.has_reauth_scope(org.org_id)

--- a/app/dashboard/templates/orgs.html
+++ b/app/dashboard/templates/orgs.html
@@ -178,6 +178,7 @@
                         </a>
                     </th>
                     <th class="px-5 py-2.5 text-right mono text-[10px] font-medium text-white/40 uppercase tracking-wider">Agents</th>
+                    <th class="px-5 py-2.5 text-left mono text-[10px] font-medium text-white/40 uppercase tracking-wider" title="Pushed by the Mastio every few minutes. Dashes mean the Mastio hasn't reported yet.">Mastio Stats</th>
                     <th class="px-5 py-2.5 text-left mono text-[10px] font-medium text-white/40 uppercase tracking-wider">PDP Webhook</th>
                     <th class="px-5 py-2.5 text-left mono text-[10px] font-medium text-white/40 uppercase tracking-wider">CA</th>
                     <th class="px-5 py-2.5 text-right mono text-[10px] font-medium text-white/40 uppercase tracking-wider">Actions</th>
@@ -211,6 +212,26 @@
                         </div>
                     </td>
                     <td class="px-5 py-3 text-right mono text-[13px] text-white/80 tnum">{{ org.agent_count }}</td>
+                    <td class="px-5 py-3">
+                        {% if org.mastio_stats %}
+                        <div class="flex items-baseline gap-2">
+                            <span class="mono text-[13px] text-white/85 tnum">{{ org.mastio_stats.agent_active_count }}</span>
+                            <span class="mono text-[11px] text-white/40 tnum">/ {{ org.mastio_stats.agent_total_count }}</span>
+                            <span class="mono text-[10px] uppercase tracking-wider text-white/35">active</span>
+                        </div>
+                        <div class="flex items-baseline gap-2 mt-0.5">
+                            <span class="mono text-[13px] text-[#00e5c7]/85 tnum">{{ org.mastio_stats.backend_count }}</span>
+                            <span class="mono text-[10px] uppercase tracking-wider text-white/35">backends</span>
+                        </div>
+                        {% if org.mastio_stats.updated_at %}
+                        <div class="mono text-[9px] text-white/25 mt-0.5" title="Last snapshot pushed by the Mastio">
+                            {{ org.mastio_stats.updated_at[:19] }}
+                        </div>
+                        {% endif %}
+                        {% else %}
+                        <span class="mono text-[10px] text-white/25">— awaiting Mastio</span>
+                        {% endif %}
+                    </td>
                     <td class="px-5 py-3">
                         {% if org.webhook_url %}
                         <span class="mono text-[11px] text-white/65 truncate block max-w-[200px]" title="{{ org.webhook_url }}">{{ org.webhook_url }}</span>

--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime, timezone
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -254,3 +255,112 @@ async def publish_agent(
         status="updated",
         cert_thumbprint=thumbprint,
     )
+
+
+# ── /publish-stats ──────────────────────────────────────────────────────────
+#
+# Fire-and-forget aggregate stats so the Court dashboard can show per-org
+# fleet size without knowing individual agents. Separate from /publish-agent
+# because it has no idempotency tracking (no per-row revision) and is pushed
+# on a looser cadence (minutes, not seconds). Re-uses the same counter-sig
+# auth pattern so Mastio identity is still pinned.
+
+
+class PublishStatsRequest(BaseModel):
+    org_id: str = Field(..., pattern=r"^[a-z0-9][a-z0-9._-]{0,127}$")
+    agent_active_count: int = Field(..., ge=0)
+    agent_total_count: int = Field(..., ge=0)
+    backend_count: int = Field(..., ge=0)
+
+
+class PublishStatsResponse(BaseModel):
+    org_id: str
+    stored_at: str
+
+
+@router.post(
+    "/publish-stats",
+    response_model=PublishStatsResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def publish_stats(
+    request: Request,
+    body: PublishStatsRequest,
+    mastio_signature: str | None = Header(
+        default=None, alias=COUNTERSIG_HEADER,
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> PublishStatsResponse:
+    """Mastio pushes aggregate counters for its org to the Court.
+
+    Stored under ``organizations.metadata_json["stats"]`` — no schema
+    migration, the metadata column is already JSON. Overwrites the prior
+    snapshot on every push (stats are point-in-time, not append-only).
+
+    Auth mirrors publish-agent: counter-signature against the pinned
+    ``mastio_pubkey``. Unknown orgs return 404; orgs without a pinned
+    pubkey return 403 so an operator who forgot onboarding step 2 gets
+    a clear message instead of a silent no-op.
+    """
+    org = await get_org_by_id(db, body.org_id)
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="organization not found",
+        )
+    if not org.mastio_pubkey:
+        await log_event(
+            db, "federation.stats_rejected", "denied",
+            org_id=body.org_id,
+            details={"reason": "mastio_pubkey_not_pinned"},
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="organization has no pinned mastio_pubkey",
+        )
+
+    raw = await request.body()
+    try:
+        verify_mastio_countersig(
+            client_assertion=raw.decode(),
+            signature_b64=mastio_signature,
+            mastio_pubkey_pem=org.mastio_pubkey,
+        )
+    except HTTPException:
+        await log_event(
+            db, "federation.stats_rejected", "denied",
+            org_id=body.org_id,
+            details={"reason": "countersig_invalid"},
+        )
+        raise
+
+    stored_at = datetime.now(timezone.utc).isoformat()
+    # Read–modify–write on metadata_json. OrganizationRecord.extra is a
+    # computed property, so we parse the text, set the "stats" sub-key,
+    # then serialize back. Invalid JSON in an existing row is recovered to
+    # an empty dict rather than failing the push.
+    try:
+        meta = json.loads(org.metadata_json or "{}")
+        if not isinstance(meta, dict):
+            meta = {}
+    except (TypeError, ValueError):
+        meta = {}
+    meta["stats"] = {
+        "agent_active_count": body.agent_active_count,
+        "agent_total_count": body.agent_total_count,
+        "backend_count": body.backend_count,
+        "updated_at": stored_at,
+    }
+    org.metadata_json = json.dumps(meta)
+    await db.commit()
+
+    await log_event(
+        db, "federation.stats_published", "ok",
+        org_id=body.org_id,
+        details={
+            "agent_active": body.agent_active_count,
+            "agent_total": body.agent_total_count,
+            "backends": body.backend_count,
+        },
+    )
+    return PublishStatsResponse(org_id=body.org_id, stored_at=stored_at)

--- a/mcp_proxy/federation/publisher.py
+++ b/mcp_proxy/federation/publisher.py
@@ -42,6 +42,11 @@ _log = logging.getLogger("mcp_proxy.federation.publisher")
 POLL_INTERVAL_S = 30.0
 HTTP_TIMEOUT_S = 10.0
 
+# Aggregate-stats push is less time-critical than per-agent revisions
+# (the Court dashboard tolerates a few minutes of staleness), so the
+# stats loop runs an order of magnitude slower than the agent loop.
+STATS_INTERVAL_S = 300.0
+
 
 async def _fetch_pending(conn) -> list[dict]:
     """Rows that need a push on this tick."""
@@ -177,3 +182,98 @@ async def run_publisher(app_state, *, stop_event: asyncio.Event) -> None:
                 continue
     finally:
         _log.info("federation publisher stopped")
+
+
+# ── Aggregate stats publisher ───────────────────────────────────────────────
+#
+# Fire-and-forget snapshot: count active/total internal agents and enabled
+# backends, POST to POST /v1/federation/publish-stats. No idempotency state
+# — every tick overwrites the Court-side snapshot. Standalone proxies skip.
+
+
+async def _collect_stats(conn, *, org_id: str) -> dict:
+    """Read the three counters off the Mastio DB."""
+    agent_rows = (await conn.execute(
+        text(
+            "SELECT COUNT(*) AS total, "
+            "SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS active "
+            "FROM internal_agents"
+        ),
+    )).mappings().first()
+    backend_row = (await conn.execute(
+        text(
+            "SELECT COUNT(*) AS total "
+            "FROM local_mcp_resources WHERE enabled = 1"
+        ),
+    )).mappings().first()
+    return {
+        "org_id": org_id,
+        "agent_active_count": int((agent_rows or {}).get("active") or 0),
+        "agent_total_count": int((agent_rows or {}).get("total") or 0),
+        "backend_count": int((backend_row or {}).get("total") or 0),
+    }
+
+
+async def _publish_stats_once(app_state) -> bool:
+    """One stats push. Returns True on 2xx, False otherwise."""
+    broker_url = getattr(app_state, "reverse_proxy_broker_url", None)
+    mgr = getattr(app_state, "agent_manager", None)
+    http = getattr(app_state, "reverse_proxy_client", None)
+    org_id = getattr(app_state, "org_id", None) or ""
+
+    if not broker_url or mgr is None or http is None or not org_id:
+        return False
+    if not getattr(mgr, "mastio_loaded", False):
+        return False
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        payload = await _collect_stats(conn, org_id=org_id)
+
+    body = json.dumps(payload).encode()
+    signature = mgr.countersign(body)
+    url = f"{broker_url.rstrip('/')}/v1/federation/publish-stats"
+    try:
+        resp = await http.post(
+            url,
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Cullis-Mastio-Signature": signature,
+            },
+            timeout=HTTP_TIMEOUT_S,
+        )
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        _log.warning("federation stats: Court unreachable (%s) — will retry", exc)
+        return False
+
+    if resp.is_success:
+        _log.info(
+            "federation stats OK org=%s active=%d total=%d backends=%d",
+            payload["org_id"], payload["agent_active_count"],
+            payload["agent_total_count"], payload["backend_count"],
+        )
+        return True
+    _log.warning(
+        "federation stats → HTTP %d: %s",
+        resp.status_code, resp.text[:200],
+    )
+    return False
+
+
+async def run_stats_publisher(app_state, *, stop_event: asyncio.Event) -> None:
+    """Stats loop — independent of the agent publisher so a slow stats
+    push doesn't delay agent revisions. Exits when ``stop_event`` is set."""
+    _log.info("federation stats publisher started (poll=%.1fs)", STATS_INTERVAL_S)
+    try:
+        while not stop_event.is_set():
+            try:
+                await _publish_stats_once(app_state)
+            except Exception as exc:
+                _log.exception("federation stats tick failed: %s", exc)
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=STATS_INTERVAL_S)
+            except asyncio.TimeoutError:
+                continue
+    finally:
+        _log.info("federation stats publisher stopped")

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -273,7 +273,7 @@ async def lifespan(app: FastAPI):
     # is loaded (pubkey pinned at the Court so counter-sig verification
     # succeeds). Standalone proxies skip entirely.
     if broker_url and getattr(agent_mgr, "mastio_loaded", False):
-        from mcp_proxy.federation.publisher import run_publisher
+        from mcp_proxy.federation.publisher import run_publisher, run_stats_publisher
         pub_stop = asyncio.Event()
         pub_task = asyncio.create_task(
             run_publisher(app.state, stop_event=pub_stop),
@@ -282,6 +282,18 @@ async def lifespan(app: FastAPI):
         app.state.federation_publisher_stop = pub_stop
         app.state.federation_publisher_task = pub_task
         _log.info("federation publisher started (org=%s)", org_id)
+
+        # Aggregate-stats publisher — fleet-size counters for the Court
+        # dashboard. Separate task so a slow stats push never delays the
+        # per-agent revision loop above.
+        stats_stop = asyncio.Event()
+        stats_task = asyncio.create_task(
+            run_stats_publisher(app.state, stop_event=stats_stop),
+            name="federation_stats_publisher",
+        )
+        app.state.federation_stats_stop = stats_stop
+        app.state.federation_stats_task = stats_task
+        _log.info("federation stats publisher started (org=%s)", org_id)
 
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
@@ -316,6 +328,20 @@ async def lifespan(app: FastAPI):
             sub_task.cancel()
             try:
                 await sub_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    stats_stop = getattr(app.state, "federation_stats_stop", None)
+    stats_task = getattr(app.state, "federation_stats_task", None)
+    if stats_stop is not None:
+        stats_stop.set()
+    if stats_task is not None:
+        try:
+            await asyncio.wait_for(stats_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            stats_task.cancel()
+            try:
+                await stats_task
             except (asyncio.CancelledError, Exception):
                 pass
 

--- a/tests/test_federation_publish_stats.py
+++ b/tests/test_federation_publish_stats.py
@@ -1,0 +1,271 @@
+"""Fase B — Court ``POST /v1/federation/publish-stats`` endpoint.
+
+The Mastio pushes aggregate fleet counters (active agents, total agents,
+enabled backends) so the Court dashboard can render per-org telemetry
+without knowing individual agents. Auth mirrors publish-agent: ADR-009
+counter-signature against the pinned ``mastio_pubkey``.
+
+Covers:
+  - Happy path: pinned pubkey + valid counter-sig → metadata_json["stats"]
+    is populated with the counters + updated_at timestamp
+  - Re-push overwrites the prior snapshot (last-writer-wins)
+  - Missing or wrong counter-sig → 403 + audit
+  - Unknown org → 404
+  - Org without pinned mastio_pubkey → 403 + audit
+  - Payload validation: negative counts rejected by pydantic
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.mastio_strict]
+
+
+def _gen_mastio_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _sign(priv: ec.EllipticCurvePrivateKey, data: bytes) -> str:
+    sig = priv.sign(data, ec.ECDSA(hashes.SHA256()))
+    return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+async def _onboard_org_with_mastio(
+    client: AsyncClient, org_id: str, mastio_pubkey_pem: str | None,
+) -> None:
+    """Create an org + pin the mastio pubkey (skipped if None).
+
+    Stats don't need the CA attached — they never reference a cert chain.
+    Keep the onboarding minimal so tests focus on the endpoint behavior.
+    """
+    org_secret = f"{org_id}-secret"
+    r = await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    assert r.status_code in (201, 409), r.text
+    if mastio_pubkey_pem is not None:
+        from app.db.database import AsyncSessionLocal
+        from app.registry.org_store import update_org_mastio_pubkey
+        async with AsyncSessionLocal() as db:
+            await update_org_mastio_pubkey(db, org_id, mastio_pubkey_pem)
+
+
+async def _fetch_stats(org_id: str) -> dict | None:
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import get_org_by_id
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        if org is None:
+            return None
+        meta = json.loads(org.metadata_json or "{}")
+        return meta.get("stats")
+
+
+# ── happy path ─────────────────────────────────────────────────────────
+
+
+async def test_publish_stats_stores_counters(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "stats-ok"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    body = {
+        "org_id": org_id,
+        "agent_active_count": 7,
+        "agent_total_count": 10,
+        "backend_count": 3,
+    }
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 200, r.text
+    payload = r.json()
+    assert payload["org_id"] == org_id
+    assert payload["stored_at"]
+
+    stats = await _fetch_stats(org_id)
+    assert stats is not None
+    assert stats["agent_active_count"] == 7
+    assert stats["agent_total_count"] == 10
+    assert stats["backend_count"] == 3
+    assert stats["updated_at"] == payload["stored_at"]
+
+
+async def test_publish_stats_overwrites_prior_snapshot(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "stats-overwrite"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    async def _push(active: int, total: int, backends: int) -> str:
+        body = {
+            "org_id": org_id, "agent_active_count": active,
+            "agent_total_count": total, "backend_count": backends,
+        }
+        raw = json.dumps(body).encode()
+        r = await client.post(
+            "/v1/federation/publish-stats",
+            content=raw,
+            headers={"Content-Type": "application/json",
+                     "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+        )
+        assert r.status_code == 200, r.text
+        return r.json()["stored_at"]
+
+    first_ts = await _push(1, 1, 0)
+    second_ts = await _push(5, 8, 2)
+
+    stats = await _fetch_stats(org_id)
+    assert stats["agent_active_count"] == 5
+    assert stats["agent_total_count"] == 8
+    assert stats["backend_count"] == 2
+    # Overwrite — only the latest push is kept.
+    assert stats["updated_at"] == second_ts
+    assert first_ts != second_ts
+
+
+async def test_publish_stats_preserves_unrelated_metadata(client: AsyncClient):
+    """Injecting ``stats`` must not wipe out other metadata_json keys."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "stats-preserve"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    # Seed an unrelated key the Court cares about.
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import get_org_by_id
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        org.metadata_json = json.dumps({"custom_tag": "keep-me"})
+        await db.commit()
+
+    body = {
+        "org_id": org_id, "agent_active_count": 2,
+        "agent_total_count": 2, "backend_count": 1,
+    }
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 200, r.text
+
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        meta = json.loads(org.metadata_json)
+    assert meta["custom_tag"] == "keep-me"
+    assert meta["stats"]["agent_active_count"] == 2
+
+
+# ── auth failures ──────────────────────────────────────────────────────
+
+
+async def test_publish_stats_missing_signature_rejected(client: AsyncClient):
+    _, pub = _gen_mastio_keypair()
+    org_id = "stats-no-sig"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    body = {"org_id": org_id, "agent_active_count": 1,
+            "agent_total_count": 1, "backend_count": 0}
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=json.dumps(body),
+        headers={"Content-Type": "application/json"},
+    )
+    # verify_mastio_countersig raises 403 when header is absent.
+    assert r.status_code == 403, r.text
+    assert await _fetch_stats(org_id) is None
+
+
+async def test_publish_stats_wrong_signature_rejected(client: AsyncClient):
+    _, pinned_pub = _gen_mastio_keypair()
+    attacker_priv, _ = _gen_mastio_keypair()
+    org_id = "stats-bad-sig"
+    await _onboard_org_with_mastio(client, org_id, pinned_pub)
+
+    body = {"org_id": org_id, "agent_active_count": 1,
+            "agent_total_count": 1, "backend_count": 0}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(attacker_priv, raw)},
+    )
+    assert r.status_code == 403, r.text
+    assert await _fetch_stats(org_id) is None
+
+
+# ── org lookup failures ────────────────────────────────────────────────
+
+
+async def test_publish_stats_unknown_org_404(client: AsyncClient):
+    priv, _ = _gen_mastio_keypair()
+    body = {"org_id": "ghost-org", "agent_active_count": 0,
+            "agent_total_count": 0, "backend_count": 0}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 404, r.text
+
+
+async def test_publish_stats_unpinned_mastio_pubkey_403(client: AsyncClient):
+    priv, _ = _gen_mastio_keypair()
+    org_id = "stats-unpinned"
+    # Create the org but DON'T pin the pubkey — onboarding is incomplete.
+    await _onboard_org_with_mastio(client, org_id, mastio_pubkey_pem=None)
+
+    body = {"org_id": org_id, "agent_active_count": 0,
+            "agent_total_count": 0, "backend_count": 0}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 403, r.text
+    assert "mastio_pubkey" in r.json()["detail"]
+
+
+# ── payload validation ─────────────────────────────────────────────────
+
+
+async def test_publish_stats_negative_count_rejected(client: AsyncClient):
+    priv, pub = _gen_mastio_keypair()
+    org_id = "stats-negative"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    body = {"org_id": org_id, "agent_active_count": -1,
+            "agent_total_count": 0, "backend_count": 0}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/publish-stats",
+        content=raw,
+        headers={"Content-Type": "application/json",
+                 "X-Cullis-Mastio-Signature": _sign(priv, raw)},
+    )
+    assert r.status_code == 422, r.text

--- a/tests/test_federation_publisher.py
+++ b/tests/test_federation_publisher.py
@@ -18,7 +18,7 @@ import pytest
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from mcp_proxy.federation.publisher import _tick
+from mcp_proxy.federation.publisher import _collect_stats, _publish_stats_once, _tick
 
 
 pytestmark = pytest.mark.asyncio
@@ -233,6 +233,155 @@ async def test_standalone_is_noop(tmp_path, monkeypatch):
         state = _AppState(_NoMgr(), "", cli)
         acked = await _tick(state)
     assert acked == 0
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── stats publisher ────────────────────────────────────────────────────
+
+
+async def _seed_backend(enabled: int, name: str = "b1") -> None:
+    """Insert a ``local_mcp_resources`` row used by _collect_stats."""
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    import uuid
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_mcp_resources (
+                    resource_id, org_id, name, endpoint_url,
+                    auth_type, allowed_domains, enabled,
+                    created_at, updated_at
+                ) VALUES (
+                    :rid, :org, :name, 'http://svc:8080',
+                    'none', '[]', :enabled,
+                    '2026-04-17T00:00:00+00:00', '2026-04-17T00:00:00+00:00'
+                )
+                """
+            ),
+            {
+                "rid": str(uuid.uuid4()), "org": "orga",
+                "name": name, "enabled": enabled,
+            },
+        )
+
+
+class _AppStateStats(_AppState):
+    def __init__(self, mgr, broker_url, client, org_id):
+        super().__init__(mgr, broker_url, client)
+        self.org_id = org_id
+
+
+async def test_collect_stats_counts_agents_and_enabled_backends(
+    tmp_path, monkeypatch,
+):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::a1", "is_active": True},
+        {"agent_id": "orga::a2", "is_active": True},
+        {"agent_id": "orga::a3", "is_active": False},
+    ])
+    await _seed_backend(enabled=1, name="postgres")
+    await _seed_backend(enabled=1, name="github")
+    await _seed_backend(enabled=0, name="disabled")
+
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        stats = await _collect_stats(conn, org_id="orga")
+
+    assert stats == {
+        "org_id": "orga",
+        "agent_active_count": 2,
+        "agent_total_count": 3,
+        "backend_count": 2,  # disabled row excluded
+    }
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_publish_stats_once_sends_signed_payload(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::a1", "is_active": True},
+    ])
+    await _seed_backend(enabled=1)
+
+    captured: dict = {}
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        captured["url"] = str(req.url)
+        captured["sig"] = req.headers.get("x-cullis-mastio-signature")
+        captured["body"] = json.loads(req.content)
+        return httpx.Response(200, json={
+            "org_id": "orga", "stored_at": "2026-04-17T12:00:00+00:00",
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppStateStats(_FakeMgr(), "http://broker", cli, "orga")
+        ok = await _publish_stats_once(state)
+
+    assert ok is True
+    assert captured["url"] == "http://broker/v1/federation/publish-stats"
+    assert captured["sig"]  # non-empty counter-sig header
+    assert captured["body"] == {
+        "org_id": "orga",
+        "agent_active_count": 1,
+        "agent_total_count": 1,
+        "backend_count": 1,
+    }
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_publish_stats_once_skips_when_standalone(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::a1", "is_active": True},
+    ])
+
+    class _NoMgr:
+        mastio_loaded = False
+
+    async with httpx.AsyncClient() as cli:
+        state = _AppStateStats(_NoMgr(), "", cli, "orga")
+        assert await _publish_stats_once(state) is False
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_publish_stats_once_returns_false_on_5xx(tmp_path, monkeypatch):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::a1", "is_active": True},
+    ])
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="overloaded")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppStateStats(_FakeMgr(), "http://broker", cli, "orga")
+        ok = await _publish_stats_once(state)
+    assert ok is False
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_publish_stats_once_survives_connection_error(
+    tmp_path, monkeypatch,
+):
+    await _seed_agents(tmp_path, monkeypatch, [
+        {"agent_id": "orga::a1", "is_active": True},
+    ])
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("broker down")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppStateStats(_FakeMgr(), "http://broker", cli, "orga")
+        ok = await _publish_stats_once(state)
+    assert ok is False
 
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- **Court** — nuovo endpoint ``POST /v1/federation/publish-stats`` (stesso counter-sig di publish-agent). Upsert di ``organizations.metadata_json[\"stats\"]``, niente migration.
- **Mastio** — secondo loop in ``mcp_proxy/federation/publisher.py`` (``run_stats_publisher``, cadenza 5min) che aggrega ``internal_agents`` (active/total) + ``local_mcp_resources`` (enabled) e li pusha fire-and-forget. Lifespan start/stop accanto al publisher di ADR-010 Phase 3.
- **Dashboard Court** — ``/dashboard/orgs`` guadagna colonna "Mastio Stats" con ``X/Y active`` + ``Z backends`` + timestamp del push. Org senza telemetria mostrano "— awaiting Mastio", non 0/0/0 (così l'admin non confonde dato mancante con fleet vuota).
- Standalone Mastios skip entirely (stesso gate del publisher esistente).

## Test plan
- [x] ``pytest tests/ -n auto --dist=loadfile`` — 1255 pass / 6 skip (esclusi ``test_ts_interop`` + ``test_postgres_integration`` preesistenti non toccati)
- [x] ``./demo_network/smoke.sh full`` PASS (message round-trip + dashboard session + hash chain + MCP forward)
- [ ] Shake-out manuale: bootstrap sandbox full, aspettare un tick del publisher (~5min) o forzare un tick via SIGUSR1/restart, verificare colonna Mastio Stats su ``/dashboard/orgs`` del Court

## Note di design
- Fire-and-forget, no state-tracking: stats sono point-in-time (snapshot), non append-only. L'ultimo push vince.
- Loop separato dal publisher di agent records: latenza stats (minuti) non ha niente a che fare con latenza revoche cert (secondi).
- ``metadata_json`` è già JSON-backed e già usato per chiavi flessibili — zero schema migration.