### PR TITLE
fix(proxy): standalone must default transport_intra_org to mtls-only

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -211,6 +211,16 @@ class ProxySettings(BaseSettings):
         # traffic" deployments — e.g. schema-only validation in CI).
         if self.standalone and _env("PROXY_INTRA_ORG") is None:
             self.intra_org_routing = True
+        # Standalone also flips the default intra-org transport from
+        # "envelope" to "mtls-only". The envelope resolve handler does
+        # not populate target_cert_pem for intra-org peers, so the SDK
+        # send_oneshot path fails with a misleading "cross-org one-shot
+        # requires recipient public key" error on a fresh install. The
+        # mtls-only path short-circuits through the proxy itself and
+        # works out of the box. Operators who explicitly set
+        # PROXY_TRANSPORT_INTRA_ORG keep full control.
+        if self.standalone and _env("PROXY_TRANSPORT_INTRA_ORG") is None:
+            self.transport_intra_org = "mtls-only"
         return self
 
 

--- a/tests/test_proxy_standalone_e2e.py
+++ b/tests/test_proxy_standalone_e2e.py
@@ -27,9 +27,11 @@ async def standalone_proxy(tmp_path, monkeypatch):
     monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
     monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
-    # Deliberately NOT setting PROXY_INTRA_ORG — the default in standalone
-    # mode must flip it on, otherwise the point of this PR is lost.
+    # Deliberately NOT setting PROXY_INTRA_ORG or PROXY_TRANSPORT_INTRA_ORG
+    # — the defaults in standalone mode must flip them both on, otherwise
+    # the point of this fixture is lost.
     monkeypatch.delenv("PROXY_INTRA_ORG", raising=False)
+    monkeypatch.delenv("PROXY_TRANSPORT_INTRA_ORG", raising=False)
     monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
     monkeypatch.delenv("MCP_PROXY_BROKER_JWKS_URL", raising=False)
 
@@ -69,6 +71,27 @@ async def test_standalone_defaults_to_intra_org_routing(standalone_proxy):
     assert settings.intra_org_routing is True, (
         "standalone mode must enable intra-org routing by default — "
         "without it /v1/egress/* 503s on missing bridge"
+    )
+
+
+@pytest.mark.asyncio
+async def test_standalone_defaults_to_mtls_only_transport(standalone_proxy):
+    """Standalone must default transport_intra_org to mtls-only.
+
+    The envelope resolve handler does not populate target_cert_pem for
+    intra-org peers, so SDK send_oneshot fails with a misleading
+    "cross-org one-shot requires recipient public key" error on a
+    fresh install. The mtls-only path short-circuits through the proxy
+    itself and works out of the box.
+    """
+    from mcp_proxy.config import get_settings
+
+    settings = get_settings()
+    assert settings.standalone is True
+    assert settings.transport_intra_org == "mtls-only", (
+        "standalone mode must default to mtls-only transport — "
+        "envelope leaves send_oneshot without target_cert_pem on "
+        "intra-org peers, fresh installs get misleading errors"
     )
 
 


### PR DESCRIPTION
## Summary

Tech-debt item #4 from the Connector v2 session — make fresh standalone installs work out of the box.

In envelope mode the proxy resolve handler does not populate `target_cert_pem` for intra-org peers. The SDK `send_oneshot` path then errors with a misleading *"cross-org one-shot requires recipient public key"* on what is actually an intra-org send, and every fresh standalone install hits this on the first message.

This PR mirrors the existing ADR-006 Fase 1 pattern — standalone implies `intra_org_routing=True` — for the transport default:

- \`MCP_PROXY_STANDALONE=true\` now flips the default \`transport_intra_org\` from \"envelope\" to \"mtls-only\" unless the operator explicitly sets \`PROXY_TRANSPORT_INTRA_ORG\`.
- Explicit \`PROXY_TRANSPORT_INTRA_ORG=envelope\` still wins (escape hatch for testing / migration scenarios).
- Sandbox \`docker-compose.yml\` already hardcodes \`mtls-only\` on both proxies — those overrides are now no-ops but kept for clarity.

## Test plan

- [x] New regression test \`test_standalone_defaults_to_mtls_only_transport\` asserts the default flip.
- [x] Existing \`test_standalone_defaults_to_intra_org_routing\` still passes — the fixture now also delenvs \`PROXY_TRANSPORT_INTRA_ORG\` for stability.
- [x] \`pytest tests/test_proxy_standalone_e2e.py\` → 5/5 pass locally.
- [x] \`ruff check\` clean.
- [ ] CI green (pytest + smoke).