### PR TITLE
feat(mastio): DPoP-bound egress auth dep + mode flag (F-B-11 Phase 1)

### DIFF
--- a/mcp_proxy/auth/dpop_api_key.py
+++ b/mcp_proxy/auth/dpop_api_key.py
@@ -1,0 +1,173 @@
+"""DPoP-bound X-API-Key authentication for the egress surface (F-B-11 Phase 1).
+
+Mastio today authenticates ``/v1/egress/*`` agents with a plain bearer
+``X-API-Key`` header (see ``mcp_proxy.auth.api_key.get_agent_from_api_key``).
+A leaked ``.env`` = full impersonation toward the Connector, asymmetric to
+the ingress surface which already enforces DPoP-bound JWT (RFC 9449) on
+every authenticated request. Audit F-B-11 (#181).
+
+This module introduces the dep that will replace the bearer path in
+``/v1/egress/*``: ``get_agent_from_dpop_api_key``. It delegates the
+API-key lookup and rate-limit enforcement to the legacy helper, then —
+when the ``CULLIS_EGRESS_DPOP_MODE`` flag is ``optional`` or
+``required`` — also verifies a DPoP proof carried in the ``DPoP``
+header. The proof is bound to the API-key via the ``ath`` claim
+(``base64url(sha256(api_key))``) and validated against the request's
+method + URL + a one-shot ``jti``.
+
+Phase 1 contract (this PR):
+  * New dep exists and is importable.
+  * Default flag ``off`` keeps runtime unchanged — no handler wired yet.
+  * ``optional`` accepts legacy-only AND DPoP-bound requests.
+  * ``required`` rejects legacy-only requests (bare bearer).
+  * Per-agent JWK thumbprint binding (``cnf.jkt`` ↔ stored ``dpop_jkt``)
+    is deferred to Phase 2 — the column does not yet exist and Agent B's
+    parallel device_info migration owns the next slot.
+
+Phase 2 will:
+  * Add ``internal_agents.dpop_jkt`` via its own migration.
+  * Populate it in the enrollment flow.
+  * Extend this dep to compare the proof's ``jkt`` with the stored value
+    — refusing requests whose proof is valid but signed by a key the
+    agent never registered.
+
+Phase 5 will swap the 12 ``/v1/egress/*`` handlers to ``Depends(...)``
+this dep, still with ``off`` as the default until Phase 6 flips it.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from fastapi import HTTPException, Request, status
+
+from mcp_proxy.auth.api_key import get_agent_from_api_key
+from mcp_proxy.config import get_settings
+from mcp_proxy.models import InternalAgent
+
+_log = logging.getLogger("mcp_proxy")
+
+# The ingress ``get_authenticated_agent`` uses RFC 9449 server nonces
+# (``require_nonce=True``). Mirror that here for parity once the flag is
+# flipped. Phase 3 SDK picks up the ``DPoP-Nonce`` header and retries.
+_REQUIRE_NONCE_DEFAULT = True
+
+# Recognised values for CULLIS_EGRESS_DPOP_MODE.
+_MODES = frozenset({"off", "optional", "required"})
+
+
+def _build_htu(request: Request) -> str:
+    """Build the canonical HTU the SDK would have signed against.
+
+    When ``proxy_public_url`` is set, every SDK builds proof htu from
+    that base + the request path (regardless of whether the proxy sits
+    behind a reverse proxy). Fall back to the request URL as uvicorn
+    reconstructs it otherwise — the DPoP verifier normalises
+    http/ws scheme pairs and strips queries/fragments so the two shapes
+    are equivalent for request-path matching.
+    """
+    settings = get_settings()
+    base = (settings.proxy_public_url or "").rstrip("/")
+    if base:
+        return base + request.url.path
+    return str(request.url)
+
+
+def _resolve_mode() -> str:
+    """Read the CULLIS_EGRESS_DPOP_MODE flag and normalise.
+
+    Unknown values fall back to ``off`` with a warning — we never want a
+    typo in ``.env`` to unexpectedly enforce (``required``) or silently
+    drop (``optional``) DPoP. Operators who flip the flag see the
+    effect only when it matches one of the three canonical values.
+    """
+    mode = (get_settings().egress_dpop_mode or "off").strip().lower()
+    if mode not in _MODES:
+        _log.warning(
+            "Unknown CULLIS_EGRESS_DPOP_MODE=%r — falling back to 'off'. "
+            "Valid values: off | optional | required.",
+            mode,
+        )
+        return "off"
+    return mode
+
+
+async def get_agent_from_dpop_api_key(request: Request) -> InternalAgent:
+    """Egress agent auth with optional DPoP-bound proof (F-B-11).
+
+    Always runs the legacy bearer lookup first so:
+      * the API-key format is sanity-checked and bcrypt-verified,
+      * rate-limiting accounts for every request regardless of mode,
+      * the returned ``InternalAgent`` record drives downstream
+        handlers exactly as before.
+
+    When the mode flag is ``off`` the function is a thin wrapper and
+    runtime is indistinguishable from the legacy dep. When it is
+    ``optional`` or ``required``, a DPoP proof from the ``DPoP`` header
+    is validated — htm/htu match the concrete request, jti is consumed
+    atomically via the shared JTI store, iat is within the acceptance
+    window, and ``ath`` must match ``base64url(sha256(api_key))`` so
+    the proof is bound to *this* API-key and not a different one that
+    the same attacker might also control.
+    """
+    agent = await get_agent_from_api_key(request)
+
+    mode = _resolve_mode()
+    if mode == "off":
+        return agent
+
+    dpop_header = request.headers.get("DPoP")
+    if not dpop_header:
+        if mode == "required":
+            _log.warning(
+                "DPoP proof required but missing on egress request "
+                "(agent=%s, path=%s)",
+                agent.agent_id,
+                request.url.path,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="DPoP proof required — set MCP_PROXY_EGRESS_DPOP_MODE=optional "
+                       "or upgrade the client SDK to emit DPoP proofs.",
+                headers={"WWW-Authenticate": 'DPoP realm="egress", algs="ES256 PS256"'},
+            )
+        # optional mode, legacy bearer accepted — grace period.
+        return agent
+
+    # Verify the DPoP proof. ``verify_dpop_proof`` raises 401 on every
+    # failure; we let it propagate.
+    api_key = request.headers.get("X-API-Key") or ""
+    htu = _build_htu(request)
+    htm = request.method
+
+    from mcp_proxy.auth.dpop import verify_dpop_proof  # local import: avoid cycle
+    proof_jkt = await verify_dpop_proof(
+        dpop_header,
+        htm=htm,
+        htu=htu,
+        access_token=api_key,
+        require_nonce=_REQUIRE_NONCE_DEFAULT,
+    )
+
+    # Phase 2 will check ``proof_jkt`` against the agent's stored
+    # ``dpop_jkt``. Until then accept any cryptographically-valid proof
+    # in optional / required modes — this already closes the
+    # "attacker captured a valid proof, replays it" threat because the
+    # verifier consumes the jti atomically. The remaining hole
+    # (attacker with the same-keypair re-signs a fresh proof) is what
+    # the Phase 2 jkt pin closes.
+    _log.debug(
+        "Egress DPoP proof accepted (agent=%s, jkt=%s, mode=%s)",
+        agent.agent_id, proof_jkt, mode,
+    )
+    return agent
+
+
+def compute_api_key_ath(api_key: str) -> str:
+    """Helper: compute the ``ath`` claim a DPoP proof must carry for
+    this API-key. Exported for SDK reuse and for tests — the server
+    side delegates to ``verify_dpop_proof`` which computes it inline.
+    """
+    import base64
+    digest = hashlib.sha256(api_key.encode()).digest()
+    return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -91,6 +91,21 @@ class ProxySettings(BaseSettings):
     # Accepts redis:// or rediss:// URLs.
     redis_url: str = ""
 
+    # Egress DPoP mode — audit F-B-11 Phase 1 (#181).
+    # Controls whether ``/v1/egress/*`` handlers accept a DPoP proof
+    # (RFC 9449) in addition to the legacy ``X-API-Key`` bearer:
+    #   off      → legacy bearer only (default, runtime unchanged)
+    #   optional → DPoP accepted when headers are present; legacy still
+    #              allowed. Grace-period stance for rolling out Phase 2
+    #              enrollment + Phase 3/4 SDK updates without breaking
+    #              in-flight clients.
+    #   required → DPoP proof mandatory on every egress call; legacy
+    #              bare bearer rejected. Flipped in Phase 6 after every
+    #              enrolled agent has registered a JWK thumbprint.
+    # The DPoP-bound dep lives in ``mcp_proxy.auth.dpop_api_key``; the
+    # per-agent jkt-vs-registered check lands with Phase 2 enrollment.
+    egress_dpop_mode: str = "off"
+
     # ADR-001 Phase 2 — SPIFFE routing decision.
     # trust_domain is the SPIFFE trust domain this proxy serves (matched against
     # recipient SPIFFE IDs to decide intra vs cross-org). intra_org_routing is

--- a/tests/test_egress_dpop_auth.py
+++ b/tests/test_egress_dpop_auth.py
@@ -1,0 +1,327 @@
+"""Unit tests for the DPoP-bound egress dep (F-B-11 Phase 1).
+
+Exercises ``mcp_proxy.auth.dpop_api_key.get_agent_from_dpop_api_key``
+in isolation by bypassing the legacy bcrypt + rate-limit path — those
+are covered by the existing ``tests/test_proxy_*`` integration suites
+and are not the contract under test here.
+
+Scope per F-B-11 Phase 1 (issue #181):
+  * ``CULLIS_EGRESS_DPOP_MODE=off`` (default) → dep delegates; no DPoP.
+  * ``...=optional`` → missing ``DPoP`` header accepted; when present,
+    the proof is fully verified (htm/htu/jti/iat/ath + nonce).
+  * ``...=required`` → missing ``DPoP`` header rejected (401 + WWW-
+    Authenticate); valid proof accepted.
+  * Invalid / malformed / replayed proofs rejected in every non-off mode.
+  * Unknown mode string falls back to ``off`` with a warning.
+
+Phase 2 (separate PR) will add the per-agent ``dpop_jkt`` binding, its
+migration, and the enrollment-side population. Those assertions live
+with that PR.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+from urllib.parse import urlparse
+
+import pytest
+from fastapi import HTTPException
+
+from mcp_proxy.auth import dpop as _dpop_mod
+from mcp_proxy.auth import dpop_api_key as _dpop_api_key_mod
+from mcp_proxy.auth.dpop_api_key import (
+    compute_api_key_ath,
+    get_agent_from_dpop_api_key,
+)
+from mcp_proxy.models import InternalAgent
+from tests.cert_factory import make_dpop_key_pair, make_dpop_proof
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Helpers ─────────────────────────────────────────────────────────
+
+class _FakeURL:
+    def __init__(self, url: str) -> None:
+        self._s = url
+        self.path = urlparse(url).path
+
+    def __str__(self) -> str:
+        return self._s
+
+
+class _FakeRequest:
+    """Stand-in for starlette Request with just the attributes read by
+    ``get_agent_from_dpop_api_key``."""
+
+    def __init__(self, *, method: str, url: str, headers: dict | None) -> None:
+        self.method = method
+        self.url = _FakeURL(url)
+        self.headers = headers or {}
+
+
+def _make_request(
+    headers: dict | None = None,
+    method: str = "POST",
+    url: str = "http://test/v1/egress/message/send",
+) -> _FakeRequest:
+    return _FakeRequest(method=method, url=url, headers=headers)
+
+
+_FAKE_AGENT = InternalAgent(
+    agent_id="fb11-test-agent",
+    display_name="fb11-test",
+    capabilities=[],
+    created_at="2026-04-17T00:00:00Z",
+    is_active=True,
+    cert_pem=None,
+)
+
+
+@pytest.fixture
+def bypass_legacy(monkeypatch):
+    """Stub ``get_agent_from_api_key`` so the dep's own logic is what
+    gets exercised — not bcrypt, DB lookup, or rate limiting."""
+    async def _ok(_request):
+        return _FAKE_AGENT
+
+    monkeypatch.setattr(_dpop_api_key_mod, "get_agent_from_api_key", _ok)
+
+
+@pytest.fixture
+def force_mode(monkeypatch):
+    """Set ``MCP_PROXY_EGRESS_DPOP_MODE`` + clear the ``get_settings``
+    lru_cache so the new value is honoured."""
+    from mcp_proxy.config import get_settings
+
+    def _set(mode: str) -> None:
+        monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", mode)
+        get_settings.cache_clear()
+
+    yield _set
+    get_settings.cache_clear()
+
+
+def _fresh_nonce() -> str:
+    """Prime the proxy-side DPoP nonce store and return the current nonce
+    so proofs carry a value the verifier accepts."""
+    return _dpop_mod.get_current_dpop_nonce()
+
+
+def _valid_proof(
+    api_key: str,
+    *,
+    method: str = "POST",
+    url: str = "http://test/v1/egress/message/send",
+    jti: str | None = None,
+    nonce: str | None = None,
+):
+    """Build (proof, priv, jwk) so tests can regenerate variants."""
+    priv, jwk = make_dpop_key_pair()
+    proof = make_dpop_proof(
+        priv, jwk, method, url,
+        access_token=api_key,
+        jti=jti,
+        nonce=nonce or _fresh_nonce(),
+    )
+    return proof, priv, jwk
+
+
+# ── mode=off (default) ──────────────────────────────────────────────
+
+async def test_mode_off_delegates_without_dpop(bypass_legacy, force_mode):
+    force_mode("off")
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": "sk_local_x_" + "a" * 32})
+    )
+    assert agent is _FAKE_AGENT
+
+
+async def test_mode_off_ignores_bogus_dpop_header(bypass_legacy, force_mode):
+    """In off mode a garbage DPoP header is NOT validated — legacy
+    bearer runs unchanged. No token flag could ever unintentionally
+    enable enforcement via a stray header."""
+    force_mode("off")
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={
+            "X-API-Key": "sk_local_x_" + "a" * 32,
+            "DPoP": "not.a.real.jwt",
+        })
+    )
+    assert agent is _FAKE_AGENT
+
+
+# ── mode=optional ───────────────────────────────────────────────────
+
+async def test_mode_optional_accepts_legacy_without_dpop(bypass_legacy, force_mode):
+    """Grace period: clients without the DPoP header still work."""
+    force_mode("optional")
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": "sk_local_x_" + "a" * 32})
+    )
+    assert agent is _FAKE_AGENT
+
+
+async def test_mode_optional_accepts_valid_proof(bypass_legacy, force_mode):
+    force_mode("optional")
+    api_key = "sk_local_test_" + "b" * 32
+    proof, _, _ = _valid_proof(api_key)
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+    )
+    assert agent is _FAKE_AGENT
+
+
+async def test_mode_optional_rejects_malformed_proof(bypass_legacy, force_mode):
+    force_mode("optional")
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": "sk_x", "DPoP": "garbage"})
+        )
+    assert exc.value.status_code == 401
+
+
+# ── mode=required ───────────────────────────────────────────────────
+
+async def test_mode_required_rejects_missing_dpop(bypass_legacy, force_mode):
+    force_mode("required")
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": "sk_x"})
+        )
+    assert exc.value.status_code == 401
+    assert "DPoP" in exc.value.headers.get("WWW-Authenticate", "")
+
+
+async def test_mode_required_accepts_valid_proof(bypass_legacy, force_mode):
+    force_mode("required")
+    api_key = "sk_local_test_" + "c" * 32
+    proof, _, _ = _valid_proof(api_key)
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+    )
+    assert agent is _FAKE_AGENT
+
+
+# ── Proof binding invariants ────────────────────────────────────────
+
+async def test_proof_bound_to_different_api_key_rejected(bypass_legacy, force_mode):
+    """``ath`` must match sha256(X-API-Key). A proof built against
+    key-A replayed with key-B in the header is rejected."""
+    force_mode("optional")
+    api_key_a = "sk_local_a_" + "d" * 32
+    api_key_b = "sk_local_b_" + "e" * 32
+    proof, _, _ = _valid_proof(api_key_a)
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key_b, "DPoP": proof})
+        )
+    assert exc.value.status_code == 401
+
+
+async def test_proof_with_wrong_htm_rejected(bypass_legacy, force_mode):
+    force_mode("optional")
+    api_key = "sk_local_htm_" + "f" * 32
+    # Proof claims GET; request arrives as POST.
+    priv, jwk = make_dpop_key_pair()
+    proof = make_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/egress/message/send",
+        access_token=api_key, nonce=_fresh_nonce(),
+    )
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+        )
+    assert exc.value.status_code == 401
+
+
+async def test_proof_with_wrong_htu_rejected(bypass_legacy, force_mode):
+    force_mode("optional")
+    api_key = "sk_local_htu_" + "g" * 32
+    # Proof signed against a different URL than the request target.
+    priv, jwk = make_dpop_key_pair()
+    proof = make_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/egress/some/other/path",
+        access_token=api_key, nonce=_fresh_nonce(),
+    )
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+        )
+    assert exc.value.status_code == 401
+
+
+async def test_replayed_jti_rejected(bypass_legacy, force_mode):
+    force_mode("optional")
+    api_key = "sk_local_replay_" + "h" * 32
+    jti = "fixed-jti-for-replay-" + "i" * 16
+    # First request: accepted.
+    priv, jwk = make_dpop_key_pair()
+    nonce = _fresh_nonce()
+    proof_1 = make_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/egress/message/send",
+        access_token=api_key, jti=jti, nonce=nonce,
+    )
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": api_key, "DPoP": proof_1})
+    )
+    assert agent is _FAKE_AGENT
+
+    # Second request: same jti, different proof signature (new ephemeral
+    # key). Still rejected because the jti has been consumed.
+    priv2, jwk2 = make_dpop_key_pair()
+    proof_2 = make_dpop_proof(
+        priv2, jwk2, "POST", "http://test/v1/egress/message/send",
+        access_token=api_key, jti=jti, nonce=nonce,
+    )
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key, "DPoP": proof_2})
+        )
+    assert exc.value.status_code == 401
+
+
+# ── Unknown mode defensive behaviour ────────────────────────────────
+
+async def test_unknown_mode_falls_back_to_off(bypass_legacy, monkeypatch):
+    """Typos in the env var must NOT silently enable enforcement
+    (``required``) nor silently drop DPoP (``optional``) — fall back to
+    off with a logged warning."""
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "Require")  # case wrong + typo
+    get_settings.cache_clear()
+
+    warnings: list[str] = []
+
+    def _record(msg, *args, **kwargs):
+        warnings.append(str(msg) % args if args else str(msg))
+
+    monkeypatch.setattr(_dpop_api_key_mod._log, "warning", _record)
+
+    try:
+        # No DPoP header: in off mode legacy passes. In required mode it
+        # would 401. So success here confirms fallback to off.
+        agent = await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": "sk_x"})
+        )
+        assert agent is _FAKE_AGENT
+        assert any("Unknown" in msg and "off" in msg for msg in warnings), (
+            f"expected fallback warning, got: {warnings}"
+        )
+    finally:
+        get_settings.cache_clear()
+
+
+# ── compute_api_key_ath helper ──────────────────────────────────────
+
+def test_compute_api_key_ath_matches_rfc9449():
+    """``ath`` = ``base64url(sha256(api_key))``, no padding. SDKs will
+    reuse this helper to emit proofs the server accepts."""
+    import hashlib
+    import base64
+
+    api_key = "sk_local_ath_test_" + "z" * 16
+    expected = base64.urlsafe_b64encode(
+        hashlib.sha256(api_key.encode()).digest()
+    ).rstrip(b"=").decode("ascii")
+    assert compute_api_key_ath(api_key) == expected

--- a/tests/test_egress_dpop_auth.py
+++ b/tests/test_egress_dpop_auth.py
@@ -20,7 +20,6 @@ with that PR.
 """
 from __future__ import annotations
 
-from unittest.mock import patch
 from urllib.parse import urlparse
 
 import pytest


### PR DESCRIPTION
## Summary

First of 6 phases for **F-B-11** — bring Mastio's \`/v1/egress/*\` surface to DPoP parity with ingress (issue #181). This PR introduces the new dep and the feature flag **without changing any handler and without any DB migration**. Default mode is \`off\`, so runtime is identical to main until a later phase flips the switch.

Closes progress on **#181** Phase 1.

## Why

\`/v1/egress/*\` authenticates via bearer \`X-API-Key\`. A leaked \`.env\` = full agent impersonation toward the Connector. Ingress uses DPoP-bound JWT (RFC 9449) on every request — this PR starts the sequence that brings egress to the same guarantee.

## What changed

New module \`mcp_proxy/auth/dpop_api_key.py\`:
- \`get_agent_from_dpop_api_key(request)\` — dep that always runs the legacy bearer lookup first (so bcrypt + rate limit still apply), then, when the flag is \`optional\` / \`required\`, verifies a DPoP proof from the \`DPoP\` header. The proof is bound to the API-key via \`ath = base64url(sha256(api_key))\` and to the concrete request via htm/htu. JTI is consumed atomically via the shared JTI store from #185.
- \`compute_api_key_ath(api_key)\` — helper for SDK and tests. Server and client must produce byte-identical ath values.

New config field in \`mcp_proxy/config.py\`:
- \`CULLIS_EGRESS_DPOP_MODE\` ∈ \`{off, optional, required}\`, default \`off\`. Unknown values fall back to \`off\` with a WARNING — typos never silently enable enforcement nor silently drop DPoP.

## Deliberate non-goals for Phase 1

- **No DB schema change.** Per-agent \`dpop_jkt\` binding (cnf.jkt ↔ stored thumbprint) is deferred to Phase 2 where it lives next to the enrollment wiring. This also avoids a migration-slot race with Agent B's device_info migration (slot 0013).
- **No handler swap.** The 12 \`/v1/egress/*\` call sites still use \`Depends(get_agent_from_api_key)\`. Phase 5 flips them.
- **No SDK change.** Phase 3/4 pick up the proof-emission side in \`cullis_sdk\` and \`sdk-ts\`.

## Phase roadmap

| Phase | Scope | Status |
|---|---|---|
| 1 | This PR: dep surface + flag | ← open |
| 2 | \`internal_agents.dpop_jkt\` migration + enrollment populate + dep extended to compare proof.jkt vs stored | next |
| 3 | Python SDK emits DPoP proofs (nonce round-trip) | |
| 4 | TS SDK + interop vectors | |
| 5 | Swap 12 egress handlers, deployment-default \`optional\` | |
| 6 | Flip default to \`required\`, delete legacy dep on egress | |

## Tests (13 new, all unit-level)

\`tests/test_egress_dpop_auth.py\` — bypasses the legacy bcrypt + rate-limit helper (covered by \`tests/test_proxy_*\`) so the dep's own contract is exercised in isolation:

- mode=off delegates (with AND without a stray \`DPoP\` header — the stray header must NOT opt in).
- mode=optional accepts legacy bearer AND valid DPoP proof.
- mode=optional rejects malformed proof.
- mode=required rejects missing DPoP with 401 + \`WWW-Authenticate: DPoP realm=\"egress\", algs=\"ES256 PS256\"\`.
- mode=required accepts valid DPoP proof.
- Proof bound to a different api_key is rejected (ath mismatch, closes \"two agents sharing a DPoP key\").
- Proof with wrong htm / wrong htu rejected.
- Replayed jti rejected — the verifier consumes atomically, even if the replay carries a different ephemeral signing key.
- Unknown mode string (typo) falls back to \`off\` with a WARNING, never silently enforces.
- \`compute_api_key_ath\` produces the RFC 9449 shape the SDK must match.

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1282 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_egress_dpop_auth.py -q\` — 13 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.

## Coordination with Agent B

Agent B owns migration slot 0013 for \`internal_agents.device_info\` (their PR #2 is imminent). This PR deliberately ships no migration so our slots do not collide. Phase 2 of this epic will take the next free slot after #2 lands.