### PR TITLE
feat(connector): M3.1 native desktop shell — tray icon + webview

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -90,6 +90,32 @@ approval or timeout. See `cullis-connector enroll --help` for all flags.
 
 ---
 
+## Native desktop shell (no terminal)
+
+```bash
+pip install 'cullis-connector[dashboard,desktop]'
+cullis-connector desktop
+```
+
+Launches a tray icon plus a native OS webview wrapping the local
+dashboard — the process you'd usually see in a browser tab is now a
+window on your taskbar. Closing the window hides it; quit from the
+tray. The dashboard, enrollment flow, IDE autoconfig cards, and inbox
+poller are identical to `cullis-connector dashboard`; only the shell
+is native.
+
+Platform prerequisites that `pip` cannot fetch:
+
+- **macOS / Windows 10+**: nothing extra. The OS ships WebKit / WebView2.
+- **Linux**: `gtk3` and `webkit2gtk` packages — present on mainstream
+  distros out of the box, installable via the distro's package manager
+  on minimal images (e.g. `apt install libgtk-3-0 libwebkit2gtk-4.1-0`).
+
+Combine with `cullis-connector install-autostart` to have the tray
+appear at login.
+
+---
+
 ## Wire up your MCP client
 
 Every example below assumes you have already enrolled successfully.

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -193,6 +193,26 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Do not auto-open a browser tab on startup.",
     )
 
+    desktop = subparsers.add_parser(
+        "desktop",
+        help="Run the Connector as a native desktop shell (tray icon + "
+             "system webview wrapping the dashboard — no terminal).",
+    )
+    _add_shared_args(desktop)
+    desktop.add_argument(
+        "--host",
+        dest="web_host",
+        default="127.0.0.1",
+        help="Bind address for the embedded dashboard (default 127.0.0.1).",
+    )
+    desktop.add_argument(
+        "--port",
+        dest="web_port",
+        type=int,
+        default=7777,
+        help="Dashboard port (default 7777).",
+    )
+
     return parser
 
 
@@ -534,6 +554,14 @@ def _cmd_dashboard(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_desktop(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
+    from cullis_connector.desktop_app import run_desktop_app
+
+    host = getattr(args, "web_host", "127.0.0.1")
+    port = int(getattr(args, "web_port", 7777))
+    return run_desktop_app(cfg, host=host, port=port)
+
+
 # ── Entry point ──────────────────────────────────────────────────────────
 
 
@@ -563,6 +591,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_install_autostart(cfg, args)
     if command == "dashboard":
         return _cmd_dashboard(cfg, args)
+    if command == "desktop":
+        return _cmd_desktop(cfg, args)
     return _cmd_serve(cfg)
 
 

--- a/cullis_connector/desktop_app.py
+++ b/cullis_connector/desktop_app.py
@@ -1,0 +1,200 @@
+"""Native desktop shell for the Connector (M3.1, Phase 3).
+
+Wraps the FastAPI dashboard in an OS-native webview so non-technical
+users never see a terminal. Adds a system-tray icon with a minimal
+menu — the dashboard process keeps running in the background when the
+user closes the window, and a click on the tray brings it back.
+
+Threading plan (all three matter, pick the wrong one and macOS hangs):
+  - Uvicorn runs in a daemon thread, owning its own asyncio loop.
+  - pystray.Icon runs detached — it spins its own platform thread
+    (AppKit runloop on macOS, GTK main loop on Linux, Win32 message
+    pump on Windows).
+  - PyWebview owns the main thread. On macOS AppKit strictly requires
+    the GUI to sit on the process's initial thread, so webview.start()
+    blocks here and everything else is a guest thread.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import TYPE_CHECKING, Callable
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
+
+    from cullis_connector.config import ConnectorConfig
+
+
+_log = logging.getLogger(__name__)
+
+# Cullis teal — matches the dashboard favicon and brand mark.
+_ACCENT = (0, 229, 199, 255)
+
+
+def _build_tray_image(size: int = 64) -> "PILImage":
+    """Draw the portcullis glyph at the requested pixel size.
+
+    We render with Pillow primitives instead of shipping a PNG asset
+    so the wheel stays smaller and the icon scales cleanly for high-
+    dpi trays. The geometry mirrors `cullis_connector/static/cullis-mark.svg`
+    (100x100 viewBox: top bar, three vertical bars, middle crossbar,
+    three triangular teeth).
+    """
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    def _s(value: int) -> int:
+        return int(round(value * size / 100))
+
+    draw.rectangle([_s(8), _s(10), _s(92), _s(16)], fill=_ACCENT)
+    for x in (20, 46, 72):
+        draw.rectangle([_s(x), _s(16), _s(x + 8), _s(78)], fill=_ACCENT)
+    draw.rectangle([_s(14), _s(44), _s(86), _s(50)], fill=_ACCENT)
+    for x in (14, 40, 66):
+        draw.polygon(
+            [
+                (_s(x), _s(78)),
+                (_s(x + 20), _s(78)),
+                (_s(x + 10), _s(96)),
+            ],
+            fill=_ACCENT,
+        )
+    return img
+
+
+def _spawn_uvicorn(
+    cfg: "ConnectorConfig",
+    host: str,
+    port: int,
+) -> threading.Thread:
+    """Launch the dashboard FastAPI app in a daemon thread."""
+    import uvicorn
+
+    from cullis_connector.web import build_app
+
+    app = build_app(cfg)
+    server = uvicorn.Server(
+        uvicorn.Config(
+            app,
+            host=host,
+            port=port,
+            log_level="info",
+            access_log=False,
+        )
+    )
+
+    thread = threading.Thread(
+        target=server.run,
+        name="cullis-uvicorn",
+        daemon=True,
+    )
+    thread.start()
+    return thread
+
+
+def _build_menu(
+    open_dashboard: Callable[[], None],
+    open_inbox: Callable[[], None],
+    on_quit: Callable[[], None],
+):
+    """Minimal tray menu: Open Dashboard / Open Inbox / Quit.
+
+    Pause-notifications and profile switcher are deliberate follow-ups
+    (M3.1b and M3.3 in the roadmap) — M3.1 keeps the surface small to
+    make the first packaged binary easy to validate.
+    """
+    import pystray
+
+    return pystray.Menu(
+        pystray.MenuItem(
+            "Open Dashboard",
+            lambda icon, item: open_dashboard(),
+            default=True,
+        ),
+        pystray.MenuItem(
+            "Open Inbox",
+            lambda icon, item: open_inbox(),
+        ),
+        pystray.Menu.SEPARATOR,
+        pystray.MenuItem(
+            "Quit",
+            lambda icon, item: on_quit(),
+        ),
+    )
+
+
+def run_desktop_app(
+    cfg: "ConnectorConfig",
+    host: str = "127.0.0.1",
+    port: int = 7777,
+) -> int:
+    """Entry point for `cullis-connector desktop`.
+
+    Returns 2 when the optional `desktop` deps are missing so the CLI
+    can surface a friendly install hint.
+    """
+    try:
+        import pystray  # noqa: F401
+        import webview
+        from PIL import Image  # noqa: F401
+    except ImportError as exc:
+        _log.error(
+            "desktop shell needs extra deps — install with "
+            "`pip install 'cullis-connector[dashboard,desktop]'` "
+            "(missing: %s)",
+            exc.name,
+        )
+        return 2
+
+    base_url = f"http://{host}:{port}"
+    _spawn_uvicorn(cfg, host, port)
+
+    window = webview.create_window(
+        "Cullis",
+        f"{base_url}/",
+        hidden=True,
+        width=1120,
+        height=760,
+    )
+
+    # Intercept the native close button: hide the window so the tray
+    # stays live and a later Open reveals the same instance instead of
+    # racing uvicorn to spawn a second one.
+    def _on_closing() -> bool:
+        window.hide()
+        return False
+
+    window.events.closing += _on_closing
+
+    def _open_dashboard() -> None:
+        window.load_url(f"{base_url}/")
+        window.show()
+
+    def _open_inbox() -> None:
+        window.load_url(f"{base_url}/inbox")
+        window.show()
+
+    import pystray
+
+    icon = pystray.Icon(
+        "cullis",
+        icon=_build_tray_image(64),
+        title="Cullis Connector",
+    )
+
+    def _quit_all() -> None:
+        icon.stop()
+        window.destroy()
+
+    icon.menu = _build_menu(_open_dashboard, _open_inbox, _quit_all)
+    icon.run_detached()
+
+    _log.info(
+        "desktop shell ready — tray icon active, dashboard at %s",
+        base_url,
+    )
+    webview.start(private_mode=False)
+    return 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,22 @@ dashboard = [
     # `connector` deploys without `dashboard` keep working.
     "plyer>=2.1",
 ]
+# Native desktop shell: tray icon + system webview wrapping the
+# dashboard so non-technical users never see a terminal. Builds on
+# top of `dashboard` — keep both installed together.
+#   pywebview: embeds the OS-native webview (Cocoa WebKit, WebView2,
+#              GTK WebKit) pointed at http://127.0.0.1:7777.
+#   pystray : system-tray icon with a minimal menu (Open / Quit).
+#   Pillow  : drawing surface for the tray glyph (we render the
+#             portcullis mark at runtime, no PNG assets to ship).
+# Platform prerequisites not installable via pip: on Linux the user
+# still needs `gtk3` + `webkit2gtk` (present by default on mainstream
+# distros); macOS and Windows 10+ ship the webview in the OS.
+desktop = [
+    "pywebview>=5.0",
+    "pystray>=0.19",
+    "Pillow>=10.0",
+]
 spiffe = [
     "spiffe>=0.2.0",
 ]

--- a/tests/connector/test_desktop_app.py
+++ b/tests/connector/test_desktop_app.py
@@ -1,0 +1,97 @@
+"""Unit tests for the M3.1 desktop shell.
+
+We can't actually spin up a GUI from CI — pywebview / pystray need a
+display and platform backends — so the tests cover:
+
+* The tray glyph renders at the expected sizes (Pillow only, no GUI).
+* The argument parser recognizes the `desktop` subcommand.
+* `run_desktop_app` returns 2 with a useful log when any of the
+  optional deps (webview / pystray / Pillow) is missing.
+"""
+from __future__ import annotations
+
+import builtins
+import logging
+
+import pytest
+
+PIL = pytest.importorskip("PIL.Image")
+
+
+def test_build_tray_image_produces_rgba_at_requested_size():
+    from cullis_connector.desktop_app import _build_tray_image
+
+    img = _build_tray_image(64)
+    assert img.size == (64, 64)
+    assert img.mode == "RGBA"
+
+
+def test_build_tray_image_scales_cleanly():
+    from cullis_connector.desktop_app import _build_tray_image
+
+    small = _build_tray_image(16)
+    big = _build_tray_image(128)
+    assert small.size == (16, 16)
+    assert big.size == (128, 128)
+
+
+def test_build_tray_image_paints_with_accent_color():
+    from cullis_connector.desktop_app import _ACCENT, _build_tray_image
+
+    img = _build_tray_image(64)
+    # The top header bar spans roughly y=6..10 at 64px — sample inside it.
+    pixel = img.getpixel((32, 8))
+    assert pixel == _ACCENT
+
+
+def test_cli_parser_knows_desktop_subcommand():
+    from cullis_connector.cli import _build_parser
+
+    parser = _build_parser()
+    args = parser.parse_args(["desktop", "--port", "7788"])
+    assert args.command == "desktop"
+    assert args.web_port == 7788
+    assert args.web_host == "127.0.0.1"
+
+
+def test_run_desktop_app_returns_2_when_webview_missing(monkeypatch, caplog):
+    """Simulate a wheel installed without the `desktop` extra. We
+    expect an ImportError funneled into a return code of 2 plus a
+    human-readable log line pointing at the correct install command."""
+    original_import = builtins.__import__
+
+    def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "webview" or name.startswith("webview."):
+            raise ImportError(name="webview")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    from cullis_connector.desktop_app import run_desktop_app
+
+    with caplog.at_level(logging.ERROR, logger="cullis_connector.desktop_app"):
+        rc = run_desktop_app(cfg=object())
+
+    assert rc == 2
+    assert any(
+        "cullis-connector[dashboard,desktop]" in rec.message for rec in caplog.records
+    )
+
+
+def test_run_desktop_app_returns_2_when_pystray_missing(monkeypatch, caplog):
+    original_import = builtins.__import__
+
+    def _blocked_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pystray" or name.startswith("pystray."):
+            raise ImportError(name="pystray")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    from cullis_connector.desktop_app import run_desktop_app
+
+    with caplog.at_level(logging.ERROR, logger="cullis_connector.desktop_app"):
+        rc = run_desktop_app(cfg=object())
+
+    assert rc == 2
+    assert any("missing: pystray" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Phase 3 M3.1 — the first milestone toward a Connector a non-technical user can install and forget. Replace the \"keep a browser tab open at localhost:7777\" friction with an OS-native webview plus a system-tray icon.

Flow for the end user after this lands (once M3.2/M3.6 ship the installers):

1. Download installer → double-click → Connector runs in background
2. Tray icon appears (macOS menubar / Windows system tray / Linux tray)
3. Click tray → native window opens on the existing FastAPI dashboard
4. Enroll, pick your IDE from the \`/connected\` cards, done

## What's in

- **\`cullis-connector desktop\` subcommand** — \`cli.py\` registers it next to \`dashboard\`.
- **\`cullis_connector/desktop_app.py\`** — ~200 LOC wiring uvicorn (daemon thread) + pywebview (main thread, required by AppKit) + pystray (detached platform thread).
- **Tray glyph rendered at runtime** from Pillow primitives mirroring \`static/cullis-mark.svg\` — no PNG assets shipped; scales cleanly for high-dpi trays.
- **\`[desktop]\` optional-dependency group** (\`pywebview\`, \`pystray\`, \`Pillow\`) separate from \`[dashboard]\` so headless server deployments stay lean.
- **README section** documents the platform prerequisites pip cannot install (\`gtk3\` + \`webkit2gtk\` on minimal Linux).
- **Tests** cover tray glyph generation, CLI parser recognition, and graceful \`return 2\` with an install hint when \`pywebview\`/\`pystray\` are missing.

## Deliberately out of scope (follow-ups)

| # | Item | Why deferred |
|---|------|--------------|
| M3.1b | Pause-notifications toggle in tray | Tiny but needs shared state with the poller; split to keep this PR reviewable |
| M3.2 | PyInstaller single binary | Separate milestone — this PR is the runtime surface only |
| M3.3 | Multi-profile switcher | Requires state refactor (ConnectorState is singleton) |
| M3.6/M3.7 | Native installers + signing | Packaging + cert procurement, the real time-sink |

## Test plan

- [x] \`pytest tests/connector/test_desktop_app.py\` → 6 pass
- [x] \`pytest tests/connector/\` → 151 pass (no regressions)
- [x] \`ruff check\` clean on app/, cullis_connector/, tests/
- [ ] CI green (pytest + smoke + helm)
- [ ] Manual QA on one host per OS (deferred to M3.9 with the packaged binaries)