### PR TITLE
feat(updates): boot detector + Prometheus gauge + sign-halt wiring (PR 2/5)

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -114,6 +114,14 @@ class AgentManager:
         # producing signatures the Court would reject.
         self._sign_halted = False
         self._staged_kid: str | None = None
+        # PR 2 federation updates — reason string populated by
+        # ``mark_sign_halted`` so the boot detector and the (future)
+        # dashboard recovery page can explain *why* signing stopped
+        # beyond the #281 staged-row case. None when the halt was set
+        # by legacy paths that pre-date the reason field (#281 branches
+        # above still set ``_sign_halted`` directly and leave this None;
+        # the dashboard treats None as "staged rotation recovery").
+        self._sign_halt_reason: str | None = None
         # Issue #285 — diagnostic flag set at boot when the Org CA in
         # ``proxy_config.org_ca_cert`` has ``BasicConstraints(pathLen=0)``
         # but the proxy mints a Mastio intermediate CA underneath it at
@@ -719,6 +727,35 @@ class AgentManager:
     def staged_kid(self) -> str | None:
         """Kid of the blocking staged row, or None."""
         return self._staged_kid
+
+    @property
+    def sign_halt_reason(self) -> str | None:
+        """Human-readable reason the halt was engaged, or None.
+
+        Set by ``mark_sign_halted``; the #281 legacy branches leave it
+        None because their state is fully captured by ``staged_kid``.
+        """
+        return self._sign_halt_reason
+
+    def mark_sign_halted(self, reason: str) -> None:
+        """Engage the sign-halt degraded mode with a structured reason.
+
+        Used by callers outside the rotation-race path (PR 2 federation
+        update boot detector) that need to declare "signing is unsafe
+        until the operator intervenes" without touching ``_staged_kid``.
+        Idempotent: re-marking with a new reason overwrites the reason
+        but leaves the halt engaged, so callers composed on top of the
+        #281 halt path don't accidentally clear state.
+
+        Logs ERROR so the operator finds the trigger in logs immediately
+        — the dashboard banner (PR 5) is the user-friendly surface, but
+        logs are the baseline.
+        """
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError("mark_sign_halted requires a non-empty reason")
+        self._sign_halted = True
+        self._sign_halt_reason = reason
+        logger.error("sign-halt engaged: %s", reason)
 
     async def _migrate_legacy_leaf_to_keystore(self) -> None:
         """Seed ``mastio_keys`` from ``proxy_config.mastio_leaf_{key,cert}``.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -163,6 +163,21 @@ async def lifespan(app: FastAPI):
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
 
+    # Federation update framework (imp/federation_hardening_plan.md
+    # Parte 1, PR 2). Must run BEFORE ``LocalIssuer`` construction so a
+    # critical-pending migration affecting this proxy's enrollments can
+    # engage sign-halt and the issuer-skip branch below picks it up.
+    # Defensive try/except so a malformed migration never blocks boot.
+    try:
+        from mcp_proxy.updates.boot import detect_pending_migrations
+        await detect_pending_migrations(agent_mgr)
+    except Exception as exc:
+        _log.warning(
+            "updates.boot: detect_pending_migrations raised at startup: %s "
+            "— continuing without a fresh scan (dashboard may show stale "
+            "state until next restart)", exc,
+        )
+
     # ADR-012 Phase 2.0 — keystore + issuer. The keystore is always
     # available (pure DB read view), the issuer requires that the Mastio
     # identity has loaded a current signer. The validator dependency
@@ -173,17 +188,17 @@ async def lifespan(app: FastAPI):
     app.state.local_issuer = None
     if getattr(agent_mgr, "mastio_loaded", False) and org_id:
         if getattr(agent_mgr, "is_sign_halted", False):
-            # Issue #281 — a staged rotation row blocks signing until
-            # the operator resolves via POST /proxy/mastio-key/
-            # complete-staged. Leaving ``local_issuer`` as None causes
-            # the ``_maybe_local_token`` dep to short-circuit with
-            # ``return None`` and fall through to DPoP, keeping the
-            # failure surface consistent with the counter-sign halt
-            # that ``AgentManager.countersign`` emits.
+            # Sign-halt engaged — either #281 staged rotation row or a
+            # PR 2 federation-update critical migration. Leaving
+            # ``local_issuer`` as None causes the ``_maybe_local_token``
+            # dep to short-circuit with ``return None`` and fall through
+            # to DPoP, keeping the failure surface consistent with the
+            # counter-sign halt that ``AgentManager.countersign`` emits.
             _log.error(
-                "LocalIssuer NOT initialized — sign-halted, staged_kid=%s. "
-                "Resolve via POST /proxy/mastio-key/complete-staged.",
+                "LocalIssuer NOT initialized — sign-halted. staged_kid=%s, "
+                "reason=%s",
                 getattr(agent_mgr, "staged_kid", None),
+                getattr(agent_mgr, "sign_halt_reason", None),
             )
         else:
             try:

--- a/mcp_proxy/updates/boot.py
+++ b/mcp_proxy/updates/boot.py
@@ -1,0 +1,163 @@
+"""Boot-time detection of pending federation update migrations.
+
+Runs once from ``main.py`` lifespan after ``ensure_mastio_identity``
+but before ``LocalIssuer`` construction. Walks every concrete
+:class:`~mcp_proxy.updates.base.Migration` via
+:func:`mcp_proxy.updates.registry.discover`, asks each whether it is
+pending against current state, and:
+
+- Populates the ``pending_updates`` table (idempotent).
+- Refreshes the Prometheus gauge grouped by status.
+- If any critical pending migration affects an enrollment type
+  currently present on this proxy, engages sign-halt via
+  :meth:`AgentManager.mark_sign_halted` — which flips the same flag
+  the staged-rotation recovery path (#281) uses, so the rest of the
+  boot pipeline (``LocalIssuer`` skip, countersign refusal) reacts
+  without further plumbing.
+
+Intentional design notes:
+
+- ``check()`` exceptions are caught and logged as WARNING, per the
+  contract declared on :class:`Migration`. No row is inserted for a
+  migration that raised; it is re-evaluated on the next boot. This
+  keeps a buggy migration from bricking startup.
+- Migrations whose ``pending_updates`` row is already ``applied`` or
+  ``rolled_back`` are skipped: the admin owns those rows and the
+  detector must not regress them to ``pending``.
+- No async concurrency inside the loop. The detector runs once at
+  boot, on a handful of migrations; sequential evaluation keeps the
+  failure surface trivial and ordering deterministic.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from mcp_proxy.db import (
+    get_db,
+    get_pending_updates,
+    insert_pending_update,
+)
+from mcp_proxy.updates.gauge import PENDING_UPDATES_TOTAL
+from mcp_proxy.updates.registry import discover
+
+if TYPE_CHECKING:  # pragma: no cover — import cycle at runtime
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+logger = logging.getLogger("mcp_proxy.updates.boot")
+
+
+_ALL_STATUSES: tuple[str, ...] = (
+    "pending", "applied", "failed", "rolled_back",
+)
+
+
+async def _current_enrollment_types() -> set[str]:
+    """Distinct ``enrollment_method`` across active agents on this proxy.
+
+    Reads ``internal_agents`` directly because the boot detector runs
+    before any higher-level cache is populated, and the set is small
+    (at most 3 values: connector, byoca, spire). An un-provisioned
+    proxy returns ``{"connector"}`` because that is the only method
+    that can self-bootstrap without prior admin action — halting on a
+    critical Connector-affecting migration before the first operator
+    login is the safe default.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT DISTINCT enrollment_method FROM internal_agents "
+                "WHERE is_active = 1 AND enrollment_method IS NOT NULL"
+            )
+        )
+        found = {row[0] for row in result.fetchall() if row[0]}
+    return found or {"connector"}
+
+
+async def _refresh_gauge() -> None:
+    """Re-read ``pending_updates`` by status and publish to Prometheus."""
+    for status in _ALL_STATUSES:
+        rows = await get_pending_updates(status=status)
+        PENDING_UPDATES_TOTAL.labels(status=status).set(float(len(rows)))
+
+
+async def detect_pending_migrations(
+    agent_manager: "AgentManager",
+) -> dict[str, list[str]]:
+    """Scan migrations, populate ``pending_updates``, engage halt if needed.
+
+    Returns a summary dict with two keys:
+
+    - ``detected_ids`` — migrations whose ``check()`` returned True and
+      whose row was inserted (or already present as ``pending`` /
+      ``failed``). Excludes rows with ``applied`` / ``rolled_back``.
+    - ``halt_reasons`` — subset of ``detected_ids`` that triggered
+      sign-halt on the agent manager.
+    """
+    migrations = discover()
+    enrollment_types = await _current_enrollment_types()
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    existing = {
+        row["migration_id"]: row["status"]
+        for row in await get_pending_updates()
+    }
+
+    detected_ids: list[str] = []
+    halt_reasons: list[str] = []
+
+    for m in migrations:
+        prior_status = existing.get(m.migration_id)
+        if prior_status in ("applied", "rolled_back"):
+            # Admin already resolved this one; respect that state.
+            continue
+
+        try:
+            is_pending = await m.check()
+        except Exception as exc:
+            logger.warning(
+                "updates.boot: check() raised for migration_id=%s (%s): %s "
+                "— skipping (will retry on next boot)",
+                m.migration_id, type(exc).__name__, exc,
+            )
+            continue
+
+        if not is_pending:
+            continue
+
+        detected_ids.append(m.migration_id)
+        # Idempotent insert. First-time rows get status='pending';
+        # ON CONFLICT / INSERT OR IGNORE means the original
+        # ``detected_at`` and any ``status`` the admin set by hand
+        # (``failed`` after a manual apply attempt) survive re-boot.
+        await insert_pending_update(
+            migration_id=m.migration_id,
+            detected_at=now_iso,
+        )
+
+        affected = set(m.affects_enrollments) & enrollment_types
+        if m.criticality == "critical" and affected:
+            halt_reasons.append(m.migration_id)
+
+    if halt_reasons:
+        reason = (
+            f"pending critical federation updates affect this proxy's "
+            f"enrollments ({sorted(enrollment_types)}): "
+            f"{', '.join(halt_reasons)}. Resolve via the dashboard "
+            f"(/proxy/updates — PR 5) or POST /admin/updates/{{id}}/apply "
+            f"once the endpoint is live (PR 4)."
+        )
+        agent_manager.mark_sign_halted(reason)
+
+    await _refresh_gauge()
+
+    logger.info(
+        "updates.boot: %d migrations registered, %d pending after scan, "
+        "%d critical → halt=%s",
+        len(migrations), len(detected_ids), len(halt_reasons),
+        bool(halt_reasons),
+    )
+    return {"detected_ids": detected_ids, "halt_reasons": halt_reasons}

--- a/mcp_proxy/updates/gauge.py
+++ b/mcp_proxy/updates/gauge.py
@@ -1,0 +1,39 @@
+"""Prometheus gauge for the federation update framework.
+
+Mirrors the ``cullis_mastio_rotation_staged`` pattern from PR #288 —
+optional ``prometheus_client`` import with a no-op fallback so the
+slim ``proxy-init`` container (``demo_network``/``sandbox``) stays
+importable without the metrics dependency.
+
+The gauge is a single multi-label series rather than one gauge per
+status bucket because pending updates are a small enum and grouping
+them lets the dashboard render a stack chart with zero extra config.
+"""
+from __future__ import annotations
+
+
+class _NoopLabeledMetric:
+    """Stand-in for ``prometheus_client.Gauge`` with the subset of the
+    labeled-gauge surface the boot detector uses.
+    """
+
+    def labels(self, **_kwargs: object) -> "_NoopLabeledMetric":  # noqa: D401
+        return self
+
+    def set(self, _value: float) -> None:  # noqa: D401 — no-op
+        return None
+
+
+try:
+    from prometheus_client import Gauge  # type: ignore
+
+    PENDING_UPDATES_TOTAL = Gauge(
+        "cullis_pending_updates_total",
+        "Federation updates grouped by status bucket "
+        "(pending / applied / failed / rolled_back). Non-zero ``pending`` "
+        "means admin attention is required via the dashboard — resolve "
+        "through POST /admin/updates/{id}/apply (endpoint lands in PR 4).",
+        labelnames=["status"],
+    )
+except ImportError:  # pragma: no cover — exercised only in slim envs
+    PENDING_UPDATES_TOTAL = _NoopLabeledMetric()  # type: ignore[assignment]

--- a/tests/test_updates_boot.py
+++ b/tests/test_updates_boot.py
@@ -114,6 +114,12 @@ def _make_migration(
         },
     )
     cls.__module__ = fake_pkg_mod.__name__
+    # Pin on the fake package so ``Migration.__subclasses__`` (weakrefs)
+    # doesn't drop the class before ``discover()`` walks the tree. Test
+    # callers that ignore the return value would otherwise rely on GC
+    # timing — works locally, flakes in CI (see the sibling comment in
+    # tests/test_updates_registry.py::_fixture_cls).
+    setattr(fake_pkg_mod, name, cls)
     return cls
 
 

--- a/tests/test_updates_boot.py
+++ b/tests/test_updates_boot.py
@@ -1,0 +1,332 @@
+"""Boot detector tests (PR 2 federation update framework).
+
+Exercises the full detect→insert→halt→gauge flow against a throwaway
+SQLite DB. Migrations are registered via the same ``fake_pkg`` trick
+used in PR 1 (module-name filter in registry isolates test classes).
+``AgentManager`` is replaced by a minimal stub with the two attributes
+the detector touches (``mark_sign_halted`` + ``is_sign_halted``) — the
+real class's ``__init__`` pulls in PKI setup that is not necessary
+here.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.db import dispose_db, get_db, get_pending_updates, init_db
+from mcp_proxy.updates import registry as registry_mod
+from mcp_proxy.updates.base import Migration
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+
+
+@pytest.fixture
+def fake_pkg(monkeypatch):
+    """Per-test throwaway migrations package.
+
+    Unique name embedded in ``__name__`` so the registry's module-name
+    filter only picks up *this* test's classes, not those registered
+    by earlier tests (they still exist in ``Migration.__subclasses__``
+    but match a stale package prefix).
+    """
+    pkg_name = (
+        f"mcp_proxy.updates.migrations._boot_testfixtures_{id(monkeypatch)}"
+    )
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, pkg_name, pkg)
+    monkeypatch.setattr(registry_mod, "_migrations_pkg", pkg)
+    return pkg
+
+
+@dataclass
+class StubAgentManager:
+    """Minimal AgentManager surface the detector touches."""
+
+    is_sign_halted: bool = False
+    sign_halt_reason: str | None = None
+    halt_calls: list[str] = field(default_factory=list)
+
+    def mark_sign_halted(self, reason: str) -> None:
+        self.is_sign_halted = True
+        self.sign_halt_reason = reason
+        self.halt_calls.append(reason)
+
+
+def _make_migration(
+    fake_pkg_mod: types.ModuleType,
+    name: str,
+    migration_id: str,
+    *,
+    criticality: str = "info",
+    affects: tuple[str, ...] = (),
+    check_returns: bool | None = True,
+    check_raises: type[Exception] | None = None,
+) -> type[Migration]:
+    """Build a fake Migration class with controllable ``check`` behaviour."""
+    async def _check(self) -> bool:
+        if check_raises is not None:
+            raise check_raises("synthetic failure for test")
+        return bool(check_returns)
+
+    async def _up(self) -> None:
+        return None
+
+    async def _rollback(self) -> None:
+        return None
+
+    cls = type(
+        name,
+        (Migration,),
+        {
+            "migration_id": migration_id,
+            "migration_type": "cert-schema",
+            "criticality": criticality,
+            "description": f"test fixture {name}",
+            "preserves_enrollments": True,
+            "affects_enrollments": affects,
+            "check": _check,
+            "up": _up,
+            "rollback": _rollback,
+        },
+    )
+    cls.__module__ = fake_pkg_mod.__name__
+    return cls
+
+
+async def _insert_active_agent_with_method(method: str) -> None:
+    """Insert one ``is_active=1`` row so ``_current_enrollment_types`` sees it."""
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents "
+                "(agent_id, display_name, capabilities, api_key_hash, "
+                " cert_pem, created_at, is_active, enrollment_method) "
+                "VALUES "
+                "(:aid, :name, '[]', :hash, NULL, '2026-04-23T00:00:00+00:00', "
+                " 1, :method)"
+            ),
+            {
+                "aid": f"agent-{method}",
+                "name": f"agent {method}",
+                "hash": "x" * 64,
+                "method": method,
+            },
+        )
+
+
+# ── Tests ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_boot_with_no_migrations_noop(fresh_db, fake_pkg):
+    from mcp_proxy.updates.boot import detect_pending_migrations
+
+    mgr = StubAgentManager()
+    result = await detect_pending_migrations(mgr)
+
+    assert result == {"detected_ids": [], "halt_reasons": []}
+    assert mgr.is_sign_halted is False
+    assert await get_pending_updates() == []
+
+
+@pytest.mark.asyncio
+async def test_boot_inserts_pending_non_critical_no_halt(fresh_db, fake_pkg):
+    _make_migration(
+        fake_pkg, "Info1", "2099-01-01-info",
+        criticality="info", affects=("connector",), check_returns=True,
+    )
+
+    from mcp_proxy.updates.boot import detect_pending_migrations
+    mgr = StubAgentManager()
+    result = await detect_pending_migrations(mgr)
+
+    assert result["detected_ids"] == ["2099-01-01-info"]
+    assert result["halt_reasons"] == []
+    assert mgr.is_sign_halted is False
+
+    rows = await get_pending_updates()
+    assert len(rows) == 1
+    assert rows[0]["migration_id"] == "2099-01-01-info"
+    assert rows[0]["status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_boot_critical_affecting_my_enrollment_halts(fresh_db, fake_pkg):
+    await _insert_active_agent_with_method("connector")
+    _make_migration(
+        fake_pkg, "CritConnector", "2099-02-01-crit",
+        criticality="critical", affects=("connector",), check_returns=True,
+    )
+
+    from mcp_proxy.updates.boot import detect_pending_migrations
+    mgr = StubAgentManager()
+    result = await detect_pending_migrations(mgr)
+
+    assert result["halt_reasons"] == ["2099-02-01-crit"]
+    assert mgr.is_sign_halted is True
+    assert mgr.sign_halt_reason is not None
+    assert "2099-02-01-crit" in mgr.sign_halt_reason
+
+
+@pytest.mark.asyncio
+async def test_boot_critical_not_affecting_my_enrollment_no_halt(
+    fresh_db, fake_pkg,
+):
+    # Proxy hosts a byoca agent; migration affects only spire.
+    await _insert_active_agent_with_method("byoca")
+    _make_migration(
+        fake_pkg, "CritSpire", "2099-02-02-crit-spire",
+        criticality="critical", affects=("spire",), check_returns=True,
+    )
+
+    from mcp_proxy.updates.boot import detect_pending_migrations
+    mgr = StubAgentManager()
+    result = await detect_pending_migrations(mgr)
+
+    # Row still inserted (operator should know), but no halt because
+    # this proxy has no spire agents.
+    assert result["detected_ids"] == ["2099-02-02-crit-spire"]
+    assert result["halt_reasons"] == []
+    assert mgr.is_sign_halted is False
+
+
+@pytest.mark.asyncio
+async def test_boot_empty_enrollment_defaults_to_connector(fresh_db, fake_pkg):
+    # No agents enrolled yet → defaults to {"connector"}; a critical
+    # connector-affecting migration must still halt, because that is
+    # the only enrollment path an un-provisioned proxy can take.
+    _make_migration(
+        fake_pkg, "EmptyCrit", "2099-02-03-empty-crit",
+        criticality="critical", affects=("connector",), check_returns=True,
+    )
+    from mcp_proxy.updates.boot import detect_pending_migrations
+    mgr = StubAgentManager()
+    result = await detect_pending_migrations(mgr)
+
+    assert result["halt_reasons"] == ["2099-02-03-empty-crit"]
+    assert mgr.is_sign_halted is True
+
+
+@pytest.mark.asyncio
+async def test_boot_check_exception_logged_skipped(
+    fresh_db, fake_pkg, monkeypatch,
+):
+    _make_migration(
+        fake_pkg, "Crash", "2099-03-01-crash",
+        criticality="critical", affects=("connector",),
+        check_raises=RuntimeError,
+    )
+    # Also register a healthy one to confirm the loop continues past the crash.
+    _make_migration(
+        fake_pkg, "Healthy", "2099-03-02-healthy",
+        criticality="info", affects=("connector",), check_returns=True,
+    )
+
+    # The ``mcp_proxy`` root logger has ``propagate=False`` so caplog
+    # does not receive warnings from its descendants. Monkeypatch the
+    # module logger directly (memory ``feedback_mcp_proxy_logger_caplog``).
+    import mcp_proxy.updates.boot as boot_mod
+    captured: list[str] = []
+
+    def _capture(msg, *args, **_kwargs):
+        try:
+            captured.append(msg % args if args else str(msg))
+        except TypeError:
+            captured.append(str(msg))
+
+    monkeypatch.setattr(boot_mod.logger, "warning", _capture)
+
+    mgr = StubAgentManager()
+    result = await boot_mod.detect_pending_migrations(mgr)
+
+    assert result["detected_ids"] == ["2099-03-02-healthy"]
+    assert "2099-03-01-crash" not in result["detected_ids"]
+    assert mgr.is_sign_halted is False
+    assert any("2099-03-01-crash" in line for line in captured), (
+        f"expected crash id in warnings; got {captured!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_boot_idempotent_double_call(fresh_db, fake_pkg):
+    _make_migration(
+        fake_pkg, "Dup", "2099-04-01-dup",
+        criticality="info", affects=(), check_returns=True,
+    )
+    from mcp_proxy.updates.boot import detect_pending_migrations
+    mgr = StubAgentManager()
+
+    first = await detect_pending_migrations(mgr)
+    second = await detect_pending_migrations(mgr)
+
+    # Same detected list both calls — row was inserted once, re-inserts
+    # were no-ops via ON CONFLICT / INSERT OR IGNORE.
+    assert first == second == {
+        "detected_ids": ["2099-04-01-dup"],
+        "halt_reasons": [],
+    }
+    rows = await get_pending_updates()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_boot_skips_already_applied_rows(fresh_db, fake_pkg):
+    from mcp_proxy.db import (
+        insert_pending_update, update_pending_update_status,
+    )
+    from mcp_proxy.updates.boot import detect_pending_migrations
+
+    # Admin applied this one prior to the restart; boot must not
+    # regress the row to "pending".
+    await insert_pending_update(
+        migration_id="2099-05-01-applied",
+        detected_at="2099-05-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id="2099-05-01-applied",
+        status="applied",
+        applied_at="2099-05-01T01:00:00+00:00",
+    )
+
+    # Its check() still returns True because the migration
+    # implementation checks for un-applied state only lazily — simulate
+    # a migration that can't tell it already ran.
+    _make_migration(
+        fake_pkg, "Applied", "2099-05-01-applied",
+        criticality="critical", affects=("connector",), check_returns=True,
+    )
+
+    mgr = StubAgentManager()
+    result = await detect_pending_migrations(mgr)
+
+    assert result["detected_ids"] == []
+    assert result["halt_reasons"] == []
+    assert mgr.is_sign_halted is False
+
+    rows = await get_pending_updates()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "applied"

--- a/tests/test_updates_registry.py
+++ b/tests/test_updates_registry.py
@@ -78,6 +78,13 @@ def _fixture_cls(
     # Pin the class to the fake migrations package so ``discover``
     # picks it up via the module-name filter.
     cls.__module__ = fake_pkg_mod.__name__
+    # Keep a strong reference on the package so ``Migration.__subclasses__``
+    # (which holds weakrefs) doesn't lose the class to GC before the
+    # test runs ``discover()``. Caller-side ``_fixture_cls("X", ...)``
+    # expressions that ignore the return value would otherwise create
+    # orphan classes that the CI runner's more-aggressive GC collects
+    # before the assertion — the test passes locally, fails in CI.
+    setattr(fake_pkg_mod, name, cls)
     return cls
 
 
@@ -166,14 +173,26 @@ def test_imports_modules_from_migrations_package(monkeypatch, tmp_path):
     Builds an ad-hoc single-file package on disk, points the registry
     at it, and asserts the module was imported and its ``Migration``
     subclass picked up.
+
+    Uses a per-test unique ``migration_id`` and a per-test unique
+    package name: once a test imports ``fake_migrations_pkg.m1``, the
+    ``M1`` class sticks around in ``Migration.__subclasses__`` for
+    the lifetime of the process (sys.modules pop doesn't evict it, and
+    the weakref can be kept alive by any stray reference). A repeated
+    test run with a static id would raise a duplicate-id error on the
+    second iteration — not a bug in ``discover``, but a fixture cost.
     """
+    unique = tmp_path.name  # pytest injects a fresh dir for every run
+    pkg_name = f"fake_migrations_pkg_{unique}".replace("-", "_")
+    migration_id = f"2099-03-03-scan-{unique}"
+
     pkg_dir = tmp_path / "fake_migrations"
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text("")
     (pkg_dir / "m1.py").write_text(
         "from mcp_proxy.updates.base import Migration\n"
         "class M1(Migration):\n"
-        "    migration_id = '2099-03-03-scan'\n"
+        f"    migration_id = '{migration_id}'\n"
         "    migration_type = 'new-feature'\n"
         "    criticality = 'info'\n"
         "    description = 'scanned from disk'\n"
@@ -184,19 +203,17 @@ def test_imports_modules_from_migrations_package(monkeypatch, tmp_path):
         "    async def rollback(self): return None\n"
     )
 
-    fake_pkg = types.ModuleType("fake_migrations_pkg")
+    fake_pkg = types.ModuleType(pkg_name)
     fake_pkg.__path__ = [str(pkg_dir)]  # type: ignore[attr-defined]
-    fake_pkg.__name__ = "fake_migrations_pkg"
-    sys.modules["fake_migrations_pkg"] = fake_pkg
+    fake_pkg.__name__ = pkg_name
+    sys.modules[pkg_name] = fake_pkg
     monkeypatch.setattr(registry_mod, "_migrations_pkg", fake_pkg)
     monkeypatch.syspath_prepend(str(tmp_path / "fake_migrations"))
-    # pkgutil.iter_modules needs the package's directory on sys.path-like
-    # resolution; fake_pkg.__path__ already points at it.
 
     try:
         result = registry_mod.discover()
         ids = [m.migration_id for m in result]
-        assert "2099-03-03-scan" in ids
+        assert migration_id in ids
     finally:
-        sys.modules.pop("fake_migrations_pkg", None)
-        sys.modules.pop("fake_migrations_pkg.m1", None)
+        sys.modules.pop(pkg_name, None)
+        sys.modules.pop(f"{pkg_name}.m1", None)


### PR DESCRIPTION
## Summary

PR 2 of 5 for the federation update framework (``imp/federation_hardening_plan.md`` Parte 1), building on the registry foundation merged in #294.

- Boot-time detector that scans registered migrations and populates ``pending_updates``.
- Prometheus gauge ``cullis_pending_updates_total{status}`` with the same no-op fallback shape as ``cullis_mastio_rotation_staged`` (#288).
- ``AgentManager.mark_sign_halted(reason)`` — public API for non-#281 callers that need the halt flag.
- Lifespan hook wires the detector AFTER ``ensure_mastio_identity`` and BEFORE ``LocalIssuer`` construction, so a halt engaged at boot is picked up by the existing issuer-skip branch without extra plumbing.

## Scope

```
mcp_proxy/updates/boot.py                  detect_pending_migrations: discover + check
                                           + insert + gauge refresh + conditional halt
mcp_proxy/updates/gauge.py                 cullis_pending_updates_total with status label
                                           and no-op fallback (no prometheus_client dep)
mcp_proxy/egress/agent_manager.py          mark_sign_halted(reason), sign_halt_reason prop,
                                           _sign_halt_reason field
mcp_proxy/main.py                          lifespan hook + log-message update so halt
                                           reason is surfaced alongside staged_kid
tests/test_updates_boot.py                 8 tests covering every branch
```

## Halt logic

```python
affected = set(m.affects_enrollments) & current_enrollment_types
if m.criticality == "critical" and affected:
    halt_reasons.append(m.migration_id)
```

``current_enrollment_types`` = ``SELECT DISTINCT enrollment_method FROM internal_agents WHERE is_active``. An un-provisioned proxy defaults to ``{connector}`` — the only enrollment path that can self-bootstrap without prior admin action, so a critical connector-affecting migration still halts before the first operator login.

## Contract behaviours preserved

- ``check()`` exceptions → WARNING log + row NOT inserted + retry next boot (per the contract declared on ``Migration`` in PR 1).
- Rows already ``applied`` or ``rolled_back`` are skipped — the admin owns them, the detector must not regress them to ``pending``.
- Insert is idempotent via the ``ON CONFLICT DO NOTHING`` / ``INSERT OR IGNORE`` branch from PR 1; re-runs do not change ``detected_at``.
- Gauge refresh runs unconditionally at the end so a row mutated out-of-band (e.g. admin endpoint in PR 4) reconverges on the next boot.

## Verifiche locali

- ``pytest tests/ -n auto --dist=loadfile``: 1793 PASS, 31 skipped (6 pre-existing failures on ``main`` — 4 connector profile-runtime-switch + 2 postgres-integration — untouched).
- ``./demo_network/smoke.sh full``: PASS.
- DCO signoff: present.

## Out of scope (tracked)

- First concrete migration (``2026-04-23-org-ca-pathlen-1``) → PR 3.
- Admin apply/rollback endpoints → PR 4.
- Dashboard UI → PR 5.
- Enterprise plugin discovery path → #293 (P2 follow-up).

## Test plan

- [x] No migrations → noop, gauge stays 0, no halt.
- [x] Non-critical pending → row inserted, gauge += 1 pending, no halt.
- [x] Critical + matching enrollment → halt engaged, reason populated with migration_id.
- [x] Critical + non-matching enrollment → no halt, row still inserted.
- [x] Empty enrollment set → defaults to ``{connector}``, halt still triggers on connector-critical.
- [x] ``check()`` raises → WARNING log, migration skipped, loop continues past crash.
- [x] Double-call → same result, no duplicate row, gauge stable.
- [x] ``applied`` / ``rolled_back`` rows preserved across boot — no regression to ``pending``.

## References

- Plan: ``imp/federation_hardening_plan.md`` Parte 1
- PR 1: #294 (merged)
- Follow-up: #293 enterprise discovery