### PR TITLE
fix(pki): rate-limit + dedupe + cache on rotation endpoints (closes #282)

### DIFF
--- a/app/onboarding/rotate_dedupe.py
+++ b/app/onboarding/rotate_dedupe.py
@@ -1,0 +1,103 @@
+"""In-process idempotency cache for
+``POST /v1/onboarding/orgs/{org_id}/mastio-pubkey/rotate``.
+
+A legitimate operator who retries a rotation (network blip, proxy
+restart, UI double-click) sends the same continuity proof twice within
+the 600-second freshness window. Without a dedupe layer the Court
+re-runs the full ECDSA verify *and* appends a fresh audit row for the
+replay, polluting the hash chain that SOC/compliance relies on.
+
+The cache keys on ``(org_id, signature_b64u)`` — the proof signature is
+the natural idempotency token because it's derived from the old private
+key over a canonical envelope (issued_at + new_kid + new_pubkey_pem +
+old_kid) that is content-unique per rotation attempt. A hit returns
+the original response body verbatim so the client sees an identical
+200 on retry.
+
+TTL matches the proof freshness window (600s): proofs older than that
+are rejected by ``verify_proof`` regardless, so keeping them in cache
+longer would not help a legitimate retry and would just enlarge the
+memory footprint.
+
+TODO(#282): Redis-backed variant when we support HA multi-replica
+brokers. The in-process map is fine for the current single-replica
+Court topology but would split-brain across replicas (each would
+allow one successful rotation, though the Court's single-row
+``organizations.mastio_pubkey`` column still converges after the
+winner commits).
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any
+
+
+_TTL_SECONDS = 600.0  # matches proof freshness window in mastio_rotation.py
+
+
+@dataclass(frozen=True)
+class _CachedResponse:
+    """Response payload snapshot. Stored so a replayed proof returns
+    exactly what the first call returned, including ``rotated_at`` —
+    a retry that sees a ``rotated_at`` later than its own ``issued_at``
+    is valid; a retry that sees a totally different ``new_kid`` would
+    be a bug.
+    """
+    body: dict[str, Any]
+    inserted_at: float
+
+
+class RotateDedupeCache:
+    """Process-local (org_id, signature) → response cache."""
+
+    def __init__(self) -> None:
+        self._entries: dict[tuple[str, str], _CachedResponse] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, org_id: str, signature_b64u: str) -> dict[str, Any] | None:
+        """Return the cached response body for this proof, or None.
+
+        Lazily evicts expired entries when keys are probed — no
+        background sweeper required, and a cold cache after a long
+        idle period costs nothing.
+        """
+        key = (org_id, signature_b64u)
+        now = time.monotonic()
+        async with self._lock:
+            entry = self._entries.get(key)
+            if entry is None:
+                return None
+            if now - entry.inserted_at > _TTL_SECONDS:
+                self._entries.pop(key, None)
+                return None
+            return dict(entry.body)
+
+    async def store(
+        self, org_id: str, signature_b64u: str, body: dict[str, Any],
+    ) -> None:
+        """Record the response for future retries within the TTL.
+
+        Called only after a successful commit + audit — a failed
+        rotation must NOT be cached, because a second attempt should
+        get a fresh verify pass (the first failure might have been a
+        transient rowcount glitch or the DB lock retry loop).
+        """
+        key = (org_id, signature_b64u)
+        async with self._lock:
+            self._entries[key] = _CachedResponse(
+                body=dict(body), inserted_at=time.monotonic(),
+            )
+
+    async def reset(self) -> None:
+        """Test helper — drop all entries. Not called by production code."""
+        async with self._lock:
+            self._entries.clear()
+
+
+# Shared module-level cache. One entry per in-flight rotation
+# (org_id, signature_b64u); max cardinality is tiny because rotations
+# are rate-limited to 5/min/IP × 600s TTL = ~50 entries per org under
+# load, so unbounded growth is not a concern.
+rotate_dedupe = RotateDedupeCache()

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -564,6 +564,7 @@ class MastioPubkeyRotateResponse(BaseModel):
     response_model=MastioPubkeyRotateResponse,
 )
 async def rotate_org_mastio_pubkey(
+    request: Request,
     org_id: str,
     body: MastioPubkeyRotateRequest,
     db: AsyncSession = Depends(get_db),
@@ -571,10 +572,20 @@ async def rotate_org_mastio_pubkey(
     """Rotate the pinned Mastio pubkey via a key-continuity proof.
 
     Flow:
-      1. Resolve the org and its currently-pinned ``mastio_pubkey``.
-      2. Derive the expected ``old_kid`` from the pinned pubkey.
-      3. Parse + verify the submitted continuity proof.
-      4. On success, update the pin and emit an audit event.
+      1. Rate-limit by client IP (bucket ``onboarding.rotate_mastio_pubkey``)
+         so an unauthenticated attacker who guesses an org_id cannot
+         burn CPU on ECDSA verify or flood the hash-chain audit log
+         (issue #282).
+      2. Dedupe on ``(org_id, proof.signature)`` — a legitimate operator
+         retry within the 600-second freshness window returns the
+         cached response verbatim, short-circuiting ECDSA verify and
+         audit append. Failed attempts are NOT cached, so a transient
+         failure still re-verifies on retry.
+      3. Resolve the org and its currently-pinned ``mastio_pubkey``.
+      4. Derive the expected ``old_kid`` from the pinned pubkey.
+      5. Parse + verify the submitted continuity proof.
+      6. On success, update the pin, emit an audit event, cache the
+         response for idempotent retries.
     """
     from app.auth.mastio_rotation_verify import (
         ContinuityProof,
@@ -582,6 +593,29 @@ async def rotate_org_mastio_pubkey(
         compute_kid_from_pubkey_pem,
         verify_proof,
     )
+    from app.onboarding.rotate_dedupe import rotate_dedupe
+
+    client_ip = get_client_ip(request)
+    await rate_limiter.check(client_ip, "onboarding.rotate_mastio_pubkey")
+
+    # Parse proof up-front so we have ``signature_b64u`` for the dedupe
+    # key. Malformed proofs still 400 — they cannot trigger an audit
+    # append, so they do not need the dedupe layer to protect against
+    # hash-chain flooding.
+    try:
+        proof = ContinuityProof.from_dict(body.proof)
+    except ValueError as exc:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            detail=f"malformed proof: {exc}",
+        ) from exc
+
+    cached = await rotate_dedupe.get(org_id, proof.signature_b64u)
+    if cached is not None:
+        # Idempotent replay within the 600s freshness window. The cached
+        # body carries the original ``rotated_at`` so the client can see
+        # this is a retry of a call that already succeeded.
+        return MastioPubkeyRotateResponse(**cached)
 
     org = await get_org_by_id(db, org_id)
     if org is None:
@@ -596,14 +630,6 @@ async def rotate_org_mastio_pubkey(
         )
 
     _validate_mastio_pubkey(body.new_pubkey_pem)
-
-    try:
-        proof = ContinuityProof.from_dict(body.proof)
-    except ValueError as exc:
-        raise HTTPException(
-            status.HTTP_400_BAD_REQUEST,
-            detail=f"malformed proof: {exc}",
-        ) from exc
 
     expected_old_kid = compute_kid_from_pubkey_pem(org.mastio_pubkey)
     try:
@@ -649,11 +675,16 @@ async def rotate_org_mastio_pubkey(
             "rotated_at": rotated_at,
         },
     )
-    return MastioPubkeyRotateResponse(
-        org_id=org_id,
-        new_kid=proof.new_kid,
-        rotated_at=rotated_at,
-    )
+    response_body = {
+        "org_id": org_id,
+        "new_kid": proof.new_kid,
+        "rotated_at": rotated_at,
+    }
+    # Cache AFTER the commit + audit so retries short-circuit. Failed
+    # paths (404, 409, 401, 400) fall through without touching the
+    # cache, so a transient failure still re-verifies on retry.
+    await rotate_dedupe.store(org_id, proof.signature_b64u, response_body)
+    return MastioPubkeyRotateResponse(**response_body)
 
 
 @admin_router.post("/orgs/{org_id}/reject",

--- a/app/rate_limit/limiter.py
+++ b/app/rate_limit/limiter.py
@@ -223,5 +223,12 @@ rate_limiter.register("broker.session",   window_seconds=60,  max_requests=20)
 rate_limiter.register("broker.message",   window_seconds=60,  max_requests=60)
 rate_limiter.register("dashboard.login",  window_seconds=300, max_requests=5)
 rate_limiter.register("onboarding.join",  window_seconds=300, max_requests=5)
+# Mastio pubkey rotation — 5/min/IP matches the ``onboarding.join`` cadence:
+# rotations are infrequent operator actions (cadence days→weeks), so 5
+# attempts per minute is plenty for a legitimate retry loop and tight
+# enough to make unauthenticated CPU-burn / audit-flood attacks expensive.
+# See issue #282.
+rate_limiter.register("onboarding.rotate_mastio_pubkey",
+                                          window_seconds=60,  max_requests=5)
 rate_limiter.register("broker.rfq",         window_seconds=60,  max_requests=5)
 rate_limiter.register("broker.rfq_respond", window_seconds=60,  max_requests=20)

--- a/mcp_proxy/auth/jwks_local.py
+++ b/mcp_proxy/auth/jwks_local.py
@@ -16,19 +16,107 @@ lets an in-flight consumer that has cached the old ``kid`` re-fetch
 the JWKS and still find the old key — without this, a rotate immediately
 invalidates every token already in flight even though the keystore
 would happily verify them internally.
+
+Hardening (#282):
+- 60-second edge cache via ``Cache-Control: public, max-age=60,
+  stale-while-revalidate=60``. The key list turns over on
+  grace-window scales (days by default), so 60s staleness is
+  negligible and lets a CDN / reverse-proxy absorb the broadcast
+  load instead of hammering the DB on every GET.
+- ``ETag`` over the sorted JWK set; ``If-None-Match`` → 304 so
+  well-behaved clients skip the body entirely after their first
+  warm fetch.
+- Per-IP rate-limit (30/min) — unauthenticated endpoints need this
+  even when cached, because cache poisoning / cache-busting query
+  strings can still reach the handler.
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, Request, status
+import hashlib
+import json
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+
+from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
 
 router = APIRouter(tags=["auth"])
+
+# Budget matches the cache max-age: a well-behaved client polling
+# once per minute never touches the limiter. A bare client polling
+# every 2 seconds still gets in for the first half-minute of any
+# burst window; only sustained traffic from one IP is throttled.
+_JWKS_RATE_LIMIT_PER_MINUTE = 30
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort IP extraction for the rate-limit subject.
+
+    Honours ``X-Forwarded-For`` (first hop) when the proxy is behind
+    a trusted edge, falls back to the socket peer. Same precedence
+    as ``app.rate_limit.limiter.get_client_ip`` — kept local because
+    ``mcp_proxy`` does not import from ``app/``.
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    client = request.client
+    return client.host if client is not None else "unknown"
+
+
+def _compute_etag(keys: list[dict]) -> str:
+    """Strong ETag over the JWK list.
+
+    Hashes the full serialised JWK set (not just the kids) so any
+    change to pubkey material busts caches even in the pathological
+    kid-reuse case. Output is the quoted-string form per RFC 7232.
+    """
+    digest = hashlib.sha256(
+        json.dumps(keys, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return f'"{digest[:32]}"'
+
+
+def _etag_matches(header: str, etag: str) -> bool:
+    """RFC 7232 §3.2 ``If-None-Match`` evaluation.
+
+    A client may send ``*`` to match any tag, or a comma-separated
+    list. Weak-ETag prefix ``W/`` is tolerated on the request side —
+    our server-emitted tags are strong but clients in the wild
+    sometimes weak-ify them.
+    """
+    value = header.strip()
+    if value == "*":
+        return True
+    for candidate in value.split(","):
+        token = candidate.strip()
+        if token.startswith("W/"):
+            token = token[2:]
+        if token == etag:
+            return True
+    return False
 
 
 @router.get(
     "/.well-known/jwks-local.json",
     summary="JWKS for the Mastio local issuer (intra-org tokens)",
 )
-async def jwks_local(request: Request) -> dict:
+async def jwks_local(request: Request, response: Response):
+    # Namespace the rate-limit subject with ``ip:`` so it cannot
+    # collide with any ``agent_id`` value using the same limiter. The
+    # prefix is deliberate — a future refactor that sees
+    # ``get_agent_rate_limiter`` and assumes the subject is an
+    # agent_id would be wrong; the mcp_proxy limiter is
+    # subject-agnostic despite the name (see its module docstring).
+    # Do NOT drop the prefix.
+    client_ip = _client_ip(request)
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}", _JWKS_RATE_LIMIT_PER_MINUTE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="jwks-local rate limit exceeded",
+        )
+
     keystore = getattr(request.app.state, "local_keystore", None)
     if keystore is None:
         raise HTTPException(
@@ -44,4 +132,30 @@ async def jwks_local(request: Request) -> dict:
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="no mastio signing keys available",
         )
-    return {"keys": [k.jwk() for k in keys]}
+
+    # Sort by ``kid`` before serialising (#282). The DB query already
+    # orders by kid ASC (see ``db.get_mastio_keys_valid``) — re-sorting
+    # here is defence-in-depth so this handler stays deterministic
+    # even if the underlying keystore changes its ordering policy.
+    # Kid-sorted output also closes the rotation-timing oracle where
+    # ``keys[-1]`` used to always be the newest signer.
+    sorted_keys = sorted(keys, key=lambda k: k.kid)
+    jwk_list = [k.jwk() for k in sorted_keys]
+    etag = _compute_etag(jwk_list)
+
+    # Cache the public JWK set — grace window is measured in days,
+    # 60s edge staleness is negligible in that context, and a CDN /
+    # reverse-proxy absorbing the broadcast load is a real win.
+    response.headers["Cache-Control"] = (
+        "public, max-age=60, stale-while-revalidate=60"
+    )
+    response.headers["ETag"] = etag
+
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match and _etag_matches(if_none_match, etag):
+        # 304 Not Modified — no body. The caller already has an
+        # equivalent copy; they keep using it.
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED,
+                        headers=dict(response.headers))
+
+    return {"keys": jwk_list}

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1966,6 +1966,31 @@ MASTIO_ROTATION_GRACE_DAYS_DEFAULT = 7
 MASTIO_ROTATION_GRACE_DAYS_MIN = 1
 MASTIO_ROTATION_GRACE_DAYS_MAX = 90
 
+# Minimum seconds between two ``/mastio-key/rotate`` calls. Configurable
+# via env so sandbox integration tests (#268) can lower / disable it
+# during ``./demo.sh full``, and so incident response can drop it to 0
+# without code edits. Not a trust-governance knob (never goes through
+# ``proxy_config``) — purely an operational guardrail against
+# burst-loop abuse from a stolen admin cookie. See #282.
+_MASTIO_ROTATION_MIN_INTERVAL_SECONDS_DEFAULT = 30
+
+
+def _mastio_rotation_min_interval_seconds() -> int:
+    """Read ``CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS`` from env.
+
+    Falls back to 30s on unset / malformed. Accepts 0 to disable the
+    guardrail (test environments, incident rollback).
+    """
+    import os
+    raw = os.environ.get("CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS")
+    if raw is None:
+        return _MASTIO_ROTATION_MIN_INTERVAL_SECONDS_DEFAULT
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _MASTIO_ROTATION_MIN_INTERVAL_SECONDS_DEFAULT
+    return max(0, value)
+
 
 async def _load_rotation_grace_days() -> int:
     """Read the configured rotation grace window (days) from proxy_config.
@@ -2155,6 +2180,53 @@ async def mastio_key_rotate(request: Request):
             status_code=409,
             detail="Mastio identity not loaded — complete setup first",
         )
+
+    # Issue #282 — minimum rotation interval. A logged-in admin can
+    # POST ``confirm_text=ROTATE`` in a tight loop and with the default
+    # grace_days=7 that's thousands of keys / hour, all passing
+    # ``is_valid_for_verification``; with the 90-day max cadence an
+    # 8-hour session could mint ~2.5M verification-valid rows.
+    # Downstream verifiers OOM, Court gets hammered. A 30-second
+    # floor (configurable via env for sandbox integration tests and
+    # incident-response rollback) puts a human-scale rate ceiling on
+    # the operator surface without entering proxy_config as a
+    # trust-governance toggle — this is an operational guardrail.
+    min_interval_s = _mastio_rotation_min_interval_seconds()
+    if min_interval_s > 0:
+        from mcp_proxy.auth.local_keystore import LocalKeyStore
+        from datetime import datetime, timezone
+        ks = LocalKeyStore()
+        try:
+            latest_act = max(
+                (k.activated_at for k in await ks.all_valid_keys()
+                 if k.activated_at is not None),
+                default=None,
+            )
+        except Exception:
+            latest_act = None
+        if latest_act is not None:
+            delta_s = (datetime.now(timezone.utc) - latest_act).total_seconds()
+            if delta_s < min_interval_s:
+                await log_audit(
+                    agent_id="admin",
+                    action="mastio_key.rotate",
+                    status="rate_limited",
+                    detail=(
+                        f"min_interval={min_interval_s}s, "
+                        f"seconds_since_last={delta_s:.1f}s"
+                    ),
+                )
+                retry_after = max(1, int(min_interval_s - delta_s) + 1)
+                raise HTTPException(
+                    status_code=429,
+                    detail=(
+                        f"Minimum rotation interval {min_interval_s}s — "
+                        f"last rotation {delta_s:.1f}s ago. Retry in "
+                        f"{retry_after}s or lower "
+                        f"CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS."
+                    ),
+                    headers={"Retry-After": str(retry_after)},
+                )
 
     grace_days = await _load_rotation_grace_days()
     broker_bridge = getattr(request.app.state, "broker_bridge", None)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -472,6 +472,12 @@ async def get_mastio_keys_active() -> list[dict]:
     The invariant is exactly one; callers raise on 0 or >1. The query
     returns a list so the caller can surface a clear error rather than
     a silent ``.first()`` miss.
+
+    Ordering: ``kid`` lexicographic. With the single-row invariant the
+    order is observationally identical to any other — but keeping the
+    same ordering policy as ``get_mastio_keys_valid`` (below) means any
+    future schema change that relaxes the invariant won't silently
+    expose a timing oracle through this query's result list. See #282.
     """
     async with get_db() as conn:
         result = await conn.execute(
@@ -480,7 +486,7 @@ async def get_mastio_keys_active() -> list[dict]:
                 SELECT * FROM mastio_keys
                  WHERE activated_at IS NOT NULL
                    AND deprecated_at IS NULL
-                 ORDER BY activated_at ASC
+                 ORDER BY kid ASC
                 """
             )
         )
@@ -566,6 +572,13 @@ async def get_mastio_keys_valid() -> list[dict]:
     passed. Deprecated-but-not-yet-expired keys remain in the set —
     that is the grace-period mechanic used by the verifier during
     rotation (Phase 2.2). Never-activated rows are excluded.
+
+    Ordering: ``kid`` lexicographic (not ``activated_at``). The JWKS
+    endpoint surfaces this list verbatim, and sorting by activation
+    time leaked a rotation-timing oracle (``keys[-1]`` was always the
+    freshest signer). Lexicographic order is stable across rotations
+    so a client that snapshots the key list cannot infer "a rotation
+    just happened" from reordering alone. See #282.
     """
     async with get_db() as conn:
         result = await conn.execute(
@@ -574,7 +587,7 @@ async def get_mastio_keys_valid() -> list[dict]:
                 SELECT * FROM mastio_keys
                  WHERE activated_at IS NOT NULL
                    AND (expires_at IS NULL OR expires_at > :now)
-                 ORDER BY activated_at ASC
+                 ORDER BY kid ASC
                 """
             ),
             {"now": datetime.now(timezone.utc).isoformat()},

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -493,7 +493,13 @@ async def security_headers(request: Request, call_next):
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
     response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains"
-    response.headers["Cache-Control"] = "no-store"
+    # ``setdefault`` so individual handlers can opt into edge caching
+    # (``/.well-known/jwks-local.json`` flips to ``public, max-age=60``
+    # — the key list turns over on rotation grace-window scales, days,
+    # so 60s staleness is negligible and lets a CDN / reverse-proxy
+    # absorb the broadcast load, see #282). Handlers that don't set
+    # Cache-Control get the conservative ``no-store`` default.
+    response.headers.setdefault("Cache-Control", "no-store")
 
     # DPoP-Nonce on API responses only (not on dashboard/health routes, and
     # not on ADR-004 reverse-proxied paths — those carry the broker's own

--- a/tests/test_broker_mastio_pubkey_rotate_rate_limit.py
+++ b/tests/test_broker_mastio_pubkey_rotate_rate_limit.py
@@ -1,0 +1,346 @@
+"""Rate-limit + dedupe for the Court's mastio-pubkey rotate endpoint.
+
+Issue #282 — the endpoint (``POST /v1/onboarding/orgs/{id}/mastio-pubkey/rotate``)
+is unauthenticated (auth derives from the continuity proof), so without
+rate limiting an attacker who guesses an org_id can burn CPU on ECDSA
+verify and flood the hash-chain audit with ``admin.mastio_pubkey_rotate_rejected``
+rows. The dedupe cache additionally makes legitimate operator retries
+idempotent over the 600-second proof freshness window — a replay
+returns the original response without re-verifying or re-auditing.
+
+The tests use ``monkeypatch`` on ``app.rate_limit.limiter.get_client_ip``
+to drive the limiter with per-test IPs — uvicorn's proxy-headers
+middleware (which would populate ``request.client.host`` from XFF in
+production) is not wired through ``httpx.AsyncClient`` + ASGI
+transport, so every request arrives with the same synthetic client
+IP without this override.
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+
+from app.config import get_settings
+from mcp_proxy.auth.local_keystore import compute_kid
+from mcp_proxy.auth.mastio_rotation import build_proof
+from tests.cert_factory import get_org_ca_pem
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN_SECRET = get_settings().admin_secret
+
+
+@pytest.fixture(autouse=True)
+async def _reset_rate_limit_between_tests():
+    """Clear the module-level rate limiter and dedupe cache before
+    each test so shared-state bleed across test ordering does not
+    cause spurious 429s or stale dedupe hits.
+    """
+    from app.rate_limit.limiter import rate_limiter
+    from app.onboarding.rotate_dedupe import rotate_dedupe
+    # In-memory backend stores its state in ``_windows`` (dict of
+    # (subject, bucket) → deque). Clear it.
+    try:
+        rate_limiter._windows.clear()
+    except AttributeError:
+        pass
+    await rotate_dedupe.reset()
+    yield
+    try:
+        rate_limiter._windows.clear()
+    except AttributeError:
+        pass
+    await rotate_dedupe.reset()
+
+
+def _gen_p256_keypair() -> tuple[ec.EllipticCurvePrivateKey, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+async def _create_org_with_pubkey(
+    client: AsyncClient, org_id: str, pubkey_pem: str,
+) -> None:
+    invite = await client.post(
+        "/v1/admin/invites",
+        json={"label": org_id, "ttl_hours": 1},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    token = invite.json()["token"]
+    await client.post("/v1/onboarding/join", json={
+        "org_id": org_id,
+        "display_name": org_id,
+        "secret": f"{org_id}-secret",
+        "ca_certificate": get_org_ca_pem(org_id),
+        "invite_token": token,
+    })
+    r = await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-pubkey",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"mastio_pubkey": pubkey_pem},
+    )
+    assert r.status_code == 200, r.text
+
+
+# ── rate-limit (5/min/IP) ────────────────────────────────────────────
+
+
+async def test_rate_limit_blocks_sixth_request_from_same_ip(
+    client: AsyncClient, monkeypatch,
+):
+    """5 fresh rotation attempts from the same IP pass the rate
+    limiter; the 6th gets a 429 before any ECDSA verify runs.
+
+    Each attempt uses a *different* proof so the dedupe cache never
+    short-circuits — we're measuring the rate limiter in isolation.
+    The rotations themselves fail 401 (foreign proof against the
+    pinned pubkey), which is fine: the budget is consumed regardless.
+    """
+    from app.onboarding import router as onboarding_router_mod
+    monkeypatch.setattr(
+        onboarding_router_mod, "get_client_ip",
+        lambda req: "203.0.113.210",
+    )
+
+    _, pinned_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rl-burst", pinned_pub)
+
+    # 5 foreign proofs — each hits the limiter once, each returns 401
+    # (foreign proof rejected by ECDSA verify).
+    for _ in range(5):
+        foreign_priv, foreign_pub = _gen_p256_keypair()
+        _, new_pub = _gen_p256_keypair()
+        proof = build_proof(
+            old_priv_key=foreign_priv,
+            old_kid=compute_kid(foreign_pub),
+            new_kid=compute_kid(new_pub),
+            new_pubkey_pem=new_pub,
+        )
+        r = await client.post(
+            "/v1/onboarding/orgs/rl-burst/mastio-pubkey/rotate",
+            json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+        )
+        assert r.status_code == 401, r.text
+
+    # 6th — must be 429, before the ECDSA verify runs.
+    foreign_priv, foreign_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    proof = build_proof(
+        old_priv_key=foreign_priv,
+        old_kid=compute_kid(foreign_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/rl-burst/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    assert r.status_code == 429, r.text
+
+
+async def test_rate_limit_is_per_ip(client: AsyncClient, monkeypatch):
+    """A second IP is not penalised when the first IP has hit the
+    budget ceiling. Proves the rate-limit key is the client IP, not
+    a global counter.
+    """
+    _, pinned_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "rl-per-ip", pinned_pub)
+
+    from app.onboarding import router as onboarding_router_mod
+
+    # Burn budget on IP A.
+    monkeypatch.setattr(
+        onboarding_router_mod, "get_client_ip",
+        lambda req: "203.0.113.220",
+    )
+    for _ in range(6):
+        foreign_priv, foreign_pub = _gen_p256_keypair()
+        _, new_pub = _gen_p256_keypair()
+        proof = build_proof(
+            old_priv_key=foreign_priv,
+            old_kid=compute_kid(foreign_pub),
+            new_kid=compute_kid(new_pub),
+            new_pubkey_pem=new_pub,
+        )
+        await client.post(
+            "/v1/onboarding/orgs/rl-per-ip/mastio-pubkey/rotate",
+            json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+        )
+
+    # IP B should still be allowed through — its own bucket.
+    monkeypatch.setattr(
+        onboarding_router_mod, "get_client_ip",
+        lambda req: "203.0.113.221",
+    )
+    foreign_priv, foreign_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    proof = build_proof(
+        old_priv_key=foreign_priv,
+        old_kid=compute_kid(foreign_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r = await client.post(
+        "/v1/onboarding/orgs/rl-per-ip/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    # 401 because the proof is foreign — but NOT 429, which is the
+    # whole point of the per-IP bucket.
+    assert r.status_code == 401, r.text
+
+
+# ── idempotency dedupe cache ─────────────────────────────────────────
+
+
+async def test_replayed_proof_returns_cached_response_and_no_new_audit(
+    client: AsyncClient,
+):
+    """A legitimate operator who retries the same proof within the
+    freshness window must get an identical 200 from the cache —
+    without a second ECDSA verify and without a second audit row
+    polluting the hash chain.
+    """
+    from app.onboarding.rotate_dedupe import rotate_dedupe
+
+    old_priv, old_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "dedupe-ok", old_pub)
+
+    proof = build_proof(
+        old_priv_key=old_priv,
+        old_kid=compute_kid(old_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+
+    # Isolate the cache so prior tests don't pollute the key space.
+    await rotate_dedupe.reset()
+
+    r1 = await client.post(
+        "/v1/onboarding/orgs/dedupe-ok/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    assert r1.status_code == 200, r1.text
+    first = r1.json()
+
+    r2 = await client.post(
+        "/v1/onboarding/orgs/dedupe-ok/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
+    )
+    assert r2.status_code == 200, r2.text
+    second = r2.json()
+
+    # Identical payload on replay — dedupe hit.
+    assert first == second
+    # Crucially: the ``rotated_at`` is the ORIGINAL rotation's
+    # timestamp, not a fresh one, because we returned the cached
+    # response instead of re-running the commit.
+    assert first["rotated_at"] == second["rotated_at"]
+
+    # Audit log should have exactly one ``admin.mastio_pubkey_rotated``
+    # for this org despite two requests.
+    from app.db.audit import AuditLog
+    from app.db.database import AsyncSessionLocal
+    from sqlalchemy import func, select
+    async with AsyncSessionLocal() as db:
+        stmt = (
+            select(func.count(AuditLog.id))
+            .where(AuditLog.event_type == "admin.mastio_pubkey_rotated")
+            .where(AuditLog.org_id == "dedupe-ok")
+        )
+        result = await db.execute(stmt)
+        count = result.scalar_one()
+    assert count == 1, f"expected 1 rotation audit row, got {count}"
+
+
+async def test_failed_rotation_is_not_cached(client: AsyncClient):
+    """A failure (e.g. 401 on a foreign proof) must NOT enter the
+    dedupe cache — otherwise a transient-failure retry would be
+    locked into the failure indefinitely. Prove this by following a
+    401 with a correct retry against the same org: the second
+    attempt should verify normally and succeed.
+    """
+    from app.onboarding.rotate_dedupe import rotate_dedupe
+    await rotate_dedupe.reset()
+
+    pinned_priv, pinned_pub = _gen_p256_keypair()
+    _, new_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "dedupe-fail-then-ok", pinned_pub)
+
+    # First attempt with a WRONG signing key → 401.
+    foreign_priv, foreign_pub = _gen_p256_keypair()
+    bad_proof = build_proof(
+        old_priv_key=foreign_priv,
+        old_kid=compute_kid(foreign_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r_bad = await client.post(
+        "/v1/onboarding/orgs/dedupe-fail-then-ok/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": bad_proof.to_dict()},
+    )
+    assert r_bad.status_code == 401, r_bad.text
+
+    # Second attempt with the CORRECT signing key → must succeed,
+    # proving that the 401 did not poison the cache key.
+    good_proof = build_proof(
+        old_priv_key=pinned_priv,
+        old_kid=compute_kid(pinned_pub),
+        new_kid=compute_kid(new_pub),
+        new_pubkey_pem=new_pub,
+    )
+    r_ok = await client.post(
+        "/v1/onboarding/orgs/dedupe-fail-then-ok/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": new_pub, "proof": good_proof.to_dict()},
+    )
+    assert r_ok.status_code == 200, r_ok.text
+
+
+async def test_different_proofs_do_not_collide_in_cache(client: AsyncClient):
+    """Dedupe is keyed on (org_id, signature_b64u). Two rotations
+    with different proofs must both be processed (sequential, not
+    replayed). The second rotation's ``old_kid`` is the first
+    rotation's ``new_kid`` — happy-path back-to-back rotation.
+    """
+    from app.onboarding.rotate_dedupe import rotate_dedupe
+    await rotate_dedupe.reset()
+
+    first_priv, first_pub = _gen_p256_keypair()
+    second_priv, second_pub = _gen_p256_keypair()
+    _, third_pub = _gen_p256_keypair()
+    await _create_org_with_pubkey(client, "dedupe-chain", first_pub)
+
+    # Rotation 1: first → second.
+    proof_1 = build_proof(
+        old_priv_key=first_priv,
+        old_kid=compute_kid(first_pub),
+        new_kid=compute_kid(second_pub),
+        new_pubkey_pem=second_pub,
+    )
+    r1 = await client.post(
+        "/v1/onboarding/orgs/dedupe-chain/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": second_pub, "proof": proof_1.to_dict()},
+    )
+    assert r1.status_code == 200, r1.text
+
+    # Rotation 2: second → third. Different signature → different
+    # cache key → must be processed, not dedupe-hit.
+    proof_2 = build_proof(
+        old_priv_key=second_priv,
+        old_kid=compute_kid(second_pub),
+        new_kid=compute_kid(third_pub),
+        new_pubkey_pem=third_pub,
+    )
+    r2 = await client.post(
+        "/v1/onboarding/orgs/dedupe-chain/mastio-pubkey/rotate",
+        json={"new_pubkey_pem": third_pub, "proof": proof_2.to_dict()},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["new_kid"] == compute_kid(third_pub)
+    assert r2.json()["rotated_at"] != r1.json()["rotated_at"]

--- a/tests/test_proxy_dashboard_mastio_key.py
+++ b/tests/test_proxy_dashboard_mastio_key.py
@@ -37,6 +37,11 @@ async def proxy_logged_in(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
     monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    # Issue #282 — the dashboard rotate endpoint rejects back-to-back
+    # rotations within 30s by default. Tests that exercise rotate
+    # immediately after fixture bootstrap need the guardrail off; the
+    # dedicated tests for the guardrail override this back.
+    monkeypatch.setenv("CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS", "0")
 
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()
@@ -230,3 +235,107 @@ async def test_rotate_grace_row_appears_after_rotation(proxy_logged_in):
     assert "deprecated · still verifier-valid" in page.text
     # And a countdown data-attribute.
     assert "data-countdown-to=" in page.text
+
+
+# ── Minimum rotation interval (#282) ─────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in_with_min_interval(tmp_path, monkeypatch):
+    """Variant fixture with ``CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS``
+    set to a *realistic* value (30s) so the guardrail rejects
+    back-to-back rotations. Dedicated because the default fixture
+    above disables the guardrail to keep existing rotation tests
+    simple.
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.setenv("CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS", "30")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_back_to_back_rotation_is_rate_limited(
+    proxy_logged_in_with_min_interval,
+):
+    """Second rotation within the 30s floor must get 429 + an audit
+    entry tagged ``rate_limited``. The active signer does not change.
+    """
+    app, client = proxy_logged_in_with_min_interval
+    mgr = app.state.agent_manager
+    assert mgr.mastio_loaded
+    kid_after_bootstrap = mgr._active_key.kid
+
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/rotate",
+        data={"csrf_token": csrf, "confirm_text": "ROTATE"},
+        follow_redirects=False,
+    )
+    # The bootstrap itself happened < 30s ago, so even the FIRST
+    # rotation attempt should be blocked. That is the correct
+    # behaviour: the guardrail is about "last activation" not "last
+    # rotation", so a proxy that just booted counts.
+    assert resp.status_code == 429, resp.text
+    assert "min_interval" in resp.text.lower() or "minimum rotation" in resp.text.lower()
+    assert resp.headers.get("Retry-After") is not None
+
+    # Active signer did NOT change.
+    assert mgr._active_key.kid == kid_after_bootstrap
+
+    # Audit row was written with status=rate_limited. Query the
+    # audit_log table directly — there's no exported helper for
+    # filtered reads in mcp_proxy.db.
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text as _text
+    async with get_db() as conn:
+        result = await conn.execute(
+            _text(
+                "SELECT action, status FROM audit_log "
+                "WHERE action = :action AND status = :status"
+            ),
+            {"action": "mastio_key.rotate", "status": "rate_limited"},
+        )
+        rows = list(result.mappings().all())
+    assert rows, "expected a rate_limited audit row, got none"
+
+
+@pytest.mark.asyncio
+async def test_rotation_succeeds_when_interval_disabled(proxy_logged_in):
+    """The default ``proxy_logged_in`` fixture sets the env var to 0
+    (guardrail off). A rotation immediately after bootstrap must
+    succeed — this is the regression-guard for the standard flow
+    and for sandbox integration tests that need rapid rotation.
+    """
+    app, client = proxy_logged_in
+    mgr = app.state.agent_manager
+    old_kid = mgr._active_key.kid
+    csrf = await _csrf(client)
+    resp = await client.post(
+        "/proxy/mastio-key/rotate",
+        data={"csrf_token": csrf, "confirm_text": "ROTATE"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303, resp.text
+    assert mgr._active_key.kid != old_kid

--- a/tests/test_proxy_local_issuer.py
+++ b/tests/test_proxy_local_issuer.py
@@ -350,3 +350,226 @@ def test_jwks_endpoint_drops_expired_deprecated_key():
         kids = {k["kid"] for k in body["keys"]}
         assert kids == {new_active.kid}
         assert expired.kid not in kids
+
+
+# ── Cache + ETag + rate-limit (#282) ─────────────────────────────────
+
+
+def _reset_agent_rate_limiter() -> None:
+    """Clear the module-level ``get_agent_rate_limiter`` state so the
+    per-IP budget is full at the start of each test that exercises it.
+    """
+    from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
+    limiter = get_agent_rate_limiter()
+    try:
+        limiter._windows.clear()
+    except AttributeError:
+        pass
+
+
+def test_jwks_endpoint_sets_cacheable_headers():
+    """The endpoint must emit ``Cache-Control: public, max-age=60,
+    stale-while-revalidate=60`` and a strong ``ETag`` so a CDN /
+    reverse-proxy in front can absorb the broadcast load during a
+    rotation grace window (#282).
+    """
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+    _reset_agent_rate_limiter()
+
+    _, priv_pem, pub_pem = _fresh_key()
+    active = _active_key(priv_pem, pub_pem)
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[active])
+
+    with TestClient(app) as client:
+        resp = client.get("/.well-known/jwks-local.json")
+        assert resp.status_code == 200
+        cc = resp.headers.get("cache-control", "")
+        assert "public" in cc, cc
+        assert "max-age=60" in cc, cc
+        assert "stale-while-revalidate=60" in cc, cc
+        etag = resp.headers.get("etag")
+        assert etag is not None
+        assert etag.startswith('"') and etag.endswith('"')
+
+
+def test_jwks_endpoint_if_none_match_returns_304():
+    """A repeat GET with ``If-None-Match: <etag>`` must return 304 and
+    no body — the classic conditional-request fast path. Proves the
+    caller can skip parsing the body after the first warm fetch.
+    """
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+    _reset_agent_rate_limiter()
+
+    _, priv_pem, pub_pem = _fresh_key()
+    active = _active_key(priv_pem, pub_pem)
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[active])
+
+    with TestClient(app) as client:
+        first = client.get("/.well-known/jwks-local.json")
+        assert first.status_code == 200
+        etag = first.headers["etag"]
+
+        second = client.get(
+            "/.well-known/jwks-local.json",
+            headers={"If-None-Match": etag},
+        )
+        assert second.status_code == 304
+        # 304 responses per RFC 7232 MUST include the same cache
+        # validators as the 200 would — especially ETag so a caller
+        # that retries can still short-circuit.
+        assert second.headers.get("etag") == etag
+        # No body content on 304.
+        assert not second.content
+
+
+def test_jwks_endpoint_etag_changes_after_rotation():
+    """After a rotation (different key set) the ETag must change so
+    any downstream cache invalidates. Conversely, identical key sets
+    yield identical ETags — a stable reads don't churn.
+    """
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+    _reset_agent_rate_limiter()
+
+    _, priv_pem_a, pub_pem_a = _fresh_key()
+    _, priv_pem_b, pub_pem_b = _fresh_key()
+    active_a = _active_key(priv_pem_a, pub_pem_a)
+    active_b = _active_key(priv_pem_b, pub_pem_b)
+
+    # State 1: single key A.
+    app1 = FastAPI()
+    app1.include_router(jwks_router)
+    app1.state.local_keystore = _FakeKeyStore(keys=[active_a])
+    with TestClient(app1) as c1:
+        r1 = c1.get("/.well-known/jwks-local.json")
+        etag_1 = r1.headers["etag"]
+
+    # State 2: post-rotation — key A + key B (grace window).
+    grace_a = _grace_key(priv_pem_a, pub_pem_a)
+    app2 = FastAPI()
+    app2.include_router(jwks_router)
+    app2.state.local_keystore = _FakeKeyStore(keys=[grace_a, active_b])
+    with TestClient(app2) as c2:
+        r2 = c2.get("/.well-known/jwks-local.json")
+        etag_2 = r2.headers["etag"]
+
+    assert etag_1 != etag_2, (
+        "ETag must differ after rotation — otherwise stale caches stick"
+    )
+
+    # State 3: identical to state 1 — same single key A.
+    app3 = FastAPI()
+    app3.include_router(jwks_router)
+    app3.state.local_keystore = _FakeKeyStore(keys=[active_a])
+    with TestClient(app3) as c3:
+        r3 = c3.get("/.well-known/jwks-local.json")
+        etag_3 = r3.headers["etag"]
+    assert etag_1 == etag_3, "stable reads must yield stable ETag"
+
+
+def test_jwks_endpoint_rate_limits_per_ip():
+    """Budget is 30/min/IP (``_JWKS_RATE_LIMIT_PER_MINUTE``). The 31st
+    request from the same client gets 429 without touching the
+    keystore or the body serialiser.
+    """
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+    _reset_agent_rate_limiter()
+
+    _, priv_pem, pub_pem = _fresh_key()
+    active = _active_key(priv_pem, pub_pem)
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=[active])
+
+    with TestClient(app) as client:
+        # TestClient sends a stable synthetic IP for all requests; 30
+        # should pass, the 31st should 429.
+        for i in range(30):
+            r = client.get("/.well-known/jwks-local.json")
+            assert r.status_code == 200, f"request {i+1}: {r.text}"
+
+        r = client.get("/.well-known/jwks-local.json")
+        assert r.status_code == 429, r.text
+
+
+def test_jwks_endpoint_emits_keys_sorted_by_kid_not_activation_time():
+    """Sorting by ``kid`` lexicographic (not by ``activated_at``)
+    closes a rotation-timing oracle: a caller could previously infer
+    "the freshest signer is the last entry" from the array order.
+    With kid-sorted output, position is stable across rotations —
+    ``keys[-1]`` is just the kid that sorts last, not the one minted
+    most recently.
+    """
+    from mcp_proxy.auth.jwks_local import router as jwks_router
+    _reset_agent_rate_limiter()
+
+    # Generate two keys, identify which kid sorts first by
+    # compute_kid output, then set activation times in the OPPOSITE
+    # order. If the endpoint sorted by ``activated_at`` the first
+    # entry would be the one activated earliest; kid-sorted output
+    # instead puts the lexicographically-smaller kid first.
+    from datetime import timedelta
+    _, priv_a, pub_a = _fresh_key()
+    _, priv_b, pub_b = _fresh_key()
+    kid_a = compute_kid(pub_a)
+    kid_b = compute_kid(pub_b)
+    now = datetime.now(timezone.utc)
+
+    # Give the lexicographically-LATER kid the EARLIER activation time
+    # so "sort by activated_at ASC" would put it first — then assert
+    # the endpoint does NOT surface that order.
+    if kid_a < kid_b:
+        earlier_ts = now - timedelta(days=2)
+        later_ts = now - timedelta(days=1)
+        ka = MastioKey(
+            kid=kid_a, pubkey_pem=pub_a, privkey_pem=priv_a, cert_pem=None,
+            created_at=later_ts, activated_at=later_ts,
+            deprecated_at=None, expires_at=None,
+        )
+        kb = MastioKey(
+            kid=kid_b, pubkey_pem=pub_b, privkey_pem=priv_b, cert_pem=None,
+            created_at=earlier_ts, activated_at=earlier_ts,
+            deprecated_at=now - timedelta(seconds=10),
+            expires_at=now + timedelta(days=30),
+        )
+    else:
+        earlier_ts = now - timedelta(days=2)
+        later_ts = now - timedelta(days=1)
+        ka = MastioKey(
+            kid=kid_a, pubkey_pem=pub_a, privkey_pem=priv_a, cert_pem=None,
+            created_at=earlier_ts, activated_at=earlier_ts,
+            deprecated_at=now - timedelta(seconds=10),
+            expires_at=now + timedelta(days=30),
+        )
+        kb = MastioKey(
+            kid=kid_b, pubkey_pem=pub_b, privkey_pem=priv_b, cert_pem=None,
+            created_at=later_ts, activated_at=later_ts,
+            deprecated_at=None, expires_at=None,
+        )
+
+    # Pre-sort by activated_at ASC (what the legacy query would have
+    # yielded) so the endpoint-under-test has to re-sort or it will
+    # leak the activation order.
+    keys_in_activation_order = sorted(
+        [ka, kb], key=lambda k: k.activated_at,
+    )
+
+    app = FastAPI()
+    app.include_router(jwks_router)
+    app.state.local_keystore = _FakeKeyStore(keys=keys_in_activation_order)
+
+    with TestClient(app) as client:
+        r = client.get("/.well-known/jwks-local.json")
+        assert r.status_code == 200, r.text
+        emitted_kids = [k["kid"] for k in r.json()["keys"]]
+
+    assert emitted_kids == sorted(emitted_kids), (
+        "JWKS must emit keys in kid-sorted order (#282), "
+        f"got {emitted_kids}"
+    )


### PR DESCRIPTION
## Summary
- Closes #282 — three state-changing / resource-expensive endpoints in the rotation subsystem shipped without rate-limiting. All the machinery exists (broker ``SlidingWindowLimiter``, proxy ``AgentRateLimiter``) and is wired on ``/v1/egress/*`` and most onboarding endpoints; the rotation paths were just missed. This PR closes the three gaps with minimal new plumbing.
- Out of scope (issue body): M-1 actor attribution, M-2 500 detail leak, M-3 cookie confidentiality. Separate hardening follow-ups.

## Fixes

### 1. Court rotation endpoint — unauth DoS + audit-chain flood
**`app/onboarding/router.py::rotate_org_mastio_pubkey`** gains:
- Rate-limit `5/min/IP` via new bucket `onboarding.rotate_mastio_pubkey` (registered in `app/rate_limit/limiter.py`). Same cadence as `onboarding.join`.
- Dedupe cache `(org_id, proof.signature_b64u)` with 600s TTL matching the proof freshness window. Legitimate operator retries return cached 200 verbatim — no re-verify, no duplicate audit row. Failures (401/400/404/409) NOT cached.
- New module `app/onboarding/rotate_dedupe.py` — in-process `dict` + `asyncio.Lock`. TODO comment flags Redis-backed variant needed before multi-replica HA.

### 2. JWKS-local endpoint — cache policy + ETag + rate-limit + timing oracle
- **`mcp_proxy/main.py` middleware**: `Cache-Control: no-store` → `setdefault`. Handlers opt in.
- **`mcp_proxy/auth/jwks_local.py`**:
  - Emits `Cache-Control: public, max-age=60, stale-while-revalidate=60`. Grace window is days; 60s edge staleness is negligible.
  - Strong ETag over the JSON-serialised JWK set; `If-None-Match` → 304.
  - `30/min/IP` rate-limit via `get_agent_rate_limiter` with `ip:` subject prefix (subject-agnostic limiter reused; prefix commented in place to prevent future refactor regression).
  - Sorts keys by `kid` lexicographic before serialisation as defence-in-depth.
- **`mcp_proxy/db.py::get_mastio_keys_valid`**: `ORDER BY activated_at ASC` → `ORDER BY kid ASC`. Closes the rotation-timing oracle (`keys[-1]` was always the freshest signer).
- **`mcp_proxy/db.py::get_mastio_keys_active`**: same `ORDER BY kid ASC` change. The query returns one row today so it is observationally identical — but keeping a consistent ordering policy means a future schema change that relaxes the single-active invariant won't silently resurface the oracle through this query.

### 3. Dashboard rotation — min-interval guardrail
**`mcp_proxy/dashboard/router.py::mastio_key_rotate`** gains:
- Configurable minimum interval via env `CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS` (default 30). Read-at-request-time so tests + incident response can override without restart.
- Under the floor → 429 with `Retry-After` header + audit event `mastio_key.rotate status=rate_limited`.
- Not a trust-governance knob, so it lives in env, not `proxy_config`.
- Set to 0 to disable (sandbox integration tests #268, incident rollback).

## Tests

| File | Scope |
|---|---|
| `tests/test_broker_mastio_pubkey_rotate_rate_limit.py` (new, 5) | 6th req/IP → 429 before ECDSA verify · per-IP isolation (monkeypatch `get_client_ip`) · dedupe replay → identical body + 1 audit row · failed rotations not cached · distinct proofs don't collide in cache |
| `tests/test_proxy_local_issuer.py` (+5) | cache-control headers present · `If-None-Match` → 304 with etag echo and no body · ETag changes after rotation and stable across identical state · 31st req/IP → 429 · keys sorted by kid regardless of insertion order |
| `tests/test_proxy_dashboard_mastio_key.py` (+2, fixture update) | rotation immediately after bootstrap → 429 with `Retry-After` + `rate_limited` audit row · guardrail disabled via env (existing fixture sets min_interval=0) → rotation succeeds as before |

### Test matrix locally

| Check | Result |
|---|---|
| `pytest` PKI + mastio + rate-limit + jwks (10 files) | **91/91 PASS** (25s) |
| `ruff check` on 8 modified files | clean (pre-existing F541 on `main.py` survives, unchanged — verified by running ruff against `origin/main` snapshot) |

## Migration
**None.** All three fixes leverage existing infrastructure:
- New bucket registered at module import — no schema change.
- Dedupe cache is in-memory only.
- JWKS client contract unchanged (same `{"keys": [...]}` body, now with cache headers + 304 fast path).
- Dashboard min-interval defaults to 30s out of the box; operators who need to disable it set the env var. No DB/config migration.

## Operational notes
- Multi-replica HA: the dedupe cache is per-process. Two brokers of the same org both handling a concurrent rotation would each process it independently. The Court's hard-swap of `mastio_pubkey` still converges (last writer wins), and the audit chain gets one row per replica — pre-existing behaviour, not worsened. Tracked informally for the Redis-backed variant TODO; full HA rotation semantics are in the backlog alongside #286 (Court grace window).

## Audit reference
- `imp/audit_2026_04_23/phase1_key_rotation_court.md` — H-1
- `imp/audit_2026_04_23/phase2_jwks_multi_key.md` — F-2-3
- `imp/audit_2026_04_23/phase4_dashboard_rotation_ui.md` — H-1
- `imp/audit_2026_04_23/phase5_sdk_proxy_surface.md` — L-1
- Aggregate: `imp/audit_2026_04_23.md` H-DOS-05

## Related
- #261 PKI hardening roadmap (parent)
- #281 (rotate_mastio_key race fixes, merged in PR #288) — shares infrastructure (`rate_limiter`, `AgentManager._rotation_lock`) with the Court-side work here
- #285 (boot warn-on-load for legacy pathLen=0 Org CA) — last residual audit item

## Test plan for reviewer
- [ ] CI green (pytest + ruff + DCO + anti-flaky gate from #281)
- [ ] Local: `pytest tests/test_broker_mastio_pubkey_rotate_rate_limit.py tests/test_proxy_local_issuer.py tests/test_proxy_dashboard_mastio_key.py`
- [ ] Manual (optional): `curl -i` against `/.well-known/jwks-local.json` 31 times from one IP → 31st returns 429
- [ ] Manual: dashboard rotation immediately after boot → 429 with Retry-After visible in response headers