### PR TITLE
fix(connector): unblock `cullis-connector desktop` on fresh Linux VMs

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -232,13 +232,19 @@ _KNOWN_SUBCOMMANDS = frozenset({
     "install-mcp",
     "install-autostart",
     "dashboard",
+    "desktop",
 })
 
 # Shared flags are parsed by the subparser that owns the chosen command.
 # When the caller wrote them *before* the subcommand (the pre-fix layout
 # some users already have persisted in MCP configs), we relocate them so
 # argparse finds them on the right subparser.
-_SHARED_VALUE_FLAGS = frozenset({"--site-url", "--config-dir", "--log-level"})
+_SHARED_VALUE_FLAGS = frozenset({
+    "--site-url",
+    "--config-dir",
+    "--log-level",
+    "--profile",
+})
 _SHARED_STORE_FLAGS = frozenset({"--no-verify-tls"})
 
 

--- a/cullis_connector/desktop_app.py
+++ b/cullis_connector/desktop_app.py
@@ -35,6 +35,21 @@ _log = logging.getLogger(__name__)
 _ACCENT = (0, 229, 199, 255)
 
 
+def _build_tray_title(profile_name: str) -> str:
+    """Compose the tooltip / WM_NAME for the tray icon.
+
+    The title MUST round-trip through latin-1: pystray on X11 writes
+    it into WM_NAME via python-xlib, which uses the ICCCM STRING
+    encoding (latin-1 only). Non-latin-1 characters (em-dash, curly
+    quotes, emoji, ...) crash with UnicodeEncodeError at icon setup.
+    ASCII-only keeps Linux Xorg working out of the box; macOS and
+    Windows tolerate unicode but we don't gain anything by branching.
+    """
+    if profile_name:
+        return f"Cullis Connector - {profile_name}"
+    return "Cullis Connector"
+
+
 def _build_tray_image(size: int = 64) -> "PILImage":
     """Draw the portcullis glyph at the requested pixel size.
 
@@ -297,10 +312,7 @@ def run_desktop_app(
     icon = pystray.Icon(
         "cullis",
         icon=_build_tray_image(64),
-        title=(
-            f"Cullis Connector — {cfg.profile_name}"
-            if cfg.profile_name else "Cullis Connector"
-        ),
+        title=_build_tray_title(cfg.profile_name or ""),
     )
 
     def _quit_all() -> None:

--- a/tests/connector/test_cli_dispatch.py
+++ b/tests/connector/test_cli_dispatch.py
@@ -1,0 +1,138 @@
+"""Regression guard for the CLI dispatcher.
+
+`_ensure_subcommand` and the argparse subparsers are two registries
+that must stay in sync: anything added to `_build_parser`'s subparser
+list MUST also live in `_KNOWN_SUBCOMMANDS`, and any shared flag
+added to `_add_shared_args` MUST live in `_SHARED_VALUE_FLAGS` or
+`_SHARED_STORE_FLAGS`.
+
+M3.1 forgot to register `desktop` and M3.3a forgot `--profile`; both
+showed up as `cullis-connector: error: unrecognized arguments: …`
+on the VM after a clean install. These tests pin the two registries
+against the parser so the next subcommand/flag can't drift.
+"""
+from __future__ import annotations
+
+import pytest
+
+from cullis_connector.cli import (
+    _KNOWN_SUBCOMMANDS,
+    _SHARED_STORE_FLAGS,
+    _SHARED_VALUE_FLAGS,
+    _build_parser,
+    _ensure_subcommand,
+)
+
+
+# ── Subparser ↔ _KNOWN_SUBCOMMANDS ───────────────────────────────────
+
+
+def _parser_subcommands() -> set[str]:
+    """Return the subcommand names argparse actually knows about."""
+    parser = _build_parser()
+    # The top-level parser has exactly one _SubParsersAction holding
+    # every registered subcommand.
+    for action in parser._actions:
+        if hasattr(action, "choices") and action.choices:
+            return set(action.choices)
+    raise AssertionError("no subparsers action found")
+
+
+def test_known_subcommands_matches_parser():
+    """The hardcoded set must cover every subcommand the parser
+    exposes — any new subcommand has to be added here too, or
+    `_ensure_subcommand` silently prepends `serve` and argparse
+    then surfaces the new command as `unrecognized arguments`."""
+    assert _KNOWN_SUBCOMMANDS == _parser_subcommands()
+
+
+@pytest.mark.parametrize("cmd", ["serve", "dashboard", "desktop"])
+def test_known_subcommand_is_passed_through(cmd):
+    """A bare subcommand must round-trip through _ensure_subcommand
+    unchanged (no silent `serve` prefix injection)."""
+    assert _ensure_subcommand([cmd]) == [cmd]
+
+
+def test_unknown_first_token_gets_serve_prefix():
+    """A root-level flag (no subcommand) still defaults to `serve`
+    — this is the carve-out the docstring documents."""
+    assert _ensure_subcommand(["--config-dir", "/tmp/x"]) == [
+        "serve",
+        "--config-dir",
+        "/tmp/x",
+    ]
+
+
+# ── Shared flag registry ↔ _add_shared_args ──────────────────────────
+
+
+def _parser_shared_flags() -> tuple[set[str], set[str]]:
+    """Walk the 'serve' subparser and collect the flag strings it
+    declares. Returns ``(value_flags, store_flags)`` — value_flags take
+    an argument, store_flags are boolean switches."""
+    parser = _build_parser()
+    for action in parser._actions:
+        if hasattr(action, "choices") and action.choices:
+            serve = action.choices["serve"]
+            break
+    else:
+        raise AssertionError("no serve subparser")
+
+    value_flags: set[str] = set()
+    store_flags: set[str] = set()
+    for sub_action in serve._actions:
+        for opt in sub_action.option_strings:
+            if not opt.startswith("--"):
+                continue
+            if opt in ("--help",):
+                continue
+            if sub_action.nargs == 0 or sub_action.const is not None:
+                store_flags.add(opt)
+            else:
+                value_flags.add(opt)
+    return value_flags, store_flags
+
+
+def test_shared_value_flags_registry_is_complete():
+    """Every --foo VALUE flag on the serve subparser must appear in
+    _SHARED_VALUE_FLAGS; otherwise pre-subcommand use of that flag
+    (common in IDE mcp.json configs) leaks into `remainder` and
+    argparse rejects the command."""
+    value_flags, _ = _parser_shared_flags()
+    missing = value_flags - _SHARED_VALUE_FLAGS
+    assert missing == set(), (
+        f"these flags take a value but aren't in _SHARED_VALUE_FLAGS: "
+        f"{missing}. Add them or pre-subcommand harvesting breaks."
+    )
+
+
+def test_shared_store_flags_registry_is_complete():
+    _, store_flags = _parser_shared_flags()
+    missing = store_flags - _SHARED_STORE_FLAGS
+    assert missing == set(), (
+        f"these boolean flags aren't in _SHARED_STORE_FLAGS: {missing}"
+    )
+
+
+# ── End-to-end harvesting cases that used to be broken ───────────────
+
+
+def test_profile_flag_before_subcommand_gets_moved_after():
+    """MCP configs sometimes list args as
+    `[--profile, north, --site-url, X, serve]`. _ensure_subcommand
+    must hoist the flags past the subcommand so the subparser sees
+    them. Before the fix `--profile` fell into `remainder` and
+    argparse said `unrecognized arguments: --profile north`."""
+    out = _ensure_subcommand(
+        ["--profile", "north", "--site-url", "http://x", "serve"]
+    )
+    assert out[0] == "serve"
+    assert "--profile" in out
+    assert "north" in out
+    # Values stick next to their flag.
+    assert out.index("north") == out.index("--profile") + 1
+
+
+def test_desktop_with_flags_round_trips():
+    argv = ["desktop", "--profile", "south", "--port", "7788"]
+    assert _ensure_subcommand(argv) == argv

--- a/tests/connector/test_desktop_app.py
+++ b/tests/connector/test_desktop_app.py
@@ -26,6 +26,28 @@ def test_build_tray_image_produces_rgba_at_requested_size():
     assert img.mode == "RGBA"
 
 
+def test_tray_title_round_trips_through_latin1():
+    """Regression for the UnicodeEncodeError crash we hit on fresh
+    Linux VMs: pystray on X11 writes WM_NAME via python-xlib's
+    latin-1 codec, so the title must not contain em-dashes, curly
+    quotes, emoji, or any other char outside latin-1 (Unicode <= U+00FF)."""
+    from cullis_connector.desktop_app import _build_tray_title
+
+    for name in ("", "default", "north", "org-1"):
+        title = _build_tray_title(name)
+        # This raises on the bad path.
+        title.encode("latin-1")
+        # And specifically not the em-dash (U+2014) we used to ship.
+        assert "\u2014" not in title
+
+
+def test_tray_title_includes_profile_name_when_present():
+    from cullis_connector.desktop_app import _build_tray_title
+
+    assert _build_tray_title("north") == "Cullis Connector - north"
+    assert _build_tray_title("") == "Cullis Connector"
+
+
 def test_build_tray_image_scales_cleanly():
     from cullis_connector.desktop_app import _build_tray_image
 

--- a/tests/test_proxy_resolve.py
+++ b/tests/test_proxy_resolve.py
@@ -21,6 +21,11 @@ async def proxy_app(tmp_path, monkeypatch):
     monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    # Scrub standalone + intra-org transport so an xdist neighbour
+    # (e.g. test_proxy_standalone_e2e) leaking into the env can't
+    # flip the default from `envelope` to `mtls-only` under us.
+    monkeypatch.delenv("MCP_PROXY_STANDALONE", raising=False)
+    monkeypatch.delenv("PROXY_TRANSPORT_INTRA_ORG", raising=False)
 
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Two sequential bugs that blocked \`cullis-connector desktop\` on any fresh Linux install. Both surfaced on the VM tester this afternoon:

1. \`unrecognized arguments: desktop\` — the CLI dispatcher rejected the subcommand.
2. \`UnicodeEncodeError: 'latin-1' codec can't encode character '\u2014'\` — once the dispatch worked, the tray icon crashed on the em-dash in its tooltip.

This PR closes both and adds regression guards for each.

## Fix 1 — CLI dispatch registries out of sync

\`_ensure_subcommand\` works against two hardcoded sets that must mirror argparse:

- **\`_KNOWN_SUBCOMMANDS\`** — M3.1 added the \`desktop\` subparser (#243) but forgot the registry entry. The dispatcher fell through the "no subcommand" branch, prepended \`serve\`, and argparse rejected \`desktop\` as an extra token.
- **\`_SHARED_VALUE_FLAGS\`** — M3.3a added \`--profile\` (#244) but forgot the registry entry. MCP configs listing args as \`[--profile, north, serve]\` leaked the flag into \`remainder\` and argparse surfaced \`unrecognized arguments: --profile north\`.

Fix: one-liner each. Regression guard: \`tests/connector/test_cli_dispatch.py\` cross-checks both sets against the actual argparse parser tree (9 cases). Any future subcommand or shared flag missing from a registry fails the suite before hitting a user.

## Fix 2 — tray title must be latin-1 encodable

pystray on X11 writes the tooltip into \`WM_NAME\` via python-xlib, which uses the ICCCM STRING encoding — **latin-1 only**. Our em-dash in \`\"Cullis Connector \u2014 <profile>\"\` (U+2014) is outside that range, so the icon never came up on Linux.

Fix: extract title composition into \`_build_tray_title()\` and swap the em-dash for ASCII \`-\`. Regression guard: new test asserts the title round-trips through latin-1 for empty / default / named / dashed profiles and that U+2014 specifically never reappears.

## Test plan

- [x] \`pytest tests/connector/test_cli_dispatch.py\` → 9 pass
- [x] \`pytest tests/connector/test_desktop_app.py\` → 8 pass (includes 3 new)
- [x] \`pytest tests/connector/\` → 246 pass / 6 pystray-gated skips, zero regressions
- [x] \`ruff check\` clean
- [x] Manual re-test on Ubuntu Server + GNOME VM: \`cullis-connector desktop\` dispatches correctly (past Fix 1) — Fix 2 next to verify after CI re-run
- [ ] CI green (pytest + smoke + helm)