### PR TITLE
feat(mastio): drop local_agents doppione (ADR-010 Phase 6b)

### DIFF
--- a/demo_network/standalone_smoke.sh
+++ b/demo_network/standalone_smoke.sh
@@ -38,43 +38,22 @@ seed_agent() {
     local agent_id="$1"
 
     # generate_api_key returns "sk_local_<agent>_<32hex>" — the only
-    # format get_agent_from_api_key accepts. We mint the key + seed
-    # BOTH tables in one python call so the raw key never hits the
-    # shell's argv:
-    #   - internal_agents:  auth surface (X-API-Key verifies here)
-    #   - local_agents:     discovery surface (/v1/agents/search reads here)
+    # format get_agent_from_api_key accepts. ADR-010 Phase 6b: the
+    # Mastio's sole agent registry is ``internal_agents`` — auth
+    # (X-API-Key) and discovery (/v1/agents/search) both read from it.
     $COMPOSE exec -T proxy python -c "
-import asyncio, json, os
-from datetime import datetime, timezone
-from sqlalchemy import text
+import asyncio, os
 from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
-from mcp_proxy.db import create_agent, get_db, init_db
+from mcp_proxy.db import create_agent, init_db
 async def main():
     raw = generate_api_key('$agent_id')
     await init_db(os.environ['MCP_PROXY_DATABASE_URL'])
-    api_hash = hash_api_key(raw)
     await create_agent(
         agent_id='$agent_id',
         display_name='$agent_id',
         capabilities=['cap.read','cap.write'],
-        api_key_hash=api_hash,
+        api_key_hash=hash_api_key(raw),
     )
-    async with get_db() as conn:
-        await conn.execute(text(\"\"\"
-            INSERT INTO local_agents (
-                agent_id, org_id, display_name, capabilities, cert_pem,
-                cert_thumbprint, api_key_hash, scope, metadata_json,
-                created_at, is_active
-            ) VALUES (
-                :aid, 'acme', :aid, :caps, NULL, NULL, :hash, 'local', '{}',
-                :ts, 1
-            )
-        \"\"\"), {
-            'aid': '$agent_id',
-            'caps': json.dumps(['cap.read','cap.write']),
-            'hash': api_hash,
-            'ts': datetime.now(timezone.utc).isoformat(),
-        })
     print(raw, end='')
 asyncio.run(main())
 "

--- a/mcp_proxy/agents/router.py
+++ b/mcp_proxy/agents/router.py
@@ -7,7 +7,7 @@ proxy already owns the canonical view of local agents + cached federated
 agents, so it can answer without touching the broker.
 
 Search semantics:
-  - ``scope=local`` returns only local_agents rows (always available).
+  - ``scope=local`` returns only ``internal_agents`` rows (always available).
   - ``scope=federated`` returns only cached_federated_agents rows.
   - No scope filter returns the union. On ``agent_id`` collision between
     the two tables, the local row wins — standalone trumps cached
@@ -33,7 +33,7 @@ from pydantic import BaseModel
 from sqlalchemy import text
 
 from mcp_proxy.auth.api_key import get_agent_from_api_key
-from mcp_proxy.db import get_db
+from mcp_proxy.db import cert_thumbprint_from_pem, get_db
 from mcp_proxy.models import InternalAgent
 
 _log = logging.getLogger("mcp_proxy.agents.router")
@@ -89,9 +89,9 @@ async def _search_local(
         rows = await conn.execute(
             text(
                 """
-                SELECT agent_id, display_name, org_id, capabilities,
-                       cert_thumbprint, is_active
-                  FROM local_agents
+                SELECT agent_id, display_name, capabilities,
+                       cert_pem, is_active
+                  FROM internal_agents
                  WHERE :active_only = 0 OR is_active = 1
                 """
             ),
@@ -103,14 +103,20 @@ async def _search_local(
             haystack = f"{row['agent_id']} {row['display_name'] or ''}"
             if not _matches_filters(caps_list, caps, haystack, q):
                 continue
+            # ADR-010 Phase 6b: ``internal_agents`` doesn't persist org_id
+            # or a thumbprint column — derive both on the fly so the
+            # response shape matches what the dropped ``local_agents``
+            # table used to serve.
+            agent_id = row["agent_id"]
+            org_id = agent_id.split("::", 1)[0] if "::" in agent_id else None
             out.append(AgentSummary(
-                agent_id=row["agent_id"],
+                agent_id=agent_id,
                 display_name=row["display_name"],
-                org_id=row["org_id"],
+                org_id=org_id,
                 capabilities=caps_list,
                 scope="local",
                 active=bool(row["is_active"]),
-                cert_thumbprint=row["cert_thumbprint"],
+                cert_thumbprint=cert_thumbprint_from_pem(row["cert_pem"]),
             ))
         return out
 

--- a/mcp_proxy/alembic/versions/0012_drop_local_agents.py
+++ b/mcp_proxy/alembic/versions/0012_drop_local_agents.py
@@ -1,0 +1,57 @@
+"""ADR-010 Phase 6b — drop ``local_agents`` (doppione of ``internal_agents``).
+
+Revision ID: 0012_drop_local_agents
+Revises: 0011_last_pushed_revision
+Create Date: 2026-04-17 22:00:00.000000
+
+``local_agents`` was introduced in 0002 as the proxy's local-scope agent
+registry (ADR-006 §2.4). ADR-010 makes ``internal_agents`` the sole
+Mastio-authoritative registry, so the two tables overlap entirely. The
+four production paths that read from ``local_agents`` are migrated to
+``internal_agents``; callers that needed ``cert_thumbprint`` or
+``org_id`` derive them on-the-fly (SHA-256 of cert DER / split of
+``agent_id`` prefix).
+
+The downgrade recreates the post-0005 schema so rolling back past this
+migration lands on a coherent shape.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0012_drop_local_agents"
+down_revision: Union[str, Sequence[str], None] = "0011_last_pushed_revision"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Indexes first — SQLite is forgiving, Postgres is not.
+    op.drop_index("idx_local_agents_thumbprint", table_name="local_agents")
+    op.drop_index("idx_local_agents_org", table_name="local_agents")
+    op.drop_table("local_agents")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "local_agents",
+        sa.Column("agent_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("display_name", sa.Text(), nullable=False),
+        sa.Column("capabilities", sa.Text(), nullable=False, server_default="[]"),
+        sa.Column("cert_pem", sa.Text(), nullable=True),
+        sa.Column("api_key_hash", sa.Text(), nullable=True),
+        sa.Column("scope", sa.Text(), nullable=False, server_default="local"),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("is_active", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("org_id", sa.Text(), nullable=True),
+        sa.Column("cert_thumbprint", sa.Text(), nullable=True),
+        sa.Column(
+            "metadata_json", sa.Text(), nullable=False, server_default="{}",
+        ),
+    )
+    op.create_index("idx_local_agents_org", "local_agents", ["org_id"])
+    op.create_index(
+        "idx_local_agents_thumbprint", "local_agents", ["cert_thumbprint"],
+    )

--- a/mcp_proxy/dashboard/mcp_resources.py
+++ b/mcp_proxy/dashboard/mcp_resources.py
@@ -175,16 +175,13 @@ async def _list_bindings_by_resource() -> dict[str, list[dict]]:
 
 
 async def _list_bindable_agents() -> list[dict]:
-    """UNION of internal_agents + local_agents active, for the binding dropdown."""
+    """Active agents available for the MCP binding dropdown."""
     async with get_db() as conn:
         rows = (await conn.execute(
             text(
                 """
                 SELECT agent_id, display_name, 'internal' AS source
                   FROM internal_agents WHERE is_active = 1
-                UNION ALL
-                SELECT agent_id, display_name, 'local' AS source
-                  FROM local_agents WHERE is_active = 1
                  ORDER BY agent_id
                 """
             )

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -381,6 +381,26 @@ async def set_config(key: str, value: str) -> None:
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
+def cert_thumbprint_from_pem(pem: str | None) -> str | None:
+    """SHA-256 hex of a cert's DER encoding.
+
+    ADR-010 Phase 6b — ``internal_agents`` does not persist a thumbprint
+    column, so callers that need one (``/public-key``, discovery search)
+    derive it on-the-fly from ``cert_pem``.
+    """
+    if not pem:
+        return None
+    import base64
+    import hashlib
+    import re as _re
+
+    try:
+        der = base64.b64decode(_re.sub(r"-----.*?-----|\s", "", pem))
+    except (ValueError, TypeError):
+        return None
+    return hashlib.sha256(der).hexdigest()
+
+
 def _agent_row_to_dict(row: RowMapping) -> dict:
     """Convert a RowMapping to a plain dict with parsed capabilities."""
     out = {

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -8,8 +8,10 @@ no accidental cross-imports.
 Tables grouped in two families:
   - Legacy (Phase 0): internal_agents, audit_log, proxy_config. Already
     populated on live deployments.
-  - Local-* (Phase 1 ADR-001): local_agents, local_sessions, local_messages,
+  - Local-* (Phase 1 ADR-001): local_sessions, local_messages,
     local_policies, local_audit. Created empty here; wiring lands Phase 4.
+    ``local_agents`` was dropped in ADR-010 Phase 6b — ``internal_agents``
+    is now the sole Mastio-authoritative registry.
 
 Column types picked to render identically on SQLite and PostgreSQL. Integer
 primary keys use plain Integer + primary_key=True — SQLAlchemy picks SERIAL
@@ -121,32 +123,6 @@ class PendingEnrollment(Base):
 # Minimal forward-compatible columns. Each table exists so that Phase 4 work
 # can assume the schema is already deployed, without requiring another
 # migration round-trip on live proxies.
-
-
-class LocalAgent(Base):
-    """Agents with scope=local. Owned by the proxy, broker never sees them.
-
-    Schema aligned with broker ``registry.agents`` (ADR-006 Fase 0) so a row
-    can be exported / promoted to federated visibility without field mapping.
-    """
-    __tablename__ = "local_agents"
-
-    agent_id = Column(Text, primary_key=True)
-    org_id = Column(Text, nullable=True)
-    display_name = Column(Text, nullable=False)
-    capabilities = Column(Text, nullable=False, server_default="[]")  # JSON array
-    cert_pem = Column(Text, nullable=True)
-    cert_thumbprint = Column(Text, nullable=True)
-    api_key_hash = Column(Text, nullable=True)
-    scope = Column(Text, nullable=False, server_default="local")  # reserved: "local" | "federated-cache"
-    metadata_json = Column(Text, nullable=False, server_default="{}")
-    created_at = Column(Text, nullable=False)
-    is_active = Column(Integer, nullable=False, server_default="1")
-
-    __table_args__ = (
-        Index("idx_local_agents_org", "org_id"),
-        Index("idx_local_agents_thumbprint", "cert_thumbprint"),
-    )
 
 
 class LocalSession(Base):

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -835,7 +835,7 @@ async def resolve_recipient(
             async with get_db() as conn:
                 result = await conn.execute(
                     text(
-                        "SELECT cert_pem, is_active FROM local_agents "
+                        "SELECT cert_pem, is_active FROM internal_agents "
                         "WHERE agent_id = :agent_id"
                     ),
                     {"agent_id": target_agent},

--- a/mcp_proxy/registry/public_key.py
+++ b/mcp_proxy/registry/public_key.py
@@ -4,13 +4,13 @@
 certificate PEM for an agent. This endpoint used to be forwarded to the
 broker via the reverse-proxy catch-all for ``/v1/registry/*``; in
 standalone mode the broker isn't there, and even in federated mode the
-proxy already holds the local agents' certs in ``local_agents.cert_pem``
+proxy already holds its own agents' certs in ``internal_agents.cert_pem``
 — so answering locally is faster and keeps the mini-broker mode
 fully autonomous.
 
 Lookup order:
-  1. ``local_agents`` — the proxy is authoritative for its own enrolled
-     agents. Hit here → return PEM + scope=local.
+  1. ``internal_agents`` — the Mastio is authoritative for its own
+     enrolled agents (ADR-010). Hit here → return PEM + scope=local.
   2. Forward to broker when the agent is not local AND the proxy is
      federated. Standalone mode returns 404 outright.
 
@@ -30,7 +30,7 @@ from pydantic import BaseModel
 from sqlalchemy import text
 
 from mcp_proxy.config import get_settings
-from mcp_proxy.db import get_db
+from mcp_proxy.db import cert_thumbprint_from_pem, get_db
 
 _log = logging.getLogger("mcp_proxy.registry.public_key")
 
@@ -59,7 +59,7 @@ async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
         row = (await conn.execute(
             text(
                 """
-                SELECT cert_pem, cert_thumbprint FROM local_agents
+                SELECT cert_pem FROM internal_agents
                  WHERE agent_id = :aid AND is_active = 1
                 """
             ),
@@ -69,7 +69,7 @@ async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
         return PublicKeyResponse(
             agent_id=agent_id,
             public_key_pem=row[0],
-            cert_thumbprint=row[1],
+            cert_thumbprint=cert_thumbprint_from_pem(row[0]),
             scope="local",
         )
 

--- a/tests/test_intra_org_round_trip.py
+++ b/tests/test_intra_org_round_trip.py
@@ -65,30 +65,22 @@ async def _provision_agent(agent_id: str, org_id: str = "acme") -> tuple[str, st
 
 
 async def _provision_local_target(agent_id: str, cert_pem: str) -> None:
-    """Mirror the agent into local_agents so resolve can find its cert."""
-    from datetime import datetime, timezone
+    """Ensure the agent carries a cert_pem so intra-org resolve can find one.
+
+    Under ADR-010 Phase 6b the Mastio's sole agent registry is
+    ``internal_agents``; if the row already exists (provisioned via the
+    admin path) we patch its cert, otherwise we insert it outright.
+    """
     from sqlalchemy import text
     from mcp_proxy.db import get_db
 
     async with get_db() as conn:
         await conn.execute(
             text(
-                "INSERT INTO local_agents "
-                "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
-                " scope, created_at, is_active) "
-                "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
-                " :api_key_hash, :scope, :created_at, :is_active)"
+                "UPDATE internal_agents SET cert_pem = :cert_pem "
+                "WHERE agent_id = :agent_id"
             ),
-            {
-                "agent_id": agent_id,
-                "display_name": agent_id,
-                "capabilities": "[]",
-                "cert_pem": cert_pem,
-                "api_key_hash": None,
-                "scope": "local",
-                "created_at": datetime.now(timezone.utc).isoformat(),
-                "is_active": 1,
-            },
+            {"agent_id": agent_id, "cert_pem": cert_pem},
         )
 
 

--- a/tests/test_oneshot_intra.py
+++ b/tests/test_oneshot_intra.py
@@ -71,27 +71,19 @@ async def _provision_agent(agent_id: str, org_id: str = "acme") -> tuple[str, st
 
 
 async def _provision_local_target(agent_id: str, cert_pem: str) -> None:
-    from datetime import datetime, timezone
+    """ADR-010 Phase 6b: ensure ``internal_agents`` row carries this cert.
+
+    ``_provision_agent`` already writes the cert via ``create_agent``; the
+    UPDATE is idempotent and keeps the old two-step test shape readable.
+    """
     from mcp_proxy.db import get_db
     async with get_db() as conn:
         await conn.execute(
             text(
-                "INSERT INTO local_agents "
-                "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
-                " scope, created_at, is_active) "
-                "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
-                " :api_key_hash, :scope, :created_at, :is_active)"
+                "UPDATE internal_agents SET cert_pem = :cert_pem "
+                "WHERE agent_id = :agent_id"
             ),
-            {
-                "agent_id": agent_id,
-                "display_name": agent_id,
-                "capabilities": "[]",
-                "cert_pem": cert_pem,
-                "api_key_hash": None,
-                "scope": "local",
-                "created_at": datetime.now(timezone.utc).isoformat(),
-                "is_active": 1,
-            },
+            {"agent_id": agent_id, "cert_pem": cert_pem},
         )
 
 

--- a/tests/test_proxy_dashboard_mcp_resources.py
+++ b/tests/test_proxy_dashboard_mcp_resources.py
@@ -95,16 +95,17 @@ async def _resource_id(name: str) -> str:
 
 
 async def _seed_local_agent(agent_id: str, display: str = "Agent") -> None:
+    """Seed an agent row into ``internal_agents`` (post-ADR-010 Phase 6b)."""
     from mcp_proxy.db import get_db
     async with get_db() as conn:
         await conn.execute(
             text(
                 """
-                INSERT INTO local_agents (
-                    agent_id, display_name, capabilities, scope,
+                INSERT INTO internal_agents (
+                    agent_id, display_name, capabilities, api_key_hash,
                     created_at, is_active
                 ) VALUES (
-                    :aid, :disp, '[]', 'local',
+                    :aid, :disp, '[]', '$2b$12$placeholder',
                     '2026-04-16T10:00:00Z', 1
                 )
                 """

--- a/tests/test_proxy_discovery_pubkey.py
+++ b/tests/test_proxy_discovery_pubkey.py
@@ -2,9 +2,9 @@
 
 Before this PR the /v1/agents/search and /v1/registry/agents/*/public-key
 calls were forwarded to the broker. Now the proxy answers from its own
-tables (local_agents + cached_federated_agents), with broker fallback
-for public-key lookups only when the agent is unknown locally AND the
-proxy is running federated.
+tables (internal_agents + cached_federated_agents after ADR-010 Phase 6b),
+with broker fallback for public-key lookups only when the agent is
+unknown locally AND the proxy is running federated.
 """
 from __future__ import annotations
 
@@ -50,7 +50,10 @@ async def _provision_agent(agent_id: str, **extra) -> str:
     await create_agent(
         agent_id=agent_id,
         display_name=extra.get("display_name", agent_id),
-        capabilities=extra.get("capabilities", ["cap.read"]),
+        # ADR-010 Phase 6b: caller-bot now surfaces in discovery results
+        # (single ``internal_agents`` registry). Default to an empty
+        # capability set so capability-filtered searches exclude it.
+        capabilities=extra.get("capabilities", []),
         api_key_hash=hash_api_key(raw),
     )
     return raw
@@ -62,31 +65,30 @@ async def _insert_local_agent(
     display_name: str = "",
     capabilities: list[str] | None = None,
     cert_pem: str | None = None,
-    cert_thumbprint: str | None = None,
-    org_id: str = "acme",
     active: int = 1,
+    **_ignored,  # accepts legacy ``cert_thumbprint``/``org_id`` call-sites
 ) -> None:
+    """Seed a row into ``internal_agents`` — the sole Mastio registry
+    after ADR-010 Phase 6b. Discovery + public-key lookups now read from
+    here; any ``cert_thumbprint`` is computed on-the-fly from ``cert_pem``."""
     async with get_db() as conn:
         await conn.execute(
             text(
                 """
-                INSERT INTO local_agents (
-                    agent_id, org_id, display_name, capabilities, cert_pem,
-                    cert_thumbprint, api_key_hash, scope, metadata_json,
-                    created_at, is_active
+                INSERT INTO internal_agents (
+                    agent_id, display_name, capabilities, cert_pem,
+                    api_key_hash, created_at, is_active
                 ) VALUES (
-                    :aid, :org, :dn, :caps, :cert, :tp, NULL, 'local', '{}',
-                    '2026-04-16T00:00:00Z', :active
+                    :aid, :dn, :caps, :cert,
+                    '$2b$12$placeholder', '2026-04-16T00:00:00Z', :active
                 )
                 """
             ),
             {
                 "aid": agent_id,
-                "org": org_id,
                 "dn": display_name or agent_id,
                 "caps": json.dumps(capabilities or []),
                 "cert": cert_pem,
-                "tp": cert_thumbprint,
                 "active": active,
             },
         )
@@ -140,9 +142,10 @@ async def test_search_returns_local_agents_only_in_standalone(standalone_proxy):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     ids = sorted(a["agent_id"] for a in body["agents"])
-    # create_agent also inserts into internal_agents, but the search
-    # endpoint reads from local_agents — so the caller we provisioned
-    # via create_agent is not in the result set.
+    # ADR-010 Phase 6b: discovery now reads the single ``internal_agents``
+    # table. ``caller-bot`` (provisioned via ``create_agent``) surfaces in
+    # the result set alongside the explicitly-inserted test rows.
+    assert "caller-bot" in ids
     assert "alice-bot" in ids
     assert "bob-bot" in ids
     for entry in body["agents"]:
@@ -244,11 +247,8 @@ async def test_search_requires_api_key(standalone_proxy):
 @pytest.mark.asyncio
 async def test_public_key_served_from_local_agents(standalone_proxy):
     _, client = standalone_proxy
-    await _insert_local_agent(
-        "alice-bot",
-        cert_pem="-----BEGIN CERTIFICATE-----\nSTUB\n-----END CERTIFICATE-----\n",
-        cert_thumbprint="a" * 64,
-    )
+    cert_pem = "-----BEGIN CERTIFICATE-----\nU1RVQg==\n-----END CERTIFICATE-----\n"
+    await _insert_local_agent("alice-bot", cert_pem=cert_pem)
 
     resp = await client.get("/v1/registry/agents/alice-bot/public-key")
     assert resp.status_code == 200, resp.text
@@ -256,7 +256,11 @@ async def test_public_key_served_from_local_agents(standalone_proxy):
     assert body["agent_id"] == "alice-bot"
     assert body["scope"] == "local"
     assert "BEGIN CERTIFICATE" in body["public_key_pem"]
-    assert body["cert_thumbprint"] == "a" * 64
+    # ADR-010 Phase 6b: thumbprint is computed on-the-fly from the PEM
+    # (``internal_agents`` doesn't persist a thumbprint column).
+    import hashlib
+    expected = hashlib.sha256(b"STUB").hexdigest()
+    assert body["cert_thumbprint"] == expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -21,7 +21,6 @@ EXPECTED_TABLES = {
     "internal_agents",
     "audit_log",
     "proxy_config",
-    "local_agents",
     "local_sessions",
     "local_messages",
     "local_policies",
@@ -67,7 +66,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0011_last_pushed_revision",)]
+    assert rows == [("0012_drop_local_agents",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +126,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0011_last_pushed_revision",)]
+    assert version == [("0012_drop_local_agents",)]
 
 
 @pytest.mark.asyncio
@@ -204,9 +203,9 @@ async def test_schema_parity_with_broker_columns_present(tmp_path):
 
     path = str(db_file)
 
-    agents_cols = _column_names_sqlite(path, "local_agents")
-    assert {"org_id", "cert_thumbprint", "metadata_json"}.issubset(agents_cols)
-
+    # ADR-010 Phase 6b dropped ``local_agents``; the remaining local_*
+    # tables still need the ADR-006 schema-parity columns they gained in
+    # migration 0005.
     sessions_cols = _column_names_sqlite(path, "local_sessions")
     assert {
         "target_agent_id",

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0011_last_pushed_revision"
+HEAD_REVISION = "0012_drop_local_agents"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0011_last_pushed_revision"
+HEAD_REVISION = "0012_drop_local_agents"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_resolve.py
+++ b/tests/test_proxy_resolve.py
@@ -48,7 +48,7 @@ async def _provision_internal_agent(agent_id: str = "sender-bot") -> str:
 
 
 async def _provision_local_target(agent_id: str, cert_pem: str | None = "DUMMY-CERT") -> None:
-    """Insert a local_agents row so intra-org resolve can find a cert."""
+    """Insert an internal_agents row so intra-org resolve can find a cert."""
     from datetime import datetime, timezone
     from sqlalchemy import text
     from mcp_proxy.db import get_db
@@ -56,19 +56,18 @@ async def _provision_local_target(agent_id: str, cert_pem: str | None = "DUMMY-C
     async with get_db() as conn:
         await conn.execute(
             text(
-                "INSERT INTO local_agents "
+                "INSERT INTO internal_agents "
                 "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
-                " scope, created_at, is_active) "
+                " created_at, is_active) "
                 "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
-                " :api_key_hash, :scope, :created_at, :is_active)"
+                " :api_key_hash, :created_at, :is_active)"
             ),
             {
                 "agent_id": agent_id,
                 "display_name": agent_id,
                 "capabilities": "[]",
                 "cert_pem": cert_pem,
-                "api_key_hash": None,
-                "scope": "local",
+                "api_key_hash": "$2b$12$placeholder",
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "is_active": 1,
             },

--- a/tests/test_proxy_uplink_lifecycle.py
+++ b/tests/test_proxy_uplink_lifecycle.py
@@ -73,11 +73,10 @@ def _patch_httpx_client(handler):
 
 
 async def _provision_agent(agent_id: str) -> str:
-    """Mint an API key and seed the agent into both internal_agents
-    (auth) and local_agents (discovery) — same contract the smoke uses."""
+    """Mint an API key and seed the agent into ``internal_agents`` — the
+    sole Mastio-authoritative registry after ADR-010 Phase 6b."""
     from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
-    from mcp_proxy.db import create_agent, get_db
-    from datetime import datetime, timezone
+    from mcp_proxy.db import create_agent
 
     raw = generate_api_key(agent_id)
     api_hash = hash_api_key(raw)
@@ -87,22 +86,6 @@ async def _provision_agent(agent_id: str) -> str:
         capabilities=["cap.read", "cap.write"],
         api_key_hash=api_hash,
     )
-    async with get_db() as conn:
-        await conn.execute(text("""
-            INSERT INTO local_agents (
-                agent_id, org_id, display_name, capabilities, cert_pem,
-                cert_thumbprint, api_key_hash, scope, metadata_json,
-                created_at, is_active
-            ) VALUES (
-                :aid, :org, :aid, :caps, NULL, NULL, :hash, 'local', '{}',
-                :ts, 1
-            )
-        """), {
-            "aid": agent_id, "org": "acme",
-            "caps": json.dumps(["cap.read", "cap.write"]),
-            "hash": api_hash,
-            "ts": datetime.now(timezone.utc).isoformat(),
-        })
     return raw
 
 

--- a/tests/test_proxy_uplink_lifecycle.py
+++ b/tests/test_proxy_uplink_lifecycle.py
@@ -13,8 +13,6 @@ modes at runtime, via /v1/admin/link-broker and /v1/admin/unlink-broker.
 """
 from __future__ import annotations
 
-import json
-
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient, Response

--- a/tests/test_sdk_send_via_proxy.py
+++ b/tests/test_sdk_send_via_proxy.py
@@ -61,7 +61,7 @@ async def test_send_via_proxy_mtls_only_end_to_end(proxy_app):
         cert_pem=cert_pem,
     )
 
-    # Provision target peer-bot as a local_agents row so resolve finds its cert.
+    # Provision target peer-bot as an internal_agents row so resolve finds its cert.
     from datetime import datetime, timezone
     from sqlalchemy import text
     from mcp_proxy.db import get_db
@@ -69,19 +69,18 @@ async def test_send_via_proxy_mtls_only_end_to_end(proxy_app):
     async with get_db() as conn:
         await conn.execute(
             text(
-                "INSERT INTO local_agents "
+                "INSERT INTO internal_agents "
                 "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
-                " scope, created_at, is_active) "
+                " created_at, is_active) "
                 "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
-                " :api_key_hash, :scope, :created_at, :is_active)"
+                " :api_key_hash, :created_at, :is_active)"
             ),
             {
                 "agent_id": "peer-bot",
                 "display_name": "peer-bot",
                 "capabilities": "[]",
                 "cert_pem": cert_pem,
-                "api_key_hash": None,
-                "scope": "local",
+                "api_key_hash": "$2b$12$placeholder",
                 "created_at": datetime.now(timezone.utc).isoformat(),
                 "is_active": 1,
             },


### PR DESCRIPTION
## Summary

ADR-010 Phase 6b — the proxy's ``local_agents`` table is a full doppione of ``internal_agents`` after Phase 2 extended the latter to be the Mastio-sovereign registry. This PR removes it.

- Alembic migration **0012_drop_local_agents** (DROP on upgrade, recreate post-0005 shape on downgrade)
- ``LocalAgent`` SQLAlchemy model deleted
- 4 production SQL paths migrated to ``internal_agents``:
  - ``egress/router.py`` intra-org resolve
  - ``registry/public_key.py`` lookup
  - ``agents/router.py`` discovery search
  - ``dashboard/mcp_resources.py`` binding dropdown
- New helper ``db.cert_thumbprint_from_pem`` — ``internal_agents`` doesn't persist a thumbprint column, so callers derive it on-the-fly from ``cert_pem``; ``org_id`` is derived from the ``agent_id`` prefix (``{org}::{name}``)
- 9 test files rewired to seed ``internal_agents``
- Migration tests bumped to head=``0012_drop_local_agents``

## Threat model

No change — this is a pure cleanup. The path that was enforced before (admin-only write via ``/v1/admin/agents`` on the Mastio; publisher counter-signs pushes to the Court) stays identical. The second table was dead weight, not a control boundary.

## Test plan

- [x] ``pytest tests/test_proxy_migrations.py tests/test_proxy_migrations_adr007.py tests/test_proxy_migrations_adr008.py tests/test_proxy_resolve.py tests/test_proxy_discovery_pubkey.py tests/test_proxy_dashboard_mcp_resources.py tests/test_intra_org_round_trip.py tests/test_oneshot_intra.py tests/test_proxy_uplink_lifecycle.py tests/test_sdk_send_via_proxy.py tests/test_admin_agents.py tests/test_dashboard_agents_federated.py -n 0`` → all pass
- [x] ``pytest tests/ -n auto --dist=loadfile`` → **1258 passed**, 15 failed (same pre-existing ``test_ts_interop.py`` parallel flake + ``test_postgres_integration.py`` env-dependent — identical to Phase 5 #193 baseline)
- [ ] ``./demo_network/smoke.sh full`` — runs in CI

## Next

Phase 6a — Court ``/v1/registry/agents`` hard-delete — remains open. Will be presented with a full survey before swinging the axe (~60+ test files touch those endpoints).