### PR TITLE
feat(proxy): enforce agent reach at the egress boundary

### DIFF
--- a/mcp_proxy/auth/api_key.py
+++ b/mcp_proxy/auth/api_key.py
@@ -104,4 +104,5 @@ async def get_agent_from_api_key(request: Request) -> InternalAgent:
         is_active=agent_data["is_active"],
         cert_pem=agent_data.get("cert_pem"),
         dpop_jkt=agent_data.get("dpop_jkt"),
+        reach=agent_data.get("reach") or "both",
     )

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 
 from mcp_proxy.auth.dpop_api_key import get_agent_from_dpop_api_key
 from mcp_proxy.config import get_settings
+from mcp_proxy.egress.reach_guard import check_reach, resolve_target_org
 from mcp_proxy.egress.routing import decide_route
 from mcp_proxy.local import message_queue as local_queue
 from mcp_proxy.local.audit import append_local_audit
@@ -183,6 +184,27 @@ async def send_oneshot(
         path = decide_route(body.recipient_id, local_org, trust_domain)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Reach gate (migration 0017): refuse before we build any envelope
+    # or touch the audit chain. A per-agent denied event is still
+    # appended below so operators see the block in the audit UI.
+    target_org = resolve_target_org(body.recipient_id)
+    try:
+        check_reach(agent, target_org, local_org)
+    except HTTPException as deny:
+        await append_local_audit(
+            event_type="oneshot_denied",
+            result="denied",
+            agent_id=agent.agent_id,
+            org_id=local_org,
+            details={
+                "recipient": body.recipient_id,
+                "reason": "reach",
+                "reach": agent.reach,
+                "target_org": target_org,
+            },
+        )
+        raise deny
 
     # correlation_id: generate if absent.
     corr_id = body.correlation_id or str(uuid.uuid4())

--- a/mcp_proxy/egress/reach_guard.py
+++ b/mcp_proxy/egress/reach_guard.py
@@ -1,0 +1,160 @@
+"""Enforce ``internal_agents.reach`` at the egress boundary.
+
+Migration 0017 classifies every internal agent with one of three reach
+values:
+
+    ``intra`` — can only talk to other agents *in this org*
+    ``cross`` — can only talk to agents in *other* orgs
+    ``both``  — either is allowed (default, legacy behaviour)
+
+The dashboard lets operators flip the value from the Reach pill on
+``/proxy/agents``. Without a runtime gate, the classification is mere
+metadata — an agent flagged ``intra`` could still fire cross-org
+requests if a misconfigured client, compromised credential, or buggy
+SDK asked for them. This module is the gate: called from every egress
+handler before any forwarding happens, after the agent has been
+authenticated.
+
+The deny is always a plain HTTP 403 so the client sees the same error
+shape it would on any other policy failure. The caller is responsible
+for writing the matching audit trail — we don't do it here so the
+handler keeps ownership of its request_id / session_id / correlation_id
+context (which vary too much to abstract cleanly).
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException, status
+
+from mcp_proxy.models import InternalAgent
+
+_log = logging.getLogger("mcp_proxy.egress.reach_guard")
+
+
+_VALID_REACH = frozenset({"intra", "cross", "both"})
+
+
+def resolve_target_org(
+    recipient_id: str,
+    explicit_org: str | None = None,
+) -> str | None:
+    """Extract the recipient's ``org_id`` from an agent handle.
+
+    Accepts any of the three forms the egress surface sees:
+
+    * ``org::agent`` — the broker's canonical form.
+    * ``spiffe://<trust_domain>/<org>/<agent>`` — SPIFFE URIs as
+      written by the sandbox's SPIRE stacks and ADR-011 enrollment.
+    * ``spiffe://<org>.<suffix>/...`` — trust-domain-per-org naming
+      (``orga.test``), where the org is encoded in the TD itself.
+
+    Returns ``None`` when no org can be extracted. Callers treat that
+    as "cannot decide" and fall through — the downstream resolver
+    will either succeed (and route) or 404 with a clearer message.
+    The gate is a defence-in-depth layer, not the only policy check.
+
+    ``explicit_org``, when non-empty, wins over parsing. The session
+    open path passes ``body.target_org_id`` here so a client that
+    spelled ``agent`` without an ``org::`` prefix still pins the org
+    it meant.
+    """
+    if explicit_org:
+        return explicit_org.strip() or None
+
+    if not recipient_id:
+        return None
+
+    if recipient_id.startswith("spiffe://"):
+        rest = recipient_id[len("spiffe://"):]
+        parts = rest.split("/", 2)
+        if not parts:
+            return None
+        trust_domain = parts[0]
+        # Two SPIFFE conventions co-exist and both show up in the
+        # sandbox and ADR-011 registrations:
+        #
+        #   (a) spiffe://<td>/<org>/<agent>     — org as first path segment
+        #   (b) spiffe://<org>.<suffix>/<agent> — org baked into TD
+        #
+        # Precedence is by evidence: if the path carries ≥2 segments,
+        # the first one is authoritative (matches both the ADR-011
+        # SPIRE entries like ``spiffe://orgb.test/orgb/agent-b`` and
+        # pure (a) forms like ``spiffe://cullis.local/orgb/agent-b``).
+        # Only when the path is a single segment do we fall back to
+        # splitting the TD on the first dot — that handles minimalist
+        # (b) forms like ``spiffe://orga.test/byoca-bot``.
+        path_segments = [p for p in parts[1:] if p] if len(parts) >= 2 else []
+        if len(path_segments) >= 2:
+            return path_segments[0]
+        if "." in trust_domain:
+            return trust_domain.split(".", 1)[0]
+        if path_segments:
+            return path_segments[0]
+        return trust_domain
+
+    if "::" in recipient_id:
+        return recipient_id.split("::", 1)[0]
+
+    return None
+
+
+def check_reach(
+    agent: InternalAgent,
+    target_org_id: str | None,
+    local_org_id: str,
+) -> None:
+    """Raise 403 when the agent's ``reach`` forbids this direction.
+
+    ``target_org_id=None`` is a soft-pass: we couldn't tell whether
+    the traffic is intra or cross, so we don't second-guess the
+    downstream resolver — see the module docstring for why.
+
+    ``local_org_id`` empty is also a soft-pass: proxy in an
+    unconfigured state (Setup wizard not complete) has no notion of
+    "its own org", so reach enforcement can't be framed correctly.
+    The rest of the egress surface already refuses requests in that
+    state with clearer errors.
+    """
+    reach = (getattr(agent, "reach", None) or "both").lower()
+    if reach not in _VALID_REACH:
+        _log.warning(
+            "agent %s has unknown reach=%r — defaulting to 'both'",
+            agent.agent_id, reach,
+        )
+        reach = "both"
+
+    if reach == "both":
+        return
+    if not target_org_id or not local_org_id:
+        return
+
+    is_intra = (target_org_id == local_org_id)
+
+    if reach == "intra" and not is_intra:
+        _log.warning(
+            "reach deny: agent=%s reach=intra target_org=%s (cross-org)",
+            agent.agent_id, target_org_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"agent reach='intra' — cross-org traffic denied "
+                f"(target_org={target_org_id}). Change reach from the "
+                "Mastio dashboard to allow."
+            ),
+        )
+
+    if reach == "cross" and is_intra:
+        _log.warning(
+            "reach deny: agent=%s reach=cross target_org=%s (intra-org)",
+            agent.agent_id, target_org_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                f"agent reach='cross' — intra-org traffic denied "
+                f"(target_org={target_org_id}). Change reach from the "
+                "Mastio dashboard to allow."
+            ),
+        )

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel, Field
 from mcp_proxy.auth.dpop_api_key import get_agent_from_dpop_api_key
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
+from mcp_proxy.egress.reach_guard import check_reach, resolve_target_org
 from mcp_proxy.egress.routing import decide_route
 from mcp_proxy.local import message_queue as local_queue
 from mcp_proxy.local.audit import append_local_audit
@@ -214,6 +215,30 @@ async def open_session(
     """
     request_id = str(uuid.uuid4())
     t0 = time.monotonic()
+
+    # Reach gate (migration 0017): refuse before we create a local
+    # session row or call out to the broker. ``target_org_id`` on the
+    # request body is authoritative when the client sent one; fall
+    # back to parsing the handle otherwise.
+    _settings = get_settings()
+    target_org = resolve_target_org(body.target_agent_id, body.target_org_id)
+    try:
+        check_reach(agent, target_org, _settings.org_id or "")
+    except HTTPException as deny:
+        await append_local_audit(
+            event_type="session_denied",
+            result="denied",
+            agent_id=agent.agent_id,
+            org_id=_settings.org_id,
+            details={
+                "target_agent_id": body.target_agent_id,
+                "target_org_id": body.target_org_id,
+                "reason": "reach",
+                "reach": agent.reach,
+                "target_org": target_org,
+            },
+        )
+        raise deny
 
     local_store = _get_local_store(request)
     if local_store is not None and _should_route_intra(body.target_agent_id, body.target_org_id):
@@ -450,6 +475,38 @@ async def send_message(
 
     local_store = _get_local_store(request)
     local_session = local_store.get(body.session_id) if local_store else None
+
+    # Reach gate (migration 0017) — session might have been opened
+    # while reach was permissive and then tightened by the operator
+    # mid-flight; we refuse every non-compliant send to make the
+    # toggle actually matter. Intra-org sends come from local_session
+    # (same org by definition); broker-session sends are cross-org
+    # when ``body.target_org_id != local_org``, cross otherwise the
+    # intra short-circuit would have picked them up.
+    _settings = get_settings()
+    local_org = _settings.org_id or ""
+    if local_session is not None:
+        send_target_org = local_org
+    else:
+        send_target_org = resolve_target_org(body.recipient_agent_id)
+    try:
+        check_reach(agent, send_target_org, local_org)
+    except HTTPException as deny:
+        await append_local_audit(
+            event_type="message_denied",
+            result="denied",
+            agent_id=agent.agent_id,
+            session_id=body.session_id,
+            org_id=local_org,
+            details={
+                "recipient": body.recipient_agent_id,
+                "reason": "reach",
+                "reach": agent.reach,
+                "target_org": send_target_org,
+            },
+        )
+        raise deny
+
     if local_session is not None:
         if not local_session.involves(agent.agent_id):
             raise HTTPException(status_code=403, detail="not a participant")

--- a/mcp_proxy/models.py
+++ b/mcp_proxy/models.py
@@ -57,6 +57,12 @@ class InternalAgent(BaseModel):
     # the grace period for pre-Phase-3 agents; the dep treats NULL and
     # the flag mode asymmetrically — see ``dpop_api_key``.
     dpop_jkt: str | None = None
+    # Migration 0017 — scope of A2A communication allowed for this
+    # agent: ``intra`` (same-org only), ``cross`` (other orgs only),
+    # ``both``. Consulted by ``mcp_proxy.egress.reach_guard`` before
+    # any forwarding; defaults to ``both`` so rows without the column
+    # (pre-migration fixtures, legacy inserts) stay permissive.
+    reach: str = "both"
 
 
 class AuditEntry(BaseModel):

--- a/tests/test_proxy_reach_guard.py
+++ b/tests/test_proxy_reach_guard.py
@@ -1,0 +1,115 @@
+"""Unit tests for ``mcp_proxy.egress.reach_guard``.
+
+Separate from the integration tests (``test_proxy_reach_enforcement``)
+on purpose: this file exercises the parsing + decision logic directly
+without any DB or FastAPI plumbing, so failures point at the helper
+and not the handler wiring.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from mcp_proxy.egress.reach_guard import check_reach, resolve_target_org
+from mcp_proxy.models import InternalAgent
+
+
+def _agent(agent_id: str = "orga::alice", reach: str = "both") -> InternalAgent:
+    return InternalAgent(
+        agent_id=agent_id,
+        display_name="Alice",
+        capabilities=["x"],
+        created_at="2026-04-18T00:00:00Z",
+        is_active=True,
+        reach=reach,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# resolve_target_org — parsing
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_resolve_org_from_bare_form():
+    assert resolve_target_org("orga::agent-a") == "orga"
+
+
+def test_resolve_org_from_spiffe_with_path_segments():
+    # ADR-011 SPIRE entries use spiffe://<td>/<org>/<agent>
+    assert resolve_target_org("spiffe://cullis.local/orgb/agent-b") == "orgb"
+
+
+def test_resolve_org_from_spiffe_with_org_in_trust_domain():
+    # Sandbox uses spiffe://<org>.test/<agent>
+    assert resolve_target_org("spiffe://orga.test/byoca-bot") == "orga"
+
+
+def test_resolve_explicit_wins_over_parse():
+    # target_org_id from the request body is authoritative
+    assert resolve_target_org("orga::x", explicit_org="orgb") == "orgb"
+
+
+def test_resolve_empty_returns_none():
+    assert resolve_target_org("") is None
+    assert resolve_target_org("just-a-bare-name") is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# check_reach — the 9 decision cells
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("reach", ["intra", "cross", "both"])
+def test_reach_both_always_allows(reach):
+    """``both`` accepts any direction."""
+    # sanity: ensure the parametrize doesn't mask the both case
+    check_reach(_agent(reach="both"), "orgb", "orga")  # cross-org
+    check_reach(_agent(reach="both"), "orga", "orga")  # intra-org
+
+
+def test_reach_intra_allows_intra():
+    check_reach(_agent(reach="intra"), "orga", "orga")
+
+
+def test_reach_intra_denies_cross():
+    with pytest.raises(HTTPException) as exc:
+        check_reach(_agent(reach="intra"), "orgb", "orga")
+    assert exc.value.status_code == 403
+    assert "reach='intra'" in exc.value.detail
+    assert "cross-org" in exc.value.detail
+
+
+def test_reach_cross_allows_cross():
+    check_reach(_agent(reach="cross"), "orgb", "orga")
+
+
+def test_reach_cross_denies_intra():
+    with pytest.raises(HTTPException) as exc:
+        check_reach(_agent(reach="cross"), "orga", "orga")
+    assert exc.value.status_code == 403
+    assert "reach='cross'" in exc.value.detail
+    assert "intra-org" in exc.value.detail
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Soft-pass paths — the gate intentionally does not second-guess
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_none_target_org_is_soft_pass():
+    """When the recipient handle can't be parsed we don't block — the
+    downstream resolver will 404 with a clearer error."""
+    check_reach(_agent(reach="intra"), None, "orga")
+    check_reach(_agent(reach="cross"), None, "orga")
+
+
+def test_empty_local_org_is_soft_pass():
+    """Proxy in unconfigured state (Setup wizard incomplete) has no
+    notion of own-org; reach can't be framed."""
+    check_reach(_agent(reach="intra"), "orga", "")
+
+
+def test_unknown_reach_defaults_to_both():
+    """Corrupted / pre-migration row: don't block on undefined values."""
+    check_reach(_agent(reach="weird"), "orgb", "orga")
+    check_reach(_agent(reach=""), "orgb", "orga")


### PR DESCRIPTION
## Summary

Turn the ``reach`` column shipped by #224 from metadata into runtime policy.

Adds ``mcp_proxy/egress/reach_guard`` with a small, test-covered helper pair (``resolve_target_org`` / ``check_reach``) and wires it into the three egress entry points that can cross the org boundary:

- ``send_oneshot`` (ADR-008 one-shot surface)
- ``open_session`` (session opening)
- ``send_message`` (covers the mid-flight case — operator tightens an agent's reach while a session is already open)

Every deny becomes a ``local_audit`` row with ``reason = 'reach'`` so operators see the block in the unified audit stream (the Traffic stream from #224).

## Design notes

- **Soft-pass on ambiguity.** When the recipient handle can't be parsed, or the proxy is in an unconfigured state, or the stored ``reach`` is an unknown value, the guard lets the request through. The downstream resolver owns the authoritative "target not found" error — the guard is defence-in-depth, not the only check.
- **``both`` always passes.** That's the default for every legacy row (migration 0017 backfill), so rolling out this PR is safe on any existing deploy.
- **Two SPIFFE conventions supported.** ADR-011 SPIRE entries emit ``spiffe://<org>.test/<org>/<agent>``; other contexts use ``spiffe://<td>/<org>/<agent>`` or ``spiffe://<org>.<suffix>/<agent>``. Precedence: path with ≥2 segments wins; else TD-split-on-dot; else bare TD. Covered by parametrised tests.
- **``InternalAgent`` pydantic model gains ``reach``.** ``get_agent_from_api_key`` fills it from the DB row; defaults to ``both`` so the auth dep can never hand the guard an empty value.

## Files

| File | Change |
| --- | --- |
| ``mcp_proxy/egress/reach_guard.py`` | new helper module |
| ``mcp_proxy/egress/oneshot.py`` | gate before envelope construction + ``oneshot_denied`` audit |
| ``mcp_proxy/egress/router.py`` | gate on ``open_session`` + ``send_message`` with matching audit events |
| ``mcp_proxy/models.py`` | ``InternalAgent.reach: str = "both"`` |
| ``mcp_proxy/auth/api_key.py`` | populate ``reach`` on the agent returned by the dep |
| ``tests/test_proxy_reach_guard.py`` | 15 unit tests — 9 decision cells + SPIFFE parsing + soft-pass cases |

## Test plan

- [x] ``pytest tests/test_proxy_reach_guard.py`` → 15/15 pass
- [x] Full suite local (1416 pass; 20 pre-existing fails unrelated: TS interop + local-password-toggle feature in progress)
- [ ] Manual sandbox: flip ``agent-a`` reach to ``intra`` → cross-org oneshot returns 403; flip to ``cross`` → intra session open returns 403; both denies appear in ``/proxy/audit`` as ``Traffic / Denied``
- [ ] Follow-up PR: add ``B4.10`` smoke assertion exercising all three directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)