### PR TITLE
test(court): migrate POST /v1/registry/agents setup to direct-DB helper (ADR-010 Phase 6a-3)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,3 +237,69 @@ def dpop():
 async def db_session() -> AsyncSession:
     async with TestSessionLocal() as session:
         yield session
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test setup helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def seed_court_agent(
+    agent_id: str,
+    org_id: str,
+    *,
+    display_name: str | None = None,
+    capabilities: list[str] | None = None,
+    metadata: dict | None = None,
+    description: str = "",
+) -> None:
+    """Direct-DB replacement for the legacy ``POST /v1/registry/agents``.
+
+    ADR-010 Phase 6a-3 — tests used the old org_secret-auth POST as setup
+    for downstream flows (auth, policy, mTLS, etc.). The endpoint is
+    being deleted in Phase 6a-4 because it bypassed the Mastio, so tests
+    bypass it themselves via the store layer. Same observable side
+    effect (AgentRecord row + federation event) with fewer moving parts.
+
+    Callers must already have created the owning org (``POST
+    /v1/registry/orgs``) — this helper does not validate that, because
+    neither does ``register_agent()``.
+    """
+    from app.registry.store import register_agent
+
+    async with TestSessionLocal() as session:
+        await register_agent(
+            session,
+            agent_id=agent_id,
+            org_id=org_id,
+            display_name=display_name or agent_id,
+            capabilities=capabilities or [],
+            metadata=metadata or {},
+            description=description,
+        )
+
+
+def seed_court_agent_sync(
+    agent_id: str,
+    org_id: str,
+    *,
+    display_name: str | None = None,
+    capabilities: list[str] | None = None,
+    metadata: dict | None = None,
+    description: str = "",
+) -> None:
+    """Sync wrapper around ``seed_court_agent`` for the handful of tests
+    built on starlette's ``TestClient`` (``test_ws.py``, ``test_m3_*``)
+    where awaiting from inside the ``with TestClient(app):`` block isn't
+    convenient."""
+    import asyncio
+
+    asyncio.run(
+        seed_court_agent(
+            agent_id=agent_id,
+            org_id=org_id,
+            display_name=display_name,
+            capabilities=capabilities,
+            metadata=metadata,
+            description=description,
+        ),
+    )

--- a/tests/test_adr009_phase1_countersig.py
+++ b/tests/test_adr009_phase1_countersig.py
@@ -20,7 +20,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from httpx import AsyncClient
 
 from tests.cert_factory import make_assertion, get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.mastio_strict]
 
@@ -66,12 +66,12 @@ async def _register_agent_with_mastio(
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
 
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id,
-        "org_id": org_id,
-        "display_name": f"Test Agent {agent_id}",
-        "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=f'Test Agent {agent_id}',
+        capabilities=['test.read'],
+    )
 
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},

--- a/tests/test_audit_r2_t2.py
+++ b/tests/test_audit_r2_t2.py
@@ -36,6 +36,7 @@ pytestmark = pytest.mark.asyncio
 from tests.cert_factory import (
     get_org_ca_pem,
 )
+from tests.conftest import seed_court_agent
 
 
 async def _setup_agent(client: AsyncClient, dpop, agent_id: str, org_id: str) -> str:
@@ -49,10 +50,12 @@ async def _setup_agent(client: AsyncClient, dpop, agent_id: str, org_id: str) ->
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["test.read", "test.write"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['test.read', 'test.write'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read", "test.write"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -37,7 +37,7 @@ from tests.cert_factory import (
     make_assertion, get_org_ca_pem,
     make_assertion_alternate,
 )
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -62,12 +62,12 @@ async def _register_agent(client: AsyncClient, agent_id: str, org_id: str):
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
 
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id,
-        "org_id": org_id,
-        "display_name": f"Test Agent {agent_id}",
-        "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=f'Test Agent {agent_id}',
+        capabilities=['test.read'],
+    )
 
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},

--- a/tests/test_auth_chain.py
+++ b/tests/test_auth_chain.py
@@ -28,7 +28,7 @@ from tests.cert_factory import (
     _key_pem,
     _now,
 )
-from tests.conftest import ADMIN_HEADERS, TestSessionLocal
+from tests.conftest import ADMIN_HEADERS, TestSessionLocal, seed_court_agent
 from app.registry.org_store import update_org_trust_domain
 
 pytestmark = pytest.mark.asyncio
@@ -56,10 +56,12 @@ async def _register_agent_with_chain_ca(
     )
     async with TestSessionLocal() as db:
         await update_org_trust_domain(db, org_id, trust_domain)
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['test.read'],
+    )
     resp = await client.post(
         "/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},

--- a/tests/test_auth_ec.py
+++ b/tests/test_auth_ec.py
@@ -11,7 +11,7 @@ import jwt as jose_jwt
 from httpx import AsyncClient
 
 from tests.cert_factory import get_org_ca_pem, make_assertion
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 
 async def _prime_nonce(client: AsyncClient, dpop) -> None:
@@ -35,10 +35,12 @@ async def _register_ec_agent(client: AsyncClient, agent_id: str, org_id: str) ->
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
 
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": f"EC Agent {agent_id}", "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=f'EC Agent {agent_id}',
+        capabilities=['test.read'],
+    )
 
     resp = await client.post(
         "/v1/registry/bindings",

--- a/tests/test_auth_svid.py
+++ b/tests/test_auth_svid.py
@@ -16,7 +16,7 @@ from tests.cert_factory import (
     make_assertion,
     make_svid_assertion,
 )
-from tests.conftest import ADMIN_HEADERS, TestSessionLocal
+from tests.conftest import ADMIN_HEADERS, TestSessionLocal, seed_court_agent
 from app.registry.org_store import update_org_trust_domain
 
 pytestmark = pytest.mark.asyncio
@@ -44,10 +44,12 @@ async def _register_agent(
     if trust_domain is not None:
         async with TestSessionLocal() as db:
             await update_org_trust_domain(db, org_id, trust_domain)
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['test.read'],
+    )
     resp = await client.post(
         "/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -35,7 +35,9 @@ async def _upload_ca(client: AsyncClient, org_id: str, org_secret: str):
 async def _register_agent(client: AsyncClient, agent_id: str, org_id: str,
                            capabilities: list[str] | None = None,
                            org_secret: str | None = None):
-    secret = org_secret or (org_id + "-secret")
+    # org_secret kept in the signature for call-site compat; the direct-DB
+    # seeder doesn't need it (ADR-010 Phase 6a-3).
+    del org_secret
     await seed_court_agent(
         agent_id=agent_id,
         org_id=org_id,

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -10,7 +10,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.cert_factory import make_assertion, get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -36,10 +36,12 @@ async def _register_agent(client: AsyncClient, agent_id: str, org_id: str,
                            capabilities: list[str] | None = None,
                            org_secret: str | None = None):
     secret = org_secret or (org_id + "-secret")
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id, "display_name": agent_id,
-        "capabilities": capabilities or [],
-    }, headers={"x-org-id": org_id, "x-org-secret": secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=capabilities or [],
+    )
 
 
 async def _create_binding(client: AsyncClient, org_id: str, org_secret: str,

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -3,7 +3,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.cert_factory import get_org_ca_pem, make_encrypted_envelope
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -20,10 +20,12 @@ async def _register_and_login(client: AsyncClient, dpop, agent_id: str, org_id: 
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["kyc.read", "kyc.write"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['kyc.read', 'kyc.write'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["kyc.read", "kyc.write"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -10,7 +10,7 @@ Verifica che:
 import pytest
 from httpx import AsyncClient
 from tests.cert_factory import get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -26,10 +26,12 @@ async def _setup(client: AsyncClient, org_id: str, agent_id: str,
         json={"ca_certificate": get_org_ca_pem(org_id)},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": capabilities,
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=capabilities,
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": capabilities},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -22,7 +22,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.cert_factory import make_assertion, get_org_ca_pem, make_encrypted_envelope, DPoPHelper
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -44,19 +44,17 @@ async def test_step1_banca_a_registra_agente(client: AsyncClient):
         headers={"x-org-id": "banca-a", "x-org-secret": "banca-a-org-secret"},
     )
 
-    resp = await client.post("/v1/registry/agents", json={
-        "agent_id": "banca-a::kyc-agent",
-        "org_id": "banca-a",
-        "display_name": "Agente KYC Banca A",
-        "capabilities": ["kyc.read", "kyc.write"],
-        "metadata": {"environment": "test"},
-    }, headers={"x-org-id": "banca-a", "x-org-secret": "banca-a-org-secret"})
-    assert resp.status_code == 201, resp.text
-    body = resp.json()
-    assert body["agent_id"] == "banca-a::kyc-agent"
-    assert body["org_id"] == "banca-a"
-    assert body["is_active"] is True
-    assert "kyc.read" in body["capabilities"]
+    # ADR-010 Phase 6a-3: setup via direct-DB helper; the HTTP-shape
+    # assertions (201 + body) lived against the legacy endpoint that
+    # 6a-4 deletes. Equivalent coverage now sits on the publish-agent
+    # test suite.
+    await seed_court_agent(
+        agent_id="banca-a::kyc-agent",
+        org_id="banca-a",
+        display_name="Agente KYC Banca A",
+        capabilities=["kyc.read", "kyc.write"],
+        metadata={"environment": "test"},
+    )
 
     # Create + approve binding
     r = await client.post("/v1/registry/bindings",
@@ -100,15 +98,13 @@ async def test_step2_banca_b_registra_agente(client: AsyncClient):
         headers={"x-org-id": "banca-b", "x-org-secret": "banca-b-org-secret"},
     )
 
-    resp = await client.post("/v1/registry/agents", json={
-        "agent_id": "banca-b::kyc-agent",
-        "org_id": "banca-b",
-        "display_name": "Agente KYC Banca B",
-        "capabilities": ["kyc.read", "kyc.write"],
-        "metadata": {"environment": "test"},
-    }, headers={"x-org-id": "banca-b", "x-org-secret": "banca-b-org-secret"})
-    assert resp.status_code == 201, resp.text
-    assert resp.json()["agent_id"] == "banca-b::kyc-agent"
+    await seed_court_agent(
+        agent_id="banca-b::kyc-agent",
+        org_id="banca-b",
+        display_name="Agente KYC Banca B",
+        capabilities=["kyc.read", "kyc.write"],
+        metadata={"environment": "test"},
+    )
 
     # Create + approve binding
     r = await client.post("/v1/registry/bindings",
@@ -301,12 +297,12 @@ async def test_step10_terzo_agente_bloccato(client: AsyncClient):
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": "banca-c", "x-org-secret": "banca-c-org-secret"},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": "banca-c::evil-agent",
-        "org_id": "banca-c",
-        "display_name": "Agente Malevolo",
-        "capabilities": [],
-    }, headers={"x-org-id": "banca-c", "x-org-secret": "banca-c-org-secret"})
+    await seed_court_agent(
+        agent_id='banca-c::evil-agent',
+        org_id='banca-c',
+        display_name='Agente Malevolo',
+        capabilities=[],
+    )
     rb = await client.post("/v1/registry/bindings",
         json={"org_id": "banca-c", "agent_id": "banca-c::evil-agent", "scope": []},
         headers={"x-org-id": "banca-c", "x-org-secret": "banca-c-org-secret"},

--- a/tests/test_enhanced_discovery.py
+++ b/tests/test_enhanced_discovery.py
@@ -14,7 +14,7 @@ Covers:
 import pytest
 from httpx import AsyncClient
 from tests.cert_factory import get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -30,10 +30,12 @@ async def _setup(client: AsyncClient, org_id: str, agent_id: str,
         json={"ca_certificate": get_org_ca_pem(org_id)},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": capabilities,
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=capabilities,
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": capabilities},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_federation_read.py
+++ b/tests/test_federation_read.py
@@ -17,7 +17,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.cert_factory import get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -33,10 +33,12 @@ async def _setup(client: AsyncClient, org_id: str, agent_id: str,
         json={"ca_certificate": get_org_ca_pem(org_id)},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": capabilities,
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=capabilities,
+    )
     resp = await client.post(
         "/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": capabilities},
@@ -136,10 +138,12 @@ async def test_public_key_same_org(client: AsyncClient, dpop):
         client, "fr-pk-a", "fr-pk-a::caller", ["cap.read"], dpop,
     )
     # Second agent in the same org, never logs in → cert_pem NULL.
-    await client.post("/v1/registry/agents", json={
-        "agent_id": "fr-pk-a::peer", "org_id": "fr-pk-a",
-        "display_name": "peer", "capabilities": ["cap.read"],
-    }, headers={"x-org-id": "fr-pk-a", "x-org-secret": "fr-pk-a-secret"})
+    await seed_court_agent(
+        agent_id='fr-pk-a::peer',
+        org_id='fr-pk-a',
+        display_name='peer',
+        capabilities=['cap.read'],
+    )
 
     resp = await client.get(
         "/v1/federation/agents/fr-pk-a::peer/public-key",
@@ -166,10 +170,12 @@ async def test_public_key_cross_org_requires_binding(client: AsyncClient, dpop):
         json={"ca_certificate": get_org_ca_pem("fr-pk-no-bind")},
         headers={"x-org-id": "fr-pk-no-bind", "x-org-secret": "fr-pk-no-bind-secret"},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": "fr-pk-no-bind::agent", "org_id": "fr-pk-no-bind",
-        "display_name": "no-bind-agent", "capabilities": ["cap.read"],
-    }, headers={"x-org-id": "fr-pk-no-bind", "x-org-secret": "fr-pk-no-bind-secret"})
+    await seed_court_agent(
+        agent_id='fr-pk-no-bind::agent',
+        org_id='fr-pk-no-bind',
+        display_name='no-bind-agent',
+        capabilities=['cap.read'],
+    )
 
     resp = await client.get(
         "/v1/federation/agents/fr-pk-no-bind::agent/public-key",

--- a/tests/test_jwks.py
+++ b/tests/test_jwks.py
@@ -4,7 +4,7 @@ Tests for the JWKS endpoint and kid in JWT header.
 import pytest
 import jwt as jose_jwt
 
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 
 @pytest.mark.asyncio
@@ -66,10 +66,12 @@ async def test_kid_in_jwt_matches_jwks(client, dpop):
     ca_pem = get_org_ca_pem(org_id)
     await client.post(f"/v1/registry/orgs/{org_id}/certificate",
         json={"ca_certificate": ca_pem}, headers=hdrs)
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": "A", "capabilities": ["test.read"],
-    }, headers=hdrs)
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name='A',
+        capabilities=['test.read'],
+    )
     resp = await client.post("/v1/registry/bindings", json={
         "org_id": org_id, "agent_id": agent_id, "scope": ["test.read"],
     }, headers=hdrs)

--- a/tests/test_m3_e2e_offline_flow.py
+++ b/tests/test_m3_e2e_offline_flow.py
@@ -30,7 +30,7 @@ from app.main import app
 from tests.cert_factory import (
     DPoPHelper, get_org_ca_pem, make_assertion, make_encrypted_envelope,
 )
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent_sync
 
 
 _TESTSERVER = "http://testserver"
@@ -46,10 +46,12 @@ def _register_login(client: TestClient, org_id: str, agent_id: str, dpop: DPoPHe
         json={"ca_certificate": get_org_ca_pem(org_id)},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["kyc.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    seed_court_agent_sync(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['kyc.read'],
+    )
     r = client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["kyc.read"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_message_signature.py
+++ b/tests/test_message_signature.py
@@ -26,7 +26,7 @@ from tests.cert_factory import (
     get_org_ca_pem, sign_message, make_agent_cert,
     get_agent_pubkey_pem, make_encrypted_envelope,
 )
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 from cryptography.hazmat.primitives import serialization
 
 pytestmark = pytest.mark.asyncio
@@ -44,10 +44,12 @@ async def _setup(client: AsyncClient, agent_id: str, org_id: str, dpop) -> str:
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read"]},
         headers={"x-org-id": org_id, "x-org-secret": secret},

--- a/tests/test_mtls_binding.py
+++ b/tests/test_mtls_binding.py
@@ -19,7 +19,7 @@ from tests.cert_factory import (
     make_agent_cert,
     make_assertion,
 )
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 
 async def _prime_nonce(client: AsyncClient, dpop) -> None:
@@ -40,10 +40,12 @@ async def _register_agent(client: AsyncClient, agent_id: str, org_id: str) -> No
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['test.read'],
+    )
     resp = await client.post(
         "/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -17,6 +17,7 @@ from tests.cert_factory import make_assertion, get_org_ca_pem
 pytestmark = pytest.mark.asyncio
 
 from app.config import get_settings
+from tests.conftest import seed_court_agent
 ADMIN_SECRET = get_settings().admin_secret
 
 
@@ -52,10 +53,12 @@ async def test_join_creates_pending_org(client: AsyncClient):
 
 async def test_pending_org_cannot_login(client: AsyncClient, dpop):
     await _join(client, "join-blocked")
-    await client.post("/v1/registry/agents", json={
-        "agent_id": "join-blocked::agent", "org_id": "join-blocked",
-        "display_name": "test", "capabilities": [],
-    }, headers={"x-org-id": "join-blocked", "x-org-secret": "join-blocked-secret"})
+    await seed_court_agent(
+        agent_id='join-blocked::agent',
+        org_id='join-blocked',
+        display_name='test',
+        capabilities=[],
+    )
     assertion = make_assertion("join-blocked::agent", "join-blocked")
     resp = await client.post(
         "/v1/auth/token",
@@ -95,10 +98,12 @@ async def test_approve_allows_login(client: AsyncClient, dpop):
     assert resp.json()["status"] == "active"
 
     # Register agent after org is active
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read'],
+    )
 
     # Ora il binding e il login devono funzionare
     resp = await client.post("/v1/registry/bindings",

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -19,7 +19,7 @@ from app.broker.db_models import SessionRecord
 from app.broker.session import session_store
 from app.broker.persistence import restore_sessions
 from tests.cert_factory import get_org_ca_pem, sign_message
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -36,10 +36,12 @@ async def _setup_agent_full(client: AsyncClient, dpop, agent_id: str, org_id: st
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read", "order.write"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read', 'order.write'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read", "order.write"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
@@ -73,10 +75,12 @@ async def _setup_agent(client: AsyncClient, dpop, agent_id: str, org_id: str) ->
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read", "order.write"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read', 'order.write'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read", "order.write"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -27,7 +27,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.cert_factory import get_org_ca_pem, sign_message
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -62,10 +62,12 @@ async def _setup_org_agent(client: AsyncClient, org_id: str, agent_id: str, dpop
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": CAPS,
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=CAPS,
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": CAPS},
         headers=org_headers(org_id),

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -23,7 +23,7 @@ from app.broker.db_models import SessionRecord, SessionMessageRecord  # noqa
 from app.broker.session import session_store
 from app.broker.persistence import restore_sessions
 from tests.cert_factory import get_org_ca_pem, sign_message, DPoPHelper
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 POSTGRES_URL = "postgresql+asyncpg://agent:trustme@localhost:5432/agent_trust"
 
@@ -98,10 +98,12 @@ async def _setup_agent(client: AsyncClient, agent_id: str, org_id: str) -> str:
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read", "order.write"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read', 'order.write'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read", "order.write"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -9,7 +9,7 @@ from httpx import AsyncClient
 
 from app.rate_limit.limiter import rate_limiter
 from tests.cert_factory import make_assertion, get_org_ca_pem, sign_message
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -37,10 +37,12 @@ async def _setup_agent(client: AsyncClient, agent_id: str, org_id: str, secret: 
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read"]},
         headers={"x-org-id": org_id, "x-org-secret": secret},
@@ -74,10 +76,12 @@ async def test_auth_token_rate_limit(client: AsyncClient, dpop):
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": "rl-token-org", "x-org-secret": "s"},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": "rl-token-org::agent", "org_id": "rl-token-org",
-        "display_name": "x", "capabilities": [],
-    }, headers={"x-org-id": "rl-token-org", "x-org-secret": "s"})
+    await seed_court_agent(
+        agent_id='rl-token-org::agent',
+        org_id='rl-token-org',
+        display_name='x',
+        capabilities=[],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": "rl-token-org", "agent_id": "rl-token-org::agent", "scope": []},
         headers={"x-org-id": "rl-token-org", "x-org-secret": "s"},

--- a/tests/test_revocation.py
+++ b/tests/test_revocation.py
@@ -19,7 +19,7 @@ from tests.cert_factory import (
     get_agent_cert_serial,
     get_agent_cert_not_after,
 )
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -38,10 +38,12 @@ async def _register_agent(client: AsyncClient, agent_id: str, org_id: str) -> No
     await client.post(f"/v1/registry/orgs/{org_id}/certificate",
                       json={"ca_certificate": ca_pem},
                       headers={"x-org-id": org_id, "x-org-secret": org_secret})
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['test.read'],
+    )
     resp = await client.post("/v1/registry/bindings",
                              json={"org_id": org_id, "agent_id": agent_id,
                                    "scope": ["test.read"]},

--- a/tests/test_rfq.py
+++ b/tests/test_rfq.py
@@ -15,7 +15,7 @@ import pytest
 from unittest.mock import AsyncMock, patch
 from httpx import AsyncClient
 from tests.cert_factory import get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -43,10 +43,12 @@ async def _setup(client: AsyncClient, org_id: str, agent_id: str,
         json={"ca_certificate": get_org_ca_pem(org_id)},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": capabilities,
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=capabilities,
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": capabilities},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -20,6 +20,7 @@ from tests.cert_factory import (
     get_org_ca_pem, make_encrypted_envelope,
 )
 from app.broker.session import Session, SessionStatus, SessionStore
+from tests.conftest import seed_court_agent, seed_court_agent_sync
 
 pytestmark = pytest.mark.asyncio
 
@@ -39,10 +40,12 @@ async def _setup_agent(client: AsyncClient, dpop, agent_id: str, org_id: str) ->
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["test.read", "test.write"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['test.read', 'test.write'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read", "test.write"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
@@ -347,10 +350,12 @@ def test_ws_binding_revoked_rejected():
             json={"ca_certificate": ca_pem},
             headers={"x-org-id": org_id, "x-org-secret": org_secret},
         )
-        client.post("/v1/registry/agents", json={
-            "agent_id": agent_id, "org_id": org_id,
-            "display_name": agent_id, "capabilities": ["order.read"],
-        }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+        seed_court_agent_sync(
+            agent_id=agent_id,
+            org_id=org_id,
+            display_name=agent_id,
+            capabilities=['order.read'],
+        )
         resp = client.post("/v1/registry/bindings",
             json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read"]},
             headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_spiffe.py
+++ b/tests/test_spiffe.py
@@ -15,7 +15,7 @@ from app.spiffe import (
     validate_spiffe_id,
 )
 from tests.cert_factory import make_agent_cert, make_assertion, get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test mapping bidirezionale
@@ -155,12 +155,12 @@ async def _register_agent_with_spiffe(
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id,
-        "org_id": org_id,
-        "display_name": f"Test Agent {agent_id}",
-        "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=f'Test Agent {agent_id}',
+        capabilities=['test.read'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
@@ -276,12 +276,12 @@ async def test_autenticazione_fallisce_con_san_sbagliato(client: AsyncClient, dp
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id,
-        "org_id": org_id,
-        "display_name": f"Test Agent {agent_id}",
-        "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=f'Test Agent {agent_id}',
+        capabilities=['test.read'],
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["test.read"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -13,7 +13,7 @@ import pytest
 from httpx import AsyncClient
 
 from tests.cert_factory import make_assertion, get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -33,12 +33,12 @@ async def _setup_agent(client: AsyncClient, agent_id: str, org_id: str, dpop) ->
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
 
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id,
-        "org_id": org_id,
-        "display_name": f"Test {agent_id}",
-        "capabilities": ["test.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=f'Test {agent_id}',
+        capabilities=['test.read'],
+    )
 
     resp = await client.post(
         "/v1/registry/bindings",

--- a/tests/test_transaction_token.py
+++ b/tests/test_transaction_token.py
@@ -14,7 +14,7 @@ import json
 import pytest
 from httpx import AsyncClient
 from tests.cert_factory import get_org_ca_pem
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
 pytestmark = pytest.mark.asyncio
 
@@ -30,10 +30,12 @@ async def _setup(client: AsyncClient, org_id: str, agent_id: str,
         json={"ca_certificate": get_org_ca_pem(org_id)},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    await client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": capabilities,
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    await seed_court_agent(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=capabilities,
+    )
     resp = await client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": capabilities},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},

--- a/tests/test_ws.py
+++ b/tests/test_ws.py
@@ -9,7 +9,7 @@ from starlette.testclient import TestClient
 
 from app.main import app
 from tests.cert_factory import make_assertion, get_org_ca_pem, DPoPHelper
-from tests.conftest import ADMIN_HEADERS
+from tests.conftest import ADMIN_HEADERS, seed_court_agent_sync
 
 
 # Starlette's sync TestClient uses "http://testserver" as the base URL, not "http://test".
@@ -28,10 +28,12 @@ def _setup_agent(client: TestClient, org_id: str, agent_id: str, dpop: DPoPHelpe
         json={"ca_certificate": ca_pem},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},
     )
-    client.post("/v1/registry/agents", json={
-        "agent_id": agent_id, "org_id": org_id,
-        "display_name": agent_id, "capabilities": ["order.read"],
-    }, headers={"x-org-id": org_id, "x-org-secret": org_secret})
+    seed_court_agent_sync(
+        agent_id=agent_id,
+        org_id=org_id,
+        display_name=agent_id,
+        capabilities=['order.read'],
+    )
     resp = client.post("/v1/registry/bindings",
         json={"org_id": org_id, "agent_id": agent_id, "scope": ["order.read"]},
         headers={"x-org-id": org_id, "x-org-secret": org_secret},


### PR DESCRIPTION
## Summary

ADR-010 Phase 6a-3 — **groundwork for 6a-4**. Every test that used ``POST /v1/registry/agents`` purely as setup now goes through two new helpers in ``tests/conftest.py`` that speak directly to ``app.registry.store.register_agent``. Same observable side effects (``AgentRecord`` row + federation event) with the HTTP round-trip and the ``x-org-secret`` header dance removed.

**Coverage**: 28 test files, 35 call sites, 29-file diff (conftest + migrated tests).

## Helpers added

- ``seed_court_agent(agent_id, org_id, ..., display_name, capabilities, metadata, description)`` — async, for the majority of tests
- ``seed_court_agent_sync(...)`` — thin ``asyncio.run()`` wrapper for the 2 starlette ``TestClient``-based tests (``test_ws.py``, ``test_m3_e2e_offline_flow.py``)

## What stays POST

- ``tests/test_audit_r2_t3.py::test_pending_org_rejected`` — asserts the 403 path while the endpoint still exists; Phase 6a-4 deletes this test with the endpoint
- ``mcp_proxy/dashboard/router.py`` + ``mcp_proxy/egress/agent_manager.py`` + ``enterprise-lab/bootstrap.sh`` + ``join_agent.py`` — production write-path callers; Phase 6a-4 handles them

## test_e2e.py specifics

The 2 ``resp = await client.post(...)`` sites captured the response and asserted ``201 + body fields``. Those assertions validated the HTTP layer we're retiring, not the end-to-end flow the test actually exercises — migrated manually and the HTTP-shape assertions dropped.

## Threat model

No change. This PR only reshapes test setup; nothing about auth, org-isolation, or the legacy endpoints' behaviour moves.

## Test plan

- [x] ``pytest tests/ -n auto --dist=loadfile --ignore=tests/test_ts_interop.py --ignore=tests/test_postgres_integration.py`` → **1301 passed**, 6 skipped (identical baseline to Phase 6a-2 #200 — same 15 pre-existing flakes excluded)
- [x] Sync helpers verified against ``tests/test_ws.py`` + ``tests/test_m3_e2e_offline_flow.py``
- [ ] ``demo_network smoke`` — runs in CI

## Next

Phase 6a-4 — hard-delete ``/v1/registry/agents`` namespace: delete ``app/registry/router.py`` endpoints (POST register, POST rotate-cert, DELETE, GETs), delete the one test class that still exercises the 403 behaviour, delete the write-path callers in production code, remove the SDK ``register()``/``rotate_cert`` methods.