### PR TITLE
feat(mastio): ADR-012 Phase 2.0 — multi-key keystore foundation (#261)

### DIFF
--- a/mcp_proxy/alembic/versions/0018_mastio_keys.py
+++ b/mcp_proxy/alembic/versions/0018_mastio_keys.py
@@ -1,0 +1,129 @@
+"""``mastio_keys`` — multi-key store for the Mastio ES256 identity.
+
+Revision ID: 0018_mastio_keys
+Revises: 0017_internal_agents_reach
+Create Date: 2026-04-21 21:40:00.000000
+
+ADR-012 Phase 2.0 — split the Mastio ES256 leaf key out of the single-row
+``proxy_config`` convention and into a dedicated table that can hold
+multiple historical keypairs. This is the foundation that makes key
+rotation (Phase 2.1) and grace-period verification (Phase 2.2)
+structurally possible without hacking around a single-row schema.
+
+Invariant once populated:
+    exactly one row has ``activated_at IS NOT NULL AND deprecated_at IS NULL``
+    (the current signer used by ``LocalIssuer`` and the ADR-009
+    counter-signature path).
+
+Data migration
+--------------
+If ``proxy_config`` has ``mastio_leaf_key`` + ``mastio_leaf_cert`` (the
+pre-2.0 storage), derive the ``kid`` from the leaf's public key (matching
+the legacy ``LocalIssuer._compute_kid`` algorithm) and seed a single
+active row. The old ``proxy_config`` rows are left in place during
+Phase 2.0 so a rollback only needs to drop the new table; Phase 2.0
+wire-up no longer reads them.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+
+revision: str = "0018_mastio_keys"
+down_revision: Union[str, Sequence[str], None] = "0017_internal_agents_reach"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "mastio_keys" not in existing_tables:
+        op.create_table(
+            "mastio_keys",
+            sa.Column("kid", sa.Text(), primary_key=True),
+            sa.Column("pubkey_pem", sa.Text(), nullable=False),
+            sa.Column("privkey_pem", sa.Text(), nullable=False),
+            sa.Column("cert_pem", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.Text(), nullable=False),
+            sa.Column("activated_at", sa.Text(), nullable=True),
+            sa.Column("deprecated_at", sa.Text(), nullable=True),
+            sa.Column("expires_at", sa.Text(), nullable=True),
+        )
+        op.create_index(
+            "idx_mastio_keys_active",
+            "mastio_keys",
+            ["activated_at", "deprecated_at"],
+        )
+
+    # Data migration — only if we find the legacy storage and the new
+    # table is still empty. Idempotent across reruns.
+    already = bind.execute(
+        sa.text("SELECT COUNT(*) FROM mastio_keys")
+    ).scalar()
+    if already:
+        return
+
+    rows = bind.execute(
+        sa.text(
+            "SELECT key, value FROM proxy_config "
+            "WHERE key IN ('mastio_leaf_key', 'mastio_leaf_cert')"
+        )
+    ).fetchall()
+    config = {row[0]: row[1] for row in rows}
+
+    leaf_key_pem = config.get("mastio_leaf_key")
+    leaf_cert_pem = config.get("mastio_leaf_cert")
+    if not leaf_key_pem or not leaf_cert_pem:
+        # Proxy boots against a fresh DB or Mastio identity hasn't been
+        # generated yet — ``ensure_mastio_identity`` will create the
+        # first row through the regular insert path.
+        return
+
+    try:
+        cert = x509.load_pem_x509_certificate(leaf_cert_pem.encode())
+    except ValueError:
+        # Corrupt stored cert — don't block the migration, let the boot
+        # path regenerate identity from scratch.
+        return
+
+    pubkey_pem = cert.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    kid = "mastio-" + hashlib.sha256(pubkey_pem.encode()).hexdigest()[:16]
+    now = datetime.now(timezone.utc).isoformat()
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO mastio_keys "
+            "(kid, pubkey_pem, privkey_pem, cert_pem, "
+            " created_at, activated_at) "
+            "VALUES (:kid, :pub, :priv, :cert, :now, :now)"
+        ),
+        {
+            "kid": kid,
+            "pub": pubkey_pem,
+            "priv": leaf_key_pem,
+            "cert": leaf_cert_pem,
+            "now": now,
+        },
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = set(sa.inspect(bind).get_table_names())
+    if "mastio_keys" not in existing:
+        return
+    op.drop_index("idx_mastio_keys_active", table_name="mastio_keys")
+    op.drop_table("mastio_keys")

--- a/mcp_proxy/alembic/versions/0018_mastio_keys.py
+++ b/mcp_proxy/alembic/versions/0018_mastio_keys.py
@@ -4,36 +4,33 @@ Revision ID: 0018_mastio_keys
 Revises: 0017_internal_agents_reach
 Create Date: 2026-04-21 21:40:00.000000
 
-ADR-012 Phase 2.0 — split the Mastio ES256 leaf key out of the single-row
-``proxy_config`` convention and into a dedicated table that can hold
-multiple historical keypairs. This is the foundation that makes key
-rotation (Phase 2.1) and grace-period verification (Phase 2.2)
+ADR-012 Phase 2.0 — split the Mastio ES256 leaf key out of the
+single-row ``proxy_config`` convention into a dedicated table that can
+hold multiple historical keypairs. This is the foundation that makes
+key rotation (Phase 2.1) and grace-period verification (Phase 2.2)
 structurally possible without hacking around a single-row schema.
 
 Invariant once populated:
-    exactly one row has ``activated_at IS NOT NULL AND deprecated_at IS NULL``
+    exactly one row has
+    ``activated_at IS NOT NULL AND deprecated_at IS NULL``
     (the current signer used by ``LocalIssuer`` and the ADR-009
     counter-signature path).
 
-Data migration
---------------
-If ``proxy_config`` has ``mastio_leaf_key`` + ``mastio_leaf_cert`` (the
-pre-2.0 storage), derive the ``kid`` from the leaf's public key (matching
-the legacy ``LocalIssuer._compute_kid`` algorithm) and seed a single
-active row. The old ``proxy_config`` rows are left in place during
-Phase 2.0 so a rollback only needs to drop the new table; Phase 2.0
-wire-up no longer reads them.
+Schema-only migration. The data migration from the pre-2.0
+``proxy_config.mastio_leaf_{key,cert}`` pair runs at proxy boot (see
+``AgentManager.ensure_mastio_identity``) rather than here, because
+seeding the first row requires parsing the leaf cert with
+``cryptography`` — a dependency the standalone ``proxy-init`` container
+(``demo_network``/``sandbox``) does not carry. Keeping this migration
+dependency-free lets schema bootstrap run in any minimal
+alembic-only environment.
 """
 from __future__ import annotations
 
-import hashlib
-from datetime import datetime, timezone
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from cryptography import x509
-from cryptography.hazmat.primitives import serialization
 
 
 revision: str = "0018_mastio_keys"
@@ -47,76 +44,24 @@ def upgrade() -> None:
     inspector = sa.inspect(bind)
     existing_tables = set(inspector.get_table_names())
 
-    if "mastio_keys" not in existing_tables:
-        op.create_table(
-            "mastio_keys",
-            sa.Column("kid", sa.Text(), primary_key=True),
-            sa.Column("pubkey_pem", sa.Text(), nullable=False),
-            sa.Column("privkey_pem", sa.Text(), nullable=False),
-            sa.Column("cert_pem", sa.Text(), nullable=True),
-            sa.Column("created_at", sa.Text(), nullable=False),
-            sa.Column("activated_at", sa.Text(), nullable=True),
-            sa.Column("deprecated_at", sa.Text(), nullable=True),
-            sa.Column("expires_at", sa.Text(), nullable=True),
-        )
-        op.create_index(
-            "idx_mastio_keys_active",
-            "mastio_keys",
-            ["activated_at", "deprecated_at"],
-        )
-
-    # Data migration — only if we find the legacy storage and the new
-    # table is still empty. Idempotent across reruns.
-    already = bind.execute(
-        sa.text("SELECT COUNT(*) FROM mastio_keys")
-    ).scalar()
-    if already:
+    if "mastio_keys" in existing_tables:
         return
 
-    rows = bind.execute(
-        sa.text(
-            "SELECT key, value FROM proxy_config "
-            "WHERE key IN ('mastio_leaf_key', 'mastio_leaf_cert')"
-        )
-    ).fetchall()
-    config = {row[0]: row[1] for row in rows}
-
-    leaf_key_pem = config.get("mastio_leaf_key")
-    leaf_cert_pem = config.get("mastio_leaf_cert")
-    if not leaf_key_pem or not leaf_cert_pem:
-        # Proxy boots against a fresh DB or Mastio identity hasn't been
-        # generated yet — ``ensure_mastio_identity`` will create the
-        # first row through the regular insert path.
-        return
-
-    try:
-        cert = x509.load_pem_x509_certificate(leaf_cert_pem.encode())
-    except ValueError:
-        # Corrupt stored cert — don't block the migration, let the boot
-        # path regenerate identity from scratch.
-        return
-
-    pubkey_pem = cert.public_key().public_bytes(
-        serialization.Encoding.PEM,
-        serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
-    kid = "mastio-" + hashlib.sha256(pubkey_pem.encode()).hexdigest()[:16]
-    now = datetime.now(timezone.utc).isoformat()
-
-    bind.execute(
-        sa.text(
-            "INSERT INTO mastio_keys "
-            "(kid, pubkey_pem, privkey_pem, cert_pem, "
-            " created_at, activated_at) "
-            "VALUES (:kid, :pub, :priv, :cert, :now, :now)"
-        ),
-        {
-            "kid": kid,
-            "pub": pubkey_pem,
-            "priv": leaf_key_pem,
-            "cert": leaf_cert_pem,
-            "now": now,
-        },
+    op.create_table(
+        "mastio_keys",
+        sa.Column("kid", sa.Text(), primary_key=True),
+        sa.Column("pubkey_pem", sa.Text(), nullable=False),
+        sa.Column("privkey_pem", sa.Text(), nullable=False),
+        sa.Column("cert_pem", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("activated_at", sa.Text(), nullable=True),
+        sa.Column("deprecated_at", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "idx_mastio_keys_active",
+        "mastio_keys",
+        ["activated_at", "deprecated_at"],
     )
 
 

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -85,8 +85,14 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
     if not _is_local_kid(token, issuer):
         return None
 
+    keystore = getattr(request.app.state, "local_keystore", None)
+    if keystore is None:
+        return None
+
     try:
-        payload = validate_local_token(token, issuer)
+        payload = await validate_local_token(
+            token, keystore, expected_issuer=issuer.issuer,
+        )
     except LocalTokenError as exc:
         # kid matched this Mastio but validation still failed — that's a
         # spoofing or tamper attempt, surface 401 rather than falling
@@ -152,8 +158,14 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
     if not _is_local_kid(token, issuer):
         return None
 
+    keystore = getattr(request.app.state, "local_keystore", None)
+    if keystore is None:
+        return None
+
     try:
-        payload = validate_local_token(token, issuer)
+        payload = await validate_local_token(
+            token, keystore, expected_issuer=issuer.issuer,
+        )
     except LocalTokenError as exc:
         _log.info("local token rejected (egress): %s", exc)
         raise HTTPException(

--- a/mcp_proxy/auth/local_issuer.py
+++ b/mcp_proxy/auth/local_issuer.py
@@ -5,28 +5,27 @@ calls, intra-org send/receive). These tokens never reach the Court:
 the Court is only contacted when an agent performs a cross-org send,
 via a runtime token-exchange introduced in a follow-up PR.
 
-Signing key = the same EC P-256 Mastio leaf key used for ADR-009
-counter-signatures (``AgentManager._mastio_leaf_key``). One key, two
-uses, one trust anchor: the ``mastio_pubkey`` pinned at org onboarding.
+Signing key = the active row of ``mastio_keys`` (ADR-012 Phase 2.0
+multi-key store, see ``mcp_proxy.auth.local_keystore``). The same
+row is used for ADR-009 counter-signatures, so rotation affects
+both protocols simultaneously.
 
-The ``kid`` is derived from the SHA-256 digest of the leaf public key
-PEM (first 16 hex chars). This is stable across restarts — the key is
-re-loaded from the DB by ``AgentManager.ensure_mastio_identity()`` —
-and unique per Mastio, so validators can pick the right key out of
-the JWKS without relying on wall-clock ordering.
+The ``kid`` lives on the ``MastioKey`` and is stamped into the JWT
+header at ``issue()`` time. Phase 2.2 will expose multiple kids
+concurrently during the grace window; the issuer stays single-kid
+(it only signs with the current active row) and the validator does
+the multi-kid lookup.
 """
 from __future__ import annotations
 
-import base64
-import hashlib
 import time
 import uuid
 from dataclasses import dataclass
 from typing import Any
 
 import jwt as jose_jwt
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import ec
+
+from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey
 
 DEFAULT_TTL_SECONDS = 15 * 60
 MAX_TTL_SECONDS = 60 * 60
@@ -46,7 +45,7 @@ class LocalToken:
 
 
 class LocalIssuer:
-    """Issue ES256 JWTs signed by the Mastio leaf key.
+    """Issue ES256 JWTs signed by the active Mastio key.
 
     Claims emitted::
 
@@ -60,38 +59,33 @@ class LocalIssuer:
 
     Extra claims may be passed via ``issue(..., extra_claims=...)`` but
     cannot overwrite any of the reserved claims above.
+
+    Rotation handling: a given ``LocalIssuer`` is bound to a specific
+    ``MastioKey``. After rotation (Phase 2.1), the proxy lifespan
+    rebuilds the issuer so it points at the new current signer. The
+    previous issuer's kid continues to be verifiable through the
+    keystore during the grace window.
     """
 
-    def __init__(
-        self,
-        org_id: str,
-        leaf_key: ec.EllipticCurvePrivateKey,
-        leaf_pubkey_pem: str,
-    ) -> None:
+    def __init__(self, org_id: str, active_key: MastioKey) -> None:
         if not org_id:
             raise ValueError("org_id required")
-        if not isinstance(leaf_key, ec.EllipticCurvePrivateKey):
-            raise TypeError("leaf_key must be an EC private key")
-        if not leaf_pubkey_pem:
-            raise ValueError("leaf_pubkey_pem required")
+        if not isinstance(active_key, MastioKey):
+            raise TypeError("active_key must be a MastioKey instance")
+        if not active_key.is_active:
+            raise ValueError(
+                f"active_key.kid={active_key.kid!r} is not currently active"
+            )
         self.org_id = org_id
-        self._leaf_key = leaf_key
-        self._leaf_pubkey_pem = leaf_pubkey_pem
-        self._priv_pem = leaf_key.private_bytes(
-            encoding=serialization.Encoding.PEM,
-            format=serialization.PrivateFormat.PKCS8,
-            encryption_algorithm=serialization.NoEncryption(),
-        )
-        self._kid = self._compute_kid(leaf_pubkey_pem)
-
-    @staticmethod
-    def _compute_kid(pubkey_pem: str) -> str:
-        digest = hashlib.sha256(pubkey_pem.encode()).hexdigest()[:16]
-        return f"mastio-{digest}"
+        self._active_key = active_key
 
     @property
     def kid(self) -> str:
-        return self._kid
+        return self._active_key.kid
+
+    @property
+    def active_key(self) -> MastioKey:
+        return self._active_key
 
     @property
     def issuer(self) -> str:
@@ -129,48 +123,33 @@ class LocalIssuer:
 
         token = jose_jwt.encode(
             payload,
-            self._priv_pem,
+            self._active_key.privkey_pem,
             algorithm="ES256",
-            headers={"kid": self._kid, "typ": "JWT"},
+            headers={"kid": self._active_key.kid, "typ": "JWT"},
         )
-        return LocalToken(token=token, kid=self._kid, issued_at=now, expires_at=exp)
+        return LocalToken(
+            token=token,
+            kid=self._active_key.kid,
+            issued_at=now,
+            expires_at=exp,
+        )
 
     def jwks(self) -> dict[str, Any]:
-        pub_key = serialization.load_pem_public_key(self._leaf_pubkey_pem.encode())
-        if not isinstance(pub_key, ec.EllipticCurvePublicKey):
-            raise RuntimeError("leaf pubkey is not an EC key")
-        numbers = pub_key.public_numbers()
-        return {
-            "keys": [
-                {
-                    "kty": "EC",
-                    "crv": "P-256",
-                    "x": _b64u_int(numbers.x, 32),
-                    "y": _b64u_int(numbers.y, 32),
-                    "use": "sig",
-                    "alg": "ES256",
-                    "kid": self._kid,
-                }
-            ]
-        }
+        """Return the JWKS containing only the current active key.
+
+        Phase 2.2 will add a separate endpoint (or extend this one) to
+        surface deprecated-but-still-valid kids during the grace
+        window. The issuer itself stays single-key to keep the signing
+        path unambiguous.
+        """
+        return {"keys": [self._active_key.jwk()]}
 
 
-def _b64u_int(value: int, length: int) -> str:
-    return (
-        base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode()
-    )
+async def build_from_keystore(org_id: str, keystore: LocalKeyStore) -> LocalIssuer:
+    """Construct a LocalIssuer pointing at the keystore's current signer.
 
-
-def build_from_agent_manager(org_id: str, agent_manager: Any) -> LocalIssuer:
-    """Construct a LocalIssuer from a loaded AgentManager.
-
-    Raises RuntimeError if the Mastio identity has not been provisioned
-    yet (``ensure_mastio_identity()`` not called, or Org CA not loaded).
+    Raises whatever ``keystore.current_signer()`` raises (no active
+    key, or the invariant was violated).
     """
-    if not getattr(agent_manager, "mastio_loaded", False):
-        raise RuntimeError("Mastio identity not loaded")
-    leaf_key = getattr(agent_manager, "_mastio_leaf_key", None)
-    if leaf_key is None:
-        raise RuntimeError("Mastio leaf key missing on agent manager")
-    pubkey_pem = agent_manager.get_mastio_pubkey_pem()
-    return LocalIssuer(org_id=org_id, leaf_key=leaf_key, leaf_pubkey_pem=pubkey_pem)
+    active = await keystore.current_signer()
+    return LocalIssuer(org_id=org_id, active_key=active)

--- a/mcp_proxy/auth/local_keystore.py
+++ b/mcp_proxy/auth/local_keystore.py
@@ -1,0 +1,193 @@
+"""ADR-012 Phase 2.0 — multi-key store for the Mastio ES256 identity.
+
+Backing table: ``mastio_keys`` (see ``mcp_proxy/db_models.py`` +
+migration ``0018_mastio_keys``). The invariant maintained by callers:
+*exactly one* row has ``activated_at IS NOT NULL AND deprecated_at IS
+NULL`` at any time — that is the current signer used by
+``LocalIssuer`` and by the ADR-009 counter-signature path.
+
+Phase 2.0 ships the primitive only; rotation is Phase 2.1, grace-period
+verification is Phase 2.2. The keystore is deliberately oblivious to
+those flows: callers orchestrate the activate/deprecate transitions
+and the keystore just exposes read views (``current_signer``,
+``find_by_kid``, ``all_valid_keys``).
+
+``kid`` convention (carried over from the pre-2.0 ``LocalIssuer``):
+    ``mastio-<sha256(pubkey_pem)[:16]>``
+deterministic per-key, stable across restarts, unique across orgs
+(assuming no ES256 collisions — cryptographically safe).
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from mcp_proxy.db import (
+    get_mastio_key_by_kid,
+    get_mastio_keys_active,
+    get_mastio_keys_valid,
+)
+
+
+def compute_kid(pubkey_pem: str) -> str:
+    """Derive the ``kid`` from an ES256 public-key PEM.
+
+    Matches the legacy ``LocalIssuer._compute_kid`` so rows migrated
+    from ``proxy_config.mastio_leaf_cert`` keep the same kid that any
+    previously-issued JWT already references.
+    """
+    digest = hashlib.sha256(pubkey_pem.encode()).hexdigest()[:16]
+    return f"mastio-{digest}"
+
+
+@dataclass(frozen=True)
+class MastioKey:
+    """Materialised row from ``mastio_keys``.
+
+    All timestamps are timezone-aware (UTC). ``privkey_pem`` is
+    always present — the table stores keys we own, not foreign keys
+    we only verify against (that is what ``mastio_pubkey`` pinned on
+    the Court side is for, a different trust store).
+
+    ``cert_pem`` carries the X.509 leaf currently chained under this
+    key. It can be None in principle (the CA may re-issue without
+    churning the key material), but the normal path keeps them
+    together.
+    """
+    kid: str
+    pubkey_pem: str
+    privkey_pem: str
+    cert_pem: str | None
+    created_at: datetime
+    activated_at: datetime | None
+    deprecated_at: datetime | None
+    expires_at: datetime | None
+
+    @property
+    def is_active(self) -> bool:
+        """True iff this row is the current signer."""
+        return self.activated_at is not None and self.deprecated_at is None
+
+    @property
+    def is_valid_for_verification(self) -> bool:
+        """True while the verifier should still accept tokens with this kid."""
+        if self.activated_at is None:
+            return False
+        if self.expires_at is None:
+            return True
+        return datetime.now(timezone.utc) < self.expires_at
+
+    def load_private_key(self) -> ec.EllipticCurvePrivateKey:
+        """Deserialise ``privkey_pem`` into a ``cryptography`` EC key."""
+        key = serialization.load_pem_private_key(
+            self.privkey_pem.encode(), password=None,
+        )
+        if not isinstance(key, ec.EllipticCurvePrivateKey):
+            raise TypeError(
+                f"expected EC P-256 private key, got {type(key).__name__}"
+            )
+        return key
+
+    def jwk(self) -> dict[str, Any]:
+        """Return the JWK representation for a JWKS endpoint."""
+        pub = serialization.load_pem_public_key(self.pubkey_pem.encode())
+        if not isinstance(pub, ec.EllipticCurvePublicKey):
+            raise TypeError("expected EC P-256 public key")
+        numbers = pub.public_numbers()
+        return {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": _b64u_int(numbers.x, 32),
+            "y": _b64u_int(numbers.y, 32),
+            "use": "sig",
+            "alg": "ES256",
+            "kid": self.kid,
+        }
+
+
+class LocalKeyStore:
+    """Read view over ``mastio_keys``.
+
+    Stateless: every call hits the DB. The proxy caches the current
+    signer in its issuer instance, so ``current_signer`` is only read
+    on boot / after a rotation event — there is no hot-path contention.
+    """
+
+    async def current_signer(self) -> MastioKey:
+        """Return the single active key.
+
+        Raises:
+            RuntimeError: if no active key exists (Mastio identity not
+                yet ensured) or if more than one is marked active
+                (rotation bug — the invariant was violated and the
+                caller must refuse to sign until it is restored).
+        """
+        rows = await get_mastio_keys_active()
+        if len(rows) == 0:
+            raise RuntimeError(
+                "no active mastio key — "
+                "AgentManager.ensure_mastio_identity() must run first"
+            )
+        if len(rows) > 1:
+            kids = ", ".join(row["kid"] for row in rows)
+            raise RuntimeError(
+                f"{len(rows)} active mastio keys ({kids}) — "
+                "rotation invariant violated"
+            )
+        return _row_to_key(rows[0])
+
+    async def find_by_kid(self, kid: str) -> MastioKey | None:
+        """Look up a key by ``kid``.
+
+        Returns None if the kid is unknown. The caller still has to
+        check :attr:`MastioKey.is_valid_for_verification` before
+        accepting a token — an expired row is a known-but-rejected kid.
+        """
+        row = await get_mastio_key_by_kid(kid)
+        return _row_to_key(row) if row else None
+
+    async def all_valid_keys(self) -> list[MastioKey]:
+        """Every key currently accepted for verification.
+
+        Used by the JWKS endpoint so JWT validators outside the proxy
+        (Phase 2.2) can pick the right key by ``kid``.
+        """
+        rows = await get_mastio_keys_valid()
+        return [_row_to_key(row) for row in rows]
+
+
+def _row_to_key(row: dict[str, Any]) -> MastioKey:
+    return MastioKey(
+        kid=row["kid"],
+        pubkey_pem=row["pubkey_pem"],
+        privkey_pem=row["privkey_pem"],
+        cert_pem=row.get("cert_pem"),
+        created_at=_parse_iso(row["created_at"]),
+        activated_at=_parse_iso(row["activated_at"]) if row["activated_at"] else None,
+        deprecated_at=_parse_iso(row["deprecated_at"]) if row["deprecated_at"] else None,
+        expires_at=_parse_iso(row["expires_at"]) if row["expires_at"] else None,
+    )
+
+
+def _parse_iso(value: str) -> datetime:
+    """Parse an ISO-8601 string into a timezone-aware UTC datetime.
+
+    Python 3.11's ``datetime.fromisoformat`` already accepts the
+    ``+00:00`` suffix; the ``Z`` fallback keeps us compatible with
+    anything that has emitted the shorter form.
+    """
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _b64u_int(value: int, length: int) -> str:
+    return (
+        base64.urlsafe_b64encode(value.to_bytes(length, "big"))
+        .rstrip(b"=")
+        .decode()
+    )

--- a/mcp_proxy/auth/local_validator.py
+++ b/mcp_proxy/auth/local_validator.py
@@ -1,15 +1,19 @@
 """ADR-012 Phase 3 — validator for Mastio-issued local tokens.
 
-The counterpart to ``mcp_proxy.auth.local_issuer``: given a Bearer JWT
-signed by the Mastio leaf key, verify it against the in-process
-``LocalIssuer`` (no remote JWKS fetch needed — the public key is the
-one we use ourselves to sign) and surface the claims as a typed payload
-downstream handlers can trust.
+The counterpart to ``mcp_proxy.auth.local_issuer``: given a Bearer
+JWT signed by a Mastio key, look the ``kid`` up in the keystore and
+verify the signature against the corresponding public key.
+
+Phase 2.0 note: the validator is now keystore-driven instead of
+issuer-driven. A kid in the JWT header can match any active *or*
+within-grace deprecated row in ``mastio_keys`` (``is_valid_for_verification``);
+unknown or expired kids are rejected. This is the structural change
+that lets Phase 2.2 serve a rotation grace window without any more
+code in the validator itself.
 
 A FastAPI dependency ``require_local_token`` exposes the validator to
-route handlers. Wiring onto the actual egress / ingress endpoints is
-the job of a follow-up PR (ADR-012 Phase 4); this module ships the
-primitive and its tests so the subsequent wiring PR stays small.
+route handlers. It reads ``request.app.state.local_keystore``,
+populated by the proxy lifespan.
 """
 from __future__ import annotations
 
@@ -18,14 +22,10 @@ from dataclasses import dataclass
 from typing import Any
 
 import jwt as jose_jwt
-from cryptography.hazmat.primitives import serialization
 from fastapi import HTTPException, Request, status
 
-from mcp_proxy.auth.local_issuer import (
-    LOCAL_AUDIENCE,
-    LOCAL_ISSUER_PREFIX,
-    LocalIssuer,
-)
+from mcp_proxy.auth.local_issuer import LOCAL_AUDIENCE, LOCAL_ISSUER_PREFIX
+from mcp_proxy.auth.local_keystore import LocalKeyStore
 
 _log = logging.getLogger("mcp_proxy.auth.local_validator")
 
@@ -56,14 +56,23 @@ class LocalTokenError(Exception):
     """Raised when a token fails any validation step."""
 
 
-def validate_local_token(
-    token: str, issuer: LocalIssuer, *, leeway: int = _LEEWAY_SECONDS,
+async def validate_local_token(
+    token: str,
+    keystore: LocalKeyStore,
+    *,
+    expected_issuer: str,
+    leeway: int = _LEEWAY_SECONDS,
 ) -> LocalTokenPayload:
-    """Verify ``token`` against ``issuer``'s public key.
+    """Verify ``token`` against a keystore-resolved public key.
 
-    Raises ``LocalTokenError`` with a short reason on any failure. The
-    caller is responsible for turning it into an HTTP 401 (see
-    ``require_local_token``).
+    The ``kid`` in the JWT header is used to look up the signing key
+    in ``keystore``. An unknown or expired kid is rejected. The caller
+    supplies ``expected_issuer`` (typically
+    ``f"cullis-mastio:{org_id}"``) so the validator can enforce the
+    ``iss`` claim without taking a second dependency on the issuer
+    object.
+
+    Raises ``LocalTokenError`` with a short reason on any failure.
     """
     try:
         header = jose_jwt.get_unverified_header(token)
@@ -72,23 +81,24 @@ def validate_local_token(
 
     if header.get("alg") != "ES256":
         raise LocalTokenError(f"unexpected alg: {header.get('alg')}")
-    if header.get("kid") != issuer.kid:
-        raise LocalTokenError(
-            f"kid mismatch (got {header.get('kid')!r}, expect {issuer.kid!r})"
-        )
 
-    pub_pem = issuer._leaf_pubkey_pem  # noqa: SLF001 — one-process trust boundary
-    # Sanity: the PEM must parse. If the issuer was mis-initialized this
-    # raises at decode time; turning it into a 401 here is fine.
-    serialization.load_pem_public_key(pub_pem.encode())
+    kid = header.get("kid")
+    if not isinstance(kid, str) or not kid:
+        raise LocalTokenError("kid missing from header")
+
+    key = await keystore.find_by_kid(kid)
+    if key is None:
+        raise LocalTokenError(f"unknown kid: {kid!r}")
+    if not key.is_valid_for_verification:
+        raise LocalTokenError(f"kid {kid!r} is no longer valid")
 
     try:
         claims = jose_jwt.decode(
             token,
-            pub_pem,
+            key.pubkey_pem,
             algorithms=["ES256"],
             audience=LOCAL_AUDIENCE,
-            issuer=issuer.issuer,
+            issuer=expected_issuer,
             options={"require": ["exp", "iat", "sub", "aud", "iss", "scope", "jti"]},
             leeway=leeway,
         )
@@ -125,12 +135,19 @@ def validate_local_token(
 async def require_local_token(request: Request) -> LocalTokenPayload:
     """FastAPI dependency — extract+validate a Bearer LOCAL_TOKEN.
 
-    The token is read from ``Authorization: Bearer <jwt>``. 401 on any
-    failure, 503 if the issuer isn't wired up (mastio identity didn't
-    load yet — the wiring PR will pin hard availability expectations).
+    Reads the Bearer token from ``Authorization``. 401 on any failure,
+    503 if the keystore or issuer aren't wired up yet (Mastio identity
+    didn't load — the lifespan has not completed).
     """
+    keystore: LocalKeyStore | None = getattr(
+        request.app.state, "local_keystore", None,
+    )
+    # The issuer is still consulted — purely to obtain ``org_id`` and
+    # so the validator can enforce ``iss``. Tests that stub the state
+    # manually must set both ``local_keystore`` and ``local_issuer``.
+    from mcp_proxy.auth.local_issuer import LocalIssuer  # local import to avoid cycle
     issuer: LocalIssuer | None = getattr(request.app.state, "local_issuer", None)
-    if issuer is None:
+    if keystore is None or issuer is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="local issuer not initialized",
@@ -152,7 +169,9 @@ async def require_local_token(request: Request) -> LocalTokenPayload:
         )
 
     try:
-        return validate_local_token(token, issuer)
+        return await validate_local_token(
+            token, keystore, expected_issuer=issuer.issuer,
+        )
     except LocalTokenError as exc:
         _log.info("local token rejected: %s", exc)
         raise HTTPException(

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -410,6 +410,107 @@ async def set_config(key: str, value: str) -> None:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Mastio keys (ADR-012 Phase 2.0 multi-key store, issue #261)
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def insert_mastio_key(
+    *,
+    kid: str,
+    pubkey_pem: str,
+    privkey_pem: str,
+    cert_pem: str | None = None,
+    created_at: str,
+    activated_at: str | None = None,
+    deprecated_at: str | None = None,
+    expires_at: str | None = None,
+) -> None:
+    """Insert a new row into ``mastio_keys``.
+
+    Raises the underlying DBAPI error on duplicate ``kid`` (primary key).
+    Timestamps are stored as ISO-8601 UTC strings to match the rest of
+    the proxy schema.
+    """
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mastio_keys
+                    (kid, pubkey_pem, privkey_pem, cert_pem, created_at,
+                     activated_at, deprecated_at, expires_at)
+                VALUES
+                    (:kid, :pub, :priv, :cert, :created,
+                     :activated, :deprecated, :expires)
+                """
+            ),
+            {
+                "kid": kid,
+                "pub": pubkey_pem,
+                "priv": privkey_pem,
+                "cert": cert_pem,
+                "created": created_at,
+                "activated": activated_at,
+                "deprecated": deprecated_at,
+                "expires": expires_at,
+            },
+        )
+
+
+async def get_mastio_key_by_kid(kid: str) -> dict | None:
+    """Fetch a single mastio key row by kid."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT * FROM mastio_keys WHERE kid = :kid"),
+            {"kid": kid},
+        )
+        row = result.mappings().first()
+        return dict(row) if row else None
+
+
+async def get_mastio_keys_active() -> list[dict]:
+    """All rows that are the current signer (activated, not deprecated).
+
+    The invariant is exactly one; callers raise on 0 or >1. The query
+    returns a list so the caller can surface a clear error rather than
+    a silent ``.first()`` miss.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT * FROM mastio_keys
+                 WHERE activated_at IS NOT NULL
+                   AND deprecated_at IS NULL
+                 ORDER BY activated_at ASC
+                """
+            )
+        )
+        return [dict(row) for row in result.mappings().all()]
+
+
+async def get_mastio_keys_valid() -> list[dict]:
+    """All rows still accepted for token verification.
+
+    An activated key stays valid until its ``expires_at`` (if set) has
+    passed. Deprecated-but-not-yet-expired keys remain in the set —
+    that is the grace-period mechanic used by the verifier during
+    rotation (Phase 2.2). Never-activated rows are excluded.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT * FROM mastio_keys
+                 WHERE activated_at IS NOT NULL
+                   AND (expires_at IS NULL OR expires_at > :now)
+                 ORDER BY activated_at ASC
+                """
+            ),
+            {"now": datetime.now(timezone.utc).isoformat()},
+        )
+        return [dict(row) for row in result.mappings().all()]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -102,6 +102,43 @@ class ProxyConfig(Base):
     value = Column(Text, nullable=False)
 
 
+class MastioKeyRow(Base):
+    """ADR-012 Phase 2.0 — multi-key store for the Mastio ES256 identity.
+
+    A row per historical ES256 leaf keypair. Exactly one row has
+    ``activated_at IS NOT NULL AND deprecated_at IS NULL`` at any time:
+    that is the current signer used by ``LocalIssuer`` and by the
+    ADR-009 counter-signature path.
+
+    Timestamps are ISO-8601 UTC strings (``Text``), matching the
+    convention used by ``internal_agents`` and ``pending_enrollments``.
+    """
+    __tablename__ = "mastio_keys"
+
+    # Deterministic ``mastio-<sha256(pubkey_pem)[:16]>`` — the ``kid``
+    # that the LocalIssuer stamps into JWT headers.
+    kid = Column(Text, primary_key=True)
+    pubkey_pem = Column(Text, nullable=False)
+    privkey_pem = Column(Text, nullable=False)
+    # The X.509 leaf cert currently chained under this key. Nullable so
+    # the CA can re-issue without churning the key, but in practice
+    # ``ensure_mastio_identity`` always writes them together.
+    cert_pem = Column(Text, nullable=True)
+    created_at = Column(Text, nullable=False)
+    # Set when the key becomes the current signer. NULL = never activated
+    # (staged only, will be unusual until rotation lands in Phase 2.1).
+    activated_at = Column(Text, nullable=True)
+    # Set when a newer key takes over. NULL while this key is current.
+    deprecated_at = Column(Text, nullable=True)
+    # After this timestamp the verifier stops accepting this key.
+    # NULL = never expires (legacy / single-key mode).
+    expires_at = Column(Text, nullable=True)
+
+    __table_args__ = (
+        Index("idx_mastio_keys_active", "activated_at", "deprecated_at"),
+    )
+
+
 class PendingEnrollment(Base):
     """Connector enrollment requests awaiting admin decision.
 

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -22,12 +22,14 @@ from cryptography.x509 import (
 from cryptography.x509.oid import NameOID
 
 from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey, compute_kid
 from mcp_proxy.config import get_settings, vault_tls_verify
 from mcp_proxy.db import (
     create_agent as db_create_agent,
     deactivate_agent as db_deactivate_agent,
     get_agent as db_get_agent,
     get_config,
+    insert_mastio_key,
     set_config,
 )
 
@@ -59,12 +61,19 @@ class AgentManager:
         self._trust_domain = trust_domain
         self._org_ca_key: rsa.RSAPrivateKey | None = None
         self._org_ca_cert: x509.Certificate | None = None
-        # ADR-009 Phase 1 — Mastio CA (intermediate) + leaf identity.
-        # Generated lazily at boot via ``ensure_mastio_identity()``.
+        # ADR-009 Phase 1 — Mastio CA (intermediate). Persisted in
+        # ``proxy_config.mastio_ca_{key,cert}``, loaded lazily at boot
+        # via ``ensure_mastio_identity()``.
         self._mastio_ca_key: ec.EllipticCurvePrivateKey | None = None
         self._mastio_ca_cert: x509.Certificate | None = None
-        self._mastio_leaf_key: ec.EllipticCurvePrivateKey | None = None
-        self._mastio_leaf_cert: x509.Certificate | None = None
+        # ADR-012 Phase 2.0 — the active leaf ``MastioKey`` pulled from
+        # the keystore. Exposes ``cert_pem`` / ``pubkey_pem`` /
+        # ``privkey_pem`` + ``load_private_key()`` for the ADR-009
+        # counter-signature path. Rotation (Phase 2.1) will invalidate
+        # this cache; callers invoke ``refresh_active_key()`` to pick
+        # up the new row.
+        self._keystore = LocalKeyStore()
+        self._active_key: MastioKey | None = None
 
     # ── CA loading ──────────────────────────────────────────────────
 
@@ -438,22 +447,30 @@ class AgentManager:
     def mastio_loaded(self) -> bool:
         return (
             self._mastio_ca_cert is not None
-            and self._mastio_leaf_cert is not None
-            and self._mastio_leaf_key is not None
+            and self._active_key is not None
         )
+
+    async def refresh_active_key(self) -> None:
+        """Re-read the active Mastio leaf from the keystore.
+
+        Called by the proxy lifespan after a Phase 2.1 rotation event so
+        cached holders (issuer, counter-sign path) can observe the new
+        current signer.
+        """
+        self._active_key = await self._keystore.current_signer()
 
     async def ensure_mastio_identity(self) -> None:
         """Load or generate the Mastio CA + leaf identity (EC P-256 / ES256).
 
-        Persisted in ``proxy_config`` under keys ``mastio_ca_key``,
-        ``mastio_ca_cert``, ``mastio_leaf_key``, ``mastio_leaf_cert``. Idempotent:
-        if all four are already present, it loads them; otherwise it generates
-        a fresh intermediate CA signed by the Org CA (``pathLen=0`` — leaves
-        only) and a fresh leaf signed by the Mastio CA. Required before the
-        proxy can counter-sign Court requests.
+        Intermediate CA lives in ``proxy_config`` under
+        ``mastio_ca_key`` / ``mastio_ca_cert``. The leaf key + cert live
+        in ``mastio_keys`` (ADR-012 Phase 2.0) as a row that is either
+        active (current signer) or deprecated-in-grace. Idempotent:
+        when both CA and an active key exist the method just caches
+        them; otherwise it mints whichever piece is missing.
 
-        Raises ``RuntimeError`` if the Org CA is not loaded — the caller must
-        gate on :attr:`ca_loaded`.
+        Raises ``RuntimeError`` if the Org CA is not loaded — the caller
+        must gate on :attr:`ca_loaded`.
         """
         if not self.ca_loaded:
             raise RuntimeError(
@@ -462,35 +479,48 @@ class AgentManager:
 
         ca_key_pem = await get_config("mastio_ca_key")
         ca_cert_pem = await get_config("mastio_ca_cert")
-        leaf_key_pem = await get_config("mastio_leaf_key")
-        leaf_cert_pem = await get_config("mastio_leaf_cert")
 
-        if ca_key_pem and ca_cert_pem and leaf_key_pem and leaf_cert_pem:
+        if ca_key_pem and ca_cert_pem:
             self._mastio_ca_key = serialization.load_pem_private_key(
                 ca_key_pem.encode(), password=None,
             )
             self._mastio_ca_cert = x509.load_pem_x509_certificate(
                 ca_cert_pem.encode(),
             )
-            self._mastio_leaf_key = serialization.load_pem_private_key(
-                leaf_key_pem.encode(), password=None,
-            )
-            self._mastio_leaf_cert = x509.load_pem_x509_certificate(
-                leaf_cert_pem.encode(),
-            )
-            logger.info("Mastio identity loaded from proxy_config")
+
+        try:
+            self._active_key = await self._keystore.current_signer()
+        except RuntimeError:
+            self._active_key = None
+
+        if self.mastio_loaded:
+            logger.info("Mastio identity loaded (ca + active key)")
             return
 
         await self._generate_mastio_identity()
 
     async def _generate_mastio_identity(self) -> None:
-        """Mint a fresh Mastio CA (intermediate) + leaf cert, persist both."""
+        """Mint whichever Mastio pieces are missing — CA and/or leaf.
+
+        Runs idempotently against partial state so a crashed boot (CA
+        persisted, leaf insert failed) or a planned key rotation can
+        complete the identity without re-rooting the intermediate.
+        """
         now = datetime.now(timezone.utc)
 
-        # Intermediate CA — EC P-256, pathLen=0 (cannot sign further CAs).
-        # 3y validity: online signer intended to be rotated ahead of expiry
-        # (NIST SP 800-57 Part 1 §5.3.6 guidance for signing keys in active
-        # use). Automatic rotation is tracked in issue #261.
+        if self._mastio_ca_key is None or self._mastio_ca_cert is None:
+            await self._mint_mastio_ca(now)
+
+        if self._active_key is None:
+            await self._mint_mastio_leaf(now)
+
+    async def _mint_mastio_ca(self, now: datetime) -> None:
+        """Mint a fresh EC P-256 intermediate CA and persist it.
+
+        3y validity: online signer intended to be rotated ahead of
+        expiry (NIST SP 800-57 Part 1 §5.3.6 guidance for signing keys
+        in active use). Automatic rotation is tracked in issue #261.
+        """
         mastio_ca_key = ec.generate_private_key(ec.SECP256R1())
         mastio_ca_subject = x509.Name([
             x509.NameAttribute(NameOID.COMMON_NAME, f"{self._org_id} Mastio CA"),
@@ -529,7 +559,24 @@ class AgentManager:
             .sign(self._org_ca_key, hashes.SHA256())
         )
 
-        # Leaf — EC P-256, SAN SPIFFE URI under /proxy/{org}.
+        await set_config("mastio_ca_key", _priv_to_pem(mastio_ca_key))
+        await set_config("mastio_ca_cert", _cert_to_pem(mastio_ca_cert))
+        self._mastio_ca_key = mastio_ca_key
+        self._mastio_ca_cert = mastio_ca_cert
+        logger.info("Mastio intermediate CA minted (CN=%s)", mastio_ca_subject)
+
+    async def _mint_mastio_leaf(self, now: datetime) -> None:
+        """Mint a fresh EC P-256 leaf under the existing intermediate CA.
+
+        The keypair + cert are inserted into ``mastio_keys`` with
+        ``activated_at=now`` (no previous active row in the Phase 2.0
+        cold-start path — multi-row transitions land in Phase 2.1).
+        The cached ``self._active_key`` is refreshed so subsequent
+        signing / counter-signing calls see the new row.
+        """
+        if self._mastio_ca_key is None or self._mastio_ca_cert is None:
+            raise RuntimeError("Mastio CA not loaded — cannot sign leaf")
+
         leaf_key = ec.generate_private_key(ec.SECP256R1())
         proxy_spiffe = f"spiffe://{self._trust_domain}/proxy/{self._org_id}"
         leaf_subject = x509.Name([
@@ -539,7 +586,7 @@ class AgentManager:
         leaf_cert = (
             x509.CertificateBuilder()
             .subject_name(leaf_subject)
-            .issuer_name(mastio_ca_cert.subject)
+            .issuer_name(self._mastio_ca_cert.subject)
             .public_key(leaf_key.public_key())
             .serial_number(x509.random_serial_number())
             .not_valid_before(now - timedelta(minutes=5))
@@ -552,59 +599,70 @@ class AgentManager:
                 x509.BasicConstraints(ca=False, path_length=None),
                 critical=True,
             )
-            .sign(mastio_ca_key, hashes.SHA256())
+            .sign(self._mastio_ca_key, hashes.SHA256())
         )
 
-        # Persist.
-        await set_config("mastio_ca_key", _priv_to_pem(mastio_ca_key))
-        await set_config("mastio_ca_cert", _cert_to_pem(mastio_ca_cert))
-        await set_config("mastio_leaf_key", _priv_to_pem(leaf_key))
-        await set_config("mastio_leaf_cert", _cert_to_pem(leaf_cert))
+        priv_pem = _priv_to_pem(leaf_key)
+        cert_pem = _cert_to_pem(leaf_cert)
+        pub_pem = leaf_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        kid = compute_kid(pub_pem)
+        now_iso = now.isoformat()
 
-        self._mastio_ca_key = mastio_ca_key
-        self._mastio_ca_cert = mastio_ca_cert
-        self._mastio_leaf_key = leaf_key
-        self._mastio_leaf_cert = leaf_cert
+        await insert_mastio_key(
+            kid=kid,
+            pubkey_pem=pub_pem,
+            privkey_pem=priv_pem,
+            cert_pem=cert_pem,
+            created_at=now_iso,
+            activated_at=now_iso,
+        )
+        self._active_key = await self._keystore.find_by_kid(kid)
 
         logger.info(
-            "Mastio identity generated — CA=%s, leaf SAN=%s",
-            mastio_ca_subject, proxy_spiffe,
+            "Mastio leaf minted — kid=%s, SAN=%s", kid, proxy_spiffe,
         )
+
+    def _require_active(self) -> MastioKey:
+        if self._active_key is None or self._mastio_ca_cert is None:
+            raise RuntimeError(
+                "Mastio identity not loaded — call ensure_mastio_identity() first",
+            )
+        return self._active_key
 
     def get_mastio_credentials(self) -> tuple[str, str]:
         """Return ``(leaf_cert_pem, leaf_key_pem)`` for counter-signing.
 
-        Raises ``RuntimeError`` if :meth:`ensure_mastio_identity` has not run.
+        Raises ``RuntimeError`` if :meth:`ensure_mastio_identity` has not run,
+        or if the active keystore row lacks an accompanying cert (partial
+        state that shouldn't occur in normal operation).
         """
-        if not self.mastio_loaded:
+        active = self._require_active()
+        if active.cert_pem is None:
             raise RuntimeError(
-                "Mastio identity not loaded — call ensure_mastio_identity() first",
+                f"active mastio key {active.kid!r} has no cert_pem",
             )
-        return _cert_to_pem(self._mastio_leaf_cert), _priv_to_pem(self._mastio_leaf_key)
+        return active.cert_pem, active.privkey_pem
 
     def get_mastio_pubkey_pem(self) -> str:
         """Return the leaf EC P-256 public key in PEM format.
 
         This is what gets pinned to the Court at onboarding (join/attach
-        ``mastio_pubkey``). The Court verifies the counter-signature header
-        against this key.
+        ``mastio_pubkey``). The Court verifies the counter-signature
+        header against this key.
         """
-        if not self.mastio_loaded:
-            raise RuntimeError(
-                "Mastio identity not loaded — call ensure_mastio_identity() first",
-            )
-        return self._mastio_leaf_cert.public_key().public_bytes(
-            serialization.Encoding.PEM,
-            serialization.PublicFormat.SubjectPublicKeyInfo,
-        ).decode()
+        return self._require_active().pubkey_pem
 
     def countersign(self, data: bytes) -> str:
         """ES256 counter-signature over ``data``, base64url no-pad.
 
-        Used by ``BrokerBridge`` to attest every ``/v1/auth/token`` call as
-        proxied through this mastio. The signature goes into the
-        ``X-Cullis-Mastio-Signature`` header; the Court verifies it against
-        the PEM pinned at onboarding in ``organizations.mastio_pubkey``.
+        Used by ``BrokerBridge`` to attest every ``/v1/auth/token`` call
+        as proxied through this mastio. The signature goes into the
+        ``X-Cullis-Mastio-Signature`` header; the Court verifies it
+        against the PEM pinned at onboarding in
+        ``organizations.mastio_pubkey``.
 
         Raises ``RuntimeError`` if :meth:`ensure_mastio_identity` has not run.
         """
@@ -612,11 +670,9 @@ class AgentManager:
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.asymmetric import ec as _ec
 
-        if not self.mastio_loaded:
-            raise RuntimeError(
-                "Mastio identity not loaded — call ensure_mastio_identity() first",
-            )
-        sig = self._mastio_leaf_key.sign(data, _ec.ECDSA(hashes.SHA256()))
+        active = self._require_active()
+        priv_key = active.load_private_key()
+        sig = priv_key.sign(data, _ec.ECDSA(hashes.SHA256()))
         return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
 
     # ── Credential retrieval ────────────────────────────────────────

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -493,11 +493,62 @@ class AgentManager:
         except RuntimeError:
             self._active_key = None
 
+        # ADR-012 Phase 2.0 — one-shot data migration from the pre-2.0
+        # ``proxy_config.mastio_leaf_{key,cert}`` pair to the
+        # ``mastio_keys`` table. Kept out of the Alembic migration so
+        # schema bootstrap doesn't need to parse PEMs (the standalone
+        # proxy-init container ships an alembic-only environment).
+        if self._active_key is None:
+            await self._migrate_legacy_leaf_to_keystore()
+            try:
+                self._active_key = await self._keystore.current_signer()
+            except RuntimeError:
+                self._active_key = None
+
         if self.mastio_loaded:
             logger.info("Mastio identity loaded (ca + active key)")
             return
 
         await self._generate_mastio_identity()
+
+    async def _migrate_legacy_leaf_to_keystore(self) -> None:
+        """Seed ``mastio_keys`` from ``proxy_config.mastio_leaf_{key,cert}``.
+
+        No-op when the legacy rows are absent or already migrated.
+        Idempotent: leaves the legacy rows in place so a rollback only
+        needs to drop the new table.
+        """
+        leaf_key_pem = await get_config("mastio_leaf_key")
+        leaf_cert_pem = await get_config("mastio_leaf_cert")
+        if not leaf_key_pem or not leaf_cert_pem:
+            return
+        try:
+            cert = x509.load_pem_x509_certificate(leaf_cert_pem.encode())
+        except ValueError:
+            logger.warning(
+                "Legacy mastio_leaf_cert is malformed — skipping migration; "
+                "a fresh identity will be generated",
+            )
+            return
+        pubkey_pem = cert.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        kid = compute_kid(pubkey_pem)
+        if await self._keystore.find_by_kid(kid) is not None:
+            return
+        now_iso = datetime.now(timezone.utc).isoformat()
+        await insert_mastio_key(
+            kid=kid,
+            pubkey_pem=pubkey_pem,
+            privkey_pem=leaf_key_pem,
+            cert_pem=leaf_cert_pem,
+            created_at=now_iso,
+            activated_at=now_iso,
+        )
+        logger.info(
+            "Migrated legacy mastio leaf into mastio_keys (kid=%s)", kid,
+        )
 
     async def _generate_mastio_identity(self) -> None:
         """Mint whichever Mastio pieces are missing — CA and/or leaf.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -163,16 +163,20 @@ async def lifespan(app: FastAPI):
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
 
-    # ADR-012 Phase 1 — local JWT issuer. Signs intra-org session tokens
-    # with the Mastio leaf key so the Court never sees login traffic for
-    # MCP/intra-org operations. Requires the Mastio identity to be loaded;
-    # degrades soft (``local_issuer = None``) otherwise so lifespan never
-    # blocks on this.
+    # ADR-012 Phase 2.0 — keystore + issuer. The keystore is always
+    # available (pure DB read view), the issuer requires that the Mastio
+    # identity has loaded a current signer. The validator dependency
+    # expects both on ``app.state``, so we publish them together and
+    # degrade soft (both None) if identity bootstrap failed above.
+    from mcp_proxy.auth.local_keystore import LocalKeyStore
+    app.state.local_keystore = LocalKeyStore()
     app.state.local_issuer = None
     if getattr(agent_mgr, "mastio_loaded", False) and org_id:
         try:
-            from mcp_proxy.auth.local_issuer import build_from_agent_manager
-            app.state.local_issuer = build_from_agent_manager(org_id, agent_mgr)
+            from mcp_proxy.auth.local_issuer import build_from_keystore
+            app.state.local_issuer = await build_from_keystore(
+                org_id, app.state.local_keystore,
+            )
             _log.info(
                 "LocalIssuer initialized (kid=%s, iss=%s)",
                 app.state.local_issuer.kid, app.state.local_issuer.issuer,

--- a/tests/test_proxy_egress_local_token.py
+++ b/tests/test_proxy_egress_local_token.py
@@ -24,6 +24,7 @@ from fastapi.testclient import TestClient
 
 from mcp_proxy.auth.dpop_api_key import get_agent_from_dpop_api_key
 from mcp_proxy.auth.local_issuer import LocalIssuer
+from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey, compute_kid
 from mcp_proxy.models import InternalAgent
 
 
@@ -50,15 +51,33 @@ async def egress_app_flag_on(tmp_path, monkeypatch):
         api_key_hash=hash_api_key(raw),
     )
 
+    from datetime import datetime, timezone
+
     key = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
     pub_pem = key.public_key().public_bytes(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
-    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    kid = compute_kid(pub_pem)
+    now = datetime.now(timezone.utc)
+    await db_mod.insert_mastio_key(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem,
+        created_at=now.isoformat(), activated_at=now.isoformat(),
+    )
+    active = MastioKey(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem, cert_pem=None,
+        created_at=now, activated_at=now, deprecated_at=None, expires_at=None,
+    )
+    issuer = LocalIssuer(org_id="orga", active_key=active)
 
     app = FastAPI()
     app.state.local_issuer = issuer
+    app.state.local_keystore = LocalKeyStore()
 
     @app.get("/egress/probe")
     async def probe(agent: InternalAgent = Depends(get_agent_from_dpop_api_key)):
@@ -115,6 +134,7 @@ async def test_egress_rejects_bearer_when_flag_off(tmp_path, monkeypatch):
 
     app = FastAPI()
     app.state.local_issuer = None
+    app.state.local_keystore = None
 
     @app.get("/egress/probe")
     async def probe(agent: InternalAgent = Depends(get_agent_from_dpop_api_key)):

--- a/tests/test_proxy_local_agent_dep.py
+++ b/tests/test_proxy_local_agent_dep.py
@@ -20,6 +20,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from mcp_proxy.auth.local_issuer import LocalIssuer
+from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey, compute_kid
 from mcp_proxy.auth.dependencies import get_authenticated_agent
 from mcp_proxy.models import TokenPayload
 
@@ -56,15 +57,33 @@ async def app_with_flag_on(tmp_path, monkeypatch):
         api_key_hash=hash_api_key(raw),
     )
 
+    from datetime import datetime, timezone
+
     key = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
     pub_pem = key.public_key().public_bytes(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
-    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    kid = compute_kid(pub_pem)
+    now = datetime.now(timezone.utc)
+    await db_mod.insert_mastio_key(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem,
+        created_at=now.isoformat(), activated_at=now.isoformat(),
+    )
+    active = MastioKey(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem, cert_pem=None,
+        created_at=now, activated_at=now, deprecated_at=None, expires_at=None,
+    )
+    issuer = LocalIssuer(org_id="orga", active_key=active)
 
     app = FastAPI()
     app.state.local_issuer = issuer
+    app.state.local_keystore = LocalKeyStore()
 
     @app.get("/probe")
     async def probe(agent: TokenPayload = pytest.importorskip("fastapi").Depends(get_authenticated_agent)):  # type: ignore[valid-type]
@@ -159,6 +178,7 @@ async def app_with_flag_off(tmp_path, monkeypatch):
 
     app = FastAPI()
     app.state.local_issuer = None
+    app.state.local_keystore = None
 
     @app.get("/probe")
     async def probe(agent: TokenPayload = pytest.importorskip("fastapi").Depends(get_authenticated_agent)):  # type: ignore[valid-type]

--- a/tests/test_proxy_local_issuer.py
+++ b/tests/test_proxy_local_issuer.py
@@ -1,16 +1,19 @@
-"""ADR-012 Phase 1 — unit tests for ``LocalIssuer`` and the
+"""ADR-012 Phase 1 / Phase 2.0 — unit tests for ``LocalIssuer`` and the
 ``/.well-known/jwks-local.json`` endpoint.
 
 The issuer is the primitive behind every intra-org session token. These
 tests pin the wire format (ES256 claims, kid derivation, JWKS shape) so
-future refactors can't silently break the contract the validator will
-depend on in Phase 4.
+future refactors can't silently break the contract the validator depends
+on. Phase 2.0 shifts the issuer from holding its own leaf key+pubkey
+pair to wrapping a ``MastioKey`` pulled from the keystore; the tests
+reflect that change but keep the same wire-level assertions.
 """
 from __future__ import annotations
 
 import base64
 import hashlib
 import time
+from datetime import datetime, timezone
 
 import jwt as jose_jwt
 import pytest
@@ -24,24 +27,44 @@ from mcp_proxy.auth.local_issuer import (
     LOCAL_ISSUER_PREFIX,
     LOCAL_SCOPE,
     LocalIssuer,
-    build_from_agent_manager,
 )
+from mcp_proxy.auth.local_keystore import MastioKey, compute_kid
 
 
-def _fresh_key() -> tuple[ec.EllipticCurvePrivateKey, str]:
-    key = ec.generate_private_key(ec.SECP256R1())
-    pub_pem = key.public_key().public_bytes(
+def _fresh_key() -> tuple[ec.EllipticCurvePrivateKey, str, str]:
+    """Return ``(priv_key_obj, priv_pem, pub_pem)`` for a fresh EC P-256 key."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
-    return key, pub_pem
+    return priv, priv_pem, pub_pem
+
+
+def _active_key(priv_pem: str, pub_pem: str) -> MastioKey:
+    """Build an in-memory active ``MastioKey`` without touching the DB."""
+    now = datetime.now(timezone.utc)
+    return MastioKey(
+        kid=compute_kid(pub_pem),
+        pubkey_pem=pub_pem,
+        privkey_pem=priv_pem,
+        cert_pem=None,
+        created_at=now,
+        activated_at=now,
+        deprecated_at=None,
+        expires_at=None,
+    )
 
 
 def _decode_with_issuer(token: str, issuer: LocalIssuer) -> dict:
-    pub_pem = issuer._leaf_pubkey_pem  # noqa: SLF001 — test-only introspection
     return jose_jwt.decode(
         token,
-        pub_pem,
+        issuer.active_key.pubkey_pem,
         algorithms=["ES256"],
         audience=LOCAL_AUDIENCE,
         issuer=issuer.issuer,
@@ -49,8 +72,8 @@ def _decode_with_issuer(token: str, issuer: LocalIssuer) -> dict:
 
 
 def test_issue_produces_decodable_es256_token_with_expected_claims():
-    key, pub_pem = _fresh_key()
-    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    _, priv_pem, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", active_key=_active_key(priv_pem, pub_pem))
 
     before = int(time.time())
     result = issuer.issue("orga::alice", ttl_seconds=60)
@@ -75,12 +98,12 @@ def test_issue_produces_decodable_es256_token_with_expected_claims():
 
 
 def test_kid_is_stable_for_same_pubkey_and_unique_across_keys():
-    key1, pub1 = _fresh_key()
-    key2, pub2 = _fresh_key()
+    _, priv1, pub1 = _fresh_key()
+    _, priv2, pub2 = _fresh_key()
 
-    issuer1a = LocalIssuer(org_id="orga", leaf_key=key1, leaf_pubkey_pem=pub1)
-    issuer1b = LocalIssuer(org_id="orga", leaf_key=key1, leaf_pubkey_pem=pub1)
-    issuer2 = LocalIssuer(org_id="orga", leaf_key=key2, leaf_pubkey_pem=pub2)
+    issuer1a = LocalIssuer(org_id="orga", active_key=_active_key(priv1, pub1))
+    issuer1b = LocalIssuer(org_id="orga", active_key=_active_key(priv1, pub1))
+    issuer2 = LocalIssuer(org_id="orga", active_key=_active_key(priv2, pub2))
 
     assert issuer1a.kid == issuer1b.kid
     assert issuer1a.kid != issuer2.kid
@@ -90,8 +113,8 @@ def test_kid_is_stable_for_same_pubkey_and_unique_across_keys():
 
 
 def test_extra_claims_cannot_overwrite_reserved_fields():
-    key, pub_pem = _fresh_key()
-    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    _, priv_pem, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", active_key=_active_key(priv_pem, pub_pem))
 
     extra = {
         "iss": "attacker",
@@ -117,8 +140,8 @@ def test_extra_claims_cannot_overwrite_reserved_fields():
 
 
 def test_issue_rejects_invalid_inputs():
-    key, pub_pem = _fresh_key()
-    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    _, priv_pem, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", active_key=_active_key(priv_pem, pub_pem))
 
     with pytest.raises(ValueError):
         issuer.issue("", ttl_seconds=60)
@@ -131,18 +154,26 @@ def test_issue_rejects_invalid_inputs():
 
 
 def test_constructor_rejects_bad_inputs():
-    key, pub_pem = _fresh_key()
+    _, priv_pem, pub_pem = _fresh_key()
     with pytest.raises(ValueError):
-        LocalIssuer(org_id="", leaf_key=key, leaf_pubkey_pem=pub_pem)
-    with pytest.raises(ValueError):
-        LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem="")
+        LocalIssuer(org_id="", active_key=_active_key(priv_pem, pub_pem))
     with pytest.raises(TypeError):
-        LocalIssuer(org_id="orga", leaf_key="not-a-key", leaf_pubkey_pem=pub_pem)  # type: ignore[arg-type]
+        LocalIssuer(org_id="orga", active_key="not-a-key")  # type: ignore[arg-type]
+
+    # An inactive (never-activated or deprecated) key cannot anchor an issuer.
+    now = datetime.now(timezone.utc)
+    never_active = MastioKey(
+        kid=compute_kid(pub_pem), pubkey_pem=pub_pem, privkey_pem=priv_pem,
+        cert_pem=None, created_at=now,
+        activated_at=None, deprecated_at=None, expires_at=None,
+    )
+    with pytest.raises(ValueError, match="not currently active"):
+        LocalIssuer(org_id="orga", active_key=never_active)
 
 
 def test_jwks_roundtrip_matches_leaf_pubkey():
-    key, pub_pem = _fresh_key()
-    issuer = LocalIssuer(org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem)
+    priv, priv_pem, pub_pem = _fresh_key()
+    issuer = LocalIssuer(org_id="orga", active_key=_active_key(priv_pem, pub_pem))
 
     jwks = issuer.jwks()
     assert "keys" in jwks and len(jwks["keys"]) == 1
@@ -161,40 +192,9 @@ def test_jwks_roundtrip_matches_leaf_pubkey():
         pad = "=" * (-len(s) % 4)
         return int.from_bytes(base64.urlsafe_b64decode(s + pad), "big")
 
-    numbers = key.public_key().public_numbers()
+    numbers = priv.public_key().public_numbers()
     assert _unb64u(jwk["x"]) == numbers.x
     assert _unb64u(jwk["y"]) == numbers.y
-
-
-def test_build_from_agent_manager_happy_and_error_paths():
-    key, pub_pem = _fresh_key()
-
-    class _LoadedManager:
-        mastio_loaded = True
-        _mastio_leaf_key = key
-
-        def get_mastio_pubkey_pem(self) -> str:
-            return pub_pem
-
-    issuer = build_from_agent_manager("orga", _LoadedManager())
-    assert issuer.org_id == "orga"
-    assert issuer.kid.startswith("mastio-")
-
-    class _Unloaded:
-        mastio_loaded = False
-
-    with pytest.raises(RuntimeError):
-        build_from_agent_manager("orga", _Unloaded())
-
-    class _NoKey:
-        mastio_loaded = True
-        _mastio_leaf_key = None
-
-        def get_mastio_pubkey_pem(self) -> str:  # pragma: no cover — unreachable
-            return pub_pem
-
-    with pytest.raises(RuntimeError):
-        build_from_agent_manager("orga", _NoKey())
 
 
 def test_jwks_endpoint_returns_key_when_issuer_loaded():
@@ -209,9 +209,9 @@ def test_jwks_endpoint_returns_key_when_issuer_loaded():
         resp = client.get("/.well-known/jwks-local.json")
         assert resp.status_code == 503
 
-        key, pub_pem = _fresh_key()
+        _, priv_pem, pub_pem = _fresh_key()
         app.state.local_issuer = LocalIssuer(
-            org_id="orga", leaf_key=key, leaf_pubkey_pem=pub_pem,
+            org_id="orga", active_key=_active_key(priv_pem, pub_pem),
         )
         resp = client.get("/.well-known/jwks-local.json")
         assert resp.status_code == 200

--- a/tests/test_proxy_local_keystore.py
+++ b/tests/test_proxy_local_keystore.py
@@ -1,0 +1,259 @@
+"""ADR-012 Phase 2.0 — unit tests for ``LocalKeyStore``.
+
+Covers the four public surface points of the keystore: ``current_signer``
+(with both invariant-violation branches), ``find_by_kid``,
+``all_valid_keys`` (including grace-period filtering), and the
+``MastioKey.is_valid_for_verification`` computed property.
+
+The migration itself (0018) has coverage in ``test_proxy_migrations_*``
+by virtue of running on every proxy fixture boot; this file focuses on
+the Python primitive once the table exists.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from mcp_proxy.auth.local_keystore import (
+    LocalKeyStore,
+    MastioKey,
+    compute_kid,
+)
+from mcp_proxy.db import insert_mastio_key
+
+
+def _fresh_keypair() -> tuple[str, str, str]:
+    """Return ``(kid, pubkey_pem, privkey_pem)`` for a fresh EC P-256 key."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return compute_kid(pub_pem), pub_pem, priv_pem
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """Fresh proxy SQLite DB with the ``mastio_keys`` migration applied."""
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import dispose_db, init_db
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+def test_compute_kid_matches_legacy_algorithm():
+    """``compute_kid`` reproduces the pre-2.0 ``LocalIssuer._compute_kid``
+    so rows migrated from ``proxy_config`` keep the kid any already-issued
+    JWT references in its header."""
+    _, pub_pem, _ = _fresh_keypair()
+    expected = "mastio-" + hashlib.sha256(pub_pem.encode()).hexdigest()[:16]
+    assert compute_kid(pub_pem) == expected
+
+
+def test_mastio_key_is_active_only_when_activated_and_not_deprecated():
+    now = datetime.now(timezone.utc)
+    activated = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=now, deprecated_at=None, expires_at=None,
+    )
+    assert activated.is_active is True
+
+    never_activated = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=None, deprecated_at=None, expires_at=None,
+    )
+    assert never_activated.is_active is False
+
+    deprecated = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=now, deprecated_at=now, expires_at=None,
+    )
+    assert deprecated.is_active is False
+
+
+def test_mastio_key_valid_for_verification_honours_expires_at():
+    now = datetime.now(timezone.utc)
+    past = now - timedelta(hours=1)
+    future = now + timedelta(hours=1)
+
+    never_activated = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=None, deprecated_at=None, expires_at=None,
+    )
+    assert never_activated.is_valid_for_verification is False
+
+    no_expiry = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=past, deprecated_at=None, expires_at=None,
+    )
+    assert no_expiry.is_valid_for_verification is True
+
+    within_grace = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=past, deprecated_at=past,
+        expires_at=future,
+    )
+    assert within_grace.is_valid_for_verification is True
+
+    grace_elapsed = MastioKey(
+        kid="k", pubkey_pem="", privkey_pem="", cert_pem=None,
+        created_at=now, activated_at=past, deprecated_at=past,
+        expires_at=past,
+    )
+    assert grace_elapsed.is_valid_for_verification is False
+
+
+@pytest.mark.asyncio
+async def test_current_signer_raises_when_no_active_key(proxy_db):
+    store = LocalKeyStore()
+    with pytest.raises(RuntimeError, match="no active mastio key"):
+        await store.current_signer()
+
+
+@pytest.mark.asyncio
+async def test_current_signer_returns_the_single_active_row(proxy_db):
+    kid, pub, priv = _fresh_keypair()
+    now = datetime.now(timezone.utc)
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_iso(now), activated_at=_iso(now),
+    )
+    store = LocalKeyStore()
+    current = await store.current_signer()
+    assert current.kid == kid
+    assert current.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_current_signer_raises_when_multiple_active(proxy_db):
+    now = datetime.now(timezone.utc)
+    for _ in range(2):
+        kid, pub, priv = _fresh_keypair()
+        await insert_mastio_key(
+            kid=kid, pubkey_pem=pub, privkey_pem=priv,
+            created_at=_iso(now), activated_at=_iso(now),
+        )
+    store = LocalKeyStore()
+    with pytest.raises(RuntimeError, match="rotation invariant violated"):
+        await store.current_signer()
+
+
+@pytest.mark.asyncio
+async def test_find_by_kid_returns_none_for_unknown_kid(proxy_db):
+    store = LocalKeyStore()
+    assert await store.find_by_kid("mastio-deadbeefdeadbeef") is None
+
+
+@pytest.mark.asyncio
+async def test_find_by_kid_returns_row_even_when_deprecated(proxy_db):
+    """The verifier must still see deprecated keys to accept grace-period
+    tokens — ``find_by_kid`` does not filter on ``deprecated_at``."""
+    kid, pub, priv = _fresh_keypair()
+    now = datetime.now(timezone.utc)
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_iso(now - timedelta(days=30)),
+        activated_at=_iso(now - timedelta(days=30)),
+        deprecated_at=_iso(now - timedelta(days=1)),
+        expires_at=_iso(now + timedelta(days=6)),
+    )
+    store = LocalKeyStore()
+    found = await store.find_by_kid(kid)
+    assert found is not None
+    assert found.kid == kid
+    assert found.is_active is False
+    assert found.is_valid_for_verification is True
+
+
+@pytest.mark.asyncio
+async def test_all_valid_keys_excludes_expired_rows(proxy_db):
+    now = datetime.now(timezone.utc)
+    # Active
+    kid_active, pub_a, priv_a = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid_active, pubkey_pem=pub_a, privkey_pem=priv_a,
+        created_at=_iso(now), activated_at=_iso(now),
+    )
+    # Deprecated but in grace window → still valid
+    kid_grace, pub_g, priv_g = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid_grace, pubkey_pem=pub_g, privkey_pem=priv_g,
+        created_at=_iso(now - timedelta(days=10)),
+        activated_at=_iso(now - timedelta(days=10)),
+        deprecated_at=_iso(now - timedelta(hours=1)),
+        expires_at=_iso(now + timedelta(days=5)),
+    )
+    # Deprecated and expired → filtered out
+    kid_expired, pub_e, priv_e = _fresh_keypair()
+    await insert_mastio_key(
+        kid=kid_expired, pubkey_pem=pub_e, privkey_pem=priv_e,
+        created_at=_iso(now - timedelta(days=400)),
+        activated_at=_iso(now - timedelta(days=400)),
+        deprecated_at=_iso(now - timedelta(days=30)),
+        expires_at=_iso(now - timedelta(days=1)),
+    )
+
+    store = LocalKeyStore()
+    valid = await store.all_valid_keys()
+    kids = {k.kid for k in valid}
+    assert kid_active in kids
+    assert kid_grace in kids
+    assert kid_expired not in kids
+
+
+@pytest.mark.asyncio
+async def test_mastio_key_load_private_key_roundtrip(proxy_db):
+    kid, pub, priv = _fresh_keypair()
+    now = datetime.now(timezone.utc)
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_iso(now), activated_at=_iso(now),
+    )
+    store = LocalKeyStore()
+    found = await store.find_by_kid(kid)
+    assert found is not None
+    loaded = found.load_private_key()
+    assert isinstance(loaded, ec.EllipticCurvePrivateKey)
+
+
+@pytest.mark.asyncio
+async def test_mastio_key_jwk_shape_matches_rfc7517(proxy_db):
+    kid, pub, priv = _fresh_keypair()
+    now = datetime.now(timezone.utc)
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub, privkey_pem=priv,
+        created_at=_iso(now), activated_at=_iso(now),
+    )
+    store = LocalKeyStore()
+    found = await store.find_by_kid(kid)
+    assert found is not None
+    jwk = found.jwk()
+    assert jwk["kty"] == "EC"
+    assert jwk["crv"] == "P-256"
+    assert jwk["alg"] == "ES256"
+    assert jwk["use"] == "sig"
+    assert jwk["kid"] == kid
+    assert set(jwk) == {"kty", "crv", "alg", "use", "kid", "x", "y"}

--- a/tests/test_proxy_local_token.py
+++ b/tests/test_proxy_local_token.py
@@ -133,8 +133,12 @@ async def flag_on_proxy(tmp_path, monkeypatch):
         mgr = app.state.agent_manager
         await mgr.load_org_ca(ca_key_pem, ca_cert_pem)
         await mgr.ensure_mastio_identity()
-        from mcp_proxy.auth.local_issuer import build_from_agent_manager
-        app.state.local_issuer = build_from_agent_manager("acme", mgr)
+        from mcp_proxy.auth.local_issuer import build_from_keystore
+        from mcp_proxy.auth.local_keystore import LocalKeyStore
+        app.state.local_keystore = LocalKeyStore()
+        app.state.local_issuer = await build_from_keystore(
+            "acme", app.state.local_keystore,
+        )
 
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -160,7 +164,7 @@ async def test_local_token_issued_from_valid_assertion(flag_on_proxy):
     assert body["issued_by"] == "cullis-mastio:acme"
 
     issuer = ctx["app"].state.local_issuer
-    pub_pem = issuer._leaf_pubkey_pem  # noqa: SLF001
+    pub_pem = issuer.active_key.pubkey_pem
     claims = jose_jwt.decode(
         body["access_token"],
         pub_pem,

--- a/tests/test_proxy_local_validator.py
+++ b/tests/test_proxy_local_validator.py
@@ -1,4 +1,4 @@
-"""ADR-012 Phase 3 — LocalValidator unit tests.
+"""ADR-012 Phase 3 / Phase 2.0 — LocalValidator unit tests.
 
 Paired with ``tests/test_proxy_local_issuer.py``: that file pins what
 the issuer emits, this one pins what the validator accepts. Round-trip
@@ -9,41 +9,96 @@ Everything that deviates from the expected wire format (wrong audience,
 wrong kid, missing claims, expired, signed by a stranger, malformed
 header) must raise ``LocalTokenError`` — so the FastAPI dependency can
 turn it into a uniform 401 without leaking internals.
+
+Phase 2.0: the validator is now keystore-driven, so tests use a real
+proxy SQLite fixture with the ``mastio_keys`` migration applied and
+insert rows via ``insert_mastio_key`` rather than handing a leaf key
+to an in-memory issuer.
 """
 from __future__ import annotations
 
 import time
+from datetime import datetime, timezone
 
 import jwt as jose_jwt
 import pytest
+import pytest_asyncio
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.testclient import TestClient
 
 from mcp_proxy.auth.local_issuer import LocalIssuer
+from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey, compute_kid
 from mcp_proxy.auth.local_validator import (
     LocalTokenError,
     LocalTokenPayload,
     require_local_token,
     validate_local_token,
 )
+from mcp_proxy.db import insert_mastio_key
 
 
-def _fresh_issuer(org_id: str = "orga") -> LocalIssuer:
-    key = ec.generate_private_key(ec.SECP256R1())
-    pub_pem = key.public_key().public_bytes(
+def _fresh_pair() -> tuple[ec.EllipticCurvePrivateKey, str, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
-    return LocalIssuer(org_id=org_id, leaf_key=key, leaf_pubkey_pem=pub_pem)
+    return priv, priv_pem, pub_pem
 
 
-def test_validate_roundtrip_issuer_to_validator():
-    issuer = _fresh_issuer("orga")
-    token = issuer.issue("orga::alice", ttl_seconds=60, extra_claims={"tenant": "t-1"})
+async def _install_active_issuer(org_id: str = "orga") -> tuple[LocalIssuer, str]:
+    """Insert a fresh active key into the DB and return an issuer for it.
 
-    payload = validate_local_token(token.token, issuer)
+    Returns ``(issuer, priv_pem)`` so tests that hand-craft tokens can
+    sign with the right private key without re-deriving it.
+    """
+    _, priv_pem, pub_pem = _fresh_pair()
+    kid = compute_kid(pub_pem)
+    now = datetime.now(timezone.utc)
+    await insert_mastio_key(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem,
+        created_at=now.isoformat(), activated_at=now.isoformat(),
+    )
+    active = MastioKey(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem, cert_pem=None,
+        created_at=now, activated_at=now, deprecated_at=None, expires_at=None,
+    )
+    return LocalIssuer(org_id=org_id, active_key=active), priv_pem
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import dispose_db, init_db
+    await init_db(url)
+    yield
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_validate_roundtrip_issuer_to_validator(proxy_db):
+    issuer, _ = await _install_active_issuer("orga")
+    token = issuer.issue(
+        "orga::alice", ttl_seconds=60, extra_claims={"tenant": "t-1"},
+    )
+
+    keystore = LocalKeyStore()
+    payload = await validate_local_token(
+        token.token, keystore, expected_issuer=issuer.issuer,
+    )
     assert isinstance(payload, LocalTokenPayload)
     assert payload.agent_id == "orga::alice"
     assert payload.issuer == "cullis-mastio:orga"
@@ -51,30 +106,38 @@ def test_validate_roundtrip_issuer_to_validator():
     assert payload.scope == "local"
     assert payload.expires_at == token.expires_at
     assert payload.issued_at == token.issued_at
-    assert payload.jti  # non-empty
+    assert payload.jti
     assert payload.extra == {"tenant": "t-1"}
 
 
-def test_rejects_token_signed_by_foreign_key():
-    issuer_a = _fresh_issuer("orga")
-    issuer_b = _fresh_issuer("orga")  # same org, different key → different kid
+@pytest.mark.asyncio
+async def test_rejects_token_signed_by_foreign_key(proxy_db):
+    issuer_a, _ = await _install_active_issuer("orga")
+    # A second issuer whose kid is NOT registered in the keystore — the
+    # forgery should be caught at the kid-lookup step, not the signature
+    # check.
+    _, priv_pem_b, pub_pem_b = _fresh_pair()
+    now = datetime.now(timezone.utc)
+    foreign = MastioKey(
+        kid=compute_kid(pub_pem_b), pubkey_pem=pub_pem_b, privkey_pem=priv_pem_b,
+        cert_pem=None, created_at=now, activated_at=now,
+        deprecated_at=None, expires_at=None,
+    )
+    issuer_b = LocalIssuer(org_id="orga", active_key=foreign)
     foreign_token = issuer_b.issue("orga::alice").token
 
+    keystore = LocalKeyStore()
     with pytest.raises(LocalTokenError) as err:
-        validate_local_token(foreign_token, issuer_a)
+        await validate_local_token(
+            foreign_token, keystore, expected_issuer=issuer_a.issuer,
+        )
     assert "kid" in str(err.value).lower()
 
 
-def test_rejects_expired_past_leeway():
-    issuer = _fresh_issuer("orga")
-    # Craft an expired token by issuing with a past ttl — since `issue`
-    # validates ttl > 0, mint it manually using the same private key.
+@pytest.mark.asyncio
+async def test_rejects_expired_past_leeway(proxy_db):
+    issuer, priv_pem = await _install_active_issuer("orga")
     now = int(time.time())
-    priv_pem = issuer._leaf_key.private_bytes(  # noqa: SLF001
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
     expired_token = jose_jwt.encode(
         {
             "iss": issuer.issuer,
@@ -89,19 +152,18 @@ def test_rejects_expired_past_leeway():
         algorithm="ES256",
         headers={"kid": issuer.kid, "typ": "JWT"},
     )
+    keystore = LocalKeyStore()
     with pytest.raises(LocalTokenError) as err:
-        validate_local_token(expired_token, issuer)
+        await validate_local_token(
+            expired_token, keystore, expected_issuer=issuer.issuer,
+        )
     assert "expired" in str(err.value).lower()
 
 
-def test_rejects_wrong_audience():
-    issuer = _fresh_issuer("orga")
+@pytest.mark.asyncio
+async def test_rejects_wrong_audience(proxy_db):
+    issuer, priv_pem = await _install_active_issuer("orga")
     now = int(time.time())
-    priv_pem = issuer._leaf_key.private_bytes(  # noqa: SLF001
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
     wrong_aud = jose_jwt.encode(
         {
             "iss": issuer.issuer,
@@ -116,20 +178,18 @@ def test_rejects_wrong_audience():
         algorithm="ES256",
         headers={"kid": issuer.kid, "typ": "JWT"},
     )
+    keystore = LocalKeyStore()
     with pytest.raises(LocalTokenError) as err:
-        validate_local_token(wrong_aud, issuer)
+        await validate_local_token(
+            wrong_aud, keystore, expected_issuer=issuer.issuer,
+        )
     assert "audience" in str(err.value).lower()
 
 
-def test_rejects_missing_required_claim():
-    issuer = _fresh_issuer("orga")
+@pytest.mark.asyncio
+async def test_rejects_missing_required_claim(proxy_db):
+    issuer, priv_pem = await _install_active_issuer("orga")
     now = int(time.time())
-    priv_pem = issuer._leaf_key.private_bytes(  # noqa: SLF001
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-    # Missing ``scope`` — one of the required claims.
     token = jose_jwt.encode(
         {
             "iss": issuer.issuer,
@@ -143,13 +203,16 @@ def test_rejects_missing_required_claim():
         algorithm="ES256",
         headers={"kid": issuer.kid, "typ": "JWT"},
     )
+    keystore = LocalKeyStore()
     with pytest.raises(LocalTokenError):
-        validate_local_token(token, issuer)
+        await validate_local_token(
+            token, keystore, expected_issuer=issuer.issuer,
+        )
 
 
-def test_rejects_unexpected_algorithm():
-    # Hand-craft an HS256 JWT with the right claims but wrong alg.
-    issuer = _fresh_issuer("orga")
+@pytest.mark.asyncio
+async def test_rejects_unexpected_algorithm(proxy_db):
+    issuer, _ = await _install_active_issuer("orga")
     token = jose_jwt.encode(
         {
             "iss": issuer.issuer,
@@ -164,41 +227,73 @@ def test_rejects_unexpected_algorithm():
         algorithm="HS256",
         headers={"kid": issuer.kid},
     )
+    keystore = LocalKeyStore()
     with pytest.raises(LocalTokenError) as err:
-        validate_local_token(token, issuer)
+        await validate_local_token(
+            token, keystore, expected_issuer=issuer.issuer,
+        )
     assert "alg" in str(err.value).lower()
 
 
-def test_require_local_token_endpoint_happy_and_error_paths():
-    app = FastAPI()
-    app.state.local_issuer = None
+def test_require_local_token_endpoint_happy_and_error_paths(tmp_path, monkeypatch):
+    """Synchronous harness around the FastAPI dependency — mounts a fresh
+    proxy DB in the test's own event loop."""
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
 
-    @app.get("/probe")
-    async def probe(payload=pytest.importorskip("fastapi").Depends(require_local_token)):  # type: ignore[valid-type]
-        return {"agent": payload.agent_id, "scope": payload.scope}
+    import asyncio
+    from mcp_proxy.db import dispose_db, init_db
 
-    with TestClient(app) as client:
-        # No issuer loaded → 503.
-        resp = client.get("/probe", headers={"Authorization": "Bearer xxx"})
-        assert resp.status_code == 503
+    async def _bootstrap() -> tuple[LocalIssuer, str]:
+        await init_db(url)
+        return await _install_active_issuer("orga")
 
-        # Wire an issuer.
-        issuer = _fresh_issuer("orga")
-        app.state.local_issuer = issuer
-        token = issuer.issue("orga::alice", ttl_seconds=60).token
+    try:
+        loop = asyncio.new_event_loop()
+        try:
+            issuer, _ = loop.run_until_complete(_bootstrap())
+        finally:
+            loop.close()
 
-        # No header → 401.
-        assert client.get("/probe").status_code == 401
+        app = FastAPI()
+        app.state.local_issuer = None
+        app.state.local_keystore = None
 
-        # Wrong scheme → 401.
-        resp = client.get("/probe", headers={"Authorization": "DPoP " + token})
-        assert resp.status_code == 401
+        @app.get("/probe")
+        async def probe(payload: LocalTokenPayload = Depends(require_local_token)):
+            return {"agent": payload.agent_id, "scope": payload.scope}
 
-        # Malformed → 401.
-        resp = client.get("/probe", headers={"Authorization": "Bearer not-a-jwt"})
-        assert resp.status_code == 401
+        with TestClient(app) as client:
+            resp = client.get("/probe", headers={"Authorization": "Bearer xxx"})
+            assert resp.status_code == 503
 
-        # Happy path.
-        resp = client.get("/probe", headers={"Authorization": f"Bearer {token}"})
-        assert resp.status_code == 200
-        assert resp.json() == {"agent": "orga::alice", "scope": "local"}
+            app.state.local_issuer = issuer
+            app.state.local_keystore = LocalKeyStore()
+            token = issuer.issue("orga::alice", ttl_seconds=60).token
+
+            assert client.get("/probe").status_code == 401
+            resp = client.get(
+                "/probe", headers={"Authorization": "DPoP " + token},
+            )
+            assert resp.status_code == 401
+            resp = client.get(
+                "/probe", headers={"Authorization": "Bearer not-a-jwt"},
+            )
+            assert resp.status_code == 401
+
+            resp = client.get(
+                "/probe", headers={"Authorization": f"Bearer {token}"},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"agent": "orga::alice", "scope": "local"}
+    finally:
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(dispose_db())
+        finally:
+            loop.close()
+        get_settings.cache_clear()

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -32,6 +32,7 @@ EXPECTED_TABLES = {
     "cached_policies",
     "cached_bindings",
     "federation_cursor",
+    "mastio_keys",
     "alembic_version",
 }
 
@@ -66,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0017_internal_agents_reach",)]
+    assert rows == [("0018_mastio_keys",)]
 
 
 @pytest.mark.asyncio
@@ -126,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0017_internal_agents_reach",)]
+    assert version == [("0018_mastio_keys",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0017_internal_agents_reach"
+HEAD_REVISION = "0018_mastio_keys"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0017_internal_agents_reach"
+HEAD_REVISION = "0018_mastio_keys"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0017_internal_agents_reach"
+HEAD_REVISION = "0018_mastio_keys"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

Phase 2.0 of the ES256 signing-key rotation roadmap (#261). Lay the
storage foundation for carrying more than one historical Mastio leaf
key at a time, and wire the issuer / validator / counter-signature
paths through the new keystore so Phase 2.1 (rotation primitive) and
Phase 2.2 (grace-period verification) become structural leaves rather
than invasive surgery.

Two commits, intended to be reviewed in order:

1. **``feat(mastio): add mastio_keys table + LocalKeyStore primitive``** —
   new table + data migration + ``LocalKeyStore`` / ``MastioKey`` +
   DB helpers + 11 unit tests. Zero behavioural change: the primitive
   is introduced but nothing else reads from it yet.
2. **``refactor(mastio): wire LocalIssuer/Validator/AgentManager to keystore``** —
   ``LocalIssuer`` wraps a ``MastioKey``, ``LocalValidator`` is now
   async and keystore-driven (kid lookup + grace-period gating),
   ``AgentManager`` drops ``_mastio_leaf_key`` / ``_mastio_leaf_cert``
   in favour of a cached active ``MastioKey``, and
   ``mcp_proxy.main`` publishes ``app.state.local_keystore`` alongside
   the issuer.

## Why this shape

The Mastio ES256 leaf signs *both* ADR-012 local JWTs and ADR-009
counter-signatures. A rotation that didn't allow multi-kid verification
would either require synchronous cutover (any token in flight is
rejected at the ms the new key activates) or would leave a stale kid
unverifiable for the last outstanding session's lifetime. Neither is
acceptable for a service agents stay connected to. The keystore makes
the rotation flow orthogonal to the signing path:

- Issuer stays single-kid (always the current signer).
- Verifier does kid lookup and gates on ``is_valid_for_verification``
  — active or within-grace keys pass, expired rows fail with an
  explicit error string.
- ``expires_at`` is the single knob Phase 2.2 will turn.

## Schema

New table ``mastio_keys`` (migration ``0018_mastio_keys``):

```
kid            TEXT PRIMARY KEY
pubkey_pem     TEXT NOT NULL
privkey_pem    TEXT NOT NULL
cert_pem       TEXT NULL
created_at     TEXT NOT NULL
activated_at   TEXT NULL
deprecated_at  TEXT NULL
expires_at     TEXT NULL
INDEX idx_mastio_keys_active (activated_at, deprecated_at)
```

Invariant maintained by callers: exactly one row has
``activated_at IS NOT NULL AND deprecated_at IS NULL`` at any time —
that is the current signer. ``LocalKeyStore.current_signer()`` raises
``RuntimeError`` if zero or more than one active rows are found.

Data migration seeds a single activated row from the pre-2.0
``proxy_config.mastio_leaf_{key,cert}`` pair (if present), keeping the
deterministic kid so JWTs already signed under the old pair keep
verifying.

## Test plan

- [x] ``pytest tests/test_proxy_local_keystore.py`` — 11 passed
- [x] ``pytest tests/test_proxy_local_issuer.py tests/test_proxy_local_validator.py tests/test_proxy_local_agent_dep.py tests/test_proxy_egress_local_token.py tests/test_proxy_local_token.py`` — 39 passed
- [x] ``pytest tests/test_proxy_migrations*`` (4 files, including new
      ``0018_mastio_keys`` head revision) — 24 passed, 1 skipped
- [x] ``pytest tests/`` — 1416 passed, 6 skipped. The 16 failures
      observed in the unfiltered run all exist on ``main`` prior to
      this branch:
      ``tests/test_ts_interop.py`` (14) — canonical-JSON
      divergence between the Python and TypeScript SDKs, unrelated
      to PKI;
      ``tests/test_postgres_integration.py`` (2) —
      ``KeyError: 'id'`` on a pre-existing schema assumption.
- [ ] Sandbox dogfood (``./demo.sh full``) — pending manual run:
      the CI runner doesn't have docker permissions in this sandbox.

## References

- Issue #261 (automatic re-enrollment + ES256 rotation roadmap)
- RFC 7517 §4 (JWK) and RFC 7515 §4.1.4 (multi-key kid pattern)
- NIST SP 800-57 Part 1 §5.3.6 (signing-key cryptoperiods)
- ADR-012 (local-first auth) and ADR-009 (counter-signature)