### PR TITLE
fix(nightly): set MCP_PROXY_PROXY_PUBLIC_URL for host-reachable Mastios

### DIFF
--- a/test/nightly/docker-compose.yml
+++ b/test/nightly/docker-compose.yml
@@ -164,9 +164,14 @@ services:
       MCP_PROXY_ADMIN_SECRET:      "${PROXY_A_ADMIN_SECRET:-nightly-proxy-admin-a}"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
-      MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9100"
+      MCP_PROXY_ALLOWED_ORIGINS:   "https://localhost:9443"
       MCP_PROXY_ENVIRONMENT:       "development"
       MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
+      # ADR-014 — host-side smoke.py + workload drivers reach this Mastio
+      # at https://localhost:9443 (mastio-nginx-a sidecar). Without this
+      # env the backend reconstructs htu as http://localhost:9443/... (no
+      # --proxy-headers) and DPoP htu match fails on every egress call.
+      MCP_PROXY_PROXY_PUBLIC_URL:  "https://localhost:9443"
       PROXY_INTRA_ORG:             "true"
       PROXY_TRANSPORT_INTRA_ORG:   "mtls-only"
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
@@ -281,9 +286,13 @@ services:
       MCP_PROXY_ADMIN_SECRET:      "${PROXY_B_ADMIN_SECRET:-nightly-proxy-admin-b}"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"
-      MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9200"
+      MCP_PROXY_ALLOWED_ORIGINS:   "https://localhost:9543"
       MCP_PROXY_ENVIRONMENT:       "development"
       MCP_PROXY_FEDERATION_POLL_INTERVAL_S: "2"
+      # ADR-014 — host-side smoke.py + workload drivers reach this Mastio
+      # at https://localhost:9543 (mastio-nginx-b sidecar, port-mapped to
+      # avoid the 9443 collision with proxy-a).
+      MCP_PROXY_PROXY_PUBLIC_URL:  "https://localhost:9543"
       PROXY_INTRA_ORG:             "true"
       PROXY_TRANSPORT_INTRA_ORG:   "mtls-only"
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"


### PR DESCRIPTION
## Summary

``./nightly.sh smoke`` reported **0/20 agents online** — every probe
failed with a 401 on ``GET /v1/egress/peers``.

**Root cause**: ADR-014 puts the Mastio behind the
``mastio-nginx-{a,b}`` sidecar (TLS termination on host ports
9443/9543) but the in-pod uvicorn doesn't run with
``--proxy-headers``. With ``MCP_PROXY_PROXY_PUBLIC_URL`` unset, the
DPoP htu validator falls back to ``request.url`` — and that's the
*backend* URL the in-pod listener sees
(``http://localhost:9443/v1/egress/peers``), while the agent signed
the proof against the host-reachable URL
(``https://localhost:9443/v1/egress/peers``). Scheme mismatch → 401.

Sandbox + reference dogfood already work because agents run inside
the docker network and address the Mastio via the in-pod service
name (``mastio-nginx-a:9443``), where backend and agent see the same
host. The mismatch only surfaces when a host-side client hits the
host-port-mapped sidecar — exactly the nightly smoke shape.

## Changes

Pin ``MCP_PROXY_PROXY_PUBLIC_URL`` explicitly to the host-reachable
URL on each Mastio:
- ``proxy-a`` → ``https://localhost:9443``
- ``proxy-b`` → ``https://localhost:9543``

Also bumped ``MCP_PROXY_ALLOWED_ORIGINS`` from the legacy http :9100/:9200 to match.

## Test plan

End-to-end on the local stack:

```bash
./test/nightly/nightly.sh down
./test/nightly/nightly.sh full        # 20 BYOCA agents, 2 Mastios + Court
./test/nightly/nightly.sh smoke       # 20/20 in 0.4s
```

- [x] Smoke reports 20/20 online
- [x] Stack tears down cleanly
- [ ] CI green

## Follow-up (separate PR)

The proper architectural fix is to add ``--proxy-headers`` to the
uvicorn CMD in ``mcp_proxy/Dockerfile`` so the backend trusts
``X-Forwarded-Proto: https`` from the nginx sidecar. That removes
the need to hard-code public URLs in compose entirely (host header
auto-detect just works). Broader blast radius across sandbox/
reference — wants its own focused review.