### PR TITLE
chore(release): bump cullis-sdk 0.1.1 + cullis-connector 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.3.4] — 2026-04-28
+
+### Fixed
+- **`install-mcp` now propagates the shared CLI flags into the saved
+  IDE / MCP-client entry** (monorepo #339). Previously every config
+  was hard-wired to ``args = ["serve"]`` regardless of what the
+  operator typed; ``--profile`` / ``--site-url`` / ``--config-dir`` /
+  ``--no-verify-tls`` are now carried through. Closes the workaround
+  in memory ``feedback_install_mcp_no_profile``.
+- **`cullis-connector serve --no-verify-tls` now actually disables
+  TLS verification** end-to-end. The flag set ``cfg.verify_tls=False``
+  but the SDK's ``CullisClient.from_connector`` derived its own
+  default from the site URL scheme (https → True), so the eager
+  ``login_via_proxy_with_local_key`` against a self-signed Org CA
+  failed at SSL handshake and left ``state.client = None``. The SDK
+  now accepts an explicit ``verify_tls`` override that the CLI
+  passes through.
+
+### Compat
+- Requires `cullis-sdk>=0.1.1` for the new `verify_tls` parameter on
+  `CullisClient.from_connector`. Older SDK installs raise `TypeError`
+  at startup.
+
 ## [v0.3.3] — 2026-04-28
 
 ### Changed
@@ -60,5 +83,6 @@ Initial public release of the Cullis Connector.
 - TLS verification is enabled by default; `--no-verify-tls` is
   accepted only for local development and logs a prominent warning.
 
+[v0.3.4]: https://github.com/cullis-security/cullis/releases/tag/connector-v0.3.4
 [v0.3.3]: https://github.com/cullis-security/cullis/releases/tag/connector-v0.3.3
 [v0.1.0]: https://github.com/cullis-security/cullis/releases/tag/connector-v0.1.0

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __all__ = ["__version__"]

--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "log_msg",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
 readme = "README_PKG.md"
 requires-python = ">=3.10"

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.3.3"
+version = "0.3.4"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"
@@ -60,7 +60,7 @@ dependencies = [
     # without dragging in the connector's MCP server stack. 0.3.1 shipped
     # without this line; `pip install cullis-connector` succeeded but every
     # subcommand died on `ModuleNotFoundError: cullis_sdk`.
-    "cullis-sdk>=0.1.0",
+    "cullis-sdk>=0.1.1",
     "mcp>=1.0",
     "httpx>=0.24.0",
     "cryptography>=41.0.0",


### PR DESCRIPTION
## Summary

Ships the #339 runtime fixes as proper PyPI artifacts:

- **cullis-sdk 0.1.0 → 0.1.1**: ``CullisClient.from_connector`` accepts
  an explicit ``verify_tls`` override (previously hard-derived from URL).
- **cullis-connector 0.3.3 → 0.3.4**: ``serve`` honours
  ``--no-verify-tls`` end-to-end; ``install-mcp`` propagates the shared
  CLI flags into the saved IDE entry.

Connector dep pinned to ``cullis-sdk>=0.1.1`` so a fresh
``pip install cullis-connector`` resolves the SDK that has the new
``verify_tls`` kwarg.

## Release order (post-merge)

1. Tag ``sdk-v0.1.1`` on the merge commit → triggers
   ``release-sdk.yml`` → cullis-sdk 0.1.1 lands on PyPI.
2. Wait ~1 min for PyPI propagation.
3. Tag ``connector-v0.3.4`` on the same merge commit → triggers
   ``release-connector.yml`` → cullis-connector 0.3.4 resolves
   ``cullis-sdk>=0.1.1`` cleanly.

## Test plan

- [x] All affected paths verified live during #339 VM dogfood
- [ ] CI green
- [ ] PyPI smoke ``pip install cullis-connector==0.3.4`` after both tags