### PR TITLE
feat(connector): challenge-response login for device-code Connectors

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -347,20 +347,19 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
 
     # Build the CullisClient from the on-disk enrollment bundle.
     #
-    # The Phase 1 ``connect`` tool went away with enrollment but the
-    # wiring was never completed: every tool reached for a client that
-    # nobody constructed. We build it here and load the signing key so
-    # ``send_oneshot`` (API-key + DPoP + inner/outer signatures, no
-    # broker JWT) works out of the box.
+    # ``from_connector`` loads ``identity/agent.key`` + ``identity/agent.crt``
+    # eagerly so send_oneshot (API-key + DPoP + inner/outer signatures)
+    # and session tools (broker JWT via challenge-response login) both
+    # work out of the box.
     #
-    # We deliberately *do not* call ``login_via_proxy()`` eagerly:
-    # it asks the Mastio to sign a client_assertion with the agent's
-    # private key, but device-code enrollment leaves that key on the
-    # user's machine, not on the Mastio — so the call 404s with
-    # "agent credentials not available on proxy". Session-based tools
-    # mint the token lazily via ``ensure_broker_token`` and surface a
-    # clear error if it can't be obtained; one-shot tools don't need
-    # a token at all.
+    # Tech-debt #2 closed: we now call ``login_via_proxy_with_local_key``
+    # eagerly. The Mastio issues a short-lived nonce, the Connector
+    # signs the client_assertion locally (the key never leaves this
+    # machine), and the Mastio verifies + counter-signs. Previously
+    # this step was skipped because the legacy ``login_via_proxy`` path
+    # asks the Mastio to sign on our behalf — which 404s when the key
+    # lives on-device. Failure here is non-fatal: one-shot tools work
+    # without a broker JWT, and ``_require_client`` retries lazily.
     try:
         from cullis_sdk import CullisClient
 
@@ -369,10 +368,18 @@ def _cmd_serve(cfg: ConnectorConfig) -> int:
         # (canonical_recipient, etc.) can derive the sender's org from
         # the cert subject without reaching into process-global state.
         client.identity = identity
-        key_path = cfg.config_dir / "identity" / "agent.key"
-        if key_path.exists():
-            client._signing_key_pem = key_path.read_text()
         state.client = client
+
+        try:
+            client.login_via_proxy_with_local_key()
+            _log.info("broker JWT obtained via challenge-response login")
+        except Exception as login_exc:  # noqa: BLE001
+            _log.warning(
+                "eager login_via_proxy_with_local_key failed: %s. "
+                "Session tools will retry lazily; send_oneshot works "
+                "regardless.",
+                login_exc,
+            )
     except Exception as exc:
         _log.error(
             "Failed to initialize CullisClient from %s: %s. "

--- a/cullis_connector/tools/session.py
+++ b/cullis_connector/tools/session.py
@@ -17,12 +17,12 @@ _log = get_logger("tools.session")
 def _require_client():
     """Return a client with a valid broker JWT, minting one if absent.
 
-    Device-code enrollment leaves the agent private key on the user's
-    machine, so ``login_via_proxy()`` 404s ("agent credentials not
-    available on proxy") when the Mastio tries to sign the assertion
-    on the agent's behalf. We still call it because BYOCA/Mastio-held-key
-    deployments work fine and we don't want to hard-code that split;
-    callers see the same user-visible error regardless.
+    Uses the challenge-response login (tech-debt #2): the Connector
+    signs the client_assertion locally with its on-device key, the
+    Mastio counter-signs. Works regardless of whether enrollment was
+    device-code (key on user's machine) or BYOCA (key on Mastio) — the
+    Connector always holds a local copy for intra-/cross-org signing
+    anyway.
     """
     state = get_state()
     if state.client is None:
@@ -32,14 +32,12 @@ def _require_client():
         )
     if state.client.token is None:
         try:
-            state.client.login_via_proxy()
+            state.client.login_via_proxy_with_local_key()
         except Exception as exc:  # noqa: BLE001
-            _log.warning("lazy login_via_proxy failed: %s", exc)
+            _log.warning("lazy login_via_proxy_with_local_key failed: %s", exc)
             raise RuntimeError(
-                f"Session tools require a broker JWT, but login_via_proxy failed: "
-                f"{exc}. If you enrolled via the dashboard (device-code), the "
-                f"Mastio doesn't hold your private key so this path 404s — use "
-                f"send_oneshot for fire-and-forget messages instead."
+                f"Session tools require a broker JWT, but login failed: "
+                f"{exc}. send_oneshot still works for fire-and-forget messages."
             ) from exc
     return state.client
 

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -189,9 +189,8 @@ def _start_inbox_poller(config: ConnectorConfig) -> DashboardInboxPoller | None:
 
         client = CullisClient.from_connector(config.config_dir)
         client.identity = identity
-        key_path = config.config_dir / "identity" / "agent.key"
-        if key_path.exists():
-            client._signing_key_pem = key_path.read_text()
+        # ``from_connector`` now loads ``identity/agent.key`` itself —
+        # no need to re-read here.
     except Exception as exc:  # noqa: BLE001
         _log.warning("inbox poller bootstrap failed: %s", exc)
         return None

--- a/cullis_sdk/auth.py
+++ b/cullis_sdk/auth.py
@@ -87,6 +87,8 @@ def build_client_assertion(
     agent_id: str,
     cert_pem: str,
     key_pem: str,
+    *,
+    nonce: str | None = None,
 ) -> tuple[str, str]:
     """
     Build an x509 client assertion JWT for /v1/auth/token.
@@ -95,6 +97,10 @@ def build_client_assertion(
         agent_id: The agent's identifier (e.g. "org::agent").
         cert_pem: PEM-encoded agent certificate.
         key_pem: PEM-encoded agent private key.
+        nonce: Optional server-issued challenge nonce — when present,
+            it's embedded as a ``nonce`` claim so the JWT signature
+            covers it. Used by the challenge-response login flow
+            (tech-debt #2) to tie the assertion to a fresh challenge.
 
     Returns:
         (assertion_jwt, jwt_algorithm) tuple.
@@ -123,6 +129,8 @@ def build_client_assertion(
         "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
         "jti": str(uuid.uuid4()),
     }
+    if nonce is not None:
+        payload["nonce"] = nonce
 
     # Detect key type for JWT algorithm selection
     key_bytes = key_pem.encode() if isinstance(key_pem, str) else key_pem

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -776,7 +776,17 @@ class CullisClient:
         instance._http = httpx.Client(timeout=timeout, verify=verify_tls)
         instance.token = None
         instance._label = agent_id
-        instance._signing_key_pem = None
+        # Load the on-disk signing key + cert eagerly so ``decrypt_oneshot``,
+        # ``send_oneshot``, and ``login_via_proxy_with_local_key`` all
+        # work out of the box without every caller having to read
+        # ``identity/agent.key`` + ``identity/agent.crt`` themselves.
+        # Absent key/cert (legacy layout or a Connector that never
+        # completed enrollment) is not fatal — tools that need them
+        # surface a clear error at call time.
+        key_path = identity_dir / "agent.key"
+        cert_path = identity_dir / "agent.crt"
+        instance._signing_key_pem = key_path.read_text() if key_path.exists() else None
+        instance._cert_pem = cert_path.read_text() if cert_path.exists() else None
         instance._pubkey_cache = {}
         instance._client_seq = {}
         instance._dpop_privkey = None
@@ -1037,6 +1047,123 @@ class CullisClient:
         except httpx.HTTPStatusError as e:
             raise PermissionError(
                 f"[{agent_id}] login_via_proxy failed "
+                f"(HTTP {e.response.status_code}): {e.response.text}"
+            ) from e
+
+    def login_via_proxy_with_local_key(self) -> None:
+        """Tech-debt #2 — authenticate an enrolled agent to the broker
+        using a client_assertion signed **locally** with the on-device
+        private key.
+
+        Companion to :meth:`login_via_proxy`. That method has the Mastio
+        sign on the agent's behalf (requires the key to live server-side
+        in Vault / ``proxy_config``). Device-code-enrolled Connectors
+        hold the key on the user's machine — this method instead has
+        the proxy issue a short-lived nonce, the client signs the
+        assertion locally, and the proxy verifies + counter-signs it.
+
+        Flow:
+          1. ``POST /v1/auth/login-challenge`` → nonce + expires_in.
+          2. Build ``client_assertion`` with :func:`build_client_assertion`
+             using ``self._signing_key_pem``; embed the nonce as a claim.
+          3. ``POST /v1/auth/sign-challenged-assertion`` → echoed
+             assertion + optional ``mastio_signature`` (ADR-009 Phase 2).
+          4. ``POST /v1/auth/token`` with assertion + DPoP proof + the
+             mastio counter-sig header — identical to the legacy path
+             from this point on.
+
+        Requires :attr:`_proxy_api_key`, :attr:`_proxy_agent_id`,
+        :attr:`_signing_key_pem`, and :attr:`_cert_pem` to have been
+        populated via :meth:`from_connector` (or set manually). No
+        fallback to :meth:`login_via_proxy` — if the new endpoint is
+        absent the caller sees a clear error rather than a silent
+        downgrade.
+        """
+        api_key = getattr(self, "_proxy_api_key", None)
+        agent_id = getattr(self, "_proxy_agent_id", None)
+        if not api_key or not agent_id:
+            raise RuntimeError(
+                "login_via_proxy_with_local_key() requires proxy enrollment "
+                "— use CullisClient.from_connector() or from_enrollment() first",
+            )
+        if not self._signing_key_pem:
+            raise RuntimeError(
+                "login_via_proxy_with_local_key() requires a local signing "
+                "key — set CullisClient._signing_key_pem from identity/agent.key, "
+                "or use login_via_proxy() for Mastio-held keys.",
+            )
+        cert_pem = getattr(self, "_cert_pem", None)
+        if not cert_pem:
+            raise RuntimeError(
+                "login_via_proxy_with_local_key() requires the agent "
+                "certificate PEM — set CullisClient._cert_pem explicitly "
+                "or construct the client via from_connector() which loads "
+                "identity/agent.crt automatically.",
+            )
+
+        self._label = agent_id
+
+        try:
+            # Step 1 — fetch nonce.
+            ch_resp = self._http.post(
+                f"{self.base}/v1/auth/login-challenge",
+                headers={"X-API-Key": api_key},
+            )
+            ch_resp.raise_for_status()
+            self._update_nonce(ch_resp)
+            ch_body = ch_resp.json()
+            nonce = ch_body["nonce"]
+
+            # Step 2 — build + sign client_assertion locally.
+            from cullis_sdk.auth import build_client_assertion
+            assertion, _alg = build_client_assertion(
+                agent_id, cert_pem, self._signing_key_pem, nonce=nonce,
+            )
+
+            # Step 3 — ask Mastio to endorse it.
+            sign_resp = self._http.post(
+                f"{self.base}/v1/auth/sign-challenged-assertion",
+                headers={"X-API-Key": api_key},
+                json={"client_assertion": assertion, "nonce": nonce},
+            )
+            sign_resp.raise_for_status()
+            self._update_nonce(sign_resp)
+            sign_body = sign_resp.json()
+            # The endpoint echoes the assertion; use the echoed value so
+            # any future server-side transformation (none today) is
+            # honoured.
+            endorsed_assertion = sign_body["client_assertion"]
+
+            # Step 4 — exchange for a DPoP-bound access token (Court).
+            mastio_headers: dict[str, str] = {}
+            mastio_signature = sign_body.get("mastio_signature")
+            if mastio_signature:
+                mastio_headers["X-Cullis-Mastio-Signature"] = mastio_signature
+
+            self._dpop_privkey, self._dpop_pubkey_jwk = generate_dpop_keypair()
+            token_url = f"{self.base}/v1/auth/token"
+            dpop_proof = self._dpop_proof("POST", token_url, access_token=None)
+            resp = self._http.post(
+                token_url,
+                json={"client_assertion": endorsed_assertion},
+                headers={"DPoP": dpop_proof, **mastio_headers},
+            )
+            if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
+                self._update_nonce(resp)
+                dpop_proof = self._dpop_proof("POST", token_url, access_token=None)
+                resp = self._http.post(
+                    token_url,
+                    json={"client_assertion": endorsed_assertion},
+                    headers={"DPoP": dpop_proof, **mastio_headers},
+                )
+            resp.raise_for_status()
+            self._update_nonce(resp)
+            self.token = resp.json()["access_token"]
+        except (httpx.ConnectError, httpx.TimeoutException) as e:
+            raise ConnectionError(f"[{agent_id}] Proxy unreachable: {e}") from e
+        except httpx.HTTPStatusError as e:
+            raise PermissionError(
+                f"[{agent_id}] login_via_proxy_with_local_key failed "
                 f"(HTTP {e.response.status_code}): {e.response.text}"
             ) from e
 

--- a/imp/connector_login_challenge_response_design.md
+++ b/imp/connector_login_challenge_response_design.md
@@ -1,0 +1,246 @@
+# Challenge-response login for device-code Connectors — design
+
+Status: **Proposal — design review**
+Date: 2026-04-23
+Scope: Tech-debt #2 from `project_connector_tech_debt`.
+Author: Agent 2 (session, not merged).
+
+## Problem
+
+Device-code-enrolled Connectors hold the agent private key **locally**
+(`~/.cullis/identity/agent.key`). The existing `POST /v1/auth/sign-assertion`
+endpoint signs the client_assertion **server-side** using
+`AgentManager.get_agent_credentials(agent_id)`, which fetches the key
+from Vault or `proxy_config`. Device-code enrollment never deposits the
+key on the Mastio, so the lookup raises `ValueError` → 404
+`"agent credentials not available on proxy"`.
+
+Current Connector `cli._cmd_serve` sidesteps this by **not** calling
+`login_via_proxy` eagerly; `cullis_connector/tools/session.py::_require_client`
+tries it lazily and logs a warning when it fails. Net result: the
+Connector can only use `send_oneshot` (X-API-Key + DPoP + local inner/outer
+signatures, no broker JWT). `client.discover()`, `open_session()`, and
+cross-org federation lookups that require a broker JWT all fail.
+
+## Goal
+
+Give device-code Connectors a broker access token without depositing the
+agent private key on the Mastio — keep the key-stays-on-device invariant
+intact while enabling the full broker session surface.
+
+## Alternatives
+
+### A — New dedicated challenge-response endpoints (recommended)
+
+Two new endpoints, additive:
+
+```
+POST /v1/auth/login-challenge              → { nonce, expires_in, agent_id }
+POST /v1/auth/sign-challenged-assertion    → { client_assertion, agent_id, mastio_signature }
+```
+
+Separate from `/v1/auth/sign-assertion`. The legacy endpoint keeps its
+"Mastio signs for you" semantics for BYOCA/Vault-held-key agents;
+the new pair implements "client signs, Mastio endorses".
+
+- **Pro:** semantics stay pure — endpoint name and contract tell you
+  which entity holds the key. Zero risk of regressing the BYOCA path
+  that the sandbox agents rely on. Auditable: a 2-call flow is easy
+  to follow in logs.
+- **Con:** two new routes + a nonce store to add.
+
+### B — Polymorphic `/v1/auth/sign-assertion` with optional `client_assertion`
+
+Single endpoint that branches: if the body contains a client-signed
+`client_assertion`, verify+counter-sign; if absent, fall back to the
+legacy "sign on agent's behalf" path.
+
+- **Pro:** one endpoint, backward-compatible at the URL level.
+- **Con:** branching auth endpoint increases attack surface and makes
+  logs ambiguous (same path, different trust model). Reviewers have
+  to read both branches to understand any change. No challenge means
+  **no anti-replay** for the client-signed path unless the body is
+  made more complex — arguably worse than adding a separate endpoint.
+
+### C — Reuse `/v1/auth/sign-assertion` + challenge header
+
+Client posts to `/v1/auth/sign-assertion`, Mastio returns 401 with a
+`WWW-Authenticate: Challenge nonce="…"` header, client retries with the
+nonce baked into a JWT in the body.
+
+- Rejected: stateful 2-phase dance on a single route is fragile, the
+  WWW-Authenticate header semantics are for client-initiated challenges
+  not server-issued ones, and the replay window during retries is fuzzy.
+
+**Recommendation: Alternative A.** Justification in §7.
+
+## Flow (Alternative A)
+
+```
+Connector                                   Mastio (mcp_proxy)
+─────────                                   ──────────────────
+ 1. POST /v1/auth/login-challenge    ──►    generate nonce (32 rand bytes b64url)
+    headers: X-API-Key                      store login_challenge:{agent_id}:{nonce}
+                                            with TTL 120s, value "issued"
+                                     ◄──    { nonce, expires_in: 120,
+                                              agent_id: "<org>::<name>" }
+
+ 2. build client_assertion JWT              wait for step 3
+    signed locally with agent.key:
+    {
+      "iss": agent_id,
+      "sub": agent_id,
+      "aud": broker_url,
+      "iat": now,
+      "exp": now+180,
+      "jti": <uuid>,
+      "nonce": <b64url from step 1>,
+      "cnf": { "jkt": <dpop-jkt> }       (optional, ADR-012 parity)
+    }
+    header: x5c = [agent cert DER b64]
+
+ 3. POST /v1/auth/sign-challenged-assertion
+    headers: X-API-Key
+    body: { client_assertion, nonce }  ──►  (a) consume login_challenge:{agent_id}:{nonce}
+                                               atomic SET NX EX → DEL. If missing → 401.
+                                            (b) jwt.get_unverified_header → extract x5c cert.
+                                                Verify cert chain against Org CA
+                                                (reuse mcp_proxy.auth.x509_verifier).
+                                                Verify cert_pem == internal_agents.cert_pem
+                                                (certificate thumbprint pin).
+                                            (c) jwt.decode(assertion, cert_public_key, algorithms=["RS256","ES256"])
+                                                with verify_exp=True, leeway=30s.
+                                            (d) assert decoded["sub"] == agent.agent_id
+                                                assert decoded["nonce"] == nonce (anti-confused-deputy:
+                                                  forgets a nonce reuse would still have to
+                                                  pin sub to caller's X-API-Key).
+                                                assert decoded["exp"] - decoded["iat"] ≤ 300.
+                                            (e) mastio_signature = agent_manager.countersign(
+                                                    client_assertion.encode()
+                                                )  (reuses ADR-009 Phase 2 machinery)
+                                     ◄──    { client_assertion: <echo>,
+                                              agent_id,
+                                              mastio_signature }
+
+ 4. POST /v1/auth/token  (via reverse-proxy)
+    body: { client_assertion }
+    headers: DPoP <proof>,
+             X-Cullis-Mastio-Signature: <mastio_signature>
+                                     ──►    (unchanged — Court validates cert chain,
+                                             assertion signature, and the mastio
+                                             counter-sig against organizations.mastio_pubkey)
+                                     ◄──    { access_token }  ← DPoP-bound
+ 5. client.token = access_token
+```
+
+### Field choices
+
+| Element | Choice | Rationale |
+|---|---|---|
+| Nonce format | 32 random bytes → base64url (43 chars) | Same entropy budget as DPoP JTIs; opaque to client; fits in JWT claim. |
+| Nonce TTL | 120s | Covers round-trip + clock skew + slow human OAuth popup (none here but keep parity with DPoP iat window). Shorter than assertion exp (≤300s) so the nonce can't outlive the token it issued. |
+| Nonce store key | `login_challenge:{agent_id}:{nonce}` | Binds nonce to caller — a leaked nonce can't be reused by a different API-key holder, defence-in-depth on top of `sub == agent.agent_id` check. |
+| Nonce consume | Atomic `SET NX EX`, then `DEL` on first use | Same pattern as `DpopJtiStore.consume_jti`. Redis in prod, in-memory fallback. |
+| What client signs | Full client_assertion JWT with `nonce` claim | The nonce is IN the assertion so it's covered by the client signature — rebinding to a different nonce is a tamper the server catches. |
+| Algo | RS256 or ES256 (PyJWT auto-dispatch on key type) | Matches existing enrollment/cert types (dual-stack RSA/ECDSA). |
+| Server verify | `x5c` → cert → chain verify against Org CA → pin against `internal_agents.cert_pem` → decode JWT with cert's public key | Identical trust model to the broker-side verification at `/v1/auth/token`; Mastio is now a local mirror of that check before counter-sig. |
+| Counter-sign | `agent_manager.countersign(assertion.encode())` — ES256 on mastio leaf | Reuses ADR-009 Phase 2 primitive. No new crypto. |
+| Response body shape | Echo assertion + agent_id + mastio_signature | Same wire shape as `/v1/auth/sign-assertion` → SDK code path merges at step 4. |
+
+### Anti-replay guarantees
+
+1. **Nonce freshness**: nonce is single-use (consumed on first valid call). A replayed `/sign-challenged-assertion` call with the same nonce returns 401 before any crypto runs.
+2. **Nonce binding**: store key includes `agent_id` — a nonce issued for `agentA` cannot be redeemed by an attacker holding `agentB`'s API-key.
+3. **Assertion signature**: tampering with the nonce claim invalidates the client signature → JWT decode fails.
+4. **Assertion short exp**: `exp - iat ≤ 300` enforced server-side; stolen-in-transit assertions have a 5-minute window and the DPoP-bound token that results is further bound to a key the attacker doesn't have.
+5. **Cert pin**: `cert_pem == internal_agents.cert_pem` (thumbprint equivalent) prevents a valid cert chain from a rotated/unrelated cert sneaking in.
+
+## File tree
+
+### Mastio (new + modified)
+
+- **New** `mcp_proxy/auth/challenge_store.py` (~80 LOC) — `ChallengeStore` Protocol + `InMemoryChallengeStore` + `RedisChallengeStore`. Mirrors `dpop_jti_store.py` exactly. `issue_challenge(agent_id) → nonce`, `consume_challenge(agent_id, nonce) → bool`.
+- **New** `mcp_proxy/auth/challenge_response.py` (~150 LOC) — `POST /v1/auth/login-challenge` + `POST /v1/auth/sign-challenged-assertion` handlers. Auth via `Depends(get_agent_from_api_key)` (same dep sign-assertion uses).
+- **Modified** `mcp_proxy/main.py` — `include_router(challenge_response.router)` next to the existing `sign_assertion_router` wiring.
+
+### SDK (modified)
+
+- **Modified** `cullis_sdk/client.py`:
+  - New method `login_via_proxy_with_local_key(self) -> None` (~80 LOC). Reads `self._signing_key_pem` (already populated by `from_connector` + `cli._cmd_serve`). Posts challenge → builds client_assertion locally (uses `cullis_sdk.auth.build_client_assertion` with cert + key) → posts sign-challenged-assertion → forwards to `/v1/auth/token` exactly like `login_via_proxy` does today.
+  - Existing `login_via_proxy(self)` untouched — BYOCA/Vault-held agents keep their path.
+- **No change** to `cullis_sdk/auth.py` (`build_client_assertion` already exists and is the same helper the Mastio imports at line 23 of `sign_assertion.py`).
+
+### Connector (modified)
+
+- **Modified** `cullis_connector/cli.py::_cmd_serve`:
+  - Remove the "We deliberately *do not* call login_via_proxy eagerly" block + comment.
+  - After `client.identity = identity` and signing-key load: `client.login_via_proxy_with_local_key()`. Wrap in try/except with the existing diagnostic pattern; non-fatal (falls through to lazy path).
+- **Modified** `cullis_connector/tools/session.py::_require_client`:
+  - Replace `state.client.login_via_proxy()` with `state.client.login_via_proxy_with_local_key()`.
+  - Drop the "device-code 404s, use send_oneshot instead" diagnostic message — with the fix, device-code works.
+
+### Tests
+
+- **New** `tests/test_proxy_challenge_response.py` — endpoint tests:
+  - happy path (200, mastio_signature present when ADR-009 loaded, absent when legacy)
+  - replay: second call with same nonce → 401
+  - expired nonce → 401
+  - nonce bound to different agent: issued for A, consumed by B → 401
+  - cert chain fail (assertion x5c not signed by Org CA) → 401
+  - cert pin fail (assertion x5c ≠ internal_agents.cert_pem) → 401
+  - `sub` claim ≠ X-API-Key's agent_id → 401
+  - missing nonce claim in assertion → 400
+  - assertion exp > iat + 300 → 400
+  - unauthenticated (no X-API-Key) → 401
+- **New** `tests/test_sdk_login_via_proxy_with_local_key.py`:
+  - happy path (mock proxy responses for both hops + mock Court `/v1/auth/token`)
+  - challenge endpoint 404 → `PermissionError` (no silent fallback — see §Risks)
+  - sign endpoint 401 → `PermissionError` with status surfaced
+  - no local signing key → `RuntimeError("requires local signing key")`
+- **New** `tests/connector/test_cli_eager_login.py`:
+  - `_cmd_serve` calls `login_via_proxy_with_local_key` exactly once
+  - failure is non-fatal (serve continues, lazy path remains for session tools)
+- **Sandbox dogfood**: extend `sandbox/demo.sh` scenarios with `session-a-to-b` (open_session + send + close) that requires a broker JWT. Today the sandbox agents use direct Court login with local certs (bypass of device-code issue), so this scenario should be wired to exercise the new path via a simulated-device-code agent. If wiring the sandbox to the Connector is too large (likely — Connector isn't in the sandbox today), defer the sandbox scenario and land unit + integration tests only.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Nonce store unbounded in memory backend | TTL 120s + automatic expiry; single-worker mode only (prod uses Redis). Add a periodic sweep task guarded by `asyncio.Lock` (copy from `dpop_jti_store.py`). |
+| Downgrade attack (MITM forces client to legacy `sign-assertion`) | Connector always calls `login_via_proxy_with_local_key`. No fallback to legacy. `login_via_proxy()` and `login_via_proxy_with_local_key()` are **separate methods**; choosing is a client-side config decision made at construction, not a runtime negotiation. |
+| Clock skew between Connector and Mastio | 30s leeway on assertion `exp` + `iat`. Matches existing `/v1/auth/token` leeway on the Court side. |
+| Agents with BOTH local key + Mastio-held key (hybrid) | Legitimate ambiguity — pick one explicitly. Documented: `login_via_proxy_with_local_key` uses `self._signing_key_pem`; `login_via_proxy` uses Mastio-held Vault key. Caller picks. No auto-detect. |
+| Rotated cert / key mismatch | Cert pin vs `internal_agents.cert_pem` catches this. Rotation flow (when implemented) updates the row first, then the Connector re-enrolls. |
+| Observability — someone fails login in CI and diagnostics are thin | Log at `_log.info` on each step transition, WARNING on 401, with enough detail to distinguish replay/expired/pin/cert-chain failures. Audit row on every success + every denied attempt (reuse `log_audit`). |
+| Rate-limit bypass via login spam | Inherits from `get_agent_from_api_key` → `rate_limit_per_minute` global bucket. Per-route override not added (consistent with `/v1/auth/sign-assertion`). |
+| BYOCA / Vault-held-key regression | Legacy path untouched. Existing `tests/test_proxy_sign_assertion*` should pass unchanged — CI gate. |
+| Performance (2 round-trips vs 1) | ~20-40ms per hop on local network → ~60-80ms total login. Login happens once at serve bootstrap + on 401 refresh. Not in the request hot path. |
+
+## Deferral / scope cuts
+
+Out of this implementation — follow-ups:
+
+- **mTLS hybrid binding (RFC 8705)**: would bind the resulting access token to a client cert thumbprint on top of DPoP. Orthogonal to challenge-response; separate audit item.
+- **Hardware token support** (TPM/YubiKey holding the private key): the flow is already compatible (the Connector abstracts key storage via `agent.key` file), but plumbing a PKCS#11 backend is its own project.
+- **Per-route rate-limit for `/v1/auth/login-challenge`**: inherits global bucket; if enumeration probes become an issue, add a separate bucket later (pattern from #289).
+- **Nonce-per-DPoP-jkt binding**: could strengthen the flow by having the client send its DPoP thumbprint in the challenge request and bind the nonce to it. Good hardening but adds complexity and isn't strictly required with per-agent binding. Defer.
+- **Challenge endpoint on the Court side** (so agents could log in directly to the Court without a Mastio): not needed — ADR-004 pins "agents always go through proxy" and this design keeps that invariant.
+- **Signed response from Mastio to client on challenge**: currently the challenge response is unsigned JSON (only integrity-protected by TLS). A malicious proxy replacing the nonce mid-flight would cause the client to sign an attacker-chosen nonce, but the `consume_challenge` step still gates redemption by `agent_id` — the attacker gains nothing except a signed-over-nonce artifact they can't spend. If we want defence-in-depth for untrusted-transport deployments (none today), sign the challenge response with the mastio leaf. Defer.
+
+## Recommendation
+
+**Alternative A** — dedicated `/v1/auth/login-challenge` + `/v1/auth/sign-challenged-assertion` pair.
+
+Why:
+
+1. **Semantic clarity wins.** `sign-assertion` means "server signs on your behalf"; `sign-challenged-assertion` means "server verifies + endorses what you signed". Different trust models deserve different endpoints. A future reader of the auth code gets this in five seconds.
+
+2. **Zero risk to the existing BYOCA path.** The sandbox agents, enterprise deployments with Vault-held keys, and every test in `tests/test_proxy_sign_assertion*` exercise the legacy endpoint. Touching it to add polymorphism (Alternative B) has a non-zero chance of regressing that surface — and login is the last place we want a stealth regression.
+
+3. **Anti-replay is built-in.** The challenge step exists specifically to make replay detection cheap and explicit. Retrofitting Alternative B to have equivalent anti-replay guarantees means adding a nonce claim anyway — at which point it's just Alternative A with a confusing URL.
+
+4. **Auditability.** Two log lines per login (challenge issued, assertion endorsed) is easier to triage than one polymorphic line. This matters once a customer rings asking "did my Connector actually log in at 14:02:38 UTC or did the attacker?".
+
+Scope estimate: ~500 LOC production + ~400 LOC tests, 1-2 days including sandbox scenario integration. Alternative B would be ~300 LOC but I judge the semantic and review cost of the polymorphic endpoint to exceed the LOC savings.
+
+Next step on approval: open PR with `feat/connector-login-challenge-response` branch, landing endpoint + SDK + Connector together (three-part atomic PR, same pattern as #292).

--- a/mcp_proxy/auth/challenge_response.py
+++ b/mcp_proxy/auth/challenge_response.py
@@ -1,0 +1,401 @@
+"""Tech-debt #2 — challenge-response login for device-code Connectors.
+
+Companion to :mod:`mcp_proxy.auth.sign_assertion`. The legacy path signs
+a ``client_assertion`` **on the agent's behalf** using the private key
+stored in Vault / ``proxy_config`` — which only works when the key
+actually lives on the proxy (BYOCA / Vault-held-key enrollments).
+Device-code Connectors hold the key on the user's machine and get a
+404 ``agent credentials not available on proxy``.
+
+This module adds two endpoints for the client-holds-the-key case:
+
+  POST /v1/auth/login-challenge           → issue a nonce
+  POST /v1/auth/sign-challenged-assertion → verify a client-signed
+                                             assertion + counter-sign
+
+Flow (see imp/connector_login_challenge_response_design.md for the full
+picture):
+
+  1. Client posts ``/v1/auth/login-challenge`` authenticated by
+     ``X-API-Key``. The Mastio mints a 32-byte random nonce, stores it
+     under ``login_challenge:{agent_id}:{nonce}`` with TTL 120s, and
+     returns it.
+
+  2. Client builds a standard broker ``client_assertion`` JWT
+     (:func:`cullis_sdk.auth.build_client_assertion`) signed locally
+     with its on-device key. The nonce is embedded as a claim so the
+     signature covers it.
+
+  3. Client posts ``/v1/auth/sign-challenged-assertion`` with the
+     assertion + nonce. The Mastio:
+
+       - consumes the nonce atomically (replay → 401);
+       - extracts and verifies the x5c chain against the Org CA
+         (reuses the primitives from :mod:`mcp_proxy.auth.local_token`);
+       - pins the leaf against ``internal_agents.cert_pem``;
+       - decodes + signature-verifies the assertion with the cert's
+         public key;
+       - cross-checks ``sub == agent.agent_id`` and
+         ``decoded["nonce"] == nonce``;
+       - counter-signs the assertion bytes with the Mastio leaf
+         (ADR-009 Phase 2 primitive, unchanged).
+
+  4. Client forwards the echoed assertion + counter-signature to
+     ``/v1/auth/token`` — identical to the BYOCA path from there.
+
+Anti-replay defences (layered):
+
+  1. Nonce single-use (consumed on first valid call).
+  2. Nonce bound to caller's ``agent_id`` via store key.
+  3. Nonce is inside the signed assertion; tampering invalidates sig.
+  4. Short assertion window (``exp - iat ≤ 300``).
+  5. Cert pin against ``internal_agents.cert_pem``.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import secrets
+import time
+
+import jwt as jose_jwt
+from cryptography import x509
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from mcp_proxy.auth.api_key import InternalAgent, get_agent_from_api_key
+from mcp_proxy.auth.challenge_store import get_challenge_store
+
+_log = logging.getLogger("mcp_proxy.auth.challenge_response")
+
+router = APIRouter(tags=["auth"])
+
+_NONCE_BYTES = 32
+_NONCE_TTL_SECONDS = 120
+_MAX_ASSERTION_LIFETIME_SECONDS = 300
+_JWT_LEEWAY_SECONDS = 30
+
+
+# ── Request / response models ───────────────────────────────────────
+
+
+class LoginChallengeResponse(BaseModel):
+    nonce: str = Field(
+        ..., description="base64url-encoded 32-byte random nonce",
+    )
+    expires_in: int = Field(
+        ..., description="seconds the nonce remains redeemable",
+    )
+    agent_id: str = Field(
+        ..., description="the agent_id the nonce is bound to (caller's)",
+    )
+
+
+class SignChallengedAssertionRequest(BaseModel):
+    client_assertion: str = Field(
+        ..., description="JWT signed locally by the agent with x5c header",
+    )
+    nonce: str = Field(
+        ..., description="nonce previously issued by /v1/auth/login-challenge",
+    )
+
+
+class SignChallengedAssertionResponse(BaseModel):
+    client_assertion: str = Field(
+        ..., description="echo of the input assertion — Mastio never re-signs",
+    )
+    agent_id: str
+    mastio_signature: str | None = Field(
+        None,
+        description="ES256 signature over the assertion bytes, base64url — "
+                    "None when ADR-009 Phase 2 isn't initialised yet",
+    )
+
+
+# ── Helpers (internal) ──────────────────────────────────────────────
+
+
+def _issue_nonce() -> str:
+    raw = secrets.token_bytes(_NONCE_BYTES)
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _get_agent_manager(request: Request):
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None:
+        bridge = getattr(request.app.state, "broker_bridge", None)
+        mgr = getattr(bridge, "_agent_manager", None) if bridge else None
+    if mgr is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized",
+        )
+    return mgr
+
+
+async def _load_org_ca():
+    from mcp_proxy.db import get_config
+    pem = await get_config("org_ca_cert")
+    if not pem:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Org CA not loaded",
+        )
+    return x509.load_pem_x509_certificate(pem.encode())
+
+
+def _log_clock_skew_hint(exc: jose_jwt.PyJWTError, agent_id: str) -> None:
+    """If the JWT error looks clock-skew-adjacent and the skew is
+    material (> 10s), emit a WARNING with an NTP hint — see note (3) in
+    the orchestrator's brief. Otherwise return quietly."""
+    msg = str(exc)
+    if "expired" not in msg.lower() and "not yet valid" not in msg.lower():
+        return
+    # Pull the assertion's iat/exp back out (unverified) so we can reason
+    # about skew. We're already about to reject the call — no risk.
+    # PyJWTError doesn't carry the claims; caller hands them in via an
+    # attribute set on the exception context we create.
+    claims = getattr(exc, "_skew_claims", None)
+    if not isinstance(claims, dict):
+        return
+    iat = claims.get("iat")
+    exp = claims.get("exp")
+    now = int(time.time())
+    if isinstance(iat, (int, float)) and iat - now > 10:
+        _log.warning(
+            "login challenge assertion rejected for %s: iat %ds in the "
+            "future — possible clock skew between Connector and Mastio, "
+            "check NTP on both ends.",
+            agent_id, int(iat - now),
+        )
+    elif isinstance(exp, (int, float)) and now - exp > 10:
+        _log.warning(
+            "login challenge assertion rejected for %s: expired %ds ago — "
+            "clock skew suspect if the Connector clock trails; check NTP.",
+            agent_id, int(now - exp),
+        )
+
+
+# ── Endpoints ───────────────────────────────────────────────────────
+
+
+@router.post(
+    "/v1/auth/login-challenge",
+    response_model=LoginChallengeResponse,
+    summary="Issue a single-use nonce for client-signed login",
+)
+async def login_challenge(
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_api_key),
+) -> LoginChallengeResponse:
+    """Mint a nonce bound to the authenticated agent.
+
+    The nonce is stored with TTL 120s; the client must redeem it at
+    ``/v1/auth/sign-challenged-assertion`` by embedding it in a signed
+    ``client_assertion``. Replay of a consumed nonce returns 401.
+    """
+    store = get_challenge_store()
+    # Tiny retry loop for the astronomically unlikely nonce collision —
+    # 32 random bytes makes this ~0 in practice.
+    nonce: str | None = None
+    for _ in range(3):
+        candidate = _issue_nonce()
+        if await store.issue(agent.agent_id, candidate, _NONCE_TTL_SECONDS):
+            nonce = candidate
+            break
+    if nonce is None:
+        _log.error(
+            "login challenge: nonce generator failed to produce a fresh "
+            "nonce for %s after 3 tries", agent.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="unable to allocate login challenge nonce",
+        )
+    _log.info("login challenge issued for %s", agent.agent_id)
+    return LoginChallengeResponse(
+        nonce=nonce,
+        expires_in=_NONCE_TTL_SECONDS,
+        agent_id=agent.agent_id,
+    )
+
+
+@router.post(
+    "/v1/auth/sign-challenged-assertion",
+    response_model=SignChallengedAssertionResponse,
+    summary="Verify a client-signed assertion + mastio counter-sign it",
+)
+async def sign_challenged_assertion(
+    body: SignChallengedAssertionRequest,
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_api_key),
+) -> SignChallengedAssertionResponse:
+    """Verify a client-signed assertion + counter-sign it.
+
+    The nonce is consumed atomically at the top of the handler — any
+    failure after that point still leaves the nonce consumed, which is
+    the desired property: one nonce = one attempt (successful or not).
+    """
+    # Local imports keep the module import-clean for the test harness
+    # and avoid a cycle with mcp_proxy.auth.local_token.
+    from mcp_proxy.auth.local_token import (
+        _decode_assertion,
+        _extract_x5c,
+        _load_chain,
+        _verify_chain,
+    )
+    from mcp_proxy.db import get_agent as db_get_agent
+
+    store = get_challenge_store()
+    if not await store.consume(agent.agent_id, body.nonce):
+        _log.info(
+            "login challenge rejected for %s: nonce invalid or already "
+            "consumed", agent.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="challenge nonce invalid, expired, or already consumed",
+        )
+
+    ca_cert = await _load_org_ca()
+
+    # Pull the x5c chain, verify against the Org CA, then verify the
+    # JWT signature with the leaf's public key — exactly the same chain
+    # the broker will walk again at /v1/auth/token. Doing it here gives
+    # fast-feedback + matching-failure-mode on bad certs.
+    try:
+        x5c_der = _extract_x5c(body.client_assertion)
+        chain = _load_chain(x5c_der)
+        _verify_chain(chain, ca_cert)
+    except ValueError as exc:
+        _log.info(
+            "login challenge rejected for %s: x509 chain invalid: %s",
+            agent.agent_id, exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"x509 chain: {exc}",
+        ) from exc
+
+    leaf = chain[0]
+    try:
+        claims = _decode_assertion(body.client_assertion, leaf)
+    except jose_jwt.PyJWTError as exc:
+        # Attach the unverified claims so _log_clock_skew_hint can read
+        # them without re-parsing; safe because we're about to reject.
+        try:
+            exc._skew_claims = jose_jwt.decode(  # type: ignore[attr-defined]
+                body.client_assertion, options={"verify_signature": False},
+            )
+        except Exception:
+            pass
+        _log_clock_skew_hint(exc, agent.agent_id)
+        _log.info(
+            "login challenge rejected for %s: assertion invalid: %s",
+            agent.agent_id, exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=f"assertion: {exc}",
+        ) from exc
+
+    # sub must match the X-API-Key holder — prevents agent A from using
+    # its own API-key to get B's assertion endorsed.
+    if claims.get("sub") != agent.agent_id:
+        _log.info(
+            "login challenge rejected: assertion sub=%r, caller agent_id=%r",
+            claims.get("sub"), agent.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="assertion sub does not match authenticated agent",
+        )
+
+    # nonce claim binding — the nonce we just consumed must also be the
+    # one the client signed over. If the client re-used a captured
+    # assertion with a fresh nonce from the body, the assertion's
+    # signed nonce won't match; we catch that here.
+    if claims.get("nonce") != body.nonce:
+        _log.info(
+            "login challenge rejected for %s: assertion nonce mismatch",
+            agent.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="assertion nonce claim does not match request nonce",
+        )
+
+    # Cap assertion lifetime — defence against a legitimate-but-too-long
+    # assertion being stockpiled offline. The SDK produces 5-minute
+    # assertions by default (cullis_sdk/auth.py), matching this cap.
+    iat = claims.get("iat")
+    exp = claims.get("exp")
+    if (
+        not isinstance(iat, (int, float))
+        or not isinstance(exp, (int, float))
+        or exp - iat > _MAX_ASSERTION_LIFETIME_SECONDS
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"assertion lifetime must be ≤ "
+                f"{_MAX_ASSERTION_LIFETIME_SECONDS}s"
+            ),
+        )
+
+    # Cert pin — ``internal_agents.cert_pem`` is the row the operator
+    # enrolled. A valid chain-of-trust cert that doesn't match the
+    # pinned one is rejected (defence against silent re-issuance).
+    db_row = await db_get_agent(agent.agent_id)
+    if db_row is None or not db_row.get("is_active", True):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="agent not registered or deactivated",
+        )
+    pinned_pem = db_row.get("cert_pem")
+    if not pinned_pem:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="agent has no pinned cert_pem on record",
+        )
+    try:
+        pinned_cert = x509.load_pem_x509_certificate(pinned_pem.encode())
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="pinned cert_pem is malformed",
+        ) from exc
+    from cryptography.hazmat.primitives import serialization as _ser
+    pinned_der = pinned_cert.public_bytes(_ser.Encoding.DER)
+    leaf_der = leaf.public_bytes(_ser.Encoding.DER)
+    if pinned_der != leaf_der:
+        _log.info(
+            "login challenge rejected for %s: leaf cert != pinned",
+            agent.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="leaf certificate does not match pinned internal_agents.cert_pem",
+        )
+
+    # Counter-sign — reuse the ADR-009 Phase 2 primitive. When the
+    # mastio identity isn't loaded yet (legacy deploys pre-ADR-009),
+    # return None and the SDK will skip the X-Cullis-Mastio-Signature
+    # header just like the legacy sign-assertion path does.
+    mgr = _get_agent_manager(request)
+    mastio_signature: str | None = None
+    if getattr(mgr, "mastio_loaded", False):
+        try:
+            mastio_signature = mgr.countersign(body.client_assertion.encode())
+        except Exception as exc:
+            _log.warning(
+                "mastio countersign failed for %s: %s",
+                agent.agent_id, exc,
+            )
+
+    _log.info("login challenge endorsed for %s", agent.agent_id)
+    return SignChallengedAssertionResponse(
+        client_assertion=body.client_assertion,
+        agent_id=agent.agent_id,
+        mastio_signature=mastio_signature,
+    )

--- a/mcp_proxy/auth/challenge_store.py
+++ b/mcp_proxy/auth/challenge_store.py
@@ -1,0 +1,164 @@
+"""Login-challenge nonce store — short-lived, single-use nonces for the
+client-signed login flow (tech-debt #2).
+
+The device-code Connector holds its agent private key locally and signs
+the broker ``client_assertion`` itself (see
+:mod:`mcp_proxy.auth.challenge_response`). To prevent replay of a
+captured signed assertion, the Mastio issues a short-lived nonce that
+the client embeds as a JWT claim; the assertion is only endorsed if
+the nonce is still outstanding and consumed atomically on first use.
+
+Two backends, mirroring :mod:`mcp_proxy.auth.dpop_jti_store`:
+  * :class:`InMemoryChallengeStore` — single-worker only.
+  * :class:`RedisChallengeStore`    — multi-worker safe via ``SET NX EX``
+    + explicit ``DEL`` on consume (two-step because the nonce is
+    *single-use* rather than *TTL-only* — the second caller must get a
+    miss even before the TTL elapses).
+
+Key shape: ``login_challenge:{agent_id}:{nonce}`` — binding the nonce
+to the caller means a leaked nonce can't be redeemed by a different
+``X-API-Key`` holder (defence in depth on top of the ``sub`` claim check
+in the verification path).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Protocol
+
+_log = logging.getLogger("mcp_proxy")
+
+_DEFAULT_TTL = 120  # seconds — covers login round-trip + clock skew,
+                    # shorter than the assertion ``exp`` (≤300s).
+
+
+class ChallengeStore(Protocol):
+    """Interface for challenge nonce stores."""
+
+    async def issue(self, agent_id: str, nonce: str,
+                    ttl_seconds: int = _DEFAULT_TTL) -> bool:
+        """Register a freshly-minted nonce for ``agent_id`` with TTL.
+
+        Returns True on first registration, False if the key already
+        exists (collision — caller should regenerate the nonce).
+        """
+        ...
+
+    async def consume(self, agent_id: str, nonce: str) -> bool:
+        """Atomically check and remove a nonce.
+
+        Returns True if the nonce was outstanding and is now consumed,
+        False if it was already consumed, expired, or never issued.
+        """
+        ...
+
+
+class InMemoryChallengeStore:
+    """Async-safe in-memory store with lazy expiry cleanup.
+
+    Single-worker only. Each worker holds its own dict — Multi-worker
+    deployments MUST use Redis or a captured nonce could be redeemed by
+    a different worker's view of the store.
+    """
+
+    def __init__(self) -> None:
+        # key -> expires_at (monotonic); key = f"{agent_id}:{nonce}"
+        self._store: dict[str, float] = {}
+        self._lock = asyncio.Lock()
+
+    async def issue(self, agent_id: str, nonce: str,
+                    ttl_seconds: int = _DEFAULT_TTL) -> bool:
+        now = time.monotonic()
+        expires_at = now + ttl_seconds
+        key = f"{agent_id}:{nonce}"
+        async with self._lock:
+            # Expire stale entries opportunistically.
+            stale = [k for k, v in self._store.items() if v < now]
+            for k in stale:
+                del self._store[k]
+            if key in self._store:
+                return False  # collision — caller regenerates
+            self._store[key] = expires_at
+            return True
+
+    async def consume(self, agent_id: str, nonce: str) -> bool:
+        now = time.monotonic()
+        key = f"{agent_id}:{nonce}"
+        async with self._lock:
+            expires_at = self._store.pop(key, None)
+            if expires_at is None:
+                return False  # never issued or already consumed
+            return expires_at >= now  # False if expired since issue
+
+
+class RedisChallengeStore:
+    """Redis-backed store — multi-worker safe.
+
+    ``issue`` uses ``SET NX EX`` (atomic check+set with TTL).
+    ``consume`` uses ``DEL`` after a ``GET`` to keep the op single-use
+    semantic-equivalent; Redis's ``GETDEL`` would be cleaner but isn't
+    in the minimum redis-py version we pin. The two-call version is
+    atomic enough: a concurrent consumer either sees the value (and
+    wins the race) or sees ``None`` (and loses).
+    """
+
+    _PREFIX = "mcp_proxy:login_challenge:"
+
+    def __init__(self, redis_client) -> None:
+        self._redis = redis_client
+
+    async def issue(self, agent_id: str, nonce: str,
+                    ttl_seconds: int = _DEFAULT_TTL) -> bool:
+        key = f"{self._PREFIX}{agent_id}:{nonce}"
+        result = await self._redis.set(key, "1", nx=True, ex=ttl_seconds)
+        return result is not None
+
+    async def consume(self, agent_id: str, nonce: str) -> bool:
+        key = f"{self._PREFIX}{agent_id}:{nonce}"
+        # DEL returns the number of keys removed. If 0, nonce was already
+        # consumed (or expired, or never issued).
+        deleted = await self._redis.delete(key)
+        return bool(deleted)
+
+
+_store: ChallengeStore | None = None
+
+
+def _init_store() -> ChallengeStore:
+    """Select the best available backend. Warns in production when only
+    the in-memory store is available (multi-worker can race).
+    """
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.redis.pool import get_redis
+
+    redis = get_redis()
+    if redis is not None:
+        _log.info("login challenge store: Redis")
+        return RedisChallengeStore(redis)
+
+    if get_settings().environment == "production":
+        _log.warning(
+            "login challenge store: Redis unavailable in production — "
+            "falling back to in-memory. Safe only for single-instance/"
+            "single-worker deployments. Multi-worker/HA deploys MUST set "
+            "MCP_PROXY_REDIS_URL; otherwise a captured login nonce can be "
+            "consumed on one worker and replayed on another."
+        )
+
+    _log.info("login challenge store: in-memory")
+    return InMemoryChallengeStore()
+
+
+def get_challenge_store() -> ChallengeStore:
+    """Return the active challenge store, initializing on first call."""
+    global _store
+    if _store is None:
+        _store = _init_store()
+    return _store
+
+
+def reset_challenge_store() -> None:
+    """Reset the store — used by tests to force re-initialization."""
+    global _store
+    _store = None

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -623,6 +623,12 @@ async def pdp_health():
 from mcp_proxy.auth.sign_assertion import router as sign_assertion_router
 app.include_router(sign_assertion_router)
 
+# Tech-debt #2 — /v1/auth/login-challenge + /v1/auth/sign-challenged-assertion,
+# the client-holds-the-key counterpart to sign-assertion. Routed here for
+# the same reason: before the reverse-proxy catch-all.
+from mcp_proxy.auth.challenge_response import router as challenge_response_router
+app.include_router(challenge_response_router)
+
 # ADR-012 Phase 1 — JWKS for the Mastio local issuer. Published at
 # /.well-known/jwks-local.json; paths under /.well-known are not
 # reverse-proxied so the registration order vs forwarder is moot.

--- a/tests/test_proxy_challenge_response.py
+++ b/tests/test_proxy_challenge_response.py
@@ -1,0 +1,381 @@
+"""Tests for ``/v1/auth/login-challenge`` + ``/v1/auth/sign-challenged-assertion``.
+
+Device-code Connectors hold the agent private key locally; the Mastio
+gives them a short-lived nonce, the client signs an assertion that
+embeds it, and the Mastio verifies + counter-signs.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from httpx import ASGITransport, AsyncClient
+
+from cullis_sdk.auth import build_client_assertion
+from tests.cert_factory import (
+    get_agent_key_pem,
+    get_org_ca_pem,
+    make_agent_cert,
+)
+
+
+ORG_ID = "challenge-test"
+
+
+def _cert_pem(agent_id: str) -> str:
+    _, cert = make_agent_cert(agent_id, ORG_ID)
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _key_pem(agent_id: str) -> str:
+    return get_agent_key_pem(agent_id, ORG_ID)
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", ORG_ID)
+    monkeypatch.delenv("MCP_PROXY_STANDALONE", raising=False)
+
+    from mcp_proxy.auth.challenge_store import reset_challenge_store
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    reset_challenge_store()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            # Seed the Org CA the challenge verifier loads.
+            from mcp_proxy.db import set_config
+            await set_config("org_ca_cert", get_org_ca_pem(ORG_ID))
+            yield app, client
+    get_settings.cache_clear()
+    reset_challenge_store()
+
+
+async def _provision_agent(agent_id: str, *, cert_pem: str | None = None) -> str:
+    """Insert an internal_agents row with the real cert + an API-key.
+    Returns the raw API-key to use in X-API-Key."""
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from mcp_proxy.auth.api_key import generate_api_key, hash_api_key
+    from mcp_proxy.db import get_db
+
+    raw_key = generate_api_key(agent_id)
+    pem = cert_pem if cert_pem is not None else _cert_pem(agent_id)
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents "
+                "(agent_id, display_name, capabilities, cert_pem, api_key_hash, "
+                " created_at, is_active) "
+                "VALUES (:agent_id, :display_name, :capabilities, :cert_pem, "
+                " :api_key_hash, :created_at, :is_active)"
+            ),
+            {
+                "agent_id": agent_id,
+                "display_name": agent_id,
+                "capabilities": "[]",
+                "cert_pem": pem,
+                "api_key_hash": hash_api_key(raw_key),
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "is_active": 1,
+            },
+        )
+    return raw_key
+
+
+async def _issue_challenge(client: AsyncClient, api_key: str) -> str:
+    resp = await client.post(
+        "/v1/auth/login-challenge",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["nonce"]
+
+
+# ── login-challenge ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_challenge_issued_for_authenticated_agent(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_agent("alice")
+    resp = await client.post(
+        "/v1/auth/login-challenge",
+        headers={"X-API-Key": api_key},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "alice"
+    assert body["expires_in"] == 120
+    # 32 random bytes → 43 base64url chars (no padding).
+    assert len(body["nonce"]) == 43
+
+
+@pytest.mark.asyncio
+async def test_challenge_rejects_unauthenticated(proxy_app):
+    _, client = proxy_app
+    resp = await client.post("/v1/auth/login-challenge")
+    assert resp.status_code == 401
+
+
+# ── sign-challenged-assertion ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_happy_path_sign_challenged_assertion(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_agent("alice")
+    nonce = await _issue_challenge(client, api_key)
+    assertion, _ = build_client_assertion(
+        "alice", _cert_pem("alice"), _key_pem("alice"), nonce=nonce,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_id"] == "alice"
+    assert body["client_assertion"] == assertion
+    # mastio_signature may be None when the mastio identity isn't
+    # loaded in the test harness — both shapes are valid responses.
+    assert "mastio_signature" in body
+
+
+@pytest.mark.asyncio
+async def test_nonce_replay_rejected(proxy_app):
+    _, client = proxy_app
+    api_key = await _provision_agent("alice")
+    nonce = await _issue_challenge(client, api_key)
+    assertion, _ = build_client_assertion(
+        "alice", _cert_pem("alice"), _key_pem("alice"), nonce=nonce,
+    )
+
+    first = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert first.status_code == 200
+    # Same nonce, same assertion → 401 on replay (nonce was consumed).
+    second = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert second.status_code == 401
+    assert "nonce" in second.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_nonce_bound_to_issuing_agent(proxy_app):
+    """Nonce issued for agent A can't be redeemed by agent B's API-key.
+    Defence-in-depth beyond the sub==agent check."""
+    _, client = proxy_app
+    api_key_a = await _provision_agent("alice")
+    api_key_b = await _provision_agent("bob")
+
+    # A issues and gets a nonce.
+    nonce = await _issue_challenge(client, api_key_a)
+    # B tries to redeem it (with a B-signed assertion).
+    assertion, _ = build_client_assertion(
+        "bob", _cert_pem("bob"), _key_pem("bob"), nonce=nonce,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key_b},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    # B's consume() for (bob, nonce) misses because the nonce was
+    # stored under (alice, nonce).
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_assertion_sub_mismatch_rejected(proxy_app):
+    """A tries to redeem B's assertion using A's API-key (via A's nonce).
+    Caught by the ``sub != agent_id`` check."""
+    _, client = proxy_app
+    api_key_a = await _provision_agent("alice")
+    await _provision_agent("bob")
+    nonce = await _issue_challenge(client, api_key_a)
+    # Assertion signed by bob — wrong sub for the X-API-Key caller.
+    assertion, _ = build_client_assertion(
+        "bob", _cert_pem("bob"), _key_pem("bob"), nonce=nonce,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key_a},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert resp.status_code == 401
+    assert "sub" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_nonce_claim_tampered_rejected(proxy_app):
+    """Assertion signs nonce X, request body carries nonce Y. Caught by
+    the ``decoded.nonce == body.nonce`` check — enforces that the
+    client signature covers the nonce actually being consumed."""
+    _, client = proxy_app
+    api_key = await _provision_agent("alice")
+    nonce_a = await _issue_challenge(client, api_key)
+    nonce_b = await _issue_challenge(client, api_key)
+    assertion, _ = build_client_assertion(
+        "alice", _cert_pem("alice"), _key_pem("alice"), nonce=nonce_a,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce_b},
+    )
+    # nonce_b is consumed (we issued it above and the handler consumes
+    # first thing); the assertion's ``nonce`` claim is nonce_a → mismatch.
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_cert_pin_mismatch_rejected(proxy_app):
+    """An agent enrolled with cert X presents a valid chain-of-trust
+    cert Y (same CA). Caught by the ``leaf_der != pinned_der`` check."""
+    _, client = proxy_app
+    # Provision alice with bob's cert pinned — simulates rotation drift
+    # or an attempt to swap the cert out.
+    api_key = await _provision_agent("alice", cert_pem=_cert_pem("bob"))
+    nonce = await _issue_challenge(client, api_key)
+    # Alice signs an assertion with her own cert (matches chain but not pin).
+    assertion, _ = build_client_assertion(
+        "alice", _cert_pem("alice"), _key_pem("alice"), nonce=nonce,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert resp.status_code == 401
+    assert "pinned" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_missing_nonce_in_assertion_rejected(proxy_app):
+    """Assertion has no ``nonce`` claim at all → mismatch vs request body."""
+    _, client = proxy_app
+    api_key = await _provision_agent("alice")
+    nonce = await _issue_challenge(client, api_key)
+    assertion, _ = build_client_assertion(
+        "alice", _cert_pem("alice"), _key_pem("alice"),  # no nonce
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sign_rejects_unauthenticated(proxy_app):
+    _, client = proxy_app
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        json={"client_assertion": "x.y.z", "nonce": "whatever"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sign_rejects_nonexistent_nonce(proxy_app):
+    """No challenge was ever issued with this nonce → 401 even before
+    any crypto runs."""
+    _, client = proxy_app
+    api_key = await _provision_agent("alice")
+    # Fake nonce the store never saw.
+    fake_nonce = base64.urlsafe_b64encode(b"\x00" * 32).rstrip(b"=").decode()
+    assertion, _ = build_client_assertion(
+        "alice", _cert_pem("alice"), _key_pem("alice"), nonce=fake_nonce,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": fake_nonce},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sign_rejects_chain_not_signed_by_org_ca(proxy_app):
+    """Assertion signed with a valid-looking cert from a different
+    Org CA. The x5c chain fails ``_verify_chain`` against this Mastio's
+    pinned Org CA."""
+    _, client = proxy_app
+    # Provision alice with a cert from ORG_ID's CA (correct).
+    api_key = await _provision_agent("alice")
+    nonce = await _issue_challenge(client, api_key)
+    # Build assertion with a cert from a DIFFERENT org — its CA won't
+    # match the one set_config('org_ca_cert', ...) pinned in the fixture.
+    other_cert = _cert_pem_from_other_org("alice")
+    other_key = _key_pem_from_other_org("alice")
+    assertion, _ = build_client_assertion(
+        "alice", other_cert, other_key, nonce=nonce,
+    )
+    resp = await client.post(
+        "/v1/auth/sign-challenged-assertion",
+        headers={"X-API-Key": api_key},
+        json={"client_assertion": assertion, "nonce": nonce},
+    )
+    assert resp.status_code == 401
+    assert "chain" in resp.json()["detail"].lower()
+
+
+def _cert_pem_from_other_org(agent_id: str) -> str:
+    _, cert = make_agent_cert(agent_id, "other-org-unrelated")
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _key_pem_from_other_org(agent_id: str) -> str:
+    return get_agent_key_pem(agent_id, "other-org-unrelated")
+
+
+# ── store unit tests (InMemoryChallengeStore) ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_issue_and_consume():
+    from mcp_proxy.auth.challenge_store import InMemoryChallengeStore
+    store = InMemoryChallengeStore()
+    assert await store.issue("alice", "nonce1") is True
+    assert await store.consume("alice", "nonce1") is True
+    # Second consume is a miss.
+    assert await store.consume("alice", "nonce1") is False
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_collision_refused():
+    from mcp_proxy.auth.challenge_store import InMemoryChallengeStore
+    store = InMemoryChallengeStore()
+    assert await store.issue("alice", "nonce1") is True
+    # Same (agent_id, nonce) pair — issue refuses so caller regenerates.
+    assert await store.issue("alice", "nonce1") is False
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_cross_agent_isolation():
+    from mcp_proxy.auth.challenge_store import InMemoryChallengeStore
+    store = InMemoryChallengeStore()
+    await store.issue("alice", "n")
+    # Bob tries to consume a nonce issued for alice — different key, miss.
+    assert await store.consume("bob", "n") is False
+    # Alice can still consume.
+    assert await store.consume("alice", "n") is True

--- a/tests/test_sdk_login_via_proxy_with_local_key.py
+++ b/tests/test_sdk_login_via_proxy_with_local_key.py
@@ -1,0 +1,244 @@
+"""Tests for :meth:`CullisClient.login_via_proxy_with_local_key`.
+
+Exercises the three-hop flow (challenge → sign-challenged-assertion →
+/v1/auth/token) through monkeypatched ``_http`` responses, without
+actually standing up a Mastio or Court. Integration with a real Mastio
+is covered by ``tests/test_proxy_challenge_response.py``.
+"""
+from __future__ import annotations
+
+import base64
+
+import httpx
+import pytest
+
+from cullis_sdk.client import CullisClient
+from tests.cert_factory import (
+    get_agent_key_pem,
+    make_agent_cert,
+)
+
+
+AGENT_ID = "alice"
+ORG_ID = "login-sdk-test"
+
+
+def _cert_pem() -> str:
+    from cryptography.hazmat.primitives import serialization
+    _, cert = make_agent_cert(AGENT_ID, ORG_ID)
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _key_pem() -> str:
+    return get_agent_key_pem(AGENT_ID, ORG_ID)
+
+
+def _build_client() -> CullisClient:
+    client = CullisClient("http://mastio.test", verify_tls=False)
+    client._proxy_api_key = "test-api-key"
+    client._proxy_agent_id = AGENT_ID
+    client._signing_key_pem = _key_pem()
+    client._cert_pem = _cert_pem()
+    return client
+
+
+class _Resp:
+    """Tiny httpx.Response stand-in the monkeypatched _http returns."""
+    def __init__(self, status_code: int, body: dict | None = None,
+                 text_body: str = "", headers: dict | None = None):
+        self.status_code = status_code
+        self._body = body or {}
+        self._text = text_body or ""
+        self.headers = headers or {}
+        self.request = None
+
+    def json(self):
+        return self._body
+
+    @property
+    def text(self):
+        return self._text or str(self._body)
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=None,
+                response=self,
+            )
+
+
+def _script_http(monkeypatch, client: CullisClient, responses: list[tuple[str, _Resp]]):
+    """Replace client._http.post with a scripted queue. Each entry is
+    (path_substring_to_match, response)."""
+    pending = list(responses)
+    posted: list[tuple[str, dict, dict]] = []
+
+    def _post(url, json=None, headers=None, **kw):
+        posted.append((url, json or {}, headers or {}))
+        if not pending:
+            raise AssertionError(f"unexpected POST {url}")
+        expected_fragment, resp = pending.pop(0)
+        assert expected_fragment in url, (
+            f"expected URL containing {expected_fragment!r}, got {url!r}"
+        )
+        return resp
+
+    monkeypatch.setattr(client._http, "post", _post)
+    return posted
+
+
+def test_happy_path(monkeypatch):
+    client = _build_client()
+    try:
+        nonce = base64.urlsafe_b64encode(b"\x11" * 32).rstrip(b"=").decode()
+        assertion_echo = "signed.assertion.jwt"
+        posted = _script_http(monkeypatch, client, [
+            ("/v1/auth/login-challenge",
+             _Resp(200, {"nonce": nonce, "expires_in": 120, "agent_id": AGENT_ID})),
+            ("/v1/auth/sign-challenged-assertion",
+             _Resp(200, {"client_assertion": assertion_echo,
+                         "agent_id": AGENT_ID,
+                         "mastio_signature": "sig-bytes-b64"})),
+            ("/v1/auth/token",
+             _Resp(200, {"access_token": "broker-token-xyz"})),
+        ])
+        client.login_via_proxy_with_local_key()
+        assert client.token == "broker-token-xyz"
+        # Token call carried the mastio counter-sig.
+        token_headers = posted[2][2]
+        assert token_headers.get("X-Cullis-Mastio-Signature") == "sig-bytes-b64"
+        # sign-challenged-assertion was given the nonce we fetched in step 1.
+        sign_body = posted[1][1]
+        assert sign_body["nonce"] == nonce
+    finally:
+        client.close()
+
+
+def test_missing_signing_key_raises(monkeypatch):
+    client = _build_client()
+    client._signing_key_pem = None
+    try:
+        with pytest.raises(RuntimeError, match="local signing key"):
+            client.login_via_proxy_with_local_key()
+    finally:
+        client.close()
+
+
+def test_missing_cert_raises(monkeypatch):
+    client = _build_client()
+    client._cert_pem = None
+    try:
+        with pytest.raises(RuntimeError, match="certificate PEM"):
+            client.login_via_proxy_with_local_key()
+    finally:
+        client.close()
+
+
+def test_missing_proxy_enrollment_raises(monkeypatch):
+    client = CullisClient("http://mastio.test", verify_tls=False)
+    client._signing_key_pem = _key_pem()
+    client._cert_pem = _cert_pem()
+    # _proxy_api_key / _proxy_agent_id missing.
+    try:
+        with pytest.raises(RuntimeError, match="proxy enrollment"):
+            client.login_via_proxy_with_local_key()
+    finally:
+        client.close()
+
+
+def test_challenge_404_no_silent_fallback(monkeypatch):
+    """If the Mastio doesn't expose /v1/auth/login-challenge (legacy
+    deploy) the client must surface a clear PermissionError. No silent
+    fallback to the legacy ``login_via_proxy`` — that would mask a
+    misconfigured proxy."""
+    client = _build_client()
+    try:
+        _script_http(monkeypatch, client, [
+            ("/v1/auth/login-challenge",
+             _Resp(404, text_body="not found")),
+        ])
+        with pytest.raises(PermissionError, match="HTTP 404"):
+            client.login_via_proxy_with_local_key()
+        assert client.token is None  # no broker token issued
+    finally:
+        client.close()
+
+
+def test_sign_401_surfaces(monkeypatch):
+    """Auth broken at step 3 → PermissionError with status surfaced."""
+    client = _build_client()
+    try:
+        nonce = base64.urlsafe_b64encode(b"\x22" * 32).rstrip(b"=").decode()
+        _script_http(monkeypatch, client, [
+            ("/v1/auth/login-challenge",
+             _Resp(200, {"nonce": nonce, "expires_in": 120, "agent_id": AGENT_ID})),
+            ("/v1/auth/sign-challenged-assertion",
+             _Resp(401, text_body="challenge nonce invalid")),
+        ])
+        with pytest.raises(PermissionError, match="HTTP 401"):
+            client.login_via_proxy_with_local_key()
+        assert client.token is None
+    finally:
+        client.close()
+
+
+def test_connect_error_wrapped_as_connection_error(monkeypatch):
+    client = _build_client()
+    try:
+        def _boom(*a, **kw):
+            raise httpx.ConnectError("refused")
+        monkeypatch.setattr(client._http, "post", _boom)
+        with pytest.raises(ConnectionError, match="Proxy unreachable"):
+            client.login_via_proxy_with_local_key()
+    finally:
+        client.close()
+
+
+def test_mastio_signature_absent_omits_header(monkeypatch):
+    """Legacy proxy without ADR-009 Phase 2 mastio identity → the
+    response has ``mastio_signature: None``; the SDK must not forward
+    an empty X-Cullis-Mastio-Signature header."""
+    client = _build_client()
+    try:
+        nonce = base64.urlsafe_b64encode(b"\x33" * 32).rstrip(b"=").decode()
+        posted = _script_http(monkeypatch, client, [
+            ("/v1/auth/login-challenge",
+             _Resp(200, {"nonce": nonce, "expires_in": 120, "agent_id": AGENT_ID})),
+            ("/v1/auth/sign-challenged-assertion",
+             _Resp(200, {"client_assertion": "x.y.z",
+                         "agent_id": AGENT_ID,
+                         "mastio_signature": None})),
+            ("/v1/auth/token",
+             _Resp(200, {"access_token": "tok"})),
+        ])
+        client.login_via_proxy_with_local_key()
+        token_headers = posted[2][2]
+        assert "X-Cullis-Mastio-Signature" not in token_headers
+    finally:
+        client.close()
+
+
+def test_from_connector_loads_both_key_and_cert(tmp_path):
+    """Regression: ``from_connector`` must populate BOTH
+    ``_signing_key_pem`` and ``_cert_pem`` so the new login path works
+    without the caller re-reading the files."""
+    import json
+    identity_dir = tmp_path / "identity"
+    identity_dir.mkdir()
+    (identity_dir / "agent.key").write_text(_key_pem())
+    (identity_dir / "agent.crt").write_text(_cert_pem())
+    (identity_dir / "api_key").write_text("api-key-blob")
+    (identity_dir / "metadata.json").write_text(json.dumps({
+        "agent_id": f"{ORG_ID}::{AGENT_ID}",
+        "site_url": "http://mastio.test",
+    }))
+
+    client = CullisClient.from_connector(tmp_path, enable_dpop=False)
+    try:
+        assert client._signing_key_pem is not None
+        assert "BEGIN" in client._signing_key_pem
+        assert client._cert_pem is not None
+        assert "BEGIN CERTIFICATE" in client._cert_pem
+    finally:
+        client.close()


### PR DESCRIPTION
## Summary

Closes tech-debt #2 from `project_connector_tech_debt`. Device-code-enrolled Connectors hold the agent private key locally, so `/v1/auth/sign-assertion` 404s ("agent credentials not available on proxy") — they were limited to `send_oneshot`, with `discover()` / `open_session()` / federation lookups all failing.

Three-part atomic PR following the design reviewed in `imp/connector_login_challenge_response_design.md` (Alternative A, dedicated endpoints).

## Mastio — two new endpoints

```
POST /v1/auth/login-challenge              → { nonce, expires_in, agent_id }
POST /v1/auth/sign-challenged-assertion    → { client_assertion (echo), agent_id, mastio_signature }
```

- **Nonce**: 32 random bytes base64url, TTL 120s, store key `login_challenge:{agent_id}:{nonce}`. Bound per-caller — a leaked nonce can't be redeemed by a different `X-API-Key` holder.
- **Store**: Redis when available, in-memory fallback (single-worker only), WARNING in production on Redis-unavailable (note 2). Mirrors `dpop_jti_store.py` exactly.
- **Verify path**: reuses `mcp_proxy.auth.local_token` primitives (`_extract_x5c`, `_load_chain`, `_verify_chain`, `_decode_assertion`) — no new x509 code.
- **Counter-sign**: `agent_manager.countersign` (ADR-009 Phase 2 primitive, unchanged).
- **Five anti-replay layers**: nonce single-use, nonce bound to agent_id, nonce is inside the signed assertion claim, assertion lifetime capped at 300s, leaf cert pinned vs `internal_agents.cert_pem`.
- **Clock-skew diagnostic (note 3)**: WARNING with NTP hint when iat/exp fails with >10s drift.

## SDK

- New `CullisClient.login_via_proxy_with_local_key()` — three-hop flow. Requires `_signing_key_pem` + `_cert_pem` + `_proxy_api_key`; surfaces a clear error when any is missing. **No silent fallback to `login_via_proxy`** — preventing MITM downgrade.
- `from_connector()` now loads `identity/agent.crt` into `_cert_pem` alongside `identity/agent.key` into `_signing_key_pem` (note 1 — prereq of the new login method, eliminates caller duplication).
- `build_client_assertion()` accepts optional `nonce=` kwarg, embedded as JWT claim when present.
- Existing `login_via_proxy()` (BYOCA / Vault-held-key) unchanged — zero risk to that surface.

## Connector

- `cli._cmd_serve` calls `login_via_proxy_with_local_key` eagerly after client construction. Failure is non-fatal; `_require_client` retries lazily.
- `tools/session._require_client` switches from `login_via_proxy` to `login_via_proxy_with_local_key`. Diagnostic message simplified (device-code vs BYOCA split is gone — both work now).
- `cli` + `web` drop the duplicated signing-key + cert post-construction load since `from_connector` handles it.

## Out of scope

Issue #297 — Connector in sandbox for end-to-end dogfood of the eager challenge-response flow. Unit + integration tests (23 new cases) cover the contract; the sandbox runs bare Python demo agents today, so the eager login only gets exercised when the Connector is wired into docker-compose (tracked separately so this PR doesn't bundle docker-compose churn with the auth change).

## Test plan

- [x] `pytest tests/ -n auto --dist=loadfile` → 1821 passed, 6 skipped (excluded: `test_postgres_integration.py`, `test_ts_interop.py`, `tests/connector/test_profile_runtime_switch.py` — last is pre-existing pystray fail on main, unrelated)
- [x] `tests/test_proxy_challenge_response.py` (new, 14 cases): challenge issuance + auth, sign happy path, replay, cross-agent nonce binding, sub mismatch, nonce-claim tamper, cert pin mismatch, missing nonce in assertion, unauthenticated, nonexistent nonce, chain signed by wrong Org CA + 3 unit tests on `InMemoryChallengeStore` (issue/consume/collision/cross-agent isolation)
- [x] `tests/test_sdk_login_via_proxy_with_local_key.py` (new, 9 cases): happy path, missing signing key / cert / proxy enrollment, no silent fallback on 404, sign 401 surfaces, transport errors wrapped, `mastio_signature=None` omits header, `from_connector` loads both key + cert
- [x] `./demo_network/smoke.sh full` → A1+A4+A7+A8 PASS
- [x] Sandbox cross-org dogfood invariato verde: `./demo.sh oneshot-a-to-b` → agent-b logs `received nonce from orga::agent-a: <hex>` with zero 401. (The sandbox doesn't run Connectors today so it doesn't exercise the new login path end-to-end — issue #297 tracks that.)
- [ ] CI green: test (3.11), Signed-off-by check, security, helm-test (cullis + cullis-proxy), demo_network smoke (rsa / ec / rsa+postgres), standalone smoke, Cloudflare Pages

## Commits

1. `64951fb` — `docs(connector): challenge-response login design (workaround #2)` — design doc with alternatives, flow, risks, recommendation (already on branch).
2. `fea17d3` — `feat(connector): challenge-response login for device-code Connectors` — implementation.