### PR TITLE
feat(updates): federation update framework registry foundation (PR 1/5)

### DIFF
--- a/mcp_proxy/alembic/versions/0019_pending_updates.py
+++ b/mcp_proxy/alembic/versions/0019_pending_updates.py
@@ -1,0 +1,67 @@
+"""``pending_updates`` — registry of migrations the boot detector flagged.
+
+Revision ID: 0019_pending_updates
+Revises: 0018_mastio_keys
+Create Date: 2026-04-23 20:00:00.000000
+
+Federation update framework (imp/federation_hardening_plan.md Parte 1)
+PR 1 of 5 — registry foundation.
+
+One row per (migration_id) that ``mcp_proxy.updates`` decided is applicable
+to the current proxy state. The boot detector populates it; the dashboard
+admin endpoint (PR 4) reads and mutates ``status`` on apply / rollback.
+
+Invariants once populated:
+    status ∈ {'pending', 'applied', 'failed', 'rolled_back'}
+    applied_at IS NOT NULL ⇔ status ∈ {'applied', 'rolled_back'}
+    error IS NOT NULL ⇒ status = 'failed'
+
+Schema-only migration. Row writes land in PR 2 (boot detector).
+Extra columns (backup_ref, dry_run_log, last_attempt_at) are deliberately
+omitted here — they are added by the PR that introduces the caller that
+needs them, per project convention for forward-only schema evolution.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0019_pending_updates"
+down_revision: Union[str, Sequence[str], None] = "0018_mastio_keys"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "pending_updates" in existing_tables:
+        return
+
+    op.create_table(
+        "pending_updates",
+        sa.Column("migration_id", sa.Text(), primary_key=True),
+        sa.Column("detected_at", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("applied_at", sa.Text(), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        "idx_pending_updates_status",
+        "pending_updates",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = set(sa.inspect(bind).get_table_names())
+    if "pending_updates" not in existing:
+        return
+    op.drop_index("idx_pending_updates_status", table_name="pending_updates")
+    op.drop_table("pending_updates")

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -727,6 +727,139 @@ async def activate_staged_and_deprecate_old(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# pending_updates — federation update framework (imp/federation_hardening_plan.md
+# Parte 1). Boot detector writes, dashboard admin endpoint reads + mutates.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ALLOWED_PENDING_STATUS: frozenset[str] = frozenset({
+    "pending", "applied", "failed", "rolled_back",
+})
+
+
+async def insert_pending_update(
+    *,
+    migration_id: str,
+    detected_at: str,
+    status: str = "pending",
+) -> int:
+    """Insert a row flagging a migration as pending against current state.
+
+    Used by the boot detector (PR 2) after each call to
+    :meth:`Migration.check` that returns True. Idempotent: if a row for
+    ``migration_id`` already exists (the detector re-ran on a boot with
+    no admin intervention in between), the insert is a no-op and returns
+    ``0``. Fresh inserts return ``1``.
+
+    The ``status`` default is ``"pending"``; callers normally omit it.
+    """
+    if status not in _ALLOWED_PENDING_STATUS:
+        raise ValueError(
+            f"status {status!r} not in {sorted(_ALLOWED_PENDING_STATUS)}"
+        )
+    async with get_db() as conn:
+        dialect = conn.dialect.name
+        if dialect == "postgresql":
+            stmt = text(
+                """
+                INSERT INTO pending_updates
+                    (migration_id, detected_at, status)
+                VALUES
+                    (:mid, :detected, :status)
+                ON CONFLICT (migration_id) DO NOTHING
+                """
+            )
+        else:
+            # SQLite equivalent; Postgres rejects this syntax.
+            stmt = text(
+                """
+                INSERT OR IGNORE INTO pending_updates
+                    (migration_id, detected_at, status)
+                VALUES
+                    (:mid, :detected, :status)
+                """
+            )
+        result = await conn.execute(
+            stmt,
+            {"mid": migration_id, "detected": detected_at, "status": status},
+        )
+        return result.rowcount or 0
+
+
+async def update_pending_update_status(
+    *,
+    migration_id: str,
+    status: str,
+    applied_at: str | None = None,
+    error: str | None = None,
+) -> int:
+    """Update ``status`` (and optionally ``applied_at`` / ``error``) of a row.
+
+    Returns the rowcount. Zero means the ``migration_id`` is not in the
+    table — the caller (admin endpoint) decides whether to surface 404
+    or treat it as a no-op.
+
+    The caller is responsible for the status-field coherence invariants
+    documented in the Alembic migration docstring; this helper does not
+    enforce them so a single UPDATE can atomically set e.g.
+    ``status='applied', applied_at='...', error=NULL``.
+    """
+    if status not in _ALLOWED_PENDING_STATUS:
+        raise ValueError(
+            f"status {status!r} not in {sorted(_ALLOWED_PENDING_STATUS)}"
+        )
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                UPDATE pending_updates
+                   SET status = :status,
+                       applied_at = :applied_at,
+                       error = :error
+                 WHERE migration_id = :mid
+                """
+            ),
+            {
+                "mid": migration_id,
+                "status": status,
+                "applied_at": applied_at,
+                "error": error,
+            },
+        )
+        return result.rowcount or 0
+
+
+async def get_pending_updates(status: str | None = None) -> list[dict]:
+    """Return ``pending_updates`` rows, optionally filtered by status.
+
+    Ordered by ``migration_id`` (lexical — chronological with the
+    ``YYYY-MM-DD-slug`` convention). An unknown ``status`` filter
+    raises :class:`ValueError`; pass ``None`` (the default) to list all.
+    """
+    if status is not None and status not in _ALLOWED_PENDING_STATUS:
+        raise ValueError(
+            f"status {status!r} not in {sorted(_ALLOWED_PENDING_STATUS)}"
+        )
+    async with get_db() as conn:
+        if status is None:
+            result = await conn.execute(
+                text(
+                    "SELECT * FROM pending_updates "
+                    "ORDER BY migration_id ASC"
+                )
+            )
+        else:
+            result = await conn.execute(
+                text(
+                    "SELECT * FROM pending_updates "
+                    "WHERE status = :status "
+                    "ORDER BY migration_id ASC"
+                ),
+                {"status": status},
+            )
+        return [dict(row) for row in result.mappings().all()]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/updates/__init__.py
+++ b/mcp_proxy/updates/__init__.py
@@ -1,0 +1,22 @@
+"""Federation update framework — registry foundation.
+
+See ``imp/federation_hardening_plan.md`` (Parte 1). This package holds
+the ``Migration`` base class, a filesystem-based discovery registry,
+and the schema for the ``pending_updates`` table that the boot detector
+(PR 2) populates.
+
+Concrete migrations live in ``mcp_proxy.updates.migrations``. Each one
+subclasses :class:`Migration`, declares metadata as class attributes,
+and implements ``check`` / ``up`` / ``rollback``.
+
+The dashboard admin endpoint (PR 4) reads the registry by id and drives
+apply / rollback through the ``Migration`` instance; the boot detector
+calls ``check`` on every registered migration at startup.
+"""
+from __future__ import annotations
+
+from mcp_proxy.updates.base import Migration
+from mcp_proxy.updates.registry import discover, get_by_id
+
+
+__all__ = ["Migration", "discover", "get_by_id"]

--- a/mcp_proxy/updates/base.py
+++ b/mcp_proxy/updates/base.py
@@ -1,0 +1,196 @@
+"""Base class for federation update migrations.
+
+A migration represents a breaking change to state the proxy owns
+(cert format, keys, schema). The boot detector finds subclasses of
+:class:`Migration`, calls :meth:`check` to decide whether they apply,
+and surfaces the pending ones in the dashboard. The admin drives
+apply / rollback via :meth:`up` / :meth:`rollback`.
+
+The five allowed ``migration_type`` values mirror the taxonomy in
+``imp/federation_hardening_plan.md`` Parte 1:
+
+- ``cert-schema``    — existing certs are format-invalid but their
+                       pubkey can be preserved (e.g. pathLen fix #280).
+- ``cert-algorithm`` — existing keys are cryptographically obsolete,
+                       re-enrollment is forced (e.g. RSA → Ed25519).
+- ``policy-change``  — toggle a runtime policy (e.g. DPoP mandatory).
+- ``new-feature``    — additive; existing state untouched.
+- ``code-refactor``  — no state change, info banner only.
+
+``criticality`` drives the degraded-mode decision at boot. ``critical``
+plus any overlap between ``affects_enrollments`` and the enrollments
+currently active puts the proxy in sign-halt (PR 2 behaviour, same
+primitive as ADR-012 staged rotation).
+
+Idempotency contract — both :meth:`up` and :meth:`rollback` MUST be
+safe to call repeatedly on the same target state. The admin UI (PR 5)
+retries on transient failures and the operator may re-run after a
+manual intervention. Non-idempotent migrations are a release-blocker.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import ClassVar
+
+
+_ALLOWED_TYPES: frozenset[str] = frozenset({
+    "cert-schema",
+    "cert-algorithm",
+    "policy-change",
+    "new-feature",
+    "code-refactor",
+})
+
+_ALLOWED_CRITICALITY: frozenset[str] = frozenset({
+    "critical",
+    "warning",
+    "info",
+})
+
+_ALLOWED_ENROLLMENTS: frozenset[str] = frozenset({
+    "connector",
+    "byoca",
+    "spire",
+})
+
+_REQUIRED_CLASSATTRS: tuple[str, ...] = (
+    "migration_id",
+    "migration_type",
+    "criticality",
+    "description",
+    "preserves_enrollments",
+    "affects_enrollments",
+)
+
+
+class Migration(ABC):
+    """Abstract base for every concrete migration in the registry.
+
+    Concrete subclasses MUST set the following class attributes. Missing
+    or mistyped attributes raise :class:`TypeError` at subclass
+    definition time so bad migrations fail loud during import, not at
+    boot-detection time when the dashboard is the only surface.
+
+    Attributes:
+        migration_id: stable identifier, data-prefixed lexical sort key.
+            Convention: ``YYYY-MM-DD-slug`` (e.g.
+            ``"2026-04-23-org-ca-pathlen-1"``).
+        migration_type: one of
+            ``cert-schema | cert-algorithm | policy-change |
+            new-feature | code-refactor``.
+        criticality: ``critical | warning | info``. Drives degraded
+            mode at boot.
+        description: one-line human prose explaining what the migration
+            does and why. Rendered verbatim in the dashboard table; keep
+            it operator-readable, no Python jargon.
+        preserves_enrollments: True iff ``up`` preserves agent pubkeys
+            (re-sign leaves) vs forcing re-enrollment.
+        affects_enrollments: enrollments touched by ``up``; subset of
+            ``("connector", "byoca", "spire")``. Empty tuple means the
+            migration is enrollment-agnostic (rare).
+    """
+
+    migration_id: ClassVar[str]
+    migration_type: ClassVar[str]
+    criticality: ClassVar[str]
+    description: ClassVar[str]
+    preserves_enrollments: ClassVar[bool]
+    affects_enrollments: ClassVar[tuple[str, ...]]
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        super().__init_subclass__(**kwargs)
+
+        # Contract enforcement runs on every subclass — ABCMeta populates
+        # ``__abstractmethods__`` *after* ``__init_subclass__`` returns,
+        # so skipping abstract helpers here is unreliable. A helper that
+        # doesn't implement ``check``/``up``/``rollback`` can still
+        # declare sensible class-attr defaults (e.g. migration_id =
+        # "__shared_base__") and pass the contract; that keeps the
+        # enforcement semantics one-line.
+        missing = [
+            name for name in _REQUIRED_CLASSATTRS
+            if name not in cls.__dict__ and not any(
+                name in base.__dict__ for base in cls.__mro__[1:-1]
+            )
+        ]
+        if missing:
+            raise TypeError(
+                f"{cls.__name__} is missing required class attributes: "
+                f"{', '.join(missing)}"
+            )
+
+        if cls.migration_type not in _ALLOWED_TYPES:
+            raise TypeError(
+                f"{cls.__name__}.migration_type = {cls.migration_type!r} "
+                f"not in {sorted(_ALLOWED_TYPES)}"
+            )
+        if cls.criticality not in _ALLOWED_CRITICALITY:
+            raise TypeError(
+                f"{cls.__name__}.criticality = {cls.criticality!r} "
+                f"not in {sorted(_ALLOWED_CRITICALITY)}"
+            )
+        if not isinstance(cls.affects_enrollments, tuple):
+            raise TypeError(
+                f"{cls.__name__}.affects_enrollments must be a tuple, "
+                f"got {type(cls.affects_enrollments).__name__}"
+            )
+        unknown = [
+            e for e in cls.affects_enrollments if e not in _ALLOWED_ENROLLMENTS
+        ]
+        if unknown:
+            raise TypeError(
+                f"{cls.__name__}.affects_enrollments has unknown values: "
+                f"{unknown}; allowed: {sorted(_ALLOWED_ENROLLMENTS)}"
+            )
+        if not isinstance(cls.preserves_enrollments, bool):
+            raise TypeError(
+                f"{cls.__name__}.preserves_enrollments must be bool, "
+                f"got {type(cls.preserves_enrollments).__name__}"
+            )
+        if not isinstance(cls.description, str) or not cls.description.strip():
+            raise TypeError(
+                f"{cls.__name__}.description must be a non-empty string"
+            )
+        if not isinstance(cls.migration_id, str) or not cls.migration_id.strip():
+            raise TypeError(
+                f"{cls.__name__}.migration_id must be a non-empty string"
+            )
+
+    @abstractmethod
+    async def check(self) -> bool:
+        """Return True iff this migration is pending against current state.
+
+        Called by the boot detector (PR 2) on every startup. Must be
+        read-only: idempotent, side-effect-free, safe to call under load.
+
+        Exceptions raised here are **detection errors**, not a negative
+        result. The boot detector catches them, logs WARNING, and does
+        NOT insert a row into ``pending_updates`` for this migration —
+        the migration will be re-evaluated on the next boot. Concrete
+        migrations should therefore only raise for genuinely unexpected
+        conditions (DB unreachable, corrupt config) and return ``False``
+        for "not applicable to this proxy".
+        """
+
+    @abstractmethod
+    async def up(self) -> None:
+        """Apply the migration.
+
+        MUST be idempotent — a second call on an already-applied target
+        is a no-op, not an error. The admin UI retries on transient
+        failure; the operator may re-run after a manual intervention.
+
+        Raises on non-recoverable errors; the caller (PR 4 endpoint)
+        records ``status='failed'`` with the exception message.
+        """
+
+    @abstractmethod
+    async def rollback(self) -> None:
+        """Revert the migration.
+
+        MUST be idempotent. May raise if the backup referenced by the
+        migration has expired or was never created (some migrations are
+        irreversible by design — ``cert-algorithm`` typically is, since
+        old keys are cryptographically obsolete). Concrete migrations
+        document whether rollback is supported in their docstring.
+        """

--- a/mcp_proxy/updates/migrations/__init__.py
+++ b/mcp_proxy/updates/migrations/__init__.py
@@ -1,0 +1,8 @@
+"""Concrete federation update migrations.
+
+Empty in PR 1 — the registry foundation does not ship any migration.
+The first concrete migration (``2026-04-23-org-ca-pathlen-1``) lands
+in PR 3; this package exists now so :func:`mcp_proxy.updates.discover`
+has a stable scan target from day one.
+"""
+from __future__ import annotations

--- a/mcp_proxy/updates/registry.py
+++ b/mcp_proxy/updates/registry.py
@@ -1,0 +1,105 @@
+"""Filesystem-based discovery of :class:`~mcp_proxy.updates.base.Migration`.
+
+Scans :mod:`mcp_proxy.updates.migrations` for every module it contains,
+imports each one, and collects every non-abstract :class:`Migration`
+subclass it finds. Sort is lexical on ``migration_id`` — the project
+convention is ``YYYY-MM-DD-slug``, so lexical sort is chronological.
+
+Design notes:
+
+- No caching. ``discover()`` walks the filesystem every call. The
+  registry is a handful of migrations, re-scanning is cheap, and
+  avoiding a cache sidesteps the stale-reload problem in tests where
+  fixtures register new migrations dynamically.
+- No topological ordering. The plan (Parte 1) keeps inter-migration
+  dependencies out of the foundation; add them only when a concrete
+  migration needs one. Lexical-by-date is sufficient today.
+- Enterprise plugin path is deliberately absent — tracked as a P2
+  follow-up issue. When it lands, this module grows a second scan
+  entry point without changing the ``Migration`` contract.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Iterable
+
+from mcp_proxy.updates import migrations as _migrations_pkg
+from mcp_proxy.updates.base import Migration
+
+
+def _iter_subclasses(cls: type) -> Iterable[type]:
+    """Yield ``cls`` and every subclass recursively, breadth-first."""
+    seen: set[type] = set()
+    stack: list[type] = [cls]
+    while stack:
+        current = stack.pop()
+        for sub in current.__subclasses__():
+            if sub in seen:
+                continue
+            seen.add(sub)
+            yield sub
+            stack.append(sub)
+
+
+def discover() -> list[Migration]:
+    """Return every concrete :class:`Migration` registered on disk.
+
+    Imports every module in :mod:`mcp_proxy.updates.migrations`
+    (non-recursive — PR 1 keeps the layout flat), then walks the
+    :class:`Migration` subclass tree and instantiates every non-abstract
+    subclass whose module lives inside the migrations package. The
+    module filter is important: :class:`Migration` subclasses can
+    be created anywhere (unit-test fixtures, ad-hoc instances in the
+    REPL), and we must not pick them up as "installed migrations".
+
+    Sorted by ``migration_id`` for deterministic ordering. Double-calling
+    is safe — each call creates fresh instances (metadata lives on the
+    class, not the instance).
+    """
+    pkg_name = _migrations_pkg.__name__
+    for mod in pkgutil.iter_modules(_migrations_pkg.__path__):
+        importlib.import_module(f"{pkg_name}.{mod.name}")
+
+    found: list[Migration] = []
+    seen_ids: set[str] = set()
+    for cls in _iter_subclasses(Migration):
+        if inspect.isabstract(cls):
+            continue
+        # Only migrations whose defining module is under the migrations
+        # package are considered installed. This filter is what keeps
+        # test-created fixtures from polluting production discovery,
+        # and lets each test point ``_migrations_pkg`` at a throwaway
+        # package for isolation.
+        if not cls.__module__.startswith(pkg_name):
+            continue
+        # Defensive: should never fire because __init_subclass__ rejects
+        # concrete subclasses without the required attrs, but a
+        # malformed plugin could still slip through via namespace tricks.
+        if not hasattr(cls, "migration_id"):
+            continue
+        if cls.migration_id in seen_ids:
+            raise RuntimeError(
+                f"duplicate migration_id {cls.migration_id!r} in registry "
+                f"— collision between {cls.__module__}.{cls.__name__} and "
+                f"an earlier definition"
+            )
+        seen_ids.add(cls.migration_id)
+        found.append(cls())
+
+    found.sort(key=lambda m: m.migration_id)
+    return found
+
+
+def get_by_id(migration_id: str) -> Migration | None:
+    """Return the concrete :class:`Migration` with the given id, or None.
+
+    Convenience wrapper around :func:`discover` for the admin endpoint
+    (PR 4), which resolves an operator-clicked id to the instance whose
+    ``up`` / ``rollback`` it drives.
+    """
+    for m in discover():
+        if m.migration_id == migration_id:
+            return m
+    return None

--- a/tests/test_pending_updates_db.py
+++ b/tests/test_pending_updates_db.py
@@ -1,0 +1,210 @@
+"""Alembic 0019 + CRUD tests for the ``pending_updates`` table.
+
+Uses a throwaway SQLite file per test so the Alembic upgrade chain
+runs end-to-end (not just ``create_all``) — that way the migration is
+exercised for real, including its idempotency branch. Matches the
+``mgr`` fixture pattern in ``test_proxy_mastio_rotation_concurrency``.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import inspect, text
+
+from mcp_proxy.db import (
+    dispose_db,
+    get_db,
+    get_pending_updates,
+    init_db,
+    insert_pending_update,
+    update_pending_update_status,
+)
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    """Fresh proxy DB migrated through the full Alembic chain."""
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+
+
+async def _inspect_table_exists(table: str) -> bool:
+    async with get_db() as conn:
+        names = await conn.run_sync(
+            lambda sync_conn: set(inspect(sync_conn).get_table_names())
+        )
+    return table in names
+
+
+async def _inspect_index_exists(index: str, table: str) -> bool:
+    async with get_db() as conn:
+        idx_names = await conn.run_sync(
+            lambda sync_conn: {
+                i["name"] for i in inspect(sync_conn).get_indexes(table)
+            }
+        )
+    return index in idx_names
+
+
+@pytest.mark.asyncio
+async def test_alembic_upgrade_creates_table(fresh_db):
+    assert await _inspect_table_exists("pending_updates")
+    assert await _inspect_index_exists(
+        "idx_pending_updates_status", "pending_updates",
+    )
+
+
+@pytest.mark.asyncio
+async def test_insert_pending_update_idempotent(fresh_db):
+    first = await insert_pending_update(
+        migration_id="2099-01-01-idem",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    assert first == 1
+    # Second call with same id is a no-op (ON CONFLICT / INSERT OR IGNORE)
+    second = await insert_pending_update(
+        migration_id="2099-01-01-idem",
+        detected_at="2099-01-02T00:00:00+00:00",
+    )
+    assert second == 0
+    # Row persisted exactly once with the *first* detected_at.
+    rows = await get_pending_updates()
+    assert len(rows) == 1
+    assert rows[0]["detected_at"] == "2099-01-01T00:00:00+00:00"
+    assert rows[0]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_update_status_sets_applied_at(fresh_db):
+    await insert_pending_update(
+        migration_id="2099-01-01-apply",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    rowcount = await update_pending_update_status(
+        migration_id="2099-01-01-apply",
+        status="applied",
+        applied_at="2099-01-01T01:00:00+00:00",
+    )
+    assert rowcount == 1
+
+    rows = await get_pending_updates(status="applied")
+    assert len(rows) == 1
+    assert rows[0]["status"] == "applied"
+    assert rows[0]["applied_at"] == "2099-01-01T01:00:00+00:00"
+    assert rows[0]["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_status_failed_records_error(fresh_db):
+    await insert_pending_update(
+        migration_id="2099-01-01-fail",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    rowcount = await update_pending_update_status(
+        migration_id="2099-01-01-fail",
+        status="failed",
+        error="DB unreachable during up()",
+    )
+    assert rowcount == 1
+    rows = await get_pending_updates(status="failed")
+    assert len(rows) == 1
+    assert rows[0]["error"] == "DB unreachable during up()"
+    assert rows[0]["applied_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_status_missing_row_returns_zero(fresh_db):
+    rowcount = await update_pending_update_status(
+        migration_id="2099-01-01-ghost",
+        status="applied",
+    )
+    assert rowcount == 0
+
+
+@pytest.mark.asyncio
+async def test_get_pending_updates_sorted_by_id(fresh_db):
+    await insert_pending_update(
+        migration_id="2099-06-01-beta",
+        detected_at="2099-06-01T00:00:00+00:00",
+    )
+    await insert_pending_update(
+        migration_id="2099-01-01-alpha",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    await insert_pending_update(
+        migration_id="2099-12-01-gamma",
+        detected_at="2099-12-01T00:00:00+00:00",
+    )
+
+    rows = await get_pending_updates()
+    assert [r["migration_id"] for r in rows] == [
+        "2099-01-01-alpha",
+        "2099-06-01-beta",
+        "2099-12-01-gamma",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_insert_rejects_unknown_status(fresh_db):
+    with pytest.raises(ValueError, match="status"):
+        await insert_pending_update(
+            migration_id="2099-01-01-bad",
+            detected_at="2099-01-01T00:00:00+00:00",
+            status="maybe",
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_rejects_unknown_status(fresh_db):
+    await insert_pending_update(
+        migration_id="2099-01-01-u",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    with pytest.raises(ValueError, match="status"):
+        await update_pending_update_status(
+            migration_id="2099-01-01-u",
+            status="done",
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_pending_updates_rejects_unknown_status_filter(fresh_db):
+    with pytest.raises(ValueError, match="status"):
+        await get_pending_updates(status="queued")
+
+
+@pytest.mark.asyncio
+async def test_get_pending_updates_filter_status_no_match(fresh_db):
+    await insert_pending_update(
+        migration_id="2099-01-01-nofilter",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    rows = await get_pending_updates(status="applied")
+    assert rows == []
+
+
+def test_alembic_revision_metadata():
+    """0019 chains to 0018 and its id stays within the Postgres limit.
+
+    ``alembic_version.version_num`` is ``VARCHAR(32)`` on Postgres; a
+    revision string longer than that ships a migration that CI smoke
+    fails on import (see memory ``feedback_alembic_revision_length``).
+    """
+    import importlib
+    mig = importlib.import_module(
+        "mcp_proxy.alembic.versions.0019_pending_updates",
+    )
+    assert mig.revision == "0019_pending_updates"
+    assert mig.down_revision == "0018_mastio_keys"
+    assert len(mig.revision) <= 32

--- a/tests/test_pending_updates_db.py
+++ b/tests/test_pending_updates_db.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import inspect, text
+from sqlalchemy import inspect
 
 from mcp_proxy.db import (
     dispose_db,

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -67,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0018_mastio_keys",)]
+    assert rows == [("0019_pending_updates",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0018_mastio_keys",)]
+    assert version == [("0019_pending_updates",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0018_mastio_keys"
+HEAD_REVISION = "0019_pending_updates"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0018_mastio_keys"
+HEAD_REVISION = "0019_pending_updates"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0018_mastio_keys"
+HEAD_REVISION = "0019_pending_updates"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 

--- a/tests/test_updates_base.py
+++ b/tests/test_updates_base.py
@@ -1,0 +1,148 @@
+"""Contract tests for :class:`mcp_proxy.updates.base.Migration`.
+
+The base class enforces its metadata contract via ``__init_subclass__``
+so bad migrations fail at import time, not at boot-detection time. These
+tests assert the raises-loud behaviour for every required attribute plus
+the enum validators.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.updates.base import Migration
+
+
+def _valid_kwargs() -> dict:
+    """Class attr bundle a concrete subclass needs to instantiate."""
+    return {
+        "migration_id": "2099-01-01-test",
+        "migration_type": "new-feature",
+        "criticality": "info",
+        "description": "Test migration — unit fixture",
+        "preserves_enrollments": True,
+        "affects_enrollments": (),
+    }
+
+
+def _make(name: str = "X", **overrides) -> type[Migration]:
+    """Build a concrete Migration subclass with the given class attrs."""
+    attrs: dict = {**_valid_kwargs(), **overrides}
+
+    async def _check(self) -> bool:  # noqa: D401 — fixture
+        return False
+
+    async def _up(self) -> None:
+        return None
+
+    async def _rollback(self) -> None:
+        return None
+
+    attrs.update({"check": _check, "up": _up, "rollback": _rollback})
+    return type(name, (Migration,), attrs)
+
+
+def test_valid_subclass_instantiates():
+    cls = _make("ValidA")
+    inst = cls()
+    assert inst.migration_id == "2099-01-01-test"
+    assert inst.migration_type == "new-feature"
+    assert inst.criticality == "info"
+    assert inst.description == "Test migration — unit fixture"
+    assert inst.preserves_enrollments is True
+    assert inst.affects_enrollments == ()
+
+
+def test_missing_classattr_rejected():
+    # Omitting ``description`` — a non-abstract subclass with missing
+    # required class attrs must raise at class-definition time.
+    async def _check(self) -> bool:
+        return False
+
+    async def _up(self) -> None:
+        return None
+
+    async def _rollback(self) -> None:
+        return None
+
+    with pytest.raises(TypeError, match="description"):
+        type(
+            "MissingDescription",
+            (Migration,),
+            {
+                "migration_id": "2099-01-01-x",
+                "migration_type": "new-feature",
+                "criticality": "info",
+                # no description
+                "preserves_enrollments": True,
+                "affects_enrollments": (),
+                "check": _check,
+                "up": _up,
+                "rollback": _rollback,
+            },
+        )
+
+
+def test_abstract_methods_not_implemented_rejected():
+    # Subclass with metadata OK but forgets to override ``up`` — the
+    # ABCMeta machinery rejects instantiation (not class creation).
+    class Partial(Migration):
+        migration_id = "2099-01-01-partial"
+        migration_type = "new-feature"
+        criticality = "info"
+        description = "partial"
+        preserves_enrollments = True
+        affects_enrollments = ()
+
+        async def check(self) -> bool:
+            return False
+
+        # up and rollback missing
+
+    with pytest.raises(TypeError, match="abstract"):
+        Partial()  # type: ignore[abstract]
+
+
+def test_migration_type_invalid_rejected():
+    with pytest.raises(TypeError, match="migration_type"):
+        _make("BadType", migration_type="not-a-real-type")
+
+
+def test_criticality_invalid_rejected():
+    with pytest.raises(TypeError, match="criticality"):
+        _make("BadCrit", criticality="catastrophic")
+
+
+def test_affects_enrollments_unknown_rejected():
+    with pytest.raises(TypeError, match="affects_enrollments"):
+        _make("BadEnr", affects_enrollments=("connector", "mainframe"))
+
+
+def test_affects_enrollments_not_tuple_rejected():
+    with pytest.raises(TypeError, match="tuple"):
+        _make("BadEnrType", affects_enrollments=["connector"])  # type: ignore[arg-type]
+
+
+def test_preserves_enrollments_must_be_bool():
+    with pytest.raises(TypeError, match="preserves_enrollments"):
+        _make("BadPreserve", preserves_enrollments="yes")  # type: ignore[arg-type]
+
+
+def test_empty_description_rejected():
+    with pytest.raises(TypeError, match="description"):
+        _make("EmptyDesc", description="   ")
+
+
+def test_empty_migration_id_rejected():
+    with pytest.raises(TypeError, match="migration_id"):
+        _make("EmptyId", migration_id="")
+
+
+def test_contract_enforced_on_every_subclass():
+    # Contract enforcement runs on every subclass, abstract or not.
+    # ABCMeta populates ``__abstractmethods__`` *after* the __init_subclass__
+    # hook returns, so skipping based on that flag is unreliable. A helper
+    # base that wants to defer ``check``/``up``/``rollback`` still has to
+    # declare sensible defaults for the metadata attrs.
+    with pytest.raises(TypeError, match="missing required class attributes"):
+        class _Naked(Migration):  # noqa: F841
+            pass

--- a/tests/test_updates_registry.py
+++ b/tests/test_updates_registry.py
@@ -1,0 +1,202 @@
+"""Discovery + sort tests for :mod:`mcp_proxy.updates.registry`.
+
+The registry walks :mod:`mcp_proxy.updates.migrations` at every call,
+so the fixtures here inject fresh modules into that package via
+``monkeypatch`` and rely on :func:`importlib.reload` semantics provided
+by the registry itself (it imports each module every call).
+
+PR 1 leaves ``mcp_proxy.updates.migrations`` empty on disk; these tests
+assert that the discover flow still works (returns []) plus the
+behaviour when fixture migrations are registered.
+"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from mcp_proxy.updates import registry as registry_mod
+from mcp_proxy.updates.base import Migration
+
+
+# Unique package name per pytest-xdist worker keeps ``_iter_subclasses``
+# traversal isolated — the real ``mcp_proxy.updates.migrations`` is
+# empty in PR 1, so any class whose ``__module__`` starts with this
+# fake package name is picked up by ``discover`` and nothing else is.
+_FAKE_PKG_NAME = "mcp_proxy.updates.migrations._testfixtures"
+
+
+@pytest.fixture
+def fake_pkg(monkeypatch):
+    """Per-test throwaway migrations package.
+
+    Each test gets a fresh :class:`types.ModuleType` with a unique id
+    embedded in ``__name__``, so fixture migrations registered in
+    earlier tests (still alive in ``Migration.__subclasses__``) do not
+    leak into the current test's ``discover()`` call — they match a
+    stale package prefix the registry does not scan.
+    """
+    pkg_name = f"{_FAKE_PKG_NAME}_{id(monkeypatch)}"
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, pkg_name, pkg)
+    monkeypatch.setattr(registry_mod, "_migrations_pkg", pkg)
+    return pkg
+
+
+def _fixture_cls(
+    fake_pkg_mod: types.ModuleType,
+    name: str,
+    migration_id: str,
+    migration_type: str = "new-feature",
+) -> type[Migration]:
+    async def _check(self) -> bool:
+        return False
+
+    async def _up(self) -> None:
+        return None
+
+    async def _rollback(self) -> None:
+        return None
+
+    cls = type(
+        name,
+        (Migration,),
+        {
+            "migration_id": migration_id,
+            "migration_type": migration_type,
+            "criticality": "info",
+            "description": f"fixture {name}",
+            "preserves_enrollments": True,
+            "affects_enrollments": (),
+            "check": _check,
+            "up": _up,
+            "rollback": _rollback,
+        },
+    )
+    # Pin the class to the fake migrations package so ``discover``
+    # picks it up via the module-name filter.
+    cls.__module__ = fake_pkg_mod.__name__
+    return cls
+
+
+def test_discover_empty(fake_pkg):
+    # No migrations registered — discover returns [].
+    assert registry_mod.discover() == []
+
+
+def test_discover_single_migration(fake_pkg):
+    _fixture_cls(fake_pkg, "Single", "2099-01-01-single")
+    result = registry_mod.discover()
+    assert len(result) == 1
+    assert result[0].migration_id == "2099-01-01-single"
+
+
+def test_discover_sorts_lexically(fake_pkg):
+    # Intentionally create out of order.
+    _fixture_cls(fake_pkg, "Late", "2099-12-31-late")
+    _fixture_cls(fake_pkg, "Mid", "2099-06-15-mid")
+    _fixture_cls(fake_pkg, "Early", "2099-01-01-early")
+    result = registry_mod.discover()
+    ids = [m.migration_id for m in result]
+    assert ids == [
+        "2099-01-01-early",
+        "2099-06-15-mid",
+        "2099-12-31-late",
+    ]
+
+
+def test_discover_ignores_abstract_classes(fake_pkg):
+    # Abstract subclasses of Migration must be skipped (otherwise the
+    # registry would TypeError on instantiation). The helper declares
+    # metadata defaults so the contract is satisfied, then stays
+    # abstract by leaving ``check`` / ``up`` / ``rollback`` untouched.
+    AbstractHelper = type(
+        "AbstractHelper",
+        (Migration,),
+        {
+            "migration_id": "2099-00-00-helper",
+            "migration_type": "new-feature",
+            "criticality": "info",
+            "description": "abstract helper — registry must skip",
+            "preserves_enrollments": True,
+            "affects_enrollments": (),
+        },
+    )
+    AbstractHelper.__module__ = fake_pkg.__name__
+
+    _fixture_cls(fake_pkg, "Concrete", "2099-02-02-concrete")
+    result = registry_mod.discover()
+    assert [m.migration_id for m in result] == ["2099-02-02-concrete"]
+
+
+def test_discover_double_call_deterministic(fake_pkg):
+    _fixture_cls(fake_pkg, "Alpha", "2099-01-01-alpha")
+    _fixture_cls(fake_pkg, "Beta", "2099-02-01-beta")
+    first = [m.migration_id for m in registry_mod.discover()]
+    second = [m.migration_id for m in registry_mod.discover()]
+    assert first == second
+
+
+def test_get_by_id_hit(fake_pkg):
+    _fixture_cls(fake_pkg, "HitTarget", "2099-01-01-hit")
+    m = registry_mod.get_by_id("2099-01-01-hit")
+    assert m is not None
+    assert m.migration_id == "2099-01-01-hit"
+
+
+def test_get_by_id_miss(fake_pkg):
+    _fixture_cls(fake_pkg, "HitTarget", "2099-01-01-hit")
+    assert registry_mod.get_by_id("2099-01-01-miss") is None
+
+
+def test_duplicate_migration_id_raises(fake_pkg):
+    # Two different classes declaring the same migration_id → registry
+    # must fail loud, not pick one silently.
+    _fixture_cls(fake_pkg, "DupA", "2099-01-01-dup")
+    _fixture_cls(fake_pkg, "DupB", "2099-01-01-dup")
+    with pytest.raises(RuntimeError, match="duplicate migration_id"):
+        registry_mod.discover()
+
+
+def test_imports_modules_from_migrations_package(monkeypatch, tmp_path):
+    """Exercise the ``pkgutil.iter_modules`` scan path.
+
+    Builds an ad-hoc single-file package on disk, points the registry
+    at it, and asserts the module was imported and its ``Migration``
+    subclass picked up.
+    """
+    pkg_dir = tmp_path / "fake_migrations"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("")
+    (pkg_dir / "m1.py").write_text(
+        "from mcp_proxy.updates.base import Migration\n"
+        "class M1(Migration):\n"
+        "    migration_id = '2099-03-03-scan'\n"
+        "    migration_type = 'new-feature'\n"
+        "    criticality = 'info'\n"
+        "    description = 'scanned from disk'\n"
+        "    preserves_enrollments = True\n"
+        "    affects_enrollments = ()\n"
+        "    async def check(self): return False\n"
+        "    async def up(self): return None\n"
+        "    async def rollback(self): return None\n"
+    )
+
+    fake_pkg = types.ModuleType("fake_migrations_pkg")
+    fake_pkg.__path__ = [str(pkg_dir)]  # type: ignore[attr-defined]
+    fake_pkg.__name__ = "fake_migrations_pkg"
+    sys.modules["fake_migrations_pkg"] = fake_pkg
+    monkeypatch.setattr(registry_mod, "_migrations_pkg", fake_pkg)
+    monkeypatch.syspath_prepend(str(tmp_path / "fake_migrations"))
+    # pkgutil.iter_modules needs the package's directory on sys.path-like
+    # resolution; fake_pkg.__path__ already points at it.
+
+    try:
+        result = registry_mod.discover()
+        ids = [m.migration_id for m in result]
+        assert "2099-03-03-scan" in ids
+    finally:
+        sys.modules.pop("fake_migrations_pkg", None)
+        sys.modules.pop("fake_migrations_pkg.m1", None)


### PR DESCRIPTION
## Summary

First of five stacked-but-merged-sequentially PRs delivering the federation update framework (``imp/federation_hardening_plan.md`` Parte 1). Introduces:

- ``Migration`` ABC with ``__init_subclass__`` contract enforcement.
- Filesystem-based discovery registry (``mcp_proxy/updates/registry.py``).
- ``pending_updates`` Alembic table (0019, chains from 0018_mastio_keys).
- CRUD helpers in ``mcp_proxy/db.py`` — idempotent insert + status mutation.

No boot detector, no dashboard, no concrete migration. Those land in PR 2-5.

## Scope in this PR

```
mcp_proxy/updates/__init__.py                    re-exports Migration + discover + get_by_id
mcp_proxy/updates/base.py                        Migration ABC, 5 migration_type values, 3 criticality
                                                 values, 3 enrollment types, 6 required class attrs
mcp_proxy/updates/registry.py                    pkgutil discovery, module-name filter,
                                                 lexical sort, duplicate-id detection
mcp_proxy/updates/migrations/__init__.py         empty package — PR 3 populates
mcp_proxy/alembic/versions/0019_pending_updates  migration_id PK + detected_at + status +
                                                 applied_at + error + idx on status
mcp_proxy/db.py                                  insert_pending_update (INSERT OR IGNORE /
                                                 ON CONFLICT DO NOTHING), update status,
                                                 get with optional status filter
tests/test_updates_base.py                       11 contract tests (missing classattr,
                                                 bad enum, empty strings, not-bool, etc.)
tests/test_updates_registry.py                   10 discovery tests (empty, single, N sorted,
                                                 abstract-skip, determinism, duplicate,
                                                 on-disk scan)
tests/test_pending_updates_db.py                 10 CRUD round-trip tests via full Alembic
                                                 upgrade chain
```

Plus ``HEAD_REVISION`` bump from ``0018_mastio_keys`` to ``0019_pending_updates`` in four
existing migration-assertion tests.

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| Table shape | Minimal (5 cols) | Extend per-caller later; ``ALTER TABLE ADD COLUMN`` on Postgres 11+ is cheap |
| Migration format | Python class | Async + imports + conditionals — YAML insufficient for cert/key migrations |
| Required ``description`` classattr | Yes | Dashboard (PR 5) renders verbatim, one-line operator prose |
| Contract enforcement | Every subclass (not just concrete) | ABCMeta populates ``__abstractmethods__`` after ``__init_subclass__`` — skip-if-abstract is unreliable |
| Discovery scope | Package + module-name filter | Classes outside ``mcp_proxy.updates.migrations`` (test fixtures, REPL) aren't "installed" |
| Migration ordering | Lexical on ``migration_id`` | Project convention ``YYYY-MM-DD-slug`` → chronological for free |
| Inter-migration deps | Not in foundation | YAGNI; add if a concrete migration needs one |
| Idempotency | Documented contract + test | Matches Alembic philosophy |

## Verifiche locali

- ``pytest tests/ -n auto --dist=loadfile``: 1762 PASS, 31 skipped (6 pre-existing failures on ``main``: 4 connector profile-runtime-switch + 2 postgres-integration — not touched by this PR).
- ``./demo_network/smoke.sh full``: PASS end-to-end.
- DCO signoff: present (``git commit -s``).
- Alembic revision id ``0019_pending_updates`` = 20 chars, well within the Postgres ``VARCHAR(32)`` limit on ``alembic_version.version_num``.

## Out of scope (tracked)

- Boot detector + Prometheus gauge → PR 2.
- First concrete migration (``2026-04-23-org-ca-pathlen-1``) → PR 3.
- Admin endpoint (``POST /admin/updates/{id}/apply``) → PR 4.
- Dashboard UI → PR 5.
- Enterprise plugin discovery path → #293 (P2 follow-up).

## Test plan

- [x] Contract rejection for each required class attr missing
- [x] Enum validators for ``migration_type``, ``criticality``, ``affects_enrollments``
- [x] Discovery returns [] on empty, sorted list on N, determinism across double-call
- [x] Abstract subclasses skipped by registry, duplicate migration_id raises
- [x] On-disk scan via ``pkgutil.iter_modules`` exercises a real package
- [x] Alembic upgrade + downgrade idempotency (revision / down_revision asserted)
- [x] CRUD: insert idempotent (1, then 0), update sets applied_at, failure records error
- [x] Unknown status rejected on insert / update / get_pending_updates filter

## References

- Plan: ``imp/federation_hardening_plan.md`` (Parte 1)
- Follow-up: #293 enterprise discovery path (P2)
- Prerequisites met: #281 (merged #288), #282 (merged #289), #285 (merged #290)