### PR TITLE
feat(sdk+proxy): migrate cross-org reads to /v1/federation/ (ADR-010 Phase 6a-2)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -558,8 +558,12 @@ class CullisClient:
         pattern: str | None = None,
         q: str | None = None,
     ) -> list[AgentInfo]:
-        """Search for agents in the network."""
-        path = "/v1/registry/agents/search"
+        """Search for agents in the network.
+
+        ADR-010 Phase 6a: reads from the ``/v1/federation/`` namespace,
+        which is where the Court now serves cross-org discovery.
+        """
+        path = "/v1/federation/agents/search"
         params: list[tuple[str, str]] = []
         if capabilities:
             params.extend([("capability", c) for c in capabilities])
@@ -576,12 +580,15 @@ class CullisClient:
         return [AgentInfo.from_dict(a) for a in resp.json().get("agents", [])]
 
     def get_agent_public_key(self, agent_id: str, force_refresh: bool = False) -> str:
-        """Retrieve agent PEM public key from the broker (TTL-cached)."""
+        """Retrieve agent PEM public key from the broker (TTL-cached).
+
+        ADR-010 Phase 6a: reads from the ``/v1/federation/`` namespace.
+        """
         if not force_refresh and agent_id in self._pubkey_cache:
             pubkey_pem, fetched_at = self._pubkey_cache[agent_id]
             if time.time() - fetched_at < _PUBKEY_CACHE_TTL:
                 return pubkey_pem
-        path = f"/v1/registry/agents/{agent_id}/public-key"
+        path = f"/v1/federation/agents/{agent_id}/public-key"
         resp = self._authed_request("GET", path)
         resp.raise_for_status()
         pubkey_pem = resp.json()["public_key_pem"]

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -573,8 +573,15 @@ app.include_router(admin_agents_router)
 # ordering uniform for clarity.
 from mcp_proxy.agents.router import router as agents_router
 app.include_router(agents_router)
-from mcp_proxy.registry.public_key import router as registry_public_key_router
+from mcp_proxy.registry.public_key import (
+    federation_router as federation_public_key_router,
+    router as registry_public_key_router,
+)
 app.include_router(registry_public_key_router)
+# ADR-010 Phase 6a-2 — same handler exposed under /v1/federation/ so
+# SDKs migrating to the new prefix hit the proxy-native (local-first)
+# lookup rather than falling through to the reverse-proxy catch-all.
+app.include_router(federation_public_key_router)
 
 # ADR-004 PR A — reverse-proxy router for /v1/broker/*, /v1/auth/*,
 # /v1/registry/*. Registered before local handlers so the proxy owns these

--- a/mcp_proxy/registry/public_key.py
+++ b/mcp_proxy/registry/public_key.py
@@ -35,11 +35,12 @@ from mcp_proxy.db import cert_thumbprint_from_pem, get_db
 _log = logging.getLogger("mcp_proxy.registry.public_key")
 
 router = APIRouter(prefix="/v1/registry/agents", tags=["registry"])
+federation_router = APIRouter(prefix="/v1/federation/agents", tags=["federation"])
 
 
 class PublicKeyResponse(BaseModel):
     agent_id: str
-    # Broker's equivalent endpoint (app/registry/router.py:185) returns
+    # Broker's equivalent endpoint (app/federation/read.py) returns
     # this exact field name; SDKs already consume `public_key_pem`.
     public_key_pem: str
     cert_thumbprint: str | None = None
@@ -47,6 +48,7 @@ class PublicKeyResponse(BaseModel):
 
 
 @router.get("/{agent_id}/public-key", response_model=PublicKeyResponse)
+@federation_router.get("/{agent_id}/public-key", response_model=PublicKeyResponse)
 async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
     """Return the agent's cert PEM.
 
@@ -91,7 +93,10 @@ async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
             detail="broker uplink not configured — cannot resolve federated agent",
         )
 
-    target = f"{broker_url.rstrip('/')}/v1/registry/agents/{agent_id}/public-key"
+    # ADR-010 Phase 6a: Court serves this endpoint under /v1/federation/.
+    # The legacy /v1/registry/ path still resolves until Phase 6a-4 deletes
+    # it, so older proxies keep working through that window.
+    target = f"{broker_url.rstrip('/')}/v1/federation/agents/{agent_id}/public-key"
     # Broker enforces org isolation + binding auth on this endpoint, so we
     # must propagate the caller's Authorization / DPoP headers. Hop-by-hop
     # headers are dropped for the same reason the reverse-proxy forwarder

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -217,9 +217,12 @@ export class BrokerClient {
       "capability",
       c,
     ]);
-    const resp = await this.authedRequest("GET", "/v1/registry/agents/search", {
-      params,
-    });
+    // ADR-010 Phase 6a — cross-org discovery now lives under /v1/federation/.
+    const resp = await this.authedRequest(
+      "GET",
+      "/v1/federation/agents/search",
+      { params },
+    );
     const data = JSON.parse(resp.text) as AgentListResponse;
     return data.agents ?? [];
   }
@@ -402,7 +405,8 @@ export class BrokerClient {
         return cached.pem;
       }
     }
-    const path = `/v1/registry/agents/${agentId}/public-key`;
+    // ADR-010 Phase 6a — public-key lookup served under /v1/federation/.
+    const path = `/v1/federation/agents/${agentId}/public-key`;
     const resp = await this.authedRequest("GET", path);
     const data = JSON.parse(resp.text) as { public_key_pem: string };
     this.pubkeyCache.set(agentId, {


### PR DESCRIPTION
## Summary

ADR-010 Phase 6a-2 — migrate the READ-path callers (Python SDK, TypeScript SDK, proxy forward) from the legacy ``/v1/registry/agents`` prefix to the Phase 6a-1 mirrors under ``/v1/federation/agents``. Write paths stay put; 6a-4 hard-deletes them with the rest of the registry namespace.

## What changes

- **``cullis_sdk/client.py``** — ``discover()`` + ``get_agent_public_key()`` hit ``/v1/federation/agents/*``
- **``sdk-ts/src/client.ts``** — same two methods swapped (dist artifact regenerated by the normal SDK build)
- **``mcp_proxy/registry/public_key.py``** — handler exposed under BOTH prefixes via stacked ``@router.get`` decorators; proxy → broker forward target also moves to ``/v1/federation/``
- **``mcp_proxy/main.py``** — wires the new ``federation_router`` so the proxy owns ``/v1/federation/agents/{id}/public-key`` locally (local-first lookup stays consistent)

## What stays

Write paths are still ``/v1/registry/agents`` on the Court:
- POST register (``cullis_sdk/client.py::register``, ``mcp_proxy/egress/agent_manager.py``, ``mcp_proxy/dashboard/router.py``, demo scripts)
- POST rotate-cert
- DELETE agent

These are deliberately untouched — 6a-4 deletes them together when the Court registry router goes away. Keeping them here keeps the PR diff small and reviewable.

## Threat model

No change. Same auth, same org-isolation, same binding check. The endpoint surface just got a new URL alongside the old one.

## Test plan

- [x] ``pytest tests/test_federation_read.py tests/test_proxy_discovery_pubkey.py tests/test_proxy_reverse_forwarding.py tests/test_sdk_send_via_proxy.py tests/test_discovery.py -n 0`` → 31/31 pass
- [x] ``pytest tests/ -n auto --dist=loadfile --ignore=tests/test_ts_interop.py --ignore=tests/test_postgres_integration.py`` → **1288 pass**, 6 skipped (excluded pre-existing TS parallel flake + Postgres env-dependent; identical baseline to Phase 6a-1 #198)
- [ ] ``demo_network smoke`` — runs in CI

## Next

Phase 6a-3 — migrate the ~60 test files that use ``POST /v1/registry/agents`` as setup to a direct-DB insert helper. Largest piece of the phase but purely mechanical. Then 6a-4 deletes the registry namespace for good.