### PR TITLE
fix(scripts): default PROXY_PUBLIC_URL to empty for non-localhost deploys

### DIFF
--- a/proxy.env.example
+++ b/proxy.env.example
@@ -49,9 +49,15 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 
 # Public URL where the proxy itself is reachable. Used for DPoP HTU
 # validation on the ingress endpoints — must match how internal agents
-# address the proxy. ADR-014: this points at the mastio-nginx sidecar
-# (TLS), not the in-network mcp-proxy listener.
-MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443
+# address the proxy. ADR-014: when set, this points at the mastio-nginx
+# sidecar (TLS), not the in-network mcp-proxy listener.
+#
+# Leave empty (default) to auto-detect htu from the inbound Host header
+# — the right call for any deploy where the public address isn't fixed
+# at config time (Docker service names, k8s ingress, VM IPs). Set
+# explicitly when fronting the Mastio with a stable public hostname
+# (e.g. https://mastio.myorg.example.com).
+MCP_PROXY_PROXY_PUBLIC_URL=
 
 # PDP webhook URL — the broker calls this to ask the proxy for policy
 # decisions. The broker reaches the Mastio over the docker network,

--- a/scripts/generate-proxy-env.sh
+++ b/scripts/generate-proxy-env.sh
@@ -77,8 +77,14 @@ case "$MODE" in
         ;;
     defaults)
         BROKER="${BROKER_URL:-http://broker:8000}"
-        # ADR-014 — public URL points at the mastio-nginx sidecar (TLS).
-        PUBLIC="${PROXY_PUBLIC_URL:-https://localhost:9443}"
+        # Empty by default → settings.py falls back to ``request.url`` for
+        # DPoP htu validation (auto-detect from the inbound Host header).
+        # Hardcoding ``localhost`` broke every non-localhost deploy
+        # (Docker, k8s, VM) because the agent's actual htu carried the
+        # service name / ingress hostname / VM IP. Operators who front
+        # the Mastio with a stable public hostname should still pass
+        # ``PROXY_PUBLIC_URL=https://mastio.example.com`` explicitly.
+        PUBLIC="${PROXY_PUBLIC_URL:-}"
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;
@@ -86,8 +92,7 @@ case "$MODE" in
         echo ""
         read -rp "  Broker URL [http://broker:8000]: " BROKER
         BROKER="${BROKER:-http://broker:8000}"
-        read -rp "  Proxy public URL [https://localhost:9443]: " PUBLIC
-        PUBLIC="${PUBLIC:-https://localhost:9443}"
+        read -rp "  Proxy public URL [empty = auto-detect from Host header]: " PUBLIC
         JWKS="${BROKER%/}/.well-known/jwks.json"
         ENVIRONMENT="development"
         ;;


### PR DESCRIPTION
## Summary

Follow-up to #339 Bug 3 (deferred). ``scripts/generate-proxy-env.sh``
was writing ``MCP_PROXY_PROXY_PUBLIC_URL=https://localhost:9443`` in
both ``--defaults`` and ``interactive`` modes. ``localhost`` is only
valid when the agent and the Mastio share a host — every other deploy
(Docker service names, k8s ingress, VM LAN IPs) hit a DPoP htu mismatch
because the agent's real ``htu`` carried the deploy-time hostname
while the Mastio signed ``localhost``. This is the same bug I hot-
fixed by hand on the standalone VM during the #339 dogfood.

Default the value to empty so ``mcp_proxy/auth/dependencies.py:92-95``
falls back to ``request.url`` (auto-detect from the inbound Host
header) — the right call for any deploy where the public address isn't
fixed at config time.

``--prod`` still rejects unset ``PROXY_PUBLIC_URL``: production fronts
the Mastio with a stable hostname (LB / ingress) and pinning htu there
is defense-in-depth against Host-header spoofing.

## Test plan

- [x] ``./scripts/generate-proxy-env.sh --defaults --force`` writes
      ``MCP_PROXY_PROXY_PUBLIC_URL=`` (empty, auto-detect kicks in)
- [x] ``./scripts/generate-proxy-env.sh --prod`` without env vars
      still fails with "--prod requires BROKER_URL env var"
- [ ] CI green