### PR TITLE
feat(sandbox): intra-org short-circuit end-to-end (ADR-011 Phase 4b)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -1225,7 +1225,19 @@ class CullisClient:
         resolve_resp.raise_for_status()
         decision = resolve_resp.json()
         transport = decision["transport"]
-        target_agent_id = decision["target_agent_id"]
+        # Resolve strips the org prefix from ``target_agent_id`` (returns
+        # just ``byoca-bot``), but every downstream handler keys on
+        # ``<org>::<agent>``. Reassemble so ``/v1/egress/message/send``'s
+        # ``decide_route`` classifies the recipient intra vs cross
+        # correctly — otherwise intra-org sends are mis-routed to the
+        # broker bridge and 404 on the Court side.
+        _resolved_org = decision.get("target_org_id")
+        _raw_target = decision["target_agent_id"]
+        target_agent_id = (
+            f"{_resolved_org}::{_raw_target}"
+            if _resolved_org and "::" not in _raw_target
+            else _raw_target
+        )
 
         sender_agent_id = getattr(self, "_proxy_agent_id", None) or self._label
         client_seq = self._client_seq.get(session_id, 0)
@@ -1382,7 +1394,19 @@ class CullisClient:
         resolve_resp.raise_for_status()
         decision = resolve_resp.json()
         transport = decision["transport"]
-        target_agent_id = decision["target_agent_id"]
+        # Resolve strips the org prefix from ``target_agent_id`` (returns
+        # just ``byoca-bot``), but every downstream handler keys on
+        # ``<org>::<agent>``. Reassemble so ``/v1/egress/message/send``'s
+        # ``decide_route`` classifies the recipient intra vs cross
+        # correctly — otherwise intra-org sends are mis-routed to the
+        # broker bridge and 404 on the Court side.
+        _resolved_org = decision.get("target_org_id")
+        _raw_target = decision["target_agent_id"]
+        target_agent_id = (
+            f"{_resolved_org}::{_raw_target}"
+            if _resolved_org and "::" not in _raw_target
+            else _raw_target
+        )
 
         if transport not in ("mtls-only", "envelope"):
             raise NotImplementedError(

--- a/cullis_sdk/crypto/e2e.py
+++ b/cullis_sdk/crypto/e2e.py
@@ -211,9 +211,19 @@ def verify_inner_signature(
     raises ValueError if invalid.
     """
     from cryptography import x509 as crypto_x509
+    from cryptography.hazmat.primitives import serialization
 
-    cert = crypto_x509.load_pem_x509_certificate(sender_cert_pem.encode())
-    pub_key = cert.public_key()
+    # Accept either a full X.509 certificate PEM or a bare SPKI public
+    # key PEM — different Cullis surfaces return one or the other (the
+    # Mastio public-key endpoint returns SPKI, the broker registry
+    # historically returned the cert). Matches the pattern in
+    # ``message_signer.verify_oneshot_envelope_signature``.
+    pem_bytes = sender_cert_pem.encode()
+    if b"CERTIFICATE" in pem_bytes:
+        cert = crypto_x509.load_pem_x509_certificate(pem_bytes)
+        pub_key = cert.public_key()
+    else:
+        pub_key = serialization.load_pem_public_key(pem_bytes)
     sig = _b64url_decode(inner_signature_b64)
 
     # Canonical format must match sign_message() in message_signer.py

--- a/enterprise_sandbox/agent/agent.py
+++ b/enterprise_sandbox/agent/agent.py
@@ -98,87 +98,72 @@ def _auth_byoca(broker: str, org_id: str, agent_id: str) -> CullisClient:
     return client
 
 
-def _auto_accept_loop(client: CullisClient, self_id: str) -> None:
-    """Accept every pending session targeting this agent."""
+def _receive_loop(client: CullisClient, self_id: str) -> None:
+    """Drain the proxy's one-shot inbox and record nonce payloads.
+
+    ADR-011 Phase 4b — replaces the old session-based poll loop. The
+    egress one-shot inbox lives on the Mastio (``/v1/egress/message/inbox``
+    under API-key + DPoP auth) for intra-org deliveries short-circuited
+    by ADR-001, and mirrors cross-org rows the broker pushed back after
+    the publisher replay. ``decrypt_oneshot`` verifies the envelope
+    signature and returns the inner payload.
+    """
     seen: set[str] = set()
     while True:
         try:
-            sessions = client.list_sessions(status="pending")
-            for s in sessions:
-                if s.target_agent_id == self_id and s.session_id not in seen:
-                    try:
-                        client.accept_session(s.session_id)
-                        seen.add(s.session_id)
-                        print(f"[{self_id}] accepted session {s.session_id[:8]} "
-                              f"from {s.initiator_agent_id}", flush=True)
-                    except Exception as exc:
-                        print(f"[{self_id}] accept {s.session_id[:8]} failed: {exc!r}",
-                              flush=True)
-        except Exception as exc:
-            print(f"[{self_id}] list_sessions(pending) failed: {exc!r}", flush=True)
-        time.sleep(1)
-
-
-def _receive_loop(client: CullisClient, self_id: str) -> None:
-    """Poll every active session and record any nonce payloads."""
-    cursors: dict[str, int] = {}
-    while True:
-        try:
-            sessions = client.list_sessions(status="active")
-            for s in sessions:
-                sid = s.session_id
-                after = cursors.get(sid, -1)
-                try:
-                    msgs = client.poll(sid, after=after, poll_interval=0)
-                except Exception as exc:
-                    print(f"[{self_id}] poll {sid[:8]} failed: {exc!r}", flush=True)
+            rows = client.receive_oneshot()
+            for row in rows:
+                msg_id = row.get("msg_id")
+                if not msg_id or msg_id in seen:
                     continue
-                for m in msgs:
-                    if isinstance(m.payload, dict) and "nonce" in m.payload:
-                        _record(m.payload["nonce"])
-                        print(f"[{self_id}] received nonce from {m.sender_agent_id}: "
-                              f"{m.payload['nonce']}", flush=True)
-                    cursors[sid] = max(cursors.get(sid, -1), m.seq)
+                try:
+                    payload = client.decrypt_oneshot(row)
+                except Exception as exc:
+                    print(f"[{self_id}] decrypt_oneshot {msg_id[:8]} failed: {exc!r}",
+                          flush=True)
+                    continue
+                # ``decrypt_oneshot`` wraps the inner payload under
+                # ``payload`` and attaches verification metadata
+                # (``sender_verified``, ``mode``). Fall back to the bare
+                # key for legacy callers that already dropped the
+                # envelope before handing us the row.
+                nested = payload.get("payload") if isinstance(payload, dict) else None
+                inner = nested if isinstance(nested, dict) and "nonce" in nested else payload
+                if isinstance(inner, dict) and "nonce" in inner:
+                    _record(inner["nonce"])
+                    sender = row.get("sender_agent_id", "?")
+                    print(f"[{self_id}] received nonce from {sender}: "
+                          f"{inner['nonce']}", flush=True)
+                seen.add(msg_id)
+                # Dedup via the ``seen`` set is enough for the sandbox —
+                # the inbox endpoint returns every undelivered row on
+                # each poll, and the demo's nonce set is bounded + small.
+                # A production runtime would also ack so pg/broker state
+                # can reclaim the row (ADR-008 Phase 2 work).
         except Exception as exc:
-            print(f"[{self_id}] list_sessions(active) failed: {exc!r}", flush=True)
+            print(f"[{self_id}] receive_oneshot failed: {exc!r}", flush=True)
         time.sleep(1)
 
 
 def _send_to_peers(client: CullisClient, self_id: str, peers: list[str]) -> None:
-    """Open a session to each peer and send one nonce, retrying until the
-    session transitions from pending → active (peer accepts)."""
-    for peer_id in peers:
-        peer_org, _ = peer_id.split("::", 1)
-        try:
-            # target_agent_id is the full "{org}::{name}" form — broker's
-            # lookup is keyed on that, not on the short name.
-            session_id = client.open_session(
-                target_agent_id=peer_id,
-                target_org_id=peer_org,
-                capabilities=["sandbox.read"],
-            )
-        except Exception as exc:
-            print(f"[{self_id}] open_session {peer_id} failed: {exc!r}", flush=True)
-            continue
-        print(f"[{self_id}] session {session_id[:8]} opened → {peer_id}", flush=True)
+    """Send one nonce per peer via the ADR-008 sessionless one-shot path.
 
+    ADR-011 Phase 4b — replaced ``open_session`` + ``send`` with
+    ``send_oneshot``. The call hits ``/v1/egress/resolve`` + ``/v1/egress/
+    message/send`` on the Mastio (API-key + DPoP), which triggers the
+    ADR-001 intra-org short-circuit when ``PROXY_INTRA_ORG=true`` and the
+    peer lives on the same proxy — the Court never sees intra-org
+    traffic. Cross-org targets resolve to ``envelope`` transport and
+    ride the ADR-009 counter-signature chain end-to-end.
+    """
+    for peer_id in peers:
         nonce = f"{self_id}->{peer_id}:{uuid.uuid4().hex[:8]}"
-        for attempt in range(90):  # up to 90s for peer auto-accept
-            try:
-                client.send(
-                    session_id=session_id,
-                    sender_agent_id=self_id,
-                    payload={"nonce": nonce},
-                    recipient_agent_id=peer_id,
-                )
-                print(f"[{self_id}] sent nonce to {peer_id}", flush=True)
-                break
-            except Exception as exc:
-                if attempt < 89:
-                    time.sleep(1)
-                else:
-                    print(f"[{self_id}] send to {peer_id} giving up: {exc!r}",
-                          flush=True)
+        try:
+            client.send_oneshot(peer_id, {"nonce": nonce})
+            print(f"[{self_id}] sent oneshot nonce to {peer_id}", flush=True)
+        except Exception as exc:
+            print(f"[{self_id}] send_oneshot {peer_id} failed: {exc!r}",
+                  flush=True)
 
 
 def _auth_api_key_file(mastio_url: str, identity_dir: str, self_id: str) -> CullisClient:
@@ -297,9 +282,9 @@ def main() -> int:
         peers = []
     print(f"[{self_id}] peers: {peers}", flush=True)
 
-    threading.Thread(
-        target=_auto_accept_loop, args=(client, self_id), daemon=True,
-    ).start()
+    # ADR-011 Phase 4b — no ``_auto_accept_loop`` anymore. One-shot
+    # envelopes are fire-and-forget on the sender side and inbox-polled
+    # on the receiver side; there is no session handshake to accept.
     threading.Thread(
         target=_receive_loop, args=(client, self_id), daemon=True,
     ).start()

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -263,6 +263,12 @@ services:
       # local mini-broker handles intra-org traffic end-to-end and
       # the Court only sees cross-org sessions.
       PROXY_INTRA_ORG: "true"
+      # ADR-011 Phase 4b — signed-but-not-encrypted transport for
+      # intra-org one-shots. Keeps the SDK from needing the peer's
+      # cert_pem at send time (the proxy verifies the signature +
+      # drops the payload into the local inbox). Hybrid/envelope
+      # would require distributing every peer's cert ahead of time.
+      PROXY_TRANSPORT_INTRA_ORG: "mtls-only"
     volumes:
       - proxy-a-data:/data
     networks:
@@ -492,6 +498,8 @@ services:
       MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
       # ADR-011 Phase 4 — intra-org short-circuit (see proxy-a).
       PROXY_INTRA_ORG: "true"
+      # ADR-011 Phase 4b — see proxy-a rationale.
+      PROXY_TRANSPORT_INTRA_ORG: "mtls-only"
     volumes:
       - proxy-b-data:/data
     networks:

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -289,28 +289,23 @@ async def send_oneshot(
             status="duplicate" if duplicate else "enqueued",
         )
 
-    # ADR-011 Phase 4b — persist the full ``<org>::<agent>`` form so the
-    # ``/inbox`` lookup (keyed on ``agent.agent_id`` from the DPoP dep,
-    # which carries the full form) matches. Session /send used to store
-    # only the bare agent name which worked because the session was
-    # already scoped to this org by the session row itself — one-shots
-    # have no such scope, so the bare form dropped rows on the floor
-    # during intra-org delivery.
-    recipient_full: str
+    # Recipient must match the internal_agents.agent_id format the
+    # receiver presents at /inbox. Session /send stores the bare agent
+    # name (recipient=session.target_agent_id); align here.
+    recipient_bare: str
     if body.recipient_id.startswith("spiffe://"):
         from mcp_proxy.spiffe import parse_spiffe
-        _, rec_org, rec_bare = parse_spiffe(body.recipient_id)
-        recipient_full = f"{rec_org}::{rec_bare}"
+        _, _, recipient_bare = parse_spiffe(body.recipient_id)
     elif "::" in body.recipient_id:
-        recipient_full = body.recipient_id
+        recipient_bare = body.recipient_id.split("::", 1)[1]
     else:
-        recipient_full = f"{local_org}::{body.recipient_id}" if local_org else body.recipient_id
+        recipient_bare = body.recipient_id
 
     envelope = _serialize_envelope(body)
 
     msg_id, inserted = await local_queue.enqueue_oneshot(
         sender_agent_id=agent.agent_id,
-        recipient_agent_id=recipient_full,
+        recipient_agent_id=recipient_bare,
         correlation_id=corr_id,
         reply_to_correlation_id=body.reply_to,
         payload_ciphertext=envelope,
@@ -324,7 +319,7 @@ async def send_oneshot(
     if ws_manager is not None and inserted:
         try:
             await ws_manager.send_to_agent(
-                recipient_full,
+                recipient_bare,
                 {
                     "type": "oneshot_message",
                     "msg_id": msg_id,
@@ -426,9 +421,17 @@ async def receive_oneshot_inbox(
                     },
                 )
 
-    all_pending = await local_queue.fetch_pending_for_recipient(
-        agent.agent_id,
-    )
+    # ADR-011 Phase 4b — match recipient in both forms. Legacy oneshot
+    # rows + session /send store the bare ``<name>``; admin + Connector
+    # enrollment under ADR-010/011 write ``<org>::<name>`` into
+    # ``internal_agents.agent_id`` so the DPoP dep presents the full
+    # form here. Union both so neither path drops rows on the floor.
+    bare_name = agent.agent_id.split("::", 1)[-1] if "::" in agent.agent_id else agent.agent_id
+    all_pending = list(await local_queue.fetch_pending_for_recipient(agent.agent_id))
+    if bare_name != agent.agent_id:
+        extras = await local_queue.fetch_pending_for_recipient(bare_name)
+        seen_ids = {m.msg_id for m in all_pending}
+        all_pending.extend(m for m in extras if m.msg_id not in seen_ids)
     one_shots = [m for m in all_pending if m.is_oneshot]
 
     return InboxResponse(

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -289,23 +289,28 @@ async def send_oneshot(
             status="duplicate" if duplicate else "enqueued",
         )
 
-    # Recipient must match the internal_agents.agent_id format the
-    # receiver presents at /inbox. Session /send stores the bare agent
-    # name (recipient=session.target_agent_id); align here.
-    recipient_bare: str
+    # ADR-011 Phase 4b — persist the full ``<org>::<agent>`` form so the
+    # ``/inbox`` lookup (keyed on ``agent.agent_id`` from the DPoP dep,
+    # which carries the full form) matches. Session /send used to store
+    # only the bare agent name which worked because the session was
+    # already scoped to this org by the session row itself — one-shots
+    # have no such scope, so the bare form dropped rows on the floor
+    # during intra-org delivery.
+    recipient_full: str
     if body.recipient_id.startswith("spiffe://"):
         from mcp_proxy.spiffe import parse_spiffe
-        _, _, recipient_bare = parse_spiffe(body.recipient_id)
+        _, rec_org, rec_bare = parse_spiffe(body.recipient_id)
+        recipient_full = f"{rec_org}::{rec_bare}"
     elif "::" in body.recipient_id:
-        recipient_bare = body.recipient_id.split("::", 1)[1]
+        recipient_full = body.recipient_id
     else:
-        recipient_bare = body.recipient_id
+        recipient_full = f"{local_org}::{body.recipient_id}" if local_org else body.recipient_id
 
     envelope = _serialize_envelope(body)
 
     msg_id, inserted = await local_queue.enqueue_oneshot(
         sender_agent_id=agent.agent_id,
-        recipient_agent_id=recipient_bare,
+        recipient_agent_id=recipient_full,
         correlation_id=corr_id,
         reply_to_correlation_id=body.reply_to,
         payload_ciphertext=envelope,
@@ -319,7 +324,7 @@ async def send_oneshot(
     if ws_manager is not None and inserted:
         try:
             await ws_manager.send_to_agent(
-                recipient_bare,
+                recipient_full,
                 {
                     "type": "oneshot_message",
                     "msg_id": msg_id,

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -837,17 +837,22 @@ async def resolve_recipient(
 
         target_cert_pem: str | None = None
         if transport == "mtls-only":
-            # ``internal_agents.agent_id`` is stored as ``<org>::<name>``;
-            # ``parse_recipient`` returns just the short name, so the
-            # lookup must reassemble the full key before querying.
+            # ``internal_agents.agent_id`` is ``<org>::<name>`` in
+            # production (ADR-010 invariant) but legacy rows + some
+            # test fixtures still use the bare ``<name>`` form. Try
+            # full first, then bare — picking the first row via
+            # ``ORDER BY`` so the full-form match wins when both
+            # exist. 404 only if neither is found.
             full_agent_id = f"{target_org}::{target_agent}"
             async with get_db() as conn:
                 result = await conn.execute(
                     text(
                         "SELECT cert_pem, is_active FROM internal_agents "
-                        "WHERE agent_id = :agent_id"
+                        "WHERE agent_id IN (:full_id, :bare_id) "
+                        "ORDER BY CASE WHEN agent_id = :full_id "
+                        "THEN 0 ELSE 1 END LIMIT 1"
                     ),
-                    {"agent_id": full_agent_id},
+                    {"full_id": full_agent_id, "bare_id": target_agent},
                 )
                 row = result.mappings().first()
                 if row is None or not row["is_active"]:

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -837,19 +837,23 @@ async def resolve_recipient(
 
         target_cert_pem: str | None = None
         if transport == "mtls-only":
+            # ``internal_agents.agent_id`` is stored as ``<org>::<name>``;
+            # ``parse_recipient`` returns just the short name, so the
+            # lookup must reassemble the full key before querying.
+            full_agent_id = f"{target_org}::{target_agent}"
             async with get_db() as conn:
                 result = await conn.execute(
                     text(
                         "SELECT cert_pem, is_active FROM internal_agents "
                         "WHERE agent_id = :agent_id"
                     ),
-                    {"agent_id": target_agent},
+                    {"agent_id": full_agent_id},
                 )
                 row = result.mappings().first()
                 if row is None or not row["is_active"]:
                     raise HTTPException(
                         status_code=404,
-                        detail=f"intra-org target not found: {target_agent}",
+                        detail=f"intra-org target not found: {full_agent_id}",
                     )
                 target_cert_pem = row["cert_pem"]
 


### PR DESCRIPTION
## Summary

Chiude l'unico gap rimasto di ADR-011 Phase 4: intra-org A2A nel sandbox attraversava ancora il Court perché gli agent usavano sessioni JWT-based anziché il path egress API-key + DPoP dove vive l'ADR-001 short-circuit.

### Sandbox — agent.py

`_send_to_peers` riscritto su `client.send_oneshot` (un envelope per peer, zero sessioni). `_receive_loop` legge da `client.receive_oneshot` + `decrypt_oneshot` con dedup. `_auto_accept_loop` rimosso. Il loop inner parse accetta sia il wrap di `decrypt_oneshot` che il bare `{"nonce": ...}`.

### Docker-compose

`PROXY_TRANSPORT_INTRA_ORG=mtls-only` su entrambi i proxy. In `envelope` (default) il SDK richiederebbe il cert del peer ad-hoc per cifrare; in `mtls-only` il proxy verifica la firma e deposita il payload in `local_messages` senza encryption.

### Bug fix scoperti durante Phase 4b (non scoped ma blocker)

1. **SDK `send_oneshot`**: dopo `/v1/egress/resolve` riassembla `<org>::<agent>` — il resolve stripava l'org prefix ma ogni handler downstream chiave su full form. Senza il fix intra-org send classificava come cross e 502ava.
2. **Mastio `resolve_recipient` intra mtls-only**: lookup DB usava bare `target_agent` invece del full `<org>::<agent>` → 404 su ogni intra-org resolve.
3. **Mastio `message/send` enqueue**: persisteva `recipient_agent_id` in bare form, il `/inbox` lo cercava in full form → row mai consegnato.
4. **SDK `verify_inner_signature`**: ora accetta sia cert PEM che SPKI public key PEM — la Mastio public-key endpoint ritorna SPKI post #212 ma `decrypt_oneshot` alzava `no BEGIN CERTIFICATE`. Matcha il branching già in `message_signer.verify_*`.

## Test plan

- [x] `SMOKE_ASSERT_INTRA_ORG=1 ./smoke.sh` → **25 PASS / 0 FAIL / 0 SKIP**
- [x] B4.7 completo: 6 nonces delivered (3 intra-org + 3 cross-org)
- [x] B4.9: zero intra-org sessions nel Court dopo il trigger
- [x] B4.8 invariato: agent no direct path to broker:8000
- [x] `pytest tests/test_sdk_enrollment_unified.py` → 10/10 (pre-existing coverage on the SDK factory methods)