### PR TITLE
fix(release): guard latest + minor tags from being pushed on prereleases

### DIFF
--- a/.github/workflows/release-mastio.yml
+++ b/.github/workflows/release-mastio.yml
@@ -102,9 +102,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/cullis-mastio
+          # latest=auto would override the explicit enable= guard below.
+          flavor: |
+            latest=false
           tags: |
             type=match,pattern=mastio-v(.*),group=1
-            type=match,pattern=mastio-v(\d+\.\d+)\..*,group=1
+            type=match,pattern=mastio-v(\d+\.\d+)\..*,group=1,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
           labels: |
             org.opencontainers.image.title=Cullis Mastio


### PR DESCRIPTION
## Summary

- `docker/metadata-action@v5` defaults `flavor.latest=auto`, which silently overrides the explicit `enable=...` guard on `type=raw,value=latest`. Set `latest=false` so the guard is authoritative.
- The `type=match,pattern=mastio-v(\d+\.\d+)\..*` (minor) pattern had no prerelease guard, so it tagged a pre-release with the floating minor (`0.3`).

## Background

Verified on the `mastio-v0.3.0-rc1` dry-run (run [25098525503](https://github.com/cullis-security/cullis/actions/runs/25098525503)): all three tags `0.3.0-rc1`, `0.3`, and `latest` were pushed to GHCR pointing at the rc digest, even though `enable=` for `latest` evaluated to `false` (visible in the metadata-action log). Result: `docker pull ghcr.io/cullis-security/cullis-mastio` (no tag) lands on a pre-release.

## Test plan

- [ ] Tag a throwaway `mastio-v0.0.0-rc1` after merge and confirm only `0.0.0-rc1` is pushed (no `0.0`, no `latest`).
- [ ] Confirm a future `mastio-v0.3.0` (no `-rc`) still produces `0.3.0`, `0.3`, and `latest`.
- [ ] Cleanup the stray `latest` and `0.3` tags from GHCR (out-of-band).

🤖 Generated with [Claude Code](https://claude.com/claude-code)