### PR TITLE
feat(mastio): enrollment metadata on internal_agents (ADR-011 Phase 1a)

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -190,11 +190,13 @@ async def create_agent(
                     INSERT INTO internal_agents (
                         agent_id, display_name, capabilities, api_key_hash,
                         cert_pem, created_at, is_active,
-                        federated, federated_at, federation_revision
+                        federated, federated_at, federation_revision,
+                        enrollment_method, enrolled_at
                     ) VALUES (
                         :aid, :name, :caps, :hash,
                         :cert, :now, 1,
-                        :federated, NULL, 1
+                        :federated, NULL, 1,
+                        'admin', :now
                     )
                     """
                 ),

--- a/mcp_proxy/alembic/versions/0016_enrollment_metadata.py
+++ b/mcp_proxy/alembic/versions/0016_enrollment_metadata.py
@@ -1,0 +1,75 @@
+"""ADR-011 Phase 1a — enrollment metadata on ``internal_agents``.
+
+Revision ID: 0016_enrollment_metadata
+Revises: 0015_enrollment_dpop_jkt
+Create Date: 2026-04-18 00:00:00.000000
+
+Adds three nullable columns to ``internal_agents`` so the Mastio can
+distinguish how an agent got enrolled and carry SPIFFE identity as a
+first-class attribute (not a credential):
+
+  * ``enrollment_method`` — enum-typed text, values ``admin`` /
+    ``connector`` / ``byoca`` / ``spiffe``. Existing rows backfilled
+    to ``admin`` (they were all created via the admin path today).
+  * ``spiffe_id`` — populated for rows where the enrollment carried an
+    SVID or the Org CA attached the SPIFFE URI SAN. Optional.
+  * ``enrolled_at`` — distinct from ``created_at`` so an admin can
+    create a placeholder row and complete enrollment later. Backfilled
+    to ``created_at`` on upgrade per ADR-011 §7.3.
+
+Columns are nullable in the schema to keep the migration idempotent and
+composable with ``metadata.create_all`` on fresh SQLite deploys. The
+application layer enforces ``enrollment_method`` NOT NULL at INSERT
+time via the model default.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0016_enrollment_metadata"
+down_revision: Union[str, Sequence[str], None] = "0015_enrollment_dpop_jkt"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_NEW_COLUMNS = ("enrollment_method", "spiffe_id", "enrolled_at")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("internal_agents")}
+
+    to_add = [c for c in _NEW_COLUMNS if c not in existing]
+    if to_add:
+        with op.batch_alter_table("internal_agents") as batch_op:
+            if "enrollment_method" in to_add:
+                batch_op.add_column(sa.Column("enrollment_method", sa.Text(), nullable=True))
+            if "spiffe_id" in to_add:
+                batch_op.add_column(sa.Column("spiffe_id", sa.Text(), nullable=True))
+            if "enrolled_at" in to_add:
+                batch_op.add_column(sa.Column("enrolled_at", sa.Text(), nullable=True))
+
+    # Backfill existing rows so reads after the migration don't see NULLs.
+    # Safe to re-run — UPDATE on already-populated rows is a no-op via the
+    # ``IS NULL`` guard.
+    op.execute(
+        "UPDATE internal_agents SET enrollment_method = 'admin' "
+        "WHERE enrollment_method IS NULL"
+    )
+    op.execute(
+        "UPDATE internal_agents SET enrolled_at = created_at "
+        "WHERE enrolled_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in sa.inspect(bind).get_columns("internal_agents")}
+    to_drop = [c for c in _NEW_COLUMNS if c in existing]
+    if not to_drop:
+        return
+    with op.batch_alter_table("internal_agents") as batch_op:
+        for col in to_drop:
+            batch_op.drop_column(col)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -272,14 +272,29 @@ async def create_agent(
     capabilities: list[str],
     api_key_hash: str,
     cert_pem: str | None = None,
+    enrollment_method: str = "admin",
+    spiffe_id: str | None = None,
 ) -> None:
-    """Register a new internal agent."""
+    """Register a new internal agent.
+
+    ADR-011 Phase 1 — ``enrollment_method`` defaults to ``admin`` so
+    legacy callers (tests, dashboard) get the right metadata without
+    code changes. The Connector approve flow and the BYOCA/SPIFFE
+    enrollment endpoints pass the matching method value explicitly.
+    """
     ts = datetime.now(timezone.utc).isoformat()
     async with get_db() as conn:
         await conn.execute(
             text(
-                """INSERT INTO internal_agents (agent_id, display_name, capabilities, api_key_hash, cert_pem, created_at)
-                   VALUES (:agent_id, :display_name, :capabilities, :api_key_hash, :cert_pem, :created_at)"""
+                """INSERT INTO internal_agents (
+                       agent_id, display_name, capabilities, api_key_hash,
+                       cert_pem, created_at, enrollment_method, spiffe_id,
+                       enrolled_at
+                   ) VALUES (
+                       :agent_id, :display_name, :capabilities, :api_key_hash,
+                       :cert_pem, :created_at, :enrollment_method, :spiffe_id,
+                       :enrolled_at
+                   )"""
             ),
             {
                 "agent_id": agent_id,
@@ -288,6 +303,9 @@ async def create_agent(
                 "api_key_hash": api_key_hash,
                 "cert_pem": cert_pem,
                 "created_at": ts,
+                "enrollment_method": enrollment_method,
+                "spiffe_id": spiffe_id,
+                "enrolled_at": ts,
             },
         )
 

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -55,6 +55,17 @@ class InternalAgent(Base):
     # ``mcp_proxy.auth.dpop_api_key.get_agent_from_dpop_api_key`` when
     # ``CULLIS_EGRESS_DPOP_MODE`` is ``optional`` or ``required``.
     dpop_jkt = Column(Text, nullable=True)
+    # ADR-011 Phase 1 — enrollment metadata. ``enrollment_method`` is one of
+    # ``admin`` / ``connector`` / ``byoca`` / ``spiffe`` and records how the
+    # agent authenticated at enrollment time. ``spiffe_id`` is populated when
+    # the Mastio received a SPIFFE SVID (either at enrollment or via a future
+    # SPIRE-attached deployment). ``enrolled_at`` is separate from
+    # ``created_at`` so an admin can create a placeholder row and complete
+    # enrollment later; on backfill of existing rows we set
+    # ``enrolled_at = created_at``.
+    enrollment_method = Column(Text, nullable=True)
+    spiffe_id = Column(Text, nullable=True)
+    enrolled_at = Column(Text, nullable=True)
 
 
 class AuditLogEntry(Base):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -303,9 +303,10 @@ async def approve(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities, api_key_hash,
-                    cert_pem, created_at, is_active, device_info, dpop_jkt)
+                    cert_pem, created_at, is_active, device_info, dpop_jkt,
+                    enrollment_method, enrolled_at)
                    VALUES (:aid, :dn, :caps, :hash, :cert, :created, 1,
-                           :device, :dpop_jkt)"""
+                           :device, :dpop_jkt, 'connector', :created)"""
             ),
             {
                 "aid": agent_id,

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -66,7 +66,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0015_enrollment_dpop_jkt",)]
+    assert rows == [("0016_enrollment_metadata",)]
 
 
 @pytest.mark.asyncio
@@ -126,7 +126,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0015_enrollment_dpop_jkt",)]
+    assert version == [("0016_enrollment_metadata",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0015_enrollment_dpop_jkt"
+HEAD_REVISION = "0016_enrollment_metadata"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0015_enrollment_dpop_jkt"
+HEAD_REVISION = "0016_enrollment_metadata"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -1,0 +1,165 @@
+"""Validate proxy Alembic migration 0016 — ADR-011 Phase 1 enrollment metadata.
+
+Covers:
+- Fresh deploy: columns present, head revision stamped.
+- Upgrade over pre-0016 SQLite: legacy row survives and is backfilled
+  with ``enrollment_method='admin'`` and ``enrolled_at=created_at``.
+- Downgrade drops the three new columns cleanly.
+- ``db.create_agent`` writes the new columns with the expected defaults.
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config as AlembicConfig
+
+from mcp_proxy.db import create_agent, dispose_db, init_db
+
+HEAD_REVISION = "0016_enrollment_metadata"
+PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
+NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
+
+
+def _columns(path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    finally:
+        conn.close()
+    return {r[1] for r in rows}
+
+
+def _alembic_cfg(url: str) -> AlembicConfig:
+    ini = Path(__file__).resolve().parents[1] / "mcp_proxy" / "alembic.ini"
+    cfg = AlembicConfig(str(ini))
+    cfg.set_main_option("sqlalchemy.url", url)
+    return cfg
+
+
+@pytest.mark.asyncio
+async def test_migration_0016_upgrade_adds_columns(tmp_path):
+    db_file = tmp_path / "0016_up.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    cols = _columns(str(db_file), "internal_agents")
+    assert NEW_COLUMNS.issubset(cols), f"missing: {NEW_COLUMNS - cols}"
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        version = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+    finally:
+        conn.close()
+    assert version == (HEAD_REVISION,)
+
+
+def test_migration_0016_backfills_existing_rows(tmp_path):
+    """Legacy row carried from the 0015 schema gets admin/created_at backfill.
+
+    Sync so ``command.upgrade`` can drive its own asyncio loop without
+    clashing with pytest-asyncio (see 0008 downgrade test).
+    """
+    db_file = tmp_path / "0016_backfill.db"
+    async_url = f"sqlite+aiosqlite:///{db_file}"
+    cfg = _alembic_cfg(async_url)
+
+    # Stamp at the previous head and insert a row in the pre-0016 shape.
+    command.upgrade(cfg, PREVIOUS_REVISION)
+    conn = sqlite3.connect(str(db_file))
+    try:
+        conn.execute(
+            """INSERT INTO internal_agents
+               (agent_id, display_name, capabilities, api_key_hash,
+                created_at, is_active)
+               VALUES (?, ?, '[]', 'h', ?, 1)""",
+            ("orga::legacy", "Legacy Bot", "2026-01-01T00:00:00+00:00"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Upgrade to head — triggers the backfill statements in 0016.
+    command.upgrade(cfg, "head")
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        row = conn.execute(
+            """SELECT enrollment_method, enrolled_at, spiffe_id, created_at
+               FROM internal_agents WHERE agent_id = ?""",
+            ("orga::legacy",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    method, enrolled_at, spiffe_id, created_at = row
+    assert method == "admin"
+    assert enrolled_at == created_at  # §7.3 of ADR-011
+    assert spiffe_id is None  # legacy rows had no SPIFFE ID
+
+
+def test_migration_0016_downgrade_drops_new_columns(tmp_path):
+    """Sync — command.downgrade drives its own event loop."""
+    db_file = tmp_path / "0016_down.db"
+    async_url = f"sqlite+aiosqlite:///{db_file}"
+    cfg = _alembic_cfg(async_url)
+
+    command.upgrade(cfg, "head")
+    assert NEW_COLUMNS.issubset(_columns(str(db_file), "internal_agents"))
+
+    command.downgrade(cfg, PREVIOUS_REVISION)
+    cols = _columns(str(db_file), "internal_agents")
+    assert NEW_COLUMNS.isdisjoint(cols), (
+        f"downgrade left new columns behind: {NEW_COLUMNS & cols}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_agent_helper_writes_enrollment_metadata(tmp_path):
+    """``db.create_agent`` defaults to ``admin`` and populates enrolled_at."""
+    db_file = tmp_path / "create.db"
+    async_url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(async_url)
+
+    try:
+        await create_agent(
+            agent_id="orga::test",
+            display_name="Test",
+            capabilities=["sandbox.read"],
+            api_key_hash="h",
+        )
+        await create_agent(
+            agent_id="orga::spiffe-test",
+            display_name="SPIFFE Test",
+            capabilities=[],
+            api_key_hash="h2",
+            enrollment_method="spiffe",
+            spiffe_id="spiffe://orga.test/spiffe-test",
+        )
+    finally:
+        await dispose_db()
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        default_row = conn.execute(
+            """SELECT enrollment_method, spiffe_id, enrolled_at, created_at
+               FROM internal_agents WHERE agent_id = ?""",
+            ("orga::test",),
+        ).fetchone()
+        spiffe_row = conn.execute(
+            """SELECT enrollment_method, spiffe_id
+               FROM internal_agents WHERE agent_id = ?""",
+            ("orga::spiffe-test",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    method, sid, enrolled_at, created_at = default_row
+    assert method == "admin"
+    assert sid is None
+    assert enrolled_at == created_at  # helper sets both to the same ts
+
+    assert spiffe_row == ("spiffe", "spiffe://orga.test/spiffe-test")


### PR DESCRIPTION
## Summary

Foundation schema for ADR-011 unified enrollment. Adds three nullable columns to `internal_agents`:

- `enrollment_method` — `admin` / `connector` / `byoca` / `spiffe`. Existing rows backfilled to `admin` (they were all created via that path pre-ADR-011); future rows get the right value from the endpoint that created them. Wired into the three existing INSERT sites (admin create, Connector approve, generic `db.create_agent` helper).
- `spiffe_id` — SPIFFE URI, populated by SPIFFE-enrollment rows (Phase 1c coming) and later by SPIRE-attached deployments. Null for every other case.
- `enrolled_at` — distinct from `created_at` so an admin can park a placeholder row and complete enrollment later. Backfilled to `created_at` on upgrade per ADR-011 §7.3.

Columns stay nullable in-schema to keep the migration idempotent (matches the 0013/0014/0015 pattern) and play nice with `metadata.create_all` on fresh SQLite deploys. App layer sets `enrollment_method` explicitly at every INSERT.

No new endpoints in this PR — Phase 1b/1c/1d add `/v1/admin/agents/enroll/{byoca,spiffe}` on top of this schema.

ADR doc: `imp/adr_011_unified_enrollment.md` (ACCEPTED 2026-04-18). Plan: `imp/adr_011_unified_enrollment_plan.md`.

## Test plan

- [x] `pytest tests/test_proxy_migrations*` + `test_admin_agents.py` + `tests/connector/` → 123 passed
- [x] `pytest tests/ --ignore=ts_interop --ignore=postgres_integration` → 1357 passed, zero regressions
- [x] New `test_proxy_migrations_adr011.py` covers: upgrade column add, legacy row backfill (`admin` + `enrolled_at = created_at`), downgrade cleanup, `create_agent` helper defaults
- [x] `HEAD_REVISION` bumped in 3 existing migration tests
- [x] Ruff F401/F541/F841 manual check (NixOS doesn't run ruff locally)