### PR TITLE
fix(bundle): default MCP_PROXY_PROXY_PUBLIC_URL to https://localhost:9443

### DIFF
--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -87,7 +87,7 @@ full values reference.
 | `docker compose is not installed` | Install Docker Engine 20.10+ with Compose v2 |
 | `network cullis-broker_default not found` (with `--shared-broker`) | Bring the Court compose project up first, or drop `--shared-broker` |
 | Browser warns "self-signed certificate" | Expected. The Org CA is local; accept once or extract `org-ca.crt` from the `mcp_proxy_data` volume and import it. |
-| `MCP_PROXY_PROXY_PUBLIC_URL` mismatch (`htu`) | Default is empty (auto-detect from Host header). Set explicitly only when fronting with a stable public hostname. |
+| Agent gets `401 Invalid DPoP proof: htu mismatch` | The Mastio validates DPoP proofs against `MCP_PROXY_PROXY_PUBLIC_URL` (default `https://localhost:9443` for quickstart). Production deploys MUST override this in `proxy.env` to match the public hostname agents reach the Mastio at — e.g. `MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com`. |
 
 ## Updating
 

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -88,6 +88,7 @@ full values reference.
 | `network cullis-broker_default not found` (with `--shared-broker`) | Bring the Court compose project up first, or drop `--shared-broker` |
 | Browser warns "self-signed certificate" | Expected. The Org CA is local; accept once or extract `org-ca.crt` from the `mcp_proxy_data` volume and import it. |
 | Agent gets `401 Invalid DPoP proof: htu mismatch` | The Mastio validates DPoP proofs against `MCP_PROXY_PROXY_PUBLIC_URL` (default `https://localhost:9443` for quickstart). Production deploys MUST override this in `proxy.env` to match the public hostname agents reach the Mastio at — e.g. `MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com`. |
+| `Bind for 0.0.0.0:9443 failed: port is already allocated` | Another service on the host is using 9443 (Caddy / Traefik / nginx-proxy / a previous Mastio that didn't shut down cleanly). Override the host port in `proxy.env`: `MCP_PROXY_PORT=9444`. **Critical:** also update `MCP_PROXY_PROXY_PUBLIC_URL` to use the same port (e.g. `https://mastio.acme.local:9444`) — agents firma DPoP htu against that exact URL+port and a mismatch silently 401s. |
 
 ## Updating
 

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -115,6 +115,30 @@ if [[ ! -f "$SCRIPT_DIR/proxy.env" ]]; then
         die "--prod requires proxy.env to exist with real values. Run: BROKER_URL=https://broker.example.com PROXY_PUBLIC_URL=https://mastio.myorg.example.com ./generate-proxy-env.sh --prod"
     fi
     bash "$SCRIPT_DIR/generate-proxy-env.sh" --defaults
+
+    # Critical: agents validate DPoP htu against MCP_PROXY_PROXY_PUBLIC_URL.
+    # Without an explicit public URL the laptop default (localhost:9443) is
+    # baked in, and any agent reaching the Mastio over a non-localhost
+    # hostname (Docker host on a LAN, internal DNS, public hostname) hits
+    # 401 ``Invalid DPoP proof: htu mismatch`` on every egress. Ask up
+    # front so the operator never finds out post-deploy.
+    echo ""
+    echo "  ${BOLD}Where will agents reach this Mastio?${RESET}"
+    echo "    ${GRAY}- Laptop quick-try: just press Enter (uses https://localhost:9443)${RESET}"
+    echo "    ${GRAY}- Internal server / VM: enter the public URL agents resolve at${RESET}"
+    echo "    ${GRAY}  e.g. https://mastio.acme.local  or  https://192.168.10.42:9443${RESET}"
+    echo "    ${GRAY}- Internet-facing: the LB/ingress hostname${RESET}"
+    echo "    ${GRAY}  e.g. https://mastio.myorg.example.com${RESET}"
+    echo ""
+    read -rp "  Public URL [https://localhost:9443]: " _public_url
+    _public_url="${_public_url:-https://localhost:9443}"
+
+    # Strip any pre-existing line and re-add (proxy.env from the
+    # generator may already carry an empty one).
+    sed -i.bak '/^#*[[:space:]]*MCP_PROXY_PROXY_PUBLIC_URL=/d' "$SCRIPT_DIR/proxy.env"
+    rm -f "$SCRIPT_DIR/proxy.env.bak"
+    echo "MCP_PROXY_PROXY_PUBLIC_URL=$_public_url" >> "$SCRIPT_DIR/proxy.env"
+    ok "proxy.env: MCP_PROXY_PROXY_PUBLIC_URL=$_public_url"
 fi
 
 if [[ "$MODE" == "production" ]]; then

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -174,6 +174,16 @@ if [[ "$MODE" == "production" ]]; then
     ok "proxy.env validated for production"
 fi
 
+# ── Pre-flight: host port not already in use ───────────────────────────────
+_host_port="$(grep -E '^MCP_PROXY_PORT=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
+_host_port="${_host_port:-9443}"
+if command -v ss >/dev/null 2>&1 && ss -tlnH "sport = :${_host_port}" 2>/dev/null | grep -q .; then
+    err "Host port ${_host_port} is already in use — another service is bound there."
+    err "Override with MCP_PROXY_PORT=<free-port> in proxy.env, and update"
+    err "MCP_PROXY_PROXY_PUBLIC_URL to use the same port (otherwise agents 401)."
+    die "Refusing to start — fix the port conflict first."
+fi
+
 # ── Pull + Start ────────────────────────────────────────────────────────────
 step "Deploying Cullis Mastio (${MODE}, $([ $SHARED_BROKER -eq 1 ] && echo shared-broker || echo standalone))"
 

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -37,10 +37,17 @@ services:
       MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
       MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}
       MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}
-      # Empty default → DPoP htu auto-detect from inbound Host header.
-      # Set explicitly when fronting the Mastio with a stable hostname
-      # (LB / ingress / production DNS): https://mastio.example.com.
-      MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-}
+      # Default ``https://localhost:9443`` covers the dev / quick-try
+      # path where the operator runs ``./deploy.sh`` on a laptop and
+      # connects local agents at ``https://localhost:9443``. Production
+      # deploys MUST override via ``proxy.env``: the agent's DPoP htu
+      # carries the public hostname they actually reach the Mastio at,
+      # and the server validates the proof against this exact URL +
+      # path. Mismatch → 401 ``Invalid DPoP proof: htu mismatch`` on
+      # every egress call. ``--proxy-headers`` (#346) does NOT
+      # auto-detect this — htu validation requires the URL the agent
+      # sees end-to-end, including the public hostname.
+      MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-https://localhost:9443}
       MCP_PROXY_ALLOWED_ORIGINS:   ${MCP_PROXY_ALLOWED_ORIGINS:-}
       MCP_PROXY_NGINX_CERT_DIR:    ${MCP_PROXY_NGINX_CERT_DIR:-/var/lib/mastio/nginx-certs}
       MCP_PROXY_NGINX_SAN:         ${MCP_PROXY_NGINX_SAN:-mastio.local,localhost}

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -18,7 +18,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_DIR="${PROJECT_DIR:-$(dirname "$SCRIPT_DIR")}"
+# Bundle layout — script lives at the bundle root next to
+# proxy.env.example. The repo-side copy in scripts/ keeps its original
+# parent-of-scripts default; PROJECT_DIR can still be overridden via env.
+PROJECT_DIR="${PROJECT_DIR:-$SCRIPT_DIR}"
 
 GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'
 BOLD=$'\033[1m'; GRAY=$'\033[90m'; RESET=$'\033[0m'

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -48,16 +48,20 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 # ─── Proxy identity ──────────────────────────────────────────────────────────
 
 # Public URL where the proxy itself is reachable. Used for DPoP HTU
-# validation on the ingress endpoints — must match how internal agents
-# address the proxy. ADR-014: when set, this points at the mastio-nginx
-# sidecar (TLS), not the in-network mcp-proxy listener.
+# validation on the ingress endpoints — MUST match the URL agents
+# actually use to address the Mastio. ADR-014: this points at the
+# mastio-nginx sidecar (TLS), not the in-network mcp-proxy listener.
 #
-# Leave empty (default) to auto-detect htu from the inbound Host header
-# — the right call for any deploy where the public address isn't fixed
-# at config time (Docker service names, k8s ingress, VM IPs). Set
-# explicitly when fronting the Mastio with a stable public hostname
-# (e.g. https://mastio.myorg.example.com).
-MCP_PROXY_PROXY_PUBLIC_URL=
+# The compose file defaults this to ``https://localhost:9443`` for the
+# dev / quick-try path. **Production deploys MUST override** with the
+# public hostname agents resolve at, e.g.:
+#
+#   MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
+#
+# Mismatch → 401 ``Invalid DPoP proof: htu mismatch`` on every egress
+# call. Leaving this commented keeps the compose default; uncomment +
+# edit when fronting the Mastio with a stable public hostname.
+#MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
 
 # PDP webhook URL — the broker calls this to ask the proxy for policy
 # decisions. The broker reaches the Mastio over the docker network,

--- a/proxy.env.example
+++ b/proxy.env.example
@@ -52,12 +52,16 @@ MCP_PROXY_BROKER_JWKS_URL=http://broker:8000/.well-known/jwks.json
 # address the proxy. ADR-014: when set, this points at the mastio-nginx
 # sidecar (TLS), not the in-network mcp-proxy listener.
 #
-# Leave empty (default) to auto-detect htu from the inbound Host header
-# — the right call for any deploy where the public address isn't fixed
-# at config time (Docker service names, k8s ingress, VM IPs). Set
-# explicitly when fronting the Mastio with a stable public hostname
-# (e.g. https://mastio.myorg.example.com).
-MCP_PROXY_PROXY_PUBLIC_URL=
+# The compose file defaults this to ``https://localhost:9443`` for the
+# dev / quick-try path. **Production deploys MUST override** with the
+# public hostname agents actually reach the Mastio at, e.g.:
+#
+#   MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
+#
+# Mismatch → 401 ``Invalid DPoP proof: htu mismatch`` on every egress
+# call. Leaving this commented keeps the compose default; uncomment +
+# edit when fronting the Mastio with a stable public hostname.
+#MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com
 
 # PDP webhook URL — the broker calls this to ask the proxy for policy
 # decisions. The broker reaches the Mastio over the docker network,


### PR DESCRIPTION
## Summary

A customer downloading ``cullis-mastio-bundle.tar.gz`` and running
``./deploy.sh`` to try the Mastio with two local agents would hit
**401 ``Invalid DPoP proof: htu mismatch``** on every egress call.

**Root cause**: PR #341 set ``MCP_PROXY_PROXY_PUBLIC_URL`` default to
empty assuming ``--proxy-headers`` (#346) would let the backend
auto-detect htu from the inbound Host header. Today's dogfood proved
the auto-detect path is incomplete — ``request.url`` does not
reconstruct the same URL the agent signs against, so DPoP htu
validation always 401s when the env is empty.

The proper architectural fix is pending (separate PR to figure out
why ``ProxyHeadersMiddleware`` + Starlette ``request.url`` don't
yield the agent-visible URL). In the meantime: the bundle needs a
working default for the quick-try path so the published ZIP is not
broken-out-of-the-box.

## Changes

- ``packaging/mastio-bundle/docker-compose.yml`` — default
  ``MCP_PROXY_PROXY_PUBLIC_URL`` to ``https://localhost:9443`` so
  the laptop quick-try works.
- ``packaging/mastio-bundle/proxy.env.example`` — reframe the
  comment: production deploys MUST override. The line is commented
  out by default so a fresh ``cp .example proxy.env`` keeps the
  compose default in effect.
- ``proxy.env.example`` (repo root) — same reframing.
- ``packaging/mastio-bundle/README.md`` — add troubleshooting row
  for ``Invalid DPoP proof: htu mismatch`` pointing at the override.

Sandbox / reference / nightly already pin
``MCP_PROXY_PROXY_PUBLIC_URL`` explicitly, so they were never
affected by the empty default.

## Test plan

- [x] ``docker compose config`` on the bundle resolves
      ``MCP_PROXY_PROXY_PUBLIC_URL: https://localhost:9443`` when the
      env is unset
- [x] Sandbox dogfood end-to-end still passes
      (``./sandbox/demo.sh oneshot-a-to-b`` + ``mcp-catalog``)
- [ ] CI green