### PR TITLE
feat(court): federation read API (ADR-010 Phase 6a-1)

### DIFF
--- a/app/federation/read.py
+++ b/app/federation/read.py
@@ -1,0 +1,172 @@
+"""ADR-010 Phase 6a — Court federation read API.
+
+Sibling of ``app/federation/publish.py``: where ``publish.py`` accepts
+Mastio-signed pushes, this module serves the **read** side of the
+federation surface — other Mastios query the Court here to discover
+cross-org agents and fetch their certs for E2E setup.
+
+Endpoints mirror the legacy ``/v1/registry/agents`` GETs bit-for-bit
+(same auth, same org-isolation, same response shape) so consumers can
+migrate by swapping the URL prefix. Once every caller lives under
+``/v1/federation/agents``, Phase 6a-4 deletes the old ``/v1/registry/``
+routes and the legacy POST write paths with them.
+"""
+from __future__ import annotations
+
+import logging
+
+from cryptography import x509 as crypto_x509
+from cryptography.hazmat.primitives import serialization
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.config import get_settings
+from app.db.database import get_db
+from app.registry.binding_store import get_approved_binding
+from app.registry.models import (
+    AgentListResponse, AgentPublicKeyResponse, AgentResponse,
+)
+from app.registry.store import get_agent_by_id, list_agents, search_agents
+from app.spiffe import internal_id_to_spiffe
+
+_log = logging.getLogger("agent_trust")
+
+router = APIRouter(prefix="/v1/federation", tags=["federation"])
+
+
+def _as_agent_response(agent, trust_domain: str) -> AgentResponse:
+    return AgentResponse(
+        agent_id=agent.agent_id,
+        org_id=agent.org_id,
+        display_name=agent.display_name,
+        description=getattr(agent, "description", "") or "",
+        capabilities=agent.capabilities,
+        is_active=agent.is_active,
+        registered_at=agent.registered_at,
+        metadata=agent.extra,
+        agent_uri=internal_id_to_spiffe(agent.agent_id, trust_domain),
+    )
+
+
+@router.get("/agents", response_model=AgentListResponse)
+async def list_federated_agents(
+    org_id: str | None = None,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """List registered agents. Same org-isolation as the legacy
+    ``/v1/registry/agents`` GET: an agent sees only its own org."""
+    filter_org = current_agent.org if org_id is None else org_id
+    if filter_org != current_agent.org:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You cannot view agents from other organizations",
+        )
+
+    agents = await list_agents(db, org_id=filter_org)
+    trust_domain = get_settings().trust_domain
+    return AgentListResponse(
+        agents=[_as_agent_response(a, trust_domain) for a in agents],
+        total=len(agents),
+    )
+
+
+@router.get("/agents/search", response_model=AgentListResponse)
+async def search_federated_agents(
+    capability: list[str] | None = Query(None, description="Filter by capabilities (AND)"),
+    agent_id: str | None = Query(None, description="Direct lookup by agent_id"),
+    agent_uri: str | None = Query(None, description="Direct lookup by SPIFFE URI"),
+    org_id: str | None = Query(None, description="Filter by organization"),
+    pattern: str | None = Query(None, description="Glob pattern on agent_id"),
+    q: str | None = Query(None, description="Free-text search"),
+    include_own_org: bool = Query(False, description="Include agents from your own org"),
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Cross-org discovery with flexible filters. At least one filter required."""
+    if not any([capability, agent_id, agent_uri, org_id, pattern, q]):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="At least one search parameter is required",
+        )
+
+    settings = get_settings()
+    is_direct = bool(agent_id or agent_uri)
+    exclude = None if (is_direct or include_own_org) else current_agent.org
+
+    agents = await search_agents(
+        db,
+        capabilities=capability,
+        agent_id=agent_id,
+        agent_uri=agent_uri,
+        org_id=org_id,
+        pattern=pattern,
+        q=q,
+        exclude_org_id=exclude,
+        trust_domain=settings.trust_domain,
+    )
+    return AgentListResponse(
+        agents=[_as_agent_response(a, settings.trust_domain) for a in agents],
+        total=len(agents),
+    )
+
+
+@router.get("/agents/{agent_id}/public-key", response_model=AgentPublicKeyResponse)
+async def get_federated_agent_public_key(
+    agent_id: str,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the PEM public key extracted from the agent's pinned cert.
+
+    Same-org always allowed; cross-org requires an approved binding.
+    """
+    agent = await get_agent_by_id(db, agent_id)
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    if agent.org_id != current_agent.org:
+        binding = await get_approved_binding(db, agent.org_id, agent_id)
+        if not binding:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No approved binding with this agent",
+            )
+
+    if not agent.cert_pem:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Certificate not available — agent must login first",
+        )
+
+    cert = crypto_x509.load_pem_x509_certificate(agent.cert_pem.encode())
+    public_key_pem = cert.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return AgentPublicKeyResponse(agent_id=agent_id, public_key_pem=public_key_pem)
+
+
+@router.get("/agents/{agent_id}", response_model=AgentResponse)
+async def get_federated_agent(
+    agent_id: str,
+    current_agent: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+):
+    """Fetch an agent's full record. Same org-isolation as ``public-key``."""
+    agent = await get_agent_by_id(db, agent_id)
+    if not agent:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Agent not found")
+
+    if agent.org_id != current_agent.org:
+        binding = await get_approved_binding(db, agent.org_id, agent_id)
+        if not binding:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No approved binding with this agent",
+            )
+
+    trust_domain = get_settings().trust_domain
+    return _as_agent_response(agent, trust_domain)

--- a/app/main.py
+++ b/app/main.py
@@ -376,6 +376,12 @@ app.include_router(v1)
 from app.federation.publish import router as federation_router
 app.include_router(federation_router)
 
+# ADR-010 Phase 6a-1 — read-side federation API (cross-org discovery +
+# public-key lookup). Mirrors the legacy /v1/registry/agents GETs so
+# consumers can migrate by URL swap; Phase 6a-4 deletes the originals.
+from app.federation.read import router as federation_read_router
+app.include_router(federation_read_router)
+
 # ── Static files ─────────────────────────────────────────────────────────────
 app.mount("/static", StaticFiles(directory="app/static"), name="static")
 

--- a/tests/test_federation_read.py
+++ b/tests/test_federation_read.py
@@ -1,0 +1,220 @@
+"""ADR-010 Phase 6a-1 — Court federation read endpoints.
+
+Mirrors ``/v1/registry/agents`` GETs under ``/v1/federation/agents``.
+These tests validate that behaviour is bit-for-bit equivalent:
+
+  - list scoped to own org (403 when asking another org)
+  - search respects capability filter + excludes own org by default
+  - public-key fetch requires same-org or an approved binding
+  - single-agent fetch follows the same isolation rule
+
+Once every caller has migrated to the new prefix, Phase 6a-4 deletes
+the legacy registry routes and we drop the parity guarantee here too.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from tests.cert_factory import get_org_ca_pem
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _setup(client: AsyncClient, org_id: str, agent_id: str,
+                 capabilities: list[str], dpop) -> str:
+    org_secret = org_id + "-secret"
+    await client.post("/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": org_id, "secret": org_secret,
+    }, headers=ADMIN_HEADERS)
+    await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": get_org_ca_pem(org_id)},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    await client.post("/v1/registry/agents", json={
+        "agent_id": agent_id, "org_id": org_id,
+        "display_name": agent_id, "capabilities": capabilities,
+    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    resp = await client.post(
+        "/v1/registry/bindings",
+        json={"org_id": org_id, "agent_id": agent_id, "scope": capabilities},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    binding_id = resp.json()["id"]
+    await client.post(
+        f"/v1/registry/bindings/{binding_id}/approve",
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    return await dpop.get_token(client, agent_id, org_id)
+
+
+# ── list ────────────────────────────────────────────────────────────────
+
+async def test_list_returns_own_org(client: AsyncClient, dpop):
+    token = await _setup(
+        client, "fr-list-a", "fr-list-a::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents",
+        headers=dpop.headers("GET", "/v1/federation/agents", token),
+    )
+    assert resp.status_code == 200
+    ids = [a["agent_id"] for a in resp.json()["agents"]]
+    assert "fr-list-a::agent" in ids
+
+
+async def test_list_rejects_other_org(client: AsyncClient, dpop):
+    token = await _setup(
+        client, "fr-list-b", "fr-list-b::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents",
+        params={"org_id": "some-other-org"},
+        headers=dpop.headers("GET", "/v1/federation/agents", token),
+    )
+    assert resp.status_code == 403
+
+
+# ── search ──────────────────────────────────────────────────────────────
+
+async def test_search_finds_cross_org_match(client: AsyncClient, dpop):
+    token_buyer = await _setup(
+        client, "fr-sup-buy", "fr-sup-buy::agent",
+        ["order.read", "order.write"], dpop,
+    )
+    await _setup(
+        client, "fr-sup-sup", "fr-sup-sup::agent",
+        ["order.read", "order.write"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents/search",
+        params={"capability": ["order.read", "order.write"]},
+        headers=dpop.headers("GET", "/v1/federation/agents/search", token_buyer),
+    )
+    assert resp.status_code == 200
+    ids = [a["agent_id"] for a in resp.json()["agents"]]
+    assert "fr-sup-sup::agent" in ids
+
+
+async def test_search_excludes_own_org_by_default(client: AsyncClient, dpop):
+    token = await _setup(
+        client, "fr-exc-self", "fr-exc-self::agent", ["cap.read"], dpop,
+    )
+    await _setup(
+        client, "fr-exc-other", "fr-exc-other::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents/search",
+        params={"capability": ["cap.read"]},
+        headers=dpop.headers("GET", "/v1/federation/agents/search", token),
+    )
+    assert resp.status_code == 200
+    ids = [a["agent_id"] for a in resp.json()["agents"]]
+    assert "fr-exc-self::agent" not in ids
+    assert "fr-exc-other::agent" in ids
+
+
+async def test_search_requires_at_least_one_filter(client: AsyncClient, dpop):
+    token = await _setup(
+        client, "fr-flt", "fr-flt::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents/search",
+        headers=dpop.headers("GET", "/v1/federation/agents/search", token),
+    )
+    assert resp.status_code == 422
+
+
+# ── public-key ──────────────────────────────────────────────────────────
+
+async def test_public_key_same_org(client: AsyncClient, dpop):
+    """Same-org fetch returns 404 when target hasn't logged in (no cert
+    pinned) — same contract the legacy ``/v1/registry`` endpoint served."""
+    token = await _setup(
+        client, "fr-pk-a", "fr-pk-a::caller", ["cap.read"], dpop,
+    )
+    # Second agent in the same org, never logs in → cert_pem NULL.
+    await client.post("/v1/registry/agents", json={
+        "agent_id": "fr-pk-a::peer", "org_id": "fr-pk-a",
+        "display_name": "peer", "capabilities": ["cap.read"],
+    }, headers={"x-org-id": "fr-pk-a", "x-org-secret": "fr-pk-a-secret"})
+
+    resp = await client.get(
+        "/v1/federation/agents/fr-pk-a::peer/public-key",
+        headers=dpop.headers(
+            "GET", "/v1/federation/agents/fr-pk-a::peer/public-key", token,
+        ),
+    )
+    assert resp.status_code == 404
+
+
+async def test_public_key_cross_org_requires_binding(client: AsyncClient, dpop):
+    """Cross-org fetch without any approved binding → 403."""
+    token = await _setup(
+        client, "fr-pk-caller", "fr-pk-caller::agent", ["cap.read"], dpop,
+    )
+    # Bootstrap the target org *without* an approved binding: we skip
+    # the binding create/approve steps that ``_setup`` does.
+    await client.post("/v1/registry/orgs", json={
+        "org_id": "fr-pk-no-bind", "display_name": "no-bind",
+        "secret": "fr-pk-no-bind-secret",
+    }, headers=ADMIN_HEADERS)
+    await client.post(
+        "/v1/registry/orgs/fr-pk-no-bind/certificate",
+        json={"ca_certificate": get_org_ca_pem("fr-pk-no-bind")},
+        headers={"x-org-id": "fr-pk-no-bind", "x-org-secret": "fr-pk-no-bind-secret"},
+    )
+    await client.post("/v1/registry/agents", json={
+        "agent_id": "fr-pk-no-bind::agent", "org_id": "fr-pk-no-bind",
+        "display_name": "no-bind-agent", "capabilities": ["cap.read"],
+    }, headers={"x-org-id": "fr-pk-no-bind", "x-org-secret": "fr-pk-no-bind-secret"})
+
+    resp = await client.get(
+        "/v1/federation/agents/fr-pk-no-bind::agent/public-key",
+        headers=dpop.headers(
+            "GET", "/v1/federation/agents/fr-pk-no-bind::agent/public-key", token,
+        ),
+    )
+    assert resp.status_code == 403
+
+
+# ── single-agent GET ────────────────────────────────────────────────────
+
+async def test_get_agent_same_org(client: AsyncClient, dpop):
+    token = await _setup(
+        client, "fr-get", "fr-get::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents/fr-get::agent",
+        headers=dpop.headers("GET", "/v1/federation/agents/fr-get::agent", token),
+    )
+    assert resp.status_code == 200
+    assert resp.json()["agent_id"] == "fr-get::agent"
+
+
+async def test_get_agent_unknown_returns_404(client: AsyncClient, dpop):
+    token = await _setup(
+        client, "fr-404", "fr-404::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents/nope::missing",
+        headers=dpop.headers("GET", "/v1/federation/agents/nope::missing", token),
+    )
+    assert resp.status_code == 404
+
+
+# ── auth ────────────────────────────────────────────────────────────────
+
+async def test_list_requires_auth(client: AsyncClient):
+    resp = await client.get("/v1/federation/agents")
+    assert resp.status_code in (401, 403)
+
+
+async def test_search_requires_auth(client: AsyncClient):
+    resp = await client.get(
+        "/v1/federation/agents/search",
+        params={"capability": ["cap.read"]},
+    )
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary

ADR-010 Phase 6a-1 — **non-breaking**. Adds 4 GET endpoints under ``/v1/federation/agents`` that mirror the legacy ``/v1/registry/agents`` reads bit-for-bit. Callers can migrate by URL swap; Phase 6a-4 deletes the legacy namespace once nothing depends on it.

New router ``app/federation/read.py``:
- ``GET /v1/federation/agents`` — list own-org agents
- ``GET /v1/federation/agents/search`` — cross-org discovery with filters (capability, agent_id, org_id, pattern, q)
- ``GET /v1/federation/agents/{id}`` — agent details
- ``GET /v1/federation/agents/{id}/public-key`` — fetch pinned cert's public key

Auth + org-isolation are identical to the registry equivalents:
- Same ``get_current_agent`` JWT dep
- Same binding check (cross-org → approved binding required)
- Same 422 on empty search, 403 on foreign-org list, 404 on unknown agent

## Phase 6a plan

| Phase | Status | What |
|---|---|---|
| **6a-1** | **this PR** | Add ``/v1/federation/agents`` GET mirrors (non-breaking) |
| 6a-2 | next | Migrate SDK ``discover()`` / ``fetch_public_key()`` + demo / sandbox callers |
| 6a-3 | next | Migrate ~60 test files from ``POST /v1/registry/agents`` setup to direct-DB insert |
| 6a-4 | last | Hard-delete ``/v1/registry/agents`` namespace + legacy SDK methods |

## Threat model

No change yet — the legacy endpoints still exist. Phase 6a-4 closes the registration-bypass via ``org_secret`` described in ADR-010.

## Test plan

- [x] ``pytest tests/test_federation_read.py -n 0`` — 11/11 pass
- [x] ``pytest tests/test_federation_read.py tests/test_federation_publish.py tests/test_federation_publisher.py tests/test_discovery.py tests/test_enhanced_discovery.py -n 0`` — 42/42 pass (no regression in neighbouring federation / registry surfaces)
- [ ] ``demo_network smoke`` — runs in CI