### PR TITLE
ci: trigger workflows on stacked PRs (base != main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # No `branches:` filter on pull_request — stacked PRs (base != main)
+  # must trigger CI too. A missing filter matches any base branch.
   pull_request:
-    branches: [main]
 
 # Require approval before running CI on PRs from forks.
 # This prevents untrusted code from executing pip install.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,8 +1,9 @@
 name: DCO
 
 on:
+  # No `branches:` filter — stacked PRs (base != main) must run
+  # DCO check too. A missing filter matches any base branch.
   pull_request:
-    branches: [main]
     types: [opened, synchronize, reopened]
 
 jobs:

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -17,8 +17,9 @@ name: helm-test
 on:
   push:
     branches: [main]
+  # No `branches:` filter on pull_request — stacked PRs (base != main)
+  # must trigger helm-test too. A missing filter matches any base.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -12,8 +12,9 @@ name: smoke
 on:
   push:
     branches: [main]
+  # No `branches:` filter on pull_request — stacked PRs (base != main)
+  # must trigger the smoke gate too. A missing filter matches any base.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Drop the `branches: [main]` filter from the `pull_request` trigger in `ci.yml`, `smoke.yml`, `helm-test.yml`, `dco.yml`.
- `push:` triggers stay main-only; we only want post-merge runs on main, not on every branch push.

## Why

Stacked PRs with `base != main` were silently skipping every required check — seen twice in the Phase 2.1 rotation series (`#263` → `#264` → `#265`). GitHub treats `pull_request: branches: [X]` as "only run when the PR targets branch X", so stacked PRs with a feature-branch base never triggered CI/smoke/helm-test/DCO and shipped blind.

With the filter removed, a missing `branches:` key matches any base branch — stacked PRs get the same required-check contract as top-level PRs.

## Test plan

- [ ] Open this PR → CI / smoke / helm-test / DCO all trigger (verifies the top-level case still works).
- [ ] Next stacked PR in any series triggers CI without manual `gh pr edit --base main` workaround.