### PR TITLE
feat(sdk): standalone PyPI packaging + release-sdk workflow

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,0 +1,234 @@
+# Release pipeline for `cullis-sdk`.
+#
+# Triggered by pushing a tag of the form `sdk-vX.Y.Z`. On tag push:
+#
+#   1. Run the SDK test subset to gate the release.
+#   2. Build a standalone PyPI wheel + sdist from packaging/pypi-sdk/.
+#   3. Create a GitHub Release and attach wheel + sdist.
+#   4. Publish to PyPI.
+#
+# This workflow is intentionally isolated from the main CI pipeline: it
+# must not run on PRs or pushes to main. Only tag pushes (or a manual
+# workflow_dispatch on a tag ref) trigger it.
+
+name: release-sdk
+
+on:
+  push:
+    tags:
+      - "sdk-v*"
+  # Manual retrigger escape hatch:
+  #   gh workflow run release-sdk.yml --ref sdk-vX.Y.Z
+  # Useful when GHA dedupes a tag-push trigger or when re-running a
+  # release on the same SHA without force-pushing the tag. (We learned
+  # this the hard way on connector-v0.3.1 — see release-connector.yml.)
+  workflow_dispatch:
+
+# Minimal default permissions; individual jobs grant what they need.
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Tests ─────────────────────────────────────────────────────────
+  test:
+    name: Test SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run SDK tests
+        env:
+          OTEL_ENABLED: "false"
+          DATABASE_URL: "sqlite+aiosqlite://"
+        run: |
+          pytest \
+            tests/test_sdk_dpop.py \
+            tests/test_sdk_decrypt_oneshot_fetcher.py \
+            tests/test_sdk_enrollment_unified.py \
+            tests/test_sdk_from_connector.py \
+            tests/test_sdk_login_via_proxy_with_local_key.py \
+            tests/test_sdk_send_via_proxy.py \
+            tests/test_sdk_spiffe.py \
+            tests/test_sdk_tls_hardening.py \
+            --tb=short
+
+  # ── 2. Build wheel + sdist (standalone PyPI distribution) ───────────
+  build-python:
+    name: Build Python distributions
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Extract version from tag
+        id: extract-version
+        run: |
+          # sdk-v1.2.3 → 1.2.3
+          version="${GITHUB_REF_NAME#sdk-v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing version: ${version}"
+
+      - name: Verify pyproject + __init__ versions match tag
+        run: |
+          tag_version="${GITHUB_REF_NAME#sdk-v}"
+          pyproject_version=$(grep -E '^version = ' packaging/pypi-sdk/pyproject.toml | head -1 | cut -d'"' -f2)
+          init_version=$(grep -E '^__version__' cullis_sdk/__init__.py | head -1 | cut -d'"' -f2)
+          fail=0
+          if [ "$tag_version" != "$pyproject_version" ]; then
+            echo "ERROR: tag version ($tag_version) != packaging/pypi-sdk/pyproject.toml version ($pyproject_version)"
+            fail=1
+          fi
+          if [ "$tag_version" != "$init_version" ]; then
+            echo "ERROR: tag version ($tag_version) != cullis_sdk/__init__.py __version__ ($init_version)"
+            fail=1
+          fi
+          if [ "$fail" = "1" ]; then
+            echo "Bump both files to match the tag before pushing the tag."
+            exit 1
+          fi
+          echo "OK: versions aligned at $tag_version"
+
+      - name: Install build tool
+        run: python -m pip install --upgrade pip build
+
+      - name: Build wheel + sdist
+        # Uses the staging helper so README_PKG.md, LICENSE, NOTICE, and
+        # the SDK source tree are copied into packaging/pypi-sdk/ before
+        # hatchling runs — the raw `python -m build packaging/pypi-sdk/`
+        # invocation skips staging and fails on the missing README_PKG.md.
+        run: bash packaging/pypi-sdk/build.sh
+
+      - name: Smoke test wheel
+        # Yesterday's connector smoke `cullis-connector --version` passed
+        # on a wheel that ImportError'd at runtime because cullis_sdk
+        # wasn't actually installable from PyPI. Lesson: a smoke test
+        # has to exercise an import path that pulls in every declared
+        # dep, not just the entry point. So here we import cullis_sdk
+        # at top level — that triggers cullis_sdk/__init__.py which
+        # imports client (httpx, websockets), dpop (PyJWT), types,
+        # cryptography. If any required dep is missing from
+        # pyproject.toml, this fails loudly before publish.
+        #
+        # The `cd /tmp` matters: when `python -c` runs from the repo
+        # checkout, sys.path[0] is the repo root, which contains
+        # cullis_sdk/ — so the import would resolve to the source tree
+        # and the smoke would pass even if the wheel was empty. cd-ing
+        # into a directory without cullis_sdk/ forces resolution from
+        # site-packages.
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install dist/cullis_sdk-*.whl
+          cd /tmp
+          /tmp/smoke/bin/python -c "import cullis_sdk; print('cullis-sdk', cullis_sdk.__version__); assert '/site-packages/' in cullis_sdk.__file__, cullis_sdk.__file__"
+          /tmp/smoke/bin/python -c "from cullis_sdk import CullisClient, DpopKey, AgentInfo, SessionInfo, InboxMessage, RfqResult, RfqQuote; print('public API imports OK')"
+          /tmp/smoke/bin/python -c "from cullis_sdk.dpop import DpopKey; k = DpopKey.generate(); print('dpop thumbprint:', k.thumbprint()[:16], '...')"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+          retention-days: 7
+
+  # ── 3. GitHub Release ────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: build-python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download wheel + sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          version="${{ needs.build-python.outputs.version }}"
+          if [[ -f CHANGELOG.md ]]; then
+            awk "/^## \\[?v?${version}\\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
+              > release-notes.md || true
+          fi
+          if [[ ! -s release-notes.md ]]; then
+            cat > release-notes.md <<NOTES
+          Release ${GITHUB_REF_NAME}
+
+          \`\`\`bash
+          pip install cullis-sdk==${version}
+          \`\`\`
+
+          With the optional SPIFFE workload-API integration:
+
+          \`\`\`bash
+          pip install 'cullis-sdk[spiffe]==${version}'
+          \`\`\`
+
+          Wheel and sdist are also attached to this release for
+          air-gapped installs.
+          NOTES
+          fi
+          cat release-notes.md
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Cullis SDK ${{ github.ref_name }}"
+          body_path: release-notes.md
+          files: |
+            dist/cullis_sdk-*.whl
+            dist/cullis_sdk-*.tar.gz
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
+
+  # ── 4. Publish to PyPI ───────────────────────────────────────────────
+  # No `if:` on `secrets.PYPI_TOKEN`: the `secrets` context cannot be
+  # referenced in any `if:` expression when the workflow is invoked via
+  # `workflow_dispatch` (parser error: "Unrecognized named-value:
+  # 'secrets'"). The token is consumed via `with: password:
+  # ${{ secrets.PYPI_TOKEN }}` below — that form is always valid. If
+  # the secret is unset, the publish action fails with a clear error;
+  # provision PYPI_TOKEN as a repo secret to enable publishing.
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build-python
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cullis-sdk
+    permissions:
+      id-token: write  # for PyPI trusted publishing once configured
+    steps:
+      - name: Download wheel + sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+          # Switch to trusted publishing (OIDC) once the PyPI project
+          # is configured; then `password` can be dropped.

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,14 @@ packaging/pypi/LICENSE-APACHE-2.0
 packaging/pypi/NOTICE
 packaging/pypi/CHANGELOG.md
 
+# Same staging pattern for the standalone `cullis-sdk` PyPI build.
+packaging/pypi-sdk/cullis_sdk/
+packaging/pypi-sdk/README_PKG.md
+packaging/pypi-sdk/LICENSE
+packaging/pypi-sdk/LICENSE-APACHE-2.0
+packaging/pypi-sdk/NOTICE
+packaging/pypi-sdk/CHANGELOG.md
+
 # Python build outputs
 dist/
 build/

--- a/cullis_sdk/README.md
+++ b/cullis_sdk/README.md
@@ -1,0 +1,104 @@
+# `cullis-sdk`
+
+**Python SDK for the Cullis federated agent-trust network.**
+
+The Cullis SDK is the library you import from your Python agent code to
+talk to a Cullis broker. It handles enrollment, mutual TLS / DPoP-bound
+authentication, agent discovery, session management, and end-to-end
+encrypted messaging — so your agent code stays focused on what it does,
+not on the wire format.
+
+The SDK is one of three Python distributions in the Cullis monorepo:
+
+| Distribution      | Purpose                                                          |
+|-------------------|------------------------------------------------------------------|
+| `cullis-sdk`      | Library you `import cullis_sdk` from your agent code (this one). |
+| `cullis-connector`| End-user MCP server bridging Claude Code / Cursor / etc.         |
+| `mcp-proxy`       | Org-level gateway (deployed as a container, not pip-installed).  |
+
+---
+
+## Install
+
+```bash
+pip install cullis-sdk
+```
+
+Python 3.10+ required.
+
+For [SPIFFE](https://spiffe.io/) workload-API integration (enroll an
+agent using its SPIRE-issued SVID), install the optional extra:
+
+```bash
+pip install 'cullis-sdk[spiffe]'
+```
+
+---
+
+## Quick start
+
+```python
+from cullis_sdk import CullisClient
+
+with CullisClient("https://broker.example.com") as client:
+    client.login(
+        agent_id="myorg::reporter",
+        org_id="myorg",
+        cert_path="reporter.crt",
+        key_path="reporter.key",
+    )
+
+    agents = client.discover(capabilities=["order.write"])
+    target = agents[0]
+
+    session = client.open_session(
+        target.agent_id, target.org_id, ["order.write"],
+    )
+    client.send(
+        session_id=session,
+        from_agent="myorg::reporter",
+        payload={"text": "Place order #42"},
+        to_agent=target.agent_id,
+    )
+```
+
+The SDK does the heavy lifting: x509 mutual TLS to the broker,
+DPoP-bound bearer tokens for replay protection, ECDH key agreement
+for end-to-end encryption to the recipient agent, and (on receive)
+hash-chain verification of the per-org audit log.
+
+---
+
+## Architecture
+
+```
+       ┌──────────┐  mTLS + DPoP   ┌──────────┐  mTLS + DPoP  ┌──────────┐
+       │ Agent A  │───────────────▶│  Broker  │◀──────────────│ Agent B  │
+       │ (cullis- │                │ (Cullis  │               │ (cullis- │
+       │   sdk)   │                │  Site)   │               │   sdk)   │
+       └──────────┘                └──────────┘               └──────────┘
+            │                                                       ▲
+            └─── E2E-encrypted payload (ECDH, broker can't read) ───┘
+```
+
+The broker authenticates both endpoints, routes messages, and
+appends a tamper-evident hash-chain entry per send. It never sees
+the cleartext payload.
+
+---
+
+## Documentation
+
+- Repository: https://github.com/cullis-security/cullis
+- Site: https://cullis.io
+- Issues: https://github.com/cullis-security/cullis/issues
+- Quickstart: https://cullis.io/docs/quickstart/getting-started/
+
+---
+
+## License
+
+Functional Source License 1.1 with Apache-2.0 future grant
+([`LICENSE`](https://github.com/cullis-security/cullis/blob/main/LICENSE)).
+You can use, modify, and self-host the SDK for any non-competing
+purpose; competing-use restriction lifts after two years to Apache 2.0.

--- a/packaging/pypi-sdk/.gitignore
+++ b/packaging/pypi-sdk/.gitignore
@@ -1,0 +1,13 @@
+# These staged files are copied in at build time by `build.sh` and are
+# not tracked in git — the monorepo root is their source of truth.
+#
+# IMPORTANT: We deliberately do NOT list `cullis_sdk/` here even
+# though it is copied in fresh on every build. Hatchling respects
+# `.gitignore` when selecting sdist/wheel contents, so ignoring the
+# package directory here would result in an empty wheel.
+
+README_PKG.md
+LICENSE
+LICENSE-APACHE-2.0
+NOTICE
+CHANGELOG.md

--- a/packaging/pypi-sdk/build.sh
+++ b/packaging/pypi-sdk/build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Build the standalone `cullis-sdk` wheel + sdist.
+#
+# Hatchling's sdist builder refuses include paths that escape the
+# pyproject directory (for good reasons — tar archives with `..` are
+# a minor footgun). So instead of playing tricks with `force-include`
+# and symlinks we stage the sources into `packaging/pypi-sdk/` first,
+# then invoke `python -m build` against the staged tree.
+#
+# Idempotent: safe to re-run. The staged copies are gitignored by the
+# repo-root `.gitignore` so they never leak into commits.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd)"
+STAGE_DIR="${SCRIPT_DIR}"
+OUT_DIR="${REPO_ROOT}/dist"
+
+echo "==> Staging sources into ${STAGE_DIR}"
+
+# Fresh copy of the SDK package every time — avoids stale files.
+rm -rf "${STAGE_DIR}/cullis_sdk"
+cp -a "${REPO_ROOT}/cullis_sdk" "${STAGE_DIR}/cullis_sdk"
+
+# Drop any __pycache__ directories the dev environment may have left
+# in the source tree before they leak into the sdist.
+find "${STAGE_DIR}/cullis_sdk" -type d -name __pycache__ -exec rm -rf {} +
+
+# Package readme for PyPI (lives next to pyproject.toml).
+cp -f "${REPO_ROOT}/cullis_sdk/README.md" "${STAGE_DIR}/README_PKG.md"
+
+# License + notices, required by FSL-1.1-Apache-2.0 distribution terms.
+# The SDK's per-file LICENSE in cullis_sdk/LICENSE already covers
+# the package itself; we additionally ship the repo-root copies so the
+# wheel is self-contained for distributors who only ever see the
+# installed package.
+cp -f "${REPO_ROOT}/LICENSE"            "${STAGE_DIR}/LICENSE"
+cp -f "${REPO_ROOT}/LICENSE-APACHE-2.0" "${STAGE_DIR}/LICENSE-APACHE-2.0"
+cp -f "${REPO_ROOT}/NOTICE"             "${STAGE_DIR}/NOTICE"
+cp -f "${REPO_ROOT}/CHANGELOG.md"       "${STAGE_DIR}/CHANGELOG.md"
+
+mkdir -p "${OUT_DIR}"
+
+echo "==> Building wheel + sdist into ${OUT_DIR}"
+( cd "${STAGE_DIR}" && python -m build --outdir "${OUT_DIR}" )
+
+echo "==> Artefacts:"
+ls -lah "${OUT_DIR}"/cullis_sdk-* 2>/dev/null || true

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -1,0 +1,108 @@
+# Standalone PyPI packaging for `cullis-sdk`.
+#
+# DO NOT invoke `python -m build` directly against this directory —
+# this pyproject expects a staged source tree next to it, created by
+# the build helper at `packaging/pypi-sdk/build.sh`. The helper copies
+# the monorepo `cullis_sdk/` package and the root license files into
+# this directory so hatchling can build a self-contained wheel and
+# sdist without cross-directory `..` include paths (which sdist
+# rejects by design).
+#
+# Run:
+#     ./packaging/pypi-sdk/build.sh       # stages + builds wheel+sdist
+#
+# The release workflow in `.github/workflows/release-sdk.yml` invokes
+# the same helper.
+
+[build-system]
+requires = ["hatchling>=1.24"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cullis-sdk"
+version = "0.1.0"
+description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
+readme = "README_PKG.md"
+requires-python = ">=3.10"
+license = { text = "FSL-1.1-Apache-2.0" }
+authors = [
+    { name = "Cullis Security", email = "hello@cullis.io" },
+]
+keywords = [
+    "cullis",
+    "agent",
+    "agent-trust",
+    "identity",
+    "spiffe",
+    "dpop",
+    "federation",
+    "mcp",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: System :: Networking",
+    "License :: Other/Proprietary License",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "httpx>=0.24.0",
+    "cryptography>=41.0.0",
+    "PyJWT[crypto]>=2.8.0",
+    "websockets>=12.0",
+    "mcp>=1.0",
+]
+
+[project.optional-dependencies]
+spiffe = [
+    "spiffe>=0.2.0",
+]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.4",
+    "build>=1.0",
+]
+
+[project.urls]
+Homepage = "https://cullis.io"
+Documentation = "https://github.com/cullis-security/cullis/tree/main/cullis_sdk"
+Repository = "https://github.com/cullis-security/cullis"
+Issues = "https://github.com/cullis-security/cullis/issues"
+Changelog = "https://github.com/cullis-security/cullis/blob/main/CHANGELOG.md"
+
+# Hatchling defaults to consulting VCS (.gitignore) when selecting files.
+# That breaks us: `packaging/pypi-sdk/cullis_sdk/` is intentionally
+# gitignored at the monorepo root (it's staged at build time), so VCS
+# mode would produce an empty wheel. Turn VCS-mode off and rely on
+# explicit include/exclude globs.
+[tool.hatch.build]
+include = [
+    "cullis_sdk/**/*.py",
+    "cullis_sdk/py.typed",
+    "LICENSE",
+    "LICENSE-APACHE-2.0",
+    "NOTICE",
+    "CHANGELOG.md",
+    "README_PKG.md",
+    "pyproject.toml",
+]
+exclude = [
+    "**/__pycache__",
+    "**/*.pyc",
+    "**/.pytest_cache",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["cullis_sdk"]
+
+[tool.hatch.build.targets.sdist]
+support-legacy = true


### PR DESCRIPTION
## Summary

Adds the missing PyPI packaging infrastructure for `cullis-sdk` so it can be published independently from `cullis-connector` and `mcp-proxy`. Today the SDK only ships as part of the legacy root `pyproject.toml` (which mixes SDK + connector and is never published) — and the connector wheel released yesterday as `0.3.1` is unusable from a fresh venv because its declared dep `cullis-sdk` does not exist on PyPI.

## Why now

End-user dogfood on a fresh `pipx install cullis-connector` (NixOS, 2026-04-25) failed immediately with `ModuleNotFoundError: cullis_sdk`. Connector 0.3.2 (next PR) will declare `cullis-sdk` in its `dependencies`, and that name has to actually resolve on PyPI before tagging.

## What's in this PR

- `packaging/pypi-sdk/pyproject.toml` — `cullis-sdk 0.1.0`, deps: `httpx`, `cryptography`, `PyJWT[crypto]`, `websockets`, `mcp`. Optional extra `[spiffe]` for the `py-spiffe` workload-API integration.
- `packaging/pypi-sdk/build.sh` — stage-and-build helper, mirrors `packaging/pypi/build.sh` for the connector. Copies `cullis_sdk/` + LICENSE/NOTICE/CHANGELOG/README_PKG.md into the staging dir so hatchling's sdist builder doesn't choke on `..` paths.
- `packaging/pypi-sdk/.gitignore` + root `.gitignore` update — staged artefacts are never committed; `cullis_sdk/` source of truth lives at the monorepo root.
- `cullis_sdk/README.md` — PyPI-facing package readme (install, quick start, architecture diagram, license note).
- `.github/workflows/release-sdk.yml` — triggered by `sdk-v*` tag (or `workflow_dispatch` on a tag ref). Runs SDK test subset, builds wheel + sdist, smoke-tests the wheel from `/tmp` (so the import resolves from site-packages, not the repo checkout), creates a GitHub Release, publishes to PyPI.

## Lessons from yesterday baked in

1. **Smoke from the wheel, not the source tree.** Yesterday's connector smoke `cullis-connector --version` would have passed even on an empty wheel because `sys.path[0]` was the repo root (which contains `cullis_connector/`). The new SDK smoke does `cd /tmp` before `python -c "import cullis_sdk"` and asserts `'/site-packages/' in cullis_sdk.__file__`. It also exercises `from cullis_sdk import ...` for the full public API and runs `DpopKey.generate().thumbprint()` to drive the crypto path — anything missing from `dependencies` blows up before publish.
2. **No `secrets` in `if:`.** GHA refuses to parse any `if:` referencing `secrets.X` when the workflow is invoked via `workflow_dispatch` — applies at job-level AND step-level. Workflow uses `with: password: ${{ secrets.PYPI_TOKEN }}` directly with no gate, matching the post-#318 connector pattern.
3. **`workflow_dispatch` from day one.** Connector pipeline needed it as a hotfix when GHA dedup'd a tag-push trigger. Adding it upfront here.

## Local verification

```
$ bash packaging/pypi-sdk/build.sh
Successfully built cullis_sdk-0.1.0.tar.gz and cullis_sdk-0.1.0-py3-none-any.whl

$ python3 -m venv /tmp/sdk-smoke
$ /tmp/sdk-smoke/bin/pip install dist/cullis_sdk-0.1.0-py3-none-any.whl
Successfully installed cullis-sdk-0.1.0 [+ httpx, cryptography, PyJWT, websockets, mcp, ...]

$ cd /tmp && /tmp/sdk-smoke/bin/python -c "import cullis_sdk; print(cullis_sdk.__file__)"
/tmp/sdk-smoke/lib/python3.11/site-packages/cullis_sdk/__init__.py

$ /tmp/sdk-smoke/bin/python -c "from cullis_sdk.dpop import DpopKey; print(DpopKey.generate().thumbprint()[:16])"
1IQgP2CC-Mou0kiP
```

Wheel inspected — 8 modules + `crypto/` subpkg + `examples/` + `py.typed` + LICENSE/NOTICE in `dist-info/licenses/`. 55 KB.

## Plan after merge

1. Merge this PR (no tag, no PyPI write).
2. Tag `sdk-v0.1.0` on the merge commit → workflow runs end-to-end: tests, build, smoke, GitHub Release, PyPI publish.
3. Fresh-venv dogfood: `pip install cullis-sdk` from a non-repo directory.
4. Open Connector 0.3.2 PR with `cullis-sdk` added to `dependencies` + `optional-dependencies.desktop = [pystray, pywebview, plyer]`.

## Test plan

- [x] Local `bash packaging/pypi-sdk/build.sh` produces both artefacts
- [x] Fresh-venv install + smoke test all pass
- [x] Wheel contents inspected (8 SDK modules + crypto + examples + LICENSE bundle)
- [x] Staged files gitignored, only sources tracked
- [ ] CI green on this PR (pytest subset + smoke, no publish on this branch)
- [ ] After tag `sdk-v0.1.0`: `pip install cullis-sdk` returns HTTP 200 from PyPI