### PR TITLE
feat(updates): admin apply/rollback endpoints + GET list (PR 4/5)

### DIFF
--- a/mcp_proxy/dashboard/updates_router.py
+++ b/mcp_proxy/dashboard/updates_router.py
@@ -1,0 +1,440 @@
+"""Dashboard endpoints for the federation update framework.
+
+Three handlers under ``/proxy/updates``:
+
+- ``GET  /proxy/updates``                     — merged list of every
+  registered :class:`Migration` with its row in ``pending_updates``.
+  JSON response so the dashboard UI (PR 5) can fetch it via ``fetch()``
+  and ``curl`` / test harnesses can consume it without following
+  redirects.
+- ``POST /proxy/updates/{migration_id}/apply``    — run ``up()``
+  wrapped in try/except, mutate ``pending_updates.status`` to
+  ``applied`` / ``failed``, log audit, then clear sign-halt and
+  re-run the boot detector so another still-pending critical
+  migration re-engages the halt on its own.
+- ``POST /proxy/updates/{migration_id}/rollback`` — same shape as apply
+  but against ``rollback()`` and gated on ``status in {'applied',
+  'failed'}``.
+
+Every state-changing endpoint requires CSRF + an authenticated
+dashboard session and ``confirm_text``: ``APPLY`` for apply,
+``ROLLBACK`` for rollback — mirrors the ``ACTIVATE`` / ``DROP`` gate
+on ``/proxy/mastio-key/complete-staged`` (PR #288).
+
+Design notes captured from planning:
+
+- Route prefix is ``/proxy/`` rather than ``/admin/`` to match the
+  existing dashboard admin surface; a separate ``/v1/admin/updates/*``
+  JSON API layer may be added later.
+- No per-route rate limit. The dashboard admin bucket covers the
+  whole ``/proxy/*`` tree; apply/rollback are deliberate authenticated
+  actions, not abuse vectors.
+- On DB UPDATE failure after a successful ``up()`` / ``rollback()``,
+  the handler retries 3 times with exponential backoff and then
+  surfaces 500. The next boot's ``detect_pending_migrations`` is the
+  self-healing safety net — ``check()`` is the source of truth.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Iterable
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import JSONResponse
+from starlette.responses import RedirectResponse
+
+from mcp_proxy.dashboard.session import (
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import (
+    get_pending_updates,
+    insert_pending_update,
+    log_audit,
+    update_pending_update_status,
+)
+from mcp_proxy.updates import Migration, discover, get_by_id
+from mcp_proxy.updates.boot import detect_pending_migrations
+
+
+_log = logging.getLogger("mcp_proxy.dashboard.updates")
+
+
+router = APIRouter(prefix="/proxy/updates", tags=["dashboard", "updates"])
+
+
+_APPLY_CONFIRM = "APPLY"
+_ROLLBACK_CONFIRM = "ROLLBACK"
+
+# DB UPDATE retry policy after a successful migration up/rollback call
+# but a transient DB write failure. Three tries with exponential backoff
+# — 0.1, 0.2, 0.4 seconds, total ~700ms worst case.
+_DB_RETRY_DELAYS_S: tuple[float, ...] = (0.1, 0.2, 0.4)
+
+
+def _migration_to_dict(
+    m: Migration,
+    row: dict | None,
+) -> dict:
+    """Flatten a Migration + its ``pending_updates`` row to a JSON-safe dict."""
+    return {
+        "migration_id": m.migration_id,
+        "migration_type": m.migration_type,
+        "criticality": m.criticality,
+        "description": m.description,
+        "preserves_enrollments": m.preserves_enrollments,
+        "affects_enrollments": list(m.affects_enrollments),
+        "db_status": (row or {}).get("status"),
+        "detected_at": (row or {}).get("detected_at"),
+        "applied_at": (row or {}).get("applied_at"),
+        "error": (row or {}).get("error"),
+    }
+
+
+async def _update_status_with_retry(
+    *,
+    migration_id: str,
+    status: str,
+    applied_at: str | None = None,
+    error: str | None = None,
+) -> None:
+    """Retry the pending_updates UPDATE a few times before giving up.
+
+    Transient DB lock / timeout during the UPDATE after a successful
+    ``up()`` / ``rollback()`` is the drift case we care about. After
+    three attempts we surface 500; the next boot's detector reconverges
+    against the real state via ``check()``.
+    """
+    last_exc: Exception | None = None
+    for idx, delay in enumerate((0.0,) + _DB_RETRY_DELAYS_S):
+        if delay:
+            await asyncio.sleep(delay)
+        try:
+            await update_pending_update_status(
+                migration_id=migration_id,
+                status=status,
+                applied_at=applied_at,
+                error=error,
+            )
+            if idx > 0:
+                _log.warning(
+                    "updates: status UPDATE succeeded after %d retries "
+                    "(migration_id=%s, status=%s)",
+                    idx, migration_id, status,
+                )
+            return
+        except Exception as exc:
+            last_exc = exc
+            _log.warning(
+                "updates: status UPDATE attempt %d failed (migration_id=%s, "
+                "status=%s): %s",
+                idx + 1, migration_id, status, exc,
+            )
+    _log.error(
+        "updates: status UPDATE drift — %d attempts all failed for "
+        "migration_id=%s. The next boot's detect_pending_migrations "
+        "will reconverge from check(). Last error: %s",
+        len(_DB_RETRY_DELAYS_S) + 1, migration_id, last_exc,
+    )
+    raise HTTPException(
+        status_code=500,
+        detail=(
+            f"status write failed for {migration_id!r} after retries; "
+            f"the physical state change succeeded but the DB row is "
+            f"stale. The next boot will reconverge. Last error: {last_exc}"
+        ),
+    )
+
+
+def _extract_form_field(form: Iterable, key: str) -> str:
+    """``form.get(key)`` with a ``.strip()``; returns '' on missing."""
+    try:
+        value = form.get(key) or ""  # type: ignore[attr-defined]
+    except AttributeError:
+        value = ""
+    return str(value).strip()
+
+
+async def _require_session_and_csrf(request: Request):
+    """Shared guard. Returns the session on success, RedirectResponse on
+    unauthenticated access, or raises ``HTTPException(403)`` on CSRF.
+
+    Matches the pattern from ``/proxy/mastio-key/complete-staged`` (#288).
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+    return session
+
+
+async def _refresh_halt_state(request: Request) -> None:
+    """Clear the sign-halt and re-run the boot detector.
+
+    Invoked after a successful apply / rollback. If another critical
+    migration is still pending against current state, the detector
+    re-engages the halt with a fresh reason; otherwise the proxy
+    returns to normal signing.
+    """
+    agent_mgr = getattr(request.app.state, "agent_manager", None)
+    if agent_mgr is None:
+        # The manager isn't attached (test harness that bypasses
+        # lifespan, or a proxy that booted without ca_loaded).
+        # Nothing to halt/clear; the detector call is still useful to
+        # refresh the Prometheus gauge but requires an agent_mgr shape;
+        # skip quietly.
+        return
+    agent_mgr.clear_sign_halt()
+    try:
+        await detect_pending_migrations(agent_mgr)
+    except Exception as exc:
+        # Defensive — the apply/rollback succeeded, we don't want to
+        # mask that success because the re-detect tripped.
+        _log.warning(
+            "updates: detect_pending_migrations after action failed: %s "
+            "— halt state may be stale until next restart", exc,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Handlers
+# ─────────────────────────────────────────────────────────────────────
+
+
+@router.get("")
+async def updates_list(request: Request):
+    """Return every registered migration merged with its DB row.
+
+    Authenticated read-only endpoint. No CSRF (GET). Consumed by the
+    dashboard UI (PR 5) and by ``curl`` during ops.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    migrations = discover()
+    rows_by_id = {
+        row["migration_id"]: row for row in await get_pending_updates()
+    }
+    return JSONResponse({
+        "updates": [
+            _migration_to_dict(m, rows_by_id.get(m.migration_id))
+            for m in migrations
+        ],
+    })
+
+
+@router.post("/{migration_id}/apply")
+async def updates_apply(migration_id: str, request: Request):
+    """Run ``migration.up()``, mutate status, clear+re-detect halt.
+
+    409 if the DB row is not in ``pending``. 404 if the migration is
+    not registered. 400 on missing/wrong ``confirm_text``. 500 with a
+    drift explanation if the DB UPDATE fails after ``up()`` succeeded.
+    """
+    session = await _require_session_and_csrf(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    form = await request.form()
+    confirm = _extract_form_field(form, "confirm_text")
+    if confirm != _APPLY_CONFIRM:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Confirmation text mismatch — type {_APPLY_CONFIRM} "
+                f"to apply this migration"
+            ),
+        )
+
+    migration = get_by_id(migration_id)
+    if migration is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"migration {migration_id!r} not registered",
+        )
+
+    rows_by_id = {
+        row["migration_id"]: row for row in await get_pending_updates()
+    }
+    row = rows_by_id.get(migration_id)
+    if row is not None and row["status"] != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"migration {migration_id!r} is currently in status "
+                f"{row['status']!r} — only pending migrations can be applied. "
+                f"Roll back first if a retry is intended."
+            ),
+        )
+
+    # Operator override — ``check()`` False here is acceptable (C. of
+    # the PR plan): the admin has decided. Log WARNING so the decision
+    # is in the ops record.
+    try:
+        if not await migration.check():
+            _log.warning(
+                "updates.apply: %s — check() returned False but admin "
+                "is applying anyway",
+                migration_id,
+            )
+    except Exception as exc:
+        _log.warning(
+            "updates.apply: %s — check() raised during pre-apply probe "
+            "(%s); proceeding with apply attempt",
+            migration_id, exc,
+        )
+
+    # Ensure a ``pending_updates`` row exists (the admin can trigger
+    # apply before the boot detector has populated it — e.g. a
+    # fresh-out-of-the-box migration). Idempotent insert.
+    now_iso = _now_iso()
+    if row is None:
+        await insert_pending_update(
+            migration_id=migration_id,
+            detected_at=now_iso,
+        )
+
+    try:
+        await migration.up()
+    except Exception as exc:
+        error_msg = f"{type(exc).__name__}: {exc}"
+        _log.error(
+            "updates.apply: %s up() failed: %s", migration_id, error_msg,
+        )
+        try:
+            await _update_status_with_retry(
+                migration_id=migration_id,
+                status="failed",
+                error=error_msg,
+            )
+        except HTTPException:
+            # Drift already surfaced as 500 to the client.
+            raise
+        await log_audit(
+            agent_id="admin",
+            action="updates.apply",
+            status="failure",
+            detail=f"migration_id={migration_id}, error={error_msg}",
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"apply failed: {error_msg}",
+        )
+
+    await _update_status_with_retry(
+        migration_id=migration_id,
+        status="applied",
+        applied_at=now_iso,
+    )
+    await log_audit(
+        agent_id="admin",
+        action="updates.apply",
+        status="success",
+        detail=f"migration_id={migration_id}",
+    )
+    await _refresh_halt_state(request)
+
+    return JSONResponse({"status": "applied", "migration_id": migration_id})
+
+
+@router.post("/{migration_id}/rollback")
+async def updates_rollback(migration_id: str, request: Request):
+    """Run ``migration.rollback()``, mutate status, clear+re-detect halt.
+
+    409 when the row is not in ``applied`` / ``failed`` (pending or
+    already rolled_back can't be rolled back). Otherwise the same shape
+    as :func:`updates_apply`.
+    """
+    session = await _require_session_and_csrf(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    form = await request.form()
+    confirm = _extract_form_field(form, "confirm_text")
+    if confirm != _ROLLBACK_CONFIRM:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Confirmation text mismatch — type {_ROLLBACK_CONFIRM} "
+                f"to roll back this migration"
+            ),
+        )
+
+    migration = get_by_id(migration_id)
+    if migration is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"migration {migration_id!r} not registered",
+        )
+
+    rows_by_id = {
+        row["migration_id"]: row for row in await get_pending_updates()
+    }
+    row = rows_by_id.get(migration_id)
+    if row is None or row["status"] not in ("applied", "failed"):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"migration {migration_id!r} is currently in status "
+                f"{(row or {}).get('status', 'none')!r} — only applied or "
+                f"failed migrations can be rolled back"
+            ),
+        )
+
+    try:
+        await migration.rollback()
+    except Exception as exc:
+        error_msg = f"{type(exc).__name__}: {exc}"
+        _log.error(
+            "updates.rollback: %s rollback() failed: %s",
+            migration_id, error_msg,
+        )
+        try:
+            await _update_status_with_retry(
+                migration_id=migration_id,
+                status="failed",
+                error=error_msg,
+            )
+        except HTTPException:
+            raise
+        await log_audit(
+            agent_id="admin",
+            action="updates.rollback",
+            status="failure",
+            detail=f"migration_id={migration_id}, error={error_msg}",
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"rollback failed: {error_msg}",
+        )
+
+    await _update_status_with_retry(
+        migration_id=migration_id,
+        status="rolled_back",
+        applied_at=_now_iso(),
+    )
+    await log_audit(
+        agent_id="admin",
+        action="updates.rollback",
+        status="success",
+        detail=f"migration_id={migration_id}",
+    )
+    await _refresh_halt_state(request)
+
+    return JSONResponse(
+        {"status": "rolled_back", "migration_id": migration_id},
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Internal helpers
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -757,6 +757,31 @@ class AgentManager:
         self._sign_halt_reason = reason
         logger.error("sign-halt engaged: %s", reason)
 
+    def clear_sign_halt(self) -> None:
+        """Release the sign-halt degraded mode unconditionally.
+
+        Used by the PR 4 admin endpoint after a federation-update apply
+        or rollback succeeds. The caller is expected to immediately
+        re-run :func:`mcp_proxy.updates.boot.detect_pending_migrations`
+        — if another critical migration is still pending, the halt
+        re-engages with a fresh reason; otherwise the proxy returns to
+        normal.
+
+        Idempotent: calling on an already-clear state is a silent no-op.
+        Does NOT touch ``_staged_kid`` — the #281 staged-row recovery
+        path owns that field; clearing it here would mask a genuine
+        rotation recovery state.
+        """
+        if not self._sign_halted and self._sign_halt_reason is None:
+            return
+        prior_reason = self._sign_halt_reason
+        self._sign_halted = False
+        self._sign_halt_reason = None
+        logger.info(
+            "sign-halt cleared (prior reason: %s)",
+            prior_reason or "<legacy #281 path, no reason>",
+        )
+
     async def _migrate_legacy_leaf_to_keystore(self) -> None:
         """Seed ``mastio_keys`` from ``proxy_config.mastio_leaf_{key,cert}``.
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -741,6 +741,11 @@ app.include_router(mcp_resources_legacy_router)
 from mcp_proxy.dashboard.downloads import router as downloads_router
 app.include_router(downloads_router)
 
+# Federation update framework (PR 4 of imp/federation_hardening_plan.md
+# Parte 1) — admin list / apply / rollback under /proxy/updates.
+from mcp_proxy.dashboard.updates_router import router as updates_router
+app.include_router(updates_router)
+
 # Static assets for the dashboard (compiled Tailwind CSS + bundled htmx).
 # Shake-out P0-09 + P1-10: serve /static/css/tailwind.css and /static/vendor/htmx.min.js
 # locally instead of pulling from cdn.tailwindcss.com / unpkg.com.

--- a/tests/test_updates_admin_endpoint.py
+++ b/tests/test_updates_admin_endpoint.py
@@ -1,0 +1,507 @@
+"""End-to-end tests for the federation-update admin endpoints.
+
+Covers the three handlers in ``mcp_proxy/dashboard/updates_router.py``:
+
+- ``GET /proxy/updates`` — merged list of migrations × pending_updates rows.
+- ``POST /proxy/updates/{id}/apply`` — confirm_text gate, up() wrapping,
+  status transitions (pending→applied / pending→failed), sign-halt clear.
+- ``POST /proxy/updates/{id}/rollback`` — confirm_text gate, rollback()
+  wrapping, status transitions (applied/failed→rolled_back / →failed),
+  sign-halt clear.
+
+Migrations are registered via the ``fake_pkg`` pattern from PR 1/2/3 —
+each test points :mod:`mcp_proxy.updates.registry` at a throwaway
+package so test-only fixture classes never leak into production
+discovery.
+
+The dashboard session is bootstrapped by the ``proxy_logged_in``
+fixture (mirrors the one in ``test_proxy_dashboard_mastio_key``).
+CSRF tokens are scraped from the rendered ``/proxy`` page because the
+new endpoint returns JSON and does not embed a token of its own.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import types
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.updates import registry as registry_mod
+from mcp_proxy.updates.base import Migration
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    """Standalone proxy with an admin session cookie in place."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.setenv("CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS", "0")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test",
+        ) as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            resp = await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            assert resp.status_code in (302, 303), resp.text
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def fake_pkg(monkeypatch):
+    """Per-test throwaway migrations package (pattern from PR 2/3 tests)."""
+    pkg_name = (
+        "mcp_proxy.updates.migrations"
+        f"._admin_endpoint_testfixtures_{id(monkeypatch)}"
+    )
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, pkg_name, pkg)
+    monkeypatch.setattr(registry_mod, "_migrations_pkg", pkg)
+    return pkg
+
+
+def _make_migration(
+    fake_pkg_mod: types.ModuleType,
+    name: str,
+    migration_id: str,
+    *,
+    criticality: str = "info",
+    affects: tuple[str, ...] = (),
+    check_returns: bool = True,
+    up_raises: type[Exception] | None = None,
+    rollback_raises: type[Exception] | None = None,
+) -> type[Migration]:
+    async def _check(self) -> bool:
+        return check_returns
+
+    async def _up(self) -> None:
+        if up_raises is not None:
+            raise up_raises("synthetic up() failure")
+        return None
+
+    async def _rollback(self) -> None:
+        if rollback_raises is not None:
+            raise rollback_raises("synthetic rollback() failure")
+        return None
+
+    cls = type(
+        name,
+        (Migration,),
+        {
+            "migration_id": migration_id,
+            "migration_type": "cert-schema",
+            "criticality": criticality,
+            "description": f"test fixture {name}",
+            "preserves_enrollments": True,
+            "affects_enrollments": affects,
+            "check": _check,
+            "up": _up,
+            "rollback": _rollback,
+        },
+    )
+    cls.__module__ = fake_pkg_mod.__name__
+    setattr(fake_pkg_mod, name, cls)  # keep weakref alive
+    return cls
+
+
+async def _csrf_token(client: AsyncClient) -> str:
+    """Scrape a CSRF token from a rendered dashboard page.
+
+    ``/proxy/updates`` returns JSON, so we pull the token from
+    ``/proxy/mastio-key`` which always renders after login on a
+    standalone proxy.
+    """
+    page = await client.get("/proxy/mastio-key")
+    assert page.status_code == 200, page.text
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token missing from /proxy/mastio-key"
+    return m.group(1)
+
+
+# ── GET /proxy/updates ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_returns_empty_when_no_migrations_registered(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    resp = await client.get("/proxy/updates")
+    assert resp.status_code == 200
+    assert resp.json() == {"updates": []}
+
+
+@pytest.mark.asyncio
+async def test_list_returns_migration_metadata_and_db_state(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "Alpha", "2099-01-01-alpha",
+        criticality="critical", affects=("connector",),
+    )
+
+    # Seed a pending_updates row as the boot detector would.
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-01-01-alpha",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/updates")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["updates"]) == 1
+
+    entry = body["updates"][0]
+    assert entry["migration_id"] == "2099-01-01-alpha"
+    assert entry["migration_type"] == "cert-schema"
+    assert entry["criticality"] == "critical"
+    assert entry["affects_enrollments"] == ["connector"]
+    assert entry["preserves_enrollments"] is True
+    assert entry["db_status"] == "pending"
+    assert entry["detected_at"] == "2099-01-01T00:00:00+00:00"
+    assert entry["applied_at"] is None
+    assert entry["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_shows_migration_without_db_row(
+    proxy_logged_in, fake_pkg,
+):
+    """Discovered migrations without a pending_updates row surface with
+    ``db_status=None`` — the boot detector may not have run or ``check()``
+    may have been False at boot."""
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "Beta", "2099-02-01-beta")
+
+    resp = await client.get("/proxy/updates")
+    body = resp.json()
+    assert body["updates"][0]["db_status"] is None
+    assert body["updates"][0]["applied_at"] is None
+
+
+# ── POST /proxy/updates/{id}/apply ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_happy_path(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "HappyApply", "2099-03-01-apply")
+
+    from mcp_proxy.db import insert_pending_update, get_pending_updates
+    await insert_pending_update(
+        migration_id="2099-03-01-apply",
+        detected_at="2099-03-01T00:00:00+00:00",
+    )
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-03-01-apply/apply",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "status": "applied", "migration_id": "2099-03-01-apply",
+    }
+
+    rows = [
+        r for r in await get_pending_updates()
+        if r["migration_id"] == "2099-03-01-apply"
+    ]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "applied"
+    assert rows[0]["applied_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_migration_not_found_404(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/does-not-exist/apply",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_apply_already_applied_returns_409(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "AlreadyApplied", "2099-04-01-done")
+
+    from mcp_proxy.db import (
+        insert_pending_update, update_pending_update_status,
+    )
+    await insert_pending_update(
+        migration_id="2099-04-01-done",
+        detected_at="2099-04-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id="2099-04-01-done",
+        status="applied",
+        applied_at="2099-04-01T01:00:00+00:00",
+    )
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-04-01-done/apply",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 409
+    assert "applied" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_apply_exception_sets_failed_and_logs_audit(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "BoomApply", "2099-05-01-boom",
+        up_raises=RuntimeError,
+    )
+
+    from mcp_proxy.db import insert_pending_update, get_pending_updates
+    await insert_pending_update(
+        migration_id="2099-05-01-boom",
+        detected_at="2099-05-01T00:00:00+00:00",
+    )
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-05-01-boom/apply",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 500
+
+    rows = [
+        r for r in await get_pending_updates()
+        if r["migration_id"] == "2099-05-01-boom"
+    ]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert "synthetic up()" in (rows[0]["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_apply_without_csrf_returns_403(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "NoCsrf", "2099-06-01-nocsrf")
+
+    resp = await client.post(
+        "/proxy/updates/2099-06-01-nocsrf/apply",
+        data={"confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_apply_wrong_confirm_text_returns_400(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "BadConfirm", "2099-07-01-bad")
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-07-01-bad/apply",
+        data={"csrf_token": csrf, "confirm_text": "GO"},
+    )
+    assert resp.status_code == 400
+    assert "APPLY" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_apply_missing_confirm_text_returns_400(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "MissingConfirm", "2099-08-01-mis")
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-08-01-mis/apply",
+        data={"csrf_token": csrf},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_clears_sign_halt(proxy_logged_in, fake_pkg):
+    """After a successful apply, the sign-halt flag is cleared.
+
+    The boot detector re-runs but the now-applied migration is skipped
+    (status='applied'), so halt stays cleared.
+    """
+    app_, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "HaltingApply", "2099-09-01-halt",
+        criticality="critical", affects=("connector",),
+    )
+
+    agent_mgr = app_.state.agent_manager
+    agent_mgr.mark_sign_halted(
+        "pending critical federation updates: 2099-09-01-halt",
+    )
+    assert agent_mgr.is_sign_halted is True
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-09-01-halt/apply",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert agent_mgr.is_sign_halted is False
+    assert agent_mgr.sign_halt_reason is None
+
+
+# ── POST /proxy/updates/{id}/rollback ────────────────────────────────
+
+
+async def _seed_applied_migration(fake_pkg, migration_id: str, **kwargs):
+    from mcp_proxy.db import (
+        insert_pending_update, update_pending_update_status,
+    )
+    _make_migration(fake_pkg, "ToRollback", migration_id, **kwargs)
+    await insert_pending_update(
+        migration_id=migration_id,
+        detected_at="2099-10-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id=migration_id,
+        status="applied",
+        applied_at="2099-10-01T01:00:00+00:00",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rollback_happy_path(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    await _seed_applied_migration(fake_pkg, "2099-10-01-rbk")
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-10-01-rbk/rollback",
+        data={"csrf_token": csrf, "confirm_text": "ROLLBACK"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "status": "rolled_back", "migration_id": "2099-10-01-rbk",
+    }
+
+    from mcp_proxy.db import get_pending_updates
+    rows = [
+        r for r in await get_pending_updates()
+        if r["migration_id"] == "2099-10-01-rbk"
+    ]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "rolled_back"
+
+
+@pytest.mark.asyncio
+async def test_rollback_pending_status_returns_409(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "PendingNoRb", "2099-11-01-pend")
+
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-11-01-pend",
+        detected_at="2099-11-01T00:00:00+00:00",
+    )
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-11-01-pend/rollback",
+        data={"csrf_token": csrf, "confirm_text": "ROLLBACK"},
+    )
+    assert resp.status_code == 409
+    assert "pending" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_rollback_exception_sets_failed(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    await _seed_applied_migration(
+        fake_pkg, "2099-12-01-rb-boom", rollback_raises=RuntimeError,
+    )
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-12-01-rb-boom/rollback",
+        data={"csrf_token": csrf, "confirm_text": "ROLLBACK"},
+    )
+    assert resp.status_code == 500
+
+    from mcp_proxy.db import get_pending_updates
+    rows = [
+        r for r in await get_pending_updates()
+        if r["migration_id"] == "2099-12-01-rb-boom"
+    ]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "failed"
+    assert "synthetic rollback()" in (rows[0]["error"] or "")
+
+
+@pytest.mark.asyncio
+async def test_rollback_clears_sign_halt(proxy_logged_in, fake_pkg):
+    app_, client = proxy_logged_in
+    await _seed_applied_migration(fake_pkg, "2099-13-01-rb-halt")
+
+    agent_mgr = app_.state.agent_manager
+    agent_mgr.mark_sign_halted("manual halt for test")
+    assert agent_mgr.is_sign_halted is True
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-13-01-rb-halt/rollback",
+        data={"csrf_token": csrf, "confirm_text": "ROLLBACK"},
+    )
+    assert resp.status_code == 200
+    assert agent_mgr.is_sign_halted is False
+
+
+@pytest.mark.asyncio
+async def test_rollback_wrong_confirm_text_returns_400(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    await _seed_applied_migration(fake_pkg, "2099-14-01-rb-bad")
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-14-01-rb-bad/rollback",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},  # wrong
+    )
+    assert resp.status_code == 400
+    assert "ROLLBACK" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

PR 4 of 5 for the federation update framework (``imp/federation_hardening_plan.md`` Parte 1). Surfaces the framework to operators: the concrete migration from PR #299 is now apply-able and rollback-able from the dashboard admin surface.

Three handlers under ``/proxy/updates``:
- ``GET  /proxy/updates`` — merged JSON list of every registered Migration × ``pending_updates`` row.
- ``POST /proxy/updates/{id}/apply`` — ``confirm_text=APPLY`` + CSRF + login. Runs ``up()`` wrapped, updates status, clears+re-detects halt.
- ``POST /proxy/updates/{id}/rollback`` — ``confirm_text=ROLLBACK`` + CSRF + login, gated on ``status ∈ {'applied','failed'}``.

## Scope

```
mcp_proxy/dashboard/updates_router.py        3 handlers, 380 LOC
mcp_proxy/egress/agent_manager.py            clear_sign_halt() public API (+30 LOC)
mcp_proxy/main.py                            include_router wire-up (+4 LOC)
tests/test_updates_admin_endpoint.py         16 tests, 480 LOC
```

## Design decisions

| Decision | Choice | Why |
|---|---|---|
| Route prefix | ``/proxy/updates/*`` | Repo convention; ``/admin/*`` is the ``/v1/admin/*`` JSON API layer (separate scope) |
| GET in this PR | Yes | Enables curl testing + incremental PR 5 UI |
| Response shape | JSON on POST success | Dashboard UI (PR 5) will ``fetch()`` + tests assert without follow redirects |
| Rate-limit | Inherit /admin bucket, no per-route | Authenticated deliberate actions, not abuse path |
| DB UPDATE retry | 3x exp backoff 0.1/0.2/0.4s → 500 | Self-heal via next-boot ``detect_pending_migrations``; ``check()`` source of truth |
| check()==False at apply | Apply anyway + WARNING log | Admin decision; migration ``up()`` already no-ops safely |
| confirm_text | ``APPLY`` / ``ROLLBACK`` | Mirrors ``ACTIVATE``/``DROP`` from #288 |
| Halt clear semantics | ``clear + re-detect`` | Single source of truth vs string-parsing reason |
| ``affects_enrollments`` override | Tracked as #298 (BYOCA variant) | Plan rationale — trust boundary |

## Contract behaviours

- ``GET`` merges registry metadata (id / type / criticality / description / affects) with DB state (status / detected_at / applied_at / error). Migrations without a DB row surface with ``db_status=null``.
- ``apply()`` idempotent via status gate: only ``pending`` (or no-row-yet) rows can be applied; 409 otherwise. The endpoint also inserts the row if missing, so the admin can apply before the boot detector has populated it.
- ``apply()`` failure sets ``status='failed'`` with ``error`` populated, emits ``updates.apply/failure`` audit, returns 500. Sign-halt not touched (another critical migration might still be pending).
- ``rollback()`` gated on ``status ∈ {'applied','failed'}``. Failure sets ``status='failed'``, emits ``updates.rollback/failure`` audit, returns 500.
- Both success paths: ``clear_sign_halt()`` + ``detect_pending_migrations()`` re-run. If another critical migration is pending, halt re-engages with a fresh reason.

## Verifiche locali

- ``pytest tests/ -n auto --dist=loadfile``: **1829 PASS**, 31 skipped (6 pre-existing on ``main``: 4 connector profile-runtime-switch + 2 postgres-integration).
- ``./demo_network/smoke.sh full``: **PASS**.
- DCO signoff present.

Note su test hardening: i 4 assert che leggevano ``rows[0]`` ora filtrano per ``migration_id`` — sanifica eventuali race con altre fixture nella full-suite run. Isolati passavano già.

## Test plan

- [x] GET empty when no migrations
- [x] GET merges metadata + DB state (all fields)
- [x] GET shows migrations without DB row (``db_status=None``)
- [x] Apply happy path (pending → applied + applied_at populated)
- [x] Apply 404 on unknown id
- [x] Apply 409 on non-pending status
- [x] Apply exception → status='failed' + error captured + audit log
- [x] Apply 403 without CSRF
- [x] Apply 400 on wrong confirm_text
- [x] Apply 400 on missing confirm_text
- [x] Apply success clears sign-halt
- [x] Rollback happy path (applied → rolled_back)
- [x] Rollback 409 on status='pending'
- [x] Rollback exception → status='failed' + error captured
- [x] Rollback success clears sign-halt
- [x] Rollback 400 on wrong confirm_text

## Out of scope (tracked)

- Dashboard UI Jinja2 (banner rosso, tabella, modal dry-run) → PR 5
- ``/v1/admin/updates/*`` JSON API layer → separate
- BYOCA variant operator-driven flow → #298
- Enterprise plugin discovery path → #293

## References

- Plan: ``imp/federation_hardening_plan.md`` Parte 1
- PR 1: #294, PR 2: #295, PR 3: #299 (all merged)
- Pattern source: ``/proxy/mastio-key/complete-staged`` from PR #288