### PR TITLE
fix(nginx): forward /static/* to mcp-proxy backend

### DIFF
--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -175,6 +175,20 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
+    # Dashboard static assets (tailwind.css, htmx, fonts, logo SVG…).
+    # The dashboard templates reference ``/static/...`` URLs verbatim;
+    # without this location nginx returns 404 and the dashboard renders
+    # unstyled (the inline logo SVG fills the viewport).
+    location ~ ^/static(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
     # ──────────────────────────────────────────────────────────────────
     # Catch-all — fail closed.
     # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Mastio dashboard rendered unstyled — Tailwind 404 because nginx
config didn't forward ``/static/*`` to the mcp-proxy backend. The
inline logo SVG ended up filling the viewport because no CSS
constrained it.

Surfaced during the VM dogfood after #335. Hot-patched the running
nginx on the VM, verified ``/static/css/tailwind.css`` now returns
200 and the dashboard re-styles.

## Test plan

- [x] curl ``/static/css/tailwind.css`` → 200
- [x] Browser reload of ``/proxy/login`` shows the styled login page