### PR TITLE
fix(connector): smoke must use metadata-only check for [desktop] extras

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -128,7 +128,22 @@ jobs:
           /tmp/smoke/bin/python -c "from cullis_connector.cli import main; print('cli main importable')"
           /tmp/smoke/bin/python -c "import cullis_sdk; assert '/site-packages/' in cullis_sdk.__file__, cullis_sdk.__file__; print('cullis-sdk dep resolved:', cullis_sdk.__version__)"
           /tmp/smoke/bin/python -c "import fastapi, uvicorn, jinja2, plyer; print('dashboard extras present')"
-          /tmp/smoke/bin/python -c "import pystray, webview, PIL; print('desktop extras present')"
+          # `[desktop]` extras are GUI libraries: pystray probes X11 at
+          # import time (Xlib.display.Display()), pywebview initialises
+          # GTK at import time on Linux. On a headless GHA runner with
+          # no DISPLAY, both crash before the smoke can verify they are
+          # actually installed. We check via importlib.metadata instead
+          # — same coverage against the "extras dep missing from
+          # pyproject" failure mode (PackageNotFoundError if pip never
+          # installed it), no GUI initialisation. The ZIP/PyInstaller
+          # bundles run on real user desktops where GUI init works.
+          /tmp/smoke/bin/python -c "
+          import importlib.metadata as m
+          for pkg in ['pystray', 'pywebview', 'Pillow']:
+              v = m.version(pkg)
+              print(f'  {pkg} {v}')
+          print('desktop extras present')
+          "
           /tmp/smoke/bin/cullis-connector --version
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

The smoke step added in #321 ran `python -c "import pystray, webview, PIL"` to verify the new `[desktop]` extras were declared and resolved. This works on a real desktop but blows up on a headless GHA runner — `pystray.__init__` instantiates `Xlib.display.Display()` at module load to probe its X11 backend, and crashes with `Xlib.error.DisplayNameError: Bad display name ""` when there's no DISPLAY set. `pywebview` initialises GTK at import time on Linux with the same problem.

Caught immediately by the `connector-v0.3.2` release run ([24953396795](https://github.com/cullis-security/cullis/actions/runs/24953396795)) — the wheel itself built fine, all "did pip resolve cullis-sdk and the dashboard extras" checks passed, but the desktop GUI probe failed and skipped publish-pypi + build-docker + release.

## Fix

`importlib.metadata.version(...)` for the three GUI packages — same coverage against the failure mode the smoke was designed to catch (raises `PackageNotFoundError` if pip never installed them, exactly like a runtime ImportError would have done) without touching any GUI subsystem.

```diff
-          /tmp/smoke/bin/python -c "import pystray, webview, PIL; print('desktop extras present')"
+          /tmp/smoke/bin/python -c "
+          import importlib.metadata as m
+          for pkg in ['pystray', 'pywebview', 'Pillow']:
+              v = m.version(pkg)
+              print(f'  {pkg} {v}')
+          print('desktop extras present')
+          "
```

Dashboard extras (`fastapi`, `uvicorn`, `jinja2`, `plyer`) stay as real imports — pure Python server libs with no GUI init.

## What this does NOT change

The 0.3.2 wheel itself. End-user `pip install 'cullis-connector[desktop]'` on Ubuntu/Mac/Windows still installs and runs correctly — this was always a CI smoke issue, not a wheel issue. ZIP/PyInstaller bundles unaffected.

## Local verification

```
$ /tmp/conn-pretest/bin/python -c "
import importlib.metadata as m
for pkg in ['pystray', 'pywebview', 'Pillow']:
    v = m.version(pkg)
    print(f'  {pkg} {v}')
print('desktop extras present')
"
  pystray 0.19.5
  pywebview 6.2.1
  Pillow 12.2.0
desktop extras present

# Negative case: missing package raises and would fail the smoke
$ /tmp/conn-pretest/bin/python -c "import importlib.metadata as m; m.version('definitely-not-installed')"
importlib.metadata.PackageNotFoundError: No package metadata was found for definitely-not-installed
```

## Plan after merge

The `connector-v0.3.2` tag exists but never produced a published artefact (publish-pypi / build-docker / release were all skipped because build-python failed). Safe to re-use the version number:

1. Delete tag locally + remotely: `git push origin :refs/tags/connector-v0.3.2`
2. Re-tag on the new HEAD with the smoke fix
3. Push tag → workflow re-runs end-to-end

## Test plan

- [x] Local metadata check returns versions for installed `[desktop]` packages
- [x] Local metadata check raises `PackageNotFoundError` for an unknown package
- [ ] CI green on this PR
- [ ] After merge + retag of `connector-v0.3.2`: `release-connector.yml` reaches publish-pypi for the first time and `pip install cullis-connector==0.3.2` returns HTTP 200