### PR TITLE
feat(mastio): enrollment auto-populates dpop_jkt end-to-end (F-B-11 Phase 3b)

### DIFF
--- a/mcp_proxy/alembic/versions/0015_enrollment_dpop_jkt.py
+++ b/mcp_proxy/alembic/versions/0015_enrollment_dpop_jkt.py
@@ -1,7 +1,7 @@
 """F-B-11 Phase 3b — ``pending_enrollments.dpop_jkt`` carries the
 agent's DPoP JWK thumbprint from start-of-enrollment to approval.
 
-Revision ID: 0015_pending_enrollments_dpop_jkt
+Revision ID: 0015_enrollment_dpop_jkt
 Revises: 0014_internal_agents_dpop_jkt
 Create Date: 2026-04-18 00:00:00.000000
 
@@ -29,7 +29,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "0015_pending_enrollments_dpop_jkt"
+revision: str = "0015_enrollment_dpop_jkt"
 down_revision: Union[str, Sequence[str], None] = "0014_internal_agents_dpop_jkt"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/mcp_proxy/alembic/versions/0015_pending_enrollments_dpop_jkt.py
+++ b/mcp_proxy/alembic/versions/0015_pending_enrollments_dpop_jkt.py
@@ -1,0 +1,59 @@
+"""F-B-11 Phase 3b — ``pending_enrollments.dpop_jkt`` carries the
+agent's DPoP JWK thumbprint from start-of-enrollment to approval.
+
+Revision ID: 0015_pending_enrollments_dpop_jkt
+Revises: 0014_internal_agents_dpop_jkt
+Create Date: 2026-04-18 00:00:00.000000
+
+Phase 2 (#204) added ``internal_agents.dpop_jkt`` + Phase 3a (#206)
+added the admin endpoint to populate it post-enrollment. This phase
+threads the JWK through the device-code enrollment flow so approvals
+auto-populate the column — the operator no longer has to hit the
+admin endpoint by hand for every new Connector.
+
+Lifecycle:
+  * ``start_enrollment`` accepts an optional ``dpop_jwk`` field on
+    the request body. The server validates it (public only, supported
+    kty), computes the RFC 7638 thumbprint, and stores it here.
+  * ``approve`` copies ``pending_enrollments.dpop_jkt`` to
+    ``internal_agents.dpop_jkt`` alongside the rest of the enrolled
+    agent's record.
+
+Nullable because the field is optional on the request — pre-Phase-3c
+SDKs will skip it and legacy agents remain governed by the egress mode
+flag's grace path.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0015_pending_enrollments_dpop_jkt"
+down_revision: Union[str, Sequence[str], None] = "0014_internal_agents_dpop_jkt"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Idempotent — matches 0013/0014 pattern. ``init_db`` calls
+    # ``metadata.create_all`` before stamping on legacy-unstamped
+    # SQLite deploys, in which case the column is already present
+    # from the current model.
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("pending_enrollments")}
+    if "dpop_jkt" in existing:
+        return
+    with op.batch_alter_table("pending_enrollments") as batch_op:
+        batch_op.add_column(
+            sa.Column("dpop_jkt", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("pending_enrollments")}
+    if "dpop_jkt" not in existing:
+        return
+    with op.batch_alter_table("pending_enrollments") as batch_op:
+        batch_op.drop_column("dpop_jkt")

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -101,6 +101,11 @@ class PendingEnrollment(Base):
     requester_email = Column(Text, nullable=False)
     reason = Column(Text, nullable=True)
     device_info = Column(Text, nullable=True)  # free-form JSON from SDK
+    # F-B-11 Phase 3b (#181) — RFC 7638 thumbprint of the DPoP JWK
+    # the Connector submitted at start_enrollment. Carried forward
+    # to ``internal_agents.dpop_jkt`` on approval. NULL when the
+    # SDK did not publish a JWK (legacy / pre-Phase-3c clients).
+    dpop_jkt = Column(Text, nullable=True)
     status = Column(
         Text, nullable=False, server_default="pending"
     )  # pending | approved | rejected | expired

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -101,6 +101,7 @@ async def start_enrollment(
                 reason=payload.reason,
                 device_info=payload.device_info,
                 api_key_hash=payload.api_key_hash,
+                dpop_jwk=payload.dpop_jwk,
             )
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -49,6 +49,21 @@ class EnrollmentStartRequest(BaseModel):
             " generate its own key during approval (legacy behaviour)."
         ),
     )
+    dpop_jwk: dict | None = Field(
+        None,
+        description=(
+            "Public JWK of the DPoP keypair the Connector generated locally."
+            " Must be a PUBLIC key (no ``d`` field); kty ``EC`` (P-256) or"
+            " ``RSA``. The server computes the RFC 7638 thumbprint and stores"
+            " it on the pending row; on approve it becomes"
+            " internal_agents.dpop_jkt and the egress dep (#199 + #204)"
+            " enforces proofs signed by this specific keypair."
+            " Optional for backward compat with pre-Phase-3c SDKs — omitting"
+            " leaves dpop_jkt NULL and the agent stays on the mode=optional"
+            " grace path until the operator populates it via the admin"
+            " endpoint (#206) or re-enrolls (audit F-B-11 Phase 3b)."
+        ),
+    )
 
 
 class EnrollmentStartResponse(BaseModel):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -122,6 +122,40 @@ async def list_pending(conn: AsyncConnection) -> list[dict[str, Any]]:
 # ── Writes ───────────────────────────────────────────────────────────────
 
 
+def _validate_and_compute_dpop_jkt(dpop_jwk: dict | None) -> str | None:
+    """Audit F-B-11 Phase 3b — validate a client-submitted public JWK and
+    return its RFC 7638 thumbprint.
+
+    Refuses private key material (``d``), unsupported kty, malformed
+    coordinates. Returns None when the caller supplied nothing — backwards
+    compat with pre-Phase-3c SDKs.
+    """
+    if dpop_jwk is None:
+        return None
+    if not isinstance(dpop_jwk, dict) or not dpop_jwk:
+        raise EnrollmentError(
+            "dpop_jwk must be a non-empty object", http_status=400,
+        )
+    if "d" in dpop_jwk:
+        raise EnrollmentError(
+            "dpop_jwk must be the public JWK — private material ('d') rejected",
+            http_status=400,
+        )
+    kty = dpop_jwk.get("kty")
+    if kty not in ("EC", "RSA"):
+        raise EnrollmentError(
+            f"dpop_jwk kty {kty!r} unsupported — expected 'EC' (P-256) or 'RSA'",
+            http_status=400,
+        )
+    try:
+        from mcp_proxy.auth.dpop import compute_jkt
+        return compute_jkt(dpop_jwk)
+    except (ValueError, KeyError) as exc:
+        raise EnrollmentError(
+            f"dpop_jwk is malformed: {exc}", http_status=400,
+        ) from exc
+
+
 async def start_enrollment(
     conn: AsyncConnection,
     *,
@@ -131,6 +165,7 @@ async def start_enrollment(
     reason: str | None,
     device_info: str | None,
     api_key_hash: str | None = None,
+    dpop_jwk: dict | None = None,
 ) -> StartedEnrollment:
     """Create a new pending enrollment.
 
@@ -143,7 +178,18 @@ async def start_enrollment(
     approve() so the connector can authenticate to /v1/egress/* from day
     one. Legacy connectors that don't send this still work — the server
     generates its own key in approve() for backward compatibility.
+
+    ``dpop_jwk`` (F-B-11 Phase 3b) is the optional public JWK of the
+    Connector's DPoP keypair. When supplied the server computes its RFC
+    7638 thumbprint and persists it on the pending row; ``approve`` then
+    copies it to ``internal_agents.dpop_jkt`` so the egress dep can
+    enforce proof binding from the first request. Omitting it leaves the
+    agent on the mode=optional grace path until the admin endpoint
+    (#206) populates it manually or a re-enrollment with a DPoP-aware
+    SDK supplies one.
     """
+    dpop_jkt = _validate_and_compute_dpop_jkt(dpop_jwk)
+
     fingerprint = _pubkey_fingerprint(pubkey_pem)
     session_id = secrets.token_urlsafe(24)
     now = _now()
@@ -154,11 +200,11 @@ async def start_enrollment(
             """INSERT INTO pending_enrollments (
                 session_id, pubkey_pem, pubkey_fingerprint,
                 requester_name, requester_email, reason, device_info,
-                status, created_at, expires_at, api_key_hash
+                status, created_at, expires_at, api_key_hash, dpop_jkt
             ) VALUES (
                 :sid, :pk, :fp,
                 :name, :email, :reason, :device,
-                'pending', :created, :expires, :keyhash
+                'pending', :created, :expires, :keyhash, :dpop_jkt
             )"""
         ),
         {
@@ -172,6 +218,7 @@ async def start_enrollment(
             "created": _iso(now),
             "expires": _iso(expires_at),
             "keyhash": api_key_hash,
+            "dpop_jkt": dpop_jkt,
         },
     )
     return StartedEnrollment(session_id=session_id, expires_at=expires_at)
@@ -256,8 +303,9 @@ async def approve(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities, api_key_hash,
-                    cert_pem, created_at, is_active, device_info)
-                   VALUES (:aid, :dn, :caps, :hash, :cert, :created, 1, :device)"""
+                    cert_pem, created_at, is_active, device_info, dpop_jkt)
+                   VALUES (:aid, :dn, :caps, :hash, :cert, :created, 1,
+                           :device, :dpop_jkt)"""
             ),
             {
                 "aid": agent_id,
@@ -270,6 +318,11 @@ async def approve(
                 # and kept through approval. We store it verbatim — the
                 # dashboard parses it via a Jinja filter for display.
                 "device": record.get("device_info"),
+                # F-B-11 Phase 3b (#181) — JWK thumbprint the SDK pinned
+                # at start_enrollment. NULL for pre-Phase-3c clients; the
+                # egress dep's grace path accepts them until operators
+                # flip to required mode (Phase 6).
+                "dpop_jkt": record.get("dpop_jkt"),
             },
         )
         await conn.execute(

--- a/tests/test_enrollment_dpop_jkt.py
+++ b/tests/test_enrollment_dpop_jkt.py
@@ -1,0 +1,343 @@
+"""F-B-11 Phase 3b — enrollment flow auto-populates ``dpop_jkt``.
+
+Covers the service layer and the HTTP path:
+  - ``start_enrollment`` accepts an optional ``dpop_jwk`` and stores
+    the RFC 7638 thumbprint on ``pending_enrollments.dpop_jkt``.
+  - ``approve`` copies that thumbprint to ``internal_agents.dpop_jkt``.
+  - Backwards compat: omitting ``dpop_jwk`` leaves the column NULL
+    throughout (pre-Phase-3c SDKs keep working).
+  - Malformed JWKs (private key material, bad ``kty``, missing
+    coords, empty object) are rejected at start time — they never
+    touch the DB.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.enrollment import service
+from mcp_proxy.enrollment.service import EnrollmentError
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+def _ec_pubkey_pem() -> str:
+    key = ec.generate_private_key(ec.SECP256R1())
+    return key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _ec_public_jwk() -> dict:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    nums = priv.public_key().public_numbers()
+    x = base64.urlsafe_b64encode(nums.x.to_bytes(32, "big")).rstrip(b"=").decode()
+    y = base64.urlsafe_b64encode(nums.y.to_bytes(32, "big")).rstrip(b"=").decode()
+    return {"kty": "EC", "crv": "P-256", "x": x, "y": y}
+
+
+def _rsa_public_jwk() -> dict:
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    nums = priv.public_key().public_numbers()
+    n = base64.urlsafe_b64encode(
+        nums.n.to_bytes((nums.n.bit_length() + 7) // 8, "big")
+    ).rstrip(b"=").decode()
+    e = base64.urlsafe_b64encode(
+        nums.e.to_bytes((nums.e.bit_length() + 7) // 8, "big")
+    ).rstrip(b"=").decode()
+    return {"kty": "RSA", "n": n, "e": e}
+
+
+@pytest_asyncio.fixture
+async def db_engine(tmp_path, monkeypatch):
+    db_file = tmp_path / "enrollment.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+# ── start_enrollment: JWK → thumbprint ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_start_with_valid_ec_jwk_stores_thumbprint(db_engine):
+    from mcp_proxy.auth.dpop import compute_jkt
+    jwk = _ec_public_jwk()
+    expected_jkt = compute_jkt(jwk)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Alice",
+            requester_email="alice@example.com",
+            reason="test",
+            device_info=None,
+            dpop_jwk=jwk,
+        )
+        row = (await conn.execute(
+            text("SELECT dpop_jkt FROM pending_enrollments WHERE session_id = :sid"),
+            {"sid": started.session_id},
+        )).first()
+
+    assert row is not None
+    assert row[0] == expected_jkt
+
+
+@pytest.mark.asyncio
+async def test_start_with_valid_rsa_jwk_stores_thumbprint(db_engine):
+    from mcp_proxy.auth.dpop import compute_jkt
+    jwk = _rsa_public_jwk()
+    expected_jkt = compute_jkt(jwk)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Bob",
+            requester_email="bob@example.com",
+            reason=None,
+            device_info=None,
+            dpop_jwk=jwk,
+        )
+        row = (await conn.execute(
+            text("SELECT dpop_jkt FROM pending_enrollments WHERE session_id = :sid"),
+            {"sid": started.session_id},
+        )).first()
+
+    assert row[0] == expected_jkt
+
+
+@pytest.mark.asyncio
+async def test_start_without_jwk_keeps_dpop_jkt_null(db_engine):
+    """Backwards compat: a pre-Phase-3c SDK that omits ``dpop_jwk`` still
+    produces a valid enrollment — the column stays NULL and the egress
+    dep falls back to the mode=optional grace path."""
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Carol",
+            requester_email="carol@example.com",
+            reason=None,
+            device_info=None,
+        )
+        row = (await conn.execute(
+            text("SELECT dpop_jkt FROM pending_enrollments WHERE session_id = :sid"),
+            {"sid": started.session_id},
+        )).first()
+
+    assert row[0] is None
+
+
+# ── Validation refusals ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_start_rejects_jwk_with_private_material(db_engine):
+    bad = _ec_public_jwk()
+    bad["d"] = "private-key-scalar-must-never-reach-the-server"
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=_ec_pubkey_pem(),
+                requester_name="Dave",
+                requester_email="dave@example.com",
+                reason=None,
+                device_info=None,
+                dpop_jwk=bad,
+            )
+    assert exc.value.http_status == 400
+    assert "private" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_unsupported_kty(db_engine):
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=_ec_pubkey_pem(),
+                requester_name="Erin",
+                requester_email="erin@example.com",
+                reason=None,
+                device_info=None,
+                dpop_jwk={"kty": "oct", "k": "symmetric-not-allowed"},
+            )
+    assert exc.value.http_status == 400
+    assert "kty" in str(exc.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_malformed_jwk(db_engine):
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=_ec_pubkey_pem(),
+                requester_name="Fred",
+                requester_email="fred@example.com",
+                reason=None,
+                device_info=None,
+                dpop_jwk={"kty": "EC", "crv": "P-256"},  # missing x/y
+            )
+    assert exc.value.http_status == 400
+
+
+@pytest.mark.asyncio
+async def test_start_rejects_empty_jwk(db_engine):
+    async with get_db() as conn:
+        with pytest.raises(EnrollmentError) as exc:
+            await service.start_enrollment(
+                conn,
+                pubkey_pem=_ec_pubkey_pem(),
+                requester_name="Gina",
+                requester_email="gina@example.com",
+                reason=None,
+                device_info=None,
+                dpop_jwk={},
+            )
+    assert exc.value.http_status == 400
+
+
+# ── approve propagates dpop_jkt ─────────────────────────────────────
+
+@pytest_asyncio.fixture
+async def agent_manager(db_engine):
+    from mcp_proxy.egress.agent_manager import AgentManager
+    mgr = AgentManager(org_id="acme", trust_domain="test.local")
+    await mgr.generate_org_ca()
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_approve_copies_jkt_to_internal_agents(agent_manager):
+    from mcp_proxy.auth.dpop import compute_jkt
+    jwk = _ec_public_jwk()
+    expected_jkt = compute_jkt(jwk)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Helen",
+            requester_email="helen@example.com",
+            reason=None,
+            device_info=None,
+            dpop_jwk=jwk,
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="acme::helen",
+            capabilities=["order.read"],
+            groups=[],
+            admin_name="ops",
+            agent_manager=agent_manager,
+        )
+        row = (await conn.execute(
+            text("SELECT dpop_jkt FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": "acme::helen"},
+        )).first()
+
+    assert row is not None
+    assert row[0] == expected_jkt
+
+
+@pytest.mark.asyncio
+async def test_approve_without_jwk_leaves_agent_dpop_jkt_null(agent_manager):
+    """Pre-Phase-3c enrollment (no dpop_jwk) → internal_agents.dpop_jkt
+    is NULL and the agent rides the mode=optional grace path."""
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=_ec_pubkey_pem(),
+            requester_name="Iris",
+            requester_email="iris@example.com",
+            reason=None,
+            device_info=None,
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="acme::iris",
+            capabilities=[],
+            groups=[],
+            admin_name="ops",
+            agent_manager=agent_manager,
+        )
+        row = (await conn.execute(
+            text("SELECT dpop_jkt FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": "acme::iris"},
+        )).first()
+
+    assert row[0] is None
+
+
+# ── HTTP path: POST /v1/enrollment/start ────────────────────────────
+
+@pytest_asyncio.fixture
+async def http_app(tmp_path, monkeypatch):
+    """Standalone Mastio app with a fresh SQLite for HTTP-layer tests."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "fb11-p3b")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    yield app
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_http_start_with_dpop_jwk_returns_201(http_app):
+    from httpx import ASGITransport, AsyncClient
+    transport = ASGITransport(app=http_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with http_app.router.lifespan_context(http_app):
+            body = {
+                "pubkey_pem": _ec_pubkey_pem(),
+                "requester_name": "Jack",
+                "requester_email": "jack@example.com",
+                "dpop_jwk": _ec_public_jwk(),
+            }
+            r = await cli.post("/v1/enrollment/start", json=body)
+            assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_http_start_rejects_malformed_dpop_jwk(http_app):
+    from httpx import ASGITransport, AsyncClient
+    transport = ASGITransport(app=http_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with http_app.router.lifespan_context(http_app):
+            body = {
+                "pubkey_pem": _ec_pubkey_pem(),
+                "requester_name": "Kate",
+                "requester_email": "kate@example.com",
+                "dpop_jwk": {"kty": "oct", "k": "bad"},
+            }
+            r = await cli.post("/v1/enrollment/start", json=body)
+            assert r.status_code == 400
+            assert "kty" in r.json()["detail"].lower()

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -66,7 +66,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0015_pending_enrollments_dpop_jkt",)]
+    assert rows == [("0015_enrollment_dpop_jkt",)]
 
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0015_pending_enrollments_dpop_jkt",)]
+    assert version == [("0015_enrollment_dpop_jkt",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -66,7 +66,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0014_internal_agents_dpop_jkt",)]
+    assert rows == [("0015_pending_enrollments_dpop_jkt",)]
 
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0014_internal_agents_dpop_jkt",)]
+    assert version == [("0015_pending_enrollments_dpop_jkt",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0015_pending_enrollments_dpop_jkt"
+HEAD_REVISION = "0015_enrollment_dpop_jkt"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0014_internal_agents_dpop_jkt"
+HEAD_REVISION = "0015_pending_enrollments_dpop_jkt"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0015_pending_enrollments_dpop_jkt"
+HEAD_REVISION = "0015_enrollment_dpop_jkt"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0014_internal_agents_dpop_jkt"
+HEAD_REVISION = "0015_pending_enrollments_dpop_jkt"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 


### PR DESCRIPTION
## Summary

Threads the DPoP JWK through the device-code enrollment flow so approved agents carry \`internal_agents.dpop_jkt\` from day one — operators no longer have to hit the Phase-3a admin endpoint (#206) by hand for every new Connector.

Part of **F-B-11** (#181). Fifth PR of six-phase epic. Schema, service, and HTTP wiring only — no SDK code yet (that is Phase 3c).

## Wire

\`\`\`
POST /v1/enrollment/start
{
  \"pubkey_pem\": \"<PEM>\",
  \"requester_name\": \"...\",
  \"requester_email\": \"...\",
  \"dpop_jwk\": {\"kty\": \"EC\", \"crv\": \"P-256\", \"x\": \"...\", \"y\": \"...\"}
}
  │
  ├─ validate (no 'd', kty ∈ {EC,RSA}, compute_jkt succeeds)
  ├─ store pending_enrollments.dpop_jkt = compute_jkt(dpop_jwk)
  │
  └─→ POST /v1/admin/enrollments/{id}/approve
       └─ INSERT internal_agents(..., dpop_jkt = pending.dpop_jkt)
\`\`\`

From that point on the egress dep (#199 + #204) compares proofs against the pinned \`dpop_jkt\`. Mismatch → 401. The admin never has to touch #206 for freshly-enrolled agents.

## What changed

Schema:
- \`mcp_proxy/alembic/versions/0015_pending_enrollments_dpop_jkt.py\` — idempotent \`ADD COLUMN dpop_jkt TEXT NULL\` (inspect-first pattern, matches 0013/0014).
- \`mcp_proxy/db_models.py\` — \`PendingEnrollment.dpop_jkt\`.

API:
- \`mcp_proxy/enrollment/schemas.py\` — \`EnrollmentStartRequest.dpop_jwk: dict | None\`. Optional.
- \`mcp_proxy/enrollment/service.py\`:
  - New \`_validate_and_compute_dpop_jkt\` helper. Rejects private material (\`d\` field), unsupported \`kty\`, malformed coords. Validation runs **before** any DB write so garbage never touches \`pending_enrollments\`.
  - \`start_enrollment(..., dpop_jwk=None)\` — accepts the optional JWK, persists thumbprint.
  - \`approve()\` — copies \`pending.dpop_jkt\` → \`internal_agents.dpop_jkt\` alongside \`device_info\` and \`api_key_hash\`.
- \`mcp_proxy/enrollment/router.py\` — forwards \`payload.dpop_jwk\` to the service call.

Tests (\`tests/test_enrollment_dpop_jkt.py\`, 11 cases):
- Service-layer happy path (EC + RSA + no-JWK backward compat).
- Service-layer validation refusals (\`d\` field, bad \`kty\`, missing coords, empty object).
- \`approve\` propagation (with JWK and without).
- HTTP layer: \`POST /v1/enrollment/start\` 201 with JWK, 400 with malformed JWK.

Migration head tests bumped to \`0015_pending_enrollments_dpop_jkt\` across the three \`test_proxy_migrations*.py\` files.

## What is NOT in this PR

- **Python SDK** — Phase 3c will generate the keypair, persist it to \`~/.cullis/dpop/<agent_id>.jwk\`, submit the public JWK at start_enrollment, and sign a DPoP proof on every egress call with nonce round-trip.
- **TS SDK** — Phase 4.
- **Handler swap** to the DPoP dep — Phase 5.
- **Cutover** to \`mode=required\` — Phase 6.

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1334 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_enrollment_dpop_jkt.py tests/test_proxy_migrations*.py -q\` — 31 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.

## Coordination with Agent B

Zero collision. Agent B's device_info migration is slot 0013 (landed in #197), my Phase 2 was 0014 (#204), this is 0015. Enrollment service changes are surgical — new kwargs + two UPDATE/INSERT column additions, no touch on their \`device_info\` wiring (the two fields travel together through approve).