### PR TITLE
feat(mastio): SPIFFE enrollment endpoint (ADR-011 Phase 1c)

### DIFF
--- a/mcp_proxy/admin/enroll.py
+++ b/mcp_proxy/admin/enroll.py
@@ -356,3 +356,211 @@ async def enroll_byoca(
         spiffe_id=spiffe_id,
         dpop_jkt=dpop_jkt,
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# ADR-011 Phase 1c — SPIFFE enrollment.
+#
+# ``/v1/admin/agents/enroll/spiffe`` verifies an SVID (X.509-SVID per
+# SPIFFE spec) against a SPIRE trust bundle and emits the standard
+# enrollment output: agent_id, one-shot API key, pinned SPIFFE URI.
+#
+# Trust bundle resolution (first hit wins):
+#   1. ``body.trust_bundle_pem`` — useful for sandbox/CI, one-off enroll.
+#   2. ``proxy_config.spire_trust_bundle`` — operator-configured baseline.
+# Missing both → 503. A future admin endpoint can PATCH the config row.
+# ─────────────────────────────────────────────────────────────────────────
+
+class SpiffeEnrollRequest(BaseModel):
+    agent_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    display_name: str = Field("", max_length=256)
+    capabilities: list[str] = Field(default_factory=list)
+    # The X.509-SVID leaf + its private key. The SVID MUST carry a
+    # ``spiffe://`` URI SAN; that URI becomes the persisted ``spiffe_id``.
+    svid_pem: str
+    svid_key_pem: str
+    # Optional per-request bundle — overrides the proxy_config baseline.
+    # Lets CI and sandbox test isolated trust domains without mutating
+    # the shared config row.
+    trust_bundle_pem: str | None = None
+    dpop_jwk: dict | None = None
+    federated: bool = False
+
+
+class SpiffeEnrollResponse(BaseModel):
+    agent_id: str
+    display_name: str
+    capabilities: list[str]
+    api_key: str
+    cert_thumbprint: str
+    spiffe_id: str       # MANDATORY for SPIFFE enrollment, unlike BYOCA
+    dpop_jkt: str | None
+
+
+async def _resolve_trust_bundle(body_override: str | None) -> x509.Certificate:
+    """Find the SPIRE trust bundle, parse it, return as an x509 Certificate.
+
+    Raises 503 when neither a body override nor a persisted config row
+    is available, and 400 when the PEM is syntactically invalid. Kept
+    as a thin helper so a future ``PATCH /v1/admin/spire/bundle`` can
+    wire in without touching the endpoint body.
+    """
+    from mcp_proxy.db import get_config
+    pem = body_override or await get_config("spire_trust_bundle")
+    if not pem:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "SPIRE trust bundle not configured — supply "
+                "`trust_bundle_pem` in the body or set the "
+                "`spire_trust_bundle` proxy_config key"
+            ),
+        )
+    try:
+        return x509.load_pem_x509_certificate(pem.encode())
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"trust_bundle_pem is not a valid X.509 PEM: {exc}",
+        ) from exc
+
+
+def _require_spiffe_uri(cert: x509.Certificate) -> str:
+    """SPIFFE enrollment requires an SVID — no URI SAN means the cert
+    is not a valid SVID and the call must fail before we persist anything."""
+    uri = _spiffe_uri_from_cert(cert)
+    if uri is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="svid_pem carries no SPIFFE URI SAN — not a valid SVID",
+        )
+    return uri
+
+
+@router.post(
+    "/spiffe",
+    response_model=SpiffeEnrollResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def enroll_spiffe(
+    body: SpiffeEnrollRequest,
+    request: Request,
+) -> SpiffeEnrollResponse:
+    """Enroll an agent with a caller-supplied SVID + SPIRE trust bundle.
+
+    Verification:
+      1. Parse ``svid_pem`` + ``svid_key_pem`` as valid PEM.
+      2. Private key's public half matches the SVID.
+      3. SVID has a ``spiffe://`` URI SAN (else the cert is not an SVID).
+      4. SVID signed by the resolved SPIRE trust bundle.
+      5. Optional DPoP jkt pinning identical to BYOCA.
+
+    Persists ``enrollment_method='spiffe'``, ``spiffe_id=<URI>``, and
+    the current SVID bytes under ``cert_pem``. The SVID rotates on the
+    SPIRE schedule — future runtime login via API-key+DPoP doesn't
+    depend on the stored cert remaining live, so the row is forever
+    valid even after the SVID it was enrolled with expires.
+    """
+    mgr = await _require_agent_mgr(request)
+    agent_name = body.agent_name
+    agent_id = f"{mgr.org_id}::{agent_name}"
+
+    # Step 1 — parse SVID.
+    try:
+        svid = x509.load_pem_x509_certificate(body.svid_pem.encode())
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"svid_pem is not a valid X.509 PEM: {exc}",
+        ) from exc
+
+    # Step 2 — key matches SVID.
+    if not _key_matches_cert(svid, body.svid_key_pem):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="svid_key_pem does not match svid_pem public key",
+        )
+
+    # Step 3 — SPIFFE URI SAN mandatory for SPIFFE enrollment.
+    spiffe_id = _require_spiffe_uri(svid)
+
+    # Step 4 — signed by SPIRE trust bundle.
+    bundle = await _resolve_trust_bundle(body.trust_bundle_pem)
+    if not _verify_signed_by_ca(svid, bundle):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="svid_pem is not signed by the configured SPIRE trust bundle",
+        )
+
+    # Step 5 — DPoP jkt pinning (optional).
+    dpop_jkt = _validate_dpop_jwk(body.dpop_jwk)
+
+    try:
+        await mgr._store_key_vault(agent_id, body.svid_key_pem)
+    except Exception as exc:  # noqa: BLE001
+        from mcp_proxy.db import set_config
+        _log.info("Vault unavailable for %s (%s) — stashing in proxy_config",
+                  agent_id, exc)
+        await set_config(f"agent_key:{agent_id}", body.svid_key_pem)
+
+    api_key = _api_key_for(agent_name)
+    api_key_hash = _bcrypt_hash(api_key)
+    ts = _now_iso()
+
+    try:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO internal_agents (
+                        agent_id, display_name, capabilities, api_key_hash,
+                        cert_pem, created_at, is_active,
+                        federated, federated_at, federation_revision,
+                        enrollment_method, spiffe_id, enrolled_at, dpop_jkt
+                    ) VALUES (
+                        :aid, :name, :caps, :hash,
+                        :cert, :now, 1,
+                        :federated, NULL, 1,
+                        'spiffe', :spiffe, :now, :dpop_jkt
+                    )
+                    """
+                ),
+                {
+                    "aid": agent_id,
+                    "name": body.display_name or agent_name,
+                    "caps": json.dumps(body.capabilities),
+                    "hash": api_key_hash,
+                    "cert": body.svid_pem,
+                    "now": ts,
+                    "federated": bool(body.federated),
+                    "spiffe": spiffe_id,
+                    "dpop_jkt": dpop_jkt,
+                },
+            )
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"agent {agent_id} already enrolled",
+        ) from exc
+
+    await log_audit(
+        agent_id=agent_id,
+        action="admin.agent_enroll_spiffe",
+        status="ok",
+        detail=(
+            f"org={mgr.org_id} spiffe={spiffe_id} "
+            f"thumbprint={_cert_thumbprint(svid)[:16]} "
+            f"dpop_bound={bool(dpop_jkt)}"
+        ),
+    )
+
+    return SpiffeEnrollResponse(
+        agent_id=agent_id,
+        display_name=body.display_name or agent_name,
+        capabilities=body.capabilities,
+        api_key=api_key,
+        cert_thumbprint=_cert_thumbprint(svid),
+        spiffe_id=spiffe_id,
+        dpop_jkt=dpop_jkt,
+    )

--- a/tests/test_admin_enroll_spiffe.py
+++ b/tests/test_admin_enroll_spiffe.py
@@ -1,0 +1,371 @@
+"""ADR-011 Phase 1c — ``/v1/admin/agents/enroll/spiffe``.
+
+Covers:
+  - Happy path: SVID signed by body-supplied trust bundle → 201 with
+    pinned ``spiffe_id`` and ``enrollment_method='spiffe'``
+  - Trust bundle resolved from ``proxy_config.spire_trust_bundle`` when
+    body omits ``trust_bundle_pem``
+  - SVID without SPIFFE URI SAN → 400 (not an SVID)
+  - SVID signed by a bundle OTHER than the configured one → 400
+  - Missing trust bundle (neither body nor config) → 503
+  - ``svid_key_pem`` does not match SVID public key → 400
+  - Duplicate agent → 409
+  - ``dpop_jwk`` pins RFC 7638 jkt
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+def _make_trust_bundle(cn: str = "spire-test-ca") -> tuple[str, str, x509.Certificate, ec.EllipticCurvePrivateKey]:
+    """Mint a self-signed root CA that stands in for the SPIRE trust bundle.
+
+    Returns ``(bundle_pem, key_pem, bundle_cert, bundle_key)`` — callers
+    keep the private parts to issue SVID leaves underneath.
+    """
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30)
+        )
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    bundle_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return bundle_pem, key_pem, cert, key
+
+
+def _issue_svid(
+    bundle_cert: x509.Certificate,
+    bundle_key: ec.EllipticCurvePrivateKey,
+    *,
+    spiffe_uri: str | None,
+    cn: str = "svid-leaf",
+) -> tuple[str, str]:
+    """Issue an SVID signed by the trust bundle CA. ``spiffe_uri=None``
+    produces a plain cert without the URI SAN (used to prove rejection)."""
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)]))
+        .issuer_name(bundle_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=7)
+        )
+    )
+    if spiffe_uri:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_uri)]),
+            critical=False,
+        )
+    cert = builder.sign(bundle_key, hashes.SHA256())
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = leaf_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return cert_pem, key_pem
+
+
+async def _fetch_row(agent_id: str) -> dict:
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT enrollment_method, spiffe_id, dpop_jkt, cert_pem "
+                 "FROM internal_agents WHERE agent_id = :aid"),
+            {"aid": agent_id},
+        )).first()
+    assert row is not None, f"missing row {agent_id}"
+    return {"enrollment_method": row[0], "spiffe_id": row[1],
+            "dpop_jkt": row[2], "cert_pem": row[3]}
+
+
+# ── happy paths ──────────────────────────────────────────────────────────
+
+async def test_spiffe_enroll_happy_path_with_body_bundle(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-happy")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            spiffe = "spiffe://sp-happy.test/agent/alice"
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_cert, bundle_key, spiffe_uri=spiffe, cn="alice",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "alice",
+                    "capabilities": ["order.read"],
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": svid_key_pem,
+                    "trust_bundle_pem": bundle_pem,
+                },
+            )
+            assert r.status_code == 201, r.text
+            body = r.json()
+            assert body["agent_id"] == "sp-happy::alice"
+            assert body["spiffe_id"] == spiffe
+            assert body["api_key"].startswith("sk_local_alice_")
+
+            row = await _fetch_row("sp-happy::alice")
+            assert row["enrollment_method"] == "spiffe"
+            assert row["spiffe_id"] == spiffe
+            assert row["cert_pem"] == svid_pem
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_spiffe_enroll_uses_proxy_config_bundle_when_body_omits_it(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-config")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            # Persist the bundle in proxy_config so the endpoint can
+            # resolve it without a per-request override.
+            from mcp_proxy.db import set_config
+            await set_config("spire_trust_bundle", bundle_pem)
+
+            spiffe = "spiffe://sp-config.test/bob"
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_cert, bundle_key, spiffe_uri=spiffe, cn="bob",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "bob",
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": svid_key_pem,
+                    # No trust_bundle_pem — endpoint falls back to config.
+                },
+            )
+            assert r.status_code == 201, r.text
+            assert r.json()["spiffe_id"] == spiffe
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_spiffe_enroll_pins_dpop_jkt_when_jwk_supplied(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-dpop")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            spiffe = "spiffe://sp-dpop.test/agent/carol"
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_cert, bundle_key, spiffe_uri=spiffe, cn="carol",
+            )
+            dpop_key = ec.generate_private_key(ec.SECP256R1())
+            pub = dpop_key.public_key().public_numbers()
+            import base64
+            def b64u(n: int) -> str:
+                return base64.urlsafe_b64encode(n.to_bytes(32, "big")).rstrip(b"=").decode()
+            dpop_jwk = {"kty": "EC", "crv": "P-256",
+                        "x": b64u(pub.x), "y": b64u(pub.y)}
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "carol",
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": svid_key_pem,
+                    "trust_bundle_pem": bundle_pem,
+                    "dpop_jwk": dpop_jwk,
+                },
+            )
+            assert r.status_code == 201, r.text
+            assert r.json()["dpop_jkt"] is not None
+            row = await _fetch_row("sp-dpop::carol")
+            assert row["dpop_jkt"] == r.json()["dpop_jkt"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── rejection paths ──────────────────────────────────────────────────────
+
+async def test_spiffe_enroll_rejects_cert_without_spiffe_uri(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-no-uri")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            # SVID without URI SAN — technically valid cert, but not an SVID.
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_cert, bundle_key, spiffe_uri=None, cn="no-uri",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "nouri",
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": svid_key_pem,
+                    "trust_bundle_pem": bundle_pem,
+                },
+            )
+            assert r.status_code == 400, r.text
+            assert "no SPIFFE URI" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_spiffe_enroll_rejects_svid_signed_by_wrong_bundle(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-wrong")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_A_pem, _, _, _ = _make_trust_bundle(cn="trust-A")
+            _, _, bundle_B_cert, bundle_B_key = _make_trust_bundle(cn="trust-B")
+            # SVID signed by B, submitted against bundle A.
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_B_cert, bundle_B_key,
+                spiffe_uri="spiffe://other.test/agent/rogue", cn="rogue",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "rogue",
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": svid_key_pem,
+                    "trust_bundle_pem": bundle_A_pem,
+                },
+            )
+            assert r.status_code == 400, r.text
+            assert "trust bundle" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_spiffe_enroll_503_when_no_bundle_configured(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-none")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_cert, bundle_key,
+                spiffe_uri="spiffe://sp-none.test/x", cn="x",
+            )
+            # No body bundle, no proxy_config row.
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "nobundle",
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": svid_key_pem,
+                },
+            )
+            assert r.status_code == 503, r.text
+            assert "trust bundle not configured" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_spiffe_enroll_rejects_mismatched_key(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-mismatch")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            svid_pem, _ = _issue_svid(
+                bundle_cert, bundle_key,
+                spiffe_uri="spiffe://sp-mismatch.test/x", cn="x",
+            )
+            _, wrong_key_pem = _issue_svid(
+                bundle_cert, bundle_key,
+                spiffe_uri="spiffe://sp-mismatch.test/y", cn="y",
+            )
+            r = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(),
+                json={
+                    "agent_name": "mismatch",
+                    "svid_pem": svid_pem,
+                    "svid_key_pem": wrong_key_pem,
+                    "trust_bundle_pem": bundle_pem,
+                },
+            )
+            assert r.status_code == 400, r.text
+            assert "does not match" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_spiffe_enroll_duplicate_agent_returns_409(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "sp-dup")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            bundle_pem, _, bundle_cert, bundle_key = _make_trust_bundle()
+            svid_pem, svid_key_pem = _issue_svid(
+                bundle_cert, bundle_key,
+                spiffe_uri="spiffe://sp-dup.test/twice", cn="twice",
+            )
+            body = {
+                "agent_name": "twice",
+                "svid_pem": svid_pem,
+                "svid_key_pem": svid_key_pem,
+                "trust_bundle_pem": bundle_pem,
+            }
+            r1 = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(), json=body,
+            )
+            assert r1.status_code == 201
+            r2 = await cli.post(
+                "/v1/admin/agents/enroll/spiffe",
+                headers=await _headers(), json=body,
+            )
+            assert r2.status_code == 409
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Reapertura di [#217](../pull/217) — chiusa automaticamente quando #216 è stato mergiato con `--delete-branch` (il branch parent era la base dell'originale). Contenuto identico a #217, rebased su main post-#216.

Second of four enrollment variants under ADR-011. Adds `POST /v1/admin/agents/enroll/spiffe` — takes an X.509-SVID + SPIRE trust bundle, verifies the chain, and emits the standard enrollment output with a pinned `spiffe_id`.

Verification chain:
1. SVID + key parse as valid PEM
2. private key's public half matches SVID (anti mix-up)
3. SVID carries a `spiffe://` URI SAN — **mandatory** for SPIFFE enrollment. URI persisted as `spiffe_id`
4. SVID signed by the resolved SPIRE trust bundle
5. optional `dpop_jwk` → RFC 7638 jkt pinned

Trust bundle resolution:
- `body.trust_bundle_pem` (per-request override, useful for sandbox/CI)
- fallback to `proxy_config.spire_trust_bundle` (operator-configured baseline)
- neither → 503 (future admin PATCH endpoint will wire this without touching enrollment body)

Reuses every helper Phase 1b (#216) landed — `_key_matches_cert`, `_verify_signed_by_ca`, `_validate_dpop_jwk`, `_cert_thumbprint`, `_spiffe_uri_from_cert`. Two new: `_resolve_trust_bundle` (body override → proxy_config → 503) and `_require_spiffe_uri` (lifts the SAN extractor to a mandatory 400).

## Test plan

- [x] 8 cases in `tests/test_admin_enroll_spiffe.py`:
  - happy path with body bundle
  - bundle resolved from proxy_config when body omits it
  - DPoP jkt pinning
  - cert without SPIFFE URI → 400
  - SVID signed by wrong bundle → 400
  - no bundle configured → 503
  - key mismatch → 400
  - duplicate → 409
- [x] `pytest tests/test_admin_enroll_spiffe.py tests/test_admin_enroll_byoca.py` → 16 passed
- [x] Ruff F401/F841 manual check (NixOS) — imports clean