### PR TITLE
feat(mastio): ADR-012 Phase 2 — local /v1/auth/token handler

### DIFF
--- a/mcp_proxy/auth/local_token.py
+++ b/mcp_proxy/auth/local_token.py
@@ -1,0 +1,235 @@
+"""ADR-012 Phase 2 — proxy-native ``POST /v1/auth/token``.
+
+When ``MCP_PROXY_LOCAL_AUTH_ENABLED`` is true, the Mastio verifies the
+client x509 assertion against its local Org CA and issues a
+``LocalIssuer`` token in-process. The Court is never contacted for
+intra-org login traffic — closing the metadata leak that today's
+reverse-proxy path introduces.
+
+The verifier is intentionally thinner than the Court's
+``app.auth.x509_verifier`` — Phase 1 trusts the Org CA pinned in
+``proxy_config`` as the sole chain anchor, checks standard JWT claims
+(exp/iat/aud/sub), and emits a ``scope=local`` Bearer token. Deeper
+checks (jti replay via Redis, SPIFFE SAN enforcement, DPoP binding,
+revocation) land in later phases alongside the validator split.
+
+The handler is registered **conditionally**: the router is only mounted
+when the flag is on. With the flag off, the reverse-proxy catch-all in
+``reverse_proxy/forwarder.py`` keeps forwarding ``/v1/auth/token`` to
+the Court, preserving behavior for every caller who hasn't opted in.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import time
+from typing import Any
+
+import jwt as jose_jwt
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from mcp_proxy.auth.local_issuer import LOCAL_AUDIENCE, LOCAL_SCOPE, LocalIssuer
+from mcp_proxy.db import get_config
+
+_log = logging.getLogger("mcp_proxy.auth.local_token")
+
+_ASSERTION_AUDIENCE = "agent-trust-broker"
+_ALLOWED_HASH_ALGS = (hashes.SHA256, hashes.SHA384, hashes.SHA512)
+_MAX_CHAIN_LENGTH = 6
+
+router = APIRouter(tags=["auth"])
+
+
+class TokenRequest(BaseModel):
+    client_assertion: str = Field(
+        ...,
+        description=(
+            "JWT signed by the agent's private key with x5c in the header. "
+            "Same wire format as the Court's /v1/auth/token."
+        ),
+    )
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "Bearer"
+    expires_in: int
+    scope: str = LOCAL_SCOPE
+    issued_by: str
+
+
+def _unauthorized(detail: str) -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail=detail,
+        headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+    )
+
+
+def _load_chain(cert_bytes_list: list[bytes]) -> list[x509.Certificate]:
+    if not cert_bytes_list:
+        raise ValueError("empty chain")
+    if len(cert_bytes_list) > _MAX_CHAIN_LENGTH:
+        raise ValueError(f"chain too long ({len(cert_bytes_list)} > {_MAX_CHAIN_LENGTH})")
+    return [x509.load_der_x509_certificate(b) for b in cert_bytes_list]
+
+
+def _verify_chain(chain: list[x509.Certificate], ca_cert: x509.Certificate) -> None:
+    """Walk ``chain`` (leaf → intermediates) and verify the last link is
+    signed by ``ca_cert``. Raises ValueError on any failure.
+    """
+    if not chain:
+        raise ValueError("empty chain")
+
+    now = _utcnow()
+    for cert in (*chain, ca_cert):
+        if cert.not_valid_before_utc > now or cert.not_valid_after_utc < now:
+            raise ValueError("certificate outside validity window")
+
+    # leaf → intermediates: each cert must be signed by its successor.
+    for i in range(len(chain) - 1):
+        _verify_sig(chain[i], chain[i + 1].public_key())
+    # last link of x5c must be signed by the pinned Org CA.
+    _verify_sig(chain[-1], ca_cert.public_key())
+
+
+def _verify_sig(child: x509.Certificate, parent_pub: Any) -> None:
+    if not isinstance(child.signature_hash_algorithm, _ALLOWED_HASH_ALGS):
+        raise ValueError("weak signature hash algorithm")
+    try:
+        if isinstance(parent_pub, rsa.RSAPublicKey):
+            parent_pub.verify(
+                child.signature,
+                child.tbs_certificate_bytes,
+                padding.PKCS1v15(),
+                child.signature_hash_algorithm,
+            )
+        elif isinstance(parent_pub, ec.EllipticCurvePublicKey):
+            parent_pub.verify(
+                child.signature,
+                child.tbs_certificate_bytes,
+                ec.ECDSA(child.signature_hash_algorithm),
+            )
+        else:
+            raise ValueError(f"unsupported parent key type: {type(parent_pub).__name__}")
+    except InvalidSignature as exc:
+        raise ValueError("chain signature invalid") from exc
+
+
+def _utcnow():
+    # Indirected for monkeypatching in tests.
+    import datetime
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+async def _load_org_ca() -> x509.Certificate | None:
+    pem = await get_config("org_ca_cert")
+    if not pem:
+        return None
+    return x509.load_pem_x509_certificate(pem.encode())
+
+
+def _decode_assertion(assertion: str, leaf: x509.Certificate) -> dict:
+    pub = leaf.public_key()
+    if isinstance(pub, rsa.RSAPublicKey):
+        alg = "RS256"
+    elif isinstance(pub, ec.EllipticCurvePublicKey):
+        alg = "ES256"
+    else:
+        raise ValueError(f"unsupported leaf key type: {type(pub).__name__}")
+    pub_pem = pub.public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return jose_jwt.decode(
+        assertion,
+        pub_pem,
+        algorithms=[alg],
+        audience=_ASSERTION_AUDIENCE,
+        options={"require": ["exp", "iat", "sub", "aud"]},
+        leeway=30,
+    )
+
+
+def _extract_x5c(assertion: str) -> list[bytes]:
+    header = jose_jwt.get_unverified_header(assertion)
+    x5c = header.get("x5c")
+    if not x5c or not isinstance(x5c, list):
+        raise ValueError("x5c header missing or malformed")
+    out: list[bytes] = []
+    for entry in x5c:
+        if not isinstance(entry, str):
+            raise ValueError("x5c entry must be a string")
+        try:
+            out.append(base64.b64decode(entry))
+        except Exception as exc:
+            raise ValueError("x5c entry is not valid base64") from exc
+    return out
+
+
+@router.post(
+    "/v1/auth/token",
+    response_model=TokenResponse,
+    summary="Issue a Mastio-local intra-org session token (ADR-012)",
+)
+async def issue_local_token(body: TokenRequest, request: Request) -> TokenResponse:
+    issuer: LocalIssuer | None = getattr(request.app.state, "local_issuer", None)
+    if issuer is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="local issuer not initialized",
+        )
+
+    ca_cert = await _load_org_ca()
+    if ca_cert is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Org CA not loaded",
+        )
+
+    try:
+        x5c_der = _extract_x5c(body.client_assertion)
+        chain = _load_chain(x5c_der)
+        _verify_chain(chain, ca_cert)
+    except ValueError as exc:
+        _log.info("local /auth/token rejected: chain invalid: %s", exc)
+        raise _unauthorized(f"x509 chain: {exc}") from exc
+
+    leaf = chain[0]
+    try:
+        claims = _decode_assertion(body.client_assertion, leaf)
+    except jose_jwt.PyJWTError as exc:
+        _log.info("local /auth/token rejected: assertion invalid: %s", exc)
+        raise _unauthorized(f"assertion: {exc}") from exc
+
+    agent_id = claims.get("sub")
+    if not agent_id or not isinstance(agent_id, str):
+        raise _unauthorized("assertion missing sub")
+
+    ttl = _resolve_ttl(request)
+    token = issuer.issue(agent_id=agent_id, ttl_seconds=ttl)
+    _log.info(
+        "local /auth/token issued sub=%s iss=%s kid=%s ttl=%ds",
+        agent_id, issuer.issuer, token.kid, ttl,
+    )
+    return TokenResponse(
+        access_token=token.token,
+        token_type="Bearer",
+        expires_in=ttl,
+        scope=LOCAL_SCOPE,
+        issued_by=issuer.issuer,
+    )
+
+
+def _resolve_ttl(request: Request) -> int:
+    settings = getattr(request.app.state, "settings", None)
+    if settings is not None:
+        ttl = getattr(settings, "local_auth_token_ttl_seconds", 0)
+        if ttl and ttl > 0:
+            return int(ttl)
+    return 15 * 60

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -155,6 +155,15 @@ class ProxySettings(BaseSettings):
     # local cache tables. Default off — flip via PROXY_FEDERATION_SYNC.
     federation_sync_enabled: bool = False
 
+    # ADR-012 Phase 2 — local /v1/auth/token issuance. When true the
+    # Mastio's LocalIssuer signs session tokens in-process for intra-org
+    # operations and the Court is never contacted for login traffic.
+    # Default off so the existing reverse-proxy behavior is preserved —
+    # operators opt in after migrating clients to accept Bearer tokens
+    # scoped to ``local``. Flip via MCP_PROXY_LOCAL_AUTH_ENABLED /
+    # PROXY_LOCAL_AUTH.
+    local_auth_enabled: bool = False
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")
@@ -208,6 +217,12 @@ class ProxySettings(BaseSettings):
         force_pwd = _env("MCP_PROXY_FORCE_LOCAL_PASSWORD")
         if force_pwd is not None:
             self.force_local_password = force_pwd.lower() in (
+                "1", "true", "yes", "on",
+            )
+
+        local_auth_flag = _env("MCP_PROXY_LOCAL_AUTH_ENABLED") or _env("PROXY_LOCAL_AUTH")
+        if local_auth_flag is not None:
+            self.local_auth_enabled = local_auth_flag.lower() in (
                 "1", "true", "yes", "on",
             )
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -590,6 +590,16 @@ app.include_router(sign_assertion_router)
 from mcp_proxy.auth.jwks_local import router as jwks_local_router
 app.include_router(jwks_local_router)
 
+# ADR-012 Phase 2 — proxy-native /v1/auth/token. Gated behind
+# ``settings.local_auth_enabled`` so the reverse-proxy path remains the
+# default. MUST be registered before ``build_reverse_proxy_router()`` so
+# it wins route matching against the ``/v1/auth/*`` catch-all when the
+# flag is on.
+if get_settings().local_auth_enabled:
+    from mcp_proxy.auth.local_token import router as local_token_router
+    app.include_router(local_token_router)
+    _log.info("ADR-012 local /v1/auth/token handler ENABLED")
+
 # ADR-009 Phase 2 — /v1/admin/mastio-pubkey for bootstrap automation.
 from mcp_proxy.admin.info import router as admin_info_router
 app.include_router(admin_info_router)

--- a/tests/test_proxy_local_token.py
+++ b/tests/test_proxy_local_token.py
@@ -1,0 +1,288 @@
+"""ADR-012 Phase 2 — proxy-native ``POST /v1/auth/token`` integration tests.
+
+When the feature flag is on the Mastio must:
+  * issue Bearer tokens signed by its own leaf key,
+  * reject assertions that don't chain to the pinned Org CA,
+  * never forward the login to the Court (the core ADR-012 promise).
+
+The last property is verified by pointing the proxy at an unreachable
+broker URL and asserting a successful 200 — a response at all proves
+the reverse-proxy catch-all never ran, because that forwarder's httpx
+client would have faulted on the dead address.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import importlib
+import uuid
+
+import jwt as jose_jwt
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+
+def _gen_ca() -> tuple[bytes, str, str]:
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "acme-ca")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_subject).issuer_name(ca_subject)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    key_pem = ca_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+    return ca_key, key_pem, cert_pem
+
+
+def _issue_leaf(ca_key, ca_cert_pem: str, agent_id: str) -> tuple[str, str, list[str]]:
+    """Mint a leaf cert for ``agent_id`` signed by ``ca_key``. Returns
+    ``(leaf_key_pem, leaf_cert_pem, x5c_der_b64)``.
+    """
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, agent_id)])
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_subject).issuer_name(ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30))
+        .sign(ca_key, hashes.SHA256())
+    )
+    key_pem = leaf_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = leaf.public_bytes(serialization.Encoding.PEM).decode()
+    x5c = [base64.b64encode(leaf.public_bytes(serialization.Encoding.DER)).decode()]
+    return key_pem, cert_pem, x5c
+
+
+def _build_assertion(
+    agent_id: str,
+    leaf_key_pem: str,
+    x5c: list[str],
+    *,
+    exp_seconds: int = 300,
+    audience: str = "agent-trust-broker",
+) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = {
+        "sub": agent_id,
+        "iss": agent_id,
+        "aud": audience,
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(seconds=exp_seconds)).timestamp()),
+        "jti": uuid.uuid4().hex,
+    }
+    return jose_jwt.encode(
+        payload, leaf_key_pem, algorithm="RS256", headers={"x5c": x5c}
+    )
+
+
+@pytest_asyncio.fixture
+async def flag_on_proxy(tmp_path, monkeypatch):
+    """Proxy app booted with ``MCP_PROXY_LOCAL_AUTH_ENABLED=1``.
+
+    The fixture also installs the Org CA and forces the Mastio identity
+    to bootstrap so ``app.state.local_issuer`` is live by the time the
+    test runs.
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    # Dead-address broker: if the reverse-proxy fallback runs for any
+    # reason, the httpx call here will raise — the test will see that.
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.invalid")
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "1")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.main as main_mod
+    importlib.reload(main_mod)
+    app = main_mod.app
+
+    async with app.router.lifespan_context(app):
+        # Seed Org CA so ensure_mastio_identity() has what it needs, then
+        # rebuild the LocalIssuer (lifespan ran before the CA was present).
+        from mcp_proxy.db import set_config
+        ca_key, ca_key_pem, ca_cert_pem = _gen_ca()
+        await set_config("org_ca_key", ca_key_pem)
+        await set_config("org_ca_cert", ca_cert_pem)
+
+        mgr = app.state.agent_manager
+        await mgr.load_org_ca(ca_key_pem, ca_cert_pem)
+        await mgr.ensure_mastio_identity()
+        from mcp_proxy.auth.local_issuer import build_from_agent_manager
+        app.state.local_issuer = build_from_agent_manager("acme", mgr)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield {"app": app, "client": client, "ca_key": ca_key, "ca_cert_pem": ca_cert_pem}
+
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_local_token_issued_from_valid_assertion(flag_on_proxy):
+    """Happy path — valid x5c chains to Org CA, Mastio signs a Bearer."""
+    ctx = flag_on_proxy
+    client = ctx["client"]
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
+
+    resp = await client.post("/v1/auth/token", json={"client_assertion": assertion})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["token_type"] == "Bearer"
+    assert body["scope"] == "local"
+    assert body["expires_in"] > 0
+    assert body["issued_by"] == "cullis-mastio:acme"
+
+    issuer = ctx["app"].state.local_issuer
+    pub_pem = issuer._leaf_pubkey_pem  # noqa: SLF001
+    claims = jose_jwt.decode(
+        body["access_token"],
+        pub_pem,
+        algorithms=["ES256"],
+        audience="cullis-local",
+        issuer="cullis-mastio:acme",
+    )
+    assert claims["sub"] == "acme::alice"
+    assert claims["scope"] == "local"
+
+
+@pytest.mark.asyncio
+async def test_local_token_rejects_foreign_ca(flag_on_proxy):
+    """An assertion signed by a CA *not* pinned on this Mastio is 401."""
+    ctx = flag_on_proxy
+    other_ca_key, _, other_ca_cert_pem = _gen_ca()
+    leaf_key_pem, _, x5c = _issue_leaf(other_ca_key, other_ca_cert_pem, "acme::mallory")
+    assertion = _build_assertion("acme::mallory", leaf_key_pem, x5c)
+
+    resp = await ctx["client"].post(
+        "/v1/auth/token", json={"client_assertion": assertion}
+    )
+    assert resp.status_code == 401
+    assert "chain" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_local_token_rejects_wrong_signature(flag_on_proxy):
+    """Assertion signed with a key that doesn't match the cert in x5c → 401."""
+    ctx = flag_on_proxy
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    stray_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    stray_pem = stray_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    bogus = jose_jwt.encode(
+        {
+            "sub": "acme::alice",
+            "iss": "acme::alice",
+            "aud": "agent-trust-broker",
+            "iat": int(now.timestamp()),
+            "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
+            "jti": uuid.uuid4().hex,
+        },
+        stray_pem,
+        algorithm="RS256",
+        headers={"x5c": x5c},
+    )
+    resp = await ctx["client"].post("/v1/auth/token", json={"client_assertion": bogus})
+    assert resp.status_code == 401
+    assert "assertion" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_local_token_rejects_expired_assertion(flag_on_proxy):
+    """Expired assertion (beyond the 30s leeway) → 401."""
+    ctx = flag_on_proxy
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion(
+        "acme::alice", leaf_key_pem, x5c, exp_seconds=-3600,
+    )
+    resp = await ctx["client"].post(
+        "/v1/auth/token", json={"client_assertion": assertion}
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_local_token_never_hits_the_court(flag_on_proxy):
+    """MCP_PROXY_BROKER_URL points to an unresolvable host; a successful
+    200 here is itself proof that no forward to the Court happened.
+    """
+    ctx = flag_on_proxy
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
+    resp = await ctx["client"].post("/v1/auth/token", json={"client_assertion": assertion})
+    assert resp.status_code == 200
+
+
+@pytest_asyncio.fixture
+async def flag_off_proxy(tmp_path, monkeypatch):
+    """Proxy app with the flag *off*. /v1/auth/token must fall through to
+    the reverse-proxy forwarder and surface an upstream error because
+    broker.invalid is not resolvable.
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.invalid")
+    monkeypatch.delenv("MCP_PROXY_LOCAL_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PROXY_LOCAL_AUTH", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.main as main_mod
+    importlib.reload(main_mod)
+    app = main_mod.app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield {"app": app, "client": client}
+
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_path_falls_through_to_reverse_proxy(flag_off_proxy):
+    """When the flag is off, /v1/auth/token must hit the reverse-proxy and
+    fail at DNS on the dead broker address — proves the local handler
+    isn't registered.
+    """
+    client = flag_off_proxy["client"]
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": "irrelevant"},
+    )
+    # The forwarder reports upstream unavailability as 502/503/504.
+    assert resp.status_code >= 500


### PR DESCRIPTION
**Stacked on #254.** Merge #254 first; then rebase this onto main.

## Summary
- Proxy-native ``POST /v1/auth/token`` gated behind ``MCP_PROXY_LOCAL_AUTH_ENABLED``.
- Verifies x509 ``client_assertion`` against the local Org CA (thin verifier, Phase 1 scope) and hands back a Bearer token signed by the ``LocalIssuer`` introduced in #254.
- When the flag is on, the Court is never contacted for login traffic — the core ADR-012 promise.

## Why a feature flag
Flipping the behavior globally would change the response contract for every caller (``token_type`` moves from ``DPoP`` to ``Bearer``, a new ``scope=local`` claim appears). Shipping behind a flag keeps every existing deploy on the reverse-proxy path until operators explicitly opt in after updating their SDKs / validators. Flag flips to on in a later phase once the validator split and token-exchange PRs land.

## Verification that the Court is bypassed
The ``flag_on_proxy`` fixture deliberately sets ``MCP_PROXY_BROKER_URL=http://broker.invalid``. The reverse-proxy fallback, if it ran, would fault on DNS. A 200 from ``/v1/auth/token`` is itself proof the local handler won the route. ``test_local_token_never_hits_the_court`` asserts exactly that.

## Out of scope
- Runtime token-exchange for cross-org sends — Phase 3.
- Validator split intra (``cullis-local``) vs cross (``cullis-broker``) — Phase 4.
- Audit chain split + ADR-012 doc + smoke assertion — Phase 5.
- jti replay in Redis, SPIFFE SAN enforcement, DPoP binding — follow-up hardening.

## Test plan
- [x] 6 integration tests in ``tests/test_proxy_local_token.py``. All green on xdist.
- [x] Regression: ``test_proxy_sign_assertion``, ``test_proxy_reverse_forwarding``, ``test_proxy_standalone`` — 13/13 green.
- [ ] Full suite (``pytest tests/ -n auto --dist=loadfile``) before merging the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)