### PR TITLE
feat(mastio): ADR-012 Phase 1 — local ES256 issuer + JWKS endpoint

### DIFF
--- a/mcp_proxy/auth/jwks_local.py
+++ b/mcp_proxy/auth/jwks_local.py
@@ -1,0 +1,30 @@
+"""ADR-012 §3 — JWKS endpoint for the Mastio local issuer.
+
+Exposes the Mastio leaf public key as a JWKS document so intra-org
+validators (Mastio-side middleware, MCP aggregator, local session
+store) can verify tokens without a remote round-trip.
+
+The endpoint is served unauthenticated by design — it publishes public
+key material only, mirrors the /.well-known/jwks.json pattern used
+by the broker, and is read by internal components sharing the same
+FastAPI process.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+router = APIRouter(tags=["auth"])
+
+
+@router.get(
+    "/.well-known/jwks-local.json",
+    summary="JWKS for the Mastio local issuer (intra-org tokens)",
+)
+async def jwks_local(request: Request) -> dict:
+    issuer = getattr(request.app.state, "local_issuer", None)
+    if issuer is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="local issuer not initialized",
+        )
+    return issuer.jwks()

--- a/mcp_proxy/auth/local_issuer.py
+++ b/mcp_proxy/auth/local_issuer.py
@@ -1,0 +1,176 @@
+"""ADR-012 §3 — local ES256 JWT issuer for intra-org operations.
+
+The Mastio signs session tokens locally for intra-org traffic (MCP
+calls, intra-org send/receive). These tokens never reach the Court:
+the Court is only contacted when an agent performs a cross-org send,
+via a runtime token-exchange introduced in a follow-up PR.
+
+Signing key = the same EC P-256 Mastio leaf key used for ADR-009
+counter-signatures (``AgentManager._mastio_leaf_key``). One key, two
+uses, one trust anchor: the ``mastio_pubkey`` pinned at org onboarding.
+
+The ``kid`` is derived from the SHA-256 digest of the leaf public key
+PEM (first 16 hex chars). This is stable across restarts — the key is
+re-loaded from the DB by ``AgentManager.ensure_mastio_identity()`` —
+and unique per Mastio, so validators can pick the right key out of
+the JWKS without relying on wall-clock ordering.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+import jwt as jose_jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+DEFAULT_TTL_SECONDS = 15 * 60
+MAX_TTL_SECONDS = 60 * 60
+LOCAL_AUDIENCE = "cullis-local"
+LOCAL_ISSUER_PREFIX = "cullis-mastio"
+LOCAL_SCOPE = "local"
+
+_RESERVED_CLAIMS = frozenset({"iss", "aud", "sub", "exp", "iat", "jti", "scope"})
+
+
+@dataclass(frozen=True)
+class LocalToken:
+    token: str
+    kid: str
+    issued_at: int
+    expires_at: int
+
+
+class LocalIssuer:
+    """Issue ES256 JWTs signed by the Mastio leaf key.
+
+    Claims emitted::
+
+        iss   = "cullis-mastio:{org_id}"
+        aud   = "cullis-local"
+        sub   = agent_id
+        scope = "local"
+        iat   = now
+        exp   = now + ttl
+        jti   = uuid4
+
+    Extra claims may be passed via ``issue(..., extra_claims=...)`` but
+    cannot overwrite any of the reserved claims above.
+    """
+
+    def __init__(
+        self,
+        org_id: str,
+        leaf_key: ec.EllipticCurvePrivateKey,
+        leaf_pubkey_pem: str,
+    ) -> None:
+        if not org_id:
+            raise ValueError("org_id required")
+        if not isinstance(leaf_key, ec.EllipticCurvePrivateKey):
+            raise TypeError("leaf_key must be an EC private key")
+        if not leaf_pubkey_pem:
+            raise ValueError("leaf_pubkey_pem required")
+        self.org_id = org_id
+        self._leaf_key = leaf_key
+        self._leaf_pubkey_pem = leaf_pubkey_pem
+        self._priv_pem = leaf_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        self._kid = self._compute_kid(leaf_pubkey_pem)
+
+    @staticmethod
+    def _compute_kid(pubkey_pem: str) -> str:
+        digest = hashlib.sha256(pubkey_pem.encode()).hexdigest()[:16]
+        return f"mastio-{digest}"
+
+    @property
+    def kid(self) -> str:
+        return self._kid
+
+    @property
+    def issuer(self) -> str:
+        return f"{LOCAL_ISSUER_PREFIX}:{self.org_id}"
+
+    def issue(
+        self,
+        agent_id: str,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> LocalToken:
+        if not agent_id:
+            raise ValueError("agent_id required")
+        if ttl_seconds <= 0 or ttl_seconds > MAX_TTL_SECONDS:
+            raise ValueError(
+                f"ttl_seconds must be in (0, {MAX_TTL_SECONDS}]",
+            )
+
+        now = int(time.time())
+        exp = now + ttl_seconds
+        payload: dict[str, Any] = {
+            "iss": self.issuer,
+            "aud": LOCAL_AUDIENCE,
+            "sub": agent_id,
+            "scope": LOCAL_SCOPE,
+            "iat": now,
+            "exp": exp,
+            "jti": str(uuid.uuid4()),
+        }
+        if extra_claims:
+            for key, value in extra_claims.items():
+                if key in _RESERVED_CLAIMS:
+                    continue
+                payload[key] = value
+
+        token = jose_jwt.encode(
+            payload,
+            self._priv_pem,
+            algorithm="ES256",
+            headers={"kid": self._kid, "typ": "JWT"},
+        )
+        return LocalToken(token=token, kid=self._kid, issued_at=now, expires_at=exp)
+
+    def jwks(self) -> dict[str, Any]:
+        pub_key = serialization.load_pem_public_key(self._leaf_pubkey_pem.encode())
+        if not isinstance(pub_key, ec.EllipticCurvePublicKey):
+            raise RuntimeError("leaf pubkey is not an EC key")
+        numbers = pub_key.public_numbers()
+        return {
+            "keys": [
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": _b64u_int(numbers.x, 32),
+                    "y": _b64u_int(numbers.y, 32),
+                    "use": "sig",
+                    "alg": "ES256",
+                    "kid": self._kid,
+                }
+            ]
+        }
+
+
+def _b64u_int(value: int, length: int) -> str:
+    return (
+        base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode()
+    )
+
+
+def build_from_agent_manager(org_id: str, agent_manager: Any) -> LocalIssuer:
+    """Construct a LocalIssuer from a loaded AgentManager.
+
+    Raises RuntimeError if the Mastio identity has not been provisioned
+    yet (``ensure_mastio_identity()`` not called, or Org CA not loaded).
+    """
+    if not getattr(agent_manager, "mastio_loaded", False):
+        raise RuntimeError("Mastio identity not loaded")
+    leaf_key = getattr(agent_manager, "_mastio_leaf_key", None)
+    if leaf_key is None:
+        raise RuntimeError("Mastio leaf key missing on agent manager")
+    pubkey_pem = agent_manager.get_mastio_pubkey_pem()
+    return LocalIssuer(org_id=org_id, leaf_key=leaf_key, leaf_pubkey_pem=pubkey_pem)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -163,6 +163,23 @@ async def lifespan(app: FastAPI):
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
 
+    # ADR-012 Phase 1 — local JWT issuer. Signs intra-org session tokens
+    # with the Mastio leaf key so the Court never sees login traffic for
+    # MCP/intra-org operations. Requires the Mastio identity to be loaded;
+    # degrades soft (``local_issuer = None``) otherwise so lifespan never
+    # blocks on this.
+    app.state.local_issuer = None
+    if getattr(agent_mgr, "mastio_loaded", False) and org_id:
+        try:
+            from mcp_proxy.auth.local_issuer import build_from_agent_manager
+            app.state.local_issuer = build_from_agent_manager(org_id, agent_mgr)
+            _log.info(
+                "LocalIssuer initialized (kid=%s, iss=%s)",
+                app.state.local_issuer.kid, app.state.local_issuer.issuer,
+            )
+        except Exception as exc:
+            _log.warning("LocalIssuer init failed: %s", exc)
+
     # ADR-007 Phase 1 PR #3 — SecretProvider is consumed by the MCP
     # resource forwarder (env:// / vault:// refs). Same instance used by
     # /v1/ingress/execute via the executor, now also exposed on state so
@@ -566,6 +583,12 @@ async def pdp_health():
 # reverse-proxy catch-all so the sign endpoint wins route matching.
 from mcp_proxy.auth.sign_assertion import router as sign_assertion_router
 app.include_router(sign_assertion_router)
+
+# ADR-012 Phase 1 — JWKS for the Mastio local issuer. Published at
+# /.well-known/jwks-local.json; paths under /.well-known are not
+# reverse-proxied so the registration order vs forwarder is moot.
+from mcp_proxy.auth.jwks_local import router as jwks_local_router
+app.include_router(jwks_local_router)
 
 # ADR-009 Phase 2 — /v1/admin/mastio-pubkey for bootstrap automation.
 from mcp_proxy.admin.info import router as admin_info_router

--- a/tests/test_proxy_local_issuer.py
+++ b/tests/test_proxy_local_issuer.py
@@ -1,0 +1,220 @@
+"""ADR-012 Phase 1 — unit tests for ``LocalIssuer`` and the
+``/.well-known/jwks-local.json`` endpoint.
+
+The issuer is the primitive behind every intra-org session token. These
+tests pin the wire format (ES256 claims, kid derivation, JWKS shape) so
+future refactors can't silently break the contract the validator will
+depend on in Phase 4.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import time
+
+import jwt as jose_jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.local_issuer import (
+    LOCAL_AUDIENCE,
+    LOCAL_ISSUER_PREFIX,
+    LOCAL_SCOPE,
+    LocalIssuer,
+    build_from_agent_manager,
+)
+
+
+def _fresh_key() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return key, pub_pem
+
+
+def _decode_with_issuer(token: str, issuer: LocalIssuer) -> dict:
+    pub_pem = issuer._leaf_pubkey_pem  # noqa: SLF001 — test-only introspection
+    return jose_jwt.decode(
+        token,
+        pub_pem,
+        algorithms=["ES256"],
+        audience=LOCAL_AUDIENCE,
+        issuer=issuer.issuer,
+    )
+
+
+def test_issue_produces_decodable_es256_token_with_expected_claims():
+    key, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+    before = int(time.time())
+    result = issuer.issue("orga::alice", ttl_seconds=60)
+    after = int(time.time())
+
+    header = jose_jwt.get_unverified_header(result.token)
+    assert header["alg"] == "ES256"
+    assert header["typ"] == "JWT"
+    assert header["kid"] == issuer.kid
+    assert header["kid"] == result.kid
+
+    claims = _decode_with_issuer(result.token, issuer)
+    assert claims["iss"] == f"{LOCAL_ISSUER_PREFIX}:orga"
+    assert claims["aud"] == LOCAL_AUDIENCE
+    assert claims["sub"] == "orga::alice"
+    assert claims["scope"] == LOCAL_SCOPE
+    assert before <= claims["iat"] <= after
+    assert claims["exp"] == claims["iat"] + 60
+    assert isinstance(claims["jti"], str) and len(claims["jti"]) >= 32
+    assert result.issued_at == claims["iat"]
+    assert result.expires_at == claims["exp"]
+
+
+def test_kid_is_stable_for_same_pubkey_and_unique_across_keys():
+    key1, pub1 = _fresh_key()
+    key2, pub2 = _fresh_key()
+
+    issuer1a = LocalIssuer(org_id="orga", leaf_key=key1, leaf_pubkey_pem=pub1)
+    issuer1b = LocalIssuer(org_id="orga", leaf_key=key1, leaf_pubkey_pem=pub1)
+    issuer2 = LocalIssuer(org_id="orga", leaf_key=key2, leaf_pubkey_pem=pub2)
+
+    assert issuer1a.kid == issuer1b.kid
+    assert issuer1a.kid != issuer2.kid
+
+    expected = f"mastio-{hashlib.sha256(pub1.encode()).hexdigest()[:16]}"
+    assert issuer1a.kid == expected
+
+
+def test_extra_claims_cannot_overwrite_reserved_fields():
+    key, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+    extra = {
+        "iss": "attacker",
+        "sub": "attacker",
+        "aud": "attacker",
+        "scope": "root",
+        "exp": 0,
+        "iat": 0,
+        "jti": "pinned",
+        "capabilities": ["order.read"],
+        "tenant_id": "t-42",
+    }
+    result = issuer.issue("orga::alice", ttl_seconds=60, extra_claims=extra)
+    claims = _decode_with_issuer(result.token, issuer)
+
+    assert claims["iss"] == issuer.issuer
+    assert claims["sub"] == "orga::alice"
+    assert claims["aud"] == LOCAL_AUDIENCE
+    assert claims["scope"] == LOCAL_SCOPE
+    assert claims["jti"] != "pinned"
+    assert claims["capabilities"] == ["order.read"]
+    assert claims["tenant_id"] == "t-42"
+
+
+def test_issue_rejects_invalid_inputs():
+    key, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+    with pytest.raises(ValueError):
+        issuer.issue("", ttl_seconds=60)
+    with pytest.raises(ValueError):
+        issuer.issue("orga::alice", ttl_seconds=0)
+    with pytest.raises(ValueError):
+        issuer.issue("orga::alice", ttl_seconds=-1)
+    with pytest.raises(ValueError):
+        issuer.issue("orga::alice", ttl_seconds=3601)
+
+
+def test_constructor_rejects_bad_inputs():
+    key, pub_pem = _fresh_key()
+    with pytest.raises(ValueError):
+        LocalIssuer(org_id="", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    with pytest.raises(ValueError):
+        LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem="")
+    with pytest.raises(TypeError):
+        LocalIssuer(org_id="orga", leaf_key="not-a-key", leaf_pubkey_pem=pub_pem)  # type: ignore[arg-type]
+
+
+def test_jwks_roundtrip_matches_leaf_pubkey():
+    key, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+    jwks = issuer.jwks()
+    assert "keys" in jwks and len(jwks["keys"]) == 1
+    jwk = jwks["keys"][0]
+    assert jwk == {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": jwk["x"],
+        "y": jwk["y"],
+        "use": "sig",
+        "alg": "ES256",
+        "kid": issuer.kid,
+    }
+
+    def _unb64u(s: str) -> int:
+        pad = "=" * (-len(s) % 4)
+        return int.from_bytes(base64.urlsafe_b64decode(s + pad), "big")
+
+    numbers = key.public_key().public_numbers()
+    assert _unb64u(jwk["x"]) == numbers.x
+    assert _unb64u(jwk["y"]) == numbers.y
+
+
+def test_build_from_agent_manager_happy_and_error_paths():
+    key, pub_pem = _fresh_key()
+
+    class _LoadedManager:
+        mastio_loaded = True
+        _mastio_leaf_key = key
+
+        def get_mastio_pubkey_pem(self) -> str:
+            return pub_pem
+
+    issuer = build_from_agent_manager("orga", _LoadedManager())
+    assert issuer.org_id == "orga"
+    assert issuer.kid.startswith("mastio-")
+
+    class _Unloaded:
+        mastio_loaded = False
+
+    with pytest.raises(RuntimeError):
+        build_from_agent_manager("orga", _Unloaded())
+
+    class _NoKey:
+        mastio_loaded = True
+        _mastio_leaf_key = None
+
+        def get_mastio_pubkey_pem(self) -> str:  # pragma: no cover — unreachable
+            return pub_pem
+
+    with pytest.raises(RuntimeError):
+        build_from_agent_manager("orga", _NoKey())
+
+
+def test_jwks_endpoint_returns_key_when_issuer_loaded():
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+
+    with TestClient(app) as client:
+        # No issuer attached → 503.
+        app.state.local_issuer = None
+        resp = client.get("/.well-known/jwks-local.json")
+        assert resp.status_code == 503
+
+        key, pub_pem = _fresh_key()
+        app.state.local_issuer = LocalIssuer(
+            org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem,
+        )
+        resp = client.get("/.well-known/jwks-local.json")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["keys"][0]["kid"] == app.state.local_issuer.kid
+        assert body["keys"][0]["alg"] == "ES256"


### PR DESCRIPTION
## Summary
- Adds `mcp_proxy/auth/local_issuer.py` — ES256 JWT issuer signed with the Mastio leaf key already provisioned for ADR-009 counter-sig. One key, two uses, same trust anchor (`mastio_pubkey` pinned at onboarding).
- Publishes `/.well-known/jwks-local.json` so intra-org validators (coming in a follow-up PR) can verify tokens in-process without a remote round-trip.
- Wires the issuer at lifespan time once `agent_mgr.ensure_mastio_identity()` succeeds; degrades soft (`app.state.local_issuer = None`) otherwise.

## Context — ADR-012 in one paragraph
The Mastio today forwards every `/v1/auth/token` to the Court, which means even intra-org MCP calls leak metadata (`auth.token.issued`) to a third-party broker. ADR-012 splits the path: the Mastio issues its own tokens for intra-org traffic (this PR provides the primitive); the Court is only contacted at runtime via token-exchange when an agent performs a cross-org send (later PR). The `zero-knowledge broker` claim in the deck becomes true end-to-end for intra-org operations.

## Out of scope for this PR
- `/v1/auth/token` handler + removal from `FORWARDED_PREFIXES` — next PR (#2 in the epic).
- Runtime Court token-exchange — PR #3.
- Validator split intra vs cross — PR #4.
- Audit chain split — PR #5 + ADR-012 doc.

## Test plan
- [x] 8 unit tests in `tests/test_proxy_local_issuer.py` — wire format, kid stability, reserved-claim tamper resistance, JWKS endpoint 503/200 paths. All green on xdist.
- [ ] Full regression suite (`pytest tests/ -n auto --dist=loadfile`) before merge — reviewer runs locally.
- [ ] Next PR re-runs lifespan smoke to confirm `LocalIssuer init` log shows up on sandbox boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)