### PR TITLE
feat(mcp_proxy): ADR-013 Phase 3 — DB latency circuit breaker

### DIFF
--- a/mcp_proxy/admin/observability.py
+++ b/mcp_proxy/admin/observability.py
@@ -1,0 +1,116 @@
+"""Admin observability endpoints — ADR-013 circuit breaker surface.
+
+Operators need a single place to answer "is the breaker shedding
+right now, and what is it seeing?" without grepping logs or
+instrumenting anything custom. This endpoint exposes the minimum
+state that matters during an incident.
+
+Auth uses the shared ``admin_secret`` — same pattern as
+``mcp_proxy/admin/info.py``.
+"""
+from __future__ import annotations
+
+import hmac
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel
+
+from mcp_proxy.config import get_settings
+
+router = APIRouter(prefix="/v1/admin/observability", tags=["admin", "observability"])
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+class CircuitBreakerResponse(BaseModel):
+    """Snapshot of the DB latency circuit breaker (ADR-013 layer 6).
+
+    All latency fields are rounded milliseconds. ``None`` on a
+    p99 field means the corresponding source hasn't collected
+    enough samples yet (``probe_ready = false`` covers the
+    composite: at least one source must be ready for the breaker
+    to ever shed). Shed counters are absolute: the breaker never
+    resets them at runtime, so a monitoring scrape can
+    ``rate(shed_total)`` if it wants.
+    """
+    probe_ready: bool
+    p99_ms_probe: float | None
+    p99_ms_passive: float | None
+    p99_ms_effective: float | None
+    probe_samples_in_window: int
+    passive_samples_in_window: int
+    is_shedding: bool
+    shed_fraction: float
+    shed_count_last_60s: int
+    shed_count_total: int
+    activation_threshold_ms: float
+    deactivation_threshold_ms: float
+    max_shed_fraction: float
+
+
+@router.get(
+    "/circuit-breaker",
+    response_model=CircuitBreakerResponse,
+    dependencies=[Depends(_require_admin_secret)],
+    summary="DB latency circuit breaker runtime snapshot",
+)
+async def get_circuit_breaker(request: Request) -> CircuitBreakerResponse:
+    tracker = getattr(request.app.state, "db_latency_tracker", None)
+    state = getattr(request.app.state, "db_latency_cb_state", None)
+
+    if tracker is None or state is None:
+        # The middleware/tracker haven't been wired in yet. Return a
+        # deterministic "nothing configured" payload rather than 500.
+        return CircuitBreakerResponse(
+            probe_ready=False,
+            p99_ms_probe=None,
+            p99_ms_passive=None,
+            p99_ms_effective=None,
+            probe_samples_in_window=0,
+            passive_samples_in_window=0,
+            is_shedding=False,
+            shed_fraction=0.0,
+            shed_count_last_60s=0,
+            shed_count_total=0,
+            activation_threshold_ms=0.0,
+            deactivation_threshold_ms=0.0,
+            max_shed_fraction=0.0,
+        )
+
+    probe_p99, passive_p99, effective_p99 = tracker.p99_ms()
+    probe_samples, passive_samples = tracker.sample_counts()
+    probe_ready = effective_p99 is not None
+
+    # The shed fraction the breaker would apply *right now* for a
+    # request that arrived this instant. When not in the shedding
+    # state the fraction is 0 regardless of p99.
+    current_fraction = (
+        state.shed_fraction(effective_p99)
+        if state.is_shedding and effective_p99 is not None
+        else 0.0
+    )
+
+    return CircuitBreakerResponse(
+        probe_ready=probe_ready,
+        p99_ms_probe=round(probe_p99, 1) if probe_p99 is not None else None,
+        p99_ms_passive=round(passive_p99, 1) if passive_p99 is not None else None,
+        p99_ms_effective=round(effective_p99, 1) if effective_p99 is not None else None,
+        probe_samples_in_window=probe_samples,
+        passive_samples_in_window=passive_samples,
+        is_shedding=state.is_shedding,
+        shed_fraction=round(current_fraction, 3),
+        shed_count_last_60s=state.shed_count_last_60s(),
+        shed_count_total=state.shed_total,
+        activation_threshold_ms=state.activation_ms,
+        deactivation_threshold_ms=state.deactivation_ms,
+        max_shed_fraction=state.max_shed_fraction,
+    )

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -122,6 +122,20 @@ class ProxySettings(BaseSettings):
     global_rate_limit_rps: float = 500.0
     global_rate_limit_burst: int = 1000
 
+    # ADR-013 layer 6 — DB latency circuit breaker. Sheds a fraction
+    # of requests while DB p99 sits above the activation threshold,
+    # so the Mastio stays responsive as the pool recovers rather
+    # than piling new work onto connections that never free up.
+    # Hysteresis between activation and deactivation prevents
+    # flapping at the boundary. Lerp from 10 % at activation up to
+    # max_shed_fraction at 3× activation. See ADR-013 §Phase 3.
+    cb_db_latency_activation_ms: float = 500.0
+    cb_db_latency_deactivation_ms: float = 350.0
+    cb_db_latency_max_shed_fraction: float = 0.95
+    cb_db_latency_probe_interval_s: float = 1.0
+    cb_db_latency_probe_timeout_s: float = 2.0
+    cb_db_latency_window_s: float = 5.0
+
     # Redis — optional. Empty = in-memory JTI store + rate limiter (single-
     # instance Mastio is fine without Redis). Multi-worker / HA deploys MUST
     # set this so the DPoP JTI store is shared across workers (audit F-B-12).

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -358,6 +358,38 @@ async def lifespan(app: FastAPI):
         app.state.federation_stats_task = stats_task
         _log.info("federation stats publisher started (org=%s)", org_id)
 
+    # ADR-013 layer 6 — DB latency tracker + circuit breaker state.
+    # Started after init_db (need the engine) and after the federation
+    # task, so the probe's first ``SELECT 1`` runs against a fully
+    # initialized pool. The middleware reads these off app.state at
+    # request time; see mcp_proxy.middleware.db_latency_circuit_breaker.
+    from mcp_proxy.db import _require_engine
+    from mcp_proxy.middleware.db_latency_circuit_breaker import (
+        CircuitBreakerState,
+    )
+    from mcp_proxy.observability.db_latency import DbLatencyTracker
+
+    db_latency_tracker = DbLatencyTracker(
+        _require_engine(),
+        window_s=settings.cb_db_latency_window_s,
+        probe_interval_s=settings.cb_db_latency_probe_interval_s,
+        probe_timeout_s=settings.cb_db_latency_probe_timeout_s,
+    )
+    await db_latency_tracker.start()
+    app.state.db_latency_tracker = db_latency_tracker
+    app.state.db_latency_cb_state = CircuitBreakerState(
+        activation_ms=settings.cb_db_latency_activation_ms,
+        deactivation_ms=settings.cb_db_latency_deactivation_ms,
+        max_shed_fraction=settings.cb_db_latency_max_shed_fraction,
+    )
+    _log.info(
+        "DB latency circuit breaker: activation=%.0fms deactivation=%.0fms "
+        "max_shed=%.2f (ADR-013 layer 6)",
+        settings.cb_db_latency_activation_ms,
+        settings.cb_db_latency_deactivation_ms,
+        settings.cb_db_latency_max_shed_fraction,
+    )
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
@@ -365,7 +397,15 @@ async def lifespan(app: FastAPI):
 
     yield
 
-    # Cleanup
+    # Cleanup — stop the latency tracker first so the background probe
+    # doesn't race with engine dispose.
+    tracker = getattr(app.state, "db_latency_tracker", None)
+    if tracker is not None:
+        try:
+            await tracker.stop()
+        except Exception as exc:  # noqa: BLE001
+            _log.warning("db_latency_tracker.stop raised: %s", exc)
+
     stop_event = getattr(app.state, "local_sweeper_stop", None)
     sweeper_task = getattr(app.state, "local_sweeper_task", None)
     if stop_event is not None:
@@ -545,6 +585,28 @@ async def security_headers(request: Request, call_next):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# DB latency circuit breaker (ADR-013 layer 6)
+#
+# Registered *before* the global rate limit in the code, so Starlette's LIFO
+# execution order runs the circuit breaker AFTER the global bucket: a burst
+# big enough to saturate the DB gets shed by the global bucket first,
+# leaving only the residue for the breaker to evaluate. Reads its tracker +
+# state off app.state at request time (wired by the lifespan hook above)
+# so the middleware can be registered at module-import time before the
+# engine exists.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from mcp_proxy.middleware.db_latency_circuit_breaker import (
+    DbLatencyCircuitBreakerMiddleware,
+)
+
+app.add_middleware(DbLatencyCircuitBreakerMiddleware)
+_log.info(
+    "DB latency circuit breaker middleware registered (ADR-013 layer 6)"
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Global rate limit (ADR-013 layer 2)
 #
 # Registered last among the middlewares so Starlette's LIFO execution order
@@ -678,6 +740,10 @@ if get_settings().local_auth_enabled:
 # ADR-009 Phase 2 — /v1/admin/mastio-pubkey for bootstrap automation.
 from mcp_proxy.admin.info import router as admin_info_router
 app.include_router(admin_info_router)
+
+# ADR-013 layer 6 — /v1/admin/observability/circuit-breaker.
+from mcp_proxy.admin.observability import router as admin_observability_router
+app.include_router(admin_observability_router)
 
 # ADR-009 sandbox — Connector JSON API for MCP resources + bindings.
 from mcp_proxy.admin.mcp_resources import router as admin_mcp_resources_router

--- a/mcp_proxy/middleware/db_latency_circuit_breaker.py
+++ b/mcp_proxy/middleware/db_latency_circuit_breaker.py
@@ -1,0 +1,249 @@
+"""DB latency circuit breaker — ADR-013 layer 6.
+
+Sheds a fraction of incoming requests with 503 when the DB latency
+signal (from ``mcp_proxy.observability.db_latency.DbLatencyTracker``)
+sits above the activation threshold. Goal: keep the Mastio responsive
+as the DB recovers, rather than piling every new request onto a
+saturated pool where they compete for connections that never come.
+
+Key design choices, each addressing a failure mode we thought about:
+
+- **Pure ASGI middleware**, same reason as the global rate limit
+  (PR #306 / #307): ``__call__`` runs in the request's own task, no
+  BaseHTTPMiddleware wrapper task, stderr-direct log emit survives
+  the uvicorn logger mute issue.
+
+- **Shed is pre-state**: the decision happens before the auth dep
+  and before any handler touches the DB, the session store, the
+  DPoP nonce cache, etc. A shed 503 never consumes server-side state
+  the client would have to reconcile on retry.
+
+- **Hysteresis** with asymmetric thresholds (500 ms activation /
+  350 ms deactivation): without it, a p99 oscillating around 500 ms
+  ± jitter would flap the shed fraction between 0 and 10 %,
+  producing random 503s when the system is actually fine. Two
+  thresholds = one extra line, eliminates the flap. Inside the
+  shedding state the fraction itself lerps from 10 % at activation
+  up to ``max_shed_fraction`` (default 0.95) at 3× the activation
+  threshold. 0.95 and not 1.0 on purpose: a small trickle of traffic
+  still reaches handlers under full shed, so the operator can tell
+  "breaker active, DB recovering" from "breaker active, DB dead"
+  from the traffic alone without having to read the latency probe
+  separately.
+
+- **Fail-open on warmup**: if the tracker hasn't collected enough
+  samples yet (first few seconds after boot, or if something broke
+  the probe + passive sampler together), the middleware falls
+  through to pass-through. Phase 1 (DB pool cap) and Phase 2 (global
+  bucket) continue to protect; silently dropping every request
+  during warmup is the wrong default.
+
+- **Bypass observability paths**: /health, /metrics, /.well-known/
+  never shed. Same reasoning as the global rate limit — an operator
+  trying to diagnose a slow DB needs /health and /metrics to answer.
+
+- **Shed-aware emit**: every shed writes a JSON WARNING record
+  directly to stderr in the ``JSONFormatter`` shape, bypassing the
+  Python logger for the same reason documented in
+  ``global_rate_limit.py``.
+"""
+from __future__ import annotations
+
+import json
+import random
+import sys
+import time
+from collections import deque
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mcp_proxy.observability.db_latency import DbLatencyTracker
+
+
+_BYPASS_PREFIXES: tuple[str, ...] = (
+    "/health",
+    "/metrics",
+    "/.well-known/",
+)
+
+_SHED_BODY = json.dumps({
+    "detail": "DB latency high — circuit breaker shedding, retry shortly",
+    "error": "db_latency_circuit_breaker_open",
+}).encode()
+
+_SHED_HEADERS: list[tuple[bytes, bytes]] = [
+    (b"content-type", b"application/json"),
+    (b"content-length", str(len(_SHED_BODY)).encode()),
+    (b"retry-after", b"5"),
+    (b"x-cullis-shed-reason", b"db_latency_circuit_breaker"),
+]
+
+# 95th-percentile samples retained for the "last 60 s" counter. 60 s
+# at typical shed rates stays well under a few thousand entries.
+_SHED_WINDOW_S: float = 60.0
+
+# Minimum shed fraction the moment the breaker enters the shedding
+# state — enough to relieve the DB immediately without a cold-start
+# behaviour that looks indistinguishable from ``not shedding``.
+_ENTRY_SHED_FRACTION: float = 0.10
+
+# Above this multiple of the activation threshold the lerp saturates.
+# Chosen so a well-saturated system (p99 at 3× target) is held at
+# ``max_shed_fraction`` rather than overshooting to 100 %.
+_SATURATION_MULTIPLIER: float = 3.0
+
+
+def _emit_shed_log(path: str, method: str, p99_ms: float, fraction: float,
+                   shed_total: int) -> None:
+    """Write a WARNING record straight to stderr, matching the JSON
+    shape of ``mcp_proxy.logging_setup.JSONFormatter``. The
+    ``mcp_proxy`` logger is muted inside the ASGI dispatch path at
+    runtime — see global_rate_limit.py for the full story."""
+    record = json.dumps({
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": "WARNING",
+        "logger": "mcp_proxy",
+        "message": (
+            f"db latency circuit breaker shed: path={path} method={method} "
+            f"p99_ms={p99_ms:.0f} shed_fraction={fraction:.2f} "
+            f"total_shed={shed_total}"
+        ),
+    }, default=str)
+    print(record, file=sys.stderr, flush=True)
+
+
+class CircuitBreakerState:
+    """Shed bookkeeping for the middleware. Injected into the
+    middleware at construction and exposed via ``app.state`` so the
+    admin observability endpoint can read counters + state without
+    walking the middleware stack.
+    """
+
+    def __init__(
+        self,
+        *,
+        activation_ms: float = 500.0,
+        deactivation_ms: float = 350.0,
+        max_shed_fraction: float = 0.95,
+    ) -> None:
+        if deactivation_ms >= activation_ms:
+            raise ValueError(
+                f"deactivation_ms ({deactivation_ms}) must be below "
+                f"activation_ms ({activation_ms}) — asymmetric thresholds "
+                f"are the whole point of the hysteresis"
+            )
+        if not 0.0 < max_shed_fraction <= 1.0:
+            raise ValueError(
+                f"max_shed_fraction must be in (0, 1], got {max_shed_fraction}"
+            )
+        self.activation_ms = activation_ms
+        self.deactivation_ms = deactivation_ms
+        self.max_shed_fraction = max_shed_fraction
+        self.is_shedding: bool = False
+        self.shed_total: int = 0
+        self._shed_timestamps: deque[float] = deque()
+
+    def update_state(self, p99_ms: float) -> None:
+        """Apply hysteresis to the latency signal."""
+        if self.is_shedding:
+            if p99_ms < self.deactivation_ms:
+                self.is_shedding = False
+        else:
+            if p99_ms > self.activation_ms:
+                self.is_shedding = True
+
+    def shed_fraction(self, p99_ms: float) -> float:
+        """Linear lerp between activation threshold and saturation.
+
+        Called only while ``is_shedding`` is True — outside that state
+        the middleware bypasses this path entirely.
+        """
+        if p99_ms <= self.activation_ms:
+            return _ENTRY_SHED_FRACTION
+        saturation_ms = self.activation_ms * _SATURATION_MULTIPLIER
+        if p99_ms >= saturation_ms:
+            return self.max_shed_fraction
+        ratio = (p99_ms - self.activation_ms) / (saturation_ms - self.activation_ms)
+        return _ENTRY_SHED_FRACTION + ratio * (
+            self.max_shed_fraction - _ENTRY_SHED_FRACTION
+        )
+
+    def record_shed(self) -> None:
+        self.shed_total += 1
+        self._shed_timestamps.append(time.monotonic())
+        self._trim_window()
+
+    def shed_count_last_60s(self) -> int:
+        self._trim_window()
+        return len(self._shed_timestamps)
+
+    def _trim_window(self) -> None:
+        cutoff = time.monotonic() - _SHED_WINDOW_S
+        while self._shed_timestamps and self._shed_timestamps[0] < cutoff:
+            self._shed_timestamps.popleft()
+
+
+class DbLatencyCircuitBreakerMiddleware:
+    """Pure ASGI middleware that sheds when DB p99 sits above threshold."""
+
+    def __init__(
+        self,
+        app,
+        tracker: "DbLatencyTracker",
+        state: CircuitBreakerState,
+        bypass_prefixes: tuple[str, ...] = _BYPASS_PREFIXES,
+        rng: "random.Random | None" = None,
+    ) -> None:
+        self.app = app
+        self._tracker = tracker
+        self._state = state
+        self._bypass_prefixes = bypass_prefixes
+        # Injectable RNG so tests can run with a deterministic seed
+        # when they need exact shed/pass counts per fraction.
+        self._rng = rng or random
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if any(path.startswith(p) for p in self._bypass_prefixes):
+            await self.app(scope, receive, send)
+            return
+
+        _, _, p99 = self._tracker.p99_ms()
+        if p99 is None:
+            # Warmup or both sources quiet: fail-open. Phase 1/2/6 all
+            # cooperate — the global bucket + DB pool cap still protect
+            # us while the tracker scales its sample window.
+            await self.app(scope, receive, send)
+            return
+
+        self._state.update_state(p99)
+        if not self._state.is_shedding:
+            await self.app(scope, receive, send)
+            return
+
+        fraction = self._state.shed_fraction(p99)
+        if self._rng.random() >= fraction:
+            # Pass-through within the shedding state — keeps a trickle
+            # of real traffic flowing so operators can tell recovering
+            # from dead at a glance, and so the passive sampler has
+            # something to measure as the DB returns.
+            await self.app(scope, receive, send)
+            return
+
+        self._state.record_shed()
+        method = scope.get("method", "?")
+        _emit_shed_log(path, method, p99, fraction, self._state.shed_total)
+        await send({
+            "type": "http.response.start",
+            "status": 503,
+            "headers": _SHED_HEADERS,
+        })
+        await send({
+            "type": "http.response.body",
+            "body": _SHED_BODY,
+        })

--- a/mcp_proxy/middleware/db_latency_circuit_breaker.py
+++ b/mcp_proxy/middleware/db_latency_circuit_breaker.py
@@ -185,19 +185,27 @@ class CircuitBreakerState:
 
 
 class DbLatencyCircuitBreakerMiddleware:
-    """Pure ASGI middleware that sheds when DB p99 sits above threshold."""
+    """Pure ASGI middleware that sheds when DB p99 sits above threshold.
+
+    Reads the ``DbLatencyTracker`` and ``CircuitBreakerState`` from
+    ``scope["app"].state`` at request time rather than taking them as
+    constructor arguments. Reason: ``app.add_middleware`` runs at
+    module import, but the tracker needs a live DB engine and is
+    created inside the lifespan — the state-lookup pattern lets the
+    middleware be registered early and picked up later once the
+    lifespan has wired ``app.state.db_latency_tracker`` and
+    ``app.state.db_latency_cb_state``. When either attribute is
+    missing (warmup, standalone test harness) the middleware
+    pass-through-s: fail-open.
+    """
 
     def __init__(
         self,
         app,
-        tracker: "DbLatencyTracker",
-        state: CircuitBreakerState,
         bypass_prefixes: tuple[str, ...] = _BYPASS_PREFIXES,
         rng: "random.Random | None" = None,
     ) -> None:
         self.app = app
-        self._tracker = tracker
-        self._state = state
         self._bypass_prefixes = bypass_prefixes
         # Injectable RNG so tests can run with a deterministic seed
         # when they need exact shed/pass counts per fraction.
@@ -213,7 +221,16 @@ class DbLatencyCircuitBreakerMiddleware:
             await self.app(scope, receive, send)
             return
 
-        _, _, p99 = self._tracker.p99_ms()
+        app_state = scope["app"].state
+        tracker = getattr(app_state, "db_latency_tracker", None)
+        state = getattr(app_state, "db_latency_cb_state", None)
+        if tracker is None or state is None:
+            # Lifespan hasn't wired us yet (or the standalone test
+            # harness omitted the tracker on purpose): fail-open.
+            await self.app(scope, receive, send)
+            return
+
+        _, _, p99 = tracker.p99_ms()
         if p99 is None:
             # Warmup or both sources quiet: fail-open. Phase 1/2/6 all
             # cooperate — the global bucket + DB pool cap still protect
@@ -221,12 +238,12 @@ class DbLatencyCircuitBreakerMiddleware:
             await self.app(scope, receive, send)
             return
 
-        self._state.update_state(p99)
-        if not self._state.is_shedding:
+        state.update_state(p99)
+        if not state.is_shedding:
             await self.app(scope, receive, send)
             return
 
-        fraction = self._state.shed_fraction(p99)
+        fraction = state.shed_fraction(p99)
         if self._rng.random() >= fraction:
             # Pass-through within the shedding state — keeps a trickle
             # of real traffic flowing so operators can tell recovering
@@ -235,9 +252,9 @@ class DbLatencyCircuitBreakerMiddleware:
             await self.app(scope, receive, send)
             return
 
-        self._state.record_shed()
+        state.record_shed()
         method = scope.get("method", "?")
-        _emit_shed_log(path, method, p99, fraction, self._state.shed_total)
+        _emit_shed_log(path, method, p99, fraction, state.shed_total)
         await send({
             "type": "http.response.start",
             "status": 503,

--- a/mcp_proxy/observability/db_latency.py
+++ b/mcp_proxy/observability/db_latency.py
@@ -1,0 +1,279 @@
+"""DB latency tracking — ADR-013 layer 6 (circuit breaker input).
+
+The circuit breaker reads one number from here: "what's the p99 of DB
+operations right now?" Getting that number honest under every failure
+mode is the whole point.
+
+We combine two sources and take the max:
+
+1. **Active probe** (``_ActiveProbe``) — background asyncio task
+   executing ``SELECT 1`` at a fixed cadence using the **shared
+   engine pool**, not a dedicated connection. That's deliberate: the
+   probe's wall time includes both the pool-acquire wait and the
+   query, so pool saturation (the common shape of silent DoS) shows
+   up immediately. A trivial ``SELECT 1`` on a dedicated connection
+   would stay fast while every real request piled up in the pool —
+   the breaker would never fire and the Mastio would die smiling.
+
+2. **Passive sampler** (``_PassiveSampler``) — SQLAlchemy
+   before_cursor_execute / after_cursor_execute event listener that
+   times every real query the application runs. Honest signal for
+   pool latency + slow queries under the actual workload shape. Costs
+   a few microseconds per query.
+
+Probe alone lies under pool saturation. Passive alone has lag (no
+sample = no data, breaker can't react until a request happens). The
+``max(probe_p99, passive_p99)`` trick gives us the one that's
+currently honest and ignores the one that isn't.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from typing import TYPE_CHECKING, NamedTuple
+
+from sqlalchemy import event, text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+_log = logging.getLogger("mcp_proxy")
+
+# A source needs at least this many samples in-window before its p99
+# is returned. With fewer, p99 is statistically meaningless and would
+# make the breaker flap on single outliers.
+_MIN_SAMPLES_FOR_P99 = 3
+
+
+class LatencySample(NamedTuple):
+    ts: float
+    latency_ms: float
+
+
+class _RingBuffer:
+    """Latency samples trimmed to a sliding time window.
+
+    Thread-safety: a single ``asyncio.Lock`` guards mutations. The
+    passive sampler's event listener runs on the SQLAlchemy thread
+    (async engine offloads sync driver work), so record() is called
+    from multiple contexts and must be safe. The lock is held only
+    for cheap ops (append + deque pop-left), never blocking.
+    """
+
+    def __init__(self, window_s: float) -> None:
+        self._window_s = float(window_s)
+        self._samples: deque[LatencySample] = deque()
+        self._lock = asyncio.Lock()
+
+    def record_nowait(self, latency_ms: float) -> None:
+        """Record without awaiting the lock — safe when the caller
+        can't yield to an event loop (SQLAlchemy sync event handlers).
+        Uses a small race window that's acceptable because samples
+        are statistical; an occasional lost/extra sample doesn't
+        break p99.
+        """
+        self._samples.append(LatencySample(time.monotonic(), latency_ms))
+        self._trim_nolock()
+
+    async def record(self, latency_ms: float) -> None:
+        async with self._lock:
+            self._samples.append(LatencySample(time.monotonic(), latency_ms))
+            self._trim_nolock()
+
+    def _trim_nolock(self) -> None:
+        cutoff = time.monotonic() - self._window_s
+        while self._samples and self._samples[0].ts < cutoff:
+            self._samples.popleft()
+
+    def p99_or_none(self) -> float | None:
+        self._trim_nolock()
+        values = [s.latency_ms for s in self._samples]
+        if len(values) < _MIN_SAMPLES_FOR_P99:
+            return None
+        return _percentile(values, 0.99)
+
+    def sample_count(self) -> int:
+        self._trim_nolock()
+        return len(self._samples)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    vs = sorted(values)
+    idx = min(len(vs) - 1, max(0, int(len(vs) * pct) - 1))
+    return vs[idx]
+
+
+class _ActiveProbe:
+    """Background task: measure pool-acquire + SELECT 1 at an interval."""
+
+    def __init__(
+        self,
+        engine: "AsyncEngine",
+        buffer: _RingBuffer,
+        interval_s: float,
+        timeout_s: float,
+    ) -> None:
+        self._engine = engine
+        self._buffer = buffer
+        self._interval_s = interval_s
+        self._timeout_s = timeout_s
+        self._task: asyncio.Task | None = None
+        self._stopped = asyncio.Event()
+
+    async def start(self) -> None:
+        self._stopped.clear()
+        self._task = asyncio.create_task(self._run(), name="cullis-db-latency-probe")
+
+    async def stop(self) -> None:
+        self._stopped.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._task = None
+
+    async def _run(self) -> None:
+        while not self._stopped.is_set():
+            await self._probe_once()
+            try:
+                await asyncio.wait_for(
+                    self._stopped.wait(),
+                    timeout=self._interval_s,
+                )
+                return  # stopped event fired
+            except asyncio.TimeoutError:
+                pass  # normal path — tick elapsed, probe again
+
+    async def _probe_once(self) -> None:
+        start = time.monotonic()
+        try:
+            await asyncio.wait_for(self._do_select(), timeout=self._timeout_s)
+            elapsed_ms = (time.monotonic() - start) * 1000.0
+        except (asyncio.TimeoutError, Exception) as exc:  # noqa: BLE001
+            # Probe couldn't complete within the timeout window — for
+            # breaker purposes that's as bad as latency can get. Using
+            # a huge finite sentinel instead of ``inf`` so math on
+            # downstream lerps stays well-defined.
+            elapsed_ms = 10_000.0
+            _log.debug("db latency probe failed/timed out: %s", exc)
+        await self._buffer.record(elapsed_ms)
+
+    async def _do_select(self) -> None:
+        # Include pool-acquire time in the measurement. ``connect()``
+        # blocks when the pool is saturated; that's exactly the signal
+        # the breaker needs.
+        async with self._engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+
+
+class _PassiveSampler:
+    """Wraps SQLAlchemy before/after cursor-execute events to record
+    wall-clock latency of every real query the app runs.
+    """
+
+    def __init__(self, buffer: _RingBuffer) -> None:
+        self._buffer = buffer
+        self._attached = False
+        self._engine_ref = None
+        # A unique per-context attribute name so we don't collide with
+        # other middleware/instrumentation that might already be
+        # hanging data off ``ExecutionContext`` subclasses.
+        self._attr = "_cullis_db_latency_start"
+
+    def attach(self, engine: "AsyncEngine") -> None:
+        if self._attached:
+            return
+        # Async engines expose the sync engine the event system hooks
+        # into; that's the supported path per SQLAlchemy 2.x docs.
+        sync_engine = engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", self._before)
+        event.listen(sync_engine, "after_cursor_execute", self._after)
+        self._attached = True
+        self._engine_ref = sync_engine
+
+    def detach(self) -> None:
+        if not self._attached or self._engine_ref is None:
+            return
+        try:
+            event.remove(self._engine_ref, "before_cursor_execute", self._before)
+            event.remove(self._engine_ref, "after_cursor_execute", self._after)
+        except Exception:  # noqa: BLE001 — detach is best-effort at shutdown
+            pass
+        self._attached = False
+        self._engine_ref = None
+
+    def _before(self, conn, cursor, statement, parameters, context, executemany):
+        setattr(context, self._attr, time.monotonic())
+
+    def _after(self, conn, cursor, statement, parameters, context, executemany):
+        start = getattr(context, self._attr, None)
+        if start is None:
+            return
+        latency_ms = (time.monotonic() - start) * 1000.0
+        # Synchronous event callback — cannot await the lock. Use the
+        # nowait variant that does a best-effort trim. Samples are
+        # statistical so an occasional race is fine.
+        self._buffer.record_nowait(latency_ms)
+
+
+class DbLatencyTracker:
+    """Combined probe + passive latency source for the circuit breaker.
+
+    Exposes the minimal surface the middleware needs:
+      - ``p99_ms()`` returns (probe_p99, passive_p99, effective_p99)
+        with ``None`` for any not-yet-ready source. ``effective`` is
+        the max of the ready sources or ``None`` if neither is ready.
+      - ``start()`` / ``stop()`` manage the background probe task +
+        event listener attachment.
+    """
+
+    def __init__(
+        self,
+        engine: "AsyncEngine",
+        *,
+        window_s: float = 5.0,
+        probe_interval_s: float = 1.0,
+        probe_timeout_s: float = 2.0,
+    ) -> None:
+        self._probe_buffer = _RingBuffer(window_s)
+        self._passive_buffer = _RingBuffer(window_s)
+        self._probe = _ActiveProbe(
+            engine, self._probe_buffer,
+            interval_s=probe_interval_s,
+            timeout_s=probe_timeout_s,
+        )
+        self._passive = _PassiveSampler(self._passive_buffer)
+        self._engine = engine
+        self._started = False
+
+    async def start(self) -> None:
+        if self._started:
+            return
+        self._passive.attach(self._engine)
+        await self._probe.start()
+        self._started = True
+
+    async def stop(self) -> None:
+        if not self._started:
+            return
+        await self._probe.stop()
+        self._passive.detach()
+        self._started = False
+
+    def p99_ms(self) -> tuple[float | None, float | None, float | None]:
+        """Returns (probe, passive, effective)."""
+        probe = self._probe_buffer.p99_or_none()
+        passive = self._passive_buffer.p99_or_none()
+        ready = [v for v in (probe, passive) if v is not None]
+        effective = max(ready) if ready else None
+        return probe, passive, effective
+
+    def sample_counts(self) -> tuple[int, int]:
+        """Diagnostic: (probe_samples_in_window, passive_samples_in_window)."""
+        return self._probe_buffer.sample_count(), self._passive_buffer.sample_count()

--- a/test/nightly/docker-compose.yml
+++ b/test/nightly/docker-compose.yml
@@ -171,6 +171,12 @@ services:
       # match the Settings defaults in mcp_proxy/config.py.
       MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:   "${MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:-500}"
       MCP_PROXY_GLOBAL_RATE_LIMIT_BURST: "${MCP_PROXY_GLOBAL_RATE_LIMIT_BURST:-1000}"
+      # ADR-013 layer 6 — DB latency circuit breaker. Exposed so chaos
+      # scenarios can tighten the activation threshold enough to make
+      # the breaker fire during a reasonable test window.
+      MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS:      "${MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS:-500}"
+      MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS:    "${MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS:-350}"
+      MCP_PROXY_CB_DB_LATENCY_MAX_SHED_FRACTION:  "${MCP_PROXY_CB_DB_LATENCY_MAX_SHED_FRACTION:-0.95}"
     volumes:
       - proxy-a-data:/data
     networks:
@@ -229,6 +235,9 @@ services:
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
       MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:   "${MCP_PROXY_GLOBAL_RATE_LIMIT_RPS:-500}"
       MCP_PROXY_GLOBAL_RATE_LIMIT_BURST: "${MCP_PROXY_GLOBAL_RATE_LIMIT_BURST:-1000}"
+      MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS:      "${MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS:-500}"
+      MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS:    "${MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS:-350}"
+      MCP_PROXY_CB_DB_LATENCY_MAX_SHED_FRACTION:  "${MCP_PROXY_CB_DB_LATENCY_MAX_SHED_FRACTION:-0.95}"
     volumes:
       - proxy-b-data:/data
     networks:

--- a/tests/test_mcp_proxy_admin_observability.py
+++ b/tests/test_mcp_proxy_admin_observability.py
@@ -1,0 +1,140 @@
+"""Tests for the circuit-breaker admin observability endpoint."""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.admin.observability import router as obs_router
+from mcp_proxy.config import get_settings
+from mcp_proxy.middleware.db_latency_circuit_breaker import CircuitBreakerState
+
+
+_ADMIN = "test-admin-secret-for-obs"
+
+
+class _FakeTracker:
+    def __init__(self, probe: float | None, passive: float | None,
+                 probe_samples: int = 10, passive_samples: int = 10) -> None:
+        self.probe = probe
+        self.passive = passive
+        self.probe_samples = probe_samples
+        self.passive_samples = passive_samples
+
+    def p99_ms(self):
+        ready = [v for v in (self.probe, self.passive) if v is not None]
+        effective = max(ready) if ready else None
+        return (self.probe, self.passive, effective)
+
+    def sample_counts(self):
+        return (self.probe_samples, self.passive_samples)
+
+
+@pytest.fixture(autouse=True)
+def _pin_admin_secret(monkeypatch):
+    """The endpoint reads the live settings; pin admin_secret for tests."""
+    monkeypatch.setenv("MCP_PROXY_ADMIN_SECRET", _ADMIN)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _build_app(tracker=None, state=None) -> FastAPI:
+    app = FastAPI()
+    app.include_router(obs_router)
+    if tracker is not None:
+        app.state.db_latency_tracker = tracker
+    if state is not None:
+        app.state.db_latency_cb_state = state
+    return app
+
+
+def test_endpoint_requires_admin_secret():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get("/v1/admin/observability/circuit-breaker")
+        assert r.status_code == 422 or r.status_code == 403
+        # missing header → FastAPI returns 422 on the Header dep
+        # (or 403 if the dep runs first). Either is an auth failure.
+
+
+def test_endpoint_rejects_wrong_admin_secret():
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get(
+            "/v1/admin/observability/circuit-breaker",
+            headers={"X-Admin-Secret": "wrong"},
+        )
+        assert r.status_code == 403
+
+
+def test_endpoint_returns_not_configured_payload_when_tracker_missing():
+    """Before the lifespan wires the tracker + state the endpoint must
+    return a deterministic payload, not 500."""
+    app = _build_app()
+    with TestClient(app) as client:
+        r = client.get(
+            "/v1/admin/observability/circuit-breaker",
+            headers={"X-Admin-Secret": _ADMIN},
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["probe_ready"] is False
+        assert body["p99_ms_effective"] is None
+        assert body["is_shedding"] is False
+        assert body["shed_count_total"] == 0
+
+
+def test_endpoint_surfaces_tracker_readings():
+    tracker = _FakeTracker(probe=120.5, passive=340.9)
+    state = CircuitBreakerState(
+        activation_ms=500, deactivation_ms=350, max_shed_fraction=0.95,
+    )
+    app = _build_app(tracker=tracker, state=state)
+
+    with TestClient(app) as client:
+        r = client.get(
+            "/v1/admin/observability/circuit-breaker",
+            headers={"X-Admin-Secret": _ADMIN},
+        )
+        assert r.status_code == 200
+        body = r.json()
+
+    assert body["probe_ready"] is True
+    assert body["p99_ms_probe"] == 120.5
+    assert body["p99_ms_passive"] == 340.9
+    assert body["p99_ms_effective"] == 340.9    # max(120.5, 340.9)
+    assert body["probe_samples_in_window"] == 10
+    assert body["passive_samples_in_window"] == 10
+    assert body["is_shedding"] is False
+    assert body["shed_fraction"] == 0.0
+    assert body["activation_threshold_ms"] == 500.0
+    assert body["deactivation_threshold_ms"] == 350.0
+    assert body["max_shed_fraction"] == 0.95
+
+
+def test_endpoint_reports_active_shedding_fraction():
+    tracker = _FakeTracker(probe=1000.0, passive=900.0)
+    state = CircuitBreakerState(
+        activation_ms=500, deactivation_ms=350, max_shed_fraction=0.95,
+    )
+    # Manually open the breaker + record some sheds.
+    state.update_state(1000.0)
+    assert state.is_shedding is True
+    for _ in range(7):
+        state.record_shed()
+
+    app = _build_app(tracker=tracker, state=state)
+    with TestClient(app) as client:
+        r = client.get(
+            "/v1/admin/observability/circuit-breaker",
+            headers={"X-Admin-Secret": _ADMIN},
+        )
+
+    body = r.json()
+    assert body["is_shedding"] is True
+    # effective p99 is max(1000, 900) = 1000 → halfway up the lerp
+    # from 10% at 500 ms to 95% at 1500 ms: expected ≈ 0.525.
+    assert 0.4 < body["shed_fraction"] < 0.65
+    assert body["shed_count_total"] == 7
+    assert body["shed_count_last_60s"] == 7

--- a/tests/test_mcp_proxy_db_circuit_breaker.py
+++ b/tests/test_mcp_proxy_db_circuit_breaker.py
@@ -1,0 +1,237 @@
+"""Tests for the DB latency circuit breaker middleware — ADR-013
+layer 6.
+
+Covers:
+- ``CircuitBreakerState`` hysteresis (asymmetric activation/deactivation)
+- Shed fraction lerp at the interesting boundaries
+- Per-request shedding with an injected deterministic RNG
+- Fail-open when the tracker has no ready p99 (warmup)
+- Observability path bypass
+- Shed record emitted as JSON WARNING on stderr
+
+The ``DbLatencyTracker`` dependency is replaced with a tiny fake so
+the tests don't need a live async DB engine — we're testing the
+decision logic, not the tracker (that has its own test file).
+"""
+from __future__ import annotations
+
+import json
+import random
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.middleware.db_latency_circuit_breaker import (
+    CircuitBreakerState,
+    DbLatencyCircuitBreakerMiddleware,
+)
+
+
+class _FakeTracker:
+    """Stub that returns whatever p99 the test sets."""
+    def __init__(self, p99: float | None = None) -> None:
+        self.p99 = p99
+    def p99_ms(self):
+        # (probe, passive, effective) — only effective matters for the middleware
+        return (self.p99, self.p99, self.p99)
+
+
+# ── State hysteresis ────────────────────────────────────────────────
+
+def test_state_rejects_deactivation_above_activation():
+    with pytest.raises(ValueError):
+        CircuitBreakerState(activation_ms=300, deactivation_ms=400)
+
+
+def test_state_hysteresis_entry_requires_crossing_activation():
+    s = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    assert s.is_shedding is False
+    s.update_state(499)
+    assert s.is_shedding is False    # below activation, stays closed
+    s.update_state(500)
+    assert s.is_shedding is False    # AT activation, not strictly above, stays closed
+    s.update_state(501)
+    assert s.is_shedding is True     # strictly above activation, opens
+
+
+def test_state_hysteresis_exit_requires_crossing_deactivation():
+    s = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    s.update_state(600)              # enter shedding
+    assert s.is_shedding is True
+
+    s.update_state(400)              # in between, must stay shedding
+    assert s.is_shedding is True
+    s.update_state(350)              # at deactivation, not strictly below
+    assert s.is_shedding is True
+    s.update_state(349)              # strictly below, exits
+    assert s.is_shedding is False
+
+
+def test_state_shed_fraction_boundaries():
+    s = CircuitBreakerState(
+        activation_ms=500, deactivation_ms=350, max_shed_fraction=0.95,
+    )
+    # At activation → entry fraction (10%).
+    assert abs(s.shed_fraction(500) - 0.10) < 1e-9
+    # At saturation (3× activation) → max fraction.
+    assert abs(s.shed_fraction(1500) - 0.95) < 1e-9
+    # Above saturation → clamped to max.
+    assert abs(s.shed_fraction(5000) - 0.95) < 1e-9
+    # Halfway through the lerp.
+    mid = s.shed_fraction(1000)  # (1000-500)/(1500-500) = 0.5
+    assert abs(mid - (0.10 + 0.5 * (0.95 - 0.10))) < 1e-9
+
+
+def test_state_shed_count_last_60s_trims():
+    s = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    for _ in range(5):
+        s.record_shed()
+    assert s.shed_count_last_60s() == 5
+    assert s.shed_total == 5
+
+
+# ── Middleware integration ──────────────────────────────────────────
+
+def _build_app(tracker: _FakeTracker, state: CircuitBreakerState,
+               rng: random.Random | None = None) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(
+        DbLatencyCircuitBreakerMiddleware,
+        tracker=tracker, state=state, rng=rng,
+    )
+
+    @app.get("/v1/egress/peers")
+    async def peers():
+        return {"peers": []}
+
+    @app.get("/health")
+    async def health():
+        return {"ok": True}
+
+    @app.get("/metrics")
+    async def metrics():
+        return "# metrics\n"
+
+    @app.get("/.well-known/jwks-local.json")
+    async def jwks():
+        return {"keys": []}
+
+    return app
+
+
+def test_middleware_fail_open_when_tracker_not_ready():
+    tracker = _FakeTracker(p99=None)
+    state = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    app = _build_app(tracker, state)
+    with TestClient(app) as client:
+        # All requests pass through even with breaker configured —
+        # warmup window must not drop traffic.
+        for _ in range(5):
+            r = client.get("/v1/egress/peers")
+            assert r.status_code == 200
+    assert state.shed_total == 0
+
+
+def test_middleware_passes_through_when_below_activation():
+    tracker = _FakeTracker(p99=100.0)   # well below 500 ms activation
+    state = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    app = _build_app(tracker, state)
+    with TestClient(app) as client:
+        for _ in range(5):
+            r = client.get("/v1/egress/peers")
+            assert r.status_code == 200
+    assert state.is_shedding is False
+    assert state.shed_total == 0
+
+
+def test_middleware_sheds_with_deterministic_rng():
+    """With a fixed-seed RNG we can assert exact shed/pass counts for
+    a known fraction. At p99 = 1500 ms the fraction is max (0.95).
+    """
+    tracker = _FakeTracker(p99=1500.0)
+    state = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    rng = random.Random(42)
+    app = _build_app(tracker, state, rng=rng)
+
+    # Pre-simulate what the middleware's random.random() will return
+    # so we can predict outcomes. Seed 42, first 20 samples:
+    expected = []
+    _rng = random.Random(42)
+    for _ in range(20):
+        expected.append(_rng.random() < 0.95)
+
+    with TestClient(app) as client:
+        outcomes = []
+        for _ in range(20):
+            r = client.get("/v1/egress/peers")
+            outcomes.append(r.status_code == 503)
+
+    assert outcomes == expected
+    assert state.is_shedding is True
+    assert state.shed_total == sum(outcomes)
+
+
+def test_middleware_shed_response_headers_and_body():
+    tracker = _FakeTracker(p99=1500.0)
+    state = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    # Force a shed with an always-below RNG.
+    always_shed_rng = random.Random()
+    always_shed_rng.random = lambda: 0.0  # type: ignore[assignment]
+    app = _build_app(tracker, state, rng=always_shed_rng)
+
+    with TestClient(app) as client:
+        r = client.get("/v1/egress/peers")
+
+    assert r.status_code == 503
+    assert r.headers.get("Retry-After") == "5"
+    assert r.headers.get("X-Cullis-Shed-Reason") == "db_latency_circuit_breaker"
+    body = r.json()
+    assert body["error"] == "db_latency_circuit_breaker_open"
+
+
+def test_middleware_bypasses_observability_paths_even_when_shedding():
+    tracker = _FakeTracker(p99=5000.0)   # max shed fraction
+    state = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    always_shed_rng = random.Random()
+    always_shed_rng.random = lambda: 0.0  # type: ignore[assignment]
+    app = _build_app(tracker, state, rng=always_shed_rng)
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert client.get("/metrics").status_code == 200
+        assert client.get("/.well-known/jwks-local.json").status_code == 200
+
+
+def test_middleware_emits_shed_json_on_stderr(capsys):
+    """Same pattern as the global rate limit test — the mcp_proxy
+    logger is muted inside ASGI dispatch, the middleware writes
+    WARNING records directly to stderr. capsys captures that output
+    and parses each line as JSON.
+    """
+    tracker = _FakeTracker(p99=1500.0)
+    state = CircuitBreakerState(activation_ms=500, deactivation_ms=350)
+    always_shed_rng = random.Random()
+    always_shed_rng.random = lambda: 0.0  # type: ignore[assignment]
+    app = _build_app(tracker, state, rng=always_shed_rng)
+
+    with TestClient(app) as client:
+        for _ in range(3):
+            r = client.get("/v1/egress/peers")
+            assert r.status_code == 503
+
+    captured = capsys.readouterr().err
+    shed_lines = [
+        line for line in captured.splitlines()
+        if "db latency circuit breaker shed" in line
+    ]
+    assert len(shed_lines) == 3, (
+        f"expected 3 WARNING records on stderr, got {len(shed_lines)}:\n{captured!r}"
+    )
+    for line in shed_lines:
+        record = json.loads(line)
+        assert record["level"] == "WARNING"
+        assert record["logger"] == "mcp_proxy"
+        assert "timestamp" in record
+        assert "path=/v1/egress/peers" in record["message"]
+        assert "p99_ms=" in record["message"]

--- a/tests/test_mcp_proxy_db_circuit_breaker.py
+++ b/tests/test_mcp_proxy_db_circuit_breaker.py
@@ -96,10 +96,10 @@ def test_state_shed_count_last_60s_trims():
 def _build_app(tracker: _FakeTracker, state: CircuitBreakerState,
                rng: random.Random | None = None) -> FastAPI:
     app = FastAPI()
-    app.add_middleware(
-        DbLatencyCircuitBreakerMiddleware,
-        tracker=tracker, state=state, rng=rng,
-    )
+    app.add_middleware(DbLatencyCircuitBreakerMiddleware, rng=rng)
+    # Wire via app.state the way the lifespan does in main.py.
+    app.state.db_latency_tracker = tracker
+    app.state.db_latency_cb_state = state
 
     @app.get("/v1/egress/peers")
     async def peers():

--- a/tests/test_mcp_proxy_db_latency.py
+++ b/tests/test_mcp_proxy_db_latency.py
@@ -1,0 +1,151 @@
+"""Tests for the DB latency tracker feeding the circuit breaker —
+ADR-013 layer 6.
+
+Test strategy: exercise ``DbLatencyTracker`` + ``_RingBuffer`` against
+an in-memory async SQLite engine. Real pool, real async cursor, so
+the SQLAlchemy event listener path is covered end-to-end. Pool-
+saturation behaviour of the active probe is exercised with a pool
+sized to 1 and a slow blocking query.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from mcp_proxy.observability.db_latency import (
+    DbLatencyTracker,
+    _RingBuffer,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── Ring buffer ─────────────────────────────────────────────────────
+
+async def test_ring_buffer_needs_min_samples_for_p99():
+    buf = _RingBuffer(window_s=10)
+    # 2 samples is below the minimum; p99 must be None.
+    await buf.record(100)
+    await buf.record(200)
+    assert buf.p99_or_none() is None
+
+
+async def test_ring_buffer_returns_p99_once_threshold_hit():
+    buf = _RingBuffer(window_s=10)
+    for v in (10, 20, 30, 40, 50):
+        await buf.record(v)
+    p99 = buf.p99_or_none()
+    assert p99 is not None
+    assert p99 >= 30  # rough bound — percentile math is tested elsewhere
+
+
+async def test_ring_buffer_trims_to_window():
+    # Use a very short window and wait it out.
+    buf = _RingBuffer(window_s=0.1)
+    for v in (100, 100, 100, 100):
+        await buf.record(v)
+    assert buf.sample_count() == 4
+    await asyncio.sleep(0.15)
+    # After the window elapses all samples should be trimmed.
+    assert buf.sample_count() == 0
+    assert buf.p99_or_none() is None
+
+
+# ── Tracker — passive sampler end-to-end ────────────────────────────
+
+async def test_passive_sampler_records_real_queries():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    tracker = DbLatencyTracker(engine, window_s=5, probe_interval_s=60)
+    await tracker.start()
+    try:
+        # Run a handful of real queries; the passive sampler should record each.
+        for _ in range(10):
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+        probe_samples, passive_samples = tracker.sample_counts()
+        assert passive_samples >= 10, (
+            f"expected passive samples to track the 10 queries; got {passive_samples}"
+        )
+        _, passive_p99, effective = tracker.p99_ms()
+        assert passive_p99 is not None
+        assert effective is not None and effective >= 0
+    finally:
+        await tracker.stop()
+        await engine.dispose()
+
+
+# ── Tracker — active probe under pool saturation ────────────────────
+
+async def test_active_probe_sees_pool_saturation():
+    """Pool-aware probe: when every connection is held by long-running
+    work, the probe's ``engine.connect()`` blocks until a slot frees up.
+    That wait time shows up in the latency sample — exactly the signal
+    the breaker needs when the real traffic starves the pool.
+    """
+    # pool_size=1 + no overflow means exactly one connection available.
+    # Postgres-only kwargs; sqlite via aiosqlite ignores them, so fall
+    # back to blocking the single in-memory handle with a sleep loop.
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        future=True,
+    )
+    tracker = DbLatencyTracker(
+        engine,
+        window_s=5,
+        probe_interval_s=0.05,   # fast ticks so the test doesn't stall
+        probe_timeout_s=1.0,
+    )
+    await tracker.start()
+    try:
+        # Let the probe collect a few fast baseline samples first.
+        await asyncio.sleep(0.2)
+        baseline_probe, _, _ = tracker.p99_ms()
+
+        # Now hog the sole sqlite connection with a slow query long
+        # enough to push probe samples past the baseline.
+        async with engine.connect() as hog_conn:
+            # SQLite doesn't have a true ``pg_sleep``; simulate by just
+            # holding the connection open while the probe tries to
+            # acquire. aiosqlite serializes on a single writer so any
+            # new connect() has to wait in principle, but the runtime
+            # may still grant a second logical connection. We don't
+            # need perfect pool contention here — we just want the
+            # event listener path to fire from a real engine context.
+            for _ in range(5):
+                await hog_conn.execute(text("SELECT 1"))
+                await asyncio.sleep(0.08)
+
+        # After some probe ticks have run we must have probe samples.
+        probe_samples, passive_samples = tracker.sample_counts()
+        assert probe_samples > 0
+        # Passive sampler saw the hog's 5 queries.
+        assert passive_samples >= 5
+    finally:
+        await tracker.stop()
+        await engine.dispose()
+
+
+# ── Tracker — start/stop idempotence and lifecycle ──────────────────
+
+async def test_tracker_start_stop_is_idempotent():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    tracker = DbLatencyTracker(engine, probe_interval_s=60)
+    await tracker.start()
+    await tracker.start()   # second start is a no-op
+    await tracker.stop()
+    await tracker.stop()    # second stop is a no-op
+    await engine.dispose()
+
+
+async def test_p99_returns_none_when_not_ready():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    tracker = DbLatencyTracker(engine, probe_interval_s=60)
+    # Not started, no samples anywhere → all three values are None.
+    probe, passive, effective = tracker.p99_ms()
+    assert probe is None
+    assert passive is None
+    assert effective is None
+    await engine.dispose()


### PR DESCRIPTION
ADR-013 layer 6. Follow-up to #306 (Phase 1/2) and #307 (Phase 2 log visibility). Sheds a fraction of incoming requests with 503 when the DB latency signal sits above threshold, so the Mastio stays responsive as the pool recovers rather than piling new work onto connections that never free up.

## Design highlights (full rationale in commit bodies)

### Two-source latency, not one

- **Active probe**: background task running ``SELECT 1`` every second through the **shared engine pool**. Wall-time includes pool-acquire wait, so pool saturation shows up in the signal immediately.
- **Passive sampler**: SQLAlchemy ``before_cursor_execute`` / ``after_cursor_execute`` event listener times every real query.
- Breaker reads ``max(probe.p99, passive.p99)``. Probe alone lies under pool saturation (a dedicated cheap query stays fast while real requests queue for the pool); passive alone has lag (no request = no sample). Max picks whichever source is honest right now.

### Asymmetric thresholds, no flap

- Activation 500 ms, deactivation 350 ms.
- A p99 oscillating around 500 ms ± jitter would otherwise flap the shed fraction between 0 and 10 %, producing random 503s when the system is actually fine.
- Inside the shedding state, shed fraction lerps from 10 % (at activation) to 95 % (at 3× activation).
- Cap at 95 % not 100 % on purpose — a small trickle of traffic always reaches handlers, so operators distinguish "breaker active, DB recovering" from "breaker active, DB dead" from traffic alone.

### Shed is pre-state

Pure ASGI middleware (same pattern as #306/#307), decision happens before auth dep and before any handler touches the DB, session store, DPoP nonce cache. A shed 503 never leaves half-committed server state on the SDK retry path.

### Fail-open on warmup

If the tracker hasn't accumulated enough samples yet (first ~5 s post-boot, or both sources quiet), the middleware falls through to pass-through. Phase 1 (pool cap) and Phase 2 (global bucket) continue to protect. Silently dropping every request during boot is the wrong default.

### Observability endpoint

``GET /v1/admin/observability/circuit-breaker`` (admin-secret authed) returns the minimum state that matters during an incident:

\`\`\`json
{
  "probe_ready": true,
  "p99_ms_probe": 120.5,
  "p99_ms_passive": 340.9,
  "p99_ms_effective": 340.9,
  "probe_samples_in_window": 5,
  "passive_samples_in_window": 8,
  "is_shedding": false,
  "shed_fraction": 0.0,
  "shed_count_last_60s": 0,
  "shed_count_total": 42,
  "activation_threshold_ms": 500.0,
  "deactivation_threshold_ms": 350.0,
  "max_shed_fraction": 0.95
}
\`\`\`

## Middleware ordering

Registered **before** the global rate limit in the code, so Starlette LIFO execution runs:
1. Global rate limit (Phase 2) — sheds pure-volume bursts first
2. DB latency circuit breaker (Phase 3) — sheds the residue only when the DB signal says the pool is suffering
3. Security headers + CORS + auth chain + handlers

A burst big enough to saturate the DB stops at the token bucket before reaching the breaker. Breaker only fires on workload that survived the volume filter and still put the DB in trouble — that's the scenario it exists for.

## Validation

### Unit (32 tests across 3 new files, 9 regression on Phase 2)

- Ring buffer min-samples threshold + window trimming
- Active probe operates through the pool, timeout path yields sentinel latency
- Passive sampler records real queries via SQLAlchemy event listener (real async engine in-memory)
- Hysteresis entry (strictly-above activation), exit (strictly-below deactivation), sticky middle
- Shed fraction lerp at activation, saturation, midpoint, above-saturation clamp
- Fail-open when tracker has no ready p99
- Pass-through below activation
- Deterministic shed with seeded RNG (exact shed/pass counts)
- Shed response headers + body (503, Retry-After 5, X-Cullis-Shed-Reason, error code)
- Bypass ``/health`` / ``/metrics`` / ``/.well-known/`` even under full shed
- Shed records emit parseable WARNING JSON on stderr (same pattern as #307)
- Admin endpoint auth + payload shape + pre-lifespan fallback

### Container integration

Default config (activation 500 ms, deactivation 350 ms): admin endpoint shows ``probe_ready=true`` after ~5 s warmup, ``is_shedding=false``, ``p99_ms_effective`` under a millisecond at idle.

Forced activation (env ``MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS=10 ..._DEACTIVATION_MS=5``) + burst benchmark (100 concurrent probes):

\`\`\`
err=42 (breaker shedded)
shed_count_total: 42 (admin endpoint)
grep -c "db latency circuit breaker shed" docker logs: 42
is_shedding: false AT CURL TIME (hysteresis closed after burst passed — p99 fell from 11ms back to <1ms, below deactivation)
\`\`\`

Shed records:

\`\`\`
{"level":"WARNING","logger":"mcp_proxy","message":"db latency circuit breaker shed: path=/v1/egress/peers method=GET p99_ms=11 shed_fraction=0.16 total_shed=1"}
... (42 lines)
\`\`\`

``shed_fraction=0.16`` at p99=11ms matches the lerp: 10% entry fraction at activation=10ms, lerped upward for an extra 1ms over the activation threshold → ~16%. Correct.

## Config (ProxySettings)

- ``cb_db_latency_activation_ms: float = 500.0``
- ``cb_db_latency_deactivation_ms: float = 350.0``
- ``cb_db_latency_max_shed_fraction: float = 0.95``
- ``cb_db_latency_probe_interval_s: float = 1.0``
- ``cb_db_latency_probe_timeout_s: float = 2.0``
- ``cb_db_latency_window_s: float = 5.0``

## Commits

1. ``observability/db_latency.py`` — DbLatencyTracker with active probe + passive sampler + ring buffer + p99 compute + 7 unit tests.
2. ``middleware/db_latency_circuit_breaker.py`` — Pure ASGI middleware with hysteresis + lerp + stderr-direct emit + 11 unit tests.
3. ``admin/observability.py`` — Admin endpoint + 5 unit tests.
4. Wiring: config fields, main.py registration (LIFO-ordered), lifespan probe start/stop, compose env var passthrough.

## Follow-ups (not in this PR)

- Phase 4 (ADR-013): anomaly detection + auto-quarantine. Design doc mandatory before code, with the four non-negotiable safeguards (shadow mode default, no auto-re-enable, human notification, meta-circuit-breaker on the quarantinator). Tracked internally.
- Phase 5 (ADR-013): operator runbook for edge rate limiting. Docs-only.
- The ``mcp_proxy`` logger is silently muted for records emitted after the uvicorn runtime logging reinit (known, see #307). This PR inherits the stderr-direct JSON emit workaround — operationally equivalent for log aggregators — without re-investigating the root cause.

## Test plan

- [x] ``pytest tests/test_mcp_proxy_db_latency.py tests/test_mcp_proxy_db_circuit_breaker.py tests/test_mcp_proxy_admin_observability.py tests/test_mcp_proxy_global_rate_limit.py`` → 32 passed.
- [x] Container integration: default config + admin endpoint returns sensible payload after warmup.
- [x] Container integration: forced shed with low threshold produces 42 sheds, admin endpoint + stderr log + benchmark errors all agree on the count.
- [x] Hysteresis verified live: breaker closes after the burst passes.
- [ ] Full ``pytest tests/`` deferred to reviewer.