### PR TITLE
feat(mastio): migration 0014 + jkt binding on egress DPoP dep (F-B-11 Phase 2)

### DIFF
--- a/mcp_proxy/alembic/versions/0014_internal_agents_dpop_jkt.py
+++ b/mcp_proxy/alembic/versions/0014_internal_agents_dpop_jkt.py
@@ -1,0 +1,54 @@
+"""F-B-11 Phase 2 — ``internal_agents.dpop_jkt`` pins the agent's DPoP JWK.
+
+Revision ID: 0014_internal_agents_dpop_jkt
+Revises: 0013_internal_agents_device_info
+Create Date: 2026-04-17 23:30:00.000000
+
+Adds a nullable ``dpop_jkt`` column on ``internal_agents`` so each
+enrolled agent can bind its ``X-API-Key`` to a locally-held EC/RSA
+keypair (RFC 7638 JWK thumbprint). Without the binding, a leaked
+``.env`` is enough to impersonate an agent on the Mastio egress
+surface (audit F-B-11, issue #181).
+
+Nullable on purpose — Phase 3 wires the SDK to send the JWK at
+enrollment time and Phase 6 flips ``CULLIS_EGRESS_DPOP_MODE`` to
+``required``. Until then, legacy bearer auth keeps working for any
+row with NULL ``dpop_jkt``. See
+``mcp_proxy/auth/dpop_api_key.get_agent_from_dpop_api_key`` for the
+runtime enforcement rules.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0014_internal_agents_dpop_jkt"
+down_revision: Union[str, Sequence[str], None] = "0013_internal_agents_device_info"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Idempotent add — ``init_db`` may call ``metadata.create_all``
+    # before stamping on legacy-unstamped SQLite deploys, in which case
+    # the table already carries ``dpop_jkt`` from the current model.
+    # See the ``feedback_alembic_partial_legacy`` convention +
+    # migration 0013 for the precedent.
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("internal_agents")}
+    if "dpop_jkt" in existing:
+        return
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.add_column(
+            sa.Column("dpop_jkt", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("internal_agents")}
+    if "dpop_jkt" not in existing:
+        return
+    with op.batch_alter_table("internal_agents") as batch_op:
+        batch_op.drop_column("dpop_jkt")

--- a/mcp_proxy/auth/api_key.py
+++ b/mcp_proxy/auth/api_key.py
@@ -103,4 +103,5 @@ async def get_agent_from_api_key(request: Request) -> InternalAgent:
         created_at=agent_data["created_at"],
         is_active=agent_data["is_active"],
         cert_pem=agent_data.get("cert_pem"),
+        dpop_jkt=agent_data.get("dpop_jkt"),
     )

--- a/mcp_proxy/auth/dpop_api_key.py
+++ b/mcp_proxy/auth/dpop_api_key.py
@@ -37,6 +37,7 @@ this dep, still with ``off`` as the default until Phase 6 flips it.
 from __future__ import annotations
 
 import hashlib
+import hmac
 import logging
 
 from fastapi import HTTPException, Request, status
@@ -149,16 +150,46 @@ async def get_agent_from_dpop_api_key(request: Request) -> InternalAgent:
         require_nonce=_REQUIRE_NONCE_DEFAULT,
     )
 
-    # Phase 2 will check ``proof_jkt`` against the agent's stored
-    # ``dpop_jkt``. Until then accept any cryptographically-valid proof
-    # in optional / required modes — this already closes the
-    # "attacker captured a valid proof, replays it" threat because the
-    # verifier consumes the jti atomically. The remaining hole
-    # (attacker with the same-keypair re-signs a fresh proof) is what
-    # the Phase 2 jkt pin closes.
+    # F-B-11 Phase 2 — pin the proof to the agent's registered JWK.
+    # A cryptographically-valid proof is not sufficient on its own: the
+    # keypair that signed it must be the one the agent registered at
+    # enrollment. Without this pin, an attacker who steals an API-key
+    # but not the agent's private key could still synthesise a valid
+    # proof with their own keypair. The jkt comparison closes that.
+    stored_jkt = getattr(agent, "dpop_jkt", None)
+    if stored_jkt:
+        if not hmac.compare_digest(proof_jkt, stored_jkt):
+            _log.warning(
+                "DPoP proof jkt mismatch (agent=%s, proof_jkt=%s, "
+                "stored_jkt=%s)",
+                agent.agent_id, proof_jkt, stored_jkt,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="DPoP proof was signed by a key not registered "
+                       "for this agent.",
+            )
+    elif mode == "required":
+        # ``required`` mode with no stored jkt = agent has not been
+        # re-enrolled via the Phase 3 flow. Refuse so operators who
+        # flipped the flag see the gap surface instead of silently
+        # accepting every proof. Phase 3 teaches the SDK to push a
+        # JWK during enrollment; existing agents must re-enroll before
+        # the operator flips to ``required``.
+        _log.warning(
+            "DPoP required but agent %s has no registered dpop_jkt — "
+            "re-enrollment needed to populate it (see F-B-11 Phase 3).",
+            agent.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Agent has no DPoP key registered. Re-enroll the "
+                   "Connector so it can publish its JWK thumbprint.",
+        )
+
     _log.debug(
-        "Egress DPoP proof accepted (agent=%s, jkt=%s, mode=%s)",
-        agent.agent_id, proof_jkt, mode,
+        "Egress DPoP proof accepted (agent=%s, jkt=%s, mode=%s, bound=%s)",
+        agent.agent_id, proof_jkt, mode, bool(stored_jkt),
     )
     return agent
 

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -425,4 +425,7 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
     # by hand (without the column) don't blow up.
     if "device_info" in row.keys():
         out["device_info"] = row["device_info"]
+    # Migration 0014 (F-B-11 Phase 2) — same permissiveness.
+    if "dpop_jkt" in row.keys():
+        out["dpop_jkt"] = row["dpop_jkt"]
     return out

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -49,6 +49,12 @@ class InternalAgent(Base):
     # Free-form JSON carried from pending_enrollments.device_info on approval
     # (OS, hostname, Connector version). Null for agents created via CLI.
     device_info = Column(Text, nullable=True)
+    # F-B-11 Phase 2 (#181) — RFC 7638 JWK thumbprint of the agent's DPoP
+    # keypair. NULL during the Phase 2–6 grace period; populated by the
+    # Phase 3 enrollment flow and checked by
+    # ``mcp_proxy.auth.dpop_api_key.get_agent_from_dpop_api_key`` when
+    # ``CULLIS_EGRESS_DPOP_MODE`` is ``optional`` or ``required``.
+    dpop_jkt = Column(Text, nullable=True)
 
 
 class AuditLogEntry(Base):

--- a/mcp_proxy/models.py
+++ b/mcp_proxy/models.py
@@ -52,6 +52,11 @@ class InternalAgent(BaseModel):
     created_at: str
     is_active: bool = True
     cert_pem: str | None = None
+    # F-B-11 Phase 2 (#181) — JWK thumbprint (RFC 7638) of the DPoP
+    # keypair this agent registered during enrollment. ``None`` during
+    # the grace period for pre-Phase-3 agents; the dep treats NULL and
+    # the flag mode asymmetrically — see ``dpop_api_key``.
+    dpop_jkt: str | None = None
 
 
 class AuditEntry(BaseModel):

--- a/tests/test_egress_dpop_auth.py
+++ b/tests/test_egress_dpop_auth.py
@@ -191,14 +191,32 @@ async def test_mode_required_rejects_missing_dpop(bypass_legacy, force_mode):
     assert "DPoP" in exc.value.headers.get("WWW-Authenticate", "")
 
 
-async def test_mode_required_accepts_valid_proof(bypass_legacy, force_mode):
+async def test_mode_required_accepts_valid_proof(
+    bound_agent_factory, force_mode,
+):
+    """Mode=required + bound agent + matching proof → accepted.
+
+    Phase 2 tightened the required path: an agent with NULL
+    ``dpop_jkt`` is refused under required mode. The dedicated
+    coverage of that behavior lives in
+    ``test_unbound_agent_rejected_in_required_mode`` below.
+    """
+    from mcp_proxy.auth.dpop import compute_jkt
     force_mode("required")
     api_key = "sk_local_test_" + "c" * 32
-    proof, _, _ = _valid_proof(api_key)
+
+    priv, jwk = make_dpop_key_pair()
+    registered_jkt = compute_jkt(jwk)
+    bound_agent_factory(registered_jkt)
+
+    proof = make_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/egress/message/send",
+        access_token=api_key, nonce=_fresh_nonce(),
+    )
     agent = await get_agent_from_dpop_api_key(
         _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
     )
-    assert agent is _FAKE_AGENT
+    assert agent.dpop_jkt == registered_jkt
 
 
 # ── Proof binding invariants ────────────────────────────────────────
@@ -324,3 +342,171 @@ def test_compute_api_key_ath_matches_rfc9449():
         hashlib.sha256(api_key.encode()).digest()
     ).rstrip(b"=").decode("ascii")
     assert compute_api_key_ath(api_key) == expected
+
+
+# ── F-B-11 Phase 2: JWK thumbprint binding ──────────────────────────
+#
+# After Phase 2, a cryptographically-valid proof is necessary but not
+# sufficient: the keypair that signed it must be the one the agent
+# registered at enrollment. Stored via ``internal_agents.dpop_jkt``
+# (migration 0014) and surfaced on the ``InternalAgent`` model.
+
+
+def _agent_with_jkt(jkt: str) -> InternalAgent:
+    return InternalAgent(
+        agent_id="fb11-phase2-bound-agent",
+        display_name="fb11-p2",
+        capabilities=[],
+        created_at="2026-04-17T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt=jkt,
+    )
+
+
+@pytest.fixture
+def bound_agent_factory(monkeypatch):
+    """Return a helper that installs an agent with the given jkt as the
+    fake legacy-dep return value."""
+    def _install(jkt: str) -> InternalAgent:
+        agent = _agent_with_jkt(jkt)
+
+        async def _ok(_request):
+            return agent
+
+        monkeypatch.setattr(_dpop_api_key_mod, "get_agent_from_api_key", _ok)
+        return agent
+
+    return _install
+
+
+async def test_bound_agent_accepts_proof_from_registered_key(
+    bound_agent_factory, force_mode,
+):
+    """Agent has ``dpop_jkt`` registered. A proof signed by the matching
+    keypair is accepted."""
+    from mcp_proxy.auth.dpop import compute_jkt
+    force_mode("optional")
+    api_key = "sk_local_bound_ok_" + "a" * 32
+
+    priv, jwk = make_dpop_key_pair()
+    registered_jkt = compute_jkt(jwk)
+    bound_agent_factory(registered_jkt)
+
+    proof = make_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/egress/message/send",
+        access_token=api_key, nonce=_fresh_nonce(),
+    )
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+    )
+    assert agent.dpop_jkt == registered_jkt
+
+
+async def test_bound_agent_rejects_proof_from_different_key(
+    bound_agent_factory, force_mode,
+):
+    """Proof is cryptographically valid but signed by a keypair the
+    agent never registered → 401 with a body that names the mismatch.
+    This is the core F-B-11 Phase 2 invariant: key-possession proof
+    only counts when it is THIS agent's key."""
+    from mcp_proxy.auth.dpop import compute_jkt
+    force_mode("optional")
+    api_key = "sk_local_bound_mismatch_" + "b" * 32
+
+    # Agent registers key A.
+    priv_a, jwk_a = make_dpop_key_pair()
+    registered_jkt = compute_jkt(jwk_a)
+    bound_agent_factory(registered_jkt)
+
+    # Attacker signs with their own key B.
+    priv_b, jwk_b = make_dpop_key_pair()
+    assert compute_jkt(jwk_b) != registered_jkt, (
+        "sanity: keypairs are distinct"
+    )
+    proof = make_dpop_proof(
+        priv_b, jwk_b, "POST", "http://test/v1/egress/message/send",
+        access_token=api_key, nonce=_fresh_nonce(),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+        )
+    assert exc.value.status_code == 401
+    assert "not registered" in exc.value.detail.lower()
+
+
+async def test_bound_agent_mismatch_rejected_in_required_mode_too(
+    bound_agent_factory, force_mode,
+):
+    """The jkt pin applies in both ``optional`` and ``required`` modes
+    — once the agent has a stored jkt, any non-matching proof is a
+    hard reject."""
+    from mcp_proxy.auth.dpop import compute_jkt
+    force_mode("required")
+    api_key = "sk_local_bound_required_" + "c" * 32
+
+    priv_a, jwk_a = make_dpop_key_pair()
+    registered_jkt = compute_jkt(jwk_a)
+    bound_agent_factory(registered_jkt)
+
+    priv_b, jwk_b = make_dpop_key_pair()
+    proof = make_dpop_proof(
+        priv_b, jwk_b, "POST", "http://test/v1/egress/message/send",
+        access_token=api_key, nonce=_fresh_nonce(),
+    )
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+        )
+    assert exc.value.status_code == 401
+
+
+async def test_unbound_agent_accepted_in_optional_grace(
+    bypass_legacy, force_mode,
+):
+    """Agent has NULL ``dpop_jkt`` (pre-Phase-3, not re-enrolled). In
+    ``optional`` mode a valid proof is accepted — grace period."""
+    force_mode("optional")
+    api_key = "sk_local_unbound_opt_" + "d" * 32
+    proof, _, _ = _valid_proof(api_key)
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+    )
+    assert agent is _FAKE_AGENT  # no jkt set
+    assert agent.dpop_jkt is None
+
+
+async def test_unbound_agent_rejected_in_required_mode(
+    bypass_legacy, force_mode,
+):
+    """Agent has NULL ``dpop_jkt`` but mode is ``required``. Refuse so
+    operators who flipped the flag before every Connector was
+    re-enrolled see the gap surface instead of silently accepting
+    proofs that have no binding. The error body tells the operator
+    what to do next."""
+    force_mode("required")
+    api_key = "sk_local_unbound_req_" + "e" * 32
+    proof, _, _ = _valid_proof(api_key)
+    with pytest.raises(HTTPException) as exc:
+        await get_agent_from_dpop_api_key(
+            _make_request(headers={"X-API-Key": api_key, "DPoP": proof})
+        )
+    assert exc.value.status_code == 401
+    assert "no DPoP key registered" in exc.value.detail.lower() or \
+           "re-enroll" in exc.value.detail.lower()
+
+
+async def test_unbound_agent_still_works_in_off_mode(
+    bypass_legacy, force_mode,
+):
+    """Mode=off short-circuits BEFORE any jkt logic runs. A pre-Phase-3
+    agent + mode=off is exactly the pre-F-B-11 state: legacy bearer
+    works, DPoP header is ignored."""
+    force_mode("off")
+    agent = await get_agent_from_dpop_api_key(
+        _make_request(headers={"X-API-Key": "sk_local_unbound_off_" + "f" * 32})
+    )
+    assert agent is _FAKE_AGENT
+    assert agent.dpop_jkt is None

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -66,7 +66,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0013_internal_agents_device_info",)]
+    assert rows == [("0014_internal_agents_dpop_jkt",)]
 
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0013_internal_agents_device_info",)]
+    assert version == [("0014_internal_agents_dpop_jkt",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0013_internal_agents_device_info"
+HEAD_REVISION = "0014_internal_agents_dpop_jkt"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0013_internal_agents_device_info"
+HEAD_REVISION = "0014_internal_agents_dpop_jkt"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 


### PR DESCRIPTION
## Summary

Second of 6 phases for **F-B-11** (#181). Phase 1 (#199) landed the dep surface + flag with default \`off\`. This PR adds the **per-agent JWK thumbprint pin** on the egress DPoP dep: a cryptographically-valid proof from a keypair the agent never registered is now rejected.

The schema change is a single nullable column, slot **0014** (agent B's \`device_info\` took 0013 in #197). No handler swap, no SDK update — those are Phase 3/4/5.

## What the binding closes

Phase 1 already made every proof prove:
- Possession of SOME keypair (signature validates).
- Freshness (iat window + one-shot jti).
- Binding to htm/htu of this concrete request.
- Binding to the API-key via \`ath = sha256(api_key)\`.

What it did NOT yet prove was that the keypair is *this specific agent's* key. An attacker who steals \`X-API-Key\` but not the agent's private key could still synthesise a valid proof with their own EC keypair. Phase 2 closes that hole by pinning the proof's \`jkt\` (JWK thumbprint, RFC 7638) against a value stored on the agent row.

## Behavior matrix (runtime, dep logic)

| Agent \`dpop_jkt\` | Mode | DPoP header | Outcome |
|---|---|---|---|
| NULL | off | any | legacy bearer (unchanged) |
| NULL | optional | missing | 200 (grace) |
| NULL | optional | valid | 200 (grace — no pin yet) |
| NULL | required | missing | 401 |
| NULL | required | valid | **401** (\"re-enroll the Connector\") |
| set | off | any | legacy bearer (unchanged) |
| set | optional | missing | 200 (legacy grace) |
| set | optional | proof from registered key | 200 |
| set | optional | proof from different key | **401** (jkt mismatch) |
| set | required | proof from registered key | 200 |
| set | required | proof from different key | **401** |

Key takeaway: once an agent has a pinned jkt, \`optional\` mode is no longer a grace-period for key mismatch — only for the absence of the DPoP header. This is intentional: a client that bothers to send a proof has either the right key or is malicious.

## What changed

Schema + models:
- \`mcp_proxy/alembic/versions/0014_internal_agents_dpop_jkt.py\` — idempotent \`ADD COLUMN dpop_jkt TEXT NULL\`, following migration 0013's inspect-first pattern (stamp-legacy compat).
- \`mcp_proxy/db_models.py\` — \`InternalAgent.dpop_jkt\` SQLAlchemy column.
- \`mcp_proxy/models.py\` — \`InternalAgent\` pydantic field.
- \`mcp_proxy/db.py\` — \`_agent_row_to_dict\` surfaces \`dpop_jkt\` when present (matches the existing \`device_info\` / federation pattern).
- \`mcp_proxy/auth/api_key.py\` — legacy dep propagates \`dpop_jkt\` into the returned \`InternalAgent\`.

Runtime:
- \`mcp_proxy/auth/dpop_api_key.py\` — after \`verify_dpop_proof\` returns, compare \`proof_jkt\` against \`agent.dpop_jkt\` using \`hmac.compare_digest\`. Mismatch → 401. NULL + \`required\` → 401 with \"re-enroll\" message. NULL + \`optional\` → grace.

Tests (+7 cases in \`tests/test_egress_dpop_auth.py\`):
- \`test_bound_agent_accepts_proof_from_registered_key\`
- \`test_bound_agent_rejects_proof_from_different_key\` — core invariant.
- \`test_bound_agent_mismatch_rejected_in_required_mode_too\`
- \`test_unbound_agent_accepted_in_optional_grace\`
- \`test_unbound_agent_rejected_in_required_mode\`
- \`test_unbound_agent_still_works_in_off_mode\`
- Phase 1's \`test_mode_required_accepts_valid_proof\` updated to supply a bound agent (required mode now enforces binding).

Migration-head tests: \`HEAD_REVISION\` bumped to \`0014_internal_agents_dpop_jkt\` in the three \`test_proxy_migrations*.py\` files.

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1313 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_egress_dpop_auth.py tests/test_proxy_migrations*.py -q\` — 39 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.

## Roadmap remaining

| Phase | Scope |
|---|---|
| 3 | Python SDK generates a DPoP keypair at first run, publishes JWK at enrollment, signs proofs on every egress call. Populates \`internal_agents.dpop_jkt\` via the enrollment service. |
| 4 | TS SDK parity + interop test vectors. |
| 5 | Swap the 12 \`/v1/egress/*\` handlers to \`Depends(get_agent_from_dpop_api_key)\`, default \`MCP_PROXY_EGRESS_DPOP_MODE=optional\`. |
| 6 | Flip default to \`required\`, delete the legacy egress dep, deprecation notice. |

## Coordination with Agent B

Zero file collision — Phase 2 touches \`mcp_proxy/{auth,db_models,db,models,alembic}\` + its tests. Agent B's active surface is \`mcp_proxy/{federation,registry,admin,dashboard}\`. Slot 0014 was acknowledged in advance.