### PR TITLE
refactor(connector): drop process-global state from canonical_recipient

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -334,7 +334,6 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
 
     state = get_state()
     state.agent_id = identity.metadata.agent_id
-    state.extra["identity"] = identity
 
     # The enrollment flow already pinned the Site URL in metadata.json —
     # adopt it if the operator did not pass --site-url / CULLIS_SITE_URL.
@@ -366,6 +365,10 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
         from cullis_sdk import CullisClient
 
         client = CullisClient.from_connector(cfg.config_dir)
+        # Attach the loaded identity bundle so downstream helpers
+        # (canonical_recipient, etc.) can derive the sender's org from
+        # the cert subject without reaching into process-global state.
+        client.identity = identity
         key_path = cfg.config_dir / "identity" / "agent.key"
         if key_path.exists():
             client._signing_key_pem = key_path.read_text()

--- a/cullis_connector/inbox_poller.py
+++ b/cullis_connector/inbox_poller.py
@@ -190,7 +190,7 @@ class DashboardInboxPoller:
         sender_raw = row.get("sender_agent_id", "?")
         sender = (
             sender_raw if "::" in sender_raw
-            else canonical_recipient(sender_raw)
+            else canonical_recipient(sender_raw, self._client.identity)
         )
         msg_id = row.get("msg_id")
         if not msg_id:

--- a/cullis_connector/tools/_identity.py
+++ b/cullis_connector/tools/_identity.py
@@ -1,29 +1,39 @@
 """Sender-identity helpers shared by Connector tool modules.
 
-Both ``oneshot.py`` and ``intent.py`` need to read the sender's own org
-from the loaded identity bundle (cert subject ``O=<org_id>``) and to
-canonicalise bare recipient handles into the ``<org>::<agent>`` form
-the Mastio's ``/v1/egress/*`` endpoints require. Keeping the helpers
-here avoids the circular import that would happen if ``intent.py``
-tried to pull them from ``oneshot.py``.
+Both ``oneshot.py`` and the dashboard inbox poller need to read the
+sender's own org from the loaded identity bundle (cert subject
+``O=<org_id>``) and to canonicalise bare recipient handles into the
+``<org>::<agent>`` form the Mastio's ``/v1/egress/*`` endpoints
+require.
+
+Identity is passed as an **explicit parameter** — these helpers do
+not read process-global state. Production callers attach the loaded
+``IdentityBundle`` via ``CullisClient.identity`` and forward
+``client.identity`` here. The previous variant read
+``get_state().extra["identity"]`` and silently returned the input
+unchanged when state had not been populated, which masked a
+bootstrap bug in the dashboard poller (M2.4).
 """
 from __future__ import annotations
 
+import logging
+from typing import Any
+
 from cryptography import x509
 
-from cullis_connector.state import get_state
+_log = logging.getLogger("cullis_connector.tools._identity")
 
 
-def own_org_id() -> str | None:
-    """Return the sender's org_id from the loaded identity's cert subject.
+def own_org_id(identity: Any | None) -> str | None:
+    """Return the sender's org_id from an identity bundle's cert subject.
 
-    The Mastio's ``/v1/egress/resolve`` rejects bare recipient names —
-    it needs ``org::agent``. Enrollment writes the agent's cert with
-    ``O=<org_id>`` so we can recover the sender's org even when
-    ``metadata.json`` stored only the short agent_id.
+    Duck-typed on ``identity.cert`` — any object with a ``cert`` whose
+    ``subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)`` returns
+    a non-empty list works. Returns ``None`` when ``identity`` is
+    ``None``, has no cert, or the cert subject has no ``O=`` attribute.
     """
-    state = get_state()
-    identity = state.extra.get("identity")
+    if identity is None:
+        return None
     cert = getattr(identity, "cert", None)
     if cert is None:
         return None
@@ -33,11 +43,27 @@ def own_org_id() -> str | None:
     return attrs[0].value or None
 
 
-def canonical_recipient(recipient_id: str) -> str:
-    """Prefix the sender's org when the caller gave a bare agent name."""
+def canonical_recipient(recipient_id: str, identity: Any | None) -> str:
+    """Prefix sender's org when recipient is bare; pass through if already qualified.
+
+    ``identity=None`` is accepted deliberately (e.g. diagnostic tools
+    before enrollment completes), but calling with ``identity=None``
+    AND a bare ``recipient_id`` logs a warning and returns the input
+    unchanged — the Mastio will then reject with 400 ``"internal id
+    must be 'org::agent'"``. Production code paths always attach
+    identity via ``CullisClient.identity = load_identity(config_dir)``.
+    """
     if "::" in recipient_id:
         return recipient_id
-    org = own_org_id()
+    if identity is None:
+        _log.warning(
+            "canonical_recipient: bare recipient %r with identity=None; "
+            "passing through as-is — server will likely 400. Production "
+            "callers must attach identity via CullisClient.identity.",
+            recipient_id,
+        )
+        return recipient_id
+    org = own_org_id(identity)
     if not org:
         return recipient_id
     return f"{org}::{recipient_id}"

--- a/cullis_connector/tools/oneshot.py
+++ b/cullis_connector/tools/oneshot.py
@@ -62,7 +62,7 @@ def register(mcp: "FastMCP") -> None:
         client = _require_oneshot_client()
         state = get_state()
         caps = [c.strip() for c in capabilities.split(",") if c.strip()]
-        canonical = _canonical_recipient(recipient_id)
+        canonical = _canonical_recipient(recipient_id, client.identity)
         try:
             result = client.send_oneshot(
                 canonical,
@@ -129,7 +129,7 @@ def register(mcp: "FastMCP") -> None:
                 if msg_id:
                     last_decoded_sender = (
                         sender if "::" in sender
-                        else _canonical_recipient(sender)
+                        else _canonical_recipient(sender, client.identity)
                     )
                     last_decoded_msg_id = msg_id
             except Exception as exc:  # noqa: BLE001

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -175,22 +175,20 @@ def _start_inbox_poller(config: ConnectorConfig) -> DashboardInboxPoller | None:
     interval_s = float(os.environ.get("CULLIS_CONNECTOR_POLL_S", "10"))
     try:
         from cullis_sdk import CullisClient
-
-        # Mirror cli._cmd_serve: load the identity into the process-
-        # global state so helpers like own_org_id() / canonical_recipient
-        # can read the sender's org from the cert subject. Without this
-        # the prime_sender_pubkey_cache helper sends a bare recipient
-        # to /v1/egress/resolve and gets a 400 "internal id must be
-        # 'org::agent'" — which then cascades into the JWT-required
-        # fallback path in decrypt_oneshot and surfaces as
-        # "Not authenticated — call login() first" every poll tick.
         from cullis_connector.state import get_state
+
+        # Load the identity bundle and attach it to the client. Helpers
+        # like ``canonical_recipient`` read the sender's org from
+        # ``client.identity.cert`` rather than process-global state —
+        # the previous variant relied on ``state.extra["identity"]`` and
+        # silently failed when that wasn't seeded (the M2.4 dashboard
+        # bootstrap bug).
         identity = load_identity(config.config_dir)
         state = get_state()
         state.agent_id = identity.metadata.agent_id
-        state.extra["identity"] = identity
 
         client = CullisClient.from_connector(config.config_dir)
+        client.identity = identity
         key_path = config.config_dir / "identity" / "agent.key"
         if key_path.exists():
             client._signing_key_pem = key_path.read_text()

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -138,6 +138,16 @@ class CullisClient:
         # detect which role is in front of it without a config change.
         self.server_role: str | None = None
 
+        # Opaque identity bundle attached by the caller after
+        # construction. Connector callers set this to the loaded
+        # ``cullis_connector.identity.IdentityBundle`` so helpers like
+        # ``cullis_connector.tools._identity.canonical_recipient`` can
+        # read the sender's org from the cert subject. The SDK never
+        # reads this itself — it's a duck-typed handle for tools
+        # layered on top. ``None`` means "no identity attached"; the
+        # tools that need it must handle that case.
+        self.identity: Any = None
+
     def __enter__(self) -> CullisClient:
         return self
 
@@ -284,6 +294,9 @@ class CullisClient:
         instance._proxy_api_key = config["api_key"]
         instance._proxy_agent_id = config["agent_id"]
         instance._proxy_org_id = config["org_id"]
+        # Mirror __init__: callers may attach the on-disk identity bundle
+        # afterwards (see ``canonical_recipient`` in cullis_connector).
+        instance.identity = None
 
         # F-B-11 Phase 3c (#181) — load or generate the persistent
         # DPoP keypair. The server stores the thumbprint in
@@ -465,6 +478,7 @@ class CullisClient:
         # since we skip ``__init__`` above (the ``cls.__new__(cls)`` route
         # that other factories also use), the attribute must exist.
         instance.server_role = None
+        instance.identity = None
 
         if dpop_key_path is not None:
             from cullis_sdk.dpop import DpopKey
@@ -656,6 +670,7 @@ class CullisClient:
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
         instance.server_role = None
+        instance.identity = None
 
         log("sdk", f"Enrolled {agent_id} via {endpoint_path}")
         return instance
@@ -772,6 +787,9 @@ class CullisClient:
         instance._proxy_api_key = api_key
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
+        # Mirror __init__: callers may attach the on-disk identity bundle
+        # afterwards (see ``canonical_recipient`` in cullis_connector).
+        instance.identity = None
 
         # F-B-11 Phase 3c + 3d — load the DPoP keypair alongside the
         # rest of the Connector identity. Phase 3d (#181) has the

--- a/tests/connector/test_inbox_poller.py
+++ b/tests/connector/test_inbox_poller.py
@@ -29,6 +29,7 @@ class _FakeClient:
         self,
         rounds: list[Any],
         decoder=None,
+        identity=None,
     ) -> None:
         # Each entry in ``rounds`` is either a list of rows (success)
         # or an Exception class/instance (failure round).
@@ -38,6 +39,9 @@ class _FakeClient:
         )
         self.calls = 0
         self.pubkey_fetch_calls: list[str] = []
+        # Mirror the real CullisClient.identity contract — the poller's
+        # canonical_recipient call reads it for bare senders.
+        self.identity = identity
 
     def get_agent_public_key_via_egress(
         self, agent_id: str, force_refresh: bool = False,
@@ -270,27 +274,26 @@ async def test_pubkey_fetch_failure_skips_message_does_not_crash_loop():
 async def test_canonicalizes_bare_sender():
     """A row whose sender_agent_id is bare (legacy intra-org) must be
     promoted to ``<org>::<name>`` so downstream reply() speaks the
-    canonical form the Mastio expects."""
-    from unittest.mock import MagicMock
-    from cullis_connector.state import get_state, reset_state
+    canonical form the Mastio expects.
 
-    reset_state()
+    Identity is attached directly to the SDK client (mirrors production
+    wiring); the legacy ``state.extra["identity"]`` global is gone."""
+    from unittest.mock import MagicMock
+
     fake_attr = MagicMock()
     fake_attr.value = "acme"
     fake_cert = MagicMock()
     fake_cert.subject.get_attributes_for_oid.return_value = [fake_attr]
     fake_identity = MagicMock()
     fake_identity.cert = fake_cert
-    get_state().extra["identity"] = fake_identity
 
     rows = [{"msg_id": "m1", "sender_agent_id": "alice", "correlation_id": "c", "reply_to": None, "text": "hi"}]
-    client = _FakeClient(rounds=[rows])
+    client = _FakeClient(rounds=[rows], identity=fake_identity)
     poller = DashboardInboxPoller(client, poll_interval_s=99.0)
     poller.start()
     try:
         events = await _drain_events(poller, n=1)
     finally:
         await poller.stop(timeout_s=1.0)
-        reset_state()
 
     assert events[0].sender_agent_id == "acme::alice"

--- a/tests/connector/test_oneshot_state_update.py
+++ b/tests/connector/test_oneshot_state_update.py
@@ -35,11 +35,15 @@ class _FakeClient:
         rows: list[dict],
         decoder=None,
         signing_key: str = "PEM",
+        identity=None,
     ) -> None:
         self._rows = rows
         self._decoder = decoder or (lambda r: {"payload": {"text": "decoded"}})
         self._signing_key_pem = signing_key
         self._pubkey_cache: dict = {}
+        # canonical_recipient pulls the sender's org from this attribute
+        # (mirrors the real CullisClient.identity contract).
+        self.identity = identity
 
     def receive_oneshot(self) -> list[dict]:
         return list(self._rows)
@@ -79,14 +83,13 @@ def receive_tool():
     return mcp.tools["receive_oneshot"]
 
 
-def _install_client(rows, decoder=None) -> _FakeClient:
+def _install_client(rows, decoder=None, identity=None) -> _FakeClient:
     import time as _time
 
-    client = _FakeClient(rows=rows, decoder=decoder)
-    # Pre-seed the cache so prime() short-circuits on the TTL-fresh
-    # branch. The timestamp must be current — a 0.0 seed is always
-    # stale and would trigger the _egress_http refetch path (which
-    # returns 404 in this fixture → PubkeyPrimeError on purpose).
+    client = _FakeClient(rows=rows, decoder=decoder, identity=identity)
+    # Pre-seed the cache so the SDK pubkey-fetcher short-circuits on
+    # the TTL-fresh branch. Timestamp must be current — a 0.0 seed is
+    # always stale and would trigger the _egress_http refetch path.
     now = _time.time()
     for r in rows:
         client._pubkey_cache[r["sender_agent_id"]] = ("PEM", now)
@@ -112,10 +115,11 @@ def test_receive_updates_last_peer_and_reply_to(receive_tool):
 def test_receive_canonicalizes_bare_sender(receive_tool):
     """Older inbox rows can carry the bare agent name; ensure we
     canonicalize it before storing in last_peer_resolved so reply()
-    speaks the form /v1/egress/* expects."""
-    # No identity loaded → canonical_recipient returns the input
-    # unchanged. Set up state.extra["identity"] with a fake cert
-    # whose org name is "acme".
+    speaks the form /v1/egress/* expects.
+
+    Identity is attached to the SDK client (mirrors the production
+    wiring in cli._cmd_serve / web._start_inbox_poller); the legacy
+    state.extra["identity"] global is gone."""
     from unittest.mock import MagicMock
     fake_attr = MagicMock()
     fake_attr.value = "acme"
@@ -123,7 +127,6 @@ def test_receive_canonicalizes_bare_sender(receive_tool):
     fake_cert.subject.get_attributes_for_oid.return_value = [fake_attr]
     fake_identity = MagicMock()
     fake_identity.cert = fake_cert
-    get_state().extra["identity"] = fake_identity
 
     rows = [{
         "sender_agent_id": "mario",
@@ -132,7 +135,7 @@ def test_receive_canonicalizes_bare_sender(receive_tool):
         "reply_to": None,
         "payload_ciphertext": "{}",
     }]
-    _install_client(rows)
+    _install_client(rows, identity=fake_identity)
     receive_tool()
     assert get_state().last_peer_resolved == "acme::mario"
     assert get_state().last_reply_to == "msg-A"

--- a/tests/connector/test_tools_identity.py
+++ b/tests/connector/test_tools_identity.py
@@ -1,62 +1,119 @@
 """Tests for ``cullis_connector.tools._identity``.
 
-Since the ``prime_sender_pubkey_cache`` workaround was replaced by the
-SDK-side ``pubkey_fetcher`` injection backed by the Mastio's
-``/v1/egress/agents/{id}/public-key`` endpoint, this module now only
-owns the small identity helpers ``own_org_id`` and
-``canonical_recipient``. Tests mirror that narrower surface.
+The helpers take identity as an **explicit parameter** — they no
+longer read process-global state. These tests pin the new contract:
+silent passthrough when already qualified, prefix when both identity
+and bare recipient are present, and a warning (but no exception)
+when a bare recipient is paired with ``identity=None``.
 """
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from cullis_connector.state import get_state, reset_state
 from cullis_connector.tools._identity import canonical_recipient, own_org_id
 
 
-def _seed_identity(org_id: str) -> None:
-    reset_state()
+def _fake_identity(org_id: str) -> MagicMock:
+    """Minimal duck-typed IdentityBundle stub — only the
+    ``.cert.subject.get_attributes_for_oid`` chain matters."""
     fake_attr = MagicMock()
     fake_attr.value = org_id
     fake_cert = MagicMock()
     fake_cert.subject.get_attributes_for_oid.return_value = [fake_attr]
     fake_identity = MagicMock()
     fake_identity.cert = fake_cert
-    get_state().extra["identity"] = fake_identity
+    return fake_identity
+
+
+# ── own_org_id ───────────────────────────────────────────────────────
 
 
 def test_own_org_id_reads_subject_O_attr():
-    _seed_identity("acme")
-    try:
-        assert own_org_id() == "acme"
-    finally:
-        reset_state()
+    assert own_org_id(_fake_identity("acme")) == "acme"
 
 
-def test_own_org_id_none_when_no_identity_loaded():
-    reset_state()
-    assert own_org_id() is None
+def test_own_org_id_returns_none_when_identity_none():
+    assert own_org_id(None) is None
 
 
-def test_canonical_recipient_prefixes_bare_handle():
-    _seed_identity("acme")
-    try:
-        assert canonical_recipient("mario") == "acme::mario"
-    finally:
-        reset_state()
+def test_own_org_id_returns_none_when_cert_missing():
+    fake = MagicMock()
+    fake.cert = None
+    assert own_org_id(fake) is None
+
+
+def test_own_org_id_returns_none_when_no_O_attr():
+    fake_cert = MagicMock()
+    fake_cert.subject.get_attributes_for_oid.return_value = []
+    fake = MagicMock()
+    fake.cert = fake_cert
+    assert own_org_id(fake) is None
+
+
+# ── canonical_recipient ──────────────────────────────────────────────
+
+
+def test_canonical_recipient_prefixes_bare_handle_with_identity():
+    assert canonical_recipient("mario", _fake_identity("acme")) == "acme::mario"
 
 
 def test_canonical_recipient_passthrough_when_already_qualified():
-    _seed_identity("acme")
-    try:
-        assert canonical_recipient("other-org::luigi") == "other-org::luigi"
-    finally:
-        reset_state()
+    # ``::`` present → identity is irrelevant, passthrough silent.
+    assert canonical_recipient(
+        "other-org::luigi", _fake_identity("acme"),
+    ) == "other-org::luigi"
 
 
-def test_canonical_recipient_no_identity_returns_input_unchanged():
-    """Without an identity loaded there is no org to prefix with —
-    returning the bare handle is the safe fallback; the server will
-    reject it with a clear 400."""
-    reset_state()
-    assert canonical_recipient("mario") == "mario"
+def test_canonical_recipient_qualified_with_none_identity_is_silent(monkeypatch):
+    """Already-qualified input + identity=None must NOT log a warning.
+    The warning is only for the ambiguous case (bare + no identity).
+    Covers diagnostic tools that pass qualified handles before
+    enrollment completes."""
+    from cullis_connector.tools import _identity as identity_mod
+
+    captured: list = []
+    monkeypatch.setattr(
+        identity_mod._log, "warning",
+        lambda msg, *args, **kw: captured.append((msg, args)),
+    )
+
+    assert canonical_recipient("other-org::luigi", None) == "other-org::luigi"
+    assert captured == []
+
+
+def test_canonical_recipient_bare_with_none_identity_warns_and_passes_through(monkeypatch):
+    """Bare recipient + identity=None → log warning + return input
+    unchanged. The Mastio then rejects with 400; the warning tells
+    the dev they forgot to attach identity.
+
+    Monkeypatch the module's ``_log.warning`` directly rather than
+    relying on caplog — the memory ``feedback_mcp_proxy_logger_caplog``
+    documents that some module loggers don't propagate cleanly under
+    xdist and caplog comes back empty. Direct interception is the
+    portable pattern."""
+    from cullis_connector.tools import _identity as identity_mod
+
+    captured: list[tuple[str, tuple]] = []
+
+    def _capture(msg, *args, **kwargs):
+        captured.append((msg, args))
+
+    monkeypatch.setattr(identity_mod._log, "warning", _capture)
+
+    result = canonical_recipient("mario", None)
+    assert result == "mario"
+    assert len(captured) == 1, captured
+    msg, args = captured[0]
+    assert "identity=None" in msg
+    assert args[0] == "mario"
+
+
+def test_canonical_recipient_bare_with_identity_missing_org_passes_through():
+    """Identity present but cert has no ``O=`` attribute → passthrough
+    (no warning). Unusual state but not a programmer error the caller
+    should have caught; the server will still produce a clean 400."""
+    fake_cert = MagicMock()
+    fake_cert.subject.get_attributes_for_oid.return_value = []
+    fake = MagicMock()
+    fake.cert = fake_cert
+    assert canonical_recipient("mario", fake) == "mario"


### PR DESCRIPTION
## Summary

Closes tech-debt #6 from `project_connector_tech_debt`. The helpers `own_org_id` / `canonical_recipient` in `cullis_connector.tools._identity` used to read the sender's identity from `get_state().extra["identity"]` — that coupling caused the M2.4 dashboard bootstrap bug (inbox poller built a `CullisClient` without seeding state, bare recipients leaked to `/v1/egress/resolve` and produced opaque 400s that cascaded into misleading JWT-required errors downstream).

Signature changed to take identity as an **explicit parameter**:

```python
own_org_id(identity) -> str | None
canonical_recipient(recipient_id, identity) -> str
```

Identity is attached to the SDK client after construction:

```python
client = CullisClient.from_connector(config_dir)
client.identity = load_identity(config_dir)
```

`CullisClient.identity: Any = None` is a public duck-typed attribute — the SDK never reads it, it's a handle for tools layered on top. Zero dependency from `cullis_sdk` on `cullis_connector`; the Connector simply attaches its `IdentityBundle`.

### `identity=None` policy — passthrough + warning (NOT ValueError)

- Already-qualified recipient + `identity=None` → **silent passthrough** (diagnostic tools that pass qualified handles before enrollment completes are a legitimate use).
- Bare recipient + `identity=None` → **log warning + passthrough**; the Mastio then rejects with its existing clean 400 `internal id must be "org::agent"`. The warning tells the dev they forgot to attach identity without forcing a breaking change on legit pre-enrollment callers.

The prior global-state coupling — not the runtime check — was the actual bug; an explicit parameter makes it impossible to repeat the M2.4 omission.

### Callers updated

| File | Change |
|---|---|
| `cullis_connector/cli.py::_cmd_serve` | drop `state.extra["identity"]` write; `client.identity = identity` after construction |
| `cullis_connector/web.py::_start_inbox_poller` | idem |
| `cullis_connector/tools/oneshot.py::send_oneshot` | `canonical_recipient(x, client.identity)` |
| `cullis_connector/tools/oneshot.py::receive_oneshot` (threading hint) | idem |
| `cullis_connector/inbox_poller.py::_decode_row` | `canonical_recipient(sender, self._client.identity)` |

## Out of scope

- `get_state()` stays in use for `active_peer`, `last_correlation_id`, etc. Only the `state.extra["identity"]` channel is removed.
- Tech-debt #2 (`login_via_proxy` bypass) — separate scope (challenge-response Mastio).

## Test plan

- [x] `pytest tests/ -n auto --dist=loadfile` → 1789 passed, 6 skipped (excluded: `test_postgres_integration.py`, `test_ts_interop.py`, `tests/connector/test_profile_runtime_switch.py` — last is a pre-existing pystray fail on `main`, unrelated)
- [x] `tests/connector/test_tools_identity.py` rewritten — 9 cases covering `own_org_id` duck-typing edges, silent-passthrough vs warn-passthrough, and identity with missing `O=` attr. Warning assertion uses monkeypatch on `_log.warning` directly per `feedback_mcp_proxy_logger_caplog` (caplog is flaky under xdist for module-scoped loggers)
- [x] `tests/connector/test_oneshot_state_update.py` + `test_inbox_poller.py` — `_FakeClient` gains an `identity` attribute; bare-sender canonicalization attaches identity to the client instead of global state
- [x] `./demo_network/smoke.sh full` → A1+A4+A7+A8 PASS
- [x] **Sandbox dogfood cross-org still verde after refactor**: `./demo.sh oneshot-a-to-b` → agent-b logs `received nonce from orga::agent-a: <hex>` with zero 401/failed/error. The cross-org E2E that turned green in #292 is preserved.
- [ ] CI green: test (3.11), Signed-off-by check, security, helm-test (cullis + cullis-proxy), demo_network smoke (rsa / ec / rsa+postgres), standalone smoke, Cloudflare Pages