### PR TITLE
fix(connector): exit 78 on port-busy + systemd no crash-loop (Findings #1+#2)

### DIFF
--- a/cullis_connector/_port_check.py
+++ b/cullis_connector/_port_check.py
@@ -1,0 +1,87 @@
+"""Port availability + already-running-dashboard detection.
+
+Wraps a tight bind/connect probe so the dashboard CLI can fail with
+an actionable message *before* uvicorn touches the loop, and so the
+systemd autostart unit can use ``RestartPreventExitStatus=`` to keep
+a port collision from turning into a crash-loop. The dogfood
+incident on 2026-04-29 (~350 fail/h on errno 98) is the motivating
+case — see Finding #1 in
+``project_dogfood_findings_2026_04_29.md``.
+
+The probe is best-effort. We do not race the eventual ``uvicorn.run``
+(``SO_REUSEADDR`` differences across kernels would make us lie either
+direction); we just give the operator a fast, clear failure when the
+port is obviously held by something else.
+"""
+from __future__ import annotations
+
+import socket
+from typing import Literal
+
+# Exit code reserved for "the configuration says start me, but the
+# environment doesn't allow it" (configuration error, not transient).
+# systemd ``RestartPreventExitStatus=78`` then refuses to crash-loop
+# on this signal; ``sysexits.h`` documents 78 as ``EX_CONFIG``.
+EXIT_PORT_UNAVAILABLE = 78
+
+
+def check_port_available(host: str, port: int) -> bool:
+    """Return ``True`` iff ``(host, port)`` is free for binding *now*.
+
+    We open a short-lived AF_INET socket, attempt the bind, and close
+    it immediately. ``EADDRINUSE`` and ``EACCES`` (privileged port,
+    sandbox) both count as "not available". Any other socket error
+    is also treated as unavailable — the operator gets the same
+    actionable error and the systemd unit doesn't crash-loop.
+    """
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    sock = socket.socket(family, socket.SOCK_STREAM)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return True
+
+
+_DashboardKind = Literal["cullis_connector", "unknown", "no_response"]
+
+
+def detect_running_dashboard(
+    host: str, port: int, *, timeout_s: float = 0.5,
+) -> _DashboardKind:
+    """Best-effort probe: is *another* Connector dashboard already on this port?
+
+    The Connector dashboard exposes ``GET /api/ping`` returning
+    ``{"app": "cullis-connector"}``. We match on the app field, not
+    on header strings — uvicorn's ``Server`` header is shared by
+    lots of unrelated services.
+
+    Returns ``"cullis_connector"`` on a clear positive, ``"unknown"``
+    if something is listening but doesn't smell like our dashboard
+    (so the operator at least knows the port is *taken*, not just
+    flaky), or ``"no_response"`` if nothing answered in time. We
+    never raise — this is purely a diagnostic helper.
+    """
+    try:
+        import httpx  # imported lazily so ``serve``/``enroll`` don't pay the cost
+    except ImportError:
+        return "no_response"
+
+    url = f"http://{host}:{port}/api/ping"
+    try:
+        resp = httpx.get(url, timeout=timeout_s)
+    except (httpx.HTTPError, OSError):
+        return "no_response"
+
+    if resp.status_code != 200:
+        return "unknown"
+    try:
+        body = resp.json()
+    except ValueError:
+        return "unknown"
+    if isinstance(body, dict) and body.get("app") == "cullis-connector":
+        return "cullis_connector"
+    return "unknown"

--- a/cullis_connector/autostart.py
+++ b/cullis_connector/autostart.py
@@ -307,6 +307,10 @@ def _render_linux_unit(command: list[str]) -> str:
     # respects double-quoted words and backslash-escaped spaces; we pick
     # the backslash route so log output matches the original argv.
     exec_start = " ".join(a.replace(" ", r"\ ") for a in command)
+    # ``RestartPreventExitStatus=78`` keeps a port-busy or other
+    # configuration error (the CLI exits 78 = EX_CONFIG, see
+    # ``cullis_connector._port_check``) from turning into a crash-loop
+    # — dogfood 2026-04-29 saw ~350 fail/h before this guard landed.
     return textwrap.dedent(
         f"""
         [Unit]
@@ -319,6 +323,7 @@ def _render_linux_unit(command: list[str]) -> str:
         ExecStart={exec_start}
         Restart=on-failure
         RestartSec=3s
+        RestartPreventExitStatus=78
         StandardOutput=append:%h/.cullis/logs/connector.out.log
         StandardError=append:%h/.cullis/logs/connector.err.log
 

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -581,12 +581,48 @@ def _cmd_dashboard(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
 
     # Import late so the dashboard deps stay optional for serve/enroll.
     from cullis_connector.web import build_app
-
-    app = build_app(cfg)
+    from cullis_connector._port_check import (
+        EXIT_PORT_UNAVAILABLE,
+        check_port_available,
+        detect_running_dashboard,
+    )
 
     host = getattr(args, "web_host", "127.0.0.1")
     port = int(getattr(args, "web_port", 7777))
     url = f"http://{host}:{port}"
+
+    # Pre-flight: a port-busy here used to bubble up as ``errno 98 address
+    # already in use`` from inside uvicorn's loop. With ``Restart=on-failure``
+    # in the systemd autostart unit, that meant ~350 fail/h crash-loop
+    # (dogfood Finding #1, 2026-04-29). Failing fast with EX_CONFIG (78)
+    # lets the unit's ``RestartPreventExitStatus=78`` keep the loop
+    # quiet and gives the operator an actionable message.
+    if not check_port_available(host, port):
+        kind = detect_running_dashboard(host, port)
+        if kind == "cullis_connector":
+            _log.error(
+                "Another Cullis Connector dashboard is already serving "
+                "%s. Open it in your browser, or pass ``--port <N>`` to "
+                "run a second instance on a different port (e.g. 7778).",
+                url,
+            )
+        elif kind == "unknown":
+            _log.error(
+                "Port %d on %s is already in use by another process "
+                "(not a Connector dashboard). Stop it, or pass "
+                "``--port <N>`` to choose a different port.",
+                port, host,
+            )
+        else:
+            _log.error(
+                "Cannot bind %s — the port is unavailable but no "
+                "process responded to a probe. Pass ``--port <N>`` "
+                "or check ``ss -ltnp | grep :%d``.",
+                url, port,
+            )
+        return EXIT_PORT_UNAVAILABLE
+
+    app = build_app(cfg)
 
     if getattr(args, "open_browser", True):
         import threading

--- a/cullis_connector/templates/connected.html
+++ b/cullis_connector/templates/connected.html
@@ -71,6 +71,11 @@
                 Keep the connector running so MCP tools stay available the
                 moment you open Cursor or Claude Desktop — no manual launch.
             </div>
+            {% if autostart_enabled and autostart_service_path %}
+            <div class="toggle-desc mono" style="margin-top: 6px; font-size: 11px; opacity: 0.7;">
+                Active at <span title="{{ autostart_service_path }}">{{ autostart_service_path }}</span>
+            </div>
+            {% endif %}
         </div>
         <button type="button"
                 class="toggle-switch"

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -446,6 +446,18 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             },
         )
 
+    @app.get("/api/ping")
+    def api_ping() -> JSONResponse:
+        """Stable identity probe — used by ``cullis-connector dashboard``
+        on startup to detect a Connector dashboard already bound to the
+        port and tell the operator instead of crashing on EADDRINUSE.
+
+        Returns the app name (and process port for diagnostics). Stays
+        cheap and side-effect-free so we can call it from a port-busy
+        path without coupling it to enrollment state.
+        """
+        return JSONResponse({"app": "cullis-connector"})
+
     @app.get("/api/status")
     def api_status() -> JSONResponse:
         """Single-shot poll of the remote enrollment status.
@@ -634,6 +646,9 @@ def build_app(config: ConnectorConfig) -> FastAPI:
                 "mcp_snippet": mcp_entry_snippet(),
                 "autostart_enabled": astatus.installed,
                 "autostart_platform": astatus.platform,
+                "autostart_service_path": (
+                    str(astatus.service_path) if astatus.service_path else None
+                ),
             },
         )
 

--- a/tests/connector/test_autostart.py
+++ b/tests/connector/test_autostart.py
@@ -67,6 +67,21 @@ def test_linux_unit_escapes_spaces_in_args():
     assert "with\\ space" in text
 
 
+def test_linux_unit_prevents_crash_loop_on_port_busy():
+    """Dogfood Finding #1 (2026-04-29): a stale autostart unit and a
+    manually-launched dashboard collided on 7777 and the unit's
+    ``Restart=on-failure RestartSec=3s`` produced ~350 fail/h.
+    The CLI now exits 78 (EX_CONFIG) on port-busy; the unit must
+    pin that exit code into ``RestartPreventExitStatus`` so systemd
+    stops looping.
+    """
+    text = autostart._render_linux_unit(["cullis-connector", "dashboard"])
+    assert "RestartPreventExitStatus=78" in text
+    # Sanity: the existing on-failure restart stays in place — only
+    # the EX_CONFIG signal is excluded from the retry policy.
+    assert "Restart=on-failure" in text
+
+
 # ── Linux install / uninstall (file-level, subprocess mocked) ───────────
 
 

--- a/tests/connector/test_port_check.py
+++ b/tests/connector/test_port_check.py
@@ -1,0 +1,135 @@
+"""Tests for the port pre-flight + already-running-dashboard probe.
+
+Drives ``cullis_connector._port_check`` against a live socket on a
+kernel-chosen port (so the test never collides with a real Connector
+running on 7777), and stubs ``httpx.get`` to exercise the dashboard
+fingerprint detection.
+"""
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import httpx
+
+from cullis_connector._port_check import (
+    EXIT_PORT_UNAVAILABLE,
+    check_port_available,
+    detect_running_dashboard,
+)
+
+
+def _bound_port() -> tuple[int, socket.socket]:
+    """Bind a TCP socket to a kernel-chosen free port and keep it
+    held — caller closes it when the test is done."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    s.listen(1)
+    return s.getsockname()[1], s
+
+
+def test_check_port_available_true_when_port_is_free():
+    """Sanity baseline — pick a port we know is free (kernel-chosen,
+    then released) and confirm the probe says it's free."""
+    port, holder = _bound_port()
+    holder.close()
+    assert check_port_available("127.0.0.1", port) is True
+
+
+def test_check_port_available_false_when_port_is_busy():
+    """Live binding on the port → probe must return False so the CLI
+    knows to bail with EX_CONFIG instead of crashing in uvicorn."""
+    port, holder = _bound_port()
+    try:
+        assert check_port_available("127.0.0.1", port) is False
+    finally:
+        holder.close()
+
+
+def test_exit_code_is_ex_config_78():
+    """Pinning the constant: systemd's ``RestartPreventExitStatus=78``
+    in the autostart unit (autostart.py) relies on this exact value."""
+    assert EXIT_PORT_UNAVAILABLE == 78
+
+
+def test_detect_returns_no_response_when_port_silent():
+    """Truly free port → nothing answers → ``no_response`` so the CLI
+    can give the operator a generic 'check ss -ltnp' suggestion."""
+    port, holder = _bound_port()
+    holder.close()  # immediately free, nothing listening
+    assert detect_running_dashboard("127.0.0.1", port, timeout_s=0.2) == "no_response"
+
+
+def test_detect_classifies_cullis_connector_response():
+    """Stub /api/ping with the dashboard's exact body shape — the
+    classifier must see the ``app`` field and report cullis_connector."""
+    def _fake_get(url, *, timeout):
+        return httpx.Response(
+            200, json={"app": "cullis-connector"},
+            request=httpx.Request("GET", url),
+        )
+    with patch("httpx.get", _fake_get):
+        kind = detect_running_dashboard("127.0.0.1", 65535)
+    assert kind == "cullis_connector"
+
+
+def test_detect_classifies_unknown_when_response_does_not_match():
+    """Something is listening but it's not us (e.g. another tool's
+    health endpoint). Operator gets the 'taken by another process'
+    message rather than a misleading 'open it in your browser' one."""
+    def _fake_get(url, *, timeout):
+        return httpx.Response(
+            200, json={"hello": "world"},
+            request=httpx.Request("GET", url),
+        )
+    with patch("httpx.get", _fake_get):
+        kind = detect_running_dashboard("127.0.0.1", 65535)
+    assert kind == "unknown"
+
+
+def test_detect_handles_non_200_without_raising():
+    """A 404 (or 503, or anything non-200) at /api/ping → classifier
+    treats it as ``unknown``, never raises."""
+    def _fake_get(url, *, timeout):
+        return httpx.Response(
+            404, text="not found", request=httpx.Request("GET", url),
+        )
+    with patch("httpx.get", _fake_get):
+        kind = detect_running_dashboard("127.0.0.1", 65535)
+    assert kind == "unknown"
+
+
+def test_detect_swallows_connection_errors():
+    """A connect-refused or DNS error during probing must NOT bubble —
+    the probe is best-effort and the caller uses the result for
+    diagnostics, not control flow."""
+    def _fake_get(url, *, timeout):
+        raise httpx.ConnectError("connection refused")
+    with patch("httpx.get", _fake_get):
+        kind = detect_running_dashboard("127.0.0.1", 65535)
+    assert kind == "no_response"
+
+
+def test_cli_dashboard_exits_78_when_port_busy(tmp_path):
+    """Integration: ``_cmd_dashboard`` must short-circuit with
+    ``EXIT_PORT_UNAVAILABLE`` *before* uvicorn imports its loop.
+    Otherwise the systemd unit's ``Restart=on-failure`` would
+    crash-loop again on this exact case.
+    """
+    import argparse
+
+    from cullis_connector.cli import _cmd_dashboard
+    from cullis_connector.config import ConnectorConfig
+
+    cfg = ConnectorConfig(config_dir=tmp_path)
+    port, holder = _bound_port()
+    try:
+        args = argparse.Namespace(
+            web_host="127.0.0.1",
+            web_port=port,
+            open_browser=False,
+        )
+        rc = _cmd_dashboard(cfg, args)
+    finally:
+        holder.close()
+    assert rc == EXIT_PORT_UNAVAILABLE


### PR DESCRIPTION
## Summary

- Closes the dogfood crash-loop where a port collision on `127.0.0.1:7777` produced ~350 fail/h until suspend (Finding #1 in `project_dogfood_findings_2026_04_29.md`).
- Adds visibility for Finding #2 (autostart unit installed without enough signal — the toggle now shows the unit path inline when enabled).
- Pre-flight port check + actionable CLI error + systemd `RestartPreventExitStatus=78` so EX_CONFIG no longer cycles the unit.

## What changes

- **New** `cullis_connector/_port_check.py` — `check_port_available(host, port)` (live bind probe) and `detect_running_dashboard(host, port)` (probes the new `GET /api/ping` returning `{\"app\": \"cullis-connector\"}` to tell apart \"another Connector dashboard\" from \"some other tool\").
- **CLI** `_cmd_dashboard` runs the pre-flight before importing uvicorn and exits `78` (`EX_CONFIG`) with one of three actionable messages depending on what's holding the port.
- **systemd unit** — `_render_linux_unit` now emits `RestartPreventExitStatus=78`. `Restart=on-failure` stays on for legitimate transient failures.
- **Dashboard `connected.html`** — autostart toggle shows the actual unit path (`~/.config/systemd/user/cullis-connector.service` on Linux, plist on macOS, Task name on Windows) underneath the toggle whenever it is enabled.
- **`/api/ping`** — new tiny endpoint exposing the app fingerprint. Cheap, side-effect-free, used only by the port-busy detection path.

## Test plan

- [x] `tests/connector/test_port_check.py` (9 tests): live-bind probe (free / busy), fingerprint matrix for detection (cullis / unknown / no_response, including connect-refused and non-200), exit-code pin (78), end-to-end `_cmd_dashboard` returns 78 on busy port.
- [x] `tests/connector/test_autostart.py` extended: `RestartPreventExitStatus=78` pinned.
- [x] Full `tests/connector/` regression: 270 pass, 4 pre-existing fails on `test_profile_runtime_switch.py` unrelated to this PR (pystray API).
- [x] **Live smoke**:
  - `cullis-connector dashboard --port 7785` started in background → `/api/ping` returns `{\"app\":\"cullis-connector\"}`.
  - Second `cullis-connector dashboard --port 7785` → exits 78 with `Another Cullis Connector dashboard is already serving http://127.0.0.1:7785. Open it in your browser, or pass --port <N> …`.
- [ ] Manual: re-render the autostart unit on the dogfood machine (toggle off + on) and confirm `RestartPreventExitStatus=78` lands; trigger a port collision and confirm `journalctl --user -u cullis-connector.service` shows a single failure instead of a 3s loop.

## Notes

Existing autostart units are unchanged on disk until the operator next re-renders them (toggle off + on, or a future upgrade rewrites them). No DB / wire / SDK changes.

Existing `cullis` and `system` dogfood profiles unaffected — they share the upgrade path with everyone else.