### PR TITLE
fix(connector): deep-link to admin enrollments page on waiting screen (#4)

### DIFF
--- a/cullis_connector/templates/waiting.html
+++ b/cullis_connector/templates/waiting.html
@@ -66,6 +66,13 @@
         <button type="button" class="copy-btn" onclick="copyText('{{ enroll_url|e }}')">Copy</button>
     </div>
 
+    {% if admin_enrollments_url %}
+    <p class="footer-hint" style="margin-top: 1rem;">
+        Admin? Open <a href="{{ admin_enrollments_url|e }}" target="_blank" rel="noopener" id="admin-enrollments-link">{{ admin_enrollments_url }}</a>
+        on the Mastio dashboard to review and approve this request.
+    </p>
+    {% endif %}
+
     <div class="btn-row">
         <form method="post" action="/cancel" style="display: inline;">
             <button type="submit" class="btn btn-ghost">Cancel enrollment</button>

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -442,6 +442,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
                 "connector_status_label": "Pending approval",
                 "session_id": _pending.session_id,
                 "enroll_url": _pending.enroll_url,
+                "admin_enrollments_url": f"{_pending.site_url.rstrip('/')}/proxy/enrollments",
                 "started_at_ms": int(_pending.started_at * 1000),
             },
         )

--- a/tests/connector/test_web_waiting.py
+++ b/tests/connector/test_web_waiting.py
@@ -1,0 +1,79 @@
+"""Tests for the /waiting dashboard page.
+
+Pinning behaviour the dogfood Finding #4 cared about: the user who
+just submitted an enrollment request must see a discoverable link to
+``<site>/proxy/enrollments`` so they (or their admin colleague) know
+where to go to approve. Before this fix the page only displayed an
+opaque enroll URL and the operator had to hunt for the admin UI by
+hand.
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi.testclient import TestClient
+
+import cullis_connector.web as _web
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.enrollment import RequesterInfo
+from cullis_connector.web import _Pending, build_app
+
+
+@pytest.fixture
+def cfg(tmp_path) -> ConnectorConfig:
+    return ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://fake-mastio.test:9443",
+        verify_tls=True,
+    )
+
+
+@pytest.fixture
+def client(cfg, monkeypatch) -> TestClient:
+    monkeypatch.setattr(_web, "has_identity", lambda _: False)
+    return TestClient(build_app(cfg))
+
+
+@pytest.fixture
+def with_pending(monkeypatch):
+    """Inject a fake _pending so /waiting renders instead of redirecting."""
+    pending = _Pending(
+        session_id="abcdef0123456789",
+        enroll_url="https://fake-mastio.test:9443/v1/enrollment/abcdef0123456789",
+        site_url="https://fake-mastio.test:9443",
+        verify_tls=True,
+        private_key=ec.generate_private_key(ec.SECP256R1()),
+        requester=RequesterInfo(name="alice", email="alice@example.test"),
+    )
+    monkeypatch.setattr(_web, "_pending", pending)
+    return pending
+
+
+def test_waiting_page_shows_admin_enrollments_link(client, with_pending):
+    """The waiting page must surface the absolute admin URL so the
+    operator doesn't need to guess where pending enrollments live."""
+    resp = client.get("/waiting")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "https://fake-mastio.test:9443/proxy/enrollments" in body
+    # Hyperlink, not raw text — the operator has to be able to click it.
+    assert 'id="admin-enrollments-link"' in body
+    assert 'href="https://fake-mastio.test:9443/proxy/enrollments"' in body
+
+
+def test_waiting_page_strips_trailing_slash_on_site_url(monkeypatch, client):
+    """Operators paste site URLs with or without a trailing slash; the
+    deep-link must not produce ``//proxy/enrollments``."""
+    pending = _Pending(
+        session_id="abcdef0123456789",
+        enroll_url="https://fake-mastio.test:9443/v1/enrollment/abcdef0123456789",
+        site_url="https://fake-mastio.test:9443/",  # trailing slash
+        verify_tls=True,
+        private_key=ec.generate_private_key(ec.SECP256R1()),
+        requester=RequesterInfo(name="alice", email="alice@example.test"),
+    )
+    monkeypatch.setattr(_web, "_pending", pending)
+    resp = client.get("/waiting")
+    assert resp.status_code == 200
+    assert "https://fake-mastio.test:9443/proxy/enrollments" in resp.text
+    assert "9443//proxy" not in resp.text


### PR DESCRIPTION
## Summary

Closes Finding #4 from the 2026-04-29 dogfood. The operator who just submitted an enrollment request had no way to discover where to go to approve it — the waiting page only showed an opaque enroll URL, so they (or the admin colleague) had to hunt the \"Enrollments\" section in the Mastio sidebar by hand.

Now the waiting page surfaces a clickable link to ``<site>/proxy/enrollments`` directly under the URL box.

## Changes

- ``cullis_connector/web.py``: pass ``admin_enrollments_url`` (``site_url.rstrip('/') + '/proxy/enrollments'``) to the waiting template
- ``cullis_connector/templates/waiting.html``: render the link as a footer hint with ``target=\"_blank\"`` and ``rel=\"noopener\"``
- ``tests/connector/test_web_waiting.py``: 2 tests — link present + trailing-slash sanitization

## Test plan

- [x] ``pytest tests/connector/test_web_waiting.py`` — 2/2 pass
- [x] Full ``pytest tests/connector/`` — only pre-existing pystray failures unrelated to this change
- [ ] Manual: hit /waiting on a real Connector dashboard and verify the link points at the live Mastio admin page