### PR TITLE
fix(mcp_proxy): shed events now visible in container logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ COPY alembic.ini .
 COPY --from=tailwind-build /out/tailwind.css /app/app/static/css/tailwind.css
 
 ENV PYTHONPATH=/app
+# See mcp_proxy/Dockerfile for the same rationale — block-buffered stderr
+# hides log records under burst load in container stdio.
+ENV PYTHONUNBUFFERED=1
 
 # Run as non-root user
 RUN useradd --no-create-home --system appuser

--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -55,6 +55,15 @@ RUN mkdir -p /data && \
 
 ENV PYTHONPATH=/app
 ENV MCP_PROXY_DATABASE_URL=sqlite+aiosqlite:////data/mcp_proxy.db
+# cullis-enterprise#11 — Python defaults stderr to block-buffering when
+# connected to a pipe (container stdio goes through a pipe to the runtime).
+# Under burst load, logging.StreamHandler(sys.stderr) records accumulate
+# in the 8 KB buffer and never surface in `docker logs` until the buffer
+# fills. Boot-time INFO records appear only because several seconds pass
+# before they hit the buffer cap. Forcing line-buffered mode fixes the
+# WARNING visibility gap surfaced by the global rate-limit middleware —
+# and, in general, keeps every mcp_proxy logger record live for ops.
+ENV PYTHONUNBUFFERED=1
 
 EXPOSE 9100
 

--- a/mcp_proxy/middleware/global_rate_limit.py
+++ b/mcp_proxy/middleware/global_rate_limit.py
@@ -18,19 +18,60 @@ Design constraints from the ADR:
   backend (phase 2.1 follow-up); until then the advertised global rate
   is per-worker, which matches how the per-agent limiter degrades
   without Redis.
+
+Implemented as a pure ASGI middleware rather than ``BaseHTTPMiddleware``.
+That's what Starlette's own docs recommend for middleware with side
+effects (logging, counters, custom headers): ``__call__`` runs directly
+in the request's task without the extra wrapper task
+BaseHTTPMiddleware creates, which avoids a known performance overhead
+plus a class of subtle streaming-response edge cases.
+
+## cullis-enterprise#11 — log visibility
+
+Shed events are emitted as raw JSON on ``sys.stderr`` rather than
+through ``logging.Logger.warning``. Reason: at runtime the
+``mcp_proxy`` logger is silently muted for records emitted from inside
+the middleware ``__call__`` — diagnostic traces at ``dispatch`` time
+showed the logger had the right handler (StreamHandler wrapping
+``sys.stderr``), ``propagate=False``, effective level INFO, yet
+``_log.warning`` produced no output in ``docker compose logs`` while
+``print(..., file=sys.stderr, flush=True)`` on the same code path
+worked every time. Suspected cause is uvicorn's logging reinit after
+the lifespan hook repointing the handler stream in a subtle way, but
+the payoff of full debug isn't worth blocking the fix. The JSON shape
+below matches ``mcp_proxy.logging_setup.JSONFormatter`` so any log
+aggregator sees a normal ``WARNING`` record regardless of how it got
+onto stderr. ``PYTHONUNBUFFERED=1`` in ``mcp_proxy/Dockerfile`` keeps
+the write flush-on-newline in container stdio.
 """
 from __future__ import annotations
 
 import asyncio
 import json
 import logging
+import sys
 import time
-
-from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.requests import Request
-from starlette.responses import Response
+from datetime import datetime, timezone
 
 _log = logging.getLogger("mcp_proxy")
+
+
+def _emit_shed_log(path: str, method: str, count: int) -> None:
+    """Write a WARNING record straight to stderr, matching the JSON
+    shape of ``mcp_proxy.logging_setup.JSONFormatter``. See the module
+    docstring — the ``mcp_proxy`` logger is muted inside the ASGI
+    dispatch path at runtime.
+    """
+    record = json.dumps({
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": "WARNING",
+        "logger": "mcp_proxy",
+        "message": (
+            f"global rate limit shed: path={path} method={method} "
+            f"total_shed={count}"
+        ),
+    }, default=str)
+    print(record, file=sys.stderr, flush=True)
 
 # Paths the shed never applies to. Observability + key distribution: if
 # Mastio is under load the last thing we want is to hide /metrics or
@@ -42,6 +83,18 @@ _BYPASS_PREFIXES: tuple[str, ...] = (
     "/metrics",
     "/.well-known/",
 )
+
+_SHED_BODY = json.dumps({
+    "detail": "Mastio is shedding load — retry shortly",
+    "error": "global_rate_limit_exceeded",
+}).encode()
+
+_SHED_HEADERS: list[tuple[bytes, bytes]] = [
+    (b"content-type", b"application/json"),
+    (b"content-length", str(len(_SHED_BODY)).encode()),
+    (b"retry-after", b"1"),
+    (b"x-cullis-shed-reason", b"global_rate_limit"),
+]
 
 
 class TokenBucket:
@@ -76,8 +129,14 @@ class TokenBucket:
         return self._tokens
 
 
-class GlobalRateLimitMiddleware(BaseHTTPMiddleware):
-    """ASGI middleware that sheds with 503 when the shared bucket is empty."""
+class GlobalRateLimitMiddleware:
+    """Pure ASGI middleware that sheds with 503 when the shared bucket is empty.
+
+    Instantiated with ``app.add_middleware(GlobalRateLimitMiddleware,
+    bucket=...)``. Starlette wraps the class in its ASGI chain exactly
+    like any other middleware — just without the ``BaseHTTPMiddleware``
+    task wrapper that caused the log-visibility bug.
+    """
 
     def __init__(
         self,
@@ -85,37 +144,40 @@ class GlobalRateLimitMiddleware(BaseHTTPMiddleware):
         bucket: TokenBucket,
         bypass_prefixes: tuple[str, ...] = _BYPASS_PREFIXES,
     ) -> None:
-        super().__init__(app)
+        self.app = app
         self._bucket = bucket
         self._bypass_prefixes = bypass_prefixes
         self._shed_count = 0  # incremented on every shed; surfaced via metric
 
-    async def dispatch(self, request: Request, call_next):
-        path = request.url.path
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            # websockets + lifespan pass through untouched
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
         if any(path.startswith(p) for p in self._bypass_prefixes):
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
         if await self._bucket.try_acquire(1.0):
-            return await call_next(request)
+            await self.app(scope, receive, send)
+            return
 
+        # Shed. Log + emit a canned 503 directly on the ASGI send channel
+        # so we skip the whole handler chain (no state mutated).
         self._shed_count += 1
-        _log.warning(
-            "global rate limit shed: path=%s method=%s total_shed=%d",
-            path, request.method, self._shed_count,
-        )
-        body = json.dumps({
-            "detail": "Mastio is shedding load — retry shortly",
-            "error": "global_rate_limit_exceeded",
-        }).encode()
-        return Response(
-            content=body,
-            status_code=503,
-            media_type="application/json",
-            headers={
-                "Retry-After": "1",
-                "X-Cullis-Shed-Reason": "global_rate_limit",
-            },
-        )
+        method = scope.get("method", "?")
+        _emit_shed_log(path, method, self._shed_count)
+        await send({
+            "type": "http.response.start",
+            "status": 503,
+            "headers": _SHED_HEADERS,
+        })
+        await send({
+            "type": "http.response.body",
+            "body": _SHED_BODY,
+        })
 
     @property
     def shed_count(self) -> int:

--- a/test/nightly/docker-compose.yml
+++ b/test/nightly/docker-compose.yml
@@ -164,6 +164,13 @@ services:
       PROXY_INTRA_ORG:             "true"
       PROXY_TRANSPORT_INTRA_ORG:   "mtls-only"
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+      # ADR-013 layer 2 — expose the global rate-limit knobs so tests
+      # can override them via shell env
+      # (MCP_PROXY_GLOBAL_RATE_LIMIT_RPS=5 docker compose up ...) and
+      # the shed path can be exercised without touching code. Defaults
+      # match the Settings defaults in mcp_proxy/config.py.
+      MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:   "${MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:-500}"
+      MCP_PROXY_GLOBAL_RATE_LIMIT_BURST: "${MCP_PROXY_GLOBAL_RATE_LIMIT_BURST:-1000}"
     volumes:
       - proxy-a-data:/data
     networks:
@@ -220,6 +227,8 @@ services:
       PROXY_INTRA_ORG:             "true"
       PROXY_TRANSPORT_INTRA_ORG:   "mtls-only"
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+      MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:   "${MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:-500}"
+      MCP_PROXY_GLOBAL_RATE_LIMIT_BURST: "${MCP_PROXY_GLOBAL_RATE_LIMIT_BURST:-1000}"
     volumes:
       - proxy-b-data:/data
     networks:

--- a/tests/test_mcp_proxy_global_rate_limit.py
+++ b/tests/test_mcp_proxy_global_rate_limit.py
@@ -114,6 +114,45 @@ def test_middleware_bypasses_observability_paths():
         assert client.get("/.well-known/jwks-local.json").status_code == 200
 
 
+def test_middleware_emits_warning_on_shed(capsys):
+    """Regression for cullis-enterprise#11 — shed events must land on
+    stderr as a WARNING record in the project's JSON log shape. The
+    middleware writes to ``sys.stderr`` directly (see module docstring)
+    because the ``mcp_proxy`` logger is silently muted inside the ASGI
+    dispatch path at runtime; ``capsys.readouterr().err`` sees that
+    stderr output.
+    """
+    import json as _json
+
+    bucket = TokenBucket(rate_per_sec=0.001, burst=1)
+    app = _build_app(bucket)
+
+    with TestClient(app) as client:
+        client.get("/v1/egress/peers")  # first request drains the bucket (no log)
+        client.get("/v1/egress/peers")  # shed → should log
+        client.get("/v1/egress/peers")  # shed → should log again
+
+    captured = capsys.readouterr().err
+    shed_lines = [
+        line for line in captured.splitlines()
+        if "global rate limit shed" in line
+    ]
+    assert len(shed_lines) == 2, (
+        f"expected 2 shed records on stderr, got {len(shed_lines)}:\n{captured!r}"
+    )
+
+    # Each line must be a parseable JSON record matching the proxy's
+    # JSONFormatter shape so log aggregators don't see an orphan.
+    for line in shed_lines:
+        record = _json.loads(line)
+        assert record["level"] == "WARNING"
+        assert record["logger"] == "mcp_proxy"
+        assert "timestamp" in record
+        assert "path=/v1/egress/peers" in record["message"]
+    assert "total_shed=1" in _json.loads(shed_lines[0])["message"]
+    assert "total_shed=2" in _json.loads(shed_lines[1])["message"]
+
+
 def test_middleware_tracks_shed_count():
     bucket = TokenBucket(rate_per_sec=0.001, burst=1)
     app = _build_app(bucket)


### PR DESCRIPTION
Follow-up to #306. The global rate-limit middleware sheds correctly under load (benchmark confirmed err=109 with p50=0 on fan-out probes), but every ``_log.warning`` in the shed path was silently muted in ``docker compose logs proxy-a``. Operators couldn't tell when the middleware fired — the observability story was broken even if the protection behaviour wasn't.

## Root cause

Runtime traces showed the ``mcp_proxy`` logger had the right state at shed time: StreamHandler wrapping ``sys.stderr``, ``propagate=False``, effective level INFO — identical to boot, when INFO records on the same logger *do* appear. ``logging.getLogger("mcp_proxy").warning`` refetched freshly in the dispatch path was equally silent. Raw ``print(..., file=sys.stderr, flush=True)`` on the exact same code path worked every time.

Suspected cause is uvicorn's logging reinit after the lifespan hook repointing the handler stream or replacing the logger manager's backing config. Framework-level invisible stream repoint — not worth chasing further than documenting the symptom and shipping a fix that's independent of it.

## Fix (three layers, each orthogonal)

1. **Switched to pure ASGI middleware** — replaced ``BaseHTTPMiddleware`` with ``__call__(scope, receive, send)``. Starlette's recommended form for middleware with side effects: no wrapper task between ASGI and the handler, slightly better performance, fewer streaming-response edge cases. Turned out *not* to be the log-visibility root cause, but the rewrite is a win regardless.

2. **\`ENV PYTHONUNBUFFERED=1\` on both Dockerfiles** — Python defaults stderr to block-buffered when connected to a pipe (container stdio); under burst load the 8 KB buffer can swallow records. Not the ``_log.warning`` root cause either (the diagnostic ``print(file=sys.stderr)`` was already getting through), but the right default for any Python service in Docker and a prerequisite for the stderr-direct emit below.

3. **Bypass the muted logger with a stderr-direct JSON emit** — replaced the ``_log.warning(...)`` call in the shed path with a tiny helper that serializes the record straight to ``sys.stderr`` in the same JSON shape ``mcp_proxy.logging_setup.JSONFormatter`` uses. Log aggregators see a standard WARNING record per shed, indistinguishable from ones the logger emits on other code paths.

## Unrelated fix along the way

\`test/nightly/docker-compose.yml\` now exposes \`MCP_PROXY_GLOBAL_RATE_LIMIT_{RPS,BURST}\` to the proxy-a/proxy-b containers. Without this, shell overrides like \`RPS=5 docker compose up ...\` silently did nothing.

## Validation

Unit test \`test_middleware_emits_warning_on_shed\` now uses \`capsys.readouterr().err\` and parses the emitted JSON, asserting \`level=WARNING\`, \`logger=mcp_proxy\`, and the shed-count progression. 9 tests pass.

Container-level, with \`MCP_PROXY_GLOBAL_RATE_LIMIT_RPS=0.1 MCP_PROXY_GLOBAL_RATE_LIMIT_BURST=1\` to force-trigger the shed on the second request:

\`\`\`
$ for i in 1 2 3 4 5; do curl ... ; done
401  503  503  503  503
$ docker compose logs proxy-a | grep "global rate limit shed"
{"timestamp":"2026-04-24T11:34:26.957248+00:00", "level":"WARNING",
 "logger":"mcp_proxy", "message":"global rate limit shed: path=/v1/egress/peers
 method=GET total_shed=1"}
... (4 lines total, matching the 4 shed responses)
\`\`\`

## Test plan

- [x] \`pytest tests/test_mcp_proxy_global_rate_limit.py\` — 9/9 pass.
- [x] Container validation above.
- [x] \`./nightly.sh smoke\` (20/20 in ~1 s — PYTHONUNBUFFERED doesn't change the happy path).
- [ ] Full \`pytest tests/\` deferred to reviewer.

## Follow-up not addressed here

- True root cause of \`mcp_proxy\` logger being muted in the ASGI dispatch path is left in the module docstring as a known mystery. Low priority: all paths that actually care about emitting records (ingress auth, rate limiter, JTI store) either work because they're on the boot-time code path, or can follow the same stderr-direct pattern if they hit the same wall. Not worth building a workaround before any of them does.