### PR TITLE
fix(auth): close cross-org agent-existence oracle on revoke-agent (F-B-8)

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -193,13 +193,15 @@ async def revoke_agent_tokens(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
                             detail="Invalid organization credentials")
 
+    # Audit F-B-8: collapse "no such agent" and "agent belongs to a
+    # different org" into a single 404 with the same detail body.
+    # Previously a caller holding one valid org_secret could enumerate
+    # agents in *other* orgs by observing 404 vs 403. The caller must
+    # only learn about their own org's agents.
     agent = await get_agent_by_id(db, agent_id)
-    if not agent:
+    if not agent or agent.org_id != org.org_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND,
                             detail="Agent not found")
-    if agent.org_id != org.org_id:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
-                            detail="Agent does not belong to your organization")
 
     await invalidate_agent_tokens(db, agent_id)
     await log_event(

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -158,7 +158,11 @@ async def test_admin_revoke_wrong_secret(client: AsyncClient, dpop):
 
 
 async def test_admin_revoke_cross_org_rejected(client: AsyncClient, dpop):
-    """Org F cannot revoke tokens for an agent belonging to org E."""
+    """Org F cannot revoke tokens for an agent belonging to org E.
+
+    Audit F-B-8: response collapses to 404 (same as missing agent) so
+    org F cannot enumerate org E's agents by observing 404 vs 403.
+    """
     await _setup_agent(client, "tok-rev-e::agent-1", "tok-rev-e", dpop)
     await _setup_agent(client, "tok-rev-f::agent-1", "tok-rev-f", dpop)
 
@@ -166,7 +170,54 @@ async def test_admin_revoke_cross_org_rejected(client: AsyncClient, dpop):
         "/v1/auth/revoke-agent/tok-rev-e::agent-1",
         headers={"x-org-id": "tok-rev-f", "x-org-secret": "tok-rev-f-secret"},
     )
-    assert rev.status_code == 403
+    assert rev.status_code == 404
+
+
+async def test_admin_revoke_missing_vs_cross_org_indistinguishable(
+    client: AsyncClient, dpop,
+):
+    """Audit F-B-8: the 404 response for 'agent does not exist in any
+    org' and 'agent exists but in a different org' must be byte-
+    identical — status code and detail body alike. Otherwise an
+    attacker with any org_secret can enumerate agents across the whole
+    broker fleet.
+
+    Distinct org_ids (``fb8-x``/``fb8-y``) avoid colliding with
+    sibling tests in this file that reuse ``tok-rev-*`` org names.
+    """
+    # org X registered + has an agent, org Y registered without agents.
+    await _setup_agent(client, "fb8-x::agent-1", "fb8-x", dpop)
+
+    import bcrypt
+    import json
+    from app.registry.org_store import OrganizationRecord
+    from tests.conftest import TestSessionLocal
+
+    async with TestSessionLocal() as session:
+        session.add(OrganizationRecord(
+            org_id="fb8-y",
+            display_name="fb8-y",
+            secret_hash=bcrypt.hashpw(
+                b"fb8-y-secret", bcrypt.gensalt(rounds=4),
+            ).decode(),
+            metadata_json=json.dumps({}),
+            status="active",
+        ))
+        await session.commit()
+
+    # Case 1: agent does not exist anywhere.
+    missing = await client.post(
+        "/v1/auth/revoke-agent/fb8-y::never-registered",
+        headers={"x-org-id": "fb8-y", "x-org-secret": "fb8-y-secret"},
+    )
+    # Case 2: agent exists but in a different org (fb8-x).
+    cross_org = await client.post(
+        "/v1/auth/revoke-agent/fb8-x::agent-1",
+        headers={"x-org-id": "fb8-y", "x-org-secret": "fb8-y-secret"},
+    )
+
+    assert missing.status_code == cross_org.status_code == 404
+    assert missing.json() == cross_org.json()
 
 
 async def test_binding_revocation_invalidates_tokens(client: AsyncClient, dpop):


### PR DESCRIPTION
## Summary

\`POST /v1/auth/revoke-agent/{agent_id}\` no longer distinguishes \"agent does not exist\" from \"agent exists but belongs to a different org\" — both respond with a single 404 and the same body. Previously the caller observed 404 vs 403, which let any org_secret holder enumerate agents across the whole broker fleet.

Closes audit finding **F-B-8** (Medium, \`imp/audit_2026_04_17/phase1_B_authz.md:328\`).

## The leak

\`app/auth/router.py:196-202\` (pre-fix):

\`\`\`python
agent = await get_agent_by_id(db, agent_id)
if not agent:
    raise HTTPException(404, \"Agent not found\")
if agent.org_id != org.org_id:
    raise HTTPException(403, \"Agent does not belong to your organization\")
\`\`\`

The org auth above (via \`verify_org_credentials\`, unchanged) already confirms the caller owns some org. What remains is the 404/403 asymmetry: the caller learns whether a guessed \`agent_id\` resolves anywhere in the broker even if it is in a different org than theirs.

This is cheap recon for phishing or for a targeted attack where the attacker knows one valid org_secret but wants to map other orgs' deployments.

## Fix

Collapse both cases into a single 404:

\`\`\`python
agent = await get_agent_by_id(db, agent_id)
if not agent or agent.org_id != org.org_id:
    raise HTTPException(404, \"Agent not found\")
\`\`\`

Caller learns only about agents in their own org. The wrong-secret 403 (from \`verify_org_credentials\`, step above) is a different class — credential failure, distinct path, body mentions \"Invalid organization credentials\" — and is unchanged.

## Tests

\`tests/test_token_revocation.py\`:

- \`test_admin_revoke_cross_org_rejected\` — updated: was \`assert 403\`, now \`assert 404\`. Docstring names the finding.
- \`test_admin_revoke_missing_vs_cross_org_indistinguishable\` — new regression guard: the two responses must be byte-identical (status AND detail body). Uses \`fb8-*\` org_ids to avoid colliding with the pre-existing \`tok-rev-*\` names in the same file (sibling test \`test_binding_revocation_invalidates_tokens\` reuses \`tok-rev-g\`).

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1289 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_token_revocation.py -q\` — 7 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.

## Context

Third enumeration oracle closed in the F-B-6 / F-B-7 / F-B-8 family:

| Finding | Endpoint | Leak | PR |
|---|---|---|---|
| F-B-6 | \`GET /orgs/me\` | 404 vs 403 + bcrypt timing | #187 |
| F-B-7 | \`POST /orgs/{id}/certificate\` | 404 vs 401 + bcrypt timing | #196 |
| F-B-8 | \`POST /auth/revoke-agent/{id}\` | 404 vs 403 cross-org | this PR |

Each uses the pattern that matches the endpoint's natural constraint (org-secret auth in F-B-6/7 ⇒ 403 unified; admin-revoke already 404 on the happy miss ⇒ 404 unified).