### PR TITLE
fix(site): align connector download/install pages with real release assets

### DIFF
--- a/site/src/content/docs/install/connector.md
+++ b/site/src/content/docs/install/connector.md
@@ -23,29 +23,24 @@ Pick one of three install channels. All produce the same `cullis-connector` bina
 
 ### A. Desktop installer (zip from GitHub Releases)
 
-The official release bundles a single executable per platform — no Python install, no network libraries to match.
-
-```bash
-# Find the latest release URL (always points to connector-v0.3.0 or newer)
-open https://github.com/cullis-security/cullis/releases/tag/connector-v0.3.0
-```
-
-Unpack the zip for your platform:
+The official release bundles a single executable per platform — no Python install, no network libraries to match. The links below always resolve to the latest release.
 
 | Platform | File | Unpack |
 |---|---|---|
-| macOS (Apple Silicon) | `cullis-connector-macos-arm64.zip` | `unzip cullis-connector-macos-arm64.zip && chmod +x cullis-connector` |
-| macOS (Intel) | `cullis-connector-macos-amd64.zip` | `unzip cullis-connector-macos-amd64.zip && chmod +x cullis-connector` |
-| Linux amd64 | `cullis-connector-linux-amd64.zip` | `unzip cullis-connector-linux-amd64.zip && chmod +x cullis-connector` |
-| Windows | `cullis-connector-windows-amd64.zip` | Right-click → Extract All, then place `cullis-connector.exe` on your `PATH` |
+| macOS (Apple Silicon) | [`cullis-connector-macos.zip`](https://github.com/cullis-security/cullis/releases/latest/download/cullis-connector-macos.zip) | `unzip cullis-connector-macos.zip && chmod +x cullis-connector-macos-arm64` |
+| Linux x86_64 | [`cullis-connector-linux.zip`](https://github.com/cullis-security/cullis/releases/latest/download/cullis-connector-linux.zip) | `unzip cullis-connector-linux.zip && chmod +x cullis-connector-linux-x86_64` |
+| Windows x86_64 | [`cullis-connector-windows.zip`](https://github.com/cullis-security/cullis/releases/latest/download/cullis-connector-windows.zip) | Right-click → Extract All. Then place `cullis-connector-windows-x86_64.exe` on your `PATH`. |
 
-Move the binary somewhere on your `PATH`:
+Each zip ships the platform-specific binary plus an `install.sh` / `install.command` / `install.bat` helper that puts the binary on `PATH` for you. If you prefer to do it by hand:
 
 ```bash
-sudo mv cullis-connector /usr/local/bin/
+# Linux example — adjust filename for your platform
+sudo mv cullis-connector-linux-x86_64 /usr/local/bin/cullis-connector
 cullis-connector --version
-# cullis-connector 0.3.0
+# cullis-connector 0.3.1
 ```
+
+> macOS Intel and Linux on ARM are not currently published as standalone binaries. Use **option B (`pip install`)** on those platforms.
 
 ### B. `pip install` (Python 3.10+)
 
@@ -60,12 +55,9 @@ Useful if you want the `[dashboard,desktop]` extras for the native OS webview:
 pip install 'cullis-connector[dashboard,desktop]'
 ```
 
-### C. Homebrew (macOS, Linux)
+### C. Homebrew (macOS, Linux) — *coming soon*
 
-```bash
-brew tap cullis-security/tap
-brew install cullis-connector
-```
+A `cullis-security/homebrew-tap` is on the roadmap but not yet published. In the meantime use option **A** (zip) or **B** (`pip install`) on macOS — both produce the same `cullis-connector` binary.
 
 ## 2. First enrollment
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -44,8 +44,8 @@ const platforms = [
         </aside>
         <div>
           <div class="eyebrow reveal" data-delay="1">
-            <span class="eyebrow-number">Latest</span>
-            <code class="v-badge">{RELEASE}</code>
+            <span class="eyebrow-number">Latest release</span>
+            <a class="v-badge" href="https://github.com/cullis-security/cullis/releases/latest">view on GitHub →</a>
           </div>
           <h1 class="reveal" data-delay="2">
             Get the <em>Connector</em>.

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -1,8 +1,11 @@
 ---
 import Layout from '../layouts/Layout.astro';
 
-const RELEASE = 'connector-v0.2.0-rc5';
-const BASE = `https://github.com/cullis-security/cullis/releases/download/${RELEASE}`;
+// `releases/latest/download/<file>` is GitHub's stable redirect: it always
+// resolves to the latest published (non-prerelease) Connector release. No
+// need to bump this on every tag — push a new release and the site picks
+// it up automatically.
+const BASE = 'https://github.com/cullis-security/cullis/releases/latest/download';
 
 const platforms = [
   {


### PR DESCRIPTION
## Summary

Three classes of bug on cullis.io/download and the install/connector docs page:

1. **download.astro hard-coded \`connector-v0.2.0-rc5\`** as the release tag, so every download button pointed at the release candidate from 9 days ago instead of the latest release. Switched to \`releases/latest/download/<file>\` so the site auto-tracks every future release without a manual bump.

2. **install/connector.md referenced filenames that do not exist**: \`cullis-connector-macos-arm64.zip\`, \`-macos-amd64.zip\`, \`-linux-amd64.zip\`, \`-windows-amd64.zip\`. The actual zip assets are named \`cullis-connector-{linux,macos,windows}.zip\`. Replaced the table with the real filenames and direct \`releases/latest/download/...\` links. Added a note that macOS Intel and Linux ARM aren't built as standalone binaries — those platforms should use \`pip install\`.

3. **install/connector.md promised \`brew tap cullis-security/tap\`** which 404s (the tap doesn't exist). Marked option C as "coming soon" and pointed users to A or B, matching the language already on the download page.

Also bumped the example output from \`0.3.0\` to \`0.3.1\`.

## Why

Discovered during the 0.3.1 publish session: the README \`pip install\` path is now real, but the **site** was still pointing at non-existent assets and a 9-day-old rc5. Anyone landing on cullis.io/download would download the wrong binary or hit a 404 on a missing zip.

## Test plan

- [ ] CI green
- [ ] After deploy: cullis.io/download links resolve to assets on the \`connector-v0.3.1\` release
- [ ] After deploy: install/connector docs table filenames match actual GitHub Release assets