### PR TITLE
fix(pki): Org CA pathLen + verifier off-by-one (closes #280)

### DIFF
--- a/app/auth/x509_verifier.py
+++ b/app/auth/x509_verifier.py
@@ -144,20 +144,23 @@ def _walk_chain(
             pass
 
     # Path length: each parent's pathLenConstraint bounds the number of
-    # non-self-issued CAs that MAY follow below it. Walking top-down
-    # (trust_anchor first) lets us enforce it simply.
+    # non-self-issued intermediate CAs that MAY follow below it
+    # (RFC 5280 §4.2.1.9). ``full = [leaf, *intermediates, trust_anchor]``
+    # so iterating ``idx`` from ``len - 1`` (trust_anchor) down to ``1``
+    # covers every CA in the chain; ``below_ca_count = idx - 1`` is the
+    # number of CA certs strictly between ``parent`` and the leaf — the
+    # leaf itself sits at index 0 and is not counted (it is not a CA).
     for idx in range(len(full) - 1, 0, -1):
         parent = full[idx]
-        below_ca_count = max(0, (idx - 1))  # intermediates remaining below
+        below_ca_count = idx - 1
         try:
             bc = parent.extensions.get_extension_for_class(x509.BasicConstraints).value
-            if bc.path_length is not None and below_ca_count - 1 > bc.path_length:
-                # -1 because the leaf is not a CA, so it doesn't consume path length
+            if bc.path_length is not None and below_ca_count > bc.path_length:
                 raise HTTPException(
                     status.HTTP_401_UNAUTHORIZED,
                     detail=(f"certificate chain violates pathLenConstraint "
                             f"(parent allows {bc.path_length} below, chain has "
-                            f"{max(0, below_ca_count - 1)} intermediates)"),
+                            f"{below_ca_count} intermediates)"),
                 )
         except x509.ExtensionNotFound:
             # Non-CA wouldn't have BC; shouldn't reach here for intermediates

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -1315,7 +1315,13 @@ async def org_onboard_generate_ca(request: Request):
         .serial_number(_x509.random_serial_number())
         .not_valid_before(now - _dt.timedelta(minutes=5))  # tolerate minor clock skew
         .not_valid_after(now + _dt.timedelta(days=365 * 2))
-        .add_extension(_x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        # pathLen=1 because the proxy that inherits this Org CA then
+        # mints a Mastio intermediate CA (_mint_mastio_ca) underneath
+        # it and signs agent leaves under that intermediate. RFC 5280
+        # §4.2.1.9: pathLen=0 would forbid the intermediate and any
+        # stdlib verifier (OpenSSL, Go crypto/x509, webpki, browser)
+        # would reject the full chain at federation/mTLS time. See #280.
+        .add_extension(_x509.BasicConstraints(ca=True, path_length=1), critical=True)
         .add_extension(
             _x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
             critical=False,

--- a/demo_network/bootstrap/bootstrap.py
+++ b/demo_network/bootstrap/bootstrap.py
@@ -106,7 +106,19 @@ def _gen_org_ca(org_id: str) -> tuple[bytes, bytes]:
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + datetime.timedelta(days=3650))
-        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        # pathLen=1: the Org CA PEM written here is mounted into the
+        # proxy container (compose.yml proxy-a / proxy-b build
+        # mcp_proxy/Dockerfile and read /state/{org_id}/ca-key.pem).
+        # On boot, mcp_proxy runs ensure_mastio_identity() →
+        # _mint_mastio_ca() (mcp_proxy/egress/agent_manager.py:572-621)
+        # which signs a Mastio intermediate CA under THIS Org CA,
+        # and agent leaves are then minted under that intermediate.
+        # Runtime chain is therefore 3-tier (Org CA → Mastio CA →
+        # agent leaf) and RFC 5280 §4.2.1.9 requires pathLen≥1 on
+        # the Org CA so the intermediate is allowed. pathLen=0 would
+        # be rejected by any stdlib verifier (OpenSSL, Go crypto/x509,
+        # webpki, browser, kubectl mTLS) — see #280.
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
         .add_extension(
             x509.KeyUsage(
                 digital_signature=True, key_cert_sign=True, crl_sign=True,

--- a/generate_certs.py
+++ b/generate_certs.py
@@ -164,6 +164,13 @@ def gen_org_ca(
         .serial_number(x509.random_serial_number())
         .not_valid_before(NOW)
         .not_valid_after(NOW + datetime.timedelta(days=365 * 3))
+        # pathLen=0: dev/e2e chain is 3-tier flat
+        # (broker_ca → org_ca → agent_leaf) — no Mastio intermediate
+        # is minted below this Org CA, so pathLen=0 is RFC-correct
+        # (agent_leaf has ca=False and does not consume path length).
+        # Distinct from mcp_proxy/dashboard/router.py:123 which must
+        # use pathLen=1 because its chain does include a Mastio
+        # intermediate underneath. See #280.
         .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
         .add_extension(
             x509.SubjectKeyIdentifier.from_public_key(key.public_key()),

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -120,7 +120,12 @@ def generate_org_ca(org_id: str) -> tuple[str, str]:
         .serial_number(x509.random_serial_number())
         .not_valid_before(now)
         .not_valid_after(now + timedelta(days=3650))
-        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        # pathLen=1 because this Org CA signs a Mastio intermediate
+        # (_mint_mastio_ca) which then signs agent leaves. RFC 5280
+        # §4.2.1.9: pathLen=0 would forbid the intermediate and any
+        # stdlib verifier (OpenSSL, Go crypto/x509, webpki, browser)
+        # would reject the full chain at federation/mTLS time. See #280.
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
         .add_extension(
             x509.KeyUsage(
                 digital_signature=True, key_cert_sign=True, crl_sign=True,

--- a/tests/test_chain_external_verify.py
+++ b/tests/test_chain_external_verify.py
@@ -1,0 +1,208 @@
+"""External-verifier acceptance test for the dashboard-bootstrapped
+chain topology (Org CA → Mastio intermediate CA → agent leaf).
+
+The internal ``_walk_chain`` used to have an off-by-one that silently
+accepted invalid chains; ``tests/test_x509_verifier_pathlen.py`` guards
+that regression. This file exercises the same topology against
+``openssl verify``, which has no knowledge of our verifier and applies
+RFC 5280 strictly. A regression that re-emits ``pathLen=0`` on the Org
+CA would pass our internal tests if anyone re-introduced the ``-1`` but
+would still fail here — which is the whole point.
+
+The test rebuilds the certificate shapes inline rather than spinning up
+``AgentManager`` so it stays hermetic and free of DB / async plumbing.
+Skipped when ``openssl`` is not on ``PATH`` (CI has it; some local
+NixOS shells may not).
+"""
+from __future__ import annotations
+
+import datetime
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+
+_OPENSSL = shutil.which("openssl")
+
+pytestmark = pytest.mark.skipif(
+    _OPENSSL is None,
+    reason="openssl binary not available in PATH",
+)
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _mint_org_ca(path_length: int) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    """Mirror ``mcp_proxy/dashboard/router.py`` Org CA emission shape,
+    parametrised on pathLen so a single test can drive both the fixed
+    (``1``) and the buggy (``0``) case.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "dashboard-ext-verify CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "dashboard-ext-verify"),
+    ])
+    now = _now()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, key_cert_sign=True, crl_sign=True,
+                content_commitment=False, key_encipherment=False,
+                data_encipherment=False, key_agreement=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _mint_mastio_intermediate(
+    org_ca_key: rsa.RSAPrivateKey, org_ca_cert: x509.Certificate,
+) -> tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
+    """Mirror ``AgentManager._mint_mastio_ca``: EC P-256, pathLen=0,
+    signed by the Org CA."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "dashboard-ext-verify Mastio CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "dashboard-ext-verify"),
+    ])
+    now = _now()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(org_ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=180))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=0), critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(org_ca_key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _mint_agent_leaf(
+    issuer_key: ec.EllipticCurvePrivateKey,
+    issuer_cert: x509.Certificate,
+) -> x509.Certificate:
+    """Agent leaf signed by the Mastio intermediate, ca=False."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "agent-ext-verify"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "dashboard-ext-verify"),
+    ])
+    now = _now()
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=30))
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None), critical=True,
+        )
+        .sign(issuer_key, hashes.SHA256())
+    )
+
+
+def _write_pem(path: Path, cert: x509.Certificate) -> None:
+    path.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
+def _openssl_verify(root: Path, intermediate: Path, leaf: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            _OPENSSL, "verify",
+            "-CAfile", str(root),
+            "-untrusted", str(intermediate),
+            str(leaf),
+        ],
+        capture_output=True, text=True, timeout=10,
+    )
+
+
+def test_openssl_accepts_dashboard_chain_with_pathlen_one_root(tmp_path: Path):
+    """Fixed flow: Org CA pathLen=1 → Mastio intermediate pathLen=0 →
+    agent leaf. A stdlib verifier must accept it.
+    """
+    org_key, org_cert = _mint_org_ca(path_length=1)
+    int_key, int_cert = _mint_mastio_intermediate(org_key, org_cert)
+    leaf = _mint_agent_leaf(int_key, int_cert)
+
+    root_pem = tmp_path / "root.pem"
+    int_pem = tmp_path / "intermediate.pem"
+    leaf_pem = tmp_path / "leaf.pem"
+    _write_pem(root_pem, org_cert)
+    _write_pem(int_pem, int_cert)
+    _write_pem(leaf_pem, leaf)
+
+    result = _openssl_verify(root_pem, int_pem, leaf_pem)
+    assert result.returncode == 0, (
+        f"openssl rejected fixed chain — stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )
+
+
+def test_openssl_rejects_dashboard_chain_with_pathlen_zero_root(tmp_path: Path):
+    """Regression guard for #280: if any future change re-emits the
+    dashboard Org CA with pathLen=0 but keeps the Mastio intermediate
+    below it, openssl must reject the chain — even if our own verifier
+    mistakenly accepted it (as the pre-fix code did).
+    """
+    org_key, org_cert = _mint_org_ca(path_length=0)  # <-- the bug shape
+    int_key, int_cert = _mint_mastio_intermediate(org_key, org_cert)
+    leaf = _mint_agent_leaf(int_key, int_cert)
+
+    root_pem = tmp_path / "root.pem"
+    int_pem = tmp_path / "intermediate.pem"
+    leaf_pem = tmp_path / "leaf.pem"
+    _write_pem(root_pem, org_cert)
+    _write_pem(int_pem, int_cert)
+    _write_pem(leaf_pem, leaf)
+
+    result = _openssl_verify(root_pem, int_pem, leaf_pem)
+    assert result.returncode != 0, (
+        "openssl accepted a chain that violates pathLenConstraint — "
+        "bug has regressed"
+    )
+    # Message wording varies across openssl versions; match on the
+    # RFC-idiomatic phrasing without over-fitting.
+    combined = (result.stdout + result.stderr).lower()
+    assert "path length" in combined or "pathlen" in combined, (
+        f"openssl rejection did not mention path length — stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )

--- a/tests/test_x509_verifier_pathlen.py
+++ b/tests/test_x509_verifier_pathlen.py
@@ -1,0 +1,173 @@
+"""Regression tests for ``app.auth.x509_verifier._walk_chain`` pathLen
+constraint enforcement.
+
+Pre-fix the loop used ``below_ca_count - 1 > bc.path_length`` with a
+misleading comment about the leaf. The ``-1`` systematically under-counted
+the CAs below each parent by one, which silently accepted chains that
+violated pathLenConstraint by exactly one intermediate. The three tests
+here pin the RFC 5280 §4.2.1.9 semantics at the boundary where the
+off-by-one used to hide:
+
+- ``pathLen=0`` + 1 intermediate below → reject
+- ``pathLen=1`` + 1 intermediate below → accept
+- ``pathLen=1`` + 2 intermediates below → reject
+
+Together they prove the fix doesn't over-reject while still catching the
+original #280 regression (dashboard-bootstrapped Org CA with pathLen=0
+but a Mastio intermediate signed underneath).
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from fastapi import HTTPException
+
+from app.auth.x509_verifier import _walk_chain
+
+
+def _now() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _ca_cert(
+    name: str,
+    path_length: int | None,
+    *,
+    issuer_key: rsa.RSAPrivateKey | None = None,
+    issuer_cert: x509.Certificate | None = None,
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    """Build a CA cert. Self-signed when issuer_* omitted."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, name),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "pathlen-test"),
+    ])
+    issuer_name = issuer_cert.subject if issuer_cert else subject
+    signer_key = issuer_key or key
+    now = _now()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=30))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(signer_key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _leaf_cert(
+    issuer_key: rsa.RSAPrivateKey,
+    issuer_cert: x509.Certificate,
+) -> x509.Certificate:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "leaf"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "pathlen-test"),
+    ])
+    now = _now()
+    return (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=30))
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None), critical=True,
+        )
+        .sign(issuer_key, hashes.SHA256())
+    )
+
+
+def test_pathlen_zero_with_one_intermediate_rejected():
+    """Regression test for #280: pre-fix this chain was silently accepted
+    because ``below_ca_count - 1 > 0`` evaluated to ``0 > 0 = False``.
+    RFC 5280 §4.2.1.9: an Org CA with ``pathLen=0`` forbids any CA to
+    follow below it.
+    """
+    root_key, root_cert = _ca_cert("root", path_length=0)
+    int_key, int_cert = _ca_cert(
+        "intermediate", path_length=0,
+        issuer_key=root_key, issuer_cert=root_cert,
+    )
+    leaf = _leaf_cert(int_key, int_cert)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _walk_chain(
+            leaf=leaf,
+            intermediates=[int_cert],
+            trust_anchor=root_cert,
+            now=_now(),
+        )
+    assert exc_info.value.status_code == 401
+    assert "pathlen" in exc_info.value.detail.lower()
+
+
+def test_pathlen_one_with_one_intermediate_accepted():
+    """Positive case: pathLen=1 legally permits one intermediate below
+    the root. This is exactly the fixed dashboard chain (Org CA pathLen=1
+    → Mastio intermediate pathLen=0 → agent leaf).
+    """
+    root_key, root_cert = _ca_cert("root", path_length=1)
+    int_key, int_cert = _ca_cert(
+        "intermediate", path_length=0,
+        issuer_key=root_key, issuer_cert=root_cert,
+    )
+    leaf = _leaf_cert(int_key, int_cert)
+
+    _walk_chain(
+        leaf=leaf,
+        intermediates=[int_cert],
+        trust_anchor=root_cert,
+        now=_now(),
+    )
+
+
+def test_pathlen_one_with_two_intermediates_rejected():
+    """Guard against the systematic nature of the pre-fix bug: under
+    ``below_ca_count - 1 > bc.path_length`` this chain was also silently
+    accepted (``2 - 1 = 1 > 1 = False``), even though pathLen=1 only
+    permits a single intermediate.
+    """
+    root_key, root_cert = _ca_cert("root", path_length=1)
+    int1_key, int1_cert = _ca_cert(
+        "intermediate-1", path_length=1,
+        issuer_key=root_key, issuer_cert=root_cert,
+    )
+    int2_key, int2_cert = _ca_cert(
+        "intermediate-2", path_length=0,
+        issuer_key=int1_key, issuer_cert=int1_cert,
+    )
+    leaf = _leaf_cert(int2_key, int2_cert)
+
+    with pytest.raises(HTTPException) as exc_info:
+        _walk_chain(
+            leaf=leaf,
+            intermediates=[int2_cert, int1_cert],
+            trust_anchor=root_cert,
+            now=_now(),
+        )
+    assert exc_info.value.status_code == 401
+    assert "pathlen" in exc_info.value.detail.lower()


### PR DESCRIPTION
## Summary
- Closes #280 — **three Org CA issuance sites were emitting `pathLen=0`** while the downstream proxy runtime minted a Mastio intermediate CA under them. Resulting chain `Org CA(pathLen=0) → Mastio CA → agent leaf` violates RFC 5280 §4.2.1.9 and is rejected by any stdlib verifier (OpenSSL, Go crypto/x509, webpki, browser, kubectl mTLS). Cross-org federation silently failed authentication for every org bootstrapped via one of these flows.
- Our own chain walker masked all three because of a `- 1` off-by-one — test gap explained.
- **Correction vs the first review**: `demo_network/bootstrap/bootstrap.py` is **also** a 3-tier runtime flow and needed the fix. The earlier framing ("2-tier flat, docstring clarifier only") was wrong — the bootstrap-generated leaves are only seed material; the proxy containers (`compose.yml` builds `mcp_proxy/Dockerfile`) call `ensure_mastio_identity()` → `_mint_mastio_ca()` on boot, which mints a Mastio intermediate underneath the Org CA and then signs new agent leaves under that.

## The three broken issuance sites
| File | Fix | Why pathLen=1 |
|---|---|---|
| `mcp_proxy/dashboard/router.py:123` | 0 → **1** | Standalone proxy setup wizard. This Org CA's runtime chain includes a Mastio intermediate below it. |
| `app/dashboard/router.py:1318` | 0 → **1** | Court admin-generated Org CA. Proxies that inherit it then mint the same Mastio intermediate underneath. |
| `demo_network/bootstrap/bootstrap.py:109` | 0 → **1** | Demo compose builds `mcp_proxy/Dockerfile` for proxy-a / proxy-b; each proxy runs `ensure_mastio_identity()` → `_mint_mastio_ca()` on boot, producing the same 3-tier chain. |

## The verifier off-by-one that hid it
`app/auth/x509_verifier.py:146-167` compared `below_ca_count - 1 > bc.path_length` with a comment blaming the `- 1` on the leaf "not consuming path length". But `below_ca_count = idx - 1` already excluded the leaf (`full = [leaf, *intermediates, trust_anchor]`). The extra subtraction systematically under-counted CAs below each parent by one, so every chain that violated pathLen by exactly one intermediate passed the internal check.

Fixed to `below_ca_count > bc.path_length` (RFC 5280). Stale comment about "trust_anchor first" also corrected — `full` is leaf-first.

## Docstring clarifier (no behavior change)
- `generate_certs.py:167` (dev e2e flow via `deploy_broker.sh` / `tests/e2e/conftest.py`): chain is `broker_ca(pathLen=1) → org_ca(pathLen=0) → agent_leaf`. Leaves are minted directly under the Org CA by `gen_agent_cert` — **no intermediate below this Org CA in this flow**, so pathLen=0 is RFC-correct here. Docstring added to explain why this file keeps `0` while the three sites above flip to `1`.

## Tests added
- **`tests/test_x509_verifier_pathlen.py`** — three unit tests pinning RFC semantics at the off-by-one boundary:
  - pathLen=0 + 1 intermediate → reject (the #280 regression).
  - pathLen=1 + 1 intermediate → accept (every fixed chain).
  - pathLen=1 + 2 intermediates → reject (proves the fix isn't over-permissive).
- **`tests/test_chain_external_verify.py`** — builds the dashboard-shape chain inline and runs `openssl verify`:
  - Fixed (pathLen=1 root) → returncode 0.
  - Regression shape (pathLen=0 root + intermediate) → returncode != 0 with "path length" in stderr.
  - Guards against anyone re-introducing the `- 1` in our own verifier and silently accepting broken chains. Skipped when `openssl` isn't on PATH.

## Test matrix (ran locally)
| Check | Result |
|---|---|
| `pytest tests/test_auth_chain.py + test_x509_verifier_pathlen + test_chain_external_verify` (`-n auto --dist=loadfile`) | **12/12 PASS** |
| `./demo_network/smoke.sh full` (down -v + up + check + down -v) | **4/4 PASS** (round-trip + A4 signing-key persistence + A7 hash-chain 38 entries + A8 /v1/mcp forward) |
| Sandbox smoke | skipped — no `sandbox/bootstrap/` files touched |
| `ruff check` on changed files | clean on the new tests; pre-existing warnings on `generate_certs.py` are unchanged (F401 `os`, F541 placeholder-free f-strings — already on `main`) |

## Migration required (**dashboard-bootstrapped proxies only**)
Existing `proxy_config.org_ca_cert` rows with `pathLen=0` will now be rejected by the fixed verifier on top of all stdlib verifiers. Operators running a dashboard-bootstrapped standalone proxy must rotate the Org CA via the `/pki/rotate-ca` dashboard flow after merge.

### Not affected (does not require migration)
- **Helm bootstrap** — uses `AgentManager._mint_org_ca` at `mcp_proxy/egress/agent_manager.py:163` which already emits `pathLen=1` correctly today (this was the reference pattern).
- **Sandbox** (`./demo.sh full`) — re-bootstraps fresh every run.
- **demo_network smoke** — re-bootstraps fresh every run (`./smoke.sh full` tears down volumes first).
- **`generate_certs.py`** (dev e2e) — 3-tier chain but leaves directly under Org CA, pathLen=0 is RFC-correct (docstring clarifier only).
- **Design partners** — zero deployments today.

## Audit reference
Surfaced by `imp/audit_2026_04_23/phase3_intermediate_ca.md` (aggregate `imp/audit_2026_04_23.md` H-PKI-04).

## Related
- #261 PKI hardening roadmap (parent).
- #279 grace-window kid lookup (PR #283, merged).
- #281 / #282 — remaining audit findings, separate PRs.

## Test plan for reviewer
- [ ] CI green (pytest + ruff + DCO).
- [ ] CI `openssl` available on runner — the new `test_chain_external_verify.py` skips when not, but CI is expected to have it.
- [ ] Manual sandbox repro: trigger dashboard setup wizard, extract `proxy_config.org_ca_cert`, run `openssl verify` on a generated chain → rc 0.
