### PR TITLE
fix(proxy): surface MCP_PROXY_STANDALONE in docker-compose

### DIFF
--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -30,6 +30,10 @@ services:
       - "${MCP_PROXY_PORT:-9100}:9100"
     environment:
       MCP_PROXY_ENVIRONMENT:       ${MCP_PROXY_ENVIRONMENT:-development}
+      # ADR-006 Trojan Horse — flip to true to run this Mastio as a
+      # self-contained mini-broker (no Court uplink, no JWKS fetch). Intra-org
+      # flows keep working; cross-org is disabled until federation is enabled.
+      MCP_PROXY_STANDALONE:        ${MCP_PROXY_STANDALONE:-false}
       MCP_PROXY_ADMIN_SECRET:      ${MCP_PROXY_ADMIN_SECRET:-change-me-in-production}
       # Persistent signing key — without this, admin sessions are invalid
       # after every proxy restart (per-process random fallback).


### PR DESCRIPTION
## Summary

`MCP_PROXY_STANDALONE=true` in `proxy.env` was silently ignored because `docker-compose.proxy.yml` never referenced the variable in its `environment:` block, so compose never forwarded it to the container. The Mastio therefore always booted in federated mode regardless of what the operator put in `proxy.env`.

Adds the variable with the same `${VAR:-false}` pattern used for the other `MCP_PROXY_*` settings. Now an operator can opt into ADR-006 Trojan Horse mini-broker mode with:

```
echo "MCP_PROXY_STANDALONE=true" >> proxy.env
./deploy_proxy.sh --standalone
```

## Notes

Orthogonal to `deploy_proxy.sh --standalone` — that flag only swaps docker networks so the proxy can run on a host different from the broker (which assumes there still *is* a broker). The env var is the runtime switch for "there is no broker, I am the broker". Naming overlap is confusing but kept here to avoid breaking existing docs / Helm values.

## Test plan

- [ ] `MCP_PROXY_STANDALONE=true ./deploy_proxy.sh --standalone` → `curl -sI http://localhost:9100/health | grep -i cullis-mode` returns `x-cullis-mode: standalone`
- [ ] `/proxy/setup` wizard accepts empty broker URL (or skips the step) in standalone mode
- [ ] Default deploy (no env var) → `x-cullis-mode: federation`, unchanged behaviour