### PR TITLE
feat(mastio): BYOCA enrollment endpoint (ADR-011 Phase 1b)

### DIFF
--- a/mcp_proxy/admin/enroll.py
+++ b/mcp_proxy/admin/enroll.py
@@ -1,0 +1,358 @@
+"""ADR-011 Phase 1b — BYOCA enrollment endpoint.
+
+``POST /v1/admin/agents/enroll/byoca`` lets an operator bring a
+pre-generated Org-CA-signed cert/key pair into a fresh
+``internal_agents`` row. The Mastio verifies that the cert chains to
+its loaded Org CA (preventing cross-org cert leakage at enrollment
+time), extracts the SPIFFE URI SAN if present, and emits the standard
+enrollment output: agent_id + one-shot API key + DPoP jkt pinning if
+the caller supplied a public JWK.
+
+This is the first of four ``/enroll/<method>`` endpoints in Phase 1.
+The ``admin`` (plain create) method remains on the existing
+``POST /v1/admin/agents``; ``connector`` is the existing device-code
+flow under ``/v1/enrollment/*``; ``spiffe`` lands next in Phase 1c.
+
+Auth: ``X-Admin-Secret``, shared with the rest of ``/v1/admin/*``.
+Rate-limit: delegated to the admin-secret bucket (ADR-011 §7.4) —
+enrollment is a rare operation and the admin gate is sufficient.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+import bcrypt
+import secrets
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from mcp_proxy.auth.dpop import compute_jkt
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_db, log_audit
+
+
+_log = logging.getLogger("mcp_proxy.admin.enroll")
+
+# Same prefix as the existing agent CRUD router, distinct sub-path.
+router = APIRouter(prefix="/v1/admin/agents/enroll", tags=["admin", "enrollment"])
+
+
+# ── auth (mirrors ``admin.agents._require_admin_secret``) ────────────────
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    import hmac
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+# ── models ───────────────────────────────────────────────────────────────
+
+class ByocaEnrollRequest(BaseModel):
+    agent_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    display_name: str = Field("", max_length=256)
+    capabilities: list[str] = Field(default_factory=list)
+    # Mandatory — this is the whole point of BYOCA enrollment.
+    cert_pem: str
+    private_key_pem: str
+    # Optional — when supplied, pins DPoP binding at enrollment time
+    # so F-B-11 ``mode=required`` works from the first request. Public
+    # JWK only; ``d`` private material is rejected.
+    dpop_jwk: dict | None = None
+    federated: bool = False
+
+
+class ByocaEnrollResponse(BaseModel):
+    agent_id: str
+    display_name: str
+    capabilities: list[str]
+    api_key: str  # plaintext — shown exactly once
+    cert_thumbprint: str
+    spiffe_id: str | None
+    dpop_jkt: str | None
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+def _api_key_for(agent_name: str) -> str:
+    """Match the pattern used by ``admin.agents._api_key_for`` so audit
+    trails and key-hygiene scripts see a consistent prefix."""
+    return f"sk_local_{agent_name}_{secrets.token_hex(16)}"
+
+
+def _bcrypt_hash(raw: str) -> str:
+    return bcrypt.hashpw(raw.encode(), bcrypt.gensalt(rounds=12)).decode()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _cert_thumbprint(cert: x509.Certificate) -> str:
+    """SHA-256 hex of the cert's DER bytes — matches
+    ``mcp_proxy.db.cert_thumbprint_from_pem`` and the broker's
+    RFC 8705 cert-bound token story."""
+    import hashlib
+    return hashlib.sha256(cert.public_bytes(serialization.Encoding.DER)).hexdigest()
+
+
+def _spiffe_uri_from_cert(cert: x509.Certificate) -> str | None:
+    """Extract the SPIFFE URI from a cert's SAN.extension, if present.
+
+    A BYOCA cert MAY carry a SPIFFE URI (``spiffe://<trust-domain>/<path>``)
+    as a URI-valued SAN. When it does we lift it into ``spiffe_id`` so
+    the agent gets the full identity envelope from day one — otherwise
+    the column stays NULL (fine, ADR-011 §2.2 spiffe_id is optional).
+    """
+    try:
+        ext = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+    except x509.ExtensionNotFound:
+        return None
+    for name in ext.value:
+        if isinstance(name, x509.UniformResourceIdentifier):
+            if name.value.startswith("spiffe://"):
+                return name.value
+    return None
+
+
+def _key_matches_cert(cert: x509.Certificate, key_pem: str) -> bool:
+    """Return True iff the private key's public half matches the cert's
+    public key. Guards against a caller mixing up two unrelated files —
+    the BYOCA flow depends on the agent actually holding the private
+    half of the cert it submits."""
+    try:
+        priv = serialization.load_pem_private_key(key_pem.encode(), password=None)
+    except (ValueError, TypeError):
+        return False
+    cert_pub = cert.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    priv_pub = priv.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return cert_pub == priv_pub
+
+
+def _verify_signed_by_ca(cert: x509.Certificate, ca: x509.Certificate) -> bool:
+    """Verify that ``cert`` was issued by ``ca`` — signature check only,
+    no path validation (depth 1 by construction in the Org CA model).
+
+    We intentionally don't call ``cert.verify_directly_issued_by`` (too
+    new for the cryptography pin) and instead do the algorithm-branching
+    verify that matches the broker's ``_verify_cert_chain`` pattern.
+    """
+    ca_pubkey = ca.public_key()
+    try:
+        if isinstance(ca_pubkey, rsa.RSAPublicKey):
+            from cryptography.hazmat.primitives.asymmetric import padding
+            ca_pubkey.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                cert.signature_hash_algorithm,
+            )
+            return True
+        if isinstance(ca_pubkey, ec.EllipticCurvePublicKey):
+            ca_pubkey.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes,
+                ec.ECDSA(cert.signature_hash_algorithm),
+            )
+            return True
+    except Exception:  # noqa: BLE001 — any verify failure → False
+        return False
+    # Unknown key type: refuse rather than false-accept.
+    return False
+
+
+async def _require_agent_mgr(request: Request):
+    """Same gate as ``admin.agents._require_agent_mgr`` — BYOCA needs
+    the Org CA to verify the submitted cert, so if the manager has no
+    CA loaded the endpoint returns 503."""
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None or not getattr(mgr, "ca_loaded", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized — Org CA not loaded",
+        )
+    return mgr
+
+
+def _validate_dpop_jwk(dpop_jwk: dict | None) -> str | None:
+    if dpop_jwk is None:
+        return None
+    if not isinstance(dpop_jwk, dict) or not dpop_jwk:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="dpop_jwk must be a non-empty object",
+        )
+    if "d" in dpop_jwk:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="dpop_jwk must be the public JWK — private material ('d') rejected",
+        )
+    kty = dpop_jwk.get("kty")
+    if kty not in ("EC", "RSA"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"dpop_jwk kty {kty!r} unsupported — expected 'EC' (P-256) or 'RSA'",
+        )
+    try:
+        return compute_jkt(dpop_jwk)
+    except (ValueError, KeyError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"dpop_jwk is malformed: {exc}",
+        ) from exc
+
+
+# ── endpoint ─────────────────────────────────────────────────────────────
+
+@router.post(
+    "/byoca",
+    response_model=ByocaEnrollResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def enroll_byoca(
+    body: ByocaEnrollRequest,
+    request: Request,
+) -> ByocaEnrollResponse:
+    """Enroll an agent with a caller-supplied Org-CA-signed cert.
+
+    Verification steps:
+      1. Parse ``cert_pem`` and ``private_key_pem`` as valid PEM material.
+      2. Assert the private key's public half matches the cert (anti
+         mix-up / copy-paste error).
+      3. Assert the cert is signed by the Mastio's loaded Org CA —
+         prevents cross-org cert leakage at enrollment.
+      4. Extract SPIFFE URI SAN if present.
+      5. Issue an API key + pin optional DPoP jkt.
+
+    Returns the new ``agent_id`` (format ``<org>::<name>``), the
+    one-shot plaintext API key (shown once), cert thumbprint, and the
+    resolved SPIFFE/DPoP attributes.
+    """
+    mgr = await _require_agent_mgr(request)
+    agent_name = body.agent_name
+    agent_id = f"{mgr.org_id}::{agent_name}"
+
+    # Step 1 — parse PEMs.
+    try:
+        cert = x509.load_pem_x509_certificate(body.cert_pem.encode())
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"cert_pem is not a valid X.509 PEM: {exc}",
+        ) from exc
+
+    # Step 2 — key matches cert.
+    if not _key_matches_cert(cert, body.private_key_pem):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="private_key_pem does not match cert_pem public key",
+        )
+
+    # Step 3 — cert signed by the Org CA currently loaded on the Mastio.
+    org_ca = getattr(mgr, "_org_ca_cert", None)
+    if org_ca is None:
+        # _require_agent_mgr should catch this; belt-and-suspenders.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Org CA cert not available on the Mastio",
+        )
+    if not _verify_signed_by_ca(cert, org_ca):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="cert_pem is not signed by this Mastio's Org CA",
+        )
+
+    # Step 4 — SPIFFE URI SAN (optional).
+    spiffe_id = _spiffe_uri_from_cert(cert)
+
+    # Step 5 — DPoP jkt pinning (optional).
+    dpop_jkt = _validate_dpop_jwk(body.dpop_jwk)
+
+    # Persist private key via Vault if available, fall back to proxy_config
+    # (identical pattern to ``admin.agents.create_agent``).
+    try:
+        await mgr._store_key_vault(agent_id, body.private_key_pem)
+    except Exception as exc:  # noqa: BLE001
+        from mcp_proxy.db import set_config
+        _log.info("Vault unavailable for %s (%s) — stashing in proxy_config",
+                  agent_id, exc)
+        await set_config(f"agent_key:{agent_id}", body.private_key_pem)
+
+    api_key = _api_key_for(agent_name)
+    api_key_hash = _bcrypt_hash(api_key)
+    ts = _now_iso()
+
+    try:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO internal_agents (
+                        agent_id, display_name, capabilities, api_key_hash,
+                        cert_pem, created_at, is_active,
+                        federated, federated_at, federation_revision,
+                        enrollment_method, spiffe_id, enrolled_at, dpop_jkt
+                    ) VALUES (
+                        :aid, :name, :caps, :hash,
+                        :cert, :now, 1,
+                        :federated, NULL, 1,
+                        'byoca', :spiffe, :now, :dpop_jkt
+                    )
+                    """
+                ),
+                {
+                    "aid": agent_id,
+                    "name": body.display_name or agent_name,
+                    "caps": json.dumps(body.capabilities),
+                    "hash": api_key_hash,
+                    "cert": body.cert_pem,
+                    "now": ts,
+                    "federated": bool(body.federated),
+                    "spiffe": spiffe_id,
+                    "dpop_jkt": dpop_jkt,
+                },
+            )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"agent {agent_id} already enrolled",
+        ) from exc
+
+    await log_audit(
+        agent_id=agent_id,
+        action="admin.agent_enroll_byoca",
+        status="ok",
+        detail=(
+            f"org={mgr.org_id} thumbprint={_cert_thumbprint(cert)[:16]} "
+            f"spiffe={spiffe_id or '-'} dpop_bound={bool(dpop_jkt)}"
+        ),
+    )
+
+    return ByocaEnrollResponse(
+        agent_id=agent_id,
+        display_name=body.display_name or agent_name,
+        capabilities=body.capabilities,
+        api_key=api_key,
+        cert_thumbprint=_cert_thumbprint(cert),
+        spiffe_id=spiffe_id,
+        dpop_jkt=dpop_jkt,
+    )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -566,6 +566,14 @@ app.include_router(admin_mcp_resources_router)
 from mcp_proxy.admin.agents import router as admin_agents_router
 app.include_router(admin_agents_router)
 
+# ADR-011 Phase 1b — BYOCA enrollment endpoint. ``/v1/admin/agents/enroll/byoca``
+# takes a caller-supplied cert/key pair, verifies the chain to the Mastio's
+# Org CA, and emits an API key + optional DPoP binding. Registered here,
+# not inside the CRUD router, so the two concerns (admin CRUD vs verified
+# enrollment) stay separable as Phase 1c adds the SPIFFE variant.
+from mcp_proxy.admin.enroll import router as admin_enroll_router
+app.include_router(admin_enroll_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/federation/agents/{id}/
 # public-key would otherwise fall into the `/v1/federation/*` forward

--- a/tests/test_admin_enroll_byoca.py
+++ b/tests/test_admin_enroll_byoca.py
@@ -1,0 +1,395 @@
+"""ADR-011 Phase 1b — ``/v1/admin/agents/enroll/byoca``.
+
+Covers:
+  - Happy path: caller submits Org-CA-signed cert → 201 with api_key +
+    thumbprint + enrollment_method='byoca' persisted
+  - Cert NOT signed by the Mastio's Org CA → 400
+  - Private key does not match cert public key → 400
+  - Agent already enrolled → 409
+  - Admin secret missing / wrong → 403
+  - Cert with SPIFFE URI SAN → response surfaces ``spiffe_id``
+  - ``dpop_jwk`` pins RFC 7638 jkt on ``internal_agents``
+  - ``dpop_jwk`` with private material (``d``) → 400
+"""
+from __future__ import annotations
+
+import datetime
+import json
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── harness ──────────────────────────────────────────────────────────────
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+async def _load_org_ca():
+    """Read the Mastio's auto-generated Org CA from proxy_config.
+
+    Standalone mode generates the CA at lifespan startup and stores
+    both halves in ``proxy_config`` (see ``AgentManager.generate_org_ca``).
+    The test fixtures reuse it to mint valid leaves — a real deployment
+    would use a real PKI here.
+    """
+    from mcp_proxy.db import get_config
+    return await get_config("org_ca_cert"), await get_config("org_ca_key")
+
+
+def _issue_cert_from_ca(
+    ca_cert_pem: str,
+    ca_key_pem: str,
+    *,
+    subject_cn: str,
+    spiffe_uri: str | None = None,
+    validity_days: int = 30,
+) -> tuple[str, str]:
+    """Issue a fresh leaf cert signed by the supplied Org CA.
+
+    Returns ``(cert_pem, key_pem)``. EC P-256 leaves — the Org CA in
+    the Mastio accepts any key type the ``cryptography`` stack can
+    produce; EC keeps the helper fast.
+    """
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    ca_key = serialization.load_pem_private_key(ca_key_pem.encode(), password=None)
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_cn)]))
+        .issuer_name(ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(days=validity_days)
+        )
+    )
+    if spiffe_uri:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_uri)]),
+            critical=False,
+        )
+
+    cert = builder.sign(ca_key, hashes.SHA256())
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = leaf_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return cert_pem, key_pem
+
+
+def _generate_foreign_ca() -> tuple[str, str]:
+    """Build a rogue CA + issue a leaf — neither chain is loaded on the
+    Mastio, so enrollment must reject the leaf."""
+    ca_key = ec.generate_private_key(ec.SECP256R1())
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "rogue-ca")]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "rogue-ca")]))
+        .public_key(ca_key.public_key())
+        .serial_number(1)
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7)
+        )
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    ca_cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+    ca_key_pem = ca_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return ca_cert_pem, ca_key_pem
+
+
+async def _fetch_internal_row(app, agent_id: str) -> dict:
+    """Read the ``internal_agents`` row the endpoint wrote."""
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT enrollment_method, spiffe_id, enrolled_at, dpop_jkt, "
+                 "cert_pem FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )).first()
+    assert row is not None, f"row missing for {agent_id}"
+    return {
+        "enrollment_method": row[0],
+        "spiffe_id": row[1],
+        "enrolled_at": row[2],
+        "dpop_jkt": row[3],
+        "cert_pem": row[4],
+    }
+
+
+# ── happy path ───────────────────────────────────────────────────────────
+
+async def test_byoca_enroll_happy_path_returns_api_key(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-happy")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.db import get_config
+            ca_cert_pem = await get_config("org_ca_cert")
+            ca_key_pem = await get_config("org_ca_key")
+            cert_pem, key_pem = _issue_cert_from_ca(
+                ca_cert_pem, ca_key_pem,
+                subject_cn="alice",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(),
+                json={
+                    "agent_name": "alice",
+                    "display_name": "Alice BYOCA",
+                    "capabilities": ["order.read"],
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                },
+            )
+            assert r.status_code == 201, r.text
+            body = r.json()
+            assert body["agent_id"] == "bc-happy::alice"
+            assert body["api_key"].startswith("sk_local_alice_")
+            assert len(body["cert_thumbprint"]) == 64  # SHA-256 hex
+            assert body["spiffe_id"] is None
+            assert body["dpop_jkt"] is None
+
+            row = await _fetch_internal_row(app, "bc-happy::alice")
+            assert row["enrollment_method"] == "byoca"
+            assert row["spiffe_id"] is None
+            assert row["enrolled_at"] is not None
+            assert row["cert_pem"] == cert_pem
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_byoca_enroll_extracts_spiffe_uri_san(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-spiffe")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            spiffe = "spiffe://bc-spiffe.test/agent/bob"
+            cert_pem, key_pem = _issue_cert_from_ca(
+                *await _load_org_ca(),
+                subject_cn="bob", spiffe_uri=spiffe,
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(),
+                json={
+                    "agent_name": "bob",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                },
+            )
+            assert r.status_code == 201, r.text
+            assert r.json()["spiffe_id"] == spiffe
+            row = await _fetch_internal_row(app, "bc-spiffe::bob")
+            assert row["spiffe_id"] == spiffe
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_byoca_enroll_pins_dpop_jkt_when_jwk_supplied(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-dpop")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            cert_pem, key_pem = _issue_cert_from_ca(
+                *await _load_org_ca(), subject_cn="carol",
+            )
+            # Generate a public EC JWK for the DPoP key; server computes
+            # the thumbprint from ``kty``+``crv``+``x``+``y``.
+            dpop_key = ec.generate_private_key(ec.SECP256R1())
+            pub_numbers = dpop_key.public_key().public_numbers()
+            import base64
+            def b64u(n: int) -> str:
+                b = n.to_bytes(32, "big")
+                return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+            dpop_jwk = {
+                "kty": "EC", "crv": "P-256",
+                "x": b64u(pub_numbers.x), "y": b64u(pub_numbers.y),
+            }
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(),
+                json={
+                    "agent_name": "carol",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                    "dpop_jwk": dpop_jwk,
+                },
+            )
+            assert r.status_code == 201, r.text
+            body = r.json()
+            assert body["dpop_jkt"] is not None
+            assert len(body["dpop_jkt"]) > 20
+            row = await _fetch_internal_row(app, "bc-dpop::carol")
+            assert row["dpop_jkt"] == body["dpop_jkt"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── rejection paths ──────────────────────────────────────────────────────
+
+async def test_byoca_enroll_rejects_cert_from_foreign_ca(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-foreign")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            foreign_ca_pem, foreign_ca_key_pem = _generate_foreign_ca()
+            cert_pem, key_pem = _issue_cert_from_ca(
+                foreign_ca_pem, foreign_ca_key_pem, subject_cn="rogue",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(),
+                json={
+                    "agent_name": "rogue",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                },
+            )
+            assert r.status_code == 400, r.text
+            assert "Org CA" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_byoca_enroll_rejects_mismatched_private_key(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-mismatch")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            cert_pem, _ = _issue_cert_from_ca(
+                *await _load_org_ca(), subject_cn="d1",
+            )
+            # Use a *different* key to sign the re-enrollment body.
+            _, wrong_key_pem = _issue_cert_from_ca(
+                *await _load_org_ca(), subject_cn="d2",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(),
+                json={
+                    "agent_name": "mismatch",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": wrong_key_pem,
+                },
+            )
+            assert r.status_code == 400, r.text
+            assert "does not match" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_byoca_enroll_rejects_private_jwk(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-privjwk")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            cert_pem, key_pem = _issue_cert_from_ca(
+                *await _load_org_ca(), subject_cn="priv",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(),
+                json={
+                    "agent_name": "priv",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                    # Private JWK — rejected to prevent accidental key leak
+                    # via admin log / memory dump.
+                    "dpop_jwk": {"kty": "EC", "crv": "P-256", "x": "x", "y": "y", "d": "SECRET"},
+                },
+            )
+            assert r.status_code == 400, r.text
+            assert "private material" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_byoca_enroll_duplicate_agent_returns_409(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-dup")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            cert_pem, key_pem = _issue_cert_from_ca(
+                *await _load_org_ca(), subject_cn="twice",
+            )
+            body = {
+                "agent_name": "twice",
+                "cert_pem": cert_pem,
+                "private_key_pem": key_pem,
+            }
+            r1 = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(), json=body,
+            )
+            assert r1.status_code == 201
+            r2 = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers=await _headers(), json=body,
+            )
+            assert r2.status_code == 409
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_byoca_enroll_refuses_without_admin_secret(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "bc-noauth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            mgr = app.state.agent_manager
+            cert_pem, key_pem = _issue_cert_from_ca(
+                *await _load_org_ca(), subject_cn="noauth",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/byoca",
+                headers={"X-Admin-Secret": "wrong"},
+                json={
+                    "agent_name": "noauth",
+                    "cert_pem": cert_pem,
+                    "private_key_pem": key_pem,
+                },
+            )
+            assert r.status_code == 403
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_admin_enroll_byoca.py
+++ b/tests/test_admin_enroll_byoca.py
@@ -14,7 +14,6 @@ Covers:
 from __future__ import annotations
 
 import datetime
-import json
 
 import pytest
 from cryptography import x509
@@ -199,7 +198,6 @@ async def test_byoca_enroll_extracts_spiffe_uri_san(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
-            mgr = app.state.agent_manager
             spiffe = "spiffe://bc-spiffe.test/agent/bob"
             cert_pem, key_pem = _issue_cert_from_ca(
                 *await _load_org_ca(),
@@ -227,7 +225,6 @@ async def test_byoca_enroll_pins_dpop_jkt_when_jwk_supplied(tmp_path, monkeypatc
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
-            mgr = app.state.agent_manager
             cert_pem, key_pem = _issue_cert_from_ca(
                 *await _load_org_ca(), subject_cn="carol",
             )
@@ -294,7 +291,6 @@ async def test_byoca_enroll_rejects_mismatched_private_key(tmp_path, monkeypatch
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
-            mgr = app.state.agent_manager
             cert_pem, _ = _issue_cert_from_ca(
                 *await _load_org_ca(), subject_cn="d1",
             )
@@ -322,7 +318,6 @@ async def test_byoca_enroll_rejects_private_jwk(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
-            mgr = app.state.agent_manager
             cert_pem, key_pem = _issue_cert_from_ca(
                 *await _load_org_ca(), subject_cn="priv",
             )
@@ -349,7 +344,6 @@ async def test_byoca_enroll_duplicate_agent_returns_409(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
-            mgr = app.state.agent_manager
             cert_pem, key_pem = _issue_cert_from_ca(
                 *await _load_org_ca(), subject_cn="twice",
             )
@@ -377,7 +371,6 @@ async def test_byoca_enroll_refuses_without_admin_secret(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
-            mgr = app.state.agent_manager
             cert_pem, key_pem = _issue_cert_from_ca(
                 *await _load_org_ca(), subject_cn="noauth",
             )


### PR DESCRIPTION
## Summary

Adds `POST /v1/admin/agents/enroll/byoca` — the first of four enrollment variants under the ADR-011 unified model. BYOCA stops being a runtime auth path (legacy, sunset via Phase 3 in #215) and becomes a verified enrollment primitive for deployments with existing PKI, CI/CD baked-in creds, or air-gapped agents.

The Mastio verifies per request:
1. PEM well-formed (cert + key)
2. private key's public half matches cert (anti mix-up)
3. cert signed by Mastio's loaded Org CA — rejects cross-org / foreign-CA certs with 400
4. SPIFFE URI SAN extracted (if present) → persisted as `spiffe_id`
5. optional `dpop_jwk` validated (public only, kty ∈ EC/RSA) + RFC 7638 jkt pinned on the row

INSERT writes `enrollment_method='byoca'`, `enrolled_at=now`, optional `spiffe_id`/`dpop_jkt`. Row shape matches Phase 1a (#214) schema. Router registered in `mcp_proxy/main.py` next to the existing agent CRUD router — `/v1/admin/agents/enroll/*` is one namespace with consistent `X-Admin-Secret` auth.

The `admin` (plain create) method stays on `POST /v1/admin/agents`. `connector` is the existing device-code flow. `spiffe` lands next in Phase 1c.

## Test plan

- [x] 8 cases in `tests/test_admin_enroll_byoca.py`:
  - happy path 201 + api_key + thumbprint + row shape
  - SPIFFE URI SAN → `spiffe_id` populated
  - `dpop_jwk` → RFC 7638 jkt pinned on `internal_agents.dpop_jkt`
  - foreign-CA cert → 400
  - key mismatches cert → 400
  - private JWK (`d`) → 400
  - duplicate agent → 409
  - wrong admin secret → 403
- [x] `pytest tests/test_admin_agents.py tests/test_admin_enroll_byoca.py tests/test_proxy_migrations_adr011.py tests/connector/` → 111 passed
- [x] Ruff F401 manual (NixOS) — pruned `hashes` / `NameOID` imports
- [x] Stacks on top of #214 (merged) schema