### PR TITLE
feat(mastio): ADR-012 Phase 4 — route intra-org ingress through local validator

### DIFF
--- a/mcp_proxy/auth/dependencies.py
+++ b/mcp_proxy/auth/dependencies.py
@@ -16,6 +16,22 @@ _DPOP_WWW_AUTH = 'DPoP realm="mcp-proxy", algs="ES256 PS256"'
 
 
 async def get_authenticated_agent(request: Request) -> TokenPayload:
+    """Authenticate an external agent.
+
+    ADR-012 Phase 4: when ``local_auth_enabled`` is true and the request
+    carries ``Authorization: Bearer <jwt>``, validate the JWT against the
+    in-process ``LocalIssuer`` and surface a ``TokenPayload`` derived
+    from local claims + DB lookup (capabilities, is_active). Otherwise
+    fall through to the legacy DPoP-bound path below.
+    """
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+    local = await _maybe_local_token(request)
+    if local is not None:
+        return local
+    return await _get_authenticated_agent_dpop(request)
+
+
+async def _get_authenticated_agent_dpop(request: Request) -> TokenPayload:
     """Authenticate an external agent via DPoP-bound JWT (RFC 9449).
 
     Requires:

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -1,0 +1,95 @@
+"""ADR-012 Phase 4 — FastAPI dependency that accepts either a
+Mastio-local Bearer JWT (ADR-012 Phase 2 onwards) or the legacy
+DPoP-bound token the ingress handlers have used since ADR-011.
+
+Lookup order:
+  1. If ``settings.local_auth_enabled`` is true *and* the request
+     carries ``Authorization: Bearer …``, validate the token via the
+     in-process ``LocalIssuer`` and return a ``TokenPayload`` synthesized
+     from the local claims + a DB lookup for the agent's capabilities.
+  2. Otherwise fall through to ``get_authenticated_agent`` (DPoP).
+
+The adapter keeps handler code unchanged — they still receive a
+``TokenPayload`` — while the Court is kept out of the loop for intra-org
+traffic. Handlers that need to reach a broker for cross-org operations
+continue to use ``BrokerBridge``, which takes the agent_id surfaced
+here and performs its own lazy Court login (``_create_client``).
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException, Request, status
+
+from mcp_proxy.auth.local_validator import LocalTokenError, validate_local_token
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_agent
+from mcp_proxy.models import TokenPayload
+
+_log = logging.getLogger("mcp_proxy.auth.local_agent_dep")
+
+
+async def _maybe_local_token(request: Request) -> TokenPayload | None:
+    """Return a TokenPayload if the request bears a valid LOCAL_TOKEN,
+    else ``None`` so the caller falls through to the DPoP path.
+    """
+    settings = get_settings()
+    if not settings.local_auth_enabled:
+        return None
+
+    issuer = getattr(request.app.state, "local_issuer", None)
+    if issuer is None:
+        return None
+
+    auth = request.headers.get("Authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+
+    token = auth[7:].strip()
+    if not token:
+        return None
+
+    try:
+        payload = validate_local_token(token, issuer)
+    except LocalTokenError as exc:
+        # Bearer was provided but invalid — surface 401 rather than
+        # falling through to DPoP, otherwise we'd leak a confusing
+        # "DPoP required" message for what is clearly a local-auth
+        # attempt. Operators opted into local_auth_enabled; a bad Bearer
+        # is a client mistake, not a probe.
+        _log.info("local token rejected: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"local token: {exc}",
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        ) from exc
+
+    record = await get_agent(payload.agent_id)
+    if record is None or not record.get("is_active", True):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="agent not registered or deactivated",
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        )
+
+    capabilities = record.get("capabilities") or []
+    if isinstance(capabilities, str):
+        # Defensive: some DB backends store JSON as TEXT; split if needed.
+        import json
+        try:
+            capabilities = json.loads(capabilities)
+        except Exception:
+            capabilities = [c for c in capabilities.split(",") if c]
+
+    return TokenPayload(
+        sub=payload.agent_id,
+        agent_id=payload.agent_id,
+        org=payload.org_id,
+        exp=payload.expires_at,
+        iat=payload.issued_at,
+        jti=payload.jti,
+        scope=list(capabilities),
+        cnf=None,
+    )
+
+

--- a/tests/test_proxy_local_agent_dep.py
+++ b/tests/test_proxy_local_agent_dep.py
@@ -1,0 +1,156 @@
+"""ADR-012 Phase 4 — local-first ingress auth adapter.
+
+Covers the happy path the sandbox demo needs: when the feature flag is
+on and an agent presents a Bearer LOCAL_TOKEN, the MCP ingress handler
+serves the request without DPoP and without contacting the Court.
+
+Also pins the two invariants the dual dep must hold:
+  * flag off → legacy DPoP path unchanged (Bearer ignored, DPoP required),
+  * flag on + bad Bearer → 401 with a local-auth-specific message
+    (we don't silently fall through to DPoP because that leaks a
+    misleading error back to the client that opted into local auth).
+"""
+from __future__ import annotations
+
+import importlib
+import time
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.local_issuer import LocalIssuer
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.models import TokenPayload
+
+
+@pytest_asyncio.fixture
+async def app_with_flag_on(tmp_path, monkeypatch):
+    """Minimal FastAPI app with the local-first dep wired + a live DB
+    containing one active agent. We don't boot the full proxy app here
+    — the dep is what we're testing, and isolating it keeps the test
+    fast and deterministic.
+    """
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "1")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    # Reload db module so its engine picks up the new URL.
+    import mcp_proxy.db as db_mod
+    importlib.reload(db_mod)
+    await db_mod.init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    raw = generate_api_key("orga::alice")
+    await db_mod.create_agent(
+        agent_id="orga::alice",
+        display_name="alice",
+        capabilities=["order.read", "order.write"],
+        api_key_hash=hash_api_key(raw),
+    )
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+    app = FastAPI()
+    app.state.local_issuer = issuer
+
+    @app.get("/probe")
+    async def probe(agent: TokenPayload = pytest.importorskip("fastapi").Depends(get_authenticated_agent)):  # type: ignore[valid-type]
+        return {"agent_id": agent.agent_id, "org": agent.org, "caps": agent.scope}
+
+    yield {"app": app, "issuer": issuer}
+
+    get_settings.cache_clear()
+    await db_mod.dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_local_token_happy_path_returns_agent_with_capabilities(app_with_flag_on):
+    """Bearer LOCAL_TOKEN → 200 with agent_id + org + capabilities from DB."""
+    issuer = app_with_flag_on["issuer"]
+    token = issuer.issue("orga::alice", ttl_seconds=60).token
+
+    with TestClient(app_with_flag_on["app"]) as client:
+        resp = client.get("/probe", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["agent_id"] == "orga::alice"
+    assert body["org"] == "orga"
+    assert sorted(body["caps"]) == ["order.read", "order.write"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_is_rejected(app_with_flag_on):
+    """LOCAL_TOKEN for an agent not registered in the DB → 401."""
+    issuer = app_with_flag_on["issuer"]
+    token = issuer.issue("orga::ghost", ttl_seconds=60).token
+
+    with TestClient(app_with_flag_on["app"]) as client:
+        resp = client.get("/probe", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert "not registered" in resp.json()["detail"].lower() or "deactivated" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_invalid_bearer_does_not_fall_through_to_dpop(app_with_flag_on):
+    """Flag on + bad Bearer → 401 "local token: …", not a DPoP challenge."""
+    with TestClient(app_with_flag_on["app"]) as client:
+        resp = client.get("/probe", headers={"Authorization": "Bearer not-a-jwt"})
+    assert resp.status_code == 401
+    assert "local token" in resp.json()["detail"].lower()
+
+
+@pytest_asyncio.fixture
+async def app_with_flag_off(tmp_path, monkeypatch):
+    """Flag-off variant: no local_issuer on state, MCP_PROXY_LOCAL_AUTH_ENABLED unset.
+    A Bearer token should be ignored and the dep should fall through to
+    the DPoP path (which, with no DPoP header, returns 401 DPoP-realm).
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("MCP_PROXY_LOCAL_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PROXY_LOCAL_AUTH", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.db as db_mod
+    importlib.reload(db_mod)
+    await db_mod.init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    app = FastAPI()
+    app.state.local_issuer = None
+
+    @app.get("/probe")
+    async def probe(agent: TokenPayload = pytest.importorskip("fastapi").Depends(get_authenticated_agent)):  # type: ignore[valid-type]
+        return {"agent_id": agent.agent_id}
+
+    yield app
+
+    get_settings.cache_clear()
+    await db_mod.dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_flag_off_falls_through_to_dpop(app_with_flag_off):
+    """Bearer presented, flag off → dep falls through to DPoP which
+    requires an ``Authorization: DPoP …`` scheme, surfacing a DPoP 401.
+    """
+    with TestClient(app_with_flag_off) as client:
+        resp = client.get("/probe", headers={"Authorization": "Bearer whatever"})
+    assert resp.status_code == 401
+    # WWW-Authenticate should be DPoP (realm), not Bearer — proves fall-through.
+    assert "dpop" in resp.headers.get("WWW-Authenticate", "").lower()

--- a/tests/test_proxy_local_agent_dep.py
+++ b/tests/test_proxy_local_agent_dep.py
@@ -13,7 +13,6 @@ Also pins the two invariants the dual dep must hold:
 from __future__ import annotations
 
 import importlib
-import time
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
**Stacked on #256.** Merge #256 first, then rebase this onto main.

## Summary
- ``get_authenticated_agent`` now tries LOCAL_TOKEN (via the LocalIssuer on ``app.state``) first when ``MCP_PROXY_LOCAL_AUTH_ENABLED`` is on; falls through to the existing DPoP-bound path otherwise.
- No handler churn: ingress routes (``/v1/ingress/*``, ``/v1/mcp``) keep the same ``Depends(get_authenticated_agent)`` import. Existing tests that use ``app.dependency_overrides[get_authenticated_agent]`` continue to work — the refactor is in-place in ``dependencies.py``.
- With the flag on, the sandbox demo can run MCP intra-org end-to-end without the Court seeing anything: login = LOCAL_TOKEN, MCP call = LocalIssuer validation, no hop.

## Why the flag-on + bad-Bearer path returns 401 instead of falling through
An operator who opted into local auth is sending a Bearer on purpose. Falling through to DPoP would return ``DPoP required`` which is confusing for what is clearly a local-auth mistake. The dep surfaces ``local token: <reason>`` 401 instead.

## Out of scope
- Cross-org egress envelope still goes through BrokerBridge (which already does per-agent lazy Court auth). Wiring the egress side to accept LOCAL_TOKEN + delegate to BrokerBridge is the next PR in the stack.
- Audit chain split + smoke assertion (``./demo.sh mcp-catalog`` → 0 rows on the Court) — Phase 5.

## Test plan
- [x] 4 integration tests in ``tests/test_proxy_local_agent_dep.py``: happy path, unknown agent, bad Bearer with flag on, flag off fall-through.
- [x] Regression: 34 tests across ingress / MCP aggregator / sign_assertion / local_token — all green.
- [x] Confirmed 21 pre-existing failures on main (ts_interop, connector desktop, postgres integration) are unrelated to this change.
- [ ] Full suite on CI before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)