### PR TITLE
fix(sandbox): down.sh must cover the full profile

### DIFF
--- a/enterprise_sandbox/down.sh
+++ b/enterprise_sandbox/down.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 # Enterprise sandbox — down
+#
+# ``--profile full`` is required: several services (byoca-a, mcp-catalog,
+# the runtime agents) are gated behind ``profiles: ["full"]`` in
+# docker-compose.yml. A vanilla ``docker compose down`` ignores them, so
+# after ``demo.sh full`` they survive as zombies on stale networks, and
+# the next ``demo.sh full`` reuses them without recreating — which breaks
+# inter-org DNS and surfaces as spurious 401s on ``/v1/egress/message/inbox``
+# in smoke B4.7. Whenever a new profile is added to compose, extend this.
 set -euo pipefail
 
 cd "$(dirname "$0")"
 
-docker compose down -v --remove-orphans
+docker compose --profile full down -v --remove-orphans


### PR DESCRIPTION
## Summary

- ``enterprise_sandbox/down.sh`` now runs the compose teardown under ``--profile full`` so profile-gated services (``byoca-a``, ``mcp-catalog``, runtime agents) are actually removed.
- Without this, ``demo.sh full → down.sh → demo.sh full`` leaves those containers alive on stale inter-org networks, compose skips recreating them, and smoke **B4.7** fails with empty ``/tmp/received.json`` + repeated 401s on ``/v1/egress/message/inbox``.
- Added a docstring in ``down.sh`` flagging the invariant for future profiles.

## Root cause

``docker compose down`` ignores services with ``profiles: [...]``. After ADR-011 Phase 4b (#222), ``byoca-a`` is profile-gated. A vanilla down left it attached to removed-and-recreated networks — the container's DNS cache pointed at the old ``proxy-a`` IP and every subsequent request failed.

## Test plan

- [x] ``./demo.sh full → ./down.sh → ./demo.sh full → ./smoke.sh`` → **24 PASS / 0 FAIL / 1 SKIP** (baseline; SKIP is the existing ``B4.9`` gate on ``SMOKE_ASSERT_INTRA_ORG=1``)
- [x] ``docker ps -a --filter name=enterprise_sandbox`` after ``./down.sh`` → 0 containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)