### PR TITLE
fix(registry): close /orgs/{id}/certificate enumeration oracle (F-B-7)

### DIFF
--- a/app/registry/org_router.py
+++ b/app/registry/org_router.py
@@ -140,15 +140,23 @@ async def upload_org_ca_certificate(
     x_org_id: str = Header(...),
     x_org_secret: str = Header(...),
 ):
-    """Upload the organization's CA certificate. Requires x-org-id and x-org-secret."""
+    """Upload the organization's CA certificate. Requires x-org-id and x-org-secret.
+
+    Audit F-B-7: auth failures collapse to a single 403 whether the org
+    is missing, inactive, or the secret is wrong, and bcrypt runs on
+    every path via ``verify_org_credentials``. Previously the endpoint
+    returned 404 on miss and 401 on wrong secret, differentiating the
+    two cases by status code and by latency (no bcrypt on miss).
+    """
     if x_org_id != org_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="org_id mismatch")
 
     org = await get_org_by_id(db, org_id)
-    if not org:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Organization not found")
-    if not org.verify_secret(x_org_secret):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid org credentials")
+    if not verify_org_credentials(org, x_org_secret, active_only=True):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid organization credentials",
+        )
 
     # Validate the CA certificate before accepting it
     from cryptography import x509 as crypto_x509

--- a/tests/test_fb7_certificate_no_enumeration.py
+++ b/tests/test_fb7_certificate_no_enumeration.py
@@ -1,0 +1,168 @@
+"""Audit F-B-7 — ``POST /v1/registry/orgs/{org_id}/certificate`` must
+not leak org existence.
+
+Same pattern as F-B-6, same helper. Before the fix the endpoint
+returned 404 on missing org and 401 on wrong secret, distinguishing the
+two cases by status code and timing (no bcrypt on miss vs one bcrypt
+on hit). After the fix both paths collapse to 403 with bcrypt on
+every branch via ``verify_org_credentials(org, secret, active_only=True)``.
+
+Unlike ``/orgs/me``, this endpoint keeps ``active_only=True``: there is
+no legitimate use case for uploading a CA certificate to an org that
+is not ``active``.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = pytest.mark.asyncio
+
+
+VALID_CA_PEM = None  # lazily built once at import
+
+
+def _make_ca_pem() -> str:
+    """Build a minimal valid CA cert so the cert-shape checks downstream
+    do not mask auth failures with a 400 Bad Request."""
+    global VALID_CA_PEM
+    if VALID_CA_PEM is not None:
+        return VALID_CA_PEM
+
+    import datetime
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(x509.NameOID.COMMON_NAME, "fb7-test"),
+        x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, "fb7-test"),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject).issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    VALID_CA_PEM = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return VALID_CA_PEM
+
+
+async def _register_org(client: AsyncClient, org_id: str, secret: str) -> None:
+    resp = await client.post(
+        "/v1/registry/orgs",
+        json={"org_id": org_id, "display_name": org_id, "secret": secret},
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+# ── Primary regression: 403 whether missing, wrong secret, or inactive ──
+
+async def test_certificate_missing_org_returns_403(client: AsyncClient):
+    resp = await client.post(
+        "/v1/registry/orgs/fb7-missing/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "fb7-missing", "x-org-secret": "whatever"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    # Body must not leak org-existence info.
+    assert "not found" not in body.get("detail", "").lower()
+
+
+async def test_certificate_wrong_secret_returns_403(client: AsyncClient):
+    await _register_org(client, "fb7-org-a", "real-secret-fb7a")
+    resp = await client.post(
+        "/v1/registry/orgs/fb7-org-a/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "fb7-org-a", "x-org-secret": "wrong"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_certificate_missing_vs_wrong_are_indistinguishable(client: AsyncClient):
+    """Status code AND detail body must be identical — the whole
+    F-B-7 invariant."""
+    await _register_org(client, "fb7-org-b", "real-secret-fb7b")
+    missing = await client.post(
+        "/v1/registry/orgs/fb7-absent/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "fb7-absent", "x-org-secret": "x"},
+    )
+    wrong_secret = await client.post(
+        "/v1/registry/orgs/fb7-org-b/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "fb7-org-b", "x-org-secret": "wrong"},
+    )
+    assert missing.status_code == wrong_secret.status_code == 403
+    assert missing.json() == wrong_secret.json()
+
+
+# ── org_id mismatch stays its own 403 (different semantic) ──
+
+async def test_certificate_mismatch_org_id_still_blocks_with_403(client: AsyncClient):
+    """``x-org-id`` header vs path param mismatch is a different
+    semantic (caller authenticated as a different org) and the 403
+    body is allowed to differ. What matters is that no enumeration
+    oracle exists AFTER the mismatch check passes."""
+    await _register_org(client, "fb7-org-c", "real-secret-fb7c")
+    resp = await client.post(
+        "/v1/registry/orgs/fb7-org-c/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "some-other-org", "x-org-secret": "real-secret-fb7c"},
+    )
+    assert resp.status_code == 403
+
+
+# ── Happy path + active_only semantics ──
+
+async def test_certificate_active_org_correct_secret_200(client: AsyncClient):
+    await _register_org(client, "fb7-org-d", "real-secret-fb7d")
+    resp = await client.post(
+        "/v1/registry/orgs/fb7-org-d/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "fb7-org-d", "x-org-secret": "real-secret-fb7d"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["org_id"] == "fb7-org-d"
+    assert body["ca_certificate_loaded"] is True
+
+
+async def test_certificate_pending_org_rejected_with_403(
+    client: AsyncClient, db_session,
+):
+    """Uploading a CA to a non-active org is refused. Distinct from
+    ``/orgs/me`` which needs to accept pending for polling — here
+    there is no legitimate pending use case (the org hasn't been
+    approved yet, you shouldn't be rotating its CA)."""
+    from app.registry.org_store import OrganizationRecord
+    import bcrypt
+    import json
+
+    secret = "pending-secret-fb7"
+    record = OrganizationRecord(
+        org_id="fb7-org-pending",
+        display_name="pending",
+        secret_hash=bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=4)).decode(),
+        metadata_json=json.dumps({}),
+        status="pending",
+    )
+    db_session.add(record)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/v1/registry/orgs/fb7-org-pending/certificate",
+        json={"ca_certificate": _make_ca_pem()},
+        headers={"x-org-id": "fb7-org-pending", "x-org-secret": secret},
+    )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Same pattern as #187 (F-B-6), same helper, one more endpoint. \`POST /v1/registry/orgs/{org_id}/certificate\` no longer distinguishes missing-org from wrong-secret: both return 403 with the same body, and bcrypt runs on every branch via \`verify_org_credentials\` (unified by #187).

Closes audit finding **F-B-7** (Medium, \`imp/audit_2026_04_17/phase1_B_authz.md:314\`).

## The leak

Before this PR (\`app/registry/org_router.py:147-151\`):

\`\`\`python
org = await get_org_by_id(db, org_id)
if not org:
    raise HTTPException(404, \"Organization not found\")            # 404 = missing
if not org.verify_secret(x_org_secret):
    raise HTTPException(401, \"Invalid org credentials\")           # 401 = wrong secret
\`\`\`

Two leaks in one path, same shape as F-B-6:

1. **Status code**: 404 vs 401 distinguishes \"org is not registered\" from \"registered but wrong secret\".
2. **Timing**: 404 returns instantly; 401 runs bcrypt (~100ms).

Pre-attack reconnaissance gets cheaper: an attacker iterating candidate \`org_id\` values with a fixed wrong secret learns which orgs exist from either dimension.

## Fix

\`\`\`python
org = await get_org_by_id(db, org_id)
if not verify_org_credentials(org, x_org_secret, active_only=True):
    raise HTTPException(403, \"Invalid organization credentials\")
\`\`\`

One shape for missing / wrong / inactive. Bcrypt on every path. \`active_only=True\` is the right semantic here — unlike \`/orgs/me\` (#187 kept \`active_only=False\` for the Mastio status-polling use case), there is no legitimate reason to rotate a CA on a non-active org.

## What is NOT changed

- The \`x-org-id\` (header) vs \`org_id\` (path) mismatch check stays ahead of the credential check with its own 403 (different semantic: caller authenticated as a different org). That is not an enumeration oracle — any matching \`x-org-id\` still funnels through \`verify_org_credentials\`.
- The \"replacing an existing CA invalidates agent thumbprints\" block is untouched. That interlock is already in place, and the admin-session-to-org-secret escalation concern that the audit note linked to is closed by F-B-2 (PR #161, sealed-org flag).
- The downstream cert-shape validation (CA flag, RSA key size, validity window) runs only after a successful auth — unchanged.

## Tests

\`tests/test_fb7_certificate_no_enumeration.py\` — 6 cases:

- \`test_certificate_missing_org_returns_403\` — the 404 regression guard.
- \`test_certificate_wrong_secret_returns_403\` — wrong-secret baseline.
- \`test_certificate_missing_vs_wrong_are_indistinguishable\` — status + body byte-equality.
- \`test_certificate_mismatch_org_id_still_blocks_with_403\` — the pre-credential mismatch check still does its job.
- \`test_certificate_active_org_correct_secret_200\` — happy path.
- \`test_certificate_pending_org_rejected_with_403\` — \`active_only=True\` enforced.

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1269 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_fb7_certificate_no_enumeration.py -q\` — 6 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.

## Follow-up candidates

- **F-B-8** — revoke-agent tokens cross-org agent-existence oracle (same class, different surface).
- **F-B-6..F-B-20 general sweep** — documented in the audit: remaining enumeration oracles on the registry surface. Not urgent after this one and F-B-6 close the two High/Medium ones.