### PR TITLE
fix(sandbox): ADR-014 mTLS — per-org nginx sidecar + agent cert auth

### DIFF
--- a/sandbox/agent/agent.py
+++ b/sandbox/agent/agent.py
@@ -132,27 +132,45 @@ def _auth_api_key_file(mastio_url: str, identity_dir: str, self_id: str) -> Cull
     bootstrap-mastio stage enrolled for them.
 
     Layout matches what ``_enroll_agents_via_byoca`` writes under
-    ``/state/{org}/agents/{name}/``: ``api-key`` + ``dpop.jwk`` (both
-    required for egress DPoP enforcement).
+    ``/state/{org}/agents/{name}/``: ``api-key`` + ``dpop.jwk`` +
+    ``agent.pem`` (cert) + ``agent-key.pem`` (private key).
+
+    ADR-014 — cert+key are passed to ``from_api_key_file`` so the
+    SDK's httpx client presents them at the TLS handshake against the
+    per-org nginx sidecar on 9443. ``verify_tls=False`` because the
+    sandbox's Org CA is self-signed (no system trust store entry); a
+    real deploy points at a CA-trusted hostname or a custom
+    ``CULLIS_CA_BUNDLE``.
     """
     api_key_path = pathlib.Path(identity_dir) / "api-key"
     dpop_key_path = pathlib.Path(identity_dir) / "dpop.jwk"
+    cert_path = pathlib.Path(identity_dir) / "agent.pem"
+    key_path = pathlib.Path(identity_dir) / "agent-key.pem"
     deadline = time.monotonic() + 60
     while time.monotonic() < deadline:
-        if api_key_path.exists() and dpop_key_path.exists():
+        if (
+            api_key_path.exists()
+            and dpop_key_path.exists()
+            and cert_path.exists()
+            and key_path.exists()
+        ):
             break
         time.sleep(0.5)
     else:
         raise RuntimeError(
-            f"[{self_id}] api-key or dpop.jwk missing under {identity_dir} "
-            "— did bootstrap-mastio run?"
+            f"[{self_id}] missing identity material under {identity_dir} "
+            "(need api-key, dpop.jwk, agent.pem, agent-key.pem) — "
+            "did bootstrap-mastio + bootstrap run?"
         )
     client = CullisClient.from_api_key_file(
         mastio_url,
         api_key_path=api_key_path,
         dpop_key_path=dpop_key_path,
+        cert_path=cert_path,
+        key_path=key_path,
         agent_id=self_id,
         org_id=self_id.split("::", 1)[0],
+        verify_tls=False,
     )
     # Session APIs (``list_sessions`` / ``open_session`` / ``send``) still
     # require a broker JWT. ``login_via_proxy`` converts the API key into

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -29,6 +29,10 @@ volumes:
   bootstrap-state:
   proxy-a-data:
   proxy-b-data:
+  # ADR-014 — Mastio writes Org CA + nginx server cert here at first-boot;
+  # the per-org sidecar mounts read-only.
+  mastio-a-nginx-certs:
+  mastio-b-nginx-certs:
   # Blocco 4 — SPIRE stacks per org
   spire-a-server-api:
   spire-a-server-data:
@@ -282,11 +286,23 @@ services:
       # BrokerBridge's own per-agent Court login, so the envelope path
       # keeps working.
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+      # ADR-014 — first-boot writes Org CA + nginx server cert into the
+      # shared volume so the mastio-nginx-a sidecar can serve TLS on
+      # 9443 against the same CA the agents' certs chain to. SAN
+      # includes ``proxy-a`` (the alias agents resolve over
+      # orga-internal) and ``localhost`` (smoke + dev curl from host).
+      MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"
+      MCP_PROXY_NGINX_SAN: "proxy-a,localhost"
     volumes:
       - proxy-a-data:/data
+      - mastio-a-nginx-certs:/var/lib/mastio/nginx-certs:rw
     networks:
       orga-internal:
-        aliases: [proxy-a]
+        # ``mcp-proxy`` is the upstream name nginx/mastio/mastio.conf
+        # hard-codes (matches the canonical compose service name); add
+        # it as an alias here so the sidecar's ``proxy_pass`` resolves
+        # without forking the shared nginx config.
+        aliases: [proxy-a, mcp-proxy]
       public-wan:
         aliases: [proxy-a]
     expose: ["9100"]
@@ -297,6 +313,42 @@ services:
       timeout: 3s
       retries: 20
       start_period: 10s
+
+  # ADR-014 — TLS terminator + mTLS gate for orga agents. Lives only
+  # on orga-internal: the sidecar verifies client certs against the
+  # Org CA the Mastio just minted, terminates TLS on 9443, and
+  # forwards plaintext to mcp-proxy:9100 inside the same network.
+  # Host port 9443 lets smoke + curl from the host hit it without
+  # going through orga-internal.
+  mastio-nginx-a:
+    image: nginx:1.27-alpine
+    depends_on:
+      proxy-a:
+        condition: service_healthy
+    volumes:
+      - ../nginx/mastio:/etc/nginx/conf.d:ro
+      - mastio-a-nginx-certs:/etc/nginx/certs:ro
+    networks:
+      orga-internal:
+        aliases: [mastio-nginx-a]
+    expose: ["9443"]
+    ports: ["9443:9443"]
+    healthcheck:
+      # Cert files on disk + master pid alive — same logic as the
+      # standalone smoke (busybox wget TLS handshake against the
+      # self-signed Org CA flakes on Alpine; if the cert material
+      # were invalid nginx wouldn't have started).
+      test:
+        - CMD-SHELL
+        - >-
+          test -s /etc/nginx/certs/mastio-server.crt &&
+          test -s /etc/nginx/certs/mastio-server.key &&
+          test -s /etc/nginx/certs/org-ca.crt &&
+          test -s /var/run/nginx.pid
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
 
   # ── Blocco 4 — SPIRE stack per Org A ──────────────────────────────────────
   #
@@ -398,8 +450,16 @@ services:
         condition: service_completed_successfully
       broker:
         condition: service_healthy
+      # ADR-014 — wait for the nginx sidecar to be serving 9443 before
+      # the agent's first SDK call hits the wire.
+      mastio-nginx-a:
+        condition: service_healthy
     environment:
-      BROKER_URL: "http://proxy-a:9100"
+      # ADR-014 — agents reach the Mastio over mTLS via the per-org
+      # nginx sidecar on 9443. The agent presents its Org-CA-signed
+      # cert (loaded from /state/{org}/agents/{name}/agent.{pem,key})
+      # at the TLS handshake; nginx verifies + forwards.
+      BROKER_URL: "https://proxy-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "agent-a"
       PEERS_FILE: "/state/peers.json"
@@ -439,8 +499,11 @@ services:
         condition: service_completed_successfully
       broker:
         condition: service_healthy
+      mastio-nginx-a:
+        condition: service_healthy
     environment:
-      BROKER_URL: "http://proxy-a:9100"
+      # ADR-014 — see agent-a rationale; same nginx sidecar.
+      BROKER_URL: "https://proxy-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "byoca-bot"
       PEERS_FILE: "/state/peers.json"
@@ -509,11 +572,15 @@ services:
       PROXY_TRANSPORT_INTRA_ORG: "mtls-only"
       # ADR-012 — Mastio-local /v1/auth/token (see proxy-a rationale).
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+      # ADR-014 — see proxy-a rationale.
+      MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"
+      MCP_PROXY_NGINX_SAN: "proxy-b,localhost"
     volumes:
       - proxy-b-data:/data
+      - mastio-b-nginx-certs:/var/lib/mastio/nginx-certs:rw
     networks:
       orgb-internal:
-        aliases: [proxy-b]
+        aliases: [proxy-b, mcp-proxy]
       public-wan:
         aliases: [proxy-b]
     expose: ["9100"]
@@ -524,6 +591,34 @@ services:
       timeout: 3s
       retries: 20
       start_period: 10s
+
+  # ADR-014 — TLS terminator + mTLS gate for orgb agents. Mirrors
+  # mastio-nginx-a; host port 9543 keeps proxy-a's 9443 free.
+  mastio-nginx-b:
+    image: nginx:1.27-alpine
+    depends_on:
+      proxy-b:
+        condition: service_healthy
+    volumes:
+      - ../nginx/mastio:/etc/nginx/conf.d:ro
+      - mastio-b-nginx-certs:/etc/nginx/certs:ro
+    networks:
+      orgb-internal:
+        aliases: [mastio-nginx-b]
+    expose: ["9443"]
+    ports: ["9543:9443"]
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          test -s /etc/nginx/certs/mastio-server.crt &&
+          test -s /etc/nginx/certs/mastio-server.key &&
+          test -s /etc/nginx/certs/org-ca.crt &&
+          test -s /var/run/nginx.pid
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
 
   # ── Blocco 4 — SPIRE stack per Org B ──────────────────────────────────────
 
@@ -611,8 +706,11 @@ services:
         condition: service_completed_successfully
       broker:
         condition: service_healthy
+      mastio-nginx-b:
+        condition: service_healthy
     environment:
-      BROKER_URL: "http://proxy-b:9100"
+      # ADR-014 — agents reach Mastio B via the orgb nginx sidecar.
+      BROKER_URL: "https://proxy-b:9443"
       ORG_ID: "orgb"
       AGENT_NAME: "agent-b"
       PEERS_FILE: "/state/peers.json"


### PR DESCRIPTION
## Summary
Post-PR-B (#332) regression sweep for the **published sandbox demo**. With `/v1/egress/*` and `/v1/agents/search` now mTLS-gated, the sandbox agents (talking plain HTTP on 9100 / 9200) 401'd at the cert dep on the first `send_oneshot` / `receive_oneshot`.

This wires each proxy behind a per-org nginx sidecar — same pattern as PR-B's standalone smoke fix, scoped to the sandbox topology.

## What changed
- `sandbox/docker-compose.yml`:
  - New `mastio-nginx-a` (orga-internal, host 9443) + `mastio-nginx-b` (orgb-internal, host 9543) sidecars using the shared `nginx/mastio/` config and per-org cert volumes (`mastio-{a,b}-nginx-certs`).
  - `proxy-a` / `proxy-b` grow the `mcp-proxy` network alias so the shared nginx config's `proxy_pass http://mcp-proxy:9100` resolves without a fork.
  - `MCP_PROXY_NGINX_CERT_DIR` + `MCP_PROXY_NGINX_SAN` (`proxy-a,localhost` / `proxy-b,localhost`) so first-boot mints the TLS server cert against the right hostname.
  - 9100 / 9200 host publishes preserved: smoke browser OIDC flows and `bootstrap_mastio` admin path keep working over HTTP. PR-C will collapse this once api_key is gone.
  - Agent containers depend on `mastio-nginx-{a,b}: service_healthy` so the first SDK call doesn't race the sidecar's start.

- `sandbox/agent/agent.py`:
  - `BROKER_URL` env switches to `https://proxy-{a,b}:9443` (was `http://...:9100`).
  - `_auth_api_key_file` now loads `agent.pem` + `agent-key.pem` from the existing `/state/{org}/agents/{name}/` layout and passes them to `CullisClient.from_api_key_file(..., cert_path=, key_path=, verify_tls=False)`. The SDK's PR-B pre-flight (`_cert_key_pair_matches`) gates on a matching pair — bootstrap generates them paired so it always passes.

## Out of scope
- `reference/` and `test/nightly/` get the same treatment in a follow-up (or as the first commit of PR-C). Both are internal — no published-demo pressure.
- Full kill of `9100`/`9200` host publish — defer to PR-C, which removes api_key entirely.

## Test plan
- [x] `git diff` reviewed — only sandbox-scoped changes
- [ ] CI: helm-test (cullis + cullis-proxy)
- [ ] CI: demo_network smoke (rsa, ec, postgres) — should still be green (different compose)
- [ ] CI: standalone smoke — should still be green (different compose)
- [ ] CI: test (3.11) — should still be green (no test surface touched)
- [ ] Local sandbox dogfood: `cd sandbox && ./demo.sh full && ./smoke.sh` — verify agents enroll + send/receive over mTLS

## ADR-014 progress
| PR | Stato |
|----|-------|
| #328 ADR doc | ✅ |
| #329 PR-A nginx sidecar | ✅ |
| #330 PR-D standalone default | ✅ |
| #331 PR-E1 wizard | ✅ |
| #332 PR-B client-cert auth | ✅ |
| **this PR-A3 sandbox sweep** | open |
| PR-C drop api_key path (closes #325) | next |
| #327 smoke E2E gate | post-PR-C |

🤖 Generated with [Claude Code](https://claude.com/claude-code)