### PR TITLE
feat(updates): dashboard UI + badge + retry-from-failed (PR 5/5)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -2846,6 +2846,64 @@ async def badge_audit(request: Request):
     return HTMLResponse("")
 
 
+@router.get("/badge/updates")
+async def badge_updates(request: Request):
+    """Return federation-update pending count badge fragment.
+
+    Tint encodes the most severe pending criticality on the proxy:
+      - red  → at least one ``critical`` pending migration.
+      - amber → only ``warning`` / ``info`` migrations pending.
+      - empty → no pending migrations.
+
+    Counts all pending migrations regardless of severity so operators
+    see the workload at a glance; the tint signals urgency.
+    """
+    session = get_session(request)
+    if not session.logged_in:
+        return HTMLResponse("")
+
+    try:
+        from mcp_proxy.db import get_pending_updates
+        from mcp_proxy.updates import discover
+    except Exception:
+        return HTMLResponse("")
+
+    migrations = discover()
+    try:
+        rows_by_id = {
+            r["migration_id"]: r for r in await get_pending_updates()
+        }
+    except Exception:
+        # Table may not exist yet on a pre-0019 deploy; the badge is
+        # observability, not a correctness signal — degrade silent.
+        return HTMLResponse("")
+
+    critical_pending = 0
+    other_pending = 0
+    for m in migrations:
+        row = rows_by_id.get(m.migration_id)
+        if row is None or row["status"] != "pending":
+            continue
+        if m.criticality == "critical":
+            critical_pending += 1
+        else:
+            other_pending += 1
+
+    total = critical_pending + other_pending
+    if not total:
+        return HTMLResponse("")
+
+    tint_cls = (
+        "bg-red-500/20 text-red-400"
+        if critical_pending
+        else "bg-amber-500/20 text-amber-400"
+    )
+    return HTMLResponse(
+        f'<span class="px-1.5 py-0.5 rounded-full text-xs {tint_cls}">'
+        f'{total}</span>'
+    )
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Overview (post-login landing)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -74,6 +74,12 @@
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"/></svg>
                 Signing Key
             </a>
+            <a href="/proxy/updates"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'updates' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
+                Updates
+                <span hx-get="/proxy/badge/updates" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+            </a>
             <a href="/proxy/vault"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'vault' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"/></svg>

--- a/mcp_proxy/dashboard/templates/proxy_updates.html
+++ b/mcp_proxy/dashboard/templates/proxy_updates.html
@@ -1,0 +1,346 @@
+{% extends "base.html" %}
+{% block title %}Updates{% endblock %}
+{% block header_title %}Federation Updates{% endblock %}
+{% block content %}
+<div class="max-w-6xl space-y-6">
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Flash toast — recent action (apply/rollback just happened).    #}
+    {# ────────────────────────────────────────────────────────────── #}
+    {% if request.query_params.get('applied') %}
+    <div id="updates-flash" class="bg-emerald-500/5 border border-emerald-500/30 rounded-lg px-5 py-4 flex items-center gap-4 card-glow">
+        <div class="w-8 h-8 rounded-full bg-emerald-500/15 flex items-center justify-center flex-shrink-0">
+            <svg class="w-4 h-4 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+        </div>
+        <div class="flex-1 min-w-0">
+            <p class="text-[11px] text-emerald-400 uppercase tracking-[0.18em] font-medium">
+                {% if request.query_params.get('applied') == 'rolled_back' %}Rollback complete{% else %}Apply complete{% endif %}
+            </p>
+            <p class="text-xs text-gray-400 mt-1 font-mono truncate">{{ request.query_params.get('migration_id', '—') }}</p>
+        </div>
+        <button type="button"
+                onclick="document.getElementById('updates-flash').remove(); history.replaceState({}, '', '/proxy/updates');"
+                class="text-gray-500 hover:text-gray-300 transition-colors">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+    </div>
+    {% endif %}
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Critical banner — fires when any row is pending+critical.      #}
+    {# Anchors to the first critical row in the table.                 #}
+    {# ────────────────────────────────────────────────────────────── #}
+    {% if has_critical_pending %}
+    <div class="bg-red-500/5 border border-red-500/40 rounded-lg px-5 py-4 flex items-start gap-4 sticky top-4 z-10 card-glow">
+        <div class="w-9 h-9 rounded-full bg-red-500/15 flex items-center justify-center flex-shrink-0 mt-0.5">
+            <svg class="w-5 h-5 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+        </div>
+        <div class="flex-1 min-w-0">
+            <p class="text-xs text-red-400 uppercase tracking-[0.18em] font-semibold">Critical updates pending</p>
+            <p class="text-xs text-gray-400 mt-1.5 leading-relaxed">
+                One or more critical federation updates must be applied to
+                restore full service. Signing has been halted for the
+                affected enrollments until an apply or rollback succeeds.
+            </p>
+        </div>
+        <a href="#first-critical"
+           class="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider rounded border border-red-500/40 text-red-300 hover:bg-red-500/10 transition-colors self-center flex-shrink-0">
+            Jump to row
+        </a>
+    </div>
+    {% endif %}
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Hero — what this page is + why it exists.                      #}
+    {# ────────────────────────────────────────────────────────────── #}
+    <div class="bg-[#111827]/60 border border-gray-800/50 rounded-lg px-6 py-5 backdrop-blur-sm">
+        <p class="text-[10px] text-gray-600 uppercase tracking-[0.22em] mb-2">Federation update framework · Parte 1</p>
+        <h2 class="font-heading text-xl font-semibold text-white tracking-wide">Schema, keys &amp; policy updates</h2>
+        <p class="text-xs text-gray-500 mt-2 leading-relaxed max-w-2xl">
+            Each row is a migration that touches state the proxy owns —
+            certificates, schemas, or policy toggles. ``apply`` runs the
+            migration's idempotent ``up()``; ``rollback`` restores the
+            pre-apply state from the per-migration snapshot. Critical
+            migrations engage sign-halt until resolved.
+        </p>
+    </div>
+
+    {# ────────────────────────────────────────────────────────────── #}
+    {# Table — one row per registered migration.                      #}
+    {# ────────────────────────────────────────────────────────────── #}
+    {% if not updates %}
+    <div class="bg-[#111827]/80 border border-gray-800/50 rounded-lg p-10 backdrop-blur-sm text-center">
+        <svg class="w-12 h-12 mx-auto text-gray-800 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 13l4 4L19 7"/></svg>
+        <p class="text-sm text-gray-500 mb-1">No migrations registered</p>
+        <p class="text-xs text-gray-700">This proxy is up to date with the shipped update framework.</p>
+    </div>
+    {% else %}
+    <div class="bg-[#111827]/80 border border-gray-800/50 rounded-lg backdrop-blur-sm overflow-hidden">
+        <table class="w-full text-sm">
+            <thead class="bg-surface-950/60 text-[10px] text-gray-600 uppercase tracking-wider">
+                <tr>
+                    <th class="px-4 py-3 text-left">Migration</th>
+                    <th class="px-4 py-3 text-left">Type</th>
+                    <th class="px-4 py-3 text-left">Affects</th>
+                    <th class="px-4 py-3 text-left">Status</th>
+                    <th class="px-4 py-3 text-right">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% set ns = namespace(first_critical_rendered=false) %}
+                {% for u in updates %}
+                {% set is_first_critical = (u.criticality == 'critical' and u.db_status == 'pending' and not ns.first_critical_rendered) %}
+                {% if is_first_critical %}{% set ns.first_critical_rendered = true %}{% endif %}
+                <tr {% if is_first_critical %}id="first-critical"{% endif %}
+                    class="{% if u.criticality == 'critical' %}bg-red-500/[0.03]{% elif u.criticality == 'warning' %}bg-amber-500/[0.03]{% endif %} hover:bg-gray-800/20 transition-colors">
+                    <td class="px-4 py-4 align-top">
+                        <p class="font-mono text-xs text-gray-200 break-all">{{ u.migration_id }}</p>
+                        <p class="text-[11px] text-gray-500 mt-1 leading-snug max-w-md">{{ u.description }}</p>
+                        {% if u.error %}
+                        <details class="mt-2 text-[11px]">
+                            <summary class="cursor-pointer text-red-400 hover:text-red-300 uppercase tracking-wider select-none flex items-center gap-1.5">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01"/></svg>
+                                Last error
+                            </summary>
+                            <pre class="mt-2 font-mono text-[11px] text-red-300/80 bg-red-500/5 border border-red-500/20 p-2 rounded overflow-x-auto max-w-md">{{ u.error }}</pre>
+                        </details>
+                        {% endif %}
+                    </td>
+                    <td class="px-4 py-4 align-top">
+                        <span class="inline-block text-[10px] text-gray-500 font-mono">{{ u.migration_type }}</span>
+                        <div class="mt-1">
+                            {% if u.criticality == 'critical' %}
+                            <span class="inline-block px-1.5 py-0.5 rounded text-[10px] bg-red-500/15 text-red-400 uppercase tracking-wider">Critical</span>
+                            {% elif u.criticality == 'warning' %}
+                            <span class="inline-block px-1.5 py-0.5 rounded text-[10px] bg-amber-500/15 text-amber-400 uppercase tracking-wider">Warning</span>
+                            {% else %}
+                            <span class="inline-block px-1.5 py-0.5 rounded text-[10px] bg-gray-500/15 text-gray-400 uppercase tracking-wider">Info</span>
+                            {% endif %}
+                        </div>
+                    </td>
+                    <td class="px-4 py-4 align-top">
+                        {% if u.affects_enrollments %}
+                        <div class="flex flex-wrap gap-1">
+                            {% for kind in u.affects_enrollments %}
+                            <span class="inline-block px-1.5 py-0.5 rounded text-[10px] bg-gray-800/80 text-gray-300 font-mono">{{ kind }}</span>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <span class="text-[11px] text-gray-600">—</span>
+                        {% endif %}
+                        {% if u.preserves_enrollments %}
+                        <p class="text-[10px] text-gray-600 mt-1">Preserves pubkeys</p>
+                        {% endif %}
+                    </td>
+                    <td class="px-4 py-4 align-top">
+                        {% if u.db_status == 'pending' %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-amber-500 pulse-dot"></span>Pending
+                        </span>
+                        {% elif u.db_status == 'applied' %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>Applied
+                        </span>
+                        {% if u.applied_at %}
+                        <p class="text-[10px] text-gray-600 mt-1 font-mono">{{ u.applied_at[:19] }}</p>
+                        {% endif %}
+                        {% elif u.db_status == 'failed' %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Failed
+                        </span>
+                        {% elif u.db_status == 'rolled_back' %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-gray-500"></span>Rolled back
+                        </span>
+                        {% if u.applied_at %}
+                        <p class="text-[10px] text-gray-600 mt-1 font-mono">{{ u.applied_at[:19] }}</p>
+                        {% endif %}
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-600/10 text-gray-600 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-gray-700"></span>Not detected
+                        </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-4 py-4 align-top text-right">
+                        {# Action buttons are context-aware: pending→Apply, applied→Rollback,    #}
+                        {# failed→Retry+Rollback, rolled_back→no-action, null→Apply (operator   #}
+                        {# override allowed; backend inserts the row).                            #}
+                        {% if u.db_status in ('pending', None) %}
+                        <button type="button"
+                                data-update-action="apply"
+                                data-migration-id="{{ u.migration_id }}"
+                                class="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider rounded transition-all"
+                                style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em;"
+                                onmouseover="this.style.background='#fff'"
+                                onmouseout="this.style.background='#00e5c7'">
+                            Apply
+                        </button>
+                        {% elif u.db_status == 'applied' %}
+                        <button type="button"
+                                data-update-action="rollback"
+                                data-migration-id="{{ u.migration_id }}"
+                                class="px-3 py-1.5 text-xs font-medium uppercase tracking-wider rounded border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors">
+                            Rollback
+                        </button>
+                        {% elif u.db_status == 'failed' %}
+                        <div class="flex items-center justify-end gap-2">
+                            <button type="button"
+                                    data-update-action="apply"
+                                    data-migration-id="{{ u.migration_id }}"
+                                    class="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider rounded transition-all"
+                                    style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em;"
+                                    onmouseover="this.style.background='#fff'"
+                                    onmouseout="this.style.background='#00e5c7'">
+                                Retry apply
+                            </button>
+                            <button type="button"
+                                    data-update-action="rollback"
+                                    data-migration-id="{{ u.migration_id }}"
+                                    class="px-3 py-1.5 text-xs font-medium uppercase tracking-wider rounded border border-gray-700 text-gray-300 hover:bg-gray-800 transition-colors">
+                                Rollback
+                            </button>
+                        </div>
+                        {% else %}
+                        <span class="text-[11px] text-gray-600">—</span>
+                        {% endif %}
+
+                        {# PR 6 slot for dry-run preview button — deferred                        #}
+                        {# (tracked as a follow-up issue). The backend transactional              #}
+                        {# preview + diff UI lands then.                                          #}
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+
+</div>
+
+{# ────────────────────────────────────────────────────────────── #}
+{# Confirm modal — apply. Type APPLY to enable submit.            #}
+{# Mirrors /proxy/mastio-key rotate modal (PR #288).              #}
+{# ────────────────────────────────────────────────────────────── #}
+<div id="update-apply-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+         onclick="closeUpdateModal('update-apply-modal')"></div>
+    <div class="relative bg-surface-900 border border-gray-800/50 rounded-lg p-6 w-full max-w-md shadow-2xl">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-3 font-heading">Apply migration</h3>
+        <div class="p-3 bg-[#0a0f1a] border border-accent-400/15 rounded mb-4">
+            <p class="text-xs text-gray-400 leading-relaxed">
+                Running <span id="update-apply-id" class="font-mono text-accent-300">—</span>.
+                This may re-sign certificates or mutate persistent state; the
+                backend takes a snapshot before applying so a rollback is
+                possible if the operation succeeds technically but proves
+                wrong in policy.
+            </p>
+        </div>
+        <form id="update-apply-form" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-[0.2em]">Type APPLY to confirm</label>
+            <input type="text" name="confirm_text" required
+                   autocomplete="off" spellcheck="false"
+                   placeholder="APPLY"
+                   class="update-confirm-input w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono tracking-widest transition-all mb-4 focus:outline-none focus:border-accent-400/60"
+                   data-expected="APPLY"
+                   data-submit-id="update-apply-submit">
+            <div class="flex items-center gap-3">
+                <button type="submit" id="update-apply-submit" disabled
+                        class="px-4 py-2 text-xs font-semibold uppercase tracking-wider rounded transition-all disabled:opacity-40 disabled:cursor-not-allowed"
+                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em;">
+                    Confirm apply
+                </button>
+                <button type="button"
+                        onclick="closeUpdateModal('update-apply-modal')"
+                        class="px-4 py-2 text-xs text-gray-500 border border-gray-700 rounded hover:bg-gray-800 transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+{# ────────────────────────────────────────────────────────────── #}
+{# Confirm modal — rollback. Type ROLLBACK to enable submit.      #}
+{# ────────────────────────────────────────────────────────────── #}
+<div id="update-rollback-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center">
+    <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"
+         onclick="closeUpdateModal('update-rollback-modal')"></div>
+    <div class="relative bg-surface-900 border border-gray-800/50 rounded-lg p-6 w-full max-w-md shadow-2xl">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-3 font-heading">Rollback migration</h3>
+        <div class="p-3 bg-[#0a0f1a] border border-red-500/15 rounded mb-4">
+            <p class="text-xs text-gray-400 leading-relaxed">
+                Restoring pre-apply state for <span id="update-rollback-id" class="font-mono text-red-300">—</span>
+                from the backup snapshot taken before the last apply. Some
+                migrations (``cert-algorithm``) are irreversible by design
+                and raise instead of rolling back.
+            </p>
+        </div>
+        <form id="update-rollback-form" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-[0.2em]">Type ROLLBACK to confirm</label>
+            <input type="text" name="confirm_text" required
+                   autocomplete="off" spellcheck="false"
+                   placeholder="ROLLBACK"
+                   class="update-confirm-input w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono tracking-widest transition-all mb-4 focus:outline-none focus:border-red-400/60"
+                   data-expected="ROLLBACK"
+                   data-submit-id="update-rollback-submit">
+            <div class="flex items-center gap-3">
+                <button type="submit" id="update-rollback-submit" disabled
+                        class="px-4 py-2 text-xs font-semibold uppercase tracking-wider rounded bg-red-500/90 text-white hover:bg-red-500 disabled:opacity-40 disabled:cursor-not-allowed transition-all">
+                    Confirm rollback
+                </button>
+                <button type="button"
+                        onclick="closeUpdateModal('update-rollback-modal')"
+                        class="px-4 py-2 text-xs text-gray-500 border border-gray-700 rounded hover:bg-gray-800 transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+(function() {
+    function openModal(id) {
+        document.getElementById(id).classList.remove('hidden');
+        const input = document.querySelector('#' + id + ' .update-confirm-input');
+        if (input) { input.focus(); input.value = ''; input.dispatchEvent(new Event('input')); }
+    }
+    window.closeUpdateModal = function(id) {
+        document.getElementById(id).classList.add('hidden');
+    };
+
+    // Wire up every action button to open the right modal with the
+    // correct form action wired to the migration id.
+    document.querySelectorAll('[data-update-action]').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+            const action = btn.getAttribute('data-update-action');
+            const mid = btn.getAttribute('data-migration-id');
+            if (action === 'apply') {
+                document.getElementById('update-apply-id').textContent = mid;
+                document.getElementById('update-apply-form').action =
+                    '/proxy/updates/' + encodeURIComponent(mid) + '/apply';
+                openModal('update-apply-modal');
+            } else if (action === 'rollback') {
+                document.getElementById('update-rollback-id').textContent = mid;
+                document.getElementById('update-rollback-form').action =
+                    '/proxy/updates/' + encodeURIComponent(mid) + '/rollback';
+                openModal('update-rollback-modal');
+            }
+        });
+    });
+
+    // Disable/enable the submit button as the operator types the
+    // confirmation text — live comparison to the expected literal.
+    document.querySelectorAll('.update-confirm-input').forEach(function(input) {
+        const expected = input.getAttribute('data-expected');
+        const submitId = input.getAttribute('data-submit-id');
+        input.addEventListener('input', function() {
+            document.getElementById(submitId).disabled =
+                (this.value !== expected);
+        });
+    });
+})();
+</script>
+{% endblock %}

--- a/mcp_proxy/dashboard/updates_router.py
+++ b/mcp_proxy/dashboard/updates_router.py
@@ -41,11 +41,15 @@ import json
 import logging
 from typing import Iterable
 
+import pathlib
+
 from fastapi import APIRouter, HTTPException, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse
 
 from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
     require_login,
     verify_csrf,
 )
@@ -57,6 +61,9 @@ from mcp_proxy.db import (
 )
 from mcp_proxy.updates import Migration, discover, get_by_id
 from mcp_proxy.updates.boot import detect_pending_migrations
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+_templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
 
 
 _log = logging.getLogger("mcp_proxy.dashboard.updates")
@@ -204,27 +211,62 @@ async def _refresh_halt_state(request: Request) -> None:
 # ─────────────────────────────────────────────────────────────────────
 
 
-@router.get("")
-async def updates_list(request: Request):
-    """Return every registered migration merged with its DB row.
+async def _build_updates_view() -> list[dict]:
+    """Shared assembler used by the HTML page and the JSON endpoint."""
+    migrations = discover()
+    rows_by_id = {
+        row["migration_id"]: row for row in await get_pending_updates()
+    }
+    return [
+        _migration_to_dict(m, rows_by_id.get(m.migration_id))
+        for m in migrations
+    ]
 
-    Authenticated read-only endpoint. No CSRF (GET). Consumed by the
-    dashboard UI (PR 5) and by ``curl`` during ops.
+
+def _has_critical_pending(updates_view: list[dict]) -> bool:
+    return any(
+        u["criticality"] == "critical" and u["db_status"] == "pending"
+        for u in updates_view
+    )
+
+
+@router.get("", response_class=HTMLResponse)
+async def updates_page(request: Request):
+    """Render the dashboard UI for federation updates.
+
+    HTML response. Login-gated; GET so no CSRF. The UI consumes the
+    same ``updates`` view the JSON endpoint exposes — matching the
+    dashboard convention of one URL, one content type. The JSON
+    view lives at ``/proxy/updates/api`` for scripts and tests.
     """
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return session
 
-    migrations = discover()
-    rows_by_id = {
-        row["migration_id"]: row for row in await get_pending_updates()
-    }
-    return JSONResponse({
-        "updates": [
-            _migration_to_dict(m, rows_by_id.get(m.migration_id))
-            for m in migrations
-        ],
-    })
+    updates_view = await _build_updates_view()
+    return _templates.TemplateResponse(
+        "proxy_updates.html",
+        {
+            "request": request,
+            "session": session,
+            "csrf_token": session.csrf_token,
+            "active": "updates",
+            "updates": updates_view,
+            "has_critical_pending": _has_critical_pending(updates_view),
+        },
+    )
+
+
+@router.get("/api")
+async def updates_list_json(request: Request):
+    """JSON view of every registered migration + its ``pending_updates`` row.
+
+    Companion to :func:`updates_page` for curl / scripts / tests.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return JSONResponse({"updates": await _build_updates_view()})
 
 
 @router.post("/{migration_id}/apply")
@@ -261,13 +303,17 @@ async def updates_apply(migration_id: str, request: Request):
         row["migration_id"]: row for row in await get_pending_updates()
     }
     row = rows_by_id.get(migration_id)
-    if row is not None and row["status"] != "pending":
+    if row is not None and row["status"] not in ("pending", "failed"):
+        # ``applied`` and ``rolled_back`` terminal states require an
+        # explicit rollback before a new apply; retry-from-failed is
+        # the intended path for recovering a prior failed attempt,
+        # safe because Migration.up() is documented idempotent (PR 1).
         raise HTTPException(
             status_code=409,
             detail=(
                 f"migration {migration_id!r} is currently in status "
-                f"{row['status']!r} — only pending migrations can be applied. "
-                f"Roll back first if a retry is intended."
+                f"{row['status']!r} — only pending or failed migrations "
+                f"can be applied. Roll back first if a reset is intended."
             ),
         )
 

--- a/tests/test_updates_admin_endpoint.py
+++ b/tests/test_updates_admin_endpoint.py
@@ -152,7 +152,7 @@ async def test_list_returns_empty_when_no_migrations_registered(
     proxy_logged_in, fake_pkg,
 ):
     _, client = proxy_logged_in
-    resp = await client.get("/proxy/updates")
+    resp = await client.get("/proxy/updates/api")
     assert resp.status_code == 200
     assert resp.json() == {"updates": []}
 
@@ -174,7 +174,7 @@ async def test_list_returns_migration_metadata_and_db_state(
         detected_at="2099-01-01T00:00:00+00:00",
     )
 
-    resp = await client.get("/proxy/updates")
+    resp = await client.get("/proxy/updates/api")
     assert resp.status_code == 200
     body = resp.json()
     assert len(body["updates"]) == 1
@@ -201,7 +201,7 @@ async def test_list_shows_migration_without_db_row(
     _, client = proxy_logged_in
     _make_migration(fake_pkg, "Beta", "2099-02-01-beta")
 
-    resp = await client.get("/proxy/updates")
+    resp = await client.get("/proxy/updates/api")
     body = resp.json()
     assert body["updates"][0]["db_status"] is None
     assert body["updates"][0]["applied_at"] is None
@@ -353,6 +353,59 @@ async def test_apply_missing_confirm_text_returns_400(
         data={"csrf_token": csrf},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_retry_from_failed_status(proxy_logged_in, fake_pkg):
+    """PR 5: apply() accepts status='failed' and clears the stale error.
+
+    Retry semantics: the admin fixed whatever made up() fail and re-runs.
+    up() is documented idempotent (PR 1 ABC contract), so the second call
+    is safe. Post-success the error field must be NULL — a stale error
+    next to a successful apply would confuse the UI badge and the audit
+    trail.
+    """
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "RetryOK", "2099-retry-01")
+
+    from mcp_proxy.db import (
+        insert_pending_update,
+        update_pending_update_status,
+        get_pending_updates,
+    )
+
+    # Seed the prior-failed state — row exists, status='failed',
+    # error populated.
+    await insert_pending_update(
+        migration_id="2099-retry-01",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id="2099-retry-01",
+        status="failed",
+        error="transient: flaky filesystem, now fixed",
+    )
+
+    csrf = await _csrf_token(client)
+    resp = await client.post(
+        "/proxy/updates/2099-retry-01/apply",
+        data={"csrf_token": csrf, "confirm_text": "APPLY"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "status": "applied", "migration_id": "2099-retry-01",
+    }
+
+    rows = [
+        r for r in await get_pending_updates()
+        if r["migration_id"] == "2099-retry-01"
+    ]
+    assert len(rows) == 1
+    assert rows[0]["status"] == "applied"
+    assert rows[0]["applied_at"] is not None
+    # The stale ``error`` must be cleared — otherwise the UI shows a
+    # red "Last error" panel next to an applied badge.
+    assert rows[0]["error"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_updates_dashboard_ui.py
+++ b/tests/test_updates_dashboard_ui.py
@@ -1,0 +1,406 @@
+"""Rendering tests for the federation-update dashboard UI.
+
+Exercises:
+- ``GET /proxy/updates`` HTML page (login-gated, context-aware action
+  buttons, critical banner, empty state).
+- ``GET /proxy/badge/updates`` HTMX fragment (empty / amber / red).
+- Nav entry in ``base.html``.
+
+Assertions look for specific stable strings in the rendered HTML —
+regex / in-string checks rather than DOM parsing — so a minor style
+tweak doesn't break the test but a functional regression does.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import types
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.updates import registry as registry_mod
+from mcp_proxy.updates.base import Migration
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    monkeypatch.setenv("CULLIS_MASTIO_ROTATION_MIN_INTERVAL_SECONDS", "0")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test",
+        ) as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            resp = await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            assert resp.status_code in (302, 303), resp.text
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def fake_pkg(monkeypatch):
+    pkg_name = (
+        "mcp_proxy.updates.migrations"
+        f"._ui_testfixtures_{id(monkeypatch)}"
+    )
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, pkg_name, pkg)
+    monkeypatch.setattr(registry_mod, "_migrations_pkg", pkg)
+    return pkg
+
+
+def _make_migration(
+    fake_pkg_mod: types.ModuleType,
+    name: str,
+    migration_id: str,
+    *,
+    criticality: str = "info",
+    affects: tuple[str, ...] = (),
+    description: str = "test fixture migration",
+) -> type[Migration]:
+    async def _check(self) -> bool:
+        return True
+
+    async def _up(self) -> None:
+        return None
+
+    async def _rollback(self) -> None:
+        return None
+
+    cls = type(
+        name,
+        (Migration,),
+        {
+            "migration_id": migration_id,
+            "migration_type": "cert-schema",
+            "criticality": criticality,
+            "description": description,
+            "preserves_enrollments": True,
+            "affects_enrollments": affects,
+            "check": _check,
+            "up": _up,
+            "rollback": _rollback,
+        },
+    )
+    cls.__module__ = fake_pkg_mod.__name__
+    setattr(fake_pkg_mod, name, cls)
+    return cls
+
+
+# ── Page renders ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_page_requires_login_redirects(tmp_path, monkeypatch):
+    """Unauthenticated GET /proxy/updates → 303 to /proxy/login."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}",
+    )
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(
+            transport=transport, base_url="http://test",
+        ) as client:
+            resp = await client.get("/proxy/updates", follow_redirects=False)
+            assert resp.status_code in (302, 303)
+            assert "/proxy/login" in resp.headers.get("location", "")
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_page_renders_empty_state_when_no_migrations(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    resp = await client.get("/proxy/updates")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "No migrations registered" in html
+    # Critical banner must NOT render on empty registry.
+    assert "Critical updates pending" not in html
+
+
+@pytest.mark.asyncio
+async def test_page_renders_pending_migration_with_apply_button(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "MigPending", "2099-ui-01-pending",
+        criticality="info", affects=("connector",),
+    )
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-ui-01-pending",
+        detected_at="2099-01-01T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    assert resp.status_code == 200
+    assert "2099-ui-01-pending" in html
+    # Apply button wired with the id.
+    assert 'data-update-action="apply"' in html
+    assert 'data-migration-id="2099-ui-01-pending"' in html
+    # Pending status badge rendered.
+    assert "Pending" in html
+
+
+@pytest.mark.asyncio
+async def test_page_renders_applied_migration_with_rollback_button(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "MigApplied", "2099-ui-02-applied")
+    from mcp_proxy.db import (
+        insert_pending_update, update_pending_update_status,
+    )
+    await insert_pending_update(
+        migration_id="2099-ui-02-applied",
+        detected_at="2099-02-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id="2099-ui-02-applied",
+        status="applied",
+        applied_at="2099-02-01T01:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    assert "2099-ui-02-applied" in html
+    # Rollback button, NOT apply.
+    assert (
+        'data-update-action="rollback"' in html
+        and 'data-migration-id="2099-ui-02-applied"' in html
+    )
+    # Applied badge.
+    assert "Applied" in html
+
+
+@pytest.mark.asyncio
+async def test_page_renders_failed_migration_with_retry_and_rollback(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "MigFailed", "2099-ui-03-failed")
+    from mcp_proxy.db import (
+        insert_pending_update, update_pending_update_status,
+    )
+    await insert_pending_update(
+        migration_id="2099-ui-03-failed",
+        detected_at="2099-03-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id="2099-ui-03-failed",
+        status="failed",
+        error="synthetic: disk full",
+    )
+
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    # Both action buttons rendered for failed status.
+    assert "Retry apply" in html
+    assert "Rollback" in html
+    # Error expander surfaces the message.
+    assert "synthetic: disk full" in html
+
+
+@pytest.mark.asyncio
+async def test_page_renders_critical_banner_when_critical_pending(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "MigCrit", "2099-ui-04-crit",
+        criticality="critical", affects=("connector",),
+    )
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-ui-04-crit",
+        detected_at="2099-04-01T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    assert "Critical updates pending" in html
+    # Anchor into the first critical row is wired.
+    assert 'id="first-critical"' in html
+
+
+@pytest.mark.asyncio
+async def test_page_no_banner_when_only_non_critical_pending(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "MigWarn", "2099-ui-05-warn",
+        criticality="warning", affects=("connector",),
+    )
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-ui-05-warn",
+        detected_at="2099-05-01T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    assert "Critical updates pending" not in html
+    assert "2099-ui-05-warn" in html
+
+
+@pytest.mark.asyncio
+async def test_page_csrf_token_embedded_in_forms(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "MigCsrf", "2099-ui-06-csrf")
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-ui-06-csrf",
+        detected_at="2099-06-01T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    # At least two csrf_token hidden fields — one per modal form.
+    # base.html may embed additional copies (logout etc.); what matters
+    # is that both modals on this page inherit the same session token.
+    tokens = re.findall(r'name="csrf_token" value="([^"]+)"', html)
+    assert len(tokens) >= 2
+    assert tokens[0]  # non-empty
+    assert all(t == tokens[0] for t in tokens)
+
+
+@pytest.mark.asyncio
+async def test_nav_link_present_and_active(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    resp = await client.get("/proxy/updates")
+    html = resp.text
+    # Nav anchor for Updates page.
+    assert 'href="/proxy/updates"' in html
+    # Active marker on the nav entry when we're on this page.
+    active = re.search(
+        r'href="/proxy/updates"[^>]*class="[^"]*nav-active',
+        html,
+    )
+    assert active, "Updates nav entry is not marked active"
+
+
+# ── Badge endpoint ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_badge_empty_when_no_pending(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    resp = await client.get("/proxy/badge/updates")
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+@pytest.mark.asyncio
+async def test_badge_amber_when_only_non_critical_pending(
+    proxy_logged_in, fake_pkg,
+):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "MigBadgeWarn", "2099-badge-01-warn",
+        criticality="warning",
+    )
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-badge-01-warn",
+        detected_at="2099-07-01T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/badge/updates")
+    assert resp.status_code == 200
+    # Amber tint classes present.
+    assert "amber" in resp.text
+    # Count of 1.
+    assert ">1<" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_badge_red_when_critical_pending(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    _make_migration(
+        fake_pkg, "MigBadgeCrit", "2099-badge-02-crit",
+        criticality="critical",
+    )
+    _make_migration(
+        fake_pkg, "MigBadgeInfo", "2099-badge-02-info",
+        criticality="info",
+    )
+    from mcp_proxy.db import insert_pending_update
+    await insert_pending_update(
+        migration_id="2099-badge-02-crit",
+        detected_at="2099-08-01T00:00:00+00:00",
+    )
+    await insert_pending_update(
+        migration_id="2099-badge-02-info",
+        detected_at="2099-08-02T00:00:00+00:00",
+    )
+
+    resp = await client.get("/proxy/badge/updates")
+    assert resp.status_code == 200
+    # Red tint because at least one critical is pending.
+    assert "red" in resp.text
+    # Total count is 2.
+    assert ">2<" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_badge_ignores_non_pending_rows(proxy_logged_in, fake_pkg):
+    _, client = proxy_logged_in
+    _make_migration(fake_pkg, "MigBadgeDone", "2099-badge-03-done")
+    from mcp_proxy.db import (
+        insert_pending_update, update_pending_update_status,
+    )
+    await insert_pending_update(
+        migration_id="2099-badge-03-done",
+        detected_at="2099-09-01T00:00:00+00:00",
+    )
+    await update_pending_update_status(
+        migration_id="2099-badge-03-done",
+        status="applied",
+        applied_at="2099-09-01T01:00:00+00:00",
+    )
+    resp = await client.get("/proxy/badge/updates")
+    assert resp.status_code == 200
+    assert resp.text == ""


### PR DESCRIPTION
## Summary

Final PR (5 of 5) of the federation-update epic (``imp/federation_hardening_plan.md`` Parte 1). Completes the operator-facing surface on top of the framework plumbing from #294 / #295 / #299 / #301.

- Jinja2 dashboard page at ``/proxy/updates`` with critical banner, migration table, per-status actions (Apply / Rollback / Retry+Rollback) and 2 confirm modals (``APPLY`` / ``ROLLBACK``) mirroring #288.
- JSON view moved to ``/proxy/updates/api`` (companion to the HTML page — 1 URL = 1 content-type, dashboard repo convention).
- HTMX badge ``/proxy/badge/updates`` with severity-tinted counter (red / amber / empty).
- Nav entry under Signing Key in ``base.html``.
- ``apply`` policy widened to accept ``status ∈ {'pending','failed'}`` — retry-from-failed is now a first-class flow, enabled by the idempotent contract on ``Migration.up()`` (PR 1 ABC). On retry success the stale ``error`` column is cleared so the UI badge and audit trail stay coherent.

## Scope

```
mcp_proxy/dashboard/templates/proxy_updates.html  new, ~280 LOC Jinja + vanilla JS modals
mcp_proxy/dashboard/updates_router.py             GET / → HTML, GET /api → JSON;
                                                  apply widened to pending|failed
mcp_proxy/dashboard/router.py                     GET /proxy/badge/updates (HTMX)
mcp_proxy/dashboard/templates/base.html           Updates nav entry + badge hook
tests/test_updates_dashboard_ui.py                13 new tests
tests/test_updates_admin_endpoint.py              GET paths retargeted + retry test
```

## Design decisions

| Decision | Choice | Why |
|---|---|---|
| Route split | ``/proxy/updates`` HTML + ``/proxy/updates/api`` JSON | Dashboard convention: 1 URL = 1 content-type; bookmark-safe; no content negotiation |
| Badge tint | Red / amber / empty | Criticality is tristate (critical/warning/info); binary badge would lose info |
| Retry-from-failed | ``apply`` accepts ``status=failed`` | ``up()`` idempotent by contract (PR 1); fixes UX gap — admin couldn't recover from transient failures without rollback-first dance |
| Stale-error clear | ``error=NULL`` on retry success | Without this the UI keeps showing the red "Last error" panel next to an Applied badge |
| Dry-run preview | Deferred → #302 | Complicates Migration contract; existing rollback is sufficient fallback |
| Sticky critical banner | ``sticky top-4`` on the banner div | Visible while operator scrolls the table |
| Anchor to first critical | ``id="first-critical"`` on first row matching criticality=critical+status=pending | One-click jump from banner |
| Action buttons context-aware | pending→Apply / applied→Rollback / failed→Retry+Rollback / rolled_back→none | Matches the state machine; keeps the UI decluttered |

## Verifiche locali

- ``pytest tests/ -n auto --dist=loadfile``: **1867 PASS**, 31 skipped (6 pre-existing: 4 connector profile-runtime-switch + 2 postgres-integration).
- ``./demo_network/smoke.sh full``: PASS.
- DCO signoff present.
- Template renders standalone (``jinja2.Environment`` smoke).

## Test plan

- [x] Login redirect on unauthenticated GET
- [x] Empty state when no migrations registered
- [x] Pending row renders with Apply button
- [x] Applied row renders with Rollback button
- [x] Failed row renders with Retry apply + Rollback + error expander
- [x] Critical banner when any critical+pending
- [x] No banner when only non-critical pending
- [x] CSRF token embedded in every modal form (same token)
- [x] Nav link present and active on this page
- [x] Badge empty / amber / red branches
- [x] Badge ignores rows not in ``pending`` status
- [x] Admin endpoint tests retargeted to ``/proxy/updates/api`` for JSON
- [x] Apply retry-from-failed clears ``error`` on success

## Out of scope (tracked)

- Dry-run preview (transactional preview + diff) → #302 P2
- BYOCA variant operator-driven flow → #298 P2
- Enterprise plugin discovery path → #293 P2

## Epic closure

| PR | Scope | Status |
|---|---|---|
| 1 | Registry foundation | MERGED #294 |
| 2 | Boot detector + Prometheus gauge + sign-halt wiring | MERGED #295 |
| 3 | First concrete migration ``2026-04-23-org-ca-pathlen-1`` | MERGED #299 |
| 4 | Admin apply/rollback endpoints + GET list | MERGED #301 |
| 5 | Dashboard UI + badge + retry-from-failed | **this PR** |

Framework 100% functional end-to-end after this merges.

## References

- Plan: ``imp/federation_hardening_plan.md`` Parte 1
- Pattern source: ``/proxy/mastio-key/complete-staged`` (PR #288)