### PR TITLE
feat(mastio): ADR-012 Phase 3 — LocalValidator primitive

### DIFF
--- a/mcp_proxy/auth/local_validator.py
+++ b/mcp_proxy/auth/local_validator.py
@@ -1,0 +1,162 @@
+"""ADR-012 Phase 3 — validator for Mastio-issued local tokens.
+
+The counterpart to ``mcp_proxy.auth.local_issuer``: given a Bearer JWT
+signed by the Mastio leaf key, verify it against the in-process
+``LocalIssuer`` (no remote JWKS fetch needed — the public key is the
+one we use ourselves to sign) and surface the claims as a typed payload
+downstream handlers can trust.
+
+A FastAPI dependency ``require_local_token`` exposes the validator to
+route handlers. Wiring onto the actual egress / ingress endpoints is
+the job of a follow-up PR (ADR-012 Phase 4); this module ships the
+primitive and its tests so the subsequent wiring PR stays small.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import jwt as jose_jwt
+from cryptography.hazmat.primitives import serialization
+from fastapi import HTTPException, Request, status
+
+from mcp_proxy.auth.local_issuer import (
+    LOCAL_AUDIENCE,
+    LOCAL_ISSUER_PREFIX,
+    LocalIssuer,
+)
+
+_log = logging.getLogger("mcp_proxy.auth.local_validator")
+
+_LEEWAY_SECONDS = 30
+
+
+@dataclass(frozen=True)
+class LocalTokenPayload:
+    agent_id: str
+    issuer: str
+    scope: str
+    issued_at: int
+    expires_at: int
+    jti: str
+    extra: dict[str, Any]
+
+    @property
+    def org_id(self) -> str:
+        """Extract the org_id from the issuer claim. Returns ``""`` if
+        the issuer doesn't follow the ``cullis-mastio:<org>`` convention
+        (defensive — validator has already enforced the prefix).
+        """
+        prefix = f"{LOCAL_ISSUER_PREFIX}:"
+        return self.issuer[len(prefix):] if self.issuer.startswith(prefix) else ""
+
+
+class LocalTokenError(Exception):
+    """Raised when a token fails any validation step."""
+
+
+def validate_local_token(
+    token: str, issuer: LocalIssuer, *, leeway: int = _LEEWAY_SECONDS,
+) -> LocalTokenPayload:
+    """Verify ``token`` against ``issuer``'s public key.
+
+    Raises ``LocalTokenError`` with a short reason on any failure. The
+    caller is responsible for turning it into an HTTP 401 (see
+    ``require_local_token``).
+    """
+    try:
+        header = jose_jwt.get_unverified_header(token)
+    except jose_jwt.PyJWTError as exc:
+        raise LocalTokenError(f"malformed header: {exc}") from exc
+
+    if header.get("alg") != "ES256":
+        raise LocalTokenError(f"unexpected alg: {header.get('alg')}")
+    if header.get("kid") != issuer.kid:
+        raise LocalTokenError(
+            f"kid mismatch (got {header.get('kid')!r}, expect {issuer.kid!r})"
+        )
+
+    pub_pem = issuer._leaf_pubkey_pem  # noqa: SLF001 — one-process trust boundary
+    # Sanity: the PEM must parse. If the issuer was mis-initialized this
+    # raises at decode time; turning it into a 401 here is fine.
+    serialization.load_pem_public_key(pub_pem.encode())
+
+    try:
+        claims = jose_jwt.decode(
+            token,
+            pub_pem,
+            algorithms=["ES256"],
+            audience=LOCAL_AUDIENCE,
+            issuer=issuer.issuer,
+            options={"require": ["exp", "iat", "sub", "aud", "iss", "scope", "jti"]},
+            leeway=leeway,
+        )
+    except jose_jwt.ExpiredSignatureError as exc:
+        raise LocalTokenError("token expired") from exc
+    except jose_jwt.InvalidAudienceError as exc:
+        raise LocalTokenError("wrong audience") from exc
+    except jose_jwt.InvalidIssuerError as exc:
+        raise LocalTokenError("wrong issuer") from exc
+    except jose_jwt.PyJWTError as exc:
+        raise LocalTokenError(f"invalid: {exc}") from exc
+
+    sub = claims.get("sub")
+    scope = claims.get("scope")
+    if not isinstance(sub, str) or not sub:
+        raise LocalTokenError("sub missing")
+    if not isinstance(scope, str):
+        raise LocalTokenError("scope missing")
+
+    reserved = {"sub", "iss", "aud", "exp", "iat", "jti", "scope"}
+    extra = {k: v for k, v in claims.items() if k not in reserved}
+
+    return LocalTokenPayload(
+        agent_id=sub,
+        issuer=claims["iss"],
+        scope=scope,
+        issued_at=int(claims["iat"]),
+        expires_at=int(claims["exp"]),
+        jti=str(claims["jti"]),
+        extra=extra,
+    )
+
+
+async def require_local_token(request: Request) -> LocalTokenPayload:
+    """FastAPI dependency — extract+validate a Bearer LOCAL_TOKEN.
+
+    The token is read from ``Authorization: Bearer <jwt>``. 401 on any
+    failure, 503 if the issuer isn't wired up (mastio identity didn't
+    load yet — the wiring PR will pin hard availability expectations).
+    """
+    issuer: LocalIssuer | None = getattr(request.app.state, "local_issuer", None)
+    if issuer is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="local issuer not initialized",
+        )
+
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Bearer token required",
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        )
+    token = auth_header[7:].strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="empty bearer token",
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        )
+
+    try:
+        return validate_local_token(token, issuer)
+    except LocalTokenError as exc:
+        _log.info("local token rejected: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        ) from exc

--- a/tests/test_proxy_local_validator.py
+++ b/tests/test_proxy_local_validator.py
@@ -1,0 +1,204 @@
+"""ADR-012 Phase 3 — LocalValidator unit tests.
+
+Paired with ``tests/test_proxy_local_issuer.py``: that file pins what
+the issuer emits, this one pins what the validator accepts. Round-trip
+coverage is the main invariant — a token produced by ``LocalIssuer``
+must always decode to a ``LocalTokenPayload`` whose fields match.
+
+Everything that deviates from the expected wire format (wrong audience,
+wrong kid, missing claims, expired, signed by a stranger, malformed
+header) must raise ``LocalTokenError`` — so the FastAPI dependency can
+turn it into a uniform 401 without leaking internals.
+"""
+from __future__ import annotations
+
+import time
+
+import jwt as jose_jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.local_issuer import LocalIssuer
+from mcp_proxy.auth.local_validator import (
+    LocalTokenError,
+    LocalTokenPayload,
+    require_local_token,
+    validate_local_token,
+)
+
+
+def _fresh_issuer(org_id: str = "orga") -> LocalIssuer:
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return LocalIssuer(org_id=org_id, leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+
+def test_validate_roundtrip_issuer_to_validator():
+    issuer = _fresh_issuer("orga")
+    token = issuer.issue("orga::alice", ttl_seconds=60, extra_claims={"tenant": "t-1"})
+
+    payload = validate_local_token(token.token, issuer)
+    assert isinstance(payload, LocalTokenPayload)
+    assert payload.agent_id == "orga::alice"
+    assert payload.issuer == "cullis-mastio:orga"
+    assert payload.org_id == "orga"
+    assert payload.scope == "local"
+    assert payload.expires_at == token.expires_at
+    assert payload.issued_at == token.issued_at
+    assert payload.jti  # non-empty
+    assert payload.extra == {"tenant": "t-1"}
+
+
+def test_rejects_token_signed_by_foreign_key():
+    issuer_a = _fresh_issuer("orga")
+    issuer_b = _fresh_issuer("orga")  # same org, different key → different kid
+    foreign_token = issuer_b.issue("orga::alice").token
+
+    with pytest.raises(LocalTokenError) as err:
+        validate_local_token(foreign_token, issuer_a)
+    assert "kid" in str(err.value).lower()
+
+
+def test_rejects_expired_past_leeway():
+    issuer = _fresh_issuer("orga")
+    # Craft an expired token by issuing with a past ttl — since `issue`
+    # validates ttl > 0, mint it manually using the same private key.
+    now = int(time.time())
+    priv_pem = issuer._leaf_key.private_bytes(  # noqa: SLF001
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    expired_token = jose_jwt.encode(
+        {
+            "iss": issuer.issuer,
+            "aud": "cullis-local",
+            "sub": "orga::alice",
+            "scope": "local",
+            "iat": now - 3600,
+            "exp": now - 3000,
+            "jti": "x",
+        },
+        priv_pem,
+        algorithm="ES256",
+        headers={"kid": issuer.kid, "typ": "JWT"},
+    )
+    with pytest.raises(LocalTokenError) as err:
+        validate_local_token(expired_token, issuer)
+    assert "expired" in str(err.value).lower()
+
+
+def test_rejects_wrong_audience():
+    issuer = _fresh_issuer("orga")
+    now = int(time.time())
+    priv_pem = issuer._leaf_key.private_bytes(  # noqa: SLF001
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    wrong_aud = jose_jwt.encode(
+        {
+            "iss": issuer.issuer,
+            "aud": "someone-else",
+            "sub": "orga::alice",
+            "scope": "local",
+            "iat": now,
+            "exp": now + 60,
+            "jti": "x",
+        },
+        priv_pem,
+        algorithm="ES256",
+        headers={"kid": issuer.kid, "typ": "JWT"},
+    )
+    with pytest.raises(LocalTokenError) as err:
+        validate_local_token(wrong_aud, issuer)
+    assert "audience" in str(err.value).lower()
+
+
+def test_rejects_missing_required_claim():
+    issuer = _fresh_issuer("orga")
+    now = int(time.time())
+    priv_pem = issuer._leaf_key.private_bytes(  # noqa: SLF001
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    # Missing ``scope`` — one of the required claims.
+    token = jose_jwt.encode(
+        {
+            "iss": issuer.issuer,
+            "aud": "cullis-local",
+            "sub": "orga::alice",
+            "iat": now,
+            "exp": now + 60,
+            "jti": "x",
+        },
+        priv_pem,
+        algorithm="ES256",
+        headers={"kid": issuer.kid, "typ": "JWT"},
+    )
+    with pytest.raises(LocalTokenError):
+        validate_local_token(token, issuer)
+
+
+def test_rejects_unexpected_algorithm():
+    # Hand-craft an HS256 JWT with the right claims but wrong alg.
+    issuer = _fresh_issuer("orga")
+    token = jose_jwt.encode(
+        {
+            "iss": issuer.issuer,
+            "aud": "cullis-local",
+            "sub": "orga::alice",
+            "scope": "local",
+            "iat": int(time.time()),
+            "exp": int(time.time()) + 60,
+            "jti": "x",
+        },
+        "symmetric-key",
+        algorithm="HS256",
+        headers={"kid": issuer.kid},
+    )
+    with pytest.raises(LocalTokenError) as err:
+        validate_local_token(token, issuer)
+    assert "alg" in str(err.value).lower()
+
+
+def test_require_local_token_endpoint_happy_and_error_paths():
+    app = FastAPI()
+    app.state.local_issuer = None
+
+    @app.get("/probe")
+    async def probe(payload=pytest.importorskip("fastapi").Depends(require_local_token)):  # type: ignore[valid-type]
+        return {"agent": payload.agent_id, "scope": payload.scope}
+
+    with TestClient(app) as client:
+        # No issuer loaded → 503.
+        resp = client.get("/probe", headers={"Authorization": "Bearer xxx"})
+        assert resp.status_code == 503
+
+        # Wire an issuer.
+        issuer = _fresh_issuer("orga")
+        app.state.local_issuer = issuer
+        token = issuer.issue("orga::alice", ttl_seconds=60).token
+
+        # No header → 401.
+        assert client.get("/probe").status_code == 401
+
+        # Wrong scheme → 401.
+        resp = client.get("/probe", headers={"Authorization": "DPoP " + token})
+        assert resp.status_code == 401
+
+        # Malformed → 401.
+        resp = client.get("/probe", headers={"Authorization": "Bearer not-a-jwt"})
+        assert resp.status_code == 401
+
+        # Happy path.
+        resp = client.get("/probe", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        assert resp.json() == {"agent": "orga::alice", "scope": "local"}


### PR DESCRIPTION
## Summary
Companion to the ``LocalIssuer`` shipped in #254. Provides ``validate_local_token`` (pure primitive) and ``require_local_token`` (FastAPI dep) so the handlers coming in Phase 4 can trust the Bearer JWTs the Mastio hands back from ``POST /v1/auth/token`` (#255).

## Scope reduction vs original plan
The original ADR-012 plan had Phase 3 as *CourtTokenExchange* — a wrapper that scambia il token locale con un token Court quando l'agent vuole fare cross-org. Reading the existing code changed the plan: ``BrokerBridge._create_client()`` (``mcp_proxy/egress/broker_bridge.py:49-71``) already maintains a per-agent ``CullisClient`` authenticated to the Court, lazily, with retry. That IS the token exchange. What's missing is the ``/v1/egress/*`` + ``/v1/ingress/*`` handlers switching to the local validator so they accept a Bearer LOCAL_TOKEN (sub=agent_id) and route to BrokerBridge on cross-org.

This PR lands the validator primitive; the wiring becomes Phase 4 and stays chirurgical instead of bundling two concerns.

## Out of scope
- Swapping egress/ingress deps from DPoP/API-key to ``require_local_token`` — Phase 4.
- Audit chain split + smoke assertion — Phase 5.
- Validator doesn't check jti replay yet; TTL=15min is the current containment. Redis-backed replay guard joins in a later hardening PR.

## Test plan
- [x] 7 unit tests in ``tests/test_proxy_local_validator.py``: round-trip, foreign key, expired, wrong aud, missing required claim, wrong alg, FastAPI dep 503/401/200 paths. All green on xdist.
- [ ] Full regression (``pytest tests/ -n auto --dist=loadfile``) before merging the stack.
- [ ] Phase 4 re-runs ``demo.sh full`` + ``./demo.sh mcp-catalog`` and asserts zero ``auth.token.issued`` on the Court for intra-org operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)