### PR TITLE
fix(connector): re-enable DPoP on egress client (tech-debt #1)

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -329,14 +329,7 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
     try:
         from cullis_sdk import CullisClient
 
-        # ``enable_dpop=False`` — the SDK otherwise generates a local DPoP
-        # keypair whose thumbprint the Mastio doesn't know about, so the
-        # egress endpoint 401s on the DPoP proof even though the API-key
-        # itself is valid. Until enrollment binds the Connector's DPoP
-        # jkt server-side (ADR-011 Phase 3d follow-up / #206), fall back
-        # to the legacy X-API-Key bearer — accepted while the Mastio's
-        # ``egress_dpop_mode`` stays at ``optional`` (Phase 5 default).
-        client = CullisClient.from_connector(cfg.config_dir, enable_dpop=False)
+        client = CullisClient.from_connector(cfg.config_dir)
         key_path = cfg.config_dir / "identity" / "agent.key"
         if key_path.exists():
             client._signing_key_pem = key_path.read_text()

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -182,7 +182,7 @@ def _start_inbox_poller(config: ConnectorConfig) -> DashboardInboxPoller | None:
         state.agent_id = identity.metadata.agent_id
         state.extra["identity"] = identity
 
-        client = CullisClient.from_connector(config.config_dir, enable_dpop=False)
+        client = CullisClient.from_connector(config.config_dir)
         key_path = config.config_dir / "identity" / "agent.key"
         if key_path.exists():
             client._signing_key_pem = key_path.read_text()


### PR DESCRIPTION
## Summary

Tech-debt item #1 from the Connector UX v2 session — the Connector was forcing \`enable_dpop=False\` on its \`CullisClient\` because previously the ephemeral DPoP jkt wasn't bound server-side. That binding landed in earlier phases; the Connector override is the last hook holding the API-key bearer open.

Server-side pieces already in place:

- \`internal_agents.dpop_jkt\` column (migration 0014, Phase 2).
- \`pending_enrollments.dpop_jkt\` threaded through device-code enroll → approve → \`internal_agents\` (migration 0015, enrollment service).
- Admin endpoint \`POST /v1/admin/agents/{id}/dpop-jwk\` for post-hoc registration or rotation (#206).
- \`/v1/egress/*\` DPoP verification with mode-gating (\`off\` / \`optional\` / \`required\`) in \`auth/dpop_api_key.py\`.

This PR drops \`enable_dpop=False\` from \`cli._cmd_serve\` and \`web._start_inbox_poller\` so the SDK default (\`True\`) applies.

### Backwards compatibility

- **Fresh enrollments**: ship the DPoP JWK in \`/v1/enrollment/start\`; Mastio stores its jkt; egress proofs verify cleanly.
- **Older identities without a persisted \`dpop.jwk\`**: SDK generates a fresh key on \`from_connector\`, warns via \`RuntimeWarning\`, and the Mastio's default \`egress_dpop_mode=optional\` still accepts the bare API-key bearer. Operator can use the admin endpoint or re-enroll to bind the new jkt when convenient.

## Test plan

- [x] \`pytest tests/connector/ tests/test_sdk_dpop.py tests/test_sdk_enrollment_unified.py\` → 169 pass.
- [x] \`ruff check\` clean.
- [ ] CI green (pytest + smoke + helm).

## Follow-up

Tech-debt #3 — pluggable pubkey fetcher in the SDK so the Connector can retire \`prime_sender_pubkey_cache\` and stop reaching into SDK internals — is tracked separately, next PR.