### PR TITLE
fix(sandbox+reference): ADR-014 mTLS — agent BROKER_URL + htu pinning + scenarios

### DIFF
--- a/reference/docker-compose.yml
+++ b/reference/docker-compose.yml
@@ -273,12 +273,14 @@ services:
       MCP_PROXY_STANDALONE: "false"  # PR-D: explicit federated opt-in
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      # Intentionally unset: the sandbox serves the same proxy at two
-      # hostnames (``proxy-a`` intra-docker, ``localhost:9100`` from the
-      # host). Leaving ``proxy_public_url`` empty falls back to
-      # ``request.url`` for DPoP htu reconstruction — matches the agent's
-      # signed htu in both cases instead of pinning one.
-      # MCP_PROXY_PROXY_PUBLIC_URL: unset
+      # ADR-014 — agents reach the Mastio over TLS via the
+      # mastio-nginx-a sidecar on 9443. nginx forwards plain HTTP to
+      # mcp-proxy:9100, so without an explicit override Starlette would
+      # reconstruct htu as ``http://...:9100/...`` and fail the match
+      # against the ``https://mastio-nginx-a:9443/...`` the agent
+      # signed. Pin so ``_build_htu`` returns the URL agents actually
+      # signed.
+      MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-a:9443"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
@@ -479,7 +481,7 @@ services:
       # ADR-014 — agents reach the Mastio over mTLS via the per-org
       # nginx sidecar on 9443. The agent presents its Org-CA-signed
       # cert at the TLS handshake; nginx verifies + forwards.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "agent-a"
       PEERS_FILE: "/state/peers.json"
@@ -524,7 +526,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — see agent-a rationale; same nginx sidecar.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "byoca-bot"
       PEERS_FILE: "/state/peers.json"
@@ -578,8 +580,8 @@ services:
       MCP_PROXY_STANDALONE: "false"  # PR-D: explicit federated opt-in
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      # See proxy-a comment above — unset so DPoP htu falls back to request.url.
-      # MCP_PROXY_PROXY_PUBLIC_URL: unset
+      # ADR-014 — see proxy-a rationale; pin htu to the orgb sidecar.
+      MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-b:9443"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"
@@ -733,7 +735,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio B via the orgb nginx sidecar.
-      BROKER_URL: "https://proxy-b:9443"
+      BROKER_URL: "https://mastio-nginx-b:9443"
       ORG_ID: "orgb"
       AGENT_NAME: "agent-b"
       PEERS_FILE: "/state/peers.json"
@@ -777,7 +779,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio A via the orga nginx sidecar.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "alice-byoca"
       AGENT_ROLE: "buyer"
@@ -810,7 +812,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio A via the orga nginx sidecar.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "alice-spiffe"
       AGENT_ROLE: "inventory"
@@ -842,7 +844,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio A via the orga nginx sidecar.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "alice-connector"
       AGENT_ROLE: "broker"
@@ -874,7 +876,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio B via the orgb nginx sidecar.
-      BROKER_URL: "https://proxy-b:9443"
+      BROKER_URL: "https://mastio-nginx-b:9443"
       ORG_ID: "orgb"
       AGENT_NAME: "bob-byoca"
       AGENT_ROLE: "inventory"
@@ -906,7 +908,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio B via the orgb nginx sidecar.
-      BROKER_URL: "https://proxy-b:9443"
+      BROKER_URL: "https://mastio-nginx-b:9443"
       ORG_ID: "orgb"
       AGENT_NAME: "bob-spiffe"
       AGENT_ROLE: "supplier"
@@ -938,7 +940,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio B via the orgb nginx sidecar.
-      BROKER_URL: "https://proxy-b:9443"
+      BROKER_URL: "https://mastio-nginx-b:9443"
       ORG_ID: "orgb"
       AGENT_NAME: "bob-connector"
       AGENT_ROLE: "broker"

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -250,12 +250,14 @@ services:
       MCP_PROXY_STANDALONE: "false"  # PR-D: explicit federated opt-in
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      # Intentionally unset: the sandbox serves the same proxy at two
-      # hostnames (``proxy-a`` intra-docker, ``localhost:9100`` from the
-      # host). Leaving ``proxy_public_url`` empty falls back to
-      # ``request.url`` for DPoP htu reconstruction — matches the agent's
-      # signed htu in both cases instead of pinning one.
-      # MCP_PROXY_PROXY_PUBLIC_URL: unset
+      # ADR-014 — agents now reach the Mastio over TLS via the
+      # mastio-nginx-a sidecar on 9443. The DPoP htu the agent signs is
+      # ``https://mastio-nginx-a:9443/...``; nginx forwards plain HTTP
+      # to mcp-proxy:9100, so without an explicit override Starlette
+      # would reconstruct htu as ``http://...:9100/...`` and fail the
+      # match. Pin it here so ``_build_htu`` returns the URL the agent
+      # actually signed.
+      MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-a:9443"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
@@ -459,7 +461,7 @@ services:
       # nginx sidecar on 9443. The agent presents its Org-CA-signed
       # cert (loaded from /state/{org}/agents/{name}/agent.{pem,key})
       # at the TLS handshake; nginx verifies + forwards.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "agent-a"
       PEERS_FILE: "/state/peers.json"
@@ -503,7 +505,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — see agent-a rationale; same nginx sidecar.
-      BROKER_URL: "https://proxy-a:9443"
+      BROKER_URL: "https://mastio-nginx-a:9443"
       ORG_ID: "orga"
       AGENT_NAME: "byoca-bot"
       PEERS_FILE: "/state/peers.json"
@@ -557,8 +559,8 @@ services:
       MCP_PROXY_STANDALONE: "false"  # PR-D: explicit federated opt-in
       MCP_PROXY_BROKER_URL:        "http://broker:8000"
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
-      # See proxy-a comment above — unset so DPoP htu falls back to request.url.
-      # MCP_PROXY_PROXY_PUBLIC_URL: unset
+      # ADR-014 — see proxy-a rationale; pin htu to the orgb sidecar.
+      MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-b:9443"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"
@@ -710,7 +712,7 @@ services:
         condition: service_healthy
     environment:
       # ADR-014 — agents reach Mastio B via the orgb nginx sidecar.
-      BROKER_URL: "https://proxy-b:9443"
+      BROKER_URL: "https://mastio-nginx-b:9443"
       ORG_ID: "orgb"
       AGENT_NAME: "agent-b"
       PEERS_FILE: "/state/peers.json"

--- a/sandbox/scenarios/_identity.py
+++ b/sandbox/scenarios/_identity.py
@@ -1,11 +1,12 @@
 """Shared helper — load a CullisClient using the credentials that
-``bootstrap-mastio`` enrolled for each sandbox agent (ADR-011 Phase 4).
+``bootstrap`` minted + ``bootstrap-mastio`` enrolled for each sandbox
+agent (ADR-014).
 
-Mirrors the runtime auth used by ``sandbox/agent/agent.py``:
-read ``api-key`` + ``dpop.jwk`` from ``/state/{org}/agents/{name}/`` and
-hand them to ``CullisClient.from_api_key_file``. That is the same API-key
-+ DPoP identity the egress surface expects for ``send_oneshot`` and the
-``/v1/mcp`` aggregator.
+Mirrors the runtime auth used by ``sandbox/agent/agent.py``: read
+``agent.pem`` + ``agent-key.pem`` + ``dpop.jwk`` from
+``/state/{org}/agents/{name}/`` and hand them to
+``CullisClient.from_identity_dir``. The TLS client cert presented at
+the per-org nginx sidecar's handshake IS the agent credential.
 """
 from __future__ import annotations
 
@@ -19,29 +20,32 @@ def load_enrolled_client(
     org_id: str,
     agent_name: str,
     identity_root: str | Path = "/state",
+    verify_tls: bool = False,
 ) -> CullisClient:
     identity_dir = Path(identity_root) / org_id / "agents" / agent_name
-    api_key_path = identity_dir / "api-key"
+    cert_path = identity_dir / "agent.pem"
+    key_path = identity_dir / "agent-key.pem"
     dpop_key_path = identity_dir / "dpop.jwk"
-    if not api_key_path.exists() or not dpop_key_path.exists():
+    if not cert_path.exists() or not key_path.exists() or not dpop_key_path.exists():
         raise RuntimeError(
             f"enrolled identity missing under {identity_dir} "
-            f"(expected api-key + dpop.jwk) — is bootstrap-mastio done?"
+            f"(expected agent.pem + agent-key.pem + dpop.jwk) — "
+            "is bootstrap-mastio done?"
         )
-    client = CullisClient.from_api_key_file(
+    client = CullisClient.from_identity_dir(
         mastio_url,
-        api_key_path=api_key_path,
+        cert_path=cert_path,
+        key_path=key_path,
         dpop_key_path=dpop_key_path,
         agent_id=f"{org_id}::{agent_name}",
         org_id=org_id,
+        verify_tls=verify_tls,
     )
-    # Mirror the runtime wiring in agent.py ``_auth_api_key_file``:
+    # Mirror the runtime wiring in agent.py ``_auth_identity_dir``:
     #   • ``login_via_proxy`` mints a broker JWT so ``_authed_request``
     #     works (needed by the /v1/mcp aggregator and any session API).
     #   • ``_signing_key_pem`` feeds the outer-envelope signature for
     #     ``send_oneshot`` non-repudiation.
     client.login_via_proxy()
-    key_path = identity_dir / "agent-key.pem"
-    if key_path.exists():
-        client._signing_key_pem = key_path.read_text()
+    client._signing_key_pem = key_path.read_text()
     return client

--- a/sandbox/scenarios/mcp_call_local.py
+++ b/sandbox/scenarios/mcp_call_local.py
@@ -102,7 +102,7 @@ def main() -> int:
 
     _step(1, "Load enrolled identity and authenticate to the local Mastio")
     _info(
-        f"reading api-key + dpop.jwk from {identity_root}/{org_id}/agents/{agent_name}/"
+        f"reading agent.pem + agent-key.pem + dpop.jwk from {identity_root}/{org_id}/agents/{agent_name}/"
     )
     try:
         client = load_enrolled_client(broker, org_id, agent_name, identity_root)

--- a/sandbox/scenarios/oneshot_cross_org.py
+++ b/sandbox/scenarios/oneshot_cross_org.py
@@ -71,7 +71,7 @@ def main() -> int:
 
     _step(1, "Load enrolled identity and authenticate to the local Mastio")
     _info(
-        f"reading api-key + dpop.jwk from {identity_root}/{org_id}/agents/{agent_name}/"
+        f"reading agent.pem + agent-key.pem + dpop.jwk from {identity_root}/{org_id}/agents/{agent_name}/"
     )
     try:
         client = load_enrolled_client(broker, org_id, agent_name, identity_root)


### PR DESCRIPTION
## Summary

Three live-demo bugs surfaced during the post-PR-C dogfood (#334).
None caught by CI because demo_network smoke exercises a different
topology and unit tests don't run docker compose.

### Bug 1 — agent BROKER_URL points at the wrong container
PR-A3 (#333) set ``BROKER_URL: https://proxy-{a,b}:9443`` for sandbox
agents, but the ``proxy-{a,b}`` container only listens on 9100. The
per-org nginx sidecar is on ``mastio-nginx-{a,b}:9443``. Agents got
ECONNREFUSED on every poll. Fix: ``BROKER_URL:
https://mastio-nginx-{a,b}:9443``.

### Bug 2 — DPoP htu mismatch behind nginx
``MCP_PROXY_PROXY_PUBLIC_URL`` was left unset on sandbox so htu fell
back to ``request.url``. Correct pre-PR-A3 (agents on plain HTTP
:9100), broken once nginx terminates TLS on :9443 and forwards plain
HTTP to mcp-proxy:9100 — uvicorn isn't started with
``--proxy-headers``, so Starlette sees ``http://...:9100/...`` while
the agent signed ``https://mastio-nginx-{a,b}:9443/...``. Result:
``Invalid DPoP proof: htu mismatch`` 401 on every egress call. Fix:
pin to the sidecar URL so ``_build_htu`` returns what agents sign.

### Bug 3 — scenario scripts use the dead api_key path
``sandbox/scenarios/_identity.py`` (used by ``demo.sh oneshot-*`` and
``mcp-*``) still called
``CullisClient.from_api_key_file(api_key_path=, dpop_key_path=)``.
PR-C made that a deprecation shim that requires ``cert_path`` +
``key_path``, and bootstrap_mastio no longer writes the ``api-key``
file at all → scenarios crashed at "enrolled identity missing
under ... (expected api-key + dpop.jwk)". Fix: switch to
``from_identity_dir(cert_path=, key_path=, dpop_key_path=)``.

## Verified end-to-end

After ``./demo.sh down -v && BOOTSTRAP_SCOPE=full ./demo.sh full``:

- ``./demo.sh oneshot-a-to-b`` — orga::agent-a sends nonce
  ``dea3c3d4daf14d03`` cross-org via the Court, agent-b's inbox loop
  prints ``[orgb::agent-b] received nonce from orga::agent-a:
  dea3c3d4daf14d03``
- ``./demo.sh mcp-catalog`` — orga::agent-a → ``get_catalog`` through
  the MCP aggregator returns 2 SKUs (WIDGET-X + GADGET-Y)
- All 3 demo agents healthy, no 401, no htu errors

## Reference

Same compose fixes applied to ``reference/docker-compose.yml``. The
LLM-driven reference scenarios already use ``from_identity_dir`` via
``llm_agent._load_client``, so no scenario change there.

## Test plan

- [x] sandbox demo.sh full — agents healthy + auth OK
- [x] sandbox demo.sh oneshot-a-to-b — cross-org delivery verified
- [x] sandbox demo.sh mcp-catalog — intra-org MCP call verified
- [ ] CI green (existing tests don't cover these compose paths)
- [ ] reference demo.sh full — needs Ollama, deferred