### PR TITLE
test(nightly): lean stress-test scaffold — Court + 2 Mastio + N BYOCA agents

### DIFF
--- a/test/nightly/.gitignore
+++ b/test/nightly/.gitignore
@@ -1,0 +1,4 @@
+state/
+logs/
+reports/
+*.pid

--- a/test/nightly/README.md
+++ b/test/nightly/README.md
@@ -1,0 +1,61 @@
+# Nightly stress test
+
+Lean multi-org setup for long-running load / soak / chaos runs. Surfaces the
+criticalities that the ~50s `sandbox/smoke.sh` can't hit: queue depth under
+sustained load, WS reconnect spikes, message expiry, cert rotation in-flight,
+memory growth, etc.
+
+**Scope**: Court + 2 Mastio (`orga`, `orgb`) + N agents/org enrolled via BYOCA.
+No SPIRE, no Keycloak, no MCP servers — pure agent-to-agent traffic.
+
+## Quick start
+
+```bash
+cd test/nightly
+./nightly.sh full        # bring up stack + enroll 10 agents/org (default)
+./nightly.sh smoke       # verify 20/20 agents can authenticate
+./nightly.sh logs        # tail docker compose logs
+./nightly.sh down        # tear down + wipe state/
+```
+
+Customise via `config.env` or env vars:
+
+```bash
+AGENTS_PER_ORG=20 ./nightly.sh full
+```
+
+## Commands (roadmap)
+
+| Command  | Status    | Description                                     |
+|----------|-----------|-------------------------------------------------|
+| `full`   | PR 1      | Bring up the lean stack + BYOCA enroll agents.  |
+| `down`   | PR 1      | Tear down containers, volumes, and state.       |
+| `smoke`  | PR 1      | Probe N/N agents via `/v1/egress/peers`.        |
+| `logs`   | PR 1      | Tail compose logs (optionally for one service). |
+| `go`     | PR 2 (TBD) | Start workload drivers (spammer/sessionator/chatter). |
+| `chaos`  | PR 3 (TBD) | Fault injection (kill, restart, clock skew).    |
+| `report` | PR 3 (TBD) | Render markdown report from collected metrics.  |
+
+## Layout
+
+```
+test/nightly/
+├── nightly.sh              # entry point
+├── config.env              # defaults
+├── docker-compose.yml      # lean topology
+├── bootstrap/              # bootstrap + bootstrap_mastio docker build
+├── smoke.py                # host-side auth probe
+└── state/                  # bind-mounted, gitignored
+    ├── orga/, orgb/        # CA + org_secret + agents/*/identity
+    └── agents.json         # manifest written by bootstrap
+```
+
+## Ports
+
+| Host port | Service     |
+|-----------|-------------|
+| 8000      | Court       |
+| 9100      | Mastio A    |
+| 9200      | Mastio B    |
+
+Conflicts with `sandbox/` — only one stack at a time.

--- a/test/nightly/bootstrap/Dockerfile
+++ b/test/nightly/bootstrap/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+RUN pip install --no-cache-dir httpx==0.27.2 cryptography==43.0.1 asyncpg==0.29.0
+
+WORKDIR /app
+COPY bootstrap.py /app/bootstrap.py
+COPY bootstrap_mastio.py /app/bootstrap_mastio.py
+
+ENTRYPOINT ["python", "/app/bootstrap.py"]

--- a/test/nightly/bootstrap/bootstrap.py
+++ b/test/nightly/bootstrap/bootstrap.py
@@ -1,0 +1,461 @@
+"""Nightly stress-test bootstrap: 2 orgs, N agents/org, no MCP servers.
+
+Adapted from sandbox/bootstrap/bootstrap.py. Differences:
+- AGENTS list is generated from AGENTS_PER_ORG (default 10).
+- No BOOTSTRAP_SCOPE variants — always register both orgs + all agents.
+- No PEERS file (agents are driven by host-side scripts, not containers).
+- No MCP resource seeding logic here (done in proxy-init via SEED_MCP_*).
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import secrets
+import sys
+import time
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+from cryptography.x509.oid import NameOID
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+BROKER_URL        = os.environ.get("BROKER_URL", "http://broker:8000")
+ADMIN_SECRET      = os.environ["ADMIN_SECRET"]
+STATE             = pathlib.Path(os.environ.get("STATE_DIR", "/state"))
+DONE_FLAG         = STATE / "bootstrap.done"
+PKI_KEY_TYPE      = os.environ.get("PKI_KEY_TYPE", "ec").strip().lower()
+TRUST_DOMAIN_SUF  = os.environ.get("TRUST_DOMAIN_SUFFIX", ".test")
+AGENTS_PER_ORG    = int(os.environ.get("AGENTS_PER_ORG", "10"))
+
+_PDP_WEBHOOKS = {
+    "orga": os.environ.get("ORGA_PDP_WEBHOOK", "http://proxy-a:9100/pdp/policy"),
+    "orgb": os.environ.get("ORGB_PDP_WEBHOOK", "http://proxy-b:9100/pdp/policy"),
+}
+
+# ANSI helpers
+RESET, BOLD  = "\033[0m", "\033[1m"
+GREEN, YELLOW, RED, CYAN, GRAY = (
+    "\033[32m", "\033[33m", "\033[31m", "\033[36m", "\033[90m"
+)
+
+def _header(phase: int, title: str) -> None:
+    line = f"═══ PHASE {phase} — {title} "
+    print(f"\n{BOLD}{CYAN}{line}{'═' * max(0, 60 - len(line))}{RESET}\n", flush=True)
+
+def _ok(msg: str) -> None:   print(f"  {GREEN}✓{RESET} {msg}", flush=True)
+def _warn(msg: str) -> None: print(f"  {YELLOW}⚠{RESET} {msg}", flush=True)
+def _fail(msg: str) -> None: print(f"  {RED}✗{RESET} {msg}", flush=True)
+def _info(msg: str) -> None: print(f"  {GRAY}…{RESET} {msg}", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Org / Agent definitions (parametric)
+# ---------------------------------------------------------------------------
+ORGS = [
+    {"org_id": "orga", "display_name": "Nightly Org A", "flow": "join"},
+    {"org_id": "orgb", "display_name": "Nightly Org B", "flow": "attach"},
+]
+
+def _agent_list() -> list[dict]:
+    caps = ["oneshot.message", "session.open", "session.message"]
+    out = []
+    for org in ORGS:
+        oid = org["org_id"]
+        short = oid[-1]  # 'a' or 'b'
+        for i in range(1, AGENTS_PER_ORG + 1):
+            name = f"nightly-{short}-{i:02d}"
+            out.append({
+                "agent_id": f"{oid}::{name}",
+                "org_id": oid,
+                "capabilities": caps,
+            })
+    return out
+
+AGENTS = _agent_list()
+
+
+# ---------------------------------------------------------------------------
+# PKI helpers
+# ---------------------------------------------------------------------------
+def _gen_key():
+    if PKI_KEY_TYPE == "ec":
+        return ec.generate_private_key(ec.SECP256R1())
+    if PKI_KEY_TYPE == "rsa":
+        return rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    raise SystemExit(f"bootstrap: unsupported PKI_KEY_TYPE={PKI_KEY_TYPE!r}")
+
+def _thumbprint(cert: x509.Certificate) -> str:
+    return cert.fingerprint(hashes.SHA256()).hex()[:16]
+
+def _serial_hex(cert: x509.Certificate) -> str:
+    return format(cert.serial_number, "x")
+
+def _trust_domain(org_id: str) -> str:
+    return f"{org_id}{TRUST_DOMAIN_SUF}"
+
+def _spiffe_id(org_id: str, agent_name: str) -> str:
+    return f"spiffe://{_trust_domain(org_id)}/{org_id}/{agent_name}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Wait for Court
+# ---------------------------------------------------------------------------
+def _wait_broker(client: httpx.Client, timeout_s: float = 120.0) -> None:
+    _header(1, "Waiting for Court (broker)")
+    _info(f"polling {BROKER_URL}/health (timeout {timeout_s:.0f}s)")
+    start = time.monotonic()
+    last_exc: Exception | None = None
+    while time.monotonic() - start < timeout_s:
+        try:
+            r = client.get(f"{BROKER_URL}/health")
+            if r.status_code == 200:
+                _ok(f"GET /health → 200 OK  ({time.monotonic() - start:.1f}s)")
+                return
+        except Exception as exc:
+            last_exc = exc
+        time.sleep(1)
+    _fail(f"broker not healthy after {timeout_s:.0f}s — last error: {last_exc}")
+    raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Generate Org CAs
+# ---------------------------------------------------------------------------
+def _gen_org_ca(org_id: str) -> tuple[x509.Certificate, bytes, bytes]:
+    key = _gen_key()
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id} CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now).not_valid_after(now + datetime.timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, key_cert_sign=True, crl_sign=True,
+                content_commitment=False, key_encipherment=False,
+                data_encipherment=False, key_agreement=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return cert, cert_pem, key_pem
+
+def _persist_org(org_id: str, display_name: str, cert_pem: bytes,
+                 key_pem: bytes, org_secret: str) -> None:
+    d = STATE / org_id
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "ca.pem").write_bytes(cert_pem)
+    (d / "ca-key.pem").write_bytes(key_pem)
+    (d / "org_secret").write_text(org_secret)
+    (d / "display_name").write_text(display_name)
+    for p in d.iterdir():
+        p.chmod(0o644)
+
+def _load_existing_org(org_id: str) -> dict | None:
+    d = STATE / org_id
+    required = ("ca.pem", "ca-key.pem", "org_secret", "display_name")
+    if not all((d / f).exists() for f in required):
+        return None
+    try:
+        cert_pem = (d / "ca.pem").read_bytes()
+        key_pem = (d / "ca-key.pem").read_bytes()
+        org_secret = (d / "org_secret").read_text().strip()
+        display_name = (d / "display_name").read_text().strip()
+        cert = x509.load_pem_x509_certificate(cert_pem)
+    except Exception as exc:
+        _warn(f"state files unreadable for {org_id} ({exc}) — regenerating")
+        return None
+    return {"cert": cert, "cert_pem": cert_pem, "key_pem": key_pem,
+            "org_secret": org_secret, "display_name": display_name}
+
+def phase_2_generate_cas() -> dict[str, dict]:
+    _header(2, "Generate Org CAs")
+    out: dict[str, dict] = {}
+    for org in ORGS:
+        oid = org["org_id"]
+        reused = _load_existing_org(oid)
+        if reused is not None:
+            cert = reused["cert"]
+            cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+            _ok(f"org_id={BOLD}{oid}{RESET}  {YELLOW}reused from state{RESET}  CN={cn}")
+            _ok(f"serial={GRAY}{_serial_hex(cert)}{RESET}  thumbprint={CYAN}{_thumbprint(cert)}{RESET}")
+            out[oid] = reused
+            continue
+        cert, cert_pem, key_pem = _gen_org_ca(oid)
+        org_secret = secrets.token_urlsafe(32)
+        _persist_org(oid, org["display_name"], cert_pem, key_pem, org_secret)
+        cn = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+        _ok(f"org_id={BOLD}{oid}{RESET}  key={PKI_KEY_TYPE.upper()}  CN={cn}")
+        _ok(f"serial={GRAY}{_serial_hex(cert)}{RESET}  thumbprint={CYAN}{_thumbprint(cert)}{RESET}")
+        _ok(f"persisted → {STATE / oid}/")
+        out[oid] = {"cert": cert, "cert_pem": cert_pem, "key_pem": key_pem,
+                    "org_secret": org_secret, "display_name": org["display_name"]}
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Register orgs on Court
+# ---------------------------------------------------------------------------
+def _admin_headers() -> dict[str, str]:
+    return {"x-admin-secret": ADMIN_SECRET}
+
+def _org_headers(org_id: str, org_secret: str) -> dict[str, str]:
+    return {"x-org-id": org_id, "x-org-secret": org_secret}
+
+def _log_http(method: str, path: str, r: httpx.Response) -> None:
+    color = GREEN if 200 <= r.status_code < 300 else (YELLOW if r.status_code < 400 else RED)
+    _ok(f"{method} {path} → {color}{r.status_code} {r.reason_phrase or ''}{RESET}")
+
+def _onboard_via_join(client: httpx.Client, org_id: str, display_name: str,
+                      cert_pem: bytes, org_secret: str) -> None:
+    r = client.post(f"{BROKER_URL}/v1/admin/invites",
+                    json={"label": f"nightly-{org_id}", "ttl_hours": 1},
+                    headers=_admin_headers())
+    r.raise_for_status()
+    token = r.json()["token"]
+    _log_http("POST", "/v1/admin/invites", r)
+
+    r = client.post(f"{BROKER_URL}/v1/onboarding/join", json={
+        "org_id": org_id, "display_name": display_name, "secret": org_secret,
+        "ca_certificate": cert_pem.decode(),
+        "contact_email": f"admin@{org_id}.test",
+        "invite_token": token, "trust_domain": _trust_domain(org_id),
+        "webhook_url": _PDP_WEBHOOKS.get(org_id),
+    })
+    if r.status_code == 409:
+        _warn(f"{org_id} already registered — skipping join")
+        return
+    if r.status_code not in (200, 201, 202):
+        _fail(f"join failed: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _log_http("POST", "/v1/onboarding/join", r)
+
+    r = client.post(f"{BROKER_URL}/v1/admin/orgs/{org_id}/approve",
+                    headers=_admin_headers())
+    if r.status_code not in (200, 409):
+        r.raise_for_status()
+    _log_http("POST", f"/v1/admin/orgs/{org_id}/approve", r)
+    _ok(f"{BOLD}{org_id}{RESET} active via join flow")
+
+def _onboard_via_attach(client: httpx.Client, org_id: str, display_name: str,
+                        cert_pem: bytes, org_secret: str) -> None:
+    r = client.post(f"{BROKER_URL}/v1/registry/orgs", json={
+        "org_id": org_id, "display_name": display_name,
+        "secret": "placeholder-will-be-rotated",
+    }, headers=_admin_headers())
+    if r.status_code == 409:
+        _warn(f"{org_id} already registered — skipping attach")
+        return
+    r.raise_for_status()
+    _log_http("POST", "/v1/registry/orgs", r)
+
+    r = client.post(f"{BROKER_URL}/v1/admin/orgs/{org_id}/attach-invite",
+                    json={"label": f"nightly-attach-{org_id}", "ttl_hours": 1},
+                    headers=_admin_headers())
+    r.raise_for_status()
+    token = r.json()["token"]
+    _log_http("POST", f"/v1/admin/orgs/{org_id}/attach-invite", r)
+
+    r = client.post(f"{BROKER_URL}/v1/onboarding/attach", json={
+        "ca_certificate": cert_pem.decode(), "invite_token": token,
+        "secret": org_secret, "trust_domain": _trust_domain(org_id),
+        "webhook_url": _PDP_WEBHOOKS.get(org_id),
+    })
+    if r.status_code not in (200, 201, 202):
+        _fail(f"attach failed: {r.status_code} {r.text}")
+        raise SystemExit(1)
+    _log_http("POST", "/v1/onboarding/attach", r)
+    _ok(f"{BOLD}{org_id}{RESET} active via attach flow")
+
+def phase_3_register_orgs(client: httpx.Client, orgs_data: dict[str, dict]) -> None:
+    _header(3, "Register orgs on Court")
+    for org in ORGS:
+        oid = org["org_id"]
+        d = orgs_data[oid]
+        _info(f"registering {BOLD}{oid}{RESET} via {org['flow']} flow")
+        if org["flow"] == "join":
+            _onboard_via_join(client, oid, d["display_name"], d["cert_pem"], d["org_secret"])
+        elif org["flow"] == "attach":
+            _onboard_via_attach(client, oid, d["display_name"], d["cert_pem"], d["org_secret"])
+        else:
+            raise SystemExit(f"unknown flow: {org['flow']}")
+
+    r = client.get(f"{BROKER_URL}/v1/registry/orgs", headers=_admin_headers())
+    r.raise_for_status()
+    active = {o["org_id"] for o in r.json() if o.get("status") == "active"}
+    expected = {o["org_id"] for o in ORGS}
+    missing = expected - active
+    if missing:
+        _fail(f"orgs not active: {missing}")
+        raise SystemExit(1)
+    _ok(f"verified {len(expected)} orgs active on Court")
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Mint agent certs
+# ---------------------------------------------------------------------------
+def _gen_agent_cert(agent_id: str, org_id: str,
+                    ca_cert_pem: bytes, ca_key_pem: bytes) -> tuple[x509.Certificate, bytes, bytes]:
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem)
+    ca_key = load_pem_private_key(ca_key_pem, password=None)
+    key = _gen_key()
+    _, agent_name = agent_id.split("::", 1)
+    spiffe = _spiffe_id(org_id, agent_name)
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject).issuer_name(ca_cert.subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now).not_valid_after(now + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False)
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe)]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM)
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM, serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    )
+    return cert, cert_pem, key_pem
+
+def _provision_agent(agent_def: dict, orgs_data: dict[str, dict]) -> dict:
+    agent_id = agent_def["agent_id"]
+    org_id = agent_def["org_id"]
+    caps = agent_def["capabilities"]
+    _, agent_name = agent_id.split("::", 1)
+    spiffe = _spiffe_id(org_id, agent_name)
+    od = orgs_data[org_id]
+
+    cert, cert_pem, key_pem = _gen_agent_cert(agent_id, org_id, od["cert_pem"], od["key_pem"])
+
+    agent_dir = STATE / org_id / "agents" / agent_name
+    agent_dir.mkdir(parents=True, exist_ok=True)
+    (agent_dir / "agent.pem").write_bytes(cert_pem)
+    (agent_dir / "agent-key.pem").write_bytes(key_pem)
+    (agent_dir / "agent.pem").chmod(0o644)
+    (agent_dir / "agent-key.pem").chmod(0o644)
+
+    return {"agent_id": agent_id, "org_id": org_id, "spiffe_id": spiffe,
+            "capabilities": caps, "cert_serial": _serial_hex(cert),
+            "cert_thumbprint": _thumbprint(cert)}
+
+def phase_4_register_agents(orgs_data: dict[str, dict]) -> list[dict]:
+    _header(4, f"Mint agent certs (count={len(AGENTS)})")
+    results = []
+    for agent_def in AGENTS:
+        results.append(_provision_agent(agent_def, orgs_data))
+
+    # Progress line per 5 agents to avoid wall of text at scale
+    n = len(results)
+    by_org: dict[str, int] = {}
+    for m in results:
+        by_org[m["org_id"]] = by_org.get(m["org_id"], 0) + 1
+    for oid, c in by_org.items():
+        _ok(f"{oid}: {c} agents minted → /state/{oid}/agents/*/")
+
+    manifest = [
+        {"agent_id": a["agent_id"], "org_id": a["org_id"],
+         "agent_name": a["agent_id"].split("::", 1)[1],
+         "capabilities": a["capabilities"]}
+        for a in AGENTS
+    ]
+    (STATE / "agents.json").write_text(json.dumps(manifest, indent=2))
+    (STATE / "agents.json").chmod(0o644)
+    _ok(f"manifest ({n} agents) → {STATE / 'agents.json'}")
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Session policies (allow-all per org)
+# ---------------------------------------------------------------------------
+def phase_5_session_policies(client: httpx.Client, orgs_data: dict[str, dict]) -> None:
+    _header(5, "Create session policies")
+    for org in ORGS:
+        oid = org["org_id"]
+        od = orgs_data[oid]
+        policy_id = f"{oid}::session-allow-all"
+        r = client.post(
+            f"{BROKER_URL}/v1/policy/rules",
+            json={
+                "policy_id": policy_id, "org_id": oid, "policy_type": "session",
+                "rules": {"effect": "allow",
+                          "conditions": {"target_org_id": [], "capabilities": []}},
+            },
+            headers=_org_headers(oid, od["org_secret"]),
+        )
+        if r.status_code not in (200, 201, 409):
+            _fail(f"policy create {policy_id}: {r.status_code} {r.text}")
+            raise SystemExit(1)
+        _log_http("POST", "/v1/policy/rules", r)
+        _ok(f"policy_id={BOLD}{policy_id}{RESET}  effect={GREEN}allow{RESET}")
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — Summary
+# ---------------------------------------------------------------------------
+def phase_6_summary(agents_meta: list[dict]) -> None:
+    _header(6, "Summary")
+    print(f"  {BOLD}{'ORG ID':<12} {'DISPLAY NAME':<22} {'FLOW':<8} {'AGENTS'}{RESET}", flush=True)
+    print(f"  {'─' * 12} {'─' * 22} {'─' * 8} {'─' * 6}", flush=True)
+    by_org: dict[str, int] = {}
+    for m in agents_meta:
+        by_org[m["org_id"]] = by_org.get(m["org_id"], 0) + 1
+    for org in ORGS:
+        oid = org["org_id"]
+        print(f"  {GREEN}{oid:<12}{RESET} {org['display_name']:<22} "
+              f"{org['flow']:<8} {by_org.get(oid, 0):<6}", flush=True)
+    print(flush=True)
+    DONE_FLAG.touch()
+    _ok(f"bootstrap.done → {DONE_FLAG}")
+    print(f"\n  {BOLD}{GREEN}Bootstrap complete.{RESET}\n", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main() -> int:
+    STATE.mkdir(parents=True, exist_ok=True)
+    if DONE_FLAG.exists():
+        DONE_FLAG.unlink()
+
+    with httpx.Client(verify=False, timeout=30.0) as client:
+        _wait_broker(client)
+        orgs_data = phase_2_generate_cas()
+        phase_3_register_orgs(client, orgs_data)
+        agents_meta = phase_4_register_agents(orgs_data)
+        phase_5_session_policies(client, orgs_data)
+    phase_6_summary(agents_meta)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/nightly/bootstrap/bootstrap_mastio.py
+++ b/test/nightly/bootstrap/bootstrap_mastio.py
@@ -1,0 +1,390 @@
+"""Post-proxy-boot wiring: mastio_pubkey pin + agent seeding + bindings.
+
+Runs **after** the proxies have booted and generated their Mastio CA +
+leaf identity (lifespan hook in ``mcp_proxy/main.py``).
+
+Three responsibilities:
+
+1. **ADR-009 mastio pubkey pinning** (original job):
+   - poll ``GET /v1/admin/mastio-pubkey`` on each proxy until populated
+   - ``PATCH /v1/admin/orgs/{org_id}/mastio-pubkey`` on the Court
+
+2. **ADR-010 Phase 4 — Mastio-authoritative agent registry seeding**:
+   - for every agent the outer bootstrap minted a cert/key for under
+     ``/state/{org}/agents/{name}/``, ``POST /v1/admin/agents`` on the
+     owning Mastio with the pre-generated material and ``federated=true``
+   - the Phase 3 publisher loop picks the row up from
+     ``internal_agents`` and pushes it to the Court
+
+3. **ADR-010 Phase 6a-4 — binding create+approve on the Court**:
+   - PR #191 removed the binding step from ``bootstrap.py`` but never
+     migrated it anywhere; without an approved binding the agent's
+     ``/v1/auth/login`` on the Court returns 403 "No approved binding".
+   - We retry ``POST /v1/registry/bindings`` until the publisher has
+     pushed the agent (404 = not yet visible, retry). 409 = already
+     there, fetch id. Then ``POST .../approve``.
+
+Idempotent: the Mastio returns 409 on duplicates; we silently continue.
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+import time
+
+import httpx
+
+
+BROKER_URL   = os.environ.get("BROKER_URL", "http://broker:8000")
+ADMIN_SECRET = os.environ["ADMIN_SECRET"]
+
+# ADR-009 sandbox — scope=up has only orgb on the Court. Patching orga
+# would fail with 404 because the bootstrap container skipped its
+# registration. scope=full pins both.
+SCOPE = os.environ.get("BOOTSTRAP_SCOPE", "full").strip().lower()
+if SCOPE not in ("up", "full"):
+    SCOPE = "full"
+
+# Per-org proxy URL + proxy admin secret. Sandbox uses the broker's
+# admin secret for simplicity — in prod each proxy carries its own.
+_ALL_PROXIES = [
+    {
+        "org_id":       "orga",
+        "proxy_url":    os.environ.get("PROXY_A_URL", "http://proxy-a:9100"),
+        "admin_secret": os.environ.get("PROXY_A_ADMIN_SECRET", ADMIN_SECRET),
+    },
+    {
+        "org_id":       "orgb",
+        "proxy_url":    os.environ.get("PROXY_B_URL", "http://proxy-b:9200"),
+        "admin_secret": os.environ.get("PROXY_B_ADMIN_SECRET", ADMIN_SECRET),
+    },
+]
+PROXIES = [
+    p for p in _ALL_PROXIES if SCOPE == "full" or p["org_id"] != "orga"
+]
+
+RESET = "\033[0m"
+BOLD  = "\033[1m"
+GREEN = "\033[32m"
+YELLOW = "\033[33m"
+RED   = "\033[31m"
+CYAN  = "\033[36m"
+GRAY  = "\033[90m"
+
+
+def _log(sym: str, color: str, msg: str) -> None:
+    print(f"  {color}{sym}{RESET} {msg}", flush=True)
+
+
+def _ok(msg: str) -> None:
+    _log("✓", GREEN, msg)
+
+
+def _warn(msg: str) -> None:
+    _log("⚠", YELLOW, msg)
+
+
+def _fail(msg: str) -> None:
+    _log("✗", RED, msg)
+
+
+def _info(msg: str) -> None:
+    _log("…", GRAY, msg)
+
+
+def _fetch_mastio_pubkey(
+    client: httpx.Client, proxy_url: str, admin_secret: str,
+    timeout_s: float = 120.0,
+) -> str:
+    """Poll the proxy until mastio_pubkey is populated. Fails with
+    ``SystemExit`` if the deadline elapses."""
+    deadline = time.monotonic() + timeout_s
+    last_err = "(no response yet)"
+    while time.monotonic() < deadline:
+        try:
+            r = client.get(
+                f"{proxy_url}/v1/admin/mastio-pubkey",
+                headers={"X-Admin-Secret": admin_secret},
+                timeout=5.0,
+            )
+            if r.status_code == 200:
+                pem = r.json().get("mastio_pubkey")
+                if pem:
+                    return pem
+                last_err = "mastio_pubkey still null (first boot finalizing)"
+            else:
+                last_err = f"HTTP {r.status_code}: {r.text[:120]}"
+        except httpx.TransportError as exc:
+            last_err = f"connection: {exc}"
+        time.sleep(1.0)
+    _fail(f"timeout fetching mastio_pubkey from {proxy_url} — last: {last_err}")
+    raise SystemExit(1)
+
+
+def _pin_on_court(
+    client: httpx.Client, org_id: str, pem: str,
+) -> None:
+    r = client.patch(
+        f"{BROKER_URL}/v1/admin/orgs/{org_id}/mastio-pubkey",
+        headers={"X-Admin-Secret": ADMIN_SECRET},
+        json={"mastio_pubkey": pem},
+        timeout=10.0,
+    )
+    if r.status_code != 200:
+        _fail(
+            f"court PATCH failed for {org_id}: "
+            f"HTTP {r.status_code} {r.text[:200]}",
+        )
+        raise SystemExit(1)
+
+
+def _load_manifest() -> list[dict]:
+    """Load the agents manifest written by bootstrap.py phase_4.
+
+    Each entry has ``agent_id``, ``org_id``, ``agent_name``, and
+    ``capabilities``. Returns ``[]`` if the file is missing (older
+    bootstrap, or scope=up without agents for this org) — callers fall
+    back to directory scan with empty caps.
+    """
+    path = pathlib.Path("/state/agents.json")
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        _warn(f"/state/agents.json corrupt ({exc}) — treating as empty")
+        return []
+
+
+def _read_org_secret(org_id: str) -> str | None:
+    """Read the per-org secret the outer bootstrap persisted."""
+    path = pathlib.Path("/state") / org_id / "org_secret"
+    if not path.exists():
+        return None
+    return path.read_text().strip()
+
+
+def _generate_dpop_jwk() -> tuple[dict, dict]:
+    """Generate an EC P-256 DPoP keypair. Returns ``(public_jwk, private_jwk)``.
+
+    ADR-011 Phase 4 — enrollment must ship a public JWK so the Mastio
+    pins its jkt from the first request, and the agent container needs
+    the matching private JWK on disk to sign proofs at runtime. The
+    sandbox bootstrap is the single producer/consumer, so we hand-roll
+    the keypair here rather than import cullis_sdk.dpop (keeps the
+    container lean — SDK lives in the agent image, not here).
+    """
+    import base64 as _b64
+    from cryptography.hazmat.primitives.asymmetric import ec
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_nums = priv.public_key().public_numbers()
+    priv_nums = priv.private_numbers()
+    def _b64url(n: int) -> str:
+        return _b64.urlsafe_b64encode(n.to_bytes(32, "big")).rstrip(b"=").decode()
+    public_jwk = {
+        "kty": "EC", "crv": "P-256",
+        "x": _b64url(pub_nums.x), "y": _b64url(pub_nums.y),
+    }
+    private_jwk = {**public_jwk, "d": _b64url(priv_nums.private_value)}
+    return public_jwk, private_jwk
+
+
+def _enroll_agents_via_byoca(
+    client: httpx.Client, proxy_url: str, admin_secret: str, org_id: str,
+    manifest: list[dict],
+) -> list[dict]:
+    """ADR-011 Phase 4 — enroll each bootstrap-minted agent via
+    ``/v1/admin/agents/enroll/byoca``.
+
+    The outer bootstrap already minted an Org-CA-signed cert/key pair
+    per agent under ``/state/{org}/agents/{name}/``. Phase 1b exposed a
+    verified enrollment endpoint that accepts that material, verifies
+    the chain, and emits an API key + pins DPoP jkt. We persist the
+    returned credentials alongside the cert so agent containers can
+    ``from_api_key_file(...)`` at runtime — no more SPIFFE/BYOCA
+    direct login to the Court.
+
+    Returns the subset of manifest rows successfully enrolled so the
+    caller can drive binding create+approve on the Court. Row shape
+    matches the old ``_seed_agents_on_mastio`` contract for caller
+    back-compat.
+    """
+    agents_dir = pathlib.Path("/state") / org_id / "agents"
+    if not agents_dir.exists():
+        _info(f"{org_id}: no agents directory — skipping enroll")
+        return []
+
+    caps_by_name = {e["agent_name"]: e.get("capabilities", []) for e in manifest
+                    if e.get("org_id") == org_id}
+    enrolled: list[dict] = []
+    for entry in sorted(p for p in agents_dir.iterdir() if p.is_dir()):
+        name = entry.name
+        cert_path = entry / "agent.pem"
+        key_path = entry / "agent-key.pem"
+        if not cert_path.exists() or not key_path.exists():
+            _warn(f"{org_id}::{name}: missing agent.pem/agent-key.pem — skipping")
+            continue
+        cert_pem = cert_path.read_text()
+        key_pem = key_path.read_text()
+        capabilities = caps_by_name.get(name, [])
+        public_jwk, private_jwk = _generate_dpop_jwk()
+        r = client.post(
+            f"{proxy_url}/v1/admin/agents/enroll/byoca",
+            headers={"X-Admin-Secret": admin_secret},
+            json={
+                "agent_name": name,
+                "display_name": name,
+                "capabilities": capabilities,
+                "federated": True,
+                "cert_pem": cert_pem,
+                "private_key_pem": key_pem,
+                "dpop_jwk": public_jwk,
+            },
+            timeout=10.0,
+        )
+        if r.status_code == 201:
+            resp = r.json()
+            # Persist the runtime credentials next to the cert so the
+            # agent container's volume mount finds them. Layout matches
+            # ``CullisClient.from_api_key_file`` expectations: one file
+            # per artifact, 0600-ish (sandbox mount is 0644 by default).
+            (entry / "api-key").write_text(resp["api_key"])
+            (entry / "api-key").chmod(0o644)
+            import json as _json
+            (entry / "dpop.jwk").write_text(
+                _json.dumps({"private_jwk": private_jwk}, separators=(",", ":"))
+            )
+            (entry / "dpop.jwk").chmod(0o644)
+            _ok(f"{org_id}::{name}: enrolled via BYOCA "
+                f"(caps={capabilities or '[]'}, jkt={resp.get('dpop_jkt', '')[:12]}…)")
+            enrolled.append({"org_id": org_id, "agent_name": name,
+                             "capabilities": capabilities})
+        elif r.status_code == 409:
+            _info(f"{org_id}::{name}: already enrolled — skipping")
+            enrolled.append({"org_id": org_id, "agent_name": name,
+                             "capabilities": capabilities})
+        else:
+            _fail(
+                f"{org_id}::{name}: enroll failed "
+                f"HTTP {r.status_code} {r.text[:200]}"
+            )
+    return enrolled
+
+
+def _bind_agents_on_court(
+    client: httpx.Client, seeded: list[dict],
+    timeout_s: float = 60.0, retry_s: float = 2.0,
+) -> None:
+    """ADR-010 Phase 6a-4 — create + approve a binding per seeded agent.
+
+    Retries ``POST /v1/registry/bindings`` while the publisher is still
+    catching up (404 on the agent lookup). 409 = already bound, look up
+    the existing id and approve idempotently.
+    """
+    if not seeded:
+        return
+    for agent in seeded:
+        org_id = agent["org_id"]
+        agent_name = agent["agent_name"]
+        agent_id = f"{org_id}::{agent_name}"
+        capabilities = agent["capabilities"]
+        org_secret = _read_org_secret(org_id)
+        if org_secret is None:
+            _fail(f"{agent_id}: no /state/{org_id}/org_secret — cannot bind")
+            raise SystemExit(1)
+        headers = {"X-Org-Id": org_id, "X-Org-Secret": org_secret}
+        body = {"org_id": org_id, "agent_id": agent_id, "scope": capabilities}
+
+        binding_id: int | str | None = None
+        deadline = time.monotonic() + timeout_s
+        last = "(no attempt)"
+        while time.monotonic() < deadline:
+            r = client.post(
+                f"{BROKER_URL}/v1/registry/bindings",
+                json=body, headers=headers, timeout=10.0,
+            )
+            if r.status_code == 201:
+                binding_id = r.json().get("id")
+                break
+            if r.status_code == 409:
+                lr = client.get(
+                    f"{BROKER_URL}/v1/registry/bindings",
+                    params={"org_id": org_id}, headers=headers, timeout=10.0,
+                )
+                lr.raise_for_status()
+                binding_id = next(
+                    (b["id"] for b in lr.json() if b.get("agent_id") == agent_id),
+                    None,
+                )
+                break
+            last = f"HTTP {r.status_code} {r.text[:160]}"
+            time.sleep(retry_s)
+
+        if binding_id is None:
+            _fail(
+                f"{agent_id}: binding create never succeeded in {timeout_s:.0f}s "
+                f"(publisher stuck? last={last})"
+            )
+            raise SystemExit(1)
+
+        ar = client.post(
+            f"{BROKER_URL}/v1/registry/bindings/{binding_id}/approve",
+            headers=headers, timeout=10.0,
+        )
+        if ar.status_code not in (200, 204):
+            _fail(
+                f"{agent_id}: binding approve failed "
+                f"HTTP {ar.status_code} {ar.text[:200]}"
+            )
+            raise SystemExit(1)
+        _ok(f"{agent_id}: binding {binding_id} approved (scope={capabilities or '[]'})")
+
+
+def main() -> int:
+    print(
+        f"\n{BOLD}{CYAN}═══ Post-proxy-boot — mastio_pubkey + agent seeding "
+        f"{'═' * 10}{RESET}\n",
+        flush=True,
+    )
+    manifest = _load_manifest()
+    all_seeded: list[dict] = []
+    with httpx.Client(timeout=10.0) as client:
+        for cfg in PROXIES:
+            org_id = cfg["org_id"]
+            _info(f"fetching mastio_pubkey from {BOLD}{cfg['proxy_url']}{RESET}")
+            pem = _fetch_mastio_pubkey(
+                client, cfg["proxy_url"], cfg["admin_secret"],
+            )
+            preview = pem.split("\n")[1][:40] if "\n" in pem else pem[:40]
+            _ok(f"{org_id}: pubkey fetched ({preview}…)")
+
+            _info(f"pinning on Court for {BOLD}{org_id}{RESET}")
+            _pin_on_court(client, org_id, pem)
+            _ok(f"{org_id}: mastio_pubkey pinned — counter-sig enforcement active")
+
+            _info(f"enrolling agents via BYOCA on Mastio {BOLD}{org_id}{RESET}")
+            enrolled = _enroll_agents_via_byoca(
+                client, cfg["proxy_url"], cfg["admin_secret"], org_id,
+                manifest,
+            )
+            all_seeded.extend(enrolled)
+
+        if all_seeded:
+            _info(
+                f"creating+approving bindings on Court "
+                f"({len(all_seeded)} agent(s), waiting for publisher)"
+            )
+            _bind_agents_on_court(client, all_seeded)
+
+    print(
+        f"\n{BOLD}{GREEN}"
+        f"✓ mastio identities pinned + agents seeded + bindings approved{RESET}\n",
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/nightly/config.env
+++ b/test/nightly/config.env
@@ -1,0 +1,15 @@
+# Nightly stress test — defaults. Override with env vars before sourcing.
+
+# Number of agents per org (enrolled via BYOCA). Total = 2 * AGENTS_PER_ORG.
+AGENTS_PER_ORG="${AGENTS_PER_ORG:-10}"
+
+# PKI key type for Org CAs + agent leaves (ec | rsa).
+PKI_KEY_TYPE="${PKI_KEY_TYPE:-ec}"
+
+# Admin secret used by bootstrap + smoke scripts. Never reuse in production.
+ADMIN_SECRET="${ADMIN_SECRET:-nightly-admin-secret-change-me}"
+
+# Host-side URLs for smoke/workload scripts (they run outside docker).
+COURT_URL="${COURT_URL:-http://localhost:8000}"
+MASTIO_A_URL="${MASTIO_A_URL:-http://localhost:9100}"
+MASTIO_B_URL="${MASTIO_B_URL:-http://localhost:9200}"

--- a/test/nightly/docker-compose.yml
+++ b/test/nightly/docker-compose.yml
@@ -1,0 +1,262 @@
+# Nightly stress test — lean topology (no SPIRE, no Keycloak, no MCP servers).
+#
+# Services: Court + 2 Mastio (orga/orgb) + bootstrap. Agents run on the host
+# as Python scripts driven by test/nightly/workload/*.py and connect via the
+# published ports (8000/9100/9200).
+#
+# State persisted in ./state/ as a bind mount so host-side scripts can read
+# the BYOCA-minted agent credentials.
+
+networks:
+  orga-internal:
+    name: cullis-nightly-orga
+    driver: bridge
+  orgb-internal:
+    name: cullis-nightly-orgb
+    driver: bridge
+  public-wan:
+    name: cullis-nightly-wan
+    driver: bridge
+
+volumes:
+  broker-ca:
+  postgres-data:
+  proxy-a-data:
+  proxy-b-data:
+
+services:
+
+  broker-ca-init:
+    build: ../../sandbox/broker-ca-init
+    environment:
+      ORG_ID: broker
+    volumes:
+      - broker-ca:/broker-certs
+    networks: [public-wan]
+    restart: "no"
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER:     atn
+      POSTGRES_PASSWORD: atn-nightly
+      POSTGRES_DB:       agent_trust
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks: [public-wan]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U atn -d agent_trust"]
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    networks: [public-wan]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 2s
+      retries: 20
+
+  broker:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      broker-ca-init:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      ADMIN_SECRET:            "${ADMIN_SECRET:-nightly-admin-secret-change-me}"
+      KMS_BACKEND:             "local"
+      BROKER_CA_KEY_PATH:      /broker-certs/broker-ca-key.pem
+      BROKER_CA_CERT_PATH:     /broker-certs/broker-ca.pem
+      DATABASE_URL:            "postgresql+asyncpg://atn:atn-nightly@postgres:5432/agent_trust"
+      REDIS_URL:               "redis://redis:6379"
+      POLICY_BACKEND:          "webhook"
+      POLICY_ENFORCEMENT:      "true"
+      POLICY_WEBHOOK_ALLOW_PRIVATE_IPS: "true"
+      TRUST_DOMAIN:            "court.nightly"
+      OTEL_ENABLED:            "false"
+      ENVIRONMENT:             "development"
+      FORWARDED_ALLOW_IPS:     "172.16.0.0/12"
+    tmpfs:
+      - /app/certs:uid=999,gid=999
+    volumes:
+      - broker-ca:/broker-certs:ro
+    entrypoint: ["sh", "-c"]
+    command:
+      - |
+        exec uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 1 --proxy-headers --forwarded-allow-ips 172.16.0.0/12
+    networks:
+      public-wan:
+        aliases: [broker]
+    expose: ["8000"]
+    ports: ["8000:8000"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 15s
+
+  # ── Bootstrap: create orgs on Court + mint N agent certs ──────────────────
+
+  bootstrap:
+    build: ./bootstrap
+    depends_on:
+      broker:
+        condition: service_healthy
+    environment:
+      BROKER_URL:       "http://broker:8000"
+      ADMIN_SECRET:     "${ADMIN_SECRET:-nightly-admin-secret-change-me}"
+      STATE_DIR:        /state
+      AGENTS_PER_ORG:   "${AGENTS_PER_ORG:-10}"
+      PKI_KEY_TYPE:     "${PKI_KEY_TYPE:-ec}"
+    volumes:
+      - ./state:/state
+    networks: [public-wan]
+    restart: "no"
+
+  # ── Org A Mastio (proxy) ──────────────────────────────────────────────────
+
+  proxy-a-init:
+    build:
+      context: ../..
+      dockerfile: sandbox/proxy-init/Dockerfile
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    environment:
+      ORG_ID:              "orga"
+      BROKER_URL:          "http://broker:8000"
+      PROXY_PUBLIC_URL:    "http://localhost:9100"
+      PROXY_DB_PATH:       /data/mcp_proxy.db
+      STATE_DIR:           /state
+      # OIDC intentionally unset — local password auth for dashboard.
+      SEED_MCP_RESOURCES:  "0"
+    volumes:
+      - ./state:/state:ro
+      - proxy-a-data:/data
+    networks: [orga-internal, public-wan]
+    restart: "no"
+
+  proxy-a:
+    build:
+      context: ../..
+      dockerfile: mcp_proxy/Dockerfile
+    depends_on:
+      proxy-a-init:
+        condition: service_completed_successfully
+    environment:
+      MCP_PROXY_BROKER_URL:        "http://broker:8000"
+      MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
+      MCP_PROXY_ADMIN_SECRET:      "${PROXY_A_ADMIN_SECRET:-nightly-proxy-admin-a}"
+      MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
+      MCP_PROXY_ORG_ID:            "orga"
+      MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9100"
+      MCP_PROXY_ENVIRONMENT:       "development"
+      MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
+      PROXY_INTRA_ORG:             "true"
+      PROXY_TRANSPORT_INTRA_ORG:   "mtls-only"
+      MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+    volumes:
+      - proxy-a-data:/data
+    networks:
+      orga-internal:
+        aliases: [proxy-a]
+      public-wan:
+        aliases: [proxy-a]
+    expose: ["9100"]
+    ports: ["9100:9100"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  # ── Org B Mastio (proxy) ──────────────────────────────────────────────────
+
+  proxy-b-init:
+    build:
+      context: ../..
+      dockerfile: sandbox/proxy-init/Dockerfile
+    depends_on:
+      bootstrap:
+        condition: service_completed_successfully
+    environment:
+      ORG_ID:              "orgb"
+      BROKER_URL:          "http://broker:8000"
+      PROXY_PUBLIC_URL:    "http://localhost:9200"
+      PROXY_DB_PATH:       /data/mcp_proxy.db
+      STATE_DIR:           /state
+      SEED_MCP_RESOURCES:  "0"
+    volumes:
+      - ./state:/state:ro
+      - proxy-b-data:/data
+    restart: "no"
+
+  proxy-b:
+    build:
+      context: ../..
+      dockerfile: mcp_proxy/Dockerfile
+    depends_on:
+      proxy-b-init:
+        condition: service_completed_successfully
+    environment:
+      MCP_PROXY_BROKER_URL:        "http://broker:8000"
+      MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
+      MCP_PROXY_ADMIN_SECRET:      "${PROXY_B_ADMIN_SECRET:-nightly-proxy-admin-b}"
+      MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
+      MCP_PROXY_ORG_ID:            "orgb"
+      MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9200"
+      MCP_PROXY_ENVIRONMENT:       "development"
+      MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
+      PROXY_INTRA_ORG:             "true"
+      PROXY_TRANSPORT_INTRA_ORG:   "mtls-only"
+      MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+    volumes:
+      - proxy-b-data:/data
+    networks:
+      orgb-internal:
+        aliases: [proxy-b]
+      public-wan:
+        aliases: [proxy-b]
+    expose: ["9100"]
+    ports: ["9200:9100"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
+
+  # ── Post-proxy-boot: pin mastio_pubkey + BYOCA enroll N agents ────────────
+
+  bootstrap-mastio:
+    build: ./bootstrap
+    depends_on:
+      broker:
+        condition: service_healthy
+      proxy-a:
+        condition: service_healthy
+      proxy-b:
+        condition: service_healthy
+    entrypoint: ["python", "/app/bootstrap_mastio.py"]
+    environment:
+      BROKER_URL:            "http://broker:8000"
+      ADMIN_SECRET:          "${ADMIN_SECRET:-nightly-admin-secret-change-me}"
+      PROXY_A_URL:           "http://proxy-a:9100"
+      PROXY_A_ADMIN_SECRET:  "${PROXY_A_ADMIN_SECRET:-nightly-proxy-admin-a}"
+      PROXY_B_URL:           "http://proxy-b:9100"
+      PROXY_B_ADMIN_SECRET:  "${PROXY_B_ADMIN_SECRET:-nightly-proxy-admin-b}"
+      BOOTSTRAP_SCOPE:       "full"
+    volumes:
+      - ./state:/state
+    networks: [public-wan, orga-internal, orgb-internal]
+    restart: "no"

--- a/test/nightly/nightly.sh
+++ b/test/nightly/nightly.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Nightly stress test driver. Entry point for the full | go | chaos | report cycle.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$SCRIPT_DIR"
+
+# shellcheck disable=SC1091
+source ./config.env
+
+COMPOSE="docker compose"
+
+# Host-side Python used by smoke.py / workload drivers. Prefer the repo's
+# .venv (where cullis_sdk is installed in editable mode) over the system
+# python3/python.
+pick_python() {
+    if [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+        echo "$REPO_ROOT/.venv/bin/python"; return
+    fi
+    for cmd in python3 python; do
+        if command -v "$cmd" >/dev/null 2>&1; then
+            echo "$cmd"; return
+        fi
+    done
+    echo "[nightly] no python interpreter found (looked for .venv, python3, python)" >&2
+    exit 1
+}
+PY="$(pick_python)"
+
+usage() {
+    cat <<'EOF'
+Usage: nightly.sh <command>
+
+Commands:
+  full      Bring the lean stack up (Court + 2 Mastio + bootstrap + BYOCA N agents).
+  down      Tear down containers and volumes, wipe state/.
+  status    docker compose ps for the stack.
+  smoke     Run smoke.py to verify N/N agents can log in.
+  logs [svc]  Tail compose logs (optionally for one service).
+  go        [PR 2] Start workload drivers (spammer/sessionator/chatter).
+  chaos     [PR 3] Run fault injection sequence.
+  report    [PR 3] Render markdown report from collected metrics.
+
+Env vars (see config.env):
+  AGENTS_PER_ORG  (default 10)   ADMIN_SECRET
+  PKI_KEY_TYPE    (default ec)   COURT_URL / MASTIO_A_URL / MASTIO_B_URL
+EOF
+}
+
+cmd_full() {
+    echo "[nightly] bringing up lean stack (agents_per_org=${AGENTS_PER_ORG})"
+    mkdir -p state logs reports
+    AGENTS_PER_ORG="$AGENTS_PER_ORG" \
+    PKI_KEY_TYPE="$PKI_KEY_TYPE" \
+    ADMIN_SECRET="$ADMIN_SECRET" \
+    $COMPOSE up -d --wait
+
+    # --wait only blocks on services with healthchecks. bootstrap-mastio is
+    # restart:no with no healthcheck, so poll its exit code + the sentinel
+    # file it leaves behind before handing back to the user.
+    local deadline=$(( $(date +%s) + 180 ))
+    while (( $(date +%s) < deadline )); do
+        local state
+        state="$($COMPOSE ps --format '{{.Service}} {{.State}} {{.ExitCode}}' \
+                 | awk '$1=="bootstrap-mastio" {print $2,$3}')"
+        if [[ "$state" == "exited 0" ]]; then
+            break
+        fi
+        if [[ "$state" == "exited"* ]]; then
+            echo "[nightly] bootstrap-mastio failed ($state) — check 'nightly.sh logs bootstrap-mastio'" >&2
+            exit 1
+        fi
+        sleep 2
+    done
+    if [[ ! -f state/bootstrap.done ]]; then
+        echo "[nightly] bootstrap.done sentinel missing after 180s" >&2
+        exit 1
+    fi
+    echo "[nightly] stack up — run './nightly.sh smoke' to verify agents"
+}
+
+cmd_down() {
+    echo "[nightly] tearing down stack + volumes + state"
+    $COMPOSE down -v --remove-orphans
+    rm -rf state/* logs/* 2>/dev/null || true
+    echo "[nightly] clean"
+}
+
+cmd_status() {
+    $COMPOSE ps
+}
+
+cmd_smoke() {
+    if [[ ! -f state/bootstrap.done ]]; then
+        echo "[nightly] state/bootstrap.done missing — run './nightly.sh full' first" >&2
+        exit 1
+    fi
+    "$PY" "$SCRIPT_DIR/smoke.py"
+}
+
+cmd_logs() {
+    if [[ $# -eq 0 ]]; then
+        $COMPOSE logs --tail=200 -f
+    else
+        $COMPOSE logs --tail=200 -f "$@"
+    fi
+}
+
+cmd_not_implemented() {
+    local name="$1"; shift
+    echo "[nightly] '$name' is not implemented in this PR — tracked for follow-up" >&2
+    exit 2
+}
+
+if [[ $# -eq 0 ]]; then
+    usage
+    exit 0
+fi
+
+sub="$1"; shift || true
+case "$sub" in
+    full)      cmd_full "$@" ;;
+    down)      cmd_down "$@" ;;
+    status)    cmd_status "$@" ;;
+    smoke)     cmd_smoke "$@" ;;
+    logs)      cmd_logs "$@" ;;
+    go)        cmd_not_implemented "go" "$@" ;;
+    chaos)     cmd_not_implemented "chaos" "$@" ;;
+    report)    cmd_not_implemented "report" "$@" ;;
+    -h|--help|help) usage ;;
+    *) echo "unknown command: $sub" >&2; usage; exit 1 ;;
+esac

--- a/test/nightly/smoke.py
+++ b/test/nightly/smoke.py
@@ -1,0 +1,87 @@
+"""Smoke test: load identity files for every enrolled agent and verify
+each can authenticate against its Mastio by calling GET /v1/egress/peers.
+
+Run with './nightly.sh smoke' after './nightly.sh full' has completed.
+Exits 0 if N/N agents are online, 1 otherwise.
+"""
+from __future__ import annotations
+
+import concurrent.futures
+import json
+import os
+import pathlib
+import sys
+import time
+
+from cullis_sdk import CullisClient
+
+STATE = pathlib.Path(__file__).parent / "state"
+MANIFEST = STATE / "agents.json"
+MASTIO_URLS = {
+    "orga": os.environ.get("MASTIO_A_URL", "http://localhost:9100"),
+    "orgb": os.environ.get("MASTIO_B_URL", "http://localhost:9200"),
+}
+
+GREEN, RED, RESET = "\033[32m", "\033[31m", "\033[0m"
+
+
+def _probe(entry: dict) -> tuple[str, bool, str]:
+    org_id = entry["org_id"]
+    name = entry["agent_name"]
+    agent_id = entry["agent_id"]
+    agent_dir = STATE / org_id / "agents" / name
+    api_key = agent_dir / "api-key"
+    dpop = agent_dir / "dpop.jwk"
+
+    for f in (api_key, dpop):
+        if not f.exists():
+            return agent_id, False, f"missing {f.name}"
+
+    mastio_url = MASTIO_URLS[org_id]
+    try:
+        client = CullisClient.from_api_key_file(
+            mastio_url,
+            api_key_path=api_key, dpop_key_path=dpop,
+            agent_id=agent_id, org_id=org_id,
+            timeout=30.0,
+        )
+        peers = client.list_peers(limit=50)
+        return agent_id, True, f"{len(peers)} peers visible"
+    except Exception as exc:  # noqa: BLE001 — capture any failure mode
+        return agent_id, False, f"{type(exc).__name__}: {exc}"
+
+
+def main() -> int:
+    if not MANIFEST.exists():
+        print(f"{RED}✗{RESET} {MANIFEST} missing — run './nightly.sh full' first",
+              file=sys.stderr)
+        return 1
+
+    manifest = json.loads(MANIFEST.read_text())
+    total = len(manifest)
+    print(f"[smoke] probing {total} agents via Mastio /v1/egress/peers")
+
+    start = time.monotonic()
+    # Mild concurrency (2 workers). A wider fan-out stalls Mastio's single
+    # uvicorn worker under DPoP validation — that's the kind of finding
+    # 'nightly.sh go' will surface deliberately; smoke just wants a yes/no
+    # "N/N identities work", not a load test.
+    results: list[tuple[str, bool, str]] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(_probe, manifest))
+
+    ok = sum(1 for _, up, _ in results if up)
+    elapsed = time.monotonic() - start
+
+    # Always log failures, summarize successes
+    for agent_id, up, detail in results:
+        if not up:
+            print(f"  {RED}✗{RESET} {agent_id:<28} {detail}")
+
+    print(f"\n[smoke] {GREEN if ok == total else RED}{ok}/{total}{RESET} "
+          f"agents online  ({elapsed:.1f}s)")
+    return 0 if ok == total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

First of three PRs building the **nightly** test lane (Fase 3 in `imp/execution_plan.md`): long-running load/soak/chaos runs that surface criticalities the ~50s sandbox smoke can't hit.

This PR is the scaffold — bring up, bring down, verify identities. No workload drivers yet (that's PR2), no chaos (PR3).

- `test/nightly/nightly.sh` — entry point, subcommands `full | down | status | smoke | logs` (go/chaos/report stubbed).
- Lean compose: Court + 2 Mastio + bootstrap. **No SPIRE, no Keycloak, no MCP servers.** Agents run on the host as standalone Python scripts, not in containers.
- Parametric `AGENTS_PER_ORG=10` default — BYOCA-enrolled via the same flow an admin would use (invite → onboarding → cert minting → `/v1/admin/agents/enroll/byoca`).
- Host-side `smoke.py` probes `/v1/egress/peers` for each identity.

## Already surfacing criticalities

During scaffold validation: Mastio's single uvicorn worker stalls when ~10 DPoP-signed requests fan out in parallel — single-agent probe takes 420ms, 10-way fan-out times out. Smoke dropped to `max_workers=2` as a workaround; full load characterization moves to `nightly.sh go` (PR2), with the concurrency stall tracked as a follow-up investigation.

## Test plan

- [x] `./nightly.sh full` brings up 10-service stack (Court + 2 Postgres + Redis + 2 Mastio + 2 proxy-init + 2 bootstrap).
- [x] Bootstrap onboards `orga` (join) + `orgb` (attach), mints 20 agent certs.
- [x] `bootstrap-mastio` pins pubkeys on Court + BYOCA-enrolls all 20 agents + approves bindings.
- [x] `./nightly.sh smoke` returns `20/20 agents online`.
- [ ] `./nightly.sh down -v` leaves zero containers/volumes/state. (manual check)