### PR TITLE
fix(pki): warn at boot on legacy Org CA with pathLen=0 (closes #285)

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -36,11 +36,28 @@ from mcp_proxy.db import (
     insert_mastio_key,
     set_config,
 )
-from mcp_proxy.telemetry_metrics import MASTIO_ROTATION_STAGED
+from mcp_proxy.telemetry_metrics import (
+    LEGACY_CA_PATHLEN_ZERO,
+    MASTIO_ROTATION_STAGED,
+)
 
 from typing import Awaitable, Callable
 
 logger = logging.getLogger("mcp_proxy.egress.agent_manager")
+
+
+def _strict_pki_enabled() -> bool:
+    """Issue #285 — ``MCP_PROXY_STRICT_PKI=1`` opts the proxy into
+    refuse-to-boot-on-legacy-PKI semantics. Default OFF; flipping it
+    ON as the default would brick legacy proxies that ``docker pull``
+    a newer image before an operator has a chance to rotate their
+    Org CA. Accept only the exact strings ``1``, ``true``, ``yes``
+    (case-insensitive) so a stray empty / malformed value cannot
+    surprise an operator.
+    """
+    import os
+    raw = os.environ.get("MCP_PROXY_STRICT_PKI", "").strip().lower()
+    return raw in ("1", "true", "yes")
 
 
 def _priv_to_pem(key) -> str:
@@ -97,6 +114,18 @@ class AgentManager:
         # producing signatures the Court would reject.
         self._sign_halted = False
         self._staged_kid: str | None = None
+        # Issue #285 — diagnostic flag set at boot when the Org CA in
+        # ``proxy_config.org_ca_cert`` has ``BasicConstraints(pathLen=0)``
+        # but the proxy mints a Mastio intermediate CA underneath it at
+        # runtime (``_mint_mastio_ca``). That chain violates RFC 5280
+        # §4.2.1.9 — stdlib verifiers (OpenSSL, Go crypto/x509, webpki,
+        # browser, kubectl mTLS) reject it during cross-org federation,
+        # even though #280's verifier fix now catches it locally too.
+        # The flag surfaces in ``/health`` warnings and on the
+        # ``cullis_proxy_legacy_ca_pathlen_zero`` Prometheus gauge so
+        # operators see a clear signal before a design partner trips
+        # over silent federation failures.
+        self._legacy_ca_pathlen_zero = False
 
     # ── CA loading ──────────────────────────────────────────────────
 
@@ -528,6 +557,12 @@ class AgentManager:
             except RuntimeError:
                 self._active_key = None
 
+        # Issue #285 — legacy-CA detection runs before identity check so
+        # the flag is set even when the proxy generates a fresh Mastio
+        # identity on first boot with a legacy Org CA inherited from
+        # pre-#280 bootstrap.
+        self._detect_legacy_ca_pathlen_zero()
+
         if self.mastio_loaded:
             # Issue #281 — detect staged rotation rows left behind by a
             # crash between propagator-ACK and local activation. Court
@@ -542,6 +577,93 @@ class AgentManager:
             return
 
         await self._generate_mastio_identity()
+
+    def _detect_legacy_ca_pathlen_zero(self) -> None:
+        """Issue #285 — flag a pre-#280 bootstrap Org CA.
+
+        Before PR #284 (closes #280), the dashboard setup wizard and
+        the Court admin-generated CA flow emitted Org CAs with
+        ``BasicConstraints(pathLen=0)``. Proxies that bootstrapped
+        during that window still carry that CA in
+        ``proxy_config.org_ca_cert`` and cannot produce a chain that
+        stdlib verifiers accept — the Mastio intermediate CA minted
+        under the Org CA violates the pathLen constraint, and every
+        cross-org federation handshake that terminates at a peer
+        running OpenSSL / Go / webpki silently 401s.
+
+        This method inspects the loaded Org CA, raises ``RuntimeError``
+        when ``MCP_PROXY_STRICT_PKI=1`` is set (opt-in for sandbox /
+        CI / strict-enforcement deployments — not the default, because
+        a legacy proxy that ``docker pull``s a new image would then
+        refuse to boot without a remediation framework in place), and
+        otherwise just records the state for ``/health`` + the
+        Prometheus gauge to surface. Remediation is operator action:
+        ``POST /pki/rotate-ca`` rotates the Org CA in place.
+        """
+        if self._org_ca_cert is None:
+            return
+        try:
+            bc = self._org_ca_cert.extensions.get_extension_for_class(
+                x509.BasicConstraints
+            ).value
+        except x509.ExtensionNotFound:
+            # Unusual — a CA that skipped BasicConstraints. Leave
+            # without flagging; other validation will reject it.
+            return
+        if bc.path_length != 0:
+            # pathLen=1 (post-#280) or pathLen=None (unbounded). Either
+            # is OK for the current 3-tier chain.
+            LEGACY_CA_PATHLEN_ZERO.set(0)
+            return
+
+        self._legacy_ca_pathlen_zero = True
+        LEGACY_CA_PATHLEN_ZERO.set(1)
+
+        # Pull the subject CN for the log. Fall back to empty string
+        # if the CA lacks CN — the serial + org_id alone are enough
+        # to identify the CA.
+        cn = ""
+        try:
+            cn_attrs = self._org_ca_cert.subject.get_attributes_for_oid(
+                NameOID.COMMON_NAME
+            )
+            if cn_attrs:
+                cn = cn_attrs[0].value
+        except Exception:
+            pass
+
+        logger.warning(
+            "org_ca_legacy_pathlen_zero: Org CA has pathLen=0 but the "
+            "proxy mints a Mastio intermediate under it. Stdlib "
+            "verifiers (OpenSSL, Go crypto/x509, webpki) reject the "
+            "chain during cross-org federation. Remediation: POST "
+            "/pki/rotate-ca. (org_id=%s ca_serial=%s cn=%s)",
+            self._org_id,
+            self._org_ca_cert.serial_number,
+            cn,
+        )
+
+        if _strict_pki_enabled():
+            raise RuntimeError(
+                "MCP_PROXY_STRICT_PKI=1 refuses boot on legacy Org CA "
+                "with pathLen=0 — run POST /pki/rotate-ca and restart, "
+                "or unset MCP_PROXY_STRICT_PKI to boot with a warning "
+                f"(org_id={self._org_id!r}, "
+                f"ca_serial={self._org_ca_cert.serial_number})"
+            )
+
+    @property
+    def has_legacy_ca_pathlen_zero(self) -> bool:
+        """True when the loaded Org CA has ``BasicConstraints(pathLen=0)``.
+
+        Set at boot by ``_detect_legacy_ca_pathlen_zero``. Consumers:
+          - ``/health`` — surfaces ``"org_ca_legacy_pathlen_zero"``
+            in the ``warnings`` array.
+          - ``cullis_proxy_legacy_ca_pathlen_zero`` Prometheus gauge
+            (via the ``LEGACY_CA_PATHLEN_ZERO`` metric in
+            ``telemetry_metrics``).
+        """
+        return self._legacy_ca_pathlen_zero
 
     async def _detect_staged_and_maybe_halt(self) -> None:
         """Boot-time check for an orphaned staged rotation row.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -739,9 +739,28 @@ if _static_dir.is_dir():
 # ─────────────────────────────────────────────────────────────────────────────
 
 @app.get("/health", tags=["infra"])
-async def health():
-    """Basic health check — always 200 if the process is running."""
-    return {"status": "ok", "version": "0.1.0"}
+async def health(request: Request):
+    """Basic health check — always 200 if the process is running.
+
+    Surfaces operator-visible warnings in a ``warnings`` array when
+    present (omitted entirely when clean so existing consumers that
+    just assert ``status == "ok"`` stay green). Current warnings:
+
+      - ``org_ca_legacy_pathlen_zero`` — #285, the proxy booted with
+        an Org CA that has pathLen=0 but mints a Mastio intermediate
+        underneath. Stdlib-verifier cross-org federation silently
+        401s; remediation is ``POST /pki/rotate-ca``.
+    """
+    body: dict = {"status": "ok", "version": "0.1.0"}
+    warnings: list[str] = []
+    agent_mgr = getattr(request.app.state, "agent_manager", None)
+    if agent_mgr is not None and getattr(
+        agent_mgr, "has_legacy_ca_pathlen_zero", False,
+    ):
+        warnings.append("org_ca_legacy_pathlen_zero")
+    if warnings:
+        body["warnings"] = warnings
+    return body
 
 
 @app.get("/healthz", tags=["infra"])

--- a/mcp_proxy/telemetry_metrics.py
+++ b/mcp_proxy/telemetry_metrics.py
@@ -38,5 +38,13 @@ try:
         "0 otherwise. Non-zero means admin intervention is required via "
         "POST /proxy/mastio-key/complete-staged.",
     )
+    LEGACY_CA_PATHLEN_ZERO = Gauge(
+        "cullis_proxy_legacy_ca_pathlen_zero",
+        "1 when the proxy booted with an Org CA that has pathLen=0 and "
+        "therefore cannot accommodate the Mastio intermediate CA without "
+        "breaking RFC 5280 §4.2.1.9. Remediation: POST /pki/rotate-ca. "
+        "See issues #280 and #285.",
+    )
 except ImportError:  # pragma: no cover — exercised only in slim envs
     MASTIO_ROTATION_STAGED = _NoopMetric()  # type: ignore[assignment]
+    LEGACY_CA_PATHLEN_ZERO = _NoopMetric()  # type: ignore[assignment]

--- a/tests/test_proxy_legacy_ca_warn.py
+++ b/tests/test_proxy_legacy_ca_warn.py
@@ -1,0 +1,339 @@
+"""Boot-time detection + surface of legacy Org CAs with
+``BasicConstraints(pathLen=0)``.
+
+Issue #285 — proxies that bootstrapped before #280 kept an Org CA
+with ``pathLen=0`` in ``proxy_config.org_ca_cert``. Their own
+verifier (post-#284) now rejects the chain, but the silent
+cross-org federation failure mode bites only at peer-verification
+time. These tests pin the detection path + the surfaces operators
+see: the WARNING log, the ``/health`` ``warnings`` array, the
+Prometheus gauge, and the opt-in strict-PKI refuse-to-boot mode.
+
+Fresh bootstraps (post-#280) emit ``pathLen=1`` and must NOT
+trigger any of those signals — the regression-guard that keeps the
+fix from becoming sticky.
+"""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.egress.agent_manager import AgentManager
+
+
+def _mint_org_ca(path_length: int) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    """Mint a self-signed Org CA with the requested pathLen.
+
+    Mirrors the dashboard setup wizard's emission shape so the
+    detection path exercises exactly the cert shape a legacy /
+    fresh proxy would carry in ``proxy_config.org_ca_cert``.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "legacy-warn-test CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "legacy-warn-test"),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, key_cert_sign=True, crl_sign=True,
+                content_commitment=False, key_encipherment=False,
+                data_encipherment=False, key_agreement=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _pem_pair(key: rsa.RSAPrivateKey, cert: x509.Certificate) -> tuple[str, str]:
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return key_pem, cert_pem
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """Isolated SQLite proxy DB + cleared settings cache per test."""
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_STRICT_PKI", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import dispose_db, init_db
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+# ── Detection + WARN log ─────────────────────────────────────────────
+
+
+def _capture_warnings(monkeypatch) -> list[str]:
+    """Monkeypatch ``mcp_proxy.egress.agent_manager.logger.warning`` to
+    record invocations into a list.
+
+    ``mcp_proxy.logging_setup`` sets ``propagate = False`` on the
+    ``mcp_proxy`` parent logger (memory: ``feedback_mcp_proxy_logger_caplog``),
+    so pytest's ``caplog`` — which hangs off the root — never sees
+    records emitted under ``mcp_proxy.*``. Replacing the bound
+    ``warning`` method with a capturing closure keeps the test
+    independent of logger configuration.
+    """
+    captured: list[str] = []
+    import mcp_proxy.egress.agent_manager as agent_mgr_mod
+
+    def _fake_warning(msg, *args, **kwargs):
+        # Match logging's ``%``-style formatting so the test sees the
+        # fully-rendered string the real handler would emit.
+        captured.append(msg % args if args else msg)
+
+    monkeypatch.setattr(agent_mgr_mod.logger, "warning", _fake_warning)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_legacy_ca_pathlen_zero_triggers_warning_and_flag(
+    proxy_db, monkeypatch,
+):
+    """pathLen=0 Org CA → flag True, WARN log with the exact marker,
+    Prometheus gauge goes to 1. The proxy still boots (no strict
+    mode) so intra-org flows keep working.
+    """
+    key, cert = _mint_org_ca(path_length=0)
+    key_pem, cert_pem = _pem_pair(key, cert)
+
+    mgr = AgentManager(org_id="legacy-warn")
+    await mgr.load_org_ca(key_pem, cert_pem)
+
+    messages = _capture_warnings(monkeypatch)
+    await mgr.ensure_mastio_identity()
+
+    assert mgr.has_legacy_ca_pathlen_zero is True
+    # Structured marker operators can grep for.
+    assert any("org_ca_legacy_pathlen_zero" in m for m in messages), (
+        f"expected WARN with marker, got: {messages}"
+    )
+    # Remediation hint present.
+    assert any("/pki/rotate-ca" in m for m in messages), (
+        "WARN must tell the operator how to fix"
+    )
+
+    from mcp_proxy.telemetry_metrics import LEGACY_CA_PATHLEN_ZERO
+    # Gauge is 1 when the no-op shim is in place (set() returns None)
+    # or when prometheus_client is installed. We probe the Gauge via
+    # its private ``_value`` attribute when available; otherwise just
+    # trust the shim behaviour.
+    value = getattr(LEGACY_CA_PATHLEN_ZERO, "_value", None)
+    if value is not None:
+        # prometheus_client Gauge exposes ``_value.get()``.
+        assert value.get() == 1.0
+
+
+@pytest.mark.asyncio
+async def test_fresh_ca_pathlen_one_does_not_trigger(proxy_db, monkeypatch):
+    """Regression guard: post-#280 bootstraps emit ``pathLen=1``. The
+    detection must NOT fire — no flag, no warning, gauge stays at 0.
+    """
+    key, cert = _mint_org_ca(path_length=1)
+    key_pem, cert_pem = _pem_pair(key, cert)
+
+    mgr = AgentManager(org_id="fresh-ok")
+    await mgr.load_org_ca(key_pem, cert_pem)
+
+    messages = _capture_warnings(monkeypatch)
+    await mgr.ensure_mastio_identity()
+
+    assert mgr.has_legacy_ca_pathlen_zero is False
+    assert not any("org_ca_legacy_pathlen_zero" in m for m in messages)
+
+
+# ── Strict mode (opt-in via env) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_strict_pki_mode_refuses_boot_on_legacy_ca(
+    proxy_db, monkeypatch,
+):
+    """``MCP_PROXY_STRICT_PKI=1`` flips detection from warn-and-continue
+    to refuse-to-boot. The WARN is still emitted (ops visibility),
+    then ``ensure_mastio_identity`` raises with a message telling
+    the operator how to recover.
+    """
+    monkeypatch.setenv("MCP_PROXY_STRICT_PKI", "1")
+
+    key, cert = _mint_org_ca(path_length=0)
+    key_pem, cert_pem = _pem_pair(key, cert)
+
+    mgr = AgentManager(org_id="legacy-strict")
+    await mgr.load_org_ca(key_pem, cert_pem)
+
+    messages = _capture_warnings(monkeypatch)
+    with pytest.raises(RuntimeError, match="MCP_PROXY_STRICT_PKI"):
+        await mgr.ensure_mastio_identity()
+
+    # WARN must still be emitted before the raise — ops need the log
+    # marker regardless of whether boot proceeds.
+    assert any("org_ca_legacy_pathlen_zero" in m for m in messages), messages
+
+
+@pytest.mark.asyncio
+async def test_strict_pki_mode_does_not_refuse_fresh_ca(
+    proxy_db, monkeypatch,
+):
+    """``MCP_PROXY_STRICT_PKI=1`` does NOT refuse a healthy pathLen=1
+    CA — the refuse-to-boot guard only fires on the legacy shape.
+    """
+    monkeypatch.setenv("MCP_PROXY_STRICT_PKI", "1")
+
+    key, cert = _mint_org_ca(path_length=1)
+    key_pem, cert_pem = _pem_pair(key, cert)
+
+    mgr = AgentManager(org_id="fresh-strict")
+    await mgr.load_org_ca(key_pem, cert_pem)
+
+    # No raise — fresh CA boots cleanly even in strict mode.
+    await mgr.ensure_mastio_identity()
+    assert mgr.has_legacy_ca_pathlen_zero is False
+
+
+@pytest.mark.asyncio
+async def test_strict_pki_accepts_common_truthy_values(proxy_db, monkeypatch):
+    """``MCP_PROXY_STRICT_PKI`` accepts ``1`` / ``true`` / ``yes``
+    (case-insensitive). Other values behave as off — keeping a
+    malformed env var from surprising the operator.
+    """
+    from mcp_proxy.egress.agent_manager import _strict_pki_enabled
+
+    for value in ("1", "true", "TRUE", "yes", "YES"):
+        monkeypatch.setenv("MCP_PROXY_STRICT_PKI", value)
+        assert _strict_pki_enabled() is True, value
+
+    for value in ("", "0", "false", "no", "maybe", "  "):
+        monkeypatch.setenv("MCP_PROXY_STRICT_PKI", value)
+        assert _strict_pki_enabled() is False, value
+
+
+# ── /health surface ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_health_surfaces_legacy_ca_warning(tmp_path, monkeypatch):
+    """End-to-end: boot a proxy with a legacy Org CA, hit ``/health``,
+    assert the response carries ``warnings: ["org_ca_legacy_pathlen_zero"]``.
+    Backward-compat: the ``warnings`` key is omitted entirely when
+    the proxy is clean — consumers that assert ``status == "ok"``
+    stay green.
+    """
+    # Seed proxy_config with a legacy Org CA before lifespan runs.
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "health-warn")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_STRICT_PKI", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import init_db, set_config, dispose_db
+    await init_db(url)
+    try:
+        key, cert = _mint_org_ca(path_length=0)
+        key_pem, cert_pem = _pem_pair(key, cert)
+        await set_config("org_ca_key", key_pem)
+        await set_config("org_ca_cert", cert_pem)
+    finally:
+        await dispose_db()
+
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/health")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "ok"
+            assert body.get("warnings") == ["org_ca_legacy_pathlen_zero"]
+
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_health_omits_warnings_array_when_clean(tmp_path, monkeypatch):
+    """Backward-compat: a clean proxy returns ``{"status": "ok",
+    "version": ...}`` without a ``warnings`` key. Consumers that
+    just check ``status`` don't see a new key appear.
+    """
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "health-clean")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_STRICT_PKI", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import init_db, set_config, dispose_db
+    await init_db(url)
+    try:
+        key, cert = _mint_org_ca(path_length=1)
+        key_pem, cert_pem = _pem_pair(key, cert)
+        await set_config("org_ca_key", key_pem)
+        await set_config("org_ca_cert", cert_pem)
+    finally:
+        await dispose_db()
+
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/health")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["status"] == "ok"
+            assert "warnings" not in body
+
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- Closes #285 — last audit 2026-04-23 residual. Detection + operator-visible signals (log + ``/health`` + Prometheus gauge) when a proxy boots with an Org CA carrying the pre-#280 ``BasicConstraints(pathLen=0)`` shape.
- **Minimal scope per the issue body**: no dashboard UI, no auto-migration, strict mode opt-in only. Rationale in PR body below.

## Why this matters
Post-#284 our own verifier rejects the legacy chain (``Org CA(pathLen=0) → Mastio intermediate → agent leaf``), but the chain only flows to a peer verifier during cross-org federation — so the failure mode is **silent 401s** at peers running OpenSSL / Go crypto/x509 / webpki. A legacy proxy keeps handling intra-org traffic fine and only breaks federation. The operator has no signal today. This PR closes that gap with three surfaces:

1. **Structured WARN** (`org_ca_legacy_pathlen_zero` marker + org_id / serial / CN + remediation pointer).
2. **`/health` warnings array** (backward compatible — key omitted when clean).
3. **Prometheus gauge** `cullis_proxy_legacy_ca_pathlen_zero` (consistent with #288's `cullis_mastio_rotation_staged`; no-op fallback when `prometheus_client` isn't installed).

## Why strict mode defaults to OFF
``MCP_PROXY_STRICT_PKI=1`` opts the proxy into refuse-to-boot-on-legacy-PKI. It stays opt-in because flipping it ON as the default would brick legacy proxies that ``docker pull`` a newer image before an operator can rotate their Org CA — and we don't have a migration framework yet (that's federation plan Parte 1). Opt-in is the right shape for sandbox / CI / customers who want enforcement hard today; the default will flip once the pending-updates registry lands.

Naming is ``STRICT_PKI`` (not ``REFUSE_LEGACY_ORG_CA``) as the issue body suggests — umbrella-ready so future PKI strict checks (KeyUsage, algorithm, validity) can land under the same env var without a second knob.

## Files changed

| File | Change |
|---|---|
| `mcp_proxy/egress/agent_manager.py` | `_detect_legacy_ca_pathlen_zero()` + `has_legacy_ca_pathlen_zero` property + `_strict_pki_enabled()` helper + `__init__` flag + call-site in `ensure_mastio_identity` |
| `mcp_proxy/main.py` | `/health` now takes `Request`, appends `"org_ca_legacy_pathlen_zero"` to `warnings` array when flag set. Omitted when clean. |
| `mcp_proxy/telemetry_metrics.py` | New `LEGACY_CA_PATHLEN_ZERO` gauge (Prometheus when available, no-op fallback otherwise) |
| `tests/test_proxy_legacy_ca_warn.py` (new) | 7 tests covering detection + flag + WARN + strict mode + env parsing + /health surface + backward compat |

## Tests (7 in new file)

- `test_legacy_ca_pathlen_zero_triggers_warning_and_flag` — pathLen=0 → flag True + WARN + remediation hint + gauge=1.
- `test_fresh_ca_pathlen_one_does_not_trigger` — regression guard on the post-#280 shape.
- `test_strict_pki_mode_refuses_boot_on_legacy_ca` — opt-in strict mode → `RuntimeError`; WARN still emitted before raise.
- `test_strict_pki_mode_does_not_refuse_fresh_ca` — strict mode is selective, only trips on legacy.
- `test_strict_pki_accepts_common_truthy_values` — env parser accepts `1` / `true` / `yes` case-insensitive, rejects malformed.
- `test_health_surfaces_legacy_ca_warning` — end-to-end: legacy CA seeded in `proxy_config` + lifespan boot → `/health` returns `warnings: ["org_ca_legacy_pathlen_zero"]`.
- `test_health_omits_warnings_array_when_clean` — backward-compat: clean proxy's `/health` has no `warnings` key.

Log capture uses `monkeypatch.setattr` on the module logger's `warning` method rather than `caplog` — the `mcp_proxy` parent logger sets `propagate = False` via `logging_setup.py`, which short-circuits pytest's root handler. Documented in `memory/feedback_mcp_proxy_logger_caplog.md`.

### Test matrix (local)
| Check | Result |
|---|---|
| `pytest tests/test_proxy_legacy_ca_warn.py` | **7/7 PASS** |
| `pytest` full PKI/mastio/rotate/jwks/verifier suite (11 files) | **90/90 PASS** (25s) |
| `ruff check` on modified files | clean (pre-existing `main.py` F541/E402 survives, unchanged — verified against `origin/main`) |

## Migration
**None.** Detection is read-only. The WARN + gauge + `/health` key are operator-visible signals; the flag is read-only from `AgentManager`. `POST /pki/rotate-ca` is the existing remediation (not touched by this PR).

## Not in this PR (tracked)
- **Dashboard UI** for legacy-CA visibility — belongs in federation plan Parte 1's pending-updates registry + auto-apply flow, not in #287 (`/complete-staged` UI for a different scenario).
- **Auto-migration** — rejected by design in the issue body (rotating the CA invalidates every enrolled agent cert; operator must opt in explicitly).
- **Flipping `MCP_PROXY_STRICT_PKI` to default-on** — blocked on the migration framework.

## Audit reference
`imp/audit_2026_04_23/phase3_intermediate_ca.md` (#280 followup).

## Related
- #261 PKI hardening roadmap (parent)
- #280 / PR #284 — root fix (pathLen emission + verifier off-by-one)
- #281 / PR #288 — rotation race with same Prometheus-gauge pattern (`cullis_mastio_rotation_staged`)
- #282 / PR #289 — rate-limit on rotation endpoints

## Test plan for reviewer
- [ ] CI green (pytest + ruff + DCO + anti-flaky gate from #281 — unchanged)
- [ ] Local: `curl -s http://proxy:9100/health | jq` against a legacy-bootstrapped proxy shows `"warnings": ["org_ca_legacy_pathlen_zero"]`; same against a fresh proxy omits the key.
- [ ] Local: set `MCP_PROXY_STRICT_PKI=1` on a legacy-bootstrapped proxy, restart, observe boot fails with actionable error.