### PR TITLE
feat(sdk): unified runtime + enrollment helpers (ADR-011 Phase 2)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -383,6 +383,299 @@ class CullisClient:
             self._egress_dpop_nonce = rotated
         return resp
 
+    # ── ADR-011 — unified enrollment + runtime auth ───────────────────
+
+    @classmethod
+    def from_api_key_file(
+        cls,
+        mastio_url: str,
+        *,
+        api_key_path: "str | Path",
+        dpop_key_path: "str | Path | None" = None,
+        agent_id: str | None = None,
+        org_id: str | None = None,
+        verify_tls: bool = True,
+        timeout: float = 10.0,
+    ) -> "CullisClient":
+        """Primary runtime constructor under ADR-011.
+
+        Reads the API key + (optional) DPoP JWK the agent was enrolled
+        with and returns a client pre-configured for the Mastio's egress
+        API. Authentication from here on is **API-key + DPoP**, never
+        a direct login to the Court. See ADR-011 for the enrollment
+        methods that produce these files (``enroll_via_byoca``,
+        ``enroll_via_spiffe``, ``enroll_via_admin_token``,
+        ``enroll_via_connector``).
+
+        Args:
+            mastio_url: base URL of the Mastio (``http://proxy-a:9100``).
+            api_key_path: file that holds the plaintext API key.
+            dpop_key_path: file holding the private DPoP JWK. Omit to
+                run without DPoP binding — only accepted while the
+                server's ``egress_dpop_mode`` is ``off`` or ``optional``.
+            agent_id, org_id: optional identity metadata. Populated on
+                the client instance; the Mastio doesn't require them on
+                egress calls but callers rely on them for logging.
+
+        Example::
+
+            client = CullisClient.from_api_key_file(
+                "http://proxy-a:9100",
+                api_key_path="/etc/cullis/agent/api-key",
+                dpop_key_path="/etc/cullis/agent/dpop.jwk",
+            )
+            client.send_oneshot("orgb::agent-b", {"hello": "world"})
+        """
+        api_key_path = Path(api_key_path)
+        api_key = api_key_path.read_text().strip()
+        if not api_key:
+            raise ValueError(f"{api_key_path} is empty — no API key to use")
+
+        instance = cls.__new__(cls)
+        instance.base = mastio_url.rstrip("/")
+        instance._verify_tls = verify_tls
+        instance._http = httpx.Client(timeout=timeout, verify=verify_tls)
+        instance.token = None
+        instance._label = agent_id or "(api-key-auth)"
+        instance._signing_key_pem = None
+        instance._pubkey_cache = {}
+        instance._client_seq = {}
+        instance._dpop_privkey = None
+        instance._dpop_pubkey_jwk = None
+        instance._dpop_nonce = None
+        instance._egress_dpop_key = None
+        instance._egress_dpop_nonce = None
+        instance._proxy_api_key = api_key
+        instance._proxy_agent_id = agent_id
+        instance._proxy_org_id = org_id
+
+        if dpop_key_path is not None:
+            from cullis_sdk.dpop import DpopKey
+            instance._egress_dpop_key = DpopKey.load(Path(dpop_key_path))
+            log("sdk", f"Loaded DPoP key from {dpop_key_path} "
+                       f"(jkt={instance._egress_dpop_key.thumbprint()[:16]}…)")
+
+        log("sdk", f"Runtime client ready (mastio={mastio_url}, "
+                   f"agent={instance._label})")
+        return instance
+
+    @classmethod
+    def enroll_via_byoca(
+        cls,
+        mastio_url: str,
+        *,
+        admin_secret: str,
+        agent_name: str,
+        cert_pem: str,
+        private_key_pem: str,
+        capabilities: list[str] | None = None,
+        display_name: str = "",
+        persist_to: "str | Path | None" = None,
+        enable_dpop: bool = True,
+        federated: bool = False,
+        verify_tls: bool = True,
+        timeout: float = 10.0,
+    ) -> "CullisClient":
+        """Operator-side helper: enroll an agent via BYOCA and return a
+        runtime-ready client.
+
+        Under ADR-011 BYOCA is an **enrollment** primitive, not a runtime
+        auth path — the Mastio verifies the cert chains to its Org CA,
+        emits an API key + pins an optional DPoP jkt. The returned client
+        is configured with those credentials for the agent's runtime.
+
+        Call this from provisioning code (Helm hook, Vault policy init,
+        CI/CD step), not from the agent's runtime entry point. The
+        agent itself should use :meth:`from_api_key_file` once the
+        credentials are on disk.
+
+        Persists to ``persist_to/{api-key, dpop.jwk, agent.json}`` when
+        supplied (mode 0600); otherwise the credentials stay in memory.
+
+        Requires admin access to the Mastio (``admin_secret``).
+        """
+        return cls._do_enroll(
+            mastio_url=mastio_url,
+            endpoint_path="/v1/admin/agents/enroll/byoca",
+            admin_secret=admin_secret,
+            body={
+                "agent_name": agent_name,
+                "display_name": display_name,
+                "capabilities": list(capabilities or []),
+                "cert_pem": cert_pem,
+                "private_key_pem": private_key_pem,
+                "federated": federated,
+            },
+            persist_to=persist_to,
+            enable_dpop=enable_dpop,
+            verify_tls=verify_tls,
+            timeout=timeout,
+        )
+
+    @classmethod
+    def enroll_via_spiffe(
+        cls,
+        mastio_url: str,
+        *,
+        admin_secret: str,
+        agent_name: str,
+        svid_pem: str,
+        svid_key_pem: str,
+        trust_bundle_pem: str | None = None,
+        capabilities: list[str] | None = None,
+        display_name: str = "",
+        persist_to: "str | Path | None" = None,
+        enable_dpop: bool = True,
+        federated: bool = False,
+        verify_tls: bool = True,
+        timeout: float = 10.0,
+    ) -> "CullisClient":
+        """Operator-side helper: enroll an agent via SPIFFE SVID and
+        return a runtime-ready client.
+
+        The Mastio verifies the SVID against the SPIRE trust bundle
+        (either the per-request ``trust_bundle_pem`` override or the
+        operator-configured ``proxy_config.spire_trust_bundle``), pins
+        the SPIFFE URI SAN as the agent's ``spiffe_id``, and emits the
+        API key + DPoP jkt. See :meth:`enroll_via_byoca` for the
+        persistence / runtime split.
+        """
+        body = {
+            "agent_name": agent_name,
+            "display_name": display_name,
+            "capabilities": list(capabilities or []),
+            "svid_pem": svid_pem,
+            "svid_key_pem": svid_key_pem,
+            "federated": federated,
+        }
+        if trust_bundle_pem is not None:
+            body["trust_bundle_pem"] = trust_bundle_pem
+        return cls._do_enroll(
+            mastio_url=mastio_url,
+            endpoint_path="/v1/admin/agents/enroll/spiffe",
+            admin_secret=admin_secret,
+            body=body,
+            persist_to=persist_to,
+            enable_dpop=enable_dpop,
+            verify_tls=verify_tls,
+            timeout=timeout,
+        )
+
+    @classmethod
+    def _do_enroll(
+        cls,
+        *,
+        mastio_url: str,
+        endpoint_path: str,
+        admin_secret: str,
+        body: dict,
+        persist_to: "str | Path | None",
+        enable_dpop: bool,
+        verify_tls: bool,
+        timeout: float,
+    ) -> "CullisClient":
+        """Shared machinery for every ``enroll_via_*`` helper.
+
+        Generates a DPoP keypair in memory, attaches its public JWK to
+        the enrollment body, POSTs to the Mastio endpoint, persists the
+        credentials and returns a runtime-ready client. Kept private —
+        the public surface is ``enroll_via_byoca`` / ``enroll_via_spiffe``
+        so the method names read as the user's intent, not as the
+        underlying transport.
+        """
+        from cullis_sdk.dpop import DpopKey
+
+        _check_insecure_tls(verify_tls)
+        dpop_key: "DpopKey | None" = None
+        if enable_dpop:
+            dpop_key = DpopKey.generate(path=None)
+            body = {**body, "dpop_jwk": dict(dpop_key.public_jwk)}
+
+        url = f"{mastio_url.rstrip('/')}{endpoint_path}"
+        headers = {
+            "X-Admin-Secret": admin_secret,
+            "Content-Type": "application/json",
+        }
+
+        http = httpx.Client(timeout=timeout, verify=verify_tls)
+        try:
+            resp = http.post(url, json=body, headers=headers)
+        finally:
+            http.close()
+        if resp.status_code not in (200, 201):
+            raise PermissionError(
+                f"Enrollment failed (HTTP {resp.status_code}): {resp.text}"
+            )
+        enrolled = resp.json()
+        api_key = enrolled["api_key"]
+        agent_id = enrolled["agent_id"]
+        org_id = agent_id.split("::", 1)[0] if "::" in agent_id else None
+
+        if persist_to is not None:
+            cls._persist_enrollment(
+                Path(persist_to),
+                api_key=api_key,
+                agent_id=agent_id,
+                org_id=org_id,
+                mastio_url=mastio_url,
+                dpop_key=dpop_key,
+            )
+
+        instance = cls.__new__(cls)
+        instance.base = mastio_url.rstrip("/")
+        instance._verify_tls = verify_tls
+        instance._http = httpx.Client(timeout=timeout, verify=verify_tls)
+        instance.token = None
+        instance._label = agent_id
+        instance._signing_key_pem = None
+        instance._pubkey_cache = {}
+        instance._client_seq = {}
+        instance._dpop_privkey = None
+        instance._dpop_pubkey_jwk = None
+        instance._dpop_nonce = None
+        instance._egress_dpop_key = dpop_key
+        instance._egress_dpop_nonce = None
+        instance._proxy_api_key = api_key
+        instance._proxy_agent_id = agent_id
+        instance._proxy_org_id = org_id
+
+        log("sdk", f"Enrolled {agent_id} via {endpoint_path}")
+        return instance
+
+    @staticmethod
+    def _persist_enrollment(
+        persist_to: "Path",
+        *,
+        api_key: str,
+        agent_id: str,
+        org_id: str | None,
+        mastio_url: str,
+        dpop_key,  # DpopKey | None
+    ) -> None:
+        """Write enrollment credentials under ``persist_to/`` with 0600
+        perms on secrets. Layout:
+
+            persist_to/api-key        — plaintext API key
+            persist_to/dpop.jwk       — private DPoP JWK (only if enabled)
+            persist_to/agent.json     — {agent_id, org_id, mastio_url}
+        """
+        import json as _json
+        import os as _os
+        persist_to.mkdir(parents=True, exist_ok=True)
+
+        api_key_path = persist_to / "api-key"
+        api_key_path.write_text(api_key)
+        _os.chmod(api_key_path, 0o600)
+
+        (persist_to / "agent.json").write_text(_json.dumps({
+            "agent_id": agent_id,
+            "org_id": org_id,
+            "mastio_url": mastio_url,
+        }, indent=2))
+
+        if dpop_key is not None:
+            dpop_key.save(persist_to / "dpop.jwk")
+
     @classmethod
     def from_connector(
         cls,
@@ -504,40 +797,41 @@ class CullisClient:
         verify_tls: bool = True,
         timeout: float = 10.0,
     ) -> CullisClient:
-        """Bootstrap a broker-connected client using a SPIFFE X.509-SVID.
+        """**Deprecated under ADR-011.** SPIFFE→Court direct login.
+
+        Under the unified model SPIFFE becomes an *enrollment* primitive:
+        operators use :meth:`enroll_via_spiffe` once (at provisioning
+        time) to exchange an SVID for an API key + DPoP jkt, then the
+        agent runs with :meth:`from_api_key_file` at runtime. The
+        Court's ``/v1/auth/token`` endpoint is sunset (see the
+        ``Deprecation`` / ``Sunset`` headers the server returns). This
+        method continues to work until the Court returns 410 Gone.
+
+        Bootstrap a broker-connected client using a SPIFFE X.509-SVID.
 
         Fetches the workload's SVID from the local SPIFFE Workload API
         (typically a SPIRE agent Unix socket), then authenticates to the
         broker using that certificate. Requires the ``[spiffe]`` extra.
-
-        The Org CA must be configured as the SPIRE server's UpstreamAuthority
-        so that SVIDs chain to a root the broker trusts.
-
-        Args:
-            broker_url: Cullis broker base URL.
-            org_id: Cullis org identifier (the broker's view of the org).
-            socket_path: Workload API socket. Defaults to
-                ``SPIFFE_ENDPOINT_SOCKET`` env var.
-            agent_id: Override the default SPIFFE ID → agent_id mapping.
-                If None, uses ``{org_id}::{last_spiffe_path_segment}``.
-            verify_tls: Whether to verify the broker's TLS cert.
-            timeout: HTTP timeout in seconds.
-
-        Example::
-
-            client = CullisClient.from_spiffe_workload_api(
-                "https://broker.cullis.test",
-                org_id="orga",
-                socket_path="/tmp/spire-agent/public/api.sock",
-            )
         """
+        import warnings
+        warnings.warn(
+            "CullisClient.from_spiffe_workload_api is deprecated under "
+            "ADR-011. Use CullisClient.enroll_via_spiffe(...) once at "
+            "provisioning time, then CullisClient.from_api_key_file(...) "
+            "at runtime. The Court's /v1/auth/token returns 410 Gone "
+            "after sunset (~90d).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         from cullis_sdk.spiffe import fetch_x509_svid, default_agent_id
 
         svid = fetch_x509_svid(socket_path)
         resolved_agent_id = agent_id or default_agent_id(svid.spiffe_id, org_id)
 
         instance = cls(broker_url, verify_tls=verify_tls, timeout=timeout)
-        instance.login_from_pem(resolved_agent_id, org_id, svid.cert_pem, svid.key_pem)
+        instance._legacy_login_from_pem(
+            resolved_agent_id, org_id, svid.cert_pem, svid.key_pem,
+        )
         log("sdk", f"Authenticated {resolved_agent_id} via SPIFFE ({svid.spiffe_id})")
         return instance
 
@@ -558,7 +852,14 @@ class CullisClient:
                        cert_pem: str, key_pem: str,
                        *,
                        countersign_fn: Optional[Callable[[str], str]] = None) -> None:
-        """
+        """**Deprecated under ADR-011.** Direct BYOCA login to the Court.
+
+        Under the unified model BYOCA is an enrollment primitive, not a
+        runtime auth path: operators exchange cert+key for an API key +
+        DPoP jkt via :meth:`enroll_via_byoca`, and agents authenticate
+        with :meth:`from_api_key_file`. This method continues to work
+        until the Court's ``/v1/auth/token`` returns 410 Gone.
+
         Authenticate via x509 + DPoP using PEM strings directly.
 
         Use this when loading credentials from a secret manager (Vault,
@@ -570,6 +871,31 @@ class CullisClient:
         ``X-Cullis-Mastio-Signature``. The mastio proxy is the typical
         caller that wires this.
         """
+        import warnings
+        warnings.warn(
+            "CullisClient.login_from_pem is deprecated under ADR-011. "
+            "Use CullisClient.enroll_via_byoca(...) once at provisioning "
+            "time, then CullisClient.from_api_key_file(...) at runtime. "
+            "The Court's /v1/auth/token returns 410 Gone after sunset "
+            "(~90d).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._legacy_login_from_pem(
+            agent_id, org_id, cert_pem, key_pem,
+            countersign_fn=countersign_fn,
+        )
+
+    def _legacy_login_from_pem(
+        self, agent_id: str, org_id: str,
+        cert_pem: str, key_pem: str,
+        *,
+        countersign_fn: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        """Internal impl shared by the deprecated ``login_from_pem`` and
+        ``from_spiffe_workload_api`` entry points. Kept around so the
+        deprecation warning fires exactly once per user call (the public
+        methods emit the warning before delegating here)."""
         self._label = agent_id
         try:
             self._signing_key_pem = key_pem

--- a/tests/test_sdk_enrollment_unified.py
+++ b/tests/test_sdk_enrollment_unified.py
@@ -1,0 +1,339 @@
+"""ADR-011 Phase 2 — unified SDK runtime + enrollment helpers.
+
+Covers:
+  - ``from_api_key_file`` reads credentials from disk and returns a
+    runtime-ready client.
+  - ``enroll_via_byoca`` POSTs the Mastio endpoint, persists API key
+    + DPoP JWK, and returns a client with those credentials wired.
+  - ``enroll_via_spiffe`` same shape, different body + endpoint path.
+  - Persistence layout matches the ADR-011 contract:
+    ``<persist_to>/{api-key, dpop.jwk, agent.json}`` with 0600 on
+    secrets.
+  - ``from_spiffe_workload_api`` + ``login_from_pem`` emit
+    ``DeprecationWarning`` — the sunset signal operators should see
+    at call time.
+  - ``enable_dpop=False`` omits the DPoP JWK from the enrollment body
+    and from the persisted layout.
+
+No live Mastio: the enroll helpers call the endpoint through a
+patched ``httpx.Client`` that returns a canned success body. The
+``internal_agents`` row is not exercised — the Phase 1b/1c test
+suites already cover that.
+"""
+from __future__ import annotations
+
+import json
+import warnings
+
+import httpx
+import pytest
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+class _StubResponse:
+    """Minimal ``httpx.Response`` surface the SDK consumes on the enroll
+    hot path — status_code, text, .json()."""
+
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = json.dumps(payload)
+
+    def json(self) -> dict:
+        return self._payload
+
+
+@pytest.fixture
+def patched_httpx(monkeypatch):
+    """Intercept ``httpx.Client.post`` calls the enroll helpers make.
+
+    Returns a dict the test can poke at to check URL / headers / body,
+    and can set ``.next_response`` to any ``_StubResponse`` before
+    issuing the SDK call.
+    """
+    state: dict = {"calls": [], "next_response": None}
+
+    class _StubClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def post(self, url, *, json=None, headers=None):
+            state["calls"].append({"url": url, "json": json, "headers": headers})
+            resp = state["next_response"]
+            assert resp is not None, "test forgot to set next_response"
+            return resp
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(httpx, "Client", _StubClient)
+    return state
+
+
+# ── from_api_key_file ────────────────────────────────────────────────────
+
+
+def test_from_api_key_file_reads_credentials_from_disk(tmp_path):
+    from cullis_sdk import CullisClient
+    from cullis_sdk.dpop import DpopKey
+
+    api_key_path = tmp_path / "api-key"
+    api_key_path.write_text("sk_local_alice_deadbeef")
+
+    dpop_key = DpopKey.generate(path=tmp_path / "dpop.jwk")
+
+    client = CullisClient.from_api_key_file(
+        "http://proxy-a:9100",
+        api_key_path=api_key_path,
+        dpop_key_path=tmp_path / "dpop.jwk",
+        agent_id="orga::alice",
+        org_id="orga",
+    )
+
+    assert client._proxy_api_key == "sk_local_alice_deadbeef"
+    assert client._proxy_agent_id == "orga::alice"
+    assert client._proxy_org_id == "orga"
+    assert client._egress_dpop_key is not None
+    # Loaded key must match the one we wrote — thumbprint equality
+    # is a sharper assertion than comparing the JWK dict byte-for-byte.
+    assert client._egress_dpop_key.thumbprint() == dpop_key.thumbprint()
+
+
+def test_from_api_key_file_without_dpop_stays_bearer_only(tmp_path):
+    from cullis_sdk import CullisClient
+
+    api_key_path = tmp_path / "api-key"
+    api_key_path.write_text("sk_bearer_only")
+
+    client = CullisClient.from_api_key_file(
+        "http://proxy-a:9100",
+        api_key_path=api_key_path,
+    )
+    assert client._proxy_api_key == "sk_bearer_only"
+    assert client._egress_dpop_key is None
+
+
+def test_from_api_key_file_rejects_empty_key(tmp_path):
+    from cullis_sdk import CullisClient
+
+    api_key_path = tmp_path / "empty"
+    api_key_path.write_text("")
+
+    with pytest.raises(ValueError, match="empty"):
+        CullisClient.from_api_key_file(
+            "http://proxy-a:9100",
+            api_key_path=api_key_path,
+        )
+
+
+# ── enroll_via_byoca ─────────────────────────────────────────────────────
+
+
+def test_enroll_via_byoca_posts_and_persists(tmp_path, patched_httpx):
+    from cullis_sdk import CullisClient
+
+    patched_httpx["next_response"] = _StubResponse(201, {
+        "agent_id": "orga::alice",
+        "api_key": "sk_local_alice_abc",
+        "cert_thumbprint": "0" * 64,
+        "spiffe_id": None,
+        "dpop_jkt": None,  # server echoes whatever we sent
+    })
+
+    client = CullisClient.enroll_via_byoca(
+        "http://proxy-a:9100",
+        admin_secret="top-secret",
+        agent_name="alice",
+        cert_pem="-----BEGIN CERTIFICATE-----\nX\n-----END CERTIFICATE-----\n",
+        private_key_pem="-----BEGIN EC PRIVATE KEY-----\nY\n-----END EC PRIVATE KEY-----\n",
+        capabilities=["order.read"],
+        persist_to=tmp_path / "identity",
+    )
+
+    # HTTP call shape
+    call = patched_httpx["calls"][0]
+    assert call["url"] == "http://proxy-a:9100/v1/admin/agents/enroll/byoca"
+    assert call["headers"]["X-Admin-Secret"] == "top-secret"
+    assert call["json"]["agent_name"] == "alice"
+    assert call["json"]["capabilities"] == ["order.read"]
+    # enable_dpop default True → SDK generated a JWK and attached it
+    assert "dpop_jwk" in call["json"]
+    assert call["json"]["dpop_jwk"]["kty"] == "EC"
+    assert "d" not in call["json"]["dpop_jwk"]  # private material never shipped
+
+    # Client credentials wired
+    assert client._proxy_api_key == "sk_local_alice_abc"
+    assert client._proxy_agent_id == "orga::alice"
+    assert client._proxy_org_id == "orga"
+    assert client._egress_dpop_key is not None
+
+    # Persisted layout
+    persist = tmp_path / "identity"
+    assert (persist / "api-key").read_text() == "sk_local_alice_abc"
+    assert (persist / "dpop.jwk").exists()
+    agent_meta = json.loads((persist / "agent.json").read_text())
+    assert agent_meta["agent_id"] == "orga::alice"
+    assert agent_meta["org_id"] == "orga"
+    assert agent_meta["mastio_url"] == "http://proxy-a:9100"
+    # Secret files must be 0600 — avoid co-tenant read.
+    assert (persist / "api-key").stat().st_mode & 0o777 == 0o600
+    assert (persist / "dpop.jwk").stat().st_mode & 0o777 == 0o600
+
+
+def test_enroll_via_byoca_raises_on_server_error(tmp_path, patched_httpx):
+    from cullis_sdk import CullisClient
+
+    patched_httpx["next_response"] = _StubResponse(400, {"detail": "foreign CA"})
+
+    with pytest.raises(PermissionError, match="400"):
+        CullisClient.enroll_via_byoca(
+            "http://proxy-a:9100",
+            admin_secret="top-secret",
+            agent_name="alice",
+            cert_pem="X",
+            private_key_pem="Y",
+            persist_to=tmp_path / "identity",
+        )
+    # Nothing persisted on failure.
+    assert not (tmp_path / "identity").exists()
+
+
+def test_enroll_via_byoca_enable_dpop_false_skips_jwk(tmp_path, patched_httpx):
+    from cullis_sdk import CullisClient
+
+    patched_httpx["next_response"] = _StubResponse(201, {
+        "agent_id": "orga::nodpop",
+        "api_key": "sk_no_dpop",
+        "cert_thumbprint": "0" * 64,
+        "spiffe_id": None,
+        "dpop_jkt": None,
+    })
+
+    client = CullisClient.enroll_via_byoca(
+        "http://proxy-a:9100",
+        admin_secret="top-secret",
+        agent_name="nodpop",
+        cert_pem="X",
+        private_key_pem="Y",
+        enable_dpop=False,
+        persist_to=tmp_path / "id",
+    )
+
+    call = patched_httpx["calls"][0]
+    assert "dpop_jwk" not in call["json"]
+    assert client._egress_dpop_key is None
+    assert not (tmp_path / "id" / "dpop.jwk").exists()
+
+
+# ── enroll_via_spiffe ────────────────────────────────────────────────────
+
+
+def test_enroll_via_spiffe_posts_svid_and_bundle(tmp_path, patched_httpx):
+    from cullis_sdk import CullisClient
+
+    spiffe = "spiffe://orga.test/agent/bob"
+    patched_httpx["next_response"] = _StubResponse(201, {
+        "agent_id": "orga::bob",
+        "api_key": "sk_local_bob_xyz",
+        "cert_thumbprint": "0" * 64,
+        "spiffe_id": spiffe,
+        "dpop_jkt": "fake-jkt",
+    })
+
+    client = CullisClient.enroll_via_spiffe(
+        "http://proxy-a:9100",
+        admin_secret="top-secret",
+        agent_name="bob",
+        svid_pem="-----BEGIN CERTIFICATE-----\nSVID\n-----END CERTIFICATE-----\n",
+        svid_key_pem="-----BEGIN EC PRIVATE KEY-----\nK\n-----END EC PRIVATE KEY-----\n",
+        trust_bundle_pem="-----BEGIN CERTIFICATE-----\nBUNDLE\n-----END CERTIFICATE-----\n",
+        persist_to=tmp_path / "identity",
+    )
+
+    call = patched_httpx["calls"][0]
+    assert call["url"] == "http://proxy-a:9100/v1/admin/agents/enroll/spiffe"
+    assert call["json"]["svid_pem"].startswith("-----BEGIN")
+    assert call["json"]["trust_bundle_pem"].startswith("-----BEGIN")
+    assert "dpop_jwk" in call["json"]
+
+    assert client._proxy_agent_id == "orga::bob"
+    assert (tmp_path / "identity" / "api-key").read_text() == "sk_local_bob_xyz"
+
+
+def test_enroll_via_spiffe_omits_bundle_when_none_supplied(tmp_path, patched_httpx):
+    from cullis_sdk import CullisClient
+
+    patched_httpx["next_response"] = _StubResponse(201, {
+        "agent_id": "orga::bob",
+        "api_key": "sk",
+        "cert_thumbprint": "0" * 64,
+        "spiffe_id": "spiffe://x.test/y",
+        "dpop_jkt": None,
+    })
+
+    CullisClient.enroll_via_spiffe(
+        "http://proxy-a:9100",
+        admin_secret="top-secret",
+        agent_name="bob",
+        svid_pem="X",
+        svid_key_pem="Y",
+        # no trust_bundle_pem — server should fall back to proxy_config
+        persist_to=tmp_path / "id",
+    )
+
+    call = patched_httpx["calls"][0]
+    assert "trust_bundle_pem" not in call["json"]
+
+
+# ── deprecation warnings ─────────────────────────────────────────────────
+
+
+def test_login_from_pem_emits_deprecation_warning():
+    """Documented ADR-011 Phase 2 signal: deprecation fires at call site
+    so SDK users see it without digging through audit events."""
+    from cullis_sdk import CullisClient
+
+    c = CullisClient("http://any", verify_tls=False)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # Will fail the broker call downstream — we only care the
+        # warning fires before any network activity.
+        try:
+            c.login_from_pem("orga::a", "orga", "cert", "key")
+        except Exception:
+            pass
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep, "login_from_pem must emit DeprecationWarning"
+    assert "ADR-011" in str(dep[0].message)
+    assert "from_api_key_file" in str(dep[0].message)
+
+
+def test_from_spiffe_workload_api_emits_deprecation_warning(monkeypatch):
+    from cullis_sdk import CullisClient
+
+    # Stub the SPIFFE fetch so the test doesn't need a live SPIRE.
+    class _FakeSvid:
+        spiffe_id = "spiffe://test/agent"
+        cert_pem = "C"
+        key_pem = "K"
+
+    monkeypatch.setattr(
+        "cullis_sdk.spiffe.fetch_x509_svid",
+        lambda _sock: _FakeSvid(),
+    )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            CullisClient.from_spiffe_workload_api(
+                "http://any", org_id="test", socket_path="/dev/null",
+            )
+        except Exception:
+            pass
+    dep = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert dep, "from_spiffe_workload_api must emit DeprecationWarning"
+    msg = str(dep[0].message)
+    assert "ADR-011" in msg
+    assert "enroll_via_spiffe" in msg


### PR DESCRIPTION
## Summary

Python SDK half of ADR-011. One primary runtime constructor + three enrollment helpers + two deprecations.

**Runtime** — `CullisClient.from_api_key_file(mastio_url, api_key_path, dpop_key_path=...)` is the canonical entry point under ADR-011. Reads API key + optional DPoP JWK from disk and returns a client pre-configured for the Mastio egress surface. No direct Court auth ever.

**Enrollment helpers** (operator-side, not runtime):
- `enroll_via_byoca(mastio_url, admin_secret, agent_name, cert_pem, private_key_pem, persist_to=..., enable_dpop=True)` — POSTs `/v1/admin/agents/enroll/byoca` (landed via #216), persists credentials, returns a runtime-ready client
- `enroll_via_spiffe(mastio_url, admin_secret, agent_name, svid_pem, svid_key_pem, trust_bundle_pem=None, persist_to=...)` — same shape, targets `/v1/admin/agents/enroll/spiffe` (landed via #218)

Persistence layout matches the Connector identity dir: `{api-key, dpop.jwk, agent.json}` with 0600 on secrets.

**Deprecations** — emit `DeprecationWarning` per call:
- `from_spiffe_workload_api` → use `enroll_via_spiffe` + `from_api_key_file`
- `login_from_pem` → use `enroll_via_byoca` + `from_api_key_file`

Shared internal `_legacy_login_from_pem` holds the implementation so the two public deprecations fire exactly once per user call (no chain-warnings from nested delegation).

ADR doc: `imp/adr_011_unified_enrollment.md`. Plan: `imp/adr_011_unified_enrollment_plan.md`.

## Test plan

- [x] 10 cases in `tests/test_sdk_enrollment_unified.py`:
  - `from_api_key_file` loads with/without DPoP, rejects empty key
  - `enroll_via_byoca` posts correct body shape (agent_name, caps, DPoP JWK attached, no private `d`), admin secret header, persists 0600 api-key + dpop.jwk + agent.json, raises on 400
  - `enable_dpop=False` omits JWK from body and skips dpop.jwk persistence
  - `enroll_via_spiffe` posts svid + bundle, persists identically
  - both deprecated methods emit `DeprecationWarning` with ADR-011 pointer + migration target in message
- [x] `pytest tests/test_sdk_enrollment_unified.py tests/test_auth.py tests/test_spiffe.py tests/test_sdk_*` → 78 passed, no regressions
- [x] Ruff F401 manual (NixOS) — unused `Path` import pruned