### PR TITLE
fix(reference): scenarios use from_identity_dir post ADR-014 PR-C

### DIFF
--- a/reference/scenarios/_identity.py
+++ b/reference/scenarios/_identity.py
@@ -1,11 +1,11 @@
 """Shared helper — load a CullisClient using the credentials that
-``bootstrap-mastio`` enrolled for each sandbox agent (ADR-011 Phase 4).
+``bootstrap-mastio`` enrolled for each reference agent (ADR-014).
 
-Mirrors the runtime auth used by ``sandbox/agent/agent.py``:
-read ``api-key`` + ``dpop.jwk`` from ``/state/{org}/agents/{name}/`` and
-hand them to ``CullisClient.from_api_key_file``. That is the same API-key
-+ DPoP identity the egress surface expects for ``send_oneshot`` and the
-``/v1/mcp`` aggregator.
+Mirrors the runtime auth used by ``reference/agent/agent.py``: read
+``agent.pem`` + ``agent-key.pem`` + ``dpop.jwk`` from
+``/state/{org}/agents/{name}/`` and hand them to
+``CullisClient.from_identity_dir``. The TLS client cert presented at
+the per-org nginx sidecar's handshake IS the agent credential.
 """
 from __future__ import annotations
 
@@ -19,29 +19,32 @@ def load_enrolled_client(
     org_id: str,
     agent_name: str,
     identity_root: str | Path = "/state",
+    verify_tls: bool = False,
 ) -> CullisClient:
     identity_dir = Path(identity_root) / org_id / "agents" / agent_name
-    api_key_path = identity_dir / "api-key"
+    cert_path = identity_dir / "agent.pem"
+    key_path = identity_dir / "agent-key.pem"
     dpop_key_path = identity_dir / "dpop.jwk"
-    if not api_key_path.exists() or not dpop_key_path.exists():
+    if not cert_path.exists() or not key_path.exists() or not dpop_key_path.exists():
         raise RuntimeError(
             f"enrolled identity missing under {identity_dir} "
-            f"(expected api-key + dpop.jwk) — is bootstrap-mastio done?"
+            f"(expected agent.pem + agent-key.pem + dpop.jwk) — "
+            "is bootstrap-mastio done?"
         )
-    client = CullisClient.from_api_key_file(
+    client = CullisClient.from_identity_dir(
         mastio_url,
-        api_key_path=api_key_path,
+        cert_path=cert_path,
+        key_path=key_path,
         dpop_key_path=dpop_key_path,
         agent_id=f"{org_id}::{agent_name}",
         org_id=org_id,
+        verify_tls=verify_tls,
     )
-    # Mirror the runtime wiring in agent.py ``_auth_api_key_file``:
+    # Mirror the runtime wiring in agent.py ``_auth_identity_dir``:
     #   • ``login_via_proxy`` mints a broker JWT so ``_authed_request``
     #     works (needed by the /v1/mcp aggregator and any session API).
     #   • ``_signing_key_pem`` feeds the outer-envelope signature for
     #     ``send_oneshot`` non-repudiation.
     client.login_via_proxy()
-    key_path = identity_dir / "agent-key.pem"
-    if key_path.exists():
-        client._signing_key_pem = key_path.read_text()
+    client._signing_key_pem = key_path.read_text()
     return client

--- a/reference/scenarios/inject.sh
+++ b/reference/scenarios/inject.sh
@@ -38,15 +38,23 @@ CYAN='\033[36m'
 GRAY='\033[90m'
 RESET='\033[0m'
 
+# Each helper builds a CullisClient inside an agent container using
+# ADR-014 mTLS identity material (agent.pem + agent-key.pem + dpop.jwk
+# under /state/<org>/agents/<name>/). Mirrors reference/agent/agent.py
+# ``_auth_identity_dir``. The /scenarios dir is NOT mounted into the
+# agent containers so the credential-load block is inlined per helper
+# instead of importing the shared _identity helper.
+
 _inject_intra_orga() {
     local sku="$1"
     docker compose --profile full exec -T alice-byoca python - <<PY 2>&1 | grep -v "^\[sdk\]" | tail -1
 import pathlib
 from cullis_sdk import CullisClient
 ID = pathlib.Path("/state/orga/agents/alice-byoca")
-c = CullisClient.from_api_key_file("http://proxy-a:9100",
-    api_key_path=ID/"api-key", dpop_key_path=ID/"dpop.jwk",
-    agent_id="orga::alice-byoca", org_id="orga")
+c = CullisClient.from_identity_dir("https://mastio-nginx-a:9443",
+    cert_path=ID/"agent.pem", key_path=ID/"agent-key.pem",
+    dpop_key_path=ID/"dpop.jwk",
+    agent_id="orga::alice-byoca", org_id="orga", verify_tls=False)
 c.login_via_proxy()
 c._signing_key_pem = (ID/"agent-key.pem").read_text()
 r = c.send_oneshot("orga::alice-spiffe",
@@ -61,9 +69,10 @@ _inject_intra_orgb() {
 import pathlib
 from cullis_sdk import CullisClient
 ID = pathlib.Path("/state/orgb/agents/bob-byoca")
-c = CullisClient.from_api_key_file("http://proxy-b:9100",
-    api_key_path=ID/"api-key", dpop_key_path=ID/"dpop.jwk",
-    agent_id="orgb::bob-byoca", org_id="orgb")
+c = CullisClient.from_identity_dir("https://mastio-nginx-b:9443",
+    cert_path=ID/"agent.pem", key_path=ID/"agent-key.pem",
+    dpop_key_path=ID/"dpop.jwk",
+    agent_id="orgb::bob-byoca", org_id="orgb", verify_tls=False)
 c.login_via_proxy()
 c._signing_key_pem = (ID/"agent-key.pem").read_text()
 r = c.send_oneshot("orgb::bob-spiffe",
@@ -78,9 +87,10 @@ _inject_cross_org() {
 import pathlib
 from cullis_sdk import CullisClient
 ID = pathlib.Path("/state/orga/agents/alice-connector")
-c = CullisClient.from_api_key_file("http://proxy-a:9100",
-    api_key_path=ID/"api-key", dpop_key_path=ID/"dpop.jwk",
-    agent_id="orga::alice-connector", org_id="orga")
+c = CullisClient.from_identity_dir("https://mastio-nginx-a:9443",
+    cert_path=ID/"agent.pem", key_path=ID/"agent-key.pem",
+    dpop_key_path=ID/"dpop.jwk",
+    agent_id="orga::alice-connector", org_id="orga", verify_tls=False)
 c.login_via_proxy()
 c._signing_key_pem = (ID/"agent-key.pem").read_text()
 r = c.send_oneshot("orgb::bob-connector",


### PR DESCRIPTION
## Summary

Caught while dogfooding the deploy bundle (#342). PR #334 (ADR-014
PR-C, mergiata stamattina) dropped the ``api_key`` credential path:
``CullisClient.from_api_key_file`` now hard-fails without
``cert_path`` + ``key_path``. The reference scenarios were not
migrated and broke at runtime:

```
ValueError: from_api_key_file (deprecated): cert_path and key_path
are now required. Use from_identity_dir for the canonical entry
point.
```

Sandbox already uses ``from_identity_dir``; reference was the
straggler.

## Changes

- ``reference/scenarios/_identity.py`` — mirror the sandbox helper:
  ``from_identity_dir(cert_path=, key_path=, dpop_key_path=)``
  against the per-org nginx sidecar at
  ``https://mastio-nginx-{a,b}:9443``, ``verify_tls=False`` for the
  self-signed Org CA.
- ``reference/scenarios/inject.sh`` — inline the same load pattern
  per ``_inject_*`` helper. The ``/scenarios`` dir is not mounted
  into agent containers so the shared helper isn't importable via
  ``docker compose exec``.

## Test plan

Dogfood end-to-end against fresh stack:

```bash
./reference/demo.sh full
./reference/scenarios/inject.sh           # 1 burst
for i in 1..8; do ./reference/scenarios/inject.sh; done   # 8 mixed
./reference/demo.sh down
```

- [x] All three paths return ``msg_id`` (intra-orga, intra-orgb, cross-org)
- [x] No deprecation ``ValueError`` thrown
- [ ] CI green