### PR TITLE
feat(connector): M3.4 Claude Code CLI autoconfig

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -166,7 +166,15 @@ appear at login.
 
 Every example below assumes you have already enrolled successfully.
 
-### Claude Code
+### Claude Code CLI
+
+If the `claude` binary is on your `PATH`, the dashboard `/connected`
+page has a **Claude Code CLI** card — one click runs `claude mcp add
+cullis --scope user -- cullis-connector serve` for you (idempotent, so
+re-clicking is a no-op). `--scope user` makes the registration persist
+across projects on this machine.
+
+Manual fallback, same thing by hand:
 
 ```bash
 claude mcp add cullis cullis-connector \

--- a/cullis_connector/ide_config.py
+++ b/cullis_connector/ide_config.py
@@ -22,8 +22,10 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -42,6 +44,20 @@ DEFAULT_COMMAND = "cullis-connector"
 DEFAULT_ARGS = ["serve"]
 
 
+class InstallerKind(str, Enum):
+    """How a given MCP client accepts server registrations.
+
+    ``FILE`` — the client keeps its servers in a JSON file at a
+    well-known path (Claude Desktop, Cursor, Cline).
+    ``COMMAND`` — the client exposes a CLI to register servers and
+    stores them somewhere of its own (Claude Code CLI, which uses
+    ``claude mcp add``). We never touch that storage directly;
+    we just shell out to the binary.
+    """
+    FILE = "file"
+    COMMAND = "command"
+
+
 class IDEStatus(str, Enum):
     CONFIGURED = "configured"  # file exists AND cullis entry present & correct
     DETECTED = "detected"      # IDE installed, but cullis not configured yet
@@ -53,11 +69,18 @@ class IDEStatus(str, Enum):
 class IDEDescriptor:
     id: str
     display_name: str
-    # Per-OS path to the MCP config file. Missing OS key means "not supported".
-    paths: dict[str, str]
-    # Top-level JSON key inside the config file where servers live.
-    # All three IDEs currently use "mcpServers".
+    # Per-OS path to the MCP config file (empty dict for COMMAND kind).
+    # Missing OS key means "not supported".
+    paths: dict[str, str] = field(default_factory=dict)
+    # Top-level JSON key inside the config file where servers live
+    # (ignored for COMMAND kind). All three file-based IDEs use
+    # "mcpServers".
     servers_key: str = MCP_SERVERS_KEY
+    # How install/detect work for this client.
+    kind: InstallerKind = InstallerKind.FILE
+    # For COMMAND kind: name of the binary we probe on PATH (e.g.
+    # "claude"). None for FILE kind.
+    detect_binary: str | None = None
 
 
 KNOWN_IDES: dict[str, IDEDescriptor] = {
@@ -91,7 +114,30 @@ KNOWN_IDES: dict[str, IDEDescriptor] = {
             "linux":  "~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
         },
     ),
+    "claude-code-cli": IDEDescriptor(
+        id="claude-code-cli",
+        display_name="Claude Code CLI",
+        kind=InstallerKind.COMMAND,
+        detect_binary="claude",
+    ),
 }
+
+
+# Exposed for the tests / web layer so they can stub subprocess / which.
+def _run_claude(args: list[str], *, timeout: float = 15.0) -> subprocess.CompletedProcess:
+    """Invoke the `claude` CLI. Isolated so tests can monkey-patch it."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _which_claude() -> str | None:
+    """Locate the `claude` binary on PATH. Isolated for the same reason."""
+    return shutil.which("claude")
 
 
 @dataclass
@@ -141,6 +187,9 @@ def detect_ide_status(ide_id: str) -> DetectResult:
     ide = KNOWN_IDES.get(ide_id)
     if ide is None:
         return DetectResult(ide_id, ide_id, IDEStatus.MISSING, note="Unknown IDE.")
+
+    if ide.kind is InstallerKind.COMMAND:
+        return _detect_command_ide(ide)
 
     path = resolve_config_path(ide_id)
     if path is None:
@@ -210,6 +259,9 @@ def install_mcp(
     ide = KNOWN_IDES.get(ide_id)
     if ide is None:
         return InstallResult(ide_id, "error", error=f"Unknown IDE: {ide_id}")
+
+    if ide.kind is InstallerKind.COMMAND:
+        return _install_command_ide(ide, command=command, args=args)
 
     path = resolve_config_path(ide_id)
     if path is None:
@@ -294,6 +346,115 @@ def install_mcp(
     )
 
 
+# ── COMMAND-kind client helpers ─────────────────────────────────────────
+
+
+def _detect_command_ide(ide: IDEDescriptor) -> DetectResult:
+    """Detect a CLI-backed MCP client (currently Claude Code CLI).
+
+    Two probes:
+      1. ``shutil.which(detect_binary)`` — is the binary on PATH?
+      2. ``<bin> mcp list`` — parse stdout to check whether a
+         server named ``cullis`` is already registered.
+
+    The second probe is best-effort: if the CLI's output format
+    changes we downgrade from CONFIGURED to DETECTED rather than
+    surfacing an ERROR, because a wrong status here is fixable by
+    the user but a spurious ERROR would hide the install card.
+    """
+    binary = ide.detect_binary
+    if not binary:
+        return DetectResult(
+            ide.id, ide.display_name, IDEStatus.MISSING,
+            note="No detect_binary configured.",
+        )
+    if _which_claude() is None and binary == "claude":
+        return DetectResult(
+            ide.id, ide.display_name, IDEStatus.MISSING,
+            note=f"`{binary}` not on PATH.",
+        )
+
+    # Probe with `claude mcp list`. If that fails, still surface
+    # DETECTED — the user can click install and see the real error
+    # from the write path.
+    try:
+        res = _run_claude([binary, "mcp", "list"], timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        return DetectResult(
+            ide.id, ide.display_name, IDEStatus.DETECTED,
+            note=f"`{binary}` installed; MCP list query failed.",
+        )
+
+    output = (res.stdout or "") + (res.stderr or "")
+    if res.returncode == 0 and MCP_ENTRY_NAME in output:
+        return DetectResult(
+            ide.id, ide.display_name, IDEStatus.CONFIGURED,
+            note="`cullis` is registered as an MCP server.",
+        )
+    return DetectResult(
+        ide.id, ide.display_name, IDEStatus.DETECTED,
+        note=f"`{binary}` installed; `cullis` not registered yet.",
+    )
+
+
+def _install_command_ide(
+    ide: IDEDescriptor,
+    *,
+    command: str = DEFAULT_COMMAND,
+    args: list[str] | None = None,
+) -> InstallResult:
+    """Register Cullis as an MCP server in a CLI-backed client.
+
+    For Claude Code CLI we use:
+        claude mcp add cullis --scope user -- <command> [args...]
+
+    ``--scope user`` makes the registration persist across projects
+    on this machine, which matches the UX the dashboard's other
+    cards give (configure once per machine, not once per repo).
+    """
+    binary = ide.detect_binary
+    if not binary:
+        return InstallResult(
+            ide.id, "error",
+            error="Descriptor missing detect_binary.",
+        )
+
+    if _which_claude() is None and binary == "claude":
+        return InstallResult(
+            ide.id, "missing",
+            error=f"`{binary}` CLI not installed or not on PATH.",
+        )
+
+    # Idempotency: if `claude mcp list` already mentions cullis we
+    # skip the add rather than letting it fail with "already exists".
+    existing = _detect_command_ide(ide)
+    if existing.status is IDEStatus.CONFIGURED:
+        return InstallResult(ide.id, "already_configured")
+
+    args_list = list(args) if args is not None else list(DEFAULT_ARGS)
+    cmd = [
+        binary, "mcp", "add", MCP_ENTRY_NAME,
+        "--scope", "user",
+        "--",
+        command,
+    ] + args_list
+
+    try:
+        res = _run_claude(cmd, timeout=15)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return InstallResult(
+            ide.id, "error",
+            error=f"Failed to invoke `{binary} mcp add`: {exc}",
+        )
+    if res.returncode != 0:
+        message = (res.stderr or res.stdout or "").strip()
+        return InstallResult(
+            ide.id, "error",
+            error=f"`{binary} mcp add` exited {res.returncode}: {message}",
+        )
+    return InstallResult(ide.id, "installed")
+
+
 def uninstall_mcp(
     ide_id: str,
     *,
@@ -303,6 +464,21 @@ def uninstall_mcp(
     ide = KNOWN_IDES.get(ide_id)
     if ide is None:
         return InstallResult(ide_id, "error", error=f"Unknown IDE: {ide_id}")
+
+    if ide.kind is InstallerKind.COMMAND:
+        # Command-backed clients get a hand-wave for now: we surface
+        # the CLI invocation the user should run rather than running
+        # it ourselves. Removing someone's Claude Code CLI MCP
+        # entries from a background dashboard click is exactly the
+        # flavour of surprise we want to avoid.
+        return InstallResult(
+            ide_id, "error",
+            error=(
+                "Removal via dashboard isn't supported for "
+                f"{ide.display_name}. Run `{ide.detect_binary} mcp "
+                f"remove {MCP_ENTRY_NAME}` yourself."
+            ),
+        )
 
     path = resolve_config_path(ide_id)
     if path is None or not path.exists():

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -570,7 +570,13 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         payload.
         """
         backup_dir = config.config_dir / "backups"
-        result = ide_install_mcp(ide_id, backup_dir=backup_dir)
+        # Propagate the active profile into the registered args so the
+        # IDE spawns the connector with --profile <name> when a profile
+        # is loaded. Falls back to the SDK default ["serve"] otherwise.
+        extra_args: list[str] | None = None
+        if config.profile_name:
+            extra_args = ["serve", "--profile", config.profile_name]
+        result = ide_install_mcp(ide_id, backup_dir=backup_dir, args=extra_args)
 
         if result.status == "installed":
             _log.info(

--- a/tests/connector/test_claude_code_cli.py
+++ b/tests/connector/test_claude_code_cli.py
@@ -1,0 +1,187 @@
+"""M3.4 — dashboard autoconfig for Claude Code CLI.
+
+Claude Code CLI stores its MCP servers behind the `claude mcp add`
+command rather than in a JSON file we can diff-and-merge. This
+module tests the COMMAND-kind install path:
+
+* detection branches on `shutil.which("claude")` + `claude mcp list`.
+* install shells out to `claude mcp add cullis --scope user -- ...`.
+* idempotency: already-registered → ``already_configured``.
+* profile propagation: an active profile threads ``--profile <name>``
+  through to the subprocess invocation.
+
+subprocess is never actually spawned — we patch the two seams
+(`_which_claude`, `_run_claude`) the module exposes for tests.
+"""
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+from cullis_connector import ide_config as ic
+
+
+def _mk_completed(returncode: int, stdout: str = "", stderr: str = ""):
+    """Minimal stand-in for subprocess.CompletedProcess that only has
+    the attributes our detect/install code reads."""
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ── Detection ────────────────────────────────────────────────────────
+
+
+def test_detect_claude_cli_missing_when_binary_not_on_path(monkeypatch):
+    monkeypatch.setattr(ic, "_which_claude", lambda: None)
+    r = ic.detect_ide_status("claude-code-cli")
+    assert r.status is ic.IDEStatus.MISSING
+    assert "not on PATH" in (r.note or "")
+
+
+def test_detect_claude_cli_configured_when_cullis_in_list(monkeypatch):
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+    monkeypatch.setattr(
+        ic, "_run_claude",
+        lambda args, timeout=5: _mk_completed(0, stdout="cullis: cullis-connector serve\n"),
+    )
+    r = ic.detect_ide_status("claude-code-cli")
+    assert r.status is ic.IDEStatus.CONFIGURED
+
+
+def test_detect_claude_cli_detected_when_list_lacks_cullis(monkeypatch):
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+    monkeypatch.setattr(
+        ic, "_run_claude",
+        lambda args, timeout=5: _mk_completed(0, stdout="someoneelse: foo\n"),
+    )
+    r = ic.detect_ide_status("claude-code-cli")
+    assert r.status is ic.IDEStatus.DETECTED
+    assert "not registered yet" in (r.note or "")
+
+
+def test_detect_claude_cli_gracefully_downgrades_on_probe_failure(monkeypatch):
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+
+    def _boom(args, timeout=5):
+        raise subprocess.TimeoutExpired(cmd=args, timeout=timeout)
+
+    monkeypatch.setattr(ic, "_run_claude", _boom)
+    r = ic.detect_ide_status("claude-code-cli")
+    # A probe failure should NOT bubble up as ERROR — worst case the
+    # user clicks install and sees the real error there.
+    assert r.status is ic.IDEStatus.DETECTED
+
+
+# ── Install ──────────────────────────────────────────────────────────
+
+
+def test_install_claude_cli_missing_reports_cleanly(monkeypatch):
+    monkeypatch.setattr(ic, "_which_claude", lambda: None)
+    res = ic.install_mcp("claude-code-cli")
+    assert res.status == "missing"
+    assert "not installed" in (res.error or "").lower()
+
+
+def test_install_claude_cli_already_configured_is_noop(monkeypatch):
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+    monkeypatch.setattr(
+        ic, "_run_claude",
+        lambda args, timeout=5: _mk_completed(0, stdout="cullis: running\n"),
+    )
+    res = ic.install_mcp("claude-code-cli")
+    assert res.status == "already_configured"
+
+
+def test_install_claude_cli_happy_path_shells_out(monkeypatch):
+    calls: list[list[str]] = []
+
+    def _fake_run(args, timeout=15):
+        calls.append(list(args))
+        if "list" in args:
+            # Pre-install probe sees no existing entry.
+            return _mk_completed(0, stdout="")
+        # Actual `mcp add` invocation succeeds.
+        return _mk_completed(0, stdout="Added MCP server 'cullis'.\n")
+
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+    monkeypatch.setattr(ic, "_run_claude", _fake_run)
+
+    res = ic.install_mcp("claude-code-cli")
+    assert res.status == "installed"
+
+    # Two subprocess calls: list (idempotency probe) + add.
+    assert any("list" in c for c in calls)
+    add_call = next(c for c in calls if "add" in c)
+    assert add_call[:5] == ["claude", "mcp", "add", "cullis", "--scope"]
+    assert add_call[5] == "user"
+    assert "--" in add_call
+    # Command + default args appear after the `--` separator.
+    sep = add_call.index("--")
+    assert add_call[sep + 1:] == ["cullis-connector", "serve"]
+
+
+def test_install_claude_cli_propagates_profile(monkeypatch):
+    """When the dashboard is running with --profile north, the web
+    layer threads ``args=["serve", "--profile", "north"]`` through,
+    and we expect that to land verbatim after the `--` separator."""
+    calls: list[list[str]] = []
+
+    def _fake_run(args, timeout=15):
+        calls.append(list(args))
+        if "list" in args:
+            return _mk_completed(0, stdout="")
+        return _mk_completed(0, stdout="Added MCP server 'cullis'.\n")
+
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+    monkeypatch.setattr(ic, "_run_claude", _fake_run)
+
+    res = ic.install_mcp(
+        "claude-code-cli",
+        args=["serve", "--profile", "north"],
+    )
+    assert res.status == "installed"
+
+    add_call = next(c for c in calls if "add" in c)
+    sep = add_call.index("--")
+    assert add_call[sep + 1:] == [
+        "cullis-connector", "serve", "--profile", "north",
+    ]
+
+
+def test_install_claude_cli_surfaces_subprocess_error(monkeypatch):
+    def _fake_run(args, timeout=15):
+        if "list" in args:
+            return _mk_completed(0, stdout="")
+        return _mk_completed(
+            2,
+            stdout="",
+            stderr="error: invalid scope 'user'\n",
+        )
+
+    monkeypatch.setattr(ic, "_which_claude", lambda: "/usr/local/bin/claude")
+    monkeypatch.setattr(ic, "_run_claude", _fake_run)
+
+    res = ic.install_mcp("claude-code-cli")
+    assert res.status == "error"
+    assert "invalid scope" in (res.error or "")
+
+
+# ── Uninstall guard ──────────────────────────────────────────────────
+
+
+def test_uninstall_claude_cli_refuses_and_hints(monkeypatch):
+    """We deliberately don't uninstall COMMAND-kind entries from the
+    dashboard — surfacing the CLI command is safer than silently
+    rewriting the user's registered MCP servers."""
+    res = ic.uninstall_mcp("claude-code-cli")
+    assert res.status == "error"
+    assert "claude mcp remove cullis" in (res.error or "")
+
+
+# ── Descriptor registration ──────────────────────────────────────────
+
+
+def test_claude_cli_shows_up_in_known_ides():
+    assert "claude-code-cli" in ic.KNOWN_IDES
+    d = ic.KNOWN_IDES["claude-code-cli"]
+    assert d.kind is ic.InstallerKind.COMMAND
+    assert d.detect_binary == "claude"


### PR DESCRIPTION
## Summary

Phase 3 M3.4 — the last IDE that still required a terminal. From this PR the dashboard \`/connected\` page has a **Claude Code CLI** card next to Claude Desktop, Cursor, and Cline. One click runs \`claude mcp add cullis --scope user -- cullis-connector serve\` for you (idempotent — re-clicking is a noop).

Up until now the user had to remember the exact \`claude mcp add\` invocation; after this, the only thing they touch in a terminal is if they want to paste the command manually (still documented in the README as a fallback).

## Design — COMMAND vs FILE installer kinds

Claude Code CLI doesn't keep MCP servers in a JSON file we can diff-and-merge; it exposes a CLI to register them and stores them somewhere of its own. Two approaches on the table:

- (a) Reverse-engineer the CLI's storage and diff like the other three — brittle, breaks on CLI upgrades.
- (b) Shell out to the CLI and treat it as the source of truth.

(b) wins. Introduces \`IDEDescriptor.kind: InstallerKind = FILE | COMMAND\`; the existing three IDEs keep the file-write path untouched, Claude Code CLI is the first COMMAND-kind client. Future CLI-only clients (e.g. Zed's future \`zed mcp add\` if it lands) plug into the same branch.

## What's in

- **\`InstallerKind\` enum** + \`IDEDescriptor.kind\` / \`detect_binary\` fields.
- **\`_detect_command_ide()\`** — probes \`shutil.which(\"claude\")\` + \`claude mcp list\`, distinguishes MISSING / DETECTED / CONFIGURED. Probe failures downgrade to DETECTED (never ERROR — false-positives are harmless, false-negatives hide the install card).
- **\`_install_command_ide()\`** — invokes \`claude mcp add cullis --scope user -- ...\`. \`--scope user\` matches the dashboard's \"configure once per machine\" UX.
- **Idempotency** — pre-install probe + \`already_configured\` short-circuit.
- **Profile propagation** — \`/configure/{ide_id}\` route threads \`args=[\"serve\", \"--profile\", <name>]\` whenever a profile is active, so the registered invocation matches the currently-loaded profile.
- **Uninstall guard** — refusing removal via dashboard for COMMAND-kind clients with a clear \`claude mcp remove cullis\` hint. Silently rewriting the user's registered MCP servers is exactly the surprise the Connector must not ship.
- **README** updates the \`### Claude Code CLI\` section: one-click first, manual fallback second.

## Test plan

- [x] \`pytest tests/connector/test_claude_code_cli.py\` → 11 pass (detection branches, install happy path, idempotency, profile propagation, subprocess error surfacing, uninstall guard).
- [x] \`pytest tests/connector/\` → 220 pass (+ 2 skipped, pystray-gated, same as before).
- [x] \`ruff check cullis_connector/ tests/\` clean.
- [ ] CI green.