### PR TITLE
feat(mastio): persist Connector device_info on agents + show it in dashboard

### DIFF
--- a/mcp_proxy/alembic/versions/0013_internal_agents_device_info.py
+++ b/mcp_proxy/alembic/versions/0013_internal_agents_device_info.py
@@ -1,0 +1,50 @@
+"""Persist the Connector device_info JSON on internal_agents.
+
+Revision ID: 0013_internal_agents_device_info
+Revises: 0012_drop_local_agents
+Create Date: 2026-04-17 23:00:00.000000
+
+When a device-code enrollment is approved, the pending row holds a
+free-form JSON blob describing the requester's machine (OS, hostname,
+Connector version). Before this migration that blob was discarded once
+the row became an ``internal_agents`` entry — the admin could see it in
+the enrollment queue but every post-approval surface lost it.
+
+Adding ``device_info`` to ``internal_agents`` lets the dashboard show
+OS/host/version next to each agent without hopping back to
+``pending_enrollments`` (which is pruned over time).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0013_internal_agents_device_info"
+down_revision: Union[str, Sequence[str], None] = "0012_drop_local_agents"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Idempotent add — ``init_db`` may call ``metadata.create_all`` before
+    # stamping on legacy-unstamped SQLite deploys, in which case the table
+    # already carries ``device_info`` from the current model. See the
+    # "Alembic stamp partial schema" convention elsewhere in this repo.
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("internal_agents")}
+    if "device_info" in existing:
+        return
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.add_column(
+            sa.Column("device_info", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("internal_agents")}
+    if "device_info" not in existing:
+        return
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.drop_column("device_info")

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -50,6 +50,37 @@ _log = logging.getLogger("mcp_proxy.dashboard")
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
 templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
 
+
+def _parse_device_info(raw):
+    """Best-effort parse of ``internal_agents.device_info`` (migration 0013)
+    — Connectors send a mix of conventions across versions, so we normalize
+    a handful of aliases and fall back to ``None`` on anything malformed so
+    the template short-circuits to a dash."""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _pick(*keys):
+        for k in keys:
+            v = data.get(k)
+            if v:
+                return str(v)
+        return None
+
+    return {
+        "os": _pick("os", "platform", "system"),
+        "hostname": _pick("hostname", "host", "node"),
+        "version": _pick("version", "connector_version", "client_version"),
+    }
+
+
+templates.env.filters["parse_device"] = _parse_device_info
+
 router = APIRouter(prefix="/proxy", tags=["dashboard"])
 
 

--- a/mcp_proxy/dashboard/templates/agents.html
+++ b/mcp_proxy/dashboard/templates/agents.html
@@ -133,6 +133,7 @@
                 <tr class="border-b border-gray-800/60">
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Agent ID</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display Name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider" title="OS / hostname / version captured at device-code enrollment">Device</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Capabilities</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Certificate</th>
@@ -149,6 +150,21 @@
                     </td>
                     <td class="px-5 py-4">
                         <a href="/proxy/agents/{{ agent.agent_id }}" class="text-sm text-white hover:text-accent-400 transition-colors">{{ agent.display_name }}</a>
+                    </td>
+                    <td class="px-5 py-4">
+                        {% set dev = agent.device_info | parse_device %}
+                        {% if dev %}
+                        <div class="text-xs text-gray-400 leading-tight">
+                            {% if dev.os %}
+                            <div>{{ dev.os }}{% if dev.version %} <span class="text-gray-600">· {{ dev.version }}</span>{% endif %}</div>
+                            {% endif %}
+                            {% if dev.hostname %}
+                            <div class="text-[10px] text-gray-600 font-mono truncate max-w-[160px]" title="{{ dev.hostname }}">{{ dev.hostname }}</div>
+                            {% endif %}
+                        </div>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
                     </td>
                     <td class="px-5 py-4">
                         <div class="flex flex-wrap gap-1">
@@ -215,7 +231,7 @@
                 {% endfor %}
                 {% if not agents %}
                 <tr>
-                    <td colspan="8" class="px-5 py-16 text-center">
+                    <td colspan="9" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                         <p class="text-sm text-gray-600">No agents registered</p>
                         <p class="text-xs text-gray-700 mt-1">Create an agent to get started with the Mastio.</p>

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -421,4 +421,8 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
             out[key] = (
                 bool(row[key]) if key == "federated" else row[key]
             )
+    # Migration 0013 — optional at read time so fixtures that build a row
+    # by hand (without the column) don't blow up.
+    if "device_info" in row.keys():
+        out["device_info"] = row["device_info"]
     return out

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -46,6 +46,9 @@ class InternalAgent(Base):
     cert_pem = Column(Text, nullable=True)
     created_at = Column(Text, nullable=False)
     is_active = Column(Integer, nullable=False, server_default="1")
+    # Free-form JSON carried from pending_enrollments.device_info on approval
+    # (OS, hostname, Connector version). Null for agents created via CLI.
+    device_info = Column(Text, nullable=True)
 
 
 class AuditLogEntry(Base):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -256,8 +256,8 @@ async def approve(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities, api_key_hash,
-                    cert_pem, created_at, is_active)
-                   VALUES (:aid, :dn, :caps, :hash, :cert, :created, 1)"""
+                    cert_pem, created_at, is_active, device_info)
+                   VALUES (:aid, :dn, :caps, :hash, :cert, :created, 1, :device)"""
             ),
             {
                 "aid": agent_id,
@@ -266,6 +266,10 @@ async def approve(
                 "hash": api_key_hash,
                 "cert": cert_pem,
                 "created": now,
+                # Free-form JSON carried from the Connector at start_enrollment
+                # and kept through approval. We store it verbatim — the
+                # dashboard parses it via a Jinja filter for display.
+                "device": record.get("device_info"),
             },
         )
         await conn.execute(

--- a/tests/test_proxy_device_info.py
+++ b/tests/test_proxy_device_info.py
@@ -1,0 +1,198 @@
+"""Migration 0013 device_info contract — unit-level coverage.
+
+Two entry points:
+  1. ``_parse_device_info`` — dashboard Jinja filter. Pure function over
+     the raw JSON column, with fallbacks for malformed input.
+  2. ``enrollment.service.approve`` — copies ``pending_enrollments.device_info``
+     verbatim into the new ``internal_agents.device_info`` column on admin
+     approval. Covers the SDK contract: whatever the Connector sent at
+     enrollment-start survives to the Agents dashboard.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_proxy.dashboard.router import _parse_device_info
+
+
+# ── Filter: pure-function behaviors ────────────────────────────────────
+
+
+def test_parse_device_none_and_empty_return_none():
+    assert _parse_device_info(None) is None
+    assert _parse_device_info("") is None
+
+
+def test_parse_device_malformed_json_returns_none():
+    assert _parse_device_info("not-json") is None
+    # JSON that isn't a dict (array / string / number) is also None — we
+    # don't want the template to receive the raw value and try to
+    # index it.
+    assert _parse_device_info("[]") is None
+    assert _parse_device_info('"scalar"') is None
+
+
+def test_parse_device_picks_canonical_keys():
+    raw = json.dumps({
+        "os": "macOS 14.5",
+        "hostname": "laptop.local",
+        "version": "0.2.0",
+    })
+    assert _parse_device_info(raw) == {
+        "os": "macOS 14.5",
+        "hostname": "laptop.local",
+        "version": "0.2.0",
+    }
+
+
+def test_parse_device_falls_back_through_aliases():
+    # Older connectors may send these keys; the filter normalises them.
+    raw = json.dumps({"platform": "linux", "host": "srv-01"})
+    assert _parse_device_info(raw) == {
+        "os": "linux",
+        "hostname": "srv-01",
+        "version": None,
+    }
+
+
+def test_parse_device_skips_empty_strings():
+    """Empty strings should fall through to the next alias rather than
+    pinning ``""`` on the template."""
+    raw = json.dumps({"os": "", "platform": "windows", "hostname": "",
+                      "host": "desktop-01", "version": "1.3.0"})
+    assert _parse_device_info(raw) == {
+        "os": "windows",
+        "hostname": "desktop-01",
+        "version": "1.3.0",
+    }
+
+
+def test_parse_device_coerces_non_string_values():
+    """Some SDKs send numbers for version. Coerce rather than drop — the
+    operator still wants to see the value."""
+    raw = json.dumps({"os": "freebsd", "version": 1})
+    out = _parse_device_info(raw)
+    assert out["version"] == "1"
+
+
+# ── Enrollment: device_info survives approve() into internal_agents ───
+
+
+@pytest.fixture
+async def _proxy_db(tmp_path, monkeypatch):
+    """Isolated SQLite DB for the enrollment carry-over test."""
+    db_file = tmp_path / "approve.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import init_db, dispose_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+class _FakeAgentManager:
+    """Minimal stand-in for AgentManager. ``approve`` only needs
+    ``ca_loaded`` + ``sign_external_pubkey`` to run."""
+
+    ca_loaded = True
+
+    def sign_external_pubkey(self, *, pubkey_pem: str, agent_name: str) -> str:
+        # Not a real cert — approve() only stores it on the row.
+        return f"-----BEGIN CERTIFICATE-----\nstub-{agent_name}\n-----END CERTIFICATE-----\n"
+
+
+def _fresh_pubkey_pem() -> str:
+    """Generate a real ECDSA P-256 public key PEM; start_enrollment() parses
+    it to fingerprint, so a stub string gets rejected."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    priv = ec.generate_private_key(ec.SECP256R1())
+    return priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+@pytest.mark.asyncio
+async def test_approve_copies_device_info_to_internal_agents(_proxy_db):
+    """A device_info blob submitted at enrollment-start must land in
+    ``internal_agents.device_info`` on approval — the admin dashboard
+    relies on it for the Agents table Device column."""
+    from mcp_proxy.db import get_db
+    from mcp_proxy.enrollment.service import start_enrollment, approve
+
+    device_json = json.dumps({
+        "os": "linux",
+        "hostname": "dev-laptop-01",
+        "version": "0.2.3",
+    })
+
+    async with get_db() as conn:
+        started = await start_enrollment(
+            conn,
+            pubkey_pem=_fresh_pubkey_pem(),
+            requester_name="alice",
+            requester_email="alice@example.com",
+            reason=None,
+            device_info=device_json,
+        )
+
+    async with get_db() as conn:
+        await approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="testorg::alice",
+            capabilities=["order.read"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=_FakeAgentManager(),
+        )
+
+    # Verify device_info lands verbatim (we store the raw JSON string —
+    # parsing happens at display time via the Jinja filter).
+    from mcp_proxy.db import get_agent
+    row = await get_agent("testorg::alice")
+    assert row is not None
+    assert row["device_info"] == device_json
+
+
+@pytest.mark.asyncio
+async def test_approve_without_device_info_yields_null(_proxy_db):
+    """Connectors that don't advertise device metadata (CLI enrollments,
+    legacy SDK versions) must still approve cleanly — the column stays
+    NULL and the template shows a dash."""
+    from mcp_proxy.db import get_db
+    from mcp_proxy.enrollment.service import start_enrollment, approve
+
+    async with get_db() as conn:
+        started = await start_enrollment(
+            conn,
+            pubkey_pem=_fresh_pubkey_pem(),
+            requester_name="bob",
+            requester_email="bob@example.com",
+            reason=None,
+            device_info=None,
+        )
+
+    async with get_db() as conn:
+        await approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="testorg::bob",
+            capabilities=[],
+            groups=[],
+            admin_name="admin",
+            agent_manager=_FakeAgentManager(),
+        )
+
+    from mcp_proxy.db import get_agent
+    row = await get_agent("testorg::bob")
+    assert row is not None
+    assert row["device_info"] is None

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -66,7 +66,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0012_drop_local_agents",)]
+    assert rows == [("0013_internal_agents_device_info",)]
 
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0012_drop_local_agents",)]
+    assert version == [("0013_internal_agents_device_info",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0012_drop_local_agents"
+HEAD_REVISION = "0013_internal_agents_device_info"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0012_drop_local_agents"
+HEAD_REVISION = "0013_internal_agents_device_info"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 


### PR DESCRIPTION
## Summary
Follow-up di PR #190 (rebrand/overview): la parte device_info che avevamo splittato per evitare collisione di slot migration con l'altro agente.

- Migration ``0013_internal_agents_device_info`` (down_revision ``0012_drop_local_agents``) — colonna ``device_info TEXT NULL`` su ``internal_agents``. Idempotente (gestisce il pattern ``create_all`` su legacy-unstamped SQLite).
- ``enrollment/service.py::approve`` copia ``pending_enrollments.device_info`` verbatim sulla nuova colonna. Prima veniva scartato dopo l'approvazione.
- Jinja filter ``parse_device`` in ``dashboard/router.py``: normalizza chiavi alias (``os|platform|system``, ``hostname|host|node``, ``version|connector_version|client_version``), coerce non-string, fallback ``None`` su JSON malformati.
- Nuova colonna **Device** in ``/proxy/agents`` con ``OS · version`` + hostname, dash per righe senza metadata.
- HEAD_REVISION fixture aggiornate in ``test_proxy_migrations*``.

## Test plan
- [x] ``pytest tests/ -n auto --dist=loadfile`` — 1277 pass / 6 skip
- [x] ``./demo_network/smoke.sh full`` PASS
- [ ] Shake-out manuale: enroll un Connector dalla sandbox con device_info non vuoto, approvare dalla dashboard Mastio, verificare che la colonna Device mostri ``os · version`` + hostname anche dopo che il pending enrollment viene pruned

## Note
- Nessuna modifica al modello ``InternalAgent`` oltre l'aggiunta della colonna nuova.
- Legacy agents (pre-0013) restano con ``device_info = NULL`` e renderizzano un dash — niente migration dati.