### PR TITLE
feat(connector): M3.3a multi-profile foundation (--profile flag)

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -90,6 +90,52 @@ approval or timeout. See `cullis-connector enroll --help` for all flags.
 
 ---
 
+## Multiple profiles on the same machine
+
+Need more than one identity on a single workstation — say a `north`
+and a `south` agent for testing, or a personal profile alongside a
+work one? Pass `--profile <name>` (or set `CULLIS_PROFILE`) and each
+profile lives in its own directory under `~/.cullis/profiles/<name>/`
+with a separate enrollment, config, and certificate.
+
+```bash
+# enroll two independent identities
+cullis-connector enroll --profile north \
+  --site-url https://cullis.acme.local \
+  --requester-name "North Bot" --requester-email north@acme.example
+cullis-connector enroll --profile south \
+  --site-url https://cullis.acme.local \
+  --requester-name "South Bot" --requester-email south@acme.example
+
+# run them as two MCP stdio servers (different shell sessions or
+# different IDE mcp.json entries)
+cullis-connector serve --profile north
+cullis-connector serve --profile south
+```
+
+Wiring both into the same MCP client is just two entries in its JSON:
+
+```json
+{
+  "mcpServers": {
+    "cullis-north": {"command": "cullis-connector", "args": ["serve", "--profile", "north"]},
+    "cullis-south": {"command": "cullis-connector", "args": ["serve", "--profile", "south"]}
+  }
+}
+```
+
+Legacy installs using the flat `~/.cullis/identity/` layout keep
+working untouched — we don't auto-migrate so existing keys aren't
+moved without the operator's consent. To convert an in-place install
+to a named profile, stop the connector and `mv ~/.cullis/identity
+~/.cullis/profiles/default/identity` (same for any other state you
+keep alongside).
+
+Explicit `--config-dir /some/path` still wins over `--profile` for
+operators who need to pin the directory elsewhere.
+
+---
+
 ## Native desktop shell (no terminal)
 
 ```bash

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -54,8 +54,18 @@ def _add_shared_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--config-dir",
         dest="config_dir",
-        help="Directory holding config.yaml and identity/. Defaults to ~/.cullis/. "
-             "Use distinct dirs for multi-org setups.",
+        help="Directory holding config.yaml and identity/. Overrides "
+             "--profile entirely; only use this when you need to point "
+             "the connector at an arbitrary path.",
+    )
+    parser.add_argument(
+        "--profile",
+        dest="profile",
+        help="Name of the profile to activate (default: 'default'). Each "
+             "profile has its own enrollment under "
+             "~/.cullis/profiles/<name>/ — use distinct profiles to "
+             "host several identities on one machine (e.g. 'north' and "
+             "'south').",
     )
     parser.add_argument(
         "--no-verify-tls",

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -1,16 +1,25 @@
 """Configuration loading for cullis-connector.
 
 Resolution order (highest priority first):
-    1. CLI flags (e.g. --site-url, --config-dir)
-    2. Environment variables (CULLIS_SITE_URL, CULLIS_CONFIG_DIR, ...)
+    1. CLI flags (e.g. --site-url, --config-dir, --profile)
+    2. Environment variables (CULLIS_SITE_URL, CULLIS_CONFIG_DIR,
+       CULLIS_PROFILE, ...)
     3. Config file <config_dir>/config.yaml
     4. Built-in defaults
 
-The config_dir defaults to ~/.cullis/ and holds:
+`--config-dir` always wins: an operator who points the connector at an
+explicit directory knows what they're doing and we won't second-guess
+them. Otherwise `--profile <name>` (or `CULLIS_PROFILE`) maps to
+``~/.cullis/profiles/<name>/``. With neither flag, legacy installs
+(anyone with ``~/.cullis/identity/`` predating M3.3) keep using the
+flat ``~/.cullis/`` layout so in-place upgrades don't lose keys; fresh
+installs land on ``~/.cullis/profiles/default/``.
+
+A profile directory holds:
     config.yaml             — user-editable settings
-    identity/agent.crt      — agent certificate (created by Phase 2 enrollment)
+    identity/agent.crt      — agent certificate (Phase 2 enrollment)
     identity/agent.key      — agent private key (chmod 600)
-    identity/ca-chain.pem   — trust chain for verifying Site/Broker responses
+    identity/ca-chain.pem   — trust chain for Site/Broker verification
 """
 from __future__ import annotations
 
@@ -27,7 +36,11 @@ except ImportError:  # pragma: no cover - tested via integration
     _yaml = None  # type: ignore[assignment]
 
 
-DEFAULT_CONFIG_DIR = Path.home() / ".cullis"
+DEFAULT_CONFIG_ROOT = Path.home() / ".cullis"
+# Back-compat alias — old tests / external integrations may import
+# this name. Keep pointing at the root; the effective config_dir is
+# now resolved through :func:`resolve_config_dir`.
+DEFAULT_CONFIG_DIR = DEFAULT_CONFIG_ROOT
 DEFAULT_CONFIG_FILENAME = "config.yaml"
 
 
@@ -42,8 +55,19 @@ class ConnectorConfig:
     transitional cullis_sdk path. Phase 2+ targets Site exclusively.
     """
 
-    config_dir: Path = field(default_factory=lambda: DEFAULT_CONFIG_DIR)
-    """Directory holding identity/ and config.yaml."""
+    config_dir: Path = field(default_factory=lambda: DEFAULT_CONFIG_ROOT)
+    """Directory holding identity/ and config.yaml.
+
+    With M3.3a this is usually a profile directory under
+    ``~/.cullis/profiles/<name>/`` rather than ``~/.cullis/`` itself,
+    unless the operator forced ``--config-dir`` or the machine still
+    holds a pre-M3.3 flat layout.
+    """
+
+    profile_name: str = ""
+    """Active profile name, or empty string when running against a
+    legacy flat layout / explicit --config-dir. Informational — the
+    authoritative source of truth is ``config_dir``."""
 
     verify_tls: bool = True
     """Whether to verify TLS certificates of the Site. Disable only for dev."""
@@ -94,6 +118,54 @@ def _coerce_bool(value: Any) -> bool:
     return bool(value)
 
 
+def resolve_config_dir(
+    cli: dict[str, Any],
+    env_map: dict[str, str],
+    *,
+    root: Path | None = None,
+) -> tuple[Path, str]:
+    """Pick the effective config_dir and (optional) profile name.
+
+    Ordering reflects operator intent: explicit --config-dir wins
+    unconditionally, then --profile / CULLIS_PROFILE, then legacy
+    flat layout compatibility, then fresh-install default.
+
+    Returns ``(config_dir, profile_name)``. ``profile_name`` is the
+    empty string when no profile is in effect (legacy layout or
+    explicit --config-dir override).
+    """
+    from cullis_connector.profile import (
+        DEFAULT_PROFILE_NAME,
+        has_legacy_layout,
+        profile_dir,
+        validate_profile_name,
+    )
+
+    config_root = (root or DEFAULT_CONFIG_ROOT).expanduser()
+
+    # 1. Explicit override — honour it verbatim.
+    if cli.get("config_dir"):
+        return Path(cli["config_dir"]).expanduser(), ""
+    env_override = env_map.get("CULLIS_CONFIG_DIR")
+    if env_override:
+        return Path(env_override).expanduser(), ""
+
+    # 2. --profile / CULLIS_PROFILE.
+    profile = cli.get("profile") or env_map.get("CULLIS_PROFILE")
+    if profile:
+        validate_profile_name(profile)
+        return profile_dir(config_root, profile), profile
+
+    # 3. Legacy flat layout — keep using it to preserve in-place
+    # upgrades. The operator can `mv identity/ profiles/default/`
+    # on their own schedule.
+    if has_legacy_layout(config_root):
+        return config_root, ""
+
+    # 4. Fresh install.
+    return profile_dir(config_root, DEFAULT_PROFILE_NAME), DEFAULT_PROFILE_NAME
+
+
 def load_config(
     cli_overrides: dict[str, Any] | None = None,
     *,
@@ -113,12 +185,9 @@ def load_config(
     env_map = env if env is not None else os.environ
     cli = {k: v for k, v in (cli_overrides or {}).items() if v is not None}
 
-    # 1. Determine config_dir first so we can locate config.yaml.
-    config_dir = Path(
-        cli.get("config_dir")
-        or env_map.get("CULLIS_CONFIG_DIR")
-        or DEFAULT_CONFIG_DIR
-    ).expanduser()
+    # 1. Determine config_dir (and optional profile) before anything
+    #    else, so we can locate config.yaml.
+    config_dir, profile_name = resolve_config_dir(cli, env_map)
 
     # 2. Read file (if present).
     file_data = _read_yaml(config_dir / DEFAULT_CONFIG_FILENAME)
@@ -140,6 +209,7 @@ def load_config(
     return ConnectorConfig(
         site_url=site_url,
         config_dir=config_dir,
+        profile_name=profile_name,
         verify_tls=verify_tls,
         log_level=log_level,
         request_timeout_s=request_timeout_s,

--- a/cullis_connector/profile.py
+++ b/cullis_connector/profile.py
@@ -1,0 +1,101 @@
+"""Multi-profile support for the Connector (M3.3a).
+
+A profile is an isolated enrollment — separate identity, separate
+config.yaml, separate state — living under
+``~/.cullis/profiles/<name>/`` instead of the original flat
+``~/.cullis/`` layout. It lets a single machine host several
+identities (say ``north`` and ``south``) without the user having to
+juggle distinct config dirs or shell profiles.
+
+Resolution rules (highest priority first, handled in `config.py`):
+
+1. Explicit ``--config-dir`` / ``CULLIS_CONFIG_DIR`` — respected as-is
+   (the operator knows what they're doing).
+2. ``--profile`` / ``CULLIS_PROFILE`` — maps to
+   ``~/.cullis/profiles/<name>/``.
+3. Legacy layout — if ``~/.cullis/identity/`` exists without a
+   ``profiles/`` sibling, keep using ``~/.cullis/`` so upgrades of
+   in-place installs don't break.
+4. Fresh install — use ``~/.cullis/profiles/default/``.
+
+We do NOT move the legacy identity directory automatically. The user
+sees both the legacy layout and any explicit profiles in
+:func:`list_profiles`; they can migrate when they want (a one-line
+``mv`` documented in the README) without us silently touching
+production keys.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# RFC-friendly names: letters, digits, dash, underscore. Keeps the
+# resulting directory safe on every filesystem we care about and
+# avoids shell-injection surprises in docs.
+_PROFILE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_\-]{0,62}$")
+
+DEFAULT_PROFILE_NAME = "default"
+
+
+def validate_profile_name(name: str) -> str:
+    """Return ``name`` if it's a safe profile identifier, else raise."""
+    if not _PROFILE_NAME_RE.match(name):
+        raise ValueError(
+            f"invalid profile name {name!r}: must start with "
+            "an alphanumeric character and contain only letters, "
+            "digits, '-', or '_' (max 63 chars)"
+        )
+    return name
+
+
+def profile_dir(root: Path, name: str) -> Path:
+    """Return the directory holding a given profile's files."""
+    return root / "profiles" / validate_profile_name(name)
+
+
+def has_legacy_layout(root: Path) -> bool:
+    """True when the root directory still uses the pre-M3.3 flat layout
+    (identity/ sitting directly under the root, no profiles/ sibling).
+
+    The caller can decide whether to keep using it or migrate — we
+    only observe.
+    """
+    if not (root / "identity").is_dir():
+        return False
+    if (root / "profiles").is_dir():
+        # The user already has profiles/ alongside a flat identity/
+        # (maybe a half-done manual migration). Treat it as legacy
+        # until the flat identity/ is moved out of the way; anything
+        # else would hide the existing keys from the user.
+        return True
+    return True
+
+
+def list_profiles(root: Path) -> list[str]:
+    """Return the profile names known under ``root``.
+
+    Includes the ``default`` pseudo-entry for the legacy flat layout
+    if it's present. Names are returned sorted with ``default`` first
+    so tray menus and dropdowns stay stable across runs.
+    """
+    found: set[str] = set()
+    profiles_root = root / "profiles"
+    if profiles_root.is_dir():
+        for child in profiles_root.iterdir():
+            if not child.is_dir():
+                continue
+            try:
+                validate_profile_name(child.name)
+            except ValueError:
+                # Skip directories that don't look like profiles
+                # (stray editor tmp files, lost+found, etc.).
+                continue
+            found.add(child.name)
+    if has_legacy_layout(root):
+        found.add(DEFAULT_PROFILE_NAME)
+
+    ordered = sorted(found)
+    if DEFAULT_PROFILE_NAME in ordered:
+        ordered.remove(DEFAULT_PROFILE_NAME)
+        ordered.insert(0, DEFAULT_PROFILE_NAME)
+    return ordered

--- a/tests/connector/test_profile_resolver.py
+++ b/tests/connector/test_profile_resolver.py
@@ -1,0 +1,242 @@
+"""Tests for the M3.3a multi-profile config resolver.
+
+Four paths to exercise:
+- explicit --config-dir wins unconditionally
+- --profile / CULLIS_PROFILE maps to ~/.cullis/profiles/<name>/
+- legacy flat layout (identity/ at root, no profiles/) preserved
+- fresh install lands on ~/.cullis/profiles/default/
+
+Plus the helpers in :mod:`cullis_connector.profile`:
+- validate_profile_name rejects hostile inputs
+- list_profiles orders ``default`` first and ignores stray files
+"""
+from __future__ import annotations
+
+import pytest
+
+from cullis_connector.config import load_config, resolve_config_dir
+from cullis_connector.profile import (
+    DEFAULT_PROFILE_NAME,
+    has_legacy_layout,
+    list_profiles,
+    profile_dir,
+    validate_profile_name,
+)
+
+
+# ── validate_profile_name ────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["default", "north", "south", "org-1", "agent_01", "A1b2C3"],
+)
+def test_validate_profile_name_accepts_safe_names(name):
+    assert validate_profile_name(name) == name
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "-leading-dash",
+        "_underscore-first",
+        "has space",
+        "has/slash",
+        "has..dot",
+        "has$dollar",
+        "../escape",
+        "x" * 64,
+    ],
+)
+def test_validate_profile_name_rejects_hostile(bad):
+    with pytest.raises(ValueError):
+        validate_profile_name(bad)
+
+
+# ── has_legacy_layout ────────────────────────────────────────────────
+
+
+def test_has_legacy_layout_false_on_empty_root(tmp_path):
+    assert has_legacy_layout(tmp_path) is False
+
+
+def test_has_legacy_layout_true_when_identity_dir_present(tmp_path):
+    (tmp_path / "identity").mkdir()
+    assert has_legacy_layout(tmp_path) is True
+
+
+def test_has_legacy_layout_true_during_half_done_migration(tmp_path):
+    # If a user has both the flat identity/ AND profiles/ we still
+    # flag legacy — their flat keys are the ones actively in use.
+    (tmp_path / "identity").mkdir()
+    (tmp_path / "profiles").mkdir()
+    assert has_legacy_layout(tmp_path) is True
+
+
+# ── list_profiles ────────────────────────────────────────────────────
+
+
+def test_list_profiles_empty_root_returns_nothing(tmp_path):
+    assert list_profiles(tmp_path) == []
+
+
+def test_list_profiles_picks_up_explicit_profiles(tmp_path):
+    for name in ("south", "north", "central"):
+        (tmp_path / "profiles" / name).mkdir(parents=True)
+    assert list_profiles(tmp_path) == ["central", "north", "south"]
+
+
+def test_list_profiles_ignores_stray_files_and_bad_names(tmp_path):
+    (tmp_path / "profiles" / "valid").mkdir(parents=True)
+    (tmp_path / "profiles" / "ok-name").mkdir(parents=True)
+    (tmp_path / "profiles" / ".hidden").mkdir(parents=True)
+    (tmp_path / "profiles" / "..escape").mkdir(parents=True)
+    (tmp_path / "profiles" / "stray.txt").write_text("not a profile")
+    assert list_profiles(tmp_path) == ["ok-name", "valid"]
+
+
+def test_list_profiles_surfaces_legacy_as_default(tmp_path):
+    # A fresh ~/.cullis/ with only the flat identity/ shows up under
+    # the pseudo-name "default".
+    (tmp_path / "identity").mkdir()
+    assert list_profiles(tmp_path) == [DEFAULT_PROFILE_NAME]
+
+
+def test_list_profiles_puts_default_first_when_mixed(tmp_path):
+    (tmp_path / "identity").mkdir()
+    (tmp_path / "profiles" / "north").mkdir(parents=True)
+    (tmp_path / "profiles" / "south").mkdir(parents=True)
+    assert list_profiles(tmp_path) == ["default", "north", "south"]
+
+
+# ── resolve_config_dir ───────────────────────────────────────────────
+
+
+def test_resolve_config_dir_explicit_config_dir_beats_everything(tmp_path):
+    forced = tmp_path / "forced"
+    cli = {"config_dir": str(forced), "profile": "north"}
+    env = {"CULLIS_PROFILE": "south", "CULLIS_CONFIG_DIR": str(tmp_path / "envdir")}
+    path, profile = resolve_config_dir(cli, env, root=tmp_path)
+    assert path == forced
+    assert profile == ""
+
+
+def test_resolve_config_dir_env_config_dir_beats_profile(tmp_path):
+    envdir = tmp_path / "env-forced"
+    cli = {"profile": "north"}
+    env = {"CULLIS_CONFIG_DIR": str(envdir)}
+    path, profile = resolve_config_dir(cli, env, root=tmp_path)
+    assert path == envdir
+    assert profile == ""
+
+
+def test_resolve_config_dir_cli_profile_maps_to_subdir(tmp_path):
+    path, profile = resolve_config_dir(
+        {"profile": "north"}, {}, root=tmp_path
+    )
+    assert path == profile_dir(tmp_path, "north")
+    assert profile == "north"
+
+
+def test_resolve_config_dir_env_profile_picks_up(tmp_path):
+    path, profile = resolve_config_dir(
+        {}, {"CULLIS_PROFILE": "south"}, root=tmp_path
+    )
+    assert path == profile_dir(tmp_path, "south")
+    assert profile == "south"
+
+
+def test_resolve_config_dir_cli_profile_beats_env_profile(tmp_path):
+    path, profile = resolve_config_dir(
+        {"profile": "north"},
+        {"CULLIS_PROFILE": "south"},
+        root=tmp_path,
+    )
+    assert profile == "north"
+    assert path == profile_dir(tmp_path, "north")
+
+
+def test_resolve_config_dir_legacy_layout_keeps_flat_root(tmp_path):
+    (tmp_path / "identity").mkdir()
+    path, profile = resolve_config_dir({}, {}, root=tmp_path)
+    assert path == tmp_path
+    assert profile == ""
+
+
+def test_resolve_config_dir_fresh_install_picks_default_profile(tmp_path):
+    path, profile = resolve_config_dir({}, {}, root=tmp_path)
+    assert path == profile_dir(tmp_path, DEFAULT_PROFILE_NAME)
+    assert profile == DEFAULT_PROFILE_NAME
+
+
+def test_resolve_config_dir_rejects_hostile_profile_name(tmp_path):
+    with pytest.raises(ValueError):
+        resolve_config_dir({"profile": "../escape"}, {}, root=tmp_path)
+
+
+# ── load_config end-to-end ───────────────────────────────────────────
+
+
+def test_load_config_propagates_profile_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "cullis_connector.config.DEFAULT_CONFIG_ROOT", tmp_path
+    )
+    cfg = load_config({"profile": "north"}, env={})
+    assert cfg.profile_name == "north"
+    assert cfg.config_dir == tmp_path / "profiles" / "north"
+    assert cfg.identity_dir == tmp_path / "profiles" / "north" / "identity"
+
+
+def test_load_config_empty_profile_name_on_legacy_layout(tmp_path, monkeypatch):
+    (tmp_path / "identity").mkdir()
+    monkeypatch.setattr(
+        "cullis_connector.config.DEFAULT_CONFIG_ROOT", tmp_path
+    )
+    cfg = load_config({}, env={})
+    assert cfg.profile_name == ""
+    assert cfg.config_dir == tmp_path
+    assert cfg.identity_dir == tmp_path / "identity"
+
+
+def test_load_config_explicit_config_dir_clears_profile_name(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "cullis_connector.config.DEFAULT_CONFIG_ROOT", tmp_path
+    )
+    custom = tmp_path / "custom"
+    cfg = load_config({"config_dir": str(custom), "profile": "north"}, env={})
+    # --config-dir wins → profile name cleared.
+    assert cfg.profile_name == ""
+    assert cfg.config_dir == custom
+
+
+def test_load_config_default_profile_on_fresh_install(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "cullis_connector.config.DEFAULT_CONFIG_ROOT", tmp_path
+    )
+    cfg = load_config({}, env={})
+    assert cfg.profile_name == DEFAULT_PROFILE_NAME
+    assert cfg.config_dir == tmp_path / "profiles" / DEFAULT_PROFILE_NAME
+
+
+# ── CLI plumbing sanity ──────────────────────────────────────────────
+
+
+def test_cli_parser_accepts_profile_flag_on_subcommands():
+    from cullis_connector.cli import _build_parser
+
+    parser = _build_parser()
+    simple = ("serve", "dashboard", "desktop")
+    for cmd in simple:
+        args = parser.parse_args([cmd, "--profile", "north"])
+        assert args.profile == "north"
+
+    # ``enroll`` has its own required flags; supply them so argparse
+    # doesn't abort before reaching --profile.
+    enroll = parser.parse_args([
+        "enroll",
+        "--profile", "north",
+        "--requester-name", "Alice",
+        "--requester-email", "alice@example.com",
+    ])
+    assert enroll.profile == "north"


### PR DESCRIPTION
## Summary

Phase 3 M3.3a — the first half of multi-profile support. A single workstation can now host several Cullis identities (say \`north\` and \`south\`) via a \`--profile <name>\` flag. Each profile lives under \`~/.cullis/profiles/<name>/\` with its own enrollment, config, and certificate.

This is the pain point every end-to-end test has hit so far: the user had to duplicate the \`~/.cullis\` directory, keep two shells, and manually register two MCP entries. From this PR onward:

\`\`\`bash
cullis-connector enroll --profile north --site-url https://cullis.acme.local ...
cullis-connector enroll --profile south --site-url https://cullis.acme.local ...
cullis-connector serve   --profile north   # terminal 1
cullis-connector serve   --profile south   # terminal 2
\`\`\`

MCP clients wire both at once by using two server entries (README documents the pattern).

## What's in

- \`cullis_connector/profile.py\` — \`validate_profile_name\`, \`profile_dir\`, \`list_profiles\`, \`has_legacy_layout\` helpers.
- \`config.resolve_config_dir()\` — strict priority: explicit \`--config-dir\` → \`--profile\` / \`CULLIS_PROFILE\` → legacy flat layout → fresh-install default.
- \`ConnectorConfig.profile_name\` — informational field, empty when legacy layout or \`--config-dir\` wins.
- \`--profile\` / \`CULLIS_PROFILE\` plumbed through shared CLI args so every subcommand (\`serve\` / \`enroll\` / \`dashboard\` / \`desktop\` / \`install-mcp\` / \`install-autostart\`) honours it.
- README section \"Multiple profiles on the same machine\".

## Deliberate non-goals

- **No auto-migration** of \`~/.cullis/identity/\` into \`~/.cullis/profiles/default/\`. Moving production keys without the operator's consent is exactly the kind of surprise the Connector must not ship. Legacy installs keep working; a one-line \`mv\` documented in the README lets operators convert when they choose.
- **No UI** yet — tray submenu and dashboard \`/profiles\` page are M3.3b. Today the profile is picked via flag / env var; the tray window implicitly reflects the active profile.

## Test plan

- [x] \`pytest tests/connector/test_profile_resolver.py\` → 36 pass (validate, resolver priority, load_config propagation, CLI plumbing).
- [x] \`pytest tests/connector/\` → 204 pass (no regressions, including M3.1 desktop shell).
- [x] \`ruff check cullis_connector/ tests/\` clean.
- [ ] CI green.