### PR TITLE
feat(updates): first concrete migration — Org CA pathLen=0 auto-fix (PR 3/5)

### DIFF
--- a/mcp_proxy/alembic/versions/0020_migration_state_backups.py
+++ b/mcp_proxy/alembic/versions/0020_migration_state_backups.py
@@ -1,0 +1,51 @@
+"""``migration_state_backups`` — snapshot blob for federation update rollback.
+
+Revision ID: 0020_migration_state_backups
+Revises: 0019_pending_updates
+Create Date: 2026-04-23 22:00:00.000000
+
+Federation update framework (imp/federation_hardening_plan.md Parte 1)
+PR 3 of 5 — backup storage for the first concrete migration.
+
+One row per ``migration_id``; ``snapshot_json`` is an opaque per-migration
+blob whose schema is owned by the migration itself, not by the DB layer.
+``INSERT OR REPLACE`` on apply means a second apply overwrites the prior
+backup (the previous state is no longer recoverable by design — the
+admin drove a fresh apply, acknowledging the reset).
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0020_migration_state_backups"
+down_revision: Union[str, Sequence[str], None] = "0019_pending_updates"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "migration_state_backups" in existing_tables:
+        return
+
+    op.create_table(
+        "migration_state_backups",
+        sa.Column("migration_id", sa.Text(), primary_key=True),
+        sa.Column("created_at", sa.Text(), nullable=False),
+        sa.Column("snapshot_json", sa.Text(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = set(sa.inspect(bind).get_table_names())
+    if "migration_state_backups" not in existing:
+        return
+    op.drop_table("migration_state_backups")

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -860,6 +860,91 @@ async def get_pending_updates(status: str | None = None) -> list[dict]:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# migration_state_backups — per-migration snapshot blob for rollback
+# (PR 3 federation update framework).
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def insert_migration_backup(
+    *,
+    migration_id: str,
+    created_at: str,
+    snapshot_json: str,
+) -> None:
+    """Write (or overwrite) the backup row for a migration.
+
+    ``INSERT OR REPLACE`` (SQLite) / ``ON CONFLICT ... DO UPDATE``
+    (Postgres) — a second apply on the same ``migration_id`` overwrites
+    the prior snapshot. Rollback always uses the most recent backup; the
+    previous state is deliberately not recoverable because the admin
+    drove a fresh apply and implicitly acknowledged that reset.
+    """
+    async with get_db() as conn:
+        dialect = conn.dialect.name
+        if dialect == "postgresql":
+            stmt = text(
+                """
+                INSERT INTO migration_state_backups
+                    (migration_id, created_at, snapshot_json)
+                VALUES
+                    (:mid, :created, :snapshot)
+                ON CONFLICT (migration_id) DO UPDATE
+                    SET created_at = EXCLUDED.created_at,
+                        snapshot_json = EXCLUDED.snapshot_json
+                """
+            )
+        else:
+            stmt = text(
+                """
+                INSERT OR REPLACE INTO migration_state_backups
+                    (migration_id, created_at, snapshot_json)
+                VALUES
+                    (:mid, :created, :snapshot)
+                """
+            )
+        await conn.execute(
+            stmt,
+            {
+                "mid": migration_id,
+                "created": created_at,
+                "snapshot": snapshot_json,
+            },
+        )
+
+
+async def get_migration_backup(migration_id: str) -> dict | None:
+    """Return the backup row for a migration, or None."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT migration_id, created_at, snapshot_json "
+                "FROM migration_state_backups WHERE migration_id = :mid"
+            ),
+            {"mid": migration_id},
+        )
+        row = result.mappings().first()
+        return dict(row) if row else None
+
+
+async def delete_migration_backup(migration_id: str) -> int:
+    """Delete the backup row for a migration.
+
+    Returns the rowcount. Zero means there was no backup to begin with;
+    the caller decides whether that matters (``rollback`` treats "no
+    backup" as an error, ``up`` ignores).
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "DELETE FROM migration_state_backups "
+                "WHERE migration_id = :mid"
+            ),
+            {"mid": migration_id},
+        )
+        return result.rowcount or 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Helpers
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/updates/migrations/org_ca_pathlen_1_20260423.py
+++ b/mcp_proxy/updates/migrations/org_ca_pathlen_1_20260423.py
@@ -1,0 +1,404 @@
+"""First concrete federation update — fix the pathLen=0 bug retroactively.
+
+Context: PR #284 (``2cba826``) repaired the Org CA generation code that
+emitted ``BasicConstraints(ca=True, path_length=0)`` despite the proxy
+minting a Mastio intermediate CA underneath it at runtime. Proxies
+already deployed with that CA stay broken after a ``git pull``, because
+their Org CA cert sits in ``proxy_config.org_ca_cert`` and is never
+regenerated on its own. Issue #285 surfaces the broken state (warn at
+boot + Prometheus gauge) but does not repair it.
+
+This migration repairs it — idempotently, preserving every agent's
+public key so no re-enrollment is required. It applies only to
+Mastio-managed Org CAs (Connector enrollment), not BYOCA: when the
+Org CA private key lives outside ``proxy_config.org_ca_key`` (held by
+the org's secret manager), :meth:`check` returns False and the
+migration stays dormant. A BYOCA-variant operator-driven flow is
+tracked as a follow-up issue.
+
+Rollback: restores the pre-rotation cert state (both the old Org CA
+and every agent's old leaf) from ``migration_state_backups``. The old
+CA private key is restored too, so the old chain validates again.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from mcp_proxy.db import (
+    delete_migration_backup,
+    get_config,
+    get_db,
+    get_migration_backup,
+    insert_migration_backup,
+    set_config,
+)
+from mcp_proxy.updates.base import Migration
+
+from sqlalchemy import text
+
+logger = logging.getLogger("mcp_proxy.updates.migrations.org_ca_pathlen_1")
+
+
+_CA_NEW_SKEW_MINUTES = 5  # matches ``AgentManager.generate_org_ca`` convention
+
+
+class OrgCAPathLenFix(Migration):
+    """Rotate Org CA to ``pathLen=1`` preserving agent pubkeys.
+
+    Concrete migration for ``2026-04-23-org-ca-pathlen-1``. See module
+    docstring for context.
+    """
+
+    migration_id = "2026-04-23-org-ca-pathlen-1"
+    migration_type = "cert-schema"
+    criticality = "critical"
+    description = (
+        "Rotate the Org CA to BasicConstraints(pathLen=1) preserving every "
+        "agent's public key — repairs proxies whose Org CA was generated "
+        "before PR #284 fixed the pathLen=0 bug (#280). Without this, "
+        "the full chain (Org CA → Mastio intermediate → agent leaf) is "
+        "rejected by every stdlib x509 verifier."
+    )
+    preserves_enrollments = True
+    # Connector-only: BYOCA rotation would require operator-driven upload
+    # of a new CA (the private key lives outside proxy_config); tracked
+    # as a separate follow-up issue.
+    affects_enrollments = ("connector",)
+
+    # ── Detection ─────────────────────────────────────────────────────
+
+    async def check(self) -> bool:
+        """True iff this proxy has the pathLen=0 bug AND we can fix it.
+
+        Returns False (migration not applicable) when:
+          - No Org CA cert loaded (fresh / attached-CA-pre-consume).
+          - Org CA already has pathLen >= 1 or None (post-#284 install).
+          - No intermediate CA minted below it (no chain violation — a
+            2-tier deploy with pathLen=0 is technically valid).
+          - Org CA private key absent from ``proxy_config.org_ca_key``
+            (BYOCA with secret-manager-held key — operator-driven only).
+
+        Any unexpected read / parse error propagates as an exception —
+        the boot detector catches it, logs WARNING, and retries next
+        boot (contract from PR 1).
+        """
+        ca_cert_pem = await get_config("org_ca_cert")
+        if not ca_cert_pem:
+            return False
+
+        ca_key_pem = await get_config("org_ca_key")
+        if not ca_key_pem:
+            # BYOCA with secret-manager-held privkey — not auto-migrable.
+            return False
+
+        ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+        try:
+            bc = ca_cert.extensions.get_extension_for_class(
+                x509.BasicConstraints,
+            ).value
+        except x509.ExtensionNotFound:
+            return False
+
+        # pathLen is an int (constrained) or None (unbounded). Only the
+        # explicit 0 triggers the bug.
+        if bc.path_length != 0:
+            return False
+
+        # Intermediate presence — the #280 failure mode is pathLen=0 +
+        # a mastio intermediate CA underneath (violates RFC 5280 §4.2.1.9).
+        mastio_cert_pem = await get_config("mastio_ca_cert")
+        if not mastio_cert_pem:
+            return False
+
+        return True
+
+    # ── Apply ─────────────────────────────────────────────────────────
+
+    async def up(self) -> None:
+        """Rotate Org CA, re-sign every agent leaf, snapshot for rollback.
+
+        Idempotent: if :meth:`check` would currently return False (state
+        already fixed or not applicable), returns without touching the
+        DB and without writing a backup. Expiry guard raises
+        ``RuntimeError`` rather than silently rotating a dead CA.
+        """
+        if not await self.check():
+            logger.info(
+                "org_ca_pathlen_1: up() called but check() returns False — "
+                "state already fixed or not applicable; no-op."
+            )
+            return
+
+        old_cert_pem = await get_config("org_ca_cert")
+        old_key_pem = await get_config("org_ca_key")
+        assert old_cert_pem is not None  # check() gated us
+        assert old_key_pem is not None
+
+        old_cert = x509.load_pem_x509_certificate(old_cert_pem.encode())
+        old_key = serialization.load_pem_private_key(
+            old_key_pem.encode(), password=None,
+        )
+
+        now = datetime.now(timezone.utc)
+        # Explicit expiry guard — a CA that's already dead has bigger
+        # problems than pathLen, and the rotate-ca flow (full re-enroll)
+        # is the correct recovery path.
+        try:
+            old_not_after = old_cert.not_valid_after_utc
+        except AttributeError:  # cryptography < 42 fallback
+            old_not_after = old_cert.not_valid_after.replace(
+                tzinfo=timezone.utc,
+            )
+        if old_not_after <= now:
+            raise RuntimeError(
+                f"org_ca_pathlen_1: cannot auto-rotate an expired Org CA "
+                f"(notAfter={old_not_after.isoformat()}). Use POST "
+                f"/pki/rotate-ca for full re-enrollment."
+            )
+
+        # Snapshot BEFORE writing anything — if anything fails after the
+        # snapshot write, rollback is still possible.
+        agents_rows = await _load_internal_agent_certs()
+        snapshot = {
+            "org_ca_cert_pem": old_cert_pem,
+            "org_ca_key_pem": old_key_pem,
+            "internal_agents": {
+                row["agent_id"]: row["cert_pem"] for row in agents_rows
+                if row["cert_pem"]
+            },
+        }
+        await insert_migration_backup(
+            migration_id=self.migration_id,
+            created_at=now.isoformat(),
+            snapshot_json=json.dumps(snapshot),
+        )
+
+        # Generate the new CA inline (not via the shared helper — we
+        # need a custom notAfter that mirrors the old CA's end-of-life,
+        # which the shared helper doesn't expose).
+        new_ca_key, new_ca_cert = _build_new_org_ca(
+            old_cert=old_cert,
+            now=now,
+        )
+
+        # Re-sign every leaf preserving pubkey / subject / extensions /
+        # validity. Serial is regenerated (stale-serial caches in
+        # verifier implementations would otherwise conflict).
+        new_leaves: dict[str, str] = {}
+        for row in agents_rows:
+            if not row["cert_pem"]:
+                continue
+            old_leaf = x509.load_pem_x509_certificate(
+                row["cert_pem"].encode(),
+            )
+            new_leaf = _resign_leaf(
+                old_leaf=old_leaf,
+                new_ca_cert=new_ca_cert,
+                new_ca_key=new_ca_key,
+            )
+            new_leaves[row["agent_id"]] = (
+                new_leaf.public_bytes(serialization.Encoding.PEM).decode()
+            )
+
+        new_ca_cert_pem = new_ca_cert.public_bytes(
+            serialization.Encoding.PEM,
+        ).decode()
+        new_ca_key_pem = new_ca_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ).decode()
+
+        # Commit. Two-phase wrt Vault is out of scope — a crash between
+        # writing proxy_config and writing internal_agents means the
+        # operator sees a mismatch at next boot and replays up(); the
+        # snapshot backup row from this run lets rollback() unwind if
+        # needed.
+        await set_config("org_ca_cert", new_ca_cert_pem)
+        await set_config("org_ca_key", new_ca_key_pem)
+        for agent_id, new_cert_pem in new_leaves.items():
+            await _update_internal_agent_cert(agent_id, new_cert_pem)
+
+        logger.info(
+            "org_ca_pathlen_1: rotated Org CA (new_serial=%s), re-signed "
+            "%d agent leaves; backup row stored.",
+            new_ca_cert.serial_number, len(new_leaves),
+        )
+
+    # ── Rollback ──────────────────────────────────────────────────────
+
+    async def rollback(self) -> None:
+        """Restore the pre-rotation CA + agent leaves from the backup.
+
+        Raises ``RuntimeError`` when no backup exists — the operator
+        needs to know that rollback is impossible without prior
+        :meth:`up`.
+        """
+        backup = await get_migration_backup(self.migration_id)
+        if backup is None:
+            raise RuntimeError(
+                f"org_ca_pathlen_1: no backup exists for "
+                f"{self.migration_id!r} — cannot rollback. A rotation "
+                f"must have run successfully before rollback is usable."
+            )
+
+        snapshot = json.loads(backup["snapshot_json"])
+
+        await set_config("org_ca_cert", snapshot["org_ca_cert_pem"])
+        await set_config("org_ca_key", snapshot["org_ca_key_pem"])
+        for agent_id, old_cert_pem in snapshot["internal_agents"].items():
+            await _update_internal_agent_cert(agent_id, old_cert_pem)
+
+        # Clear the backup row so a second rollback fails loudly (the
+        # state has already been restored, a second restore would be a
+        # no-op over data that may have moved on in the meantime).
+        await delete_migration_backup(self.migration_id)
+
+        logger.info(
+            "org_ca_pathlen_1: rolled back Org CA + %d agent leaves from "
+            "backup taken at %s.",
+            len(snapshot["internal_agents"]), backup["created_at"],
+        )
+
+
+# ── Module-level helpers ──────────────────────────────────────────────
+
+
+def _generate_serial() -> int:
+    """Positive 128-bit integer per RFC 5280 §4.1.2.2 guidance."""
+    return int.from_bytes(os.urandom(16), "big")
+
+
+def _build_new_org_ca(
+    *,
+    old_cert: x509.Certificate,
+    now: datetime,
+) -> tuple[rsa.RSAPrivateKey, x509.Certificate]:
+    """Build the replacement Org CA with pathLen=1, inheriting end-of-life.
+
+    Matches the conventions of ``generate_org_ca`` in
+    ``mcp_proxy/dashboard/router.py`` (RSA-4096, SHA-256,
+    subject=issuer=old subject, same KeyUsage) except for:
+      - ``notAfter`` inherited from the old CA (preserve renewal cadence).
+      - explicit pathLen=1.
+      - new keypair.
+    """
+    new_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    subject = old_cert.subject
+    try:
+        old_not_after = old_cert.not_valid_after_utc
+    except AttributeError:
+        old_not_after = old_cert.not_valid_after.replace(tzinfo=timezone.utc)
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)  # self-signed root
+        .public_key(new_key.public_key())
+        .serial_number(_generate_serial())
+        .not_valid_before(now - timedelta(minutes=_CA_NEW_SKEW_MINUTES))
+        .not_valid_after(old_not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=1),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(new_key.public_key()),
+            critical=False,
+        )
+    )
+    new_cert = builder.sign(new_key, hashes.SHA256())
+    return new_key, new_cert
+
+
+def _resign_leaf(
+    *,
+    old_leaf: x509.Certificate,
+    new_ca_cert: x509.Certificate,
+    new_ca_key: rsa.RSAPrivateKey,
+) -> x509.Certificate:
+    """Re-issue a leaf preserving every operator-visible field.
+
+    Changed: issuer (= new CA subject), AuthorityKeyIdentifier (points
+    to new CA), serial (new 128-bit), signature. Preserved: subject,
+    pubkey, notBefore / notAfter, all other extensions including SAN,
+    KeyUsage, EKU, SubjectKeyIdentifier, anything custom.
+    """
+    try:
+        old_not_before = old_leaf.not_valid_before_utc
+        old_not_after = old_leaf.not_valid_after_utc
+    except AttributeError:
+        old_not_before = old_leaf.not_valid_before.replace(tzinfo=timezone.utc)
+        old_not_after = old_leaf.not_valid_after.replace(tzinfo=timezone.utc)
+
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(old_leaf.subject)
+        .issuer_name(new_ca_cert.subject)
+        .public_key(old_leaf.public_key())
+        .serial_number(_generate_serial())
+        .not_valid_before(old_not_before)
+        .not_valid_after(old_not_after)
+    )
+
+    for ext in old_leaf.extensions:
+        if isinstance(ext.value, x509.AuthorityKeyIdentifier):
+            # Will be re-added below pointing at the new CA.
+            continue
+        builder = builder.add_extension(ext.value, critical=ext.critical)
+
+    builder = builder.add_extension(
+        x509.AuthorityKeyIdentifier.from_issuer_public_key(
+            new_ca_cert.public_key(),
+        ),
+        critical=False,
+    )
+
+    return builder.sign(new_ca_key, hashes.SHA256())
+
+
+async def _load_internal_agent_certs() -> list[dict]:
+    """Return every active agent's (agent_id, cert_pem) tuple."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT agent_id, cert_pem FROM internal_agents "
+                "WHERE is_active = 1 AND cert_pem IS NOT NULL "
+                "ORDER BY agent_id ASC"
+            )
+        )
+        return [dict(row) for row in result.mappings().all()]
+
+
+async def _update_internal_agent_cert(
+    agent_id: str, cert_pem: str,
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "UPDATE internal_agents SET cert_pem = :cert "
+                "WHERE agent_id = :aid"
+            ),
+            {"cert": cert_pem, "aid": agent_id},
+        )

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -67,7 +67,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0019_pending_updates",)]
+    assert rows == [("0020_migration_state_backups",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0019_pending_updates",)]
+    assert version == [("0020_migration_state_backups",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0019_pending_updates"
+HEAD_REVISION = "0020_migration_state_backups"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0019_pending_updates"
+HEAD_REVISION = "0020_migration_state_backups"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0019_pending_updates"
+HEAD_REVISION = "0020_migration_state_backups"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 

--- a/tests/test_updates_org_ca_pathlen_fix.py
+++ b/tests/test_updates_org_ca_pathlen_fix.py
@@ -1,0 +1,495 @@
+"""Tests for the first concrete federation update migration.
+
+Covers :class:`OrgCAPathLenFix` end-to-end:
+
+- ``check()`` returns True/False for every interesting state (pathLen,
+  intermediate presence, Org CA key presence).
+- ``up()`` preserves agent pubkeys, preserves validity, produces a
+  chain that ``Certificate.verify_directly_issued_by`` accepts (the
+  exact verifier that failed on the #280 legacy chain).
+- ``up()`` is idempotent on a no-op state, refuses to rotate an
+  expired CA, and writes a backup row.
+- ``rollback()`` restores the pre-rotation state and raises when no
+  backup exists.
+
+Each test builds its own legacy / current state via fixtures, so the
+entire Alembic chain runs (0001 → 0020) against a throwaway SQLite file.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from sqlalchemy import text
+
+from mcp_proxy.db import (
+    dispose_db,
+    get_config,
+    get_db,
+    get_migration_backup,
+    init_db,
+    set_config,
+)
+from mcp_proxy.updates.migrations.org_ca_pathlen_1_20260423 import (
+    OrgCAPathLenFix,
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+
+
+def _build_legacy_org_ca(
+    *,
+    path_length: int = 0,
+    not_after_delta_days: int = 3650,
+) -> tuple[x509.Certificate, rsa.RSAPrivateKey]:
+    """Build an Org CA matching the pre-#284 broken shape.
+
+    Default ``path_length=0`` reproduces the bug. ``not_after_delta_days``
+    is the offset from now; negative values produce an already-expired
+    CA for the expiry-guard test (``not_valid_before`` is adjusted
+    backwards so the builder's
+    ``not_valid_before <= not_valid_after`` invariant holds).
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test-org CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "test-org"),
+    ])
+    now = datetime.now(timezone.utc)
+    not_after = now + timedelta(days=not_after_delta_days)
+    # Place ``not_valid_before`` a year before ``not_valid_after`` so the
+    # builder accepts even expired fixtures (expired-CA test case).
+    not_before = not_after - timedelta(days=365)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=path_length),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=True, crl_sign=True,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return cert, key
+
+
+def _build_intermediate_ca(
+    *, org_ca_cert: x509.Certificate, org_ca_key: rsa.RSAPrivateKey,
+) -> x509.Certificate:
+    """Build a Mastio-style intermediate CA under the Org CA."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "mastio intermediate"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "test-org"),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(org_ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=1825))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=0),
+            critical=True,
+        )
+        .sign(org_ca_key, hashes.SHA256())
+    )
+    return cert
+
+
+def _build_leaf(
+    *,
+    org_ca_cert: x509.Certificate,
+    org_ca_key: rsa.RSAPrivateKey,
+    agent_id: str,
+) -> tuple[x509.Certificate, rsa.RSAPrivateKey]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "test-org"),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(org_ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(
+                    f"spiffe://test-org/{agent_id}"
+                ),
+            ]),
+            critical=False,
+        )
+        .sign(org_ca_key, hashes.SHA256())
+    )
+    return cert, key
+
+
+async def _seed_legacy_state(
+    *,
+    path_length: int = 0,
+    with_intermediate: bool = True,
+    with_ca_key: bool = True,
+    not_after_delta_days: int = 3650,
+    agent_ids: tuple[str, ...] = ("alpha", "beta"),
+) -> dict:
+    """Populate proxy_config + internal_agents to mimic a pre-#284 proxy.
+
+    Returns a dict with the cryptographic material the test may want to
+    compare against after ``up()``.
+    """
+    ca_cert, ca_key = _build_legacy_org_ca(
+        path_length=path_length,
+        not_after_delta_days=not_after_delta_days,
+    )
+    ca_cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+    ca_key_pem = ca_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+    await set_config("org_ca_cert", ca_cert_pem)
+    if with_ca_key:
+        await set_config("org_ca_key", ca_key_pem)
+
+    if with_intermediate:
+        intermediate = _build_intermediate_ca(
+            org_ca_cert=ca_cert, org_ca_key=ca_key,
+        )
+        await set_config(
+            "mastio_ca_cert",
+            intermediate.public_bytes(serialization.Encoding.PEM).decode(),
+        )
+
+    leaves: dict[str, x509.Certificate] = {}
+    async with get_db() as conn:
+        for aid in agent_ids:
+            leaf_cert, _ = _build_leaf(
+                org_ca_cert=ca_cert, org_ca_key=ca_key, agent_id=aid,
+            )
+            leaf_pem = leaf_cert.public_bytes(
+                serialization.Encoding.PEM,
+            ).decode()
+            leaves[aid] = leaf_cert
+            await conn.execute(
+                text(
+                    "INSERT INTO internal_agents "
+                    "(agent_id, display_name, capabilities, api_key_hash, "
+                    " cert_pem, created_at, is_active, enrollment_method) "
+                    "VALUES "
+                    "(:aid, :name, '[]', :hash, :cert, "
+                    " '2026-04-23T00:00:00+00:00', 1, 'connector')"
+                ),
+                {
+                    "aid": aid,
+                    "name": f"agent {aid}",
+                    "hash": "x" * 64,
+                    "cert": leaf_pem,
+                },
+            )
+
+    return {
+        "ca_cert": ca_cert,
+        "ca_key": ca_key,
+        "leaves": leaves,
+    }
+
+
+# ── check() branches ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_true_when_pathlen_zero_with_intermediate(fresh_db):
+    await _seed_legacy_state(path_length=0, with_intermediate=True)
+    assert await OrgCAPathLenFix().check() is True
+
+
+@pytest.mark.asyncio
+async def test_check_false_when_pathlen_one(fresh_db):
+    # Post-#284 fresh install — CA has pathLen=1, no auto-migration.
+    await _seed_legacy_state(path_length=1, with_intermediate=True)
+    assert await OrgCAPathLenFix().check() is False
+
+
+@pytest.mark.asyncio
+async def test_check_false_when_no_intermediate(fresh_db):
+    # pathLen=0 without an intermediate is a valid 2-tier deploy,
+    # no chain violation to repair.
+    await _seed_legacy_state(path_length=0, with_intermediate=False)
+    assert await OrgCAPathLenFix().check() is False
+
+
+@pytest.mark.asyncio
+async def test_check_false_when_no_org_ca_loaded(fresh_db):
+    # Fresh proxy (or attached-CA-pre-consume) — no Org CA cert yet.
+    assert await OrgCAPathLenFix().check() is False
+
+
+@pytest.mark.asyncio
+async def test_check_false_when_org_ca_key_missing(fresh_db):
+    # BYOCA with secret-manager-held privkey — not auto-migrable.
+    await _seed_legacy_state(
+        path_length=0, with_intermediate=True, with_ca_key=False,
+    )
+    assert await OrgCAPathLenFix().check() is False
+
+
+# ── up() ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_up_rotates_ca_to_pathlen_one(fresh_db):
+    await _seed_legacy_state(path_length=0, with_intermediate=True)
+    await OrgCAPathLenFix().up()
+
+    new_ca_pem = await get_config("org_ca_cert")
+    new_ca = x509.load_pem_x509_certificate(new_ca_pem.encode())
+    bc = new_ca.extensions.get_extension_for_class(
+        x509.BasicConstraints,
+    ).value
+    assert bc.ca is True
+    assert bc.path_length == 1
+
+
+@pytest.mark.asyncio
+async def test_up_preserves_agent_pubkeys(fresh_db):
+    seeded = await _seed_legacy_state(
+        path_length=0, with_intermediate=True,
+        agent_ids=("alpha", "beta", "gamma"),
+    )
+    old_pubkeys = {
+        aid: leaf.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        for aid, leaf in seeded["leaves"].items()
+    }
+
+    await OrgCAPathLenFix().up()
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT agent_id, cert_pem FROM internal_agents "
+                "WHERE is_active = 1"
+            )
+        )
+        rows = {row["agent_id"]: row["cert_pem"] for row in result.mappings()}
+
+    assert set(rows) == set(old_pubkeys)
+    for aid, new_pem in rows.items():
+        new_leaf = x509.load_pem_x509_certificate(new_pem.encode())
+        new_pub_der = new_leaf.public_key().public_bytes(
+            serialization.Encoding.DER,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        assert new_pub_der == old_pubkeys[aid], (
+            f"pubkey changed for {aid} — migration broke preservation"
+        )
+
+
+@pytest.mark.asyncio
+async def test_up_preserves_agent_validity(fresh_db):
+    seeded = await _seed_legacy_state(path_length=0, with_intermediate=True)
+    old_validity = {
+        aid: (leaf.not_valid_before_utc, leaf.not_valid_after_utc)
+        for aid, leaf in seeded["leaves"].items()
+    }
+
+    await OrgCAPathLenFix().up()
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT agent_id, cert_pem FROM internal_agents")
+        )
+        rows = {row["agent_id"]: row["cert_pem"] for row in result.mappings()}
+
+    for aid, new_pem in rows.items():
+        new_leaf = x509.load_pem_x509_certificate(new_pem.encode())
+        assert new_leaf.not_valid_before_utc == old_validity[aid][0]
+        assert new_leaf.not_valid_after_utc == old_validity[aid][1]
+
+
+@pytest.mark.asyncio
+async def test_up_chain_verifies_with_stdlib(fresh_db):
+    """Post-migration, each leaf is directly issued by the new Org CA.
+
+    Uses ``Certificate.verify_directly_issued_by`` — the exact
+    cryptography-lib verifier that rejected the pre-#284 chain in the
+    original bug #280 reproducer.
+    """
+    await _seed_legacy_state(path_length=0, with_intermediate=True)
+    await OrgCAPathLenFix().up()
+
+    new_ca = x509.load_pem_x509_certificate(
+        (await get_config("org_ca_cert")).encode(),
+    )
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT cert_pem FROM internal_agents")
+        )
+        leaves = [
+            x509.load_pem_x509_certificate(row["cert_pem"].encode())
+            for row in result.mappings()
+        ]
+
+    for leaf in leaves:
+        # Raises on verification failure; stateless assertion.
+        leaf.verify_directly_issued_by(new_ca)
+
+
+@pytest.mark.asyncio
+async def test_up_idempotent_on_already_fixed_state(fresh_db):
+    # First apply: rotates.
+    await _seed_legacy_state(path_length=0, with_intermediate=True)
+    await OrgCAPathLenFix().up()
+
+    after_first = await get_config("org_ca_cert")
+
+    # Second apply: check() returns False (pathLen=1 now), up() no-ops.
+    await OrgCAPathLenFix().up()
+
+    after_second = await get_config("org_ca_cert")
+    assert after_first == after_second
+
+
+@pytest.mark.asyncio
+async def test_up_refuses_expired_ca(fresh_db):
+    # notAfter in the past by a minute → guard must fire.
+    await _seed_legacy_state(
+        path_length=0, with_intermediate=True,
+        not_after_delta_days=-1,  # 1 day in the past — comfortably expired
+    )
+    # ``check()`` might still return True (pathLen==0 doesn't know about
+    # expiry), but ``up()`` must refuse.
+    with pytest.raises(RuntimeError, match="expired Org CA"):
+        await OrgCAPathLenFix().up()
+
+
+@pytest.mark.asyncio
+async def test_up_accepts_near_expiry_ca(fresh_db):
+    # notAfter in the future — no guard, rotation proceeds.
+    await _seed_legacy_state(
+        path_length=0, with_intermediate=True,
+        not_after_delta_days=1,  # 1 day remaining
+    )
+    await OrgCAPathLenFix().up()
+    new_ca_pem = await get_config("org_ca_cert")
+    new_ca = x509.load_pem_x509_certificate(new_ca_pem.encode())
+    assert new_ca.extensions.get_extension_for_class(
+        x509.BasicConstraints,
+    ).value.path_length == 1
+
+
+@pytest.mark.asyncio
+async def test_up_writes_snapshot_to_backup_table(fresh_db):
+    seeded = await _seed_legacy_state(path_length=0, with_intermediate=True)
+    await OrgCAPathLenFix().up()
+
+    backup = await get_migration_backup("2026-04-23-org-ca-pathlen-1")
+    assert backup is not None
+
+    import json
+    snap = json.loads(backup["snapshot_json"])
+    assert "org_ca_cert_pem" in snap
+    assert "org_ca_key_pem" in snap
+    assert set(snap["internal_agents"]) == set(seeded["leaves"])
+
+
+# ── rollback() ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rollback_restores_original_state(fresh_db):
+    seeded = await _seed_legacy_state(path_length=0, with_intermediate=True)
+    old_ca_pem = (
+        seeded["ca_cert"].public_bytes(serialization.Encoding.PEM).decode()
+    )
+
+    await OrgCAPathLenFix().up()
+    # Confirm we actually rotated (new cert differs from old).
+    rotated_pem = await get_config("org_ca_cert")
+    assert rotated_pem != old_ca_pem
+
+    await OrgCAPathLenFix().rollback()
+
+    restored_pem = await get_config("org_ca_cert")
+    assert restored_pem == old_ca_pem
+
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT agent_id, cert_pem FROM internal_agents")
+        )
+        restored_leaves = {
+            row["agent_id"]: row["cert_pem"] for row in result.mappings()
+        }
+
+    for aid, cert in seeded["leaves"].items():
+        expected_pem = cert.public_bytes(
+            serialization.Encoding.PEM,
+        ).decode()
+        assert restored_leaves[aid] == expected_pem
+
+
+@pytest.mark.asyncio
+async def test_rollback_raises_when_no_backup(fresh_db):
+    # No up() call → no backup row → rollback must raise.
+    with pytest.raises(RuntimeError, match="no backup exists"):
+        await OrgCAPathLenFix().rollback()
+
+
+@pytest.mark.asyncio
+async def test_rollback_second_call_raises(fresh_db):
+    # First rollback succeeds; second must fail because the backup row
+    # is gone.
+    await _seed_legacy_state(path_length=0, with_intermediate=True)
+    await OrgCAPathLenFix().up()
+    await OrgCAPathLenFix().rollback()
+    with pytest.raises(RuntimeError, match="no backup exists"):
+        await OrgCAPathLenFix().rollback()


### PR DESCRIPTION
## Summary

PR 3 of 5 for the federation update framework (``imp/federation_hardening_plan.md`` Parte 1). Registers the first concrete ``Migration`` in the registry built by PR 1/PR 2: an automatic, idempotent repair of the Org CA ``pathLen=0`` bug that PR #284 fixed in code but left unrepaired on already-deployed proxies.

## Context

- PR #284 repaired the generator that emitted ``BasicConstraints(ca=True, pathLen=0)``.
- Proxies already deployed with the broken CA stay broken after a ``git pull`` — the cert sits in ``proxy_config.org_ca_cert``, untouched.
- #285 detects the broken state (warn + Prometheus gauge) but does not repair it.
- This migration closes the gap: auto-rotate the Org CA to ``pathLen=1``, preserving every agent's public key so no re-enrollment is needed.

## Scope

```
mcp_proxy/alembic/versions/0020_migration_state_backups.py   snapshot table for rollback
mcp_proxy/db.py                                              3 CRUD helpers (insert/get/delete)
mcp_proxy/updates/migrations/org_ca_pathlen_1_20260423.py   OrgCAPathLenFix concrete
tests/test_updates_org_ca_pathlen_fix.py                     16 tests
tests/test_proxy_migrations*.py                              HEAD_REVISION bump (4 files)
```

## Design decisions

| Decision | Choice | Why |
|---|---|---|
| State backup | Dedicated table ``migration_state_backups`` | Keeps ``pending_updates`` lean; snapshot_json opaque per-migration |
| Backup PK | ``migration_id`` only | Apply overwrites — admin drove fresh apply, acknowledged reset |
| Leaf re-sign | Preserve subject/pubkey/validity/SAN/KU | Operator-visible fields unchanged |
| Leaf serial | New 128-bit ``os.urandom(16)`` | RFC 5280 §4.1.2.2 + avoids stale-cache verifier conflicts |
| CA keypair | New RSA-4096 | Fresh — doesn't carry the bug key |
| CA ``notAfter`` | Inherit from old CA | Preserves renewal calendar |
| Expired CA | Refuse with RuntimeError | Rotate-ca flow is the correct recovery path |
| ``affects_enrollments`` | ``(\"connector\",)`` only | BYOCA = org owns privkey, not auto-migrable — tracked as #298 |

## Contract behaviours

- ``check()`` returns False on any unfixable state (no CA, pathLen≥1, no intermediate, no key) — the boot detector logs nothing, the migration stays dormant.
- ``up()`` is idempotent: re-applied on a fixed state, ``check()`` returns False → no-op, no backup written.
- ``up()`` writes the snapshot BEFORE mutating state; a crash mid-apply leaves rollback still usable.
- ``rollback()`` raises ``RuntimeError`` when no backup exists; deletes the backup row on success so a second rollback fails loudly (state has already moved).

## Verifiche locali

- ``pytest tests/ -n auto --dist=loadfile``: 1813 PASS, 31 skipped (6 pre-existing on ``main``: 4 connector profile-runtime-switch + 2 postgres-integration).
- ``./demo_network/smoke.sh full``: PASS.
- DCO signoff present.

## Test plan

- [x] ``check()`` True when pathLen=0 + intermediate + org_ca_key present.
- [x] ``check()`` False for pathLen=1 (post-#284), no intermediate, no CA loaded, no CA key (BYOCA).
- [x] ``up()`` rotates to pathLen=1.
- [x] Every agent's pubkey preserved across ``up()`` (DER byte-compare).
- [x] Every agent's validity window preserved (notBefore + notAfter identical).
- [x] Chain verifies via ``Certificate.verify_directly_issued_by`` — the exact cryptography-lib verifier that rejected the #280 chain.
- [x] ``up()`` idempotent on already-fixed state.
- [x] ``up()`` refuses expired CA with RuntimeError.
- [x] ``up()`` accepts near-expiry CA (skew sanity).
- [x] Snapshot written to backup table.
- [x] ``rollback()`` restores Org CA + agent leaves.
- [x] ``rollback()`` raises when no backup exists.
- [x] Second ``rollback()`` raises (backup row deleted on first success).

## Out of scope (tracked)

- Admin endpoint ``/admin/updates/{id}/apply`` → PR 4.
- Dashboard UI → PR 5.
- BYOCA variant → #298.
- Enterprise discovery path → #293.

## References

- Plan: ``imp/federation_hardening_plan.md`` Parte 1
- PR 1: #294 (merged), PR 2: #295 (merged)
- Origin bug: #280 (closed via PR #284)
- Detection: #285 (closed via PR #290)
- Follow-ups: #298 (BYOCA variant), #293 (enterprise discovery)