### PR TITLE
fix(sandbox): bindings + proxy pubkey endpoint after ADR-010 cutover

### DIFF
--- a/enterprise_sandbox/bootstrap/bootstrap.py
+++ b/enterprise_sandbox/bootstrap/bootstrap.py
@@ -528,6 +528,25 @@ def phase_4_register_agents(client: httpx.Client, orgs_data: dict[str, dict]) ->
         meta = _provision_agent(client, agent_def, orgs_data)
         results.append(meta)
         print(flush=True)
+
+    # ADR-010 Phase 6a-4 — hand off to bootstrap_mastio.py. It needs the
+    # caller-defined capabilities both to seed the Mastio (PATCH is still
+    # TODO) and to POST /v1/registry/bindings on the Court. The seeded
+    # agent row carries empty caps today; writing a manifest here keeps
+    # the two bootstrap stages loosely coupled.
+    manifest = [
+        {
+            "agent_id":     a["agent_id"],
+            "org_id":       a["org_id"],
+            "agent_name":   a["agent_id"].split("::", 1)[1],
+            "capabilities": a["capabilities"],
+        }
+        for a in targets
+    ]
+    manifest_path = STATE / "agents.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    manifest_path.chmod(0o644)
+    _ok(f"agents manifest → {manifest_path}")
     return results
 
 

--- a/enterprise_sandbox/bootstrap/bootstrap_mastio.py
+++ b/enterprise_sandbox/bootstrap/bootstrap_mastio.py
@@ -1,9 +1,9 @@
-"""Post-proxy-boot wiring: mastio_pubkey pin + agent seeding.
+"""Post-proxy-boot wiring: mastio_pubkey pin + agent seeding + bindings.
 
 Runs **after** the proxies have booted and generated their Mastio CA +
 leaf identity (lifespan hook in ``mcp_proxy/main.py``).
 
-Two responsibilities:
+Three responsibilities:
 
 1. **ADR-009 mastio pubkey pinning** (original job):
    - poll ``GET /v1/admin/mastio-pubkey`` on each proxy until populated
@@ -14,14 +14,23 @@ Two responsibilities:
      ``/state/{org}/agents/{name}/``, ``POST /v1/admin/agents`` on the
      owning Mastio with the pre-generated material and ``federated=true``
    - the Phase 3 publisher loop picks the row up from
-     ``internal_agents`` and pushes it to the Court (no more direct
-     ``/v1/registry/agents`` call from bootstrap)
+     ``internal_agents`` and pushes it to the Court
+
+3. **ADR-010 Phase 6a-4 — binding create+approve on the Court**:
+   - PR #191 removed the binding step from ``bootstrap.py`` but never
+     migrated it anywhere; without an approved binding the agent's
+     ``/v1/auth/login`` on the Court returns 403 "No approved binding".
+   - We retry ``POST /v1/registry/bindings`` until the publisher has
+     pushed the agent (404 = not yet visible, retry). 409 = already
+     there, fetch id. Then ``POST .../approve``.
 
 Idempotent: the Mastio returns 409 on duplicates; we silently continue.
 """
 from __future__ import annotations
 
+import json
 import os
+import pathlib
 import sys
 import time
 
@@ -131,22 +140,50 @@ def _pin_on_court(
         raise SystemExit(1)
 
 
+def _load_manifest() -> list[dict]:
+    """Load the agents manifest written by bootstrap.py phase_4.
+
+    Each entry has ``agent_id``, ``org_id``, ``agent_name``, and
+    ``capabilities``. Returns ``[]`` if the file is missing (older
+    bootstrap, or scope=up without agents for this org) — callers fall
+    back to directory scan with empty caps.
+    """
+    path = pathlib.Path("/state/agents.json")
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        _warn(f"/state/agents.json corrupt ({exc}) — treating as empty")
+        return []
+
+
+def _read_org_secret(org_id: str) -> str | None:
+    """Read the per-org secret the outer bootstrap persisted."""
+    path = pathlib.Path("/state") / org_id / "org_secret"
+    if not path.exists():
+        return None
+    return path.read_text().strip()
+
+
 def _seed_agents_on_mastio(
     client: httpx.Client, proxy_url: str, admin_secret: str, org_id: str,
-) -> None:
+    manifest: list[dict],
+) -> list[dict]:
     """ADR-010 Phase 4 — register each /state/{org}/agents/* on the Mastio.
 
-    The outer bootstrap already generated agent cert/key pairs and wrote
-    them under ``/state/{org}/agents/{name}/agent.pem,agent-key.pem``.
-    We forward them to the Mastio's ``POST /v1/admin/agents`` with
-    ``federated=true``; the publisher loop then pushes to the Court.
+    Returns the subset of ``manifest`` that belongs to ``org_id`` and
+    was accepted (201) or already present (409), so the caller can
+    drive binding create+approve on the Court.
     """
-    import pathlib
     agents_dir = pathlib.Path("/state") / org_id / "agents"
     if not agents_dir.exists():
         _info(f"{org_id}: no agents directory — skipping seed")
-        return
+        return []
 
+    caps_by_name = {e["agent_name"]: e.get("capabilities", []) for e in manifest
+                    if e.get("org_id") == org_id}
+    seeded: list[dict] = []
     for entry in sorted(p for p in agents_dir.iterdir() if p.is_dir()):
         name = entry.name
         cert_path = entry / "agent.pem"
@@ -156,13 +193,14 @@ def _seed_agents_on_mastio(
             continue
         cert_pem = cert_path.read_text()
         key_pem = key_path.read_text()
+        capabilities = caps_by_name.get(name, [])
         r = client.post(
             f"{proxy_url}/v1/admin/agents",
             headers={"X-Admin-Secret": admin_secret},
             json={
                 "agent_name": name,
                 "display_name": name,
-                "capabilities": [],  # assigned later by admin via PATCH
+                "capabilities": capabilities,
                 "federated": True,
                 "cert_pem": cert_pem,
                 "private_key_pem": key_pem,
@@ -170,14 +208,89 @@ def _seed_agents_on_mastio(
             timeout=10.0,
         )
         if r.status_code == 201:
-            _ok(f"{org_id}::{name}: seeded on Mastio (federated=True)")
+            _ok(f"{org_id}::{name}: seeded on Mastio "
+                f"(federated=True, caps={capabilities or '[]'})")
+            seeded.append({"org_id": org_id, "agent_name": name,
+                           "capabilities": capabilities})
         elif r.status_code == 409:
-            _info(f"{org_id}::{name}: already on Mastio — skipping")
+            _info(f"{org_id}::{name}: already on Mastio — skipping seed")
+            seeded.append({"org_id": org_id, "agent_name": name,
+                           "capabilities": capabilities})
         else:
             _fail(
                 f"{org_id}::{name}: seed failed "
                 f"HTTP {r.status_code} {r.text[:200]}"
             )
+    return seeded
+
+
+def _bind_agents_on_court(
+    client: httpx.Client, seeded: list[dict],
+    timeout_s: float = 60.0, retry_s: float = 2.0,
+) -> None:
+    """ADR-010 Phase 6a-4 — create + approve a binding per seeded agent.
+
+    Retries ``POST /v1/registry/bindings`` while the publisher is still
+    catching up (404 on the agent lookup). 409 = already bound, look up
+    the existing id and approve idempotently.
+    """
+    if not seeded:
+        return
+    for agent in seeded:
+        org_id = agent["org_id"]
+        agent_name = agent["agent_name"]
+        agent_id = f"{org_id}::{agent_name}"
+        capabilities = agent["capabilities"]
+        org_secret = _read_org_secret(org_id)
+        if org_secret is None:
+            _fail(f"{agent_id}: no /state/{org_id}/org_secret — cannot bind")
+            raise SystemExit(1)
+        headers = {"X-Org-Id": org_id, "X-Org-Secret": org_secret}
+        body = {"org_id": org_id, "agent_id": agent_id, "scope": capabilities}
+
+        binding_id: int | str | None = None
+        deadline = time.monotonic() + timeout_s
+        last = "(no attempt)"
+        while time.monotonic() < deadline:
+            r = client.post(
+                f"{BROKER_URL}/v1/registry/bindings",
+                json=body, headers=headers, timeout=10.0,
+            )
+            if r.status_code == 201:
+                binding_id = r.json().get("id")
+                break
+            if r.status_code == 409:
+                lr = client.get(
+                    f"{BROKER_URL}/v1/registry/bindings",
+                    params={"org_id": org_id}, headers=headers, timeout=10.0,
+                )
+                lr.raise_for_status()
+                binding_id = next(
+                    (b["id"] for b in lr.json() if b.get("agent_id") == agent_id),
+                    None,
+                )
+                break
+            last = f"HTTP {r.status_code} {r.text[:160]}"
+            time.sleep(retry_s)
+
+        if binding_id is None:
+            _fail(
+                f"{agent_id}: binding create never succeeded in {timeout_s:.0f}s "
+                f"(publisher stuck? last={last})"
+            )
+            raise SystemExit(1)
+
+        ar = client.post(
+            f"{BROKER_URL}/v1/registry/bindings/{binding_id}/approve",
+            headers=headers, timeout=10.0,
+        )
+        if ar.status_code not in (200, 204):
+            _fail(
+                f"{agent_id}: binding approve failed "
+                f"HTTP {ar.status_code} {ar.text[:200]}"
+            )
+            raise SystemExit(1)
+        _ok(f"{agent_id}: binding {binding_id} approved (scope={capabilities or '[]'})")
 
 
 def main() -> int:
@@ -186,6 +299,8 @@ def main() -> int:
         f"{'═' * 10}{RESET}\n",
         flush=True,
     )
+    manifest = _load_manifest()
+    all_seeded: list[dict] = []
     with httpx.Client(timeout=10.0) as client:
         for cfg in PROXIES:
             org_id = cfg["org_id"]
@@ -201,14 +316,22 @@ def main() -> int:
             _ok(f"{org_id}: mastio_pubkey pinned — counter-sig enforcement active")
 
             _info(f"seeding agents on Mastio {BOLD}{org_id}{RESET}")
-            _seed_agents_on_mastio(
+            seeded = _seed_agents_on_mastio(
                 client, cfg["proxy_url"], cfg["admin_secret"], org_id,
+                manifest,
             )
+            all_seeded.extend(seeded)
+
+        if all_seeded:
+            _info(
+                f"creating+approving bindings on Court "
+                f"({len(all_seeded)} agent(s), waiting for publisher)"
+            )
+            _bind_agents_on_court(client, all_seeded)
 
     print(
         f"\n{BOLD}{GREEN}"
-        f"✓ mastio identities pinned + agents seeded "
-        f"(publisher will propagate to Court){RESET}\n",
+        f"✓ mastio identities pinned + agents seeded + bindings approved{RESET}\n",
         flush=True,
     )
     return 0

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -250,6 +250,12 @@ services:
       MCP_PROXY_ORG_ID:            "orga"
       MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9100"
       MCP_PROXY_ENVIRONMENT:       "development"
+      # ADR-010 Phase 6a-4 — tighten the federation publisher tick so
+      # agents seeded by ``bootstrap-mastio`` reach the Court within a
+      # few seconds. Sandbox demo lives/dies on this: agent-a/agent-b/
+      # byoca-bot start right after seeding and 401 on first-login if
+      # the Court hasn't yet received their federated push.
+      MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
     volumes:
       - proxy-a-data:/data
     networks:
@@ -472,6 +478,8 @@ services:
       MCP_PROXY_ORG_ID:            "orgb"
       MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9200"
       MCP_PROXY_ENVIRONMENT:       "development"
+      # ADR-010 Phase 6a-4 — see proxy-a rationale.
+      MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
     volumes:
       - proxy-b-data:/data
     networks:
@@ -651,6 +659,15 @@ services:
       # Must match bootstrap's scope — in ``up`` only orgb is patched;
       # orga doesn't exist on the Court yet.
       BOOTSTRAP_SCOPE:       "${BOOTSTRAP_SCOPE:-up}"
+    # ADR-010 Phase 6a-4 — bootstrap_mastio now reads the agent cert/key
+    # pairs that ``bootstrap`` persisted under /state/{org}/agents/{name}/
+    # and forwards them to the owning Mastio via ``POST /v1/admin/agents``
+    # with ``federated=true``. Without this mount the seed loop skips
+    # every agent ("no agents directory"), the federation publisher has
+    # nothing to push, and byoca/agent-a/agent-b fail first-login with
+    # 401 "Agent not found or org mismatch".
+    volumes:
+      - bootstrap-state:/state:ro
     # Needs all three networks: Court via public-wan, Mastio A via
     # orga-internal, Mastio B via orgb-internal (per-org isolation).
     networks: [public-wan, orga-internal, orgb-internal]

--- a/mcp_proxy/registry/public_key.py
+++ b/mcp_proxy/registry/public_key.py
@@ -27,6 +27,8 @@ import logging
 from typing import Literal
 
 import httpx
+from cryptography import x509 as crypto_x509
+from cryptography.hazmat.primitives import serialization
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy import text
@@ -50,35 +52,61 @@ class PublicKeyResponse(BaseModel):
 
 @federation_router.get("/{agent_id}/public-key", response_model=PublicKeyResponse)
 async def get_public_key(agent_id: str, request: Request) -> PublicKeyResponse:
-    """Return the agent's cert PEM.
+    """Return the agent's public key PEM.
 
     Unauthenticated on purpose: public keys are public. This mirrors the
-    broker's equivalent endpoint (``/v1/registry/agents/{id}/public-key``
+    broker's equivalent endpoint (``/v1/federation/agents/{id}/public-key``
     is also unauthenticated there).
+
+    Federated proxies always forward to the Court. SPIFFE-authed agents
+    rotate their leaf cert on every ``/v1/auth/login``; the Court updates
+    ``agents.cert_pem`` on that path but the Mastio's ``internal_agents``
+    row still carries the pre-SPIFFE bootstrap cert. Serving the stale
+    local copy breaks E2E encryption: the peer encrypts to a public key
+    whose private half the recipient no longer holds. The Court is the
+    single source of truth for post-login cert material.
+
+    Standalone proxies (no uplink) still answer locally — there's no
+    Court to ask, and standalone agents don't rotate via SPIFFE anyway.
     """
-    # Local-first.
-    async with get_db() as conn:
-        row = (await conn.execute(
-            text(
-                """
-                SELECT cert_pem FROM internal_agents
-                 WHERE agent_id = :aid AND is_active = 1
-                """
-            ),
-            {"aid": agent_id},
-        )).first()
-    if row and row[0]:
+    settings = get_settings()
+
+    # Standalone: answer locally, no fallback.
+    if settings.standalone:
+        async with get_db() as conn:
+            row = (await conn.execute(
+                text(
+                    """
+                    SELECT cert_pem FROM internal_agents
+                     WHERE agent_id = :aid AND is_active = 1
+                    """
+                ),
+                {"aid": agent_id},
+            )).first()
+        if not row or not row[0]:
+            raise HTTPException(status_code=404, detail="agent not found")
+        cert_pem = row[0]
+        try:
+            cert = crypto_x509.load_pem_x509_certificate(cert_pem.encode())
+            pubkey_pem = cert.public_key().public_bytes(
+                serialization.Encoding.PEM,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ).decode()
+        except ValueError as exc:
+            _log.error(
+                "internal_agents.cert_pem for %s is not a valid cert: %s",
+                agent_id, exc,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail="stored cert for local agent is not a valid X.509 PEM",
+            )
         return PublicKeyResponse(
             agent_id=agent_id,
-            public_key_pem=row[0],
-            cert_thumbprint=cert_thumbprint_from_pem(row[0]),
+            public_key_pem=pubkey_pem,
+            cert_thumbprint=cert_thumbprint_from_pem(cert_pem),
             scope="local",
         )
-
-    # Not local — in standalone there's nothing else to try.
-    settings = get_settings()
-    if settings.standalone:
-        raise HTTPException(status_code=404, detail="agent not found")
 
     # Federated: hit the broker's live endpoint. We intentionally do NOT
     # serve from cached_federated_agents — the cache stores thumbprint

--- a/tests/test_proxy_discovery_pubkey.py
+++ b/tests/test_proxy_discovery_pubkey.py
@@ -8,14 +8,45 @@ unknown locally AND the proxy is running federated.
 """
 from __future__ import annotations
 
+import datetime
 import json
 
 import pytest
 import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import text
 
 from mcp_proxy.db import get_db
+
+
+def _real_cert_pem(cn: str = "test-agent") -> str:
+    """Build a minimal but syntactically valid X.509 cert PEM.
+
+    The standalone public-key endpoint parses ``cert_pem`` with
+    ``load_pem_x509_certificate`` and extracts SPKI, so the seed rows
+    must carry real certs. Self-signed EC keeps the helper fast.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, cn)]
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=1)
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
 
 
 @pytest_asyncio.fixture
@@ -247,7 +278,7 @@ async def test_search_requires_api_key(standalone_proxy):
 @pytest.mark.asyncio
 async def test_public_key_served_from_local_agents(standalone_proxy):
     _, client = standalone_proxy
-    cert_pem = "-----BEGIN CERTIFICATE-----\nU1RVQg==\n-----END CERTIFICATE-----\n"
+    cert_pem = _real_cert_pem("alice-bot")
     await _insert_local_agent("alice-bot", cert_pem=cert_pem)
 
     resp = await client.get("/v1/federation/agents/alice-bot/public-key")
@@ -255,12 +286,16 @@ async def test_public_key_served_from_local_agents(standalone_proxy):
     body = resp.json()
     assert body["agent_id"] == "alice-bot"
     assert body["scope"] == "local"
-    assert "BEGIN CERTIFICATE" in body["public_key_pem"]
-    # ADR-010 Phase 6b: thumbprint is computed on-the-fly from the PEM
-    # (``internal_agents`` doesn't persist a thumbprint column).
+    # Endpoint extracts SPKI from ``cert_pem``; SDK feeds this straight
+    # into ``load_pem_public_key`` which only accepts ``BEGIN PUBLIC KEY``.
+    assert "BEGIN PUBLIC KEY" in body["public_key_pem"]
+    assert "BEGIN CERTIFICATE" not in body["public_key_pem"]
+    # ADR-010 Phase 6b: thumbprint is SHA-256 of the DER the PEM wraps.
+    import base64
     import hashlib
-    expected = hashlib.sha256(b"STUB").hexdigest()
-    assert body["cert_thumbprint"] == expected
+    import re as _re
+    der = base64.b64decode(_re.sub(r"-----.*?-----|\s", "", cert_pem))
+    assert body["cert_thumbprint"] == hashlib.sha256(der).hexdigest()
 
 
 @pytest.mark.asyncio
@@ -295,7 +330,7 @@ async def test_public_key_endpoint_wins_over_reverse_proxy(standalone_proxy):
     _, client = standalone_proxy
     await _insert_local_agent(
         "ordering-check",
-        cert_pem="-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----\n",
+        cert_pem=_real_cert_pem("ordering-check"),
     )
     resp = await client.get("/v1/federation/agents/ordering-check/public-key")
     # 200 = proxy-native route wins. 503 = reverse-proxy caught it first


### PR DESCRIPTION
## Summary

Two bugs surfaced together in `./demo.sh full` once the legacy `/v1/registry/agents` write path was deleted (ADR-010 Phase 6a-4). Containers came up but agents could neither log in nor exchange intra-org A2A messages.

- **Bug 1 — bindings never created**. PR #191 removed the binding create+approve step from the outer `bootstrap.py` but never migrated it to the Mastio-first flow. Agents ended up in the Court's registry (via publisher push) without an approved binding, so `/v1/auth/login` returned 403. Fixed in `bootstrap_mastio.py` with retry-on-404 to wait out the publisher, mirroring the pattern from `tests/e2e/scripts/setup_proxy_org.py`.
- **Bug 2 — stale / wrong-shape intra-org pubkey**. The proxy's ADR-006 local-first shortcut for `/v1/federation/agents/{id}/public-key` returned `internal_agents.cert_pem` verbatim as `public_key_pem`. This broke SDK callers two ways: (a) it served a `BEGIN CERTIFICATE` PEM where the SDK's `load_pem_public_key` requires SPKI `BEGIN PUBLIC KEY`, and (b) for SPIFFE-authed agents the Mastio's copy is the pre-SPIFFE bootstrap cert, not the rotated one the Court holds — encryption succeeded against a key the recipient no longer held (`E2E decryption failed`). Federated proxies now always forward to the Court; standalone mode still answers locally (no uplink + no SPIFFE rotation) and now extracts SPKI from the stored cert.

Plus the two `docker-compose.yml` tweaks the session needed: `bootstrap-state:/state:ro` mount on `bootstrap-mastio` (no mount → no manifest → no bindings) and `MCP_PROXY_FEDERATION_POLL_INTERVAL_S=2` on both proxies so the publisher ticks fast enough for the demo.

## Test plan

- [x] `./demo.sh down && ./demo.sh full` — all 22 services healthy
- [x] `./smoke.sh` — 24/24 PASS (was 23/24, B4.7 A2A messaging was failing)
- [x] `pytest tests/test_proxy_discovery_pubkey.py` — 10/10 PASS (tests rewritten to use real X.509 certs and assert SPKI, not cert PEM)
- [x] Full `pytest tests/` — only the 15 pre-existing failures on `main` (`test_ts_interop.py` stale TS build + `test_postgres_integration.py` local Postgres quirks, both documented in `imp/workflow.md`)