### PR TITLE
chore(pki): align intermediate-CA validity with NIST SP 800-57 §5.3.6

### DIFF
--- a/generate_certs.py
+++ b/generate_certs.py
@@ -163,7 +163,7 @@ def gen_org_ca(
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(NOW)
-        .not_valid_after(NOW + datetime.timedelta(days=365 * 5))
+        .not_valid_after(NOW + datetime.timedelta(days=365 * 3))
         .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
         .add_extension(
             x509.SubjectKeyIdentifier.from_public_key(key.public_key()),

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -99,7 +99,13 @@ def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
 
 
 def generate_org_ca(org_id: str) -> tuple[str, str]:
-    """Generate self-signed Org CA. Returns (cert_pem, key_pem)."""
+    """Generate self-signed Org CA. Returns (cert_pem, key_pem).
+
+    10-year validity: this is an offline-held root (NIST SP 800-57
+    Part 1 §5.3.6 — root CAs held offline with long lifetimes).
+    All online signing is done by the Mastio intermediate CA minted
+    underneath this root; the intermediate rotates on a shorter cycle.
+    """
     key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
     subject = issuer = x509.Name([
         x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id} CA"),

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -488,6 +488,9 @@ class AgentManager:
         now = datetime.now(timezone.utc)
 
         # Intermediate CA — EC P-256, pathLen=0 (cannot sign further CAs).
+        # 3y validity: online signer intended to be rotated ahead of expiry
+        # (NIST SP 800-57 Part 1 §5.3.6 guidance for signing keys in active
+        # use). Automatic rotation is tracked in issue #261.
         mastio_ca_key = ec.generate_private_key(ec.SECP256R1())
         mastio_ca_subject = x509.Name([
             x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} Mastio CA"),
@@ -500,7 +503,7 @@ class AgentManager:
             .public_key(mastio_ca_key.public_key())
             .serial_number(x509.random_serial_number())
             .not_valid_before(now - timedelta(minutes=5))
-            .not_valid_after(now + timedelta(days=3650))
+            .not_valid_after(now + timedelta(days=365 * 3))
             .add_extension(
                 x509.BasicConstraints(ca=True, path_length=0),
                 critical=True,


### PR DESCRIPTION
## Summary

Bring the two online intermediate CAs down from 5-10 y to 3 y, the
NIST SP 800-57 Part 1 §5.3.6 guidance for signing keys in active
use. Root CAs stay at 10 y (offline-held, carved out by the same
section).

- ``mcp_proxy/egress/agent_manager.py``: Mastio intermediate CA
  3650 d → 3 × 365 d. Online signer behind ADR-009 counter-sigs
  and ADR-012 local JWT issuance.
- ``generate_certs.py``: legacy org intermediate CA
  5 × 365 d → 3 × 365 d (consistency with the runtime path above).
- ``mcp_proxy/dashboard/router.py``: expand ``generate_org_ca``
  docstring to call out the offline-root rationale behind the
  10-y validity.

## Follow-on

Automatic re-enrollment on TTL expiry and ES256 signing-key
rotation are tracked in #261. Moving the standalone agent leaf
below the current 365 d toward the SPIFFE default 1 h depends on
that renewal loop landing first.

## Test plan

- [x] ``pytest tests/test_proxy_standalone_ca.py tests/test_proxy_standalone.py tests/test_admin_enroll_byoca.py tests/test_enrollment.py tests/test_admin_enroll_spiffe.py`` — 39 passed
- [ ] CI full suite
- [ ] Sandbox dogfood ``./demo.sh full`` after merge

## References

- NIST SP 800-57 Part 1 Rev 5 §5.3.6 (cryptoperiods for signing keys)
- CA/Browser Forum Baseline Requirements §6.3.2 (max TLS validity)
- SPIFFE SVID spec §4 (short-lived leaves)
- WIMSE architecture draft §3 (workload identity lifecycle)