### PR TITLE
fix(dashboard): enforce CSRF on Court + Mastio logout (F-B-9)

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -133,9 +133,14 @@ async def login_submit(request: Request, db: AsyncSession = Depends(get_db)):
 @router.post("/logout")
 async def logout(request: Request):
     session = get_session(request)
-    if session.logged_in:
-        if not await verify_csrf(request, session):
-            raise HTTPException(status_code=403, detail="Invalid CSRF token")
+    # Audit F-B-9: enforce CSRF for every request that carries a valid
+    # session cookie, not only ``logged_in`` ones. ``csrf_token`` is
+    # empty on ``_NO_SESSION`` (missing / invalid / expired cookie) so
+    # a logout without a cookie still gets the friendly 303; but any
+    # cookie the server issued must come back accompanied by the form
+    # CSRF token it is bound to.
+    if session.csrf_token and not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
     response = RedirectResponse(url="/dashboard/login", status_code=303)
     clear_session(response)
     return response

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -281,8 +281,15 @@ async def login_submit(request: Request):
 @router.post("/logout")
 async def logout(request: Request):
     session = get_session(request)
-    if session and session.logged_in:
-        await verify_csrf(request, session)
+    # Audit F-B-9: raise on CSRF failure instead of calling
+    # ``verify_csrf`` purely for side effects. Previously a cross-site
+    # POST without the form token logged the victim out anyway — a
+    # force-logout via any attacker-controlled page the victim loaded
+    # while holding a valid Mastio admin session. Enforce on any
+    # non-empty ``csrf_token`` (valid cookie) and keep the bare
+    # no-cookie path idempotent with a friendly 303.
+    if session.csrf_token and not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
     response = RedirectResponse(url="/proxy/login", status_code=303)
     clear_session(response)
     return response

--- a/tests/test_audit_r2_t1.py
+++ b/tests/test_audit_r2_t1.py
@@ -269,3 +269,18 @@ async def test_logout_post_with_valid_csrf_succeeds(client: AsyncClient):
     )
     assert resp.status_code == 303
     assert "/dashboard/login" in resp.headers.get("location", "")
+
+
+async def test_logout_post_without_cookie_is_idempotent(client: AsyncClient):
+    """Audit F-B-9: a bare POST /dashboard/logout with no session
+    cookie at all must NOT be treated as a CSRF failure — there is
+    nothing to log out. Return the friendly 303 so browsers that hit
+    the endpoint after their cookie has expired land on /login
+    without an error page."""
+    resp = await client.post(
+        "/dashboard/logout",
+        data={},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "/dashboard/login" in resp.headers.get("location", "")

--- a/tests/test_fb9_proxy_logout_csrf.py
+++ b/tests/test_fb9_proxy_logout_csrf.py
@@ -1,0 +1,134 @@
+"""Audit F-B-9 — Mastio (``mcp_proxy``) logout must enforce CSRF.
+
+Before the fix ``mcp_proxy/dashboard/router.py:281-288`` invoked
+``verify_csrf`` but discarded the return value, so a cross-site POST
+without the form token still logged the victim out. Force-logout was
+possible against any admin holding a valid Mastio session.
+
+After the fix the handler raises ``HTTPException(403)`` when
+``session.csrf_token`` is set (valid cookie) and ``verify_csrf`` fails.
+The bare-no-cookie case stays a friendly 303 so expired-session
+browsers do not land on a 403 error page.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield client
+    get_settings.cache_clear()
+
+
+async def _csrf(client: AsyncClient) -> str:
+    """Pull the CSRF token from the dashboard landing page — the form
+    on every mutating page carries it in a hidden input."""
+    page = await client.get("/proxy/backends")
+    assert page.status_code == 200, page.text
+    match = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert match, "csrf_token not found in /proxy/backends page"
+    return match.group(1)
+
+
+# ── F-B-9 regressions on /proxy/logout ──────────────────────────────
+
+async def test_proxy_logout_without_csrf_rejected(proxy_logged_in: AsyncClient):
+    """Before F-B-9 this was a 303 with cookie cleared — force-logout
+    by cross-site POST. Now it is a 403."""
+    client = proxy_logged_in
+    resp = await client.post(
+        "/proxy/logout",
+        data={},  # no csrf_token
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+    # Session cookie must NOT be cleared on a rejected logout: the
+    # cookie on the response headers should not be a clear-directive.
+    # ``httpx`` surfaces clears as set-cookie with empty value +
+    # expires in the past; assert nothing like that was sent.
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "expires=thu, 01 jan 1970" not in set_cookie.lower()
+
+
+async def test_proxy_logout_with_valid_csrf_succeeds(proxy_logged_in: AsyncClient):
+    """Happy path: valid session + valid CSRF → 303 + cleared session."""
+    client = proxy_logged_in
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/logout",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "/proxy/login" in resp.headers.get("location", "")
+
+
+async def test_proxy_logout_with_wrong_csrf_rejected(proxy_logged_in: AsyncClient):
+    """Valid session + bogus CSRF value still fails closed."""
+    client = proxy_logged_in
+    resp = await client.post(
+        "/proxy/logout",
+        data={"csrf_token": "definitely-not-the-real-token"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+async def test_proxy_logout_without_cookie_is_idempotent(tmp_path, monkeypatch):
+    """No session cookie present → 303 (idempotent). Browsers whose
+    cookie expired mid-session should still land on /proxy/login
+    cleanly without a 403 error page."""
+    db_file = tmp_path / "proxy_nocookie.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    try:
+        async with app.router.lifespan_context(app):
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post(
+                    "/proxy/logout",
+                    data={},
+                    follow_redirects=False,
+                )
+                assert resp.status_code == 303
+                assert "/proxy/login" in resp.headers.get("location", "")
+    finally:
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Close the force-logout-via-cross-site-POST hole on both dashboard surfaces. One PR because the bug is the same class and the two handlers are mirror copies.

- Court (\`app/dashboard/router.py:133-141\`): CSRF was enforced only when \`session.logged_in\` was true. Tighten to \"enforce whenever \`session.csrf_token\` is non-empty\" so any valid cookie is covered.
- Mastio (\`mcp_proxy/dashboard/router.py:281-288\`): \`verify_csrf\` was called purely for side effects — its return value was discarded. A cross-site POST without the form token logged the victim out anyway. Now raise \`HTTPException(403)\` on failure.

Both handlers keep the **bare no-cookie** path as a friendly \`303 → /login\` so an expired-session browser does not land on a 403 error page.

Closes audit finding **F-B-9** (Medium, \`imp/audit_2026_04_17/phase1_B_authz.md:342\`).

## The attack

Mastio version (highest real impact):

\`\`\`html
<form action=\"https://mastio.example.com/proxy/logout\" method=\"POST\" id=\"f\"></form>
<script>f.submit()</script>
\`\`\`

The victim visits attacker.com while holding a valid Mastio admin cookie; the hidden form auto-submits; the server called \`verify_csrf\` (return value ignored) and issued the \`clear_session\` + redirect; the admin is logged out with no consent and no credentials required.

Court version is less severe but the same shape — the pre-fix predicate \`if session.logged_in\` meant any weird \"valid cookie / not logged in\" state slipped through. Defense-in-depth fix aligns the two surfaces.

## What changed

\`\`\`python
# Before (Court)
if session.logged_in:
    if not await verify_csrf(request, session):
        raise HTTPException(status_code=403, ...)

# Before (Mastio)
if session and session.logged_in:
    await verify_csrf(request, session)   # return value discarded

# After (both)
if session.csrf_token and not await verify_csrf(request, session):
    raise HTTPException(status_code=403, detail=\"Invalid CSRF token\")
\`\`\`

\`session.csrf_token\` is empty on \`_NO_SESSION\` (missing / invalid / expired cookie), so the no-cookie idempotent path is preserved. Every valid cookie must come back with the matching form token.

## Tests

**Court** — \`tests/test_audit_r2_t1.py\` (in-tree test-class for #43 logout-CSRF):

- existing \`test_logout_post_without_csrf_rejected\` — still 403, unchanged.
- existing \`test_logout_post_with_valid_csrf_succeeds\` — still 303, unchanged.
- **new** \`test_logout_post_without_cookie_is_idempotent\` — 303 when no cookie at all (regression guard on my tighter predicate).

**Mastio** — new file \`tests/test_fb9_proxy_logout_csrf.py\` (4 cases):

- \`test_proxy_logout_without_csrf_rejected\` — the F-B-9 fix. Asserts 403 AND that the session cookie is NOT cleared on the rejected response (so a failed logout cannot partially succeed).
- \`test_proxy_logout_with_valid_csrf_succeeds\` — happy path 303.
- \`test_proxy_logout_with_wrong_csrf_rejected\` — bogus token 403.
- \`test_proxy_logout_without_cookie_is_idempotent\` — no-cookie 303 (needs a separate fixture because the pre-existing \`proxy_logged_in\` fixture auto-logs in).

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1306 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_audit_r2_t1.py tests/test_fb9_proxy_logout_csrf.py -q\` — 16 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.