### PR TITLE
fix(scripts): honor BROKER_URL / PROXY_PUBLIC_URL env vars in generate-proxy-env --defaults

### DIFF
--- a/scripts/generate-proxy-env.sh
+++ b/scripts/generate-proxy-env.sh
@@ -76,9 +76,9 @@ case "$MODE" in
         ENVIRONMENT="production"
         ;;
     defaults)
-        BROKER="http://broker:8000"
-        PUBLIC="http://localhost:9100"
-        JWKS="http://broker:8000/.well-known/jwks.json"
+        BROKER="${BROKER_URL:-http://broker:8000}"
+        PUBLIC="${PROXY_PUBLIC_URL:-http://localhost:9100}"
+        JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;
     interactive)


### PR DESCRIPTION
## Summary
- `generate-proxy-env.sh --defaults` now reads `BROKER_URL` and `PROXY_PUBLIC_URL` from the environment (same precedence `--prod` already uses), falling back to the existing `http://broker:8000` / `http://localhost:9100` defaults when unset.
- Unblocks operators running a Mastio on a host the agents reach via a different address — a libvirt VM (`192.168.122.154`), a bastion, a container on a separate bridge. Before this patch the hardcoded localhost URL was written into `proxy.env` every time the file was regenerated, and the DPoP htu check on `/v1/egress/*` rejected every agent whose request URL didn't match it (`401 Invalid DPoP proof: htu mismatch`).

## Context — how this was discovered
Dogfooding the Connector ↔ Connector oneshot flow with a Mastio running inside a libvirt VM: the two Claude-North / Claude-South Connectors on the host could authenticate for discovery but every egress call failed `htu mismatch` after a `./deploy_proxy.sh --down && --standalone` cycle. Root cause was `generate-proxy-env.sh --defaults` recreating `proxy.env` with `MCP_PROXY_PROXY_PUBLIC_URL=http://localhost:9100` while the Connector signed proofs against `http://192.168.122.154:9100` (the VM IP in its `metadata.json`).

With this patch, a single `export PROXY_PUBLIC_URL=http://192.168.122.154:9100` in the VM's shell rc survives any regeneration.

## Test plan
- [x] `bash -n scripts/generate-proxy-env.sh` (syntax)
- [x] Manual: `PROXY_PUBLIC_URL=http://192.168.122.154:9100 ./scripts/generate-proxy-env.sh --defaults --force` → `proxy.env` contains the override
- [x] Manual: `./scripts/generate-proxy-env.sh --defaults --force` with no env vars → `proxy.env` keeps the original localhost defaults (zero behavior change)