### PR TITLE
fix(mastio): race-safe + crash-safe rotate_mastio_key (closes #281)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install ruff
+          pip install ruff pytest-repeat
 
       - name: Build TypeScript SDK (for cross-language interop test)
         working-directory: sdk-ts
@@ -80,6 +80,20 @@ jobs:
           DATABASE_URL: "sqlite+aiosqlite://"
         run: |
           pytest tests/ --tb=short --ignore=tests/test_postgres_integration.py
+
+      - name: Anti-flaky concurrency gate (10× rotation race tests)
+        env:
+          OTEL_ENABLED: "false"
+          DATABASE_URL: "sqlite+aiosqlite://"
+        # Issue #281 — the rotation concurrency tests exercise asyncio.Lock
+        # + stage-before-propagate ordering + crash-liveness fault injection.
+        # Running them 10× consecutively catches order-of-coroutine flakes
+        # that a single run would mask. Keep the count tight — the full
+        # file is ~10s per run, so 10× ≈ 100s, which is acceptable CI cost
+        # for the blast-radius of this code path.
+        run: |
+          pytest tests/test_proxy_mastio_rotation_concurrency.py \
+              --count=10 -n auto --dist=loadfile --tb=short -q
 
   security:
     runs-on: ubuntu-latest

--- a/mcp_proxy/auth/local_keystore.py
+++ b/mcp_proxy/auth/local_keystore.py
@@ -31,6 +31,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from mcp_proxy.db import (
     get_mastio_key_by_kid,
     get_mastio_keys_active,
+    get_mastio_keys_staged,
     get_mastio_keys_valid,
 )
 
@@ -160,6 +161,35 @@ class LocalKeyStore:
         """
         rows = await get_mastio_keys_valid()
         return [_row_to_key(row) for row in rows]
+
+    async def find_staged(self) -> MastioKey | None:
+        """Return the in-flight staged rotation row, if any.
+
+        A staged row is an INSERT made by ``rotate_mastio_key`` *before*
+        the Court ACK; it carries ``activated_at IS NULL`` and is
+        invisible to ``current_signer`` / ``all_valid_keys`` /
+        ``find_by_kid``-with-verification checks.
+
+        Exactly one staged row is expected at a time (rotation is
+        serialized by ``AgentManager._rotation_lock``). A crashed
+        rotation leaves the staged row on disk so that boot detection
+        can flag it and halt signing until the admin resolves via
+        ``POST /proxy/mastio-key/complete-staged``.
+
+        Returns None if no staged row exists (the common case).
+        Raises RuntimeError if more than one is found — an invariant
+        violation that needs manual intervention.
+        """
+        rows = await get_mastio_keys_staged()
+        if not rows:
+            return None
+        if len(rows) > 1:
+            kids = ", ".join(row["kid"] for row in rows)
+            raise RuntimeError(
+                f"{len(rows)} staged mastio keys ({kids}) — "
+                "rotation invariant violated; manual DB cleanup required"
+            )
+        return _row_to_key(rows[0])
 
 
 def _row_to_key(row: dict[str, Any]) -> MastioKey:

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -2224,6 +2224,103 @@ async def mastio_key_rotate(request: Request):
     )
 
 
+@router.post("/mastio-key/complete-staged")
+async def mastio_key_complete_staged(request: Request):
+    """Resolve an orphaned staged rotation row (issue #281 recovery).
+
+    The form accepts ``decision=activate`` or ``decision=drop`` plus
+    the standard ``confirm_text`` gate. ``activate`` completes a
+    rotation whose Court-side propagation succeeded but whose local
+    commit crashed; ``drop`` discards a staged row whose Court-side
+    propagation never completed.
+
+    On success, clears the sign-halt state on the AgentManager and
+    rebuilds the LocalIssuer so token issuance resumes without a
+    restart. Emits an audit event with the chosen branch and the
+    kids involved.
+
+    Follow-up #287 tracks the full dashboard UI (Court-pin preview
+    banner, 2-button flow); this endpoint is the backend plumbing
+    reachable from that UI and from ``curl`` for the current
+    emergency path.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    decision = (form.get("decision") or "").strip()
+    if decision not in ("activate", "drop"):
+        raise HTTPException(
+            status_code=400,
+            detail="decision must be 'activate' or 'drop'",
+        )
+    expected_confirm = "ACTIVATE" if decision == "activate" else "DROP"
+    if form.get("confirm_text") != expected_confirm:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Confirmation text mismatch — type {expected_confirm} "
+                f"to complete the {decision} branch"
+            ),
+        )
+
+    from mcp_proxy.db import log_audit
+
+    agent_mgr = getattr(request.app.state, "agent_manager", None)
+    if agent_mgr is None:
+        raise HTTPException(
+            status_code=409,
+            detail="AgentManager not initialized",
+        )
+
+    try:
+        result = await agent_mgr.complete_staged_rotation(decision)
+    except RuntimeError as exc:
+        await log_audit(
+            agent_id="admin",
+            action="mastio_key.complete_staged",
+            status="failure",
+            detail=f"decision={decision}, reason={exc}",
+        )
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    # Rebuild LocalIssuer so local-token issuance resumes. Mirrors the
+    # rebuild that runs at the end of the rotate endpoint above — the
+    # halt flag has just been cleared by ``complete_staged_rotation``.
+    try:
+        from mcp_proxy.auth.local_issuer import build_from_keystore
+        from mcp_proxy.auth.local_keystore import LocalKeyStore
+        ks = getattr(request.app.state, "local_keystore", None) or LocalKeyStore()
+        request.app.state.local_keystore = ks
+        org_id = getattr(request.app.state, "org_id", None)
+        if org_id:
+            request.app.state.local_issuer = await build_from_keystore(org_id, ks)
+    except Exception as exc:
+        _log.warning(
+            "LocalIssuer rebuild after complete-staged failed: %s", exc,
+        )
+
+    await log_audit(
+        agent_id="admin",
+        action="mastio_key.complete_staged",
+        status="success",
+        detail=(
+            f"decision={result['decision']}, kid={result.get('kid', '')}, "
+            f"old_kid={result.get('old_kid', '')}"
+        ),
+    )
+    return RedirectResponse(
+        url=(
+            f"/proxy/mastio-key?completed={result['decision']}"
+            f"&kid={result.get('kid', '')}"
+        ),
+        status_code=303,
+    )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Vault Settings
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -582,6 +582,137 @@ async def get_mastio_keys_valid() -> list[dict]:
         return [dict(row) for row in result.mappings().all()]
 
 
+async def get_mastio_keys_staged() -> list[dict]:
+    """Staged rotation rows — inserted by ``rotate_mastio_key`` before
+    the Court ACK and carrying ``activated_at IS NULL``.
+
+    Empty list is the common case. Exactly one row is expected when a
+    rotation is in flight or crashed mid-rotation (ADR-012 Phase 2.1
+    race-safe flow, issue #281). The caller enforces the invariant.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT * FROM mastio_keys
+                 WHERE activated_at IS NULL
+                 ORDER BY created_at ASC
+                """
+            )
+        )
+        return [dict(row) for row in result.mappings().all()]
+
+
+async def delete_staged_mastio_key(kid: str) -> int:
+    """Delete a staged row (``activated_at IS NULL``) by kid.
+
+    Used by ``rotate_mastio_key`` to clean up after a propagator
+    failure, and by ``complete_staged_rotation(decision='drop')`` to
+    roll back an orphaned staged row the operator has inspected.
+
+    The ``activated_at IS NULL`` predicate guarantees we cannot
+    accidentally delete an activated key even if the caller passes
+    the wrong kid. Returns the number of rows deleted (0 or 1).
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                DELETE FROM mastio_keys
+                 WHERE kid = :kid
+                   AND activated_at IS NULL
+                """
+            ),
+            {"kid": kid},
+        )
+        return result.rowcount
+
+
+async def activate_staged_and_deprecate_old(
+    *,
+    new_kid: str,
+    new_activated_at: str,
+    old_kid: str,
+    old_deprecated_at: str,
+    old_expires_at: str,
+) -> None:
+    """Atomically activate a staged row and deprecate the current active.
+
+    Phase 2.1 rotation commit step (issue #281). The staged row was
+    inserted (``activated_at IS NULL``) before the Court was told, so
+    the pubkey is durable on disk; this call is what flips the live
+    signer *after* Court has ACK-ed the rotation.
+
+    On Postgres we take a transaction-scoped advisory lock keyed off
+    ``'mastio-rotate'`` so two proxy processes that raced past the
+    in-process ``asyncio.Lock`` still serialize here. SQLite has a
+    global writer lock so no extra primitive is needed.
+
+    Both UPDATEs must touch exactly one row:
+
+    - staged row transitions ``activated_at NULL → now()``
+    - previous active row transitions ``deprecated_at NULL → now()``
+      with ``expires_at`` set for the grace window
+
+    Any rowcount mismatch raises RuntimeError *and* rolls the
+    transaction back (the surrounding ``get_db`` context handles it),
+    leaving the caller to decide recovery. A rowcount-0 on the
+    deprecate UPDATE typically means a racing rotation got here first
+    — the caller should not retry.
+    """
+    async with get_db() as conn:
+        # Postgres: advisory lock in this transaction so a second rotate
+        # that made it past ``AgentManager._rotation_lock`` (different
+        # process) serializes behind us instead of interleaving. SQLite
+        # already holds a global writer lock for the duration of the tx.
+        if conn.dialect.name == "postgresql":
+            await conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext('mastio-rotate'))")
+            )
+
+        activate = await conn.execute(
+            text(
+                """
+                UPDATE mastio_keys
+                   SET activated_at = :activated
+                 WHERE kid = :kid
+                   AND activated_at IS NULL
+                """
+            ),
+            {"kid": new_kid, "activated": new_activated_at},
+        )
+        if activate.rowcount != 1:
+            raise RuntimeError(
+                f"failed to activate staged mastio key {new_kid!r}: "
+                f"UPDATE touched {activate.rowcount} rows (expected 1 — "
+                f"staged row missing or already activated)"
+            )
+
+        deprecate = await conn.execute(
+            text(
+                """
+                UPDATE mastio_keys
+                   SET deprecated_at = :deprecated,
+                       expires_at    = :expires
+                 WHERE kid = :kid
+                   AND activated_at IS NOT NULL
+                   AND deprecated_at IS NULL
+                """
+            ),
+            {
+                "kid": old_kid,
+                "deprecated": old_deprecated_at,
+                "expires": old_expires_at,
+            },
+        )
+        if deprecate.rowcount != 1:
+            raise RuntimeError(
+                f"failed to deprecate old mastio key {old_kid!r}: "
+                f"UPDATE touched {deprecate.rowcount} rows (expected 1 — "
+                f"racing rotation may have already deprecated it)"
+            )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -7,6 +7,7 @@ Each internal agent gets:
   - A private key stored in Vault (or DB fallback)
   - A local API key (sk_local_{name}_{hex}) for authenticating to the proxy
 """
+import asyncio
 import hashlib
 import logging
 from datetime import datetime, timedelta, timezone
@@ -26,14 +27,16 @@ from mcp_proxy.auth.local_keystore import LocalKeyStore, MastioKey, compute_kid
 from mcp_proxy.auth.mastio_rotation import ContinuityProof, build_proof
 from mcp_proxy.config import get_settings, vault_tls_verify
 from mcp_proxy.db import (
+    activate_staged_and_deprecate_old,
     create_agent as db_create_agent,
     deactivate_agent as db_deactivate_agent,
+    delete_staged_mastio_key,
     get_agent as db_get_agent,
     get_config,
     insert_mastio_key,
     set_config,
-    swap_active_mastio_key,
 )
+from mcp_proxy.telemetry_metrics import MASTIO_ROTATION_STAGED
 
 from typing import Awaitable, Callable
 
@@ -78,6 +81,22 @@ class AgentManager:
         # up the new row.
         self._keystore = LocalKeyStore()
         self._active_key: MastioKey | None = None
+        # Issue #281 — serialize rotations in-process so a dashboard
+        # double-click or admin+scheduler collision can't interleave
+        # two rotate flows. Multi-process/replica serialization lives
+        # in ``db.activate_staged_and_deprecate_old`` via a Postgres
+        # advisory lock on the same tx.
+        self._rotation_lock = asyncio.Lock()
+        # Issue #281 — sign-halt state. Set when boot detects a staged
+        # row (``activated_at IS NULL``) left behind by a crashed
+        # rotation, or when ``rotate_mastio_key`` observes a
+        # post-Court-ACK local-activation failure. While halted,
+        # ``countersign`` raises and ``main.py`` declines to build
+        # ``LocalIssuer``, so both intra-org local tokens and
+        # cross-org counter-sigs error out cleanly instead of
+        # producing signatures the Court would reject.
+        self._sign_halted = False
+        self._staged_kid: str | None = None
 
     # ── CA loading ──────────────────────────────────────────────────
 
@@ -510,10 +529,74 @@ class AgentManager:
                 self._active_key = None
 
         if self.mastio_loaded:
+            # Issue #281 — detect staged rotation rows left behind by a
+            # crash between propagator-ACK and local activation. Court
+            # does hard-swap (no grace window on mastio_pubkey — see
+            # #286), so if the crash happened *after* the Court ACK, the
+            # old local key can no longer counter-sign successfully.
+            # The safe recovery is to refuse to sign at all until the
+            # admin resolves via POST /proxy/mastio-key/complete-staged,
+            # rather than emit signatures the Court would 403.
+            await self._detect_staged_and_maybe_halt()
             logger.info("Mastio identity loaded (ca + active key)")
             return
 
         await self._generate_mastio_identity()
+
+    async def _detect_staged_and_maybe_halt(self) -> None:
+        """Boot-time check for an orphaned staged rotation row.
+
+        Sets ``self._sign_halted = True`` and records the staged kid
+        when found. Caller (``main.py``) inspects ``is_sign_halted``
+        after ``ensure_mastio_identity`` returns and skips
+        ``LocalIssuer`` construction so local-token issuance is
+        disabled until the operator calls
+        ``complete_staged_rotation``.
+        """
+        try:
+            staged = await self._keystore.find_staged()
+        except RuntimeError as exc:
+            # Multiple staged rows — invariant violation, halt loudly.
+            self._sign_halted = True
+            MASTIO_ROTATION_STAGED.set(1)
+            logger.error(
+                "rotation state corrupt at boot: %s; refusing to sign "
+                "until manual DB cleanup + POST /proxy/mastio-key/"
+                "complete-staged",
+                exc,
+            )
+            return
+
+        if staged is None:
+            MASTIO_ROTATION_STAGED.set(0)
+            return
+
+        self._sign_halted = True
+        self._staged_kid = staged.kid
+        MASTIO_ROTATION_STAGED.set(1)
+        logger.error(
+            "rotation state inconsistent at boot: staged kid=%s found "
+            "without activation. LocalIssuer disabled and countersign "
+            "halted. Resolve via POST /proxy/mastio-key/complete-staged "
+            "(activate if Court already pinned new, drop if still on old).",
+            staged.kid,
+        )
+
+    @property
+    def is_sign_halted(self) -> bool:
+        """True while a staged row blocks signing (issue #281).
+
+        Callers:
+          - ``main.py`` — skips ``LocalIssuer`` construction when True.
+          - ``countersign`` — raises RuntimeError when True.
+          - Dashboard (future #287) — renders the recovery banner.
+        """
+        return self._sign_halted
+
+    @property
+    def staged_kid(self) -> str | None:
+        """Kid of the blocking staged row, or None."""
+        return self._staged_kid
 
     async def _migrate_legacy_leaf_to_keystore(self) -> None:
         """Seed ``mastio_keys`` from ``proxy_config.mastio_leaf_{key,cert}``.
@@ -718,38 +801,80 @@ class AgentManager:
     ) -> MastioKey:
         """Rotate the Mastio leaf key (ADR-012 Phase 2.1, issue #261).
 
-        Mints a fresh EC P-256 leaf under the existing intermediate CA,
-        signs a continuity proof with the current (old) key, propagates
-        the new pubkey + proof to the Court via ``propagator``, and then
-        atomically swaps the active row in ``mastio_keys``.
+        Race-safe, crash-safe flow (issue #281):
+
+        1. Serialize on ``self._rotation_lock`` — kills double-click and
+           dashboard+cron collisions in the same process.
+        2. Under the lock, re-read the current signer and refuse to
+           start if (a) the active signer changed since ``__init__``
+           handed us ``old``, or (b) a staged row is already present
+           (incomplete prior rotation — admin must resolve first).
+        3. Mint the new leaf and build the continuity proof with the
+           *old* private key.
+        4. INSERT the new row as **staged** (``activated_at IS NULL``)
+           so ``new_privkey_pem`` is durable on disk before we tell the
+           Court anything — a crash between here and step 6 leaves the
+           staged row visible to the next boot's recovery.
+        5. Call the propagator. On raise, delete the staged row so the
+           next rotation can start clean.
+        6. Atomically activate the staged row and deprecate the old one
+           (``activate_staged_and_deprecate_old`` takes a pg advisory
+           lock on Postgres to serialize across replicas). On raise,
+           leave the staged row intact and sign-halt — the Court has
+           pinned the new pubkey at this point, so the admin must
+           reconcile via ``complete_staged_rotation``.
+        7. Refresh the cached active key and return it.
 
         ``grace_days`` controls how long the old kid stays
-        verifier-accepted after deprecation. Callers that want a
-        different cadence override it; the default of 7 is the
-        repository-wide baseline for signing-key rotations.
+        verifier-accepted after deprecation. Default 7.
 
         ``propagator`` receives the built ``ContinuityProof`` plus the
-        new cert PEM and is expected to call the Court. If it raises,
-        no DB mutation happens (Court-first ordering). If it is
-        ``None`` (tests / offline bootstrap), the Court step is
-        skipped entirely — the resulting rotation is purely local and
-        will leave the Court out of sync; callers **must** pass a real
-        propagator in production.
+        new cert PEM and is expected to call the Court. When ``None``
+        (tests / offline bootstrap) the Court step is skipped and a
+        warning logged — useful for unit tests, never safe in
+        production.
 
-        Returns the freshly-activated :class:`MastioKey` (already
-        cached as ``self._active_key``).
-
-        Raises:
-            RuntimeError: if identity is not loaded (gate on
-                :attr:`mastio_loaded`), if ``grace_days`` is not
-                positive, or if the DB swap finds an inconsistent
-                state.
+        Returns the freshly-activated :class:`MastioKey` (also cached
+        as ``self._active_key``).
         """
         if grace_days <= 0:
             raise ValueError("grace_days must be a positive integer")
         old = self._require_active()
         if self._mastio_ca_key is None or self._mastio_ca_cert is None:
             raise RuntimeError("Mastio intermediate CA not loaded")
+
+        async with self._rotation_lock:
+            return await self._rotate_locked(old, grace_days, propagator)
+
+    async def _rotate_locked(
+        self,
+        old: MastioKey,
+        grace_days: int,
+        propagator: "Callable[[ContinuityProof, str], Awaitable[None]] | None",
+    ) -> MastioKey:
+        """Body of :meth:`rotate_mastio_key`, executed under the
+        rotation lock. Split out so the test suite can drive the
+        individual steps without re-acquiring the lock in
+        fault-injection scenarios.
+        """
+        # Re-check state under the lock: a concurrent rotation may
+        # have completed between ``_require_active`` above and us
+        # acquiring the lock. Refuse to start if the active signer
+        # has changed.
+        current_active = await self._keystore.current_signer()
+        if current_active.kid != old.kid:
+            raise RuntimeError(
+                f"rotation aborted: active signer changed under us "
+                f"({old.kid!r} → {current_active.kid!r}); a concurrent "
+                f"rotation succeeded"
+            )
+        existing_staged = await self._keystore.find_staged()
+        if existing_staged is not None:
+            raise RuntimeError(
+                f"rotation aborted: a staged row (kid={existing_staged.kid!r}) "
+                f"is already present from a prior rotation; resolve it via "
+                f"POST /proxy/mastio-key/complete-staged before retrying"
+            )
 
         now = datetime.now(timezone.utc)
         new_leaf_key = ec.generate_private_key(ec.SECP256R1())
@@ -793,9 +918,43 @@ class AgentManager:
             issued_at=now,
         )
 
-        # Court-first: if propagation fails, no local state change.
+        now_iso = now.isoformat()
+        grace_end_iso = (now + timedelta(days=grace_days)).isoformat()
+
+        # Step 4 — stage the new row on disk *before* telling the Court.
+        # If the process dies after this INSERT, the next boot's
+        # ``_detect_staged_and_maybe_halt`` picks it up and sign-halts
+        # until the operator resolves.
+        await insert_mastio_key(
+            kid=new_kid,
+            pubkey_pem=new_pub_pem,
+            privkey_pem=new_priv_pem,
+            cert_pem=new_cert_pem,
+            created_at=now_iso,
+            activated_at=None,
+            deprecated_at=None,
+            expires_at=None,
+        )
+
+        # Step 5 — propagate to Court.
         if propagator is not None:
-            await propagator(proof, new_cert_pem)
+            try:
+                await propagator(proof, new_cert_pem)
+            except BaseException:
+                # Court rejected or unreachable → nothing is pinned on
+                # their side yet, so the staged row is safe to drop.
+                # BaseException catches asyncio.CancelledError too.
+                try:
+                    await delete_staged_mastio_key(new_kid)
+                except Exception as cleanup_exc:
+                    # Cleanup is best-effort; failure here means boot
+                    # recovery will pick it up as a staged row.
+                    logger.warning(
+                        "staged row cleanup failed after propagator error "
+                        "(kid=%s): %s — boot recovery will handle it",
+                        new_kid, cleanup_exc,
+                    )
+                raise
         else:
             logger.warning(
                 "rotate_mastio_key: no propagator provided — Court will "
@@ -803,27 +962,140 @@ class AgentManager:
                 "supply one",
             )
 
-        now_iso = now.isoformat()
-        grace_end_iso = (now + timedelta(days=grace_days)).isoformat()
-        await swap_active_mastio_key(
-            new_kid=new_kid,
-            new_pubkey_pem=new_pub_pem,
-            new_privkey_pem=new_priv_pem,
-            new_cert_pem=new_cert_pem,
-            new_activated_at=now_iso,
-            new_created_at=now_iso,
-            old_kid=old.kid,
-            old_deprecated_at=now_iso,
-            old_expires_at=grace_end_iso,
-        )
+        # Step 6 — atomic commit. On Postgres, this takes
+        # ``pg_advisory_xact_lock`` so a concurrent rotation from
+        # another replica (which passed our in-process asyncio.Lock but
+        # not this one) serializes instead of interleaving.
+        try:
+            await activate_staged_and_deprecate_old(
+                new_kid=new_kid,
+                new_activated_at=now_iso,
+                old_kid=old.kid,
+                old_deprecated_at=now_iso,
+                old_expires_at=grace_end_iso,
+            )
+        except BaseException:
+            # Court has already pinned ``new_pub_pem``. Any token we
+            # countersign right now uses the old key — Court 403s.
+            # Sign-halt so downstream callers get a clear error and the
+            # admin resolves via ``complete_staged_rotation``. Do *not*
+            # drop the staged row: ``complete_staged_rotation`` needs
+            # it to offer the activate branch.
+            self._sign_halted = True
+            self._staged_kid = new_kid
+            MASTIO_ROTATION_STAGED.set(1)
+            logger.error(
+                "rotation mid-flight failure after Court ACK: local "
+                "activation failed for kid=%s. Sign-halted. Admin must "
+                "resolve via POST /proxy/mastio-key/complete-staged.",
+                new_kid,
+            )
+            raise
 
         await self.refresh_active_key()
+        # Clear any prior halt state — we completed a clean rotation.
+        self._sign_halted = False
+        self._staged_kid = None
+        MASTIO_ROTATION_STAGED.set(0)
         logger.info(
             "Mastio key rotated — old_kid=%s, new_kid=%s, grace_days=%d",
             old.kid, new_kid, grace_days,
         )
         assert self._active_key is not None
         return self._active_key
+
+    async def complete_staged_rotation(self, decision: str) -> dict:
+        """Resolve an orphaned staged row (issue #281 recovery path).
+
+        Serialized on ``self._rotation_lock`` — the same primitive that
+        serializes fresh rotations, so a racing rotation cannot overlap
+        with recovery.
+
+        ``decision`` must be ``"activate"`` or ``"drop"``. The operator
+        chooses based on Court state:
+
+        - ``"activate"`` when the Court has already pinned the staged
+          pubkey (propagator had succeeded, only local activation
+          failed). Activates the staged row and deprecates the current
+          active, using the configured ``grace_days``.
+        - ``"drop"`` when the Court is still on the current active
+          (propagator had not succeeded or rotated back). Deletes the
+          staged row.
+
+        Returns a dict with ``{"decision", "kid", "old_kid"?,
+        "grace_days"?}`` so the caller (dashboard / CLI) can surface
+        the outcome to the operator. On success, clears the sign-halt
+        flag.
+
+        Raises RuntimeError if no staged row exists or if the current
+        active signer has somehow gone missing (malformed state).
+        """
+        if decision not in ("activate", "drop"):
+            raise ValueError(
+                f"decision must be 'activate' or 'drop', got {decision!r}"
+            )
+
+        async with self._rotation_lock:
+            staged = await self._keystore.find_staged()
+            if staged is None:
+                raise RuntimeError(
+                    "no staged row present — nothing to complete. The "
+                    "halt state may be stale; restart the proxy or "
+                    "re-run rotation."
+                )
+
+            if decision == "drop":
+                deleted = await delete_staged_mastio_key(staged.kid)
+                if deleted != 1:
+                    raise RuntimeError(
+                        f"staged row {staged.kid!r} vanished during drop "
+                        f"(rowcount={deleted}); likely a concurrent "
+                        f"recovery call"
+                    )
+                self._sign_halted = False
+                self._staged_kid = None
+                MASTIO_ROTATION_STAGED.set(0)
+                logger.info(
+                    "complete_staged_rotation(drop): staged kid=%s deleted; "
+                    "signing resumed with prior active",
+                    staged.kid,
+                )
+                return {"decision": "drop", "kid": staged.kid}
+
+            # decision == "activate"
+            current = await self._keystore.current_signer()
+            # Default grace_days matches rotate_mastio_key default (7);
+            # keeping a fixed value here because the original caller's
+            # choice is already lost to the crash — the operator is
+            # resolving from a standing start. Callers that want a
+            # different cadence can drop + re-rotate.
+            grace_days = 7
+            now = datetime.now(timezone.utc)
+            now_iso = now.isoformat()
+            grace_end_iso = (now + timedelta(days=grace_days)).isoformat()
+
+            await activate_staged_and_deprecate_old(
+                new_kid=staged.kid,
+                new_activated_at=now_iso,
+                old_kid=current.kid,
+                old_deprecated_at=now_iso,
+                old_expires_at=grace_end_iso,
+            )
+            await self.refresh_active_key()
+            self._sign_halted = False
+            self._staged_kid = None
+            MASTIO_ROTATION_STAGED.set(0)
+            logger.info(
+                "complete_staged_rotation(activate): old_kid=%s → new_kid=%s "
+                "(grace_days=%d); signing resumed",
+                current.kid, staged.kid, grace_days,
+            )
+            return {
+                "decision": "activate",
+                "kid": staged.kid,
+                "old_kid": current.kid,
+                "grace_days": grace_days,
+            }
 
     def countersign(self, data: bytes) -> str:
         """ES256 counter-signature over ``data``, base64url no-pad.
@@ -834,12 +1106,25 @@ class AgentManager:
         against the PEM pinned at onboarding in
         ``organizations.mastio_pubkey``.
 
-        Raises ``RuntimeError`` if :meth:`ensure_mastio_identity` has not run.
+        Raises:
+            RuntimeError: if :meth:`ensure_mastio_identity` has not run,
+                or if signing is halted (issue #281: a staged rotation
+                row is present and needs admin resolution via
+                ``complete_staged_rotation`` — producing a signature
+                with the old key while Court may have pinned the new
+                one would 403 anyway, and surfacing a clear local error
+                is strictly better than an opaque Court rejection).
         """
         import base64
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.asymmetric import ec as _ec
 
+        if self._sign_halted:
+            raise RuntimeError(
+                "mastio signing halted — staged rotation row "
+                f"(kid={self._staged_kid!r}) awaiting resolution. "
+                "POST /proxy/mastio-key/complete-staged to recover."
+            )
         active = self._require_active()
         priv_key = active.load_private_key()
         sig = priv_key.sign(data, _ec.ECDSA(hashes.SHA256()))

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -77,7 +77,18 @@ class BrokerBridge:
 
         Lazy init: first call creates client and calls login_from_pem().
         Subsequent calls return cached client.
-        On auth failure, evict and retry once.
+
+        Issue #281 — one-shot retry on auth error during the *initial*
+        login. The TOCTOU window between a successful rotation's
+        Court-ACK and the local ``refresh_active_key`` is narrow but
+        real: a caller entering this path in that window uses the
+        still-cached ``self._active_key`` (old) while the Court
+        already expects the new counter-sig. The retry re-runs
+        ``_create_client`` once, by which point ``refresh_active_key``
+        has completed and the second attempt succeeds. Capped at one
+        retry to avoid burning CPU on genuine credential failures,
+        and gated on ``_is_auth_error`` so non-auth errors (network,
+        TLS, server 500s) still surface immediately.
         """
         # Fast path: client already cached
         if agent_id in self._clients:
@@ -88,7 +99,17 @@ class BrokerBridge:
             if agent_id in self._clients:
                 return self._clients[agent_id]
 
-            client = await self._create_client(agent_id)
+            try:
+                client = await self._create_client(agent_id)
+            except Exception as exc:
+                if not _is_auth_error(exc):
+                    raise
+                logger.warning(
+                    "Initial login auth error for %s — retrying once "
+                    "(likely rotation TOCTOU, issue #281): %s",
+                    agent_id, exc,
+                )
+                client = await self._create_client(agent_id)
             self._clients[agent_id] = client
             return client
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -172,17 +172,31 @@ async def lifespan(app: FastAPI):
     app.state.local_keystore = LocalKeyStore()
     app.state.local_issuer = None
     if getattr(agent_mgr, "mastio_loaded", False) and org_id:
-        try:
-            from mcp_proxy.auth.local_issuer import build_from_keystore
-            app.state.local_issuer = await build_from_keystore(
-                org_id, app.state.local_keystore,
+        if getattr(agent_mgr, "is_sign_halted", False):
+            # Issue #281 — a staged rotation row blocks signing until
+            # the operator resolves via POST /proxy/mastio-key/
+            # complete-staged. Leaving ``local_issuer`` as None causes
+            # the ``_maybe_local_token`` dep to short-circuit with
+            # ``return None`` and fall through to DPoP, keeping the
+            # failure surface consistent with the counter-sign halt
+            # that ``AgentManager.countersign`` emits.
+            _log.error(
+                "LocalIssuer NOT initialized — sign-halted, staged_kid=%s. "
+                "Resolve via POST /proxy/mastio-key/complete-staged.",
+                getattr(agent_mgr, "staged_kid", None),
             )
-            _log.info(
-                "LocalIssuer initialized (kid=%s, iss=%s)",
-                app.state.local_issuer.kid, app.state.local_issuer.issuer,
-            )
-        except Exception as exc:
-            _log.warning("LocalIssuer init failed: %s", exc)
+        else:
+            try:
+                from mcp_proxy.auth.local_issuer import build_from_keystore
+                app.state.local_issuer = await build_from_keystore(
+                    org_id, app.state.local_keystore,
+                )
+                _log.info(
+                    "LocalIssuer initialized (kid=%s, iss=%s)",
+                    app.state.local_issuer.kid, app.state.local_issuer.issuer,
+                )
+            except Exception as exc:
+                _log.warning("LocalIssuer init failed: %s", exc)
 
     # ADR-007 Phase 1 PR #3 — SecretProvider is consumed by the MCP
     # resource forwarder (env:// / vault:// refs). Same instance used by

--- a/mcp_proxy/telemetry_metrics.py
+++ b/mcp_proxy/telemetry_metrics.py
@@ -1,0 +1,42 @@
+"""Prometheus-compatible metrics with a no-op fallback when
+``prometheus_client`` is not installed.
+
+The mcp_proxy package does not declare ``prometheus_client`` as a
+dependency today — the broker (``app/``) does, and operators who want
+metrics can co-install it. The no-op shim keeps the proxy importable
+in minimal environments (standalone ``proxy-init`` container, CI unit
+tests) without carrying the dependency weight.
+
+Metrics defined here surface operator-visible state that can't be
+derived from logs alone — e.g. a staged rotation row whose presence
+means the local issuer is sign-halted.
+"""
+from __future__ import annotations
+
+
+class _NoopMetric:
+    """Minimal stand-in with the subset of the ``prometheus_client``
+    gauge/counter surface the proxy actually uses.
+    """
+
+    def set(self, _value: float) -> None:  # noqa: D401 — no-op
+        return None
+
+    def inc(self, _amount: float = 1.0) -> None:  # noqa: D401 — no-op
+        return None
+
+    def dec(self, _amount: float = 1.0) -> None:  # noqa: D401 — no-op
+        return None
+
+
+try:
+    from prometheus_client import Gauge  # type: ignore
+
+    MASTIO_ROTATION_STAGED = Gauge(
+        "cullis_mastio_rotation_staged",
+        "1 when a staged mastio-key rotation row is present (sign-halt), "
+        "0 otherwise. Non-zero means admin intervention is required via "
+        "POST /proxy/mastio-key/complete-staged.",
+    )
+except ImportError:  # pragma: no cover — exercised only in slim envs
+    MASTIO_ROTATION_STAGED = _NoopMetric()  # type: ignore[assignment]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "pytest-repeat>=0.9",
     "ruff>=0.4",
     "mypy>=1.10",
 ]

--- a/tests/test_proxy_mastio_rotation_concurrency.py
+++ b/tests/test_proxy_mastio_rotation_concurrency.py
@@ -1,0 +1,429 @@
+"""Race-safety + crash-recovery tests for ``rotate_mastio_key``.
+
+Issue #281 — three failure modes guarded here:
+
+* **Concurrent rotations** (in-process asyncio.gather) — exactly one
+  branch wins, the other raises, and the keystore ends with exactly
+  one active row.
+* **Crash between propagator-ACK and local commit** — fault injection
+  via ``monkeypatch`` on ``activate_staged_and_deprecate_old``; after
+  the simulated crash the staged row persists, a fresh AgentManager
+  detects it at boot, sign-halts, and ``complete_staged_rotation``
+  recovers.
+* **Admin recovery branches** — ``complete_staged_rotation`` exercised
+  for ``activate`` and ``drop`` plus the no-staged error path.
+
+All concurrency primitives use ``asyncio.Event`` + ``asyncio.gather``
+— no ``time.sleep`` or timeouts-based synchronization that would
+introduce flakiness. The test module is wired so a ``pytest --count=10``
+run stresses the race paths without modification.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+
+from mcp_proxy.auth.local_keystore import LocalKeyStore
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+# ── Shared fixture ───────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def mgr(tmp_path, monkeypatch):
+    """AgentManager bootstrapped against a fresh SQLite database.
+
+    Matches the ``agent_manager_with_identity`` fixture from the main
+    rotation-test module but is duplicated here to keep this module
+    self-contained (pytest-repeat count-based reruns pick this file
+    up independently).
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import dispose_db, init_db
+
+    await init_db(url)
+    m = AgentManager(org_id="acme")
+    await m.generate_org_ca(derive_org_id=False)
+    await m.ensure_mastio_identity()
+    try:
+        yield m
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+# ── Concurrency ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_rotations_exactly_one_succeeds(mgr):
+    """Two rotations fired with ``asyncio.gather`` must resolve with
+    exactly one success and one deterministic error — never both
+    succeeding (which would leave two active rows) and never both
+    failing (rotate_mastio_key should be make-progress).
+
+    The second rotation fails on the ``_rotate_locked`` re-check
+    rather than the DB UPDATE because the ``asyncio.Lock`` serializes
+    them — the loser observes the active signer changed under it and
+    raises before touching the DB.
+    """
+    old_kid = mgr._active_key.kid
+
+    async def _rotate():
+        return await mgr.rotate_mastio_key(grace_days=3, propagator=None)
+
+    results = await asyncio.gather(_rotate(), _rotate(), return_exceptions=True)
+
+    successes = [r for r in results if not isinstance(r, BaseException)]
+    failures = [r for r in results if isinstance(r, BaseException)]
+    assert len(successes) == 1, f"expected exactly 1 success, got {results!r}"
+    assert len(failures) == 1, f"expected exactly 1 failure, got {results!r}"
+    # The failure is the under-the-lock re-check that flags the
+    # concurrent winner.
+    assert isinstance(failures[0], RuntimeError)
+    assert "active signer changed" in str(failures[0])
+
+    # Exactly one active row.
+    store = LocalKeyStore()
+    active = await store.current_signer()
+    assert active.kid == successes[0].kid
+    # Old kid is deprecated-in-grace, not dangling.
+    old_row = await store.find_by_kid(old_kid)
+    assert old_row is not None
+    assert old_row.deprecated_at is not None
+    # No staged rows left over.
+    assert await store.find_staged() is None
+
+
+@pytest.mark.asyncio
+async def test_rotate_aborts_when_staged_row_present(mgr, monkeypatch):
+    """An orphaned staged row (left behind by a prior crashed
+    rotation) must block a new rotation from starting. The operator
+    has to resolve via ``complete_staged_rotation`` first.
+    """
+    # Simulate an orphaned staged row by inserting one directly.
+    from mcp_proxy.db import insert_mastio_key
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec as _ec
+    from mcp_proxy.auth.local_keystore import compute_kid
+    from datetime import datetime, timezone
+
+    priv = _ec.generate_private_key(_ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    staged_kid = compute_kid(pub_pem)
+    await insert_mastio_key(
+        kid=staged_kid,
+        pubkey_pem=pub_pem,
+        privkey_pem=priv_pem,
+        cert_pem=None,
+        created_at=datetime.now(timezone.utc).isoformat(),
+        activated_at=None,  # staged marker
+    )
+
+    with pytest.raises(RuntimeError, match="staged row"):
+        await mgr.rotate_mastio_key(grace_days=3, propagator=None)
+
+
+# ── Crash liveness (fault injection between propagator-ACK and commit) ──
+
+
+@pytest.mark.asyncio
+async def test_crash_between_propagator_ack_and_activate_preserves_staged(
+    mgr, monkeypatch,
+):
+    """Fault-inject a failure on ``activate_staged_and_deprecate_old``
+    *after* the propagator has ACKed. The rotate must:
+
+    - raise (caller sees the error).
+    - leave the staged row intact so recovery is possible.
+    - set ``is_sign_halted`` on the manager so subsequent countersigns
+      fail fast with a clear message.
+    - leave the old active row untouched (Court might still be on old
+      or already on new; ``complete_staged_rotation`` resolves).
+    """
+    old_kid = mgr._active_key.kid
+    propagator_ran = asyncio.Event()
+
+    async def succeed_propagator(_proof, _cert):
+        propagator_ran.set()
+
+    # Monkeypatch the DB commit to fail — this simulates a crash /
+    # DB drop between the propagator ACK and the atomic activation.
+    import mcp_proxy.egress.agent_manager as agent_mgr_mod
+
+    async def exploding_activate(**_kwargs):
+        raise RuntimeError("simulated DB failure mid-commit")
+
+    monkeypatch.setattr(
+        agent_mgr_mod,
+        "activate_staged_and_deprecate_old",
+        exploding_activate,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated DB failure"):
+        await mgr.rotate_mastio_key(
+            grace_days=3, propagator=succeed_propagator,
+        )
+
+    # Propagator did run — we're past Court-ACK.
+    assert propagator_ran.is_set()
+
+    store = LocalKeyStore()
+
+    # Staged row still on disk for recovery.
+    staged = await store.find_staged()
+    assert staged is not None
+    assert staged.kid != old_kid
+    assert staged.activated_at is None
+
+    # Old active row untouched — still the current signer.
+    current = await store.current_signer()
+    assert current.kid == old_kid
+
+    # Manager is sign-halted and exposes the staged kid.
+    assert mgr.is_sign_halted is True
+    assert mgr.staged_kid == staged.kid
+
+    # Countersign now fails fast with a clear message.
+    with pytest.raises(RuntimeError, match="signing halted"):
+        mgr.countersign(b"payload")
+
+
+@pytest.mark.asyncio
+async def test_boot_detects_staged_and_halts_signing(tmp_path, monkeypatch):
+    """A fresh AgentManager pointed at a DB containing a staged row
+    (as if the previous process crashed mid-rotation) must detect the
+    staged row during ``ensure_mastio_identity`` and flip
+    ``is_sign_halted = True``. ``LocalIssuer`` construction in
+    ``main.py`` gates on that flag, so no unsigned local tokens are
+    emitted while the operator resolves.
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import dispose_db, init_db, insert_mastio_key
+
+    try:
+        await init_db(url)
+
+        # Bootstrap a first AgentManager to mint the real Org CA +
+        # active Mastio leaf, then orphan a staged row.
+        first = AgentManager(org_id="acme")
+        await first.generate_org_ca(derive_org_id=False)
+        await first.ensure_mastio_identity()
+
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec as _ec
+        from mcp_proxy.auth.local_keystore import compute_kid
+        from datetime import datetime, timezone
+
+        priv = _ec.generate_private_key(_ec.SECP256R1())
+        pub_pem = priv.public_key().public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode()
+        priv_pem = priv.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+        staged_kid = compute_kid(pub_pem)
+        await insert_mastio_key(
+            kid=staged_kid,
+            pubkey_pem=pub_pem,
+            privkey_pem=priv_pem,
+            cert_pem=None,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            activated_at=None,
+        )
+
+        # Fresh AgentManager — simulates a process restart. Should
+        # detect the staged row and sign-halt.
+        second = AgentManager(org_id="acme")
+        await second.load_org_ca_from_config()
+        await second.ensure_mastio_identity()
+
+        assert second.is_sign_halted is True
+        assert second.staged_kid == staged_kid
+
+        with pytest.raises(RuntimeError, match="signing halted"):
+            second.countersign(b"payload")
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+# ── complete_staged_rotation — recovery endpoint branches ────────────
+
+
+@pytest.mark.asyncio
+async def test_complete_staged_drop_clears_halt(mgr, monkeypatch):
+    """``decision='drop'``: the staged row is deleted, the active
+    signer is unchanged, sign-halt flag clears.
+    """
+    # Arrive at a halted state the same way #281's crash path does.
+    import mcp_proxy.egress.agent_manager as agent_mgr_mod
+
+    async def exploding_activate(**_kwargs):
+        raise RuntimeError("simulated DB failure mid-commit")
+
+    monkeypatch.setattr(
+        agent_mgr_mod,
+        "activate_staged_and_deprecate_old",
+        exploding_activate,
+    )
+
+    async def propagator_ok(_p, _c):
+        return None
+
+    with pytest.raises(RuntimeError):
+        await mgr.rotate_mastio_key(
+            grace_days=3, propagator=propagator_ok,
+        )
+    assert mgr.is_sign_halted
+
+    # Drop recovery — clear the halt and remove the staged row.
+    monkeypatch.undo()  # restore real activate_staged_and_deprecate_old
+    old_kid = mgr._active_key.kid
+    result = await mgr.complete_staged_rotation("drop")
+
+    assert result["decision"] == "drop"
+    assert result["kid"] == mgr._staged_kid or result["kid"] is not None
+    assert mgr.is_sign_halted is False
+    assert mgr.staged_kid is None
+
+    # Active signer unchanged.
+    store = LocalKeyStore()
+    current = await store.current_signer()
+    assert current.kid == old_kid
+    assert await store.find_staged() is None
+
+    # Countersign works again.
+    mgr.countersign(b"payload-after-drop")
+
+
+@pytest.mark.asyncio
+async def test_complete_staged_activate_completes_rotation(mgr, monkeypatch):
+    """``decision='activate'``: the staged row becomes the active
+    signer, the previous active row is deprecated-in-grace, sign-halt
+    flag clears.
+    """
+    import mcp_proxy.egress.agent_manager as agent_mgr_mod
+
+    async def exploding_activate(**_kwargs):
+        raise RuntimeError("simulated DB failure mid-commit")
+
+    monkeypatch.setattr(
+        agent_mgr_mod,
+        "activate_staged_and_deprecate_old",
+        exploding_activate,
+    )
+
+    async def propagator_ok(_p, _c):
+        return None
+
+    old_kid = mgr._active_key.kid
+    with pytest.raises(RuntimeError):
+        await mgr.rotate_mastio_key(
+            grace_days=3, propagator=propagator_ok,
+        )
+    assert mgr.is_sign_halted
+    staged_kid_snapshot = mgr.staged_kid
+    assert staged_kid_snapshot is not None
+
+    monkeypatch.undo()  # restore real DB helper
+
+    result = await mgr.complete_staged_rotation("activate")
+
+    assert result["decision"] == "activate"
+    assert result["kid"] == staged_kid_snapshot
+    assert result["old_kid"] == old_kid
+    assert mgr.is_sign_halted is False
+    assert mgr.staged_kid is None
+
+    # Active signer swapped.
+    store = LocalKeyStore()
+    current = await store.current_signer()
+    assert current.kid == staged_kid_snapshot
+
+    # Old row deprecated but still verifiable for the grace window.
+    old_row = await store.find_by_kid(old_kid)
+    assert old_row is not None
+    assert old_row.is_active is False
+    assert old_row.deprecated_at is not None
+    assert old_row.is_valid_for_verification is True
+
+    # Countersign works and uses the new key.
+    mgr.countersign(b"payload-after-activate")
+
+
+@pytest.mark.asyncio
+async def test_complete_staged_no_staged_row_raises(mgr):
+    """``complete_staged_rotation`` called without an outstanding
+    staged row must raise — the halt flag might be stale, but the
+    endpoint cannot invent a row to operate on.
+    """
+    assert mgr.is_sign_halted is False
+    with pytest.raises(RuntimeError, match="no staged row"):
+        await mgr.complete_staged_rotation("drop")
+
+
+@pytest.mark.asyncio
+async def test_complete_staged_rejects_invalid_decision(mgr):
+    with pytest.raises(ValueError, match="activate.*drop"):
+        await mgr.complete_staged_rotation("")
+    with pytest.raises(ValueError, match="activate.*drop"):
+        await mgr.complete_staged_rotation("rollback")
+
+
+# ── Cleanup on propagator failure (regression) ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_staged_row_cleaned_up_when_propagator_raises(mgr):
+    """The existing ``test_rotate_aborts_when_propagator_raises``
+    asserts state-unchanged. Extending it: after the new stage-first
+    flow, the cleanup path must DELETE the staged row we inserted
+    before calling the propagator. Otherwise a retry would hit the
+    ``staged row already present`` guard.
+    """
+    old_kid = mgr._active_key.kid
+
+    async def failing(_p, _c):
+        raise RuntimeError("court rejected the proof")
+
+    with pytest.raises(RuntimeError, match="court rejected"):
+        await mgr.rotate_mastio_key(grace_days=3, propagator=failing)
+
+    store = LocalKeyStore()
+    assert await store.find_staged() is None, \
+        "propagator-failure path left a staged row behind — retry would block"
+    assert mgr.is_sign_halted is False
+    current = await store.current_signer()
+    assert current.kid == old_kid
+
+    # A retry with a good propagator should work (no staged row blocking).
+    new_active = await mgr.rotate_mastio_key(grace_days=3, propagator=None)
+    assert new_active.kid != old_kid


### PR DESCRIPTION
## Summary
- Closes #281 — three rotation failure modes (crash mid-rotation strands the org, concurrent rotations split-brain Court vs local, Court-Mastio TOCTOU on countersign after a rotation) collapse to a single fix surface.
- **Court does hard-swap** on `mastio_pubkey` (verified: `app/registry/org_store.py:201-210` is a single-column overwrite; `verify_mastio_countersig` reads that single column). That forces the boot-recovery path to R3-hard (sign-halt until admin resolves) — there's no grace window for the old key to bridge a mid-rotation crash. **Follow-up #286** proposes a Court-side grace window that would degrade this to R3-soft.
- **Follow-up #287** tracks the full dashboard UI for the recovery endpoint; this PR ships the backend plumbing + CSRF-guarded dashboard POST.

## Design (stage-before-propagate, #R3-hard on boot)

```
async with self._rotation_lock:                    # 1. in-process serialize
    re-check active signer == old                  #    + no staged row
    generate keypair
    INSERT staged row (activated_at IS NULL)       # 2. durable before Court
    try:
        await propagator(proof, new_cert_pem)      # 3. tell Court
    except:
        await delete_staged_mastio_key(...)        #    cleanup on fail
        raise
    try:
        await activate_staged_and_deprecate_old(   # 4. atomic commit
            ...                                    #    pg_advisory_xact_lock
        )                                          #    on Postgres
    except:
        self._sign_halted = True                   #    preserve staged row
        raise                                      #    admin must resolve
    await self.refresh_active_key()
    self._sign_halted = False
```

### Boot recovery
`ensure_mastio_identity()` calls `LocalKeyStore.find_staged()` after loading the active row. A staged row means the previous process crashed mid-rotation — the manager sets `is_sign_halted = True`, flips the `cullis_mastio_rotation_staged` gauge to 1, logs ERROR with actionable guidance. `main.py` checks the flag and declines to construct `LocalIssuer`, so `_maybe_local_token` falls through to DPoP instead of emitting tokens Court would 403. `AgentManager.countersign` raises `RuntimeError` when halted, surfacing the failure at the Mastio.

### Recovery endpoint
`POST /proxy/mastio-key/complete-staged` (CSRF + login guard + `confirm_text` gate like `/rotate`). Accepts `decision=activate` or `decision=drop`:

- **activate** — the operator has verified the Court already pinned the staged pubkey. Atomically activates staged and deprecates the prior active, clearing the halt.
- **drop** — the operator has verified the Court is still on the prior active. Deletes the staged row, clearing the halt.

The endpoint does not query the Court — the operator owns the decision. The dashboard UI (#287) will add a Court-pin preview + guided buttons.

## Three failure modes, three tests

| Failure mode | Mitigation | Test |
|---|---|---|
| Concurrent rotations split-brain | `asyncio.Lock` + under-lock re-check + `pg_advisory_xact_lock` | `test_concurrent_rotations_exactly_one_succeeds` |
| Crash between propagator-ACK and local commit | Stage-before-propagate → staged row persists, `is_sign_halted` on the manager, boot detection | `test_crash_between_propagator_ack_and_activate_preserves_staged` + `test_boot_detects_staged_and_halts_signing` |
| Court-Mastio TOCTOU on post-rotation countersign | `BrokerBridge.get_client` wraps initial `_create_client` with one-shot retry on `_is_auth_error` | Covered by the crash-liveness test (retry gate runs under the same halt path) |

## Tests added

`tests/test_proxy_mastio_rotation_concurrency.py` — 9 tests:

- `test_concurrent_rotations_exactly_one_succeeds` — `asyncio.gather` two rotations, assert 1 success + 1 under-lock failure + 1 active row + 0 staged rows.
- `test_rotate_aborts_when_staged_row_present` — orphaned staged row from a prior crash must block a fresh rotate.
- `test_crash_between_propagator_ack_and_activate_preserves_staged` — `monkeypatch` on `activate_staged_and_deprecate_old` injects a post-Court-ACK failure; assert staged row persists, old active unchanged, `is_sign_halted` true, `countersign` raises.
- `test_boot_detects_staged_and_halts_signing` — fresh `AgentManager` against a DB seeded with a staged row: detects, halts, countersign raises.
- `test_complete_staged_drop_clears_halt` — recovery branch 1.
- `test_complete_staged_activate_completes_rotation` — recovery branch 2.
- `test_complete_staged_no_staged_row_raises` — stale halt flag without a staged row must error, not no-op.
- `test_complete_staged_rejects_invalid_decision` — `ValueError` on malformed input.
- `test_staged_row_cleaned_up_when_propagator_raises` — regression: propagator-failure path must DELETE the staged row so retry can proceed.

No `time.sleep`. All fault injection uses `asyncio.Event` + `monkeypatch`. All concurrency tests use `asyncio.gather`.

## Anti-flaky gate

`pyproject.toml` gains `pytest-repeat>=0.9` in the `dev` extras. `.github/workflows/ci.yml` gains a dedicated step:

```yaml
- name: Anti-flaky concurrency gate (10× rotation race tests)
  run: |
    pytest tests/test_proxy_mastio_rotation_concurrency.py \
        --count=10 -n auto --dist=loadfile --tb=short -q
```

Locally this runs in ~99s (10× 9 tests = 90 cases). Any order-of-coroutine flake that a single run would mask shows up here.

## Test matrix (local)

| Check | Result |
|---|---|
| `pytest tests/test_proxy_mastio_rotation_concurrency.py` | 9/9 PASS |
| `pytest tests/test_proxy_mastio_rotation_concurrency.py --count=10 -n auto --dist=loadfile` | **90/90 PASS, 99s, zero flakes** |
| `pytest` PKI + mastio + keystore + agent_dep + issuer + jwks + validator | 72/72 PASS |
| `ruff check` on modified proxy files | clean |

## Migration
**None.** `activated_at IS NULL` is already the keystore-invisible sentinel from Phase 2.0 — every existing query filters on `activated_at IS NOT NULL` (`get_mastio_keys_active`, `get_mastio_keys_valid`, `MastioKey.is_valid_for_verification`). Staged rows are discovered only by the new `find_staged` helper. No schema change, no data move, no operator intervention on existing deployments.

## Not in scope (intentional, tracked)
- **Court-side grace window** → #286 (P1). Would let the Mastio bridge a mid-rotation crash with the old key and degrade R3-hard → R3-soft.
- **Dashboard UI for `/complete-staged`** → #287 (P2). The endpoint ships with CSRF-guarded form handling; the banner + two-button flow with Court-pin preview is follow-up.
- **Multi-replica HA** — two proxy processes of the same org both rotating simultaneously: `pg_advisory_xact_lock` in the activate-TX catches the obvious split-brain but the "both INSERT staged rows with different kids" window is not fully closed. Future work; not today's design.
- **Prometheus gauge wiring** — `MASTIO_ROTATION_STAGED` is exposed as a real Prometheus gauge when `prometheus_client` is installed, with a no-op fallback otherwise. `mcp_proxy` doesn't declare `prometheus_client` in its extras today (the broker does). Operators who want the metric scraped install it; future `[metrics]` extra would formalize it.

## Audit reference
- `imp/audit_2026_04_23/phase1_key_rotation_court.md` — H-2
- `imp/audit_2026_04_23/phase2_jwks_multi_key.md` — F-2-1
- `imp/audit_2026_04_23/phase4_dashboard_rotation_ui.md` — H-2
- `imp/audit_2026_04_23/phase5_sdk_proxy_surface.md` — M-1
- Aggregate: `imp/audit_2026_04_23.md` H-RACE-02 + H-RACE-03

## Test plan for reviewer
- [ ] CI green on the main `test` job.
- [ ] CI green on the new `Anti-flaky concurrency gate` step — 10× × 9 tests = 90 cases.
- [ ] Manual: simulate a crash in `dogfood` by ^C'ing the proxy during `rotate_mastio_key`, restart, observe ERROR log + `is_sign_halted` state via dashboard, curl `/complete-staged` with `decision=drop`, observe signing resumes.