### PR TITLE
fix(nginx): redirect bare / to /proxy/login

### DIFF
--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -189,6 +189,12 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
+    # Bare URL (https://host:9443/) → dashboard login. Without this an
+    # operator opening the host root sees nginx 404.
+    location = / {
+        return 302 /proxy/login;
+    }
+
     # ──────────────────────────────────────────────────────────────────
     # Catch-all — fail closed.
     # ──────────────────────────────────────────────────────────────────

--- a/packaging/mastio-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-bundle/nginx/mastio/mastio.conf
@@ -189,6 +189,12 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
+    # Bare URL (https://host:9443/) → dashboard login. Without this an
+    # operator opening the host root sees nginx 404.
+    location = / {
+        return 302 /proxy/login;
+    }
+
     # ──────────────────────────────────────────────────────────────────
     # Catch-all — fail closed.
     # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Add `location = /` that 302-redirects to `/proxy/login`. Without this an operator opening `https://host:9443/` in a browser hits the existing catch-all `location / { return 404 }` and sees a bare nginx 404 page instead of the dashboard login.

The exact-match (`= /`) takes priority over the prefix-match catch-all, so any other unmapped path keeps failing closed.

## Background

Surfaced during the mastio-v0.3.0-rc1 bundle dogfood — the deploy.sh prints `Dashboard https://host:9443/proxy/login` at the end, but a user opening just `https://host:9443/` (the natural muscle-memory) gets nginx 404. Both `nginx/mastio/mastio.conf` (used by the dev-side `deploy_proxy.sh`) and `packaging/mastio-bundle/nginx/mastio/mastio.conf` (shipped in the bundle tarball) are kept in sync.

## Test plan

- [ ] Apply the patched mastio.conf on a running rc1 bundle deploy, `docker exec cullis-mastio-mastio-nginx-1 nginx -s reload`, then `curl -kI https://host:9443/` → expect `302 Location: /proxy/login`.
- [ ] `curl -kI https://host:9443/some-bogus-path` → still `404` (catch-all unchanged).
- [ ] Open `https://host:9443/` in a browser → lands on dashboard login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)