### PR TITLE
chore(sandbox): drop dead SPIFFE/BYOCA auth branches from demo agent

### DIFF
--- a/enterprise_sandbox/agent/Dockerfile
+++ b/enterprise_sandbox/agent/Dockerfile
@@ -1,5 +1,7 @@
-# Demo Cullis agent — installs the SDK from the local repo (with [spiffe] extra)
-# and uses CullisClient.from_spiffe_workload_api() to authenticate.
+# Demo Cullis agent — installs the SDK from the local repo and uses
+# CullisClient.from_api_key_file() under ADR-011 to authenticate. The
+# [spiffe] extra is still pulled in so scenario drivers that exercise
+# the deprecated SPIFFE entry point still build.
 #
 # Build context must be the repo root (so pyproject.toml + cullis_sdk/ are visible).
 FROM python:3.11-slim

--- a/enterprise_sandbox/agent/agent.py
+++ b/enterprise_sandbox/agent/agent.py
@@ -1,19 +1,18 @@
-"""Sandbox demo agent — SPIFFE or BYOCA auth + A2A messaging round-trip.
+"""Sandbox demo agent — ADR-011 unified API-key+DPoP auth + A2A messaging.
 
-Each agent authenticates to the broker, opens a session with every peer
-listed in ``/state/peers.json``, and sends a single nonce payload. In
-parallel it auto-accepts inbound sessions (so peers can send to it) and
-polls every active session for messages, accumulating received nonces
-to ``/tmp/received.json`` for the smoke suite to inspect.
+Each agent authenticates to the Mastio with the API key + DPoP key the
+bootstrap stage enrolled for it, drains the one-shot inbox, and (when
+``AGENT_AUTO_SEND=true``) fires a nonce at every peer listed in
+``/state/peers.json``. Received nonces land in ``/tmp/received.json``
+for the smoke suite to inspect.
 
 Env:
-    BROKER_URL                e.g. http://broker:8000
+    BROKER_URL                e.g. http://proxy-a:9100
     ORG_ID                    e.g. orga
     AGENT_NAME                short name (becomes {ORG_ID}::{AGENT_NAME})
-    AGENT_AUTH                'spire' (default) or 'byoca'
-    SPIFFE_ENDPOINT_SOCKET    spire mode only
-    CERT_PATH, KEY_PATH       byoca mode only
+    IDENTITY_DIR              /state/{ORG_ID}/agents/{AGENT_NAME} by default
     PEERS_FILE                /state/peers.json (written by bootstrap)
+    AGENT_AUTO_SEND           'true' to trigger the legacy nonce round-trip
 """
 from __future__ import annotations
 
@@ -47,15 +46,6 @@ def _record(nonce: str) -> None:
     _persist_received()
 
 
-def wait_for_socket(path: str, timeout: float = 60.0) -> bool:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        if pathlib.Path(path).exists():
-            return True
-        time.sleep(0.5)
-    return False
-
-
 def wait_for_http(url: str, timeout: float = 60.0) -> bool:
     import urllib.request
     import urllib.error
@@ -67,35 +57,6 @@ def wait_for_http(url: str, timeout: float = 60.0) -> bool:
         except (urllib.error.URLError, OSError):
             time.sleep(1)
     return False
-
-
-def _auth_spire(broker: str, org_id: str) -> CullisClient:
-    socket = os.environ.get(
-        "SPIFFE_ENDPOINT_SOCKET", "/run/spire/sockets/agent.sock"
-    )
-    raw = socket.removeprefix("unix://") if socket.startswith("unix://") else socket
-    if not wait_for_socket(raw, timeout=60):
-        raise RuntimeError(f"socket {raw} not available after 60s")
-    return CullisClient.from_spiffe_workload_api(
-        broker, org_id=org_id, socket_path=socket,
-    )
-
-
-def _auth_byoca(broker: str, org_id: str, agent_id: str) -> CullisClient:
-    cert_path = os.environ["CERT_PATH"]
-    key_path = os.environ["KEY_PATH"]
-    deadline = time.monotonic() + 60
-    while time.monotonic() < deadline:
-        if pathlib.Path(cert_path).exists() and pathlib.Path(key_path).exists():
-            break
-        time.sleep(0.5)
-    else:
-        raise RuntimeError(f"BYOCA cert/key not found at {cert_path} / {key_path}")
-    cert_pem = pathlib.Path(cert_path).read_text()
-    key_pem = pathlib.Path(key_path).read_text()
-    client = CullisClient(broker)
-    client.login_from_pem(agent_id, org_id, cert_pem, key_pem)
-    return client
 
 
 def _receive_loop(client: CullisClient, self_id: str) -> None:
@@ -219,7 +180,6 @@ def main() -> int:
     broker = os.environ["BROKER_URL"].rstrip("/")
     org_id = os.environ["ORG_ID"]
     name = os.environ["AGENT_NAME"]
-    auth_mode = os.environ.get("AGENT_AUTH", "api-key").lower()
     peers_file = os.environ.get("PEERS_FILE", "/state/peers.json")
     # ADR-011 Phase 4 — auto-send demo traffic on boot is opt-in now.
     # Default is idle (auto_accept + receive loops run in background,
@@ -235,34 +195,19 @@ def main() -> int:
         return 1
 
     try:
-        if auth_mode == "api-key":
-            identity_dir = os.environ.get(
-                "IDENTITY_DIR", f"/state/{org_id}/agents/{name}",
-            )
-            client = _auth_api_key_file(broker, identity_dir, self_id)
-            auth_label = "API-key+DPoP"
-        elif auth_mode == "spire":
-            # ADR-011: legacy SPIFFE-direct-to-Court path. Retained for
-            # smoke B4 backwards-compat until the smoke assertions are
-            # flipped to the unified model; emits DeprecationWarning.
-            client = _auth_spire(broker, org_id)
-            auth_label = "SPIFFE (deprecated)"
-        elif auth_mode == "byoca":
-            client = _auth_byoca(broker, org_id, self_id)
-            auth_label = "BYOCA (deprecated)"
-        else:
-            print(f"[{self_id}] FAIL: unknown AGENT_AUTH={auth_mode!r}",
-                  file=sys.stderr, flush=True)
-            return 2
+        identity_dir = os.environ.get(
+            "IDENTITY_DIR", f"/state/{org_id}/agents/{name}",
+        )
+        client = _auth_api_key_file(broker, identity_dir, self_id)
     except Exception as exc:
-        print(f"[{self_id}] FAIL: {auth_mode} auth: {exc!r}",
+        print(f"[{self_id}] FAIL: api-key auth: {exc!r}",
               file=sys.stderr, flush=True)
         return 2
 
     token_preview = (
         client.token[:24] if getattr(client, "token", None) else "(api-key only)"
     )
-    print(f"[{self_id}] {auth_label} auth OK — token={token_preview}...",
+    print(f"[{self_id}] API-key+DPoP auth OK — token={token_preview}...",
           flush=True)
     pathlib.Path("/tmp/ready").write_text(self_id + "\n")
     _persist_received()  # initialize empty /tmp/received.json

--- a/enterprise_sandbox/docker-compose.yml
+++ b/enterprise_sandbox/docker-compose.yml
@@ -389,7 +389,6 @@ services:
       BROKER_URL: "http://proxy-a:9100"
       ORG_ID: "orga"
       AGENT_NAME: "agent-a"
-      SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
       PEERS_FILE: "/state/peers.json"
     volumes:
       - spire-a-agent-socket:/run/spire/sockets:ro
@@ -431,12 +430,6 @@ services:
       BROKER_URL: "http://proxy-a:9100"
       ORG_ID: "orga"
       AGENT_NAME: "byoca-bot"
-      # ADR-011 Phase 4 — every sandbox agent authenticates the new way
-      # (API-key + DPoP via Mastio). Legacy BYOCA direct login to the
-      # Court still works but emits DeprecationWarning; the demo stays
-      # on the unified path so the Court's session count is zero until
-      # the user drives an explicit scenario.
-      AGENT_AUTH: "api-key"
       PEERS_FILE: "/state/peers.json"
     volumes:
       - bootstrap-state:/state:ro
@@ -606,7 +599,6 @@ services:
       BROKER_URL: "http://proxy-b:9100"
       ORG_ID: "orgb"
       AGENT_NAME: "agent-b"
-      SPIFFE_ENDPOINT_SOCKET: "/run/spire/sockets/agent.sock"
       PEERS_FILE: "/state/peers.json"
     volumes:
       - spire-b-agent-socket:/run/spire/sockets:ro

--- a/enterprise_sandbox/smoke.sh
+++ b/enterprise_sandbox/smoke.sh
@@ -245,35 +245,33 @@ else
     fail "B4.3 spire-agent healthy"
 fi
 
-# B4.4 — agent-a authenticates to broker via SVID (no CN/O, full 3-level
-# chain leaf ← SPIRE intermediate ← Org CA). The container writes
-# /tmp/ready only after CullisClient.from_spiffe_workload_api returns a
-# token, and that file is what the Docker healthcheck reads.
+# B4.4 — agent-a authenticates to the Mastio via ADR-011 API-key+DPoP.
+# bootstrap-mastio enrolls the agent (BYOCA-style cert + key) and writes
+# api-key + dpop.jwk under /state/orga/agents/agent-a/. The container
+# writes /tmp/ready only after CullisClient.from_api_key_file returns,
+# and the Docker healthcheck reads that marker.
 if docker compose ps agent-a --format json | grep -q '"Health":"healthy"'; then
-    pass "B4.4 agent-a SPIFFE auth OK (container healthy, /tmp/ready marker set)"
+    pass "B4.4 agent-a API-key+DPoP auth OK (container healthy, /tmp/ready marker set)"
 else
-    fail "B4.4 agent-a SPIFFE auth"
+    fail "B4.4 agent-a API-key+DPoP auth"
 fi
 
-# B4.5 — same for agent-b under a different trust_domain (orgb.test).
-# Exercises the per-org trust_domain lookup and the independent Org CA
-# chain walk for a second tenant.
+# B4.5 — same for agent-b in orgb (independent trust_domain orgb.test
+# and independent Org CA chain). Proves the unified ADR-011 flow holds
+# across tenants.
 if docker compose ps agent-b --format json | grep -q '"Health":"healthy"'; then
-    pass "B4.5 agent-b SPIFFE auth OK (container healthy, /tmp/ready marker set)"
+    pass "B4.5 agent-b API-key+DPoP auth OK (container healthy, /tmp/ready marker set)"
 else
-    fail "B4.5 agent-b SPIFFE auth"
+    fail "B4.5 agent-b API-key+DPoP auth"
 fi
 
-# B4.6 — classic BYOCA agent (byoca-bot) coexists with the SPIRE workload
-# in Org A (ADR-003 §2.6 mixed mode). Login uses a CN/O cert signed
-# directly by the Org CA — hits the classic code path with thumbprint
-# pinning active — while agent-a in the same org goes through the SPIFFE
-# SVID path with pinning skipped. Same broker, same org, different auth
-# branches resolving to different agent_ids.
+# B4.6 — byoca-bot coexists with agent-a in orga. Both enroll through
+# the ADR-011 unified path now, so this assertion is mostly proving the
+# second orga agent is healthy (no auth-mode divergence anymore).
 if docker compose ps byoca-a --format json | grep -q '"Health":"healthy"'; then
-    pass "B4.6 byoca-a classic auth OK (mixed mode alongside SPIRE in orga)"
+    pass "B4.6 byoca-a API-key+DPoP auth OK (second orga agent alongside agent-a)"
 else
-    fail "B4.6 byoca-a classic auth"
+    fail "B4.6 byoca-a API-key+DPoP auth"
 fi
 
 # B4.7 — full 3-agent A2A round-trip under the ADR-011 unified model.
@@ -288,19 +286,13 @@ for c in agent-a byoca-a agent-b; do
     docker compose exec -dT "$c" python -c "
 import json, os, pathlib, sys
 sys.path.insert(0, '/app')
-from agent import _send_to_peers, _auth_api_key_file, _auth_spire, _auth_byoca
+from agent import _send_to_peers, _auth_api_key_file
 broker = os.environ['BROKER_URL'].rstrip('/')
 org_id = os.environ['ORG_ID']
 name = os.environ['AGENT_NAME']
-mode = os.environ.get('AGENT_AUTH', 'api-key').lower()
 self_id = f'{org_id}::{name}'
-if mode == 'api-key':
-    identity_dir = os.environ.get('IDENTITY_DIR', f'/state/{org_id}/agents/{name}')
-    client = _auth_api_key_file(broker, identity_dir, self_id)
-elif mode == 'spire':
-    client = _auth_spire(broker, org_id)
-else:
-    client = _auth_byoca(broker, org_id, self_id)
+identity_dir = os.environ.get('IDENTITY_DIR', f'/state/{org_id}/agents/{name}')
+client = _auth_api_key_file(broker, identity_dir, self_id)
 peers = json.loads(pathlib.Path(os.environ.get('PEERS_FILE', '/state/peers.json')).read_text()).get(self_id, [])
 _send_to_peers(client, self_id, peers)
 " 2>/dev/null || true


### PR DESCRIPTION
## Summary

Phase 7 ADR-011 cleanup. The sandbox demo agent (``enterprise_sandbox/agent/agent.py``) still dispatched on ``AGENT_AUTH`` with ``_auth_spire`` / ``_auth_byoca`` branches, but the docker-compose set ``AGENT_AUTH=api-key`` on byoca-a and agent-a / agent-b defaulted to it, so those branches were already dead. This PR removes them together with the env-var plumbing that fed them.

- ``agent.py``: drop ``_auth_spire``, ``_auth_byoca``, ``wait_for_socket``; collapse ``main()`` to the single api-key path; fix the module docstring (was still advertising ``AGENT_AUTH 'spire' (default) or 'byoca'`` against a code default of ``api-key``).
- ``docker-compose.yml``: drop ``SPIFFE_ENDPOINT_SOCKET`` from ``agent-a`` and ``agent-b`` (only ``_auth_spire`` read it); drop the ``AGENT_AUTH`` override from ``byoca-a`` (the value it set is now the only path).
- ``smoke.sh``: drop the ``_auth_spire`` / ``_auth_byoca`` imports + mode dispatch in B4.7; refresh B4.4 / B4.5 / B4.6 descriptions so they name the ADR-011 unified auth path instead of the old ``SPIFFE auth`` / ``classic BYOCA auth`` labels.
- ``Dockerfile``: fix the header comment that still pointed at ``CullisClient.from_spiffe_workload_api()``.

SPIFFE agent attestation + SPIRE infrastructure are untouched — ``spire-server`` and ``spire-agent-{a,b}`` still run and gate agent startup via ``depends_on``, and ``bootstrap-mastio`` continues to enroll the agents off the SPIFFE SVID. Only the runtime path inside the demo agent is simplified to the path the fleet actually takes.

Net diff: +39 / -108.

## Test plan

- [x] ``pytest tests/ -n auto --dist=loadfile`` — 1410 passed, 6 skipped (same baseline as ``origin/main``).
- [x] ``python -c 'import ast; ast.parse(open(\"enterprise_sandbox/agent/agent.py\").read())'`` — agent.py parses.
- [x] ``docker compose -f enterprise_sandbox/docker-compose.yml config`` — compose still valid after env drops.
- [x] ``grep -r _auth_spire\|_auth_byoca\|wait_for_socket\|SPIFFE_ENDPOINT_SOCKET enterprise_sandbox/`` — no leftovers.
- [ ] ``enterprise_sandbox/smoke.sh`` — not executed locally (docker-in-vm constraint). Dev-only sandbox, not gated in CI.