### PR TITLE
fix(sandbox): align scenarios to ADR-011 Phase 4b + UX polish

### DIFF
--- a/enterprise_sandbox/demo.sh
+++ b/enterprise_sandbox/demo.sh
@@ -24,16 +24,45 @@ _header() { echo -e "\n${BOLD}${CYAN}═══ $1 ═══${RESET}\n"; }
 _ok()     { echo -e "  ${GREEN}✓${RESET} $1"; }
 _note()   { echo -e "  ${YELLOW}•${RESET} $1"; }
 
+_court_bootstrap_token() {
+    # One-shot token generated at broker startup (F-B-4). Used only on
+    # the very first /dashboard/setup visit to pick the admin password.
+    # Empty once consumed — that means an admin has already set the password.
+    docker compose exec -T broker \
+        sh -c 'cat /app/certs/.admin_bootstrap_token 2>/dev/null' \
+        2>/dev/null | tr -d '[:space:]'
+}
+
 _print_dashboards() {
     _header "Dashboard URLs"
-    echo -e "  ${GREEN}Court (broker)${RESET}      http://localhost:8000/dashboard/login"
-    echo -e "                       admin / sandbox-admin-secret-change-me"
+    echo -e "  ${GREEN}Court (broker)${RESET}      http://localhost:8000/dashboard/setup"
+    local token
+    token=$(_court_bootstrap_token || true)
+    if [ -n "$token" ]; then
+        echo -e "                       first visit → paste this bootstrap token and pick your password:"
+        echo -e "                       ${BOLD}${token}${RESET}"
+    else
+        echo -e "                       (admin password already set — login at /dashboard/login)"
+    fi
     echo -e "  ${GREEN}Mastio A (proxy-a)${RESET}  http://localhost:9100/proxy"
     echo -e "                       admin secret: sandbox-proxy-admin-a"
     echo -e "  ${GREEN}Mastio B (proxy-b)${RESET}  http://localhost:9200/proxy"
     echo -e "                       admin secret: sandbox-proxy-admin-b"
     echo -e "  ${GREEN}Keycloak A${RESET}          http://localhost:8180 (alice / alice-sandbox)"
     echo -e "  ${GREEN}Keycloak B${RESET}          http://localhost:8280 (bob / bob-sandbox)"
+}
+
+_print_scenarios() {
+    _header "Try it — send messages between agents"
+    echo -e "  ${GREEN}./demo.sh oneshot-a-to-b${RESET}   cross-org: orga::agent-a → orgb::agent-b (via Court)"
+    echo -e "  ${GREEN}./demo.sh oneshot-b-to-a${RESET}   cross-org: orgb::agent-b → orga::agent-a (via Court)"
+    echo -e "  ${GREEN}./demo.sh mcp-catalog${RESET}      intra-org MCP: orga::agent-a → get_catalog"
+    echo -e "  ${GREEN}./demo.sh mcp-inventory${RESET}    intra-org MCP: orgb::agent-b → check_inventory"
+}
+
+_print_teardown() {
+    _header "Teardown"
+    echo -e "  ${GREEN}./demo.sh down${RESET}             stop everything + drop volumes"
 }
 
 case "${1:-help}" in
@@ -48,6 +77,7 @@ case "${1:-help}" in
     _header "Services Running"
     docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
     _print_dashboards
+    _print_teardown
     echo ""
     _ok "Sandbox ready. Run ${BOLD}demo.sh help${RESET} to see commands."
     ;;
@@ -61,6 +91,8 @@ case "${1:-help}" in
     _header "Services Running"
     docker compose --profile full ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
     _print_dashboards
+    _print_scenarios
+    _print_teardown
     echo ""
     _ok "Full sandbox ready."
     ;;
@@ -138,7 +170,7 @@ Lifecycle:
 Inspection:
   status          List services + health.
   logs [svc]      Tail compose logs (default: --tail=50).
-  dashboard       Print dashboard URLs + admin secrets.
+  dashboard       Print dashboard URLs + Court bootstrap token (first login).
   bootstrap-logs  Replay the verbose Phase 1-7 bootstrap output.
 
 Scenarios (require 'full' mode — orga workloads must be running):

--- a/enterprise_sandbox/scenarios/_identity.py
+++ b/enterprise_sandbox/scenarios/_identity.py
@@ -1,0 +1,47 @@
+"""Shared helper — load a CullisClient using the credentials that
+``bootstrap-mastio`` enrolled for each sandbox agent (ADR-011 Phase 4).
+
+Mirrors the runtime auth used by ``enterprise_sandbox/agent/agent.py``:
+read ``api-key`` + ``dpop.jwk`` from ``/state/{org}/agents/{name}/`` and
+hand them to ``CullisClient.from_api_key_file``. That is the same API-key
++ DPoP identity the egress surface expects for ``send_oneshot`` and the
+``/v1/mcp`` aggregator.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from cullis_sdk import CullisClient
+
+
+def load_enrolled_client(
+    mastio_url: str,
+    org_id: str,
+    agent_name: str,
+    identity_root: str | Path = "/state",
+) -> CullisClient:
+    identity_dir = Path(identity_root) / org_id / "agents" / agent_name
+    api_key_path = identity_dir / "api-key"
+    dpop_key_path = identity_dir / "dpop.jwk"
+    if not api_key_path.exists() or not dpop_key_path.exists():
+        raise RuntimeError(
+            f"enrolled identity missing under {identity_dir} "
+            f"(expected api-key + dpop.jwk) — is bootstrap-mastio done?"
+        )
+    client = CullisClient.from_api_key_file(
+        mastio_url,
+        api_key_path=api_key_path,
+        dpop_key_path=dpop_key_path,
+        agent_id=f"{org_id}::{agent_name}",
+        org_id=org_id,
+    )
+    # Mirror the runtime wiring in agent.py ``_auth_api_key_file``:
+    #   • ``login_via_proxy`` mints a broker JWT so ``_authed_request``
+    #     works (needed by the /v1/mcp aggregator and any session API).
+    #   • ``_signing_key_pem`` feeds the outer-envelope signature for
+    #     ``send_oneshot`` non-repudiation.
+    client.login_via_proxy()
+    key_path = identity_dir / "agent-key.pem"
+    if key_path.exists():
+        client._signing_key_pem = key_path.read_text()
+    return client

--- a/enterprise_sandbox/scenarios/mcp_call_local.py
+++ b/enterprise_sandbox/scenarios/mcp_call_local.py
@@ -9,24 +9,27 @@ agent is bound to (ADR-007 Phase 1). This driver drives one
 cross-org MCP has to go through A2A message wrapping, out of scope
 for this walkthrough.
 
+Auth is the ADR-011 Phase 4 unified path: the agent reuses the
+API-key + DPoP credentials that ``bootstrap-mastio`` enrolled under
+``/state/{org}/agents/{name}/``.
+
 Env:
     BROKER_URL          proxy reverse-proxy URL (= the proxy the agent lives on)
     ORG_ID              this agent's org
     AGENT_NAME          this agent's short name
-    AGENT_AUTH          'spire' (default) | 'byoca'
     MCP_TOOL_NAME       e.g. 'get_catalog' or 'check_inventory' — required
     MCP_TOOL_ARGS       JSON-encoded arguments object (default: '{}')
-    SPIFFE_ENDPOINT_SOCKET  (spire mode only)
-    CERT_PATH, KEY_PATH     (byoca mode only)
+    IDENTITY_ROOT       where bootstrap-mastio wrote credentials (default /state)
 """
 from __future__ import annotations
 
 import json
 import os
 import sys
-from pathlib import Path
 
 from cullis_sdk import CullisClient
+
+from _identity import load_enrolled_client
 
 
 RESET = "\033[0m"
@@ -51,32 +54,6 @@ def _info(msg: str) -> None:
 
 def _fail(msg: str) -> None:
     print(f"  {YELLOW}✗{RESET} {msg}", flush=True)
-
-
-def _auth() -> CullisClient:
-    broker = os.environ["BROKER_URL"]
-    org_id = os.environ["ORG_ID"]
-    agent_name = os.environ["AGENT_NAME"]
-    mode = os.environ.get("AGENT_AUTH", "spire").lower()
-
-    if mode == "spire":
-        socket = os.environ.get(
-            "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock",
-        )
-        _info(f"authenticating via SPIRE workload API at {socket}")
-        return CullisClient.from_spiffe_workload_api(
-            broker, org_id=org_id, socket_path=socket,
-        )
-
-    if mode == "byoca":
-        cert = Path(os.environ["CERT_PATH"]).read_text()
-        key = Path(os.environ["KEY_PATH"]).read_text()
-        _info(f"authenticating via BYOCA (cert={os.environ['CERT_PATH']})")
-        client = CullisClient(broker, verify_tls=False)
-        client.login_from_pem(f"{org_id}::{agent_name}", org_id, cert, key)
-        return client
-
-    raise SystemExit(f"unknown AGENT_AUTH: {mode}")
 
 
 def _rpc(client: CullisClient, method: str, params: dict | None = None) -> dict:
@@ -111,8 +88,10 @@ def main() -> int:
         _fail(f"MCP_TOOL_ARGS is not valid JSON: {exc}")
         return 2
 
+    broker = os.environ["BROKER_URL"].rstrip("/")
     org_id = os.environ["ORG_ID"]
     agent_name = os.environ["AGENT_NAME"]
+    identity_root = os.environ.get("IDENTITY_ROOT", "/state")
     sender = f"{org_id}::{agent_name}"
 
     print(
@@ -121,9 +100,16 @@ def main() -> int:
         flush=True,
     )
 
-    _step(1, "Authenticate through the local Mastio")
-    client = _auth()
-    _ok(f"logged in as {sender}")
+    _step(1, "Load enrolled identity and authenticate to the local Mastio")
+    _info(
+        f"reading api-key + dpop.jwk from {identity_root}/{org_id}/agents/{agent_name}/"
+    )
+    try:
+        client = load_enrolled_client(broker, org_id, agent_name, identity_root)
+    except Exception as exc:
+        _fail(f"auth failed: {exc!r}")
+        return 1
+    _ok(f"ready as {sender}")
 
     _step(2, "Discover available tools (MCP tools/list)")
     try:

--- a/enterprise_sandbox/scenarios/oneshot_cross_org.py
+++ b/enterprise_sandbox/scenarios/oneshot_cross_org.py
@@ -1,24 +1,21 @@
-"""Sandbox scenario — cross-org A2A message round-trip.
+"""Sandbox scenario — cross-org A2A message via sessionless one-shot (ADR-011 Phase 4b).
 
 Executed inside a running agent container with:
     docker compose exec agent-X python /app/scenarios/oneshot_cross_org.py
 
-Uses the session flow (``open_session`` + ``send`` + ``close``) because
-the SPIRE and BYOCA agents in this sandbox authenticate directly to the
-broker, and ``send_oneshot`` requires proxy API-key enrollment
-(``CullisClient.from_connector`` or ``from_enrollment``). The session
-path exercises the same cross-org envelope + ADR-009 counter-signature
-chain, just with a session handshake in front.
+Uses ``send_oneshot`` on the proxy egress surface — the intra-org
+short-circuit (ADR-001) routes same-proxy peers without involving the
+Court, while cross-org targets resolve to ``envelope`` transport and
+ride the ADR-009 counter-signature chain end-to-end. No session
+handshake, no accept: fire-and-forget enqueue, inbox-polled on the
+recipient side.
 
 Env:
-    BROKER_URL         proxy reverse-proxy URL
+    BROKER_URL         proxy reverse-proxy URL (the Mastio this agent sits behind)
     ORG_ID             this agent's org
     AGENT_NAME         this agent's short name
-    AGENT_AUTH         'spire' (default) | 'byoca'
     TARGET_AGENT_ID    peer (e.g. orgb::agent-b) — required
-    TARGET_ORG_ID      peer org_id (defaults to the prefix of TARGET_AGENT_ID)
-    SPIFFE_ENDPOINT_SOCKET  (spire mode only)
-    CERT_PATH, KEY_PATH     (byoca mode only)
+    IDENTITY_ROOT      where bootstrap-mastio wrote credentials (default /state)
 """
 from __future__ import annotations
 
@@ -26,9 +23,8 @@ import os
 import sys
 import time
 import uuid
-from pathlib import Path
 
-from cullis_sdk import CullisClient
+from _identity import load_enrolled_client
 
 
 RESET = "\033[0m"
@@ -55,70 +51,36 @@ def _fail(msg: str) -> None:
     print(f"  {YELLOW}✗{RESET} {msg}", flush=True)
 
 
-def _auth() -> CullisClient:
-    broker = os.environ["BROKER_URL"]
-    org_id = os.environ["ORG_ID"]
-    agent_name = os.environ["AGENT_NAME"]
-    mode = os.environ.get("AGENT_AUTH", "spire").lower()
-
-    if mode == "spire":
-        socket = os.environ.get(
-            "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock",
-        )
-        _info(f"authenticating via SPIRE workload API at {socket}")
-        return CullisClient.from_spiffe_workload_api(
-            broker, org_id=org_id, socket_path=socket,
-        )
-
-    if mode == "byoca":
-        cert = Path(os.environ["CERT_PATH"]).read_text()
-        key = Path(os.environ["KEY_PATH"]).read_text()
-        _info(f"authenticating via BYOCA (cert={os.environ['CERT_PATH']})")
-        client = CullisClient(broker, verify_tls=False)
-        client.login_from_pem(f"{org_id}::{agent_name}", org_id, cert, key)
-        return client
-
-    raise SystemExit(f"unknown AGENT_AUTH: {mode}")
-
-
 def main() -> int:
     target = os.environ.get("TARGET_AGENT_ID")
     if not target or "::" not in target:
         _fail("TARGET_AGENT_ID is required, format ``org::agent``")
         return 2
 
-    target_org = os.environ.get("TARGET_ORG_ID") or target.split("::", 1)[0]
+    broker = os.environ["BROKER_URL"].rstrip("/")
     org_id = os.environ["ORG_ID"]
     agent_name = os.environ["AGENT_NAME"]
+    identity_root = os.environ.get("IDENTITY_ROOT", "/state")
     sender = f"{org_id}::{agent_name}"
 
     print(
-        f"\n{BOLD}═══ Cross-org session message — "
+        f"\n{BOLD}═══ Cross-org sessionless one-shot — "
         f"{sender} → {target} ═══{RESET}",
         flush=True,
     )
 
-    _step(1, "Authenticate through the local Mastio")
-    client = _auth()
-    _ok(f"logged in as {sender}")
-
-    _step(2, "Open a cross-org session")
-    _info(f"target_org={target_org}, target_agent={target}")
+    _step(1, "Load enrolled identity and authenticate to the local Mastio")
+    _info(
+        f"reading api-key + dpop.jwk from {identity_root}/{org_id}/agents/{agent_name}/"
+    )
     try:
-        session_id = client.open_session(
-            target_agent_id=target,
-            target_org_id=target_org,
-            capabilities=["oneshot.message"],
-        )
+        client = load_enrolled_client(broker, org_id, agent_name, identity_root)
     except Exception as exc:
-        _fail(f"open_session failed: {exc!r}")
+        _fail(f"auth failed: {exc!r}")
         return 1
-    _ok(f"session_id={session_id}")
+    _ok(f"ready as {sender}")
 
-    _info("waiting ~2s for the recipient's auto-accept loop to pick up the session")
-    time.sleep(2.5)
-
-    _step(3, "Send an end-to-end encrypted message")
+    _step(2, "Send an end-to-end encrypted one-shot")
     nonce = uuid.uuid4().hex[:16]
     payload = {
         "nonce": nonce,
@@ -128,26 +90,28 @@ def main() -> int:
     }
     _info(f"payload nonce = {nonce}")
     try:
-        msg_id = client.send(
-            session_id=session_id,
-            sender_agent_id=sender,
-            payload=payload,
-            recipient_agent_id=target,
-        )
+        resp = client.send_oneshot(target, payload)
     except Exception as exc:
-        _fail(f"send failed: {exc!r}")
+        _fail(f"send_oneshot failed: {exc!r}")
         return 1
-    _ok(f"message enqueued — msg_id={msg_id}")
+    msg_id = resp.get("msg_id")
+    status = resp.get("status")
+    correlation_id = resp.get("correlation_id")
+    _ok(
+        f"enqueued — msg_id={msg_id}, status={status}, "
+        f"correlation_id={correlation_id}"
+    )
 
-    _step(4, "Verify on the recipient side")
+    _step(3, "Verify on the recipient side")
+    recipient_name = target.split("::", 1)[1]
     _info(
-        f"grep the recipient's log — "
-        f"`demo.sh logs {target.split('::', 1)[1]} | grep {nonce}`"
+        f"the recipient's inbox loop prints incoming nonces — tail with: "
+        f"`demo.sh logs {recipient_name} | grep {nonce}`"
     )
 
     print(
-        f"\n{BOLD}{GREEN}✓ cross-org session + envelope exercised "
-        f"end-to-end ({sender} → {target}, nonce={nonce}){RESET}",
+        f"\n{BOLD}{GREEN}✓ cross-org one-shot exercised end-to-end "
+        f"({sender} → {target}, nonce={nonce}){RESET}",
         flush=True,
     )
     return 0


### PR DESCRIPTION
## Summary

- `oneshot_cross_org.py` still used `open_session`+`send` which needed an auto-accept loop removed in Phase 4b → every cross-org demo failed with `409 Session not active`. Now uses `send_oneshot`.
- `mcp_call_local.py` re-authenticated via SPIFFE workload API from scratch, emitting the deprecation warning. Now reuses enrolled credentials.
- New `scenarios/_identity.py` helper mirrors `agent.py:_auth_api_key_file` 1:1 (`from_api_key_file` + `login_via_proxy` + `_signing_key_pem`). Both scenarios import it.
- `demo.sh`: prints the Court bootstrap token on `up`/`full` so first-login is self-contained; prints the 4 scenario commands + teardown hint. `ADMIN_SECRET` remains as the API-only admin secret (`X-Admin-Secret` header).

## Test plan

- [ ] `./demo.sh down && ./demo.sh full` — dashboard URL block shows the bootstrap token
- [ ] `./demo.sh oneshot-a-to-b` — `✓ enqueued` instead of 409
- [ ] `./demo.sh oneshot-b-to-a` — symmetric
- [ ] `./demo.sh mcp-catalog` + `./demo.sh mcp-inventory` — tool output, no DeprecationWarning
- [ ] `./demo.sh logs agent-b | grep <nonce>` — receive loop picked it up