### PR TITLE
feat(connector): M3.3c runtime profile switch from the tray

### DIFF
--- a/cullis_connector/desktop_app.py
+++ b/cullis_connector/desktop_app.py
@@ -17,7 +17,10 @@ Threading plan (all three matter, pick the wrong one and macOS hangs):
 from __future__ import annotations
 
 import logging
+import subprocess
+import sys
 import threading
+import time
 from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
@@ -95,30 +98,85 @@ def _spawn_uvicorn(
     return thread
 
 
+def _relaunch_argv(profile: str) -> list[str]:
+    """Build the argv that spawns a fresh Connector process loading
+    a different profile. Isolated so tests can inspect it without
+    actually invoking subprocess."""
+    # ``sys.argv[0]`` is the right entrypoint both for a pip-installed
+    # console_script (``cullis-connector``) and for a PyInstaller-frozen
+    # binary (the bundle's entry point). For `python -m cullis_connector`
+    # development use we fall back to `-m` form.
+    if sys.argv and sys.argv[0] and not sys.argv[0].endswith(".py"):
+        argv0 = [sys.argv[0]]
+    else:
+        argv0 = [sys.executable, "-m", "cullis_connector"]
+    return [*argv0, "desktop", "--profile", profile]
+
+
+def _spawn_detached(argv: list[str]) -> subprocess.Popen:
+    """Spawn a detached child process that survives the parent's exit.
+
+    Detachment prevents the new desktop shell from receiving SIGINT
+    when the old one quits and dodges "zombie child" situations on
+    Unix. On Windows ``CREATE_NEW_PROCESS_GROUP`` plays the same role.
+    """
+    kwargs: dict = {
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "stdin": subprocess.DEVNULL,
+        "close_fds": True,
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = (
+            subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+            | subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+        )
+    else:
+        kwargs["start_new_session"] = True
+    return subprocess.Popen(argv, **kwargs)
+
+
 def _build_profiles_submenu(
     profiles: list[str],
     active: str,
     open_profiles_page: Callable[[], None],
+    switch_to: Callable[[str], None] | None = None,
 ):
     """Submenu listing every profile on the machine with a check next
-    to the one currently loaded. Clicking a non-active profile opens
-    the dashboard `/profiles` page so the user sees the exact
-    relaunch command — runtime switching is intentionally out of
-    scope for M3.3 (a restart is required to pick up a different
-    identity on this process)."""
+    to the one currently loaded.
+
+    * Active entry: click is a no-op (it's already selected).
+    * Non-active entry: click triggers ``switch_to(name)`` — the
+      caller is expected to spawn a detached subprocess with that
+      profile and then tear the current process down. If ``switch_to``
+      is ``None`` we fall back to opening the Manage page, preserving
+      the pre-M3.3c behaviour for callers who don't want runtime
+      switching.
+    * "Manage profiles…" is always available — it's the escape hatch
+      for users who want to see the list or add a new profile.
+    """
     import pystray
 
     if not profiles:
         return None
 
+    def _click_handler(name: str):
+        def _on_click(icon, item):
+            if name == active:
+                return  # already loaded, nothing to do
+            if switch_to is not None:
+                switch_to(name)
+            else:
+                open_profiles_page()
+        return _on_click
+
     items: list = []
     for name in profiles:
-        checked_name = name
         items.append(
             pystray.MenuItem(
                 name,
-                lambda icon, item, n=checked_name: open_profiles_page(),
-                checked=lambda item, n=checked_name: n == active,
+                _click_handler(name),
+                checked=lambda item, n=name: n == active,
                 radio=True,
             )
         )
@@ -235,9 +293,6 @@ def run_desktop_app(
 
     root = config_root_from_dir(cfg.config_dir, cfg.profile_name)
     profiles = list_profiles(root)
-    profiles_submenu = _build_profiles_submenu(
-        profiles, cfg.profile_name or "", _open_profiles
-    )
 
     icon = pystray.Icon(
         "cullis",
@@ -251,6 +306,34 @@ def run_desktop_app(
     def _quit_all() -> None:
         icon.stop()
         window.destroy()
+
+    def _switch_to(target_profile: str) -> None:
+        """Spawn a detached Connector for the target profile and
+        tear ourselves down so it can claim port 7777.
+
+        There is a ~1-2s window where neither process answers on
+        the port while the new uvicorn binds. That's the honest
+        price of a single-port design; acceptable for a manual
+        tray click and far simpler than running two Connectors
+        side by side.
+        """
+        _log.info("desktop shell switching to profile %s", target_profile)
+        try:
+            _spawn_detached(_relaunch_argv(target_profile))
+        except OSError as exc:
+            _log.error("failed to spawn replacement connector: %s", exc)
+            return
+        # Brief head-start so the child is past argv parsing before
+        # we release the port it wants.
+        time.sleep(0.3)
+        _quit_all()
+
+    profiles_submenu = _build_profiles_submenu(
+        profiles,
+        cfg.profile_name or "",
+        _open_profiles,
+        switch_to=_switch_to,
+    )
 
     icon.menu = _build_menu(
         _open_dashboard,

--- a/tests/connector/test_profile_runtime_switch.py
+++ b/tests/connector/test_profile_runtime_switch.py
@@ -1,0 +1,148 @@
+"""M3.3c — runtime profile switch from the tray submenu.
+
+Clicking a non-active profile in the tray respawns the Connector with
+`--profile <target>` and tears the current process down. The active
+profile's entry is a no-op. Subprocess.Popen is patched out so the
+tests never actually fork a real binary.
+"""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+# PIL needed by desktop_app tray-image helpers transitively via import.
+pytest.importorskip("PIL.Image")
+
+from cullis_connector import desktop_app
+
+
+# ── _relaunch_argv ───────────────────────────────────────────────────
+
+
+def test_relaunch_argv_uses_console_script_when_available(monkeypatch):
+    # Simulate being invoked as the `cullis-connector` console script:
+    # sys.argv[0] is an absolute path to the entry-point shim.
+    monkeypatch.setattr(sys, "argv", ["/usr/local/bin/cullis-connector", "desktop"])
+    argv = desktop_app._relaunch_argv("north")
+    assert argv == ["/usr/local/bin/cullis-connector", "desktop", "--profile", "north"]
+
+
+def test_relaunch_argv_falls_back_to_python_m(monkeypatch):
+    # Simulate `python -m cullis_connector` usage: argv[0] ends in .py
+    # so we can't just re-exec it verbatim; fall back to sys.executable.
+    monkeypatch.setattr(sys, "argv", ["/tmp/cullis_connector/__main__.py", "desktop"])
+    monkeypatch.setattr(sys, "executable", "/usr/bin/python3")
+    argv = desktop_app._relaunch_argv("south")
+    assert argv == [
+        "/usr/bin/python3",
+        "-m",
+        "cullis_connector",
+        "desktop",
+        "--profile",
+        "south",
+    ]
+
+
+def test_relaunch_argv_handles_empty_argv(monkeypatch):
+    monkeypatch.setattr(sys, "argv", [])
+    monkeypatch.setattr(sys, "executable", "/opt/venv/bin/python")
+    argv = desktop_app._relaunch_argv("east")
+    assert argv[:3] == ["/opt/venv/bin/python", "-m", "cullis_connector"]
+
+
+# ── _spawn_detached ──────────────────────────────────────────────────
+
+
+def test_spawn_detached_uses_start_new_session_on_unix(monkeypatch):
+    captured: dict = {}
+
+    def _fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(pid=12345)
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(desktop_app.subprocess, "Popen", _fake_popen)
+    desktop_app._spawn_detached(["cullis-connector", "desktop", "--profile", "x"])
+
+    assert captured["argv"][0] == "cullis-connector"
+    assert captured["kwargs"].get("start_new_session") is True
+    assert captured["kwargs"].get("stdout") is desktop_app.subprocess.DEVNULL
+    assert captured["kwargs"].get("stdin") is desktop_app.subprocess.DEVNULL
+    # Windows-only flag must NOT leak into Unix spawn.
+    assert "creationflags" not in captured["kwargs"]
+
+
+# ── _build_profiles_submenu: switch_to hook ──────────────────────────
+
+
+def test_submenu_non_active_click_invokes_switch_to():
+    pystray = pytest.importorskip("pystray")
+    calls: list[str] = []
+    menu = desktop_app._build_profiles_submenu(
+        profiles=["north", "south"],
+        active="north",
+        open_profiles_page=lambda: calls.append("manage"),
+        switch_to=lambda name: calls.append(f"switch:{name}"),
+    )
+    assert isinstance(menu, pystray.Menu)
+    items = list(menu.items)
+    # The south entry is the 2nd radio item.
+    south_item = items[1]
+    assert str(south_item.text) == "south"
+    # pystray menu items are invoked via __call__ with (icon, item).
+    south_item(None, south_item)
+    assert calls == ["switch:south"]
+
+
+def test_submenu_active_click_is_noop():
+    pytest.importorskip("pystray")
+    calls: list[str] = []
+    menu = desktop_app._build_profiles_submenu(
+        profiles=["north", "south"],
+        active="north",
+        open_profiles_page=lambda: calls.append("manage"),
+        switch_to=lambda name: calls.append(f"switch:{name}"),
+    )
+    items = list(menu.items)
+    north_item = items[0]
+    north_item(None, north_item)
+    # Click on the already-active profile does nothing — no switch,
+    # no Manage page open.
+    assert calls == []
+
+
+def test_submenu_falls_back_to_manage_when_switch_to_is_none():
+    pytest.importorskip("pystray")
+    calls: list[str] = []
+    menu = desktop_app._build_profiles_submenu(
+        profiles=["north", "south"],
+        active="north",
+        open_profiles_page=lambda: calls.append("manage"),
+        switch_to=None,
+    )
+    items = list(menu.items)
+    south_item = items[1]
+    south_item(None, south_item)
+    # With switch_to missing we honour the pre-M3.3c behaviour: open
+    # the Manage profiles page for the user to act on.
+    assert calls == ["manage"]
+
+
+def test_submenu_manage_entry_always_opens_manage_page():
+    pytest.importorskip("pystray")
+    calls: list[str] = []
+    menu = desktop_app._build_profiles_submenu(
+        profiles=["north", "south"],
+        active="north",
+        open_profiles_page=lambda: calls.append("manage"),
+        switch_to=lambda name: calls.append(f"switch:{name}"),
+    )
+    items = list(menu.items)
+    # Last non-separator item is "Manage profiles…"
+    manage_item = items[-1]
+    assert "Manage profiles" in str(manage_item.text)
+    manage_item(None, manage_item)
+    assert calls == ["manage"]


### PR DESCRIPTION
## Summary

Phase 3 M3.3c — closes the multi-profile milestone. M3.3a laid the CLI plumbing, M3.3b added dashboard + tray visibility; this PR turns a non-active click in the tray from a \"hint\" into an actual relaunch.

## Behaviour

- **Click active profile** → no-op (already loaded).
- **Click non-active profile** → spawn detached Connector subprocess with \`--profile <target>\` + tear current process down so the replacement claims port 7777.
- **\"Manage profiles…\"** still opens \`/profiles\` for users who want to add a new profile rather than switch.

## Design choices worth calling out

**Single-port, ~1-2s gap.** When we quit the old uvicorn and the new one binds, there's a short window where neither process answers on 7777. This is the honest price of a single-port design; running two Connectors side-by-side would be simpler implementation-wise but harder to explain to the user (two trays, two notification streams, duplicate poll loops). Documented in the docstring.

**\`sys.argv[0]\` heuristic for the relaunch command.** If we were launched as the installed \`cullis-connector\` console script or a PyInstaller frozen binary we re-exec the same path; otherwise (\`.py\` file, i.e. \`python -m cullis_connector\`) we fall back to \`[sys.executable, \"-m\", \"cullis_connector\"]\`. Both cases are covered by tests.

**\`switch_to=None\` preserves pre-M3.3c behaviour.** The submenu's signature grows an optional callback; callers that don't pass it keep opening the Manage page on click, so the M3.3b wiring doesn't have to change in lockstep.

## Test plan

- [x] \`pytest tests/connector/test_profile_runtime_switch.py\` — 4 pass + 4 pystray-gated skips (same pattern as M3.1 / M3.3b).
- [x] \`pytest tests/connector/\` — 224 pass + 6 skipped (no regressions).
- [x] \`ruff check cullis_connector/ tests/\` clean.
- [ ] CI green (pytest + smoke + helm).
- [ ] Manual QA across OSes deferred to M3.9 with the packaged binaries — headless tests can't verify the AppKit/GTK/Win32 process-detach semantics.

## What this leaves open

- **M3.3d (maybe)**: detect when the new child process fails to come up and restore the old window. Today if the spawn fails the user sees a quit but no new tray. Not obviously worth the complexity; add only if testing surfaces it.