### PR TITLE
feat(connector): M3.3b multi-profile UI (dashboard + tray)

### DIFF
--- a/cullis_connector/desktop_app.py
+++ b/cullis_connector/desktop_app.py
@@ -95,20 +95,59 @@ def _spawn_uvicorn(
     return thread
 
 
+def _build_profiles_submenu(
+    profiles: list[str],
+    active: str,
+    open_profiles_page: Callable[[], None],
+):
+    """Submenu listing every profile on the machine with a check next
+    to the one currently loaded. Clicking a non-active profile opens
+    the dashboard `/profiles` page so the user sees the exact
+    relaunch command — runtime switching is intentionally out of
+    scope for M3.3 (a restart is required to pick up a different
+    identity on this process)."""
+    import pystray
+
+    if not profiles:
+        return None
+
+    items: list = []
+    for name in profiles:
+        checked_name = name
+        items.append(
+            pystray.MenuItem(
+                name,
+                lambda icon, item, n=checked_name: open_profiles_page(),
+                checked=lambda item, n=checked_name: n == active,
+                radio=True,
+            )
+        )
+    items.append(pystray.Menu.SEPARATOR)
+    items.append(
+        pystray.MenuItem(
+            "Manage profiles…",
+            lambda icon, item: open_profiles_page(),
+        )
+    )
+    return pystray.Menu(*items)
+
+
 def _build_menu(
     open_dashboard: Callable[[], None],
     open_inbox: Callable[[], None],
     on_quit: Callable[[], None],
+    *,
+    profiles_submenu=None,
 ):
-    """Minimal tray menu: Open Dashboard / Open Inbox / Quit.
+    """Tray menu: Open Dashboard / Open Inbox / [Profiles ▸] / Quit.
 
-    Pause-notifications and profile switcher are deliberate follow-ups
-    (M3.1b and M3.3 in the roadmap) — M3.1 keeps the surface small to
-    make the first packaged binary easy to validate.
+    Pause-notifications remains a deliberate follow-up (M3.1b) — the
+    top-level surface stays small so the first packaged binary is
+    easy to validate across OSes.
     """
     import pystray
 
-    return pystray.Menu(
+    items = [
         pystray.MenuItem(
             "Open Dashboard",
             lambda icon, item: open_dashboard(),
@@ -118,12 +157,19 @@ def _build_menu(
             "Open Inbox",
             lambda icon, item: open_inbox(),
         ),
-        pystray.Menu.SEPARATOR,
+    ]
+    if profiles_submenu is not None:
+        items.append(
+            pystray.MenuItem("Profiles", profiles_submenu)
+        )
+    items.append(pystray.Menu.SEPARATOR)
+    items.append(
         pystray.MenuItem(
             "Quit",
             lambda icon, item: on_quit(),
-        ),
+        )
     )
+    return pystray.Menu(*items)
 
 
 def run_desktop_app(
@@ -177,19 +223,41 @@ def run_desktop_app(
         window.load_url(f"{base_url}/inbox")
         window.show()
 
+    def _open_profiles() -> None:
+        window.load_url(f"{base_url}/profiles")
+        window.show()
+
     import pystray
+
+    # Enumerate profiles on disk so the tray can surface them. We do
+    # this at startup only — a future M3.3c can refresh on demand.
+    from cullis_connector.profile import config_root_from_dir, list_profiles
+
+    root = config_root_from_dir(cfg.config_dir, cfg.profile_name)
+    profiles = list_profiles(root)
+    profiles_submenu = _build_profiles_submenu(
+        profiles, cfg.profile_name or "", _open_profiles
+    )
 
     icon = pystray.Icon(
         "cullis",
         icon=_build_tray_image(64),
-        title="Cullis Connector",
+        title=(
+            f"Cullis Connector — {cfg.profile_name}"
+            if cfg.profile_name else "Cullis Connector"
+        ),
     )
 
     def _quit_all() -> None:
         icon.stop()
         window.destroy()
 
-    icon.menu = _build_menu(_open_dashboard, _open_inbox, _quit_all)
+    icon.menu = _build_menu(
+        _open_dashboard,
+        _open_inbox,
+        _quit_all,
+        profiles_submenu=profiles_submenu,
+    )
     icon.run_detached()
 
     _log.info(

--- a/cullis_connector/profile.py
+++ b/cullis_connector/profile.py
@@ -71,6 +71,23 @@ def has_legacy_layout(root: Path) -> bool:
     return True
 
 
+def config_root_from_dir(config_dir: Path, profile_name: str) -> Path:
+    """Walk back from an active config_dir to the ``~/.cullis/`` root.
+
+    When a profile is active ``config_dir`` ends in
+    ``<root>/profiles/<name>`` so the root is two levels up.
+    Otherwise the caller is either on a legacy flat layout (in which
+    case the config_dir IS the root and ``list_profiles`` will report
+    the pseudo-``default`` entry) or on an explicit ``--config-dir``
+    override, where we can't reliably locate any profiles/ sibling —
+    returning the override itself is the least surprising behaviour
+    (``list_profiles`` will simply find nothing).
+    """
+    if profile_name:
+        return config_dir.parent.parent
+    return config_dir
+
+
 def list_profiles(root: Path) -> list[str]:
     """Return the profile names known under ``root``.
 

--- a/cullis_connector/static/style.css
+++ b/cullis_connector/static/style.css
@@ -172,6 +172,15 @@ body::after {
   color: var(--text-muted);
 }
 
+.brand-role-sub-link {
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.brand-role-sub-link:hover {
+  color: var(--accent);
+}
+
 .topbar-status {
   display: flex;
   align-items: center;
@@ -958,4 +967,129 @@ body::after {
 @keyframes toast-in {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: translateY(0); }
+}
+
+/* --- Profiles page ---------------------------------------------------- */
+
+.profile-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.profile-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 14px 16px;
+  transition: border-color 0.15s ease;
+}
+
+.profile-card.active {
+  border-color: var(--border-accent);
+  box-shadow: var(--shadow-glow);
+}
+
+.profile-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.profile-name {
+  font-family: var(--font-display);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: 0.04em;
+}
+
+.profile-badge {
+  font-family: var(--font-display);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 229, 199, 0.12);
+  border: 1px solid rgba(0, 229, 199, 0.25);
+  color: var(--accent);
+}
+
+.profile-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.profile-path {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.profile-enrolled-ok   { color: var(--success); }
+.profile-enrolled-pending { color: var(--warning); }
+
+.profile-empty {
+  color: var(--text-muted);
+  font-style: italic;
+  margin: 12px 0 0;
+}
+
+.profile-create-form {
+  display: flex;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.profile-create-form input {
+  flex: 1;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.profile-create-form input:focus {
+  outline: none;
+  border-color: var(--border-accent);
+}
+
+.profile-create-result {
+  margin-top: 14px;
+}
+
+.profile-create-ok p {
+  margin: 10px 0 6px;
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.profile-create-snippet {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 10px 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--accent);
+  overflow-x: auto;
+  white-space: pre;
+}
+
+.profile-create-error {
+  color: var(--danger);
+  font-size: 13px;
+  margin-top: 10px;
 }

--- a/cullis_connector/templates/base.html
+++ b/cullis_connector/templates/base.html
@@ -18,7 +18,11 @@
                 <span class="brand-name">Cullis</span>
                 <div class="brand-role-row">
                     <span class="brand-role-chip">Connector</span>
+                    {% if active_profile %}
+                    <a href="/profiles" class="brand-role-sub brand-role-sub-link" title="Manage profiles">Profile · {{ active_profile }}</a>
+                    {% else %}
                     <span class="brand-role-sub">Local Edge · Your Machine</span>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/cullis_connector/templates/profiles.html
+++ b/cullis_connector/templates/profiles.html
@@ -1,0 +1,66 @@
+{% extends "base.html" %}
+{% block title %}Profiles{% endblock %}
+{% block content %}
+
+<section class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Identities on this machine</div>
+        <h1 class="panel-title"><em>Profiles</em></h1>
+        <p class="panel-sub">
+            Each profile is an isolated enrollment with its own certificate
+            and config. Use distinct profiles when you need more than one
+            identity on the same workstation — e.g. a personal bot and a
+            work bot, or a staging and production pair.
+        </p>
+    </div>
+
+    {% if profiles %}
+    <div class="profile-list">
+        {% for p in profiles %}
+        <div class="profile-card {% if p.name == active_profile %}active{% endif %}">
+            <div class="profile-card-head">
+                <span class="profile-name">{{ p.name }}</span>
+                {% if p.name == active_profile %}
+                <span class="profile-badge">Active</span>
+                {% endif %}
+            </div>
+            <div class="profile-meta">
+                <code class="profile-path">{{ p.path }}</code>
+                {% if p.enrolled %}
+                <span class="profile-enrolled-ok">enrolled</span>
+                {% else %}
+                <span class="profile-enrolled-pending">not yet enrolled</span>
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+    {% else %}
+    <p class="profile-empty">
+        No profiles found. Pick a name below to create your first one.
+    </p>
+    {% endif %}
+</section>
+
+<section class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Add a new profile</div>
+        <h1 class="panel-title">Create <em>another identity</em></h1>
+        <p class="panel-sub">
+            Pick a name (letters, digits, dashes or underscores — up to
+            63 chars). The connector doesn't switch profiles at runtime,
+            so after creating one you'll relaunch with
+            <code>--profile &lt;name&gt;</code> to enrol it. The snippet
+            below already has everything filled in.
+        </p>
+    </div>
+
+    <form class="profile-create-form" hx-post="/profiles/create" hx-target="#profile-create-result" hx-swap="innerHTML">
+        <input type="text" name="name" placeholder="north" maxlength="63" pattern="[A-Za-z0-9][A-Za-z0-9_\-]{0,62}" required>
+        <button type="submit" class="btn-primary">Generate instructions</button>
+    </form>
+
+    <div id="profile-create-result" class="profile-create-result"></div>
+</section>
+
+{% endblock %}

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -19,6 +19,7 @@ until the server has approved.
 from __future__ import annotations
 
 import contextlib
+import html
 import logging
 import os
 import secrets
@@ -217,6 +218,12 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     app.state.connector_config = config
 
     templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+    # Expose the active profile name to every template (topbar shows
+    # "Profile · north" when non-empty). Legacy flat layout and
+    # explicit --config-dir override keep the empty-string default so
+    # the template falls back to the plain "Local Edge · Your Machine"
+    # sub-label.
+    templates.env.globals["active_profile"] = config.profile_name or ""
     app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
     # ── Routes ────────────────────────────────────────────────────────────
@@ -763,6 +770,95 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         except Exception as exc:
             _log.warning("mcp_bind_self failed: %s", exc)
         return RedirectResponse("/mcp", status_code=303)
+
+    @app.get("/profiles", response_class=HTMLResponse)
+    def profiles_get(request: Request) -> Response:
+        """List the profiles on this workstation.
+
+        The page is informational — runtime switching is out of scope
+        for M3.3b. The bottom of the page turns a chosen profile name
+        into a ready-to-paste shell snippet the user can run in a new
+        terminal to enrol it.
+        """
+        from cullis_connector.profile import (
+            config_root_from_dir,
+            list_profiles,
+            profile_dir,
+        )
+        from cullis_connector.identity.store import has_identity
+
+        root = config_root_from_dir(config.config_dir, config.profile_name)
+        rows: list[dict[str, Any]] = []
+        for name in list_profiles(root):
+            if name == "default" and not config.profile_name and (
+                config.config_dir == root
+            ):
+                # Legacy flat layout — the "default" profile actually
+                # lives at the root, not under profiles/default/.
+                pdir = root
+            else:
+                pdir = profile_dir(root, name)
+            rows.append({
+                "name": name,
+                "path": str(pdir),
+                "enrolled": has_identity(pdir),
+            })
+
+        return templates.TemplateResponse(
+            request,
+            "profiles.html",
+            {
+                "connector_status": "online"
+                    if has_identity(config.config_dir) else "waiting",
+                "connector_status_label": "Online"
+                    if has_identity(config.config_dir) else "Setting up",
+                "profiles": rows,
+            },
+        )
+
+    @app.post("/profiles/create", response_class=HTMLResponse)
+    def profiles_create(request: Request, name: str = Form(...)) -> Response:
+        """HTMX handler — validates a candidate profile name and
+        returns a snippet of shell commands that enrol it. No
+        filesystem side effects: the user runs the snippet when
+        they're ready, so nothing is partially created if they
+        change their mind."""
+        from cullis_connector.profile import validate_profile_name
+
+        try:
+            validate_profile_name(name.strip())
+        except ValueError as exc:
+            return HTMLResponse(
+                f'<div class="profile-create-error">'
+                f'{html.escape(str(exc))}</div>',
+                status_code=400,
+            )
+
+        site_url = ""
+        if has_identity(config.config_dir):
+            try:
+                site_url = load_identity(config.config_dir).metadata.site_url or ""
+            except Exception:
+                site_url = ""
+
+        clean_name = name.strip()
+        enroll_cmd = (
+            f"cullis-connector enroll --profile {clean_name} "
+            f"--site-url {site_url or 'https://cullis.example'} "
+            f"--requester-name \"You\" "
+            f"--requester-email \"you@example.com\""
+        )
+        serve_cmd = f"cullis-connector desktop --profile {clean_name}"
+
+        snippet = (
+            f'<div class="profile-create-ok">'
+            f'<p>Run these in a new terminal:</p>'
+            f'<pre class="profile-create-snippet">{html.escape(enroll_cmd)}</pre>'
+            f'<p>Once your admin approves, launch the new profile with:</p>'
+            f'<pre class="profile-create-snippet">{html.escape(serve_cmd)}</pre>'
+            f'</div>'
+        )
+        return HTMLResponse(snippet)
 
     return app
 

--- a/tests/connector/test_profiles_page.py
+++ b/tests/connector/test_profiles_page.py
@@ -1,0 +1,123 @@
+"""M3.3b — dashboard /profiles page and tray-menu wiring.
+
+Covers:
+* GET /profiles renders a card per profile found on disk, with an
+  "active" badge on the one matching ConnectorConfig.profile_name.
+* POST /profiles/create returns a copy-pasteable enrollment snippet
+  for a valid name, rejects hostile names with 400.
+* Tray submenu builder emits one radio entry per profile plus a
+  "Manage profiles…" escape hatch, and returns None when the machine
+  has no profiles yet (so the top menu doesn't grow an empty
+  submenu).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+
+
+@pytest.fixture
+def profile_tree(tmp_path):
+    """A realistic ~/.cullis/ tree with two profiles, active = north."""
+    root = tmp_path / "cullis"
+    (root / "profiles" / "north" / "identity").mkdir(parents=True)
+    (root / "profiles" / "south").mkdir(parents=True)
+    # Mark north as enrolled, south as pending.
+    (root / "profiles" / "north" / "identity" / "agent.crt").write_text("pem")
+    return root
+
+
+@pytest.fixture
+def client_on_north(profile_tree, monkeypatch):
+    """Boot the dashboard as if the user launched
+    `cullis-connector desktop --profile north`."""
+    import cullis_connector.web as _web
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+
+    cfg = ConnectorConfig(
+        config_dir=profile_tree / "profiles" / "north",
+        profile_name="north",
+        site_url="http://mastio.test",
+        verify_tls=False,
+    )
+    from cullis_connector.web import build_app
+    return TestClient(build_app(cfg))
+
+
+def test_profiles_page_lists_profiles_and_flags_active(client_on_north):
+    resp = client_on_north.get("/profiles")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "north" in body
+    assert "south" in body
+    # Active badge only rendered for the currently-loaded profile.
+    # Look for the badge span next to "north" but not "south".
+    assert body.count("profile-badge") == 1
+
+
+def test_profiles_page_topbar_shows_active_profile(client_on_north):
+    resp = client_on_north.get("/profiles")
+    # Base template exposes active_profile via Jinja globals — the
+    # linked sub-label renders "Profile · north".
+    assert "Profile · north" in resp.text
+
+
+def test_profiles_create_returns_snippet_for_valid_name(client_on_north):
+    resp = client_on_north.post("/profiles/create", data={"name": "east"})
+    assert resp.status_code == 200
+    text = resp.text
+    assert "--profile east" in text
+    # Both the enroll command and the desktop relaunch command show up.
+    assert "cullis-connector enroll --profile east" in text
+    assert "cullis-connector desktop --profile east" in text
+
+
+def test_profiles_create_rejects_hostile_name(client_on_north):
+    resp = client_on_north.post(
+        "/profiles/create", data={"name": "../escape"}
+    )
+    assert resp.status_code == 400
+    assert "invalid profile name" in resp.text
+
+
+def test_profiles_create_rejects_empty_name(client_on_north):
+    # FastAPI's Form(...) treats empty string as present, so our own
+    # validator catches it. An omitted `name` field gets a 422 from
+    # FastAPI's request validation — both are acceptable rejection
+    # paths here.
+    resp = client_on_north.post("/profiles/create", data={"name": ""})
+    assert resp.status_code in (400, 422)
+
+
+# ── tray-menu wiring (headless — no GUI) ─────────────────────────────
+
+
+def test_build_profiles_submenu_returns_none_when_no_profiles():
+    pystray = pytest.importorskip("pystray")  # noqa: F841
+    from cullis_connector.desktop_app import _build_profiles_submenu
+
+    out = _build_profiles_submenu([], active="", open_profiles_page=lambda: None)
+    assert out is None
+
+
+def test_build_profiles_submenu_emits_item_per_profile():
+    pystray = pytest.importorskip("pystray")
+    from cullis_connector.desktop_app import _build_profiles_submenu
+
+    menu = _build_profiles_submenu(
+        ["default", "north", "south"],
+        active="north",
+        open_profiles_page=lambda: None,
+    )
+    assert isinstance(menu, pystray.Menu)
+    items = list(menu.items)
+    # 3 radio entries + separator + "Manage profiles…"
+    assert len(items) == 5
+    # First three items are the profile radio entries.
+    radio_texts = [str(it.text) for it in items[:3]]
+    assert radio_texts == ["default", "north", "south"]
+    # Only "north" should be marked checked.
+    checks = [it.checked(it) if callable(it.checked) else it.checked for it in items[:3]]
+    assert checks == [False, True, False]


### PR DESCRIPTION
## Summary

Phase 3 M3.3b — the GUI layer on top of the \`--profile\` plumbing that landed in #244. The dashboard now shows which profile is loaded, lists every profile on the machine, and turns a chosen name into a copy-pasteable enrollment snippet. The tray grows a **Profiles** submenu with the active one checked.

Nothing switches profiles at runtime — that's an M3.3c follow-up that needs a clean process relaunch path. Today's flow is the honest one: pick \"south\" from the tray → \`/profiles\` page opens → shell snippet with \`cullis-connector desktop --profile south\` ready to paste in a new terminal.

## What's in

- **\`GET /profiles\`** — one card per profile with enrolled/pending marker + glowing border + \"Active\" badge on the one matching \`ConnectorConfig.profile_name\`.
- **\`POST /profiles/create\`** — HTMX endpoint, validates the name with the M3.3a regex, returns enroll + desktop snippets. No filesystem side effect; if the user bails mid-flow nothing is left behind.
- **Topbar sub-label** swaps from \"Local Edge · Your Machine\" to \"Profile · <name>\" (clickable link to \`/profiles\`) whenever a profile is active. Legacy flat layout keeps the original text.
- **Tray Profiles submenu** — one radio entry per profile with the active one checked, plus a \"Manage profiles…\" escape that opens \`/profiles\` in the webview. Non-active clicks route to the same page.
- **\`profile.config_root_from_dir()\`** helper walks from an active \`config_dir\` back to \`~/.cullis/\`.
- **Profile card / submenu CSS** in \`style.css\` (panel cards, badges, snippet code blocks).

## What's deliberately NOT in

- **Runtime process relaunch** when clicking a non-active profile from the tray — that's M3.3c. The webview would have to tear down uvicorn, spawn a fresh Connector process with the new \`--profile\` flag, and re-attach. Enough scope to justify its own PR.
- **Filesystem materialisation** of a profile on /profiles/create — would force the user to either complete enrollment or clean up a half-made directory.

## Test plan

- [x] \`pytest tests/connector/test_profiles_page.py\` — 5 pass + 2 correctly skipped when pystray isn't installed in the dev venv.
- [x] \`pytest tests/connector/\` — 209 pass (no regressions).
- [x] \`ruff check cullis_connector/ tests/\` clean.
- [ ] CI green (pytest + smoke + helm).
- [ ] Manual visual QA deferred to M3.9 when the installers land.