### PR TITLE
chore(connector): add workflow_dispatch trigger to release-connector

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -18,6 +18,10 @@ on:
   push:
     tags:
       - "connector-v*"
+  # Manual retrigger escape hatch: `gh workflow run release-connector.yml --ref connector-vX.Y.Z`.
+  # Useful when GHA dedupes a tag-push trigger (we hit this on connector-v0.3.1)
+  # or when re-running a release on the same SHA without a force-push.
+  workflow_dispatch:
 
 # Minimal default permissions; individual jobs grant what they need.
 permissions:


### PR DESCRIPTION
## Summary

Adds a manual escape hatch (\`gh workflow run release-connector.yml --ref connector-vX.Y.Z\`) for cases where:

- GHA dedupes a tag-push trigger and the release does not run (we hit this on \`connector-v0.3.1\`: the tag points to the same SHA as the merge commit on main, and GHA registered phantom validation runs on main but skipped the actual tag-push run).
- An ops engineer needs to re-run the release on the same SHA without force-pushing the tag.

The push-tag trigger is unchanged.

## Test plan

- [ ] CI green
- [ ] After merge: move \`connector-v0.3.1\` to new HEAD, then \`gh workflow run release-connector.yml --ref connector-v0.3.1\` actually runs the release pipeline (currently a no-op).