### PR TITLE
fix(proxy): enforce agent reach filter on list_peers endpoint

### DIFF
--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -1009,6 +1009,20 @@ async def list_peers(
     local_org = settings.org_id or ""
     qnorm = (q or "").strip().lower()
 
+    # Audit NEW #4 — reach gate mirrors ``check_reach`` used by session
+    # open / send, but expressed as a filter rather than a deny: the
+    # listing must NEVER surface peers the caller couldn't contact
+    # anyway. Without this gate an ``intra``-only agent would receive a
+    # ready-made cross-org target list the moment federation primes
+    # the cache, which is a layering violation (defence-in-depth if the
+    # send-path gate is ever weakened). Unknown reach values default to
+    # ``both`` to match ``check_reach``'s permissive fallback.
+    caller_reach = (getattr(agent, "reach", None) or "both").lower()
+    if caller_reach not in {"intra", "cross", "both"}:
+        caller_reach = "both"
+    include_intra = caller_reach in {"intra", "both"}
+    include_cross = caller_reach in {"cross", "both"}
+
     from sqlalchemy import text
 
     from mcp_proxy.db import get_db
@@ -1019,68 +1033,76 @@ async def list_peers(
         # Intra-org from the authoritative local registry. Self-row
         # excluded so the caller never sees themselves in their own
         # contact list (the DB stores both bare and ``org::name`` rows
-        # historically; check both forms).
-        bare = agent.agent_id.split("::", 1)[-1]
-        result = await conn.execute(
-            text(
-                """
-                SELECT agent_id, display_name, capabilities, is_active
-                  FROM internal_agents
-                 WHERE is_active = 1
-                   AND agent_id NOT IN (:full, :bare)
-                 ORDER BY display_name, agent_id
-                """
-            ),
-            {"full": agent.agent_id, "bare": bare},
-        )
-        for row in result.mappings():
-            aid_full = (
-                row["agent_id"]
-                if "::" in row["agent_id"]
-                else f"{local_org}::{row['agent_id']}"
-            )
-            display = row["display_name"] or row["agent_id"]
-            if qnorm and qnorm not in aid_full.lower() and qnorm not in display.lower():
-                continue
-            peers.append(PeerInfo(
-                agent_id=aid_full,
-                org_id=local_org,
-                display_name=display,
-                capabilities=json.loads(row["capabilities"] or "[]"),
-                status="active",
-                scope="intra-org",
-            ))
-
-        # Cross-org cached snapshots, if federation has primed the cache.
-        # The table is missing in older standalone deploys — tolerate
-        # that and skip silently.
-        try:
+        # historically; check both forms). Skipped entirely when the
+        # caller's reach forbids intra-org traffic — the SELECT does
+        # not run, so the filter is enforced at the SQL layer (no
+        # post-hoc Python strip that could regress silently if
+        # refactored).
+        if include_intra:
+            bare = agent.agent_id.split("::", 1)[-1]
             result = await conn.execute(
                 text(
                     """
-                    SELECT agent_id, org_id, display_name, capabilities
-                      FROM cached_federated_agents
-                     WHERE revoked = 0
-                       AND org_id != :local_org
-                     ORDER BY org_id, display_name
+                    SELECT agent_id, display_name, capabilities, is_active
+                      FROM internal_agents
+                     WHERE is_active = 1
+                       AND agent_id NOT IN (:full, :bare)
+                     ORDER BY display_name, agent_id
                     """
                 ),
-                {"local_org": local_org},
+                {"full": agent.agent_id, "bare": bare},
             )
             for row in result.mappings():
-                aid = row["agent_id"]
-                display = row["display_name"] or aid
-                if qnorm and qnorm not in aid.lower() and qnorm not in display.lower():
+                aid_full = (
+                    row["agent_id"]
+                    if "::" in row["agent_id"]
+                    else f"{local_org}::{row['agent_id']}"
+                )
+                display = row["display_name"] or row["agent_id"]
+                if qnorm and qnorm not in aid_full.lower() and qnorm not in display.lower():
                     continue
                 peers.append(PeerInfo(
-                    agent_id=aid,
-                    org_id=row["org_id"],
+                    agent_id=aid_full,
+                    org_id=local_org,
                     display_name=display,
                     capabilities=json.loads(row["capabilities"] or "[]"),
-                    scope="cross-org",
+                    status="active",
+                    scope="intra-org",
                 ))
-        except Exception as exc:  # noqa: BLE001
-            logger.debug("federated cache unreadable, skipping: %s", exc)
+
+        # Cross-org cached snapshots, if federation has primed the cache.
+        # The table is missing in older standalone deploys — tolerate
+        # that and skip silently. Skipped entirely when the caller's
+        # reach forbids cross-org traffic (same SQL-level rationale as
+        # the intra-org branch above).
+        if include_cross:
+            try:
+                result = await conn.execute(
+                    text(
+                        """
+                        SELECT agent_id, org_id, display_name, capabilities
+                          FROM cached_federated_agents
+                         WHERE revoked = 0
+                           AND org_id != :local_org
+                         ORDER BY org_id, display_name
+                        """
+                    ),
+                    {"local_org": local_org},
+                )
+                for row in result.mappings():
+                    aid = row["agent_id"]
+                    display = row["display_name"] or aid
+                    if qnorm and qnorm not in aid.lower() and qnorm not in display.lower():
+                        continue
+                    peers.append(PeerInfo(
+                        agent_id=aid,
+                        org_id=row["org_id"],
+                        display_name=display,
+                        capabilities=json.loads(row["capabilities"] or "[]"),
+                        scope="cross-org",
+                    ))
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("federated cache unreadable, skipping: %s", exc)
 
     if limit and len(peers) > limit:
         peers = peers[:limit]

--- a/tests/test_proxy_peers.py
+++ b/tests/test_proxy_peers.py
@@ -162,3 +162,95 @@ async def test_peers_requires_auth(proxy_app):
     resp = await client.get("/v1/egress/peers")
     # Same shape as every other /v1/egress/* endpoint without API-key.
     assert resp.status_code in (401, 403, 422)
+
+
+# ── Reach filter (audit NEW #4) ─────────────────────────────────────
+#
+# The send-path reach gate is enforced in ``reach_guard.check_reach``;
+# the listing path must apply the same discipline at the SQL layer so
+# an intra-only agent never receives cross-org handles in the first
+# place (layering defence-in-depth). These three cases pin the
+# filter behaviour for intra / cross / both.
+
+async def _set_reach(agent_id: str, reach: str) -> None:
+    """Flip ``internal_agents.reach`` for an already-provisioned row."""
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE internal_agents SET reach = :reach WHERE agent_id = :aid"),
+            {"reach": reach, "aid": agent_id},
+        )
+
+
+async def _seed_cross_org_peer(agent_id: str, org_id: str) -> None:
+    """Seed a cached cross-org peer row the way federation would."""
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO cached_federated_agents (
+                    agent_id, org_id, display_name, capabilities,
+                    thumbprint, revoked, updated_at
+                ) VALUES (:aid, :org, :aid, '["cap.peer"]', NULL, 0,
+                          '2026-04-19T00:00:00Z')
+                """
+            ),
+            {"aid": agent_id, "org": org_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_peers_reach_intra_hides_cross_org(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_caller("caller-bot")
+    await _set_reach("caller-bot", "intra")
+    await _provision_local_peer("mario", "Mario Rossi")
+    await _seed_cross_org_peer("remote-bot", "orgb")
+
+    resp = await client.get("/v1/egress/peers", headers={"X-API-Key": api_key})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    scopes = {p["scope"] for p in body["peers"]}
+    assert scopes == {"intra-org"}
+    handles = {p["agent_id"] for p in body["peers"]}
+    assert "acme::mario" in handles
+    assert "remote-bot" not in handles
+
+
+@pytest.mark.asyncio
+async def test_peers_reach_cross_hides_intra_org(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_caller("caller-bot")
+    await _set_reach("caller-bot", "cross")
+    await _provision_local_peer("mario", "Mario Rossi")
+    await _seed_cross_org_peer("remote-bot", "orgb")
+
+    resp = await client.get("/v1/egress/peers", headers={"X-API-Key": api_key})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    scopes = {p["scope"] for p in body["peers"]}
+    assert scopes == {"cross-org"}
+    handles = {p["agent_id"] for p in body["peers"]}
+    assert "remote-bot" in handles
+    assert "acme::mario" not in handles
+
+
+@pytest.mark.asyncio
+async def test_peers_reach_both_returns_all(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_caller("caller-bot")
+    # ``both`` is the DB default but pin it explicitly so the test
+    # documents the contract rather than relying on a server_default.
+    await _set_reach("caller-bot", "both")
+    await _provision_local_peer("mario", "Mario Rossi")
+    await _seed_cross_org_peer("remote-bot", "orgb")
+
+    resp = await client.get("/v1/egress/peers", headers={"X-API-Key": api_key})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    scopes = {p["scope"] for p in body["peers"]}
+    assert scopes == {"intra-org", "cross-org"}
+    handles = {p["agent_id"] for p in body["peers"]}
+    assert "acme::mario" in handles
+    assert "remote-bot" in handles


### PR DESCRIPTION
## Summary
- `GET /v1/egress/peers` on Mastio returned all intra + cached cross peers regardless of the caller's `reach` attribute
- Intra-only agents could enumerate cross-org targets; the runtime reach gate caught the subsequent send, but the peer list itself was a layering violation
- Applies the reach filter at the SQL level (skips the relevant SELECT when reach forbids that peer class)

## Finding
NEW #4 from the Connector UX v2 zero-trust audit (2026-04-19). HIGH.

## Test plan
- [x] `pytest tests/ -n auto --dist=loadfile -k "list_peers or egress_peers or reach or peers"` — 31 pass
- [x] New tests: `test_peers_reach_intra_hides_cross_org`, `test_peers_reach_cross_hides_intra_org`, `test_peers_reach_both_returns_all`