### PR TITLE
fix(rate_limit): fall open on Redis outage instead of 500 (audit F-D-2)

### DIFF
--- a/app/rate_limit/limiter.py
+++ b/app/rate_limit/limiter.py
@@ -13,6 +13,9 @@ import uuid
 from collections import defaultdict, deque
 
 from fastapi import HTTPException, status
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import RedisError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from app.telemetry_metrics import RATE_LIMIT_REJECT_COUNTER
 
@@ -20,6 +23,18 @@ _log = logging.getLogger("agent_trust")
 
 
 _MAX_SUBJECTS = 50_000  # maximum unique subjects in memory — LRU eviction
+
+# Transient Redis failures that should trigger fail-open behaviour (audit F-D-2).
+# Rate limiting is a best-effort DoS control, not an auth gate — blocking
+# requests when Redis is unreachable creates a bigger outage than allowing
+# unlimited requests briefly. asyncio.TimeoutError is included because
+# redis.asyncio raises it on socket-level timeouts in some code paths.
+_REDIS_TRANSIENT_ERRORS = (
+    RedisConnectionError,
+    RedisTimeoutError,
+    asyncio.TimeoutError,
+    OSError,
+)
 
 
 class SlidingWindowLimiter:
@@ -38,6 +53,9 @@ class SlidingWindowLimiter:
         # Backend selection
         self._use_redis: bool | None = None  # None = not yet decided
         self._redis = None
+        # Fail-open observability: count consecutive Redis failures so we can
+        # log at WARNING without flooding logs (audit F-D-2).
+        self._redis_failure_count: int = 0
 
     def register(self, bucket: str, window_seconds: int, max_requests: int) -> None:
         """Register the configuration for a bucket. Called at startup."""
@@ -65,7 +83,41 @@ class SlidingWindowLimiter:
         self._select_backend()
 
         if self._use_redis:
-            await self._check_redis(subject, bucket, config)
+            try:
+                await self._check_redis(subject, bucket, config)
+            except HTTPException:
+                # Genuine 429 from the Lua script — must propagate.
+                raise
+            except _REDIS_TRANSIENT_ERRORS as exc:
+                # Audit F-D-2: Redis outage must not surface as HTTP 500.
+                # Fail open — rate limiting is a best-effort DoS control,
+                # not an auth gate. Blocking requests during a Redis outage
+                # is a worse DoS than allowing unlimited requests briefly.
+                self._redis_failure_count += 1
+                _log.warning(
+                    "rate limiter Redis unavailable — allowing request "
+                    "(fail-open) [bucket=%s, consecutive_failures=%d]: %s",
+                    bucket, self._redis_failure_count, exc,
+                )
+                return
+            except RedisError as exc:
+                # Other Redis errors (script errors, response errors) — also
+                # fail open but log at a distinct level so operators can
+                # distinguish transient connectivity from protocol bugs.
+                self._redis_failure_count += 1
+                _log.warning(
+                    "rate limiter Redis error — allowing request "
+                    "(fail-open) [bucket=%s, consecutive_failures=%d]: %s",
+                    bucket, self._redis_failure_count, exc,
+                )
+                return
+            # Reset the failure counter on a successful Redis round-trip.
+            if self._redis_failure_count:
+                _log.info(
+                    "rate limiter Redis recovered after %d failed checks",
+                    self._redis_failure_count,
+                )
+                self._redis_failure_count = 0
         else:
             await self._check_memory(subject, bucket, config)
 

--- a/tests/test_proxy_resolve.py
+++ b/tests/test_proxy_resolve.py
@@ -97,6 +97,12 @@ async def test_resolve_cross_org(proxy_app):
 async def test_resolve_intra_default_stays_envelope(proxy_app):
     _, client = proxy_app
     api_key = await _provision_internal_agent("sender-bot")
+    # Provision the target too: after the reach-filter landing (PR #236)
+    # the resolve endpoint returns 404 for intra-org targets that don't
+    # exist in internal_agents. This test previously relied on the
+    # pre-reach behaviour where resolve happily echoed back an envelope
+    # shape for any intra-org handle.
+    await _provision_local_target("peer-bot", cert_pem=None)
 
     resp = await client.post(
         "/v1/egress/resolve",

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -4,10 +4,16 @@ Test rate limiting — verifies that limits are enforced.
 Tests reset the limiter before each run to avoid interference
 with other tests that use the same agents/orgs.
 """
-import pytest
-from httpx import AsyncClient
+import asyncio
+from unittest.mock import AsyncMock
 
-from app.rate_limit.limiter import rate_limiter
+import pytest
+from fastapi import HTTPException
+from httpx import AsyncClient
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from app.rate_limit.limiter import SlidingWindowLimiter, rate_limiter
 from tests.cert_factory import make_assertion, get_org_ca_pem, sign_message
 from tests.conftest import ADMIN_HEADERS, seed_court_agent
 
@@ -191,3 +197,97 @@ async def test_session_rate_limit(client: AsyncClient, dpop):
         "requested_capabilities": [],
     }, headers=dpop.headers("POST", "/v1/broker/sessions", token_a))
     assert r.status_code == 429
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Audit F-D-2 — fail-open behaviour when Redis is unavailable
+#
+# Rate limiting is a best-effort DoS control, not an auth gate. When Redis
+# is unreachable the limiter must log at WARNING and allow the request
+# through rather than returning 500 (which would convert a cache outage
+# into a wider DoS).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _limiter_with_fake_redis(fake_redis) -> SlidingWindowLimiter:
+    """Build a fresh limiter already bound to a fake Redis backend."""
+    limiter = SlidingWindowLimiter()
+    limiter.register("test.bucket", window_seconds=60, max_requests=5)
+    limiter._use_redis = True
+    limiter._redis = fake_redis
+    # Pre-seed the SHA so the limiter does not try to load the Lua script
+    # (script_load would be the first call hitting the mock).
+    limiter._lua_sha = "deadbeef"
+    return limiter
+
+
+async def test_failopen_on_redis_connection_error():
+    """Redis ConnectionError → request passes (audit F-D-2).
+
+    Asserting on the failure counter rather than the WARNING log:
+    the log emit races with caplog under xdist workers and produces
+    empty records, but the counter increment is a deterministic
+    invariant of the fail-open path.
+    """
+    fake_redis = AsyncMock()
+    fake_redis.evalsha.side_effect = RedisConnectionError("connection refused")
+    limiter = _limiter_with_fake_redis(fake_redis)
+
+    # Must not raise — fail-open: request is allowed.
+    await limiter.check("subject-A", "test.bucket")
+
+    assert limiter._redis_failure_count == 1
+
+
+async def test_failopen_on_redis_timeout_error():
+    """Redis TimeoutError → request passes (audit F-D-2)."""
+    fake_redis = AsyncMock()
+    fake_redis.evalsha.side_effect = RedisTimeoutError("timed out")
+    limiter = _limiter_with_fake_redis(fake_redis)
+
+    await limiter.check("subject-B", "test.bucket")
+
+    assert limiter._redis_failure_count == 1
+
+
+async def test_failopen_on_asyncio_timeout():
+    """asyncio.TimeoutError (socket-level) → fail-open (audit F-D-2)."""
+    fake_redis = AsyncMock()
+    fake_redis.evalsha.side_effect = asyncio.TimeoutError()
+    limiter = _limiter_with_fake_redis(fake_redis)
+
+    await limiter.check("subject-C", "test.bucket")
+
+    assert limiter._redis_failure_count == 1
+
+
+async def test_redis_healthy_still_enforces_limit():
+    """Regression: when Redis answers normally the limit is still enforced."""
+    fake_redis = AsyncMock()
+    # evalsha returns 0 → the Lua script says "over limit".
+    fake_redis.evalsha.return_value = 0
+    limiter = _limiter_with_fake_redis(fake_redis)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await limiter.check("subject-D", "test.bucket")
+
+    assert exc_info.value.status_code == 429
+    # Genuine 429 must NOT be counted as a Redis failure.
+    assert limiter._redis_failure_count == 0
+
+
+async def test_failure_counter_resets_after_recovery():
+    """After a transient outage the counter resets once Redis answers OK."""
+    fake_redis = AsyncMock()
+    # First call fails, second succeeds (returns 1 = allowed).
+    fake_redis.evalsha.side_effect = [
+        RedisConnectionError("boom"),
+        1,
+    ]
+    limiter = _limiter_with_fake_redis(fake_redis)
+
+    await limiter.check("subject-E", "test.bucket")  # fails → fail-open
+    assert limiter._redis_failure_count == 1
+    await limiter.check("subject-E", "test.bucket")  # succeeds → reset
+
+    assert limiter._redis_failure_count == 0


### PR DESCRIPTION
## Summary
- Catch transient Redis errors (ConnectionError, TimeoutError, asyncio.TimeoutError, OSError) and generic RedisError in the sliding-window limiter instead of surfacing as HTTP 500
- Log WARNING with consecutive-failure counter for operator visibility; INFO on recovery
- Rate limiting is best-effort DoS control, not an auth gate — availability > strict enforcement during cache outages (matches \`app/redis/pool.py\` philosophy; DPoP JTI stays fail-closed in prod as auth-critical)

## Finding
F-D-2 from audit 2026-04-17 phase1_D_race.md. HIGH severity. Identified as highest-severity open race/availability finding in triage 2026-04-19.

## Test plan
- [x] 5 new tests: ConnectionError / TimeoutError / asyncio.TimeoutError / healthy-regression / recovery-reset
- [x] \`pytest -k "rate_limit or limiter"\` → 21 passed