### PR TITLE
docs(enrollment): collapse 4→3 methods — admin-token is not a flow

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -404,8 +404,9 @@ class CullisClient:
         API. Authentication from here on is **API-key + DPoP**, never
         a direct login to the Court. See ADR-011 for the enrollment
         methods that produce these files (``enroll_via_byoca``,
-        ``enroll_via_spiffe``, ``enroll_via_admin_token``,
-        ``enroll_via_connector``).
+        ``enroll_via_spiffe``, or the Connector device-code flow — use
+        ``from_connector(...)`` for the Connector case since it reads
+        a different on-disk layout).
 
         Args:
             mastio_url: base URL of the Mastio (``http://proxy-a:9100``).

--- a/site/src/content/docs/enrollment.md
+++ b/site/src/content/docs/enrollment.md
@@ -1,19 +1,19 @@
 ---
-title: "Agent enrollment — the four methods"
-description: "Under ADR-011, enrollment and runtime auth are separate layers. Four ways to enroll, one runtime path (API-key + DPoP via the Mastio)."
+title: "Agent enrollment — the three methods"
+description: "Under ADR-011, enrollment and runtime auth are separate layers. Three ways to enroll, one runtime path (API-key + DPoP via the Mastio)."
 category: "Identity"
 order: 25
-updated: "2026-04-18"
+updated: "2026-04-22"
 ---
 
 # Cullis — Agent enrollment
 
 Under [ADR-011](../architecture) Cullis separates two concerns:
 
-- **Enrollment** — a one-time handshake that turns whatever identity the agent already has (cert, SVID, OIDC login, admin-minted token) into a stable runtime credential.
+- **Enrollment** — a one-time handshake that turns whatever identity the agent already has (OIDC login via Connector, Org-CA cert, SVID) into a stable runtime credential.
 - **Runtime auth** — the credential the agent presents on every subsequent call: an **API key + DPoP proof**, always sent to the agent's Mastio (never directly to the Court).
 
-The four enrollment methods below are equivalent at the output layer — they all write the same three files on disk (`api-key`, `dpop.jwk`, `agent.json`) and produce the same runtime client. The difference is only in how the Mastio verifies the caller during enrollment.
+All three methods below are equivalent at the output layer — they persist the same runtime artifacts on disk (`api-key`, `dpop.jwk`, `agent.json`) and produce the same runtime client. The difference is only in how the Mastio verifies the caller during enrollment.
 
 ---
 
@@ -21,93 +21,95 @@ The four enrollment methods below are equivalent at the output layer — they al
 
 | Method | Pick it when | Trust anchor |
 |---|---|---|
-| `admin` | default, programmatic agents, CI/CD | operator-held admin secret |
-| `connector` | dev laptops, interactive onboarding | OIDC login via Connector Desktop |
-| `byoca` | enterprise PKI already in place, air-gapped, CI with baked-in creds | operator-supplied cert signed by the Org CA |
-| `spiffe` | K8s workloads under SPIRE | SVID verified against the SPIRE trust bundle |
+| `connector` | dev laptops, interactive onboarding | OIDC login via Connector Desktop, admin approves in the Mastio dashboard |
+| `byoca` | programmatic agents, CI/CD, enterprise PKI already in place, air-gapped bootstrap | operator-held admin secret + Org-CA-signed cert |
+| `spiffe` | K8s workloads under SPIRE | operator-held admin secret + SVID verified against the SPIRE trust bundle |
 
-All four are first-class. BYOCA and SPIFFE are **enrollment** primitives; runtime auth via SPIFFE/BYOCA direct login to the Court is legacy and emits deprecation headers (see [Migration from direct login](migration-from-direct-login.md)).
+BYOCA and SPIFFE are **enrollment** primitives. Runtime auth via SPIFFE/BYOCA direct login to the Court is legacy and emits deprecation headers (see [Migration from direct login](migration-from-direct-login.md)).
 
----
-
-## Method 1 — admin (default)
-
-Operator creates the agent row via the Mastio dashboard, emits an enrollment token, hands it to the runtime.
-
-```bash
-# Step 1 — dashboard: Create Agent → displays a one-shot enrollment token.
-# Step 2 — runtime reads the token at first boot:
-python -c "
-from cullis_sdk import CullisClient
-CullisClient.enroll_via_admin_token(
-    'https://mastio.acme.corp',
-    enrollment_token='enroll_xxx',
-    persist_to='/etc/cullis/agent/',
-)
-"
-# Step 3 — on every subsequent start:
-python -c "
-from cullis_sdk import CullisClient
-client = CullisClient.from_api_key_file(
-    'https://mastio.acme.corp',
-    api_key_path='/etc/cullis/agent/api-key',
-    dpop_key_path='/etc/cullis/agent/dpop.jwk',
-)
-client.send_oneshot('acme::target-bot', {'hello': 'world'})
-"
-```
+> **"Admin token" is not a separate flow.** `X-Admin-Secret` is the header that BYOCA and SPIFFE use when called non-interactively (sandbox bootstrap, Helm hook, CI/CD). The SDK's `enroll_via_byoca` / `enroll_via_spiffe` classmethods send it for you; a raw `curl` or `httpx.post(...)` to the same endpoint works identically — see the BYOCA section below.
 
 ---
 
-## Method 2 — connector (interactive)
+## Method 1 — connector (interactive, end-user)
 
 The user runs the [Connector Desktop](https://cullis.io/downloads), authenticates via OIDC against their corporate IdP (Google, Okta, Azure AD), and the Mastio admin approves the pending enrollment from the dashboard. The Connector persists credentials under `~/.cullis/identity/<org>/`.
 
 ```bash
 cullis-connector enroll --site https://mastio.acme.corp
-# OIDC browser flow opens — user logs in.
-# Admin sees a pending enrollment in the dashboard + clicks Approve.
+# Device-code flow: Connector opens a browser for OIDC login.
+# Admin sees a pending enrollment in the Mastio dashboard + clicks Approve.
+# On success, credentials are written under ~/.cullis/identity/<org>/.
+```
 
-# SDK reads the persisted identity:
+Internally the Connector calls `POST /v1/enrollment/start` and polls until the admin approves — no SDK primitive wraps this flow today. The SDK simply **loads** the persisted identity at runtime:
+
+```python
 from cullis_sdk import CullisClient
-client = CullisClient.from_connector()  # reads ~/.cullis/identity/
+
+client = CullisClient.from_connector()  # reads ~/.cullis/identity/<org>/
+client.send_oneshot('acme::target-bot', {'hello': 'world'})
 ```
 
 ---
 
-## Method 3 — BYOCA (cert + key)
+## Method 2 — BYOCA (cert + key)
 
 The operator holds an Org-CA-signed cert + private key (typically exported from Vault, Sectigo, or an enterprise CA). The Mastio verifies the signature chain against its loaded Org CA and emits the runtime credentials.
 
-```bash
-python -c "
+### Via the SDK
+
+```python
 from cullis_sdk import CullisClient
+
 CullisClient.enroll_via_byoca(
     'https://mastio.acme.corp',
-    admin_secret='\$MASTIO_ADMIN_SECRET',
+    admin_secret='$MASTIO_ADMIN_SECRET',
     agent_name='inventory-bot',
     cert_pem=open('agent.pem').read(),
     private_key_pem=open('agent-key.pem').read(),
     capabilities=['inventory.read', 'inventory.write'],
     persist_to='/etc/cullis/agent/',
 )
-"
 ```
 
 A SPIFFE URI in the cert's `SubjectAlternativeName` is picked up automatically and persisted as `spiffe_id` on the `internal_agents` row.
 
+### Via raw HTTP (sandbox bootstrap, Helm hook, CI/CD)
+
+Same endpoint, no SDK dependency — handy when the bootstrap runs in a language other than Python, or inside a minimal container:
+
+```bash
+curl -X POST https://mastio.acme.corp/v1/admin/agents/enroll/byoca \
+  -H "X-Admin-Secret: $MASTIO_ADMIN_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_name": "inventory-bot",
+    "display_name": "Inventory bot",
+    "capabilities": ["inventory.read", "inventory.write"],
+    "cert_pem": "-----BEGIN CERTIFICATE-----\n...",
+    "private_key_pem": "-----BEGIN PRIVATE KEY-----\n...",
+    "dpop_jwk": { "kty": "EC", "crv": "P-256", "x": "...", "y": "..." }
+  }'
+# 201 → { "agent_id": "...", "api_key": "sk_local_...", "dpop_jkt": "...", ... }
+# The plaintext api_key is returned exactly once. Persist it to disk
+# and feed it to CullisClient.from_api_key_file on subsequent runs.
+```
+
+This is the pattern the Cullis sandbox uses in `sandbox/bootstrap/bootstrap_mastio.py` to onboard pre-minted agents without pulling the SDK.
+
 ---
 
-## Method 4 — SPIFFE (SVID + trust bundle)
+## Method 3 — SPIFFE (SVID + trust bundle)
 
 The operator has a workload running under SPIRE with an X.509-SVID. The Mastio verifies the SVID against the SPIRE trust bundle.
 
-```bash
-python -c "
+```python
 from cullis_sdk import CullisClient
+
 CullisClient.enroll_via_spiffe(
     'https://mastio.acme.corp',
-    admin_secret='\$MASTIO_ADMIN_SECRET',
+    admin_secret='$MASTIO_ADMIN_SECRET',
     agent_name='k8s-inventory',
     svid_pem=open('svid.pem').read(),
     svid_key_pem=open('svid-key.pem').read(),
@@ -115,7 +117,6 @@ CullisClient.enroll_via_spiffe(
     capabilities=['inventory.read'],
     persist_to='/etc/cullis/agent/',
 )
-"
 ```
 
 The SPIFFE URI SAN on the SVID is **mandatory** for this method — without it the cert is not a valid SVID and the endpoint returns 400. The URI gets pinned as `spiffe_id`, the cert material lives under `cert_pem` (SPIRE rotates the SVID; the runtime credentials stay valid because auth is API-key + DPoP, not the SVID itself).
@@ -125,6 +126,8 @@ Trust bundle resolution:
 1. `body.trust_bundle_pem` (per-request override)
 2. `proxy_config.spire_trust_bundle` on the Mastio (operator-configured baseline)
 3. Neither → 503
+
+As with BYOCA, the SDK classmethod is just a wrapper around `POST /v1/admin/agents/enroll/spiffe` with `X-Admin-Secret` — same curl pattern works.
 
 ---
 
@@ -142,6 +145,8 @@ client = CullisClient.from_api_key_file(
 # Cross-org A2A message (no session — ADR-008 one-shot envelope).
 client.send_oneshot('globex::fulfillment-bot', {'order_id': 'A123'})
 ```
+
+`from_connector()` is the equivalent constructor for Method 1 — same runtime API, reads `~/.cullis/identity/<org>/` instead of an explicit path.
 
 No direct calls to the Court. No cert on the wire at runtime. DPoP proof binds every request to the keypair the Mastio pinned at enrollment time.
 

--- a/site/src/content/docs/migration-from-direct-login.md
+++ b/site/src/content/docs/migration-from-direct-login.md
@@ -166,6 +166,6 @@ During the grace window, yes — the legacy login still works. After `CULLIS_ALL
 
 ## See also
 
-- [Agent enrollment — the four methods](enrollment.md)
+- [Agent enrollment — the three methods](enrollment.md)
 - [Enrollment API reference](enrollment-api-reference.md)
 - [SPIFFE onboarding](spiffe-onboarding.md) for deploying SPIRE alongside Cullis


### PR DESCRIPTION
## Summary
- Closes #271 — Option A (align docs to reality, no new SDK code).
- `enrollment.md`: rewrite as **three** methods (connector / byoca / spiffe). \"admin-token\" is the `X-Admin-Secret` header used by BYOCA/SPIFFE when invoked non-interactively, not a standalone flow.
- `enrollment.md`: add raw `curl` example for BYOCA (sandbox bootstrap, Helm hook, CI/CD path without Python SDK dep).
- `cullis_sdk/client.py`: drop stale `enroll_via_admin_token` / `enroll_via_connector` references in `from_api_key_file` docstring; point the Connector case at `from_connector()`.
- `migration-from-direct-login.md`: update cross-link title.

## Scope check vs #271 acceptance
- [x] `cullis_sdk/client.py` docstring cites only the 2 real classmethods (`enroll_via_byoca`, `enroll_via_spiffe`).
- [x] `enrollment.md` renumbered to 3 methods, Method 1 shows the real HTTP/curl pattern, Connector clarified as separate process.
- [x] `spiffe-onboarding.md` (`site/` + `docs/`) — grepped clean, no drift.
- [x] `migration-from-direct-login.md` — cross-link fixed.
- [x] Repo-wide grep for `enroll_via_admin_token` / `enroll_via_connector` returns zero hits.

## Test plan
- [ ] CI green (docs + SDK unit tests).
- [ ] Visual pass on rendered enrollment page (Astro site build).
- [ ] `./smoke.sh full` if maintainer considers the docstring-only change in `cullis_sdk/client.py` within the smoke gate scope (no runtime code changed).

Docs-only + docstring. No behavior change.