### PR TITLE
chore(connector): bump to 0.3.1 + version-match guard + PyPI gate

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -70,6 +70,26 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "Releasing version: ${version}"
 
+      - name: Verify pyproject + __init__ versions match tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#connector-v}"
+          pyproject_version=$(grep -E '^version = ' packaging/pypi/pyproject.toml | head -1 | cut -d'"' -f2)
+          init_version=$(grep -E '^__version__' cullis_connector/__init__.py | head -1 | cut -d'"' -f2)
+          fail=0
+          if [ "$tag_version" != "$pyproject_version" ]; then
+            echo "ERROR: tag version ($tag_version) != packaging/pypi/pyproject.toml version ($pyproject_version)"
+            fail=1
+          fi
+          if [ "$tag_version" != "$init_version" ]; then
+            echo "ERROR: tag version ($tag_version) != cullis_connector/__init__.py __version__ ($init_version)"
+            fail=1
+          fi
+          if [ "$fail" = "1" ]; then
+            echo "Bump both files to match the tag before pushing the tag."
+            exit 1
+          fi
+          echo "OK: versions aligned at $tag_version"
+
       - name: Install build tool
         run: python -m pip install --upgrade pip build
 
@@ -252,7 +272,7 @@ jobs:
     name: Publish to PyPI
     needs: build-python
     runs-on: ubuntu-latest
-    if: ${{ false }}  # TODO: flip to `${{ secrets.PYPI_TOKEN != '' }}` once provisioned
+    if: ${{ secrets.PYPI_TOKEN != '' }}
     environment:
       name: pypi
       url: https://pypi.org/p/cullis-connector

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.3.1"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.1.0"
+version = "0.3.1"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump `packaging/pypi/pyproject.toml` and `cullis_connector/__init__.py` from `0.1.0` to `0.3.1`. The wheel published on the existing `connector-v0.3.0` release was a propagation bug: `pyproject.toml` was hard-coded to `0.1.0` and the build script never substituted the tag version. Rather than force-pushing the existing tag, we skip to `0.3.1` so the next published version is coherent end-to-end with no rewriting of public refs.
- Add a guard to `release-connector.yml` that fails the build if the tag version doesn't match the pyproject + `__init__` versions, so this bug cannot recur silently.
- Flip the `publish-pypi` job from `if: ${{ false }}` to `if: \${{ secrets.PYPI_TOKEN != '' }}` so the next tag push publishes to PyPI (PYPI_TOKEN already provisioned in repo secrets).

## Why

Pre-flight for distribution rollout (PyPI + GHCR + Homebrew tap). Before publishing to PyPI, the wheel version, tag, and `cullis-connector --version` output have to be coherent. Currently they diverged.

## Plan after merge

1. Tag `connector-v0.3.1` on the merge commit.
2. Workflow runs end-to-end: builds, GitHub Release, GHCR push, PyPI publish.
3. `pip install cullis-connector` becomes available with version `0.3.1`.

## Test plan

- [x] Local wheel build with `bash packaging/pypi/build.sh` produces `cullis_connector-0.3.1-py3-none-any.whl`
- [x] Smoke test in fresh venv: `pip install <wheel> && cullis-connector --version` prints `cullis-connector 0.3.1`
- [ ] CI green on this PR
- [ ] After merge + tag `connector-v0.3.1`: workflow's version-match guard passes, `publish-pypi` runs, package appears on PyPI