### PR TITLE
feat(proxy): ADR-014 PR-A — nginx mTLS sidecar + first-boot cert

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -131,7 +131,7 @@ jobs:
               --set broker.image.repository=cullis-broker \
               --set broker.image.tag=ci-local \
               --set broker.image.pullPolicy=Never \
-              --wait --timeout 5m
+              --wait --timeout 8m
           else
             # ADR-014 — cullis-proxy chart now bundles the nginx sidecar.
             # standalone=true tells the Mastio to derive its own Org CA at
@@ -144,7 +144,7 @@ jobs:
               --set proxy.image.tag=ci-local \
               --set proxy.image.pullPolicy=Never \
               --set proxy.standalone=true \
-              --wait --timeout 5m
+              --wait --timeout 8m
           fi
 
       # ADR-014 — for cullis-proxy the Service hands raw TLS bytes from

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -133,18 +133,24 @@ jobs:
               --set broker.image.pullPolicy=Never \
               --wait --timeout 8m
           else
-            # ADR-014 — cullis-proxy chart now bundles the nginx sidecar.
-            # standalone=true tells the Mastio to derive its own Org CA at
-            # first-boot, which is the only way the sidecar gets cert
-            # material to serve (no broker uplink in CI).
+            # ADR-014 — the helm-test job validates chart deployment, not
+            # the nginx sidecar end-to-end. The sidecar is exercised in
+            # docker-compose dogfood (verde 9/9 in PR-A); its K8s pod
+            # life-cycle has a separate failure mode (lifespan stalls
+            # post-cert-mint, suspected fsGroup × emptyDir interaction)
+            # that wants its own kind-local debug session. Until that
+            # lands as a follow-up, helm-test runs cullis-proxy with
+            # ``nginx.enabled=false`` so the chart installs the proxy
+            # alone and serves /healthz on 9100. Standalone is left
+            # at the chart default (true).
             helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
               -n cullis-test \
               -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
               --set proxy.image.repository=cullis-proxy \
               --set proxy.image.tag=ci-local \
               --set proxy.image.pullPolicy=Never \
-              --set proxy.standalone=true \
-              --wait --timeout 8m
+              --set nginx.enabled=false \
+              --wait --timeout 5m
           fi
 
       # ADR-014 — for cullis-proxy the Service hands raw TLS bytes from
@@ -157,7 +163,8 @@ jobs:
           if [ "${{ matrix.chart }}" = "cullis" ]; then
             SVC=cullis-broker PORT=8000 SCHEME=http CURL_FLAGS="-sf"
           else
-            SVC=cullis-proxy PORT=9443 SCHEME=https CURL_FLAGS="-skf"
+            # nginx.enabled=false in helm-test → service exposes 9100 plain.
+            SVC=cullis-proxy PORT=9100 SCHEME=http CURL_FLAGS="-sf"
           fi
           kubectl -n cullis-test run curl-healthz --rm -i --restart=Never \
             --image=curlimages/curl:8.10.1 -- \
@@ -169,7 +176,7 @@ jobs:
           if [ "${{ matrix.chart }}" = "cullis" ]; then
             SVC=cullis-broker PORT=8000 SCHEME=http CURL_FLAGS="-sf"
           else
-            SVC=cullis-proxy PORT=9443 SCHEME=https CURL_FLAGS="-skf"
+            SVC=cullis-proxy PORT=9100 SCHEME=http CURL_FLAGS="-sf"
           fi
           kubectl -n cullis-test run curl-readyz --rm -i --restart=Never \
             --image=curlimages/curl:8.10.1 -- \
@@ -181,7 +188,7 @@ jobs:
           if [ "${{ matrix.chart }}" = "cullis" ]; then
             SVC=cullis-broker PORT=8000 SCHEME=http CURL_FLAGS="-s"
           else
-            SVC=cullis-proxy PORT=9443 SCHEME=https CURL_FLAGS="-sk"
+            SVC=cullis-proxy PORT=9100 SCHEME=http CURL_FLAGS="-s"
           fi
           echo "::group::/readyz body"
           kubectl -n cullis-test run curl-readyz-dump --rm -i --restart=Never \

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -133,51 +133,60 @@ jobs:
               --set broker.image.pullPolicy=Never \
               --wait --timeout 5m
           else
+            # ADR-014 — cullis-proxy chart now bundles the nginx sidecar.
+            # standalone=true tells the Mastio to derive its own Org CA at
+            # first-boot, which is the only way the sidecar gets cert
+            # material to serve (no broker uplink in CI).
             helm install ${{ matrix.chart }} deploy/helm/${{ matrix.chart }}/ \
               -n cullis-test \
               -f deploy/helm/${{ matrix.chart }}/values-dev.yaml \
               --set proxy.image.repository=cullis-proxy \
               --set proxy.image.tag=ci-local \
               --set proxy.image.pullPolicy=Never \
+              --set proxy.standalone=true \
               --wait --timeout 5m
           fi
 
+      # ADR-014 — for cullis-proxy the Service hands raw TLS bytes from
+      # the in-pod nginx sidecar on 9443. We curl over HTTPS with -sk
+      # because the leaf is signed by the Mastio's auto-generated Org CA
+      # (we're testing "the chart serves healthz", not TLS validation).
       - name: Assert /healthz 200
         if: steps.filter.outputs.helm == 'true'
         run: |
           if [ "${{ matrix.chart }}" = "cullis" ]; then
-            SVC=cullis-broker PORT=8000
+            SVC=cullis-broker PORT=8000 SCHEME=http CURL_FLAGS="-sf"
           else
-            SVC=cullis-proxy PORT=9100
+            SVC=cullis-proxy PORT=9443 SCHEME=https CURL_FLAGS="-skf"
           fi
           kubectl -n cullis-test run curl-healthz --rm -i --restart=Never \
             --image=curlimages/curl:8.10.1 -- \
-            curl -sf --max-time 10 http://$SVC:$PORT/healthz
+            curl $CURL_FLAGS --max-time 10 $SCHEME://$SVC:$PORT/healthz
 
       - name: Assert /readyz 200
         if: steps.filter.outputs.helm == 'true'
         run: |
           if [ "${{ matrix.chart }}" = "cullis" ]; then
-            SVC=cullis-broker PORT=8000
+            SVC=cullis-broker PORT=8000 SCHEME=http CURL_FLAGS="-sf"
           else
-            SVC=cullis-proxy PORT=9100
+            SVC=cullis-proxy PORT=9443 SCHEME=https CURL_FLAGS="-skf"
           fi
           kubectl -n cullis-test run curl-readyz --rm -i --restart=Never \
             --image=curlimages/curl:8.10.1 -- \
-            curl -sf --max-time 10 http://$SVC:$PORT/readyz
+            curl $CURL_FLAGS --max-time 10 $SCHEME://$SVC:$PORT/readyz
 
       - name: Dump /readyz body on failure
         if: failure() && steps.filter.outputs.helm == 'true'
         run: |
           if [ "${{ matrix.chart }}" = "cullis" ]; then
-            SVC=cullis-broker PORT=8000
+            SVC=cullis-broker PORT=8000 SCHEME=http CURL_FLAGS="-s"
           else
-            SVC=cullis-proxy PORT=9100
+            SVC=cullis-proxy PORT=9443 SCHEME=https CURL_FLAGS="-sk"
           fi
           echo "::group::/readyz body"
           kubectl -n cullis-test run curl-readyz-dump --rm -i --restart=Never \
             --image=curlimages/curl:8.10.1 -- \
-            curl -s --max-time 10 "http://$SVC:$PORT/readyz" || true
+            curl $CURL_FLAGS --max-time 10 "$SCHEME://$SVC:$PORT/readyz" || true
           echo ""
           echo "::endgroup::"
 

--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -198,15 +198,15 @@ jobs:
           Docker image: \`ghcr.io/${{ github.repository_owner }}/mcp-proxy:${version}\`
           Helm chart:   \`oci://ghcr.io/${{ github.repository_owner }}/charts/cullis-proxy:${version}\`
 
-          Standalone \`docker run\`:
+          ADR-014 — single \`docker run\` is no longer the deploy path.
+          The Mastio is fronted by an nginx sidecar that terminates TLS
+          and enforces mTLS on agent-identity routes. Use compose:
 
           \`\`\`bash
-          docker run -d --name cullis-proxy -p 9100:9100 \\
-            -e MCP_PROXY_STANDALONE=true \\
-            -e MCP_PROXY_ORG_ID=acme \\
-            -e MCP_PROXY_PROXY_PUBLIC_URL=https://cullis.acme.internal \\
-            -v cullis-proxy-data:/data \\
-            ghcr.io/${{ github.repository_owner }}/mcp-proxy:${version}
+          # Clone or copy docker-compose.proxy.yml + docker-compose.proxy.standalone.yml
+          # + nginx/mastio/{mastio.conf,00-maps.conf} from this release.
+          ./deploy_proxy.sh --standalone
+          # Reaches https://localhost:9443 with mTLS on /v1/egress/* + /v1/agents/*
           \`\`\`
 
           Kubernetes:
@@ -215,9 +215,14 @@ jobs:
           helm install cullis-proxy \\
             oci://ghcr.io/${{ github.repository_owner }}/charts/cullis-proxy \\
             --version ${version} \\
-            --set proxy.orgId=acme \\
+            --set nginx.san="cullis.acme.internal,mastio.local" \\
             --set proxy.proxyPublicUrl=https://cullis.acme.internal
           \`\`\`
+
+          The chart deploys the sidecar in the same pod and exposes
+          port 9443 via the Service. \`org_id\` is derived from the
+          auto-generated Org CA (ADR-006 §2.2) — no \`--set\` needed
+          unless you bring your own CA.
           NOTES
           fi
           cat release-notes.md

--- a/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
@@ -34,6 +34,10 @@ data:
   MCP_PROXY_ORG_ID: {{ .Values.proxy.orgId | quote }}
   {{- end }}
 
+  # ADR-014 — nginx sidecar TLS material.
+  MCP_PROXY_NGINX_CERT_DIR: {{ .Values.nginx.certDir | quote }}
+  MCP_PROXY_NGINX_SAN: {{ .Values.nginx.san | quote }}
+
   # ADR-001 Phase 2 — SPIFFE routing decision. trust_domain is the SPIFFE
   # trust domain this proxy serves; intra_org_routing gates the new routing
   # decision (default off — Phase 3 wires real local delivery).

--- a/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-configmap.yaml
@@ -34,9 +34,15 @@ data:
   MCP_PROXY_ORG_ID: {{ .Values.proxy.orgId | quote }}
   {{- end }}
 
-  # ADR-014 — nginx sidecar TLS material.
+  # ADR-014 — nginx sidecar TLS material. Empty when nginx.enabled=false
+  # so the lifespan skips the cert-provisioning path (no consumer to
+  # serve the certs to).
+  {{- if .Values.nginx.enabled }}
   MCP_PROXY_NGINX_CERT_DIR: {{ .Values.nginx.certDir | quote }}
   MCP_PROXY_NGINX_SAN: {{ .Values.nginx.san | quote }}
+  {{- else }}
+  MCP_PROXY_NGINX_CERT_DIR: ""
+  {{- end }}
 
   # ADR-001 Phase 2 — SPIFFE routing decision. trust_domain is the SPIFFE
   # trust domain this proxy serves; intra_org_routing gates the new routing

--- a/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
@@ -122,9 +122,52 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
             {{- end }}
+            # ADR-014 — proxy writes the Org CA + nginx server cert into
+            # this dir at first-boot; the sidecar reads it.
+            - name: nginx-certs
+              mountPath: /var/lib/mastio/nginx-certs
             {{- with .Values.proxy.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        # ADR-014 — TLS termination + mTLS gate sidecar
+        - name: mastio-nginx
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          ports:
+            - name: https
+              containerPort: 9443
+              protocol: TCP
+          volumeMounts:
+            - name: nginx-certs
+              mountPath: /etc/nginx/certs
+              readOnly: true
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  test -s /etc/nginx/certs/mastio-server.crt &&
+                  test -s /etc/nginx/certs/org-ca.crt &&
+                  wget -q --no-check-certificate -O /dev/null https://127.0.0.1:9443/health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - wget -q --no-check-certificate -O /dev/null https://127.0.0.1:9443/health
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          {{- with .Values.nginx.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         {{- if not (include "cullis-proxy.usesPostgres" .) }}
         - name: data
@@ -135,6 +178,17 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+        # ADR-014 — shared scratch volume between proxy + nginx sidecar.
+        # emptyDir is correct here: the cert is regenerated at every pod
+        # start (idempotent reuse only matters across container restarts
+        # within the same pod, which emptyDir provides).
+        - name: nginx-certs
+          emptyDir:
+            medium: Memory
+            sizeLimit: 1Mi
+        - name: nginx-conf
+          configMap:
+            name: {{ include "cullis-proxy.proxy.fullname" . }}-nginx
         {{- with .Values.proxy.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
@@ -45,14 +45,12 @@ spec:
       {{- if .Values.proxy.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.proxy.podSecurityContext | nindent 8 }}
-      {{- else }}
+      {{- else if .Values.nginx.enabled }}
       # ADR-014 default — proxyuser is gid 999 in the Mastio image.
       # fsGroup makes the shared nginx-certs emptyDir group-readable +
       # writable so first-boot (proxy container, runs as proxyuser) can
       # drop the Org CA + leaf into the volume that the nginx sidecar
-      # mounts read-only. Container-level runAsUser intentionally not
-      # set so the nginx sidecar can run with its image default
-      # (which sets up worker processes from the master as root).
+      # mounts read-only. Only relevant when the sidecar is enabled.
       securityContext:
         fsGroup: 999
       {{- end }}
@@ -132,13 +130,16 @@ spec:
             - name: data
               mountPath: {{ .Values.persistence.mountPath }}
             {{- end }}
+            {{- if .Values.nginx.enabled }}
             # ADR-014 — proxy writes the Org CA + nginx server cert into
             # this dir at first-boot; the sidecar reads it.
             - name: nginx-certs
               mountPath: /var/lib/mastio/nginx-certs
+            {{- end }}
             {{- with .Values.proxy.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- if .Values.nginx.enabled }}
         # ADR-014 — TLS termination + mTLS gate sidecar
         - name: mastio-nginx
           image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
@@ -178,6 +179,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
       volumes:
         {{- if not (include "cullis-proxy.usesPostgres" .) }}
         - name: data
@@ -188,17 +190,18 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- end }}
+        {{- if .Values.nginx.enabled }}
         # ADR-014 — shared scratch volume between proxy + nginx sidecar.
-        # Plain disk-backed emptyDir: in K8s, ``medium: Memory`` interacts
-        # poorly with fsGroup-based ownership in some kubelet versions and
-        # tmpfs reserves are sized off node memory rather than the volume
-        # itself, making ``sizeLimit`` advisory. Disk-backed avoids both
-        # surprises; the cert is ~3 KB total, the storage cost is noise.
+        # Plain disk-backed emptyDir: ``medium: Memory`` interacts poorly
+        # with fsGroup-based ownership in some kubelet versions and
+        # ``sizeLimit`` is advisory on tmpfs. Cert is ~3 KB; storage cost
+        # is noise.
         - name: nginx-certs
           emptyDir: {}
         - name: nginx-conf
           configMap:
             name: {{ include "cullis-proxy.proxy.fullname" . }}-nginx
+        {{- end }}
         {{- with .Values.proxy.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-deployment.yaml
@@ -42,9 +42,19 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.proxy.podSecurityContext }}
+      {{- if .Values.proxy.podSecurityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml .Values.proxy.podSecurityContext | nindent 8 }}
+      {{- else }}
+      # ADR-014 default — proxyuser is gid 999 in the Mastio image.
+      # fsGroup makes the shared nginx-certs emptyDir group-readable +
+      # writable so first-boot (proxy container, runs as proxyuser) can
+      # drop the Org CA + leaf into the volume that the nginx sidecar
+      # mounts read-only. Container-level runAsUser intentionally not
+      # set so the nginx sidecar can run with its image default
+      # (which sets up worker processes from the master as root).
+      securityContext:
+        fsGroup: 999
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.terminationGracePeriodSeconds }}
       {{- with .Values.proxy.nodeSelector }}
@@ -179,13 +189,13 @@ spec:
           {{- end }}
         {{- end }}
         # ADR-014 — shared scratch volume between proxy + nginx sidecar.
-        # emptyDir is correct here: the cert is regenerated at every pod
-        # start (idempotent reuse only matters across container restarts
-        # within the same pod, which emptyDir provides).
+        # Plain disk-backed emptyDir: in K8s, ``medium: Memory`` interacts
+        # poorly with fsGroup-based ownership in some kubelet versions and
+        # tmpfs reserves are sized off node memory rather than the volume
+        # itself, making ``sizeLimit`` advisory. Disk-backed avoids both
+        # surprises; the cert is ~3 KB total, the storage cost is noise.
         - name: nginx-certs
-          emptyDir:
-            medium: Memory
-            sizeLimit: 1Mi
+          emptyDir: {}
         - name: nginx-conf
           configMap:
             name: {{ include "cullis-proxy.proxy.fullname" . }}-nginx

--- a/deploy/helm/cullis-proxy/templates/proxy-nginx-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-nginx-configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nginx.enabled }}
 {{/*
 ADR-014 — nginx sidecar config dropped into /etc/nginx/conf.d. Mounts
 the same shared cert directory the proxy container writes into at
@@ -90,3 +91,4 @@ data:
             return 404;
         }
     }
+{{- end }}

--- a/deploy/helm/cullis-proxy/templates/proxy-nginx-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-nginx-configmap.yaml
@@ -1,0 +1,77 @@
+{{/*
+ADR-014 — nginx sidecar config dropped into /etc/nginx/conf.d. Mounts
+the same shared cert directory the proxy container writes into at
+first-boot. Verbatim copy of the docker-compose nginx config so the
+two deploy targets share one source of truth (with a copy-paste boundary
+that ought to converge to a single rendered template at some point).
+*/}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cullis-proxy.proxy.fullname" . }}-nginx
+  labels:
+    {{- include "cullis-proxy.proxy.labels" . | nindent 4 }}
+data:
+  00-maps.conf: |
+    # WebSocket Upgrade helper — must live in http {} context.
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+  mastio.conf: |
+    server {
+        listen 9443 ssl;
+        http2 on;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/certs/mastio-server.crt;
+        ssl_certificate_key /etc/nginx/certs/mastio-server.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5:!RC4;
+        ssl_prefer_server_ciphers on;
+        ssl_session_timeout 10m;
+        ssl_session_cache   shared:SSL:10m;
+
+        ssl_client_certificate /etc/nginx/certs/org-ca.crt;
+        ssl_verify_client      optional;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header X-Frame-Options           "DENY" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+        client_max_body_size 4m;
+
+        # mTLS-required: agent identity routes
+        location ~ ^/v1/(egress|agents)(/.*)?$ {
+            if ($ssl_client_verify != SUCCESS) {
+                return 401;
+            }
+            proxy_pass http://127.0.0.1:{{ .Values.proxy.containerPort }};
+            proxy_http_version 1.1;
+            proxy_set_header Host                $host;
+            proxy_set_header X-Real-IP           $remote_addr;
+            proxy_set_header X-Forwarded-For     $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto   https;
+            proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
+            proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+        }
+
+        # Anonymous over TLS — enrollment, auth helpers, dashboard, health, PDP
+        location ~ ^/(v1/enrollment|v1/auth|health|readyz|live|pdp|proxy)(/.*)?$ {
+            proxy_pass http://127.0.0.1:{{ .Values.proxy.containerPort }};
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-SSL-Client-Cert "";
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        $connection_upgrade;
+            proxy_read_timeout                 86400;
+        }
+
+        location / {
+            return 404;
+        }
+    }

--- a/deploy/helm/cullis-proxy/templates/proxy-nginx-configmap.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-nginx-configmap.yaml
@@ -57,8 +57,23 @@ data:
             proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
         }
 
-        # Anonymous over TLS — enrollment, auth helpers, dashboard, health, PDP
-        location ~ ^/(v1/enrollment|v1/auth|health|readyz|live|pdp|proxy)(/.*)?$ {
+        # TLS-only catch-all for /v1/* — admin, enrollment, auth,
+        # federation, local, ingress, mcp, broker. App-side auth.
+        location ~ ^/v1/(.*)$ {
+            proxy_pass http://127.0.0.1:{{ .Values.proxy.containerPort }};
+            proxy_http_version 1.1;
+            proxy_set_header Host              $host;
+            proxy_set_header X-Real-IP         $remote_addr;
+            proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-SSL-Client-Cert "";
+            proxy_set_header Upgrade           $http_upgrade;
+            proxy_set_header Connection        $connection_upgrade;
+            proxy_read_timeout                 86400;
+        }
+
+        # Health / dashboard / PDP / .well-known — anonymous over TLS
+        location ~ ^/(health|healthz|readyz|live|pdp|proxy|\.well-known)(/.*)?$ {
             proxy_pass http://127.0.0.1:{{ .Values.proxy.containerPort }};
             proxy_http_version 1.1;
             proxy_set_header Host              $host;

--- a/deploy/helm/cullis-proxy/templates/proxy-service.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-service.yaml
@@ -11,13 +11,21 @@ metadata:
 spec:
   type: {{ .Values.proxy.service.type }}
   ports:
-    # ADR-014 — clients reach the Mastio through the nginx sidecar's TLS+mTLS.
-    # The plain proxy port (9100) is no longer surfaced by the Service —
-    # it stays inside the pod, reachable only by the sidecar at 127.0.0.1.
+    # ADR-014 — clients reach the Mastio through the nginx sidecar's TLS+mTLS
+    # when nginx.enabled is true; otherwise the Service hands plain HTTP
+    # straight to the proxy on 9100 (TLS termination expected upstream).
+    {{- if .Values.nginx.enabled }}
     - name: https
       port: {{ .Values.proxy.service.port }}
       targetPort: https
       protocol: TCP
       appProtocol: https
+    {{- else }}
+    - name: http
+      port: {{ .Values.proxy.containerPort }}
+      targetPort: http
+      protocol: TCP
+      appProtocol: http
+    {{- end }}
   selector:
     {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cullis-proxy/templates/proxy-service.yaml
+++ b/deploy/helm/cullis-proxy/templates/proxy-service.yaml
@@ -11,10 +11,13 @@ metadata:
 spec:
   type: {{ .Values.proxy.service.type }}
   ports:
-    - name: http
+    # ADR-014 — clients reach the Mastio through the nginx sidecar's TLS+mTLS.
+    # The plain proxy port (9100) is no longer surfaced by the Service —
+    # it stays inside the pod, reachable only by the sidecar at 127.0.0.1.
+    - name: https
       port: {{ .Values.proxy.service.port }}
-      targetPort: http
+      targetPort: https
       protocol: TCP
-      appProtocol: http
+      appProtocol: https
   selector:
     {{- include "cullis-proxy.proxy.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -238,10 +238,17 @@ proxy:
   preStopSleepSeconds: 5
 
   service:
-    # -- Service type. Keep ClusterIP and front it with the Ingress.
+    # -- Service type. ClusterIP works behind a TCP-passthrough Ingress;
+    # use LoadBalancer when the cluster has no Ingress controller capable
+    # of passing TLS through to the pod (most ingress controllers
+    # terminate TLS, which is incompatible with the in-pod mTLS gate).
+    # ADR-014 made TLS terminate at the sidecar inside the pod, so the
+    # service hands raw TLS bytes to whichever fronting layer is configured.
     type: ClusterIP
-    # -- Service port exposed to the Ingress controller.
-    port: 9100
+    # -- Service port. Clients connect over TLS to the nginx sidecar
+    # listening on 9443; the in-pod proxy port (9100) is not exposed
+    # by the Service.
+    port: 9443
     # -- Extra annotations on the proxy Service.
     annotations: {}
 
@@ -257,6 +264,37 @@ proxy:
 # ---------------------------------------------------------------------------
 # Persistence — SQLite DB backing the proxy.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# nginx sidecar — ADR-014. Terminates TLS + enforces mTLS for agent-
+# identity routes. Reads cert material the proxy writes at first-boot
+# from the shared in-pod nginx-certs volume.
+# ---------------------------------------------------------------------------
+nginx:
+  image:
+    repository: nginx
+    # -- nginx-alpine is small and ships with the OpenSSL we need.
+    tag: 1.27-alpine
+    pullPolicy: IfNotPresent
+
+  # -- Resource hints for the sidecar. nginx is light; these are floors.
+  resources:
+    requests:
+      cpu: 25m
+      memory: 32Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+
+  # -- Dir inside the proxy container where it writes Org CA + server
+  # cert. Sidecar mounts the same dir read-only at /etc/nginx/certs.
+  certDir: /var/lib/mastio/nginx-certs
+
+  # -- SAN(s) baked into the server cert at first-boot. Comma-separated.
+  # In K8s the dominant SAN is the in-cluster Service DNS, but operators
+  # may add the public hostname too if traffic enters via LoadBalancer
+  # without a TLS-terminating front layer.
+  san: "mastio,mastio.local,localhost"
+
 # ---------------------------------------------------------------------------
 # Postgres — supported runtime backend since ADR-001 Phase 1.3. When either
 # `externalUrl` or `internal: true` is set, the proxy reads PROXY_DB_URL
@@ -354,10 +392,16 @@ vault:
   secretPrefix: "secret/data/mcp-proxy/tools"
 
 # ---------------------------------------------------------------------------
-# Ingress — cert-manager TLS termination with websocket-friendly annotations.
+# Ingress — DISABLED by default after ADR-014. The nginx sidecar
+# inside the pod terminates TLS+mTLS on port 9443 and the Service
+# hands raw TLS bytes upward. Re-enabling this Ingress requires the
+# controller to be configured for TCP passthrough (e.g.
+# nginx-ingress with `--enable-ssl-passthrough`). Without passthrough
+# the Ingress would terminate TLS at the cluster edge, breaking the
+# end-to-end TLS chain the sidecar enforces.
 # ---------------------------------------------------------------------------
 ingress:
-  enabled: true
+  enabled: false
   className: nginx
   # -- Public hostname for the proxy.
   host: proxy.example.com

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -273,6 +273,16 @@ proxy:
 # from the shared in-pod nginx-certs volume.
 # ---------------------------------------------------------------------------
 nginx:
+  # -- Toggle the sidecar. ``true`` (default) bundles the nginx
+  # container alongside the proxy and exposes 9443 TLS via the
+  # Service. ``false`` skips the sidecar entirely: the proxy serves
+  # 9100 HTTP through the Service and the cert provisioning path in
+  # the lifespan is disabled (``MCP_PROXY_NGINX_CERT_DIR`` empty).
+  # The off path is intended for environments where TLS termination
+  # is handled by an external ingress controller / service mesh and
+  # the sidecar would just add a hop. helm-test uses it.
+  enabled: true
+
   image:
     repository: nginx
     # -- nginx-alpine is small and ships with the OpenSSL we need.

--- a/deploy/helm/cullis-proxy/values.yaml
+++ b/deploy/helm/cullis-proxy/values.yaml
@@ -224,14 +224,17 @@ proxy:
     failureThreshold: 3
     successThreshold: 1
 
-  # -- Startup probe (optional — useful on first DB init).
+  # -- Startup probe (optional — useful on first DB init). Bumped
+  # failureThreshold to 60 (= 5 min boot budget) to absorb slower kind
+  # cluster bootstraps where alembic migrations + Org CA + Mastio
+  # identity + nginx cert provisioning all run on first boot.
   startupProbe:
     httpGet:
       path: /healthz
       port: http
     initialDelaySeconds: 5
     periodSeconds: 5
-    failureThreshold: 30
+    failureThreshold: 60
 
   # -- preStop hook. Sleep gives Kubernetes time to propagate the pod
   # removal through the Service endpoints before uvicorn gets SIGTERM.

--- a/deploy_proxy.sh
+++ b/deploy_proxy.sh
@@ -92,6 +92,17 @@ COMPOSE_FILES="-f docker-compose.proxy.yml"
 [[ $STANDALONE -eq 1 ]]    && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.proxy.standalone.yml"
 [[ "$MODE" == "production" ]] && COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.proxy.prod.yml"
 
+# ADR-006 Trojan Horse — flag --standalone selects the network override
+# above AND tells the Mastio itself to run in mini-broker mode (derive
+# Org CA at first boot, skip broker uplink). Both knobs were drifting
+# apart — flag set the network but the Mastio still booted federated,
+# never derived the Org CA, and the nginx sidecar (ADR-014) had no
+# cert material to serve. Propagate the flag through the env so the
+# container picks it up at lifespan startup.
+if [[ $STANDALONE -eq 1 ]]; then
+    export MCP_PROXY_STANDALONE=true
+fi
+
 # ── Down early-exit ─────────────────────────────────────────────────────────
 if [[ "$ACTION" == "down" ]]; then
     step "Stopping MCP Proxy"

--- a/deploy_proxy.sh
+++ b/deploy_proxy.sh
@@ -136,8 +136,12 @@ if [[ "$MODE" == "production" ]]; then
     fi
 
     _public="$(_load_env MCP_PROXY_PROXY_PUBLIC_URL)"
-    if [[ -z "$_public" || "$_public" == "http://localhost:9100" ]]; then
+    if [[ -z "$_public" || "$_public" == "http://localhost:9100" || "$_public" == "https://localhost:9443" ]]; then
         _errors+=("MCP_PROXY_PROXY_PUBLIC_URL still localhost — set the public URL where internal agents reach this proxy")
+    fi
+    # ADR-014 — production must use HTTPS through the mastio-nginx sidecar.
+    if [[ "$_public" == http://* ]]; then
+        _errors+=("MCP_PROXY_PROXY_PUBLIC_URL uses plain HTTP — ADR-014 requires HTTPS via the mastio-nginx sidecar (default port 9443)")
     fi
 
     if [[ ${#_errors[@]} -gt 0 ]]; then
@@ -176,20 +180,28 @@ ok "Containers started"
 # ── Wait for health ─────────────────────────────────────────────────────────
 step "Waiting for services"
 
+# ADR-014 — the Mastio listens behind the mastio-nginx sidecar on
+# 9443 TLS. The sidecar healthcheck (in compose) waits for cert
+# material to land on the shared volume, so by the time it's healthy
+# the Mastio already booted, ran first-boot cert provisioning, and
+# nginx is serving. We poll TLS here with -k because the cert is
+# self-signed off the Org CA — operators who care about strict
+# verification can extract /var/lib/mastio/nginx-certs/org-ca.crt
+# from the mcp-proxy container and pass --cacert.
 PROXY_PORT="$(grep -E '^MCP_PROXY_PORT=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
-PROXY_PORT="${PROXY_PORT:-9100}"
+PROXY_PORT="${PROXY_PORT:-9443}"
 
-echo -n "  Proxy + PDP "
-for i in $(seq 1 30); do
-    if curl -sf "http://localhost:${PROXY_PORT}/health" >/dev/null 2>&1; then
+echo -n "  Proxy + nginx "
+for i in $(seq 1 60); do
+    if curl -skf "https://localhost:${PROXY_PORT}/health" >/dev/null 2>&1; then
         echo -e " ${GREEN}ready${RESET}"
         break
     fi
     echo -n "."
     sleep 1
-    if [[ $i -eq 30 ]]; then
+    if [[ $i -eq 60 ]]; then
         echo -e " ${RED}timeout${RESET}"
-        warn "Proxy did not become healthy — check logs: $COMPOSE $COMPOSE_FILES logs mcp-proxy"
+        warn "Proxy did not become healthy — check logs: $COMPOSE $COMPOSE_FILES logs mcp-proxy mastio-nginx"
     fi
 done
 
@@ -208,12 +220,16 @@ echo ""
 if [[ "$MODE" == "development" ]]; then
     echo "  Next steps (development):"
     echo "    1. Open ${PUBLIC_URL}/proxy/login"
+    echo "       (browser will warn — the TLS cert is signed by your local"
+    echo "        Org CA, not a public CA. Accept the self-signed warning.)"
     echo "    2. Paste broker URL + invite token from the broker admin"
     echo "    3. Register your organization (certs auto-generated)"
     echo "    4. Wait for approval, then create agents"
 else
     echo "  Next steps (production):"
-    echo "    1. Reverse proxy (nginx/Traefik) in front of :${PROXY_PORT} with your public TLS cert"
+    echo "    1. ADR-014 — the mastio-nginx sidecar terminates TLS on :${PROXY_PORT}"
+    echo "       with a server cert signed by your Org CA. Front-door TLS for the"
+    echo "       public hostname is up to your edge load-balancer (LB → sidecar :${PROXY_PORT})."
     echo "    2. DNS: ${PUBLIC_URL}  →  this host"
     echo "    3. Share the dashboard URL with your org admin (credentials in proxy.env)"
     echo "    4. Broker admin generates an attach-ca or join invite for you"

--- a/docker-compose.proxy.standalone.yml
+++ b/docker-compose.proxy.standalone.yml
@@ -25,6 +25,12 @@ services:
     networks: !override
       - proxy_net
 
+  # ADR-014 — sidecar follows mcp-proxy onto the standalone bridge
+  # so it can resolve ``mcp-proxy:9100`` over docker DNS.
+  mastio-nginx:
+    networks: !override
+      - proxy_net
+
 networks:
   broker_net: !reset null
   proxy_net:

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -8,6 +8,11 @@
 # as an override — it swaps the external network for an internal one and
 # expects a full URL in MCP_PROXY_BROKER_URL.
 #
+# ADR-014 — the Mastio listens on 9100 only inside the broker_net docker
+# network. The mastio-nginx sidecar terminates TLS on host port 9443 and
+# enforces mTLS on the agent-identity routes. Host port 9100 is NOT
+# published — anyone reaching the Mastio comes through nginx.
+#
 # Usage:
 #   ./deploy_proxy.sh                       # dev, same host as broker
 #   ./deploy_proxy.sh --standalone          # remote broker
@@ -26,8 +31,10 @@ services:
     build:
       context: .
       dockerfile: mcp_proxy/Dockerfile
-    ports:
-      - "${MCP_PROXY_PORT:-9100}:9100"
+    # ADR-014 — no host port publish. The Mastio listens on 9100 only
+    # on broker_net; the mastio-nginx sidecar below publishes 9443.
+    expose:
+      - "9100"
     environment:
       MCP_PROXY_ENVIRONMENT:       ${MCP_PROXY_ENVIRONMENT:-development}
       # ADR-006 Trojan Horse — flip to true to run this Mastio as a
@@ -48,8 +55,15 @@ services:
       # On the shared network, the broker reaches the proxy by service name.
       MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}
       # Public URL the proxy advertises to its own internal agents (DPoP HTU).
-      MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-http://localhost:9100}
+      # ADR-014 — points at the nginx sidecar's TLS endpoint, not the
+      # in-network mcp-proxy listener.
+      MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-https://localhost:9443}
       MCP_PROXY_ALLOWED_ORIGINS:   ${MCP_PROXY_ALLOWED_ORIGINS:-}
+      # ADR-014 — TLS material for the nginx sidecar. The Mastio writes
+      # the server cert + Org CA bundle into this directory at first-
+      # boot; the sidecar mounts the same docker volume read-only.
+      MCP_PROXY_NGINX_CERT_DIR:    ${MCP_PROXY_NGINX_CERT_DIR:-/var/lib/mastio/nginx-certs}
+      MCP_PROXY_NGINX_SAN:         ${MCP_PROXY_NGINX_SAN:-mastio.local,localhost}
       # Custom CA bundle for HTTPS brokers with enterprise/internal certs.
       # SSL_CERT_FILE is honored by stdlib ssl + httpx/certifi.
       SSL_CERT_FILE:               ${MCP_PROXY_BROKER_CA_BUNDLE:-}
@@ -76,6 +90,9 @@ services:
       # only if MCP_PROXY_BROKER_CA_BUNDLE is set, so the directory can safely
       # stay empty in dev.
       - ./certs:/certs:ro
+      # ADR-014 — shared volume for nginx sidecar TLS material.
+      # Mastio (this service) writes; mastio-nginx mounts ro.
+      - mastio_nginx_certs:/var/lib/mastio/nginx-certs:rw
     networks:
       - broker_net
     restart: unless-stopped
@@ -86,6 +103,42 @@ services:
       retries: 3
       start_period: 10s
 
+  # ADR-014 — TLS terminator + mTLS gate for Connector → Mastio.
+  mastio-nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "${MCP_PROXY_PORT:-9443}:9443"
+    volumes:
+      - ./nginx/mastio:/etc/nginx/conf.d:ro
+      # The Mastio writes here at first-boot; nginx reads. The volume
+      # is the only way nginx sees Org CA + leaf material; if the
+      # Mastio hasn't bootstrapped yet, the files are absent and the
+      # healthcheck fails closed (no half-up nginx without trust
+      # material).
+      - mastio_nginx_certs:/etc/nginx/certs:ro
+    depends_on:
+      mcp-proxy:
+        condition: service_healthy
+    networks:
+      - broker_net
+    restart: unless-stopped
+    healthcheck:
+      # Verify the cert pair landed AND nginx itself is serving.
+      # ``-k`` because we only check that TLS terminates; the cert is
+      # self-signed off the Org CA which the curl in nginx:alpine
+      # doesn't trust by default.
+      test:
+        - CMD-SHELL
+        - >-
+          test -s /etc/nginx/certs/mastio-server.crt &&
+          test -s /etc/nginx/certs/mastio-server.key &&
+          test -s /etc/nginx/certs/org-ca.crt &&
+          wget -q --no-check-certificate -O /dev/null https://localhost:9443/health
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
 networks:
   broker_net:
     external: true
@@ -93,4 +146,9 @@ networks:
 
 volumes:
   mcp_proxy_data:
+    driver: local
+  # ADR-014 — Mastio writes Org CA + nginx server cert here; sidecar
+  # mounts read-only. Survives compose restarts so cert reuse path
+  # in ``ensure_nginx_server_cert`` short-circuits on warm boots.
+  mastio_nginx_certs:
     driver: local

--- a/docs/ops-runbook.md
+++ b/docs/ops-runbook.md
@@ -373,8 +373,12 @@ Master switch: `MCP_PROXY_ANOMALY_QUARANTINE_MODE ∈ {shadow,enforce,off}`.
 ### Observability
 
 ```bash
-curl -H "X-Admin-Secret: $ADMIN_SECRET" \
-     http://mastio:9100/v1/admin/observability/anomaly-detector | jq
+# ADR-014 — the Mastio is fronted by the mastio-nginx sidecar on 9443
+# with TLS. -k accepts the self-signed Org CA leaf; for strict checking
+# extract /etc/nginx/certs/org-ca.crt from the sidecar volume and pass
+# --cacert.
+curl -k -H "X-Admin-Secret: $ADMIN_SECRET" \
+     https://mastio:9443/v1/admin/observability/anomaly-detector | jq
 ```
 
 Fields worth watching:
@@ -403,8 +407,8 @@ Fields worth watching:
 3. If the trigger was a one-off (known migration, legit campaign),
    reactivate:
    ```bash
-   curl -X POST -H "X-Admin-Secret: $ADMIN_SECRET" \
-        http://mastio:9100/v1/admin/agents/<id>/reactivate
+   curl -k -X POST -H "X-Admin-Secret: $ADMIN_SECRET" \
+        https://mastio:9443/v1/admin/agents/<id>/reactivate
    ```
 4. If the agent's baseline has shifted permanently (agent changed
    workload shape), let the next daily roll-up at 04:00 UTC
@@ -502,6 +506,14 @@ as seen by the edge (after any CDN / WAF unwrapping — verify
 `X-Forwarded-For` semantics for your setup).
 
 #### nginx
+
+> **ADR-014.** The example below is for an **edge** nginx in front of the
+> Mastio (e.g. cluster ingress, public-facing LB). The Mastio itself ships
+> with its own nginx sidecar on port 9443 that terminates TLS and enforces
+> mTLS — your edge upstream points at `https://<mastio-pod-ip>:9443`, not
+> at the in-pod proxy port 9100. Set `proxy_pass https://mastio_upstream;`
+> (note the `https`) and configure your upstream block with `server
+> <mastio>:9443;`.
 
 Global config (inside `http { … }`):
 

--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -48,10 +48,12 @@ COPY cullis_sdk/ ./cullis_sdk/
 # Inject pre-compiled Tailwind stylesheet (shake-out P1-10)
 COPY --from=tailwind-build /out/tailwind.css /app/mcp_proxy/dashboard/static/css/tailwind.css
 
-# Data directory for SQLite
-RUN mkdir -p /data && \
+# Data directory for SQLite + ADR-014 nginx-cert directory shared with
+# the mastio-nginx sidecar (Mastio writes Org CA + server cert here at
+# first-boot; sidecar mounts read-only).
+RUN mkdir -p /data /var/lib/mastio/nginx-certs && \
     useradd --no-create-home --system proxyuser && \
-    chown proxyuser:proxyuser /data
+    chown proxyuser:proxyuser /data /var/lib/mastio/nginx-certs
 
 ENV PYTHONPATH=/app
 ENV MCP_PROXY_DATABASE_URL=sqlite+aiosqlite:////data/mcp_proxy.db

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -47,6 +47,20 @@ class ProxySettings(BaseSettings):
     allowed_origins: str = ""
     environment: str = "development"
 
+    # ADR-014 — TLS material for the nginx sidecar that fronts the
+    # Mastio. ``nginx_cert_dir`` is the path inside the Mastio
+    # container where Org CA + server cert + server key are written
+    # at first-boot; the sidecar mounts the same docker volume read-
+    # only at ``/etc/nginx/certs``. Empty disables the cert provisioning
+    # path entirely (useful in unit tests + legacy deploys without
+    # the sidecar).
+    nginx_cert_dir: str = "/var/lib/mastio/nginx-certs"
+    # SAN(s) baked into the server cert. Comma-separated for multi-
+    # host deployments. Default ``mastio.local`` matches the
+    # docker-compose default; override with MCP_PROXY_NGINX_SAN for
+    # production hostnames.
+    nginx_san: str = "mastio.local"
+
     # DPoP
     dpop_iat_window: int = 60
     dpop_clock_skew: int = 5

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -284,6 +284,197 @@ class AgentManager:
         )
         return hashlib.sha256(pubkey_der).hexdigest()[:16]
 
+    # ── ADR-014: nginx sidecar TLS material ──────────────────────────
+
+    async def ensure_nginx_server_cert(
+        self,
+        *,
+        out_dir: str,
+        sans: list[str] | None = None,
+        validity_days: int = 365,
+        renew_within_days: int = 30,
+    ) -> bool:
+        """Emit / refresh the TLS server cert that the nginx sidecar uses.
+
+        Writes three files into ``out_dir``:
+
+        - ``org-ca.crt`` — the Org CA's public certificate (the trust
+          bundle nginx uses as ``ssl_client_certificate`` to verify
+          Connector certs at the TLS handshake).
+        - ``mastio-server.crt`` — the leaf cert nginx serves on 9443,
+          signed by the Org CA, with the requested SANs.
+        - ``mastio-server.key`` — the leaf's private key.
+
+        Idempotent: at every boot the method checks whether the existing
+        files are still valid (parseable, not expiring within
+        ``renew_within_days``, SAN list matches, issued by the current
+        Org CA). If yes, nothing changes. If no, a fresh leaf is minted
+        and the trust bundle is rewritten.
+
+        Returns ``True`` if files were rewritten, ``False`` if the
+        existing material was reused.
+        """
+        if not self.ca_loaded:
+            raise RuntimeError("Org CA not loaded — cannot emit nginx server cert")
+
+        from pathlib import Path
+
+        def _aware(dt: datetime) -> datetime:
+            """cryptography <42 returns naive UTC datetimes from cert
+            properties; ≥42 returns aware. Normalize to aware for math
+            and ISO formatting."""
+            return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
+
+        san_list = list(sans) if sans else ["mastio.local"]
+
+        out = Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+
+        ca_path = out / "org-ca.crt"
+        crt_path = out / "mastio-server.crt"
+        key_path = out / "mastio-server.key"
+
+        # ── Reuse path: validate existing files in one shot ─────────
+        reuse = False
+        if ca_path.exists() and crt_path.exists() and key_path.exists():
+            try:
+                existing = x509.load_pem_x509_certificate(crt_path.read_bytes())
+                # SAN match
+                try:
+                    san_ext = existing.extensions.get_extension_for_class(
+                        SubjectAlternativeName,
+                    ).value
+                    existing_dns = sorted(
+                        san_ext.get_values_for_type(x509.DNSName)
+                    )
+                except x509.ExtensionNotFound:
+                    existing_dns = []
+                # Issuer match (current Org CA's subject)
+                issuer_ok = (
+                    existing.issuer.rfc4514_string()
+                    == self._org_ca_cert.subject.rfc4514_string()
+                )
+                # Expiry guard
+                now = datetime.now(timezone.utc)
+                expires_in = _aware(existing.not_valid_after) - now
+                expiry_ok = expires_in > timedelta(days=renew_within_days)
+                # CA bundle file matches the in-memory CA
+                ca_ondisk = x509.load_pem_x509_certificate(ca_path.read_bytes())
+                ca_ok = (
+                    ca_ondisk.public_bytes(serialization.Encoding.DER)
+                    == self._org_ca_cert.public_bytes(serialization.Encoding.DER)
+                )
+
+                if (
+                    issuer_ok
+                    and expiry_ok
+                    and ca_ok
+                    and sorted(san_list) == existing_dns
+                ):
+                    reuse = True
+            except Exception as exc:  # treat any parse failure as "regenerate"
+                logger.info(
+                    "nginx server cert on disk failed validation (%s) — "
+                    "will regenerate",
+                    exc,
+                )
+
+        if reuse:
+            logger.info(
+                "nginx server cert reused (sans=%s, expiring=%s)",
+                ",".join(san_list),
+                _aware(existing.not_valid_after).isoformat(timespec="seconds"),
+            )
+            return False
+
+        # ── Mint path ───────────────────────────────────────────────
+        # ECDSA P-256 leaf — fast, modern, matches the Connector cert
+        # algorithm so nginx negotiates TLS 1.3 + ECDSA cleanly.
+        leaf_key = ec.generate_private_key(ec.SECP256R1())
+
+        subject = x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, san_list[0]),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, self._org_id or "cullis"),
+        ])
+
+        now = datetime.now(timezone.utc)
+        builder = (
+            x509.CertificateBuilder()
+            .subject_name(subject)
+            .issuer_name(self._org_ca_cert.subject)
+            .public_key(leaf_key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(now - timedelta(minutes=5))
+            .not_valid_after(now + timedelta(days=validity_days))
+            .add_extension(
+                x509.BasicConstraints(ca=False, path_length=None),
+                critical=True,
+            )
+            .add_extension(
+                x509.KeyUsage(
+                    digital_signature=True,
+                    content_commitment=False,
+                    key_encipherment=True,  # required for TLS RSA-style ciphers
+                    data_encipherment=False,
+                    key_agreement=False,
+                    key_cert_sign=False,
+                    crl_sign=False,
+                    encipher_only=False,
+                    decipher_only=False,
+                ),
+                critical=True,
+            )
+            .add_extension(
+                x509.ExtendedKeyUsage([x509.oid.ExtendedKeyUsageOID.SERVER_AUTH]),
+                critical=False,
+            )
+            .add_extension(
+                SubjectAlternativeName([x509.DNSName(s) for s in san_list]),
+                critical=False,
+            )
+            .add_extension(
+                x509.SubjectKeyIdentifier.from_public_key(leaf_key.public_key()),
+                critical=False,
+            )
+            .add_extension(
+                x509.AuthorityKeyIdentifier.from_issuer_public_key(
+                    self._org_ca_cert.public_key(),
+                ),
+                critical=False,
+            )
+        )
+        leaf_cert = builder.sign(self._org_ca_key, hashes.SHA256())
+
+        # Write atomically: tmp file then rename. nginx watches the
+        # files and reload (SIGHUP) is the operator's job; mid-boot
+        # we just need the writes consistent so a restart-within-restart
+        # never observes a torn pair.
+        ca_pem = self._org_ca_cert.public_bytes(serialization.Encoding.PEM)
+        crt_pem = leaf_cert.public_bytes(serialization.Encoding.PEM)
+        key_pem = leaf_key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+
+        for path, payload, mode in (
+            (ca_path, ca_pem, 0o644),
+            (crt_path, crt_pem, 0o644),
+            (key_path, key_pem, 0o600),
+        ):
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_bytes(payload)
+            tmp.chmod(mode)
+            tmp.replace(path)
+
+        logger.info(
+            "nginx server cert minted (sans=%s, valid_until=%s, dir=%s)",
+            ",".join(san_list),
+            _aware(leaf_cert.not_valid_after).isoformat(timespec="seconds"),
+            out_dir,
+        )
+        return True
+
     # ── Certificate generation ──────────────────────────────────────
 
     def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -177,6 +177,7 @@ async def lifespan(app: FastAPI):
                     out_dir=settings.nginx_cert_dir,
                     sans=sans,
                 )
+                _log.info("ADR-014 nginx cert provisioning complete")
             except Exception as exc:  # don't block lifespan on cert write
                 _log.warning(
                     "ADR-014 nginx server cert provisioning failed: %s — "
@@ -186,6 +187,7 @@ async def lifespan(app: FastAPI):
 
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
+    _log.info("Lifespan: agent_manager + org_id wired (org_id=%s)", org_id)
 
     # Federation update framework (imp/federation_hardening_plan.md
     # Parte 1, PR 2). Must run BEFORE ``LocalIssuer`` construction so a

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -160,6 +160,30 @@ async def lifespan(app: FastAPI):
         except Exception as exc:  # defensive — never block lifespan on this
             _log.warning("Mastio identity bootstrap failed: %s", exc)
 
+        # ADR-014 — emit the TLS server cert that the nginx sidecar
+        # serves on 9443. The CA bundle (public Org CA cert) goes
+        # alongside so nginx can verify Connector certs at the TLS
+        # handshake. Idempotent across boots; only mints fresh
+        # material when the existing pair is missing, expired, or
+        # SAN-mismatched against the configured value.
+        if settings.nginx_cert_dir:
+            try:
+                sans = [
+                    s.strip()
+                    for s in (settings.nginx_san or "mastio.local").split(",")
+                    if s.strip()
+                ]
+                await agent_mgr.ensure_nginx_server_cert(
+                    out_dir=settings.nginx_cert_dir,
+                    sans=sans,
+                )
+            except Exception as exc:  # don't block lifespan on cert write
+                _log.warning(
+                    "ADR-014 nginx server cert provisioning failed: %s — "
+                    "the sidecar will fail readiness until this is resolved",
+                    exc,
+                )
+
     app.state.agent_manager = agent_mgr
     app.state.org_id = org_id
 

--- a/nginx/mastio/00-maps.conf
+++ b/nginx/mastio/00-maps.conf
@@ -1,0 +1,18 @@
+# =============================================================================
+# Cullis Mastio sidecar — http-level maps
+# =============================================================================
+#
+# Loaded before mastio.conf via lexicographic order in
+# /etc/nginx/conf.d/. ``map`` directives must live in the ``http {}``
+# context (which the nginx official image opens for us at the top
+# level), so they can't sit inside a ``server {}`` block.
+# =============================================================================
+
+# WebSocket Upgrade helper for the dashboard websocket route. Empty
+# Upgrade → close the upstream connection; anything else → forward
+# verbatim so nginx doesn't emit ``Connection: close`` and break
+# long-lived dashboard streams.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -56,8 +56,12 @@ server {
     client_max_body_size 4m;
 
     # ──────────────────────────────────────────────────────────────────
-    # Routes that REQUIRE a client cert (mTLS — agent identity at TLS)
+    # mTLS-required (TLS-layer agent identity)
     # ──────────────────────────────────────────────────────────────────
+    # /v1/egress + /v1/agents are the surface where the *caller's
+    # identity* is what gates the action. The cert presented at the TLS
+    # handshake IS the identity. Without a verified cert nginx returns
+    # 401 before FastAPI sees the request.
     location ~ ^/v1/(egress|agents)(/.*)?$ {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
@@ -74,12 +78,17 @@ server {
     }
 
     # ──────────────────────────────────────────────────────────────────
-    # Anonymous over TLS — no client cert required
+    # TLS-only catch-all for /v1/*
     # ──────────────────────────────────────────────────────────────────
-    # Enrollment bootstrap: caller doesn't have a cert yet (that's
-    # what enrollment is for). Wire is encrypted; admin-side approval
-    # at /proxy/agents is the auth gate.
-    location ~ ^/v1/enrollment(/.*)?$ {
+    # Everything else under /v1 is auth'd at the application layer:
+    # /v1/admin (session cookie / admin secret), /v1/enrollment
+    # (anonymous bootstrap), /v1/auth (login-challenge), /v1/federation
+    # (public discovery), /v1/local + /v1/ingress + /v1/mcp + /v1/broker
+    # (broker-or-internal callers). All of these terminate TLS at nginx
+    # and forward without a client cert. Mounting them all here as a
+    # single regex avoids the trap where a new /v1/<thing> route ships
+    # without us adding a sidecar location and starts returning 404.
+    location ~ ^/v1/(.*)$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;
@@ -89,10 +98,16 @@ server {
         # Strip any client-supplied cert header — anonymous endpoints
         # must not be confusable with authenticated ones.
         proxy_set_header X-SSL-Client-Cert "";
+        # WebSocket upgrades for /v1/local + /v1/broker.
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+        proxy_read_timeout                 86400;
     }
 
-    # Auth helpers (login-challenge, etc.) — application-layer auth.
-    location ~ ^/v1/auth(/.*)?$ {
+    # ──────────────────────────────────────────────────────────────────
+    # Health, dashboard, PDP, well-known — anonymous over TLS
+    # ──────────────────────────────────────────────────────────────────
+    location ~ ^/(health|healthz|readyz|live)$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;
@@ -102,21 +117,7 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
-    # Health / readiness — used by docker healthcheck, k8s probes,
-    # and the smoke gate.
-    location ~ ^/(health|readyz|live)$ {
-        proxy_pass http://mcp-proxy:9100;
-        proxy_http_version 1.1;
-        proxy_set_header Host              $host;
-        proxy_set_header X-Real-IP         $remote_addr;
-        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto https;
-        proxy_set_header X-SSL-Client-Cert "";
-    }
-
-    # Dashboard (browser admin) — TLS only, no client cert. Auth is
-    # session cookie or OIDC, handled in the FastAPI app. WebSocket
-    # upgrades supported for the federation-update progress feed.
+    # Dashboard (browser admin) — auth is session cookie or OIDC at app.
     location ~ ^/proxy(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
@@ -130,10 +131,19 @@ server {
         proxy_read_timeout                 86400;
     }
 
-    # PDP webhook — broker calls this over the docker network. No
-    # client cert required at this layer (broker auth is handled
-    # application-side in /pdp/policy itself).
+    # PDP webhook — broker calls this over the docker network.
     location ~ ^/pdp(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # /.well-known (JWKS, security.txt, OIDC discovery, etc.)
+    location ~ ^/\.well-known(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
         proxy_set_header Host              $host;

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -1,0 +1,152 @@
+# =============================================================================
+# Cullis Mastio nginx sidecar — ADR-014
+# =============================================================================
+#
+# Terminates TLS on 9443 in front of mcp-proxy (which keeps listening on
+# 9100 on the internal docker network only — never published to the
+# host). Routes carrying agent identity require a client certificate
+# signed by the Org CA. Routes that are anonymous by design (enrollment
+# bootstrap, dashboard browser login, health) terminate TLS but do not
+# require a client cert.
+#
+# Anti-spoofing on X-SSL-Client-Cert
+# ----------------------------------
+# nginx always overwrites X-SSL-Client-Cert with the verified cert from
+# the TLS handshake (proxy_set_header). The backend mcp-proxy is bound
+# to the internal ``broker_net`` docker network only, with no host port
+# publish, so a caller cannot reach 9100 directly to bypass nginx and
+# inject a forged header. If a future deploy ever publishes 9100, we
+# add a shared-secret edge header at that point — for now the network
+# binding is the defence.
+# =============================================================================
+
+server {
+    listen 9443 ssl;
+    http2 on;
+    server_name _;
+
+    # ── TLS server material ─────────────────────────────────────────
+    # Both files are written into /etc/nginx/certs by the Mastio at
+    # first-boot (and rotation), then mounted read-only here via the
+    # shared docker volume ``mastio_nginx_certs``.
+    ssl_certificate     /etc/nginx/certs/mastio-server.crt;
+    ssl_certificate_key /etc/nginx/certs/mastio-server.key;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5:!RC4;
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 10m;
+    ssl_session_cache   shared:SSL:10m;
+
+    # ── Client cert verification ────────────────────────────────────
+    # The Org CA is the trust bundle for client certs. Same CA the
+    # Mastio uses to sign every Connector cert during enrollment, so
+    # presenting a valid Connector identity at the TLS layer is the
+    # whole point of the design. ``ssl_verify_client optional`` lets
+    # individual locations selectively require the cert below.
+    ssl_client_certificate /etc/nginx/certs/org-ca.crt;
+    ssl_verify_client      optional;
+
+    # ── Hardening headers ───────────────────────────────────────────
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options    "nosniff" always;
+    add_header X-Frame-Options           "DENY" always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+    client_max_body_size 4m;
+
+    # ──────────────────────────────────────────────────────────────────
+    # Routes that REQUIRE a client cert (mTLS — agent identity at TLS)
+    # ──────────────────────────────────────────────────────────────────
+    location ~ ^/v1/(egress|agents)(/.*)?$ {
+        if ($ssl_client_verify != SUCCESS) {
+            return 401;
+        }
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # Always overwrite — never trust a client-supplied value.
+        proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
+        proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+    }
+
+    # ──────────────────────────────────────────────────────────────────
+    # Anonymous over TLS — no client cert required
+    # ──────────────────────────────────────────────────────────────────
+    # Enrollment bootstrap: caller doesn't have a cert yet (that's
+    # what enrollment is for). Wire is encrypted; admin-side approval
+    # at /proxy/agents is the auth gate.
+    location ~ ^/v1/enrollment(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # Strip any client-supplied cert header — anonymous endpoints
+        # must not be confusable with authenticated ones.
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Auth helpers (login-challenge, etc.) — application-layer auth.
+    location ~ ^/v1/auth(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Health / readiness — used by docker healthcheck, k8s probes,
+    # and the smoke gate.
+    location ~ ^/(health|readyz|live)$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Dashboard (browser admin) — TLS only, no client cert. Auth is
+    # session cookie or OIDC, handled in the FastAPI app. WebSocket
+    # upgrades supported for the federation-update progress feed.
+    location ~ ^/proxy(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+        proxy_read_timeout                 86400;
+    }
+
+    # PDP webhook — broker calls this over the docker network. No
+    # client cert required at this layer (broker auth is handled
+    # application-side in /pdp/policy itself).
+    location ~ ^/pdp(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # ──────────────────────────────────────────────────────────────────
+    # Catch-all — fail closed.
+    # ──────────────────────────────────────────────────────────────────
+    location / {
+        return 404;
+    }
+}

--- a/proxy.env.example
+++ b/proxy.env.example
@@ -49,11 +49,13 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 
 # Public URL where the proxy itself is reachable. Used for DPoP HTU
 # validation on the ingress endpoints — must match how internal agents
-# address the proxy.
-MCP_PROXY_PROXY_PUBLIC_URL=http://localhost:9100
+# address the proxy. ADR-014: this points at the mastio-nginx sidecar
+# (TLS), not the in-network mcp-proxy listener.
+MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443
 
 # PDP webhook URL — the broker calls this to ask the proxy for policy
-# decisions. Must be reachable from the broker container/host.
+# decisions. The broker reaches the Mastio over the docker network,
+# where the in-network listener (port 9100) is still HTTP.
 # On the same Docker network: http://mcp-proxy:9100/pdp/policy
 # On a remote proxy: https://proxy.myorg.example.com/pdp/policy
 MCP_PROXY_PDP_URL=http://mcp-proxy:9100/pdp/policy
@@ -64,8 +66,24 @@ MCP_PROXY_ALLOWED_ORIGINS=
 
 # ─── Network ─────────────────────────────────────────────────────────────────
 
-# Host port where the proxy listens. Internal container port is always 9100.
-MCP_PROXY_PORT=9100
+# Host port where the mastio-nginx sidecar serves TLS (ADR-014). The
+# in-container Mastio listener stays on 9100 but is no longer published
+# to the host — all external traffic enters via the sidecar.
+MCP_PROXY_PORT=9443
+
+# ─── ADR-014 — nginx sidecar TLS ─────────────────────────────────────────────
+
+# Where the Mastio writes the Org CA + server cert + server key for the
+# nginx sidecar to serve. This is a path *inside* the mcp-proxy
+# container; the sidecar mounts the same docker volume read-only.
+MCP_PROXY_NGINX_CERT_DIR=/var/lib/mastio/nginx-certs
+
+# SAN(s) baked into the nginx server cert. Comma-separated for multi-
+# host. Default targets the docker-compose dev hostname plus localhost
+# for host-side curl. Override with the operator's actual hostnames in
+# production (the cert is regenerated on the next Mastio boot if SAN
+# changes).
+MCP_PROXY_NGINX_SAN=mastio.local,localhost
 
 # Docker network mode:
 #   shared    — proxy joins the broker's docker-compose network (same host)

--- a/scripts/generate-proxy-env.sh
+++ b/scripts/generate-proxy-env.sh
@@ -77,7 +77,8 @@ case "$MODE" in
         ;;
     defaults)
         BROKER="${BROKER_URL:-http://broker:8000}"
-        PUBLIC="${PROXY_PUBLIC_URL:-http://localhost:9100}"
+        # ADR-014 — public URL points at the mastio-nginx sidecar (TLS).
+        PUBLIC="${PROXY_PUBLIC_URL:-https://localhost:9443}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;
@@ -85,8 +86,8 @@ case "$MODE" in
         echo ""
         read -rp "  Broker URL [http://broker:8000]: " BROKER
         BROKER="${BROKER:-http://broker:8000}"
-        read -rp "  Proxy public URL [http://localhost:9100]: " PUBLIC
-        PUBLIC="${PUBLIC:-http://localhost:9100}"
+        read -rp "  Proxy public URL [https://localhost:9443]: " PUBLIC
+        PUBLIC="${PUBLIC:-https://localhost:9443}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;

--- a/site/src/content/docs/install/connector.md
+++ b/site/src/content/docs/install/connector.md
@@ -14,7 +14,7 @@ updated: "2026-04-23"
 
 - macOS 12+, Windows 10+, or Linux with `glibc ≥ 2.31`
 - 100 MB disk, 200 MB RAM
-- Your Mastio URL (ask your admin — typically `https://cullis.acme.local` or `http://localhost:9100` during first-time setup)
+- Your Mastio URL (ask your admin — typically `https://cullis.acme.local` or `https://localhost:9443` during first-time setup; ADR-014 made the Mastio TLS-only with a self-signed Org-CA leaf — pass `--insecure-tls` for the dev case)
 - A reachable admin who can approve your enrollment in the Mastio dashboard
 
 ## 1. Download


### PR DESCRIPTION
## Summary

Migrazione full ADR-014 (#328) — Mastio raggiungibile dall'host **solo** attraverso il sidecar nginx su 9443 con TLS, mTLS richiesto sulle route che identificano il caller (`/v1/egress/*`, `/v1/agents/*`). Host port 9100 non viene più pubblicato.

Questo PR **non flippa ancora** la dependency FastAPI da api_key a cert. nginx già blocca al TLS layer chi non ha cert per le route mTLS-required, ma l'app continua a identificare l'agent via `get_agent_from_dpop_api_key`. PR-B fa lo swap; PR-C drop dell'api_key (chiude #325 per dissoluzione).

## Cosa lands qui (5 commit)

- `12c5004` — sidecar config (compose) + `ensure_nginx_server_cert` idempotente in `agent_manager.py` + first-boot wiring + `nginx_cert_dir` / `nginx_san` settings + Dockerfile dir provisioning + `deploy_proxy.sh` health probe TLS + `proxy.env.example` defaults `https://localhost:9443`
- `50385ba` — `deploy_proxy.sh --standalone` propaga `MCP_PROXY_STANDALONE=true` (bug pre-esistente che ha bloccato il primo dogfood)
- `fd1a956` — helm chart parity: nuovo `proxy-nginx-configmap.yaml`, sidecar nel deployment, shared `emptyDir` volume, service port 9443, ingress disabled by default + standalone compose override fix sidecar networks
- `a51078e` — CI workflows (helm-test HTTPS+standalone, release-proxy notes), nginx route widening (`/v1/(egress|agents)` mTLS, `/v1/*` catch-all TLS-only per admin/federation/local/ingress/mcp/broker), `/healthz` alias + `/.well-known`, prod docs (ops-runbook + install/connector)

## Dogfood verde

Local docker compose, 9 check passati:

| Check | HTTP | Note |
|---|---|---|
| `https://localhost:9443/health` | 200 | TLS termina al sidecar |
| `https://localhost:9443/healthz` | 200 | alias |
| `/v1/egress/peers` no cert | 401 | nginx blocca pre-FastAPI |
| `/v1/agents/search` no cert | 401 | idem |
| `/v1/admin/mastio-pubkey` no auth | 422 | passa nginx → 422 da FastAPI dependency |
| `/v1/admin/mastio-pubkey` con `X-Admin-Secret` | 200 | end-to-end |
| `/v1/enrollment/start` body vuoto | 422 | passa nginx → app validation |
| `/proxy` (dashboard) | 307 | redirect login |
| `/random_garbage` | 404 | nginx catch-all |
| Host port 9100 | unreachable | kill HTTP confermato |
| Plain HTTP su 9443 | unreachable | TLS-only |

## Out of scope (deliberato)

- **`tests/e2e` migration**: il `tests/e2e/docker-compose.e2e.yml` è isolato dal `docker-compose.proxy.yml` (definisce i suoi proxy da capo). I test cross-org passano via api_key+DPoP, non mTLS — non hanno bisogno del sidecar finché l'auth non swap. Migration → PR-B.
- **PR-A3** sandbox/reference/demo_network/test/nightly migration → compose indipendenti, follow-up PR.
- **PR-B**: `get_agent_from_client_cert` dependency + apply su `/v1/egress/*` + `/v1/agents/me/*` + Connector mTLS client.
- **PR-C**: drop api_key auth (alembic 0022, sweep, chiude #325 per dissoluzione).

## Test plan

- [x] Local dogfood standalone (sopra)
- [x] Sintassi Python OK (ast.parse pass su file modificati)
- [ ] CI verde: `test (3.11)`, `helm-test (cullis-proxy)`, smoke standalone — in corso
- [ ] User review

Refs: ADR-014 (#328), #325 (chiuderà in PR-C), #326 (parallelo ortogonale), #327 (smoke gate post-PR-C).