### PR TITLE
fix(connector): 0.3.2 — declare cullis-sdk + add [desktop] extras

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -105,9 +105,30 @@ jobs:
         run: bash packaging/pypi/build.sh
 
       - name: Smoke test wheel
+        # Yesterday (connector-v0.3.1) this step was just `pip install
+        # <wheel> && cullis-connector --version`. It passed even though
+        # the wheel ImportError'd at runtime: `--version` only reads
+        # `__version__` and never touches `cullis_sdk` or any extras
+        # dep. End-user `pipx install cullis-connector` then died on
+        # `ModuleNotFoundError: cullis_sdk` because `cullis-sdk` wasn't
+        # declared and (worse) wasn't even on PyPI.
+        #
+        # The new smoke installs WITH the extras a real user would
+        # request, runs `import cullis_connector` from a directory that
+        # does NOT contain the source tree (so the import resolves from
+        # site-packages, not the repo checkout), and explicitly imports
+        # each extras-only module. Anything missing from `dependencies`
+        # or from an `optional-dependencies` group blows up here, before
+        # publish.
         run: |
           python -m venv /tmp/smoke
-          /tmp/smoke/bin/pip install dist/cullis_connector-*.whl
+          /tmp/smoke/bin/pip install "$(ls dist/cullis_connector-*.whl)[dashboard,desktop]"
+          cd /tmp
+          /tmp/smoke/bin/python -c "import cullis_connector; print('cullis-connector', cullis_connector.__version__); assert '/site-packages/' in cullis_connector.__file__, cullis_connector.__file__"
+          /tmp/smoke/bin/python -c "from cullis_connector.cli import main; print('cli main importable')"
+          /tmp/smoke/bin/python -c "import cullis_sdk; assert '/site-packages/' in cullis_sdk.__file__, cullis_sdk.__file__; print('cullis-sdk dep resolved:', cullis_sdk.__version__)"
+          /tmp/smoke/bin/python -c "import fastapi, uvicorn, jinja2, plyer; print('dashboard extras present')"
+          /tmp/smoke/bin/python -c "import pystray, webview, PIL; print('desktop extras present')"
           /tmp/smoke/bin/cullis-connector --version
 
       - uses: actions/upload-artifact@v4

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.3.1"
+version = "0.3.2"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"
@@ -54,6 +54,13 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    # The Cullis SDK is the in-process client the connector uses to talk to
+    # the broker (enrollment, sessions, send/receive, DPoP/mTLS). It lives
+    # in its own PyPI distribution so other Python agents can depend on it
+    # without dragging in the connector's MCP server stack. 0.3.1 shipped
+    # without this line; `pip install cullis-connector` succeeded but every
+    # subcommand died on `ModuleNotFoundError: cullis_sdk`.
+    "cullis-sdk>=0.1.0",
     "mcp>=1.0",
     "httpx>=0.24.0",
     "cryptography>=41.0.0",
@@ -67,6 +74,29 @@ dashboard = [
     "uvicorn[standard]>=0.27",
     "jinja2>=3.1",
     "python-multipart>=0.0.9",
+    # OS-native desktop notifications for the inbox poller (libnotify on
+    # Linux, NSUserNotification on macOS, Toast on Windows). Falls back to
+    # stderr when missing so a plain `connector` install without
+    # `dashboard` keeps working.
+    "plyer>=2.1",
+]
+# Native desktop shell: tray icon + system webview wrapping the dashboard
+# so non-technical users never see a terminal. Builds on top of
+# `dashboard` — keep both installed together.
+#   pywebview: embeds the OS-native webview (Cocoa WebKit, WebView2,
+#              GTK WebKit) pointed at http://127.0.0.1:7777.
+#   pystray : system-tray icon with a minimal menu (Open / Quit).
+#   Pillow  : drawing surface for the tray glyph (we render the
+#             portcullis mark at runtime, no PNG assets to ship).
+# Platform prerequisites NOT installable via pip: on Linux the user still
+# needs `gtk3` + `webkit2gtk` (present by default on mainstream distros);
+# macOS and Windows 10+ ship the webview in the OS. These cannot be
+# expressed as pip dependencies, so they are documented in install/desktop
+# rather than enforced here.
+desktop = [
+    "pywebview>=5.0",
+    "pystray>=0.19",
+    "Pillow>=10.0",
 ]
 dev = [
     "pytest>=8.0",


### PR DESCRIPTION
## Summary

Connector `0.3.1` shipped to PyPI yesterday (#318) with a wheel that was broken from a fresh venv. This PR is the surgical fix:

1. Declare `cullis-sdk>=0.1.0` in `dependencies` — published earlier today by #320 / `sdk-v0.1.0`.
2. Add the `[desktop]` extras group (`pywebview`, `pystray`, `Pillow`) that `README_PKG.md` already advertised.
3. Add `plyer>=2.1` to `[dashboard]` for OS-native inbox notifications.
4. Bump `0.3.1 → 0.3.2` in `packaging/pypi/pyproject.toml` + `cullis_connector/__init__.py` (version-match guard fails the workflow if these drift from the tag).
5. Strengthen the workflow smoke test so a wheel like 0.3.1 cannot pass CI again.

## Why now

Yesterday end-user dogfood (NixOS, fresh `pipx install cullis-connector`) failed with:

```
ModuleNotFoundError: cullis_sdk        # from cli.py
No module named 'pystray' / 'webview'  # from desktop.py
```

The smoke step at `release-connector.yml:107` ran `cullis-connector --version` from the repo checkout, which only reads `__version__` and never touches `cullis_sdk` or any extras module — so 0.3.1 went out the door looking healthy.

## Smoke test before / after

```diff
-      - name: Smoke test wheel
-        run: |
-          python -m venv /tmp/smoke
-          /tmp/smoke/bin/pip install dist/cullis_connector-*.whl
-          /tmp/smoke/bin/cullis-connector --version
+      - name: Smoke test wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install "$(ls dist/cullis_connector-*.whl)[dashboard,desktop]"
+          cd /tmp                                                                       # ← critical: keeps `import` from resolving the source tree
+          /tmp/smoke/bin/python -c "import cullis_connector; assert '/site-packages/' in cullis_connector.__file__"
+          /tmp/smoke/bin/python -c "from cullis_connector.cli import main"             # ← this would have caught 0.3.1's missing cullis-sdk dep
+          /tmp/smoke/bin/python -c "import cullis_sdk; assert '/site-packages/' in cullis_sdk.__file__"
+          /tmp/smoke/bin/python -c "import fastapi, uvicorn, jinja2, plyer"            # ← [dashboard]
+          /tmp/smoke/bin/python -c "import pystray, webview, PIL"                      # ← [desktop]
+          /tmp/smoke/bin/cullis-connector --version
```

The `cd /tmp` matters: with `sys.path[0]` pointing at the repo root, `import cullis_connector` would resolve to the source tree and the smoke would pass even on an empty wheel. Same lesson the SDK workflow already learned in #320.

## Local verification

```
$ bash packaging/pypi/build.sh
Successfully built cullis_connector-0.3.2.tar.gz and cullis_connector-0.3.2-py3-none-any.whl

$ python3 -m venv /tmp/conn-pretest
$ /tmp/conn-pretest/bin/pip install 'dist/cullis_connector-0.3.2-py3-none-any.whl[dashboard,desktop]'
[... resolves cullis-sdk + httpx + pystray + pywebview + plyer + Pillow + fastapi + uvicorn + ...]

$ cd /tmp && /tmp/conn-pretest/bin/python -c "import cullis_sdk; print(cullis_sdk.__version__)"
0.1.0

$ /tmp/conn-pretest/bin/cullis-connector dashboard --port 7779
{"msg": "dashboard listening on http://127.0.0.1:7779 — open it in a browser to enroll"}
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:7779

$ curl -s -o /dev/null -w "%{http_code}\n" http://127.0.0.1:7779/
303
```

This is exactly the dogfood that 0.3.1 missed.

## Plan after merge

1. Merge this PR (no tag, no PyPI write).
2. Tag `connector-v0.3.2` on the merge commit → `release-connector.yml` runs end-to-end: tests, build, hardened smoke, GitHub Release, GHCR push, PyPI publish, PyInstaller bundle.
3. Fresh-venv dogfood from PyPI on a non-NixOS machine: `pip install 'cullis-connector[dashboard,desktop]'` then `cullis-connector dashboard`.
4. Update `README_PKG.md` if any wording is now stale (extras names already match).

## NixOS caveat (unchanged)

`pywebview` installs cleanly from pip on every platform, but on Linux the *runtime* GTK webview needs `python-gi` + `webkit2gtk` from the OS package manager — those cannot be expressed as pip deps. NixOS has neither by default; on Ubuntu/Debian/Fedora they ship with the desktop env. Affected only by the `cullis-connector desktop` subcommand (tray + webview); `cullis-connector dashboard` (browser) works on every Linux including NixOS.

## Test plan

- [x] Local `bash packaging/pypi/build.sh` produces 0.3.2 wheel + sdist
- [x] Fresh-venv install with `[dashboard,desktop]` resolves `cullis-sdk 0.1.0` from PyPI (the SDK we just published)
- [x] All extras modules importable
- [x] `cullis-connector dashboard` actually starts uvicorn and serves HTTP
- [ ] CI green on this PR
- [ ] After tag `connector-v0.3.2`: PyPI publishes 0.3.2, fresh-venv install on Ubuntu VM succeeds end-to-end