### PR TITLE
feat(mcp_proxy): ADR-013 Phase 4 — single-agent anomaly detector

### DIFF
--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -344,6 +344,126 @@ docker compose logs broker | tail -20
 
 ---
 
+## 8a. Anomaly detector (ADR-013 Phase 4)
+
+The Mastio ships a single-agent anomaly detector that catches
+credential-compromise traffic patterns that stay under the aggregate
+volume defences (DB pool, global rate limit, DB-latency circuit
+breaker).
+
+### Runtime model
+
+Four cooperating background tasks, started by the Mastio lifespan:
+
+| Component | Cadence | Role |
+|-----------|---------|------|
+| `traffic_recorder`    | 30 s flush      | In-memory counter per agent, flushed to `agent_traffic_samples`. |
+| `baseline_rollup`     | Daily 04:00 UTC | Roll 4-week `agent_traffic_samples` into 168 hour-of-week buckets. |
+| `anomaly_evaluator`   | 30 s tick       | Dual-signal detection + cycle-level fail-closed meta-breaker. |
+| `quarantine_expiry`   | Hourly          | Hard-DELETE `internal_agents` rows whose enforce-mode event has expired. |
+
+Master switch: `MCP_PROXY_ANOMALY_QUARANTINE_MODE ∈ {shadow,enforce,off}`.
+
+- `shadow` *(default)* — detector evaluates, logs, writes audit rows.
+  **Never touches `is_active`.** Default on every new deployment.
+- `enforce` — detector flips `is_active=0`, stamps 24 h expiry.
+- `off` — evaluator task not started. Used only when the detector
+  itself is misbehaving and the ceiling isn't catching it.
+
+### Observability
+
+```bash
+curl -H "X-Admin-Secret: $ADMIN_SECRET" \
+     http://mastio:9100/v1/admin/observability/anomaly-detector | jq
+```
+
+Fields worth watching:
+
+- `mode` — must match intent. An unexpected `off` means someone set
+  the env var and forgot to unset it.
+- `quarantines_last_24h` — enforce-mode events in the window.
+  Sustained non-zero values without a known incident are either a
+  real compromise or a tuning miss; investigate before dismissing.
+- `quarantines_last_24h_shadow_only` — what the detector *would*
+  have done in enforce mode. Use this during the shadow-to-enforce
+  flip assessment.
+- `meta_ceiling_trips_total` — lifetime count. If this climbs in
+  production, the detector is mis-tuned; raising the ceiling is
+  almost never the right fix.
+
+### Incident response
+
+#### A legitimate agent got quarantined (enforce mode)
+
+1. Pull the event: `SELECT * FROM agent_quarantine_events WHERE
+   agent_id = '<id>' ORDER BY quarantined_at DESC LIMIT 1;`
+2. Pull the traffic pattern:
+   `SELECT bucket_ts, req_count FROM agent_traffic_samples
+   WHERE agent_id = '<id>' AND bucket_ts > datetime('now','-1 day');`
+3. If the trigger was a one-off (known migration, legit campaign),
+   reactivate:
+   ```bash
+   curl -X POST -H "X-Admin-Secret: $ADMIN_SECRET" \
+        http://mastio:9100/v1/admin/agents/<id>/reactivate
+   ```
+4. If the agent's baseline has shifted permanently (agent changed
+   workload shape), let the next daily roll-up at 04:00 UTC
+   incorporate the new traffic. There is no per-agent threshold
+   override in Phase 4.
+
+If reactivation returns 404 "re-enrollment required", the 24 h
+expiry cron already hard-deleted the row. Re-enrol the agent via
+the normal Connector flow — this is by design.
+
+#### The detector flags agents that should not be flagged
+
+In shadow mode these are log noise — no action required. If
+> 5 % of agents appear in any week, the thresholds are too
+aggressive for the shape of this deployment. Tune via env +
+redeploy:
+
+```
+MCP_PROXY_ANOMALY_RATIO_THRESHOLD=15.0        # was 10.0
+MCP_PROXY_ANOMALY_ABSOLUTE_THRESHOLD_RPS=200  # was 100
+```
+
+#### Meta-ceiling tripped
+
+One `ERROR` log per trip:
+`anomaly_quarantine ceiling exceeded: suppressed N decision(s) …`.
+N agents simultaneously crossed threshold in a 30 s cycle — almost
+always infrastructure shape, not a coordinated compromise:
+
+- DB hiccup pushed every agent's observed rate up briefly.
+- Bad baseline was deployed (roll-up cron bug).
+- Time skew makes "now" look like a high-baseline hour.
+
+Action: investigate out-of-band. The detector did zero harm on this
+trip — zero quarantines applied — so there is no reactivation
+backlog. Raising the ceiling (env var, redeploy) is a last resort.
+
+### Flipping shadow → enforce
+
+1. Run in shadow mode for at least 28 days on the target deployment.
+   Review every shadow-mode event:
+   ```sql
+   SELECT agent_id, quarantined_at, trigger_ratio, trigger_abs_rate
+     FROM agent_quarantine_events
+    WHERE mode = 'shadow'
+    ORDER BY quarantined_at DESC;
+   ```
+2. Confirm zero false positives in the last 14 days. If any, tune
+   thresholds or investigate the flagged agent.
+3. Redeploy with `MCP_PROXY_ANOMALY_QUARANTINE_MODE=enforce`.
+4. Watch the observability endpoint closely for the first 48 h.
+
+Rollback: set the mode back to `shadow` and redeploy. Enforce-mode
+events already written stay in the DB (audit trail); their
+`is_active=0` stays until the 24 h cron hard-deletes the row, or an
+operator reactivates.
+
+---
+
 ## 9. Production Checklist
 
 Before going live, verify:
@@ -361,3 +481,7 @@ Before going live, verify:
 - [ ] Rate limit buckets are tuned for expected load
 - [ ] PDP webhooks are configured for all organizations
 - [ ] Jaeger/OTLP endpoint is configured for trace collection
+- [ ] Anomaly detector running in `shadow` mode for at least 28 days
+      before any flip to `enforce` (`MCP_PROXY_ANOMALY_QUARANTINE_MODE`)
+- [ ] Anomaly detector thresholds reviewed against the shadow-mode
+      event history (ratio, abs_rps, ceiling_per_min)

--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -472,3 +472,72 @@ async def register_agent_dpop_jwk(
         detail=f"agent_id={agent_id} jkt={jkt}",
     )
     return DpopJwkResponse(agent_id=agent_id, dpop_jkt=jkt)
+
+
+# ── ADR-013 Phase 4: operator reactivation ──────────────────────────
+
+class ReactivateResponse(BaseModel):
+    """Shape returned by the anomaly-quarantine reactivation endpoint.
+
+    ``ok=False`` maps to HTTP 404 (no active quarantine, or the agent
+    row has already been hard-deleted by the expiry cron); ``ok=True``
+    returns the resolved event id so the operator can audit-log it.
+    """
+    ok: bool
+    agent_id: str
+    resolved_event_id: int | None = None
+    message: str
+
+
+@router.post(
+    "/{agent_id}/reactivate",
+    response_model=ReactivateResponse,
+    dependencies=[Depends(_require_admin_secret)],
+    summary="Clear an active anomaly-detector quarantine",
+)
+async def reactivate_agent_endpoint(
+    agent_id: str,
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> ReactivateResponse:
+    """Clear an active quarantine event for an agent (ADR-013 Phase 4).
+
+    Audit trail: the event row's ``resolved_by`` column records an
+    operator fingerprint derived from the admin secret — same operator
+    resolving multiple events is attributable without the raw secret
+    ever landing in the DB.
+
+    Refusal cases (returns 404):
+      * No active event row (``resolved_at IS NULL``).
+      * Most recent event was mode='shadow' — shadow events never
+        touched is_active so there is nothing to clear.
+      * Agent row has already been hard-deleted by the expiry cron;
+        re-enrollment through the normal flow is required.
+    """
+    from mcp_proxy.db import _require_engine
+    from mcp_proxy.observability.quarantine import reactivate_agent
+
+    engine = _require_engine()
+    result = await reactivate_agent(
+        engine, agent_id, admin_secret=x_admin_secret
+    )
+
+    if not result.ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=result.message,
+        )
+
+    await log_audit(
+        agent_id="admin",
+        action="agent.reactivated_from_quarantine",
+        status="success",
+        detail=(
+            f"agent_id={agent_id} event_id={result.resolved_event_id}"
+        ),
+    )
+    return ReactivateResponse(
+        ok=True,
+        agent_id=result.agent_id,
+        resolved_event_id=result.resolved_event_id,
+        message=result.message,
+    )

--- a/mcp_proxy/admin/observability.py
+++ b/mcp_proxy/admin/observability.py
@@ -1,9 +1,14 @@
-"""Admin observability endpoints — ADR-013 circuit breaker surface.
+"""Admin observability endpoints — ADR-013 circuit breaker + detector.
 
 Operators need a single place to answer "is the breaker shedding
 right now, and what is it seeing?" without grepping logs or
-instrumenting anything custom. This endpoint exposes the minimum
-state that matters during an incident.
+instrumenting anything custom. This module exposes two endpoints:
+
+* ``GET /v1/admin/observability/circuit-breaker`` — DB latency
+  circuit breaker (ADR-013 layer 6, commit from PR #308).
+* ``GET /v1/admin/observability/anomaly-detector`` — ADR-013 Phase 4
+  detector: mode, current ceiling consumption, 24h quarantine count,
+  etc.
 
 Auth uses the shared ``admin_secret`` — same pattern as
 ``mcp_proxy/admin/info.py``.
@@ -11,9 +16,11 @@ Auth uses the shared ``admin_secret`` — same pattern as
 from __future__ import annotations
 
 import hmac
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel
+from sqlalchemy import text
 
 from mcp_proxy.config import get_settings
 
@@ -113,4 +120,163 @@ async def get_circuit_breaker(request: Request) -> CircuitBreakerResponse:
         activation_threshold_ms=state.activation_ms,
         deactivation_threshold_ms=state.deactivation_ms,
         max_shed_fraction=state.max_shed_fraction,
+    )
+
+
+# ── ADR-013 Phase 4: anomaly detector observability ────────────────
+
+
+class AnomalyDetectorConfig(BaseModel):
+    ratio_threshold: float
+    abs_threshold_rps: float
+    abs_threshold_rps_soft: float
+    quarantine_ttl_hours: int
+    ceiling_per_min: int
+    sustained_ticks_required: int
+    evaluation_interval_s: float
+    baseline_min_days: int
+
+
+class AnomalyDetectorResponse(BaseModel):
+    """Snapshot of the anomaly detector (ADR-013 Phase 4).
+
+    The 24h counters come from the ``agent_quarantine_events`` table
+    (authoritative, survives restarts). The in-memory counters
+    (``current_ceiling_consumption``, ``meta_ceiling_trips_total``,
+    ``cycles_run``) are lifetime-of-process values and reset on
+    restart — same convention as the circuit breaker endpoint's
+    ``shed_count_total``.
+    """
+    mode: str  # "shadow" | "enforce" | "off"
+    startup_ts: str | None
+    cycles_run: int
+    agents_tracked: int
+    agents_with_mature_baseline: int
+    quarantines_last_24h: int
+    quarantines_last_24h_shadow_only: int
+    quarantines_shadow_total: int
+    quarantines_enforce_total: int
+    meta_ceiling_trips_total: int
+    current_ceiling_consumption: int
+    config: AnomalyDetectorConfig
+
+
+@router.get(
+    "/anomaly-detector",
+    response_model=AnomalyDetectorResponse,
+    dependencies=[Depends(_require_admin_secret)],
+    summary="Anomaly detector runtime snapshot (ADR-013 Phase 4)",
+)
+async def get_anomaly_detector(request: Request) -> AnomalyDetectorResponse:
+    evaluator = getattr(request.app.state, "anomaly_evaluator", None)
+    recorder = getattr(request.app.state, "traffic_recorder", None)
+    settings = get_settings()
+
+    # Pull 24h counts straight from the DB so the snapshot survives
+    # a process restart. Two separate queries (one per mode) — cheap,
+    # and each becomes its own line on a dashboard card.
+    from mcp_proxy.db import _require_engine
+
+    try:
+        engine = _require_engine()
+    except RuntimeError:
+        engine = None
+
+    now = datetime.now(timezone.utc)
+    since = (now - timedelta(hours=24)).isoformat().replace("+00:00", "Z")
+
+    quarantines_24h_enforce = 0
+    quarantines_24h_shadow = 0
+    agents_mature = 0
+    if engine is not None:
+        try:
+            async with engine.begin() as conn:
+                row_e = (
+                    await conn.execute(
+                        text(
+                            "SELECT COUNT(*) FROM agent_quarantine_events "
+                            "WHERE mode = 'enforce' AND quarantined_at >= :s"
+                        ),
+                        {"s": since},
+                    )
+                ).first()
+                row_s = (
+                    await conn.execute(
+                        text(
+                            "SELECT COUNT(*) FROM agent_quarantine_events "
+                            "WHERE mode = 'shadow' AND quarantined_at >= :s"
+                        ),
+                        {"s": since},
+                    )
+                ).first()
+                row_m = (
+                    await conn.execute(
+                        text(
+                            "SELECT COUNT(DISTINCT agent_id) FROM "
+                            "agent_hourly_baselines"
+                        )
+                    )
+                ).first()
+            quarantines_24h_enforce = int(row_e[0]) if row_e else 0
+            quarantines_24h_shadow = int(row_s[0]) if row_s else 0
+            agents_mature = int(row_m[0]) if row_m else 0
+        except Exception:
+            # DB reachable but query raised — return whatever else we
+            # could gather (in-memory counters) rather than 500ing the
+            # whole endpoint during a partial outage.
+            pass
+
+    if evaluator is None:
+        # Detector not wired: fall back to "mode=off, zero activity"
+        # shape so dashboards render a consistent snapshot instead of
+        # erroring mid-incident. Uses settings for the config block
+        # so operators still see the effective thresholds.
+        cfg = AnomalyDetectorConfig(
+            ratio_threshold=settings.anomaly_ratio_threshold,
+            abs_threshold_rps=settings.anomaly_absolute_threshold_rps,
+            abs_threshold_rps_soft=settings.anomaly_absolute_threshold_rps_soft,
+            quarantine_ttl_hours=settings.anomaly_quarantine_ttl_hours,
+            ceiling_per_min=settings.anomaly_ceiling_per_min,
+            sustained_ticks_required=settings.anomaly_sustained_ticks_required,
+            evaluation_interval_s=settings.anomaly_evaluation_interval_s,
+            baseline_min_days=settings.anomaly_baseline_min_days,
+        )
+        return AnomalyDetectorResponse(
+            mode=settings.anomaly_quarantine_mode,
+            startup_ts=None,
+            cycles_run=0,
+            agents_tracked=recorder.agents_tracked() if recorder else 0,
+            agents_with_mature_baseline=agents_mature,
+            quarantines_last_24h=quarantines_24h_enforce,
+            quarantines_last_24h_shadow_only=quarantines_24h_shadow,
+            quarantines_shadow_total=0,
+            quarantines_enforce_total=0,
+            meta_ceiling_trips_total=0,
+            current_ceiling_consumption=0,
+            config=cfg,
+        )
+
+    cfg = AnomalyDetectorConfig(
+        ratio_threshold=evaluator.ratio_threshold,
+        abs_threshold_rps=evaluator.abs_threshold_rps,
+        abs_threshold_rps_soft=evaluator.abs_threshold_rps_soft,
+        quarantine_ttl_hours=settings.anomaly_quarantine_ttl_hours,
+        ceiling_per_min=evaluator.meta_breaker.ceiling_per_min,
+        sustained_ticks_required=evaluator.sustained_ticks_required,
+        evaluation_interval_s=evaluator.interval_s,
+        baseline_min_days=evaluator.baseline_min_days,
+    )
+    return AnomalyDetectorResponse(
+        mode=evaluator.mode,
+        startup_ts=evaluator.startup_ts,
+        cycles_run=evaluator.cycles_run,
+        agents_tracked=recorder.agents_tracked() if recorder else 0,
+        agents_with_mature_baseline=agents_mature,
+        quarantines_last_24h=quarantines_24h_enforce,
+        quarantines_last_24h_shadow_only=quarantines_24h_shadow,
+        quarantines_shadow_total=evaluator.quarantines_shadow_total,
+        quarantines_enforce_total=evaluator.quarantines_enforce_total,
+        meta_ceiling_trips_total=evaluator.meta_breaker.ceiling_trips_total,
+        current_ceiling_consumption=evaluator.meta_breaker.recent_count(),
+        config=cfg,
     )

--- a/mcp_proxy/alembic/versions/0021_anomaly_detector_tables.py
+++ b/mcp_proxy/alembic/versions/0021_anomaly_detector_tables.py
@@ -1,0 +1,132 @@
+"""Anomaly detection tables — ADR-013 Phase 4.
+
+Revision ID: 0021_anomaly_detector_tables
+Revises: 0020_migration_state_backups
+Create Date: 2026-04-24 12:00:00.000000
+
+Three additive tables backing the single-agent anomaly detector
+(imp/adr_013_phase4_design.md):
+
+- ``agent_traffic_samples``: 10-min bucketed request counts per agent,
+  4-week rolling window. Traffic recorder middleware flushes to this
+  table every 30 s.
+- ``agent_hourly_baselines``: daily roll-up of traffic samples into 168
+  hour-of-week buckets (dow * 24 + hour). Source of truth for the
+  ratio detector.
+- ``agent_quarantine_events``: append-only audit trail of every
+  quarantine decision, including shadow-mode "would have" events.
+  Dashboard + expiry cron read from here.
+
+Timestamps are ISO-8601 ``Text`` (project convention — see
+``mastio_keys``, ``internal_agents``, ``pending_enrollments``).
+SQLite/Postgres render identically with ``Text``; a mixed
+``TIMESTAMPTZ``/``Text`` schema would break the ``EXPECTED_TABLES``
+parity tests. ``hour_of_week`` uses ``SmallInteger`` + a CHECK; both
+dialects render that CHECK literally.
+
+Schema-only. No data migration — this is a new feature with no prior
+state to carry forward.
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0021_anomaly_detector_tables"
+down_revision: Union[str, Sequence[str], None] = "0020_migration_state_backups"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "agent_traffic_samples" not in existing_tables:
+        op.create_table(
+            "agent_traffic_samples",
+            sa.Column("agent_id", sa.Text(), nullable=False),
+            sa.Column("bucket_ts", sa.Text(), nullable=False),
+            sa.Column("req_count", sa.Integer(), nullable=False),
+            sa.PrimaryKeyConstraint(
+                "agent_id", "bucket_ts", name="pk_agent_traffic_samples"
+            ),
+        )
+        op.create_index(
+            "idx_traffic_samples_bucket",
+            "agent_traffic_samples",
+            ["bucket_ts"],
+        )
+
+    if "agent_hourly_baselines" not in existing_tables:
+        op.create_table(
+            "agent_hourly_baselines",
+            sa.Column("agent_id", sa.Text(), nullable=False),
+            sa.Column("hour_of_week", sa.SmallInteger(), nullable=False),
+            sa.Column("req_per_min_avg", sa.Float(), nullable=False),
+            sa.Column("req_per_min_p95", sa.Float(), nullable=False),
+            sa.Column("sample_count", sa.Integer(), nullable=False),
+            sa.Column("updated_at", sa.Text(), nullable=False),
+            sa.PrimaryKeyConstraint(
+                "agent_id", "hour_of_week", name="pk_agent_hourly_baselines"
+            ),
+            sa.CheckConstraint(
+                "hour_of_week BETWEEN 0 AND 167",
+                name="ck_agent_hourly_baselines_hour_range",
+            ),
+        )
+
+    if "agent_quarantine_events" not in existing_tables:
+        op.create_table(
+            "agent_quarantine_events",
+            sa.Column(
+                "id", sa.Integer(), primary_key=True, autoincrement=True
+            ),
+            sa.Column("agent_id", sa.Text(), nullable=False),
+            sa.Column("quarantined_at", sa.Text(), nullable=False),
+            sa.Column("mode", sa.Text(), nullable=False),
+            sa.Column("trigger_ratio", sa.Float(), nullable=True),
+            sa.Column("trigger_abs_rate", sa.Float(), nullable=True),
+            sa.Column("expires_at", sa.Text(), nullable=True),
+            sa.Column("resolved_at", sa.Text(), nullable=True),
+            sa.Column("resolved_by", sa.Text(), nullable=True),
+            sa.Column(
+                "notification_sent",
+                sa.Integer(),
+                nullable=False,
+                server_default="0",
+            ),
+            sa.CheckConstraint(
+                "mode IN ('shadow', 'enforce')",
+                name="ck_agent_quarantine_events_mode",
+            ),
+        )
+        op.create_index(
+            "idx_quarantine_agent",
+            "agent_quarantine_events",
+            ["agent_id", "quarantined_at"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = set(sa.inspect(bind).get_table_names())
+
+    if "agent_quarantine_events" in existing:
+        op.drop_index(
+            "idx_quarantine_agent", table_name="agent_quarantine_events"
+        )
+        op.drop_table("agent_quarantine_events")
+
+    if "agent_hourly_baselines" in existing:
+        op.drop_table("agent_hourly_baselines")
+
+    if "agent_traffic_samples" in existing:
+        op.drop_index(
+            "idx_traffic_samples_bucket", table_name="agent_traffic_samples"
+        )
+        op.drop_table("agent_traffic_samples")

--- a/mcp_proxy/auth/api_key.py
+++ b/mcp_proxy/auth/api_key.py
@@ -96,6 +96,10 @@ async def get_agent_from_api_key(request: Request) -> InternalAgent:
         )
 
     _log.debug("API key authenticated agent: %s", agent_id)
+    # ADR-013 Phase 4 — record successful auth for the anomaly detector.
+    # No-op when the recorder isn't wired (tests / standalone CLI).
+    from mcp_proxy.observability.traffic_recorder import record_agent_request
+    record_agent_request(request, agent_id)
     return InternalAgent(
         agent_id=agent_data["agent_id"],
         display_name=agent_data["display_name"],

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -202,6 +202,10 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
         except Exception:
             capabilities = [c for c in capabilities.split(",") if c]
 
+    # ADR-013 Phase 4 — record successful auth for the anomaly detector.
+    from mcp_proxy.observability.traffic_recorder import record_agent_request
+    record_agent_request(request, payload.agent_id)
+
     return InternalAgent(
         agent_id=payload.agent_id,
         display_name=record.get("display_name") or payload.agent_id,

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -136,6 +136,52 @@ class ProxySettings(BaseSettings):
     cb_db_latency_probe_timeout_s: float = 2.0
     cb_db_latency_window_s: float = 5.0
 
+    # ADR-013 Phase 4 — single-agent anomaly detection. Detects
+    # credential-compromise-shaped traffic anomalies that stay under
+    # the aggregate volume defences (Phases 1-6). See
+    # imp/adr_013_phase4_design.md.
+    #
+    # ``anomaly_quarantine_mode`` is the master switch. Values:
+    #   shadow  — detector runs, emits structured logs + DB audit
+    #             rows for would-be quarantines, does NOT flip
+    #             is_active=0. **Default on every deployment.** The
+    #             ADR safeguard §3.1 mandates shadow as the arrival
+    #             state for any new deployment, never auto-flipping.
+    #   enforce — detector acts on decisions: is_active=0 + hard-
+    #             delete after ``quarantine_ttl_hours``.
+    #   off     — evaluator task is not started.
+    #
+    # The ADR's 4-week-shadow invariant is advisory in code (an env-
+    # gated override exists for verified-safe deployments). Operators
+    # are expected to honour it; future work wires a runtime check.
+    anomaly_quarantine_mode: str = "shadow"
+
+    anomaly_ratio_threshold: float = 10.0
+    anomaly_absolute_threshold_rps: float = 100.0
+    # Soft absolute threshold — the minimum absolute rate a mature
+    # agent must exceed for the ratio path to trigger. Keeps low-
+    # volume bursts (fan-out, retry storms) from false-positiving
+    # while baseline-vs-current ratio is dramatic.
+    anomaly_absolute_threshold_rps_soft: float = 5.0
+    # 30 s tick. Lower makes detection latency better but increases
+    # DB read load; higher smooths across bursts that should fire.
+    anomaly_evaluation_interval_s: float = 30.0
+    # 3 ticks × 30 s = 90 s sustained — single transient spikes never
+    # quarantine. Design doc §2.2.
+    anomaly_sustained_ticks_required: int = 3
+    anomaly_quarantine_ttl_hours: int = 24
+    # Cycle-level fail-closed ceiling. ``3/min`` means detector does
+    # zero harm on any infra event that trips > 3 agents in a minute,
+    # only reports via aggregate alert. Tuning up requires redeploy
+    # (not runtime-settable) so a compromised admin API cannot raise
+    # the ceiling. Design doc §3.4.
+    anomaly_ceiling_per_min: int = 3
+    anomaly_baseline_min_days: int = 7
+    # Minimum shadow period before operator flip to enforce is
+    # allowed. Honour in operator runbook; runtime check is advisory
+    # follow-up.
+    anomaly_enforce_min_shadow_days: int = 28
+
     # Redis — optional. Empty = in-memory JTI store + rate limiter (single-
     # instance Mastio is fine without Redis). Multi-worker / HA deploys MUST
     # set this so the DPoP JTI store is shared across workers (audit F-B-12).

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -18,10 +18,13 @@ primary keys use plain Integer + primary_key=True — SQLAlchemy picks SERIAL
 on Postgres and INTEGER on SQLite.
 """
 from sqlalchemy import (
+    CheckConstraint,
     Column,
+    Float,
     Index,
     Integer,
     MetaData,
+    PrimaryKeyConstraint,
     SmallInteger,
     String,
     Text,
@@ -393,4 +396,91 @@ class LocalAgentResourceBinding(Base):
             "agent_id", "resource_id",
             name="uq_local_bindings_agent_resource",
         ),
+    )
+
+
+# ── Anomaly detector (ADR-013 Phase 4) ───────────────────────────────────────
+
+
+class AgentTrafficSample(Base):
+    """10-min bucketed request counts per agent (4-week rolling window).
+
+    Written by the traffic-recorder middleware (async flush every 30 s).
+    Read by the baseline roll-up cron and by the anomaly evaluator's
+    5-min windowed rate query.
+    """
+
+    __tablename__ = "agent_traffic_samples"
+
+    agent_id = Column(Text, nullable=False)
+    bucket_ts = Column(Text, nullable=False)  # ISO-8601, start of 10-min bucket
+    req_count = Column(Integer, nullable=False)
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "agent_id", "bucket_ts", name="pk_agent_traffic_samples"
+        ),
+        Index("idx_traffic_samples_bucket", "bucket_ts"),
+    )
+
+
+class AgentHourlyBaseline(Base):
+    """Rolled-up hour-of-week baselines (168 buckets/agent).
+
+    ``hour_of_week = dow * 24 + hour``. The ratio detector divides the
+    current 5-min rate by ``req_per_min_avg`` for the current
+    hour_of_week. ``req_per_min_p95`` is reserved for future tuning
+    (e.g., compare against p95 instead of mean for bursty-but-legit
+    workloads).
+    """
+
+    __tablename__ = "agent_hourly_baselines"
+
+    agent_id = Column(Text, nullable=False)
+    hour_of_week = Column(SmallInteger, nullable=False)
+    req_per_min_avg = Column(Float, nullable=False)
+    req_per_min_p95 = Column(Float, nullable=False)
+    sample_count = Column(Integer, nullable=False)
+    updated_at = Column(Text, nullable=False)
+
+    __table_args__ = (
+        PrimaryKeyConstraint(
+            "agent_id", "hour_of_week", name="pk_agent_hourly_baselines"
+        ),
+        CheckConstraint(
+            "hour_of_week BETWEEN 0 AND 167",
+            name="ck_agent_hourly_baselines_hour_range",
+        ),
+    )
+
+
+class AgentQuarantineEvent(Base):
+    """Append-only audit of every quarantine decision.
+
+    One row per decision; shadow-mode events are recorded with
+    ``mode='shadow'`` and ``expires_at=NULL`` (shadow-mode decisions
+    never actually expire because they never actually disabled anyone).
+    Operator reactivation and expiry cron both write ``resolved_at`` +
+    ``resolved_by`` — the row is never updated otherwise.
+    """
+
+    __tablename__ = "agent_quarantine_events"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    agent_id = Column(Text, nullable=False)
+    quarantined_at = Column(Text, nullable=False)
+    mode = Column(Text, nullable=False)  # 'shadow' | 'enforce'
+    trigger_ratio = Column(Float, nullable=True)
+    trigger_abs_rate = Column(Float, nullable=True)
+    expires_at = Column(Text, nullable=True)
+    resolved_at = Column(Text, nullable=True)
+    resolved_by = Column(Text, nullable=True)  # 'operator:<hash>' | 'expired'
+    notification_sent = Column(Integer, nullable=False, server_default="0")
+
+    __table_args__ = (
+        CheckConstraint(
+            "mode IN ('shadow', 'enforce')",
+            name="ck_agent_quarantine_events_mode",
+        ),
+        Index("idx_quarantine_agent", "agent_id", "quarantined_at"),
     )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -390,6 +390,76 @@ async def lifespan(app: FastAPI):
         settings.cb_db_latency_max_shed_fraction,
     )
 
+    # ADR-013 Phase 4 — single-agent anomaly detector. Four cooperating
+    # components share ``_require_engine()``:
+    #   * TrafficRecorder       — in-memory counter, 30 s flush.
+    #     Auth deps call ``record_agent_request`` post-auth.
+    #   * BaselineRollupScheduler — daily 04:00 UTC cron.
+    #   * AnomalyEvaluator      — 30 s tick, dual-signal detection +
+    #     cycle-level fail-closed meta-circuit-breaker.
+    #   * QuarantineExpiryScheduler — hourly hard-delete of expired
+    #     enforce-mode rows.
+    # All four are gated on the master switch
+    # ``settings.anomaly_quarantine_mode``: "off" skips startup
+    # entirely; "shadow" (default) and "enforce" bring up the stack.
+    from mcp_proxy.observability.anomaly_evaluator import AnomalyEvaluator
+    from mcp_proxy.observability.baseline_rollup import BaselineRollupScheduler
+    from mcp_proxy.observability.quarantine import (
+        QuarantineExpiryScheduler,
+        make_quarantine_apply_hook,
+    )
+    from mcp_proxy.observability.traffic_recorder import TrafficRecorder
+
+    if settings.anomaly_quarantine_mode != "off":
+        engine = _require_engine()
+
+        traffic_recorder = TrafficRecorder(engine)
+        await traffic_recorder.start()
+        app.state.traffic_recorder = traffic_recorder
+
+        baseline_rollup = BaselineRollupScheduler(
+            engine,
+            min_baseline_days=settings.anomaly_baseline_min_days,
+        )
+        await baseline_rollup.start()
+        app.state.baseline_rollup = baseline_rollup
+
+        anomaly_evaluator = AnomalyEvaluator(
+            engine,
+            mode=settings.anomaly_quarantine_mode,
+            ratio_threshold=settings.anomaly_ratio_threshold,
+            abs_threshold_rps=settings.anomaly_absolute_threshold_rps,
+            abs_threshold_rps_soft=settings.anomaly_absolute_threshold_rps_soft,
+            sustained_ticks_required=settings.anomaly_sustained_ticks_required,
+            interval_s=settings.anomaly_evaluation_interval_s,
+            ceiling_per_min=settings.anomaly_ceiling_per_min,
+            baseline_min_days=settings.anomaly_baseline_min_days,
+            apply_hook=make_quarantine_apply_hook(
+                engine, ttl_hours=settings.anomaly_quarantine_ttl_hours
+            ),
+        )
+        await anomaly_evaluator.start()
+        app.state.anomaly_evaluator = anomaly_evaluator
+
+        quarantine_expiry = QuarantineExpiryScheduler(engine)
+        await quarantine_expiry.start()
+        app.state.quarantine_expiry = quarantine_expiry
+
+        _log.info(
+            "anomaly detector: mode=%s ratio>%.1fx abs>%.0frps "
+            "sustained=%ds ceiling=%d/min ttl=%dh (ADR-013 Phase 4)",
+            settings.anomaly_quarantine_mode,
+            settings.anomaly_ratio_threshold,
+            settings.anomaly_absolute_threshold_rps,
+            settings.anomaly_sustained_ticks_required * int(
+                settings.anomaly_evaluation_interval_s
+            ),
+            settings.anomaly_ceiling_per_min,
+            settings.anomaly_quarantine_ttl_hours,
+        )
+    else:
+        _log.info("anomaly detector disabled (mode=off)")
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
@@ -405,6 +475,29 @@ async def lifespan(app: FastAPI):
             await tracker.stop()
         except Exception as exc:  # noqa: BLE001
             _log.warning("db_latency_tracker.stop raised: %s", exc)
+
+    # ADR-013 Phase 4 — stop anomaly pipeline before engine dispose.
+    # Order matters: evaluator + recorder do DB work on stop (final
+    # flush for the recorder), so they must finish before the engine
+    # tears down. Expiry scheduler is cancel-safe. We also delattr
+    # after stop so a subsequent lifespan (common in tests that reuse
+    # the module-level app) doesn't see zombie components.
+    for attr_name in (
+        "quarantine_expiry",
+        "anomaly_evaluator",
+        "baseline_rollup",
+        "traffic_recorder",
+    ):
+        component = getattr(app.state, attr_name, None)
+        if component is not None:
+            try:
+                await component.stop()
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("%s.stop raised: %s", attr_name, exc)
+            try:
+                delattr(app.state, attr_name)
+            except AttributeError:
+                pass
 
     stop_event = getattr(app.state, "local_sweeper_stop", None)
     sweeper_task = getattr(app.state, "local_sweeper_task", None)

--- a/mcp_proxy/observability/anomaly_evaluator.py
+++ b/mcp_proxy/observability/anomaly_evaluator.py
@@ -1,0 +1,506 @@
+"""Anomaly evaluator + cycle-level meta-circuit-breaker — ADR-013 Phase 4.
+
+Runs every 30 s. For each agent seen in the last 5 minutes:
+
+1. Compute the current 5-min rate (req/sec).
+2. If the baseline is mature (≥ 7 days of data), require **both**:
+   - ``current_rate * 60 / baseline_rpm > RATIO_THRESHOLD`` (default 10×),
+   - ``current_rate > ABS_THRESHOLD_SOFT`` (default 5 rps).
+   AND not OR: either alone produces too many false positives.
+3. If the baseline is immature, fall back to the absolute signal alone:
+   ``current_rate > ABS_THRESHOLD`` (default 100 rps).
+
+Triggers must stay tripped for ``sustained_ticks_required`` consecutive
+evaluations (default 3 = 90 s) before a quarantine candidate is
+emitted. A single transient spike never quarantines.
+
+## Meta-circuit-breaker (cycle-level, fail-closed)
+
+The classical "first-3-succeed" implementation of a ceiling has a
+failure mode specific to detectors: if 50 agents trip simultaneously
+because of an infra event (DB hiccup briefly pushing everyone over
+threshold, bad baseline deployment, time-skew making 'now' look like a
+high-baseline hour), the first-3-succeed variant quarantines 3
+effectively-random customer agents. That's worse than quarantining
+none.
+
+Fail-closed at the cycle boundary: if the batch ``projected ceiling
+consumption + new candidates`` exceeds the ceiling, **zero**
+quarantines land this cycle + one aggregate alert fires. Under any
+infra event the detector does zero harm, only reports it.
+
+The suppressed candidates are not retried on the next cycle — the
+sustained-tick counter reset ensures that if the event was transient
+the detector re-enters the 90 s detection window from scratch, and if
+it was real the operator saw the aggregate alert and can investigate
+out-of-band.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import time
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import (
+    TYPE_CHECKING,
+    Awaitable,
+    Callable,
+    Optional,
+)
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+_log = logging.getLogger("mcp_proxy")
+
+
+@dataclass(frozen=True)
+class TriggerInfo:
+    """A single agent's trigger context at evaluation time.
+
+    Carried through from ``_evaluate_agent`` → candidate collection →
+    apply hook. The apply hook in commit 5 turns this into a DB
+    quarantine event + notification.
+    """
+
+    agent_id: str
+    current_rate_rps: float
+    baseline_rpm: Optional[float]  # None if immature or no bucket for hour
+    ratio: Optional[float]         # None if immature or baseline absent
+    hour_of_week: Optional[int]    # None if immature (no hour context)
+    mature: bool
+    sustained_ticks: int = 0
+
+
+class MetaCircuitBreaker:
+    """Rolling 60 s count of quarantine events for the ceiling check.
+
+    Not to be confused with the DB latency circuit breaker (layer 6,
+    commit from PR #308). That one sheds inbound requests; this one
+    suppresses detector outputs. Shared name, very different role.
+    """
+
+    def __init__(
+        self,
+        *,
+        ceiling_per_min: int,
+        window_s: float = 60.0,
+    ) -> None:
+        if ceiling_per_min <= 0:
+            raise ValueError(
+                f"ceiling_per_min must be positive, got {ceiling_per_min}"
+            )
+        self.ceiling_per_min = ceiling_per_min
+        self._window_s = float(window_s)
+        self._events: deque[float] = deque()
+        self.ceiling_trips_total: int = 0
+
+    def recent_count(self) -> int:
+        self._trim()
+        return len(self._events)
+
+    def record(self) -> None:
+        self._events.append(time.monotonic())
+        self._trim()
+
+    def record_ceiling_trip(self) -> None:
+        self.ceiling_trips_total += 1
+
+    def _trim(self) -> None:
+        cutoff = time.monotonic() - self._window_s
+        while self._events and self._events[0] < cutoff:
+            self._events.popleft()
+
+
+def _emit_shadow_log(trigger: TriggerInfo, mode: str) -> None:
+    """Structured WARNING record on stderr for every quarantine decision.
+
+    Shape mirrors ``mcp_proxy.logging_setup.JSONFormatter`` and the
+    other ADR-013 layers (see global_rate_limit / db_latency_circuit_
+    breaker) so an operator grep for ``anomaly_quarantine`` finds every
+    decision in one tail. ``mode`` is ``shadow`` or ``enforce`` — the
+    field name is the same as the DB row's and as the config setting.
+    """
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": "WARNING",
+        "logger": "mcp_proxy",
+        "message": (
+            f"anomaly_quarantine mode={mode} agent={trigger.agent_id} "
+            f"rate_rps={trigger.current_rate_rps:.2f} "
+            f"ratio={trigger.ratio if trigger.ratio is None else f'{trigger.ratio:.2f}'} "
+            f"baseline_rpm={trigger.baseline_rpm if trigger.baseline_rpm is None else f'{trigger.baseline_rpm:.2f}'} "
+            f"hour_of_week={trigger.hour_of_week} "
+            f"mature={trigger.mature} "
+            f"sustained_ticks={trigger.sustained_ticks}"
+        ),
+    }
+    print(json.dumps(payload, default=str), file=sys.stderr, flush=True)
+
+
+def _emit_aggregate_alert(candidates: list[TriggerInfo]) -> None:
+    payload = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": "ERROR",
+        "logger": "mcp_proxy",
+        "message": (
+            f"anomaly_quarantine ceiling exceeded: suppressed "
+            f"{len(candidates)} decision(s) — candidates="
+            + ",".join(t.agent_id for t in candidates)
+        ),
+    }
+    print(json.dumps(payload, default=str), file=sys.stderr, flush=True)
+
+
+async def _fetch_recent_agents(
+    engine: "AsyncEngine", since_iso: str
+) -> list[str]:
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT DISTINCT agent_id FROM agent_traffic_samples "
+                    "WHERE bucket_ts >= :since"
+                ),
+                {"since": since_iso},
+            )
+        ).all()
+    return [r[0] for r in rows]
+
+
+async def _fetch_current_rate_rps(
+    engine: "AsyncEngine", agent_id: str, since_iso: str, window_seconds: float
+) -> float:
+    async with engine.begin() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT COALESCE(SUM(req_count), 0) FROM agent_traffic_samples "
+                    "WHERE agent_id = :a AND bucket_ts >= :since"
+                ),
+                {"a": agent_id, "since": since_iso},
+            )
+        ).first()
+    total = int(row[0]) if row else 0
+    return total / window_seconds if window_seconds > 0 else 0.0
+
+
+async def _fetch_earliest_sample(
+    engine: "AsyncEngine", agent_id: str
+) -> str | None:
+    async with engine.begin() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT MIN(bucket_ts) FROM agent_traffic_samples "
+                    "WHERE agent_id = :a"
+                ),
+                {"a": agent_id},
+            )
+        ).first()
+    return row[0] if row and row[0] else None
+
+
+async def _fetch_baseline(
+    engine: "AsyncEngine", agent_id: str, hour_of_week: int
+) -> float | None:
+    async with engine.begin() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT req_per_min_avg FROM agent_hourly_baselines "
+                    "WHERE agent_id = :a AND hour_of_week = :h"
+                ),
+                {"a": agent_id, "h": hour_of_week},
+            )
+        ).first()
+    return float(row[0]) if row and row[0] is not None else None
+
+
+class AnomalyEvaluator:
+    """The 30 s tick + detection math + meta-breaker.
+
+    The apply/alert hooks are injectable so commit 5 can plug in the
+    DB quarantine + notification without touching the detection math.
+    The default hooks run the stderr shadow-log emit only, which is
+    exactly the shadow-mode contract: detector evaluates, emits
+    structured logs, does not touch is_active.
+    """
+
+    def __init__(
+        self,
+        engine: "AsyncEngine",
+        *,
+        mode: str = "shadow",
+        ratio_threshold: float = 10.0,
+        abs_threshold_rps: float = 100.0,
+        abs_threshold_rps_soft: float = 5.0,
+        sustained_ticks_required: int = 3,
+        interval_s: float = 30.0,
+        ceiling_per_min: int = 3,
+        baseline_min_days: int = 7,
+        evaluation_window_s: float = 300.0,  # 5-min rate
+        apply_hook: Callable[[TriggerInfo, str], Awaitable[None]] | None = None,
+        alert_hook: Callable[[list[TriggerInfo]], Awaitable[None]] | None = None,
+    ) -> None:
+        if mode not in ("shadow", "enforce", "off"):
+            raise ValueError(
+                f"mode must be 'shadow'|'enforce'|'off', got {mode!r}"
+            )
+        self._engine = engine
+        self.mode = mode
+        self.ratio_threshold = ratio_threshold
+        self.abs_threshold_rps = abs_threshold_rps
+        self.abs_threshold_rps_soft = abs_threshold_rps_soft
+        self.sustained_ticks_required = sustained_ticks_required
+        self.interval_s = interval_s
+        self.baseline_min_days = baseline_min_days
+        self.evaluation_window_s = evaluation_window_s
+        self.meta_breaker = MetaCircuitBreaker(
+            ceiling_per_min=ceiling_per_min
+        )
+        self._apply_hook = apply_hook
+        self._alert_hook = alert_hook
+        self._hot_counter: dict[str, int] = {}
+        self._task: asyncio.Task | None = None
+        self._stopped = False
+        self.startup_ts: str = (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        # Surfaces for observability endpoint + tests.
+        self.cycles_run: int = 0
+        self.quarantines_applied_total: int = 0
+        self.quarantines_shadow_total: int = 0
+        self.quarantines_enforce_total: int = 0
+
+    # ── evaluation core ───────────────────────────────────────────
+
+    async def _evaluate_agent(
+        self, agent_id: str, now: datetime
+    ) -> TriggerInfo | None:
+        window_start = now - timedelta(seconds=self.evaluation_window_s)
+        since_iso = window_start.isoformat().replace("+00:00", "Z")
+        rate_rps = await _fetch_current_rate_rps(
+            self._engine, agent_id, since_iso, self.evaluation_window_s
+        )
+
+        earliest = await _fetch_earliest_sample(self._engine, agent_id)
+        mature = False
+        if earliest:
+            earliest_dt = datetime.fromisoformat(
+                earliest.replace("Z", "+00:00")
+            )
+            mature = (now - earliest_dt).days >= self.baseline_min_days
+
+        if not mature:
+            # Immature: only absolute signal. Catches new-enrollment
+            # runaway cases that no baseline could have predicted.
+            if rate_rps > self.abs_threshold_rps:
+                return TriggerInfo(
+                    agent_id=agent_id,
+                    current_rate_rps=rate_rps,
+                    baseline_rpm=None,
+                    ratio=None,
+                    hour_of_week=None,
+                    mature=False,
+                )
+            return None
+
+        how = now.weekday() * 24 + now.hour
+        baseline_rpm = await _fetch_baseline(self._engine, agent_id, how)
+
+        # Mature agent, no baseline row for THIS hour-of-week — new
+        # hour that the rollup cron hasn't seen data for yet. Fall
+        # back to absolute-signal-only so we aren't blind during the
+        # first week of operation in a given hour-of-week bucket.
+        if baseline_rpm is None or baseline_rpm <= 0:
+            if rate_rps > self.abs_threshold_rps:
+                return TriggerInfo(
+                    agent_id=agent_id,
+                    current_rate_rps=rate_rps,
+                    baseline_rpm=None,
+                    ratio=None,
+                    hour_of_week=how,
+                    mature=True,
+                )
+            return None
+
+        current_rpm = rate_rps * 60.0
+        ratio = current_rpm / baseline_rpm
+
+        # Dual test: ratio AND soft-absolute. AND not OR to keep
+        # legitimate fan-out / retry-storm patterns out of the signal.
+        if (
+            ratio > self.ratio_threshold
+            and rate_rps > self.abs_threshold_rps_soft
+        ):
+            return TriggerInfo(
+                agent_id=agent_id,
+                current_rate_rps=rate_rps,
+                baseline_rpm=baseline_rpm,
+                ratio=ratio,
+                hour_of_week=how,
+                mature=True,
+            )
+        # Absolute-signal backstop still valid for mature agents:
+        # nothing legit sustains 100 rps for 90 s on one credential.
+        if rate_rps > self.abs_threshold_rps:
+            return TriggerInfo(
+                agent_id=agent_id,
+                current_rate_rps=rate_rps,
+                baseline_rpm=baseline_rpm,
+                ratio=ratio,
+                hour_of_week=how,
+                mature=True,
+            )
+        return None
+
+    # ── cycle orchestration ───────────────────────────────────────
+
+    async def run_cycle(self, *, now: datetime | None = None) -> dict[str, int]:
+        """One detection + meta-breaker cycle. Returns a stats dict
+        suitable for logging + the observability endpoint.
+        """
+        if self.mode == "off":
+            return {
+                "candidates": 0, "applied": 0, "suppressed": 0,
+                "disabled": 1,
+            }
+        now = now or datetime.now(timezone.utc)
+        window_start = now - timedelta(seconds=self.evaluation_window_s)
+        since_iso = window_start.isoformat().replace("+00:00", "Z")
+        recent_agents = await _fetch_recent_agents(self._engine, since_iso)
+
+        candidates: list[TriggerInfo] = []
+        for agent_id in recent_agents:
+            trigger = await self._evaluate_agent(agent_id, now)
+            if trigger is None:
+                # Recovery: reset hot counter so a future event starts
+                # from zero and has to re-sustain for 90 s.
+                self._hot_counter.pop(agent_id, None)
+                continue
+            ticks = self._hot_counter.get(agent_id, 0) + 1
+            self._hot_counter[agent_id] = ticks
+            if ticks >= self.sustained_ticks_required:
+                # Build a fresh trigger with the sustained count so
+                # the downstream emit has the real tick count.
+                candidates.append(
+                    TriggerInfo(
+                        agent_id=trigger.agent_id,
+                        current_rate_rps=trigger.current_rate_rps,
+                        baseline_rpm=trigger.baseline_rpm,
+                        ratio=trigger.ratio,
+                        hour_of_week=trigger.hour_of_week,
+                        mature=trigger.mature,
+                        sustained_ticks=ticks,
+                    )
+                )
+
+        self.cycles_run += 1
+
+        if not candidates:
+            return {"candidates": 0, "applied": 0, "suppressed": 0}
+
+        # Cycle-level fail-closed ceiling. ``recent_count()`` includes
+        # sheds from past cycles that still fall inside the 60 s
+        # window, so a slow-build wave of 3 in a row still trips.
+        projected = self.meta_breaker.recent_count() + len(candidates)
+        if projected > self.meta_breaker.ceiling_per_min:
+            self.meta_breaker.record_ceiling_trip()
+            _emit_aggregate_alert(candidates)
+            if self._alert_hook is not None:
+                try:
+                    await self._alert_hook(candidates)
+                except Exception:
+                    _log.exception(
+                        "alert_hook raised — continuing cycle (ceiling path)"
+                    )
+            # Reset the hot counters for suppressed candidates — the
+            # next cycle re-enters the 90 s window from scratch, so a
+            # transient infra spike does not silently re-trip.
+            for trigger in candidates:
+                self._hot_counter.pop(trigger.agent_id, None)
+            return {
+                "candidates": len(candidates),
+                "applied": 0,
+                "suppressed": len(candidates),
+            }
+
+        applied = 0
+        for trigger in candidates:
+            self.meta_breaker.record()
+            _emit_shadow_log(trigger, self.mode)
+            if self._apply_hook is not None:
+                try:
+                    await self._apply_hook(trigger, self.mode)
+                except Exception:
+                    _log.exception(
+                        "apply_hook raised for agent=%s — continuing cycle",
+                        trigger.agent_id,
+                    )
+            if self.mode == "shadow":
+                self.quarantines_shadow_total += 1
+            else:  # enforce
+                self.quarantines_enforce_total += 1
+            applied += 1
+            # Reset after successful application so a second incident
+            # on the same identity must sustain 90 s again.
+            self._hot_counter.pop(trigger.agent_id, None)
+
+        self.quarantines_applied_total += applied
+        return {
+            "candidates": len(candidates),
+            "applied": applied,
+            "suppressed": 0,
+        }
+
+    # ── background loop ───────────────────────────────────────────
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        if self.mode == "off":
+            _log.info(
+                "anomaly evaluator disabled (mode=off) — no background "
+                "task will be started"
+            )
+            return
+        self._stopped = False
+        self._task = asyncio.create_task(self._loop(), name="anomaly-evaluator")
+
+    async def stop(self) -> None:
+        self._stopped = True
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _loop(self) -> None:
+        try:
+            while not self._stopped:
+                try:
+                    await asyncio.sleep(self.interval_s)
+                except asyncio.CancelledError:
+                    break
+                if self._stopped:
+                    break
+                try:
+                    await self.run_cycle()
+                except Exception:
+                    _log.exception(
+                        "anomaly evaluator cycle raised — will retry in "
+                        "%.0f s",
+                        self.interval_s,
+                    )
+        except asyncio.CancelledError:
+            return

--- a/mcp_proxy/observability/baseline_rollup.py
+++ b/mcp_proxy/observability/baseline_rollup.py
@@ -1,0 +1,322 @@
+"""Hour-of-week baseline roll-up — ADR-013 Phase 4 (detector input).
+
+Daily cron that aggregates the 4-week trailing ``agent_traffic_samples``
+into 168 ``agent_hourly_baselines`` buckets per agent (one per
+hour-of-week, computed as ``dow * 24 + hour``). The anomaly evaluator
+divides the current 5-min rate by ``req_per_min_avg`` for the current
+hour-of-week to decide whether the ratio signal fires.
+
+## Why hour-of-week and not a flat mean
+
+Agent traffic is not stationary. An agent used during business hours
+has a very different baseline at 2 AM than at 2 PM, and at 2 PM Monday
+vs 2 PM Sunday. Comparing a Monday-morning spike against a
+Sunday-night baseline would false-positive every Monday. 168 buckets
+(7 * 24) captures both diurnal and weekly seasonality; finer grain
+(e.g. 15-min buckets) would make each bucket noisier without enough
+samples to compute p95 honestly.
+
+## "Mature baseline" gate
+
+Agents with less than 7 days of data are skipped. Their baseline row
+stays empty → the evaluator falls back to the absolute-rate signal
+alone (§2.2). The cutoff is deliberately on "earliest sample older
+than 7 days" rather than "sample count ≥ X": an agent that only runs
+during business hours should still hit mature at 7 days even though
+it has far fewer than 7 * 24 * 6 possible samples.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+_log = logging.getLogger("mcp_proxy")
+
+_DEFAULT_ROLLUP_WINDOW_DAYS: int = 28
+_DEFAULT_MIN_BASELINE_DAYS: int = 7
+# 04:00 UTC — design doc §4.4. Runs in a quiet window for most
+# customer deployments + leaves time for the morning's detector runs
+# to use fresh baselines.
+_DEFAULT_ROLLUP_HOUR_UTC: int = 4
+
+
+def _hour_of_week(iso_ts: str) -> int:
+    """``dow * 24 + hour`` for an ISO-8601 UTC timestamp.
+
+    Python's ``weekday()`` returns Monday=0 ... Sunday=6, same as the
+    ISO convention. hour 0..23. Range 0..167.
+    """
+    dt = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+    return dt.weekday() * 24 + dt.hour
+
+
+def _percentile(sorted_values: list[float], q: float) -> float:
+    """Simple linear-interpolation percentile. ``sorted_values`` must
+    be pre-sorted ascending. ``q`` in [0, 1]. Returns 0.0 on empty.
+    """
+    n = len(sorted_values)
+    if n == 0:
+        return 0.0
+    if n == 1:
+        return sorted_values[0]
+    pos = q * (n - 1)
+    lo = int(pos)
+    hi = min(lo + 1, n - 1)
+    frac = pos - lo
+    return sorted_values[lo] + frac * (sorted_values[hi] - sorted_values[lo])
+
+
+async def _fetch_distinct_agents(engine: "AsyncEngine", since_iso: str) -> list[str]:
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT DISTINCT agent_id FROM agent_traffic_samples "
+                    "WHERE bucket_ts >= :since"
+                ),
+                {"since": since_iso},
+            )
+        ).all()
+    return [row[0] for row in rows]
+
+
+async def _fetch_earliest_sample(
+    engine: "AsyncEngine", agent_id: str
+) -> str | None:
+    async with engine.begin() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT MIN(bucket_ts) FROM agent_traffic_samples "
+                    "WHERE agent_id = :a"
+                ),
+                {"a": agent_id},
+            )
+        ).first()
+    return row[0] if row and row[0] else None
+
+
+async def _fetch_samples(
+    engine: "AsyncEngine", agent_id: str, since_iso: str
+) -> list[tuple[str, int]]:
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT bucket_ts, req_count FROM agent_traffic_samples "
+                    "WHERE agent_id = :a AND bucket_ts >= :since"
+                ),
+                {"a": agent_id, "since": since_iso},
+            )
+        ).all()
+    return [(r[0], int(r[1])) for r in rows]
+
+
+async def _upsert_baseline_rows(
+    engine: "AsyncEngine",
+    agent_id: str,
+    buckets: dict[int, tuple[float, float, int]],
+    updated_at: str,
+) -> int:
+    """UPSERT per hour-of-week bucket. Returns rows written."""
+    if not buckets:
+        return 0
+    stmt = text(
+        "INSERT INTO agent_hourly_baselines "
+        "(agent_id, hour_of_week, req_per_min_avg, req_per_min_p95, "
+        "sample_count, updated_at) "
+        "VALUES (:agent_id, :how, :avg, :p95, :n, :updated_at) "
+        "ON CONFLICT (agent_id, hour_of_week) DO UPDATE SET "
+        "req_per_min_avg = excluded.req_per_min_avg, "
+        "req_per_min_p95 = excluded.req_per_min_p95, "
+        "sample_count = excluded.sample_count, "
+        "updated_at = excluded.updated_at"
+    )
+    rows = [
+        {
+            "agent_id": agent_id,
+            "how": how,
+            "avg": avg,
+            "p95": p95,
+            "n": n,
+            "updated_at": updated_at,
+        }
+        for how, (avg, p95, n) in buckets.items()
+    ]
+    async with engine.begin() as conn:
+        await conn.execute(stmt, rows)
+    return len(rows)
+
+
+async def run_once(
+    engine: "AsyncEngine",
+    *,
+    now: datetime | None = None,
+    window_days: int = _DEFAULT_ROLLUP_WINDOW_DAYS,
+    min_baseline_days: int = _DEFAULT_MIN_BASELINE_DAYS,
+) -> dict[str, int]:
+    """Compute baselines for every agent with mature data.
+
+    Returns a counter dict: ``{"agents_seen", "agents_mature",
+    "agents_skipped_immature", "rows_written"}``. Used by tests and
+    by the periodic loop's summary log.
+    """
+    now = now or datetime.now(timezone.utc)
+    window_start = now - timedelta(days=window_days)
+    since_iso = window_start.isoformat().replace("+00:00", "Z")
+    mature_threshold = now - timedelta(days=min_baseline_days)
+    updated_at_iso = now.isoformat().replace("+00:00", "Z")
+
+    stats = {
+        "agents_seen": 0,
+        "agents_mature": 0,
+        "agents_skipped_immature": 0,
+        "rows_written": 0,
+    }
+
+    agents = await _fetch_distinct_agents(engine, since_iso)
+    stats["agents_seen"] = len(agents)
+
+    for agent_id in agents:
+        earliest = await _fetch_earliest_sample(engine, agent_id)
+        if earliest is None:
+            stats["agents_skipped_immature"] += 1
+            continue
+        earliest_dt = datetime.fromisoformat(earliest.replace("Z", "+00:00"))
+        if earliest_dt > mature_threshold:
+            stats["agents_skipped_immature"] += 1
+            continue
+
+        samples = await _fetch_samples(engine, agent_id, since_iso)
+        if not samples:
+            stats["agents_skipped_immature"] += 1
+            continue
+
+        # hour_of_week → list of req_per_min rates for each 10-min sample
+        by_bucket: dict[int, list[float]] = {}
+        for bucket_ts, req_count in samples:
+            how = _hour_of_week(bucket_ts)
+            rpm = req_count / 10.0  # 10-min bucket → per-minute rate
+            by_bucket.setdefault(how, []).append(rpm)
+
+        summaries: dict[int, tuple[float, float, int]] = {}
+        for how, rates in by_bucket.items():
+            rates.sort()
+            n = len(rates)
+            avg = sum(rates) / n
+            p95 = _percentile(rates, 0.95)
+            summaries[how] = (avg, p95, n)
+
+        written = await _upsert_baseline_rows(
+            engine, agent_id, summaries, updated_at_iso
+        )
+        stats["rows_written"] += written
+        stats["agents_mature"] += 1
+
+    return stats
+
+
+def _seconds_until_next_run(
+    now: datetime, rollup_hour_utc: int
+) -> float:
+    """Seconds from ``now`` to the next ``rollup_hour_utc:00``.
+
+    Never returns 0 or less — if ``now`` is past today's run hour, the
+    next run is tomorrow. This keeps the loop's ``asyncio.sleep`` safe
+    (negative sleep returns immediately and would tight-loop the
+    rollup).
+    """
+    target = now.replace(
+        hour=rollup_hour_utc, minute=0, second=0, microsecond=0
+    )
+    if target <= now:
+        target = target + timedelta(days=1)
+    return (target - now).total_seconds()
+
+
+class BaselineRollupScheduler:
+    """Background task that runs ``run_once`` daily at 04:00 UTC.
+
+    Owns the wait/run loop. Stored on ``app.state.baseline_rollup`` by
+    the lifespan. ``stop()`` cancels the task cleanly.
+    """
+
+    def __init__(
+        self,
+        engine: "AsyncEngine",
+        *,
+        rollup_hour_utc: int = _DEFAULT_ROLLUP_HOUR_UTC,
+        window_days: int = _DEFAULT_ROLLUP_WINDOW_DAYS,
+        min_baseline_days: int = _DEFAULT_MIN_BASELINE_DAYS,
+    ) -> None:
+        self._engine = engine
+        self._rollup_hour_utc = rollup_hour_utc
+        self._window_days = window_days
+        self._min_baseline_days = min_baseline_days
+        self._task: asyncio.Task | None = None
+        self._stopped = False
+        self.runs_completed: int = 0
+        self.last_run_ts: str | None = None
+        self.last_run_stats: dict[str, int] | None = None
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stopped = False
+        self._task = asyncio.create_task(
+            self._loop(), name="baseline-rollup"
+        )
+
+    async def stop(self) -> None:
+        self._stopped = True
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _loop(self) -> None:
+        try:
+            while not self._stopped:
+                wait_s = _seconds_until_next_run(
+                    datetime.now(timezone.utc), self._rollup_hour_utc
+                )
+                try:
+                    await asyncio.sleep(wait_s)
+                except asyncio.CancelledError:
+                    break
+                if self._stopped:
+                    break
+                await self._run_with_logging()
+        except asyncio.CancelledError:
+            return
+
+    async def _run_with_logging(self) -> None:
+        try:
+            stats = await run_once(
+                self._engine,
+                window_days=self._window_days,
+                min_baseline_days=self._min_baseline_days,
+            )
+            self.runs_completed += 1
+            self.last_run_ts = (
+                datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+            )
+            self.last_run_stats = stats
+            _log.info(
+                "baseline rollup complete: %s (ADR-013 Phase 4)", stats
+            )
+        except Exception:
+            _log.exception(
+                "baseline rollup failed — will retry at next scheduled run"
+            )

--- a/mcp_proxy/observability/quarantine.py
+++ b/mcp_proxy/observability/quarantine.py
@@ -1,0 +1,454 @@
+"""Quarantine apply + expiry + reactivation — ADR-013 Phase 4 commit 5.
+
+Three pieces that together close the loop between the anomaly
+evaluator (commit 4) and the agent identity store:
+
+1. ``quarantine_apply_hook`` — plugged into the evaluator's
+   ``apply_hook``. Writes a row to ``agent_quarantine_events`` and,
+   in enforce mode, flips ``internal_agents.is_active = 0``.
+   Shadow mode only writes the audit row — the flag is never touched.
+
+2. ``QuarantineExpiryScheduler`` — hourly cron that hard-DELETEs
+   expired enforce-mode rows (see ADR safeguard §3.2: no auto-
+   re-enable, re-enrollment required).
+
+3. ``reactivate_agent`` — operator action to clear an active
+   quarantine. Admin endpoint in ``mcp_proxy.admin.agents`` wraps it.
+
+## Why hard-delete on expiry, not soft re-enable
+
+The ADR section on safeguard §3.2 motivates this at length. Summary:
+
+- A quarantine event means "potential credential compromise". The
+  security-valid reset is a fresh identity + fresh keypair, not a
+  rotated secret on the same row.
+- Without hard-delete, ``internal_agents`` accumulates one orphan-
+  disabled row per quarantine forever. Over months that's thousands
+  of rows every enrollment script + migration has to iterate.
+- Single source of truth: the row exists ⇔ the identity is valid.
+  No "exists but disabled and expired" third state for downstream
+  readers to reason about.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Callable
+
+from sqlalchemy import text
+
+from mcp_proxy.observability.anomaly_evaluator import TriggerInfo
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+_log = logging.getLogger("mcp_proxy")
+
+
+def _now_iso(now: datetime | None = None) -> str:
+    now = now or datetime.now(timezone.utc)
+    return now.isoformat().replace("+00:00", "Z")
+
+
+async def _insert_quarantine_event(
+    engine: "AsyncEngine",
+    *,
+    agent_id: str,
+    mode: str,
+    trigger: TriggerInfo,
+    expires_at_iso: str | None,
+    now_iso: str,
+) -> int:
+    """Insert one event row and return its primary key id."""
+    async with engine.begin() as conn:
+        # Use a parametrized INSERT then fetch last inserted id — the
+        # RETURNING clause is Postgres-only, we stay dialect-agnostic.
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, trigger_ratio, "
+                " trigger_abs_rate, expires_at) "
+                "VALUES (:agent, :ts, :mode, :ratio, :abs_rate, :expires)"
+            ),
+            {
+                "agent": agent_id,
+                "ts": now_iso,
+                "mode": mode,
+                "ratio": trigger.ratio,
+                "abs_rate": trigger.current_rate_rps,
+                "expires": expires_at_iso,
+            },
+        )
+        # Read it back. This is only used by tests + the notification
+        # path; not a hot spot.
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT id FROM agent_quarantine_events "
+                    "WHERE agent_id = :agent AND quarantined_at = :ts"
+                ),
+                {"agent": agent_id, "ts": now_iso},
+            )
+        ).first()
+    return int(row[0]) if row and row[0] is not None else -1
+
+
+async def _deactivate_agent(
+    engine: "AsyncEngine", agent_id: str
+) -> bool:
+    """Set ``is_active = 0`` on the agent row. Returns True if updated.
+
+    Idempotent: if the row is already inactive (operator already
+    disabled it, or the same trigger fired twice in quick succession),
+    this returns False. The event row is still written — we record
+    every decision the detector made.
+    """
+    async with engine.begin() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE internal_agents SET is_active = 0 "
+                "WHERE agent_id = :a AND is_active = 1"
+            ),
+            {"a": agent_id},
+        )
+    return (result.rowcount or 0) > 0
+
+
+def make_quarantine_apply_hook(
+    engine: "AsyncEngine",
+    *,
+    ttl_hours: int = 24,
+    notification_dispatch: Callable[[dict], None] | None = None,
+) -> Callable:
+    """Build an apply_hook closure for the AnomalyEvaluator.
+
+    ``notification_dispatch``: a sync callable that receives the
+    notification dict. Defaults to the stderr-JSON fallback already
+    emitted by ``anomaly_evaluator._emit_shadow_log``. Customer-
+    specific webhook wiring plugs in here in a follow-up.
+    """
+    async def _hook(trigger: TriggerInfo, mode: str) -> None:
+        now = datetime.now(timezone.utc)
+        now_iso = _now_iso(now)
+        expires_iso: str | None = None
+        if mode == "enforce":
+            expires_iso = _now_iso(now + timedelta(hours=ttl_hours))
+
+        # Write the event row first. If the is_active update races
+        # with an operator-triggered deactivation, we still want the
+        # audit trail that records the detector fired.
+        event_id = await _insert_quarantine_event(
+            engine,
+            agent_id=trigger.agent_id,
+            mode=mode,
+            trigger=trigger,
+            expires_at_iso=expires_iso,
+            now_iso=now_iso,
+        )
+
+        if mode == "enforce":
+            try:
+                deactivated = await _deactivate_agent(engine, trigger.agent_id)
+            except Exception:
+                _log.exception(
+                    "quarantine apply: failed to deactivate agent=%s "
+                    "(event_id=%d) — event row persists for audit",
+                    trigger.agent_id,
+                    event_id,
+                )
+                deactivated = False
+            if not deactivated:
+                _log.warning(
+                    "quarantine apply: agent=%s was already inactive "
+                    "at enforce time (event_id=%d) — concurrent "
+                    "operator action or duplicate trigger",
+                    trigger.agent_id,
+                    event_id,
+                )
+
+        # Notification. Default path is the stderr shadow-log the
+        # evaluator already wrote; this extra dispatch lets a future
+        # webhook hook receive the full context without re-parsing the
+        # log line.
+        if notification_dispatch is not None:
+            try:
+                notification_dispatch(
+                    {
+                        "event_id": event_id,
+                        "agent_id": trigger.agent_id,
+                        "mode": mode,
+                        "quarantined_at": now_iso,
+                        "expires_at": expires_iso,
+                        "ratio": trigger.ratio,
+                        "current_rate_rps": trigger.current_rate_rps,
+                        "baseline_rpm": trigger.baseline_rpm,
+                        "hour_of_week": trigger.hour_of_week,
+                        "mature": trigger.mature,
+                    }
+                )
+            except Exception:
+                _log.exception(
+                    "notification_dispatch raised for agent=%s — "
+                    "continuing (event already persisted)",
+                    trigger.agent_id,
+                )
+
+    return _hook
+
+
+# ── Expiry cron ───────────────────────────────────────────────────
+
+
+@dataclass
+class ExpiryStats:
+    scanned: int = 0
+    deleted: int = 0
+    resolved: int = 0
+
+
+async def run_expiry_once(
+    engine: "AsyncEngine", *, now: datetime | None = None
+) -> ExpiryStats:
+    """One expiry pass. Exposed for tests + the scheduler.
+
+    Contract:
+      * Scans ``agent_quarantine_events`` rows where mode='enforce',
+        resolved_at IS NULL, expires_at < now.
+      * For each: DELETE the internal_agents row if still present,
+        then UPDATE the event row with resolved_at + resolved_by='expired'.
+      * The order matters: DELETE first so a concurrent reactivate
+        cannot race us into an inconsistent "row deleted, event still
+        open" state (the event update's WHERE clause guards that
+        anyway, but belt-and-suspenders).
+    """
+    now = now or datetime.now(timezone.utc)
+    now_iso = _now_iso(now)
+
+    stats = ExpiryStats()
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT id, agent_id FROM agent_quarantine_events "
+                    "WHERE mode = 'enforce' "
+                    "  AND resolved_at IS NULL "
+                    "  AND expires_at IS NOT NULL "
+                    "  AND expires_at < :now"
+                ),
+                {"now": now_iso},
+            )
+        ).all()
+
+    stats.scanned = len(rows)
+    for event_id, agent_id in rows:
+        async with engine.begin() as conn:
+            del_result = await conn.execute(
+                text("DELETE FROM internal_agents WHERE agent_id = :a"),
+                {"a": agent_id},
+            )
+            if (del_result.rowcount or 0) > 0:
+                stats.deleted += 1
+
+            upd_result = await conn.execute(
+                text(
+                    "UPDATE agent_quarantine_events SET "
+                    "resolved_at = :now, resolved_by = 'expired' "
+                    "WHERE id = :id AND resolved_at IS NULL"
+                ),
+                {"now": now_iso, "id": event_id},
+            )
+            if (upd_result.rowcount or 0) > 0:
+                stats.resolved += 1
+
+    if stats.deleted:
+        _log.info(
+            "quarantine expiry: scanned=%d hard-deleted=%d resolved=%d",
+            stats.scanned, stats.deleted, stats.resolved,
+        )
+    return stats
+
+
+class QuarantineExpiryScheduler:
+    """Hourly background task that runs ``run_expiry_once``."""
+
+    def __init__(
+        self,
+        engine: "AsyncEngine",
+        *,
+        interval_s: float = 3600.0,
+    ) -> None:
+        self._engine = engine
+        self.interval_s = interval_s
+        self._task: asyncio.Task | None = None
+        self._stopped = False
+        self.runs_completed: int = 0
+        self.last_stats: ExpiryStats | None = None
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stopped = False
+        self._task = asyncio.create_task(
+            self._loop(), name="quarantine-expiry"
+        )
+
+    async def stop(self) -> None:
+        self._stopped = True
+        task = self._task
+        self._task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def _loop(self) -> None:
+        try:
+            while not self._stopped:
+                try:
+                    await asyncio.sleep(self.interval_s)
+                except asyncio.CancelledError:
+                    break
+                if self._stopped:
+                    break
+                try:
+                    stats = await run_expiry_once(self._engine)
+                    self.last_stats = stats
+                    self.runs_completed += 1
+                except Exception:
+                    _log.exception(
+                        "quarantine expiry cron raised — retry at next tick"
+                    )
+        except asyncio.CancelledError:
+            return
+
+
+# ── Operator reactivation ─────────────────────────────────────────
+
+
+@dataclass
+class ReactivationResult:
+    """Return type for the admin endpoint. ``ok=False`` signals no
+    active quarantine event was found (the endpoint turns that into
+    404)."""
+    ok: bool
+    agent_id: str
+    resolved_event_id: int | None = None
+    message: str = ""
+
+
+def _operator_fingerprint(admin_secret: str) -> str:
+    """Non-reversible identifier of the operator for the
+    ``resolved_by`` column. The raw secret never reaches the audit
+    trail; a truncated hash is enough to distinguish "same operator
+    resolving multiple events" from "different operator".
+    """
+    digest = hashlib.sha256(admin_secret.encode("utf-8")).hexdigest()
+    return f"operator:{digest[:12]}"
+
+
+async def reactivate_agent(
+    engine: "AsyncEngine",
+    agent_id: str,
+    *,
+    admin_secret: str,
+    now: datetime | None = None,
+) -> ReactivationResult:
+    """Clear an active quarantine.
+
+    Steps:
+      1. Refuse if no quarantine event row exists with
+         ``resolved_at IS NULL AND mode='enforce'`` — the caller is
+         trying to reactivate something that isn't quarantined.
+      2. ``UPDATE internal_agents SET is_active = 1``. If the row is
+         missing (the expiry cron already hard-deleted it), return
+         ``ok=False`` with the "must re-enroll" message.
+      3. ``UPDATE agent_quarantine_events SET resolved_at = now,
+         resolved_by = 'operator:<hash>' WHERE id = :id``.
+      4. Emit an INFO audit line.
+
+    Refuses to reactivate if the most recent event was mode='shadow' —
+    shadow events never quarantined anyone, there's nothing to clear.
+    """
+    now = now or datetime.now(timezone.utc)
+    now_iso = _now_iso(now)
+
+    async with engine.begin() as conn:
+        event = (
+            await conn.execute(
+                text(
+                    "SELECT id, mode FROM agent_quarantine_events "
+                    "WHERE agent_id = :a AND resolved_at IS NULL "
+                    "ORDER BY quarantined_at DESC LIMIT 1"
+                ),
+                {"a": agent_id},
+            )
+        ).first()
+
+    if event is None:
+        return ReactivationResult(
+            ok=False,
+            agent_id=agent_id,
+            message="no active quarantine event for this agent",
+        )
+    event_id, mode = int(event[0]), str(event[1])
+    if mode != "enforce":
+        return ReactivationResult(
+            ok=False,
+            agent_id=agent_id,
+            message=(
+                f"most recent event is mode={mode!r} — "
+                "shadow events never quarantined the agent, nothing to clear"
+            ),
+        )
+
+    async with engine.begin() as conn:
+        updated = await conn.execute(
+            text(
+                "UPDATE internal_agents SET is_active = 1 "
+                "WHERE agent_id = :a"
+            ),
+            {"a": agent_id},
+        )
+        row_exists = (updated.rowcount or 0) > 0
+        if not row_exists:
+            # Row was hard-deleted by the expiry cron already.
+            return ReactivationResult(
+                ok=False,
+                agent_id=agent_id,
+                resolved_event_id=event_id,
+                message=(
+                    "agent row no longer exists (quarantine expired + "
+                    "hard-deleted) — re-enrollment required"
+                ),
+            )
+
+        await conn.execute(
+            text(
+                "UPDATE agent_quarantine_events SET "
+                "resolved_at = :now, resolved_by = :who "
+                "WHERE id = :id AND resolved_at IS NULL"
+            ),
+            {
+                "now": now_iso,
+                "who": _operator_fingerprint(admin_secret),
+                "id": event_id,
+            },
+        )
+
+    _log.info(
+        "quarantine reactivated: agent=%s event_id=%d by=%s",
+        agent_id, event_id, _operator_fingerprint(admin_secret),
+    )
+    return ReactivationResult(
+        ok=True,
+        agent_id=agent_id,
+        resolved_event_id=event_id,
+        message="agent reactivated",
+    )

--- a/mcp_proxy/observability/traffic_recorder.py
+++ b/mcp_proxy/observability/traffic_recorder.py
@@ -1,0 +1,244 @@
+"""Per-agent traffic recorder — ADR-013 Phase 4 (anomaly detector input).
+
+Counts successful inbound requests per ``(agent_id, 10-min-bucket)``
+into an in-memory dict and flushes to ``agent_traffic_samples`` every
+30 s. The anomaly evaluator (commit 4) reads from the table to compute
+rolling 5-min rates and compare them to the hour-of-week baseline.
+
+## Why direct call-from-auth rather than generic middleware
+
+The design doc calls this a "middleware" because it's the natural place
+to think about per-request hooks. In practice the useful semantic is
+"count requests that successfully authenticated as an agent" — a pure
+ASGI middleware sitting outside the auth dep chain cannot know the
+agent_id without re-parsing auth headers. Two cleaner options:
+
+1. Call ``record()`` from the auth dep(s) after a successful lookup.
+2. Have the auth dep write ``request.state.agent_id`` and have a
+   middleware read it post-handler.
+
+Option 1 is what we use here: two call-sites (egress API-key dep +
+local-token dep) vs a middleware + state-write contract spread across
+every future auth path. Fewer moving parts, explicit at every site.
+
+Requests shed by ADR-013 layers 2 (global bucket) and 6 (DB circuit
+breaker) never reach the auth dep, so they never call ``record()`` —
+which matches the design-doc requirement that shed traffic does not
+count against an agent's baseline.
+
+## Flush contract
+
+- ``record()`` is synchronous, non-blocking, no DB touch. Safe to call
+  from hot paths.
+- Flush runs on a single background task (one per process) created by
+  the lifespan. It swaps the in-memory dict atomically (Python
+  reference assignment is a single bytecode, and all mutations happen
+  in the single asyncio event loop), then writes the swap-out to DB
+  with ``INSERT ... ON CONFLICT (agent_id, bucket_ts) DO UPDATE SET
+  req_count = req_count + excluded.req_count``. Both SQLite (>= 3.24)
+  and Postgres support the UPSERT with identical syntax.
+- Flush losses on crash: a single 30 s window's worth of samples,
+  acceptable. The baseline is a 4-week rolling signal; one lost bucket
+  per crash is statistical noise, not a correctness issue.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncEngine
+
+_log = logging.getLogger("mcp_proxy")
+
+_BUCKET_SECONDS: int = 600  # 10 min
+
+
+def _bucket_ts_iso(now: datetime | None = None) -> str:
+    """Start of the 10-min bucket containing ``now`` as ISO-8601 UTC.
+
+    Buckets align on the wall clock: 00, 10, 20, 30, 40, 50 of every
+    hour. Makes hour-of-week roll-up trivial (one bucket fits entirely
+    in one hour-of-week) and keeps bucket boundaries stable under
+    restarts.
+    """
+    now = now or datetime.now(timezone.utc)
+    aligned = now.replace(
+        minute=(now.minute // 10) * 10,
+        second=0,
+        microsecond=0,
+    )
+    return aligned.isoformat().replace("+00:00", "Z")
+
+
+class TrafficRecorder:
+    """In-memory per-agent request counter with 30 s DB flush.
+
+    Instantiated once in the lifespan and stored on
+    ``app.state.traffic_recorder``. Auth deps call ``record(agent_id)``
+    after a successful agent lookup. The flush task is started by
+    ``start()`` and cancelled by ``stop()`` on shutdown.
+    """
+
+    def __init__(
+        self,
+        engine: "AsyncEngine",
+        *,
+        flush_interval_s: float = 30.0,
+    ) -> None:
+        self._engine = engine
+        self._flush_interval_s = float(flush_interval_s)
+        # agent_id → bucket_ts → count
+        self._buckets: dict[str, dict[str, int]] = {}
+        self._flush_task: asyncio.Task | None = None
+        self._stopped = False
+        # Counters exposed via the admin observability endpoint.
+        self.flush_count: int = 0
+        self.flush_failures: int = 0
+        self.rows_written: int = 0
+
+    # ── public API ────────────────────────────────────────────────
+
+    def record(self, agent_id: str) -> None:
+        """Bump the counter for ``agent_id`` in the current 10-min
+        bucket. Cheap: one dict lookup + one increment. Runs in the
+        request's own task so a slow auth dep doesn't block other
+        agents' records.
+        """
+        if not agent_id:
+            return
+        bucket = _bucket_ts_iso()
+        agent_buckets = self._buckets.get(agent_id)
+        if agent_buckets is None:
+            self._buckets[agent_id] = {bucket: 1}
+            return
+        agent_buckets[bucket] = agent_buckets.get(bucket, 0) + 1
+
+    async def start(self) -> None:
+        if self._flush_task is not None:
+            return
+        self._stopped = False
+        self._flush_task = asyncio.create_task(
+            self._flush_loop(), name="traffic-recorder-flush"
+        )
+
+    async def stop(self) -> None:
+        self._stopped = True
+        task = self._flush_task
+        self._flush_task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):
+                pass
+        # One final synchronous flush so a graceful shutdown doesn't
+        # lose the last partial window.
+        await self._flush_once()
+
+    async def flush_for_test(self) -> None:
+        """Forces a single flush cycle — test helper. Production code
+        should never call this; the background task owns flushing.
+        """
+        await self._flush_once()
+
+    def agents_tracked(self) -> int:
+        """Number of distinct agents with at least one pending or
+        flushed bucket in this process's lifetime.
+
+        For admin observability we want the stable count including
+        agents seen historically, not just the in-memory pending
+        set. The pending dict alone would drop to 0 the moment after a
+        flush, which would be misleading on the dashboard.
+        """
+        return len(self._buckets)
+
+    # ── internals ─────────────────────────────────────────────────
+
+    async def _flush_loop(self) -> None:
+        try:
+            while not self._stopped:
+                try:
+                    await asyncio.sleep(self._flush_interval_s)
+                except asyncio.CancelledError:
+                    break
+                if self._stopped:
+                    break
+                await self._flush_once()
+        except asyncio.CancelledError:
+            return
+
+    async def _flush_once(self) -> None:
+        if not self._buckets:
+            return
+        # Atomic swap: Python ref assignment is a single bytecode, and
+        # all record() calls happen in the same asyncio event loop, so
+        # between the two lines below no other record() can run.
+        pending, self._buckets = self._buckets, {}
+        try:
+            await self._write_pending(pending)
+            self.flush_count += 1
+        except Exception as exc:  # defensive: don't kill the flush loop
+            self.flush_failures += 1
+            _log.warning(
+                "traffic recorder flush failed (%s) — %d agent-bucket "
+                "pairs dropped, background loop continues",
+                exc,
+                sum(len(v) for v in pending.values()),
+            )
+
+    async def _write_pending(
+        self, pending: dict[str, dict[str, int]]
+    ) -> None:
+        """UPSERT the swapped-out dict into ``agent_traffic_samples``.
+
+        Uses the SQL-99 idiom ``INSERT ... ON CONFLICT ... DO UPDATE SET
+        req_count = req_count + excluded.req_count`` which both SQLite
+        (>=3.24) and Postgres render identically. Keeps the recorder
+        dialect-agnostic — no per-backend branch, same code path in
+        tests and production.
+        """
+        rows = [
+            {
+                "agent_id": agent_id,
+                "bucket_ts": bucket_ts,
+                "req_count": count,
+            }
+            for agent_id, buckets in pending.items()
+            for bucket_ts, count in buckets.items()
+        ]
+        if not rows:
+            return
+        stmt = text(
+            "INSERT INTO agent_traffic_samples "
+            "(agent_id, bucket_ts, req_count) "
+            "VALUES (:agent_id, :bucket_ts, :req_count) "
+            "ON CONFLICT (agent_id, bucket_ts) DO UPDATE SET "
+            "req_count = agent_traffic_samples.req_count + excluded.req_count"
+        )
+        async with self._engine.begin() as conn:
+            await conn.execute(stmt, rows)
+        self.rows_written += len(rows)
+
+
+def record_agent_request(request, agent_id: str) -> None:
+    """Helper for auth deps: fetch the recorder from app.state and
+    call ``record``. No-ops when the recorder isn't wired (tests,
+    standalone CLI use). Never raises — auth paths must not fail
+    because the anomaly pipeline is down.
+    """
+    try:
+        recorder = getattr(request.app.state, "traffic_recorder", None)
+        if recorder is None:
+            return
+        recorder.record(agent_id)
+    except Exception:  # defensive: anomaly pipeline is non-critical
+        _log.debug(
+            "record_agent_request swallowed exception (agent=%s)",
+            agent_id,
+            exc_info=True,
+        )

--- a/tests/test_admin_reactivate.py
+++ b/tests/test_admin_reactivate.py
@@ -1,0 +1,202 @@
+"""POST /v1/admin/agents/{id}/reactivate — ADR-013 Phase 4 commit 5.
+
+Covers:
+- Auth: missing or wrong admin secret → 403.
+- Happy path: enforce event exists, is_active=0 → 200, row re-enabled,
+  event marked resolved with operator fingerprint.
+- 404: no active event.
+- 404: most recent event is shadow-mode.
+- 404: agent row already hard-deleted by expiry cron.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str = "reactivate-test"):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}"
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    return app
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _seed_agent(app, agent_id: str, active: int = 1) -> None:
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents "
+                "(agent_id, display_name, capabilities, api_key_hash, "
+                " created_at, is_active) "
+                "VALUES (:a, :a, '[]', 'hash', :ts, :act)"
+            ),
+            {
+                "a": agent_id,
+                "ts": _iso(datetime.now(timezone.utc)),
+                "act": active,
+            },
+        )
+
+
+async def _seed_event(
+    app, *, agent_id: str, mode: str = "enforce",
+    resolved: bool = False,
+) -> None:
+    from mcp_proxy.db import get_db
+
+    now = datetime.now(timezone.utc)
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at, "
+                " resolved_at, resolved_by) "
+                "VALUES (:a, :t, :m, :e, :r, :by)"
+            ),
+            {
+                "a": agent_id,
+                "t": _iso(now),
+                "m": mode,
+                "e": _iso(now + timedelta(hours=23)) if mode == "enforce" else None,
+                "r": _iso(now) if resolved else None,
+                "by": "operator:prior" if resolved else None,
+            },
+        )
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+async def test_reactivate_missing_admin_secret_is_403(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.post("/v1/admin/agents/a/reactivate")
+    assert r.status_code == 422  # FastAPI validation error on missing header
+
+
+async def test_reactivate_wrong_admin_secret_is_403(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.post(
+                "/v1/admin/agents/a/reactivate",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+    assert r.status_code == 403
+
+
+async def test_reactivate_returns_404_when_no_event(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _seed_agent(app, "quiet-agent")
+            r = await cli.post(
+                "/v1/admin/agents/quiet-agent/reactivate",
+                headers=await _headers(),
+            )
+    assert r.status_code == 404
+    assert "no active quarantine" in r.json()["detail"]
+
+
+async def test_reactivate_refuses_shadow_event(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _seed_agent(app, "shadow-only")
+            await _seed_event(app, agent_id="shadow-only", mode="shadow")
+            r = await cli.post(
+                "/v1/admin/agents/shadow-only/reactivate",
+                headers=await _headers(),
+            )
+    assert r.status_code == 404
+    assert "shadow" in r.json()["detail"]
+
+
+async def test_reactivate_clears_enforce_event(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _seed_agent(app, "quarantined", active=0)
+            await _seed_event(app, agent_id="quarantined", mode="enforce")
+
+            r = await cli.post(
+                "/v1/admin/agents/quarantined/reactivate",
+                headers=await _headers(),
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["ok"] is True
+            assert body["agent_id"] == "quarantined"
+            assert body["resolved_event_id"] is not None
+
+            from mcp_proxy.db import get_db
+
+            async with get_db() as conn:
+                active = (
+                    await conn.execute(
+                        text(
+                            "SELECT is_active FROM internal_agents "
+                            "WHERE agent_id = 'quarantined'"
+                        )
+                    )
+                ).scalar()
+                event = (
+                    await conn.execute(
+                        text(
+                            "SELECT resolved_at, resolved_by FROM "
+                            "agent_quarantine_events "
+                            "WHERE agent_id = 'quarantined'"
+                        )
+                    )
+                ).first()
+    assert active == 1
+    assert event[0] is not None
+    assert event[1].startswith("operator:")
+
+
+async def test_reactivate_after_hard_delete_returns_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            # Insert event but no internal_agents row — simulates
+            # a post-expiry-cron state.
+            await _seed_event(app, agent_id="deleted-agent", mode="enforce")
+
+            r = await cli.post(
+                "/v1/admin/agents/deleted-agent/reactivate",
+                headers=await _headers(),
+            )
+    assert r.status_code == 404
+    assert "re-enrollment" in r.json()["detail"]

--- a/tests/test_mcp_proxy_admin_observability_anomaly.py
+++ b/tests/test_mcp_proxy_admin_observability_anomaly.py
@@ -1,0 +1,157 @@
+"""GET /v1/admin/observability/anomaly-detector — ADR-013 Phase 4 c6.
+
+Covers:
+- Auth: wrong admin secret → 403.
+- Detector not wired (startup race / mode=off): deterministic zero-ish
+  payload with config reflected from settings.
+- DB-backed 24h counts are returned even when the evaluator is absent.
+- When evaluator + recorder are present, their counters flow through.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str = "anomaly-obs"):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}"
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    return app
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+async def _seed_event(app, *, agent_id: str, mode: str, offset: timedelta) -> None:
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode) VALUES (:a, :t, :m)"
+            ),
+            {
+                "a": agent_id,
+                "t": _iso(datetime.now(timezone.utc) - offset),
+                "m": mode,
+            },
+        )
+
+
+async def test_requires_admin_secret(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get(
+                "/v1/admin/observability/anomaly-detector",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+    assert r.status_code == 403
+
+
+async def test_no_evaluator_returns_default_shape(tmp_path, monkeypatch):
+    """Detector not yet wired (settings=shadow default, no app.state).
+
+    Commit 6 ships the endpoint before commit 7 wires the lifespan, so
+    the "no evaluator" branch is the happy path until the wiring
+    commit lands. Must return a consistent shape with settings-based
+    config so dashboards don't 500 mid-deploy.
+    """
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get(
+                "/v1/admin/observability/anomaly-detector",
+                headers=await _headers(),
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "shadow"
+    assert body["startup_ts"] is None
+    assert body["cycles_run"] == 0
+    assert body["quarantines_last_24h"] == 0
+    assert body["config"]["ratio_threshold"] == 10.0
+    assert body["config"]["abs_threshold_rps"] == 100.0
+    assert body["config"]["ceiling_per_min"] == 3
+
+
+async def test_24h_counts_reflect_db_events(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            # Inside window: 2 enforce + 1 shadow.
+            await _seed_event(app, agent_id="a", mode="enforce", offset=timedelta(hours=1))
+            await _seed_event(app, agent_id="b", mode="enforce", offset=timedelta(hours=12))
+            await _seed_event(app, agent_id="c", mode="shadow", offset=timedelta(hours=2))
+            # Outside window: ignored.
+            await _seed_event(app, agent_id="d", mode="enforce", offset=timedelta(hours=30))
+
+            r = await cli.get(
+                "/v1/admin/observability/anomaly-detector",
+                headers=await _headers(),
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["quarantines_last_24h"] == 2
+    assert body["quarantines_last_24h_shadow_only"] == 1
+
+
+async def test_evaluator_wired_flows_through_counters(tmp_path, monkeypatch):
+    """When app.state.anomaly_evaluator is set, the endpoint reports its
+    counters instead of the fallback zeros."""
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.db import _require_engine
+            from mcp_proxy.observability.anomaly_evaluator import AnomalyEvaluator
+
+            engine = _require_engine()
+            ev = AnomalyEvaluator(
+                engine, mode="enforce", ratio_threshold=42.0
+            )
+            ev.cycles_run = 17
+            ev.quarantines_enforce_total = 3
+            ev.quarantines_shadow_total = 0
+            ev.meta_breaker.ceiling_trips_total = 1
+            app.state.anomaly_evaluator = ev
+
+            r = await cli.get(
+                "/v1/admin/observability/anomaly-detector",
+                headers=await _headers(),
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "enforce"
+    assert body["cycles_run"] == 17
+    assert body["quarantines_enforce_total"] == 3
+    assert body["meta_ceiling_trips_total"] == 1
+    assert body["config"]["ratio_threshold"] == 42.0

--- a/tests/test_mcp_proxy_admin_observability_anomaly.py
+++ b/tests/test_mcp_proxy_admin_observability_anomaly.py
@@ -75,14 +75,13 @@ async def test_requires_admin_secret(tmp_path, monkeypatch):
     assert r.status_code == 403
 
 
-async def test_no_evaluator_returns_default_shape(tmp_path, monkeypatch):
-    """Detector not yet wired (settings=shadow default, no app.state).
-
-    Commit 6 ships the endpoint before commit 7 wires the lifespan, so
-    the "no evaluator" branch is the happy path until the wiring
-    commit lands. Must return a consistent shape with settings-based
-    config so dashboards don't 500 mid-deploy.
+async def test_mode_off_returns_default_shape(tmp_path, monkeypatch):
+    """With ``anomaly_quarantine_mode=off`` the lifespan skips wiring
+    the evaluator, and the endpoint falls back to a deterministic
+    settings-only snapshot so dashboards don't 500 when the detector
+    is intentionally disabled.
     """
+    monkeypatch.setenv("MCP_PROXY_ANOMALY_QUARANTINE_MODE", "off")
     app = await _spin_proxy(tmp_path, monkeypatch)
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
@@ -93,13 +92,40 @@ async def test_no_evaluator_returns_default_shape(tmp_path, monkeypatch):
             )
     assert r.status_code == 200
     body = r.json()
-    assert body["mode"] == "shadow"
+    assert body["mode"] == "off"
     assert body["startup_ts"] is None
     assert body["cycles_run"] == 0
     assert body["quarantines_last_24h"] == 0
     assert body["config"]["ratio_threshold"] == 10.0
     assert body["config"]["abs_threshold_rps"] == 100.0
     assert body["config"]["ceiling_per_min"] == 3
+
+
+async def test_shadow_mode_default_wires_evaluator(tmp_path, monkeypatch):
+    """Default config → lifespan wires detector in shadow mode.
+
+    Validates the commit 7 wiring: evaluator + recorder land on
+    app.state, the endpoint reports their state, cycles_run is a
+    real live counter rather than the fallback zero.
+    """
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            # Detector is wired: attributes exist on app.state.
+            assert hasattr(app.state, "anomaly_evaluator")
+            assert hasattr(app.state, "traffic_recorder")
+            assert hasattr(app.state, "baseline_rollup")
+            assert hasattr(app.state, "quarantine_expiry")
+
+            r = await cli.get(
+                "/v1/admin/observability/anomaly-detector",
+                headers=await _headers(),
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "shadow"
+    assert body["startup_ts"] is not None
 
 
 async def test_24h_counts_reflect_db_events(tmp_path, monkeypatch):

--- a/tests/test_mcp_proxy_anomaly_evaluator.py
+++ b/tests/test_mcp_proxy_anomaly_evaluator.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 
 import pytest
 from sqlalchemy import text

--- a/tests/test_mcp_proxy_anomaly_evaluator.py
+++ b/tests/test_mcp_proxy_anomaly_evaluator.py
@@ -1,0 +1,464 @@
+"""Anomaly evaluator + meta-circuit-breaker tests — ADR-013 Phase 4 c4.
+
+Covers:
+- Immature agent: absolute signal only.
+- Mature agent with baseline: dual test (ratio AND abs-soft).
+- Hot-counter hysteresis: single tick does not quarantine, 3 does.
+- Meta-circuit-breaker: cycle-level fail-closed when projected > ceiling.
+- Shadow vs enforce mode accounting.
+- apply_hook / alert_hook are awaited; their exceptions do not abort
+  the cycle.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.observability.anomaly_evaluator import (
+    AnomalyEvaluator,
+    MetaCircuitBreaker,
+    TriggerInfo,
+)
+
+
+@pytest.fixture
+async def engine(tmp_path):
+    db_file = tmp_path / "anomaly.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    eng: AsyncEngine = create_async_engine(url, future=True)
+    yield eng
+    await eng.dispose()
+    await dispose_db()
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _insert_sample(
+    engine: AsyncEngine, agent_id: str, ts: datetime, count: int
+) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_traffic_samples "
+                "(agent_id, bucket_ts, req_count) VALUES (:a, :b, :c) "
+                "ON CONFLICT(agent_id, bucket_ts) DO UPDATE SET "
+                "req_count = excluded.req_count"
+            ),
+            {"a": agent_id, "b": _iso(ts), "c": count},
+        )
+
+
+async def _insert_baseline(
+    engine: AsyncEngine,
+    agent_id: str,
+    hour_of_week: int,
+    avg_rpm: float,
+) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_hourly_baselines "
+                "(agent_id, hour_of_week, req_per_min_avg, req_per_min_p95, "
+                " sample_count, updated_at) "
+                "VALUES (:a, :h, :avg, :p95, :n, :u)"
+            ),
+            {
+                "a": agent_id,
+                "h": hour_of_week,
+                "avg": avg_rpm,
+                "p95": avg_rpm * 1.2,
+                "n": 10,
+                "u": _iso(datetime.now(timezone.utc)),
+            },
+        )
+
+
+# ── MetaCircuitBreaker ────────────────────────────────────────────
+
+
+def test_meta_breaker_rejects_zero_or_negative_ceiling():
+    with pytest.raises(ValueError):
+        MetaCircuitBreaker(ceiling_per_min=0)
+
+
+def test_meta_breaker_records_within_window():
+    mb = MetaCircuitBreaker(ceiling_per_min=3, window_s=60.0)
+    for _ in range(5):
+        mb.record()
+    assert mb.recent_count() == 5
+
+
+def test_meta_breaker_trims_old_entries():
+    mb = MetaCircuitBreaker(ceiling_per_min=3, window_s=0.05)
+    mb.record()
+    import time
+
+    time.sleep(0.1)
+    # 0.1 s > 0.05 window → trimmed out.
+    assert mb.recent_count() == 0
+
+
+# ── Immature-agent path ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_immature_agent_only_absolute_fires(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+    # 3000 reqs in a single 10-min bucket — 3000 / 300 = 10 rps exactly,
+    # below threshold. Bump it to 3001 for a hair over.
+    await _insert_sample(engine, "new-agent", now - timedelta(minutes=2), 3001)
+
+    out = await ev.run_cycle(now=now)
+    assert out == {"candidates": 1, "applied": 1, "suppressed": 0}
+    assert ev.quarantines_shadow_total == 1
+
+
+@pytest.mark.asyncio
+async def test_immature_agent_low_rate_does_not_fire(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "new-agent", now - timedelta(minutes=2), 100)
+
+    out = await ev.run_cycle(now=now)
+    assert out == {"candidates": 0, "applied": 0, "suppressed": 0}
+
+
+# ── Mature-agent dual-test ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mature_agent_dual_test_fires(engine):
+    """current_rpm / baseline_rpm > ratio AND current_rps > soft_abs."""
+    ev = AnomalyEvaluator(
+        engine,
+        ratio_threshold=10.0,
+        abs_threshold_rps=100.0,
+        abs_threshold_rps_soft=5.0,
+        sustained_ticks_required=1,
+    )
+    now = datetime(2026, 4, 22, 14, 0, 0, tzinfo=timezone.utc)
+    # Earliest sample 10 days ago → mature.
+    await _insert_sample(
+        engine, "a", now - timedelta(days=10), 1
+    )
+    # Current 5-min window: 3000 reqs / 300 s = 10 rps = 600 rpm.
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 3000)
+
+    # Baseline: 1 rpm → ratio = 600 → > 10, and 10 rps > 5 soft.
+    how = now.weekday() * 24 + now.hour  # Wed 14:00 = 2*24+14 = 62
+    await _insert_baseline(engine, "a", how, 1.0)
+
+    out = await ev.run_cycle(now=now)
+    assert out == {"candidates": 1, "applied": 1, "suppressed": 0}
+
+
+@pytest.mark.asyncio
+async def test_mature_agent_ratio_high_but_abs_below_soft_does_not_fire(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        ratio_threshold=10.0,
+        abs_threshold_rps=100.0,
+        abs_threshold_rps_soft=5.0,
+        sustained_ticks_required=1,
+    )
+    now = datetime(2026, 4, 22, 14, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(days=10), 1)
+    # 600 reqs / 300 s = 2 rps → below soft (5).
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 600)
+    how = now.weekday() * 24 + now.hour
+    await _insert_baseline(engine, "a", how, 0.1)  # ratio would be huge
+
+    out = await ev.run_cycle(now=now)
+    assert out == {"candidates": 0, "applied": 0, "suppressed": 0}
+
+
+@pytest.mark.asyncio
+async def test_mature_agent_abs_backstop_fires_even_with_low_ratio(engine):
+    """If current_rps > abs_threshold the agent is quarantined regardless
+    of ratio. Nothing legit sustains that rate on one credential.
+    """
+    ev = AnomalyEvaluator(
+        engine,
+        ratio_threshold=10.0,
+        abs_threshold_rps=100.0,
+        abs_threshold_rps_soft=5.0,
+        sustained_ticks_required=1,
+    )
+    now = datetime(2026, 4, 22, 14, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(days=10), 1)
+    # 45000 reqs / 300 s = 150 rps > 100 abs.
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 45000)
+    how = now.weekday() * 24 + now.hour
+    # High baseline → ratio 150 * 60 / 500 = 18 > 10 — actually fires
+    # both paths. Use an even higher baseline to *only* fire the abs
+    # backstop.
+    await _insert_baseline(engine, "a", how, 5000.0)  # ratio = 150*60/5000 = 1.8
+
+    out = await ev.run_cycle(now=now)
+    assert out == {"candidates": 1, "applied": 1, "suppressed": 0}
+
+
+# ── Hot-counter hysteresis ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hot_counter_requires_sustained_ticks(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=3,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 30001)
+
+    # Tick 1 + 2: no quarantine.
+    out1 = await ev.run_cycle(now=now)
+    out2 = await ev.run_cycle(now=now)
+    assert out1 == {"candidates": 0, "applied": 0, "suppressed": 0}
+    assert out2 == {"candidates": 0, "applied": 0, "suppressed": 0}
+
+    # Tick 3: quarantines.
+    out3 = await ev.run_cycle(now=now)
+    assert out3 == {"candidates": 1, "applied": 1, "suppressed": 0}
+
+
+@pytest.mark.asyncio
+async def test_hot_counter_resets_on_recovery(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=3,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    # One trip.
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 30001)
+    await ev.run_cycle(now=now)
+    assert ev._hot_counter.get("a") == 1
+
+    # Rate drops — reset.
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 10)
+    await ev.run_cycle(now=now)
+    assert "a" not in ev._hot_counter
+
+
+# ── Meta-circuit-breaker cycle-level ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_meta_breaker_suppresses_all_when_projected_exceeds_ceiling(
+    engine,
+):
+    """If len(candidates) > ceiling, zero quarantines apply (fail-closed)."""
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+        ceiling_per_min=3,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    # 5 agents all over threshold in one cycle.
+    for i in range(5):
+        await _insert_sample(
+            engine, f"agent-{i}", now - timedelta(minutes=2), 30001
+        )
+
+    out = await ev.run_cycle(now=now)
+    assert out == {
+        "candidates": 5,
+        "applied": 0,
+        "suppressed": 5,
+    }
+    assert ev.meta_breaker.ceiling_trips_total == 1
+    assert ev.quarantines_shadow_total == 0
+
+
+@pytest.mark.asyncio
+async def test_meta_breaker_allows_batch_below_ceiling(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+        ceiling_per_min=3,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    for i in range(3):
+        await _insert_sample(
+            engine, f"agent-{i}", now - timedelta(minutes=2), 30001
+        )
+
+    out = await ev.run_cycle(now=now)
+    assert out == {"candidates": 3, "applied": 3, "suppressed": 0}
+
+
+@pytest.mark.asyncio
+async def test_meta_breaker_accumulates_across_cycles(engine):
+    """Sheds from past cycles count toward the projected total."""
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+        ceiling_per_min=3,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    for i in range(3):
+        await _insert_sample(
+            engine, f"agent-{i}", now - timedelta(minutes=2), 30001
+        )
+    # Cycle 1: 3 applied (fills ceiling).
+    out1 = await ev.run_cycle(now=now)
+    assert out1["applied"] == 3
+
+    # Drop the high-rate samples for the first three so they stop
+    # firing; only the new agent should be a candidate in cycle 2.
+    async with engine.begin() as conn:
+        for i in range(3):
+            await conn.execute(
+                text(
+                    "UPDATE agent_traffic_samples SET req_count = 1 "
+                    "WHERE agent_id = :a"
+                ),
+                {"a": f"agent-{i}"},
+            )
+    # Cycle 2: one new candidate. projected = 3 + 1 = 4 > 3 → suppressed.
+    await _insert_sample(engine, "agent-extra", now - timedelta(minutes=2), 30001)
+    out2 = await ev.run_cycle(now=now)
+    assert out2 == {"candidates": 1, "applied": 0, "suppressed": 1}
+    assert ev.meta_breaker.ceiling_trips_total == 1
+
+
+# ── Mode behaviour ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mode_off_runs_no_cycle(engine):
+    ev = AnomalyEvaluator(engine, mode="off", sustained_ticks_required=1)
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 30001)
+    out = await ev.run_cycle(now=now)
+    assert out["disabled"] == 1
+    assert ev.quarantines_shadow_total == 0
+
+
+@pytest.mark.asyncio
+async def test_mode_enforce_accounts_separately(engine):
+    ev = AnomalyEvaluator(
+        engine,
+        mode="enforce",
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 30001)
+
+    await ev.run_cycle(now=now)
+    assert ev.quarantines_enforce_total == 1
+    assert ev.quarantines_shadow_total == 0
+
+
+# ── Hooks ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_hook_is_awaited(engine):
+    received: list[tuple[str, str]] = []
+
+    async def hook(trigger: TriggerInfo, mode: str) -> None:
+        received.append((trigger.agent_id, mode))
+
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+        apply_hook=hook,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 30001)
+
+    await ev.run_cycle(now=now)
+    assert received == [("a", "shadow")]
+
+
+@pytest.mark.asyncio
+async def test_apply_hook_exception_does_not_abort_cycle(engine):
+    async def hook(trigger: TriggerInfo, mode: str) -> None:
+        raise RuntimeError("hook failure")
+
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+        apply_hook=hook,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", now - timedelta(minutes=2), 30001)
+    await _insert_sample(engine, "b", now - timedelta(minutes=2), 30001)
+
+    out = await ev.run_cycle(now=now)
+    # Both candidates counted as applied even if hook raised.
+    assert out == {"candidates": 2, "applied": 2, "suppressed": 0}
+
+
+@pytest.mark.asyncio
+async def test_alert_hook_fires_on_ceiling_trip(engine):
+    received: list[list[str]] = []
+
+    async def alert(candidates):
+        received.append([c.agent_id for c in candidates])
+
+    ev = AnomalyEvaluator(
+        engine,
+        abs_threshold_rps=10.0,
+        sustained_ticks_required=1,
+        ceiling_per_min=3,
+        alert_hook=alert,
+    )
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    for i in range(5):
+        await _insert_sample(
+            engine, f"agent-{i}", now - timedelta(minutes=2), 30001
+        )
+    await ev.run_cycle(now=now)
+
+    assert len(received) == 1
+    assert sorted(received[0]) == [f"agent-{i}" for i in range(5)]
+
+
+# ── Background loop ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_stop_runs_cycles(engine):
+    ev = AnomalyEvaluator(
+        engine, interval_s=0.05, sustained_ticks_required=1
+    )
+    await ev.start()
+    await asyncio.sleep(0.15)
+    await ev.stop()
+    assert ev.cycles_run >= 1
+
+
+@pytest.mark.asyncio
+async def test_start_noop_when_mode_off(engine):
+    ev = AnomalyEvaluator(engine, mode="off")
+    await ev.start()
+    assert ev._task is None
+    await ev.stop()

--- a/tests/test_mcp_proxy_baseline_rollup.py
+++ b/tests/test_mcp_proxy_baseline_rollup.py
@@ -1,0 +1,258 @@
+"""Baseline roll-up unit tests — ADR-013 Phase 4 commit 3.
+
+Directly exercises the hour-of-week grouping, the maturity gate, and
+the UPSERT semantics. The daily scheduler loop is covered by a
+separate ``_seconds_until_next_run`` unit test.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.observability.baseline_rollup import (
+    _hour_of_week,
+    _percentile,
+    _seconds_until_next_run,
+    run_once,
+)
+
+
+@pytest.fixture
+async def engine(tmp_path):
+    db_file = tmp_path / "baseline.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    eng: AsyncEngine = create_async_engine(url, future=True)
+    yield eng
+    await eng.dispose()
+    await dispose_db()
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _insert_sample(
+    engine: AsyncEngine, agent_id: str, bucket_ts: str, count: int
+) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_traffic_samples "
+                "(agent_id, bucket_ts, req_count) VALUES (:a, :b, :c)"
+            ),
+            {"a": agent_id, "b": bucket_ts, "c": count},
+        )
+
+
+def test_hour_of_week_monday_midnight_is_zero():
+    # 2026-04-20 was a Monday.
+    assert _hour_of_week("2026-04-20T00:00:00Z") == 0
+
+
+def test_hour_of_week_sunday_last_hour_is_167():
+    # 2026-04-26 is the following Sunday.
+    assert _hour_of_week("2026-04-26T23:00:00Z") == 167
+
+
+def test_hour_of_week_various():
+    # 2026-04-22 is Wednesday (dow=2); 14:30 UTC → 2*24 + 14 = 62.
+    assert _hour_of_week("2026-04-22T14:30:00Z") == 62
+
+
+def test_percentile_edges():
+    assert _percentile([], 0.95) == 0.0
+    assert _percentile([1.0], 0.95) == 1.0
+    # Linear interpolation at q=0.5 over [1,2,3,4] = 2.5.
+    assert _percentile([1.0, 2.0, 3.0, 4.0], 0.5) == pytest.approx(2.5)
+
+
+def test_seconds_until_next_run_before_hour():
+    now = datetime(2026, 4, 24, 2, 0, 0, tzinfo=timezone.utc)
+    # 04:00 UTC → 2h away = 7200 s.
+    assert _seconds_until_next_run(now, 4) == pytest.approx(7200.0)
+
+
+def test_seconds_until_next_run_after_hour_rolls_to_tomorrow():
+    now = datetime(2026, 4, 24, 5, 0, 0, tzinfo=timezone.utc)
+    # Past 04:00 today → next run is 04:00 tomorrow → 23h = 82800 s.
+    assert _seconds_until_next_run(now, 4) == pytest.approx(82800.0)
+
+
+def test_seconds_until_next_run_at_exact_hour_rolls_to_tomorrow():
+    # Exact-hour match must advance to the next day so the loop does
+    # not double-fire back-to-back.
+    now = datetime(2026, 4, 24, 4, 0, 0, tzinfo=timezone.utc)
+    assert _seconds_until_next_run(now, 4) == pytest.approx(86400.0)
+
+
+@pytest.mark.asyncio
+async def test_run_once_skips_agent_below_min_baseline_days(engine):
+    # Only 3 days of data → below the default 7-day threshold.
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    for day in range(3):
+        ts = now - timedelta(days=day, hours=1)
+        await _insert_sample(
+            engine, "immature", _iso(ts), 10
+        )
+
+    stats = await run_once(engine, now=now)
+    assert stats["agents_seen"] == 1
+    assert stats["agents_mature"] == 0
+    assert stats["agents_skipped_immature"] == 1
+    assert stats["rows_written"] == 0
+
+    async with engine.begin() as conn:
+        count = (
+            await conn.execute(
+                text("SELECT COUNT(*) FROM agent_hourly_baselines")
+            )
+        ).scalar()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_run_once_writes_baseline_for_mature_agent(engine):
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    # 10 days of data → mature. Put 6 samples per day in hour 2
+    # (02:00..02:50 UTC). Each day maps to a different hour_of_week
+    # (Mon=2, Tue=26, ..., Sun=146), wrapping back to Mon=2 on day 7.
+    # → hour_of_week=2 gets samples from day 0 and day 7 (2 Mondays) ×
+    #   6 samples = 12 samples; other days of the week get 6 each.
+    base = datetime(2026, 4, 13, 2, 0, 0, tzinfo=timezone.utc)  # a Monday
+    for day_offset in range(10):
+        for minute in (0, 10, 20, 30, 40, 50):
+            ts = base + timedelta(days=day_offset, minutes=minute)
+            if ts > now:
+                continue
+            await _insert_sample(
+                engine, "mature", _iso(ts), 100  # 100 req in 10 min → 10 req/min
+            )
+
+    stats = await run_once(engine, now=now)
+    assert stats["agents_mature"] == 1
+    assert stats["rows_written"] >= 7  # at least 7 distinct hour_of_week buckets
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT hour_of_week, req_per_min_avg, sample_count "
+                    "FROM agent_hourly_baselines WHERE agent_id = 'mature' "
+                    "ORDER BY hour_of_week"
+                )
+            )
+        ).all()
+    houred = {r[0]: (r[1], r[2]) for r in rows}
+    # hour_of_week=2 (Monday 02:00) appears twice in the 10-day window
+    # (Mon Apr 13 + Mon Apr 20) × 6 samples/day = 12.
+    assert 2 in houred
+    avg, n = houred[2]
+    assert n == 12
+    assert avg == pytest.approx(10.0)  # 100 req / 10 min = 10 req/min
+    # Sanity: total samples across all buckets = 10 days × 6 samples = 60.
+    total_samples = sum(n for _, n in houred.values())
+    assert total_samples == 60
+
+
+@pytest.mark.asyncio
+async def test_run_once_upsert_replaces_baseline(engine):
+    """Second roll-up with different data must overwrite the first."""
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    # Four Mondays at 02:00 UTC — all in the same hour_of_week bucket
+    # (hour_of_week=2). Count=100 → 10 req/min. Use a wider window so
+    # the first Monday (March 30) stays in scope for both passes.
+    mondays = [
+        datetime(2026, 3, 30, 2, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 6, 2, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 13, 2, 0, 0, tzinfo=timezone.utc),
+        datetime(2026, 4, 20, 2, 0, 0, tzinfo=timezone.utc),
+    ]
+    for mon in mondays:
+        await _insert_sample(engine, "a", _iso(mon), 100)
+    await run_once(engine, now=now, window_days=60)
+
+    async with engine.begin() as conn:
+        row1 = (
+            await conn.execute(
+                text(
+                    "SELECT sample_count, req_per_min_avg "
+                    "FROM agent_hourly_baselines "
+                    "WHERE agent_id = 'a' AND hour_of_week = 2"
+                )
+            )
+        ).first()
+    assert row1 == (4, pytest.approx(10.0))
+
+    # Add a Monday at 02:00 with a much higher rate.
+    new_monday = datetime(2026, 4, 20, 2, 10, 0, tzinfo=timezone.utc)
+    await _insert_sample(engine, "a", _iso(new_monday), 1000)  # 100 req/min
+
+    await run_once(engine, now=now, window_days=60)
+
+    async with engine.begin() as conn:
+        row2 = (
+            await conn.execute(
+                text(
+                    "SELECT sample_count, req_per_min_avg "
+                    "FROM agent_hourly_baselines "
+                    "WHERE agent_id = 'a' AND hour_of_week = 2"
+                )
+            )
+        ).first()
+    assert row2 is not None
+    sample_count, avg = row2
+    # 5 samples: 4×10 + 1×100 = 140 → avg 28.
+    assert sample_count == 5
+    assert avg == pytest.approx(28.0)
+
+
+@pytest.mark.asyncio
+async def test_run_once_filters_samples_older_than_window(engine):
+    """Samples older than window_days are ignored (bounded roll-up).
+
+    But the earliest-sample check still sees them — the agent is mature
+    even if only the in-window samples are used for the baseline.
+    """
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    # An ancient sample 60 days old — outside the 28-day window.
+    ancient = now - timedelta(days=60)
+    # And one recent sample inside the window but only 2 days ago (so
+    # the earliest bucket_ts query returns 60d → agent looks mature).
+    recent = now - timedelta(days=2)
+
+    await _insert_sample(engine, "a", _iso(ancient), 500)
+    await _insert_sample(engine, "a", _iso(recent), 50)
+
+    stats = await run_once(engine, now=now, window_days=28)
+    # Only the recent sample goes into the rollup. The ancient one is
+    # filtered out by the window bound.
+    assert stats["agents_mature"] == 1
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT sample_count FROM agent_hourly_baselines "
+                    "WHERE agent_id = 'a'"
+                )
+            )
+        ).all()
+    # Exactly 1 bucket, with sample_count = 1.
+    assert [r[0] for r in rows] == [1]
+
+
+@pytest.mark.asyncio
+async def test_run_once_handles_zero_agents(engine):
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    stats = await run_once(engine, now=now)
+    assert stats == {
+        "agents_seen": 0,
+        "agents_mature": 0,
+        "agents_skipped_immature": 0,
+        "rows_written": 0,
+    }

--- a/tests/test_mcp_proxy_phase4_integration.py
+++ b/tests/test_mcp_proxy_phase4_integration.py
@@ -1,0 +1,231 @@
+"""ADR-013 Phase 4 end-to-end integration — commit 8.
+
+Spins up the Mastio with the anomaly stack wired (commit 7) and
+exercises the full path: seed traffic → run one evaluator cycle →
+verify DB side effects match the configured mode.
+
+Shadow mode: event row written with mode='shadow', is_active stays 1.
+Enforce mode: event row written with mode='enforce', is_active flips
+to 0, expires_at populated.
+Ceiling trip: five simultaneous candidates, zero applied, one
+``meta_ceiling_trips_total`` bump.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin(tmp_path, monkeypatch, *, mode: str, ceiling: int = 3,
+                org_id: str = "ph4-int"):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}"
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ANOMALY_QUARANTINE_MODE", mode)
+    monkeypatch.setenv(
+        "MCP_PROXY_ANOMALY_ABSOLUTE_THRESHOLD_RPS", "10"
+    )
+    monkeypatch.setenv(
+        "MCP_PROXY_ANOMALY_SUSTAINED_TICKS_REQUIRED", "1"
+    )
+    monkeypatch.setenv(
+        "MCP_PROXY_ANOMALY_CEILING_PER_MIN", str(ceiling)
+    )
+    from mcp_proxy.config import get_settings
+
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+
+    return app
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _seed_agent(agent_id: str) -> None:
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents "
+                "(agent_id, display_name, capabilities, api_key_hash, "
+                " created_at, is_active) "
+                "VALUES (:a, :a, '[]', 'hash', :ts, 1)"
+            ),
+            {
+                "a": agent_id,
+                "ts": _iso(datetime.now(timezone.utc)),
+            },
+        )
+
+
+async def _seed_traffic(
+    agent_id: str, *, rps: int = 30, window_minutes: int = 5
+) -> None:
+    """Insert one 10-min bucket that will produce ``rps`` in the 5-min
+    rate computation. ``rps * 300`` total reqs in the 5-min window."""
+    from mcp_proxy.db import get_db
+
+    total = rps * 300
+    now = datetime.now(timezone.utc)
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_traffic_samples "
+                "(agent_id, bucket_ts, req_count) VALUES (:a, :b, :c)"
+            ),
+            {
+                "a": agent_id,
+                "b": _iso(now - timedelta(minutes=2)),
+                "c": total,
+            },
+        )
+
+
+async def test_shadow_mode_logs_decision_without_deactivating(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, mode="shadow")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test"):
+        async with app.router.lifespan_context(app):
+            await _seed_agent("suspect")
+            await _seed_traffic("suspect", rps=30)
+            # Force one cycle — the background task is every 30s; we
+            # don't want the test to hang. run_cycle is sync-on-DB.
+            result = await app.state.anomaly_evaluator.run_cycle()
+            assert result == {"candidates": 1, "applied": 1, "suppressed": 0}
+
+            from mcp_proxy.db import get_db
+
+            async with get_db() as conn:
+                active = (
+                    await conn.execute(
+                        text(
+                            "SELECT is_active FROM internal_agents "
+                            "WHERE agent_id = 'suspect'"
+                        )
+                    )
+                ).scalar()
+                event = (
+                    await conn.execute(
+                        text(
+                            "SELECT mode, expires_at FROM "
+                            "agent_quarantine_events WHERE agent_id = 'suspect'"
+                        )
+                    )
+                ).first()
+    assert active == 1  # shadow never touches is_active
+    assert event is not None
+    assert event[0] == "shadow"
+    assert event[1] is None  # shadow events have no expiry
+
+
+async def test_enforce_mode_deactivates_and_stamps_expiry(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, mode="enforce")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test"):
+        async with app.router.lifespan_context(app):
+            await _seed_agent("bad-agent")
+            await _seed_traffic("bad-agent", rps=30)
+            result = await app.state.anomaly_evaluator.run_cycle()
+            assert result == {"candidates": 1, "applied": 1, "suppressed": 0}
+
+            from mcp_proxy.db import get_db
+
+            async with get_db() as conn:
+                active = (
+                    await conn.execute(
+                        text(
+                            "SELECT is_active FROM internal_agents "
+                            "WHERE agent_id = 'bad-agent'"
+                        )
+                    )
+                ).scalar()
+                event = (
+                    await conn.execute(
+                        text(
+                            "SELECT mode, expires_at FROM "
+                            "agent_quarantine_events "
+                            "WHERE agent_id = 'bad-agent'"
+                        )
+                    )
+                ).first()
+    assert active == 0
+    assert event[0] == "enforce"
+    assert event[1] is not None  # expires_at populated
+
+
+async def test_meta_ceiling_suppresses_batch(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, mode="enforce", ceiling=3)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test"):
+        async with app.router.lifespan_context(app):
+            # 5 agents, all over threshold → projected 5 > ceiling 3.
+            for i in range(5):
+                await _seed_agent(f"burst-{i}")
+                await _seed_traffic(f"burst-{i}", rps=30)
+
+            result = await app.state.anomaly_evaluator.run_cycle()
+            assert result == {"candidates": 5, "applied": 0, "suppressed": 5}
+            assert app.state.anomaly_evaluator.meta_breaker.ceiling_trips_total == 1
+
+            # Zero events written, every agent still active.
+            from mcp_proxy.db import get_db
+
+            async with get_db() as conn:
+                count = (
+                    await conn.execute(
+                        text(
+                            "SELECT COUNT(*) FROM agent_quarantine_events"
+                        )
+                    )
+                ).scalar()
+                active_count = (
+                    await conn.execute(
+                        text(
+                            "SELECT COUNT(*) FROM internal_agents "
+                            "WHERE is_active = 1"
+                        )
+                    )
+                ).scalar()
+    assert count == 0
+    assert active_count == 5
+
+
+async def test_observability_endpoint_reports_quarantine_after_shadow_run(
+    tmp_path, monkeypatch
+):
+    app = await _spin(tmp_path, monkeypatch, mode="shadow")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _seed_agent("watched")
+            await _seed_traffic("watched", rps=30)
+            await app.state.anomaly_evaluator.run_cycle()
+
+            from mcp_proxy.config import get_settings
+
+            r = await cli.get(
+                "/v1/admin/observability/anomaly-detector",
+                headers={"X-Admin-Secret": get_settings().admin_secret},
+            )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mode"] == "shadow"
+    assert body["quarantines_shadow_total"] == 1
+    assert body["quarantines_enforce_total"] == 0
+    assert body["quarantines_last_24h_shadow_only"] == 1
+    # No enforce rows inside the last 24h window either.
+    assert body["quarantines_last_24h"] == 0

--- a/tests/test_mcp_proxy_quarantine.py
+++ b/tests/test_mcp_proxy_quarantine.py
@@ -17,7 +17,6 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.observability.anomaly_evaluator import TriggerInfo
 from mcp_proxy.observability.quarantine import (
-    ReactivationResult,
     make_quarantine_apply_hook,
     reactivate_agent,
     run_expiry_once,

--- a/tests/test_mcp_proxy_quarantine.py
+++ b/tests/test_mcp_proxy_quarantine.py
@@ -1,0 +1,430 @@
+"""Quarantine apply + expiry + reactivation tests — ADR-013 Phase 4 c5.
+
+Covers:
+- make_quarantine_apply_hook in shadow and enforce modes.
+- run_expiry_once hard-deletes enforce-mode rows and marks events.
+- reactivate_agent refuses shadow-mode events, handles hard-deleted
+  rows, resolves enforce-mode events with an operator fingerprint.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.observability.anomaly_evaluator import TriggerInfo
+from mcp_proxy.observability.quarantine import (
+    ReactivationResult,
+    make_quarantine_apply_hook,
+    reactivate_agent,
+    run_expiry_once,
+    _operator_fingerprint,
+)
+
+
+@pytest.fixture
+async def engine(tmp_path):
+    db_file = tmp_path / "quarantine.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    eng: AsyncEngine = create_async_engine(url, future=True)
+    yield eng
+    await eng.dispose()
+    await dispose_db()
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+async def _insert_agent(engine: AsyncEngine, agent_id: str, active: int = 1) -> None:
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO internal_agents "
+                "(agent_id, display_name, capabilities, api_key_hash, "
+                " created_at, is_active) "
+                "VALUES (:a, :a, '[]', 'hash', :ts, :act)"
+            ),
+            {
+                "a": agent_id,
+                "ts": _iso(datetime.now(timezone.utc)),
+                "act": active,
+            },
+        )
+
+
+def _trigger(agent_id: str = "a", rps: float = 150.0) -> TriggerInfo:
+    return TriggerInfo(
+        agent_id=agent_id,
+        current_rate_rps=rps,
+        baseline_rpm=10.0,
+        ratio=15.0,
+        hour_of_week=30,
+        mature=True,
+        sustained_ticks=3,
+    )
+
+
+# ── apply_hook ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_shadow_hook_inserts_event_without_touching_is_active(engine):
+    await _insert_agent(engine, "a")
+    hook = make_quarantine_apply_hook(engine)
+    await hook(_trigger("a"), "shadow")
+
+    async with engine.begin() as conn:
+        event = (
+            await conn.execute(
+                text(
+                    "SELECT mode, expires_at FROM agent_quarantine_events "
+                    "WHERE agent_id = 'a'"
+                )
+            )
+        ).first()
+        active = (
+            await conn.execute(
+                text(
+                    "SELECT is_active FROM internal_agents WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+    assert event is not None
+    assert event[0] == "shadow"
+    # Shadow events never expire — the expires_at column is NULL.
+    assert event[1] is None
+    # is_active untouched.
+    assert active == 1
+
+
+@pytest.mark.asyncio
+async def test_enforce_hook_inserts_event_and_deactivates(engine):
+    await _insert_agent(engine, "a")
+    hook = make_quarantine_apply_hook(engine, ttl_hours=24)
+    await hook(_trigger("a"), "enforce")
+
+    async with engine.begin() as conn:
+        event = (
+            await conn.execute(
+                text(
+                    "SELECT mode, expires_at, trigger_ratio, trigger_abs_rate "
+                    "FROM agent_quarantine_events WHERE agent_id = 'a'"
+                )
+            )
+        ).first()
+        active = (
+            await conn.execute(
+                text(
+                    "SELECT is_active FROM internal_agents WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+    assert event is not None
+    assert event[0] == "enforce"
+    assert event[1] is not None  # expires_at populated
+    assert event[2] == pytest.approx(15.0)
+    assert event[3] == pytest.approx(150.0)
+    assert active == 0
+
+
+@pytest.mark.asyncio
+async def test_enforce_hook_idempotent_when_agent_already_inactive(engine):
+    """If an operator already deactivated the agent, the event row must
+    still be written (audit integrity) but no error raised."""
+    await _insert_agent(engine, "a", active=0)
+    hook = make_quarantine_apply_hook(engine)
+    await hook(_trigger("a"), "enforce")  # must not raise
+
+    async with engine.begin() as conn:
+        count = (
+            await conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM agent_quarantine_events "
+                    "WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_notification_dispatch_receives_context(engine):
+    await _insert_agent(engine, "a")
+    received: list[dict] = []
+
+    def dispatcher(payload):
+        received.append(payload)
+
+    hook = make_quarantine_apply_hook(
+        engine, notification_dispatch=dispatcher
+    )
+    await hook(_trigger("a"), "enforce")
+
+    assert len(received) == 1
+    msg = received[0]
+    assert msg["agent_id"] == "a"
+    assert msg["mode"] == "enforce"
+    assert msg["ratio"] == 15.0
+    assert msg["expires_at"] is not None
+    assert "event_id" in msg
+
+
+@pytest.mark.asyncio
+async def test_notification_dispatch_exception_does_not_abort(engine):
+    """A raising dispatcher must not prevent DB side-effects."""
+    await _insert_agent(engine, "a")
+
+    def dispatcher(payload):
+        raise RuntimeError("webhook down")
+
+    hook = make_quarantine_apply_hook(
+        engine, notification_dispatch=dispatcher
+    )
+    await hook(_trigger("a"), "enforce")  # must not raise
+
+    async with engine.begin() as conn:
+        active = (
+            await conn.execute(
+                text(
+                    "SELECT is_active FROM internal_agents WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+    assert active == 0
+
+
+# ── expiry cron ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_expiry_hard_deletes_expired_enforce_rows(engine):
+    await _insert_agent(engine, "a")
+    await _insert_agent(engine, "b")
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+
+    # One expired, one not yet.
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at) "
+                "VALUES ('a', :t0, 'enforce', :expired)"
+            ),
+            {
+                "t0": _iso(now - timedelta(days=2)),
+                "expired": _iso(now - timedelta(hours=1)),
+            },
+        )
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at) "
+                "VALUES ('b', :t0, 'enforce', :future)"
+            ),
+            {
+                "t0": _iso(now),
+                "future": _iso(now + timedelta(hours=23)),
+            },
+        )
+
+    stats = await run_expiry_once(engine, now=now)
+    assert stats.scanned == 1
+    assert stats.deleted == 1
+    assert stats.resolved == 1
+
+    async with engine.begin() as conn:
+        a_row = (
+            await conn.execute(
+                text(
+                    "SELECT agent_id FROM internal_agents WHERE agent_id = 'a'"
+                )
+            )
+        ).first()
+        b_row = (
+            await conn.execute(
+                text(
+                    "SELECT agent_id FROM internal_agents WHERE agent_id = 'b'"
+                )
+            )
+        ).first()
+        resolved_a = (
+            await conn.execute(
+                text(
+                    "SELECT resolved_by FROM agent_quarantine_events "
+                    "WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+    assert a_row is None
+    assert b_row is not None
+    assert resolved_a == "expired"
+
+
+@pytest.mark.asyncio
+async def test_expiry_ignores_shadow_events(engine):
+    await _insert_agent(engine, "a")
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at) "
+                "VALUES ('a', :t0, 'shadow', :expired)"
+            ),
+            {
+                "t0": _iso(now - timedelta(days=1)),
+                "expired": _iso(now - timedelta(hours=1)),
+            },
+        )
+
+    stats = await run_expiry_once(engine, now=now)
+    assert stats.scanned == 0
+    assert stats.deleted == 0
+
+    # Agent row untouched.
+    async with engine.begin() as conn:
+        active = (
+            await conn.execute(
+                text(
+                    "SELECT is_active FROM internal_agents WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+    assert active == 1
+
+
+@pytest.mark.asyncio
+async def test_expiry_skips_already_resolved(engine):
+    await _insert_agent(engine, "a")
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at, "
+                " resolved_at, resolved_by) "
+                "VALUES ('a', :t0, 'enforce', :expired, :r, 'operator:abc')"
+            ),
+            {
+                "t0": _iso(now - timedelta(days=2)),
+                "expired": _iso(now - timedelta(hours=1)),
+                "r": _iso(now - timedelta(minutes=10)),
+            },
+        )
+
+    stats = await run_expiry_once(engine, now=now)
+    assert stats.scanned == 0
+    assert stats.deleted == 0
+
+
+# ── reactivate_agent ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reactivate_refuses_when_no_event(engine):
+    await _insert_agent(engine, "a")
+    result = await reactivate_agent(engine, "a", admin_secret="s")
+    assert result.ok is False
+    assert "no active quarantine event" in result.message
+
+
+@pytest.mark.asyncio
+async def test_reactivate_refuses_shadow_event(engine):
+    await _insert_agent(engine, "a")
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode) "
+                "VALUES ('a', :t, 'shadow')"
+            ),
+            {"t": _iso(now)},
+        )
+
+    result = await reactivate_agent(engine, "a", admin_secret="s")
+    assert result.ok is False
+    assert "shadow" in result.message
+
+
+@pytest.mark.asyncio
+async def test_reactivate_clears_enforce_event(engine):
+    await _insert_agent(engine, "a", active=0)
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at) "
+                "VALUES ('a', :t, 'enforce', :e)"
+            ),
+            {
+                "t": _iso(now - timedelta(hours=1)),
+                "e": _iso(now + timedelta(hours=23)),
+            },
+        )
+
+    result = await reactivate_agent(engine, "a", admin_secret="mysecret")
+    assert result.ok is True
+    assert result.resolved_event_id is not None
+
+    async with engine.begin() as conn:
+        row = (
+            await conn.execute(
+                text(
+                    "SELECT is_active FROM internal_agents WHERE agent_id = 'a'"
+                )
+            )
+        ).scalar()
+        event = (
+            await conn.execute(
+                text(
+                    "SELECT resolved_at, resolved_by FROM "
+                    "agent_quarantine_events WHERE agent_id = 'a'"
+                )
+            )
+        ).first()
+    assert row == 1
+    assert event[0] is not None  # resolved_at populated
+    assert event[1] == _operator_fingerprint("mysecret")
+
+
+@pytest.mark.asyncio
+async def test_reactivate_after_hard_delete_returns_not_ok(engine):
+    """If the expiry cron already deleted the agent row, reactivation
+    must fail with a clear message — not silently re-insert a ghost.
+    """
+    # No internal_agents row exists for 'a', but an event does.
+    now = datetime(2026, 4, 24, 12, 0, 0, tzinfo=timezone.utc)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode, expires_at) "
+                "VALUES ('ghost', :t, 'enforce', :e)"
+            ),
+            {
+                "t": _iso(now - timedelta(hours=1)),
+                "e": _iso(now + timedelta(hours=23)),
+            },
+        )
+
+    result = await reactivate_agent(engine, "ghost", admin_secret="s")
+    assert result.ok is False
+    assert "re-enrollment" in result.message
+
+
+def test_operator_fingerprint_is_deterministic_but_not_reversible():
+    f1 = _operator_fingerprint("secret-1")
+    f2 = _operator_fingerprint("secret-1")
+    f3 = _operator_fingerprint("secret-2")
+    assert f1 == f2
+    assert f1 != f3
+    # No part of the secret appears in the fingerprint.
+    assert "secret-1" not in f1
+    assert f1.startswith("operator:")

--- a/tests/test_mcp_proxy_traffic_recorder.py
+++ b/tests/test_mcp_proxy_traffic_recorder.py
@@ -1,0 +1,252 @@
+"""TrafficRecorder unit tests — ADR-013 Phase 4 commit 2.
+
+Covers the recording path + flush contract in isolation from the ASGI
+stack. Integration with auth deps + app.state wiring is exercised by
+the shadow-mode test (commit 8).
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+from mcp_proxy.db import dispose_db, init_db
+from mcp_proxy.observability.traffic_recorder import (
+    TrafficRecorder,
+    _bucket_ts_iso,
+)
+
+
+@pytest.fixture
+async def engine(tmp_path):
+    db_file = tmp_path / "recorder.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    eng: AsyncEngine = create_async_engine(url, future=True)
+    yield eng
+    await eng.dispose()
+    await dispose_db()
+
+
+def _now_replace(dt: datetime) -> str:
+    return _bucket_ts_iso(dt)
+
+
+def test_bucket_ts_aligns_on_10_min_boundaries():
+    for (src_minute, expected_minute) in [
+        (0, 0),
+        (9, 0),
+        (10, 10),
+        (11, 10),
+        (29, 20),
+        (59, 50),
+    ]:
+        dt = datetime(2026, 4, 24, 12, src_minute, 30, tzinfo=timezone.utc)
+        bucket = _bucket_ts_iso(dt)
+        assert f":{expected_minute:02d}:00Z" in bucket, (
+            f"expected minute {expected_minute} in bucket {bucket}"
+        )
+
+
+def test_bucket_ts_is_iso8601_with_z_suffix():
+    bucket = _bucket_ts_iso(
+        datetime(2026, 4, 24, 12, 34, 56, tzinfo=timezone.utc)
+    )
+    assert bucket == "2026-04-24T12:30:00Z"
+
+
+@pytest.mark.asyncio
+async def test_record_bumps_in_memory_counter(engine):
+    r = TrafficRecorder(engine)
+    r.record("agent-a")
+    r.record("agent-a")
+    r.record("agent-b")
+    assert r.agents_tracked() == 2
+    total = sum(
+        c for buckets in r._buckets.values() for c in buckets.values()
+    )
+    assert total == 3
+
+
+@pytest.mark.asyncio
+async def test_record_ignores_empty_agent_id(engine):
+    r = TrafficRecorder(engine)
+    r.record("")
+    r.record(None)  # type: ignore[arg-type]
+    assert r.agents_tracked() == 0
+
+
+@pytest.mark.asyncio
+async def test_flush_writes_rows_and_clears_buffer(engine):
+    r = TrafficRecorder(engine)
+    r.record("agent-a")
+    r.record("agent-a")
+    r.record("agent-b")
+
+    await r.flush_for_test()
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT agent_id, req_count FROM agent_traffic_samples "
+                    "ORDER BY agent_id"
+                )
+            )
+        ).all()
+    assert [(r[0], r[1]) for r in rows] == [("agent-a", 2), ("agent-b", 1)]
+
+    # Buffer is cleared.
+    assert r._buckets == {}
+    assert r.flush_count == 1
+    assert r.rows_written == 2
+
+
+@pytest.mark.asyncio
+async def test_flush_upserts_accumulate_on_same_bucket(engine):
+    r = TrafficRecorder(engine)
+    r.record("agent-a")
+    await r.flush_for_test()
+
+    # Second flush in the same 10-min bucket — UPSERT must sum.
+    r.record("agent-a")
+    r.record("agent-a")
+    await r.flush_for_test()
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT req_count FROM agent_traffic_samples "
+                    "WHERE agent_id = 'agent-a'"
+                )
+            )
+        ).all()
+    assert [r[0] for r in rows] == [3]
+
+
+@pytest.mark.asyncio
+async def test_flush_no_op_on_empty_buffer(engine):
+    r = TrafficRecorder(engine)
+    await r.flush_for_test()
+    # No crash, counters unchanged.
+    assert r.flush_count == 0
+    assert r.rows_written == 0
+
+
+@pytest.mark.asyncio
+async def test_start_stop_runs_background_flush(engine, monkeypatch):
+    # Shrink the interval to make the test fast.
+    r = TrafficRecorder(engine, flush_interval_s=0.05)
+    await r.start()
+    try:
+        r.record("agent-a")
+        # Wait long enough for at least one flush tick.
+        await asyncio.sleep(0.15)
+    finally:
+        await r.stop()
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text("SELECT req_count FROM agent_traffic_samples")
+            )
+        ).all()
+    # Exact count may be 1 depending on timing, but must be at least 1.
+    assert sum(r[0] for r in rows) >= 1
+
+
+@pytest.mark.asyncio
+async def test_stop_flushes_pending_before_exit(engine):
+    r = TrafficRecorder(engine, flush_interval_s=60.0)  # effectively never
+    await r.start()
+    r.record("agent-a")
+    r.record("agent-b")
+    # The background loop won't fire for 60s, but stop() must flush
+    # the pending buffer before returning.
+    await r.stop()
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT agent_id FROM agent_traffic_samples "
+                    "ORDER BY agent_id"
+                )
+            )
+        ).all()
+    assert [row[0] for row in rows] == ["agent-a", "agent-b"]
+
+
+@pytest.mark.asyncio
+async def test_flush_failure_does_not_kill_loop(engine, monkeypatch):
+    """If the DB write raises, the next flush still runs."""
+    r = TrafficRecorder(engine, flush_interval_s=60.0)
+
+    original = r._write_pending
+    call_count = {"n": 0}
+
+    async def failing_write(pending):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated DB outage")
+        await original(pending)
+
+    monkeypatch.setattr(r, "_write_pending", failing_write)
+
+    r.record("agent-a")
+    await r.flush_for_test()
+    assert r.flush_failures == 1
+    assert r.flush_count == 0
+
+    r.record("agent-a")
+    await r.flush_for_test()
+    assert r.flush_failures == 1
+    assert r.flush_count == 1
+
+    async with engine.begin() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT req_count FROM agent_traffic_samples "
+                    "WHERE agent_id = 'agent-a'"
+                )
+            )
+        ).all()
+    # Only the second attempt's record survived — first flush's data
+    # was dropped (acceptable per the statistical-loss design note).
+    assert [row[0] for row in rows] == [1]
+
+
+def test_record_agent_request_noops_when_app_state_missing():
+    """The helper must never raise even if app.state.traffic_recorder is
+    absent — auth paths must not fail because anomaly pipeline is down.
+    """
+    from mcp_proxy.observability.traffic_recorder import record_agent_request
+
+    class _Request:
+        class app:
+            class state:
+                pass
+
+    # Should be a clean no-op, no exception.
+    record_agent_request(_Request(), "agent-a")
+
+
+def test_record_agent_request_ignores_exceptions():
+    from mcp_proxy.observability.traffic_recorder import record_agent_request
+
+    class _ExplodingRecorder:
+        def record(self, agent_id):
+            raise RuntimeError("boom")
+
+    class _Request:
+        class app:
+            class state:
+                traffic_recorder = _ExplodingRecorder()
+
+    # Exception is swallowed — helper never propagates.
+    record_agent_request(_Request(), "agent-a")

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -33,6 +33,11 @@ EXPECTED_TABLES = {
     "cached_bindings",
     "federation_cursor",
     "mastio_keys",
+    "pending_updates",
+    "migration_state_backups",
+    "agent_traffic_samples",
+    "agent_hourly_baselines",
+    "agent_quarantine_events",
     "alembic_version",
 }
 
@@ -67,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0020_migration_state_backups",)]
+    assert rows == [("0021_anomaly_detector_tables",)]
 
 
 @pytest.mark.asyncio
@@ -127,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0020_migration_state_backups",)]
+    assert version == [("0021_anomaly_detector_tables",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0020_migration_state_backups"
+HEAD_REVISION = "0021_anomaly_detector_tables"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0020_migration_state_backups"
+HEAD_REVISION = "0021_anomaly_detector_tables"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0020_migration_state_backups"
+HEAD_REVISION = "0021_anomaly_detector_tables"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 

--- a/tests/test_proxy_migrations_adr013_phase4.py
+++ b/tests/test_proxy_migrations_adr013_phase4.py
@@ -1,0 +1,225 @@
+"""Migration 0021 coverage — ADR-013 Phase 4 anomaly detector tables.
+
+Covers:
+- Three new tables created with the correct columns + PKs + indexes.
+- CHECK constraints accept valid rows and reject invalid ones.
+- Alembic upgrade is idempotent (re-running on a schema that already
+  has the tables is a no-op, not an error).
+- Downgrade drops all three tables cleanly.
+"""
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from mcp_proxy.db import dispose_db, init_db
+
+
+def _tables(path: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+def _columns(path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+    finally:
+        conn.close()
+
+
+def _indexes(path: str, table: str) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {r[1] for r in conn.execute(f"PRAGMA index_list({table})")}
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_three_tables_with_expected_columns(tmp_path):
+    db_file = tmp_path / "phase4.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    path = str(db_file)
+    tables = _tables(path)
+    assert {
+        "agent_traffic_samples",
+        "agent_hourly_baselines",
+        "agent_quarantine_events",
+    }.issubset(tables)
+
+    assert _columns(path, "agent_traffic_samples") == {
+        "agent_id",
+        "bucket_ts",
+        "req_count",
+    }
+    assert _columns(path, "agent_hourly_baselines") == {
+        "agent_id",
+        "hour_of_week",
+        "req_per_min_avg",
+        "req_per_min_p95",
+        "sample_count",
+        "updated_at",
+    }
+    assert _columns(path, "agent_quarantine_events") == {
+        "id",
+        "agent_id",
+        "quarantined_at",
+        "mode",
+        "trigger_ratio",
+        "trigger_abs_rate",
+        "expires_at",
+        "resolved_at",
+        "resolved_by",
+        "notification_sent",
+    }
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_expected_indexes(tmp_path):
+    db_file = tmp_path / "indexes.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    path = str(db_file)
+    assert "idx_traffic_samples_bucket" in _indexes(path, "agent_traffic_samples")
+    assert "idx_quarantine_agent" in _indexes(path, "agent_quarantine_events")
+
+
+@pytest.mark.asyncio
+async def test_quarantine_events_mode_check_rejects_invalid(tmp_path):
+    db_file = tmp_path / "check.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        # Valid modes succeed.
+        conn.execute(
+            "INSERT INTO agent_quarantine_events "
+            "(agent_id, quarantined_at, mode) VALUES (?, ?, ?)",
+            ("a1", "2026-04-24T00:00:00Z", "shadow"),
+        )
+        conn.execute(
+            "INSERT INTO agent_quarantine_events "
+            "(agent_id, quarantined_at, mode) VALUES (?, ?, ?)",
+            ("a2", "2026-04-24T00:00:00Z", "enforce"),
+        )
+        conn.commit()
+
+        # Invalid mode rejected.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO agent_quarantine_events "
+                "(agent_id, quarantined_at, mode) VALUES (?, ?, ?)",
+                ("a3", "2026-04-24T00:00:00Z", "bogus"),
+            )
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_hourly_baselines_hour_range_check(tmp_path):
+    db_file = tmp_path / "hour.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        # Boundaries accepted.
+        for h in (0, 167):
+            conn.execute(
+                "INSERT INTO agent_hourly_baselines "
+                "(agent_id, hour_of_week, req_per_min_avg, "
+                "req_per_min_p95, sample_count, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (f"h{h}", h, 1.0, 2.0, 10, "2026-04-24T00:00:00Z"),
+            )
+        conn.commit()
+
+        # Out-of-range rejected.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO agent_hourly_baselines "
+                "(agent_id, hour_of_week, req_per_min_avg, "
+                "req_per_min_p95, sample_count, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                ("bad", 168, 1.0, 2.0, 10, "2026-04-24T00:00:00Z"),
+            )
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_traffic_samples_composite_pk(tmp_path):
+    db_file = tmp_path / "pk.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+
+    conn = sqlite3.connect(str(db_file))
+    try:
+        conn.execute(
+            "INSERT INTO agent_traffic_samples "
+            "(agent_id, bucket_ts, req_count) VALUES (?, ?, ?)",
+            ("a", "2026-04-24T00:00:00Z", 1),
+        )
+        # Same (agent_id, bucket_ts) — duplicate PK.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO agent_traffic_samples "
+                "(agent_id, bucket_ts, req_count) VALUES (?, ?, ?)",
+                ("a", "2026-04-24T00:00:00Z", 5),
+            )
+        # Same agent, different bucket — fine.
+        conn.execute(
+            "INSERT INTO agent_traffic_samples "
+            "(agent_id, bucket_ts, req_count) VALUES (?, ?, ?)",
+            ("a", "2026-04-24T00:10:00Z", 3),
+        )
+        conn.commit()
+
+        rows = conn.execute(
+            "SELECT bucket_ts, req_count FROM agent_traffic_samples "
+            "WHERE agent_id = 'a' ORDER BY bucket_ts"
+        ).fetchall()
+        assert rows == [
+            ("2026-04-24T00:00:00Z", 1),
+            ("2026-04-24T00:10:00Z", 3),
+        ]
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_migration_idempotent_on_existing_schema(tmp_path):
+    """Running init_db twice must not error — upgrade skips existing tables."""
+    db_file = tmp_path / "idem.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    await init_db(url)
+    await dispose_db()
+    # Second call reuses the head revision; the upgrade path's
+    # existing-table guard keeps this from raising.
+    await init_db(url)
+    await dispose_db()
+
+    assert {
+        "agent_traffic_samples",
+        "agent_hourly_baselines",
+        "agent_quarantine_events",
+    }.issubset(_tables(str(db_file)))


### PR DESCRIPTION
## Summary

Closes ADR-013 Phase 4 (single-agent anomaly detection + auto-quarantine).
Phases 1/2/3/6 cap **aggregate** damage; Phase 4 catches the gap they
cannot close — a single compromised credential operating at 10× its
own baseline while staying well under the global limits.

9 commits, shadow-mode default on every deployment (safeguard §3.1),
full lifespan wiring, operator runbook, 85 new tests.

Design contract: [`imp/adr_013_phase4_design.md`](imp/adr_013_phase4_design.md).

## What lands

| Commit | Delivers |
|--------|----------|
| 1/9 | Alembic 0021 + three tables (`agent_traffic_samples`, `agent_hourly_baselines`, `agent_quarantine_events`). |
| 2/9 | `TrafficRecorder` — per-agent in-memory counter, 30 s UPSERT flush, called from both auth deps. |
| 3/9 | Daily 04:00 UTC baseline roll-up into 168 hour-of-week buckets, 7-day maturity gate. |
| 4/9 | `AnomalyEvaluator` — dual-signal (ratio + abs-soft) with absolute backstop, 90 s hysteresis, cycle-level fail-closed meta-circuit-breaker. |
| 5/9 | Quarantine apply hook (shadow logs / enforce flips `is_active`), hourly hard-delete expiry, `POST /v1/admin/agents/{id}/reactivate`. |
| 6/9 | `GET /v1/admin/observability/anomaly-detector` + 10 config fields. |
| 7/9 | Lifespan wiring with clean shutdown (reverse dependency order, delattr for re-entry). |
| 8/9 | End-to-end integration tests (shadow, enforce, ceiling trip, observability snapshot). |
| 9/9 | Runbook section §8a in `docs/ops-runbook.md` + production-checklist entries. |

## Four non-negotiable safeguards (all implemented)

- **§3.1 Shadow default** — `anomaly_quarantine_mode=shadow` by default, never auto-flips.
- **§3.2 No auto-re-enable; hard-delete on expiry** — `internal_agents` row is DELETEd at 24 h, re-enrollment required. Reactivation endpoint refuses if the row is gone.
- **§3.3 Human notification on every quarantine** — structured WARNING log + optional `notification_dispatch` callable for webhook wiring.
- **§3.4 Cycle-level fail-closed meta-breaker** — if `projected ceiling consumption + new candidates > CEILING`, ZERO quarantines apply + one aggregate alert. Never "first-N-succeed".

## Test plan

- [ ] `pytest tests/ -q` green (modulo pre-existing env-dependent failures: TS interop, Connector webview, Postgres).
- [ ] Migration tests updated head revision → `0021_anomaly_detector_tables`.
- [ ] Verify end-to-end in nightly: shadow events should appear on stderr and in `agent_quarantine_events` during normal workload with threshold lowered for demo.

## Follow-ups (not blocking)

- Webhook notification dispatch (currently stderr-only).
- 28-day shadow runtime enforcement check on mode flip (runbook note only in Phase 4).
- Per-agent threshold override (`agent_overrides`) → Phase 4.1.
- Cross-agent coordination detection → Phase 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)