### PR TITLE
fix(proxy): uvicorn --proxy-headers so backend trusts nginx sidecar TLS

### DIFF
--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -74,4 +74,19 @@ USER proxyuser
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')" || exit 1
 
-CMD ["uvicorn", "mcp_proxy.main:app", "--host", "0.0.0.0", "--port", "9100"]
+# ADR-014 — the Mastio is always fronted by the mastio-nginx sidecar
+# (TLS termination + mTLS gate). nginx sets X-Forwarded-Proto: https
+# and X-Forwarded-For; uvicorn must opt in to those headers via
+# ``--proxy-headers`` or it reconstructs ``request.url`` from its own
+# bind (``http://localhost:9100/...``), and DPoP htu validation 401s
+# every host-side egress call (host signs ``https://<public>:9443/...``,
+# server expects ``http``).
+#
+# ``--forwarded-allow-ips='*'`` is safe in this image because the
+# backend listener (9100) is **never** published to the host or LAN —
+# it is reachable only from the sidecar inside the same docker pod /
+# k8s pod / compose network. Operators who run the bare image without
+# a sidecar (not the supported topology) override this CMD or rebind
+# 9100 to 127.0.0.1.
+CMD ["uvicorn", "mcp_proxy.main:app", "--host", "0.0.0.0", "--port", "9100", \
+     "--proxy-headers", "--forwarded-allow-ips", "*"]


### PR DESCRIPTION
## Summary

Architectural follow-up to #345.

ADR-014 puts the Mastio behind ``mastio-nginx``; nginx terminates
TLS, sets ``X-Forwarded-Proto: https``, and proxies to the in-pod
backend on plain HTTP. Without ``--proxy-headers`` uvicorn ignores
those headers and reconstructs ``request.url`` from its own bind:
``http://localhost:9100/...``. ``mcp_proxy/auth/dependencies.py``
falls back to ``request.url`` for DPoP htu validation when
``MCP_PROXY_PROXY_PUBLIC_URL`` is empty — so any host-side egress
call signs ``https://<public>:9443/...`` and the server expects
``http``, mismatch → 401.

#345 worked around this by hard-coding ``MCP_PROXY_PROXY_PUBLIC_URL``
in the nightly compose. The proper fix opts uvicorn into the
proxy-headers flow so the backend sees the agent-visible scheme
directly. After this change the auto-detect path (config default
empty, ``request.url`` fallback) works for any deploy that fronts
the Mastio with the standard nginx sidecar — no per-deploy
``MCP_PROXY_PROXY_PUBLIC_URL`` workaround needed.

## Why ``--forwarded-allow-ips='*'`` is safe here

The backend listener (9100) is **never** published to the host or
LAN — it is reachable only from the sidecar inside the same docker
pod / k8s pod / compose network. Operators running the bare image
without a sidecar (not the supported topology) override the CMD or
rebind 9100 to 127.0.0.1 themselves. Trusting any source IP is
acceptable because the network reachability gate already excludes
hostile clients.

## Verified

- ``docker build -f mcp_proxy/Dockerfile -t cullis-mastio:test .``
- ``docker run`` standalone — image boots clean
- ``curl -H "X-Forwarded-Proto: https" -H "Host: mastio.local:9443" http://localhost:9100/health`` returns ``{"status":"ok",...}``

## Follow-up

A separate PR will remove the hard-coded
``MCP_PROXY_PROXY_PUBLIC_URL`` values from the sandbox / reference /
nightly compose files now that auto-detect works. Done in two PRs
because (a) this change is strictly additive and low-risk, and (b)
removing the hard-codes wants its own dogfood pass on each stack.

## Test plan

- [ ] CI green
- [ ] helm-test confirms the chart still installs
- [ ] No regressions in the existing pytest suite (no test relies on
      the legacy ``request.url.scheme == 'http'`` behavior — grepped
      ``request.url``, all use ``.path`` or check string equality
      against expected URLs that are already the public form)