### PR TITLE
fix(mastio): honor grace-window kids in local-token dep (closes #279)

### DIFF
--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -47,19 +47,30 @@ def _extract_bearer_or_dpop_token(request: Request) -> str | None:
     return None
 
 
-def _is_local_kid(token: str, issuer) -> bool:
-    """Cheap pre-check: unverified header kid == LocalIssuer's kid.
+async def _is_known_local_kid(token: str, keystore) -> bool:
+    """Pre-check: the token's ``kid`` matches a keystore row that is
+    still valid for verification (active OR within the grace window).
 
     Used to decide whether a ``Authorization: DPoP <jwt>`` should funnel
     into the local validator (and pre-empt the DPoP path) or be left
     alone. Broker-issued JWTs carry a different kid, so that path
     continues to reach ``_get_authenticated_agent_dpop`` unchanged.
+
+    Previously this compared against ``issuer.kid`` only — the current
+    active kid. That silently dropped tokens minted under the *old* kid
+    during a Phase 2.1 rotation grace window: the JWKS endpoint, the
+    keystore filter, and the validator all accepted them, but the dep
+    short-circuited before any of that ran. See issue #279.
     """
     try:
         header = jose_jwt.get_unverified_header(token)
     except jose_jwt.PyJWTError:
         return False
-    return header.get("kid") == issuer.kid
+    kid = header.get("kid")
+    if not isinstance(kid, str) or not kid:
+        return False
+    key = await keystore.find_by_kid(kid)
+    return key is not None and key.is_valid_for_verification
 
 
 async def _maybe_local_token(request: Request) -> TokenPayload | None:
@@ -74,19 +85,20 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
     if issuer is None:
         return None
 
+    keystore = getattr(request.app.state, "local_keystore", None)
+    if keystore is None:
+        return None
+
     token = _extract_bearer_or_dpop_token(request)
     if token is None:
         return None
 
     # When the scheme is DPoP, the token might be a broker-issued JWT
     # (different kid) the caller legitimately wants handled by the DPoP
-    # path. Pre-filter by kid so we only intercept tokens this Mastio
-    # actually signed.
-    if not _is_local_kid(token, issuer):
-        return None
-
-    keystore = getattr(request.app.state, "local_keystore", None)
-    if keystore is None:
+    # path. Pre-filter against the keystore so we intercept any kid
+    # this Mastio minted (active OR within rotation grace), and leave
+    # broker-issued kids alone.
+    if not await _is_known_local_kid(token, keystore):
         return None
 
     try:
@@ -152,14 +164,14 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
     if issuer is None:
         return None
 
+    keystore = getattr(request.app.state, "local_keystore", None)
+    if keystore is None:
+        return None
+
     token = _extract_bearer_or_dpop_token(request)
     if token is None:
         return None
-    if not _is_local_kid(token, issuer):
-        return None
-
-    keystore = getattr(request.app.state, "local_keystore", None)
-    if keystore is None:
+    if not await _is_known_local_kid(token, keystore):
         return None
 
     try:

--- a/tests/test_proxy_local_agent_dep.py
+++ b/tests/test_proxy_local_agent_dep.py
@@ -200,3 +200,152 @@ async def test_flag_off_falls_through_to_dpop(app_with_flag_off):
     assert resp.status_code == 401
     # WWW-Authenticate should be DPoP (realm), not Bearer — proves fall-through.
     assert "dpop" in resp.headers.get("WWW-Authenticate", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_grace_window_deprecated_kid_is_accepted(app_with_flag_on):
+    """Regression test for #279 (Phase 2.2 grace-window).
+
+    A token minted under kid K_old must keep verifying after a rotation
+    that deprecated K_old (within its grace window) and activated K_new.
+    Before the fix, the dep pre-filter compared against ``issuer.kid``
+    only (K_new) and dropped the K_old token into the DPoP fall-through,
+    producing a 401 even though JWKS/keystore/validator all accepted it.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    import mcp_proxy.db as db_mod
+    from mcp_proxy.auth.local_issuer import LocalIssuer
+    from mcp_proxy.auth.local_keystore import MastioKey, compute_kid
+
+    app = app_with_flag_on["app"]
+    old_issuer = app_with_flag_on["issuer"]
+
+    # Mint a token under the original (soon-to-be-deprecated) kid.
+    old_token = old_issuer.issue("orga::alice", ttl_seconds=60).token
+    old_kid = old_issuer.kid
+
+    # Simulate a Phase 2.1 rotation: generate a new keypair, insert as
+    # the new active row, and deprecate the old row with a grace window.
+    new_key = ec.generate_private_key(ec.SECP256R1())
+    new_priv = new_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    new_pub = new_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    new_kid = compute_kid(new_pub)
+    now = datetime.now(timezone.utc)
+    grace_expires = now + timedelta(days=7)
+
+    await db_mod.swap_active_mastio_key(
+        new_kid=new_kid,
+        new_pubkey_pem=new_pub,
+        new_privkey_pem=new_priv,
+        new_cert_pem=None,
+        new_activated_at=now.isoformat(),
+        new_created_at=now.isoformat(),
+        old_kid=old_kid,
+        old_deprecated_at=now.isoformat(),
+        old_expires_at=grace_expires.isoformat(),
+    )
+
+    # Point the app's LocalIssuer at the new active key, mirroring what
+    # the dashboard rotation handler does post-swap.
+    new_active = MastioKey(
+        kid=new_kid,
+        pubkey_pem=new_pub,
+        privkey_pem=new_priv,
+        cert_pem=None,
+        created_at=now,
+        activated_at=now,
+        deprecated_at=None,
+        expires_at=None,
+    )
+    app.state.local_issuer = LocalIssuer(org_id="orga", active_key=new_active)
+
+    # The old-kid token should still authenticate — that's the whole
+    # point of the Phase 2.2 grace window.
+    with TestClient(app) as client:
+        resp = client.get(
+            "/probe", headers={"Authorization": f"Bearer {old_token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "orga::alice"
+    assert body["org"] == "orga"
+
+
+@pytest.mark.asyncio
+async def test_expired_grace_kid_is_rejected(app_with_flag_on):
+    """Negative regression: once the grace window elapses, the deprecated
+    kid must no longer authenticate. Proves the fix doesn't over-accept.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    import mcp_proxy.db as db_mod
+    from mcp_proxy.auth.local_issuer import LocalIssuer
+    from mcp_proxy.auth.local_keystore import MastioKey, compute_kid
+
+    app = app_with_flag_on["app"]
+    old_issuer = app_with_flag_on["issuer"]
+
+    old_token = old_issuer.issue("orga::alice", ttl_seconds=3600).token
+    old_kid = old_issuer.kid
+
+    new_key = ec.generate_private_key(ec.SECP256R1())
+    new_priv = new_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    new_pub = new_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    new_kid = compute_kid(new_pub)
+    now = datetime.now(timezone.utc)
+    # grace window already elapsed
+    expired = now - timedelta(minutes=1)
+
+    await db_mod.swap_active_mastio_key(
+        new_kid=new_kid,
+        new_pubkey_pem=new_pub,
+        new_privkey_pem=new_priv,
+        new_cert_pem=None,
+        new_activated_at=now.isoformat(),
+        new_created_at=now.isoformat(),
+        old_kid=old_kid,
+        old_deprecated_at=(now - timedelta(days=8)).isoformat(),
+        old_expires_at=expired.isoformat(),
+    )
+
+    new_active = MastioKey(
+        kid=new_kid,
+        pubkey_pem=new_pub,
+        privkey_pem=new_priv,
+        cert_pem=None,
+        created_at=now,
+        activated_at=now,
+        deprecated_at=None,
+        expires_at=None,
+    )
+    app.state.local_issuer = LocalIssuer(org_id="orga", active_key=new_active)
+
+    with TestClient(app) as client:
+        resp = client.get(
+            "/probe", headers={"Authorization": f"Bearer {old_token}"},
+        )
+    # Expired-grace kid is unknown-to-the-dep, so it falls through to
+    # DPoP (no DPoP header present) → 401 DPoP realm.
+    assert resp.status_code == 401
+    assert "dpop" in resp.headers.get("WWW-Authenticate", "").lower()


### PR DESCRIPTION
## Summary
- Closes #279 — **regression of Phase 2.2 (PR #269)** at the auth-dep layer.
- `_is_local_kid(token, issuer)` → `_is_known_local_kid(token, keystore)` (async, keystore-backed).
- Every in-flight LOCAL_TOKEN minted under the old kid was 401'd the instant rotation committed, even though JWKS + keystore + validator all accepted it. This lifts the grace window to the dep layer where it belongs.

## Root cause
The dep compared only against `issuer.kid` (current active). Post-rotation, old-kid tokens were dropped into the DPoP fall-through and rejected. The grace window existed in the keystore (`is_valid_for_verification` returns True for active OR within-grace rows) but was invisible to the pre-filter.

## Fix
```python
async def _is_known_local_kid(token: str, keystore) -> bool:
    ...
    kid = header.get("kid")
    if not isinstance(kid, str) or not kid:
        return False
    key = await keystore.find_by_kid(kid)
    return key is not None and key.is_valid_for_verification
```

Reorders keystore acquisition in `_maybe_local_token` and `_maybe_local_internal_agent` so the new async pre-check has the keystore in scope. Broker-issued JWTs (kid absent from the keystore) continue to fall through to the DPoP path unchanged — verified by the existing `test_non_local_kid_falls_through_to_dpop` case.

## Tests
- `test_grace_window_deprecated_kid_is_accepted` — simulates a Phase 2.1 rotation via `swap_active_mastio_key`, presents a token minted under the deprecated kid, asserts 200.
- `test_expired_grace_kid_is_rejected` — same setup but grace already elapsed, asserts 401 with DPoP realm (proves both the fall-through still works and the fix doesn't over-accept).
- 7/7 pass locally (`pytest tests/test_proxy_local_agent_dep.py`, 35s).

## Scope check
- Only `mcp_proxy/auth/local_agent_dep.py` + the dedicated test file touched.
- `JWKS endpoint`, `keystore.find_by_kid`, `is_valid_for_verification`, `validate_local_token` untouched — already correct.
- No schema change, no migration, no API surface change.

## Audit reference
Surfaced by the 2026-04-23 audit, phase 5 (`imp/audit_2026_04_23/phase5_sdk_proxy_surface.md`, aggregate `imp/audit_2026_04_23.md` H-PKI-01).

## Test plan
- [ ] CI green (pytest + ruff)
- [ ] `./sandbox/smoke.sh full` green (running locally now, smoke gate for `mcp_proxy/` changes)
- [ ] Manual sandbox repro: rotate mid-flight with active traffic → no 401s in the grace window

## Related
- #261 PKI hardening roadmap (parent)
- PR #269 Phase 2.2 JWKS multi-key (the layer this fix completes)
- #280 #281 #282 — sibling audit findings, separate PRs