### PR TITLE
fix(connector): zero-trust hardening for UX v2 (intent tools + notifications)

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -251,22 +251,29 @@ acme::mario: ciao!` in the dashboard log.
 #### Statusline badge in Claude Code
 
 The dashboard exposes `GET http://127.0.0.1:7777/status/inbox` which
-returns the unread count + last sender. Drop this snippet into your
-`~/.claude/settings.json` to see "📨 N from <sender>" in the Claude
-Code status bar:
+returns the unread count + last sender. Both this endpoint and
+`POST /status/inbox/seen` require a bearer token generated at first
+dashboard start and persisted at
+`~/.cullis/identity/statusline.token` (chmod 0600). The loopback bind
+alone doesn't stop other local processes under your user, so the token
+is what actually authenticates the statusline poller.
+
+Drop this snippet into your `~/.claude/settings.json` to see
+"📨 N from <sender>" in the Claude Code status bar:
 
 ```json
 {
   "statusLine": {
     "type": "command",
-    "command": "s=$(curl -s http://127.0.0.1:7777/status/inbox); u=$(echo $s | jq -r .unread); n=$(echo $s | jq -r .last_sender); [ \"$u\" != \"0\" ] && echo \"📨 $u from $n\" || true"
+    "command": "t=$(cat ~/.cullis/identity/statusline.token); s=$(curl -s -H \"Authorization: Bearer $t\" http://127.0.0.1:7777/status/inbox); u=$(echo $s | jq -r .unread); n=$(echo $s | jq -r .last_sender); [ \"$u\" != \"0\" ] && echo \"📨 $u from $n\" || true"
   }
 }
 ```
 
-When you've read the messages, `POST /status/inbox/seen` clears the
-counter (the dashboard's `/inbox` view does this automatically on
-load).
+When you've read the messages,
+`curl -X POST -H "Authorization: Bearer $(cat ~/.cullis/identity/statusline.token)" http://127.0.0.1:7777/status/inbox/seen`
+clears the counter (the dashboard's `/inbox` view does this
+automatically on load).
 
 ---
 

--- a/cullis_connector/inbox_poller.py
+++ b/cullis_connector/inbox_poller.py
@@ -27,6 +27,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from cullis_connector.tools._identity import (
+    PubkeyPrimeError,
     canonical_recipient,
     prime_sender_pubkey_cache,
 )
@@ -199,8 +200,19 @@ class DashboardInboxPoller:
             return None
         # Pre-populate the SDK pubkey cache so decrypt_oneshot doesn't
         # try to fetch the sender's cert from the broker (no JWT here).
-        # Same workaround the MCP receive_oneshot tool uses.
-        prime_sender_pubkey_cache(self._client, sender_raw)
+        # Same workaround the MCP receive_oneshot tool uses. On failure
+        # the message is security-relevant: we can't verify the sender,
+        # so the poller MUST skip it (not crash, not silently downgrade
+        # to the broker JWT path). Log at ERROR so the operator sees
+        # the skip in the dashboard log without having to turn on DEBUG.
+        try:
+            prime_sender_pubkey_cache(self._client, sender_raw)
+        except PubkeyPrimeError as exc:
+            _log.error(
+                "skipping msg %s from %s — pubkey prime failed: %s",
+                msg_id, sender, exc,
+            )
+            return None
         try:
             decoded = self._client.decrypt_oneshot(row)
         except Exception as exc:  # noqa: BLE001

--- a/cullis_connector/statusline_token.py
+++ b/cullis_connector/statusline_token.py
@@ -1,0 +1,85 @@
+"""Per-install bearer token for the Connector statusline endpoints.
+
+The dashboard exposes ``GET /status/inbox`` + ``POST /status/inbox/seen``
+on ``127.0.0.1:7777`` so external statusline scripts (Claude Code, etc.)
+can render a "N unread from <sender>" badge. Without auth any local
+process on the machine could read inbox metadata (sender + preview) and
+reset the unread counter — a small but real info-disclosure + tamper
+surface. This module manages a small random token stored under
+``<config_dir>/identity/statusline.token`` (chmod 0600) that both
+endpoints require via ``Authorization: Bearer <token>``.
+
+The token is generated on first use and persists across Connector
+restarts. Callers that can read the user's ``identity/`` directory
+already hold the private key, so this adds no new trust assumption —
+it just closes the gap for "other local process, same user, no disk
+read of identity/".
+"""
+from __future__ import annotations
+
+import os
+import secrets
+import stat
+from pathlib import Path
+
+STATUSLINE_TOKEN_FILENAME = "statusline.token"
+
+_TOKEN_BYTES = 32  # 256-bit, urlsafe_b64 → 43 char string
+
+
+def _token_path(config_dir: Path) -> Path:
+    return config_dir / "identity" / STATUSLINE_TOKEN_FILENAME
+
+
+def _write_token(path: Path, token: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic-ish: write to sibling + rename. Matches the pattern used
+    # by identity/store.py for the private key.
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(token)
+    try:
+        tmp.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600 — owner only
+    except (OSError, NotImplementedError):
+        # Windows filesystems don't honour POSIX bits; best-effort only.
+        pass
+    os.replace(tmp, path)
+
+
+def ensure_statusline_token(config_dir: Path) -> str:
+    """Return the statusline bearer token, generating + persisting it
+    on first call.
+
+    Idempotent: repeat calls return the same token. If the file exists
+    but has wider-than-owner permissions on POSIX, we tighten them
+    defensively — prevents an earlier misconfigured write from
+    silently undermining the check.
+    """
+    path = _token_path(config_dir)
+    if path.exists():
+        token = path.read_text().strip()
+        if token:
+            # Re-assert 0600 — cheap and avoids a surprise if someone
+            # edits the file out-of-band with a wider umask.
+            try:
+                current = stat.S_IMODE(path.stat().st_mode)
+                if current & 0o077:
+                    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+            except (OSError, NotImplementedError):
+                pass
+            return token
+        # Empty file → treat as unset, regenerate below.
+
+    token = secrets.token_urlsafe(_TOKEN_BYTES)
+    _write_token(path, token)
+    return token
+
+
+def read_statusline_token(config_dir: Path) -> str | None:
+    """Return the persisted token or ``None`` if it has not been
+    generated yet. Used by CLI helpers that want to print the snippet
+    without forcing a fresh write."""
+    path = _token_path(config_dir)
+    if not path.exists():
+        return None
+    token = path.read_text().strip()
+    return token or None

--- a/cullis_connector/tools/_identity.py
+++ b/cullis_connector/tools/_identity.py
@@ -24,6 +24,19 @@ from cullis_connector.state import get_state
 _log = logging.getLogger("cullis_connector.tools._identity")
 
 
+class PubkeyPrimeError(RuntimeError):
+    """Raised when the sender pubkey cache cannot be primed via
+    ``/v1/egress/resolve`` — either the Mastio call failed outright
+    or the response carried no ``target_cert_pem``.
+
+    The dashboard inbox poller catches this and skips the message
+    (logging at ERROR rather than swallowing silently) so an operator
+    can see the security-relevant gap in their audit log instead of
+    silently falling back to the broker JWT path that no Connector
+    holds a token for.
+    """
+
+
 def own_org_id() -> str | None:
     """Return the sender's org_id from the loaded identity's cert subject.
 
@@ -66,17 +79,28 @@ def prime_sender_pubkey_cache(client, sender: str) -> None:
     cache directly so ``decrypt_oneshot`` finds it without needing
     the broker.
 
-    No-op on cache hit. Failures are swallowed + logged so
-    ``decrypt_oneshot`` still runs and surfaces the clearer downstream
-    error if it really can't verify.
+    No-op on cache hit.
+
+    **Error contract (security audit NEW #4):** Failures MUST propagate
+    to the caller so the audit trail records the skip at ERROR level
+    instead of the function silently falling back to the broker JWT
+    path (which has no credential → surfaces as an opaque
+    ``login()`` error). Specifically, raises ``PubkeyPrimeError`` when:
+
+      - the HTTP call to ``/v1/egress/resolve`` fails (network, 4xx, 5xx),
+      - the response is missing / has an empty ``target_cert_pem``,
+      - the client object has no ``_pubkey_cache`` attribute (programming
+        error — an incompatible client type was passed in).
+
+    The caller (inbox poller, MCP receive_oneshot) catches and
+    skips-this-message rather than crashing the poll loop.
     """
     canonical = sender if "::" in sender else canonical_recipient(sender)
     cache = getattr(client, "_pubkey_cache", None)
     if cache is None:
-        _log.warning(
-            "pubkey cache prime: client has no _pubkey_cache attribute"
+        raise PubkeyPrimeError(
+            "client has no _pubkey_cache attribute — incompatible SDK client"
         )
-        return
     # The SDK's get_agent_public_key honours its own TTL (300s); if the
     # entry is still fresh we skip, otherwise we refetch even for known
     # senders. Without this, a stale entry left over from a previous
@@ -99,20 +123,19 @@ def prime_sender_pubkey_cache(client, sender: str) -> None:
         )
         resp.raise_for_status()
         cert = resp.json().get("target_cert_pem")
+    except PubkeyPrimeError:
+        raise
     except Exception as exc:  # noqa: BLE001
-        _log.warning(
-            "pubkey cache prime for %s failed: %s (%s)",
-            canonical, exc, type(exc).__name__,
-        )
-        return
+        raise PubkeyPrimeError(
+            f"/v1/egress/resolve call for {canonical} failed: "
+            f"{exc} ({type(exc).__name__})"
+        ) from exc
     if not cert:
-        _log.warning(
-            "pubkey cache prime for %s: resolve returned no target_cert_pem "
+        raise PubkeyPrimeError(
+            f"/v1/egress/resolve for {canonical} returned no target_cert_pem "
             "(intra-org transport may be 'envelope' not 'mtls-only' — set "
-            "PROXY_TRANSPORT_INTRA_ORG=mtls-only on the Mastio)",
-            canonical,
+            "PROXY_TRANSPORT_INTRA_ORG=mtls-only on the Mastio)"
         )
-        return
     cache[canonical] = (cert, time.time())
     # Mirror under the bare handle too — `decrypt_oneshot` keys on
     # whatever the inbox row carried, which can be either form.

--- a/cullis_connector/tools/intent.py
+++ b/cullis_connector/tools/intent.py
@@ -50,22 +50,30 @@ def _candidate(info: AgentInfo, score: float) -> PeerCandidate:
     )
 
 
-def resolve_peer(client, query: str, *, fuzzy_cutoff: float = 0.5) -> list[PeerCandidate]:
+def resolve_peer(client, query: str, *, fuzzy_cutoff: float = 0.75) -> list[PeerCandidate]:
     """Look up peers matching ``query`` via the local Mastio.
 
     Strategy (cheapest first):
       1. Server-side prefilter via ``client.list_peers(q=query)``
          (substring match on agent_id / display_name).
-      2. If the prefilter returned >1 candidate, rank locally with
-         ``difflib.SequenceMatcher`` against name + agent_id and keep
-         only candidates above ``fuzzy_cutoff``.
-      3. If the prefilter returned 0, fall back to listing the full
-         visible peer set and re-running the fuzzy ranker — covers
-         typos like "marioo" / "mraio" that don't substring-match.
+      2. Promote exact / substring-prefix matches to score 1.0 so they
+         sort above any fuzzy hits — stops a well-named typosquat
+         (e.g. ``southfake``) from piggy-backing on a difflib ratio
+         higher than the legitimate substring match ``south``.
+      3. Rank remaining candidates with ``difflib.SequenceMatcher``
+         against name + agent_id and keep only those above
+         ``fuzzy_cutoff`` (default 0.75 — low enough for single-char
+         typos like ``marioo`` but high enough to reject
+         ``south → southfake``).
+      4. If the server prefilter returned 0, fall back to listing the
+         full visible peer set and re-running the fuzzy ranker — covers
+         typos that don't substring-match.
 
     The returned list is sorted by score descending. Caller decides
     how to handle 0 / 1 / many matches (the ``contact`` MCP tool
-    presents disambiguation).
+    presents disambiguation). **Callers must never auto-select a
+    single fuzzy hit** — an exact-match short-circuit is the only safe
+    auto-pick path, the ``contact`` tool enforces this below.
     """
     qnorm = query.strip()
     if not qnorm:
@@ -90,18 +98,32 @@ def resolve_peer(client, query: str, *, fuzzy_cutoff: float = 0.5) -> list[PeerC
     if not candidates:
         candidates = client.list_peers(limit=200)
 
-    # 3. Rank with difflib against both name-only and full handle.
+    # 3. Rank each candidate. Exact matches win outright; substring-
+    #    prefix matches rank higher than arbitrary difflib ratios so a
+    #    typosquat (``southfake`` containing the query ``south``) can't
+    #    outrank the legitimate substring ``south``. Substring-anywhere
+    #    gets a solid score but still below prefix so the obvious match
+    #    surfaces first in multi-candidate disambiguation.
     scored: list[PeerCandidate] = []
     qlower = qnorm.lower()
     for info in candidates:
         name = (info.display_name or _name_only(info.agent_id)).lower()
-        handle = info.agent_id.lower()
+        handle_full = info.agent_id.lower()
+        handle_short = _name_only(handle_full)
 
-        if qlower == _name_only(handle) or qlower == handle:
+        if qlower == handle_short or qlower == handle_full or qlower == name:
             score = 1.0
+        elif handle_short.startswith(qlower) or name.startswith(qlower):
+            # Substring-prefix — definitely intentional, definitely
+            # above any fuzzy ratio.
+            score = 0.95
+        elif qlower in handle_short or qlower in name:
+            # Substring-anywhere — still a clean prefilter hit, below
+            # prefix so prefixes sort first.
+            score = 0.90
         else:
             name_ratio = difflib.SequenceMatcher(None, qlower, name).ratio()
-            handle_ratio = difflib.SequenceMatcher(None, qlower, _name_only(handle)).ratio()
+            handle_ratio = difflib.SequenceMatcher(None, qlower, handle_short).ratio()
             score = max(name_ratio, handle_ratio)
 
         if score >= fuzzy_cutoff:
@@ -198,7 +220,11 @@ def register(mcp: "FastMCP") -> None:
                 )
             return base + " The peer list is empty — nobody else has enrolled yet."
 
-        if len(candidates) == 1:
+        # Auto-select ONLY on an exact match (score == 1.0). Fuzzy hits
+        # — even when they're the only candidate — must bounce through
+        # disambiguation so a typo like ``south`` can't silently land on
+        # a typosquat ``southfake`` without the user confirming.
+        if len(candidates) == 1 and candidates[0].score >= 1.0:
             state.last_peer_resolved = candidates[0].agent_id
             state.extra.pop(_CANDIDATES_KEY, None)
             return (
@@ -208,8 +234,13 @@ def register(mcp: "FastMCP") -> None:
 
         state.extra[_CANDIDATES_KEY] = candidates
         lines = [_format_candidate(i, c) for i, c in enumerate(candidates)]
+        header = (
+            f"Found {len(candidates)} match for '{peer}'"
+            if len(candidates) == 1
+            else f"Found {len(candidates)} matches for '{peer}'"
+        )
         return (
-            f"Found {len(candidates)} matches for '{peer}':\n"
+            header + " — confirm which one you meant:\n"
             + "\n".join(lines)
             + "\n→ pick one with contact('#1'), contact('#2'), …"
         )

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import secrets
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -30,12 +31,13 @@ from urllib.parse import urlparse
 
 import httpx
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
-from fastapi import FastAPI, Form, Request
+from fastapi import FastAPI, Form, Header, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from cullis_connector.config import ConnectorConfig
+from cullis_connector.statusline_token import ensure_statusline_token
 from cullis_connector.enrollment import (
     EnrollmentFailed,
     RequesterInfo,
@@ -131,6 +133,11 @@ async def _dashboard_lifespan(app: FastAPI):
     config = app.state.connector_config
     app.state.inbox_poller = None
     app.state.inbox_dispatcher = None
+    # Generate / load the statusline bearer token once at startup so the
+    # endpoints below can compare against a stable value. The file is
+    # chmod 0600 — any local process that can read it already had the
+    # means to read ``identity/agent.key`` anyway.
+    app.state.statusline_token = ensure_statusline_token(config.config_dir)
     if os.environ.get("CULLIS_CONNECTOR_NOTIFICATIONS", "on").lower() in ("0", "off", "false", "no"):
         _log.info("inbox poller disabled via CULLIS_CONNECTOR_NOTIFICATIONS")
         yield
@@ -422,8 +429,34 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         _clear_pending()
         return RedirectResponse("/setup", status_code=303)
 
+    def _require_statusline_token(authorization: str | None) -> None:
+        """Reject requests without the dashboard's statusline token.
+
+        The loopback bind (127.0.0.1:7777) stops remote callers but any
+        other local process under the same user could otherwise read
+        inbox metadata / reset the unread counter. The bearer token
+        lives under ``<config_dir>/identity/statusline.token`` (0600),
+        so any attacker with read access to it already owned the agent
+        key anyway.
+        """
+        expected = getattr(app.state, "statusline_token", None)
+        if not expected:
+            # Should never happen — lifespan seeds it — but fail closed
+            # rather than silently allow unauthenticated reads.
+            raise HTTPException(status_code=503, detail="statusline token not initialised")
+        if not authorization or not authorization.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="missing bearer token")
+        presented = authorization.removeprefix("Bearer ").strip()
+        # Constant-time compare — the token is short and the server is
+        # loopback-only, but it's still a credential.
+        if not secrets.compare_digest(presented, expected):
+            raise HTTPException(status_code=401, detail="bad bearer token")
+
     @app.get("/status/inbox")
-    def status_inbox(request: Request) -> JSONResponse:
+    def status_inbox(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> JSONResponse:
         """Statusline-friendly snapshot of the inbox state.
 
         Designed to be polled cheaply (every few seconds) by a Claude
@@ -432,7 +465,11 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         a stable shape — when notifications are off or the dashboard
         hasn't seen any messages yet, ``unread`` is 0 and the rest
         is null.
+
+        Requires ``Authorization: Bearer <token>`` — see
+        ``<config_dir>/identity/statusline.token``.
         """
+        _require_statusline_token(authorization)
         dispatcher = getattr(request.app.state, "inbox_dispatcher", None)
         if dispatcher is None:
             return JSONResponse({
@@ -445,10 +482,18 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         return JSONResponse(dispatcher.status_snapshot())
 
     @app.post("/status/inbox/seen")
-    def status_inbox_seen(request: Request) -> JSONResponse:
+    def status_inbox_seen(
+        request: Request,
+        authorization: str | None = Header(default=None),
+    ) -> JSONResponse:
         """Reset the unread counter — call when the user has read the
         latest batch (the dashboard's `/inbox` view does it on load,
-        statusline scripts can call it on click)."""
+        statusline scripts can call it on click).
+
+        Requires ``Authorization: Bearer <token>`` — see
+        ``<config_dir>/identity/statusline.token``.
+        """
+        _require_statusline_token(authorization)
         dispatcher = getattr(request.app.state, "inbox_dispatcher", None)
         if dispatcher is not None:
             dispatcher.ack()

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -1106,6 +1106,26 @@ async def list_peers(
 
     if limit and len(peers) > limit:
         peers = peers[:limit]
+
+    # Audit trail (security audit NEW #6): peer enumeration is a
+    # reconnaissance primitive — the Connector now hits this endpoint
+    # instead of /v1/federation/agents/search (which does audit), so
+    # without an entry here we'd lose the "who listed whom and with
+    # what filter" signal that compliance reviewers expect. Matches
+    # the detail shape of egress_discover below for consistency.
+    try:
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_peers_list",
+            status="success",
+            detail=f"q={q} limit={limit} results={len(peers)}",
+        )
+    except Exception as audit_exc:  # noqa: BLE001
+        # Never let an audit-write failure break the read path — log
+        # it and continue. Alembic / schema issues should surface in
+        # their own telemetry, not in the user's peer list.
+        logger.warning("egress_peers_list audit write failed: %s", audit_exc)
+
     return PeersResponse(peers=peers, count=len(peers))
 
 

--- a/tests/connector/test_inbox_poller.py
+++ b/tests/connector/test_inbox_poller.py
@@ -213,15 +213,29 @@ async def test_stop_releases_blocked_consumer_via_sentinel():
 
 
 @pytest.mark.asyncio
-async def test_pubkey_prime_failure_skips_message_does_not_crash_loop(caplog):
+async def test_pubkey_prime_failure_skips_message_does_not_crash_loop():
     """Security audit NEW #4 — if ``prime_sender_pubkey_cache`` raises
     (empty target_cert_pem, network error, incompatible client), the
     poller MUST log at ERROR and skip the row. The loop continues so
-    subsequent rounds still drain the inbox."""
-    import logging
+    subsequent rounds still drain the inbox.
 
-    class _PrimeFailClient(_FakeClient):
+    Exercise the recovery path by having the FIRST round prime-fail
+    and the SECOND round prime-succeed — then await the successful
+    event to pin the loop-survived invariant deterministically
+    (avoids flaky time-based asserts on 16-way xdist workers).
+    """
+    failure_rounds = {"left": 1}
+    resolve_calls = {"count": 0}
+    decode_attempts = {"count": 0}
+
+    class _RecoverableClient(_FakeClient):
         def _egress_http(self, method, path, *, json=None, **kw):
+            resolve_calls["count"] += 1
+            status = {"body": {"target_cert_pem": "PEM"}}
+            if failure_rounds["left"] > 0:
+                failure_rounds["left"] -= 1
+                status = {"body": {"target_cert_pem": ""}}
+
             class _R:
                 status_code = 200
 
@@ -229,32 +243,35 @@ async def test_pubkey_prime_failure_skips_message_does_not_crash_loop(caplog):
                     pass
 
                 def json(self):
-                    return {"target_cert_pem": ""}  # forces PubkeyPrimeError
+                    return status["body"]
+
             return _R()
+
+        def decrypt_oneshot(self, row: dict) -> dict:
+            decode_attempts["count"] += 1
+            return super().decrypt_oneshot(row)
 
     rows_round1 = [{"msg_id": "skip-me", "sender_agent_id": "acme::alice", "correlation_id": "c", "reply_to": None, "text": "x"}]
     rows_round2 = [{"msg_id": "next-round", "sender_agent_id": "acme::alice", "correlation_id": "c2", "reply_to": None, "text": "ok"}]
-    client = _PrimeFailClient(rounds=[rows_round1, rows_round2])
+    client = _RecoverableClient(rounds=[rows_round1, rows_round2])
 
     poller = DashboardInboxPoller(client, poll_interval_s=0.05)
-    with caplog.at_level(logging.ERROR, logger="cullis_connector.inbox_poller"):
-        poller.start()
-        try:
-            # First round's row gets skipped; second round's row also
-            # prime-fails because the fake client still returns empty.
-            # Use a short timeout and just assert no events arrive —
-            # rather than waiting for success (it'll never come with
-            # this broken stub). The invariant is: loop did not crash.
-            await asyncio.sleep(0.3)
-        finally:
-            await poller.stop(timeout_s=1.0)
+    poller.start()
+    try:
+        events = await _drain_events(poller, n=1, timeout=3.0)
+    finally:
+        await poller.stop(timeout_s=1.0)
 
-    # ERROR log recorded — operator sees the security-relevant skip.
-    assert any(
-        "pubkey prime failed" in rec.message for rec in caplog.records
-    ), [r.message for r in caplog.records]
-    # Loop stayed alive through at least 2 rounds — not crashed.
-    assert client.calls >= 2
+    # Loop kept running past the skip — the NEXT round produced.
+    assert events[0].msg_id == "next-round"
+    # Resolve endpoint was hit twice (round 1 skip + round 2 success),
+    # so the skip path actually ran — not a silent fallthrough.
+    assert resolve_calls["count"] == 2, resolve_calls
+    # decrypt_oneshot was invoked ONLY for round 2 — round 1 bailed
+    # out before decrypt because prime_sender_pubkey_cache raised.
+    # This is the security invariant: a sender whose cert we can't
+    # prime must NOT be decrypted / surfaced.
+    assert decode_attempts["count"] == 1, decode_attempts
 
 
 @pytest.mark.asyncio

--- a/tests/connector/test_inbox_poller.py
+++ b/tests/connector/test_inbox_poller.py
@@ -30,6 +30,26 @@ class _FakeClient:
             lambda r: {"payload": {"text": r.get("text", "decoded")}}
         )
         self.calls = 0
+        # Pre-seeded pubkey cache so prime_sender_pubkey_cache hits the
+        # TTL-fresh short-circuit instead of trying to call _egress_http.
+        # Real poller installs this attribute in production.
+        self._pubkey_cache: dict = {}
+
+    def _egress_http(self, method, path, *, json=None, **kw):
+        """Stand-in resolve endpoint — any row whose sender wasn't
+        preseeded above would otherwise trigger PubkeyPrimeError when
+        prime_sender_pubkey_cache can't find a cached cert. Returning
+        a non-empty PEM here is enough to satisfy the prime step."""
+        class _R:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {"target_cert_pem": "PEM"}
+
+        return _R()
 
     def receive_oneshot(self) -> list[dict]:
         self.calls += 1
@@ -190,6 +210,51 @@ async def test_stop_releases_blocked_consumer_via_sentinel():
     await poller.stop(timeout_s=1.0)
     await asyncio.wait_for(consumer_woke.wait(), timeout=1.0)
     consume_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_pubkey_prime_failure_skips_message_does_not_crash_loop(caplog):
+    """Security audit NEW #4 — if ``prime_sender_pubkey_cache`` raises
+    (empty target_cert_pem, network error, incompatible client), the
+    poller MUST log at ERROR and skip the row. The loop continues so
+    subsequent rounds still drain the inbox."""
+    import logging
+
+    class _PrimeFailClient(_FakeClient):
+        def _egress_http(self, method, path, *, json=None, **kw):
+            class _R:
+                status_code = 200
+
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return {"target_cert_pem": ""}  # forces PubkeyPrimeError
+            return _R()
+
+    rows_round1 = [{"msg_id": "skip-me", "sender_agent_id": "acme::alice", "correlation_id": "c", "reply_to": None, "text": "x"}]
+    rows_round2 = [{"msg_id": "next-round", "sender_agent_id": "acme::alice", "correlation_id": "c2", "reply_to": None, "text": "ok"}]
+    client = _PrimeFailClient(rounds=[rows_round1, rows_round2])
+
+    poller = DashboardInboxPoller(client, poll_interval_s=0.05)
+    with caplog.at_level(logging.ERROR, logger="cullis_connector.inbox_poller"):
+        poller.start()
+        try:
+            # First round's row gets skipped; second round's row also
+            # prime-fails because the fake client still returns empty.
+            # Use a short timeout and just assert no events arrive —
+            # rather than waiting for success (it'll never come with
+            # this broken stub). The invariant is: loop did not crash.
+            await asyncio.sleep(0.3)
+        finally:
+            await poller.stop(timeout_s=1.0)
+
+    # ERROR log recorded — operator sees the security-relevant skip.
+    assert any(
+        "pubkey prime failed" in rec.message for rec in caplog.records
+    ), [r.message for r in caplog.records]
+    # Loop stayed alive through at least 2 rounds — not crashed.
+    assert client.calls >= 2
 
 
 @pytest.mark.asyncio

--- a/tests/connector/test_intent_resolve_peer.py
+++ b/tests/connector/test_intent_resolve_peer.py
@@ -131,5 +131,87 @@ def test_below_cutoff_excluded():
     client = _FakeClient([_peer("mario", "Mario")])
     out = resolve_peer(client, "zzzzz")
     # difflib ratio between 'zzzzz' and 'mario' / 'acme::mario' is ~0
-    # so nothing crosses 0.5.
+    # so nothing crosses 0.75.
     assert out == []
+
+
+# ── Typosquat hardening (security audit NEW #2) ─────────────────────────
+
+
+def test_typosquat_prefix_outranks_fuzzy_match():
+    """A legitimate substring-prefix match (``south`` → ``south``)
+    must outrank a fuzzy ratio on a typosquat (``south`` → ``southfake``)
+    so the user sees the right peer at position #1 and — most
+    importantly — the auto-select path in ``contact()`` lands on the
+    real peer rather than the squatter."""
+    client = _FakeClient([
+        _peer("south", "South Bot"),
+        _peer("southfake", "South Fake"),
+    ])
+
+    out = resolve_peer(client, "south")
+    assert out, "expected at least one match"
+    # Exact name wins outright.
+    assert out[0].agent_id == "acme::south"
+    assert out[0].score == 1.0
+    # The squatter is still allowed in the list (prefix match) but
+    # must score strictly below the legitimate peer — the UI relies
+    # on this ordering for disambiguation.
+    scores_by_handle = {c.agent_id: c.score for c in out}
+    if "acme::southfake" in scores_by_handle:
+        assert scores_by_handle["acme::southfake"] < scores_by_handle["acme::south"]
+
+
+def test_fuzzy_cutoff_rejects_distant_typosquats():
+    """``north`` against ``southfake`` — no common substring, far below
+    0.75, must not show up as a match. Previous 0.5 cutoff was
+    permissive enough to surface these as plausible candidates."""
+    client = _FakeClient([_peer("southfake", "South Fake")])
+    out = resolve_peer(client, "north")
+    assert out == []
+
+
+def test_contact_does_not_auto_select_on_single_fuzzy_match(monkeypatch):
+    """When the only candidate is a fuzzy (score < 1.0) match, the
+    ``contact`` MCP tool must NOT auto-select it — the user has to
+    confirm. Protects against ``contact('south')`` landing silently
+    on ``southfake`` if someone squats the legitimate name.
+    """
+    from cullis_connector.config import ConnectorConfig
+    from cullis_connector.state import get_state, reset_state
+    from cullis_connector.tools import intent
+
+    class _FakeFastMCP:
+        def __init__(self) -> None:
+            self.tools: dict = {}
+        def tool(self):
+            def dec(fn):
+                self.tools[fn.__name__] = fn
+                return fn
+            return dec
+
+    reset_state()
+    cfg_dir = __import__("pathlib").Path("/tmp/contact-fuzzy-test")
+    get_state().config = ConnectorConfig(
+        site_url="https://mastio.test",
+        config_dir=cfg_dir,
+        verify_tls=False,
+        request_timeout_s=2.0,
+    )
+
+    # Only peer is a typo away from the query — fuzzy, not exact.
+    class _C:
+        _signing_key_pem = "PEM"
+
+        def list_peers(self, q=None, limit=50):
+            return [_peer("maria", "Maria Bianchi")]
+    get_state().client = _C()
+
+    mcp = _FakeFastMCP()
+    intent.register(mcp)
+    out = mcp.tools["contact"]("maraia")
+
+    # No silent auto-select — user is asked to pick.
+    assert get_state().last_peer_resolved is None
+    assert "confirm" in out.lower() or "pick" in out.lower()
+    reset_state()

--- a/tests/connector/test_oneshot_state_update.py
+++ b/tests/connector/test_oneshot_state_update.py
@@ -48,11 +48,15 @@ class _FakeClient:
         return self._decoder(row)
 
     def _egress_http(self, *args, **kwargs):
-        # Only invoked by _prime_sender_pubkey_cache; cache hit avoids it.
+        # Fallback for rows whose sender wasn't pre-seeded in the cache
+        # (e.g. bare names that canonicalise into a different key).
+        # Returns a valid-looking resolve response so prime succeeds
+        # rather than raising PubkeyPrimeError — unrelated to the state
+        # cursor logic these tests are exercising.
         class _R:
-            status_code = 404
+            status_code = 200
             def raise_for_status(self): pass
-            def json(self): return {}
+            def json(self): return {"target_cert_pem": "PEM"}
         return _R()
 
 
@@ -77,10 +81,16 @@ def receive_tool():
 
 
 def _install_client(rows, decoder=None) -> _FakeClient:
+    import time as _time
+
     client = _FakeClient(rows=rows, decoder=decoder)
-    # Pre-seed the cache so prime() short-circuits.
+    # Pre-seed the cache so prime() short-circuits on the TTL-fresh
+    # branch. The timestamp must be current — a 0.0 seed is always
+    # stale and would trigger the _egress_http refetch path (which
+    # returns 404 in this fixture → PubkeyPrimeError on purpose).
+    now = _time.time()
     for r in rows:
-        client._pubkey_cache[r["sender_agent_id"]] = ("PEM", 0.0)
+        client._pubkey_cache[r["sender_agent_id"]] = ("PEM", now)
     get_state().client = client
     return client
 

--- a/tests/connector/test_oneshot_state_update.py
+++ b/tests/connector/test_oneshot_state_update.py
@@ -147,6 +147,51 @@ def test_receive_only_updates_on_decode_success(receive_tool):
     assert get_state().last_reply_to is None
 
 
+def test_bad_signature_does_not_update_last_peer_resolved(receive_tool):
+    """Explicit contract test (security audit NEW #3): when
+    ``decrypt_oneshot`` raises for a signature-verification failure,
+    ``state.last_peer_resolved`` MUST NOT be touched.
+
+    The invariant protects the ``reply()`` tool: if we updated the
+    cursor on an unverified row, a reply would be addressed to an
+    attacker-controlled sender string. The existing test above covers
+    a generic RuntimeError; this one pins the specific failure mode
+    the SDK surfaces when signature verification (inner or outer)
+    doesn't match, so regressions that re-order the bookkeeping
+    around the except clause fail loudly.
+    """
+    # Seed a known-good prior state. If the bad-signature branch
+    # leaks into last_peer_resolved, this value will be overwritten
+    # and the assertion below will fire.
+    state = get_state()
+    state.last_peer_resolved = "acme::prior-known-good"
+    state.last_reply_to = "msg-prior"
+
+    def _sig_verify_fail(_row):
+        # Mirrors what cullis_sdk.client.decrypt_oneshot raises when
+        # the envelope signature chain fails to verify against the
+        # primed pubkey cache.
+        raise ValueError("envelope signature verification failed")
+
+    rows = [{
+        "sender_agent_id": "acme::mallory",
+        "msg_id": "msg-forged",
+        "correlation_id": "corr-forged",
+        "reply_to": None,
+        "payload_ciphertext": "{}",
+    }]
+    _install_client(rows, decoder=_sig_verify_fail)
+    out = receive_tool()
+
+    # User-visible failure trail is preserved.
+    assert "decrypt failed" in out
+    assert "signature verification failed" in out
+    # State is unchanged from before the call — NOT updated to the
+    # unverified sender.
+    assert state.last_peer_resolved == "acme::prior-known-good"
+    assert state.last_reply_to == "msg-prior"
+
+
 def test_receive_picks_last_decoded_row_when_multiple(receive_tool):
     """Multiple rows decoded → the LAST decoded one wins. That's the
     one the user just read, so it's the most plausible reply target."""

--- a/tests/connector/test_status_inbox_endpoint.py
+++ b/tests/connector/test_status_inbox_endpoint.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cullis_connector.config import ConnectorConfig
+from cullis_connector.statusline_token import read_statusline_token
 from cullis_connector.web import build_app
 
 
@@ -27,13 +28,19 @@ def app(tmp_path):
     return app
 
 
+def _auth_headers(app) -> dict[str, str]:
+    """Pull the token the lifespan seeded so each test can authorise."""
+    token = app.state.statusline_token
+    return {"Authorization": f"Bearer {token}"}
+
+
 def test_status_inbox_returns_zero_state_without_dispatcher(app):
     """Pre-enrolment dashboards have no dispatcher yet — endpoint
     must still return a stable shape for the statusline poller."""
     with TestClient(app) as client:
         # TestClient triggers lifespan; with no identity on disk the
         # dispatcher stays None.
-        r = client.get("/status/inbox")
+        r = client.get("/status/inbox", headers=_auth_headers(app))
     assert r.status_code == 200
     body = r.json()
     assert body == {
@@ -60,7 +67,7 @@ def test_status_inbox_returns_dispatcher_snapshot(app):
     with TestClient(app) as client:
         # Override after lifespan startup.
         app.state.inbox_dispatcher = fake
-        r = client.get("/status/inbox")
+        r = client.get("/status/inbox", headers=_auth_headers(app))
 
     assert r.status_code == 200
     assert r.json() == fake.status_snapshot.return_value
@@ -70,7 +77,7 @@ def test_status_inbox_seen_calls_ack_when_dispatcher_present(app):
     fake = MagicMock()
     with TestClient(app) as client:
         app.state.inbox_dispatcher = fake
-        r = client.post("/status/inbox/seen")
+        r = client.post("/status/inbox/seen", headers=_auth_headers(app))
     assert r.status_code == 200
     assert r.json() == {"ok": True}
     fake.ack.assert_called_once()
@@ -80,6 +87,69 @@ def test_status_inbox_seen_no_op_without_dispatcher(app):
     """Statusline scripts may call /seen before the dashboard has
     booted the dispatcher — must not 500."""
     with TestClient(app) as client:
-        r = client.post("/status/inbox/seen")
+        r = client.post("/status/inbox/seen", headers=_auth_headers(app))
     assert r.status_code == 200
     assert r.json() == {"ok": True}
+
+
+# ── Auth guard tests (NEW #1 – statusline bearer token) ─────────────────
+
+
+def test_status_inbox_rejects_missing_auth(app):
+    with TestClient(app) as client:
+        r = client.get("/status/inbox")
+    assert r.status_code == 401
+
+
+def test_status_inbox_rejects_wrong_token(app):
+    with TestClient(app) as client:
+        r = client.get(
+            "/status/inbox",
+            headers={"Authorization": "Bearer not-the-right-token"},
+        )
+    assert r.status_code == 401
+
+
+def test_status_inbox_seen_rejects_missing_auth_cannot_reset_counter(app):
+    """Without auth, a local attacker must NOT be able to ack the
+    dispatcher and hide unread messages from the user."""
+    fake = MagicMock()
+    with TestClient(app) as client:
+        app.state.inbox_dispatcher = fake
+        r = client.post("/status/inbox/seen")
+    assert r.status_code == 401
+    fake.ack.assert_not_called()
+
+
+def test_statusline_token_persisted_chmod_0600(tmp_path, app):
+    """The token file must land at <identity>/statusline.token 0600."""
+    import stat
+
+    with TestClient(app):
+        pass  # trigger lifespan
+
+    token = read_statusline_token(tmp_path)
+    assert token
+    token_path = tmp_path / "identity" / "statusline.token"
+    assert token_path.exists()
+    mode = stat.S_IMODE(token_path.stat().st_mode)
+    assert mode & 0o077 == 0, f"statusline.token must be owner-only, got {oct(mode)}"
+
+
+def test_statusline_token_stable_across_restarts(tmp_path):
+    """Two build_app() runs over the same config_dir reuse the token."""
+    cfg = ConnectorConfig(
+        site_url="http://mastio.test",
+        config_dir=tmp_path,
+        verify_tls=False,
+        request_timeout_s=2.0,
+    )
+    app1 = build_app(cfg)
+    with TestClient(app1):
+        t1 = app1.state.statusline_token
+
+    app2 = build_app(cfg)
+    with TestClient(app2):
+        t2 = app2.state.statusline_token
+
+    assert t1 == t2

--- a/tests/connector/test_tools_identity.py
+++ b/tests/connector/test_tools_identity.py
@@ -1,0 +1,129 @@
+"""Tests for ``cullis_connector.tools._identity``.
+
+Focused on the security-audit contract for ``prime_sender_pubkey_cache``
+(NEW #4): the function MUST raise ``PubkeyPrimeError`` on any failure
+to seed the SDK pubkey cache — including an empty ``target_cert_pem``
+in the ``/v1/egress/resolve`` response — instead of silently returning
+and letting the caller fall through to the broker JWT path with no
+audit trail.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from cullis_connector.tools._identity import (
+    PubkeyPrimeError,
+    prime_sender_pubkey_cache,
+)
+
+
+class _Resp:
+    def __init__(self, status_code: int = 200, body: dict | None = None) -> None:
+        self.status_code = status_code
+        self._body = body or {}
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self) -> dict:
+        return dict(self._body)
+
+
+class _Client:
+    def __init__(self, resp: _Resp | Exception) -> None:
+        self._resp = resp
+        self._pubkey_cache: dict = {}
+        self.calls: list[dict] = []
+
+    def _egress_http(self, method, path, *, json=None, **kw):
+        self.calls.append({"method": method, "path": path, "json": json})
+        if isinstance(self._resp, Exception):
+            raise self._resp
+        return self._resp
+
+
+def test_raises_when_client_missing_pubkey_cache():
+    class _BadClient:
+        # no _pubkey_cache attribute
+        pass
+
+    with pytest.raises(PubkeyPrimeError, match="_pubkey_cache"):
+        prime_sender_pubkey_cache(_BadClient(), "acme::mario")
+
+
+def test_raises_when_resolve_returns_no_target_cert_pem():
+    """Empty / missing target_cert_pem → PubkeyPrimeError, NOT silent
+    return. Previously this path logged a WARNING and returned, which
+    dropped the security-relevant skip out of the audit trail."""
+    client = _Client(_Resp(200, {"target_cert_pem": ""}))
+    with pytest.raises(PubkeyPrimeError, match="no target_cert_pem"):
+        prime_sender_pubkey_cache(client, "acme::mario")
+    # Cache stays empty — we did not seed anything.
+    assert client._pubkey_cache == {}
+
+
+def test_raises_when_resolve_http_call_fails():
+    """Network / proxy errors propagate as PubkeyPrimeError so the
+    caller can log at ERROR and skip the message."""
+    client = _Client(RuntimeError("connection refused"))
+    with pytest.raises(PubkeyPrimeError, match="connection refused"):
+        prime_sender_pubkey_cache(client, "acme::mario")
+
+
+def test_raises_when_resolve_returns_4xx():
+    client = _Client(_Resp(404, {}))
+    with pytest.raises(PubkeyPrimeError, match="404"):
+        prime_sender_pubkey_cache(client, "acme::mario")
+
+
+def test_cache_hit_is_noop_and_does_not_call_resolve():
+    """TTL-fresh cache entry → no-op, no HTTP call. Regression guard
+    for the 67e3b95 fix (prime helper must honour SDK pubkey cache TTL)."""
+    client = _Client(_Resp(200, {"target_cert_pem": "PEM"}))
+    client._pubkey_cache["acme::mario"] = ("cached-PEM", time.time())
+    prime_sender_pubkey_cache(client, "acme::mario")
+    assert client.calls == [], "cache hit should not hit the resolve endpoint"
+
+
+def test_cache_stale_triggers_refetch_and_populates():
+    """When the cached entry is older than the SDK TTL, we refetch —
+    otherwise stale pubkeys would leak into decrypt_oneshot."""
+    client = _Client(_Resp(200, {"target_cert_pem": "FRESH-PEM"}))
+    # Entry is way past the 300s TTL.
+    client._pubkey_cache["acme::mario"] = ("stale-PEM", time.time() - 3600)
+    prime_sender_pubkey_cache(client, "acme::mario")
+    assert client._pubkey_cache["acme::mario"][0] == "FRESH-PEM"
+    assert len(client.calls) == 1
+
+
+def test_bare_sender_mirrors_into_cache():
+    """Canonicalised ``<org>::<agent>`` is the primary key, the bare
+    handle is mirrored so ``decrypt_oneshot`` (which reads whatever
+    form the inbox row carried) still finds the entry."""
+    # No identity loaded → canonical_recipient falls back to input
+    # unchanged, so the mirror branch only fires when caller already
+    # passed the canonical form. Exercise that here.
+    client = _Client(_Resp(200, {"target_cert_pem": "PEM"}))
+    # Pretend the test bench has an identity loaded so bare → canonical.
+    from unittest.mock import MagicMock
+
+    from cullis_connector.state import get_state, reset_state
+
+    reset_state()
+    fake_attr = MagicMock()
+    fake_attr.value = "acme"
+    fake_cert = MagicMock()
+    fake_cert.subject.get_attributes_for_oid.return_value = [fake_attr]
+    fake_identity = MagicMock()
+    fake_identity.cert = fake_cert
+    get_state().extra["identity"] = fake_identity
+
+    try:
+        prime_sender_pubkey_cache(client, "mario")
+        assert "acme::mario" in client._pubkey_cache
+        assert "mario" in client._pubkey_cache
+    finally:
+        reset_state()

--- a/tests/test_proxy_peers.py
+++ b/tests/test_proxy_peers.py
@@ -254,3 +254,44 @@ async def test_peers_reach_both_returns_all(proxy_app):
     handles = {p["agent_id"] for p in body["peers"]}
     assert "acme::mario" in handles
     assert "remote-bot" in handles
+
+
+@pytest.mark.asyncio
+async def test_peers_writes_audit_entry(proxy_app):
+    """Security audit NEW #6 — peer enumeration must land in the
+    audit log. Before this fix, /v1/egress/peers had no audit write,
+    so a Connector's discover_agents (which now routes through here
+    instead of /v1/federation/agents/search) left no compliance
+    trail of who listed whom.
+    """
+    from mcp_proxy.db import get_db
+
+    _, client = proxy_app
+    api_key = await _provision_caller("caller-bot")
+    await _provision_local_peer("mario", "Mario Rossi")
+
+    resp = await client.get(
+        "/v1/egress/peers",
+        headers={"X-API-Key": api_key},
+        params={"q": "mar"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    async with get_db() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT agent_id, action, status, detail FROM audit_log "
+                    "WHERE action = 'egress_peers_list' "
+                    "ORDER BY id DESC LIMIT 1"
+                )
+            )
+        ).first()
+    assert row is not None, "expected an egress_peers_list audit row"
+    assert row[0] == "caller-bot"
+    assert row[1] == "egress_peers_list"
+    assert row[2] == "success"
+    # detail should capture the query + result count so the audit is
+    # useful without cross-referencing request logs.
+    assert "q=mar" in row[3]
+    assert "results=1" in row[3]


### PR DESCRIPTION
## Summary
Six zero-trust findings from the post-#234 audit. The UX v2 layer (intent tools + dashboard poller + notifications) introduced surface that convenience-wrapped the wire without carrying its invariants.

- **NEW #1/#3** — `/status/inbox` + `/status/inbox/seen` now require a per-install bearer token (0600 in `<identity_dir>/statusline.token`). Local processes can no longer read message metadata or reset the unread counter.
- **NEW #2** — `resolve_peer` difflib cutoff raised 0.5 → 0.75, exact/prefix score tiers, `contact()` never auto-selects a fuzzy hit (always disambiguate).
- **NEW #3** — explicit contract test: bad-signature rows never update `state.last_peer_resolved` (logic was already defensive, now invariant is locked in a test).
- **NEW #4** — `prime_sender_pubkey_cache` raises `PubkeyPrimeError` on missing cert; inbox poller logs ERROR and skips the row (no silent fallback to broker JWT).
- **NEW #6** — audit trail on `/v1/egress/peers` peer enumeration (was previously un-logged).
- Timing-flake hardening on the pubkey-prime skip test.

## Findings
Connector UX v2 zero-trust audit 2026-04-19 (NEW #1, #2, #3, #5, #6 from the session audit).

## Test plan
- [x] `pytest tests/ -n auto --dist=loadfile -k "connector or intent or oneshot or identity or peer"` — 240 pass
- [x] Full suite: 1488 pass (2 pre-existing postgres failures unrelated)
- [x] README statusline snippet updated to carry Authorization header