### PR TITLE
feat(proxy): swap egress handlers to DPoP-bound dep + flip default (F-B-11 Phase 5)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -94,17 +94,21 @@ class ProxySettings(BaseSettings):
     # Egress DPoP mode — audit F-B-11 Phase 1 (#181).
     # Controls whether ``/v1/egress/*`` handlers accept a DPoP proof
     # (RFC 9449) in addition to the legacy ``X-API-Key`` bearer:
-    #   off      → legacy bearer only (default, runtime unchanged)
+    #   off      → legacy bearer only (runtime pre-Phase 5).
     #   optional → DPoP accepted when headers are present; legacy still
     #              allowed. Grace-period stance for rolling out Phase 2
     #              enrollment + Phase 3/4 SDK updates without breaking
-    #              in-flight clients.
+    #              in-flight clients. This is the default since
+    #              F-B-11 Phase 5: handlers are wired to the DPoP-bound
+    #              dep, so a Phase 3c-or-newer SDK has its proof
+    #              validated and jkt-pinned end-to-end, while pre-Phase
+    #              3c clients keep working against bare bearer. No
+    #              egress call breaks on upgrade.
     #   required → DPoP proof mandatory on every egress call; legacy
     #              bare bearer rejected. Flipped in Phase 6 after every
     #              enrolled agent has registered a JWK thumbprint.
-    # The DPoP-bound dep lives in ``mcp_proxy.auth.dpop_api_key``; the
-    # per-agent jkt-vs-registered check lands with Phase 2 enrollment.
-    egress_dpop_mode: str = "off"
+    # The DPoP-bound dep lives in ``mcp_proxy.auth.dpop_api_key``.
+    egress_dpop_mode: str = "optional"
 
     # ADR-001 Phase 2 — SPIFFE routing decision.
     # trust_domain is the SPIFFE trust domain this proxy serves (matched against

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -12,7 +12,9 @@ back to the request. Cross-org recipients return 501 in this PR;
 Phase 2 wires them to the broker.
 
 Auth mirrors the rest of ``/v1/egress/*`` — ``X-API-Key`` via
-``get_agent_from_api_key``. Storage reuses the existing
+``get_agent_from_dpop_api_key`` (F-B-11 Phase 5: legacy bearer lookup
+runs first, DPoP proof validated when the mode flag is ``optional`` or
+``required``). Storage reuses the existing
 ``local_messages`` queue with ``session_id=NULL`` and ``is_oneshot=1``
 (see migration 0008). Audit is written through ``append_local_audit``
 with ``event_type`` in
@@ -28,7 +30,7 @@ from typing import Literal
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from mcp_proxy.auth.api_key import get_agent_from_api_key
+from mcp_proxy.auth.dpop_api_key import get_agent_from_dpop_api_key
 from mcp_proxy.config import get_settings
 from mcp_proxy.egress.routing import decide_route
 from mcp_proxy.local import message_queue as local_queue
@@ -162,7 +164,7 @@ def _serialize_envelope(body: SendOneShotRequest) -> str:
 async def send_oneshot(
     body: SendOneShotRequest,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ) -> SendOneShotResponse:
     """Enqueue a sessionless message for delivery to ``recipient_id``.
 
@@ -354,7 +356,7 @@ async def send_oneshot(
 @router.get("/message/inbox", response_model=InboxResponse)
 async def receive_oneshot_inbox(
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ) -> InboxResponse:
     """Poll pending one-shot messages addressed to this agent.
 

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -3,7 +3,12 @@ Egress API endpoints — internal agents authenticate with API keys and
 communicate through the Cullis broker without seeing x509 keys, DPoP,
 or any cryptography.
 
-All endpoints require X-API-Key authentication (via get_agent_from_api_key).
+All endpoints require X-API-Key authentication (via
+``get_agent_from_dpop_api_key``). That dep runs the legacy bearer
+lookup first and, when ``CULLIS_EGRESS_DPOP_MODE`` is ``optional`` or
+``required`` (F-B-11 Phase 5 default: ``optional``), additionally
+validates a DPoP proof carried in the ``DPoP`` header and pins it to
+the agent's registered ``dpop_jkt``.
 """
 import logging
 import time
@@ -16,7 +21,7 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from mcp_proxy.auth.api_key import get_agent_from_api_key
+from mcp_proxy.auth.dpop_api_key import get_agent_from_dpop_api_key
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
 from mcp_proxy.egress.routing import decide_route
@@ -198,7 +203,7 @@ def _local_session_to_dict(session: LocalSession) -> dict:
 async def open_session(
     body: OpenSessionRequest,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Open a session on behalf of an internal agent.
 
@@ -292,7 +297,7 @@ async def open_session(
 async def list_sessions(
     request: Request,
     status: str | None = None,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """List sessions for the authenticated agent — local + broker merged."""
     local_store = _get_local_store(request)
@@ -319,7 +324,7 @@ async def list_sessions(
 async def accept_session(
     session_id: str,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Accept a pending session (local or broker)."""
     _validate_session_id(session_id)
@@ -374,7 +379,7 @@ async def accept_session(
 async def close_session(
     session_id: str,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Close a session (local or broker)."""
     _validate_session_id(session_id)
@@ -430,7 +435,7 @@ async def close_session(
 async def send_message(
     body: SendMessageRequest,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Send an E2E-encrypted message.
 
@@ -673,7 +678,7 @@ async def poll_messages(
     session_id: str,
     request: Request,
     after: int = -1,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Poll for messages in a session (local or broker).
 
@@ -746,7 +751,7 @@ async def ack_message(
     session_id: str,
     msg_id: str,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Acknowledge delivery of a queued local message (ADR-001 Phase 3c).
 
@@ -786,7 +791,7 @@ async def ack_message(
 async def resolve_recipient(
     body: ResolveRequest,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Resolve a recipient and tell the SDK how to send.
 
@@ -895,7 +900,7 @@ async def resolve_recipient(
 async def discover_agents(
     body: DiscoverRequest,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Discover remote agents on the network."""
     bridge = _get_bridge(request)
@@ -924,7 +929,7 @@ async def discover_agents(
 async def invoke_remote_tool(
     body: InvokeToolRequest,
     request: Request,
-    agent: InternalAgent = Depends(get_agent_from_api_key),
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
 ):
     """Invoke a tool on a remote org via an active broker session.
 


### PR DESCRIPTION
## Summary

- Wire all 12 `/v1/egress/*` handlers (10 in `mcp_proxy/egress/router.py` + 2 in `mcp_proxy/egress/oneshot.py`) to `get_agent_from_dpop_api_key` instead of the legacy `get_agent_from_api_key`. The dep still calls the legacy bearer lookup first, then validates a DPoP proof (RFC 9449) when the mode flag is `optional` or `required` and pins it to the agent's stored `dpop_jkt` (Phase 2 binding).
- Flip `egress_dpop_mode` default from `"off"` to `"optional"`. Non-breaking by design: no DPoP header = bearer accepted (legacy path unchanged, pre-Phase-3c SDKs keep working); valid proof + matching jkt = bound enforcement active; proof present but invalid or jkt mismatched = 401. `mode=required` stays unflipped until F-B-11 Phase 6 after every Connector has re-enrolled.
- Closes F-B-11 Phase 5. Unlocks Phase 6 (`required` cutover) once the grace period elapses.

## Test plan

- [x] `pytest tests/ -n auto --dist=loadfile --ignore=tests/test_ts_interop.py --ignore=tests/test_postgres_integration.py` → **1353 passed, 6 skipped** (~102s). The two ignored suites are local-env quirks per `imp/workflow.md`; neither is touched by this change.
- [x] `tests/test_egress_dpop_auth.py` → **19 passed** (off / optional / required + jkt binding + replay + htm/htu/ath invariants).
- [x] `./demo_network/smoke.sh full` → **PASS** on all 4 assertions (round-trip `checker` nonce, dashboard key persistence across broker restart, audit hash chain over 38 entries, `/v1/mcp` aggregator → mcp-echo). Sender phases 1-6 exercise egress endpoints with bearer-only and land cleanly in `optional` mode.
- [x] Config sanity: `python -c "from mcp_proxy.config import get_settings; print(get_settings().egress_dpop_mode)"` → `optional`.

## Scope guardrails

- No changes outside `mcp_proxy/egress/*`, `mcp_proxy/config.py` — no test fixture edits needed (only `tests/test_egress_dpop_auth.py` references `get_agent_from_api_key`, and it already patches both the legacy and the DPoP-bound dep explicitly).
- Sandbox (`enterprise_sandbox/`) untouched — ADR-011 Phase 4 will revisit.
- No `required`-mode rollout here; that ships separately in F-B-11 Phase 6.