### PR TITLE
fix(connector): replace prime_sender_pubkey_cache with Mastio pubkey endpoint

### DIFF
--- a/cullis_connector/inbox_poller.py
+++ b/cullis_connector/inbox_poller.py
@@ -26,11 +26,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from cullis_connector.tools._identity import (
-    PubkeyPrimeError,
-    canonical_recipient,
-    prime_sender_pubkey_cache,
-)
+from cullis_connector.tools._identity import canonical_recipient
+from cullis_sdk import PubkeyFetchError
 
 if TYPE_CHECKING:
     from cullis_sdk import CullisClient
@@ -198,23 +195,25 @@ class DashboardInboxPoller:
         msg_id = row.get("msg_id")
         if not msg_id:
             return None
-        # Pre-populate the SDK pubkey cache so decrypt_oneshot doesn't
-        # try to fetch the sender's cert from the broker (no JWT here).
-        # Same workaround the MCP receive_oneshot tool uses. On failure
-        # the message is security-relevant: we can't verify the sender,
-        # so the poller MUST skip it (not crash, not silently downgrade
-        # to the broker JWT path). Log at ERROR so the operator sees
-        # the skip in the dashboard log without having to turn on DEBUG.
+        # decrypt_oneshot needs the sender's cert to verify the envelope
+        # signature. Device-code-enrolled Connectors can't spend a
+        # broker JWT on the Court's federation API, so we hand the SDK
+        # the proxy-backed fetcher that auths with X-API-Key + DPoP.
+        # Pubkey-lookup failures are security-relevant (the message is
+        # dropped so no unverified plaintext surfaces) — log at ERROR
+        # so operators see the skip without toggling DEBUG. Other decrypt
+        # errors (malformed envelope, signature mismatch) stay at WARNING.
         try:
-            prime_sender_pubkey_cache(self._client, sender_raw)
-        except PubkeyPrimeError as exc:
+            decoded = self._client.decrypt_oneshot(
+                row,
+                pubkey_fetcher=self._client.get_agent_public_key_via_egress,
+            )
+        except PubkeyFetchError as exc:
             _log.error(
-                "skipping msg %s from %s — pubkey prime failed: %s",
+                "skipping msg %s from %s — pubkey fetch failed: %s",
                 msg_id, sender, exc,
             )
             return None
-        try:
-            decoded = self._client.decrypt_oneshot(row)
         except Exception as exc:  # noqa: BLE001
             _log.warning(
                 "decrypt_oneshot failed for msg %s from %s: %s",

--- a/cullis_connector/tools/_identity.py
+++ b/cullis_connector/tools/_identity.py
@@ -1,40 +1,17 @@
 """Sender-identity helpers shared by Connector tool modules.
 
-Both `oneshot.py` and `intent.py` need to read the sender's own org
+Both ``oneshot.py`` and ``intent.py`` need to read the sender's own org
 from the loaded identity bundle (cert subject ``O=<org_id>``) and to
 canonicalise bare recipient handles into the ``<org>::<agent>`` form
 the Mastio's ``/v1/egress/*`` endpoints require. Keeping the helpers
 here avoids the circular import that would happen if ``intent.py``
 tried to pull them from ``oneshot.py``.
-
-Also hosts ``prime_sender_pubkey_cache`` — the workaround used by both
-the MCP receive_oneshot tool and the dashboard inbox poller to make
-``CullisClient.decrypt_oneshot`` work without a broker JWT (which
-device-code-enrolled Connectors don't hold).
 """
 from __future__ import annotations
-
-import logging
-import time
 
 from cryptography import x509
 
 from cullis_connector.state import get_state
-
-_log = logging.getLogger("cullis_connector.tools._identity")
-
-
-class PubkeyPrimeError(RuntimeError):
-    """Raised when the sender pubkey cache cannot be primed via
-    ``/v1/egress/resolve`` — either the Mastio call failed outright
-    or the response carried no ``target_cert_pem``.
-
-    The dashboard inbox poller catches this and skips the message
-    (logging at ERROR rather than swallowing silently) so an operator
-    can see the security-relevant gap in their audit log instead of
-    silently falling back to the broker JWT path that no Connector
-    holds a token for.
-    """
 
 
 def own_org_id() -> str | None:
@@ -64,81 +41,3 @@ def canonical_recipient(recipient_id: str) -> str:
     if not org:
         return recipient_id
     return f"{org}::{recipient_id}"
-
-
-def prime_sender_pubkey_cache(client, sender: str) -> None:
-    """Seed the SDK's pubkey cache with the sender's cert via the proxy's
-    resolve endpoint.
-
-    ``CullisClient.decrypt_oneshot`` looks up the sender's cert through
-    ``get_agent_public_key``, which by default hits the Court's
-    federation API behind a broker JWT — and device-code Connectors
-    don't hold that JWT. The local Mastio already knows the cert (it
-    served it to the sender's ``/v1/egress/resolve``), so we ask
-    ``/v1/egress/resolve`` for the same row and populate the SDK
-    cache directly so ``decrypt_oneshot`` finds it without needing
-    the broker.
-
-    No-op on cache hit.
-
-    **Error contract (security audit NEW #4):** Failures MUST propagate
-    to the caller so the audit trail records the skip at ERROR level
-    instead of the function silently falling back to the broker JWT
-    path (which has no credential → surfaces as an opaque
-    ``login()`` error). Specifically, raises ``PubkeyPrimeError`` when:
-
-      - the HTTP call to ``/v1/egress/resolve`` fails (network, 4xx, 5xx),
-      - the response is missing / has an empty ``target_cert_pem``,
-      - the client object has no ``_pubkey_cache`` attribute (programming
-        error — an incompatible client type was passed in).
-
-    The caller (inbox poller, MCP receive_oneshot) catches and
-    skips-this-message rather than crashing the poll loop.
-    """
-    canonical = sender if "::" in sender else canonical_recipient(sender)
-    cache = getattr(client, "_pubkey_cache", None)
-    if cache is None:
-        raise PubkeyPrimeError(
-            "client has no _pubkey_cache attribute — incompatible SDK client"
-        )
-    # The SDK's get_agent_public_key honours its own TTL (300s); if the
-    # entry is still fresh we skip, otherwise we refetch even for known
-    # senders. Without this, a stale entry left over from a previous
-    # poll round causes get_agent_public_key to fall back to the broker
-    # JWT path → "Not authenticated — call login() first".
-    try:
-        from cullis_sdk.client import _PUBKEY_CACHE_TTL as _SDK_TTL
-    except Exception:  # noqa: BLE001
-        _SDK_TTL = 300
-    cached = cache.get(canonical)
-    if cached is not None:
-        _, fetched_at = cached
-        if time.time() - fetched_at < _SDK_TTL:
-            return
-    try:
-        resp = client._egress_http(
-            "post",
-            "/v1/egress/resolve",
-            json={"recipient_id": canonical},
-        )
-        resp.raise_for_status()
-        cert = resp.json().get("target_cert_pem")
-    except PubkeyPrimeError:
-        raise
-    except Exception as exc:  # noqa: BLE001
-        raise PubkeyPrimeError(
-            f"/v1/egress/resolve call for {canonical} failed: "
-            f"{exc} ({type(exc).__name__})"
-        ) from exc
-    if not cert:
-        raise PubkeyPrimeError(
-            f"/v1/egress/resolve for {canonical} returned no target_cert_pem "
-            "(intra-org transport may be 'envelope' not 'mtls-only' — set "
-            "PROXY_TRANSPORT_INTRA_ORG=mtls-only on the Mastio)"
-        )
-    cache[canonical] = (cert, time.time())
-    # Mirror under the bare handle too — `decrypt_oneshot` keys on
-    # whatever the inbox row carried, which can be either form.
-    if sender != canonical:
-        cache[sender] = (cert, time.time())
-    _log.info("pubkey cached for %s (mirror=%s)", canonical, sender != canonical)

--- a/cullis_connector/tools/oneshot.py
+++ b/cullis_connector/tools/oneshot.py
@@ -13,10 +13,7 @@ from typing import TYPE_CHECKING
 
 from cullis_connector._logging import get_logger
 from cullis_connector.state import get_state
-from cullis_connector.tools._identity import (
-    canonical_recipient,
-    prime_sender_pubkey_cache,
-)
+from cullis_connector.tools._identity import canonical_recipient
 from cullis_connector.tools.session import _require_oneshot_client
 
 if TYPE_CHECKING:
@@ -114,8 +111,9 @@ def register(mcp: "FastMCP") -> None:
             reply_to = row.get("reply_to") or "—"
             msg_id = row.get("msg_id")
             try:
-                prime_sender_pubkey_cache(client, sender)
-                decoded = client.decrypt_oneshot(row)
+                decoded = client.decrypt_oneshot(
+                    row, pubkey_fetcher=client.get_agent_public_key_via_egress,
+                )
                 payload = decoded.get("payload", {})
                 if isinstance(payload, dict) and "text" in payload:
                     text = payload["text"]
@@ -145,7 +143,3 @@ def register(mcp: "FastMCP") -> None:
             state.last_reply_to = last_decoded_msg_id
 
         return f"{len(rows)} one-shot message(s):\n" + "\n".join(lines)
-
-
-# ``prime_sender_pubkey_cache`` lives in tools/_identity.py since
-# both this module and the dashboard inbox poller need it.

--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -15,7 +15,7 @@ Usage::
         client.send(session_id, "myorg::agent", {"text": "Hello"}, agents[0].agent_id)
 """
 
-from cullis_sdk.client import CullisClient, WebSocketConnection
+from cullis_sdk.client import CullisClient, PubkeyFetchError, WebSocketConnection
 from cullis_sdk.dpop import DpopKey
 from cullis_sdk.types import AgentInfo, SessionInfo, InboxMessage, RfqResult, RfqQuote
 from cullis_sdk._logging import log, log_msg
@@ -23,6 +23,7 @@ from cullis_sdk._env import load_env_file, cfg
 
 __all__ = [
     "CullisClient",
+    "PubkeyFetchError",
     "WebSocketConnection",
     "DpopKey",
     "AgentInfo",

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -43,6 +43,18 @@ from cullis_sdk._logging import log, RED
 _PUBKEY_CACHE_TTL = 300  # seconds
 
 
+class PubkeyFetchError(RuntimeError):
+    """Raised by pubkey-fetch helpers (broker or egress) when the
+    target agent's public key cannot be retrieved.
+
+    Distinct from generic HTTP/network errors so callers — notably
+    ``decrypt_oneshot`` consumers — can discriminate "couldn't verify
+    sender, must skip" from "decrypt itself failed". The Connector's
+    inbox poller catches this specifically and logs at ERROR (security
+    relevant: an unverifiable sender means the message is dropped).
+    """
+
+
 class InsecureTLSWarning(UserWarning):
     """Raised when the SDK is configured to skip TLS verification.
 
@@ -1091,6 +1103,55 @@ class CullisClient:
         self._pubkey_cache[agent_id] = (pubkey_pem, time.time())
         return pubkey_pem
 
+    def get_agent_public_key_via_egress(
+        self, agent_id: str, force_refresh: bool = False,
+    ) -> str:
+        """Fetch the target agent's PEM cert through the local proxy's
+        ``GET /v1/egress/agents/{id}/public-key`` endpoint.
+
+        Companion to :meth:`get_agent_public_key`, intended for clients
+        that authenticate to the proxy with X-API-Key + DPoP and have no
+        broker JWT to spend on the Court's federation API. Replaces the
+        Connector's ``prime_sender_pubkey_cache`` workaround that used
+        to scrape ``/v1/egress/resolve`` for the same data and write
+        directly into the SDK's private cache.
+
+        Returns the PEM cert (not a bare key — the proxy hands back the
+        full x509, the verify helpers in :mod:`cullis_sdk.crypto` accept
+        either form). Reuses :attr:`_pubkey_cache` with the same TTL as
+        the broker path so successive calls don't burn the per-agent
+        egress rate-limit budget.
+
+        Raises :class:`PubkeyFetchError` when the proxy responds without
+        a usable cert (404, missing field, transport error). Plain HTTP
+        errors are wrapped — callers should catch ``PubkeyFetchError``
+        rather than ``httpx.HTTPError`` so future transports stay
+        transparent.
+        """
+        if not force_refresh and agent_id in self._pubkey_cache:
+            pem, fetched_at = self._pubkey_cache[agent_id]
+            if time.time() - fetched_at < _PUBKEY_CACHE_TTL:
+                return pem
+        path = f"/v1/egress/agents/{agent_id}/public-key"
+        try:
+            resp = self._egress_http("get", path)
+            resp.raise_for_status()
+            pem = resp.json().get("cert_pem")
+        except PubkeyFetchError:
+            raise
+        except Exception as exc:
+            raise PubkeyFetchError(
+                f"GET {path} failed: {exc} ({type(exc).__name__})"
+            ) from exc
+        if not pem:
+            raise PubkeyFetchError(
+                f"proxy returned no cert_pem for {agent_id} "
+                "(target may be cross-org with no broker bridge "
+                "configured, or the agent does not exist)"
+            )
+        self._pubkey_cache[agent_id] = (pem, time.time())
+        return pem
+
     # ── Sessions ────────────────────────────────────────────────────
 
     def open_session(self, target_agent_id: str, target_org_id: str,
@@ -1559,7 +1620,12 @@ class CullisClient:
         resp.raise_for_status()
         return resp.json().get("messages", [])
 
-    def decrypt_oneshot(self, inbox_row: dict) -> dict:
+    def decrypt_oneshot(
+        self,
+        inbox_row: dict,
+        *,
+        pubkey_fetcher: Callable[[str], str] | None = None,
+    ) -> dict:
         """Decrypt and authenticate a one-shot envelope row returned by
         :meth:`receive_oneshot`.
 
@@ -1579,6 +1645,14 @@ class CullisClient:
         private key and verify the inner signature against the sender's
         cert from the broker registry. Raises ``ValueError`` on any
         cryptographic failure.
+
+        :param pubkey_fetcher: optional callable ``(sender_agent_id) -> pem``
+            used to look up the sender's cert. When ``None`` (default),
+            falls back to :meth:`get_agent_public_key` which hits the
+            broker's ``/v1/federation`` namespace and requires a broker
+            JWT. Connectors enrolled via device-code don't hold that
+            JWT and should pass
+            :meth:`get_agent_public_key_via_egress` instead.
 
         Returns ``{"payload": <plaintext_dict>, "sender_verified": True,
         "mode": "mtls-only" | "envelope"}``.
@@ -1624,7 +1698,8 @@ class CullisClient:
             )
 
         # Verify the v2 outer envelope signature against the sender's cert.
-        sender_cert_pem = self.get_agent_public_key(sender)
+        fetch = pubkey_fetcher if pubkey_fetcher is not None else self.get_agent_public_key
+        sender_cert_pem = fetch(sender)
         ok = verify_oneshot_envelope_signature(
             sender_cert_pem,
             envelope["signature"],

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -1109,12 +1109,13 @@ class CullisClient:
         """Fetch the target agent's PEM cert through the local proxy's
         ``GET /v1/egress/agents/{id}/public-key`` endpoint.
 
-        Companion to :meth:`get_agent_public_key`, intended for clients
-        that authenticate to the proxy with X-API-Key + DPoP and have no
-        broker JWT to spend on the Court's federation API. Replaces the
-        Connector's ``prime_sender_pubkey_cache`` workaround that used
-        to scrape ``/v1/egress/resolve`` for the same data and write
-        directly into the SDK's private cache.
+        Egress-only variant — no broker fallback. Intended for callers
+        that deliberately want to fail-fast when the proxy doesn't have
+        the cert (e.g. device-code-enrolled Connectors that hold no
+        broker JWT; falling back to the broker path would just
+        surface a less-informative auth error). SDK consumers that
+        want the broker fallback should leave ``decrypt_oneshot``'s
+        ``pubkey_fetcher`` unset — the default chain covers both paths.
 
         Returns the PEM cert (not a bare key — the proxy hands back the
         full x509, the verify helpers in :mod:`cullis_sdk.crypto` accept
@@ -1122,11 +1123,9 @@ class CullisClient:
         the broker path so successive calls don't burn the per-agent
         egress rate-limit budget.
 
-        Raises :class:`PubkeyFetchError` when the proxy responds without
-        a usable cert (404, missing field, transport error). Plain HTTP
-        errors are wrapped — callers should catch ``PubkeyFetchError``
-        rather than ``httpx.HTTPError`` so future transports stay
-        transparent.
+        Raises :class:`PubkeyFetchError` on any failure: 404/501 (route
+        missing), 401/403 (auth broken), transport errors, or a 200
+        response whose ``cert_pem`` is null/missing.
         """
         if not force_refresh and agent_id in self._pubkey_cache:
             pem, fetched_at = self._pubkey_cache[agent_id]
@@ -1151,6 +1150,83 @@ class CullisClient:
             )
         self._pubkey_cache[agent_id] = (pem, time.time())
         return pem
+
+    def _fetch_pubkey_proxy_then_broker(self, agent_id: str) -> str:
+        """Default pubkey lookup used by :meth:`decrypt_oneshot`.
+
+        Order of operations:
+          1. Ask the local Mastio's ``/v1/egress/agents/<id>/public-key``
+             (auth'd via X-API-Key + DPoP — every SDK consumer has this).
+          2. If the proxy returns 404 / 501 / cert_pem=null — conditions
+             that mean "the proxy doesn't know this agent" rather than
+             "the call itself failed" — fall back to the Court's
+             ``/v1/federation/agents/<id>/public-key`` (requires a broker
+             JWT).
+          3. Genuine failures — 401 / 403 (auth broken), transport
+             errors — propagate as :class:`PubkeyFetchError` WITHOUT a
+             fallback: falling back would just mask a broken setup
+             with a second, less-informative auth error.
+
+        TTL-cached on :attr:`_pubkey_cache` so successive calls don't
+        re-hit either path within the 300s window.
+        """
+        if agent_id in self._pubkey_cache:
+            pem, fetched_at = self._pubkey_cache[agent_id]
+            if time.time() - fetched_at < _PUBKEY_CACHE_TTL:
+                return pem
+
+        proxy_path = f"/v1/egress/agents/{agent_id}/public-key"
+        should_fallback = False
+        proxy_diag = ""
+        try:
+            resp = self._egress_http("get", proxy_path)
+            if resp.status_code in (404, 501):
+                should_fallback = True
+                proxy_diag = f"proxy endpoint returned {resp.status_code}"
+            else:
+                resp.raise_for_status()
+                pem = resp.json().get("cert_pem")
+                if pem:
+                    self._pubkey_cache[agent_id] = (pem, time.time())
+                    return pem
+                should_fallback = True
+                proxy_diag = (
+                    "proxy returned 200 but cert_pem was null "
+                    "(cross-org target with no broker bridge configured "
+                    "on the proxy — falling back to broker)"
+                )
+        except httpx.HTTPStatusError as exc:
+            code = exc.response.status_code if exc.response is not None else 0
+            if code in (404, 501):
+                should_fallback = True
+                proxy_diag = f"proxy endpoint returned {code}"
+            else:
+                raise PubkeyFetchError(
+                    f"proxy {proxy_path} failed with HTTP {code} — "
+                    "auth broken or proxy misconfigured, not retrying "
+                    "via broker"
+                ) from exc
+        except Exception as exc:
+            raise PubkeyFetchError(
+                f"proxy {proxy_path} transport failure: "
+                f"{exc} ({type(exc).__name__}) — not retrying via broker"
+            ) from exc
+
+        if not should_fallback:
+            # Defensive: every branch above either returned, set the
+            # flag, or raised. Reaching here is a programmer error.
+            raise PubkeyFetchError(
+                f"proxy lookup for {agent_id} ended in an unexpected state"
+            )
+
+        try:
+            return self.get_agent_public_key(agent_id)
+        except Exception as broker_exc:
+            raise PubkeyFetchError(
+                f"both pubkey lookups failed: {proxy_diag}; "
+                f"broker fallback: {broker_exc} "
+                f"({type(broker_exc).__name__})"
+            ) from broker_exc
 
     # ── Sessions ────────────────────────────────────────────────────
 
@@ -1648,11 +1724,12 @@ class CullisClient:
 
         :param pubkey_fetcher: optional callable ``(sender_agent_id) -> pem``
             used to look up the sender's cert. When ``None`` (default),
-            falls back to :meth:`get_agent_public_key` which hits the
-            broker's ``/v1/federation`` namespace and requires a broker
-            JWT. Connectors enrolled via device-code don't hold that
-            JWT and should pass
-            :meth:`get_agent_public_key_via_egress` instead.
+            uses :meth:`_fetch_pubkey_proxy_then_broker` — proxy first,
+            broker as fallback only on 404 / 501 / cert_pem=null (see
+            that method's docstring). Callers that want to pin a single
+            path (Connector device-code: proxy only; debug: broker only)
+            pass the explicit helper (:meth:`get_agent_public_key_via_egress`
+            or :meth:`get_agent_public_key`) here.
 
         Returns ``{"payload": <plaintext_dict>, "sender_verified": True,
         "mode": "mtls-only" | "envelope"}``.
@@ -1698,7 +1775,10 @@ class CullisClient:
             )
 
         # Verify the v2 outer envelope signature against the sender's cert.
-        fetch = pubkey_fetcher if pubkey_fetcher is not None else self.get_agent_public_key
+        fetch = (
+            pubkey_fetcher if pubkey_fetcher is not None
+            else self._fetch_pubkey_proxy_then_broker
+        )
         sender_cert_pem = fetch(sender)
         ok = verify_oneshot_envelope_signature(
             sender_cert_pem,

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -137,6 +137,19 @@ class PeersResponse(BaseModel):
     count: int
 
 
+class AgentPublicKeyResponse(BaseModel):
+    """Body of ``GET /v1/egress/agents/{agent_id}/public-key``.
+
+    ``cert_pem`` is the full x509 PEM — the SDK's pubkey cache stores
+    certs (not bare keys) because the crypto verifiers accept either
+    form, and the cert carries the subject binding the key to an agent
+    identity. Schema is intentionally aligned with ``/v1/egress/resolve``
+    which also returns ``target_cert_pem`` rather than a raw public key.
+    """
+    agent_id: str
+    cert_pem: str | None = None
+
+
 class InvokeToolRequest(BaseModel):
     """Cross-org tool invocation via broker session."""
     session_id: str
@@ -981,6 +994,118 @@ async def resolve_recipient(
         transport="envelope",
         egress_inspection=settings.egress_inspection_enabled,
         target_cert_pem=target_cert_pem,
+    )
+
+
+@router.get(
+    "/agents/{agent_id:path}/public-key",
+    response_model=AgentPublicKeyResponse,
+)
+async def get_agent_public_key(
+    agent_id: str,
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_dpop_api_key),
+):
+    """Return the target agent's x509 certificate PEM.
+
+    Companion endpoint to ``/v1/egress/resolve``: the SDK's
+    ``decrypt_oneshot`` needs the sender's cert to verify envelope
+    signatures, but device-code-enrolled Connectors don't hold a broker
+    JWT and so can't call the Court's ``/v1/federation/agents/{id}/public-key``
+    path. This endpoint exposes the same data behind the egress
+    ``X-API-Key`` + DPoP auth profile every ``/v1/egress/*`` handler
+    already uses.
+
+    Routing follows ``/resolve``:
+      - intra-org lookups hit ``internal_agents.cert_pem`` directly;
+      - cross-org lookups delegate to ``broker_bridge.get_peer_public_key``
+        (and fall back to ``cert_pem=None`` when the bridge is absent,
+        mirroring ``/resolve``'s standalone behaviour).
+
+    Rate-limit: inherited from ``get_agent_from_dpop_api_key`` →
+    ``get_agent_from_api_key``, which enforces the shared
+    ``rate_limit_per_minute`` (default 60/min/agent) against every
+    ``/v1/egress/*`` call. No per-route override — keeping this aligned
+    with ``/resolve`` + ``/peers`` means an enumeration-probing caller
+    burns their global egress budget, not a separate one.
+
+    Accepts both the canonical ``org::agent`` form and a SPIFFE URI;
+    bare agent names are rejected (the caller knows its own org and
+    should canonicalise before calling — keeps the server free of the
+    ambiguity intra vs cross carries for bare handles).
+    """
+    from mcp_proxy.db import get_db
+    from mcp_proxy.spiffe import InvalidRecipient, parse_recipient
+    from sqlalchemy import text
+
+    try:
+        _, target_org, target_agent = parse_recipient(agent_id)
+    except InvalidRecipient as exc:
+        # Bare agent names (no ``::`` and not a SPIFFE URI) land here
+        # too — ``parse_internal`` rejects them. The caller has to
+        # canonicalise to ``org::agent`` since the server cannot
+        # safely guess which org the caller meant.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    settings = get_settings()
+    route = decide_route(
+        agent_id,
+        local_org=settings.org_id,
+        local_trust_domain=settings.trust_domain,
+    )
+
+    if route == "intra":
+        # ``internal_agents.agent_id`` is ``<org>::<name>`` in production
+        # (ADR-010) but legacy rows + some test fixtures still use the
+        # bare ``<name>`` form; match the double-lookup ``/resolve``
+        # uses so both shapes resolve consistently.
+        full_agent_id = f"{target_org}::{target_agent}"
+        async with get_db() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT cert_pem, is_active FROM internal_agents "
+                    "WHERE agent_id IN (:full_id, :bare_id) "
+                    "ORDER BY CASE WHEN agent_id = :full_id "
+                    "THEN 0 ELSE 1 END LIMIT 1"
+                ),
+                {"full_id": full_agent_id, "bare_id": target_agent},
+            )
+            row = result.mappings().first()
+        if row is None or not row["is_active"]:
+            raise HTTPException(
+                status_code=404,
+                detail=f"intra-org agent not found: {full_agent_id}",
+            )
+        return AgentPublicKeyResponse(
+            agent_id=full_agent_id,
+            cert_pem=row["cert_pem"],
+        )
+
+    # Cross-org: mirror ``/resolve``'s contract — when no bridge is
+    # configured (pure standalone proxy) return cert_pem=None rather
+    # than 400, so callers that tolerate a missing cert (e.g. mtls-only
+    # intra-only deploys) don't need to special-case the standalone
+    # mode detection. When the bridge IS present but the fetch errors,
+    # surface a 502 so the caller can retry.
+    target_cert_pem: str | None = None
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is not None:
+        broker_peer_id = f"{target_org}::{target_agent}"
+        try:
+            target_cert_pem = await bridge.get_peer_public_key(
+                agent.agent_id, broker_peer_id,
+            )
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502,
+                detail=f"unable to resolve peer public key: {exc}",
+            ) from exc
+
+    return AgentPublicKeyResponse(
+        agent_id=f"{target_org}::{target_agent}",
+        cert_pem=target_cert_pem,
     )
 
 

--- a/tests/connector/test_inbox_poller.py
+++ b/tests/connector/test_inbox_poller.py
@@ -12,11 +12,18 @@ from cullis_connector.inbox_poller import (
     DashboardInboxPoller,
     InboxEvent,
 )
+from cullis_sdk import PubkeyFetchError
 
 
 class _FakeClient:
     """Drives the poller with scripted ``receive_oneshot`` outputs and a
-    deterministic ``decrypt_oneshot`` mock."""
+    deterministic ``decrypt_oneshot`` mock.
+
+    ``decrypt_oneshot`` accepts the ``pubkey_fetcher`` kwarg the real
+    SDK now exposes — the poller always passes it, so the fake must
+    swallow the keyword. The fetcher itself isn't invoked by this
+    fake unless an individual test wires it up.
+    """
 
     def __init__(
         self,
@@ -30,26 +37,15 @@ class _FakeClient:
             lambda r: {"payload": {"text": r.get("text", "decoded")}}
         )
         self.calls = 0
-        # Pre-seeded pubkey cache so prime_sender_pubkey_cache hits the
-        # TTL-fresh short-circuit instead of trying to call _egress_http.
-        # Real poller installs this attribute in production.
-        self._pubkey_cache: dict = {}
+        self.pubkey_fetch_calls: list[str] = []
 
-    def _egress_http(self, method, path, *, json=None, **kw):
-        """Stand-in resolve endpoint — any row whose sender wasn't
-        preseeded above would otherwise trigger PubkeyPrimeError when
-        prime_sender_pubkey_cache can't find a cached cert. Returning
-        a non-empty PEM here is enough to satisfy the prime step."""
-        class _R:
-            status_code = 200
-
-            def raise_for_status(self):
-                pass
-
-            def json(self):
-                return {"target_cert_pem": "PEM"}
-
-        return _R()
+    def get_agent_public_key_via_egress(
+        self, agent_id: str, force_refresh: bool = False,
+    ) -> str:
+        """Default fetcher — returns a stub PEM. Tests that want to
+        exercise the failure branch override this on the instance."""
+        self.pubkey_fetch_calls.append(agent_id)
+        return "-----BEGIN CERTIFICATE-----\nSTUB\n-----END CERTIFICATE-----"
 
     def receive_oneshot(self) -> list[dict]:
         self.calls += 1
@@ -62,7 +58,11 @@ class _FakeClient:
             raise (nxt() if isinstance(nxt, type) else nxt)
         return list(nxt)
 
-    def decrypt_oneshot(self, row: dict) -> dict:
+    def decrypt_oneshot(self, row: dict, *, pubkey_fetcher=None) -> dict:
+        # Mirror the real SDK contract: when a fetcher is provided, call
+        # it so tests can observe / inject failures via that surface.
+        if pubkey_fetcher is not None:
+            pubkey_fetcher(row.get("sender_agent_id", ""))
         return self._decoder(row)
 
 
@@ -213,43 +213,36 @@ async def test_stop_releases_blocked_consumer_via_sentinel():
 
 
 @pytest.mark.asyncio
-async def test_pubkey_prime_failure_skips_message_does_not_crash_loop():
-    """Security audit NEW #4 — if ``prime_sender_pubkey_cache`` raises
-    (empty target_cert_pem, network error, incompatible client), the
-    poller MUST log at ERROR and skip the row. The loop continues so
-    subsequent rounds still drain the inbox.
+async def test_pubkey_fetch_failure_skips_message_does_not_crash_loop():
+    """Security invariant — if the SDK pubkey fetcher raises
+    ``PubkeyFetchError`` (empty cert_pem, network error, peer not
+    found), the poller MUST log at ERROR and skip the row, NOT
+    surface unverified plaintext. Loop continues so subsequent rounds
+    still drain the inbox.
 
-    Exercise the recovery path by having the FIRST round prime-fail
-    and the SECOND round prime-succeed — then await the successful
-    event to pin the loop-survived invariant deterministically
-    (avoids flaky time-based asserts on 16-way xdist workers).
+    Exercise recovery: round 1 fetcher fails, round 2 succeeds —
+    we await the successful event to pin the survival invariant
+    deterministically (no flaky time-based asserts).
     """
     failure_rounds = {"left": 1}
-    resolve_calls = {"count": 0}
+    fetch_calls = {"count": 0}
     decode_attempts = {"count": 0}
 
     class _RecoverableClient(_FakeClient):
-        def _egress_http(self, method, path, *, json=None, **kw):
-            resolve_calls["count"] += 1
-            status = {"body": {"target_cert_pem": "PEM"}}
+        def get_agent_public_key_via_egress(
+            self, agent_id, force_refresh=False,
+        ):
+            fetch_calls["count"] += 1
             if failure_rounds["left"] > 0:
                 failure_rounds["left"] -= 1
-                status = {"body": {"target_cert_pem": ""}}
+                raise PubkeyFetchError(
+                    f"proxy returned no cert_pem for {agent_id}"
+                )
+            return "STUB-PEM"
 
-            class _R:
-                status_code = 200
-
-                def raise_for_status(self):
-                    pass
-
-                def json(self):
-                    return status["body"]
-
-            return _R()
-
-        def decrypt_oneshot(self, row: dict) -> dict:
+        def decrypt_oneshot(self, row, *, pubkey_fetcher=None):
             decode_attempts["count"] += 1
-            return super().decrypt_oneshot(row)
+            return super().decrypt_oneshot(row, pubkey_fetcher=pubkey_fetcher)
 
     rows_round1 = [{"msg_id": "skip-me", "sender_agent_id": "acme::alice", "correlation_id": "c", "reply_to": None, "text": "x"}]
     rows_round2 = [{"msg_id": "next-round", "sender_agent_id": "acme::alice", "correlation_id": "c2", "reply_to": None, "text": "ok"}]
@@ -264,14 +257,13 @@ async def test_pubkey_prime_failure_skips_message_does_not_crash_loop():
 
     # Loop kept running past the skip — the NEXT round produced.
     assert events[0].msg_id == "next-round"
-    # Resolve endpoint was hit twice (round 1 skip + round 2 success),
+    # Fetcher was hit twice (round 1 skip + round 2 success),
     # so the skip path actually ran — not a silent fallthrough.
-    assert resolve_calls["count"] == 2, resolve_calls
-    # decrypt_oneshot was invoked ONLY for round 2 — round 1 bailed
-    # out before decrypt because prime_sender_pubkey_cache raised.
-    # This is the security invariant: a sender whose cert we can't
-    # prime must NOT be decrypted / surfaced.
-    assert decode_attempts["count"] == 1, decode_attempts
+    assert fetch_calls["count"] == 2, fetch_calls
+    # decrypt_oneshot was entered for both rounds (the fetcher runs
+    # inside decrypt_oneshot in the real SDK; the fake mirrors that).
+    # Round 1 raised inside decrypt; round 2 succeeded.
+    assert decode_attempts["count"] == 2, decode_attempts
 
 
 @pytest.mark.asyncio

--- a/tests/connector/test_oneshot_state_update.py
+++ b/tests/connector/test_oneshot_state_update.py
@@ -44,20 +44,19 @@ class _FakeClient:
     def receive_oneshot(self) -> list[dict]:
         return list(self._rows)
 
-    def decrypt_oneshot(self, row: dict) -> dict:
+    def decrypt_oneshot(self, row: dict, *, pubkey_fetcher=None) -> dict:
+        # The real SDK accepts the fetcher kwarg; the fake swallows it.
+        # These tests exercise state-cursor bookkeeping, not pubkey
+        # lookup — the fetcher just needs to be a no-op.
         return self._decoder(row)
 
-    def _egress_http(self, *args, **kwargs):
-        # Fallback for rows whose sender wasn't pre-seeded in the cache
-        # (e.g. bare names that canonicalise into a different key).
-        # Returns a valid-looking resolve response so prime succeeds
-        # rather than raising PubkeyPrimeError — unrelated to the state
-        # cursor logic these tests are exercising.
-        class _R:
-            status_code = 200
-            def raise_for_status(self): pass
-            def json(self): return {"target_cert_pem": "PEM"}
-        return _R()
+    def get_agent_public_key_via_egress(
+        self, agent_id: str, force_refresh: bool = False,
+    ) -> str:
+        """Stub fetcher — the real one hits the proxy; for these
+        cursor-bookkeeping tests we just need a value the caller can
+        pass around."""
+        return "PEM"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/connector/test_tools_identity.py
+++ b/tests/connector/test_tools_identity.py
@@ -1,129 +1,62 @@
 """Tests for ``cullis_connector.tools._identity``.
 
-Focused on the security-audit contract for ``prime_sender_pubkey_cache``
-(NEW #4): the function MUST raise ``PubkeyPrimeError`` on any failure
-to seed the SDK pubkey cache — including an empty ``target_cert_pem``
-in the ``/v1/egress/resolve`` response — instead of silently returning
-and letting the caller fall through to the broker JWT path with no
-audit trail.
+Since the ``prime_sender_pubkey_cache`` workaround was replaced by the
+SDK-side ``pubkey_fetcher`` injection backed by the Mastio's
+``/v1/egress/agents/{id}/public-key`` endpoint, this module now only
+owns the small identity helpers ``own_org_id`` and
+``canonical_recipient``. Tests mirror that narrower surface.
 """
 from __future__ import annotations
 
-import time
+from unittest.mock import MagicMock
 
-import pytest
-
-from cullis_connector.tools._identity import (
-    PubkeyPrimeError,
-    prime_sender_pubkey_cache,
-)
+from cullis_connector.state import get_state, reset_state
+from cullis_connector.tools._identity import canonical_recipient, own_org_id
 
 
-class _Resp:
-    def __init__(self, status_code: int = 200, body: dict | None = None) -> None:
-        self.status_code = status_code
-        self._body = body or {}
-
-    def raise_for_status(self) -> None:
-        if self.status_code >= 400:
-            raise RuntimeError(f"HTTP {self.status_code}")
-
-    def json(self) -> dict:
-        return dict(self._body)
-
-
-class _Client:
-    def __init__(self, resp: _Resp | Exception) -> None:
-        self._resp = resp
-        self._pubkey_cache: dict = {}
-        self.calls: list[dict] = []
-
-    def _egress_http(self, method, path, *, json=None, **kw):
-        self.calls.append({"method": method, "path": path, "json": json})
-        if isinstance(self._resp, Exception):
-            raise self._resp
-        return self._resp
-
-
-def test_raises_when_client_missing_pubkey_cache():
-    class _BadClient:
-        # no _pubkey_cache attribute
-        pass
-
-    with pytest.raises(PubkeyPrimeError, match="_pubkey_cache"):
-        prime_sender_pubkey_cache(_BadClient(), "acme::mario")
-
-
-def test_raises_when_resolve_returns_no_target_cert_pem():
-    """Empty / missing target_cert_pem → PubkeyPrimeError, NOT silent
-    return. Previously this path logged a WARNING and returned, which
-    dropped the security-relevant skip out of the audit trail."""
-    client = _Client(_Resp(200, {"target_cert_pem": ""}))
-    with pytest.raises(PubkeyPrimeError, match="no target_cert_pem"):
-        prime_sender_pubkey_cache(client, "acme::mario")
-    # Cache stays empty — we did not seed anything.
-    assert client._pubkey_cache == {}
-
-
-def test_raises_when_resolve_http_call_fails():
-    """Network / proxy errors propagate as PubkeyPrimeError so the
-    caller can log at ERROR and skip the message."""
-    client = _Client(RuntimeError("connection refused"))
-    with pytest.raises(PubkeyPrimeError, match="connection refused"):
-        prime_sender_pubkey_cache(client, "acme::mario")
-
-
-def test_raises_when_resolve_returns_4xx():
-    client = _Client(_Resp(404, {}))
-    with pytest.raises(PubkeyPrimeError, match="404"):
-        prime_sender_pubkey_cache(client, "acme::mario")
-
-
-def test_cache_hit_is_noop_and_does_not_call_resolve():
-    """TTL-fresh cache entry → no-op, no HTTP call. Regression guard
-    for the 67e3b95 fix (prime helper must honour SDK pubkey cache TTL)."""
-    client = _Client(_Resp(200, {"target_cert_pem": "PEM"}))
-    client._pubkey_cache["acme::mario"] = ("cached-PEM", time.time())
-    prime_sender_pubkey_cache(client, "acme::mario")
-    assert client.calls == [], "cache hit should not hit the resolve endpoint"
-
-
-def test_cache_stale_triggers_refetch_and_populates():
-    """When the cached entry is older than the SDK TTL, we refetch —
-    otherwise stale pubkeys would leak into decrypt_oneshot."""
-    client = _Client(_Resp(200, {"target_cert_pem": "FRESH-PEM"}))
-    # Entry is way past the 300s TTL.
-    client._pubkey_cache["acme::mario"] = ("stale-PEM", time.time() - 3600)
-    prime_sender_pubkey_cache(client, "acme::mario")
-    assert client._pubkey_cache["acme::mario"][0] == "FRESH-PEM"
-    assert len(client.calls) == 1
-
-
-def test_bare_sender_mirrors_into_cache():
-    """Canonicalised ``<org>::<agent>`` is the primary key, the bare
-    handle is mirrored so ``decrypt_oneshot`` (which reads whatever
-    form the inbox row carried) still finds the entry."""
-    # No identity loaded → canonical_recipient falls back to input
-    # unchanged, so the mirror branch only fires when caller already
-    # passed the canonical form. Exercise that here.
-    client = _Client(_Resp(200, {"target_cert_pem": "PEM"}))
-    # Pretend the test bench has an identity loaded so bare → canonical.
-    from unittest.mock import MagicMock
-
-    from cullis_connector.state import get_state, reset_state
-
+def _seed_identity(org_id: str) -> None:
     reset_state()
     fake_attr = MagicMock()
-    fake_attr.value = "acme"
+    fake_attr.value = org_id
     fake_cert = MagicMock()
     fake_cert.subject.get_attributes_for_oid.return_value = [fake_attr]
     fake_identity = MagicMock()
     fake_identity.cert = fake_cert
     get_state().extra["identity"] = fake_identity
 
+
+def test_own_org_id_reads_subject_O_attr():
+    _seed_identity("acme")
     try:
-        prime_sender_pubkey_cache(client, "mario")
-        assert "acme::mario" in client._pubkey_cache
-        assert "mario" in client._pubkey_cache
+        assert own_org_id() == "acme"
     finally:
         reset_state()
+
+
+def test_own_org_id_none_when_no_identity_loaded():
+    reset_state()
+    assert own_org_id() is None
+
+
+def test_canonical_recipient_prefixes_bare_handle():
+    _seed_identity("acme")
+    try:
+        assert canonical_recipient("mario") == "acme::mario"
+    finally:
+        reset_state()
+
+
+def test_canonical_recipient_passthrough_when_already_qualified():
+    _seed_identity("acme")
+    try:
+        assert canonical_recipient("other-org::luigi") == "other-org::luigi"
+    finally:
+        reset_state()
+
+
+def test_canonical_recipient_no_identity_returns_input_unchanged():
+    """Without an identity loaded there is no org to prefix with —
+    returning the bare handle is the safe fallback; the server will
+    reject it with a clear 400."""
+    reset_state()
+    assert canonical_recipient("mario") == "mario"

--- a/tests/test_proxy_egress_pubkey.py
+++ b/tests/test_proxy_egress_pubkey.py
@@ -1,0 +1,269 @@
+"""Tests for ``GET /v1/egress/agents/{agent_id}/public-key``.
+
+Companion endpoint to ``/v1/egress/resolve`` that returns the target
+agent's PEM cert behind the same ``X-API-Key`` + DPoP auth profile.
+Used by the Connector SDK's ``decrypt_oneshot`` fetcher to avoid the
+broker-JWT path device-code enrollments cannot use.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    """Fresh sqlite-backed proxy with intra-org routing on."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_STANDALONE", raising=False)
+    monkeypatch.delenv("PROXY_TRANSPORT_INTRA_ORG", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+async def _provision_caller(agent_id: str = "caller-bot") -> str:
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import create_agent
+    raw = generate_api_key(agent_id)
+    await create_agent(
+        agent_id=agent_id,
+        display_name=agent_id,
+        capabilities=["cap.read"],
+        api_key_hash=hash_api_key(raw),
+    )
+    return raw
+
+
+async def _provision_target(
+    agent_id: str,
+    cert_pem: str | None = "-----BEGIN CERTIFICATE-----\nSTUB\n-----END CERTIFICATE-----",
+    is_active: bool = True,
+) -> None:
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents "
+                "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
+                " created_at, is_active) "
+                "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
+                " :api_key_hash, :created_at, :is_active)"
+            ),
+            {
+                "agent_id": agent_id,
+                "display_name": agent_id,
+                "capabilities": "[]",
+                "cert_pem": cert_pem,
+                "api_key_hash": "$2b$12$placeholder",
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "is_active": 1 if is_active else 0,
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_pubkey_intra_org_canonical_form(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_caller()
+    await _provision_target("acme::alice", cert_pem="INTRA-ALICE-CERT")
+
+    resp = await client.get(
+        "/v1/egress/agents/acme::alice/public-key",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "acme::alice"
+    assert body["cert_pem"] == "INTRA-ALICE-CERT"
+
+
+@pytest.mark.asyncio
+async def test_pubkey_intra_org_bare_legacy_row(proxy_app):
+    """Legacy fixtures still store ``agent_id = 'alice'`` without the
+    ``<org>::`` prefix. ``/resolve`` falls back to the bare row, so the
+    pubkey endpoint must too — otherwise Connectors pointed at an
+    upgraded proxy can't decrypt messages from legacy senders."""
+    _, client = proxy_app
+    api_key = await _provision_caller()
+    await _provision_target("alice", cert_pem="LEGACY-ALICE-CERT")
+
+    resp = await client.get(
+        "/v1/egress/agents/acme::alice/public-key",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "acme::alice"
+    assert body["cert_pem"] == "LEGACY-ALICE-CERT"
+
+
+@pytest.mark.asyncio
+async def test_pubkey_intra_org_not_found(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_caller()
+
+    resp = await client.get(
+        "/v1/egress/agents/acme::ghost/public-key",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 404
+    assert "acme::ghost" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_pubkey_intra_org_inactive(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_caller()
+    await _provision_target("acme::retired", cert_pem="OLD", is_active=False)
+
+    resp = await client.get(
+        "/v1/egress/agents/acme::retired/public-key",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_pubkey_cross_org_standalone_no_bridge(proxy_app):
+    """Pure standalone (no broker_bridge): cross-org target returns
+    ``cert_pem=None`` rather than 400 — mirrors ``/resolve``'s contract
+    so callers don't need to branch on standalone detection."""
+    _, client = proxy_app
+    api_key = await _provision_caller()
+
+    resp = await client.get(
+        "/v1/egress/agents/other-org::bob/public-key",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "other-org::bob"
+    assert body["cert_pem"] is None
+
+
+@pytest.mark.asyncio
+async def test_pubkey_cross_org_bridge_fetches(proxy_app):
+    """When a broker bridge is wired, cross-org lookups delegate to
+    ``bridge.get_peer_public_key`` exactly like ``/resolve``."""
+    app, client = proxy_app
+    api_key = await _provision_caller()
+
+    class _StubBridge:
+        async def get_peer_public_key(self, caller_agent_id, target):
+            assert target == "other-org::bob"
+            return "-----BEGIN CERTIFICATE-----\nCROSS-BOB\n-----END CERTIFICATE-----"
+
+    app.state.broker_bridge = _StubBridge()
+    try:
+        resp = await client.get(
+            "/v1/egress/agents/other-org::bob/public-key",
+            headers={"X-API-Key": api_key},
+        )
+    finally:
+        app.state.broker_bridge = None
+    assert resp.status_code == 200, resp.text
+    assert "CROSS-BOB" in resp.json()["cert_pem"]
+
+
+@pytest.mark.asyncio
+async def test_pubkey_cross_org_bridge_error_502(proxy_app):
+    """Bridge fetch errors surface as 502 so callers can retry."""
+    app, client = proxy_app
+    api_key = await _provision_caller()
+
+    class _FailingBridge:
+        async def get_peer_public_key(self, caller_agent_id, target):
+            raise RuntimeError("broker unreachable")
+
+    app.state.broker_bridge = _FailingBridge()
+    try:
+        resp = await client.get(
+            "/v1/egress/agents/other-org::bob/public-key",
+            headers={"X-API-Key": api_key},
+        )
+    finally:
+        app.state.broker_bridge = None
+    assert resp.status_code == 502
+    assert "broker unreachable" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_pubkey_rejects_bare_agent_id(proxy_app):
+    """Bare ``<name>`` with no ``::`` is ambiguous server-side —
+    parse_recipient raises InvalidRecipient, handler returns 400."""
+    _, client = proxy_app
+    api_key = await _provision_caller()
+
+    resp = await client.get(
+        "/v1/egress/agents/bob/public-key",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_pubkey_rejects_anonymous(proxy_app):
+    """No API key → the legacy bearer dep returns 401."""
+    _, client = proxy_app
+
+    resp = await client.get("/v1/egress/agents/acme::alice/public-key")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_pubkey_rate_limit_shared_with_egress_budget(
+    proxy_app, monkeypatch,
+):
+    """The endpoint inherits the per-agent egress rate-limit from
+    ``get_agent_from_api_key`` — burning through the quota on this path
+    still returns 429 before the handler runs (so an enumeration-probing
+    caller cannot scan the agent namespace any faster than any other
+    ``/v1/egress/*`` call)."""
+    _, client = proxy_app
+    api_key = await _provision_caller()
+    await _provision_target("acme::alice")
+
+    # Collapse the per-minute quota to a tiny budget so the test runs
+    # fast. ``rate_limit_per_minute`` is read from settings at request
+    # time via ``get_settings()``.
+    monkeypatch.setenv("MCP_PROXY_RATE_LIMIT_PER_MINUTE", "3")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+    get_settings.cache_clear()
+    reset_agent_rate_limiter()
+
+    try:
+        headers = {"X-API-Key": api_key}
+        statuses = []
+        for _ in range(5):
+            resp = await client.get(
+                "/v1/egress/agents/acme::alice/public-key",
+                headers=headers,
+            )
+            statuses.append(resp.status_code)
+        # First 3 succeed, the rest are 429.
+        assert statuses[:3] == [200, 200, 200], statuses
+        assert 429 in statuses[3:], statuses
+    finally:
+        monkeypatch.delenv("MCP_PROXY_RATE_LIMIT_PER_MINUTE", raising=False)
+        get_settings.cache_clear()
+        reset_agent_rate_limiter()

--- a/tests/test_sdk_decrypt_oneshot_fetcher.py
+++ b/tests/test_sdk_decrypt_oneshot_fetcher.py
@@ -1,0 +1,208 @@
+"""Tests for the ``pubkey_fetcher`` injection into
+:meth:`CullisClient.decrypt_oneshot` + the new
+:meth:`CullisClient.get_agent_public_key_via_egress` helper.
+
+The default (fetcher=None) path is covered by the existing audit tests
+in ``tests/test_audit_oneshot_envelope_integrity.py``. This file focuses
+on:
+  - the injected fetcher is called with the sender id;
+  - its return value is what the signature is verified against;
+  - raising ``PubkeyFetchError`` propagates to the caller unchanged so
+    the Connector's inbox poller can react specifically.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+
+import pytest
+
+from cullis_sdk.client import CullisClient, PubkeyFetchError
+from cullis_sdk.crypto.message_signer import ONESHOT_ENVELOPE_PROTO_VERSION
+
+from tests.test_audit_oneshot_envelope_integrity import (
+    _alice_cert_pem,
+    _inbox_row,
+    _mtls_envelope,
+)
+
+
+def _client() -> CullisClient:
+    """Fresh client with no pubkey cache — forces the fetcher path."""
+    c = CullisClient("http://test", verify_tls=False)
+    return c
+
+
+def test_decrypt_oneshot_uses_injected_fetcher_mtls_mode():
+    sender = "fetch1::alice"
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="fetch1",
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"note": "hello"},
+    )
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    calls: list[str] = []
+
+    def fetcher(agent_id: str) -> str:
+        calls.append(agent_id)
+        return _alice_cert_pem(sender, "fetch1")
+
+    client = _client()
+    try:
+        result = client.decrypt_oneshot(row, pubkey_fetcher=fetcher)
+    finally:
+        client.close()
+
+    assert calls == [sender]
+    assert result["mode"] == "mtls-only"
+    assert result["sender_verified"] is True
+    assert result["payload"] == {"note": "hello"}
+
+
+def test_decrypt_oneshot_propagates_fetcher_error():
+    sender = "fetch2::alice"
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="fetch2",
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"x": 1},
+    )
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    def failing_fetcher(agent_id: str) -> str:
+        raise PubkeyFetchError("proxy returned no cert_pem for " + agent_id)
+
+    client = _client()
+    try:
+        with pytest.raises(PubkeyFetchError) as excinfo:
+            client.decrypt_oneshot(row, pubkey_fetcher=failing_fetcher)
+    finally:
+        client.close()
+    assert sender in str(excinfo.value)
+
+
+def test_decrypt_oneshot_default_fetcher_hits_broker():
+    """Without a fetcher the method falls back to ``get_agent_public_key``.
+    Seed the cache directly — that's the same code path the broker fetch
+    populates once the response lands — and verify decrypt succeeds."""
+    sender = "fetch3::alice"
+    corr = str(uuid.uuid4())
+    nonce = str(uuid.uuid4())
+    ts = int(time.time())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="fetch3",
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"x": 2},
+    )
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    client = _client()
+    try:
+        client._pubkey_cache[sender] = (
+            _alice_cert_pem(sender, "fetch3"), time.time(),
+        )
+        result = client.decrypt_oneshot(row)
+    finally:
+        client.close()
+
+    assert result["sender_verified"] is True
+
+
+class _StubResponse:
+    def __init__(self, status_code: int, body: dict | None = None):
+        self.status_code = status_code
+        self._body = body or {}
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=None, response=None,
+            )
+
+
+def test_get_agent_public_key_via_egress_happy_path(monkeypatch):
+    client = _client()
+    try:
+        cert = "-----BEGIN CERTIFICATE-----\nSTUB\n-----END CERTIFICATE-----"
+
+        def fake_egress_http(method, path, **kwargs):
+            assert method == "get"
+            assert path == "/v1/egress/agents/acme::alice/public-key"
+            return _StubResponse(200, {"agent_id": "acme::alice", "cert_pem": cert})
+
+        monkeypatch.setattr(client, "_egress_http", fake_egress_http)
+        pem = client.get_agent_public_key_via_egress("acme::alice")
+        assert pem == cert
+        # Cache hit on the second call, no HTTP.
+        calls = {"n": 0}
+
+        def count_and_fail(*_a, **_kw):
+            calls["n"] += 1
+            return _StubResponse(500)
+        monkeypatch.setattr(client, "_egress_http", count_and_fail)
+        pem2 = client.get_agent_public_key_via_egress("acme::alice")
+        assert pem2 == cert
+        assert calls["n"] == 0
+    finally:
+        client.close()
+
+
+def test_get_agent_public_key_via_egress_raises_on_empty_cert(monkeypatch):
+    client = _client()
+    try:
+        def fake_egress_http(method, path, **kwargs):
+            return _StubResponse(200, {"agent_id": "acme::ghost", "cert_pem": None})
+        monkeypatch.setattr(client, "_egress_http", fake_egress_http)
+        with pytest.raises(PubkeyFetchError) as excinfo:
+            client.get_agent_public_key_via_egress("acme::ghost")
+        assert "acme::ghost" in str(excinfo.value)
+    finally:
+        client.close()
+
+
+def test_get_agent_public_key_via_egress_wraps_transport_errors(monkeypatch):
+    client = _client()
+    try:
+        def boom(*_a, **_kw):
+            raise RuntimeError("network went away")
+        monkeypatch.setattr(client, "_egress_http", boom)
+        with pytest.raises(PubkeyFetchError) as excinfo:
+            client.get_agent_public_key_via_egress("acme::alice")
+        assert "network went away" in str(excinfo.value)
+    finally:
+        client.close()
+
+
+def test_get_agent_public_key_via_egress_force_refresh(monkeypatch):
+    client = _client()
+    try:
+        cert1 = "CERT-V1"
+        cert2 = "CERT-V2"
+        state = {"cert": cert1}
+
+        def fake_egress_http(method, path, **kwargs):
+            return _StubResponse(200, {"agent_id": "acme::alice", "cert_pem": state["cert"]})
+        monkeypatch.setattr(client, "_egress_http", fake_egress_http)
+
+        assert client.get_agent_public_key_via_egress("acme::alice") == cert1
+        state["cert"] = cert2
+        # Without force_refresh, TTL cache still returns V1.
+        assert client.get_agent_public_key_via_egress("acme::alice") == cert1
+        # With force_refresh=True, HTTP is re-hit.
+        assert client.get_agent_public_key_via_egress(
+            "acme::alice", force_refresh=True,
+        ) == cert2
+    finally:
+        client.close()

--- a/tests/test_sdk_decrypt_oneshot_fetcher.py
+++ b/tests/test_sdk_decrypt_oneshot_fetcher.py
@@ -1,14 +1,15 @@
 """Tests for the ``pubkey_fetcher`` injection into
-:meth:`CullisClient.decrypt_oneshot` + the new
-:meth:`CullisClient.get_agent_public_key_via_egress` helper.
+:meth:`CullisClient.decrypt_oneshot`, the new
+:meth:`CullisClient.get_agent_public_key_via_egress` egress-only helper,
+and the default proxy-then-broker chain
+:meth:`CullisClient._fetch_pubkey_proxy_then_broker`.
 
-The default (fetcher=None) path is covered by the existing audit tests
-in ``tests/test_audit_oneshot_envelope_integrity.py``. This file focuses
-on:
-  - the injected fetcher is called with the sender id;
-  - its return value is what the signature is verified against;
-  - raising ``PubkeyFetchError`` propagates to the caller unchanged so
-    the Connector's inbox poller can react specifically.
+Covers:
+  - default chain: proxy path hit first, broker fallback ONLY on
+    404 / 501 / cert_pem=null. 401 / transport errors propagate
+    without fallback (preserves diagnostic signal);
+  - explicit ``pubkey_fetcher`` still overrides the default;
+  - egress-only helper fail-fast contract for device-code callers.
 """
 from __future__ import annotations
 
@@ -88,10 +89,10 @@ def test_decrypt_oneshot_propagates_fetcher_error():
     assert sender in str(excinfo.value)
 
 
-def test_decrypt_oneshot_default_fetcher_hits_broker():
-    """Without a fetcher the method falls back to ``get_agent_public_key``.
-    Seed the cache directly — that's the same code path the broker fetch
-    populates once the response lands — and verify decrypt succeeds."""
+def test_decrypt_oneshot_default_fetcher_uses_cache_shortcut():
+    """The default fetcher checks ``_pubkey_cache`` first before any HTTP —
+    a pre-populated cache means no proxy/broker call is made. Covers
+    the common case where a previous receive already cached the sender."""
     sender = "fetch3::alice"
     corr = str(uuid.uuid4())
     nonce = str(uuid.uuid4())
@@ -181,6 +182,268 @@ def test_get_agent_public_key_via_egress_wraps_transport_errors(monkeypatch):
         with pytest.raises(PubkeyFetchError) as excinfo:
             client.get_agent_public_key_via_egress("acme::alice")
         assert "network went away" in str(excinfo.value)
+    finally:
+        client.close()
+
+
+# ── Default fetcher: proxy-first, broker fallback on 404/501/cert=null ──
+
+
+def _make_raise_for_status(status_code):
+    """Build a raise_for_status method that mirrors httpx behaviour."""
+    def raise_for_status(self):
+        if status_code >= 400:
+            import httpx
+            # httpx.HTTPStatusError needs a response object with a
+            # ``status_code`` attribute; build a minimal stub.
+            class _Resp:
+                pass
+            resp = _Resp()
+            resp.status_code = status_code
+            raise httpx.HTTPStatusError(
+                f"HTTP {status_code}", request=None, response=resp,
+            )
+    return raise_for_status
+
+
+class _ProxyResp:
+    def __init__(self, status_code: int, cert_pem=None):
+        self.status_code = status_code
+        self._body = {"agent_id": "x", "cert_pem": cert_pem}
+
+    def json(self):
+        return self._body
+
+    def raise_for_status(self):
+        _make_raise_for_status(self.status_code)(self)
+
+
+def test_default_fetcher_proxy_happy_path(monkeypatch):
+    """Default chain: proxy returns 200 + cert_pem → no broker call."""
+    sender = "chain1::alice"
+    cert_pem = _alice_cert_pem(sender, "chain1")
+    corr, nonce, ts = str(uuid.uuid4()), str(uuid.uuid4()), int(time.time())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id="chain1",
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"ok": True},
+    )
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    client = _client()
+    try:
+        proxy_calls = []
+
+        def fake_egress(method, path, **_):
+            proxy_calls.append((method, path))
+            return _ProxyResp(200, cert_pem=cert_pem)
+
+        broker_hits = {"n": 0}
+
+        def fake_broker(agent_id, force_refresh=False):
+            broker_hits["n"] += 1
+            return "should-not-be-used"
+
+        monkeypatch.setattr(client, "_egress_http", fake_egress)
+        monkeypatch.setattr(client, "get_agent_public_key", fake_broker)
+
+        result = client.decrypt_oneshot(row)
+        assert result["sender_verified"] is True
+        assert proxy_calls == [("get", f"/v1/egress/agents/{sender}/public-key")]
+        assert broker_hits["n"] == 0
+    finally:
+        client.close()
+
+
+def _decrypt_with_default_chain(
+    monkeypatch, client, sender, org, *, proxy_resp, broker_return=None,
+    broker_exc=None,
+):
+    """Helper — wire the default chain onto the client and run a
+    decrypt_oneshot. Returns the result (or raises on failure)."""
+    corr, nonce, ts = str(uuid.uuid4()), str(uuid.uuid4()), int(time.time())
+    env = _mtls_envelope(
+        sender_agent_id=sender, sender_org_id=org,
+        correlation_id=corr, nonce=nonce, timestamp=ts,
+        payload={"n": 1},
+    )
+    row = _inbox_row(env, sender_agent_id=sender)
+
+    def fake_egress(method, path, **_):
+        if callable(proxy_resp):
+            return proxy_resp()
+        return proxy_resp
+
+    def fake_broker(agent_id, force_refresh=False):
+        if broker_exc is not None:
+            raise broker_exc
+        return broker_return
+
+    monkeypatch.setattr(client, "_egress_http", fake_egress)
+    monkeypatch.setattr(client, "get_agent_public_key", fake_broker)
+    return client.decrypt_oneshot(row)
+
+
+def test_default_fetcher_falls_back_to_broker_on_proxy_404(monkeypatch):
+    """Proxy 404 (endpoint missing on old proxy OR agent unknown to proxy)
+    → fallback to broker. Broker has the cert → decrypt succeeds."""
+    sender = "chain2::alice"
+    client = _client()
+    try:
+        result = _decrypt_with_default_chain(
+            monkeypatch, client, sender, "chain2",
+            proxy_resp=_ProxyResp(404),
+            broker_return=_alice_cert_pem(sender, "chain2"),
+        )
+        assert result["sender_verified"] is True
+    finally:
+        client.close()
+
+
+def test_default_fetcher_falls_back_to_broker_on_proxy_501(monkeypatch):
+    """501 Not Implemented → same fallback story as 404."""
+    sender = "chain3::alice"
+    client = _client()
+    try:
+        result = _decrypt_with_default_chain(
+            monkeypatch, client, sender, "chain3",
+            proxy_resp=_ProxyResp(501),
+            broker_return=_alice_cert_pem(sender, "chain3"),
+        )
+        assert result["sender_verified"] is True
+    finally:
+        client.close()
+
+
+def test_default_fetcher_falls_back_on_proxy_cert_pem_null(monkeypatch):
+    """200 with cert_pem=null means 'proxy got the request but doesn't
+    know this agent' (e.g. cross-org with no broker bridge wired on the
+    proxy). Still a fallback condition — broker might have it."""
+    sender = "chain4::alice"
+    client = _client()
+    try:
+        result = _decrypt_with_default_chain(
+            monkeypatch, client, sender, "chain4",
+            proxy_resp=_ProxyResp(200, cert_pem=None),
+            broker_return=_alice_cert_pem(sender, "chain4"),
+        )
+        assert result["sender_verified"] is True
+    finally:
+        client.close()
+
+
+def test_default_fetcher_no_fallback_on_proxy_401(monkeypatch):
+    """401 = auth broken. Falling back to the broker would just surface
+    the same auth failure (or worse, mask it) — propagate immediately
+    as PubkeyFetchError so the operator sees the real problem."""
+    sender = "chain5::alice"
+    client = _client()
+    try:
+        broker_calls = {"n": 0}
+
+        def broker(agent_id, force_refresh=False):
+            broker_calls["n"] += 1
+            return "UNUSED"
+
+        monkeypatch.setattr(client, "get_agent_public_key", broker)
+
+        with pytest.raises(PubkeyFetchError, match="HTTP 401"):
+            _decrypt_with_default_chain(
+                monkeypatch, client, sender, "chain5",
+                proxy_resp=_ProxyResp(401),
+                broker_return="UNUSED",
+            )
+        # Critical: broker was never called. 401 = no fallback.
+        assert broker_calls["n"] == 0
+    finally:
+        client.close()
+
+
+def test_default_fetcher_no_fallback_on_transport_error(monkeypatch):
+    """Network / connection errors = environment broken, not endpoint
+    missing. Propagate without touching broker (same auth likely fails)."""
+    sender = "chain6::alice"
+    client = _client()
+    try:
+        broker_calls = {"n": 0}
+
+        def broker(agent_id, force_refresh=False):
+            broker_calls["n"] += 1
+            return "UNUSED"
+
+        monkeypatch.setattr(client, "get_agent_public_key", broker)
+
+        def exploding_proxy():
+            raise RuntimeError("connection refused")
+
+        with pytest.raises(PubkeyFetchError, match="transport failure"):
+            _decrypt_with_default_chain(
+                monkeypatch, client, sender, "chain6",
+                proxy_resp=exploding_proxy,
+                broker_return="UNUSED",
+            )
+        assert broker_calls["n"] == 0
+    finally:
+        client.close()
+
+
+def test_default_fetcher_both_fail_surfaces_both_diagnostics(monkeypatch):
+    """Proxy 404 → fallback broker → broker also errors. The raised
+    PubkeyFetchError message should mention BOTH so an operator can see
+    why both lookups failed without having to re-run with DEBUG logs."""
+    sender = "chain7::alice"
+    client = _client()
+    try:
+        with pytest.raises(PubkeyFetchError) as excinfo:
+            _decrypt_with_default_chain(
+                monkeypatch, client, sender, "chain7",
+                proxy_resp=_ProxyResp(404),
+                broker_exc=RuntimeError("broker unreachable"),
+            )
+        msg = str(excinfo.value)
+        assert "404" in msg
+        assert "broker unreachable" in msg
+    finally:
+        client.close()
+
+
+def test_explicit_pubkey_fetcher_still_overrides_default(monkeypatch):
+    """When the caller passes pubkey_fetcher explicitly, NEITHER the
+    proxy nor the broker path runs — backward compat for tests and for
+    Connector device-code callers that pin the egress-only helper."""
+    sender = "chain8::alice"
+    client = _client()
+    try:
+        proxy_calls = {"n": 0}
+        broker_calls = {"n": 0}
+
+        monkeypatch.setattr(
+            client, "_egress_http",
+            lambda *a, **kw: (proxy_calls.__setitem__("n", proxy_calls["n"] + 1) or _ProxyResp(500)),
+        )
+        monkeypatch.setattr(
+            client, "get_agent_public_key",
+            lambda *a, **kw: (broker_calls.__setitem__("n", broker_calls["n"] + 1) or "UNUSED"),
+        )
+
+        fetcher_calls = []
+
+        def custom(agent_id):
+            fetcher_calls.append(agent_id)
+            return _alice_cert_pem(sender, "chain8")
+
+        corr, nonce, ts = str(uuid.uuid4()), str(uuid.uuid4()), int(time.time())
+        env = _mtls_envelope(
+            sender_agent_id=sender, sender_org_id="chain8",
+            correlation_id=corr, nonce=nonce, timestamp=ts,
+            payload={"x": 1},
+        )
+        row = _inbox_row(env, sender_agent_id=sender)
+        client.decrypt_oneshot(row, pubkey_fetcher=custom)
+
+        assert fetcher_calls == [sender]
+        assert proxy_calls["n"] == 0
+        assert broker_calls["n"] == 0
     finally:
         client.close()
 

--- a/tests/test_sdk_decrypt_oneshot_fetcher.py
+++ b/tests/test_sdk_decrypt_oneshot_fetcher.py
@@ -13,14 +13,12 @@ Covers:
 """
 from __future__ import annotations
 
-import json
 import time
 import uuid
 
 import pytest
 
 from cullis_sdk.client import CullisClient, PubkeyFetchError
-from cullis_sdk.crypto.message_signer import ONESHOT_ENVELOPE_PROTO_VERSION
 
 from tests.test_audit_oneshot_envelope_integrity import (
     _alice_cert_pem,


### PR DESCRIPTION
## Summary

Closes tech-debt #3 from `project_connector_tech_debt` AND unblocks cross-org one-shot delivery end-to-end for every SDK consumer (not just the Connector). Sandbox dogfood — `./demo.sh oneshot-a-to-b` — now decrypts on the recipient side with zero 401 loops; pre-fix this looped forever against the Court's `/v1/federation/.../public-key`.

Four-part atomic PR — endpoint / SDK default / SDK explicit helper / Connector migration:

- **Mastio**: new `GET /v1/egress/agents/{agent_id}/public-key` — companion to `/resolve`, same `Depends(get_agent_from_dpop_api_key)` auth, inherits the shared `rate_limit_per_minute` budget (no per-route override: enumeration probes burn the global egress quota, matching `/resolve` and `/peers`). Returns `cert_pem` for intra-org via direct `internal_agents` lookup or cross-org via `broker_bridge`. Standalone cross-org returns `cert_pem=null` (mirrors `/resolve`). Rejects bare agent ids as ambiguous.

- **SDK default chain** (`_fetch_pubkey_proxy_then_broker`, used by `decrypt_oneshot` when the caller passes no explicit `pubkey_fetcher`):
  1. Hits `/v1/egress/agents/<id>/public-key` on the local Mastio.
  2. Falls back to `/v1/federation/agents/<id>/public-key` ONLY on 404 / 501 / `cert_pem=null` — conditions where the proxy genuinely doesn't hold the cert.
  3. 401 / 403 / transport errors propagate as `PubkeyFetchError` immediately — no fallback, because falling back masks the real diagnostic with a second identical auth failure.

- **SDK explicit helpers** (still exposed):
  - `get_agent_public_key_via_egress(agent_id)` — fail-fast, egress only, for Connector device-code callers that have no broker JWT (fallback would just produce a confusing 401).
  - `get_agent_public_key(agent_id)` — existing broker-path helper, unchanged.
  - `PubkeyFetchError` exported in `__all__` so callers can discriminate "cannot verify sender, must skip" from other decrypt failures.

- **Connector**: `prime_sender_pubkey_cache` and `PubkeyPrimeError` removed. `tools/oneshot.py` and `inbox_poller.py` pass `client.get_agent_public_key_via_egress` explicitly (egress-only fail-fast, since device-code never holds a broker JWT). Inbox poller still logs pubkey-fetch failures at ERROR (security-relevant skip) and other decrypt failures at WARNING.

## Out of scope

- Tech-debt #2 (`login_via_proxy` bypass) — separate scope (challenge-response Mastio).
- Tech-debt #6 (state global in `canonical_recipient`) — cleanup follow-up.

## Test plan

- [x] `pytest tests/ -n auto --dist=loadfile` → 1754 passed, 6 skipped (excluded: `test_postgres_integration.py`, `test_ts_interop.py`, `tests/connector/test_profile_runtime_switch.py` — last one is a pre-existing pystray MenuItem signature fail on `main`, unrelated to this PR)
- [x] `tests/test_proxy_egress_pubkey.py` (new, 10 cases): canonical form, legacy bare row, not found, inactive, standalone cross-org `cert_pem=null`, bridge fetches, bridge error 502, bare id rejected, anonymous 401, per-agent rate-limit enforced
- [x] `tests/test_sdk_decrypt_oneshot_fetcher.py` (new, 15 cases): default chain happy path, 404/501/`cert_pem=null` → broker fallback, 401 → no fallback, transport error → no fallback, both paths fail → diagnostic mentions both, explicit fetcher overrides default, egress-only helper behavior
- [x] Existing oneshot suite (`test_audit_oneshot_envelope_integrity`, `test_oneshot_cross*`, `test_oneshot_intra`): 50/50 PASS — default chain change is backward-compat for cache-pre-populated callers
- [x] Updated Connector tests (`test_inbox_poller.py`, `test_oneshot_state_update.py`, `test_tools_identity.py`): 19/19 PASS
- [x] `./demo_network/smoke.sh full` → A1+A4+A7+A8 PASS
- [x] **Sandbox dogfood cross-org end-to-end**: `./demo.sh oneshot-a-to-b` + `./demo.sh oneshot-b-to-a` — both recipients log `received nonce from …: <hex>` with zero 401s in `./demo.sh logs agent-{a,b}`. Pre-fix behavior: infinite 401 loop on `/v1/federation/agents/.../public-key`.
- [ ] CI green: test (3.11), Signed-off-by check, security, helm-test (cullis + cullis-proxy), demo_network smoke (rsa / ec / rsa+postgres), standalone smoke, Cloudflare Pages