### PR TITLE
feat(connector): submit + persist DPoP JWK at enrollment (F-B-11 Phase 3d)

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -105,11 +105,21 @@ def enroll(
     api_key_raw = _generate_api_key()
     api_key_hash = _bcrypt_hash(api_key_raw)
 
+    # F-B-11 Phase 3d (#181) — generate the DPoP keypair locally, submit
+    # the public JWK at start, persist the private half alongside the
+    # identity on approval. The server computes its RFC 7638 thumbprint
+    # and stores it on ``internal_agents.dpop_jkt`` (#207) so every
+    # proof the SDK later signs is pinned to this specific keypair.
+    from cullis_sdk.dpop import DpopKey
+    dpop_key = DpopKey.generate()
+    dpop_public_jwk = dpop_key.public_jwk
+
     start_resp = _start(
         site_url=site_url,
         pubkey_pem=pubkey_pem,
         requester=requester,
         api_key_hash=api_key_hash,
+        dpop_jwk=dpop_public_jwk,
         verify_tls=verify_tls,
         timeout_s=request_timeout_s,
     )
@@ -167,6 +177,7 @@ def enroll(
         ca_chain_pem=None,  # Phase 2c will fetch the CA chain from the Site.
         metadata=metadata,
         api_key=api_key_raw,
+        dpop_private_jwk=dpop_key.private_jwk(),
     )
 
     print(
@@ -189,6 +200,7 @@ def _start(
     api_key_hash: str | None,
     verify_tls: bool,
     timeout_s: float,
+    dpop_jwk: dict | None = None,
 ) -> dict[str, Any]:
     body = {
         "pubkey_pem": pubkey_pem,
@@ -201,6 +213,10 @@ def _start(
         body["device_info"] = requester.device_info
     if api_key_hash:
         body["api_key_hash"] = api_key_hash
+    # F-B-11 Phase 3d — include the public DPoP JWK so Mastio can
+    # compute + store its thumbprint on approve (wire added in #207).
+    if dpop_jwk is not None:
+        body["dpop_jwk"] = dpop_jwk
 
     try:
         response = httpx.post(

--- a/cullis_connector/identity/store.py
+++ b/cullis_connector/identity/store.py
@@ -30,6 +30,9 @@ KEY_FILENAME = "agent.key"
 CA_CHAIN_FILENAME = "ca-chain.pem"
 METADATA_FILENAME = "metadata.json"
 API_KEY_FILENAME = "api_key"
+# F-B-11 Phase 3d (#181) — per-identity DPoP keypair. Persisted as a
+# private JWK; the SDK reads it back via ``cullis_sdk.DpopKey.load``.
+DPOP_KEY_FILENAME = "dpop.jwk"
 
 
 class IdentityNotFound(Exception):
@@ -91,12 +94,18 @@ def save_identity(
     ca_chain_pem: str | None,
     metadata: IdentityMetadata,
     api_key: str | None = None,
+    dpop_private_jwk: dict | None = None,
 ) -> None:
     """Persist the full identity bundle atomically per-file.
 
-    The private key and api_key file are written with ``chmod 600``; the
-    public cert and metadata stay world-readable (they contain no secret
-    material).
+    The private key, ``api_key`` file, and the DPoP private JWK
+    (audit F-B-11 Phase 3d, #181) are written with ``chmod 600``; the
+    public cert and metadata stay world-readable (they contain no
+    secret material).
+
+    ``dpop_private_jwk`` is optional — legacy Connectors that predate
+    F-B-11 omit it, and the SDK's ``from_connector`` path falls back
+    to generating a fresh keypair on first run in that case.
     """
     identity_dir = _identity_dir(config_dir)
     identity_dir.mkdir(parents=True, exist_ok=True)
@@ -135,6 +144,23 @@ def save_identity(
         _write_atomic(
             identity_dir / API_KEY_FILENAME,
             (api_key + "\n").encode(),
+            mode=0o600,
+        )
+
+    # F-B-11 Phase 3d — DPoP private JWK. Stored as a JSON wrapper the
+    # SDK's ``DpopKey.load`` accepts: ``{"private_jwk": {...}}``.
+    if dpop_private_jwk is not None:
+        if "d" not in dpop_private_jwk:
+            raise ValueError(
+                "dpop_private_jwk is missing the 'd' field — refusing "
+                "to persist a public-only JWK at dpop.jwk"
+            )
+        _write_atomic(
+            identity_dir / DPOP_KEY_FILENAME,
+            json.dumps(
+                {"private_jwk": dpop_private_jwk},
+                separators=(",", ":"),
+            ).encode(),
             mode=0o600,
         )
 

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -462,21 +462,27 @@ class CullisClient:
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
 
-        # F-B-11 Phase 3c — load the DPoP keypair alongside the rest
-        # of the Connector identity. First-run on a freshly-enrolled
-        # Connector generates it; subsequent runs reuse the same key
-        # so its thumbprint stays pinned server-side.
+        # F-B-11 Phase 3c + 3d — load the DPoP keypair alongside the
+        # rest of the Connector identity. Phase 3d (#181) has the
+        # Connector persist it at enrollment time as ``dpop.jwk``
+        # next to ``agent.crt`` / ``agent.key``. For legacy Connectors
+        # (pre-3d) that never persisted one, generate locally and
+        # reuse on subsequent runs — but note the resulting thumbprint
+        # is NOT bound server-side until the operator registers it
+        # via the admin endpoint (#206) or re-enrolls.
         if enable_dpop:
             from cullis_sdk.dpop import DpopKey
+            dpop_path = identity_dir / "dpop.jwk"
             try:
-                instance._egress_dpop_key = DpopKey.load_or_generate(
-                    agent_id, base_dir=identity_dir / "dpop",
-                )
-            except OSError as exc:
+                if dpop_path.exists():
+                    instance._egress_dpop_key = DpopKey.load(dpop_path)
+                else:
+                    instance._egress_dpop_key = DpopKey.generate(path=dpop_path)
+            except (OSError, ValueError) as exc:
                 import warnings
                 warnings.warn(
-                    f"Could not load or generate egress DPoP key under "
-                    f"{identity_dir}: {exc}. Falling back to legacy "
+                    f"Could not load or generate egress DPoP key at "
+                    f"{dpop_path}: {exc}. Falling back to legacy "
                     f"X-API-Key bearer; pass enable_dpop=False to silence.",
                     RuntimeWarning,
                     stacklevel=2,

--- a/tests/connector/test_enrollment_dpop.py
+++ b/tests/connector/test_enrollment_dpop.py
@@ -1,0 +1,313 @@
+"""F-B-11 Phase 3d — Connector generates + submits + persists the DPoP JWK.
+
+Covers the end-to-end wiring between the three parties:
+
+* ``cullis_connector.enrollment.enroll`` builds an EC P-256 keypair,
+  submits the public JWK as ``dpop_jwk`` on ``/v1/enrollment/start``,
+  and persists the private half at ``<identity_dir>/dpop.jwk`` (0600)
+  on approval.
+
+* ``cullis_connector.identity.store.save_identity`` refuses to write
+  a public-only JWK (no ``d``).
+
+* ``cullis_sdk.CullisClient.from_connector`` picks up the persisted
+  JWK and reuses the same keypair across restarts, so the server's
+  pinned thumbprint keeps matching.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from cullis_connector import enrollment
+from cullis_connector.enrollment import RequesterInfo, enroll
+from cullis_connector.identity import has_identity
+from cullis_connector.identity.store import save_identity, IdentityMetadata
+
+
+# ── Shared fake httpx harness (mirrors test_enrollment_client) ─────
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict | str):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = payload if isinstance(payload, str) else ""
+
+    def json(self) -> dict:
+        if not isinstance(self._payload, dict):
+            raise ValueError("not json")
+        return self._payload
+
+
+@pytest.fixture
+def fake_httpx(monkeypatch):
+    class Script:
+        def __init__(self):
+            self.posts: list[dict] = []
+            self.gets: list[str] = []
+            self._post_responses: list[_FakeResponse] = []
+            self._get_responses: list[_FakeResponse] = []
+
+        def enqueue_post(self, resp: _FakeResponse) -> None:
+            self._post_responses.append(resp)
+
+        def enqueue_get(self, resp: _FakeResponse) -> None:
+            self._get_responses.append(resp)
+
+        def _post(self, url: str, **kwargs) -> _FakeResponse:
+            self.posts.append({"url": url, **kwargs})
+            if not self._post_responses:
+                raise AssertionError(f"Unexpected POST to {url}")
+            return self._post_responses.pop(0)
+
+        def _get(self, url: str, **kwargs) -> _FakeResponse:
+            self.gets.append(url)
+            if not self._get_responses:
+                raise AssertionError(f"Unexpected GET to {url}")
+            return self._get_responses.pop(0)
+
+    script = Script()
+    monkeypatch.setattr(enrollment.httpx, "post", script._post)
+    monkeypatch.setattr(enrollment.httpx, "get", script._get)
+    monkeypatch.setattr(enrollment.time, "sleep", lambda _s: None)
+    return script
+
+
+def _approved_record(cert_pem: str) -> _FakeResponse:
+    return _FakeResponse(
+        200,
+        {
+            "session_id": "session-abc",
+            "status": "approved",
+            "agent_id": "acme::agent-fb11",
+            "cert_pem": cert_pem,
+            "capabilities": ["order.read"],
+        },
+    )
+
+
+def _start_response() -> _FakeResponse:
+    return _FakeResponse(
+        201,
+        {
+            "session_id": "session-abc",
+            "status": "pending",
+            "poll_url": "https://site.test/v1/enrollment/session-abc/status",
+            "enroll_url": "https://site.test/enroll?session=session-abc",
+            "poll_interval_s": 1,
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+    )
+
+
+def _real_cert_pem() -> str:
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+    from datetime import datetime, timedelta, timezone
+
+    ca_key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "acme::agent-fb11")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject).issuer_name(subject)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=30))
+        .sign(ca_key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+# ── tests ──────────────────────────────────────────────────────────
+
+
+def test_enroll_submits_dpop_jwk_in_start_body(tmp_path: Path, fake_httpx):
+    """The Connector includes ``dpop_jwk`` in the body of
+    ``/v1/enrollment/start`` — the field Phase 3b wired on the server
+    (#207) to populate ``pending_enrollments.dpop_jkt``."""
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(_approved_record(cert_pem=_real_cert_pem()))
+
+    enroll(
+        site_url="https://site.test",
+        config_dir=tmp_path,
+        requester=RequesterInfo(name="Mario Rossi", email="mario@acme.com"),
+        verify_tls=True,
+        poll_sink=io.StringIO(),
+    )
+
+    # One POST, and its body includes the public JWK.
+    assert len(fake_httpx.posts) == 1
+    body = fake_httpx.posts[0]["json"]
+    assert "dpop_jwk" in body, "Connector did not submit dpop_jwk"
+    jwk = body["dpop_jwk"]
+    assert jwk["kty"] == "EC"
+    assert jwk["crv"] == "P-256"
+    assert "x" in jwk and "y" in jwk
+    # Public JWK only — never send the private scalar on the wire.
+    assert "d" not in jwk
+
+
+def test_enroll_persists_dpop_key_on_approval(tmp_path: Path, fake_httpx):
+    """On approval, the Connector writes ``<identity_dir>/dpop.jwk``
+    with 0600 perms. The file is the private JWK that the SDK's
+    ``from_connector`` will load on subsequent runs."""
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(_approved_record(cert_pem=_real_cert_pem()))
+
+    enroll(
+        site_url="https://site.test",
+        config_dir=tmp_path,
+        requester=RequesterInfo(name="Mario", email="m@acme.com"),
+        verify_tls=True,
+        poll_sink=io.StringIO(),
+    )
+
+    assert has_identity(tmp_path)
+    dpop_path = tmp_path / "identity" / "dpop.jwk"
+    assert dpop_path.exists(), "dpop.jwk was not persisted on approval"
+
+    mode = stat.S_IMODE(os.stat(dpop_path).st_mode)
+    assert mode == 0o600, f"expected 0600, got {oct(mode)}"
+
+    persisted = json.loads(dpop_path.read_text())
+    assert "private_jwk" in persisted
+    priv_jwk = persisted["private_jwk"]
+    assert priv_jwk["kty"] == "EC"
+    assert "d" in priv_jwk  # private scalar IS on disk (0600 local file)
+
+
+def test_enroll_submitted_jwk_matches_persisted_jwk(
+    tmp_path: Path, fake_httpx,
+):
+    """The public JWK submitted to the server must be the public half
+    of the private JWK persisted locally — if they drift, the server's
+    pinned thumbprint will never match the SDK's proofs."""
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(_approved_record(cert_pem=_real_cert_pem()))
+
+    enroll(
+        site_url="https://site.test",
+        config_dir=tmp_path,
+        requester=RequesterInfo(name="x", email="x@y.z"),
+        verify_tls=True,
+        poll_sink=io.StringIO(),
+    )
+
+    submitted = fake_httpx.posts[0]["json"]["dpop_jwk"]
+    persisted = json.loads(
+        (tmp_path / "identity" / "dpop.jwk").read_text()
+    )["private_jwk"]
+    for field in ("kty", "crv", "x", "y"):
+        assert submitted[field] == persisted[field], (
+            f"drift on {field}: submitted {submitted[field]!r} vs "
+            f"persisted {persisted[field]!r}"
+        )
+
+
+def test_save_identity_rejects_public_only_dpop_jwk(tmp_path: Path):
+    """Guardrail on the storage layer: never persist a JWK without a
+    private ``d`` — a public-only file is useless for signing and an
+    operator who drops one here probably made a copy-paste mistake."""
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    priv = ec.generate_private_key(ec.SECP256R1())
+    # Build a fake public-only JWK (no 'd').
+    import base64
+    nums = priv.public_key().public_numbers()
+    pub_jwk = {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": base64.urlsafe_b64encode(nums.x.to_bytes(32, "big")).rstrip(b"=").decode(),
+        "y": base64.urlsafe_b64encode(nums.y.to_bytes(32, "big")).rstrip(b"=").decode(),
+    }
+
+    metadata = IdentityMetadata(
+        agent_id="acme::x",
+        capabilities=[],
+        site_url="https://site.test",
+        issued_at="2026-04-18T00:00:00+00:00",
+    )
+    with pytest.raises(ValueError, match="'d'"):
+        save_identity(
+            config_dir=tmp_path,
+            cert_pem=_real_cert_pem(),
+            private_key=priv,
+            ca_chain_pem=None,
+            metadata=metadata,
+            api_key="sk_local_x_" + "a" * 32,
+            dpop_private_jwk=pub_jwk,  # missing 'd'
+        )
+
+
+def test_from_connector_loads_persisted_dpop_key(tmp_path: Path, fake_httpx):
+    """End-to-end: after enroll persists the key, ``from_connector``
+    loads it. Two calls on two different ``from_connector`` instances
+    must surface the same thumbprint (server keeps matching)."""
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(_approved_record(cert_pem=_real_cert_pem()))
+
+    enroll(
+        site_url="https://site.test",
+        config_dir=tmp_path,
+        requester=RequesterInfo(name="x", email="x@y.z"),
+        verify_tls=True,
+        poll_sink=io.StringIO(),
+    )
+
+    from cullis_sdk import CullisClient
+    cli_a = CullisClient.from_connector(tmp_path)
+    cli_b = CullisClient.from_connector(tmp_path)
+    assert cli_a._egress_dpop_key is not None
+    assert cli_b._egress_dpop_key is not None
+    assert cli_a._egress_dpop_key.thumbprint() == cli_b._egress_dpop_key.thumbprint()
+
+
+def test_from_connector_without_dpop_jwk_generates(tmp_path: Path):
+    """Legacy Connector identity (no ``dpop.jwk`` persisted): the SDK
+    generates locally so users who upgrade the SDK without re-enrolling
+    still get a DPoP path. The resulting thumbprint is NOT yet bound
+    server-side — operator registers via #206 or re-enrolls."""
+    # Build a minimal legacy identity on disk: cert + key + metadata +
+    # api_key, but no dpop.jwk.
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    metadata_path = tmp_path / "identity" / "metadata.json"
+    (tmp_path / "identity").mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps({
+        "agent_id": "acme::legacy",
+        "capabilities": [],
+        "site_url": "http://site.test",
+        "issued_at": "2026-04-18T00:00:00+00:00",
+    }))
+    (tmp_path / "identity" / "api_key").write_text("sk_local_legacy_" + "a" * 32 + "\n")
+    priv = ec.generate_private_key(ec.SECP256R1())
+    from cryptography.hazmat.primitives import serialization
+    (tmp_path / "identity" / "agent.key").write_text(
+        priv.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+    )
+    (tmp_path / "identity" / "agent.crt").write_text(_real_cert_pem())
+
+    assert not (tmp_path / "identity" / "dpop.jwk").exists()
+
+    from cullis_sdk import CullisClient
+    cli = CullisClient.from_connector(tmp_path)
+    assert cli._egress_dpop_key is not None
+    # After the first from_connector, the generated key landed at
+    # the expected path so a second load is idempotent.
+    assert (tmp_path / "identity" / "dpop.jwk").exists()
+
+    cli2 = CullisClient.from_connector(tmp_path)
+    assert cli._egress_dpop_key.thumbprint() == cli2._egress_dpop_key.thumbprint()


### PR DESCRIPTION
## Summary

Closes the DPoP end-to-end loop on the Python side. The Connector generates the DPoP keypair at \`enroll()\` time, submits the public JWK to \`/v1/enrollment/start\` (consumed by Phase 3b, #207), and persists the private half alongside the rest of the identity on approval. The SDK's \`from_connector\` reads it back so every egress request is signed by the keypair the server pinned in \`internal_agents.dpop_jkt\`.

Part of **F-B-11** (#181). 7th PR of the epic.

## The full loop

\`\`\`
Connector.enroll()                                          Server
──────────────────                                          ──────
  generate EC P-256 keypair (cullis_sdk.DpopKey.generate())
    │
    ├─ POST /v1/enrollment/start { …, dpop_jwk: public JWK } ─→ pending_enrollments.dpop_jkt  (#207)
    │
    ├─ poll for approval
    │
    └─ on approve:
         save_identity(..., dpop_private_jwk=private JWK)        on approve → internal_agents.dpop_jkt
         → writes <identity_dir>/dpop.jwk (0600)
       
CullisClient.from_connector(config_dir)
────────────────────────────────────────
  loads <identity_dir>/dpop.jwk  → DpopKey instance
  sign proofs on every egress     ─→ verified against internal_agents.dpop_jkt
                                     (#204 pinning + Phase 2 dep enforcement)
\`\`\`

## What changed

- \`cullis_connector/identity/store.py\` — new \`DPOP_KEY_FILENAME = \"dpop.jwk\"\` constant; \`save_identity\` accepts optional \`dpop_private_jwk\` kwarg, writes \`{\"private_jwk\": {...}}\` with 0600. Refuses a JWK missing \`d\` — a public-only file at that path would be useless for signing.
- \`cullis_connector/enrollment.py\` — \`enroll()\` imports \`cullis_sdk.DpopKey\`, generates before \`_start\`, submits \`dpop_jwk: key.public_jwk\` in the start body, persists \`key.private_jwk()\` on approval via the new \`save_identity\` kwarg. \`_start\` signature extended with \`dpop_jwk: dict | None = None\`.
- \`cullis_sdk/client.py\` — \`from_connector\` now loads from the single-file path \`<identity_dir>/dpop.jwk\` instead of the \`<identity_dir>/dpop/\` subdirectory that Phase 3c introduced. Since 3c never actually populated that subdir (the Connector wasn't wired), the migration is free. Legacy Connectors that never persisted a \`dpop.jwk\` fall back to generating locally — note the resulting thumbprint is NOT yet bound server-side; operator registers via #206 or re-enrolls.

## Tests (\`tests/connector/test_enrollment_dpop.py\`, 6 cases)

- \`test_enroll_submits_dpop_jwk_in_start_body\` — body carries EC/P-256 public JWK without \`d\`.
- \`test_enroll_persists_dpop_key_on_approval\` — file exists, 0600, contains private JWK with \`d\`.
- \`test_enroll_submitted_jwk_matches_persisted_jwk\` — no drift between what went on the wire and what stayed on disk; if these ever diverged the server's pinned thumbprint would never match SDK proofs.
- \`test_save_identity_rejects_public_only_dpop_jwk\` — \`ValueError\` when someone passes a JWK missing \`d\`.
- \`test_from_connector_loads_persisted_dpop_key\` — end-to-end: after enroll, two \`from_connector\` instances share the same thumbprint.
- \`test_from_connector_without_dpop_jwk_generates\` — pre-Phase-3d identity on disk → SDK generates locally, caches at \`dpop.jwk\`, second call is idempotent.

## Backwards compat

- Pre-Phase-3d Connectors / legacy identity bundles keep working: \`save_identity\`'s new kwarg is optional, \`from_connector\` handles the no-file case by generating locally.
- Mastio server still defaults to \`CULLIS_EGRESS_DPOP_MODE=off\`, so even when the Connector + SDK emit proofs end-to-end the server ignores them until the operator flips the flag (Phase 5/6).

## Test plan

- [x] \`pytest tests/ -q --ignore=tests/test_postgres_integration.py\` — 1353 passed, 31 skipped.
- [x] Targeted: \`pytest tests/connector/test_enrollment_dpop.py -q\` — 6 passed.
- [x] \`./demo_network/smoke.sh full\` — A1 through A8 PASS.
- [x] Ruff mental check: all imports used (io, json, os, stat, pathlib.Path, pytest, cullis_connector.*, cullis_sdk).

## Roadmap remaining

- **Phase 4** — TS SDK parity + interop vectors.
- **Phase 5** — swap 12 \`/v1/egress/*\` handlers to the DPoP dep, default mode=optional.
- **Phase 6** — flip default to required, delete legacy egress dep, deprecation notice.