### PR TITLE
docs: ADR-011 enrollment guide + API reference + migration (Phase 5)

### DIFF
--- a/site/src/content/docs/enrollment-api-reference.md
+++ b/site/src/content/docs/enrollment-api-reference.md
@@ -1,0 +1,156 @@
+---
+title: "Enrollment API reference"
+description: "Request + response schemas for /v1/admin/agents/enroll/{byoca, spiffe} and the other ADR-011 enrollment endpoints."
+category: "Reference"
+order: 60
+updated: "2026-04-18"
+---
+
+# Cullis — Enrollment API reference
+
+Endpoints under `/v1/admin/agents/enroll/` on the **Mastio** (never on the Court). All require `X-Admin-Secret`. Returns `201 Created` on success; API key in the response body is shown **exactly once** — the server stores only its bcrypt hash.
+
+---
+
+## `POST /v1/admin/agents/enroll/byoca`
+
+Enroll an agent via a caller-supplied Org-CA-signed cert + key.
+
+### Request
+
+```json
+{
+  "agent_name": "inventory-bot",
+  "display_name": "Inventory service",
+  "capabilities": ["inventory.read", "inventory.write"],
+  "cert_pem": "-----BEGIN CERTIFICATE-----\n...",
+  "private_key_pem": "-----BEGIN EC PRIVATE KEY-----\n...",
+  "dpop_jwk": {"kty": "EC", "crv": "P-256", "x": "...", "y": "..."},
+  "federated": false
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `agent_name` | string | yes | `^[a-zA-Z0-9._-]{1,64}$` — the Mastio scopes it to its own `org_id` |
+| `display_name` | string | no | Free-form label; defaults to `agent_name` |
+| `capabilities` | string[] | no | Arbitrary capability strings; empty list allowed |
+| `cert_pem` | PEM | **yes** | Must chain to the Mastio's loaded Org CA |
+| `private_key_pem` | PEM | **yes** | Must match `cert_pem` public key |
+| `dpop_jwk` | JWK object | no | Public EC/RSA JWK. `d` (private) rejected. When supplied, the server computes RFC 7638 thumbprint and pins it |
+| `federated` | bool | no | Push the agent to the Court via the federation publisher |
+
+### Response — 201
+
+```json
+{
+  "agent_id": "acme::inventory-bot",
+  "display_name": "Inventory service",
+  "capabilities": ["inventory.read", "inventory.write"],
+  "api_key": "sk_local_inventory-bot_a1b2...",
+  "cert_thumbprint": "f3d2...",
+  "spiffe_id": null,
+  "dpop_jkt": "uP6uY..."
+}
+```
+
+If the cert carries a `spiffe://` URI in its `SubjectAlternativeName`, `spiffe_id` is populated automatically.
+
+### Errors
+
+| Code | When |
+|---|---|
+| 400 | `cert_pem` not signed by Org CA; key does not match cert; `dpop_jwk` contains `d`; unsupported `kty` |
+| 403 | Missing / wrong `X-Admin-Secret` |
+| 409 | Agent `<org>::<name>` already enrolled |
+| 503 | Mastio's Org CA not loaded |
+
+---
+
+## `POST /v1/admin/agents/enroll/spiffe`
+
+Enroll an agent via an X.509-SVID verified against a SPIRE trust bundle.
+
+### Request
+
+```json
+{
+  "agent_name": "k8s-inventory",
+  "display_name": "K8s inventory workload",
+  "capabilities": ["inventory.read"],
+  "svid_pem": "-----BEGIN CERTIFICATE-----\n...",
+  "svid_key_pem": "-----BEGIN EC PRIVATE KEY-----\n...",
+  "trust_bundle_pem": "-----BEGIN CERTIFICATE-----\n...",
+  "dpop_jwk": {"kty": "EC", "crv": "P-256", "x": "...", "y": "..."},
+  "federated": false
+}
+```
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `svid_pem` | PEM | **yes** | SVID leaf with a `spiffe://` URI SAN (mandatory for this method) |
+| `svid_key_pem` | PEM | **yes** | Must match `svid_pem` public key |
+| `trust_bundle_pem` | PEM | no | Per-request bundle override. When omitted, the Mastio falls back to `proxy_config.spire_trust_bundle` |
+| `agent_name`, `display_name`, `capabilities`, `dpop_jwk`, `federated` | — | same as BYOCA |
+
+### Response — 201
+
+```json
+{
+  "agent_id": "acme::k8s-inventory",
+  "display_name": "K8s inventory workload",
+  "capabilities": ["inventory.read"],
+  "api_key": "sk_local_k8s-inventory_c4d5...",
+  "cert_thumbprint": "e7a8...",
+  "spiffe_id": "spiffe://acme.internal/k8s-inventory",
+  "dpop_jkt": "vL3pW..."
+}
+```
+
+### Errors
+
+| Code | When |
+|---|---|
+| 400 | SVID has no SPIFFE URI SAN; not signed by trust bundle; key mismatch; invalid `dpop_jwk` |
+| 403 | Missing / wrong admin secret |
+| 409 | Duplicate |
+| 503 | Neither `trust_bundle_pem` in body nor `spire_trust_bundle` in proxy config |
+
+---
+
+## `POST /v1/admin/agents` — admin manual create
+
+The pre-ADR-011 path. Still the default for programmatic agents created from scripts or CI. See existing runbooks — behavior unchanged, except the row now carries `enrollment_method='admin'` automatically.
+
+## `POST /v1/enrollment/start` + polling — connector flow
+
+The device-code enrollment for Connector Desktop. Unchanged; see [SPIFFE onboarding](spiffe-onboarding.md) and the Connector README. Rows get `enrollment_method='connector'`.
+
+---
+
+## Persistence contract (client side)
+
+Every `enroll_via_*` helper in the Python SDK, given `persist_to=<dir>`, writes:
+
+| File | Mode | Contents |
+|---|---|---|
+| `<dir>/api-key` | 0600 | plaintext API key |
+| `<dir>/dpop.jwk` | 0600 | JSON `{"private_jwk": {...}}` |
+| `<dir>/agent.json` | 0644 | `{"agent_id": "...", "org_id": "...", "mastio_url": "..."}` |
+
+Runtime pass `api_key_path=<dir>/api-key` and `dpop_key_path=<dir>/dpop.jwk` to `CullisClient.from_api_key_file()`.
+
+---
+
+## Row shape — `internal_agents`
+
+Columns added by migration 0016 that every enroll endpoint populates:
+
+| Column | Value |
+|---|---|
+| `enrollment_method` | `admin` \| `connector` \| `byoca` \| `spiffe` |
+| `spiffe_id` | SPIFFE URI when enrollment carried one, else NULL |
+| `enrolled_at` | ISO timestamp of the successful enroll call |
+| `dpop_jkt` | RFC 7638 thumbprint of the pinned public JWK (NULL if `dpop_jwk` was not supplied) |
+
+The operator dashboard surfaces all of these so audit + migration progress is observable without touching SQL.

--- a/site/src/content/docs/enrollment.md
+++ b/site/src/content/docs/enrollment.md
@@ -1,0 +1,166 @@
+---
+title: "Agent enrollment — the four methods"
+description: "Under ADR-011, enrollment and runtime auth are separate layers. Four ways to enroll, one runtime path (API-key + DPoP via the Mastio)."
+category: "Identity"
+order: 25
+updated: "2026-04-18"
+---
+
+# Cullis — Agent enrollment
+
+Under [ADR-011](../architecture) Cullis separates two concerns:
+
+- **Enrollment** — a one-time handshake that turns whatever identity the agent already has (cert, SVID, OIDC login, admin-minted token) into a stable runtime credential.
+- **Runtime auth** — the credential the agent presents on every subsequent call: an **API key + DPoP proof**, always sent to the agent's Mastio (never directly to the Court).
+
+The four enrollment methods below are equivalent at the output layer — they all write the same three files on disk (`api-key`, `dpop.jwk`, `agent.json`) and produce the same runtime client. The difference is only in how the Mastio verifies the caller during enrollment.
+
+---
+
+## Which method to pick
+
+| Method | Pick it when | Trust anchor |
+|---|---|---|
+| `admin` | default, programmatic agents, CI/CD | operator-held admin secret |
+| `connector` | dev laptops, interactive onboarding | OIDC login via Connector Desktop |
+| `byoca` | enterprise PKI already in place, air-gapped, CI with baked-in creds | operator-supplied cert signed by the Org CA |
+| `spiffe` | K8s workloads under SPIRE | SVID verified against the SPIRE trust bundle |
+
+All four are first-class. BYOCA and SPIFFE are **enrollment** primitives; runtime auth via SPIFFE/BYOCA direct login to the Court is legacy and emits deprecation headers (see [Migration from direct login](migration-from-direct-login.md)).
+
+---
+
+## Method 1 — admin (default)
+
+Operator creates the agent row via the Mastio dashboard, emits an enrollment token, hands it to the runtime.
+
+```bash
+# Step 1 — dashboard: Create Agent → displays a one-shot enrollment token.
+# Step 2 — runtime reads the token at first boot:
+python -c "
+from cullis_sdk import CullisClient
+CullisClient.enroll_via_admin_token(
+    'https://mastio.acme.corp',
+    enrollment_token='enroll_xxx',
+    persist_to='/etc/cullis/agent/',
+)
+"
+# Step 3 — on every subsequent start:
+python -c "
+from cullis_sdk import CullisClient
+client = CullisClient.from_api_key_file(
+    'https://mastio.acme.corp',
+    api_key_path='/etc/cullis/agent/api-key',
+    dpop_key_path='/etc/cullis/agent/dpop.jwk',
+)
+client.send_oneshot('acme::target-bot', {'hello': 'world'})
+"
+```
+
+---
+
+## Method 2 — connector (interactive)
+
+The user runs the [Connector Desktop](https://cullis.io/downloads), authenticates via OIDC against their corporate IdP (Google, Okta, Azure AD), and the Mastio admin approves the pending enrollment from the dashboard. The Connector persists credentials under `~/.cullis/identity/<org>/`.
+
+```bash
+cullis-connector enroll --site https://mastio.acme.corp
+# OIDC browser flow opens — user logs in.
+# Admin sees a pending enrollment in the dashboard + clicks Approve.
+
+# SDK reads the persisted identity:
+from cullis_sdk import CullisClient
+client = CullisClient.from_connector()  # reads ~/.cullis/identity/
+```
+
+---
+
+## Method 3 — BYOCA (cert + key)
+
+The operator holds an Org-CA-signed cert + private key (typically exported from Vault, Sectigo, or an enterprise CA). The Mastio verifies the signature chain against its loaded Org CA and emits the runtime credentials.
+
+```bash
+python -c "
+from cullis_sdk import CullisClient
+CullisClient.enroll_via_byoca(
+    'https://mastio.acme.corp',
+    admin_secret='\$MASTIO_ADMIN_SECRET',
+    agent_name='inventory-bot',
+    cert_pem=open('agent.pem').read(),
+    private_key_pem=open('agent-key.pem').read(),
+    capabilities=['inventory.read', 'inventory.write'],
+    persist_to='/etc/cullis/agent/',
+)
+"
+```
+
+A SPIFFE URI in the cert's `SubjectAlternativeName` is picked up automatically and persisted as `spiffe_id` on the `internal_agents` row.
+
+---
+
+## Method 4 — SPIFFE (SVID + trust bundle)
+
+The operator has a workload running under SPIRE with an X.509-SVID. The Mastio verifies the SVID against the SPIRE trust bundle.
+
+```bash
+python -c "
+from cullis_sdk import CullisClient
+CullisClient.enroll_via_spiffe(
+    'https://mastio.acme.corp',
+    admin_secret='\$MASTIO_ADMIN_SECRET',
+    agent_name='k8s-inventory',
+    svid_pem=open('svid.pem').read(),
+    svid_key_pem=open('svid-key.pem').read(),
+    trust_bundle_pem=open('spire-bundle.pem').read(),  # optional if set on the Mastio
+    capabilities=['inventory.read'],
+    persist_to='/etc/cullis/agent/',
+)
+"
+```
+
+The SPIFFE URI SAN on the SVID is **mandatory** for this method — without it the cert is not a valid SVID and the endpoint returns 400. The URI gets pinned as `spiffe_id`, the cert material lives under `cert_pem` (SPIRE rotates the SVID; the runtime credentials stay valid because auth is API-key + DPoP, not the SVID itself).
+
+Trust bundle resolution:
+
+1. `body.trust_bundle_pem` (per-request override)
+2. `proxy_config.spire_trust_bundle` on the Mastio (operator-configured baseline)
+3. Neither → 503
+
+---
+
+## Runtime — one path for every method
+
+```python
+from cullis_sdk import CullisClient
+
+client = CullisClient.from_api_key_file(
+    mastio_url='https://mastio.acme.corp',
+    api_key_path='/etc/cullis/agent/api-key',
+    dpop_key_path='/etc/cullis/agent/dpop.jwk',
+)
+
+# Cross-org A2A message (no session — ADR-008 one-shot envelope).
+client.send_oneshot('globex::fulfillment-bot', {'order_id': 'A123'})
+```
+
+No direct calls to the Court. No cert on the wire at runtime. DPoP proof binds every request to the keypair the Mastio pinned at enrollment time.
+
+---
+
+## Internals — what gets written where
+
+| File | Owner | Contents | Permissions |
+|---|---|---|---|
+| `persist_to/api-key` | SDK / Connector | plaintext API key (shown once by server) | `0600` |
+| `persist_to/dpop.jwk` | SDK / Connector | private DPoP JWK, EC P-256 | `0600` |
+| `persist_to/agent.json` | SDK / Connector | `{agent_id, org_id, mastio_url}` | `0644` |
+
+On the Mastio side the row in `internal_agents` carries `enrollment_method`, `spiffe_id` (nullable), `enrolled_at`, and `dpop_jkt` (the thumbprint the server compares each proof against).
+
+---
+
+## See also
+
+- [Endpoint reference](enrollment-api-reference.md) — request / response schemas for each endpoint
+- [Migration from direct login](migration-from-direct-login.md) — moving existing SPIFFE/BYOCA deployments off `/v1/auth/token`
+- [SPIFFE onboarding](spiffe-onboarding.md) — deploying SPIRE alongside Cullis

--- a/site/src/content/docs/migration-from-direct-login.md
+++ b/site/src/content/docs/migration-from-direct-login.md
@@ -1,0 +1,171 @@
+---
+title: "Migrating off /v1/auth/token direct login"
+description: "How to move existing SPIFFE/BYOCA deployments from direct-to-Court login onto the ADR-011 unified enrollment path, with zero downtime."
+category: "Identity"
+order: 40
+updated: "2026-04-18"
+---
+
+# Cullis — Migrating off the legacy direct-login path
+
+Before ADR-011, Cullis supported three runtime auth paths:
+
+1. SPIFFE workload API → direct login to the Court at `/v1/auth/token`
+2. BYOCA (cert + key) → direct login to the Court
+3. Connector / admin-token → API-key + DPoP via the Mastio (ADR-008 / F-B-11)
+
+As of 2026-04-18, **path 3 is the only supported runtime**. Paths 1 and 2 continue to work but are marked deprecated; the Court's `/v1/auth/token` now returns `Deprecation: true` + `Sunset` headers on every 200, and emits `auth.token_issued` audit rows with `details.deprecated = true`. After the 90-day grace window the endpoint will return `410 Gone`.
+
+This guide walks you through re-enrolling your existing SPIFFE / BYOCA agents against the new endpoints with **no downtime** — the legacy login keeps working throughout the migration.
+
+---
+
+## When you're done, you should have
+
+- Every agent authenticating to its Mastio via API-key + DPoP (no direct calls to the Court)
+- Zero `auth.token_issued` audit rows with `details.deprecated = true` on your Mastio's dashboard
+- `CULLIS_ALLOW_LEGACY_AUTH_LOGIN=false` set on the Court (enforced from grace-period Phase B onwards)
+- BYOCA and SPIFFE kept as **enrollment primitives** — you still use the same cert / SVID material; it just becomes the trust anchor at enrollment time rather than the credential on every call
+
+---
+
+## Step 1 — upgrade the Mastio
+
+The Mastio needs the `/v1/admin/agents/enroll/{byoca,spiffe}` endpoints live. Any build tagged after 2026-04-18 includes them. Upgrade your Mastio first; the Court can stay on whatever release you were running.
+
+```bash
+# k8s example — bump the chart version on your values file:
+helm upgrade cullis-proxy cullis-security/cullis-proxy \
+  --values your-values.yaml \
+  --set image.tag=<latest-2026-04-18-or-newer>
+```
+
+Once the Mastio is on the new build, `POST /v1/admin/agents/enroll/byoca` + `/spiffe` are available. Legacy `POST /v1/admin/agents` is unchanged.
+
+---
+
+## Step 2 — re-enroll each agent via the new endpoint
+
+You keep the same cert/SVID material. The Mastio just verifies it differently.
+
+### SPIFFE agents
+
+```bash
+# Operator machine, holds admin_secret + the workload's current SVID:
+python -c "
+from cullis_sdk import CullisClient
+CullisClient.enroll_via_spiffe(
+    'https://mastio.acme.corp',
+    admin_secret='\$MASTIO_ADMIN_SECRET',
+    agent_name='inventory-k8s',
+    svid_pem=open('/tmp/svid.pem').read(),
+    svid_key_pem=open('/tmp/svid-key.pem').read(),
+    trust_bundle_pem=open('/tmp/spire-bundle.pem').read(),
+    capabilities=['inventory.read', 'inventory.write'],
+    persist_to='/etc/cullis/agent/inventory-k8s/',
+)
+"
+```
+
+The SDK writes `api-key`, `dpop.jwk`, `agent.json` under `persist_to`. Ship these to wherever the agent runs — your secret manager of choice (Vault KV, AWS Secrets Manager, K8s Secret, mounted volume) works fine because the material is per-agent and rotatable.
+
+### BYOCA agents
+
+```bash
+python -c "
+from cullis_sdk import CullisClient
+CullisClient.enroll_via_byoca(
+    'https://mastio.acme.corp',
+    admin_secret='\$MASTIO_ADMIN_SECRET',
+    agent_name='billing-bot',
+    cert_pem=open('/tmp/agent.pem').read(),
+    private_key_pem=open('/tmp/agent-key.pem').read(),
+    capabilities=['billing.read'],
+    persist_to='/etc/cullis/agent/billing-bot/',
+)
+"
+```
+
+Both helpers return `201` + the runtime credentials + a `dpop_jkt` the server has pinned. If the cert already carries a SPIFFE URI SAN, it lands on the `spiffe_id` column automatically.
+
+---
+
+## Step 3 — update the agent runtime
+
+Swap the SDK call from `from_spiffe_workload_api` / `login_from_pem` to `from_api_key_file`.
+
+**Before:**
+
+```python
+client = CullisClient.from_spiffe_workload_api(
+    "https://court.cullis.corp",
+    org_id="acme",
+    socket_path="/run/spire/sockets/agent.sock",
+)
+```
+
+**After:**
+
+```python
+client = CullisClient.from_api_key_file(
+    "https://mastio.acme.corp",
+    api_key_path="/etc/cullis/agent/inventory-k8s/api-key",
+    dpop_key_path="/etc/cullis/agent/inventory-k8s/dpop.jwk",
+)
+```
+
+The Mastio URL replaces the Court URL — agents no longer have a direct relationship with the Court; the Mastio forwards whatever crosses org boundaries and signs the counter-signature the Court expects.
+
+---
+
+## Step 4 — watch the deprecation counter go to zero
+
+On the Court's audit dashboard, filter `event_type = auth.token_issued AND details.deprecated = true`. As you re-enroll agents, the counter per org trends down. When it hits zero, you're safe to flip `CULLIS_ALLOW_LEGACY_AUTH_LOGIN=false`.
+
+Raw SQL on the Court if you prefer:
+
+```sql
+SELECT COUNT(*) FROM audit_log
+ WHERE event_type = 'auth.token_issued'
+   AND details::jsonb @> '{"deprecated": true}'
+   AND timestamp > now() - interval '24 hours';
+```
+
+---
+
+## Step 5 — enforce no-legacy
+
+Once every agent has migrated and the audit counter is zero for a meaningful window (we suggest one deploy cycle, ~72h):
+
+```bash
+# On the Court, set in your values / env:
+CULLIS_ALLOW_LEGACY_AUTH_LOGIN=false
+```
+
+The Court's `validate_config` will refuse to start in production if a non-empty org exists with unmigrated agents. Any remaining caller that hits `/v1/auth/token` now receives 403.
+
+After the full grace window (at least 90 days from sunset advertisement), the endpoint starts returning `410 Gone` and calling code must have moved. At that point `from_spiffe_workload_api` and `login_from_pem` in the SDK also stop working.
+
+---
+
+## FAQ
+
+**Do I need to rotate my certs / SVIDs?**
+No. Enrollment uses the same material you already have — the Mastio verifies it once and derives a separate runtime credential. Your PKI policy doesn't change.
+
+**Does the sandbox still demonstrate SPIFFE?**
+Yes — the `enterprise_sandbox` bootstrap now enrolls every agent via `/enroll/byoca` (SPIRE stack stays in the compose but the agents don't hit `/v1/auth/token` anymore). You can use it as a reference topology. See the GUIDE in the sandbox repo.
+
+**What if I'm running a Court-only deployment with no Mastio?**
+The ADR-009 direction is: every deployment has a Mastio. For small topologies you can run a "thin Mastio" sidecar container next to the Court — footprint is one container + SQLite, no external deps. This is the same container operators use in large deployments; it just runs in standalone mode for tiny cases.
+
+**Can I revert a migration?**
+During the grace window, yes — the legacy login still works. After `CULLIS_ALLOW_LEGACY_AUTH_LOGIN=false`, no. After 410 Gone, no.
+
+---
+
+## See also
+
+- [Agent enrollment — the four methods](enrollment.md)
+- [Enrollment API reference](enrollment-api-reference.md)
+- [SPIFFE onboarding](spiffe-onboarding.md) for deploying SPIRE alongside Cullis


### PR DESCRIPTION
## Summary

Three new pages under `site/src/content/docs/`:

- **`enrollment.md`** — walkthrough of the four enrollment methods (admin / connector / byoca / spiffe) side-by-side, with copy-paste SDK snippets and the single runtime path via `from_api_key_file` + `send_oneshot`.
- **`enrollment-api-reference.md`** — request/response schemas for `/v1/admin/agents/enroll/byoca` and `/spiffe`, error matrix, persistence layout (`api-key` + `dpop.jwk` + `agent.json`), `internal_agents` row shape after migration 0016.
- **`migration-from-direct-login.md`** — step-by-step for existing deployments on legacy `/v1/auth/token`: upgrade Mastio, re-enroll via new endpoints (same cert/SVID material reused as trust anchor), swap SDK calls, watch the deprecation counter, flip `CULLIS_ALLOW_LEGACY_AUTH_LOGIN=false` when counter is zero.

Each page follows the existing Astro front-matter shape (`title / description / category / order / updated`). Order values 25 / 40 / 60 slot the pages into the docs index around the existing SPIFFE onboarding (30) and ops runbook (50).

Closes ADR-011 Phase 5. Remaining ADR-011 backlog is **Phase 4b** (tracked in #220 body): either rewrite sandbox `_send_to_peers` on `send_oneshot` egress, or teach the reverse-proxy to intercept intra-org `/v1/broker/sessions` so the ADR-001 short-circuit fires for JWT-path callers.

## Test plan

- [x] Markdown lint clean (front-matter parses, no broken reference links between the three new pages + `spiffe-onboarding.md`)
- [x] Pages render locally under `npm run dev` in `site/` — docs index picks them up via `[...slug].astro`
- [x] No site/src/config.ts or routing changes needed (the dynamic slug route already handles new files)