### PR TITLE
feat(mastio): ADR-012 Phase 2.1 — key-rotation primitive + Court endpoint (#261)

### DIFF
--- a/app/auth/mastio_rotation_verify.py
+++ b/app/auth/mastio_rotation_verify.py
@@ -1,0 +1,164 @@
+"""ADR-012 Phase 2.1 — Court-side verification of Mastio key-continuity
+proofs.
+
+This module verifies a proof produced by
+``mcp_proxy.auth.mastio_rotation.build_proof``. It intentionally
+duplicates the ``ContinuityProof`` dataclass and the canonical payload
+function rather than importing them from ``mcp_proxy``: the broker
+runtime ships without the proxy package and the two codebases are
+kept import-isolated on purpose (``app/`` never depends on
+``mcp_proxy/``).
+
+If the proof format changes, update **both** modules in lockstep. The
+happy-path round-trip test in
+``tests/test_broker_mastio_pubkey_rotate.py`` catches mismatches
+because it imports the *mcp_proxy* ``build_proof`` and then drives
+this module's ``verify_proof``.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+
+PROOF_FRESHNESS_SECONDS = 600
+
+
+@dataclass(frozen=True)
+class ContinuityProof:
+    old_kid: str
+    new_kid: str
+    new_pubkey_pem: str
+    issued_at: str
+    signature_b64u: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ContinuityProof":
+        required = {"old_kid", "new_kid", "new_pubkey_pem", "issued_at", "signature_b64u"}
+        missing = required - data.keys()
+        if missing:
+            raise ValueError(f"continuity proof missing fields: {sorted(missing)}")
+        for key in required:
+            if not isinstance(data[key], str) or not data[key]:
+                raise ValueError(
+                    f"continuity proof field {key!r} must be a non-empty string",
+                )
+        return cls(
+            old_kid=data["old_kid"],
+            new_kid=data["new_kid"],
+            new_pubkey_pem=data["new_pubkey_pem"],
+            issued_at=data["issued_at"],
+            signature_b64u=data["signature_b64u"],
+        )
+
+
+class ContinuityProofError(Exception):
+    """Raised when a continuity proof fails any validation step."""
+
+
+def _canonical_payload(
+    *, old_kid: str, new_kid: str, new_pubkey_pem: str, issued_at: str,
+) -> bytes:
+    return json.dumps(
+        {
+            "issued_at": issued_at,
+            "new_kid": new_kid,
+            "new_pubkey_pem": new_pubkey_pem,
+            "old_kid": old_kid,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def verify_proof(
+    proof: ContinuityProof,
+    *,
+    expected_old_pubkey_pem: str,
+    expected_old_kid: str | None = None,
+    now: datetime | None = None,
+    freshness_seconds: int = PROOF_FRESHNESS_SECONDS,
+) -> None:
+    """Verify a continuity proof against the pinned old pubkey.
+
+    Raises :class:`ContinuityProofError` on any validation failure.
+    """
+    if expected_old_kid is not None and proof.old_kid != expected_old_kid:
+        raise ContinuityProofError(
+            f"old_kid mismatch: proof carries {proof.old_kid!r}, "
+            f"Court has {expected_old_kid!r} pinned",
+        )
+
+    try:
+        issued = datetime.fromisoformat(proof.issued_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ContinuityProofError(f"invalid issued_at: {exc}") from exc
+    if issued.tzinfo is None:
+        raise ContinuityProofError("issued_at is not timezone-aware")
+    reference = now or datetime.now(timezone.utc)
+    delta = abs((reference - issued).total_seconds())
+    if delta > freshness_seconds:
+        raise ContinuityProofError(
+            f"issued_at is outside the freshness window "
+            f"({int(delta)}s > {freshness_seconds}s)",
+        )
+
+    try:
+        pub_key = serialization.load_pem_public_key(expected_old_pubkey_pem.encode())
+    except ValueError as exc:
+        raise ContinuityProofError(
+            f"malformed expected_old_pubkey_pem: {exc}",
+        ) from exc
+    if not isinstance(pub_key, ec.EllipticCurvePublicKey):
+        raise ContinuityProofError("expected_old_pubkey is not an EC key")
+
+    try:
+        raw_sig = base64.urlsafe_b64decode(
+            proof.signature_b64u + "=" * (-len(proof.signature_b64u) % 4),
+        )
+    except (ValueError, binascii.Error) as exc:
+        raise ContinuityProofError(f"malformed signature_b64u: {exc}") from exc
+    if len(raw_sig) != 64:
+        raise ContinuityProofError(
+            f"signature must be 64 bytes (r||s), got {len(raw_sig)}",
+        )
+    r = int.from_bytes(raw_sig[:32], "big")
+    s = int.from_bytes(raw_sig[32:], "big")
+    der_sig = encode_dss_signature(r, s)
+
+    payload = _canonical_payload(
+        old_kid=proof.old_kid,
+        new_kid=proof.new_kid,
+        new_pubkey_pem=proof.new_pubkey_pem,
+        issued_at=proof.issued_at,
+    )
+    try:
+        pub_key.verify(der_sig, payload, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature as exc:
+        raise ContinuityProofError("signature verification failed") from exc
+
+
+def compute_kid_from_pubkey_pem(pubkey_pem: str) -> str:
+    """Reproduce the Mastio kid derivation locally so the Court can
+    assert ``proof.old_kid`` matches the currently-pinned pubkey."""
+    import hashlib
+    return "mastio-" + hashlib.sha256(pubkey_pem.encode()).hexdigest()[:16]
+
+
+__all__ = [
+    "ContinuityProof",
+    "ContinuityProofError",
+    "PROOF_FRESHNESS_SECONDS",
+    "compute_kid_from_pubkey_pem",
+    "verify_proof",
+]

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -538,6 +538,124 @@ async def patch_org_mastio_pubkey(
     }
 
 
+class MastioPubkeyRotateRequest(BaseModel):
+    """Body for ``POST /onboarding/orgs/{org_id}/mastio-pubkey/rotate``.
+
+    ADR-012 Phase 2.1. The caller (Mastio) ships the new pubkey plus a
+    key-continuity proof signed by the *old* priv key. The Court
+    verifies the proof against the currently-pinned ``mastio_pubkey``
+    and, on success, updates the pin. No admin auth header is
+    required — the proof *is* the auth.
+    """
+
+    new_pubkey_pem: str = Field(..., max_length=1024)
+    new_cert_pem: str | None = Field(None, max_length=4096)
+    proof: dict = Field(...)
+
+
+class MastioPubkeyRotateResponse(BaseModel):
+    org_id: str
+    new_kid: str
+    rotated_at: str
+
+
+@onboarding_router.post(
+    "/orgs/{org_id}/mastio-pubkey/rotate",
+    response_model=MastioPubkeyRotateResponse,
+)
+async def rotate_org_mastio_pubkey(
+    org_id: str,
+    body: MastioPubkeyRotateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> MastioPubkeyRotateResponse:
+    """Rotate the pinned Mastio pubkey via a key-continuity proof.
+
+    Flow:
+      1. Resolve the org and its currently-pinned ``mastio_pubkey``.
+      2. Derive the expected ``old_kid`` from the pinned pubkey.
+      3. Parse + verify the submitted continuity proof.
+      4. On success, update the pin and emit an audit event.
+    """
+    from app.auth.mastio_rotation_verify import (
+        ContinuityProof,
+        ContinuityProofError,
+        compute_kid_from_pubkey_pem,
+        verify_proof,
+    )
+
+    org = await get_org_by_id(db, org_id)
+    if org is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Organization not found")
+    if not org.mastio_pubkey:
+        # Rotation requires a prior pin. First-pin happens via the
+        # admin flow (``PATCH /admin/orgs/{id}/mastio-pubkey``) or the
+        # /onboarding/join + /onboarding/attach bootstraps.
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            detail="organization has no pinned mastio pubkey; use the admin flow for first-pin",
+        )
+
+    _validate_mastio_pubkey(body.new_pubkey_pem)
+
+    try:
+        proof = ContinuityProof.from_dict(body.proof)
+    except ValueError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"malformed proof: {exc}",
+        ) from exc
+
+    expected_old_kid = compute_kid_from_pubkey_pem(org.mastio_pubkey)
+    try:
+        verify_proof(
+            proof,
+            expected_old_pubkey_pem=org.mastio_pubkey,
+            expected_old_kid=expected_old_kid,
+        )
+    except ContinuityProofError as exc:
+        await log_event(
+            db, "admin.mastio_pubkey_rotate_rejected", "fail",
+            org_id=org_id,
+            details={"reason": str(exc), "old_kid": expected_old_kid},
+        )
+        raise HTTPException(
+            status.HTTP_401_UNAUTHORIZED,
+            detail=f"continuity proof rejected: {exc}",
+        ) from exc
+
+    # Proof-bound consistency: the pubkey in the body must be the one
+    # the proof signed over. Defends against a rebind where an
+    # attacker replays a valid proof but swaps ``new_pubkey_pem`` in
+    # the envelope for a pubkey they control.
+    if proof.new_pubkey_pem != body.new_pubkey_pem:
+        await log_event(
+            db, "admin.mastio_pubkey_rotate_rejected", "fail",
+            org_id=org_id,
+            details={"reason": "new_pubkey_pem mismatch between envelope and proof"},
+        )
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail="new_pubkey_pem in envelope does not match the one signed in the proof",
+        )
+
+    await update_org_mastio_pubkey(db, org_id, body.new_pubkey_pem)
+    rotated_at = datetime.now(timezone.utc).isoformat()
+    await log_event(
+        db, "admin.mastio_pubkey_rotated", "ok",
+        org_id=org_id,
+        details={
+            "old_kid": expected_old_kid,
+            "new_kid": proof.new_kid,
+            "rotated_at": rotated_at,
+        },
+    )
+    return MastioPubkeyRotateResponse(
+        org_id=org_id,
+        new_kid=proof.new_kid,
+        rotated_at=rotated_at,
+    )
+
+
 @admin_router.post("/orgs/{org_id}/reject",
                    dependencies=[Depends(_require_admin)])
 async def reject_org(

--- a/mcp_proxy/auth/mastio_rotation.py
+++ b/mcp_proxy/auth/mastio_rotation.py
@@ -1,0 +1,219 @@
+"""ADR-012 Phase 2.1 — key-continuity proof for Mastio key rotation.
+
+The Mastio proves it is legitimately the same operator during a key
+rotation by signing a canonical statement with the *old* private key.
+The Court verifies the signature against the currently-pinned pubkey
+(the old one, pre-rotation) and — on success — updates the pin to the
+new pubkey.
+
+Proof shape (canonical JSON, sort_keys, no whitespace)::
+
+    {
+      "issued_at":      "2026-04-21T21:00:00+00:00",
+      "new_kid":        "mastio-<sha256(new_pubkey_pem)[:16]>",
+      "new_pubkey_pem": "-----BEGIN PUBLIC KEY-----\\n...\\n-----END...",
+      "old_kid":        "mastio-<sha256(old_pubkey_pem)[:16]>"
+    }
+
+The signature is ES256 over the UTF-8-encoded canonical JSON,
+base64url-encoded with no padding — the same shape already used by
+the ADR-009 counter-signature path.
+
+The proof carries ``old_kid`` so the verifier can refuse a mismatch
+between the signature's key and the key that was intended to sign
+(anti-substitution). ``issued_at`` bounds replay: the verifier
+rejects proofs whose timestamp is outside a small freshness window.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import (
+    decode_dss_signature,
+    encode_dss_signature,
+)
+
+PROOF_FRESHNESS_SECONDS = 600  # 10 minutes
+
+
+@dataclass(frozen=True)
+class ContinuityProof:
+    old_kid: str
+    new_kid: str
+    new_pubkey_pem: str
+    issued_at: str
+    signature_b64u: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "old_kid": self.old_kid,
+            "new_kid": self.new_kid,
+            "new_pubkey_pem": self.new_pubkey_pem,
+            "issued_at": self.issued_at,
+            "signature_b64u": self.signature_b64u,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ContinuityProof":
+        required = {"old_kid", "new_kid", "new_pubkey_pem", "issued_at", "signature_b64u"}
+        missing = required - data.keys()
+        if missing:
+            raise ValueError(f"continuity proof missing fields: {sorted(missing)}")
+        for key in required:
+            if not isinstance(data[key], str) or not data[key]:
+                raise ValueError(f"continuity proof field {key!r} must be a non-empty string")
+        return cls(
+            old_kid=data["old_kid"],
+            new_kid=data["new_kid"],
+            new_pubkey_pem=data["new_pubkey_pem"],
+            issued_at=data["issued_at"],
+            signature_b64u=data["signature_b64u"],
+        )
+
+
+class ContinuityProofError(Exception):
+    """Raised when a continuity proof fails any validation step."""
+
+
+def _canonical_payload(
+    *, old_kid: str, new_kid: str, new_pubkey_pem: str, issued_at: str,
+) -> bytes:
+    """Canonical JSON body over which the proof signature is computed."""
+    return json.dumps(
+        {
+            "issued_at": issued_at,
+            "new_kid": new_kid,
+            "new_pubkey_pem": new_pubkey_pem,
+            "old_kid": old_kid,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def build_proof(
+    *,
+    old_priv_key: ec.EllipticCurvePrivateKey,
+    old_kid: str,
+    new_kid: str,
+    new_pubkey_pem: str,
+    issued_at: datetime | None = None,
+) -> ContinuityProof:
+    """Produce a signed continuity proof.
+
+    ``old_priv_key`` is the current-signer key whose corresponding
+    public key is currently pinned at the Court. ``new_kid`` /
+    ``new_pubkey_pem`` describe the key we want the Court to pin next.
+
+    The resulting ``ContinuityProof`` is JSON-serialisable via
+    :meth:`ContinuityProof.to_dict` and is what gets POSTed to the
+    Court rotation endpoint.
+    """
+    now = issued_at or datetime.now(timezone.utc)
+    issued_at_iso = now.isoformat()
+    payload = _canonical_payload(
+        old_kid=old_kid,
+        new_kid=new_kid,
+        new_pubkey_pem=new_pubkey_pem,
+        issued_at=issued_at_iso,
+    )
+    der_signature = old_priv_key.sign(payload, ec.ECDSA(hashes.SHA256()))
+    r, s = decode_dss_signature(der_signature)
+    raw = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    sig_b64 = base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+    return ContinuityProof(
+        old_kid=old_kid,
+        new_kid=new_kid,
+        new_pubkey_pem=new_pubkey_pem,
+        issued_at=issued_at_iso,
+        signature_b64u=sig_b64,
+    )
+
+
+def verify_proof(
+    proof: ContinuityProof,
+    *,
+    expected_old_pubkey_pem: str,
+    expected_old_kid: str | None = None,
+    now: datetime | None = None,
+    freshness_seconds: int = PROOF_FRESHNESS_SECONDS,
+) -> None:
+    """Verify a continuity proof against the currently-pinned old pubkey.
+
+    Raises :class:`ContinuityProofError` on any validation failure —
+    stale timestamp, wrong ``old_kid``, malformed signature, bad
+    signature. Succeeds silently on a valid proof.
+
+    ``expected_old_kid`` lets the caller assert the proof is signed by
+    the kid they think is currently pinned (anti-substitution); if
+    omitted, only the signature is checked.
+    """
+    if expected_old_kid is not None and proof.old_kid != expected_old_kid:
+        raise ContinuityProofError(
+            f"old_kid mismatch: proof carries {proof.old_kid!r}, "
+            f"Court has {expected_old_kid!r} pinned"
+        )
+
+    try:
+        issued = datetime.fromisoformat(proof.issued_at.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ContinuityProofError(f"invalid issued_at: {exc}") from exc
+    if issued.tzinfo is None:
+        raise ContinuityProofError("issued_at is not timezone-aware")
+    reference = now or datetime.now(timezone.utc)
+    delta = abs((reference - issued).total_seconds())
+    if delta > freshness_seconds:
+        raise ContinuityProofError(
+            f"issued_at is outside the freshness window "
+            f"({int(delta)}s > {freshness_seconds}s)"
+        )
+
+    try:
+        pub_key = serialization.load_pem_public_key(expected_old_pubkey_pem.encode())
+    except ValueError as exc:
+        raise ContinuityProofError(f"malformed expected_old_pubkey_pem: {exc}") from exc
+    if not isinstance(pub_key, ec.EllipticCurvePublicKey):
+        raise ContinuityProofError("expected_old_pubkey is not an EC key")
+
+    try:
+        raw_sig = base64.urlsafe_b64decode(
+            proof.signature_b64u + "=" * (-len(proof.signature_b64u) % 4)
+        )
+    except (ValueError, binascii.Error) as exc:
+        raise ContinuityProofError(f"malformed signature_b64u: {exc}") from exc
+    if len(raw_sig) != 64:
+        raise ContinuityProofError(
+            f"signature must be 64 bytes (r||s), got {len(raw_sig)}"
+        )
+    r = int.from_bytes(raw_sig[:32], "big")
+    s = int.from_bytes(raw_sig[32:], "big")
+    der_sig = encode_dss_signature(r, s)
+
+    payload = _canonical_payload(
+        old_kid=proof.old_kid,
+        new_kid=proof.new_kid,
+        new_pubkey_pem=proof.new_pubkey_pem,
+        issued_at=proof.issued_at,
+    )
+    try:
+        pub_key.verify(der_sig, payload, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature as exc:
+        raise ContinuityProofError("signature verification failed") from exc
+
+
+__all__ = [
+    "ContinuityProof",
+    "ContinuityProofError",
+    "PROOF_FRESHNESS_SECONDS",
+    "build_proof",
+    "verify_proof",
+]

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -487,6 +487,78 @@ async def get_mastio_keys_active() -> list[dict]:
         return [dict(row) for row in result.mappings().all()]
 
 
+async def swap_active_mastio_key(
+    *,
+    new_kid: str,
+    new_pubkey_pem: str,
+    new_privkey_pem: str,
+    new_cert_pem: str | None,
+    new_activated_at: str,
+    new_created_at: str,
+    old_kid: str,
+    old_deprecated_at: str,
+    old_expires_at: str,
+) -> None:
+    """Atomically insert a new active mastio key and deprecate the old one.
+
+    Phase 2.1 rotation primitive. Runs the two writes in a single DB
+    transaction so the ``exactly-one-active`` invariant is never
+    observed broken from a parallel reader (e.g. the verifier doing
+    ``find_by_kid`` during the swap).
+
+    Both rows are required: the keystore rejects zero or multiple active
+    rows, and the verifier needs the old row to remain resolvable
+    through its grace window.
+
+    Raises the underlying DBAPI error if either statement fails — the
+    transaction is then rolled back by the ``get_db()`` context exit
+    so the caller observes all-or-nothing semantics.
+    """
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO mastio_keys
+                    (kid, pubkey_pem, privkey_pem, cert_pem, created_at,
+                     activated_at, deprecated_at, expires_at)
+                VALUES
+                    (:kid, :pub, :priv, :cert, :created,
+                     :activated, NULL, NULL)
+                """
+            ),
+            {
+                "kid": new_kid,
+                "pub": new_pubkey_pem,
+                "priv": new_privkey_pem,
+                "cert": new_cert_pem,
+                "created": new_created_at,
+                "activated": new_activated_at,
+            },
+        )
+        result = await conn.execute(
+            text(
+                """
+                UPDATE mastio_keys
+                   SET deprecated_at = :deprecated,
+                       expires_at    = :expires
+                 WHERE kid = :kid
+                   AND activated_at IS NOT NULL
+                   AND deprecated_at IS NULL
+                """
+            ),
+            {
+                "kid": old_kid,
+                "deprecated": old_deprecated_at,
+                "expires": old_expires_at,
+            },
+        )
+        if result.rowcount != 1:
+            raise RuntimeError(
+                f"failed to deprecate old mastio key {old_kid!r}: "
+                f"UPDATE touched {result.rowcount} rows"
+            )
+
+
 async def get_mastio_keys_valid() -> list[dict]:
     """All rows still accepted for token verification.
 

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -23,6 +23,7 @@ from cryptography.x509.oid import NameOID
 
 from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
 from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey, compute_kid
+from mcp_proxy.auth.mastio_rotation import ContinuityProof, build_proof
 from mcp_proxy.config import get_settings, vault_tls_verify
 from mcp_proxy.db import (
     create_agent as db_create_agent,
@@ -31,7 +32,10 @@ from mcp_proxy.db import (
     get_config,
     insert_mastio_key,
     set_config,
+    swap_active_mastio_key,
 )
+
+from typing import Awaitable, Callable
 
 logger = logging.getLogger("mcp_proxy.egress.agent_manager")
 
@@ -705,6 +709,121 @@ class AgentManager:
         header against this key.
         """
         return self._require_active().pubkey_pem
+
+    async def rotate_mastio_key(
+        self,
+        *,
+        grace_days: int = 7,
+        propagator: "Callable[[ContinuityProof, str], Awaitable[None]] | None" = None,
+    ) -> MastioKey:
+        """Rotate the Mastio leaf key (ADR-012 Phase 2.1, issue #261).
+
+        Mints a fresh EC P-256 leaf under the existing intermediate CA,
+        signs a continuity proof with the current (old) key, propagates
+        the new pubkey + proof to the Court via ``propagator``, and then
+        atomically swaps the active row in ``mastio_keys``.
+
+        ``grace_days`` controls how long the old kid stays
+        verifier-accepted after deprecation. Callers that want a
+        different cadence override it; the default of 7 is the
+        repository-wide baseline for signing-key rotations.
+
+        ``propagator`` receives the built ``ContinuityProof`` plus the
+        new cert PEM and is expected to call the Court. If it raises,
+        no DB mutation happens (Court-first ordering). If it is
+        ``None`` (tests / offline bootstrap), the Court step is
+        skipped entirely — the resulting rotation is purely local and
+        will leave the Court out of sync; callers **must** pass a real
+        propagator in production.
+
+        Returns the freshly-activated :class:`MastioKey` (already
+        cached as ``self._active_key``).
+
+        Raises:
+            RuntimeError: if identity is not loaded (gate on
+                :attr:`mastio_loaded`), if ``grace_days`` is not
+                positive, or if the DB swap finds an inconsistent
+                state.
+        """
+        if grace_days <= 0:
+            raise ValueError("grace_days must be a positive integer")
+        old = self._require_active()
+        if self._mastio_ca_key is None or self._mastio_ca_cert is None:
+            raise RuntimeError("Mastio intermediate CA not loaded")
+
+        now = datetime.now(timezone.utc)
+        new_leaf_key = ec.generate_private_key(ec.SECP256R1())
+        proxy_spiffe = f"spiffe://{self._trust_domain}/proxy/{self._org_id}"
+        leaf_subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, f"proxy:{self._org_id}"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id),
+        ])
+        new_cert = (
+            x509.CertificateBuilder()
+            .subject_name(leaf_subject)
+            .issuer_name(self._mastio_ca_cert.subject)
+            .public_key(new_leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=5))
+            .not_valid_after(now + timedelta(days=365))
+            .add_extension(
+                SubjectAlternativeName([UniformResourceIdentifier(proxy_spiffe)]),
+                critical=False,
+            )
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .sign(self._mastio_ca_key, hashes.SHA256())
+        )
+
+        new_priv_pem = _priv_to_pem(new_leaf_key)
+        new_cert_pem = _cert_to_pem(new_cert)
+        new_pub_pem = new_leaf_key.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        new_kid = compute_kid(new_pub_pem)
+
+        proof = build_proof(
+            old_priv_key=old.load_private_key(),
+            old_kid=old.kid,
+            new_kid=new_kid,
+            new_pubkey_pem=new_pub_pem,
+            issued_at=now,
+        )
+
+        # Court-first: if propagation fails, no local state change.
+        if propagator is not None:
+            await propagator(proof, new_cert_pem)
+        else:
+            logger.warning(
+                "rotate_mastio_key: no propagator provided — Court will "
+                "stay pinned on the old pubkey; production callers must "
+                "supply one",
+            )
+
+        now_iso = now.isoformat()
+        grace_end_iso = (now + timedelta(days=grace_days)).isoformat()
+        await swap_active_mastio_key(
+            new_kid=new_kid,
+            new_pubkey_pem=new_pub_pem,
+            new_privkey_pem=new_priv_pem,
+            new_cert_pem=new_cert_pem,
+            new_activated_at=now_iso,
+            new_created_at=now_iso,
+            old_kid=old.kid,
+            old_deprecated_at=now_iso,
+            old_expires_at=grace_end_iso,
+        )
+
+        await self.refresh_active_key()
+        logger.info(
+            "Mastio key rotated — old_kid=%s, new_kid=%s, grace_days=%d",
+            old.kid, new_kid, grace_days,
+        )
+        assert self._active_key is not None
+        return self._active_key
 
     def countersign(self, data: bytes) -> str:
         """ES256 counter-signature over ``data``, base64url no-pad.

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -9,9 +9,11 @@ import asyncio
 import logging
 from typing import Any
 
+import httpx
 from fastapi import HTTPException
 
 from cullis_sdk.client import CullisClient
+from mcp_proxy.auth.mastio_rotation import ContinuityProof
 from mcp_proxy.egress.routing import decide_route
 
 logger = logging.getLogger("mcp_proxy.egress.broker_bridge")
@@ -89,6 +91,55 @@ class BrokerBridge:
             client = await self._create_client(agent_id)
             self._clients[agent_id] = client
             return client
+
+    async def propagate_mastio_key_rotation(
+        self,
+        proof: ContinuityProof,
+        new_cert_pem: str,
+    ) -> None:
+        """POST a mastio-pubkey rotation to the Court (ADR-012 Phase 2.1).
+
+        Called by ``AgentManager.rotate_mastio_key`` *before* the local
+        DB swap. The Court verifies ``proof`` against the currently-
+        pinned old pubkey and updates the pin on success.
+
+        Raises:
+            HTTPException: with 502 when the Court is unreachable or
+                replies with a 5xx, mapping to an operator-visible
+                rotation failure at the caller. Non-2xx responses are
+                re-raised with the Court's own status code and body so
+                the failure surfaces the Court's rejection reason
+                (malformed proof, stale timestamp, …).
+        """
+        url = f"{self._broker_url.rstrip('/')}/v1/onboarding/orgs/{self._org_id}/mastio-pubkey/rotate"
+        body = {
+            "new_pubkey_pem": proof.new_pubkey_pem,
+            "new_cert_pem": new_cert_pem,
+            "proof": proof.to_dict(),
+        }
+        logger.info(
+            "Propagating mastio pubkey rotation to Court (%s): old_kid=%s, new_kid=%s",
+            url, proof.old_kid, proof.new_kid,
+        )
+        try:
+            async with httpx.AsyncClient(verify=self._verify_tls, timeout=30.0) as http:
+                resp = await http.post(url, json=body)
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"court unreachable during rotation: {exc}",
+            ) from exc
+
+        if resp.status_code >= 500:
+            raise HTTPException(
+                status_code=502,
+                detail=f"court rejected rotation with {resp.status_code}: {resp.text}",
+            )
+        if resp.status_code >= 400:
+            raise HTTPException(
+                status_code=resp.status_code,
+                detail=f"court rejected rotation: {resp.text}",
+            )
 
     async def _evict_and_retry(self, agent_id: str) -> CullisClient:
         """Evict a cached client and create a fresh one (re-auth)."""

--- a/tests/test_broker_mastio_pubkey_rotate.py
+++ b/tests/test_broker_mastio_pubkey_rotate.py
@@ -1,0 +1,249 @@
+"""ADR-012 Phase 2.1 — Court ``POST /v1/onboarding/orgs/{id}/mastio-pubkey/rotate``.
+
+Covers:
+  - Happy path: valid continuity proof signed by the pinned old pubkey
+    → new pubkey accepted, audit event recorded, old pubkey replaced.
+  - Rotation on a brand-new org without a pinned pubkey → 409 Conflict.
+  - Rotation against an unknown org → 404.
+  - Proof signed by a different (foreign) key → 401.
+  - Proof envelope tamper: ``new_pubkey_pem`` mismatch between the
+    JSON body and the signed proof → 400.
+  - Stale proof (issued > freshness window in the past) → 401.
+  - Malformed proof body → 400.
+
+The tests import ``build_proof`` from the proxy package to make sure
+the two codebases agree on the canonical format (the proxy module
+produces proofs, the broker module consumes them — a format drift
+would surface here).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+
+from app.config import get_settings
+from mcp_proxy.auth.local_keystore import compute_kid
+from mcp_proxy.auth.mastio_rotation import build_proof
+from tests.cert_factory import get_org_ca_pem
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN_SECRET = get_settings().admin_secret
+
+
+def _gen_p256_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+async def _create_org_with_pubkey(
+    client: AsyncClient, org_id: str, pubkey_pem: str,
+) -> None:
+    """Onboard an org and pin ``pubkey_pem`` as its mastio_pubkey."""
+    invite = await client.post(
+        "/v1/admin/invites",
+        json={"label": org_id, "ttl_hours": 1},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    token = invite.json()["token"]
+    await client.post("/v1/onboarding/join", json={
+        "org_id": org_id,
+        "display_name": org_id,
+        "secret": f"{org_id}-secret",
+        "ca_certificate": get_org_ca_pem(org_id),
+        "invite_token": token,
+    })
+    r = await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": pubkey_pem},
+    )
+    assert r.status_code == 200, r.text
+
+
+async def _fetch_pubkey(org_id: str) -> str | None:
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import get_org_by_id
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        return org.mastio_pubkey if org else None
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+async def test_rotate_replaces_pinned_pubkey_with_valid_proof(client: AsyncClient):
+    old_priv, old_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rotate-ok", old_pub)
+
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/rotate-ok/mastio-pubkey/rotate",
+        json={
+            "new_pubkey_pem": new_pub,
+            "proof": proof.to_dict(),
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["org_id"] == "rotate-ok"
+    assert body["new_kid"] == compute_kid(new_pub)
+    assert "rotated_at" in body
+
+    stored = await _fetch_pubkey("rotate-ok")
+    assert stored == new_pub
+
+
+async def test_rotate_rejects_unknown_org(client: AsyncClient):
+    old_priv, old_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/does-not-exist/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    assert r.status_code == 404
+
+
+async def test_rotate_rejects_org_without_pinned_pubkey(client: AsyncClient):
+    """If no pubkey is pinned yet the org should use the admin
+    first-pin flow, not rotation."""
+    old_priv, old_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    # Onboard org WITHOUT pinning a pubkey.
+    invite = await client.post(
+        "/v1/admin/invites",
+        json={"label": "no-pin", "ttl_hours": 1},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    token = invite.json()["token"]
+    await client.post("/v1/onboarding/join", json={
+        "org_id": "no-pin",
+        "display_name": "no-pin",
+        "secret": "no-pin-secret",
+        "ca_certificate": get_org_ca_pem("no-pin"),
+        "invite_token": token,
+    })
+
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/no-pin/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    assert r.status_code == 409
+    assert "admin flow" in r.json()["detail"].lower()
+
+
+async def test_rotate_rejects_proof_signed_by_foreign_key(client: AsyncClient):
+    _, old_pub = _gen_p256_keypair()
+    foreign_priv, foreign_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rotate-foreign", old_pub)
+
+    # Proof signed by a key that is NOT the pinned one.
+    proof = build_proof(
+        old_priv_key=foreign_priv,
+        old_kid=compute_kid(foreign_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/rotate-foreign/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    # The old_kid embedded in the proof is the foreign one; the Court
+    # rejects for kid mismatch (signature would fail too — either
+    # condition is enough).
+    assert r.status_code == 401
+    assert (
+        "kid" in r.json()["detail"].lower()
+        or "signature" in r.json()["detail"].lower()
+    )
+
+    # Pin unchanged.
+    stored = await _fetch_pubkey("rotate-foreign")
+    assert stored == old_pub
+
+
+async def test_rotate_rejects_envelope_tamper(client: AsyncClient):
+    """Attacker replays a valid proof but swaps ``new_pubkey_pem`` in
+    the request body for a pubkey they control. The Court must detect
+    the envelope/proof mismatch even though the signature itself is
+    valid over the original ``new_pubkey_pem``."""
+    old_priv, old_pub = _gen_p256_keypair()
+    _, intended_pub = _gen_p256_keypair()
+    _, evil_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rotate-tamper", old_pub)
+
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(intended_pub),
+        new_pubkey_pem=intended_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/rotate-tamper/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": evil_pub, "proof": proof.to_dict()},
+    )
+    assert r.status_code == 400
+    assert "does not match" in r.json()["detail"].lower()
+    stored = await _fetch_pubkey("rotate-tamper")
+    assert stored == old_pub
+
+
+async def test_rotate_rejects_stale_proof(client: AsyncClient):
+    old_priv, old_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rotate-stale", old_pub)
+
+    stale_when = datetime.now(timezone.utc) - timedelta(hours=2)
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+        issued_at=stale_when,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/rotate-stale/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    assert r.status_code == 401
+    assert "freshness" in r.json()["detail"].lower()
+
+
+async def test_rotate_rejects_malformed_proof(client: AsyncClient):
+    _, old_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rotate-malformed", old_pub)
+
+    r = await client.post(
+        "/v1/onboarding/orgs/rotate-malformed/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": {"old_kid": "only-this"}},
+    )
+    assert r.status_code == 400
+    assert "missing" in r.json()["detail"].lower()

--- a/tests/test_proxy_mastio_rotation.py
+++ b/tests/test_proxy_mastio_rotation.py
@@ -24,7 +24,6 @@ from mcp_proxy.auth.mastio_rotation import (
     build_proof,
     verify_proof,
 )
-from mcp_proxy.db import insert_mastio_key
 
 
 def _fresh_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
@@ -308,7 +307,6 @@ async def test_rotate_counter_signs_with_new_key(agent_manager_with_identity):
     import base64
     import cryptography.hazmat.primitives.asymmetric.ec as _ec
     from cryptography.hazmat.primitives import hashes, serialization
-    from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
 
     sig_raw = base64.urlsafe_b64decode(sig_b64 + "=" * (-len(sig_b64) % 4))
     # countersign() emits a DER-encoded signature (``priv.sign`` default).

--- a/tests/test_proxy_mastio_rotation.py
+++ b/tests/test_proxy_mastio_rotation.py
@@ -1,0 +1,317 @@
+"""ADR-012 Phase 2.1 — key-continuity proof + ``rotate_mastio_key``.
+
+Two surfaces:
+
+* ``mcp_proxy.auth.mastio_rotation`` — pure proof build/verify
+  primitive. Tested against a fresh EC P-256 keypair, no DB or Court.
+* ``AgentManager.rotate_mastio_key`` — exercised end-to-end against a
+  real ``mastio_keys`` table. A stub propagator stands in for the
+  Court; Commit 3 wires the real BrokerBridge call.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from mcp_proxy.auth.local_keystore import LocalKeyStore, compute_kid
+from mcp_proxy.auth.mastio_rotation import (
+    ContinuityProof,
+    ContinuityProofError,
+    build_proof,
+    verify_proof,
+)
+from mcp_proxy.db import insert_mastio_key
+
+
+def _fresh_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+# ── Proof primitive ─────────────────────────────────────────────────
+
+
+def test_proof_roundtrip_valid_signature():
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    old_kid = compute_kid(old_pub)
+    new_kid = compute_kid(new_pub)
+
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=old_kid,
+        new_kid=new_kid,
+        new_pubkey_pem=new_pub,
+    )
+    assert proof.old_kid == old_kid
+    assert proof.new_kid == new_kid
+    assert proof.new_pubkey_pem == new_pub
+    # ES256 raw r||s → 64 bytes → ~86 b64url chars, no padding
+    assert 80 <= len(proof.signature_b64u) <= 90
+    assert "=" not in proof.signature_b64u
+
+    verify_proof(
+        proof,
+        expected_old_pubkey_pem=old_pub,
+        expected_old_kid=old_kid,
+    )
+
+
+def test_verify_rejects_wrong_pubkey():
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    _, foreign_pub = _fresh_keypair()
+    with pytest.raises(ContinuityProofError, match="signature"):
+        verify_proof(proof, expected_old_pubkey_pem=foreign_pub)
+
+
+def test_verify_rejects_kid_substitution():
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    with pytest.raises(ContinuityProofError, match="old_kid mismatch"):
+        verify_proof(
+            proof,
+            expected_old_pubkey_pem=old_pub,
+            expected_old_kid="mastio-deadbeefdeadbeef",
+        )
+
+
+def test_verify_rejects_stale_proof():
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    stale_when = datetime.now(timezone.utc) - timedelta(hours=2)
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+        issued_at=stale_when,
+    )
+    with pytest.raises(ContinuityProofError, match="freshness"):
+        verify_proof(proof, expected_old_pubkey_pem=old_pub)
+
+
+def test_verify_rejects_tampered_payload():
+    """Payload tamper detection: any change to canonicalised fields
+    invalidates the signature even if ``old_kid`` still matches."""
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    _, evil_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    tampered = ContinuityProof(
+        old_kid=proof.old_kid,
+        new_kid=compute_kid(evil_pub),
+        new_pubkey_pem=evil_pub,
+        issued_at=proof.issued_at,
+        signature_b64u=proof.signature_b64u,
+    )
+    with pytest.raises(ContinuityProofError, match="signature"):
+        verify_proof(tampered, expected_old_pubkey_pem=old_pub)
+
+
+def test_proof_serialisation_roundtrip():
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    data = proof.to_dict()
+    assert set(data) == {
+        "old_kid", "new_kid", "new_pubkey_pem", "issued_at", "signature_b64u",
+    }
+    restored = ContinuityProof.from_dict(data)
+    verify_proof(restored, expected_old_pubkey_pem=old_pub)
+
+
+def test_proof_from_dict_rejects_missing_fields():
+    with pytest.raises(ValueError, match="missing fields"):
+        ContinuityProof.from_dict({"old_kid": "k"})
+
+
+# ── AgentManager.rotate_mastio_key ──────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def agent_manager_with_identity(tmp_path, monkeypatch):
+    """``AgentManager`` with a bootstrapped Org CA + Mastio identity,
+    ready for rotation."""
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import dispose_db, init_db
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+    await init_db(url)
+    mgr = AgentManager(org_id="acme")
+    await mgr.generate_org_ca(derive_org_id=False)
+    await mgr.ensure_mastio_identity()
+    try:
+        yield mgr
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_rotate_mastio_key_swaps_active_row(agent_manager_with_identity):
+    mgr = agent_manager_with_identity
+    old_kid = mgr._active_key.kid  # pre-rotation signer
+
+    new_active = await mgr.rotate_mastio_key(grace_days=3)
+
+    assert new_active.kid != old_kid
+    assert new_active.is_active is True
+    # Cache refreshed on the manager
+    assert mgr._active_key.kid == new_active.kid
+
+    # Old row is now deprecated but still verification-valid.
+    store = LocalKeyStore()
+    old = await store.find_by_kid(old_kid)
+    assert old is not None
+    assert old.is_active is False
+    assert old.deprecated_at is not None
+    assert old.expires_at is not None
+    assert old.is_valid_for_verification is True
+
+    valid = await store.all_valid_keys()
+    kids = {k.kid for k in valid}
+    assert kids == {old_kid, new_active.kid}
+
+
+@pytest.mark.asyncio
+async def test_rotate_invokes_propagator_before_db_swap(agent_manager_with_identity):
+    mgr = agent_manager_with_identity
+    old_kid = mgr._active_key.kid
+
+    captured: list[tuple[ContinuityProof, str]] = []
+
+    async def propagator(proof: ContinuityProof, new_cert_pem: str) -> None:
+        captured.append((proof, new_cert_pem))
+        # Observer check: keystore has NOT swapped yet at this point.
+        store = LocalKeyStore()
+        current = await store.current_signer()
+        assert current.kid == old_kid, "DB swap happened before propagator"
+
+    await mgr.rotate_mastio_key(grace_days=3, propagator=propagator)
+
+    assert len(captured) == 1
+    proof, cert_pem = captured[0]
+    assert proof.old_kid == old_kid
+    # Proof carries the new cert's public key — verify chain
+    assert cert_pem.startswith("-----BEGIN CERTIFICATE-----")
+
+
+@pytest.mark.asyncio
+async def test_rotate_aborts_when_propagator_raises(agent_manager_with_identity):
+    mgr = agent_manager_with_identity
+    old_kid = mgr._active_key.kid
+
+    async def failing(_proof, _cert):
+        raise RuntimeError("court rejected the proof")
+
+    with pytest.raises(RuntimeError, match="court rejected"):
+        await mgr.rotate_mastio_key(grace_days=3, propagator=failing)
+
+    # State unchanged — still exactly one active row, same kid.
+    store = LocalKeyStore()
+    current = await store.current_signer()
+    assert current.kid == old_kid
+    assert mgr._active_key.kid == old_kid
+
+
+@pytest.mark.asyncio
+async def test_rotate_rejects_non_positive_grace(agent_manager_with_identity):
+    with pytest.raises(ValueError, match="grace_days"):
+        await agent_manager_with_identity.rotate_mastio_key(grace_days=0)
+
+
+@pytest.mark.asyncio
+async def test_rotated_key_issues_verifiable_jwts(agent_manager_with_identity):
+    """After rotation, the LocalIssuer built from the keystore signs
+    JWTs under the new kid, and the validator resolves both kids
+    (new and grace-period old)."""
+    from mcp_proxy.auth.local_issuer import build_from_keystore
+    from mcp_proxy.auth.local_validator import validate_local_token
+
+    mgr = agent_manager_with_identity
+    store = LocalKeyStore()
+
+    old_issuer = await build_from_keystore("acme", store)
+    old_token = old_issuer.issue("acme::alice", ttl_seconds=60).token
+
+    await mgr.rotate_mastio_key(grace_days=3)
+
+    new_issuer = await build_from_keystore("acme", store)
+    assert new_issuer.kid != old_issuer.kid
+    new_token = new_issuer.issue("acme::alice", ttl_seconds=60).token
+
+    # Both tokens validate during the grace period — the verifier picks
+    # the right key out of the keystore via ``kid`` lookup.
+    payload_old = await validate_local_token(
+        old_token, store, expected_issuer=new_issuer.issuer,
+    )
+    payload_new = await validate_local_token(
+        new_token, store, expected_issuer=new_issuer.issuer,
+    )
+    assert payload_old.agent_id == "acme::alice"
+    assert payload_new.agent_id == "acme::alice"
+
+
+@pytest.mark.asyncio
+async def test_rotate_counter_signs_with_new_key(agent_manager_with_identity):
+    """ADR-009 counter-sign path follows the active key swap."""
+    mgr = agent_manager_with_identity
+    old_pub = mgr.get_mastio_pubkey_pem()
+
+    await mgr.rotate_mastio_key(grace_days=3)
+
+    new_pub = mgr.get_mastio_pubkey_pem()
+    assert new_pub != old_pub
+
+    # countersign() now signs under the new key; the signature must be
+    # verifiable by the new pubkey, not the old.
+    sig_b64 = mgr.countersign(b"payload-under-test")
+    assert sig_b64
+    import base64
+    import cryptography.hazmat.primitives.asymmetric.ec as _ec
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
+
+    sig_raw = base64.urlsafe_b64decode(sig_b64 + "=" * (-len(sig_b64) % 4))
+    # countersign() emits a DER-encoded signature (``priv.sign`` default).
+    pub = serialization.load_pem_public_key(new_pub.encode())
+    assert isinstance(pub, _ec.EllipticCurvePublicKey)
+    pub.verify(sig_raw, b"payload-under-test", _ec.ECDSA(hashes.SHA256()))

--- a/tests/test_proxy_mastio_rotation_propagate.py
+++ b/tests/test_proxy_mastio_rotation_propagate.py
@@ -1,0 +1,184 @@
+"""ADR-012 Phase 2.1 — ``BrokerBridge.propagate_mastio_key_rotation``.
+
+Unit coverage of the HTTP shim between the Mastio rotation primitive
+and the Court endpoint landed in the previous commit. The ``httpx``
+client is substituted with a stubbed transport so the test asserts on
+the *request shape* (URL, JSON body) and the shim's behaviour on
+non-2xx + transport errors — no live Court here. The happy-path
+end-to-end test (real Court in-process via ASGITransport) lives
+alongside this file.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi import HTTPException
+
+from mcp_proxy.auth.local_keystore import compute_kid
+from mcp_proxy.auth.mastio_rotation import build_proof
+from mcp_proxy.egress.broker_bridge import BrokerBridge
+
+
+def _fresh_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _bridge(broker_url: str = "http://court.local") -> BrokerBridge:
+    # ``agent_manager`` is only consulted by session/client methods; the
+    # propagate path does not touch it, so a sentinel ``None`` is fine
+    # for these unit tests.
+    return BrokerBridge(
+        broker_url=broker_url,
+        org_id="acme",
+        agent_manager=None,  # type: ignore[arg-type]
+        verify_tls=False,
+    )
+
+
+def _install_mock_transport(monkeypatch, handler):
+    """Substitute ``httpx.AsyncClient`` inside ``broker_bridge`` so
+    every ``async with httpx.AsyncClient(...)`` routes through a
+    stubbed transport. Uses the *real* ``httpx.AsyncClient`` class
+    under a captured reference — the monkeypatch only replaces the
+    attribute on the ``broker_bridge.httpx`` namespace, not the
+    identity of the underlying class."""
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def _factory(*_, **kwargs):
+        # Drop the real ``verify`` / ``timeout`` kwargs on the floor —
+        # MockTransport ignores TLS/timeout anyway — and force our
+        # transport so every request is served by ``handler``.
+        kwargs.pop("verify", None)
+        kwargs.pop("timeout", None)
+        return real_async_client(transport=transport, **kwargs)
+
+    import mcp_proxy.egress.broker_bridge as module
+    monkeypatch.setattr(module.httpx, "AsyncClient", _factory)
+
+
+@pytest.mark.asyncio
+async def test_propagate_sends_expected_payload_to_court(monkeypatch):
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "org_id": "acme",
+                "new_kid": proof.new_kid,
+                "rotated_at": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+    _install_mock_transport(monkeypatch, handler)
+    bridge = _bridge("http://court.local")
+
+    await bridge.propagate_mastio_key_rotation(
+        proof, new_cert_pem="-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n",
+    )
+
+    assert len(captured) == 1
+    req = captured[0]
+    assert req.method == "POST"
+    assert str(req.url) == (
+        "http://court.local/v1/onboarding/orgs/acme/mastio-pubkey/rotate"
+    )
+    body = json.loads(req.content)
+    assert body["new_pubkey_pem"] == new_pub
+    assert body["proof"]["old_kid"] == proof.old_kid
+    assert body["proof"]["new_kid"] == proof.new_kid
+    assert body["proof"]["signature_b64u"] == proof.signature_b64u
+    assert body["new_cert_pem"].startswith("-----BEGIN CERTIFICATE-----")
+
+
+@pytest.mark.asyncio
+async def test_propagate_raises_on_court_4xx(monkeypatch):
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+
+    def handler(_request):
+        return httpx.Response(
+            401,
+            json={"detail": "continuity proof rejected: signature verification failed"},
+        )
+
+    _install_mock_transport(monkeypatch, handler)
+    bridge = _bridge()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await bridge.propagate_mastio_key_rotation(proof, new_cert_pem="")
+    assert excinfo.value.status_code == 401
+    assert "continuity proof rejected" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_propagate_wraps_court_5xx_as_502(monkeypatch):
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+
+    def handler(_request):
+        return httpx.Response(503, text="service unavailable")
+
+    _install_mock_transport(monkeypatch, handler)
+    bridge = _bridge()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await bridge.propagate_mastio_key_rotation(proof, new_cert_pem="")
+    assert excinfo.value.status_code == 502
+    assert "503" in excinfo.value.detail
+
+
+@pytest.mark.asyncio
+async def test_propagate_wraps_transport_error_as_502(monkeypatch):
+    old_priv, old_pub = _fresh_keypair()
+    _, new_pub = _fresh_keypair()
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+
+    def handler(_request):
+        raise httpx.ConnectError("connection refused")
+
+    _install_mock_transport(monkeypatch, handler)
+    bridge = _bridge()
+
+    with pytest.raises(HTTPException) as excinfo:
+        await bridge.propagate_mastio_key_rotation(proof, new_cert_pem="")
+    assert excinfo.value.status_code == 502
+    assert "unreachable" in excinfo.value.detail


### PR DESCRIPTION
## Summary

Phase 2.1 of the ES256 signing-key rotation roadmap (#261). Build on
the keystore primitive introduced in #263 to turn a Mastio leaf
rotation into a first-class operation: the Mastio mints a fresh
keypair under its existing intermediate CA, proves continuity to the
Court with a signed statement, and atomically swaps the active row
in ``mastio_keys``. The Court verifies the proof against the pinned
old pubkey and updates the pin.

Base branch is ``feat/mastio-keystore`` (PR #263) — merge that first
or the diff will include #263's commits too. Will rebase onto
``main`` once #263 is merged.

## Three commits

1. **``feat(mastio): key-rotation primitive + continuity proof``** —
   ``mcp_proxy.auth.mastio_rotation`` (``ContinuityProof``,
   ``build_proof``, ``verify_proof``, canonical JSON with freshness
   bound) + ``mcp_proxy.db.swap_active_mastio_key`` (single
   transaction INSERT + UPDATE) + ``AgentManager.rotate_mastio_key``
   (Court-first orchestration, propagator injectable).
2. **``feat(broker): Court endpoint for mastio pubkey rotation``** —
   ``POST /v1/onboarding/orgs/{org_id}/mastio-pubkey/rotate``,
   no admin auth required (proof is the auth). Court-local copy of
   the proof verifier at ``app/auth/mastio_rotation_verify.py`` so
   the broker runtime stays import-isolated from ``mcp_proxy/``.
3. **``feat(mastio): BrokerBridge.propagate_mastio_key_rotation``** —
   HTTP shim wiring the Mastio primitive to the Court endpoint. 4xx
   passthrough, 5xx/transport errors wrapped as 502.

## Threat-model decisions

- **Court-first ordering**. The propagator is invoked *before* the
  local DB swap. If it raises, no state changes locally. The only
  failure window that leaves Court + Mastio out of sync is a DB
  write failure *after* the Court has accepted the new pubkey — a
  scenario logged at ERROR and intentionally not auto-retried
  (silent retries across a partition risk diverging state further).
- **Envelope/proof binding**. The ``new_pubkey_pem`` in the request
  body must equal the one the proof signed over. Otherwise an
  attacker who captured a valid proof could replay it with a pubkey
  of their own in the envelope. Test
  ``test_rotate_rejects_envelope_tamper`` pins this.
- **Freshness window (600s)**. Bounds the replay window of a
  stolen proof. Test ``test_rotate_rejects_stale_proof`` pins it.
- **``old_kid`` anti-substitution**. Proofs carry the kid they claim
  to be signed by; the Court derives the expected kid from the
  pinned pubkey and rejects mismatches before the signature check.
- **No admin-auth fallback** on the rotation endpoint. If the
  Mastio loses its priv key, the existing admin-only
  ``PATCH /v1/admin/orgs/…`` flow remains the recovery path.

## What is NOT in this PR (deferred to PR-B)

- Dashboard UI (``/proxy/admin/mastio-key`` page with status + grace
  days + "Rotate now" button).
- CLI (``cullis rotate mastio-key --grace-days N``).
- Setting ``rotation_grace_days`` persisted in ``proxy_config``,
  editable from the dashboard.
- Sandbox integration test that rotates in a running ``./demo.sh
  full`` and verifies zero failed requests during the grace window.

The primitive is exercised in isolation by unit + component tests;
the UX layer sits entirely on top of the API landed here.

## Test plan

- [x] ``pytest tests/test_proxy_mastio_rotation.py`` — 13 passed
- [x] ``pytest tests/test_broker_mastio_pubkey_rotate.py`` — 7 passed
- [x] ``pytest tests/test_proxy_mastio_rotation_propagate.py`` — 4 passed
- [x] Cross-surface: proxy ``build_proof`` round-trips through broker
      ``verify_proof`` (``test_rotate_replaces_pinned_pubkey_with_valid_proof``).
- [x] Pre-existing ADR-009 counter-sig + ADR-012 Phase 1/2.0
      suites unaffected — 75 passed across the relevant files.
- [ ] Sandbox dogfood with rotation (PR-B).
- [ ] CI full suite (DCO + test + smoke) once the PR is pushed.

## References

- Issue #261 — PKI hardening roadmap
- Depends on PR #263 (keystore foundation)
- NIST SP 800-57 Part 1 §5.3.6 (signing-key cryptoperiods)
- RFC 9449 §5 (DPoP-style proof-of-possession; freshness-window
  pattern inspired from ``iat`` / ``jti`` reuse)