### PR TITLE
docs(sdk): flag SPIFFE onboarding deprecated + refresh signing-key hints

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -1213,9 +1213,12 @@ class CullisClient:
         ``recipient_id`` may be a SPIFFE URI (``spiffe://td/org/agent``) or
         the internal ``org::agent`` form.
 
-        Requires proxy credentials from :meth:`from_enrollment` (API key)
-        AND a signing key from :meth:`login` or :meth:`from_spiffe_workload_api`
-        when the resolver picks ``mtls-only``.
+        Requires proxy credentials from :meth:`from_enrollment` or
+        :meth:`from_api_key_file` (API key) AND a signing key — either
+        populated by :meth:`login` / :meth:`login_from_pem` (cert + key
+        bundle) or assigned manually to ``_signing_key_pem`` after
+        :meth:`from_api_key_file` — when the resolver picks
+        ``mtls-only``.
         """
         resolve_resp = self._egress_http(
             "post",
@@ -1247,7 +1250,8 @@ class CullisClient:
             if not self._signing_key_pem:
                 raise RuntimeError(
                     "mtls-only transport requires a signing key — "
-                    "initialize the client via login() or from_spiffe_workload_api()"
+                    "populate it via login() (cert+key bundle) or assign "
+                    "_signing_key_pem after from_api_key_file()"
                 )
             nonce = str(uuid.uuid4())
             timestamp = int(time.time())
@@ -1415,8 +1419,9 @@ class CullisClient:
 
         if not self._signing_key_pem:
             raise RuntimeError(
-                "one-shot send requires a signing key — initialize the "
-                "client via login() or from_spiffe_workload_api()"
+                "one-shot send requires a signing key — populate it via "
+                "login() (cert+key bundle) or assign _signing_key_pem "
+                "after from_api_key_file()"
             )
 
         corr_id = correlation_id or str(uuid.uuid4())
@@ -1617,7 +1622,8 @@ class CullisClient:
         if not self._signing_key_pem:
             raise RuntimeError(
                 "envelope decrypt requires a private signing key — "
-                "initialize the client via login() or from_spiffe_workload_api()"
+                "populate it via login() (cert+key bundle) or assign "
+                "_signing_key_pem after from_api_key_file()"
             )
 
         cipher_blob = envelope["payload"]

--- a/docs/spiffe-onboarding.md
+++ b/docs/spiffe-onboarding.md
@@ -1,5 +1,7 @@
 # Cullis — Onboarding an org with SPIFFE/SPIRE
 
+> **Deprecation notice (ADR-011).** `CullisClient.from_spiffe_workload_api()` as shown in Step 4 below is the **legacy direct-to-Court login** path. It still works and emits a `DeprecationWarning` until the Court's `/v1/auth/token` returns `410 Gone` (see the `Deprecation` / `Sunset` response headers). New deployments should use SPIFFE as an *enrollment* primitive instead — call `CullisClient.enroll_via_spiffe(...)` once at provisioning time to exchange an SVID for an API key + DPoP jkt, then run the agent with `CullisClient.from_api_key_file(...)` at runtime. See [`migration-from-direct-login.md`](migration-from-direct-login.md) for the full migration walkthrough.
+
 This guide is for org operators who want their Cullis agents to authenticate via short-lived SVIDs issued by SPIRE, instead of long-lived BYOCA agent certificates. Both models coexist in the same broker and even in the same org.
 
 If you're starting from scratch and your agents don't use SPIFFE, see the regular [Operations Runbook](operations-runbook.md) and quickstart — you don't need any of this.

--- a/site/src/content/docs/spiffe-onboarding.md
+++ b/site/src/content/docs/spiffe-onboarding.md
@@ -8,6 +8,8 @@ updated: "2026-04-15"
 
 # Cullis — Onboarding an org with SPIFFE/SPIRE
 
+> **Deprecation notice (ADR-011).** `CullisClient.from_spiffe_workload_api()` as shown in Step 4 below is the **legacy direct-to-Court login** path. It still works and emits a `DeprecationWarning` until the Court's `/v1/auth/token` returns `410 Gone` (see the `Deprecation` / `Sunset` response headers). New deployments should use SPIFFE as an *enrollment* primitive instead — call `CullisClient.enroll_via_spiffe(...)` once at provisioning time to exchange an SVID for an API key + DPoP jkt, then run the agent with `CullisClient.from_api_key_file(...)` at runtime. See [migration-from-direct-login](migration-from-direct-login) for the full migration walkthrough.
+
 This guide is for org operators who want their Cullis agents to authenticate via short-lived SVIDs issued by SPIRE, instead of long-lived BYOCA agent certificates. Both models coexist in the same broker and even in the same org.
 
 If you're starting from scratch and your agents don't use SPIFFE, see the regular [Operations Runbook](operations-runbook.md) and quickstart — you don't need any of this.


### PR DESCRIPTION
## Summary

Phase 7 ADR-011 SDK-side cleanup. Triage of every in-repo caller of ``CullisClient.from_spiffe_workload_api``:

- **KEEP** (documents the deprecated contract): ``cullis_sdk/client.py`` public definition + ``_legacy_login_from_pem`` internal delegate; ``cullis_sdk/spiffe.py`` helper; ``tests/test_sdk_enrollment_unified.py`` + ``tests/test_sdk_spiffe.py`` (contract tests for the DeprecationWarning and the SPIFFE helper); ``site/src/content/docs/migration-from-direct-login.md`` (its whole job is naming the old path).
- **MIGRATE** (this PR): both copies of the SPIFFE onboarding doc + the runtime error strings inside the SDK that still pushed users toward ``from_spiffe_workload_api()`` as a remedy.

Changes:

- ``docs/spiffe-onboarding.md`` + ``site/src/content/docs/spiffe-onboarding.md``: add an ADR-011 deprecation banner at the top. Point readers at ``enroll_via_spiffe`` + ``from_api_key_file`` and the migration guide. Step 4 / Step 5 code samples are intentionally unchanged — they still describe how the deprecated path works until the Court returns ``410 Gone``.
- ``cullis_sdk/client.py``: the three ``RuntimeError`` messages surfaced by ``mtls-only`` send / one-shot send / envelope decrypt without a signing key now reference ``login()`` or ``from_api_key_file()`` + ``_signing_key_pem`` instead of the deprecated helper. Same fix in the ``send`` docstring.

The one remaining in-tree production caller of ``from_spiffe_workload_api`` (``enterprise_sandbox/agent/agent.py``) was migrated in #231.

## Test plan

- [x] ``pytest tests/ -n auto --dist=loadfile`` — 1410 passed, 6 skipped.
- [x] ``./demo_network/smoke.sh full`` — A4 / A7 / A8 assertions pass (full stack, broker restart, hash chain, MCP echo).
- [x] Deprecation-warning contract test (``test_from_spiffe_workload_api_emits_deprecation_warning``) still passes — we never touched the warning plumbing.

## Open questions for human review

- The SPIFFE onboarding doc's Step 4 / Step 5 still show ``from_spiffe_workload_api()`` calls. The banner flags them as deprecated but the samples keep working. A future PR can rewrite the steps to demonstrate ``enroll_via_spiffe`` + ``from_api_key_file`` instead — that's a bigger docs rewrite, not in scope here.
- The runtime error strings reference ``_signing_key_pem``, which is a private attribute. A cleaner SDK would expose ``set_signing_key(pem)`` — out of scope, but worth noting.