### PR TITLE
test(nightly): chaos db-latency scenario + chaos env propagation fix

### DIFF
--- a/test/nightly/.env.chaos.example
+++ b/test/nightly/.env.chaos.example
@@ -1,0 +1,23 @@
+# Example .env.chaos — copy to .env.chaos and edit to tune chaos runs
+# without touching docker-compose.yml or the shell environment of the
+# `nightly.sh go` terminal.
+#
+# The chaos scripts (kill.sh, partition.sh, db-latency.sh, sequence.sh)
+# pass this file to ``docker compose --env-file`` on every invocation,
+# so variables set here override the ``${FOO:-default}`` substitutions
+# in docker-compose.yml. Without this file, the compose defaults apply.
+#
+# Typical use during a Phase 3 validation run:
+#   MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS=50
+#   MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS=20
+# → lowers the circuit breaker threshold so that the moderate latency
+#   spikes produced by chaos/db-latency.sh actually cross activation.
+
+# ADR-013 Phase 3 circuit breaker knobs
+# MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS=500
+# MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS=350
+# MCP_PROXY_CB_DB_LATENCY_MAX_SHED_FRACTION=0.95
+
+# ADR-013 Phase 2 global rate-limit knobs
+# MCP_PROXY_GLOBAL_RATE_LIMIT_RPS=500
+# MCP_PROXY_GLOBAL_RATE_LIMIT_BURST=1000

--- a/test/nightly/.gitignore
+++ b/test/nightly/.gitignore
@@ -2,3 +2,6 @@ state/
 logs/
 reports/
 *.pid
+# Operator-local chaos tuning; .env.chaos.example tracked in-repo as
+# template.
+.env.chaos

--- a/test/nightly/README.md
+++ b/test/nightly/README.md
@@ -66,9 +66,21 @@ in `logs/<run-ts>/chaos.jsonl` so `report` can correlate them with
 workload latency/failures.
 
 - `chaos light` — warm-up, 1 Mastio kill, 1 Court partition (~2 min).
-- `chaos heavy` — both Mastio killed, Court partition + kill (~5 min).
+- `chaos heavy` — both Mastio killed, Court partition + kill, DB latency injection on both proxies (~6-7 min). The DB latency step is what exercises ADR-013 Phase 3 (circuit breaker); kill/partition alone do not cause the Mastio's own SQLite to slow down.
 - `chaos kill <service> [--down-seconds N]` — one-off.
 - `chaos partition <service> [--duration N]` — one-off.
+- `chaos db-latency <service> [--duration N] [--size-mb N]` — saturate a Mastio's SQLite volume with disk I/O so the circuit breaker's passive sampler sees real query p99 rise.
+
+### Tuning via `.env.chaos`
+
+Chaos steps recreate containers (`compose up -d --no-deps` after a `kill`), which drops shell env vars set at the `nightly.sh go` terminal. To propagate overrides across chaos steps, copy `.env.chaos.example` to `.env.chaos` and edit. Every chaos script passes that file to `docker compose --env-file` when it exists. Typical use during a Phase 3 validation run:
+
+```
+MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS=50
+MCP_PROXY_CB_DB_LATENCY_DEACTIVATION_MS=20
+```
+
+→ lowers the breaker threshold so the moderate latency `db-latency.sh` produces actually crosses activation.
 
 ## Report (`report`)
 

--- a/test/nightly/chaos/_common.sh
+++ b/test/nightly/chaos/_common.sh
@@ -5,6 +5,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NIGHTLY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# ── Env propagation (cullis-enterprise#12) ──────────────────────────────────
+#
+# Chaos scripts call ``docker compose up -d --no-deps <svc>`` after a kill.
+# Compose does variable substitution on the yml using its own environment
+# lookup: any ``${MCP_PROXY_CB_...}`` that was exported into the shell that
+# ran ``nightly.sh go`` is NOT automatically visible to the chaos shell
+# a few minutes later. The recreated container then boots with defaults.
+#
+# The fix is a local ``.env.chaos`` file: the operator writes it once, the
+# ``compose()`` wrapper below points every docker invocation at it via
+# ``--env-file``. Takes precedence over the default ``.env`` if both exist.
+_CHAOS_ENV_FILE="$NIGHTLY_DIR/.env.chaos"
+
 # Resolve the current run's log directory. Prefer NIGHTLY_RUN_TS env (set
 # by the operator when coordinating with a specific go invocation);
 # otherwise pick the newest logs/<ts>/ subdir. Fail fast if no run.
@@ -44,5 +57,9 @@ chaos_log() {
 }
 
 compose() {
-    (cd "$NIGHTLY_DIR" && docker compose "$@")
+    local env_args=()
+    if [[ -f "$_CHAOS_ENV_FILE" ]]; then
+        env_args=(--env-file "$_CHAOS_ENV_FILE")
+    fi
+    (cd "$NIGHTLY_DIR" && docker compose "${env_args[@]}" "$@")
 }

--- a/test/nightly/chaos/db-latency.sh
+++ b/test/nightly/chaos/db-latency.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Disk I/O saturation on a Mastio container's SQLite volume — ADR-013
+# Phase 3 (circuit breaker) end-to-end chaos scenario.
+#
+# Why: the Phase 3 breaker protects the Mastio from its OWN DB latency
+# (pool-acquire + query wall time, read via both the active probe and
+# SQLAlchemy event-listener passive sampler). The Phase 2 / Phase 6
+# defences need their own chaos signal, and this is the one for Phase
+# 3. A kill of the Court/broker does not exercise this path because
+# the Mastio's SQLite stays fast throughout.
+#
+# What: writes a large random file into the ``/data`` volume that
+# houses ``mcp_proxy.db``, contending with sqlite's fsync writes on
+# the same device. The passive sampler then records rising query p99,
+# max(probe, passive) crosses the activation threshold, and the
+# middleware sheds until the noise file is removed.
+#
+# Usage: db-latency.sh <service> [--duration N] [--size-mb N]
+# Example: chaos/db-latency.sh proxy-a --duration 30 --size-mb 400
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_common.sh
+source "$SCRIPT_DIR/_common.sh"
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: db-latency.sh <service> [--duration N] [--size-mb N]" >&2
+    exit 1
+fi
+
+service="$1"; shift || true
+duration=30
+size_mb=400
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --duration) duration="$2"; shift 2 ;;
+        --size-mb)  size_mb="$2";  shift 2 ;;
+        *) echo "unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+container="$(compose ps -q "$service" | head -n1)"
+if [[ -z "$container" ]]; then
+    echo "[chaos] service '$service' has no running container" >&2
+    exit 1
+fi
+
+# Path inside the container: the Mastio's SQLite lives under /data
+# (see mcp_proxy/Dockerfile). Put the noise next to it so they fight
+# for the same volume bandwidth.
+noise_path="/data/cullis-chaos-noise"
+bs="4M"
+count="$(( size_mb / 4 ))"
+
+chaos_log "db_latency_start" \
+    service="$service" duration_seconds="$duration" \
+    size_mb="$size_mb" noise_path="$noise_path"
+
+# Fire-and-forget: dd runs detached so we can time the window. Use sh -c
+# so the redirection applies inside the container. /dev/urandom keeps
+# the kernel + device busy (not just the filesystem cache).
+docker exec -d "$container" sh -c \
+    "dd if=/dev/urandom of=${noise_path} bs=${bs} count=${count} 2>/dev/null; true"
+
+sleep "$duration"
+
+# Remove the noise file to restore normal sqlite write throughput.
+# ``rm -f`` never errors; if dd already finished the file is still
+# there (it gets cleaned up), and if dd is mid-write the kernel's
+# pending writes are dropped with the unlink.
+docker exec "$container" sh -c "rm -f ${noise_path}" || true
+
+chaos_log "db_latency_end" service="$service"

--- a/test/nightly/chaos/sequence.sh
+++ b/test/nightly/chaos/sequence.sh
@@ -5,7 +5,12 @@
 #
 # Profiles:
 #   light  — 1 Mastio kill + 1 partition, ~2 minutes total
-#   heavy  — both Mastio killed in sequence + court partition, ~5 minutes
+#   heavy  — both Mastio killed + court partition + court kill + DB
+#            latency injection on both proxies, ~6-7 minutes total. The
+#            DB latency step is the one that exercises ADR-013 Phase 3
+#            (circuit breaker); without it, heavy only validates the
+#            proxy's resilience to Court/broker faults, not to its
+#            OWN DB saturation.
 #
 # Usage: sequence.sh [--profile light|heavy]
 set -euo pipefail
@@ -43,6 +48,15 @@ case "$profile" in
         "$SCRIPT_DIR/partition.sh" broker --duration 30
         sleep 30
         "$SCRIPT_DIR/kill.sh" broker --down-seconds 15
+        sleep 30
+        # ADR-013 Phase 3 end-to-end: saturate the proxy's SQLite volume
+        # so the passive sampler sees real query p99 rise. Tune the
+        # breaker thresholds in .env.chaos (see .env.chaos.example) so
+        # the modest latency injected here actually crosses activation
+        # — default 500 ms is usually above the spike this produces.
+        "$SCRIPT_DIR/db-latency.sh" proxy-a --duration 30
+        sleep 15
+        "$SCRIPT_DIR/db-latency.sh" proxy-b --duration 30
         sleep 30
         ;;
     *)

--- a/test/nightly/nightly.sh
+++ b/test/nightly/nightly.sh
@@ -132,8 +132,12 @@ cmd_chaos() {
             shift
             "$SCRIPT_DIR/chaos/partition.sh" "$@"
             ;;
+        db-latency)
+            shift
+            "$SCRIPT_DIR/chaos/db-latency.sh" "$@"
+            ;;
         *)
-            echo "usage: nightly.sh chaos [light|heavy|kill <svc>|partition <svc>]" >&2
+            echo "usage: nightly.sh chaos [light|heavy|kill <svc>|partition <svc>|db-latency <svc>]" >&2
             exit 1
             ;;
     esac


### PR DESCRIPTION
Follow-up to cullis-security/cullis#308. Enriches the chaos suite with a scenario that actually stresses the Mastio's local DB — the one thing the Phase 3 circuit breaker protects. Also fixes a quieter bug in how chaos steps propagate env overrides.

## Why

The existing \`chaos heavy\` profile kills proxies and partitions the broker, which validates the proxy's resilience to *Court* faults but does **not** exercise the Phase 3 circuit breaker. A full heavy run against a Phase 3-enabled Mastio finishes with \`shed_count_total=0\` because the proxy's local SQLite stays fast throughout — Court going away doesn't slow the Mastio's own DB, just its outbound httpx calls.

Confirmed empirically during Phase 3 validation: 338 s heavy run, chaos timeline shows kill/partition/restart cycle completing cleanly, workload latencies rise to p99 914 ms (spammer) / p99 465 ms (chatter) / 100% session failures (sessions need Court) — but the admin observability endpoint shows \`p99_ms_probe: 0.8, p99_ms_passive: 0.4, is_shedding: false\` throughout. Correct behaviour, but a test lane that never triggers Phase 3 doesn't catch regressions in Phase 3.

## What

### \`chaos/db-latency.sh\`

New scenario. Fires \`dd if=/dev/urandom of=/data/cullis-chaos-noise bs=4M count=N\` detached inside the proxy container; for the window duration every sqlite write fights for the same volume bandwidth. \`rm -f\` on the noise file restores normal throughput when done. The Mastio's passive latency sampler sees query p99 rise, the probe's \`engine.connect()\` pays the pool-contention tax, \`max(probe, passive)\` crosses activation, middleware sheds.

\`chaos_log\` emits \`db_latency_start\` + \`db_latency_end\` tagged with service + duration + size, so the markdown report correlates the window with any shed spike.

### \`chaos/sequence.sh heavy\`

Extended to invoke \`db-latency.sh proxy-a\` → \`db-latency.sh proxy-b\` after the Court kill. Heavy total grows from ~5 min to ~6-7 min. Placement at the end of the sequence is deliberate — earlier faults already put the proxy in a recovery state, and stacking disk saturation on top is the realistic bad-day compound we want to shake out.

### \`chaos/_common.sh\` env propagation

Chaos steps recreate containers after a kill with \`docker compose up -d --no-deps <svc>\`. Env vars the operator exported at the \`nightly.sh go\` terminal are not visible to the chaos script's later compose invocations, so overrides like \`MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS=100\` silently fell back to compose defaults after the first recreate.

Fix: the shared \`compose()\` wrapper now passes \`--env-file .env.chaos\` when the file exists. Operator copies \`.env.chaos.example\` → \`.env.chaos\`, edits the overrides once, and every chaos step reads the same values through the whole run.

\`.env.chaos.example\` ships as a template; \`.env.chaos\` is in \`.gitignore\` as operator-local.

### \`nightly.sh chaos\` dispatcher

Routes \`nightly.sh chaos db-latency <svc>\` to the new script for one-off manual invocation.

## Test plan

- [x] Syntax-clean on all modified scripts.
- [x] \`chaos/db-latency.sh proxy-a --duration 5 --size-mb 20\` runs to completion; chaos.jsonl tags present.
- [ ] End-to-end Phase 3 validation (blocked on #308 merging — will update this PR body with actual numbers once shippable).

## Follow-ups not addressed here

- \`.env.chaos\` overrides only affect containers **recreated after** the file was written (compose does variable substitution at container-create time). A running proxy that started without the override won't pick it up until the next kill+recreate. Acceptable for chaos testing — the operator writes \`.env.chaos\` before \`nightly.sh full\`.
- The \`dd\` approach uses \`/dev/urandom\` which is Linux-specific. On Docker Desktop for macOS/Windows the Linux VM still has it, so this works. Native Windows docker would need \`NUL\` equivalents. Out of scope.