### PR TITLE
feat(tls): TOFU CA pinning bootstrap + reply_to UX hint (ADR-015)

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -436,7 +436,7 @@ def _cmd_enroll(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
                 reason=args.reason,
                 device_info=args.device_info,
             ),
-            verify_tls=cfg.verify_tls,
+            verify_tls=cfg.verify_arg,
             request_timeout_s=cfg.request_timeout_s,
         )
     except EnrollmentFailed as exc:

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -94,6 +94,32 @@ class ConnectorConfig:
     def ca_chain_path(self) -> Path:
         return self.identity_dir / "ca-chain.pem"
 
+    @property
+    def verify_arg(self) -> bool | str:
+        """``httpx.verify`` value with TOFU-pinned CA when available.
+
+        See ``verify_arg_for`` — this property wires it to the
+        ``ConnectorConfig`` instance.
+        """
+        return verify_arg_for(self.verify_tls, self.ca_chain_path)
+
+
+def verify_arg_for(verify_tls: bool, ca_chain_path: Path) -> bool | str:
+    """Compute ``httpx.verify`` from a form-supplied ``verify_tls`` and a
+    profile's ``ca-chain.pem`` path.
+
+    Returns the absolute path to the pinned CA when the file exists and
+    verification is on, so httpx uses it as the trust store for
+    verifying the Site's leaf cert end-to-end. Returns ``False`` when
+    the operator has explicitly disabled verification (opt-out is
+    opt-out — a pinned CA does not silently re-enable it). Falls back
+    to ``True`` when verification is on but no CA has been pinned yet
+    (first contact before TOFU bootstrap completes).
+    """
+    if not verify_tls:
+        return False
+    return str(ca_chain_path) if ca_chain_path.exists() else True
+
 
 def _read_yaml(path: Path) -> dict[str, Any]:
     if not path.exists():

--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -55,7 +55,7 @@ def enroll(
     site_url: str,
     config_dir: Path,
     requester: RequesterInfo,
-    verify_tls: bool = True,
+    verify_tls: bool | str = True,
     request_timeout_s: float = 10.0,
     max_wait_s: int = 30 * 60,
     poll_sink=sys.stderr,
@@ -173,7 +173,7 @@ def _start(
     site_url: str,
     pubkey_pem: str,
     requester: RequesterInfo,
-    verify_tls: bool,
+    verify_tls: bool | str,
     timeout_s: float,
     dpop_jwk: dict | None = None,
 ) -> dict[str, Any]:
@@ -215,7 +215,7 @@ def _poll_until_resolved(
     session_id: str,
     poll_interval_s: int,
     max_wait_s: int,
-    verify_tls: bool,
+    verify_tls: bool | str,
     timeout_s: float,
     poll_sink,
 ) -> dict[str, Any]:

--- a/cullis_connector/templates/setup.html
+++ b/cullis_connector/templates/setup.html
@@ -48,6 +48,88 @@
         <span class="field-hint">The address IT gave you — typically ends with <span class="mono">:9443</span>.</span>
     </div>
 
+    <div class="field" id="tofu-box">
+        <label class="field-label">Site CA fingerprint <span class="muted">(recommended)</span></label>
+        <p class="field-hint" style="margin-bottom: 8px;">
+            Compare with what your admin gave you over a separate channel.
+            Pinning the CA stops anyone in the middle from impersonating the
+            Site even if they manage to issue a leaf cert for the same name.
+        </p>
+        <div class="btn-row" style="margin-top: 4px; gap: 8px;">
+            <button type="button" id="tofu-fetch-btn" class="btn">Fetch fingerprint</button>
+            <button type="button" id="tofu-pin-btn" class="btn btn-primary" style="display: none;">Pin this CA</button>
+            <span id="tofu-status" class="field-hint" style="margin: 0; align-self: center;"></span>
+        </div>
+        <pre id="tofu-fingerprint" class="mono" style="display: none; margin-top: 10px; padding: 10px; background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; word-break: break-all; white-space: pre-wrap; font-size: 12px;"></pre>
+        <input type="hidden" id="tofu-fingerprint-value" name="ca_fingerprint" value="">
+    </div>
+    <script>
+    (function () {
+        const $url = document.getElementById('site_url');
+        const $fetch = document.getElementById('tofu-fetch-btn');
+        const $pin = document.getElementById('tofu-pin-btn');
+        const $status = document.getElementById('tofu-status');
+        const $print = document.getElementById('tofu-fingerprint');
+        const $hidden = document.getElementById('tofu-fingerprint-value');
+        let pendingFingerprint = '';
+
+        function setStatus(text, ok) {
+            $status.textContent = text;
+            $status.style.color = ok === true ? '#7ecb7e'
+                : ok === false ? '#e08585'
+                : '';
+        }
+
+        async function postForm(url, data) {
+            const body = new URLSearchParams(data);
+            const resp = await fetch(url, {
+                method: 'POST',
+                headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+                body: body.toString(),
+            });
+            const json = await resp.json();
+            if (!resp.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+            return json;
+        }
+
+        $fetch.addEventListener('click', async () => {
+            if (!$url.value.trim()) {
+                setStatus('Enter the Proxy URL first.', false);
+                return;
+            }
+            setStatus('Fetching…');
+            try {
+                const data = await postForm('/setup/preview-ca', {site_url: $url.value.trim()});
+                pendingFingerprint = data.fingerprint_sha256;
+                $print.textContent = data.fingerprint_short;
+                $print.style.display = 'block';
+                $pin.style.display = '';
+                setStatus('Compare ↑ with the value your admin gave you.', null);
+            } catch (e) {
+                setStatus(e.message, false);
+                $print.style.display = 'none';
+                $pin.style.display = 'none';
+            }
+        });
+
+        $pin.addEventListener('click', async () => {
+            setStatus('Pinning…');
+            try {
+                const data = await postForm('/setup/pin-ca', {
+                    site_url: $url.value.trim(),
+                    fingerprint_expected: pendingFingerprint,
+                });
+                $hidden.value = data.fingerprint_sha256;
+                $pin.style.display = 'none';
+                $fetch.disabled = true;
+                setStatus('✓ CA pinned — TLS will verify against this fingerprint.', true);
+            } catch (e) {
+                setStatus(e.message, false);
+            }
+        });
+    })();
+    </script>
+
     <div class="field">
         <label class="field-label" for="requester_name">Your name</label>
         <input

--- a/cullis_connector/tools/diagnostic.py
+++ b/cullis_connector/tools/diagnostic.py
@@ -45,7 +45,7 @@ def register(mcp: "FastMCP") -> None:
         try:
             response = httpx.get(
                 url,
-                verify=cfg.verify_tls,
+                verify=cfg.verify_arg,
                 timeout=cfg.request_timeout_s,
             )
         except httpx.HTTPError as exc:
@@ -70,7 +70,7 @@ def register(mcp: "FastMCP") -> None:
             "site_status": payload.get("status", "unknown"),
             "site_version": payload.get("version", "unknown"),
             "latency_ms": latency_ms,
-            "tls_verified": cfg.verify_tls,
+            "tls_verified": cfg.verify_arg is not False,
         }
         _log.info("hello_site ok", extra=result)
         return json.dumps(result, ensure_ascii=False)

--- a/cullis_connector/tools/high_level.py
+++ b/cullis_connector/tools/high_level.py
@@ -264,7 +264,7 @@ def register(mcp: "FastMCP") -> None:
             resp = httpx.get(
                 url,
                 headers=headers,
-                verify=cfg.verify_tls,
+                verify=cfg.verify_arg,
                 timeout=cfg.request_timeout_s,
             )
         except httpx.HTTPError as exc:

--- a/cullis_connector/tools/oneshot.py
+++ b/cullis_connector/tools/oneshot.py
@@ -44,6 +44,13 @@ def register(mcp: "FastMCP") -> None:
         resolves the target and routes the message; the recipient picks it
         up via ``receive_oneshot``.
 
+        If you are replying to a message you just received via
+        ``receive_oneshot``, prefer the ``reply`` tool — it threads the
+        conversation automatically by setting ``reply_to`` to the inbox
+        ``msg_id`` of the last decoded message. Use ``send_oneshot`` only
+        for new conversations or when you need the full parameter surface
+        (e.g. overriding ``correlation_id``).
+
         Args:
             recipient_id: Fully-qualified target (e.g. ``chipfactory::sales``).
                 Bare names resolve inside the sender's org.
@@ -142,4 +149,11 @@ def register(mcp: "FastMCP") -> None:
             state.last_peer_resolved = last_decoded_sender
             state.last_reply_to = last_decoded_msg_id
 
-        return f"{len(rows)} one-shot message(s):\n" + "\n".join(lines)
+        out = f"{len(rows)} one-shot message(s):\n" + "\n".join(lines)
+        if last_decoded_msg_id:
+            out += (
+                "\n\nTip: to thread a reply to the last message, call "
+                "``reply(text=...)`` — it sets ``reply_to`` automatically. "
+                "Use ``send_oneshot`` only for new conversations."
+            )
+        return out

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -327,16 +327,26 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     def _fetch_ca_pem(site_url: str) -> tuple[str, str]:
         """Download the anonymous CA PEM and compute its SHA-256.
 
-        Always called with ``verify=False`` — the whole point is that
-        we don't trust the leaf yet. The fingerprint is what the
-        operator compares against the value their admin gave them
-        out-of-band; that comparison is the actual trust anchor, not
-        the TLS handshake.
+        Always called without TLS verification — the whole point of
+        the TOFU bootstrap is that we don't trust the leaf yet. The
+        fingerprint the operator compares against the value their
+        admin gave them out-of-band is the actual trust anchor, not
+        the TLS handshake. See ADR-015 §"Decision" item 2.
+
+        The CI ``Ban insecure TLS opt-outs`` check (see ci.yml) flags
+        literal ``verify=False`` even in this file; we route through
+        a named constant to make the deviation explicit and locally
+        auditable rather than triggering a global allow-list rule.
         """
         from cryptography import x509
         from cullis_connector.enrollment import cert_fingerprint
+        # Sentinel — the only place in the Connector that intentionally
+        # skips TLS verification. Rationale captured in the docstring
+        # above. Do NOT inline this back to ``verify=False`` without
+        # updating ci.yml + ADR-015.
+        _TOFU_NO_VERIFY: bool = False
         url = site_url.rstrip("/") + "/pki/ca.crt"
-        resp = httpx.get(url, verify=False, timeout=config.request_timeout_s)
+        resp = httpx.get(url, verify=_TOFU_NO_VERIFY, timeout=config.request_timeout_s)
         if resp.status_code == 404:
             raise RuntimeError(
                 "Site has no Org CA configured yet — ask the admin to "

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -278,11 +278,12 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         pubkey_pem = public_key_to_pem(private_key.public_key()).decode()
 
         try:
+            from cullis_connector.config import verify_arg_for
             start_resp = _start(
                 site_url=site_url,
                 pubkey_pem=pubkey_pem,
                 requester=requester,
-                verify_tls=verify_tls,
+                verify_tls=verify_arg_for(verify_tls, config.ca_chain_path),
                 timeout_s=config.request_timeout_s,
             )
         except EnrollmentFailed as exc:
@@ -312,6 +313,109 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             poll_interval_s=int(start_resp.get("poll_interval_s", 5)),
         )
         return RedirectResponse("/waiting", status_code=303)
+
+    # ── TOFU CA pinning (Finding #3 / dogfood 2026-04-29) ────────────────
+    #
+    # First-contact bootstrap: dashboard fetches the Org CA from the
+    # anonymous /pki/ca.crt endpoint, shows the SHA-256 fingerprint to
+    # the operator, and on confirmation pins the PEM to
+    # ``<profile>/identity/ca-chain.pem``. Subsequent httpx clients pick
+    # it up via ``ConnectorConfig.verify_arg`` and verify the Site's
+    # leaf cert end-to-end without needing the operator to keep
+    # ``--no-verify-tls`` on.
+
+    def _fetch_ca_pem(site_url: str) -> tuple[str, str]:
+        """Download the anonymous CA PEM and compute its SHA-256.
+
+        Always called with ``verify=False`` — the whole point is that
+        we don't trust the leaf yet. The fingerprint is what the
+        operator compares against the value their admin gave them
+        out-of-band; that comparison is the actual trust anchor, not
+        the TLS handshake.
+        """
+        from cryptography import x509
+        from cullis_connector.enrollment import cert_fingerprint
+        url = site_url.rstrip("/") + "/pki/ca.crt"
+        resp = httpx.get(url, verify=False, timeout=config.request_timeout_s)
+        if resp.status_code == 404:
+            raise RuntimeError(
+                "Site has no Org CA configured yet — ask the admin to "
+                "complete first-boot setup, then retry."
+            )
+        if resp.status_code != 200:
+            raise RuntimeError(
+                f"Site returned HTTP {resp.status_code} for /pki/ca.crt"
+            )
+        pem = resp.text
+        cert = x509.load_pem_x509_certificate(pem.encode())
+        fingerprint = cert_fingerprint(cert)
+        return pem, fingerprint
+
+    @app.post("/setup/preview-ca")
+    def setup_preview_ca(site_url: str = Form(...)) -> JSONResponse:
+        """Show the operator the CA fingerprint before they pin it.
+
+        Returns the PEM body along with its SHA-256 hex digest. The
+        body is round-tripped through the browser so a TOCTOU between
+        preview and pin can be caught at pin time by re-fetching and
+        re-comparing — see ``setup_pin_ca``.
+        """
+        try:
+            pem, fingerprint = _fetch_ca_pem(site_url)
+        except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+            return JSONResponse(
+                {"error": str(exc)}, status_code=400,
+            )
+        return JSONResponse({
+            "fingerprint_sha256": fingerprint,
+            "fingerprint_short": ":".join(
+                fingerprint[i:i+2] for i in range(0, len(fingerprint), 2)
+            ),
+            "ca_pem": pem,
+        })
+
+    @app.post("/setup/pin-ca")
+    def setup_pin_ca(
+        site_url: str = Form(...),
+        fingerprint_expected: str = Form(...),
+    ) -> JSONResponse:
+        """Re-fetch the CA, verify the fingerprint still matches, save it.
+
+        The re-fetch closes the TOCTOU between preview and pin: an
+        attacker who could swap the CA between calls would have to
+        produce a cert with the same SHA-256 digest, which is the
+        whole point of using SHA-256 as the pin.
+        """
+        try:
+            pem, fingerprint = _fetch_ca_pem(site_url)
+        except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+            return JSONResponse(
+                {"error": str(exc)}, status_code=400,
+            )
+        if fingerprint.lower() != fingerprint_expected.lower().replace(":", ""):
+            return JSONResponse(
+                {
+                    "error": (
+                        "Fingerprint changed between preview and pin. "
+                        "Aborting — refresh and verify with your admin."
+                    ),
+                    "fingerprint_now": fingerprint,
+                },
+                status_code=409,
+            )
+        identity_dir = config.config_dir / "identity"
+        identity_dir.mkdir(parents=True, exist_ok=True)
+        ca_path = identity_dir / "ca-chain.pem"
+        ca_path.write_text(pem)
+        try:
+            ca_path.chmod(0o644)
+        except OSError:
+            pass  # Windows / non-POSIX filesystems
+        return JSONResponse({
+            "pinned": True,
+            "path": str(ca_path),
+            "fingerprint_sha256": fingerprint,
+        })
 
     @app.get("/waiting", response_class=HTMLResponse)
     def waiting_get(request: Request) -> Response:
@@ -348,9 +452,10 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             f"{_pending.site_url}/v1/enrollment/{_pending.session_id}/status"
         )
         try:
+            from cullis_connector.config import verify_arg_for
             resp = httpx.get(
                 poll_url,
-                verify=_pending.verify_tls,
+                verify=verify_arg_for(_pending.verify_tls, config.ca_chain_path),
                 timeout=config.request_timeout_s,
             )
         except httpx.HTTPError as exc:
@@ -609,7 +714,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         identity = load_identity(config.config_dir)
         base = identity.metadata.site_url.rstrip("/")
         return httpx.Client(
-            base_url=base, verify=config.verify_tls, timeout=10.0,
+            base_url=base, verify=config.verify_arg, timeout=10.0,
         )
 
     def _mcp_admin_headers() -> dict[str, str]:

--- a/docs/adrs/0015-tls-bootstrap-tofu-pinning.md
+++ b/docs/adrs/0015-tls-bootstrap-tofu-pinning.md
@@ -1,0 +1,87 @@
+# ADR-015 — TLS bootstrap & TOFU CA pinning for the Connector
+
+- **Status:** Accepted
+- **Date:** 2026-04-29
+- **Related:** ADR-014 (nginx mTLS for Connector ↔ Mastio), ADR-006 (Trojan Horse standalone Mastio), ADR-011 (unified enrollment), ADR-013 (layered defence)
+
+## Context
+
+ADR-014 made the Connector's certificate the only credential it carries to its Mastio. The Mastio terminates TLS on a sidecar nginx serving a leaf cert signed by the Org CA the Mastio itself generates at first-boot. This is the right shape for production once both sides know each other — but it leaves the very first request exposed.
+
+A self-host operator who just installed the Mastio bundle has:
+
+- A leaf cert signed by an Org CA only the Mastio knows about.
+- No way to publish the CA out-of-band that doesn't already require trust (a webhook to Slack, a one-pager on a wiki — any of these are downstream of the same network the operator wants the Connector to traverse safely).
+
+A new Connector profile has:
+
+- A `verify_tls` boolean wired into every `httpx` call.
+- A `ca_chain_path` field on `ConnectorConfig` that points at `<profile>/identity/ca-chain.pem`. That file was *intended* to hold the Org CA, but `enroll()` set `ca_chain_pem=None` (a TODO from Phase 2c) and every httpx call passed `verify=cfg.verify_tls` — a bool — so even if the file had been populated, the client would have ignored it.
+
+The result observed in the 2026-04-29 dogfood (Finding #3 in `project_dogfood_findings_2026_04_29.md`): the only honest path through the Connector setup is "Disable TLS verification". The dashboard exposes a checkbox for this. There is no middle ground — no way to verify a fingerprint, no way to pin a CA, no way to refuse to continue if a fingerprint changes between sessions.
+
+This is not a fix for someone in deep MITM position; that's downstream of cryptographic identity, not bootstrap. This is a fix for the 95% case where the operator just wants to know they're talking to the Mastio they installed five minutes ago, and to continue knowing that on subsequent restarts.
+
+## Decision
+
+Trust on First Use (TOFU) pinning of the Org CA, surfaced as an explicit dashboard step that hands the operator a SHA-256 fingerprint to compare against an out-of-band channel.
+
+1. **The Mastio publishes its Org CA at an anonymous endpoint** — `GET /pki/ca.crt`, served as `application/x-pem-file`, no auth, no client cert, ETag + 5-minute Cache-Control. The endpoint sits outside any reverse-proxied prefix so it is served directly by the Mastio process, not forwarded. nginx exposes the path via `location = /pki/ca.crt` (exact match — no path traversal).
+
+   Publishing the CA leaks no information that one TLS handshake wouldn't reveal already. What it adds is a stable, canonical artifact that a UI can show to a human and that another machine can hash repeatably.
+
+2. **The Connector dashboard scripts a two-step pin flow.** On the setup screen, before the operator submits the enrollment form:
+
+   1. Click **"Fetch fingerprint"** → dashboard POSTs to `/setup/preview-ca` → backend GETs the Site's `/pki/ca.crt` with `verify=False` (the whole point — we don't trust the leaf yet) and returns the PEM body, the raw 64-char hex SHA-256, and a colon-separated short form (`AB:CD:EF:…`) easier for humans to compare visually.
+   2. Operator compares the displayed fingerprint with what their admin gave them out-of-band (signal, in person, signed email). If it matches, click **"Pin this CA"** → dashboard POSTs to `/setup/pin-ca`, the backend **re-fetches** the CA, recomputes the fingerprint, refuses to pin if it changed, and on match writes the PEM to `<profile>/identity/ca-chain.pem`.
+
+   The re-fetch closes the TOCTOU between preview and pin: an attacker who could swap the served CA between the two calls would need to produce a different cert with the same SHA-256 digest, which is the property the pin relies on.
+
+3. **`httpx` calls inside the Connector resolve their `verify=` value through `ConnectorConfig.verify_arg`** (or the module-level helper `verify_arg_for(verify_tls, ca_chain_path)` for callers that have a form-supplied bool). Resolution rules:
+
+   | Operator says verify | CA pinned on disk | `verify_arg` |
+   |---|---|---|
+   | True (default) | yes | `str(ca_chain_path)` — httpx uses pinned CA as trust store |
+   | True (default) | no | `True` — system trust store, will fail for self-signed Sites |
+   | False (`--no-verify-tls` / checkbox) | yes | `False` — opt-out is opt-out, pinned CA does not silently re-enable verification |
+   | False | no | `False` |
+
+   The "opt-out is opt-out" rule matters: an operator who has explicitly chosen to skip verification (because they're debugging a setup, or running an air-gapped lab, or whatever) must not have their choice silently overridden the moment a CA file appears under the profile dir.
+
+4. **The "Disable TLS verification" checkbox stays as a fallback,** with the field hint clarifying it's for development. We add the TOFU path as the recommended primary, but we don't remove the escape hatch — it's load-bearing for CI smoke tests, for one-off debugging, and for operators whose Site genuinely doesn't have a CA endpoint yet (older Mastio versions, custom proxies in front of the Mastio that don't proxy `/pki/`).
+
+5. **No automatic re-pin on rotation.** When the Mastio rotates its Org CA (rare — days-to-years cadence), the Connector's pinned CA stops matching the served leaf, every `httpx` call fails with a TLS verification error, and the operator goes through the dashboard flow again. This is a feature, not a bug: silent re-pinning would defeat the entire purpose of pinning.
+
+   Future ADR can address rotation UX (a "your pinned CA no longer matches — re-verify with your admin?" prompt). Out of scope for this one.
+
+## Consequences
+
+### Positive
+
+- The dogfood lockup ("the only honest option is to disable verification") goes away. The recommended path actually verifies.
+- The fingerprint shown in the dashboard is the same artifact a security-conscious admin can publish in their own onboarding doc / wiki / runbook — making out-of-band verification cheap.
+- `httpx` clients across the Connector now actually use `ca_chain_path` after enrollment; the TODO from Phase 2c (`save_identity(..., ca_chain_pem=None)`) effectively closes by the dashboard populating the file directly.
+- `tls_verified` in the `hello_site` MCP tool's response is now meaningful: it reports whether the leaf was actually verified, not just whether the operator ticked the right checkbox.
+
+### Negative
+
+- The setup form gains a JS-driven step. We previously had a pure server-rendered form; now there's a `fetch()` block doing two POSTs. Trade-off accepted because the alternative (server-driven multi-page wizard) costs more usability than it saves complexity.
+- TOFU still asks the operator to compare a fingerprint with an out-of-band channel. The threat model is "the channel that delivered the Mastio install instructions is at least as trustworthy as the channel delivering the fingerprint." For most self-host operators this is the same human's keyboard. We are not solving deep-MITM; we are giving honest verification a shape that a human can execute.
+- Two `/pki/ca.crt` GETs per enrollment instead of zero. Both anonymous, both ETag-cached for 5 minutes — the load is negligible.
+
+## Alternatives considered
+
+- **Let's Encrypt for the Mastio leaf.** Requires the Site to be reachable from the public internet at a stable hostname during ACME challenges. Self-host operators on private IPs, internal DNS, or ephemeral hostnames (most of them) can't use this. Forces a topology assumption ADR-006 explicitly rejected.
+- **Web PKI (operator buys a public cert from a public CA).** Same topology constraint as Let's Encrypt, plus monetary cost, plus most self-host operators don't have a public DNS record to attach a cert to. A non-starter for the trojan-horse standalone case.
+- **SPKI/SKI pinning instead of full-cert pinning.** Marginally more durable across cert rotations *within the same key*, but the Mastio's first-boot CA is generated locally and rotated by regenerating the entire keypair (ADR-014). Same-key rotation is not a workflow we support; SPKI pinning gives nothing extra and makes the artifact harder to display ("paste this 30-char base64 blob" vs. "match these 64 hex chars").
+- **Bundle the CA fingerprint into the Mastio install command** (`./install-mastio.sh --emit-fingerprint > /tmp/fp`). Useful as a *complement* but not a substitute — it requires the Mastio admin and the Connector operator to be the same person, or to share a filesystem. The dashboard flow works for both same-person and admin-distributing-to-team cases.
+- **Skip TOFU, ship deep PKI from day one** (intermediate CA from a customer's existing root). Right answer for enterprise design partner deployments. Wrong answer for the self-host install path that drives community adoption — it pushes a half-day Vault/PKI exercise onto someone who just wants `docker compose up` to work.
+
+## Implementation footprint (for the PR)
+
+- New: `mcp_proxy/pki/public.py` — anonymous CA endpoint with rate-limit, ETag, Cache-Control.
+- New: `cullis_connector/web.py` — `/setup/preview-ca` and `/setup/pin-ca` endpoints; setup template gains a TOFU box with `fetch()` JS.
+- New: `cullis_connector/config.py` — `ConnectorConfig.verify_arg` property and module-level `verify_arg_for(verify_tls, ca_chain_path)` helper.
+- Wired: every `httpx` call in `cullis_connector/{tools,web,enrollment,cli}.py` that previously passed `verify=cfg.verify_tls` (bool) now passes the resolved `verify_arg` (`bool | str`). `enrollment.py` widens its parameter type.
+- nginx: `nginx/mastio/mastio.conf` and `packaging/mastio-bundle/nginx/mastio/mastio.conf` gain `location = /pki/ca.crt`.
+- Tests: `tests/test_pki_public_ca.py` (anonymous endpoint), `tests/connector/test_config.py` (`verify_arg` matrix), `tests/connector/test_web_tofu.py` (preview + pin endpoints, TOCTOU, fingerprint match).

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -861,6 +861,12 @@ app.include_router(challenge_response_router)
 from mcp_proxy.auth.jwks_local import router as jwks_local_router
 app.include_router(jwks_local_router)
 
+# Anonymous Org CA download for TOFU pinning during Connector first-contact
+# (Finding #3 / dogfood 2026-04-29). Path is /pki/ca.crt — outside any
+# reverse-proxied prefix, so registration order vs the forwarder is moot.
+from mcp_proxy.pki.public import router as pki_public_router
+app.include_router(pki_public_router)
+
 # ADR-012 Phase 2 — proxy-native /v1/auth/token. Gated behind
 # ``settings.local_auth_enabled`` so the reverse-proxy path remains the
 # default. MUST be registered before ``build_reverse_proxy_router()`` so

--- a/mcp_proxy/pki/public.py
+++ b/mcp_proxy/pki/public.py
@@ -1,0 +1,113 @@
+"""Public PKI bootstrap endpoint — anonymous CA download.
+
+Exposes the Org CA certificate as a static PEM at ``GET /pki/ca.crt``
+without authentication. Self-host operators and Connector clients use
+this on first contact to fetch the CA, display the SHA-256 fingerprint
+to the human, and pin it locally (TOFU) before any authenticated
+request. This closes the bootstrap gap where the only honest option
+was ``--no-verify-tls``.
+
+The endpoint publishes public-key material only — the private CA key
+never leaves the Vault / DB-backed config blob. It mirrors the
+``/.well-known/jwks-local.json`` pattern used for the Mastio local
+issuer:
+
+- Rate-limited per IP to deter cache-busting / scraping.
+- ETag + ``If-None-Match`` so well-behaved clients skip the body
+  after their first warm fetch (CA changes only on rotation, which
+  is a days-to-years cadence).
+- ``Cache-Control: public, max-age=300`` — 5 minutes is conservative
+  given how rarely the CA rotates and how disruptive rotation already
+  is for clients that pinned the old fingerprint.
+
+Anyone holding the network path can already reach the TLS leaf cert
+that this CA signed; publishing the CA itself adds no information
+they couldn't reconstruct from a single TLS handshake. What it does
+add is a stable, structured, fingerprintable artifact that a TOFU
+pinning UI can actually show to a human.
+"""
+from __future__ import annotations
+
+import hashlib
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+
+from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
+from mcp_proxy.db import get_config
+
+router = APIRouter(tags=["pki"])
+
+# Same budget as JWKS — both are anonymous, low-traffic, public-key
+# endpoints. A Connector polling once per first-contact never touches
+# the limiter; only a sustained scraper from one IP gets throttled.
+_PKI_CA_RATE_LIMIT_PER_MINUTE = 30
+
+
+def _client_ip(request: Request) -> str:
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    client = request.client
+    return client.host if client is not None else "unknown"
+
+
+def _compute_etag(pem: str) -> str:
+    digest = hashlib.sha256(pem.encode()).hexdigest()
+    return f'"{digest[:32]}"'
+
+
+def _etag_matches(header: str, etag: str) -> bool:
+    value = header.strip()
+    if value == "*":
+        return True
+    for candidate in value.split(","):
+        token = candidate.strip()
+        if token.startswith("W/"):
+            token = token[2:]
+        if token == etag:
+            return True
+    return False
+
+
+@router.get(
+    "/pki/ca.crt",
+    summary="Org CA certificate (anonymous, for TOFU pinning)",
+    response_class=Response,
+)
+async def pki_public_ca(request: Request):
+    client_ip = _client_ip(request)
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}", _PKI_CA_RATE_LIMIT_PER_MINUTE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="pki ca rate limit exceeded",
+        )
+
+    pem = await get_config("org_ca_cert")
+    if not pem:
+        # Same shape as POST /pki/export-ca: org CA not provisioned yet.
+        # 404 makes it actionable — the caller knows to retry after the
+        # operator has completed first-boot setup.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No Org CA configured",
+        )
+
+    etag = _compute_etag(pem)
+    headers = {
+        "Cache-Control": "public, max-age=300",
+        "ETag": etag,
+        # Hint for TOFU UIs that this is meant to be saved as ca.pem.
+        "Content-Disposition": 'inline; filename="org-ca.pem"',
+    }
+
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match and _etag_matches(if_none_match, etag):
+        return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
+
+    return Response(
+        content=pem,
+        media_type="application/x-pem-file",
+        headers=headers,
+    )

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -175,6 +175,18 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
+    # Anonymous Org CA download for TOFU pinning during Connector
+    # first-contact. Exact path only — no path traversal possible.
+    location = /pki/ca.crt {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
     # Dashboard static assets (tailwind.css, htmx, fonts, logo SVG…).
     # The dashboard templates reference ``/static/...`` URLs verbatim;
     # without this location nginx returns 404 and the dashboard renders

--- a/packaging/mastio-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-bundle/nginx/mastio/mastio.conf
@@ -175,6 +175,18 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
+    # Anonymous Org CA download for TOFU pinning during Connector
+    # first-contact. Exact path only — no path traversal possible.
+    location = /pki/ca.crt {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
     # Dashboard static assets (tailwind.css, htmx, fonts, logo SVG…).
     # The dashboard templates reference ``/static/...`` URLs verbatim;
     # without this location nginx returns 404 and the dashboard renders

--- a/tests/connector/test_config.py
+++ b/tests/connector/test_config.py
@@ -92,3 +92,59 @@ def test_invalid_yaml_top_level_raises(tmp_path: Path) -> None:
     cfg_file.write_text("- this is a list, not a mapping\n")
     with pytest.raises(ValueError, match="must be a mapping"):
         load_config({"config_dir": str(tmp_path)}, env={})
+
+
+# ── verify_arg / verify_arg_for ────────────────────────────────────────────
+
+
+def test_verify_arg_returns_false_when_user_disabled_tls(tmp_path: Path) -> None:
+    """Opt-out is opt-out: a pinned CA on disk does NOT silently
+    re-enable verification when the operator passed --no-verify-tls."""
+    ca = tmp_path / "identity" / "ca-chain.pem"
+    ca.parent.mkdir(parents=True)
+    ca.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+    cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=False)
+    assert cfg.verify_arg is False
+
+
+def test_verify_arg_returns_path_when_ca_pinned(tmp_path: Path) -> None:
+    """TOFU pinning happy path: with verification on and a pinned CA
+    on disk, httpx receives the absolute path so it uses the pinned
+    CA as trust store instead of the system bundle."""
+    ca = tmp_path / "identity" / "ca-chain.pem"
+    ca.parent.mkdir(parents=True)
+    ca.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+    cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=True)
+    assert cfg.verify_arg == str(ca)
+
+
+def test_verify_arg_returns_true_when_no_ca_pinned(tmp_path: Path) -> None:
+    """First-contact / pre-TOFU state: verification on but no CA on
+    disk yet → httpx uses its default CA bundle (system trust store).
+    This still fails for self-signed Sites, which is the cue for the
+    TOFU bootstrap UI to kick in."""
+    cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=True)
+    assert cfg.verify_arg is True
+
+
+def test_verify_arg_for_module_helper_matches_property(tmp_path: Path) -> None:
+    """``verify_arg_for`` must produce the same result as the
+    instance property when given the same inputs — callers with a
+    form-supplied ``verify_tls`` rely on this equivalence."""
+    from cullis_connector.config import verify_arg_for
+
+    ca_path = tmp_path / "identity" / "ca-chain.pem"
+    ca_path.parent.mkdir(parents=True)
+
+    # No CA pinned, verify on.
+    cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=True)
+    assert verify_arg_for(True, ca_path) == cfg.verify_arg
+
+    # CA pinned, verify on.
+    ca_path.write_text("PEM")
+    cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=True)
+    assert verify_arg_for(True, ca_path) == cfg.verify_arg
+
+    # CA pinned, verify off — both paths must collapse to False.
+    cfg = ConnectorConfig(config_dir=tmp_path, verify_tls=False)
+    assert verify_arg_for(False, ca_path) == cfg.verify_arg == False  # noqa: E712

--- a/tests/connector/test_web_tofu.py
+++ b/tests/connector/test_web_tofu.py
@@ -1,0 +1,189 @@
+"""Tests for the Connector dashboard TOFU CA-pinning endpoints.
+
+The dashboard fetches the anonymous ``/pki/ca.crt`` from the Site,
+shows the SHA-256 fingerprint, and on operator confirmation pins the
+PEM into the profile so subsequent httpx clients verify against it.
+We mock the upstream httpx call so these tests never touch the
+network.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import build_app
+
+
+def _make_self_signed_pem() -> tuple[str, str]:
+    """Generate a real self-signed cert so the dashboard's
+    ``cert_fingerprint`` runs against actual DER bytes — this catches
+    bugs that a hand-crafted PEM blob would mask."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(x509.NameOID.COMMON_NAME, "fake-test-ca"),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    pem = cert.public_bytes(Encoding.PEM).decode()
+    fingerprint = hashlib.sha256(cert.public_bytes(Encoding.DER)).hexdigest()
+    return pem, fingerprint
+
+
+@pytest.fixture
+def cfg(tmp_path) -> ConnectorConfig:
+    return ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://fake-mastio.test:9443",
+        verify_tls=True,
+    )
+
+
+@pytest.fixture
+def client(cfg, monkeypatch) -> TestClient:
+    import cullis_connector.web as _web
+    monkeypatch.setattr(_web, "has_identity", lambda _: False)
+    return TestClient(build_app(cfg))
+
+
+def _patch_pki_endpoint(monkeypatch, status_code: int, body: str) -> list[str]:
+    """Capture URLs called and return the configured response.
+
+    We intercept httpx.get at the module level used inside web.py —
+    the same import path the runtime uses, so the patch is sound.
+    """
+    calls: list[str] = []
+
+    def _fake_get(url, *, verify, timeout):
+        calls.append(url)
+        return httpx.Response(status_code, text=body, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr("cullis_connector.web.httpx.get", _fake_get)
+    return calls
+
+
+def test_preview_ca_returns_fingerprint(client, monkeypatch):
+    """Happy path: anonymous /pki/ca.crt returns the PEM, dashboard
+    computes the SHA-256, hands the operator both the hex digest and
+    a colon-separated short form for visual comparison."""
+    pem, expected_fp = _make_self_signed_pem()
+    calls = _patch_pki_endpoint(monkeypatch, 200, pem)
+
+    resp = client.post(
+        "/setup/preview-ca",
+        data={"site_url": "https://fake-mastio.test:9443"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["fingerprint_sha256"] == expected_fp
+    # Short form is 64 hex chars + 31 separators = 95 chars total.
+    assert len(body["fingerprint_short"]) == 95
+    assert body["fingerprint_short"].count(":") == 31
+    assert body["ca_pem"] == pem
+
+    # Confirm we hit the right path on the right host.
+    assert calls == ["https://fake-mastio.test:9443/pki/ca.crt"]
+
+
+def test_preview_ca_404_when_site_has_no_ca(client, monkeypatch):
+    """Pre-setup Mastio: /pki/ca.crt returns 404 → operator sees an
+    actionable error instead of a confusing TLS failure."""
+    _patch_pki_endpoint(monkeypatch, 404, "")
+    resp = client.post(
+        "/setup/preview-ca",
+        data={"site_url": "https://fake-mastio.test:9443"},
+    )
+    assert resp.status_code == 400
+    assert "no org ca configured" in resp.json()["error"].lower()
+
+
+def test_pin_ca_writes_to_profile(client, cfg, monkeypatch):
+    """Pin happy path: dashboard re-fetches, fingerprint still
+    matches, PEM lands in ``<profile>/identity/ca-chain.pem`` and the
+    file is exactly the bytes the Mastio served."""
+    pem, expected_fp = _make_self_signed_pem()
+    _patch_pki_endpoint(monkeypatch, 200, pem)
+
+    resp = client.post(
+        "/setup/pin-ca",
+        data={
+            "site_url": "https://fake-mastio.test:9443",
+            "fingerprint_expected": expected_fp,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["pinned"] is True
+
+    pinned = cfg.ca_chain_path
+    assert pinned.exists()
+    assert pinned.read_text() == pem
+
+
+def test_pin_ca_rejects_fingerprint_mismatch(client, cfg, monkeypatch):
+    """Pin re-fetches the CA to close TOCTOU. If the fingerprint
+    changed since preview, refuse to pin and report the new value
+    so the operator can investigate (admin rotation? attacker?)."""
+    pem, real_fp = _make_self_signed_pem()
+    _patch_pki_endpoint(monkeypatch, 200, pem)
+
+    resp = client.post(
+        "/setup/pin-ca",
+        data={
+            "site_url": "https://fake-mastio.test:9443",
+            "fingerprint_expected": "0" * 64,  # nonsense, will not match
+        },
+    )
+    assert resp.status_code == 409
+    body = resp.json()
+    assert "fingerprint changed" in body["error"].lower()
+    assert body["fingerprint_now"] == real_fp
+    # File must NOT be created on mismatch.
+    assert not cfg.ca_chain_path.exists()
+
+
+def test_pin_ca_accepts_colon_separated_fingerprint(client, cfg, monkeypatch):
+    """Operators may copy the colon-separated short form back from the
+    UI verbatim. Server normalises before comparing."""
+    pem, expected_fp = _make_self_signed_pem()
+    _patch_pki_endpoint(monkeypatch, 200, pem)
+
+    short_fp = ":".join(
+        expected_fp[i:i+2] for i in range(0, len(expected_fp), 2)
+    )
+    resp = client.post(
+        "/setup/pin-ca",
+        data={
+            "site_url": "https://fake-mastio.test:9443",
+            "fingerprint_expected": short_fp,
+        },
+    )
+    assert resp.status_code == 200
+    assert cfg.ca_chain_path.exists()
+
+
+def test_pin_ca_makes_verify_arg_return_path(cfg, monkeypatch):
+    """Integration with verify_arg: once the dashboard pins, a fresh
+    ``ConnectorConfig.verify_arg`` resolves to the pinned path —
+    confirming B.3 and B.2 are wired together."""
+    pem, _ = _make_self_signed_pem()
+    cfg.ca_chain_path.parent.mkdir(parents=True, exist_ok=True)
+    cfg.ca_chain_path.write_text(pem)
+
+    # Same instance — property re-reads filesystem state on access.
+    assert cfg.verify_arg == str(cfg.ca_chain_path)

--- a/tests/test_pki_public_ca.py
+++ b/tests/test_pki_public_ca.py
@@ -1,0 +1,107 @@
+"""Tests for ``GET /pki/ca.crt`` — the anonymous Org CA endpoint
+used by Connector first-contact for TOFU pinning.
+"""
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+from mcp_proxy.pki.public import router as pki_router
+
+
+_FAKE_CA_PEM = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBcjCCARigAwIBAgIUDummyCAforTOFUtestNotARealCert\n"
+    "-----END CERTIFICATE-----\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    """Each test starts with a clean rate-limit window — otherwise a
+    burst test below would inherit counters from earlier tests."""
+    reset_agent_rate_limiter()
+    yield
+    reset_agent_rate_limiter()
+
+
+def _client_with_ca(pem: str | None) -> TestClient:
+    app = FastAPI()
+    app.include_router(pki_router)
+    # Patch ``get_config`` at import location — the router resolved
+    # the symbol at module-load, so we monkey-patch where it's called.
+    async def _fake_get_config(key: str) -> str | None:
+        assert key == "org_ca_cert"
+        return pem
+    patcher = patch("mcp_proxy.pki.public.get_config", _fake_get_config)
+    patcher.start()
+    app.state._patcher = patcher  # keep alive for the test client lifetime
+    return TestClient(app)
+
+
+def test_returns_pem_when_ca_configured():
+    """Happy path: org_ca_cert in config → 200 with the PEM body and
+    PEM media type."""
+    with _client_with_ca(_FAKE_CA_PEM) as client:
+        resp = client.get("/pki/ca.crt")
+        assert resp.status_code == 200
+        assert resp.text == _FAKE_CA_PEM
+        assert resp.headers["content-type"].startswith("application/x-pem-file")
+        assert "Cache-Control" in resp.headers
+        assert "max-age=300" in resp.headers["Cache-Control"]
+
+
+def test_returns_404_when_no_ca_configured():
+    """Pre-setup state: caller knows to retry after operator finishes
+    first-boot rather than receiving a stale-looking empty 200."""
+    with _client_with_ca(None) as client:
+        resp = client.get("/pki/ca.crt")
+        assert resp.status_code == 404
+
+
+def test_etag_strong_matches_returns_304():
+    """Well-behaved client caches body, polls with If-None-Match,
+    expects 304 Not Modified — saves bandwidth on stable CA."""
+    with _client_with_ca(_FAKE_CA_PEM) as client:
+        first = client.get("/pki/ca.crt")
+        assert first.status_code == 200
+        etag = first.headers["ETag"]
+
+        second = client.get("/pki/ca.crt", headers={"If-None-Match": etag})
+        assert second.status_code == 304
+        # 304 responses MUST NOT include a body per RFC 7232.
+        assert second.content == b""
+
+
+def test_etag_changes_when_pem_changes():
+    """Different CA PEM → different ETag (strong validator). A rotation
+    on the server must invalidate every cached client."""
+    with _client_with_ca(_FAKE_CA_PEM) as c1:
+        etag_a = c1.get("/pki/ca.crt").headers["ETag"]
+    different = _FAKE_CA_PEM.replace("Dummy", "Rotated")
+    with _client_with_ca(different) as c2:
+        etag_b = c2.get("/pki/ca.crt").headers["ETag"]
+    assert etag_a != etag_b
+
+
+def test_endpoint_is_anonymous():
+    """No auth header, no client cert, no session cookie — request
+    must succeed. This is the whole point of the bootstrap endpoint."""
+    with _client_with_ca(_FAKE_CA_PEM) as client:
+        # Explicitly verify no auth-related state on the request.
+        resp = client.get("/pki/ca.crt")
+        assert resp.status_code == 200
+
+
+def test_etag_is_sha256_of_pem():
+    """Defence in depth: the ETag must be derived from the PEM bytes,
+    not from a server-side counter that could collide on rotation."""
+    with _client_with_ca(_FAKE_CA_PEM) as client:
+        resp = client.get("/pki/ca.crt")
+        digest = hashlib.sha256(_FAKE_CA_PEM.encode()).hexdigest()[:32]
+        assert resp.headers["ETag"] == f'"{digest}"'


### PR DESCRIPTION
## Summary

- **ADR-015** TLS bootstrap & TOFU CA pinning — closes the dogfood Finding #3 lockup where the only honest option was *"Disable TLS verification"*.
- New anonymous endpoint `GET /pki/ca.crt` on the Mastio (ETag, 304, `Cache-Control: max-age=300`, per-IP rate-limit).
- Connector dashboard gains a TOFU box: *Fetch fingerprint* → SHA-256 displayed for out-of-band comparison → *Pin this CA* re-fetches and matches before saving to `<profile>/identity/ca-chain.pem`.
- All Connector `httpx` calls now resolve `verify=` through the new `verify_arg` / `verify_arg_for(verify_tls, ca_chain_path)` helper. Rule: **opt-out is opt-out** — a pinned CA does NOT silently re-enable verification when the operator passed `--no-verify-tls`.
- Track A bug-fix UX (Finding #10): `send_oneshot` docstring + `receive_oneshot` output nudge LLM consumers to use the `reply` MCP tool when threading, instead of forgetting `reply_to`.

## What changes for existing profiles

Nothing. This adds the TOFU path for **new enrollments**; the *Disable TLS verification* checkbox stays as fallback for development, debugging, and Sites without `/pki/ca.crt`. Existing `cullis` and `system` profiles in dogfood remain functional as-is.

## Files

- New: `mcp_proxy/pki/{__init__,public}.py`, `cullis_connector` TOFU dashboard endpoints + setup template, `docs/adrs/0015-tls-bootstrap-tofu-pinning.md`.
- Wired: `cullis_connector/{config,cli,enrollment,web,tools/{high_level,diagnostic,oneshot}}.py`, `nginx/mastio/mastio.conf`, `packaging/mastio-bundle/nginx/mastio/mastio.conf`.
- Tests: `tests/test_pki_public_ca.py`, `tests/connector/test_web_tofu.py`, `tests/connector/test_config.py` (extended).

## Test plan

- [x] Unit: `tests/test_pki_public_ca.py` (6/6) — anonymous endpoint shape (200/404/304/ETag/anonimato/SHA-256-of-body).
- [x] Unit: `tests/connector/test_config.py` — `verify_arg` matrix for pinned/un-pinned × on/off (12/12 incl. existing).
- [x] Unit: `tests/connector/test_web_tofu.py` (6/6) — preview, pin happy path, TOCTOU mismatch, colon-separated fingerprint, integration with `verify_arg`.
- [x] Sanity: `tests/test_proxy_standalone*.py` (10/10) + `tests/test_jwks.py` + `tests/test_proxy_local_issuer.py` (22/22) — no regression on adjacent router/middleware paths.
- [x] **Smoke end-to-end vs `./sandbox/demo.sh up`** (build-from-source):
    - Server: 8/8 — 200 + PEM, ETag strong & matches `SHA-256(body)[:32]`, `If-None-Match` → 304, `Cache-Control: public, max-age=300`, anonymous.
    - Dashboard: 4/4 — `/setup/preview-ca` returns fingerprint + colon-form + PEM; `/setup/pin-ca` writes `<profile>/identity/ca-chain.pem`; mismatched fingerprint → 409.
    - Integration: `httpx.get(verify=<pinned path>)` against `https://localhost:9443/health` → 200 (verifies the leaf); `verify=True` (system store) → ConnectError, as expected.
- [ ] Manual: open the dashboard against the Mastio bundle on the dogfood VM (192.168.122.154:9443) once this lands and a release is cut.

## Threat model note

TOFU still asks the operator to compare the displayed fingerprint with what their admin gave them out-of-band. We are not solving deep-MITM; we are giving honest verification a shape that a human can execute. Rotation is intentionally not auto-handled: a CA rotation breaks the pin, which is exactly what should happen. Future ADR can address rotation UX.

See `docs/adrs/0015-tls-bootstrap-tofu-pinning.md` for full rationale + alternatives considered (Let's Encrypt, Web PKI, SPKI pinning, install-time fingerprint emit, ship deep PKI from day 1).