### PR TITLE
fix(connector): expose all IDEs in --ide, restart hint, add doctor (#6+#7+#8)

### DIFF
--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -132,17 +132,27 @@ def _build_parser() -> argparse.ArgumentParser:
 
     install_mcp = subparsers.add_parser(
         "install-mcp",
-        help="Write the Cullis MCP entry into Claude Desktop / Cursor / Cline.",
+        help="Write the Cullis MCP entry into a supported MCP client.",
     )
     _add_shared_args(install_mcp)
+    # Source the choices from the IDE registry so adding a new client
+    # (claude-code, zed, windsurf — landed before this PR but not
+    # exposed as ``--ide`` values) doesn't drift the CLI surface.
+    # ``claude-code`` is accepted as an operator-friendly alias for
+    # ``claude-code-cli``; the canonical id is the value the descriptor
+    # carries, but ``claude-code-cli`` reads like an internal slug to
+    # someone typing the flag.
+    from cullis_connector.ide_config import KNOWN_IDES as _KNOWN_IDES
+    _IDE_CHOICES = sorted(set(_KNOWN_IDES.keys()) | {"claude-code"})
     install_mcp.add_argument(
         "--ide",
         dest="ides",
         action="append",
         default=None,
-        choices=["claude-desktop", "cursor", "cline"],
-        help="Target a specific IDE (repeatable). Omit to auto-configure "
-             "every detected IDE on this machine.",
+        choices=_IDE_CHOICES,
+        help="Target a specific MCP client (repeatable). Omit to "
+             "auto-configure every detected client on this machine. "
+             "``claude-code`` is an alias for ``claude-code-cli``.",
     )
     install_mcp.add_argument(
         "--list",
@@ -223,6 +233,20 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Dashboard port (default 7777).",
     )
 
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="Audit IDE MCP configs for stale Cullis entries.",
+    )
+    _add_shared_args(doctor)
+    doctor.add_argument(
+        "--ide",
+        dest="ides",
+        action="append",
+        default=None,
+        help="Limit the scan to these clients (repeatable). Omit to "
+             "scan every supported MCP client.",
+    )
+
     return parser
 
 
@@ -233,6 +257,7 @@ _KNOWN_SUBCOMMANDS = frozenset({
     "install-autostart",
     "dashboard",
     "desktop",
+    "doctor",
 })
 
 # Shared flags are parsed by the subparser that owns the chosen command.
@@ -445,6 +470,14 @@ def _cmd_enroll(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     return 0
 
 
+_IDE_ALIASES = {"claude-code": "claude-code-cli"}
+
+
+def _resolve_ide_id(value: str) -> str:
+    """Map operator-friendly aliases to the canonical registry id."""
+    return _IDE_ALIASES.get(value, value)
+
+
 def _cmd_install_mcp(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     from cullis_connector.ide_config import (
         KNOWN_IDES,
@@ -455,7 +488,10 @@ def _cmd_install_mcp(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
         uninstall_mcp,
     )
 
-    target_ids = args.ides or list(KNOWN_IDES.keys())
+    target_ids = (
+        [_resolve_ide_id(i) for i in args.ides]
+        if args.ides else list(KNOWN_IDES.keys())
+    )
 
     if args.ide_list_only:
         print(f"{'IDE':<22} {'STATUS':<14} PATH")
@@ -490,6 +526,7 @@ def _cmd_install_mcp(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
 
     backup_dir = cfg.config_dir / "backups"
     any_error = False
+    installed_names: list[str] = []
 
     for ide_id in target_ids:
         detection = detect_ide_status(ide_id)
@@ -513,6 +550,8 @@ def _cmd_install_mcp(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
             print(f"[ok]   {name}: {action} at {result.config_path}")
             if result.backup_path:
                 print(f"       ↳ backup: {result.backup_path}")
+            if not args.ide_uninstall:
+                installed_names.append(name)
         elif result.status == "already_configured":
             print(f"[skip] {name}: already {'' if args.ide_uninstall else 'configured '}in place")
         else:
@@ -520,6 +559,19 @@ def _cmd_install_mcp(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
             print(f"[err]  {name}: {result.error}")
 
         _log.debug("%s result for %s: %s", verb, ide_id, result)
+
+    # Finding #7 (dogfood 2026-04-29): clients load their MCP config
+    # at session startup, so an already-running Claude Code / Cursor
+    # / Cline session won't see the new server until it restarts.
+    # Without this hint operators would invoke the tools, get a
+    # "tool not found" error, and only then realise.
+    if installed_names and not args.ide_uninstall:
+        joined = ", ".join(installed_names)
+        print(
+            f"\n→ Restart {joined} to load the Cullis MCP server. "
+            "Existing sessions will not see the new tools until a fresh "
+            "session is opened."
+        )
 
     return 1 if any_error else 0
 
@@ -649,6 +701,33 @@ def _cmd_desktop(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     return run_desktop_app(cfg, host=host, port=port)
 
 
+def _cmd_doctor(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
+    """Audit IDE MCP configs for stale Cullis entries (Finding #8)."""
+    from cullis_connector.doctor import has_problems, scan
+
+    ide_filter = (
+        [_resolve_ide_id(i) for i in args.ides] if args.ides else None
+    )
+    entries = scan(ide_filter)
+    if not entries:
+        print("No Cullis MCP entries found in any supported client.")
+        print(
+            "(Run ``cullis-connector install-mcp --list`` to see which "
+            "clients are detected on this machine.)"
+        )
+        return 0
+
+    print(f"{'IDE':<22} {'STATUS':<14} ENTRY")
+    print("-" * 80)
+    for e in entries:
+        print(f"{e.ide_display:<22} {e.status:<14} {e.server_name}")
+        if e.config_path is not None:
+            print(f"{'':<22} {'':<14} ↳ at {e.config_path}")
+        print(f"{'':<22} {'':<14} ↳ {e.detail}")
+
+    return 1 if has_problems(entries) else 0
+
+
 # ── Entry point ──────────────────────────────────────────────────────────
 
 
@@ -680,6 +759,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_dashboard(cfg, args)
     if command == "desktop":
         return _cmd_desktop(cfg, args)
+    if command == "doctor":
+        return _cmd_doctor(cfg, args)
     return _cmd_serve(cfg)
 
 

--- a/cullis_connector/doctor.py
+++ b/cullis_connector/doctor.py
@@ -1,0 +1,265 @@
+"""``cullis-connector doctor`` — scan IDE MCP configs for stale Cullis entries.
+
+Closes Finding #8 from the 2026-04-29 dogfood: an MCP entry pointed
+at a profile (``dotfiles``) and a Mastio (``localhost:9100``) that
+hadn't existed for months. Nothing surfaced the breakage until the
+operator typed ``claude mcp list`` by hand and noticed.
+
+This module walks the same ``KNOWN_IDES`` registry that
+``install-mcp`` uses, finds entries that look like a Cullis serve
+invocation, and validates two cheap, deterministic things:
+
+1. **The binary in ``command`` is reachable.** ``cullis-connector`` was
+   commonly installed in a venv that has since been blown away. We
+   check via ``shutil.which`` plus an absolute-path ``Path.exists``
+   for the literal command string the entry persisted.
+2. **The profile dir referenced by ``--profile X`` (or ``--config-dir
+   Y``) still exists.** This is the case from the dogfood: profile
+   went away, MCP entry didn't.
+
+We deliberately do NOT probe the Site at this stage — that pulls in
+``httpx``, requires the network, and produces transient noise on a
+flaky link. Operators who want a live Site check can run
+``cullis-connector hello-site`` against the profile separately.
+
+The CLI prints one line per entry with a status tag; doctor exits 0
+on a clean scan and 1 if anything is broken so it composes with
+``set -e`` in install scripts and CI.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+from cullis_connector.config import DEFAULT_CONFIG_DIR
+from cullis_connector.ide_config import (
+    KNOWN_IDES,
+    IDEDescriptor,
+    InstallerKind,
+    resolve_config_path,
+)
+
+
+@dataclass
+class DoctorEntry:
+    """One row in the doctor report."""
+
+    ide_id: str
+    ide_display: str
+    server_name: str  # the JSON key inside ``mcpServers`` (usually "cullis")
+    command: str  # the executable string the IDE will invoke
+    args: list[str]
+    config_path: Path | None
+    status: str  # "ok", "stale_binary", "stale_profile", "unreadable", "no_config"
+    detail: str  # human-readable explanation
+
+
+_CONNECTOR_HINT = "cullis-connector"
+
+
+def _looks_like_cullis(server_name: str, command: str, args: list[str]) -> bool:
+    """Heuristic: does this MCP server entry call our connector?
+
+    We match on the binary name AND the entry server name so that an
+    operator who renamed our entry to e.g. ``cullis-prod`` still gets
+    audited, and so a third-party server that happens to invoke an
+    unrelated ``cullis-connector`` (vanishingly unlikely but not zero)
+    doesn't get flagged.
+    """
+    if _CONNECTOR_HINT in command:
+        return True
+    # If the server is named ``cullis`` or ``cullis-*`` and it
+    # explicitly carries our ``serve`` subcommand, treat it as ours.
+    if server_name == "cullis" or server_name.startswith("cullis-"):
+        if "serve" in args:
+            return True
+    return False
+
+
+def _extract_profile_dir(args: list[str]) -> Path | None:
+    """Resolve the on-disk dir the MCP entry will use as its profile.
+
+    Mirrors ``ConnectorConfig`` resolution but without importing the
+    YAML/env loader — we only need the cases the install path
+    persists: ``--profile X`` (uses ``DEFAULT_CONFIG_DIR/profiles/X``)
+    or ``--config-dir Y`` (uses ``Y`` verbatim). Returns ``None`` if
+    neither is set; absence of both means the entry runs against the
+    legacy flat layout, which is its own warning class.
+    """
+    config_dir = _flag_value(args, "--config-dir")
+    if config_dir:
+        return Path(config_dir).expanduser()
+    profile = _flag_value(args, "--profile")
+    if profile:
+        return DEFAULT_CONFIG_DIR / "profiles" / profile
+    return None
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    """``--flag X`` → ``X``; ``--flag=X`` → ``X``; absent → None."""
+    for i, a in enumerate(args):
+        if a == flag:
+            return args[i + 1] if i + 1 < len(args) else None
+        if a.startswith(flag + "="):
+            return a.split("=", 1)[1]
+    return None
+
+
+def _binary_exists(command: str) -> bool:
+    """True iff the IDE will be able to launch this command on PATH /
+    at the persisted absolute path."""
+    if not command:
+        return False
+    if "/" in command or "\\" in command:
+        return Path(command).expanduser().exists()
+    return shutil.which(command) is not None
+
+
+def _scan_file_ide(ide: IDEDescriptor) -> Iterator[DoctorEntry]:
+    path = resolve_config_path(ide.id)
+    if path is None:
+        return
+    if not path.exists():
+        # Most operators won't have every supported IDE installed.
+        # Silence is the right answer — the ``--list`` flag of
+        # install-mcp already exists for "show me all of them".
+        return
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        yield DoctorEntry(
+            ide_id=ide.id,
+            ide_display=ide.display_name,
+            server_name="?",
+            command="",
+            args=[],
+            config_path=path,
+            status="unreadable",
+            detail=f"cannot parse {path.name}: {exc}",
+        )
+        return
+
+    servers = data.get(ide.servers_key, {}) if isinstance(data, dict) else {}
+    if not isinstance(servers, dict):
+        return
+
+    for name, entry in servers.items():
+        if not isinstance(entry, dict):
+            continue
+        command = str(entry.get("command", ""))
+        args_raw = entry.get("args", [])
+        args = [str(a) for a in args_raw] if isinstance(args_raw, list) else []
+        if not _looks_like_cullis(name, command, args):
+            continue
+
+        if not _binary_exists(command):
+            yield DoctorEntry(
+                ide_id=ide.id,
+                ide_display=ide.display_name,
+                server_name=name,
+                command=command,
+                args=args,
+                config_path=path,
+                status="stale_binary",
+                detail=(
+                    f"command ``{command}`` is not on PATH and is not an "
+                    "existing absolute file — IDE will fail to launch the "
+                    "MCP server. Re-install with ``cullis-connector "
+                    "install-mcp`` or remove the stale entry."
+                ),
+            )
+            continue
+
+        profile_dir = _extract_profile_dir(args)
+        if profile_dir is not None and not profile_dir.exists():
+            yield DoctorEntry(
+                ide_id=ide.id,
+                ide_display=ide.display_name,
+                server_name=name,
+                command=command,
+                args=args,
+                config_path=path,
+                status="stale_profile",
+                detail=(
+                    f"profile dir ``{profile_dir}`` no longer exists. "
+                    "The MCP entry was likely written when this profile "
+                    "was active and not cleaned up when the profile was "
+                    "removed."
+                ),
+            )
+            continue
+
+        yield DoctorEntry(
+            ide_id=ide.id,
+            ide_display=ide.display_name,
+            server_name=name,
+            command=command,
+            args=args,
+            config_path=path,
+            status="ok",
+            detail=(
+                f"profile=``{profile_dir.name}`` (resolved at {profile_dir})"
+                if profile_dir is not None
+                else "running against the legacy flat layout (no --profile / --config-dir)"
+            ),
+        )
+
+
+def _scan_command_ide(ide: IDEDescriptor) -> Iterator[DoctorEntry]:
+    """COMMAND-kind IDEs (Claude Code CLI today) keep their MCP config
+    inside the binary's own state. We can't deterministically read it
+    without invoking the CLI, which would couple ``doctor`` to a
+    specific Claude Code version and add a flaky out-of-process call.
+
+    Yield a single advisory entry pointing the operator at the right
+    command for that client, instead of pretending to validate.
+    """
+    if not _binary_exists(ide.detect_binary or ""):
+        # Binary missing → nothing to advise about, skip silently.
+        return
+    yield DoctorEntry(
+        ide_id=ide.id,
+        ide_display=ide.display_name,
+        server_name="?",
+        command=ide.detect_binary or "",
+        args=[],
+        config_path=None,
+        status="advise",
+        detail=(
+            f"{ide.display_name} stores MCP entries in its own state. "
+            "Run ``claude mcp list`` to see registered servers and "
+            "``claude mcp remove cullis`` to drop a stale one."
+        ),
+    )
+
+
+def scan(ides: Iterable[str] | None = None) -> list[DoctorEntry]:
+    """Walk the registry and return all Cullis-shaped entries with status.
+
+    ``ides=None`` scans every supported client; pass an explicit list
+    to limit the scan (e.g. ``[\"cursor\"]`` for a focused report).
+    """
+    targets = list(ides) if ides else list(KNOWN_IDES.keys())
+    out: list[DoctorEntry] = []
+    for ide_id in targets:
+        ide = KNOWN_IDES.get(ide_id)
+        if ide is None:
+            continue
+        if ide.kind is InstallerKind.COMMAND:
+            out.extend(_scan_command_ide(ide))
+        else:
+            out.extend(_scan_file_ide(ide))
+    return out
+
+
+def has_problems(entries: Iterable[DoctorEntry]) -> bool:
+    """``True`` iff anything in the report needs operator attention.
+
+    ``ok`` and ``advise`` are clean (advise is informational); the
+    other statuses (``stale_binary``, ``stale_profile``, ``unreadable``)
+    are problems doctor's exit code reflects.
+    """
+    return any(e.status in {"stale_binary", "stale_profile", "unreadable"} for e in entries)

--- a/tests/connector/test_cli_dispatch.py
+++ b/tests/connector/test_cli_dispatch.py
@@ -136,3 +136,43 @@ def test_profile_flag_before_subcommand_gets_moved_after():
 def test_desktop_with_flags_round_trips():
     argv = ["desktop", "--profile", "south", "--port", "7788"]
     assert _ensure_subcommand(argv) == argv
+
+
+# ── install-mcp --ide choices + alias resolution ─────────────────────
+
+
+def test_install_mcp_ide_choices_include_every_known_client():
+    """Finding #6 (dogfood 2026-04-29): the registry already knew
+    about ``claude-code-cli``, ``zed``, and ``windsurf`` but the CLI
+    flag accepted only the original three. Pin the choices against
+    the registry so any new descriptor lands in argparse too."""
+    from cullis_connector.cli import _build_parser
+    from cullis_connector.ide_config import KNOWN_IDES
+
+    parser = _build_parser()
+    install_mcp = None
+    for action in parser._actions:
+        if hasattr(action, "choices") and isinstance(action.choices, dict):
+            install_mcp = action.choices.get("install-mcp")
+            break
+    assert install_mcp is not None
+
+    ide_action = next(
+        a for a in install_mcp._actions if a.dest == "ides"
+    )
+    choices = set(ide_action.choices)
+    # Every registry id must be a valid choice.
+    assert set(KNOWN_IDES.keys()) <= choices
+    # And the friendly alias is also accepted.
+    assert "claude-code" in choices
+
+
+def test_install_mcp_alias_resolves_to_canonical_id():
+    """``claude-code`` is an operator-friendly alias that the
+    install-mcp dispatch must normalise to the registry's canonical
+    ``claude-code-cli`` before lookup."""
+    from cullis_connector.cli import _resolve_ide_id
+    assert _resolve_ide_id("claude-code") == "claude-code-cli"
+    # Anything not in the alias map passes through unchanged.
+    assert _resolve_ide_id("cursor") == "cursor"
+    assert _resolve_ide_id("zed") == "zed"

--- a/tests/connector/test_doctor.py
+++ b/tests/connector/test_doctor.py
@@ -1,0 +1,271 @@
+"""Tests for ``cullis-connector doctor`` — stale MCP entry audit.
+
+Drives the doctor against a temp directory holding fake IDE config
+files. The ``patched_ides`` fixture redirects each registered IDE to
+a unique JSON path under ``tmp_path`` so the test never touches the
+operator's real Cursor/Claude Desktop/etc. config.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from cullis_connector import doctor, ide_config
+from cullis_connector.ide_config import IDEDescriptor, KNOWN_IDES
+
+
+@pytest.fixture
+def patched_ides(monkeypatch, tmp_path):
+    """Redirect every IDE to a tmp path we own — same pattern as
+    ``tests/connector/test_ide_config.py::patched_ides``."""
+    paths = {ide_id: tmp_path / f"{ide_id}.json" for ide_id in KNOWN_IDES}
+    fake = {}
+    for ide_id, desc in KNOWN_IDES.items():
+        p = str(paths[ide_id])
+        fake[ide_id] = IDEDescriptor(
+            id=desc.id,
+            display_name=desc.display_name,
+            paths={"darwin": p, "win32": p, "linux": p},
+            servers_key=desc.servers_key,
+            kind=desc.kind,
+            detect_binary=desc.detect_binary,
+        )
+    monkeypatch.setattr(ide_config, "KNOWN_IDES", fake)
+    monkeypatch.setattr(doctor, "KNOWN_IDES", fake)
+    return paths
+
+
+@pytest.fixture
+def fake_connector_on_path(monkeypatch, tmp_path):
+    """Pretend ``cullis-connector`` is reachable via ``shutil.which``.
+
+    Doctor's binary check uses the system ``shutil.which`` — patching
+    it here keeps the test independent of whether the test runner
+    happens to have the connector installed in PATH.
+    """
+    fake_bin = tmp_path / "fake-bin" / "cullis-connector"
+    fake_bin.parent.mkdir(parents=True)
+    fake_bin.write_text("#!/bin/sh\nexit 0\n")
+    fake_bin.chmod(0o755)
+
+    real_which = shutil.which
+
+    def _which(cmd: str, *a, **kw):
+        if cmd == "cullis-connector":
+            return str(fake_bin)
+        return real_which(cmd, *a, **kw)
+
+    monkeypatch.setattr(doctor.shutil, "which", _which)
+    return fake_bin
+
+
+def _write_config(path: Path, entries: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"mcpServers": entries}, indent=2))
+
+
+# ── _looks_like_cullis ─────────────────────────────────────────────────────
+
+
+def test_looks_like_cullis_matches_connector_command():
+    assert doctor._looks_like_cullis("cullis", "/usr/bin/cullis-connector", ["serve"])
+
+
+def test_looks_like_cullis_matches_renamed_entry_with_serve():
+    """Operator renamed ``cullis`` to ``cullis-prod`` — still ours."""
+    assert doctor._looks_like_cullis("cullis-prod", "/some/path", ["serve", "--profile", "p"])
+
+
+def test_looks_like_cullis_rejects_unrelated_server():
+    assert not doctor._looks_like_cullis("postgres", "/usr/bin/postgres", ["--port", "5432"])
+
+
+# ── _extract_profile_dir ───────────────────────────────────────────────────
+
+
+def test_extract_profile_dir_from_dash_dash_profile():
+    p = doctor._extract_profile_dir(["serve", "--profile", "work"])
+    assert p is not None and p.name == "work"
+
+
+def test_extract_profile_dir_from_equals_form():
+    p = doctor._extract_profile_dir(["serve", "--profile=work"])
+    assert p is not None and p.name == "work"
+
+
+def test_extract_profile_dir_config_dir_takes_priority(tmp_path):
+    """``--config-dir`` is the authoritative override — if both are
+    set, doctor must validate the config-dir, not the profile-derived
+    path. (The runtime resolution in ``ConnectorConfig`` follows the
+    same precedence.)"""
+    p = doctor._extract_profile_dir([
+        "serve", "--profile", "work",
+        "--config-dir", str(tmp_path),
+    ])
+    assert p == tmp_path
+
+
+def test_extract_profile_dir_returns_none_when_neither_set():
+    assert doctor._extract_profile_dir(["serve"]) is None
+
+
+# ── scan(): happy path ─────────────────────────────────────────────────────
+
+
+def test_scan_reports_ok_when_binary_and_profile_exist(
+    patched_ides, fake_connector_on_path, tmp_path,
+):
+    """Healthy entry → ``ok`` so a clean dogfood run exits 0."""
+    profile_dir = tmp_path / "profiles" / "work"
+    profile_dir.mkdir(parents=True)
+    monkeypatched_default = tmp_path
+    # Doctor resolves --profile against DEFAULT_CONFIG_DIR; point it
+    # at our tmp tree for the test.
+    import cullis_connector.doctor as _d
+    _d.DEFAULT_CONFIG_DIR = monkeypatched_default
+
+    _write_config(patched_ides["cursor"], {
+        "cullis": {
+            "command": "cullis-connector",
+            "args": ["serve", "--profile", "work"],
+        }
+    })
+    entries = doctor.scan(["cursor"])
+    assert len(entries) == 1
+    assert entries[0].status == "ok"
+    assert not doctor.has_problems(entries)
+
+
+def test_scan_flags_stale_profile_dir(
+    patched_ides, fake_connector_on_path, tmp_path,
+):
+    """Profile dir vanished → ``stale_profile`` + non-zero exit.
+
+    This is the literal dogfood Finding #8: ``profile=dotfiles`` was
+    in the MCP config but the dir had been wiped weeks earlier.
+    """
+    import cullis_connector.doctor as _d
+    _d.DEFAULT_CONFIG_DIR = tmp_path  # no profiles/ subtree exists
+
+    _write_config(patched_ides["cursor"], {
+        "cullis": {
+            "command": "cullis-connector",
+            "args": ["serve", "--profile", "dotfiles"],
+        }
+    })
+    entries = doctor.scan(["cursor"])
+    assert len(entries) == 1
+    assert entries[0].status == "stale_profile"
+    assert "dotfiles" in entries[0].detail
+    assert doctor.has_problems(entries)
+
+
+def test_scan_flags_stale_binary(patched_ides, monkeypatch):
+    """Binary missing → ``stale_binary`` so doctor explains why the
+    IDE can't launch the MCP server, instead of letting the user
+    discover it on first invocation."""
+    monkeypatch.setattr(doctor.shutil, "which", lambda c: None)
+    _write_config(patched_ides["cursor"], {
+        "cullis": {
+            "command": "cullis-connector",
+            "args": ["serve", "--profile", "work"],
+        }
+    })
+    entries = doctor.scan(["cursor"])
+    assert len(entries) == 1
+    assert entries[0].status == "stale_binary"
+    assert doctor.has_problems(entries)
+
+
+def test_scan_ignores_non_cullis_entries(patched_ides, fake_connector_on_path):
+    """A foreign MCP server in the same config file must be silently
+    skipped — doctor reports only the entries it knows belong to us."""
+    _write_config(patched_ides["cursor"], {
+        "postgres": {"command": "postgres-mcp", "args": []},
+        "github": {"command": "gh-mcp", "args": []},
+    })
+    assert doctor.scan(["cursor"]) == []
+
+
+def test_scan_flags_unreadable_config(patched_ides):
+    """Garbled JSON → ``unreadable`` instead of an unhandled exception
+    leaking out of the doctor command."""
+    p = patched_ides["cursor"]
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("{not valid json")
+    entries = doctor.scan(["cursor"])
+    assert len(entries) == 1
+    assert entries[0].status == "unreadable"
+    assert doctor.has_problems(entries)
+
+
+def test_scan_skips_clients_without_a_config_file(patched_ides):
+    """Pre-install state: most operators won't have every supported
+    client. Empty result is correct, doctor must not warn about it."""
+    # No config files written at all — every patched path is missing.
+    entries = doctor.scan(list(patched_ides.keys()))
+    # COMMAND-kind clients (claude-code-cli) may yield ``advise`` rows
+    # when ``claude`` is on PATH, but never the file-kind problem
+    # statuses; the lack of a config file is silence by design.
+    assert all(e.status in {"advise"} for e in entries)
+
+
+# ── _cmd_doctor (CLI integration) ─────────────────────────────────────────
+
+
+def test_cmd_doctor_returns_zero_on_clean_scan(
+    patched_ides, fake_connector_on_path, tmp_path, capsys,
+):
+    """End-to-end: ``cullis-connector doctor`` exits 0 when nothing is
+    broken — composes correctly with ``set -e`` in install scripts."""
+    import argparse
+    import cullis_connector.doctor as _d
+    _d.DEFAULT_CONFIG_DIR = tmp_path
+    (tmp_path / "profiles" / "work").mkdir(parents=True)
+
+    _write_config(patched_ides["cursor"], {
+        "cullis": {
+            "command": "cullis-connector",
+            "args": ["serve", "--profile", "work"],
+        }
+    })
+
+    from cullis_connector.cli import _cmd_doctor
+    from cullis_connector.config import ConnectorConfig
+
+    cfg = ConnectorConfig(config_dir=tmp_path)
+    args = argparse.Namespace(ides=["cursor"])
+    rc = _cmd_doctor(cfg, args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "ok" in out
+
+
+def test_cmd_doctor_returns_one_on_stale_entry(
+    patched_ides, fake_connector_on_path, tmp_path, capsys,
+):
+    """Stale profile detected → exit 1 so CI / scripts can react."""
+    import argparse
+    import cullis_connector.doctor as _d
+    _d.DEFAULT_CONFIG_DIR = tmp_path  # profile ``dotfiles`` does not exist
+
+    _write_config(patched_ides["cursor"], {
+        "cullis": {
+            "command": "cullis-connector",
+            "args": ["serve", "--profile", "dotfiles"],
+        }
+    })
+
+    from cullis_connector.cli import _cmd_doctor
+    from cullis_connector.config import ConnectorConfig
+
+    cfg = ConnectorConfig(config_dir=tmp_path)
+    args = argparse.Namespace(ides=["cursor"])
+    rc = _cmd_doctor(cfg, args)
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "stale_profile" in out
+    assert "dotfiles" in out

--- a/tests/connector/test_install_mcp_restart_hint.py
+++ b/tests/connector/test_install_mcp_restart_hint.py
@@ -10,7 +10,6 @@ new server. The hint pre-empts that loop.
 from __future__ import annotations
 
 import argparse
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/connector/test_install_mcp_restart_hint.py
+++ b/tests/connector/test_install_mcp_restart_hint.py
@@ -1,0 +1,158 @@
+"""Tests for the restart hint that ``install-mcp`` prints after
+writing the Cullis entry into one or more clients (Finding #7,
+2026-04-29 dogfood).
+
+Without the hint, operators invoke a tool, get a "tool not found"
+error, and only then realise the existing Claude Code / Cursor
+session loaded its MCP config at startup and has not yet seen the
+new server. The hint pre-empts that loop.
+"""
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch
+
+import pytest
+
+from cullis_connector.cli import _cmd_install_mcp
+from cullis_connector.config import ConnectorConfig
+from cullis_connector import ide_config
+from cullis_connector.ide_config import (
+    IDEDescriptor,
+    IDEStatus,
+    KNOWN_IDES,
+)
+
+
+@pytest.fixture
+def patched_ides(monkeypatch, tmp_path):
+    """Same redirect-to-tmp pattern as test_ide_config / test_doctor."""
+    paths = {ide_id: tmp_path / f"{ide_id}.json" for ide_id in KNOWN_IDES}
+    fake = {}
+    for ide_id, desc in KNOWN_IDES.items():
+        p = str(paths[ide_id])
+        fake[ide_id] = IDEDescriptor(
+            id=desc.id,
+            display_name=desc.display_name,
+            paths={"darwin": p, "win32": p, "linux": p},
+            servers_key=desc.servers_key,
+            kind=desc.kind,
+            detect_binary=desc.detect_binary,
+        )
+    monkeypatch.setattr(ide_config, "KNOWN_IDES", fake)
+    # cli imports KNOWN_IDES inside the function — monkeypatch where
+    # the import lands.
+    monkeypatch.setattr("cullis_connector.cli.KNOWN_IDES", fake, raising=False)
+    return paths
+
+
+def _make_args(ides=None, uninstall=False, list_only=False) -> argparse.Namespace:
+    return argparse.Namespace(
+        ides=ides,
+        ide_uninstall=uninstall,
+        ide_list_only=list_only,
+        profile=None,
+        config_dir=None,
+        site_url=None,
+        verify_tls=None,
+    )
+
+
+def test_install_emits_restart_hint_with_client_name(
+    patched_ides, tmp_path, capsys, monkeypatch,
+):
+    """A successful install must print a hint that names the
+    affected clients — generic "restart your IDE" wording is too
+    vague when several clients are configured at once."""
+    cfg = ConnectorConfig(config_dir=tmp_path)
+
+    # Stub the underlying writer so the test doesn't actually touch
+    # disk via ide_config — we only care about the message the CLI
+    # surfaces to the operator.
+    from cullis_connector.ide_config import InstallResult
+
+    def _fake_install(ide_id, *, backup_dir, args):
+        return InstallResult(
+            ide_id=ide_id,
+            status="installed",
+            config_path=patched_ides[ide_id],
+        )
+
+    monkeypatch.setattr("cullis_connector.ide_config.install_mcp", _fake_install)
+    # Pretend Cursor is detected so the install path actually runs.
+    monkeypatch.setattr(
+        "cullis_connector.ide_config.detect_ide_status",
+        lambda i: type(
+            "D", (), {"status": IDEStatus.DETECTED, "display_name": KNOWN_IDES[i].display_name, "note": None},
+        )(),
+    )
+    monkeypatch.setattr(
+        "cullis_connector.ide_config.detect_all", lambda: [],
+    )
+
+    rc = _cmd_install_mcp(cfg, _make_args(ides=["cursor"]))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Restart" in out
+    assert "Cursor" in out  # specific display name, not just "your IDE"
+    assert "Existing sessions" in out  # warns the live session won't see them
+
+
+def test_install_does_not_emit_hint_when_uninstalling(
+    patched_ides, tmp_path, capsys, monkeypatch,
+):
+    """``--uninstall`` removes the entry; nothing for the operator to
+    restart-to-load. The hint would be confusing here."""
+    cfg = ConnectorConfig(config_dir=tmp_path)
+
+    from cullis_connector.ide_config import InstallResult
+
+    def _fake_uninstall(ide_id, *, backup_dir):
+        return InstallResult(
+            ide_id=ide_id,
+            status="installed",  # uninstall reuses ``installed`` status to mean "took effect"
+            config_path=patched_ides[ide_id],
+        )
+
+    monkeypatch.setattr("cullis_connector.ide_config.uninstall_mcp", _fake_uninstall)
+    monkeypatch.setattr(
+        "cullis_connector.ide_config.detect_ide_status",
+        lambda i: type(
+            "D", (), {"status": IDEStatus.CONFIGURED, "display_name": KNOWN_IDES[i].display_name, "note": None},
+        )(),
+    )
+
+    rc = _cmd_install_mcp(cfg, _make_args(ides=["cursor"], uninstall=True))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Restart" not in out
+
+
+def test_install_does_not_emit_hint_when_already_configured(
+    patched_ides, tmp_path, capsys, monkeypatch,
+):
+    """Re-running ``install-mcp`` is idempotent — if no entry actually
+    changed, the operator does NOT need to restart anything."""
+    cfg = ConnectorConfig(config_dir=tmp_path)
+
+    from cullis_connector.ide_config import InstallResult
+
+    def _fake_install(ide_id, *, backup_dir, args):
+        return InstallResult(
+            ide_id=ide_id,
+            status="already_configured",
+            config_path=patched_ides[ide_id],
+        )
+
+    monkeypatch.setattr("cullis_connector.ide_config.install_mcp", _fake_install)
+    monkeypatch.setattr(
+        "cullis_connector.ide_config.detect_ide_status",
+        lambda i: type(
+            "D", (), {"status": IDEStatus.CONFIGURED, "display_name": KNOWN_IDES[i].display_name, "note": None},
+        )(),
+    )
+
+    rc = _cmd_install_mcp(cfg, _make_args(ides=["cursor"]))
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Restart" not in out


### PR DESCRIPTION
## Summary

Three closely related dogfood findings from 2026-04-29, one PR.

- **Finding #6** — `install-mcp --ide` now exposes every supported MCP client (was: only `claude-desktop`, `cursor`, `cline`; now: also `claude-code-cli`, `zed`, `windsurf` + the operator-friendly alias `claude-code`).
- **Finding #7** — restart hint after a successful install: clients load their MCP config at session startup, so an already-running Claude Code / Cursor / Cline won't see the new tools until restart. The hint pre-empts the "tool not found" dance.
- **Finding #8** — new `cullis-connector doctor` subcommand: scans IDE MCP configs for stale Cullis entries (binary missing, profile dir wiped) and reports them with non-zero exit so it composes with `set -e`.

## What changes

### `--ide` choices + alias

- `_build_parser` derives `install-mcp --ide` choices from `KNOWN_IDES` so any new descriptor lands in argparse without a parallel edit.
- `_resolve_ide_id` maps `claude-code` → `claude-code-cli` (canonical id stays internal-shaped, operators get a friendlier flag).

### Restart hint

- `_cmd_install_mcp` prints `→ Restart <client list> to load the Cullis MCP server. Existing sessions will not see the new tools until a fresh session is opened.` after at least one successful install. Suppressed on `--uninstall` and on no-op `already_configured`.

### `doctor`

- New `cullis_connector/doctor.py`. Walks the registry, parses each FILE-kind config, identifies cullis-shaped entries via two heuristics (binary contains `cullis-connector`, OR server name `cullis*` + `serve` in args), and validates: binary on PATH / at persisted absolute path, and profile dir referenced by `--profile X` or `--config-dir Y` still exists.
- COMMAND-kind clients (Claude Code CLI) yield a single `advise` row pointing at `claude mcp list` / `claude mcp remove` since their MCP state lives inside the binary's own store.
- Status taxonomy: `ok` / `stale_binary` / `stale_profile` / `unreadable` / `advise`. `has_problems()` is `True` for the first three; `_cmd_doctor` exits 1 when problems are present.

## Test plan

- [x] `tests/connector/test_doctor.py` (15 tests): heuristic matrix (`_looks_like_cullis`), profile-dir parsing (`--profile`, `--config-dir`, equals-form, both-set precedence, neither), binary-exists, scan happy-path / stale_profile / stale_binary / unreadable / ignores foreign servers / no-config-no-warn, end-to-end `_cmd_doctor` exit 0 / exit 1.
- [x] `tests/connector/test_install_mcp_restart_hint.py` (3 tests): hint names the actual display name, suppressed on uninstall, suppressed on already_configured.
- [x] `tests/connector/test_cli_dispatch.py`: `--ide` choices set pinned against `KNOWN_IDES`; `claude-code` alias resolves correctly.
- [x] Full `tests/connector/` regression: 290 pass, 4 pre-existing fails on `test_profile_runtime_switch.py` (pystray API, unrelated).
- [x] **Smoke (live)**:
  - `cullis-connector install-mcp --help` → `--ide {claude-code,claude-code-cli,claude-desktop,cline,cursor,windsurf,zed}`.
  - `cullis-connector install-mcp --ide claude-code --list` → resolves to `Claude Code CLI`, reports `configured`.
  - `cullis-connector --profile cullis doctor` against real profiles → 2 `ok` (Claude Desktop, Cursor) + 1 `advise` (Claude Code CLI), exit 0.

## Notes

No DB / wire / SDK changes. `doctor` does not probe the network — operators wanting a Site reachability check can run `hello-site` separately. Existing `cullis` and `system` dogfood profiles unaffected.