### PR TITLE
feat(dashboard): /proxy/mastio-key — signing-key rotation UI (#261)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1954,6 +1954,272 @@ async def pki_rotate_ca(request: Request):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Mastio ES256 signing key — rotation dashboard (ADR-012 Phase 2.1 UX)
+# ─────────────────────────────────────────────────────────────────────────────
+
+MASTIO_ROTATION_GRACE_DAYS_DEFAULT = 7
+MASTIO_ROTATION_GRACE_DAYS_MIN = 1
+MASTIO_ROTATION_GRACE_DAYS_MAX = 90
+
+
+async def _load_rotation_grace_days() -> int:
+    """Read the configured rotation grace window (days) from proxy_config.
+
+    Falls back to the baseline default on first visit / malformed config.
+    """
+    from mcp_proxy.db import get_config
+    raw = await get_config("rotation_grace_days")
+    if raw is None:
+        return MASTIO_ROTATION_GRACE_DAYS_DEFAULT
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return MASTIO_ROTATION_GRACE_DAYS_DEFAULT
+    if value < MASTIO_ROTATION_GRACE_DAYS_MIN:
+        return MASTIO_ROTATION_GRACE_DAYS_MIN
+    if value > MASTIO_ROTATION_GRACE_DAYS_MAX:
+        return MASTIO_ROTATION_GRACE_DAYS_MAX
+    return value
+
+
+def _mastio_key_to_view(key, *, now: datetime) -> dict:
+    """Render a ``MastioKey`` into a plain dict the template can iterate over."""
+    expires_at = key.expires_at
+    grace_total = None
+    grace_remaining = None
+    grace_pct = None
+    if key.deprecated_at is not None and expires_at is not None:
+        grace_total_s = (expires_at - key.deprecated_at).total_seconds()
+        grace_remaining_s = max(0, (expires_at - now).total_seconds())
+        grace_total = max(1, int(grace_total_s))
+        grace_remaining = int(grace_remaining_s)
+        # 0% = just rotated, 100% = grace fully elapsed
+        grace_pct = max(
+            0, min(100, 100 - int(grace_remaining_s * 100 / grace_total)),
+        )
+    return {
+        "kid": key.kid,
+        "pubkey_pem": key.pubkey_pem,
+        "cert_pem": key.cert_pem or "",
+        "created_at": key.created_at.isoformat(),
+        "activated_at": key.activated_at.isoformat() if key.activated_at else None,
+        "deprecated_at": key.deprecated_at.isoformat() if key.deprecated_at else None,
+        "expires_at": expires_at.isoformat() if expires_at else None,
+        "is_active": key.is_active,
+        "is_valid_for_verification": key.is_valid_for_verification,
+        "grace_total_seconds": grace_total,
+        "grace_remaining_seconds": grace_remaining,
+        "grace_pct": grace_pct,
+    }
+
+
+@router.get("/mastio-key", response_class=HTMLResponse)
+async def mastio_key_page(request: Request):
+    """Signing-key rotation dashboard.
+
+    Shows the active Mastio ES256 signer, any keys still inside the
+    verifier grace window, and exposes the ``rotation_grace_days``
+    configuration + a one-click rotate action.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.auth.local_keystore import LocalKeyStore
+    from mcp_proxy.db import get_config
+
+    org_id = await get_config("org_id") or ""
+    grace_days = await _load_rotation_grace_days()
+    standalone = getattr(request.app.state, "broker_bridge", None) is None
+
+    keystore = LocalKeyStore()
+    now = datetime.now(timezone.utc)
+
+    active_view = None
+    try:
+        active_key = await keystore.current_signer()
+    except RuntimeError as exc:
+        # Identity not yet provisioned — the page renders with an
+        # empty-state CTA pointing at /proxy/setup.
+        _log.info("mastio_key page: no active signer (%s)", exc)
+        active_key = None
+
+    if active_key is not None:
+        active_view = _mastio_key_to_view(active_key, now=now)
+
+    grace_keys = []
+    try:
+        valid = await keystore.all_valid_keys()
+        for k in valid:
+            if k.deprecated_at is None:
+                continue  # that is the active one, shown above
+            grace_keys.append(_mastio_key_to_view(k, now=now))
+        grace_keys.sort(key=lambda k: k["expires_at"] or "")
+    except Exception:
+        pass
+
+    return templates.TemplateResponse("mastio_key.html", _ctx(
+        request, session,
+        active="mastio_key",
+        org_id=org_id,
+        active_key=active_view,
+        grace_keys=grace_keys,
+        grace_days=grace_days,
+        grace_days_min=MASTIO_ROTATION_GRACE_DAYS_MIN,
+        grace_days_max=MASTIO_ROTATION_GRACE_DAYS_MAX,
+        standalone=standalone,
+    ))
+
+
+@router.post("/mastio-key/grace-days")
+async def mastio_key_save_grace(request: Request):
+    """Persist the ``rotation_grace_days`` preference (clamped to 1..90)."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import log_audit, set_config
+
+    form = await request.form()
+    raw = form.get("grace_days", "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise HTTPException(
+            status_code=400,
+            detail=f"grace_days must be an integer between {MASTIO_ROTATION_GRACE_DAYS_MIN} and {MASTIO_ROTATION_GRACE_DAYS_MAX}",
+        )
+    if (
+        value < MASTIO_ROTATION_GRACE_DAYS_MIN
+        or value > MASTIO_ROTATION_GRACE_DAYS_MAX
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=f"grace_days must be between {MASTIO_ROTATION_GRACE_DAYS_MIN} and {MASTIO_ROTATION_GRACE_DAYS_MAX}",
+        )
+
+    await set_config("rotation_grace_days", str(value))
+    await log_audit(
+        agent_id="admin",
+        action="mastio_key.grace_days_set",
+        status="success",
+        detail=f"rotation_grace_days={value}",
+    )
+    return RedirectResponse(url="/proxy/mastio-key", status_code=303)
+
+
+@router.post("/mastio-key/rotate")
+async def mastio_key_rotate(request: Request):
+    """Trigger a Mastio ES256 leaf rotation.
+
+    Flow (ADR-012 Phase 2.1, issue #261):
+      1. ``AgentManager.rotate_mastio_key`` mints a new leaf under the
+         intermediate CA, signs a continuity proof with the current key.
+      2. The ``propagator`` (wired to ``BrokerBridge`` when available)
+         POSTs the proof to the Court's rotate endpoint. On Court
+         rejection we raise 502 with the Court's own error.
+      3. The local ``mastio_keys`` swap runs in a single DB transaction —
+         the previous key is marked ``deprecated_at=now`` / ``expires_at``
+         at ``now + grace_days`` and remains verifier-valid during the
+         grace window.
+
+    Standalone deploys (no broker uplink) allow rotation without
+    propagation — a warning surfaces in the UI. This is a deliberate
+    relaxation: a standalone Mastio has no Court pin to update.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    if form.get("confirm_text") != "ROTATE":
+        raise HTTPException(
+            status_code=400,
+            detail="Confirmation text mismatch — rotation aborted",
+        )
+
+    from mcp_proxy.db import log_audit
+
+    agent_mgr = getattr(request.app.state, "agent_manager", None)
+    if agent_mgr is None or not getattr(agent_mgr, "mastio_loaded", False):
+        raise HTTPException(
+            status_code=409,
+            detail="Mastio identity not loaded — complete setup first",
+        )
+
+    grace_days = await _load_rotation_grace_days()
+    broker_bridge = getattr(request.app.state, "broker_bridge", None)
+    propagator = (
+        broker_bridge.propagate_mastio_key_rotation
+        if broker_bridge is not None
+        else None
+    )
+
+    old_kid = agent_mgr._active_key.kid if agent_mgr._active_key else None
+
+    try:
+        new_active = await agent_mgr.rotate_mastio_key(
+            grace_days=grace_days,
+            propagator=propagator,
+        )
+    except HTTPException as exc:
+        await log_audit(
+            agent_id="admin",
+            action="mastio_key.rotate",
+            status="failure",
+            detail=f"old_kid={old_kid}, reason={exc.detail}",
+        )
+        raise
+    except Exception as exc:
+        await log_audit(
+            agent_id="admin",
+            action="mastio_key.rotate",
+            status="failure",
+            detail=f"old_kid={old_kid}, reason={exc}",
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"rotation failed: {exc}",
+        ) from exc
+
+    # Rebuild the LocalIssuer so subsequent token mints use the new signer.
+    try:
+        from mcp_proxy.auth.local_issuer import build_from_keystore
+        from mcp_proxy.auth.local_keystore import LocalKeyStore
+        ks = getattr(request.app.state, "local_keystore", None) or LocalKeyStore()
+        request.app.state.local_keystore = ks
+        org_id = getattr(request.app.state, "org_id", None)
+        if org_id:
+            request.app.state.local_issuer = await build_from_keystore(org_id, ks)
+    except Exception as exc:
+        _log.warning("LocalIssuer rebuild after rotation failed: %s", exc)
+
+    await log_audit(
+        agent_id="admin",
+        action="mastio_key.rotate",
+        status="success",
+        detail=(
+            f"old_kid={old_kid}, new_kid={new_active.kid}, "
+            f"grace_days={grace_days}"
+        ),
+    )
+    # Redirect with flash-state in query string so the page can render a
+    # success toast without a dedicated session flash channel.
+    return RedirectResponse(
+        url=(
+            f"/proxy/mastio-key?rotated=1"
+            f"&old_kid={old_kid or ''}"
+            f"&new_kid={new_active.kid}"
+        ),
+        status_code=303,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Vault Settings
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -69,6 +69,11 @@
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M2.166 4.999A11.954 11.954 0 0010 1.944 11.954 11.954 0 0017.834 5c.11.65.166 1.32.166 2.001 0 5.225-3.34 9.67-8 11.317C5.34 16.67 2 12.225 2 7c0-.682.057-1.35.166-2.001zm11.541 3.708a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" fill="currentColor" stroke="none"/></svg>
                 PKI
             </a>
+            <a href="/proxy/mastio-key"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'mastio_key' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>
+                Signing Key
+            </a>
             <a href="/proxy/vault"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'vault' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>

--- a/mcp_proxy/dashboard/templates/mastio_key.html
+++ b/mcp_proxy/dashboard/templates/mastio_key.html
@@ -1,0 +1,335 @@
+{% extends "base.html" %}
+{% block title %}Signing Key{% endblock %}
+{% block header_title %}Signing Identity{% endblock %}
+{% block content %}
+<div class="max-w-6xl space-y-6">
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Flash toast — rotation just happened (old_kid → new_kid).     #}
+    {# ────────────────────────────────────────────────────────────── #}
+    {% if request.query_params.get('rotated') == '1' %}
+    <div id="rotation-flash" class="bg-emerald-500/5 border border-emerald-500/30 rounded-lg px-5 py-4 flex items-center gap-4 card-glow">
+        <div class="w-8 h-8 rounded-full bg-emerald-500/15 flex items-center justify-center flex-shrink-0">
+            <svg class="w-4 h-4 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+        </div>
+        <div class="flex-1 min-w-0">
+            <p class="text-[11px] text-emerald-400 uppercase tracking-[0.18em] font-medium">Rotation complete</p>
+            <p class="text-xs text-gray-400 mt-1 font-mono truncate">
+                {{ request.query_params.get('old_kid', '—') }}
+                <span class="text-gray-600 mx-1.5">&rarr;</span>
+                <span class="text-emerald-300">{{ request.query_params.get('new_kid', '—') }}</span>
+            </p>
+        </div>
+        <button type="button"
+                onclick="document.getElementById('rotation-flash').remove(); history.replaceState({}, '', '/proxy/mastio-key');"
+                class="text-gray-500 hover:text-gray-300 transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+    </div>
+    {% endif %}
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Hero — what this page is + why it exists.                     #}
+    {# ────────────────────────────────────────────────────────────── #}
+    <div class="bg-[#111827]/60 border border-gray-800/50 rounded-lg px-6 py-5 backdrop-blur-sm">
+        <div class="flex items-start justify-between gap-6">
+            <div>
+                <p class="text-[10px] text-gray-600 uppercase tracking-[0.22em] mb-2">ADR-012 · ES256</p>
+                <h2 class="font-heading text-xl font-semibold text-white tracking-wide">Mastio signing identity</h2>
+                <p class="text-xs text-gray-500 mt-2 leading-relaxed max-w-2xl">
+                    The same EC P-256 leaf signs intra-org local JWTs and the
+                    ADR-009 counter-signatures on cross-org envelopes. Rotation
+                    propagates a new public key to the Court under a continuity
+                    proof; the previous key stays verifier-valid for the grace
+                    window so in-flight tokens never fail mid-stream.
+                </p>
+            </div>
+            {% if active_key %}
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-[0.18em] flex-shrink-0">
+                <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
+            </span>
+            {% else %}
+            <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-[0.18em] flex-shrink-0">
+                <span class="w-1.5 h-1.5 rounded-full bg-gray-600"></span>Not Configured
+            </span>
+            {% endif %}
+        </div>
+        {% if standalone %}
+        <div class="mt-4 px-3 py-2 bg-amber-500/5 border border-amber-500/20 rounded text-[11px] text-amber-300/90 leading-relaxed">
+            <span class="font-medium uppercase tracking-wider">Standalone mode</span>
+            — no broker uplink is configured, so rotation will only update the
+            local keystore. The Court will not receive the new pubkey until a
+            broker is attached and rotation is re-run.
+        </div>
+        {% endif %}
+    </div>
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Active signer — the key every current signature lands under.   #}
+    {# ────────────────────────────────────────────────────────────── #}
+    {% if active_key %}
+    <div class="bg-[#111827]/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
+        <div class="flex items-center justify-between mb-5">
+            <div class="flex items-center gap-3">
+                <div class="w-8 h-8 rounded bg-accent-400/10 flex items-center justify-center">
+                    <svg class="w-4 h-4 text-accent-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>
+                </div>
+                <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Active signer</h3>
+            </div>
+            <button type="button"
+                    onclick="copyToClipboard('{{ active_key.kid }}')"
+                    class="text-[10px] text-gray-600 hover:text-accent-400 uppercase tracking-wider transition-colors flex items-center gap-1.5">
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3"/></svg>
+                Copy kid
+            </button>
+        </div>
+
+        {# Hero kid — the identifier you'll see in JWT headers and the Court audit trail. #}
+        <div class="bg-[#0a0f1a] border border-accent-400/20 rounded-lg px-5 py-4 mb-5">
+            <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em] mb-1.5">Key ID</p>
+            <p class="font-mono text-base text-accent-300 break-all">{{ active_key.kid }}</p>
+        </div>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 gap-x-8 gap-y-4 mb-5">
+            <div>
+                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Created</p>
+                <p class="text-xs text-gray-300 font-mono">{{ active_key.created_at[:19] }}</p>
+            </div>
+            <div>
+                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Activated</p>
+                <p class="text-xs text-gray-300 font-mono">{{ active_key.activated_at[:19] if active_key.activated_at else '—' }}</p>
+            </div>
+            <div>
+                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Algorithm</p>
+                <p class="text-xs text-gray-300">ES256 · P-256</p>
+            </div>
+        </div>
+
+        <details class="group">
+            <summary class="cursor-pointer text-[10px] text-gray-600 uppercase tracking-wider hover:text-gray-400 transition-colors flex items-center gap-2 select-none">
+                <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                Public key PEM
+            </summary>
+            <div class="mt-3 relative">
+                <button type="button"
+                        onclick="copyToClipboard(document.getElementById('active-pubkey-pem').textContent)"
+                        class="absolute top-2 right-2 px-2 py-1 text-[10px] text-gray-500 border border-gray-700/60 rounded hover:bg-gray-800 hover:text-gray-300 transition-colors bg-[#0a0f1a]/80">
+                    Copy
+                </button>
+                <pre id="active-pubkey-pem" class="font-mono text-[11px] text-gray-400 bg-[#0a0f1a] p-4 rounded-lg overflow-x-auto max-h-40 border border-gray-800/40">{{ active_key.pubkey_pem }}</pre>
+            </div>
+        </details>
+    </div>
+    {% else %}
+    <div class="bg-[#111827]/80 border border-gray-800/50 rounded-lg p-10 backdrop-blur-sm text-center">
+        <svg class="w-12 h-12 mx-auto text-gray-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>
+        <p class="text-sm text-gray-500 mb-1">No signing identity provisioned yet</p>
+        <p class="text-xs text-gray-700 mb-5">The Mastio generates an EC P-256 leaf on first boot, signed by the intermediate CA under your Org CA.</p>
+        <a href="/proxy/setup"
+           class="inline-block px-5 py-2 text-xs font-semibold rounded transition-all"
+           style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
+           onmouseover="this.style.background='#fff'"
+           onmouseout="this.style.background='#00e5c7'">
+            Open Setup Wizard
+        </a>
+    </div>
+    {% endif %}
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Grace window — keys that are no longer signing but still       #}
+    {# accepted by the verifier for the duration of the grace period. #}
+    {# ────────────────────────────────────────────────────────────── #}
+    <div class="bg-[#111827]/80 border border-gray-800/50 rounded-lg backdrop-blur-sm overflow-hidden">
+        <div class="px-6 py-4 border-b border-gray-800/60 flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Grace window</h3>
+            {% if grace_keys %}
+            <span class="px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+                {{ grace_keys | length }} deprecated · still verifier-valid
+            </span>
+            {% else %}
+            <span class="text-[10px] text-gray-600 uppercase tracking-wider">Empty</span>
+            {% endif %}
+        </div>
+
+        {% if grace_keys %}
+        <div class="divide-y divide-gray-800/40">
+            {% for gk in grace_keys %}
+            <div class="px-6 py-5">
+                <div class="flex items-start justify-between gap-6 mb-3">
+                    <div class="min-w-0 flex-1">
+                        <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em] mb-1">Deprecated kid</p>
+                        <p class="font-mono text-xs text-gray-300 break-all">{{ gk.kid }}</p>
+                    </div>
+                    <div class="text-right flex-shrink-0">
+                        <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em] mb-1">Remaining</p>
+                        <p class="font-mono text-sm text-amber-400 tabular-nums"
+                           data-countdown-to="{{ gk.expires_at }}"
+                           data-countdown-total="{{ gk.grace_total_seconds }}">
+                            {{ gk.grace_remaining_seconds }}s
+                        </p>
+                    </div>
+                </div>
+
+                {# Progress bar: 0% just deprecated, 100% grace elapsed. Colour shifts amber → red as expiry approaches. #}
+                <div class="relative h-1.5 bg-gray-800/60 rounded-full overflow-hidden">
+                    <div class="absolute inset-y-0 left-0 rounded-full transition-all duration-1000"
+                         style="width: {{ gk.grace_pct }}%; background: linear-gradient(90deg, rgba(251,191,36,0.9) 0%, rgba(248,113,113,0.9) 100%);"></div>
+                </div>
+
+                <div class="flex items-center justify-between mt-2 text-[10px] text-gray-600 uppercase tracking-wider">
+                    <span>Deprecated {{ gk.deprecated_at[:19] if gk.deprecated_at else '' }}</span>
+                    <span>Expires {{ gk.expires_at[:19] if gk.expires_at else '' }}</span>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <div class="px-6 py-10 text-center">
+            <p class="text-xs text-gray-600">No keys currently in the grace window.</p>
+            <p class="text-[11px] text-gray-700 mt-1.5">Deprecated keys appear here after a rotation and stay verifier-valid until their expiry.</p>
+        </div>
+        {% endif %}
+    </div>
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Rotation controls — grace_days config + trigger button.        #}
+    {# ────────────────────────────────────────────────────────────── #}
+    <div class="bg-[#111827]/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-5">Rotation controls</h3>
+
+        <div class="grid md:grid-cols-2 gap-6 mb-6">
+            {# Grace days config — persisted in proxy_config. #}
+            <form method="post" action="/proxy/mastio-key/grace-days" class="bg-[#0a0f1a]/60 border border-gray-800/40 rounded-lg p-5">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                <p class="text-[10px] text-gray-600 uppercase tracking-[0.2em] mb-1.5">Grace window</p>
+                <p class="text-xs text-gray-500 leading-relaxed mb-4">
+                    How long a deprecated kid stays verifier-valid after the
+                    next rotation. Covers in-flight tokens and JWKS polling
+                    intervals on clients.
+                </p>
+                <div class="flex items-center gap-3">
+                    <input type="number" name="grace_days"
+                           min="{{ grace_days_min }}" max="{{ grace_days_max }}"
+                           value="{{ grace_days }}" required
+                           class="w-24 bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white font-mono tabular-nums text-center focus:outline-none focus:border-accent-400/60 transition-colors">
+                    <span class="text-xs text-gray-500 uppercase tracking-wider">days</span>
+                    <button type="submit"
+                            class="ml-auto px-3 py-2 text-[11px] font-medium uppercase tracking-wider border border-gray-700 text-gray-400 rounded hover:bg-gray-800 hover:text-gray-200 transition-colors">
+                        Save
+                    </button>
+                </div>
+                <p class="text-[10px] text-gray-700 mt-3">Range: {{ grace_days_min }}–{{ grace_days_max }} days.</p>
+            </form>
+
+            {# Rotate now — opens the confirmation modal. #}
+            <div class="bg-[#0a0f1a]/60 border border-accent-400/20 rounded-lg p-5 flex flex-col">
+                <p class="text-[10px] text-accent-400 uppercase tracking-[0.2em] mb-1.5">Rotate now</p>
+                <p class="text-xs text-gray-500 leading-relaxed mb-4 flex-1">
+                    Mints a fresh EC P-256 leaf under the existing intermediate
+                    CA, signs a continuity proof with the current key, and
+                    swaps the active row once the Court confirms. The previous
+                    kid remains verifier-valid for <span class="text-gray-300 font-mono">{{ grace_days }}d</span>.
+                </p>
+                <button type="button"
+                        {% if not active_key %}disabled{% endif %}
+                        onclick="document.getElementById('rotate-mastio-modal').classList.remove('hidden'); document.getElementById('confirm-input').focus();"
+                        class="self-start px-4 py-2 text-xs font-semibold uppercase tracking-wider rounded transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em;"
+                        onmouseover="if(!this.disabled){this.style.background='#fff'}"
+                        onmouseout="if(!this.disabled){this.style.background='#00e5c7'}">
+                    <svg class="w-3.5 h-3.5 inline mr-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                    Rotate signing key
+                </button>
+            </div>
+        </div>
+
+        {# Threat-model footnote, small but present. #}
+        <details class="text-[11px] text-gray-600 leading-relaxed">
+            <summary class="cursor-pointer hover:text-gray-400 transition-colors uppercase tracking-wider select-none flex items-center gap-2">
+                <svg class="w-3 h-3 transition-transform group-open:rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>
+                How the proof works
+            </summary>
+            <div class="mt-3 pl-5 space-y-2 text-gray-500 max-w-2xl">
+                <p>A canonical JSON body — <span class="font-mono text-gray-400">{old_kid, new_kid, new_pubkey_pem, issued_at}</span> — is signed with the current (old) private key. The Court verifies the signature against the currently-pinned pubkey and rejects stale timestamps, substituted kids, and envelope/proof mismatches.</p>
+                <p>Ordering is Court-first: if the Court rejects, the local keystore is untouched. The only failure window that can leave Mastio and Court out of sync is a DB write failure <em class="italic">after</em> the Court has accepted the new pubkey — surfaced as ERROR in the audit log and left for manual recovery.</p>
+            </div>
+        </details>
+    </div>
+
+</div>
+
+{# ────────────────────────────────────────────────────────────── #}
+{# Confirmation modal — type ROTATE to enable the submit button.  #}
+{# ────────────────────────────────────────────────────────────── #}
+<div id="rotate-mastio-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+         onclick="document.getElementById('rotate-mastio-modal').classList.add('hidden')"></div>
+    <div class="relative bg-surface-900 border border-gray-800/50 rounded-lg p-6 w-full max-w-md shadow-2xl">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-3 font-heading">Rotate signing key</h3>
+
+        <div class="p-3 bg-[#0a0f1a] border border-accent-400/15 rounded mb-4">
+            <p class="text-xs text-gray-400 leading-relaxed">
+                A new EC P-256 leaf will be minted and propagated to the Court
+                under a continuity proof. The current kid
+                {% if active_key %}<span class="font-mono text-gray-300">({{ active_key.kid }})</span>{% endif %}
+                stays verifier-valid for <span class="font-mono text-accent-400">{{ grace_days }} days</span>.
+            </p>
+        </div>
+
+        <form method="post" action="/proxy/mastio-key/rotate">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-[0.2em]">Type ROTATE to confirm</label>
+            <input type="text" id="confirm-input" name="confirm_text" required
+                   autocomplete="off" spellcheck="false"
+                   placeholder="ROTATE"
+                   class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono tracking-widest transition-all mb-4 focus:outline-none focus:border-accent-400/60"
+                   oninput="document.getElementById('rotate-submit-btn').disabled = (this.value !== 'ROTATE')">
+            <div class="flex items-center gap-3">
+                <button type="submit" id="rotate-submit-btn" disabled
+                        class="px-4 py-2 text-xs font-semibold uppercase tracking-wider rounded transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em;"
+                        onmouseover="if(!this.disabled){this.style.background='#fff'}"
+                        onmouseout="if(!this.disabled){this.style.background='#00e5c7'}">
+                    Confirm rotation
+                </button>
+                <button type="button"
+                        onclick="document.getElementById('rotate-mastio-modal').classList.add('hidden')"
+                        class="px-4 py-2 text-xs text-gray-500 border border-gray-700 rounded hover:bg-gray-800 transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+// Live countdown — tick every second on any deprecated-kid row with
+// data-countdown-to / data-countdown-total. The server-rendered value
+// is the seed, the browser keeps it fresh.
+(function() {
+    function fmt(seconds) {
+        if (seconds <= 0) return 'expired';
+        var d = Math.floor(seconds / 86400);
+        var h = Math.floor((seconds % 86400) / 3600);
+        var m = Math.floor((seconds % 3600) / 60);
+        var s = seconds % 60;
+        if (d > 0) return d + 'd ' + h + 'h';
+        if (h > 0) return h + 'h ' + m + 'm';
+        if (m > 0) return m + 'm ' + s + 's';
+        return s + 's';
+    }
+    function tick() {
+        var nodes = document.querySelectorAll('[data-countdown-to]');
+        var now = Date.now();
+        nodes.forEach(function(node) {
+            var expiresAt = Date.parse(node.dataset.countdownTo);
+            if (isNaN(expiresAt)) return;
+            var remaining = Math.max(0, Math.floor((expiresAt - now) / 1000));
+            node.textContent = fmt(remaining);
+        });
+    }
+    tick();
+    setInterval(tick, 1000);
+})();
+</script>
+{% endblock %}

--- a/tests/test_proxy_dashboard_mastio_key.py
+++ b/tests/test_proxy_dashboard_mastio_key.py
@@ -1,0 +1,232 @@
+"""ADR-012 Phase 2.1 UX — ``/proxy/mastio-key`` dashboard.
+
+Exercises the three routes added for operator-driven key rotation:
+
+* ``GET /proxy/mastio-key`` — renders the page, shows the active
+  signer, lists any deprecated-in-grace keys, reads the configured
+  grace_days, and flags standalone mode when no broker is attached.
+* ``POST /proxy/mastio-key/grace-days`` — persists the preference
+  under ``proxy_config.rotation_grace_days`` and clamps to 1..90.
+* ``POST /proxy/mastio-key/rotate`` — drives
+  ``AgentManager.rotate_mastio_key`` with a stub propagator (so no
+  network call leaves the test), audits the transition, and
+  redirects with a ``?rotated=1`` flash so the UI renders a toast.
+
+A cross-cutting render-time test asserts the key visual affordances
+(active kid, grace row, confirm modal) are in the DOM so a regression
+in the template surfaces quickly.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    """Standalone proxy booted with admin login + Org CA so the Mastio
+    identity auto-provisions during lifespan."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _csrf(client: AsyncClient) -> str:
+    page = await client.get("/proxy/mastio-key")
+    assert page.status_code == 200, page.text
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token not found in rendered page"
+    return m.group(1)
+
+
+# ── Render ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_page_renders_active_signer_and_controls(proxy_logged_in):
+    _, client = proxy_logged_in
+    resp = await client.get("/proxy/mastio-key")
+    assert resp.status_code == 200
+    html = resp.text
+    # Hero + heading text
+    assert "Mastio signing identity" in html
+    # Active signer block with kid + algorithm hints
+    assert "Active signer" in html
+    assert "ES256 · P-256" in html
+    assert "mastio-" in html  # the kid prefix should leak out somewhere
+    # Rotation controls — grace-days form + rotate button
+    assert 'name="grace_days"' in html
+    assert "Rotate signing key" in html
+    # Modal skeleton present
+    assert 'id="rotate-mastio-modal"' in html
+    assert "Type ROTATE to confirm" in html
+    # Standalone banner present because the fixture sets STANDALONE=true
+    assert "Standalone mode" in html
+
+
+@pytest.mark.asyncio
+async def test_nav_highlights_mastio_key_entry(proxy_logged_in):
+    _, client = proxy_logged_in
+    resp = await client.get("/proxy/mastio-key")
+    assert resp.status_code == 200
+    # The base.html nav renders ``nav-active`` when ``active == 'mastio_key'``.
+    assert 'href="/proxy/mastio-key"' in resp.text
+    # Check that the active nav marker is present on the Signing Key link.
+    nav_block = re.search(
+        r'href="/proxy/mastio-key"[^>]*class="[^"]*nav-active',
+        resp.text,
+    )
+    assert nav_block, "Signing Key nav entry is not marked active"
+
+
+# ── Grace-days preference ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_grace_days_save_persists_valid_value(proxy_logged_in):
+    _, client = proxy_logged_in
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/grace-days",
+        data={"csrf_token": csrf, "grace_days": "14"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/proxy/mastio-key"
+
+    from mcp_proxy.db import get_config
+    assert await get_config("rotation_grace_days") == "14"
+
+
+@pytest.mark.asyncio
+async def test_grace_days_save_rejects_out_of_range(proxy_logged_in):
+    _, client = proxy_logged_in
+    csrf = await _csrf(client)
+    # Below MIN (1)
+    resp = await client.post(
+        "/proxy/mastio-key/grace-days",
+        data={"csrf_token": csrf, "grace_days": "0"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    # Above MAX (90)
+    resp = await client.post(
+        "/proxy/mastio-key/grace-days",
+        data={"csrf_token": csrf, "grace_days": "365"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_grace_days_save_rejects_non_numeric(proxy_logged_in):
+    _, client = proxy_logged_in
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/grace-days",
+        data={"csrf_token": csrf, "grace_days": "soon"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+# ── Rotation ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rotate_requires_confirm_text(proxy_logged_in):
+    _, client = proxy_logged_in
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/rotate",
+        data={"csrf_token": csrf, "confirm_text": "nope"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "Confirmation text mismatch" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_rotate_swaps_active_signer_and_flashes(proxy_logged_in):
+    app, client = proxy_logged_in
+    # Capture the kid in use before we trigger rotation.
+    mgr = app.state.agent_manager
+    assert mgr.mastio_loaded, "fixture is expected to bootstrap Mastio identity"
+    old_kid = mgr._active_key.kid
+
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/rotate",
+        data={"csrf_token": csrf, "confirm_text": "ROTATE"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+    location = resp.headers["location"]
+    assert location.startswith("/proxy/mastio-key?rotated=1"), location
+    assert f"old_kid={old_kid}" in location
+
+    new_kid = mgr._active_key.kid
+    assert new_kid != old_kid
+    assert f"new_kid={new_kid}" in location
+
+    # The rendered page after redirect should display both kids in the flash.
+    flash_page = await client.get(location)
+    assert flash_page.status_code == 200
+    assert "Rotation complete" in flash_page.text
+    assert old_kid in flash_page.text
+    assert new_kid in flash_page.text
+
+    # LocalIssuer was rebuilt so subsequent JWTs sign under the new kid.
+    issuer = app.state.local_issuer
+    assert issuer is not None
+    assert issuer.kid == new_kid
+
+
+@pytest.mark.asyncio
+async def test_rotate_grace_row_appears_after_rotation(proxy_logged_in):
+    _, client = proxy_logged_in
+    csrf = await _csrf(client)
+    # Pre-set a short grace so the UI row has a stable countdown target.
+    await client.post(
+        "/proxy/mastio-key/grace-days",
+        data={"csrf_token": csrf, "grace_days": "1"},
+        follow_redirects=False,
+    )
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/rotate",
+        data={"csrf_token": csrf, "confirm_text": "ROTATE"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    page = await client.get("/proxy/mastio-key")
+    assert page.status_code == 200
+    # Grace window section should now carry "1 deprecated · still verifier-valid"
+    assert "deprecated · still verifier-valid" in page.text
+    # And a countdown data-attribute.
+    assert "data-countdown-to=" in page.text


### PR DESCRIPTION
## Summary

Operator-facing UI for ADR-012 Phase 2.1 key rotation. Complements
the primitive + Court endpoint already in PR #264. Single commit,
zero logic new — it wraps ``AgentManager.rotate_mastio_key`` and
exposes the ``rotation_grace_days`` preference.

Base is ``feat/mastio-rotation`` (PR #264). Will rebase onto
``main`` once #264 merges.

## What ships

- New page ``/proxy/mastio-key`` (nav entry "Signing Key" under
  PKI). Four sections stacked top-to-bottom:
  - **Hero** — what the page is, ADR-012/ES256 context, active-vs-
    not-configured pill, and a standalone-mode warning when no
    broker uplink is configured.
  - **Active signer** — hero block with the ``kid`` in monospace +
    copy-to-clipboard, created/activated timestamps, algorithm
    ("ES256 · P-256"), and a collapsible public-key PEM.
  - **Grace window** — per-deprecated-kid row with an amber→red
    progress bar (0% just deprecated → 100% expired), live 1 Hz
    countdown, and deprecated/expires timestamps. Empty state when
    no rotation has happened yet.
  - **Rotation controls** — grace-days form (1–90, default 7,
    persisted under ``proxy_config.rotation_grace_days``) next to
    a "Rotate signing key" CTA. Rotate opens a confirm modal
    requiring ``ROTATE`` in the input. A disclosure explains the
    continuity-proof flow in one paragraph.

- Three routes on the dashboard router:
  - ``GET /proxy/mastio-key`` — render.
  - ``POST /proxy/mastio-key/grace-days`` — persist preference,
    audited, 303 back to the page.
  - ``POST /proxy/mastio-key/rotate`` — requires
    ``confirm_text=ROTATE``, invokes the primitive with the
    ``BrokerBridge`` propagator when present, rebuilds
    ``app.state.local_issuer``, redirects with
    ``?rotated=1&old_kid&new_kid`` so the next render shows a
    flash toast.

- Nav entry wired in ``base.html`` right after PKI.

## Tests

``tests/test_proxy_dashboard_mastio_key.py`` — 8 cases:

- Render: active signer, algorithm, controls, modal skeleton,
  standalone banner.
- Nav: ``active=mastio_key`` is highlighted.
- Preference: valid value persists; 0, 365, and ``"soon"`` all
  rejected with 400.
- Rotation guards: missing/wrong ``confirm_text`` → 400 no-op.
- Rotation happy path: active kid swaps on the ``AgentManager``
  cache; redirect carries both kids; the rendered page includes
  the flash; ``app.state.local_issuer`` rebuilds under the new
  kid.
- Grace-window UI row + ``data-countdown-to`` attribute appear
  after a rotation with ``grace_days=1``.

Full ADR-012 regression (dashboard + rotation primitive + keystore
+ validator + counter-sig): **74 passed**, zero regressions.

## Manual smoke (optional)

1. ``./sandbox/demo.sh full``
2. Visit ``http://localhost:9100/proxy/mastio-key``.
3. Check Signing Key nav entry is active, the active kid is
   displayed, and the "Rotate signing key" button opens the
   modal.
4. Type ``ROTATE``, confirm.
5. Verify the flash banner shows ``old_kid → new_kid`` and the
   grace window now lists one row with a running countdown.
6. Query the Court audit — ``admin.mastio_pubkey_rotated`` event
   with the new kid pinned.

## References

- Issue #261 — PKI hardening roadmap
- Depends on PR #264 (rotation primitive + Court endpoint)
- ADR-012 Phase 2.1