### PR TITLE
feat(dashboard): add Cullis favicon to Mastio + Court

### DIFF
--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Cullis{% endblock %} — Cullis Court</title>
+    <link rel="icon" type="image/svg+xml" href="/static/cullis-mark.svg">
     <link rel="stylesheet" href="/static/css/tailwind.css">
     <script src="/static/vendor/htmx.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">

--- a/app/dashboard/templates/login.html
+++ b/app/dashboard/templates/login.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Network Admin Console — Cullis Court</title>
+    <link rel="icon" type="image/svg+xml" href="/static/cullis-mark.svg">
     <link rel="stylesheet" href="/static/css/tailwind.css">
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
     <style>

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Dashboard{% endblock %} — Cullis Mastio</title>
+    <link rel="icon" type="image/svg+xml" href="/static/cullis-mark.svg">
     <link rel="stylesheet" href="/static/css/tailwind.css">
     <script src="/static/vendor/htmx.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">

--- a/mcp_proxy/dashboard/templates/login.html
+++ b/mcp_proxy/dashboard/templates/login.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sign in — Cullis Mastio</title>
+    <link rel="icon" type="image/svg+xml" href="/static/cullis-mark.svg">
     <link rel="stylesheet" href="/static/css/tailwind.css">
     <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>


### PR DESCRIPTION
## Summary

- Mastio and Court dashboards rendered the browser's default globe favicon. Connector already had the Cullis mark via its `base.html`.
- Added `<link rel='icon' type='image/svg+xml' href='/static/cullis-mark.svg'>` in four templates: `mcp_proxy/dashboard/templates/base.html` + `login.html` (login is standalone, not extending base) and the same two on Court.
- The `cullis-mark.svg` asset is already served under `/static/` on both apps — no new files.

## Test plan

- [ ] Open `https://host:9443/proxy/login` (Mastio) — browser tab shows the teal portcullis mark instead of the globe.
- [ ] Sign in and navigate to `/proxy/overview` — favicon stays.
- [ ] Same for Court (`/login` → `/orgs`).
- [ ] Hard-refresh tab if cached globe persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)