### PR TITLE
fix(connector,proxy): ADR-011 Phase 4b end-to-end via Connector

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -204,24 +204,74 @@ _KNOWN_SUBCOMMANDS = frozenset({
     "dashboard",
 })
 
+# Shared flags are parsed by the subparser that owns the chosen command.
+# When the caller wrote them *before* the subcommand (the pre-fix layout
+# some users already have persisted in MCP configs), we relocate them so
+# argparse finds them on the right subparser.
+_SHARED_VALUE_FLAGS = frozenset({"--site-url", "--config-dir", "--log-level"})
+_SHARED_STORE_FLAGS = frozenset({"--no-verify-tls"})
+
 
 def _ensure_subcommand(argv: list[str]) -> list[str]:
-    """Inject ``serve`` when the user didn't name any subcommand.
+    """Normalize argv so shared flags land on the correct subparser.
 
-    Shared flags (``--site-url`` etc.) now live only on the subparsers
-    so the subcommand-level ``dest`` doesn't get silently overwritten by
-    a duplicate root-level one. The tradeoff is that argparse needs the
-    subcommand name before those flags — git-style. To keep the Phase 1
-    "just run it" UX, we prepend ``serve`` whenever argv carries neither
-    a subcommand nor a CLI-terminating flag like ``--version``.
+    Shared flags (``--site-url`` etc.) live only on the subparsers so
+    the subcommand-level ``dest`` doesn't get silently clobbered back
+    to None by a duplicated root-level one. Two UX carve-outs keep the
+    older call conventions working:
+
+    * No subcommand at all → prepend ``serve`` (covers ``cullis-connector
+      --config-dir ~/foo``).
+    * Shared flag appears *before* the subcommand → move it after it
+      (covers MCP configs that list args as
+      ``[--site-url, X, --config-dir, Y, serve]``).
+
+    ``--version`` / ``--help`` on the root exit before dispatch, so
+    we leave argv alone when we see them.
     """
-    # --version / --help on the root exit before dispatch; leave argv alone.
     for tok in argv:
         if tok in ("--version", "-V", "-h", "--help"):
             return list(argv)
-    if any(tok in _KNOWN_SUBCOMMANDS for tok in argv):
+
+    sub_idx = next(
+        (i for i, tok in enumerate(argv) if tok in _KNOWN_SUBCOMMANDS),
+        None,
+    )
+    if sub_idx is None:
+        return ["serve", *argv]
+    if sub_idx == 0:
         return list(argv)
-    return ["serve", *argv]
+
+    # Harvest shared flags (and their values) from the run of tokens
+    # before the subcommand. Anything unrecognised is left in place so
+    # argparse still raises the usual "unrecognized arguments" error
+    # — we don't want to silently drop a typo.
+    extracted: list[str] = []
+    remainder: list[str] = []
+    i = 0
+    before = argv[:sub_idx]
+    while i < len(before):
+        tok = before[i]
+        base = tok.split("=", 1)[0]
+        if base in _SHARED_VALUE_FLAGS:
+            if "=" in tok:
+                extracted.append(tok)
+                i += 1
+            elif i + 1 < len(before):
+                extracted.extend([tok, before[i + 1]])
+                i += 2
+            else:
+                remainder.append(tok)
+                i += 1
+        elif tok in _SHARED_STORE_FLAGS:
+            extracted.append(tok)
+            i += 1
+        else:
+            remainder.append(tok)
+            i += 1
+
+    after = argv[sub_idx:]
+    return [*remainder, after[0], *extracted, *after[1:]]
 
 
 # ── Commands ─────────────────────────────────────────────────────────────

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -19,6 +19,13 @@ Three top-level modes:
   that wraps enrollment in a three-screen wizard and can auto-configure
   Claude Desktop / Cursor / Cline. Intended as the default onboarding
   path for end users who shouldn't need the CLI.
+
+Shared flags (``--site-url``, ``--config-dir``, ``--no-verify-tls``,
+``--log-level``) must be placed **after** the subcommand name — git-style.
+If you omit the subcommand we inject ``serve`` for you so
+``cullis-connector --config-dir ~/foo`` keeps working, but once a
+subcommand is present argparse parses its flags from that subparser
+only.
 """
 from __future__ import annotations
 
@@ -186,10 +193,35 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Do not auto-open a browser tab on startup.",
     )
 
-    # Shared args also live on the root parser so the default (no
-    # subcommand) behaviour stays backward-compatible with Phase 1.
-    _add_shared_args(parser)
     return parser
+
+
+_KNOWN_SUBCOMMANDS = frozenset({
+    "serve",
+    "enroll",
+    "install-mcp",
+    "install-autostart",
+    "dashboard",
+})
+
+
+def _ensure_subcommand(argv: list[str]) -> list[str]:
+    """Inject ``serve`` when the user didn't name any subcommand.
+
+    Shared flags (``--site-url`` etc.) now live only on the subparsers
+    so the subcommand-level ``dest`` doesn't get silently overwritten by
+    a duplicate root-level one. The tradeoff is that argparse needs the
+    subcommand name before those flags — git-style. To keep the Phase 1
+    "just run it" UX, we prepend ``serve`` whenever argv carries neither
+    a subcommand nor a CLI-terminating flag like ``--version``.
+    """
+    # --version / --help on the root exit before dispatch; leave argv alone.
+    for tok in argv:
+        if tok in ("--version", "-V", "-h", "--help"):
+            return list(argv)
+    if any(tok in _KNOWN_SUBCOMMANDS for tok in argv):
+        return list(argv)
+    return ["serve", *argv]
 
 
 # ── Commands ─────────────────────────────────────────────────────────────
@@ -217,6 +249,47 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
     state = get_state()
     state.agent_id = identity.metadata.agent_id
     state.extra["identity"] = identity
+
+    # The enrollment flow already pinned the Site URL in metadata.json —
+    # adopt it if the operator did not pass --site-url / CULLIS_SITE_URL.
+    # Without this, diagnostic tools like hello_site report "not configured"
+    # even though the identity we just loaded was issued against that site.
+    if not cfg.site_url and identity.metadata.site_url:
+        cfg.site_url = identity.metadata.site_url
+        _log.info(
+            "adopted site_url from identity metadata: %s", cfg.site_url,
+        )
+
+    # Build the CullisClient from the on-disk enrollment bundle.
+    #
+    # The Phase 1 ``connect`` tool went away with enrollment but the
+    # wiring was never completed: every tool reached for a client that
+    # nobody constructed. We build it here and load the signing key so
+    # ``send_oneshot`` (API-key + DPoP + inner/outer signatures, no
+    # broker JWT) works out of the box.
+    #
+    # We deliberately *do not* call ``login_via_proxy()`` eagerly:
+    # it asks the Mastio to sign a client_assertion with the agent's
+    # private key, but device-code enrollment leaves that key on the
+    # user's machine, not on the Mastio — so the call 404s with
+    # "agent credentials not available on proxy". Session-based tools
+    # mint the token lazily via ``ensure_broker_token`` and surface a
+    # clear error if it can't be obtained; one-shot tools don't need
+    # a token at all.
+    try:
+        from cullis_sdk import CullisClient
+
+        client = CullisClient.from_connector(cfg.config_dir)
+        key_path = cfg.config_dir / "identity" / "agent.key"
+        if key_path.exists():
+            client._signing_key_pem = key_path.read_text()
+        state.client = client
+    except Exception as exc:
+        _log.error(
+            "Failed to initialize CullisClient from %s: %s. "
+            "Tools requiring a connected client will not work.",
+            cfg.config_dir, exc,
+        )
 
     _log.info(
         "serving as %s (cert subject %s)",
@@ -418,7 +491,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for both ``python -m cullis_connector`` and the
     installed ``cullis-connector`` console script."""
     parser = _build_parser()
-    args = parser.parse_args(argv)
+    raw = list(argv) if argv is not None else sys.argv[1:]
+    args = parser.parse_args(_ensure_subcommand(raw))
     cfg = load_config(vars(args))
     setup_logging(cfg.log_level)
 

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -329,7 +329,14 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
     try:
         from cullis_sdk import CullisClient
 
-        client = CullisClient.from_connector(cfg.config_dir)
+        # ``enable_dpop=False`` — the SDK otherwise generates a local DPoP
+        # keypair whose thumbprint the Mastio doesn't know about, so the
+        # egress endpoint 401s on the DPoP proof even though the API-key
+        # itself is valid. Until enrollment binds the Connector's DPoP
+        # jkt server-side (ADR-011 Phase 3d follow-up / #206), fall back
+        # to the legacy X-API-Key bearer — accepted while the Mastio's
+        # ``egress_dpop_mode`` stays at ``optional`` (Phase 5 default).
+        client = CullisClient.from_connector(cfg.config_dir, enable_dpop=False)
         key_path = cfg.config_dir / "identity" / "agent.key"
         if key_path.exists():
             client._signing_key_pem = key_path.read_text()

--- a/cullis_connector/state.py
+++ b/cullis_connector/state.py
@@ -25,6 +25,7 @@ class ConnectorState:
     agent_id: str = ""
     active_session: str | None = None
     active_peer: str | None = None
+    last_correlation_id: str | None = None
     extra: dict[str, object] = field(default_factory=dict)
 
 

--- a/cullis_connector/tools/__init__.py
+++ b/cullis_connector/tools/__init__.py
@@ -4,6 +4,7 @@ Tools are grouped by domain:
     diagnostic — health/version probes (no identity required)
     discovery  — discover_agents
     session    — session lifecycle: open, send, accept, close, list, etc.
+    oneshot    — sessionless send/receive (ADR-008 / ADR-011 Phase 4b)
 
 The ``register_all`` helper wires every group to a FastMCP instance so the
 server module stays a thin assembly point. Identity is loaded by the CLI
@@ -15,7 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from cullis_connector.tools import diagnostic, discovery, high_level, session
+from cullis_connector.tools import diagnostic, discovery, high_level, oneshot, session
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -25,6 +26,7 @@ def register_all(mcp: "FastMCP") -> None:
     diagnostic.register(mcp)
     discovery.register(mcp)
     session.register(mcp)
+    oneshot.register(mcp)
     high_level.register(mcp)
 
 

--- a/cullis_connector/tools/oneshot.py
+++ b/cullis_connector/tools/oneshot.py
@@ -9,6 +9,7 @@ enrollment, where the private key never leaves the user's machine.
 from __future__ import annotations
 
 import json
+import time
 from typing import TYPE_CHECKING
 
 from cryptography import x509
@@ -132,6 +133,7 @@ def register(mcp: "FastMCP") -> None:
             corr = row.get("correlation_id", "?")
             reply_to = row.get("reply_to") or "—"
             try:
+                _prime_sender_pubkey_cache(client, sender)
                 decoded = client.decrypt_oneshot(row)
                 payload = decoded.get("payload", {})
                 if isinstance(payload, dict) and "text" in payload:
@@ -147,3 +149,42 @@ def register(mcp: "FastMCP") -> None:
                     f"<decrypt failed: {exc}>"
                 )
         return f"{len(rows)} one-shot message(s):\n" + "\n".join(lines)
+
+
+def _prime_sender_pubkey_cache(client, sender: str) -> None:
+    """Seed the SDK's pubkey cache with the sender's cert via the proxy's
+    resolve endpoint.
+
+    ``CullisClient.decrypt_oneshot`` looks up the sender's cert through
+    ``get_agent_public_key``, which defaults to hitting the Court's
+    federation API — that path needs a broker JWT we don't have under
+    device-code enrollment. The local Mastio already knows the cert
+    (it just served it to ``send_oneshot``), so we ask ``/v1/egress/resolve``
+    for the same row and populate the cache directly. No-op on cache
+    hit, and failures are swallowed so ``decrypt_oneshot`` still runs
+    (and surfaces the clearer downstream error if it genuinely can't
+    verify).
+    """
+    canonical = sender if "::" in sender else _canonical_recipient(sender)
+    cache = getattr(client, "_pubkey_cache", None)
+    if cache is None or canonical in cache:
+        return
+    try:
+        resp = client._egress_http(
+            "post",
+            "/v1/egress/resolve",
+            json={"recipient_id": canonical},
+        )
+        resp.raise_for_status()
+        cert = resp.json().get("target_cert_pem")
+    except Exception as exc:  # noqa: BLE001
+        _log.debug("pubkey cache prime for %s failed: %s", canonical, exc)
+        return
+    if cert:
+        cache[canonical] = (cert, time.time())
+        # The SDK keys ``_pubkey_cache`` by the same id passed to
+        # ``get_agent_public_key``; decrypt_oneshot uses the raw
+        # ``sender`` from the inbox row, so mirror the entry under
+        # the bare handle too when the two differ.
+        if sender != canonical:
+            cache[sender] = (cert, time.time())

--- a/cullis_connector/tools/oneshot.py
+++ b/cullis_connector/tools/oneshot.py
@@ -1,0 +1,117 @@
+"""Sessionless one-shot tools (ADR-008 / ADR-011 Phase 4b).
+
+These tools bypass the broker JWT path: API-key + DPoP authenticates
+to the local Mastio's egress API, and the inner + outer envelope
+signatures are produced locally from ``agent.key``. They work even
+when ``login_via_proxy`` doesn't — for example after device-code
+enrollment, where the private key never leaves the user's machine.
+"""
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from cullis_connector._logging import get_logger
+from cullis_connector.state import get_state
+from cullis_connector.tools.session import _require_oneshot_client
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
+
+_log = get_logger("tools.oneshot")
+
+
+def register(mcp: "FastMCP") -> None:
+    @mcp.tool()
+    def send_oneshot(
+        recipient_id: str,
+        message: str,
+        reply_to: str = "",
+        correlation_id: str = "",
+        ttl_seconds: int = 300,
+        capabilities: str = "",
+    ) -> str:
+        """Send a fire-and-forget message to another agent — no session, no accept.
+
+        Intra-org → signed plaintext (``mtls-only``). Cross-org → end-to-end
+        encrypted envelope with inner + outer signatures. The local Mastio
+        resolves the target and routes the message; the recipient picks it
+        up via ``receive_oneshot``.
+
+        Args:
+            recipient_id: Fully-qualified target (e.g. ``chipfactory::sales``).
+                Bare names resolve inside the sender's org.
+            message: Plain-text body wrapped as ``{"type": "message",
+                "text": message}`` — pass structured payloads via the SDK
+                directly if you need a richer shape.
+            reply_to: Inbox ``msg_id`` from a previously received one-shot
+                — turns this send into a reply that the peer can correlate.
+            correlation_id: Override the generated UUID (rare; use when the
+                peer needs to tie this send to work it already started).
+            ttl_seconds: Server-side expiry before the message is dropped
+                if still undelivered. Default 300.
+            capabilities: Comma-separated capabilities to tag on the
+                envelope (informational; RBAC lives elsewhere).
+        """
+        client = _require_oneshot_client()
+        state = get_state()
+        caps = [c.strip() for c in capabilities.split(",") if c.strip()]
+        try:
+            result = client.send_oneshot(
+                recipient_id,
+                {"type": "message", "text": message},
+                correlation_id=correlation_id or None,
+                reply_to=reply_to or None,
+                ttl_seconds=ttl_seconds,
+                capabilities=caps or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("send_oneshot to %s failed: %s", recipient_id, exc)
+            return f"Failed to send one-shot to {recipient_id}: {exc}"
+
+        state.last_correlation_id = result.get("correlation_id")
+        return (
+            f"One-shot {result.get('status', 'sent')} to {recipient_id} "
+            f"(correlation_id={result.get('correlation_id')}, "
+            f"msg_id={result.get('msg_id')})"
+        )
+
+    @mcp.tool()
+    def receive_oneshot() -> str:
+        """Pull and decrypt pending one-shot messages from the local inbox.
+
+        Each entry includes the sender, correlation_id (for replies) and
+        the decrypted payload. The inbox is non-destructive on the server
+        side — callers are responsible for application-level dedup via
+        ``correlation_id`` if they want at-most-once semantics.
+        """
+        client = _require_oneshot_client()
+        try:
+            rows = client.receive_oneshot()
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("receive_oneshot failed: %s", exc)
+            return f"Failed to fetch one-shot inbox: {exc}"
+        if not rows:
+            return "No one-shot messages."
+
+        lines: list[str] = []
+        for row in rows:
+            sender = row.get("sender_agent_id", "?")
+            corr = row.get("correlation_id", "?")
+            reply_to = row.get("reply_to") or "—"
+            try:
+                decoded = client.decrypt_oneshot(row)
+                payload = decoded.get("payload", {})
+                if isinstance(payload, dict) and "text" in payload:
+                    text = payload["text"]
+                else:
+                    text = json.dumps(payload)
+                lines.append(
+                    f"- [{sender}] corr={corr[:8]} reply_to={reply_to}: {text}"
+                )
+            except Exception as exc:  # noqa: BLE001
+                lines.append(
+                    f"- [{sender}] corr={corr[:8]} reply_to={reply_to}: "
+                    f"<decrypt failed: {exc}>"
+                )
+        return f"{len(rows)} one-shot message(s):\n" + "\n".join(lines)

--- a/cullis_connector/tools/oneshot.py
+++ b/cullis_connector/tools/oneshot.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from cryptography import x509
+
 from cullis_connector._logging import get_logger
 from cullis_connector.state import get_state
 from cullis_connector.tools.session import _require_oneshot_client
@@ -19,6 +21,35 @@ if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
 _log = get_logger("tools.oneshot")
+
+
+def _own_org_id() -> str | None:
+    """Return the sender's org_id from the loaded identity's cert subject.
+
+    The Mastio's ``/v1/egress/resolve`` rejects bare recipient names —
+    it needs ``org::agent``. Enrollment writes the agent's cert with
+    ``O=<org_id>`` so we can recover the sender's org even when
+    ``metadata.json`` stored only the short agent_id.
+    """
+    state = get_state()
+    identity = state.extra.get("identity")
+    cert = getattr(identity, "cert", None)
+    if cert is None:
+        return None
+    attrs = cert.subject.get_attributes_for_oid(x509.NameOID.ORGANIZATION_NAME)
+    if not attrs:
+        return None
+    return attrs[0].value or None
+
+
+def _canonical_recipient(recipient_id: str) -> str:
+    """Prefix the sender's org when the caller gave a bare agent name."""
+    if "::" in recipient_id:
+        return recipient_id
+    org = _own_org_id()
+    if not org:
+        return recipient_id
+    return f"{org}::{recipient_id}"
 
 
 def register(mcp: "FastMCP") -> None:
@@ -56,9 +87,10 @@ def register(mcp: "FastMCP") -> None:
         client = _require_oneshot_client()
         state = get_state()
         caps = [c.strip() for c in capabilities.split(",") if c.strip()]
+        canonical = _canonical_recipient(recipient_id)
         try:
             result = client.send_oneshot(
-                recipient_id,
+                canonical,
                 {"type": "message", "text": message},
                 correlation_id=correlation_id or None,
                 reply_to=reply_to or None,
@@ -66,12 +98,12 @@ def register(mcp: "FastMCP") -> None:
                 capabilities=caps or None,
             )
         except Exception as exc:  # noqa: BLE001
-            _log.warning("send_oneshot to %s failed: %s", recipient_id, exc)
-            return f"Failed to send one-shot to {recipient_id}: {exc}"
+            _log.warning("send_oneshot to %s failed: %s", canonical, exc)
+            return f"Failed to send one-shot to {canonical}: {exc}"
 
         state.last_correlation_id = result.get("correlation_id")
         return (
-            f"One-shot {result.get('status', 'sent')} to {recipient_id} "
+            f"One-shot {result.get('status', 'sent')} to {canonical} "
             f"(correlation_id={result.get('correlation_id')}, "
             f"msg_id={result.get('msg_id')})"
         )

--- a/cullis_connector/tools/session.py
+++ b/cullis_connector/tools/session.py
@@ -5,16 +5,63 @@ import json
 import time
 from typing import TYPE_CHECKING
 
+from cullis_connector._logging import get_logger
 from cullis_connector.state import get_state
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
 
+_log = get_logger("tools.session")
+
 
 def _require_client():
+    """Return a client with a valid broker JWT, minting one if absent.
+
+    Device-code enrollment leaves the agent private key on the user's
+    machine, so ``login_via_proxy()`` 404s ("agent credentials not
+    available on proxy") when the Mastio tries to sign the assertion
+    on the agent's behalf. We still call it because BYOCA/Mastio-held-key
+    deployments work fine and we don't want to hard-code that split;
+    callers see the same user-visible error regardless.
+    """
     state = get_state()
-    if state.client is None or state.client.token is None:
-        raise RuntimeError("Not connected. Use the connect tool first.")
+    if state.client is None:
+        raise RuntimeError(
+            "Connector client not initialized — identity missing or unreadable. "
+            "Re-run enrollment via the Connector dashboard."
+        )
+    if state.client.token is None:
+        try:
+            state.client.login_via_proxy()
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("lazy login_via_proxy failed: %s", exc)
+            raise RuntimeError(
+                f"Session tools require a broker JWT, but login_via_proxy failed: "
+                f"{exc}. If you enrolled via the dashboard (device-code), the "
+                f"Mastio doesn't hold your private key so this path 404s — use "
+                f"send_oneshot for fire-and-forget messages instead."
+            ) from exc
+    return state.client
+
+
+def _require_oneshot_client():
+    """Client for API-key + DPoP + local-signature one-shot sends.
+
+    Does *not* need a broker JWT — ``send_oneshot`` talks to the local
+    Mastio's egress API with API-key/DPoP only, and signs the inner +
+    outer envelope locally with ``_signing_key_pem``.
+    """
+    state = get_state()
+    if state.client is None:
+        raise RuntimeError(
+            "Connector client not initialized — identity missing or unreadable. "
+            "Re-run enrollment via the Connector dashboard."
+        )
+    if not getattr(state.client, "_signing_key_pem", None):
+        raise RuntimeError(
+            "Agent signing key not loaded — send_oneshot needs the private key "
+            "at ~/.cullis/identity/agent.key. Re-run enrollment if missing."
+        )
     return state.client
 
 

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -58,6 +58,18 @@ services:
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
       MCP_PROXY_VAULT_ADDR:        ${MCP_PROXY_VAULT_ADDR:-}
       MCP_PROXY_VAULT_TOKEN:       ${MCP_PROXY_VAULT_TOKEN:-}
+      # ADR-001 §10 — intra-org routing + transport. All read by
+      # ``_apply_routing_overrides`` in mcp_proxy/config.py. Exposing
+      # them here lets operators flip behaviour through proxy.env
+      # without touching the compose file.
+      PROXY_TRUST_DOMAIN:          ${PROXY_TRUST_DOMAIN:-}
+      PROXY_INTRA_ORG:             ${PROXY_INTRA_ORG:-}
+      PROXY_TRANSPORT_INTRA_ORG:   ${PROXY_TRANSPORT_INTRA_ORG:-}
+      PROXY_EGRESS_INSPECTION_ENABLED: ${PROXY_EGRESS_INSPECTION_ENABLED:-}
+      PROXY_FEDERATION_SYNC:       ${PROXY_FEDERATION_SYNC:-}
+      # F-B-11 Phase 5 — DPoP enforcement mode for /v1/egress/*
+      # (off | optional | required). optional is the current default.
+      CULLIS_EGRESS_DPOP_MODE:     ${CULLIS_EGRESS_DPOP_MODE:-}
     volumes:
       - mcp_proxy_data:/data
       # Optional corporate CA mount. The env above points at a file under /certs

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -155,18 +155,28 @@ class ProxySettings(BaseSettings):
 
     @model_validator(mode="after")
     def _apply_routing_overrides(self):
-        td = os.environ.get("PROXY_TRUST_DOMAIN")
+        # ``os.environ.get`` returns ``""`` when docker-compose passes
+        # through an unset variable via ``${FOO:-}`` — same semantics
+        # the operator means by "not set". Treat both as absent so we
+        # don't silently clobber the model defaults (especially the
+        # standalone auto-enable path below, which used to see the empty
+        # string and conclude the operator had explicitly opted out).
+        def _env(name: str) -> str | None:
+            v = os.environ.get(name)
+            return v if v else None
+
+        td = _env("PROXY_TRUST_DOMAIN")
         if td:
             self.trust_domain = td
-        flag = os.environ.get("PROXY_INTRA_ORG")
+        flag = _env("PROXY_INTRA_ORG")
         if flag is not None:
             self.intra_org_routing = flag.lower() in ("1", "true", "yes", "on")
-        sync_flag = os.environ.get("PROXY_FEDERATION_SYNC")
+        sync_flag = _env("PROXY_FEDERATION_SYNC")
         if sync_flag is not None:
             self.federation_sync_enabled = sync_flag.lower() in (
                 "1", "true", "yes", "on",
             )
-        transport = os.environ.get("PROXY_TRANSPORT_INTRA_ORG")
+        transport = _env("PROXY_TRANSPORT_INTRA_ORG")
         if transport is not None:
             normalized = transport.strip().lower()
             if normalized not in ("envelope", "mtls-only", "hybrid"):
@@ -175,18 +185,18 @@ class ProxySettings(BaseSettings):
                     f"envelope|mtls-only|hybrid, got {transport!r}"
                 )
             self.transport_intra_org = normalized
-        egress_flag = os.environ.get("PROXY_EGRESS_INSPECTION_ENABLED")
+        egress_flag = _env("PROXY_EGRESS_INSPECTION_ENABLED")
         if egress_flag is not None:
             self.egress_inspection_enabled = egress_flag.lower() in (
                 "1", "true", "yes", "on",
             )
-        standalone_flag = os.environ.get("MCP_PROXY_STANDALONE")
+        standalone_flag = _env("MCP_PROXY_STANDALONE")
         if standalone_flag is not None:
             self.standalone = standalone_flag.lower() in (
                 "1", "true", "yes", "on",
             )
 
-        force_pwd = os.environ.get("MCP_PROXY_FORCE_LOCAL_PASSWORD")
+        force_pwd = _env("MCP_PROXY_FORCE_LOCAL_PASSWORD")
         if force_pwd is not None:
             self.force_local_password = force_pwd.lower() in (
                 "1", "true", "yes", "on",
@@ -199,7 +209,7 @@ class ProxySettings(BaseSettings):
         # overridden it via PROXY_INTRA_ORG. An explicit
         # PROXY_INTRA_ORG=0 still wins (useful for intentional "no
         # traffic" deployments — e.g. schema-only validation in CI).
-        if self.standalone and os.environ.get("PROXY_INTRA_ORG") is None:
+        if self.standalone and _env("PROXY_INTRA_ORG") is None:
             self.intra_org_routing = True
         return self
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -94,7 +94,12 @@ async def lifespan(app: FastAPI):
 
     if settings.standalone:
         broker_url = ""
-        org_id = settings.org_id
+        # Same precedence as the federated branch below: the operator's
+        # env/config pin wins, then whatever was persisted at first-boot
+        # (ADR-006 §2.2 derived id), then the default. Without the DB
+        # fall-through every restart in standalone drops org_id back to
+        # "" and decide_route mislabels every intra-org send as cross-org.
+        org_id = settings.org_id or await get_config("org_id") or ""
         app.state.reverse_proxy_broker_url = None
         app.state.reverse_proxy_client = None
         # Explicit reset: the singleton ``app`` survives across test
@@ -136,12 +141,14 @@ async def lifespan(app: FastAPI):
         await agent_mgr.generate_org_ca(derive_org_id=derive)
         if derive:
             org_id = agent_mgr.org_id
-            # ``get_settings`` is lru_cached so mutating the shared
-            # instance is how we propagate the derived id to the rest
-            # of the app. Without this, ``decide_route`` keeps reading
-            # the default ``""`` and classifies every intra-org resolve
-            # as cross-org.
-            settings.org_id = org_id
+
+    # ``get_settings`` is lru_cached so mutating the shared instance
+    # propagates the resolved id to every call-site (decide_route,
+    # reach_guard, oneshot router, dashboard fallbacks). Without this,
+    # anything that reads ``get_settings().org_id`` keeps seeing the
+    # default ``""`` and classifies intra-org traffic as cross-org.
+    if settings.standalone and org_id and not settings.org_id:
+        settings.org_id = org_id
 
     # ADR-009 Phase 1 — derive/persist the Mastio CA + leaf so the proxy can
     # counter-sign Court requests. Only possible once the Org CA is loaded;

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -136,6 +136,12 @@ async def lifespan(app: FastAPI):
         await agent_mgr.generate_org_ca(derive_org_id=derive)
         if derive:
             org_id = agent_mgr.org_id
+            # ``get_settings`` is lru_cached so mutating the shared
+            # instance is how we propagate the derived id to the rest
+            # of the app. Without this, ``decide_route`` keeps reading
+            # the default ``""`` and classifies every intra-org resolve
+            # as cross-org.
+            settings.org_id = org_id
 
     # ADR-009 Phase 1 — derive/persist the Mastio CA + leaf so the proxy can
     # counter-sign Court requests. Only possible once the Org CA is loaded;


### PR DESCRIPTION
## Summary

Closes the last gaps blocking an ADR-011 Phase 4b intra-org one-shot
message sent from a Connector-enrolled agent (device-code) to another
Connector-enrolled agent on the same standalone Mastio. End-to-end
verified with two Claude Code instances on the same host talking
through a Mastio on a separate VM.

## What was broken

Four **Connector** gaps:
1. `--site-url` / `--config-dir` placed anywhere but on the chosen
   subparser silently got clobbered back to ``None``.
2. `state.client` was never constructed after Phase 1's ``connect``
   tool was removed — every tool returned "Not connected".
3. `login_via_proxy()` 404s for device-code enrolments (the agent's
   private key is on the user's machine, not the Mastio) and it
   was called eagerly at boot.
4. DPoP proof generated on the fly, jkt not bound server-side,
   every egress call got a 401.
5. No ``send_oneshot`` / ``receive_oneshot`` tools at the MCP surface.
6. Recipient passed as ``claudesouth`` (bare) got rejected by the
   Mastio with 400 "internal id must be 'org::agent'".
7. ``decrypt_oneshot`` tried to fetch the sender cert via the Court's
   federation API — a JWT path we don't hold under device-code.

Three **Mastio / compose** gaps surfaced by the same flow:
8. Standalone's derived ``org_id`` was written to ``app.state`` but
   not to ``settings.org_id``, so ``decide_route`` kept seeing ``""``
   and classified intra-org traffic as cross-org.
9. On restart the standalone branch didn't re-read the persisted
   ``org_id`` from the DB — every reboot re-exposed the bug.
10. ``docker-compose.proxy.yml`` didn't forward the ADR-001 routing
    env vars (``PROXY_TRANSPORT_INTRA_ORG``, ``PROXY_INTRA_ORG``,
    ``CULLIS_EGRESS_DPOP_MODE``, …) to the container. Values in
    ``proxy.env`` were silently dropped — same class of bug #229
    fixed for ``MCP_PROXY_STANDALONE``.
11. The routing validator treated an empty env string (what compose
    forwards via ``${FOO:-}``) as "operator explicitly opted out",
    so standalone's auto-enable of ``intra_org_routing`` skipped
    and ``transport=mtls-only`` never kicked in even when the
    variable was actually set in ``proxy.env``.

## Test plan

- [x] `pytest tests/connector tests/test_sdk_from_connector.py` — 96 green
- [x] `pytest tests/test_proxy_resolve.py tests/test_proxy_standalone_e2e.py tests/test_intra_org_round_trip.py tests/test_oneshot_intra.py` — 23 green
- [x] Manual e2e on VM (192.168.122.154): two Claude Code instances with
      distinct Connector config dirs (~/.cullis-north, ~/.cullis-south) —
      `send_oneshot` north→south + `receive_oneshot` south decrypts
      correctly with inner + outer signature verification.
- [ ] CI green on push.

## Follow-ups (not in this PR)

- DPoP jkt binding at enrolment time so `enable_dpop=True` can be
  the default again (ADR-011 Phase 3d follow-up, admin endpoint #206).
- Intent-level MCP tool (`send_to(peer, text)` instead of
  `send_oneshot(recipient_id=…, message=…)`) + push notifications
  on receive — raised by the user during this session.
- Connector GUI deploy (Tauri / Electron) to replace the stdio/dashboard
  dance for non-technical users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)