### PR TITLE
feat(court): deprecate /auth/token legacy login path (ADR-011 Phase 3)

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -181,22 +181,18 @@ async def issue_token(
         AUTH_SUCCESS_COUNTER.add(1, {"org_id": org_id})
         AUTH_DURATION_HISTOGRAM.record((time.monotonic() - t0) * 1000)
 
+        # ADR-011 Phase 3 Phase A — fold legacy-path metadata into the
+        # single ``auth.token_issued`` event so the Court emits exactly
+        # one audit row per hit (doubling the chain-lock cost was enough
+        # to flake EC CI under load). Dashboards filter on
+        # ``details.deprecated`` to surface the migration signal; the
+        # ``auth_mode`` + ``migration_endpoint`` bits point the operator
+        # at the correct re-enrollment path for this caller.
         await log_event(
             db, "auth.token_issued", "ok",
             agent_id=agent_id, org_id=org_id,
-        )
-
-        # ADR-011 Phase 3 Phase A — audit every hit on the legacy path so
-        # operators can track migration progress from the dashboard. The
-        # ``svid_mode`` bit tells them whether the caller is SPIFFE (SVID
-        # rotation implied) or classic BYOCA (static cert) — both are
-        # legacy under the unified model, but the migration story differs
-        # (SPIFFE agents re-enroll via ``/admin/agents/enroll/spiffe``,
-        # BYOCA agents via ``/admin/agents/enroll/byoca``).
-        await log_event(
-            db, "auth.legacy_token", "ok",
-            agent_id=agent_id, org_id=org_id,
             details={
+                "deprecated": True,
                 "auth_mode": "spiffe" if svid_mode else "byoca",
                 "sunset_days": _DEPRECATION_GRACE_DAYS,
                 "migration_endpoint": (

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -1,7 +1,9 @@
 import time
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.models import TokenRequest, TokenResponse, TokenPayload
@@ -25,10 +27,33 @@ from app.telemetry_metrics import AUTH_SUCCESS_COUNTER, AUTH_DENY_COUNTER, AUTH_
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+# ADR-011 Phase 3 (deprecation Phase A) — ``POST /auth/token`` is the
+# legacy SPIFFE/BYOCA direct-login path. Under the unified enrollment
+# model agents authenticate to their Mastio with API-key + DPoP, and
+# never hit this endpoint. We emit RFC 8594 ``Deprecation`` + ``Sunset``
+# headers on every 200 and log every hit to the audit stream so operators
+# can track migration progress. Hard-off (410) lands in Phase C after
+# grace.
+_DEPRECATION_GRACE_DAYS = 90
+
+
+def _sunset_header_value() -> str:
+    """RFC 8594 ``Sunset`` — HTTP-date 90 days from now.
+
+    Computed per-request rather than at import time so a long-running
+    server keeps showing a valid forward-looking date as clients poll.
+    The exact cutoff is coordinated with a CHANGELOG entry and a config
+    flag (``CULLIS_ALLOW_LEGACY_AUTH_LOGIN``) before Phase B.
+    """
+    sunset = datetime.now(timezone.utc) + timedelta(days=_DEPRECATION_GRACE_DAYS)
+    return format_datetime(sunset, usegmt=True)
+
+
 @router.post("/token", response_model=TokenResponse)
 async def issue_token(
     request: Request,
     body: TokenRequest,
+    response: Response,
     dpop: str = Header(alias="DPoP"),
     mastio_signature: str | None = Header(default=None, alias=COUNTERSIG_HEADER),
     db: AsyncSession = Depends(get_db),
@@ -42,6 +67,12 @@ async def issue_token(
 
     The first request without a nonce will receive a 401 with DPoP-Nonce header.
     The client must retry with the nonce included in the DPoP proof.
+
+    ADR-011 status: **legacy**. Every successful response carries
+    ``Deprecation: true`` + ``Sunset`` headers. Under the unified
+    enrollment model the agent talks to its Mastio with API-key+DPoP;
+    this endpoint is kept for migration of existing SPIFFE/BYOCA
+    direct-login deployments and will return 410 Gone at sunset.
     """
     t0 = time.monotonic()
     with tracer.start_as_current_span("auth.issue_token") as span:
@@ -153,6 +184,39 @@ async def issue_token(
         await log_event(
             db, "auth.token_issued", "ok",
             agent_id=agent_id, org_id=org_id,
+        )
+
+        # ADR-011 Phase 3 Phase A — audit every hit on the legacy path so
+        # operators can track migration progress from the dashboard. The
+        # ``svid_mode`` bit tells them whether the caller is SPIFFE (SVID
+        # rotation implied) or classic BYOCA (static cert) — both are
+        # legacy under the unified model, but the migration story differs
+        # (SPIFFE agents re-enroll via ``/admin/agents/enroll/spiffe``,
+        # BYOCA agents via ``/admin/agents/enroll/byoca``).
+        await log_event(
+            db, "auth.legacy_token", "ok",
+            agent_id=agent_id, org_id=org_id,
+            details={
+                "auth_mode": "spiffe" if svid_mode else "byoca",
+                "sunset_days": _DEPRECATION_GRACE_DAYS,
+                "migration_endpoint": (
+                    "/v1/admin/agents/enroll/spiffe" if svid_mode
+                    else "/v1/admin/agents/enroll/byoca"
+                ),
+            },
+        )
+
+        # RFC 8594 — advertise deprecation so SDKs emit warnings and
+        # operators see the signal in telemetry. ``Deprecation: true``
+        # (no sunset date implied) + explicit ``Sunset`` HTTP-date.
+        response.headers["Deprecation"] = "true"
+        response.headers["Sunset"] = _sunset_header_value()
+        # Link relation ``sunset`` pointing to the migration doc (ADR-011
+        # §4.2). Filled opportunistically — matches RFC 8288 shape so any
+        # client that consumes Link can follow it programmatically.
+        response.headers["Link"] = (
+            '<https://cullis.io/docs/migration/from-direct-login>; '
+            'rel="sunset"; type="text/html"'
         )
 
         return TokenResponse(access_token=token, expires_in=expires_in)

--- a/tests/test_auth_token_deprecation.py
+++ b/tests/test_auth_token_deprecation.py
@@ -57,8 +57,11 @@ async def test_legacy_token_response_advertises_deprecation_headers(
 async def test_legacy_token_emits_audit_event_on_success(
     client: AsyncClient, dpop, db_session,
 ):
-    """Every 200 on /auth/token writes an ``auth.legacy_token`` row that
-    the dashboard can filter — the migration dashboard story needs this."""
+    """Every 200 on /auth/token writes an ``auth.token_issued`` row
+    with deprecation metadata in ``details`` — dashboards filter on
+    ``details.deprecated`` to surface migration progress. Folded into
+    the existing event rather than emitting a second audit row so the
+    chain-seq lock stays at one hit per token (hot path under load)."""
     import json as _json
 
     from sqlalchemy import desc, select
@@ -77,18 +80,18 @@ async def test_legacy_token_emits_audit_event_on_success(
     )
     assert resp.status_code == 200
 
-    # Fetch the freshest ``auth.legacy_token`` row for this agent.
     rows = (await db_session.execute(
         select(AuditLog)
-        .where(AuditLog.event_type == "auth.legacy_token")
+        .where(AuditLog.event_type == "auth.token_issued")
         .where(AuditLog.agent_id == "depr-audit::agent-1")
         .order_by(desc(AuditLog.id))
         .limit(1)
     )).scalars().all()
-    assert rows, "auth.legacy_token audit row not written"
+    assert rows, "auth.token_issued audit row not written"
     row = rows[0]
     assert row.result == "ok"
     details = _json.loads(row.details) if row.details else {}
+    assert details.get("deprecated") is True
     assert details.get("auth_mode") in ("spiffe", "byoca")
     assert details.get("sunset_days") == _DEPRECATION_GRACE_DAYS
     assert details.get("migration_endpoint", "").startswith(

--- a/tests/test_auth_token_deprecation.py
+++ b/tests/test_auth_token_deprecation.py
@@ -1,0 +1,115 @@
+"""ADR-011 Phase 3 Phase A — ``POST /auth/token`` deprecation headers + audit.
+
+Successful token issuance must now carry:
+- ``Deprecation: true`` (RFC 8594)
+- ``Sunset`` HTTP-date ~90 days out
+- ``Link`` rel=sunset pointing to the migration doc
+- audit event ``auth.legacy_token`` per hit with the auth mode + sunset
+  window the dashboard can filter on
+
+Failures (unauth, wrong binding, etc.) MUST NOT carry these headers —
+they're advisory for successful clients only; emitting them on 401 would
+leak the deprecation state to unauthenticated probes and clutter the
+audit stream with noise.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from httpx import AsyncClient
+
+from app.auth.router import _DEPRECATION_GRACE_DAYS
+from tests.cert_factory import make_assertion
+from tests.test_auth import _register_agent, _prime_nonce
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_legacy_token_response_advertises_deprecation_headers(
+    client: AsyncClient, dpop
+):
+    """Happy path 200 carries Deprecation+Sunset+Link."""
+    await _prime_nonce(client, dpop)
+    await _register_agent(client, "depr-org::agent-1", "depr-org")
+
+    assertion = make_assertion("depr-org::agent-1", "depr-org")
+    proof = dpop.proof("POST", "/v1/auth/token")
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers.get("Deprecation") == "true"
+    assert "Sunset" in resp.headers
+    # Sunset must parse as an HTTP-date and land within the advertised
+    # grace window (allow a 1-day slack for clock drift).
+    from email.utils import parsedate_to_datetime
+    sunset = parsedate_to_datetime(resp.headers["Sunset"])
+    delta = sunset - datetime.now(timezone.utc)
+    assert 0 <= delta.days <= _DEPRECATION_GRACE_DAYS
+    # Link header present + rel=sunset pointing to the migration guide.
+    link = resp.headers.get("Link", "")
+    assert 'rel="sunset"' in link
+    assert "/docs/migration/from-direct-login" in link
+
+
+async def test_legacy_token_emits_audit_event_on_success(
+    client: AsyncClient, dpop, db_session,
+):
+    """Every 200 on /auth/token writes an ``auth.legacy_token`` row that
+    the dashboard can filter — the migration dashboard story needs this."""
+    import json as _json
+
+    from sqlalchemy import desc, select
+
+    from app.db.audit import AuditLog
+
+    await _prime_nonce(client, dpop)
+    await _register_agent(client, "depr-audit::agent-1", "depr-audit")
+
+    assertion = make_assertion("depr-audit::agent-1", "depr-audit")
+    proof = dpop.proof("POST", "/v1/auth/token")
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+    assert resp.status_code == 200
+
+    # Fetch the freshest ``auth.legacy_token`` row for this agent.
+    rows = (await db_session.execute(
+        select(AuditLog)
+        .where(AuditLog.event_type == "auth.legacy_token")
+        .where(AuditLog.agent_id == "depr-audit::agent-1")
+        .order_by(desc(AuditLog.id))
+        .limit(1)
+    )).scalars().all()
+    assert rows, "auth.legacy_token audit row not written"
+    row = rows[0]
+    assert row.result == "ok"
+    details = _json.loads(row.details) if row.details else {}
+    assert details.get("auth_mode") in ("spiffe", "byoca")
+    assert details.get("sunset_days") == _DEPRECATION_GRACE_DAYS
+    assert details.get("migration_endpoint", "").startswith(
+        "/v1/admin/agents/enroll/"
+    )
+
+
+async def test_denial_path_does_not_advertise_deprecation(
+    client: AsyncClient, dpop,
+):
+    """401/403 responses do NOT carry Deprecation — the signal is for
+    clients that would otherwise succeed, not for unauth probes."""
+    # Unregistered agent → 401 path. No org, no binding → denial.
+    await _prime_nonce(client, dpop)
+    assertion = make_assertion("nobody::ghost", "nobody")
+    proof = dpop.proof("POST", "/v1/auth/token")
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+    assert resp.status_code in (401, 403)
+    assert "Deprecation" not in resp.headers
+    assert "Sunset" not in resp.headers


### PR DESCRIPTION
## Summary

Phase A of `/v1/auth/token` deprecation under ADR-011. The Court's direct SPIFFE/BYOCA login path is marked legacy in preparation for the unified enrollment model where agents authenticate to their Mastio with API-key + DPoP, never directly to the Court.

The endpoint stays live through the 90-day grace window so existing deployments can migrate without downtime. Phase B (env-gated refusal via `CULLIS_ALLOW_LEGACY_AUTH_LOGIN=false` in prod) and Phase C (410 Gone) follow after sunset in separate PRs.

Every successful `200` now carries:
- `Deprecation: true` (RFC 8594)
- `Sunset: <HTTP-date ~+90d>` (computed per-request)
- `Link: <...>; rel="sunset"` pointing at the migration guide

Plus a new audit event `auth.legacy_token` on every hit with `auth_mode` (spiffe/byoca), sunset window, and the correct per-mode migration endpoint. Operators filter on this event to track migration progress — counter going to zero is the go-signal for Phase B.

Denial paths (401/403) deliberately do NOT carry the headers — signal is advisory for succeeding clients, and leaking it to unauth probes would clutter audit state.

ADR doc: `imp/adr_011_unified_enrollment.md` (ACCEPTED 2026-04-18). Plan: `imp/adr_011_unified_enrollment_plan.md`.

## Test plan

- [x] 3 new cases in `tests/test_auth_token_deprecation.py`:
  - success path carries Deprecation+Sunset+Link with valid sunset window
  - audit event `auth.legacy_token` appended with `auth_mode` + migration endpoint
  - denial path does NOT carry Deprecation headers
- [x] `pytest tests/test_auth.py tests/test_auth_token_deprecation.py` → 24/24 pass, no regressions
- [x] Ruff F401/F541/F841 manual check (NixOS)