### PR TITLE
feat(sdk): Python SDK signs DPoP proofs on egress (F-B-11 Phase 3c)

### DIFF
--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -16,6 +16,7 @@ Usage::
 """
 
 from cullis_sdk.client import CullisClient, WebSocketConnection
+from cullis_sdk.dpop import DpopKey
 from cullis_sdk.types import AgentInfo, SessionInfo, InboxMessage, RfqResult, RfqQuote
 from cullis_sdk._logging import log, log_msg
 from cullis_sdk._env import load_env_file, cfg
@@ -23,6 +24,7 @@ from cullis_sdk._env import load_env_file, cfg
 __all__ = [
     "CullisClient",
     "WebSocketConnection",
+    "DpopKey",
     "AgentInfo",
     "SessionInfo",
     "InboxMessage",

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -104,10 +104,20 @@ class CullisClient:
         self._pubkey_cache: dict[str, tuple[str, float]] = {}
         self._client_seq: dict[str, int] = {}
 
-        # DPoP ephemeral key pair
+        # DPoP ephemeral key pair (ingress / broker /auth/token flow)
         self._dpop_privkey = None
         self._dpop_pubkey_jwk: dict | None = None
         self._dpop_nonce: str | None = None
+
+        # Egress DPoP (F-B-11 Phase 3c, #181) — persistent keypair the
+        # server stores the thumbprint of. Separate from the ingress
+        # ephemeral one because egress proofs must be signed by the
+        # key the agent registered at enrollment, not a fresh session
+        # key. Populated by from_enrollment / from_connector when
+        # ``enable_dpop`` is true; None means the SDK falls back to
+        # bare X-API-Key on /v1/egress/*.
+        self._egress_dpop_key: Any = None  # cullis_sdk.dpop.DpopKey
+        self._egress_dpop_nonce: str | None = None
 
         # ADR-004 — last-seen server role (proxy|broker|None) from
         # the `x-cullis-role` response header. The SDK's base URL can
@@ -195,6 +205,8 @@ class CullisClient:
         save_config: str | None = None,
         verify_tls: bool = True,
         timeout: float = 10.0,
+        enable_dpop: bool = True,
+        dpop_base_dir: "Path | None" = None,
     ) -> CullisClient:
         """Bootstrap a proxy-connected client from an enrollment URL.
 
@@ -254,19 +266,122 @@ class CullisClient:
         instance._dpop_privkey = None
         instance._dpop_pubkey_jwk = None
         instance._dpop_nonce = None
+        instance._egress_dpop_key = None
+        instance._egress_dpop_nonce = None
         # Store proxy credentials for egress API
         instance._proxy_api_key = config["api_key"]
         instance._proxy_agent_id = config["agent_id"]
         instance._proxy_org_id = config["org_id"]
 
+        # F-B-11 Phase 3c (#181) — load or generate the persistent
+        # DPoP keypair. The server stores the thumbprint in
+        # ``internal_agents.dpop_jkt`` and refuses proofs signed by a
+        # different key once the flag flips to ``required``. First-run
+        # generates + persists, subsequent runs load from disk.
+        if enable_dpop:
+            from cullis_sdk.dpop import DpopKey
+            try:
+                instance._egress_dpop_key = DpopKey.load_or_generate(
+                    config["agent_id"], base_dir=dpop_base_dir,
+                )
+                log("sdk", f"egress DPoP key ready (jkt={instance._egress_dpop_key.thumbprint()[:16]}…)")
+            except OSError as exc:
+                # Read-only containers, missing ``HOME``, etc. Fall
+                # back to legacy bearer with a warning rather than
+                # blowing up enrollment on a DPoP-first deploy.
+                import warnings
+                warnings.warn(
+                    f"Could not persist egress DPoP key ({exc}); "
+                    "falling back to legacy X-API-Key bearer. Set "
+                    "dpop_base_dir to a writable directory or pass "
+                    "enable_dpop=False to silence this warning.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+
         log("sdk", f"Enrolled as {config['agent_id']} via proxy {config['proxy_url']}")
         return instance
 
-    def proxy_headers(self) -> dict:
-        """Return headers for proxy egress API calls (X-API-Key auth)."""
+    def proxy_headers(self, method: str = "POST", url: str = "") -> dict:
+        """Return headers for proxy egress API calls.
+
+        Always includes ``X-API-Key``. When ``_egress_dpop_key`` is set
+        (Phase 3c, #181), also signs and includes a DPoP proof bound
+        to ``method`` + ``url`` + the API key (via ``ath``) + the last
+        server nonce we saw. Missing method/url on a DPoP-enabled
+        client falls back to the bearer header alone — the call sites
+        in this module all pass the concrete values; external callers
+        that invoke ``proxy_headers`` without them (legacy integration
+        code, custom tooling) stay on the legacy path so they never
+        silently ship unsigned proofs.
+        """
         if not hasattr(self, "_proxy_api_key") or not self._proxy_api_key:
             raise RuntimeError("Not enrolled — use from_enrollment() or set proxy credentials")
-        return {"X-API-Key": self._proxy_api_key, "Content-Type": "application/json"}
+        headers = {
+            "X-API-Key": self._proxy_api_key,
+            "Content-Type": "application/json",
+        }
+        key = getattr(self, "_egress_dpop_key", None)
+        if key is not None and url:
+            proof = key.sign_proof(
+                method,
+                url,
+                access_token=self._proxy_api_key,
+                nonce=self._egress_dpop_nonce,
+            )
+            headers["DPoP"] = proof
+        return headers
+
+    def _egress_http(
+        self,
+        method: str,
+        path_or_url: str,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Wrap an httpx call on the egress surface with a single
+        ``use_dpop_nonce`` retry (RFC 9449 §8).
+
+        On the first attempt we sign with the nonce we already have
+        (may be empty on cold-start). If the server returns 401 with
+        the ``use_dpop_nonce`` marker, we pick up the fresh nonce from
+        the ``DPoP-Nonce`` response header, re-sign, and replay the
+        request exactly once. Further 401s propagate.
+
+        ``method`` matches httpx verbs (``get`` / ``post`` / …).
+        ``path_or_url`` is either an absolute URL or a base-relative
+        path starting with ``/``. Any keyword args are forwarded.
+        """
+        url = (
+            path_or_url
+            if "://" in path_or_url
+            else f"{self.base}{path_or_url}"
+        )
+
+        extra_headers = kwargs.pop("headers", None) or {}
+
+        def _send() -> httpx.Response:
+            headers = self.proxy_headers(method.upper(), url)
+            if extra_headers:
+                headers = {**headers, **extra_headers}
+            http_fn = getattr(self._http, method.lower())
+            return http_fn(url, headers=headers, **kwargs)
+
+        resp = _send()
+        # ``headers`` is a dict-like on httpx Response; tolerate stubs
+        # and older test doubles that only set ``status_code`` + body.
+        resp_headers = getattr(resp, "headers", {}) or {}
+        if resp.status_code == 401 and "use_dpop_nonce" in getattr(resp, "text", ""):
+            fresh_nonce = resp_headers.get("dpop-nonce")
+            if fresh_nonce:
+                self._egress_dpop_nonce = fresh_nonce
+                resp = _send()
+                resp_headers = getattr(resp, "headers", {}) or {}
+        # Opportunistically cache any nonce the server rotates on a
+        # successful response so the next call does not pay the retry.
+        rotated = resp_headers.get("dpop-nonce")
+        if rotated:
+            self._egress_dpop_nonce = rotated
+        return resp
 
     @classmethod
     def from_connector(
@@ -274,6 +389,7 @@ class CullisClient:
         config_dir: str | Path | None = None,
         *,
         timeout: float = 10.0,
+        enable_dpop: bool = True,
     ) -> CullisClient:
         """Build a client from an enrolled Connector Desktop identity on disk.
 
@@ -340,9 +456,31 @@ class CullisClient:
         instance._dpop_privkey = None
         instance._dpop_pubkey_jwk = None
         instance._dpop_nonce = None
+        instance._egress_dpop_key = None
+        instance._egress_dpop_nonce = None
         instance._proxy_api_key = api_key
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
+
+        # F-B-11 Phase 3c — load the DPoP keypair alongside the rest
+        # of the Connector identity. First-run on a freshly-enrolled
+        # Connector generates it; subsequent runs reuse the same key
+        # so its thumbprint stays pinned server-side.
+        if enable_dpop:
+            from cullis_sdk.dpop import DpopKey
+            try:
+                instance._egress_dpop_key = DpopKey.load_or_generate(
+                    agent_id, base_dir=identity_dir / "dpop",
+                )
+            except OSError as exc:
+                import warnings
+                warnings.warn(
+                    f"Could not load or generate egress DPoP key under "
+                    f"{identity_dir}: {exc}. Falling back to legacy "
+                    f"X-API-Key bearer; pass enable_dpop=False to silence.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
         log("sdk", f"Loaded Connector identity {agent_id} from {identity_dir}")
         return instance
@@ -751,11 +889,9 @@ class CullisClient:
         AND a signing key from :meth:`login` or :meth:`from_spiffe_workload_api`
         when the resolver picks ``mtls-only``.
         """
-        headers = self.proxy_headers()
-
-        resolve_resp = self._http.post(
-            f"{self.base}/v1/egress/resolve",
-            headers=headers,
+        resolve_resp = self._egress_http(
+            "post",
+            "/v1/egress/resolve",
             json={"recipient_id": recipient_id},
         )
         resolve_resp.raise_for_status()
@@ -806,9 +942,9 @@ class CullisClient:
         if idempotency_key is not None:
             body["idempotency_key"] = idempotency_key
 
-        resp = self._http.post(
-            f"{self.base}/v1/egress/send",
-            headers=headers,
+        resp = self._egress_http(
+            "post",
+            "/v1/egress/send",
             json=body,
         )
         resp.raise_for_status()
@@ -837,10 +973,9 @@ class CullisClient:
         ``decrypt_from_agent`` helper remains the caller's responsibility
         until the envelope-via-proxy pass-through lands in a follow-up.
         """
-        headers = self.proxy_headers()
-        resp = self._http.get(
-            f"{self.base}/v1/egress/messages/{session_id}",
-            headers=headers,
+        resp = self._egress_http(
+            "get",
+            f"/v1/egress/messages/{session_id}",
         )
         resp.raise_for_status()
         data = resp.json()
@@ -911,11 +1046,9 @@ class CullisClient:
         Returns the proxy's response dict with ``correlation_id``,
         ``msg_id`` and ``status`` (``enqueued`` or ``duplicate``).
         """
-        headers = self.proxy_headers()
-
-        resolve_resp = self._http.post(
-            f"{self.base}/v1/egress/resolve",
-            headers=headers,
+        resolve_resp = self._egress_http(
+            "post",
+            "/v1/egress/resolve",
             json={"recipient_id": recipient_id},
         )
         resolve_resp.raise_for_status()
@@ -999,9 +1132,9 @@ class CullisClient:
             "capabilities": capabilities or [],
             "v": ONESHOT_ENVELOPE_PROTO_VERSION,
         }
-        resp = self._http.post(
-            f"{self.base}/v1/egress/message/send",
-            headers=headers,
+        resp = self._egress_http(
+            "post",
+            "/v1/egress/message/send",
             json=body,
         )
         resp.raise_for_status()
@@ -1032,9 +1165,9 @@ class CullisClient:
         envelope (same shape session /send produces) to retrieve the
         application payload.
         """
-        resp = self._http.get(
-            f"{self.base}/v1/egress/message/inbox",
-            headers=self.proxy_headers(),
+        resp = self._egress_http(
+            "get",
+            "/v1/egress/message/inbox",
         )
         resp.raise_for_status()
         return resp.json().get("messages", [])
@@ -1278,9 +1411,9 @@ class CullisClient:
 
     def ack_via_proxy(self, session_id: str, msg_id: str) -> bool:
         """Acknowledge a local-queue message to the proxy (at-least-once)."""
-        resp = self._http.post(
-            f"{self.base}/v1/egress/sessions/{session_id}/messages/{msg_id}/ack",
-            headers=self.proxy_headers(),
+        resp = self._egress_http(
+            "post",
+            f"/v1/egress/sessions/{session_id}/messages/{msg_id}/ack",
         )
         if resp.status_code == 204:
             return True

--- a/cullis_sdk/dpop.py
+++ b/cullis_sdk/dpop.py
@@ -1,0 +1,238 @@
+"""DPoP keypair management for the egress surface (F-B-11 Phase 3c).
+
+A persistent EC P-256 keypair the SDK uses to sign DPoP proofs on every
+``/v1/egress/*`` request. Unlike the ephemeral ingress DPoP key (see
+``cullis_sdk.auth.generate_dpop_keypair``), this one must survive
+restarts — the server stores its RFC 7638 thumbprint in
+``internal_agents.dpop_jkt`` (#204) and compares every proof against
+it (#207). A fresh key would mean every session re-binds.
+
+File layout, aligned with the Connector identity store:
+
+    <config_dir>/identity/dpop.jwk     # private JWK, chmod 0600
+
+Generate + persist on first use, load on subsequent runs. The public
+JWK is submitted to ``/v1/enrollment/start`` via the ``dpop_jwk``
+field that Phase 3b landed (#207); operators who are rotating an
+already-enrolled agent use the admin endpoint ``POST /v1/admin/agents/
+{id}/dpop-jwk`` from #206.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets as _pysecrets
+import time
+import uuid
+from pathlib import Path
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+_DEFAULT_KEY_FILENAME = "dpop.jwk"
+
+
+def _b64url(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _default_base_dir() -> Path:
+    """Where to put ``<agent_id>.jwk`` when the caller does not pick."""
+    return Path.home() / ".cullis" / "dpop"
+
+
+class DpopKey:
+    """EC P-256 keypair with on-disk persistence for DPoP egress auth.
+
+    Construct via :meth:`load_or_generate` (reads from disk, creates on
+    first run) rather than calling ``__init__`` directly.
+
+    Attributes
+    ----------
+    private_key:
+        The in-memory ``cryptography`` EC private key — never written
+        to the wire.
+    public_jwk:
+        The RFC 7517 public JWK dict ``{kty, crv, x, y}`` that the
+        server persists and compares its thumbprint against.
+    path:
+        File-system location of the private JWK, or ``None`` when the
+        key is held only in memory (CI / ephemeral runs).
+    """
+
+    def __init__(
+        self,
+        private_key: ec.EllipticCurvePrivateKey,
+        public_jwk: dict,
+        *,
+        path: Path | None = None,
+    ) -> None:
+        if public_jwk.get("kty") != "EC" or public_jwk.get("crv") != "P-256":
+            raise ValueError(
+                "DpopKey only supports EC P-256; got "
+                f"kty={public_jwk.get('kty')!r} crv={public_jwk.get('crv')!r}"
+            )
+        self.private_key = private_key
+        self.public_jwk = dict(public_jwk)  # defensive copy
+        self.path = path
+
+    # ── factories ──────────────────────────────────────────────────
+
+    @classmethod
+    def generate(cls, *, path: Path | None = None) -> DpopKey:
+        """Mint a fresh EC P-256 keypair. Optional ``path`` persists it."""
+        priv = ec.generate_private_key(ec.SECP256R1())
+        nums = priv.public_key().public_numbers()
+        x = _b64url(nums.x.to_bytes(32, "big"))
+        y = _b64url(nums.y.to_bytes(32, "big"))
+        jwk = {"kty": "EC", "crv": "P-256", "x": x, "y": y}
+        key = cls(priv, jwk, path=path)
+        if path is not None:
+            key.save(path)
+        return key
+
+    @classmethod
+    def load(cls, path: Path) -> DpopKey:
+        """Read a DpopKey from disk. Raises ``FileNotFoundError`` if absent."""
+        text = path.read_text()
+        blob = json.loads(text)
+        priv_jwk = blob.get("private_jwk") or blob
+        if "d" not in priv_jwk:
+            raise ValueError(
+                f"{path} does not contain a private JWK ('d' missing)"
+            )
+        priv = _ec_from_private_jwk(priv_jwk)
+        public_jwk = {k: priv_jwk[k] for k in ("kty", "crv", "x", "y")}
+        return cls(priv, public_jwk, path=path)
+
+    @classmethod
+    def load_or_generate(
+        cls, agent_id: str, *, base_dir: Path | None = None,
+    ) -> DpopKey:
+        """Return the keypair for ``agent_id``, generating + persisting on
+        first use.
+
+        Layout is ``<base_dir>/<sanitised-agent-id>.jwk``. The default
+        base dir is ``~/.cullis/dpop/``. The file is written with
+        ``chmod 0600`` so a co-resident user cannot read it.
+        """
+        if base_dir is None:
+            base_dir = _default_base_dir()
+        base_dir.mkdir(parents=True, exist_ok=True)
+        filename = _sanitise_agent_id(agent_id) + ".jwk"
+        path = base_dir / filename
+        if path.exists():
+            return cls.load(path)
+        return cls.generate(path=path)
+
+    # ── persistence ────────────────────────────────────────────────
+
+    def save(self, path: Path) -> None:
+        """Write the private JWK to ``path`` with ``chmod 0600``.
+
+        The parent directory is created if absent. The write is atomic
+        via the tempfile-then-rename pattern — a crash between bytes
+        leaves either the old file or the fully-written new one, never
+        a half-written secret.
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        priv_jwk = self.private_jwk()
+        payload = json.dumps({"private_jwk": priv_jwk}, separators=(",", ":"))
+        tmp = path.with_suffix(path.suffix + f".tmp-{_pysecrets.token_hex(8)}")
+        tmp.write_text(payload)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+        self.path = path
+
+    def private_jwk(self) -> dict:
+        """Private JWK including ``d``. Treat as secret — never log / wire."""
+        priv_numbers = self.private_key.private_numbers()
+        d = _b64url(priv_numbers.private_value.to_bytes(32, "big"))
+        return {**self.public_jwk, "d": d}
+
+    # ── proof signing ──────────────────────────────────────────────
+
+    def thumbprint(self) -> str:
+        """RFC 7638 JWK thumbprint of the public key — the jkt the
+        server compares against ``internal_agents.dpop_jkt``."""
+        required = {k: self.public_jwk[k] for k in ("crv", "kty", "x", "y")}
+        canonical = json.dumps(required, sort_keys=True, separators=(",", ":"))
+        return _b64url(hashlib.sha256(canonical.encode()).digest())
+
+    def sign_proof(
+        self,
+        method: str,
+        url: str,
+        *,
+        access_token: str | None = None,
+        nonce: str | None = None,
+        jti: str | None = None,
+        iat: int | None = None,
+    ) -> str:
+        """Build + sign a DPoP proof JWT (RFC 9449).
+
+        Parameters mirror ``cullis_sdk.auth.build_dpop_proof`` plus the
+        key-pinning property: the ``jwk`` header is *this* persistent
+        key, so every proof the SDK emits carries the thumbprint the
+        server has already registered.
+        """
+        priv_pem = self.private_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        claims: dict = {
+            "jti": jti or uuid.uuid4().hex,
+            "htm": method.upper(),
+            "htu": url,
+            "iat": int(iat if iat is not None else time.time()),
+        }
+        if access_token is not None:
+            claims["ath"] = _b64url(
+                hashlib.sha256(access_token.encode()).digest()
+            )
+        if nonce is not None:
+            claims["nonce"] = nonce
+
+        return jwt.encode(
+            claims,
+            priv_pem,
+            algorithm="ES256",
+            headers={"typ": "dpop+jwt", "jwk": self.public_jwk},
+        )
+
+
+def _sanitise_agent_id(agent_id: str) -> str:
+    """Turn an agent_id into a safe filename component.
+
+    Agent IDs look like ``org::agent`` which contains ``:`` — illegal
+    on Windows and a footgun on filesystems that treat it as a drive
+    separator. Replace non-alphanumeric chars with ``_``; keep the
+    original string recognisable enough for an operator grepping the
+    directory.
+    """
+    return "".join(c if c.isalnum() or c in "._-" else "_" for c in agent_id)
+
+
+def _ec_from_private_jwk(jwk: dict) -> ec.EllipticCurvePrivateKey:
+    """Rebuild the ``cryptography`` private key object from a JWK."""
+    if jwk.get("crv") != "P-256":
+        raise ValueError(f"unsupported crv {jwk.get('crv')!r}, expected P-256")
+    d = int.from_bytes(_b64url_decode(jwk["d"]), "big")
+    x = int.from_bytes(_b64url_decode(jwk["x"]), "big")
+    y = int.from_bytes(_b64url_decode(jwk["y"]), "big")
+    pub_numbers = ec.EllipticCurvePublicNumbers(x=x, y=y, curve=ec.SECP256R1())
+    priv_numbers = ec.EllipticCurvePrivateNumbers(
+        private_value=d, public_numbers=pub_numbers,
+    )
+    return priv_numbers.private_key()
+
+
+def _b64url_decode(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)

--- a/tests/test_sdk_dpop.py
+++ b/tests/test_sdk_dpop.py
@@ -1,0 +1,331 @@
+"""F-B-11 Phase 3c — DpopKey + CullisClient egress proof emission.
+
+Covers two levels:
+
+* Unit tests on ``cullis_sdk.dpop.DpopKey`` — generate, persist (0600,
+  atomic), load-or-generate roundtrip, thumbprint stability, sign_proof
+  produces a JWT accepted by the server verifier (``compute_jkt`` on the
+  proof's ``jwk`` header matches ``DpopKey.thumbprint()``; ``ath`` matches
+  ``sha256(api_key)``).
+
+* Integration tests on ``CullisClient`` — ``from_enrollment`` with
+  ``enable_dpop=True`` generates + persists a key under a test base
+  dir; ``_egress_http`` includes a signed ``DPoP`` header on every
+  request; a 401 with ``use_dpop_nonce`` triggers exactly one retry
+  with the new nonce claim; ``enable_dpop=False`` keeps the legacy
+  behaviour.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+
+import httpx
+import jwt as pyjwt
+import pytest
+
+from cullis_sdk import DpopKey
+
+
+# ── DpopKey unit tests ──────────────────────────────────────────────
+
+
+def test_generate_creates_valid_ec_key(tmp_path):
+    key = DpopKey.generate(path=tmp_path / "agent.jwk")
+    assert key.public_jwk["kty"] == "EC"
+    assert key.public_jwk["crv"] == "P-256"
+    # Both coords are base64url-encoded 32-byte big-endian ints.
+    for field in ("x", "y"):
+        raw = base64.urlsafe_b64decode(key.public_jwk[field] + "==")
+        assert len(raw) == 32
+    assert key.path == tmp_path / "agent.jwk"
+
+
+def test_save_uses_0600_and_atomic(tmp_path):
+    path = tmp_path / "agent.jwk"
+    key = DpopKey.generate(path=path)
+    # chmod 0600 (owner read/write only).
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+    # No lingering tempfile from the atomic write.
+    temps = list(tmp_path.glob("agent.jwk.tmp-*"))
+    assert temps == [], f"stray tempfile(s) after atomic save: {temps}"
+
+
+def test_load_or_generate_is_idempotent(tmp_path):
+    """A second call with the same agent_id returns the same key — the
+    server-side pinned thumbprint must keep matching after a restart."""
+    first = DpopKey.load_or_generate("acme::alice", base_dir=tmp_path)
+    second = DpopKey.load_or_generate("acme::alice", base_dir=tmp_path)
+    assert first.thumbprint() == second.thumbprint()
+    assert first.public_jwk == second.public_jwk
+
+
+def test_load_or_generate_sanitises_agent_id(tmp_path):
+    """``agent_id`` contains ``:`` which is illegal on Windows and a
+    footgun on some filesystems. The on-disk filename must not carry
+    it verbatim."""
+    DpopKey.load_or_generate("acme::alice", base_dir=tmp_path)
+    files = list(tmp_path.glob("*.jwk"))
+    assert len(files) == 1
+    name = files[0].name
+    assert ":" not in name
+    assert "alice" in name  # still recognisable
+
+
+def test_thumbprint_matches_rfc7638_compute_jkt(tmp_path):
+    """The SDK-side ``thumbprint()`` must match the server's
+    ``mcp_proxy.auth.dpop.compute_jkt`` byte-for-byte — they are the
+    only two parties that have to agree on the value."""
+    from mcp_proxy.auth.dpop import compute_jkt
+
+    key = DpopKey.load_or_generate("acme::alice", base_dir=tmp_path)
+    assert key.thumbprint() == compute_jkt(key.public_jwk)
+
+
+def test_sign_proof_yields_valid_dpop_jwt(tmp_path):
+    """The JWT carries ``typ=dpop+jwt`` + ``jwk`` header + claims
+    verifier requires: htm, htu, iat, jti; ``ath`` when access_token
+    given; ``nonce`` when given."""
+    key = DpopKey.load_or_generate("acme::alice", base_dir=tmp_path)
+    api_key = "sk_local_test_" + "x" * 32
+    proof = key.sign_proof(
+        "POST",
+        "http://proxy.test/v1/egress/message/send",
+        access_token=api_key,
+        nonce="server-nonce-abc",
+    )
+    header = pyjwt.get_unverified_header(proof)
+    assert header["typ"] == "dpop+jwt"
+    assert header["alg"] == "ES256"
+    assert "jwk" in header and "d" not in header["jwk"]
+    # Roundtrip: verify signature against the embedded jwk.
+    from cryptography.hazmat.primitives import serialization
+    pub = key.private_key.public_key()
+    pub_pem = pub.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    claims = pyjwt.decode(proof, pub_pem, algorithms=["ES256"], options={"verify_aud": False})
+    assert claims["htm"] == "POST"
+    assert claims["htu"] == "http://proxy.test/v1/egress/message/send"
+    assert claims["nonce"] == "server-nonce-abc"
+    assert "jti" in claims and "iat" in claims
+    expected_ath = base64.urlsafe_b64encode(
+        hashlib.sha256(api_key.encode()).digest()
+    ).rstrip(b"=").decode()
+    assert claims["ath"] == expected_ath
+
+
+def test_load_rejects_public_only_jwk(tmp_path):
+    """If the on-disk file somehow loses the ``d`` field (copy of the
+    public jwk), loading must fail loudly — we cannot sign without
+    the private half."""
+    path = tmp_path / "agent.jwk"
+    bad = {
+        "private_jwk": {
+            "kty": "EC", "crv": "P-256", "x": "A" * 43, "y": "B" * 43,
+        },  # no 'd'
+    }
+    path.write_text(json.dumps(bad))
+    with pytest.raises(ValueError, match="private"):
+        DpopKey.load(path)
+
+
+def test_reject_non_ec_p256_construction():
+    with pytest.raises(ValueError):
+        DpopKey.__init__(
+            DpopKey.__new__(DpopKey),
+            private_key=None,  # type: ignore[arg-type]
+            public_jwk={"kty": "RSA", "n": "x", "e": "y"},
+        )
+
+
+# ── CullisClient integration ────────────────────────────────────────
+
+
+@pytest.fixture
+def stub_enroll_server(tmp_path, monkeypatch):
+    """Patch the ``from_enrollment`` GET to return a synthetic config
+    without touching the network."""
+    def _mock_enroll_get(self, url, **kwargs):
+        class _Resp:
+            status_code = 200
+            def json(self):
+                return {
+                    "api_key": "sk_local_test_" + "z" * 32,
+                    "agent_id": "acme::alice",
+                    "proxy_url": "http://proxy.test",
+                    "org_id": "acme",
+                }
+            def raise_for_status(self):
+                pass
+        return _Resp()
+
+    monkeypatch.setattr(httpx.Client, "get", _mock_enroll_get)
+
+
+def test_from_enrollment_generates_and_persists_dpop_key(
+    stub_enroll_server, tmp_path,
+):
+    from cullis_sdk import CullisClient
+
+    client = CullisClient.from_enrollment(
+        "http://proxy.test/v1/enroll/fake",
+        dpop_base_dir=tmp_path,
+        verify_tls=False,
+    )
+    assert client._egress_dpop_key is not None
+    # The key was persisted to the supplied base_dir.
+    files = list(tmp_path.glob("*.jwk"))
+    assert len(files) == 1
+
+
+def test_from_enrollment_disable_dpop_keeps_legacy(
+    stub_enroll_server, tmp_path,
+):
+    from cullis_sdk import CullisClient
+
+    client = CullisClient.from_enrollment(
+        "http://proxy.test/v1/enroll/fake",
+        dpop_base_dir=tmp_path,
+        verify_tls=False,
+        enable_dpop=False,
+    )
+    assert client._egress_dpop_key is None
+    assert list(tmp_path.glob("*.jwk")) == []
+
+
+def test_proxy_headers_injects_dpop_when_key_present(
+    stub_enroll_server, tmp_path,
+):
+    from cullis_sdk import CullisClient
+
+    client = CullisClient.from_enrollment(
+        "http://proxy.test/v1/enroll/fake",
+        dpop_base_dir=tmp_path,
+        verify_tls=False,
+    )
+    headers = client.proxy_headers("POST", "http://proxy.test/v1/egress/ping")
+    assert "DPoP" in headers
+    assert "X-API-Key" in headers
+
+    # The proof's jwk thumbprint matches the registered key.
+    from mcp_proxy.auth.dpop import compute_jkt
+    proof_header = pyjwt.get_unverified_header(headers["DPoP"])
+    assert compute_jkt(proof_header["jwk"]) == client._egress_dpop_key.thumbprint()
+
+
+def test_proxy_headers_skips_dpop_without_url(
+    stub_enroll_server, tmp_path,
+):
+    """Defensive: an external caller that invokes ``proxy_headers()``
+    without method/url (legacy integration code) should never ship an
+    unsigned/empty-htu proof. Fall back to the bearer-only header."""
+    from cullis_sdk import CullisClient
+
+    client = CullisClient.from_enrollment(
+        "http://proxy.test/v1/enroll/fake",
+        dpop_base_dir=tmp_path,
+        verify_tls=False,
+    )
+    headers = client.proxy_headers()  # no method/url
+    assert "DPoP" not in headers
+    assert headers["X-API-Key"].startswith("sk_local_")
+
+
+def test_egress_http_retries_on_use_dpop_nonce(
+    stub_enroll_server, tmp_path, monkeypatch,
+):
+    """Server returns 401 ``use_dpop_nonce`` + fresh nonce header on
+    the first attempt; the SDK picks up the nonce and retries exactly
+    once, including the nonce in the new proof."""
+    from cullis_sdk import CullisClient
+
+    client = CullisClient.from_enrollment(
+        "http://proxy.test/v1/enroll/fake",
+        dpop_base_dir=tmp_path,
+        verify_tls=False,
+    )
+
+    attempts: list[dict] = []
+
+    def _mock_post(self, url, **kwargs):
+        headers = kwargs.get("headers") or {}
+        attempts.append({"headers": dict(headers)})
+        if len(attempts) == 1:
+            return _Resp401UseNonce()
+        return _Resp200()
+
+    class _Resp401UseNonce:
+        status_code = 401
+        text = '{"detail":"use_dpop_nonce"}'
+        headers = {"dpop-nonce": "fresh-server-nonce"}
+        def json(self):
+            return {"detail": "use_dpop_nonce"}
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("401", request=None, response=self)  # pragma: no cover
+
+    class _Resp200:
+        status_code = 200
+        text = "{}"
+        headers = {"dpop-nonce": "next-nonce"}
+        def json(self):
+            return {"ok": True}
+        def raise_for_status(self):
+            pass
+
+    monkeypatch.setattr(httpx.Client, "post", _mock_post)
+
+    resp = client._egress_http("post", "/v1/egress/message/send", json={})
+    assert resp.status_code == 200
+    assert len(attempts) == 2  # one initial + one retry, no loop
+
+    # Retry proof carries the fresh nonce; initial did not.
+    first_proof = attempts[0]["headers"]["DPoP"]
+    second_proof = attempts[1]["headers"]["DPoP"]
+    first_claims = pyjwt.decode(first_proof, options={"verify_signature": False})
+    second_claims = pyjwt.decode(second_proof, options={"verify_signature": False})
+    assert first_claims.get("nonce") in (None, "")
+    assert second_claims["nonce"] == "fresh-server-nonce"
+    # Client cached the nonce the server rotated on the 200.
+    assert client._egress_dpop_nonce == "next-nonce"
+
+
+def test_egress_http_gives_up_after_one_retry(
+    stub_enroll_server, tmp_path, monkeypatch,
+):
+    """Persistent ``use_dpop_nonce`` responses must NOT loop — the SDK
+    retries once, then surfaces the 401 so the caller can decide."""
+    from cullis_sdk import CullisClient
+
+    client = CullisClient.from_enrollment(
+        "http://proxy.test/v1/enroll/fake",
+        dpop_base_dir=tmp_path,
+        verify_tls=False,
+    )
+
+    calls: list[int] = []
+
+    class _Resp401:
+        status_code = 401
+        text = '{"detail":"use_dpop_nonce"}'
+        headers = {"dpop-nonce": "still-rotating"}
+        def json(self):
+            return {"detail": "use_dpop_nonce"}
+        def raise_for_status(self):
+            raise httpx.HTTPStatusError("401", request=None, response=self)  # pragma: no cover
+
+    def _mock_post(self, url, **kwargs):
+        calls.append(1)
+        return _Resp401()
+
+    monkeypatch.setattr(httpx.Client, "post", _mock_post)
+
+    resp = client._egress_http("post", "/v1/egress/x", json={})
+    assert resp.status_code == 401
+    assert len(calls) == 2  # initial + 1 retry, not more

--- a/tests/test_sdk_dpop.py
+++ b/tests/test_sdk_dpop.py
@@ -22,7 +22,6 @@ import hashlib
 import json
 import os
 import stat
-from pathlib import Path
 
 import httpx
 import jwt as pyjwt
@@ -47,7 +46,7 @@ def test_generate_creates_valid_ec_key(tmp_path):
 
 def test_save_uses_0600_and_atomic(tmp_path):
     path = tmp_path / "agent.jwk"
-    key = DpopKey.generate(path=path)
+    DpopKey.generate(path=path)
     # chmod 0600 (owner read/write only).
     mode = stat.S_IMODE(os.stat(path).st_mode)
     assert mode == 0o600, f"expected 0600, got {oct(mode)}"


### PR DESCRIPTION
## Summary

Python SDK now generates a persistent EC P-256 DPoP keypair, persists it on disk, and signs an RFC 9449 DPoP proof on every \`/v1/egress/*\` request. The proof is bound to the concrete method+URL and to the API key (via the \`ath\` claim) — the thumbprint the server pinned in \`internal_agents.dpop_jkt\` (#204 + #207) finally has a matching client.

Part of **F-B-11** (#181). Sixth PR of the epic. **Backwards compat preserved** — when the server flag stays at the default \`off\`, the server ignores the proof header; zero runtime change.

## Phase map

| Phase | Scope | Status |
|---|---|---|
| 1 | server dep + flag | ✅ #199 |
| 2 | migration + jkt pin | ✅ #204 |
| 3a | admin endpoint | ✅ #206 |
| 3b | enrollment auto-populate | ✅ #207 |
| **3c** | **Python SDK signs proofs (this PR)** | **← open** |
| 3d | cullis_connector submits JWK at enrollment | next |
| 4 | TS SDK + interop vectors | |
| 5 | swap 12 egress handlers → mode=optional | |
| 6 | flip default to required | |

## New: \`cullis_sdk/dpop.py\`

\`DpopKey\` class:

- \`generate(path=...)\` / \`load(path)\` / \`load_or_generate(agent_id, base_dir=...)\`
- Default store: \`~/.cullis/dpop/<sanitised-agent-id>.jwk\`, atomic write (tempfile-then-rename), \`chmod 0600\`.
- \`sign_proof(method, url, access_token=None, nonce=None)\` — ES256 JWT with \`typ=dpop+jwt\` header, embedded public JWK, claims \`jti / htm / htu / iat / ath / nonce\`.
- \`thumbprint()\` returns the RFC 7638 jkt. Verified against the server's \`compute_jkt\` in a cross-check test so the two sides are byte-identical.
- Guardrails: \`load\` rejects a public-only file (missing \`d\`); \`__init__\` rejects non-EC / non-P-256.

## Modified: \`cullis_sdk/client.py\`

- \`CullisClient\` stores \`_egress_dpop_key: DpopKey | None\` and \`_egress_dpop_nonce: str | None\`, separate from the existing ingress DPoP state. Ingress = session-ephemeral; egress = persistent so its thumbprint stays pinned server-side.
- \`proxy_headers(method, url)\` signs a proof when the key is loaded and method/url are supplied. Legacy callers invoking \`proxy_headers()\` without args get bearer-only headers — never silently ship a proof with empty \`htu\`.
- \`_egress_http(method, path_or_url, **kwargs)\` wraps every egress HTTP call with a **single** \`use_dpop_nonce\` retry. First attempt uses the cached nonce; 401 with \`use_dpop_nonce\` → pick up \`DPoP-Nonce\` header, replay once, then propagate any further 401 so the caller can surface it. Rotated nonces on 200 responses are cached opportunistically.
- \`from_enrollment(enable_dpop=True, dpop_base_dir=None)\` and \`from_connector(enable_dpop=True)\` load/generate at bootstrap. Persistence failures (read-only containers, missing \`HOME\`) → \`RuntimeWarning\` + legacy fallback, not a crash.
- 5 egress call sites migrated from manual \`proxy_headers() + _http.xxx\` to \`_egress_http\`:
  - \`send_via_proxy\` (resolve + send)
  - \`receive_via_proxy\`
  - \`send_oneshot\` (resolve + send)
  - \`receive_oneshot\`
  - \`ack_via_proxy\`

## Tests (\`tests/test_sdk_dpop.py\`, 14 cases)

**DpopKey unit:**
- generate creates valid EC P-256 (coords + kty + crv shape)
- save uses 0600 + atomic (no stray tempfiles)
- \`load_or_generate\` idempotent (server-pinned jkt survives restart)
- agent_id sanitisation (no \`:\` on disk)
- thumbprint matches \`mcp_proxy.auth.dpop.compute_jkt(public_jwk)\`
- sign_proof JWT roundtrip (header \`typ/alg/jwk\`, claims \`htm/htu/iat/jti/ath/nonce\`, signature verifies against embedded jwk)
- load rejects public-only (missing \`d\`)
- non-EC-P-256 refused at construction

**CullisClient integration:**
- \`from_enrollment\` generates + persists key under the supplied base_dir
- \`enable_dpop=False\` keeps legacy behavior (no file, no \`DPoP\` header)
- \`proxy_headers(method, url)\` injects \`DPoP\` with jwk whose thumbprint matches the key
- \`proxy_headers()\` (no args) skips DPoP → no unsigned-htu proof
- \`_egress_http\` retries once on \`use_dpop_nonce\`, second proof carries the fresh nonce, 200 response nonce is cached
- \`_egress_http\` gives up after one retry on persistent 401 (no loop)

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1348 passed, 31 skipped.
- [x] Targeted: \`pytest tests/test_sdk_dpop.py tests/test_sdk_send_via_proxy.py -q\` — 16 passed (fix on \`_egress_http\` to tolerate test doubles without a \`.headers\` attribute).
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.
- [x] Ruff mental check: all new imports (base64, hashlib, json, os, secrets, time, uuid, Path, jwt, cryptography) used.

## Backwards compat guarantees

- Mastio default \`CULLIS_EGRESS_DPOP_MODE=off\` (from #199) → server ignores the \`DPoP\` header even when the SDK emits one. Unmodified deployments see no behaviour change.
- Pre-Phase-3c SDK users upgrade pip package + keep their existing code: automatic DPoP emission kicks in silently. When the operator flips the flag to \`optional\` / \`required\`, the SDK is already ready.
- External integrations that still call \`proxy_headers()\` directly (legacy tooling) get bearer-only headers. No \`DPoP: <empty-htu>\` surprises.

## Out of scope

- \`cullis_connector/enrollment.py\` submitting \`dpop_jwk\` at \`/v1/enrollment/start\` — **Phase 3d**, next PR. Operators today can still bind a key:
  1. SDK runs once → generates + persists a keypair under \`~/.cullis/dpop/<agent>.jwk\`
  2. Operator POST the public JWK to \`/v1/admin/agents/<id>/dpop-jwk\` (#206)
  3. Server stores the thumbprint, next egress call is already proof-bound.
- TS SDK — **Phase 4**.