### PR TITLE
fix(nightly): thread .env.chaos into nightly.sh top-level compose

### DIFF
--- a/test/nightly/nightly.sh
+++ b/test/nightly/nightly.sh
@@ -11,6 +11,17 @@ source ./config.env
 
 COMPOSE="docker compose"
 
+# Operator-local chaos overrides (see .env.chaos.example). The chaos
+# scripts already thread --env-file into their compose invocations via
+# chaos/_common.sh; do the same at this top level so `nightly.sh full`
+# applies the overrides at container-create time instead of waiting for
+# the first chaos-triggered recreate. Typical use: set tighter circuit-
+# breaker thresholds in .env.chaos, then `nightly.sh full` brings up the
+# stack already tuned for a Phase 3 validation run.
+if [[ -f "$SCRIPT_DIR/.env.chaos" ]]; then
+    COMPOSE="$COMPOSE --env-file $SCRIPT_DIR/.env.chaos"
+fi
+
 # Host-side Python used by smoke.py / workload drivers. Prefer the repo's
 # .venv (where cullis_sdk is installed in editable mode) over the system
 # python3/python.


### PR DESCRIPTION
Follow-up to #309.

## What was broken

`chaos/_common.sh::compose()` already passes `--env-file .env.chaos` to every docker invocation in the chaos path, but `nightly.sh` itself uses `$COMPOSE="docker compose"` raw for `full`, `down`, `status`, `logs`. So an operator who creates `.env.chaos` with tighter circuit-breaker thresholds, then runs `nightly.sh full`, gets containers booted with compose defaults. The overrides only take effect on the first chaos-triggered recreate — not what the operator expected, and not what `.env.chaos.example` documents.

Found during the first Phase 3 end-to-end validation run.

## Fix

Single 3-line addition: top-level `nightly.sh` now also detects `.env.chaos` next to itself and threads `--env-file` into `$COMPOSE`. Consistent with the chaos-path behaviour and what the example file promises.

## Test plan

- [x] `bash -n` clean.
- [x] With `.env.chaos` present and `MCP_PROXY_CB_DB_LATENCY_ACTIVATION_MS=50`, `./nightly.sh full` + admin observability endpoint returns `activation_threshold_ms: 50`.
- [x] Without `.env.chaos`, behaviour unchanged.
