### PR TITLE
feat(mastio): ADR-012 Phase 2.2 — JWKS-local exposes active + grace kids

### DIFF
--- a/mcp_proxy/auth/jwks_local.py
+++ b/mcp_proxy/auth/jwks_local.py
@@ -1,6 +1,6 @@
 """ADR-012 §3 — JWKS endpoint for the Mastio local issuer.
 
-Exposes the Mastio leaf public key as a JWKS document so intra-org
+Exposes the Mastio public keys as a JWKS document so intra-org
 validators (Mastio-side middleware, MCP aggregator, local session
 store) can verify tokens without a remote round-trip.
 
@@ -8,6 +8,14 @@ The endpoint is served unauthenticated by design — it publishes public
 key material only, mirrors the /.well-known/jwks.json pattern used
 by the broker, and is read by internal components sharing the same
 FastAPI process.
+
+Phase 2.2 shift: the endpoint now enumerates every key the keystore
+still accepts for verification (active + deprecated-but-within-grace),
+not just the single active signer. During a rotation grace window this
+lets an in-flight consumer that has cached the old ``kid`` re-fetch
+the JWKS and still find the old key — without this, a rotate immediately
+invalidates every token already in flight even though the keystore
+would happily verify them internally.
 """
 from __future__ import annotations
 
@@ -21,10 +29,19 @@ router = APIRouter(tags=["auth"])
     summary="JWKS for the Mastio local issuer (intra-org tokens)",
 )
 async def jwks_local(request: Request) -> dict:
-    issuer = getattr(request.app.state, "local_issuer", None)
-    if issuer is None:
+    keystore = getattr(request.app.state, "local_keystore", None)
+    if keystore is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="local issuer not initialized",
+            detail="local keystore not initialized",
         )
-    return issuer.jwks()
+    keys = await keystore.all_valid_keys()
+    if not keys:
+        # Empty keystore means Mastio identity hasn't been ensured yet
+        # (lifespan didn't complete or migration ran but no row exists).
+        # 503 is more actionable than `{"keys": []}` for the caller.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="no mastio signing keys available",
+        )
+    return {"keys": [k.jwk() for k in keys]}

--- a/tests/test_proxy_local_issuer.py
+++ b/tests/test_proxy_local_issuer.py
@@ -1,5 +1,5 @@
-"""ADR-012 Phase 1 / Phase 2.0 — unit tests for ``LocalIssuer`` and the
-``/.well-known/jwks-local.json`` endpoint.
+"""ADR-012 Phase 1 / Phase 2.0 / Phase 2.2 — unit tests for ``LocalIssuer``
+and the ``/.well-known/jwks-local.json`` endpoint.
 
 The issuer is the primitive behind every intra-org session token. These
 tests pin the wire format (ES256 claims, kid derivation, JWKS shape) so
@@ -7,6 +7,11 @@ future refactors can't silently break the contract the validator depends
 on. Phase 2.0 shifts the issuer from holding its own leaf key+pubkey
 pair to wrapping a ``MastioKey`` pulled from the keystore; the tests
 reflect that change but keep the same wire-level assertions.
+
+Phase 2.2: the JWKS endpoint reads from the keystore (not the single-
+signer issuer) so it can enumerate every kid currently accepted for
+verification — active + deprecated-but-within-grace. The endpoint tests
+live below and exercise the rotation-grace behaviour directly.
 """
 from __future__ import annotations
 
@@ -197,24 +202,151 @@ def test_jwks_roundtrip_matches_leaf_pubkey():
     assert _unb64u(jwk["y"]) == numbers.y
 
 
-def test_jwks_endpoint_returns_key_when_issuer_loaded():
+class _FakeKeyStore:
+    """In-memory keystore stub for wire-level JWKS tests.
+
+    The real ``LocalKeyStore`` hits the DB — these tests only need to
+    pin the endpoint's contract (what it reads, what it serialises,
+    when it 503s), so a list-backed stub keeps the fixture weight at
+    zero.
+    """
+
+    def __init__(self, keys: list[MastioKey]) -> None:
+        self._keys = keys
+
+    async def all_valid_keys(self) -> list[MastioKey]:
+        return [k for k in self._keys if k.is_valid_for_verification]
+
+
+def _grace_key(priv_pem: str, pub_pem: str, *, deprecated_ago_seconds: int = 60,
+               grace_seconds: int = 3600) -> MastioKey:
+    """Build a deprecated-but-within-grace ``MastioKey`` in memory."""
+    from datetime import timedelta  # local import to avoid top-level clutter
+
+    now = datetime.now(timezone.utc)
+    activated = now - timedelta(days=30)
+    deprecated = now - timedelta(seconds=deprecated_ago_seconds)
+    expires = now + timedelta(seconds=grace_seconds)
+    return MastioKey(
+        kid=compute_kid(pub_pem),
+        pubkey_pem=pub_pem,
+        privkey_pem=priv_pem,
+        cert_pem=None,
+        created_at=activated,
+        activated_at=activated,
+        deprecated_at=deprecated,
+        expires_at=expires,
+    )
+
+
+def test_jwks_endpoint_503_when_keystore_missing():
+    """Pre-lifespan state: ``local_keystore`` not set → 503 so callers
+    can distinguish a bootstrapping proxy from an empty keystore."""
     from mcp_proxy.auth.jwks_local import router as jwks_router
 
     app = FastAPI()
     app.include_router(jwks_router)
 
     with TestClient(app) as client:
-        # No issuer attached → 503.
-        app.state.local_issuer = None
         resp = client.get("/.well-known/jwks-local.json")
         assert resp.status_code == 503
 
-        _, priv_pem, pub_pem = _fresh_key()
-        app.state.local_issuer = LocalIssuer(
-            org_id="orga", active_key=_active_key(priv_pem, pub_pem),
-        )
+
+def test_jwks_endpoint_503_when_keystore_empty():
+    """Keystore attached but has no valid key — treat as ``identity not
+    ensured yet`` rather than publishing an empty ``{"keys": []}`` that
+    would silently break every validator polling the endpoint."""
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[])
+
+    with TestClient(app) as client:
+        resp = client.get("/.well-known/jwks-local.json")
+        assert resp.status_code == 503
+
+
+def test_jwks_endpoint_returns_single_active_key_pre_rotation():
+    """Canonical pre-rotation state: one active key → one JWK with the
+    expected kid + ES256 algorithm."""
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+
+    _, priv_pem, pub_pem = _fresh_key()
+    active = _active_key(priv_pem, pub_pem)
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[active])
+
+    with TestClient(app) as client:
         resp = client.get("/.well-known/jwks-local.json")
         assert resp.status_code == 200
         body = resp.json()
-        assert body["keys"][0]["kid"] == app.state.local_issuer.kid
+        assert len(body["keys"]) == 1
+        assert body["keys"][0]["kid"] == active.kid
         assert body["keys"][0]["alg"] == "ES256"
+        assert body["keys"][0]["kty"] == "EC"
+        assert body["keys"][0]["crv"] == "P-256"
+
+
+def test_jwks_endpoint_exposes_active_plus_grace_key_during_rotation():
+    """Phase 2.2 contract: during grace the endpoint publishes both
+    kids so a consumer that cached the old kid can still verify its
+    in-flight tokens after re-fetching the JWKS."""
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+
+    _, old_priv, old_pub = _fresh_key()
+    _, new_priv, new_pub = _fresh_key()
+    grace = _grace_key(old_priv, old_pub)
+    new_active = _active_key(new_priv, new_pub)
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[grace, new_active])
+
+    with TestClient(app) as client:
+        resp = client.get("/.well-known/jwks-local.json")
+        assert resp.status_code == 200
+        body = resp.json()
+        kids = {k["kid"] for k in body["keys"]}
+        assert kids == {grace.kid, new_active.kid}
+        assert len(body["keys"]) == 2
+        for entry in body["keys"]:
+            assert entry["alg"] == "ES256"
+            assert entry["kty"] == "EC"
+
+
+def test_jwks_endpoint_drops_expired_deprecated_key():
+    """``all_valid_keys`` filters on ``expires_at`` — the endpoint
+    inherits that and MUST NOT surface a deprecated key whose grace
+    window has elapsed (otherwise a stolen old key stays verifiable)."""
+    from datetime import timedelta
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+
+    _, old_priv, old_pub = _fresh_key()
+    _, new_priv, new_pub = _fresh_key()
+    now = datetime.now(timezone.utc)
+    expired = MastioKey(
+        kid=compute_kid(old_pub),
+        pubkey_pem=old_pub,
+        privkey_pem=old_priv,
+        cert_pem=None,
+        created_at=now - timedelta(days=400),
+        activated_at=now - timedelta(days=400),
+        deprecated_at=now - timedelta(days=30),
+        expires_at=now - timedelta(days=1),  # grace elapsed
+    )
+    new_active = _active_key(new_priv, new_pub)
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[expired, new_active])
+
+    with TestClient(app) as client:
+        resp = client.get("/.well-known/jwks-local.json")
+        assert resp.status_code == 200
+        body = resp.json()
+        kids = {k["kid"] for k in body["keys"]}
+        assert kids == {new_active.kid}
+        assert expired.kid not in kids


### PR DESCRIPTION
## Summary

- `/.well-known/jwks-local.json` now enumerates every kid the keystore accepts for verification (active + deprecated-but-within-grace), not just the single active signer.
- Five endpoint tests cover missing keystore, empty keystore, pre-rotation single-key, mid-grace two-kid, post-grace (expired deprecated dropped).

## Why

ADR-012 Phase 2.1 (#264) shipped the rotation primitive: `AgentManager.rotate_mastio_key()` swaps the active row and marks the old one deprecated with a grace window. `local_validator.py` already reads the keystore by kid so intra-proxy verification works during grace.

What was still broken: any **external** consumer caching the JWKS. Pre-rotation it had `{"kid": "old"}`; post-rotation re-fetching returned `{"kid": "new"}` with the old gone — so every in-flight token signed with the old kid hit 401 even though the validator would have accepted it. This PR closes that asymmetry.

Related: closes the Phase 2.2 gap tracked in `project_pki_rotation_plan.md`.

## Test plan

- [x] `pytest tests/test_proxy_local_issuer.py` — 11/11 pass including the 5 new endpoint cases
- [x] Full suite: the pre-existing `tests/test_ts_interop.py` + `tests/connector/test_profile_runtime_switch.py` failures reproduce on untouched main, not regressions from this PR
- [x] `demo_network/smoke.sh full` — PASS (A1/A4/A7/A8 all green)

Follow-ups (tracked as GitHub issues, not on this PR):
- #267 — `cullis rotate mastio-key` CLI parity with dashboard
- #268 — sandbox integration test: rotate live during `./demo.sh full`, assert zero failed request in grace window