### PR TITLE
docs(site): SDK quickstart page + post-0.3.2 audit fixes

### DIFF
--- a/site/src/content/docs/install/connector.md
+++ b/site/src/content/docs/install/connector.md
@@ -37,7 +37,7 @@ Each zip ships the platform-specific binary plus an `install.sh` / `install.comm
 # Linux example — adjust filename for your platform
 sudo mv cullis-connector-linux-x86_64 /usr/local/bin/cullis-connector
 cullis-connector --version
-# cullis-connector 0.3.1
+# cullis-connector 0.3.2
 ```
 
 > macOS Intel and Linux on ARM are not currently published as standalone binaries. Use **option B (`pip install`)** on those platforms.

--- a/site/src/content/docs/operate/audit-export.md
+++ b/site/src/content/docs/operate/audit-export.md
@@ -14,7 +14,7 @@ updated: "2026-04-23"
 
 - Admin secret (Mastio or Court, depending on which chain you're exporting)
 - `curl`, `jq`, `python3` on the host
-- Cullis CLI installed (`pip install cullis-sdk[cli]` or the Connector's bundled `cullis` binary)
+- Cullis CLI installed (the Connector's bundled `cullis-connector` binary; a standalone `cullis` CLI on PyPI is on the roadmap)
 
 ## What's in the chain
 

--- a/site/src/content/docs/quickstart/sdk.md
+++ b/site/src/content/docs/quickstart/sdk.md
@@ -1,0 +1,223 @@
+---
+title: "Python SDK quickstart"
+description: "From `pip install cullis-sdk` to your first agent talking on the network. Three ways to load an identity, then send/receive/request-response patterns — copy-paste runnable."
+category: "Quickstart"
+order: 30
+updated: "2026-04-26"
+---
+
+# Python SDK quickstart
+
+**Who this is for**: a Python developer writing an agent that needs to talk to other agents over Cullis. You've heard of the broker / Mastio split (if not, skim [Getting started](getting-started) first), but you don't want to read protocol docs — you want code that runs.
+
+This page goes: install → load an identity → send → receive → request-response. Every block is runnable as-is once your identity exists.
+
+## 1. Install
+
+```bash
+pip install cullis-sdk
+```
+
+Python 3.10+. The SDK has no required system dependencies and works on Linux, macOS, and Windows.
+
+For SPIRE/SPIFFE workload-API integration (only if you're enrolling via SPIRE — section 2c below), install the optional extra:
+
+```bash
+pip install 'cullis-sdk[spiffe]'
+```
+
+That's it for installation. The friction is everything that comes next — *getting an identity the Mastio recognises* — and there are three ways to do it.
+
+## 2. Load an identity
+
+An agent's identity is two files on disk: `api-key` (a bcrypt-hashed secret) and `dpop.jwk` (an EC private key bound to the api-key by thumbprint). Pick the path that matches how you already authenticate today.
+
+### a. From the Connector (zero secrets in your hands)
+
+If your agent runs on the same machine as a Cullis Connector that's already enrolled (typical for dev laptops, AI assistants embedded in IDEs), reuse the Connector's identity. No admin secret involved — the Connector did the enrollment for you.
+
+```python
+from cullis_sdk import CullisClient
+
+client = CullisClient.from_connector()
+client.login_via_proxy()
+```
+
+`from_connector()` reads `~/.cullis/identity/` (or `~/.cullis/profiles/<name>/` for multi-profile installs). Override the path with `from_connector(config_dir="/path/to/profile")`.
+
+→ Connector not installed yet? See [Install the Connector](../install/connector).
+
+### b. BYOCA — your org has a PKI
+
+Your organisation already runs a CA. The agent has a cert + private key signed by it. You hand both to the Mastio once; you get back an api-key + DPoP JWK pinned to that cert.
+
+```python
+from cullis_sdk import CullisClient
+
+CullisClient.enroll_via_byoca(
+    "https://mastio.acme.corp",
+    admin_secret="$MASTIO_ADMIN_SECRET",   # one-time, from your operator
+    agent_name="inventory-bot",
+    display_name="Inventory service",
+    cert_pem=open("agent.pem").read(),
+    private_key_pem=open("agent-key.pem").read(),
+    capabilities=["inventory.read"],
+    persist_to="/etc/cullis/agent/",       # writes api-key + dpop.jwk + agent.json
+)
+
+# Subsequent runs — no admin secret, no enrollment, just load
+client = CullisClient.from_api_key_file(
+    mastio_url="https://mastio.acme.corp",
+    api_key_path="/etc/cullis/agent/api-key",
+    dpop_key_path="/etc/cullis/agent/dpop.jwk",
+)
+client.login_via_proxy()
+```
+
+→ Full BYOCA flow with cert chain rules: [BYOCA enrollment](../enroll/byoca).
+
+### c. SPIRE — you already have a workload SVID
+
+Your agent runs in a SPIRE-attested environment (Kubernetes, on-prem with SPIRE Agent on the node). The SPIRE workload API hands you an SVID; the SDK exchanges it for an api-key.
+
+```python
+from cullis_sdk import CullisClient
+
+CullisClient.enroll_via_spiffe(
+    "https://mastio.acme.corp",
+    admin_secret="$MASTIO_ADMIN_SECRET",
+    agent_name="orderbot",
+    persist_to="/var/lib/cullis/agent/",
+)
+
+# Same runtime as BYOCA
+client = CullisClient.from_api_key_file(
+    mastio_url="https://mastio.acme.corp",
+    api_key_path="/var/lib/cullis/agent/api-key",
+    dpop_key_path="/var/lib/cullis/agent/dpop.jwk",
+)
+client.login_via_proxy()
+```
+
+Requires `pip install 'cullis-sdk[spiffe]'`. → Full SPIRE flow: [SPIRE enrollment](../enroll/spire).
+
+---
+
+From here on, code is identical regardless of how you authenticated. Everything below assumes `client` is loaded and `login_via_proxy()` has been called.
+
+## 3. Send a one-shot message
+
+The simplest send: fire-and-forget envelope to a known recipient.
+
+```python
+resp = client.send_oneshot(
+    recipient_id="globex::fulfillment-bot",
+    payload={"order_id": "A123", "qty": 4},
+    ttl_seconds=300,
+)
+print(resp["msg_id"])
+```
+
+Behind the scenes the SDK signs the payload with your private key, encrypts it end-to-end to the recipient's published pubkey (broker can't read it), and submits to `/v1/egress/message/send` on your local Mastio. If the recipient is in the same org the Mastio short-circuits — the Court never sees the message. If cross-org, the Court routes the encrypted envelope to the recipient's Mastio.
+
+Discover recipients by capability rather than hardcoding agent ids:
+
+```python
+candidates = client.discover(capabilities=["fulfillment.execute"])
+target = candidates[0]
+client.send_oneshot(target.agent_id, {"order_id": "A123"})
+```
+
+## 4. Receive messages
+
+The recipient pattern is *poll the inbox*, *decrypt*, *act*, *dedup by `msg_id`*.
+
+```python
+seen = set()
+while True:
+    rows = client.receive_oneshot()  # GET /v1/egress/message/inbox
+    for row in rows:
+        msg_id = row["msg_id"]
+        if msg_id in seen:
+            continue
+        seen.add(msg_id)
+
+        try:
+            payload = client.decrypt_oneshot(row)  # verifies sig + decrypts
+        except Exception as exc:
+            print(f"discarded {msg_id[:8]}: {exc!r}")
+            continue
+
+        # decrypt_oneshot returns {"payload": ..., "sender_verified": True, ...}
+        inner = payload.get("payload", payload)
+        sender = row["sender_agent_id"]
+        print(f"from {sender}: {inner}")
+
+    time.sleep(1)
+```
+
+`decrypt_oneshot` raises if the signature doesn't verify against the sender's pinned pubkey, so you can trust the `sender_agent_id` field once it returns. For production: ack rows you've processed (ADR-008) so the inbox can reclaim storage; the demo loop above is intentionally minimal.
+
+## 5. Request-response
+
+There's no built-in RPC primitive — Cullis is message-oriented. Build request-response by attaching a correlation id, sending, then polling the inbox until a reply with that id arrives.
+
+```python
+import time, uuid
+
+def call(client, target_id, request, timeout=30):
+    corr = uuid.uuid4().hex
+    client.send_oneshot(
+        target_id,
+        {"corr_id": corr, "request": request},
+        ttl_seconds=timeout,
+    )
+
+    deadline = time.monotonic() + timeout
+    seen = set()
+    while time.monotonic() < deadline:
+        for row in client.receive_oneshot():
+            if row["msg_id"] in seen:
+                continue
+            seen.add(row["msg_id"])
+            payload = client.decrypt_oneshot(row)
+            inner = payload.get("payload", payload)
+            if isinstance(inner, dict) and inner.get("corr_id") == corr:
+                return inner.get("response")
+        time.sleep(0.5)
+
+    raise TimeoutError(f"no reply within {timeout}s for corr_id={corr}")
+
+# Usage
+reply = call(client, "globex::pricing-bot", {"sku": "A123"})
+print(reply)
+```
+
+The responder side mirrors it: receive, do work, send back with the same `corr_id`.
+
+## 6. Sessions (when one-shots aren't enough)
+
+For multi-message conversations with a single peer (chat, streaming results, long-running negotiations), open a session once and reuse it. Each `send` over the session is cheaper than a one-shot — the recipient is pinned, the audit chain knows it's the same conversation.
+
+```python
+session_id = client.open_session(
+    target_agent="globex::fulfillment-bot",
+    target_org="globex",
+    capabilities=["order.execute"],
+)
+client.send(session_id, "myorg::reporter", {"hello": "starting"}, "globex::fulfillment-bot")
+client.send(session_id, "myorg::reporter", {"more": "context"}, "globex::fulfillment-bot")
+client.close_session(session_id)
+```
+
+Use one-shots when each message is independent. Use sessions when you'd otherwise be re-sending the same context every time.
+
+## What's next
+
+- [BYOCA enrollment](../enroll/byoca) — full cert chain rules and CA attach flow
+- [SPIRE enrollment](../enroll/spire) — workload API integration in detail
+- [Connector device-code enrollment](../enroll/connector-device-code) — what `from_connector()` is reusing
+- [Configuration](../reference/configuration) — every `CULLIS_*` env var the SDK reads
+- [Enrollment API reference](../reference/enrollment-api) — raw HTTP if you'd rather not use the SDK
+
+If anything in here breaks against the version on your machine, the SDK is at `cullis_sdk.__version__` — pin to a released minor in your project's `pyproject.toml` (`cullis-sdk>=0.1,<0.2`) so a future-you doesn't get surprised by a breaking minor bump.


### PR DESCRIPTION
## Summary

- **New** `quickstart/sdk.md` — entry point for Python developers who just ran `pip install cullis-sdk` and want to write their first agent. With sdk-v0.1.0 shipped earlier today (#320), the SDK has no longer just docs that mention `from cullis_sdk import ...` — it has a proper landing.
- **Fix** `install/connector.md:40` — example output bumped `0.3.1 → 0.3.2` to match what's on PyPI right now.
- **Fix** `operate/audit-export.md:17` — removed the phantom `pip install cullis-sdk[cli]` claim. That extras group never existed in the SDK pyproject.

## Why now

Audit done in this session against the docs as they were at \`756d79a\` (PR #319 yesterday) given today's two PyPI publishes. Everything else in the docs still corresponds to reality except the two stale references above. Two larger surgeries are deliberately deferred to a follow-up PR — see commit body.

## What's in the new page

Structure (matches what was sketched in chat):

1. **Install** — \`pip install cullis-sdk\`, plus \`[spiffe]\` extra
2. **Load an identity** — three sub-sections, user scrolls to the path that fits how they already authenticate today:
   - **a.** \`from_connector()\` — zero secrets, reuses an enrolled Connector (laptop/IDE-attached agent case)
   - **b.** \`enroll_via_byoca() + from_api_key_file()\` — your org has a PKI, you bring a cert
   - **c.** \`enroll_via_spiffe() + from_api_key_file()\` — SPIRE workload-API integration
3. **Send** — \`send_oneshot\` + \`discover\` for capability lookup
4. **Receive** — poll inbox + \`decrypt_oneshot\` + dedup pattern
5. **Request-response** — correlation-id pattern (no built-in RPC; Cullis is message-oriented)
6. **Sessions** — when one-shots aren't enough (chat, streaming, multi-message conversations)
7. **What's next** — links to \`enroll/\`, \`reference/configuration\`, \`reference/enrollment-api\`

Tone: copy-paste runnable, "Who this is for" lead-in, no marketing fluff. Matches the established voice of \`getting-started.md\`. Frontmatter \`order=30\` puts it third in the Quickstart sidebar after Getting started (10) and Sandbox walkthrough (20).

## Audit also flagged (deferred to follow-up PRs)

| Doc | Issue | Why deferred |
|---|---|---|
| \`install/connector.md\` § "First enrollment" + \`getting-started.md:96\` | Uses \`cullis-connector enroll --site-url ... --requester-name ...\` (CLI invasive) — contradicts "Connector zero-CLI for end-users" rule | Rewriting both without losing the reference flow is a bigger surgery; needs its own PR |
| No \`install/sdk.md\` | Install/ has Connector and Mastio pages, no SDK | The new quickstart covers install in passing; add a dedicated page only if SDK acquires a user segment distinct from Connector users |

## Local verification

\`\`\`
$ npm run build
[build] 24 page(s) built in 1.86s
[build] Complete!
# /docs/quickstart/sdk/index.html generated, frontmatter passes Zod schema

$ npm run dev
HTTP 200 — http://localhost:4321/docs/quickstart/sdk
# Sidebar renders the new entry under Quickstart, prose styling cyan-accent intact
\`\`\`

## Test plan

- [x] Build passes (\`npm run build\`)
- [x] Frontmatter valid against Zod schema
- [x] Page renders in dev server with intact sidebar nav
- [ ] CI green on this PR
- [ ] Cloudflare Pages preview deploys cleanly