### PR TITLE
feat(mastio): admin endpoint to register/rotate agent DPoP JWK (F-B-11 Phase 3a)

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -359,3 +359,110 @@ async def deactivate_agent_endpoint(agent_id: str):
         detail=f"agent_id={agent_id}",
     )
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ── F-B-11 Phase 3a — DPoP JWK registration ─────────────────────────
+
+class DpopJwkRequest(BaseModel):
+    """Public JWK the agent will use to sign DPoP proofs.
+
+    Must be a PUBLIC key — presence of the ``d`` (private component)
+    field is a hard reject. The server stores only the RFC 7638
+    thumbprint; the JWK itself is not retained.
+    """
+    jwk: dict = Field(
+        ...,
+        description="Public JWK (EC P-256 or RSA). ``d`` field rejected.",
+    )
+
+
+class DpopJwkResponse(BaseModel):
+    agent_id: str
+    dpop_jkt: str
+
+
+@router.post(
+    "/{agent_id}/dpop-jwk",
+    response_model=DpopJwkResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def register_agent_dpop_jwk(
+    agent_id: str,
+    body: DpopJwkRequest,
+) -> DpopJwkResponse:
+    """Register or rotate the DPoP JWK bound to an existing agent.
+
+    Audit F-B-11 Phase 3a (#181). Populates ``internal_agents.dpop_jkt``
+    so the egress DPoP dep (#199 + #204) can enforce key-possession
+    proofs against this agent specifically. Before the Phase 3b SDK
+    lands, this endpoint is how operators bind agents: the agent (or
+    the operator on its behalf) generates a keypair, POSTs the public
+    JWK here, and from then on proofs signed by the matching private
+    key are accepted.
+
+    Input validation:
+      * ``d`` field must be absent — we never accept a private JWK.
+      * ``kty`` must be ``EC`` (P-256) or ``RSA``; the verifier only
+        supports those curves today.
+      * The thumbprint must be computable. A malformed JWK is rejected
+        as 400 — the caller can pinpoint the field from the message.
+
+    Effect:
+      * UPDATE ``internal_agents.dpop_jkt`` where ``agent_id`` matches
+        and the row is active.
+      * No federation impact — ``dpop_jkt`` is Mastio-local and does
+        not flow through the Court push loop.
+    """
+    from mcp_proxy.auth.dpop import compute_jkt
+
+    jwk = body.jwk or {}
+    if not isinstance(jwk, dict) or not jwk:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="jwk must be a non-empty object",
+        )
+    if "d" in jwk:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="private key material ('d') rejected — send the "
+                   "public JWK only",
+        )
+    kty = jwk.get("kty")
+    if kty not in ("EC", "RSA"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unsupported kty {kty!r} — expected 'EC' (P-256) or 'RSA'",
+        )
+
+    try:
+        jkt = compute_jkt(jwk)
+    except (ValueError, KeyError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"malformed JWK: {exc}",
+        ) from exc
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                UPDATE internal_agents
+                   SET dpop_jkt = :jkt
+                 WHERE agent_id = :aid AND is_active = 1
+                """
+            ),
+            {"jkt": jkt, "aid": agent_id},
+        )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="agent not found or inactive",
+            )
+
+    await log_audit(
+        agent_id="admin",
+        action="agent.dpop_jwk_set",
+        status="success",
+        detail=f"agent_id={agent_id} jkt={jkt}",
+    )
+    return DpopJwkResponse(agent_id=agent_id, dpop_jkt=jkt)

--- a/tests/test_admin_dpop_jwk.py
+++ b/tests/test_admin_dpop_jwk.py
@@ -1,0 +1,295 @@
+"""F-B-11 Phase 3a — admin endpoint to register/rotate an agent's DPoP JWK.
+
+``POST /v1/admin/agents/{agent_id}/dpop-jwk`` accepts the public JWK the
+Connector generated, computes the RFC 7638 thumbprint server-side, and
+stores it on ``internal_agents.dpop_jkt`` so the egress DPoP dep (#199
++ #204) can enforce key-possession binding per agent.
+
+Before the Phase 3b SDK auto-submit lands, this is the only path to
+populate the column. Tests cover:
+  * happy path (EC and RSA)
+  * rejection of private key material (``d`` field)
+  * rejection of unsupported ``kty``
+  * rejection of malformed JWK (missing coords)
+  * unknown agent → 404
+  * rotation: second POST overwrites the first
+  * admin auth missing / wrong → 403
+  * database state actually carries the new thumbprint
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── test harness ────────────────────────────────────────────────────
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str = "fb11-p3a"):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+async def _create_agent(cli: AsyncClient, name: str) -> str:
+    h = await _headers()
+    r = await cli.post(
+        "/v1/admin/agents",
+        headers=h,
+        json={"agent_name": name, "display_name": name, "capabilities": []},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["agent_id"]
+
+
+# ── JWK builders ────────────────────────────────────────────────────
+
+def _ec_public_jwk() -> dict:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    nums = priv.public_key().public_numbers()
+    x = base64.urlsafe_b64encode(nums.x.to_bytes(32, "big")).rstrip(b"=").decode()
+    y = base64.urlsafe_b64encode(nums.y.to_bytes(32, "big")).rstrip(b"=").decode()
+    return {"kty": "EC", "crv": "P-256", "x": x, "y": y}
+
+
+def _rsa_public_jwk() -> dict:
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    nums = priv.public_key().public_numbers()
+    n = base64.urlsafe_b64encode(
+        nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")
+    ).rstrip(b"=").decode()
+    e = base64.urlsafe_b64encode(
+        nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")
+    ).rstrip(b"=").decode()
+    return {"kty": "RSA", "n": n, "e": e}
+
+
+# ── happy paths ─────────────────────────────────────────────────────
+
+async def test_register_ec_jwk_sets_dpop_jkt(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "alice")
+            jwk = _ec_public_jwk()
+            h = await _headers()
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h,
+                json={"jwk": jwk},
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["agent_id"] == agent_id
+            assert isinstance(body["dpop_jkt"], str) and len(body["dpop_jkt"]) > 30
+
+            # Verify the thumbprint matches what compute_jkt produces.
+            from mcp_proxy.auth.dpop import compute_jkt
+            assert body["dpop_jkt"] == compute_jkt(jwk)
+
+            # Verify DB actually carries the value.
+            from mcp_proxy.db import get_db
+            async with get_db() as conn:
+                row = (await conn.execute(
+                    text("SELECT dpop_jkt FROM internal_agents WHERE agent_id = :a"),
+                    {"a": agent_id},
+                )).first()
+            assert row is not None
+            assert row[0] == body["dpop_jkt"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_register_rsa_jwk_sets_dpop_jkt(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "bob")
+            jwk = _rsa_public_jwk()
+            h = await _headers()
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h,
+                json={"jwk": jwk},
+            )
+            assert r.status_code == 200, r.text
+            from mcp_proxy.auth.dpop import compute_jkt
+            assert r.json()["dpop_jkt"] == compute_jkt(jwk)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_register_rotates_existing_jkt(tmp_path, monkeypatch):
+    """Second POST with a different key overwrites the first. Operators
+    need this to rotate a Connector's DPoP keypair without deleting
+    and recreating the agent."""
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "carol")
+            h = await _headers()
+
+            jwk_first = _ec_public_jwk()
+            r1 = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h, json={"jwk": jwk_first},
+            )
+            assert r1.status_code == 200
+
+            jwk_second = _ec_public_jwk()
+            r2 = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h, json={"jwk": jwk_second},
+            )
+            assert r2.status_code == 200
+            assert r2.json()["dpop_jkt"] != r1.json()["dpop_jkt"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── input validation ────────────────────────────────────────────────
+
+async def test_reject_jwk_with_private_material(tmp_path, monkeypatch):
+    """``d`` field in the JWK means the caller sent a PRIVATE key.
+    Hard reject — we never want private material on the wire."""
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "dave")
+            bad = _ec_public_jwk()
+            bad["d"] = "this-is-a-private-scalar-do-not-accept"
+            h = await _headers()
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h, json={"jwk": bad},
+            )
+            assert r.status_code == 400
+            assert "private" in r.json()["detail"].lower()
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reject_unsupported_kty(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "erin")
+            h = await _headers()
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h, json={"jwk": {"kty": "oct", "k": "x"}},
+            )
+            assert r.status_code == 400
+            assert "kty" in r.json()["detail"].lower()
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reject_malformed_jwk_missing_coords(tmp_path, monkeypatch):
+    """EC JWK with missing ``x``/``y`` → compute_jkt raises → 400."""
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "fred")
+            h = await _headers()
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h,
+                json={"jwk": {"kty": "EC", "crv": "P-256"}},  # no x/y
+            )
+            assert r.status_code == 400
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reject_empty_body(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "gina")
+            h = await _headers()
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers=h, json={"jwk": {}},
+            )
+            assert r.status_code == 400
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── routing / auth ──────────────────────────────────────────────────
+
+async def test_unknown_agent_returns_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/agents/does::not-exist/dpop-jwk",
+                headers=h,
+                json={"jwk": _ec_public_jwk()},
+            )
+            assert r.status_code == 404
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_missing_admin_secret_rejected(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "helen")
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                json={"jwk": _ec_public_jwk()},
+            )
+            # FastAPI raises 422 when the required header is missing; the
+            # handler's own check would return 403. Either flavor confirms
+            # the call was refused without touching the DB.
+            assert r.status_code in (401, 403, 422)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_wrong_admin_secret_rejected(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            agent_id = await _create_agent(cli, "iris")
+            r = await cli.post(
+                f"/v1/admin/agents/{agent_id}/dpop-jwk",
+                headers={"X-Admin-Secret": "totally-wrong-value"},
+                json={"jwk": _ec_public_jwk()},
+            )
+            assert r.status_code == 403
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_admin_dpop_jwk.py
+++ b/tests/test_admin_dpop_jwk.py
@@ -19,7 +19,6 @@ populate the column. Tests cover:
 from __future__ import annotations
 
 import base64
-import json
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric import ec, rsa


### PR DESCRIPTION
## Summary

Operator-facing REST surface to populate \`internal_agents.dpop_jkt\` — the column added by Phase 2 (#204). Before the Phase 3b SDK auto-submit lands, this is the only path to bind an agent to its DPoP keypair. Operators who plan to flip \`MCP_PROXY_EGRESS_DPOP_MODE\` to \`required\` (Phase 6) call this first for every enrolled agent; until then the \`optional\` dep keeps legacy bearer alive.

Part of **F-B-11** (#181). No SDK change, no enrollment flow change, no migration — small self-contained admin endpoint.

## Endpoint

\`\`\`
POST /v1/admin/agents/{agent_id}/dpop-jwk
Auth: X-Admin-Secret                     (same as the rest of /v1/admin/agents)
Body: {\"jwk\": {\"kty\": \"EC\"|\"RSA\", ...}}

200  {\"agent_id\": \"...\", \"dpop_jkt\": \"<RFC 7638 thumbprint>\"}
400  private key material ('d'), unsupported kty, malformed coords, empty
403  missing or wrong admin secret
404  agent not found or inactive
\`\`\`

Same thumbprint function (\`compute_jkt\`) that the egress dep (#199 + #204) uses to compare the proof's \`jkt\` — so operators and the server are guaranteed to agree byte-for-byte.

## What the validation refuses

- **\`d\` field present** → 400. We never want the Connector's private key material on the wire; this endpoint only accepts the public JWK.
- **\`kty\` other than \`EC\` / \`RSA\`** → 400. Matches the verifier's supported set.
- **Malformed coordinates (missing \`x\`/\`y\` on EC, missing \`n\`/\`e\` on RSA)** → 400. \`compute_jkt\` raises and we surface the error.
- **Empty \`jwk\` object** → 400.

All validation happens **before** the DB round-trip, so a garbage payload never touches \`internal_agents\`.

## Effect

- \`UPDATE internal_agents SET dpop_jkt = :jkt WHERE agent_id = :aid AND is_active = 1\`.
- \`rowcount == 0\` → 404 (agent missing or deactivated).
- Audit: \`action=agent.dpop_jwk_set, detail=agent_id + jkt\`.
- Zero federation impact. The column is Mastio-local; it is not published to the Court in the ADR-010 Phase 3 publisher loop (would be meaningless cross-org — the Connector holds the private key, not the Court).

## Tests (10 cases)

\`tests/test_admin_dpop_jwk.py\`:

| Case | Expected |
|---|---|
| \`test_register_ec_jwk_sets_dpop_jkt\` | 200, jkt matches \`compute_jkt(jwk)\`, DB row carries the value |
| \`test_register_rsa_jwk_sets_dpop_jkt\` | 200, jkt matches |
| \`test_register_rotates_existing_jkt\` | second POST overwrites with a different thumbprint |
| \`test_reject_jwk_with_private_material\` | 400, body names \"private\" |
| \`test_reject_unsupported_kty\` | 400, body names \"kty\" |
| \`test_reject_malformed_jwk_missing_coords\` | 400 |
| \`test_reject_empty_body\` | 400 |
| \`test_unknown_agent_returns_404\` | 404 |
| \`test_missing_admin_secret_rejected\` | 401/403/422 (FastAPI missing-required-header vs handler refuse) |
| \`test_wrong_admin_secret_rejected\` | 403 |

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1323 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_admin_dpop_jwk.py -q\` — 10 passed.
- [x] Local \`./demo_network/smoke.sh full\` flaked on docker daemon state (containers stuck in \`Created\`, unrelated to the diff which adds only a new endpoint). **CI smoke jobs in fresh runners are the authoritative gate.**

## Roadmap update

| Phase | Scope | Status |
|---|---|---|
| 1 | server dep + flag | ✅ #199 |
| 2 | migration + jkt pin on dep | ✅ #204 |
| **3a** | **admin endpoint (this PR)** | **← open** |
| 3b | enrollment flow auto-populates + Python SDK emits proofs | next |
| 4 | TS SDK parity + interop vectors | |
| 5 | swap 12 /v1/egress/* handlers, default mode=optional | |
| 6 | flip default to required + delete legacy egress dep | |

## Coordination with Agent B

Zero file collision — this PR touches \`mcp_proxy/admin/agents.py\` (appends at EOF, no existing handler modified) and a new test file. Agent B's active surface is elsewhere in \`mcp_proxy/federation\`, \`mcp_proxy/dashboard\`, enrollment device_info persistence.