### PR TITLE
chore(connector): move PyPI gate from job-level to step-level

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -270,26 +270,34 @@ jobs:
 
   # ── 6. PyPI upload (opt-in via PYPI_TOKEN secret) ────────────────────
   #
-  # TODO: once PYPI_TOKEN is provisioned in repository secrets, remove
-  # the `if:` guard below. Until then this job is a no-op on releases.
+  # Step-level `if:` on `secrets.PYPI_TOKEN` instead of job-level: when
+  # the workflow is invoked via `workflow_dispatch`, GitHub refuses to
+  # parse a job-level `if:` that references the `secrets` context
+  # ("Unrecognized named-value: 'secrets'"). Step-level `if:` works in
+  # both push-tag and workflow_dispatch invocations.
   publish-pypi:
     name: Publish to PyPI
     needs: build-python
     runs-on: ubuntu-latest
-    if: ${{ secrets.PYPI_TOKEN != '' }}
     environment:
       name: pypi
       url: https://pypi.org/p/cullis-connector
     permissions:
       id-token: write  # for PyPI trusted publishing once configured
     steps:
+      - name: Skip notice when PYPI_TOKEN unset
+        if: ${{ secrets.PYPI_TOKEN == '' }}
+        run: echo "PYPI_TOKEN secret is not configured — skipping PyPI publish."
+
       - name: Download wheel + sdist
+        if: ${{ secrets.PYPI_TOKEN != '' }}
         uses: actions/download-artifact@v4
         with:
           name: python-dist
           path: dist
 
       - name: Publish to PyPI
+        if: ${{ secrets.PYPI_TOKEN != '' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
## Summary

GHA refuses to parse a job-level \`if:\` that references the \`secrets\` context when the workflow is invoked via \`workflow_dispatch\`:

\`\`\`
HTTP 422: failed to parse workflow:
(Line: 279, Col: 9): Unrecognized named-value: 'secrets'.
\`\`\`

Step-level \`if:\` on the same expression works for both tag-push and \`workflow_dispatch\` invocations. This is the documented workaround.

## Why now

We need to retrigger the \`connector-v0.3.1\` release without force-pushing the tag again. The first attempt failed because of this parser limitation.

## Test plan

- [ ] CI green
- [ ] After merge: \`gh workflow run release-connector.yml --ref connector-v0.3.1\` actually starts the release pipeline