### PR TITLE
chore(adr-012): followup fixes from sandbox dogfood

### DIFF
--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -21,12 +21,45 @@ import logging
 
 from fastapi import HTTPException, Request, status
 
+import jwt as jose_jwt
+
 from mcp_proxy.auth.local_validator import LocalTokenError, validate_local_token
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_agent
 from mcp_proxy.models import InternalAgent, TokenPayload
 
 _log = logging.getLogger("mcp_proxy.auth.local_agent_dep")
+
+
+def _extract_bearer_or_dpop_token(request: Request) -> str | None:
+    """Pull the opaque JWT from ``Authorization: Bearer …`` OR
+    ``Authorization: DPoP …``. The SDK's ``login_via_proxy`` path still
+    sends the token with the ``DPoP`` scheme on the downstream request
+    even when the Mastio handed it a LOCAL_TOKEN (Phase 2 kept the wire
+    format stable). Both shapes must funnel into the local-first branch.
+    """
+    auth = request.headers.get("Authorization", "")
+    lower = auth.lower()
+    if lower.startswith("bearer "):
+        return auth[7:].strip() or None
+    if lower.startswith("dpop "):
+        return auth[5:].strip() or None
+    return None
+
+
+def _is_local_kid(token: str, issuer) -> bool:
+    """Cheap pre-check: unverified header kid == LocalIssuer's kid.
+
+    Used to decide whether a ``Authorization: DPoP <jwt>`` should funnel
+    into the local validator (and pre-empt the DPoP path) or be left
+    alone. Broker-issued JWTs carry a different kid, so that path
+    continues to reach ``_get_authenticated_agent_dpop`` unchanged.
+    """
+    try:
+        header = jose_jwt.get_unverified_header(token)
+    except jose_jwt.PyJWTError:
+        return False
+    return header.get("kid") == issuer.kid
 
 
 async def _maybe_local_token(request: Request) -> TokenPayload | None:
@@ -41,22 +74,23 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
     if issuer is None:
         return None
 
-    auth = request.headers.get("Authorization", "")
-    if not auth.lower().startswith("bearer "):
+    token = _extract_bearer_or_dpop_token(request)
+    if token is None:
         return None
 
-    token = auth[7:].strip()
-    if not token:
+    # When the scheme is DPoP, the token might be a broker-issued JWT
+    # (different kid) the caller legitimately wants handled by the DPoP
+    # path. Pre-filter by kid so we only intercept tokens this Mastio
+    # actually signed.
+    if not _is_local_kid(token, issuer):
         return None
 
     try:
         payload = validate_local_token(token, issuer)
     except LocalTokenError as exc:
-        # Bearer was provided but invalid — surface 401 rather than
-        # falling through to DPoP, otherwise we'd leak a confusing
-        # "DPoP required" message for what is clearly a local-auth
-        # attempt. Operators opted into local_auth_enabled; a bad Bearer
-        # is a client mistake, not a probe.
+        # kid matched this Mastio but validation still failed — that's a
+        # spoofing or tamper attempt, surface 401 rather than falling
+        # through silently.
         _log.info("local token rejected: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -112,11 +146,10 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
     if issuer is None:
         return None
 
-    auth = request.headers.get("Authorization", "")
-    if not auth.lower().startswith("bearer "):
+    token = _extract_bearer_or_dpop_token(request)
+    if token is None:
         return None
-    token = auth[7:].strip()
-    if not token:
+    if not _is_local_kid(token, issuer):
         return None
 
     try:

--- a/sandbox/demo.sh
+++ b/sandbox/demo.sh
@@ -73,7 +73,8 @@ case "${1:-help}" in
     _note "is NOT registered on the Court — you will do that from the guide."
     export BOOTSTRAP_SCOPE=up
     docker compose build --quiet
-    docker compose up -d --wait
+    _note "booting services (this takes ~60s)…"
+    docker compose --progress quiet up -d --wait --quiet-pull
     _header "Services Running"
     docker compose ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
     _print_dashboards
@@ -87,7 +88,8 @@ case "${1:-help}" in
     _note "Both orgs registered, three agents enrolled, two MCP servers online."
     export BOOTSTRAP_SCOPE=full
     docker compose --profile full build --quiet
-    docker compose --profile full up -d --wait
+    _note "booting services (this takes ~60s)…"
+    docker compose --progress quiet --profile full up -d --wait --quiet-pull
     _header "Services Running"
     docker compose --profile full ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}"
     _print_dashboards

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -89,7 +89,13 @@ services:
         condition: service_healthy
     environment:
       ADMIN_SECRET: "sandbox-admin-secret-change-me"
-      DASHBOARD_SIGNING_KEY: "sandbox-dashboard-signing-key-32chars-long"
+      # Intentionally unset — the broker auto-generates a signing key at
+      # first boot and persists it under /app/certs/ (tmpfs). Each
+      # ``demo.sh down && demo.sh full`` cycle therefore rotates the key,
+      # invalidating any dashboard cookie the browser held from the
+      # previous run. Pinning a static value made the "reset password"
+      # demo point look broken: the cookie kept validating across
+      # reboots because the signature stayed good.
       KMS_BACKEND: "local"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem

--- a/tests/test_proxy_local_agent_dep.py
+++ b/tests/test_proxy_local_agent_dep.py
@@ -104,10 +104,37 @@ async def test_unknown_agent_is_rejected(app_with_flag_on):
 
 
 @pytest.mark.asyncio
-async def test_invalid_bearer_does_not_fall_through_to_dpop(app_with_flag_on):
-    """Flag on + bad Bearer → 401 "local token: …", not a DPoP challenge."""
+async def test_non_local_kid_falls_through_to_dpop(app_with_flag_on):
+    """Flag on + token whose kid does NOT match the LocalIssuer → the
+    local branch must step aside so the DPoP path can decide. This is
+    how broker-issued JWTs keep working alongside local tokens and how
+    a malformed bearer never short-circuits the canonical auth flow.
+    """
     with TestClient(app_with_flag_on["app"]) as client:
         resp = client.get("/probe", headers={"Authorization": "Bearer not-a-jwt"})
+    assert resp.status_code == 401
+    # Fall-through to DPoP → challenge mentions DPoP realm.
+    assert "dpop" in resp.headers.get("WWW-Authenticate", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_tampered_local_token_is_rejected(app_with_flag_on):
+    """Kid matches but signature / claims invalid → 401 "local token: …".
+    This catches tamper attempts that stripped and resigned a genuine
+    header without the matching key.
+    """
+    import jwt as jose_jwt
+    issuer = app_with_flag_on["issuer"]
+    # Forge a header that mimics the LocalIssuer's kid so we go past the
+    # pre-filter, but sign with an HMAC key so the signature check fails.
+    tampered = jose_jwt.encode(
+        {"sub": "orga::alice"},
+        "not-the-mastio-key",
+        algorithm="HS256",
+        headers={"kid": issuer.kid},
+    )
+    with TestClient(app_with_flag_on["app"]) as client:
+        resp = client.get("/probe", headers={"Authorization": f"Bearer {tampered}"})
     assert resp.status_code == 401
     assert "local token" in resp.json()["detail"].lower()
 


### PR DESCRIPTION
## Summary
Three fixes discovered during end-to-end verification of ADR-012 in the sandbox. Bundled because they were all found in the same ``./demo.sh full`` cycle and each is tiny on its own.

### 1. ``local_agent_dep`` accepts ``Authorization: DPoP <jwt>``
The SDK's ``login_via_proxy`` path keeps the DPoP scheme on every downstream request even when the token it carries is a Mastio LOCAL_TOKEN. The ingress / egress adapters were Bearer-only and returned 401 on MCP calls. New ``_extract_bearer_or_dpop_token`` + ``_is_local_kid`` helpers accept both schemes but pre-filter by kid so broker-issued JWTs still reach the DPoP path unchanged.

Test rename: ``test_invalid_bearer_does_not_fall_through_to_dpop`` → ``test_non_local_kid_falls_through_to_dpop``. The behavior changed on purpose — unknown kid means "not for us", not "reject with local 401". A real tamper attempt (spoofed kid, bad signature) is still caught (new ``test_tampered_local_token_is_rejected``).

### 2. Broker dashboard signing key rotates on every ``demo.sh down && demo.sh full``
The sandbox compose used to pin ``DASHBOARD_SIGNING_KEY`` statically. Cookies left in the browser kept validating across full resets, which made the "reset password at first boot" demo point look broken. The env var is now unset; the Court auto-generates the key under ``/app/certs`` (tmpfs), so every down/up rotates it.

### 3. ``./demo.sh full`` output is no longer noisy
``docker compose up --progress quiet`` — on terminals that don't interpret cursor-up escapes cleanly, the redraw was appending ~40 lines per frame to scrollback. With the progress renderer silenced, the final ``docker compose ps`` table is the only service-level output.

## Test plan
- [x] 53 tests pass across all ADR-012 suites + MCP aggregator + sign-assertion.
- [ ] Sandbox smoke (manual): ``./demo.sh down && ./demo.sh full && ./demo.sh mcp-catalog`` — confirmed locally, ready to record the demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)