### PR TITLE
feat(mastio): ADR-012 Phase 5 — wire egress + flag on in sandbox

### DIFF
--- a/mcp_proxy/auth/dpop_api_key.py
+++ b/mcp_proxy/auth/dpop_api_key.py
@@ -110,7 +110,19 @@ async def get_agent_from_dpop_api_key(request: Request) -> InternalAgent:
     window, and ``ath`` must match ``base64url(sha256(api_key))`` so
     the proof is bound to *this* API-key and not a different one that
     the same attacker might also control.
+
+    ADR-012 Phase 5: when ``local_auth_enabled`` is on and the request
+    carries a Bearer LOCAL_TOKEN issued by this Mastio, return an
+    ``InternalAgent`` synthesized from the token claims + DB record and
+    skip the X-API-Key path entirely. Cross-org work downstream goes
+    through ``BrokerBridge`` which performs its own per-agent login
+    against the Court, so the LOCAL_TOKEN never leaves the Mastio.
     """
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_internal_agent
+    local_agent = await _maybe_local_internal_agent(request)
+    if local_agent is not None:
+        return local_agent
+
     agent = await get_agent_from_api_key(request)
 
     mode = _resolve_mode()

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -24,7 +24,7 @@ from fastapi import HTTPException, Request, status
 from mcp_proxy.auth.local_validator import LocalTokenError, validate_local_token
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_agent
-from mcp_proxy.models import TokenPayload
+from mcp_proxy.models import InternalAgent, TokenPayload
 
 _log = logging.getLogger("mcp_proxy.auth.local_agent_dep")
 
@@ -90,6 +90,69 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
         jti=payload.jti,
         scope=list(capabilities),
         cnf=None,
+    )
+
+
+async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
+    """Egress variant of ``_maybe_local_token``.
+
+    Egress handlers consume ``InternalAgent`` (API-key + DB shape), not
+    ``TokenPayload``. Accept a Bearer LOCAL_TOKEN here so an SDK that
+    logged in via the Mastio's ``/v1/auth/token`` (ADR-012 Phase 2) can
+    also drive ``/v1/egress/*`` without re-authenticating. When the send
+    is cross-org, the handlers then delegate to ``BrokerBridge`` which
+    lazily performs its own per-agent login_from_pem against the Court
+    — the ``LOCAL_TOKEN`` never leaves this process.
+    """
+    settings = get_settings()
+    if not settings.local_auth_enabled:
+        return None
+
+    issuer = getattr(request.app.state, "local_issuer", None)
+    if issuer is None:
+        return None
+
+    auth = request.headers.get("Authorization", "")
+    if not auth.lower().startswith("bearer "):
+        return None
+    token = auth[7:].strip()
+    if not token:
+        return None
+
+    try:
+        payload = validate_local_token(token, issuer)
+    except LocalTokenError as exc:
+        _log.info("local token rejected (egress): %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"local token: {exc}",
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        ) from exc
+
+    record = await get_agent(payload.agent_id)
+    if record is None or not record.get("is_active", True):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="agent not registered or deactivated",
+            headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+        )
+
+    capabilities = record.get("capabilities") or []
+    if isinstance(capabilities, str):
+        import json
+        try:
+            capabilities = json.loads(capabilities)
+        except Exception:
+            capabilities = [c for c in capabilities.split(",") if c]
+
+    return InternalAgent(
+        agent_id=payload.agent_id,
+        display_name=record.get("display_name") or payload.agent_id,
+        capabilities=list(capabilities),
+        created_at=str(record.get("created_at") or ""),
+        is_active=bool(record.get("is_active", True)),
+        cert_pem=record.get("cert_pem"),
+        dpop_jkt=record.get("dpop_jkt"),
     )
 
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -269,6 +269,12 @@ services:
       # drops the payload into the local inbox). Hybrid/envelope
       # would require distributing every peer's cert ahead of time.
       PROXY_TRANSPORT_INTRA_ORG: "mtls-only"
+      # ADR-012 — Mastio-local /v1/auth/token. With this on, login
+      # traffic for intra-org operations (MCP, intra-org send/receive)
+      # never reaches the Court. Cross-org sends still route through
+      # BrokerBridge's own per-agent Court login, so the envelope path
+      # keeps working.
+      MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
     volumes:
       - proxy-a-data:/data
     networks:
@@ -493,6 +499,8 @@ services:
       PROXY_INTRA_ORG: "true"
       # ADR-011 Phase 4b — see proxy-a rationale.
       PROXY_TRANSPORT_INTRA_ORG: "mtls-only"
+      # ADR-012 — Mastio-local /v1/auth/token (see proxy-a rationale).
+      MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
     volumes:
       - proxy-b-data:/data
     networks:

--- a/tests/test_proxy_egress_local_token.py
+++ b/tests/test_proxy_egress_local_token.py
@@ -1,0 +1,134 @@
+"""ADR-012 Phase 5 — egress auth accepts LOCAL_TOKEN.
+
+The egress dep ``get_agent_from_dpop_api_key`` historically required
+``X-API-Key`` + DPoP. With the flag on, it must short-circuit on a
+Bearer LOCAL_TOKEN and return an ``InternalAgent`` synthesized from
+the DB record keyed by the token's ``sub`` claim. Handlers downstream
+(``egress/router``, ``egress/oneshot``) are unchanged — they still
+receive an ``InternalAgent``.
+
+The opposite path (flag off or missing Bearer) must stay bit-identical
+to the legacy DPoP/API-key flow so today's egress callers don't break
+on this change.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.dpop_api_key import get_agent_from_dpop_api_key
+from mcp_proxy.auth.local_issuer import LocalIssuer
+from mcp_proxy.models import InternalAgent
+
+
+@pytest_asyncio.fixture
+async def egress_app_flag_on(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "1")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.db as db_mod
+    importlib.reload(db_mod)
+    await db_mod.init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    raw = generate_api_key("orga::sender")
+    await db_mod.create_agent(
+        agent_id="orga::sender",
+        display_name="sender",
+        capabilities=["oneshot.message"],
+        api_key_hash=hash_api_key(raw),
+    )
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+
+    app = FastAPI()
+    app.state.local_issuer = issuer
+
+    @app.get("/egress/probe")
+    async def probe(agent: InternalAgent = Depends(get_agent_from_dpop_api_key)):
+        return {"agent_id": agent.agent_id, "caps": agent.capabilities}
+
+    yield {"app": app, "issuer": issuer, "api_key": raw}
+
+    get_settings.cache_clear()
+    await db_mod.dispose_db()
+
+
+@pytest.mark.asyncio
+async def test_egress_accepts_local_token_when_flag_on(egress_app_flag_on):
+    issuer = egress_app_flag_on["issuer"]
+    token = issuer.issue("orga::sender", ttl_seconds=60).token
+
+    with TestClient(egress_app_flag_on["app"]) as client:
+        resp = client.get(
+            "/egress/probe",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["agent_id"] == "orga::sender"
+    assert resp.json()["caps"] == ["oneshot.message"]
+
+
+@pytest.mark.asyncio
+async def test_egress_api_key_path_still_works_alongside(egress_app_flag_on):
+    """X-API-Key must keep working even with the flag on — operators can
+    mix the two during the migration window."""
+    with TestClient(egress_app_flag_on["app"]) as client:
+        resp = client.get(
+            "/egress/probe",
+            headers={"X-API-Key": egress_app_flag_on["api_key"]},
+        )
+    # API-key path returns the same shape.
+    assert resp.status_code == 200
+    assert resp.json()["agent_id"] == "orga::sender"
+
+
+@pytest.mark.asyncio
+async def test_egress_rejects_bearer_when_flag_off(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("MCP_PROXY_LOCAL_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("PROXY_LOCAL_AUTH", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.db as db_mod
+    importlib.reload(db_mod)
+    await db_mod.init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    app = FastAPI()
+    app.state.local_issuer = None
+
+    @app.get("/egress/probe")
+    async def probe(agent: InternalAgent = Depends(get_agent_from_dpop_api_key)):
+        return {"agent_id": agent.agent_id}
+
+    try:
+        with TestClient(app) as client:
+            resp = client.get(
+                "/egress/probe",
+                headers={"Authorization": "Bearer whatever"},
+            )
+        # Flag off → falls through to the legacy X-API-Key path, which
+        # rejects because no X-API-Key header was provided.
+        assert resp.status_code == 401
+    finally:
+        get_settings.cache_clear()
+        await db_mod.dispose_db()


### PR DESCRIPTION
**Stacked on #257.** Merge #257 first; then rebase this onto main.

## Summary
Closes out the ADR-012 rollout (5 phases, 5 PRs):

- Egress dep ``get_agent_from_dpop_api_key`` now accepts Bearer LOCAL_TOKEN first, falls through to the legacy X-API-Key + DPoP when the flag is off or no Bearer is present.
- ``sandbox/docker-compose.yml`` flips ``MCP_PROXY_LOCAL_AUTH_ENABLED=true`` for proxy-a and proxy-b. The sandbox demo now exercises the intra/cross split by default.
- Cross-org envelope still goes through ``BrokerBridge._create_client()`` which performs the Court login lazily per agent — so the cross-org row on the Court audit keeps appearing for ``./demo.sh oneshot-a-to-b`` and *stops* appearing for ``./demo.sh mcp-catalog``. That's the deck's promise made real.

## Demo assertion (manual until Phase 6 wires a smoke)
```bash
./demo.sh full
./demo.sh mcp-catalog
docker compose exec broker sqlite3 /data/cullis.db \
  "SELECT count(*) FROM audit WHERE kind='auth.token.issued' AND agent_id='orga::agent-a'"
# → 0

./demo.sh oneshot-a-to-b
# Same query → ≥ 1 (BrokerBridge performed the Court login for cross-org).
```

## Out of scope
- Automated sandbox smoke assertion (``./demo.sh verify-intra-privacy``) — follow-up.
- Redis-backed jti replay guard for LOCAL_TOKEN — hardening follow-up; 15min TTL is the current containment.
- SDK: still sends Bearer ``Authorization`` with the opaque token from ``/v1/auth/token`` response body; no SDK-side code change needed for this PR.

## Test plan
- [x] 3 new integration tests in ``tests/test_proxy_egress_local_token.py``.
- [x] Full ``test_proxy_*.py`` regression: 375 passed, 1 skipped.
- [ ] CI green (full suite including demo_network smoke ec/rsa/postgres).
- [ ] Manual: boot sandbox with this PR merged, run both scenarios, confirm the Court audit delta matches the assertion above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)