### PR TITLE
feat(connector): dashboard "Test connection" smoke probe (#5)

### DIFF
--- a/cullis_connector/templates/connected.html
+++ b/cullis_connector/templates/connected.html
@@ -60,6 +60,19 @@
             <span class="identity-v">{{ issued_at or '—' }}</span>
         </div>
     </div>
+
+    <div class="btn-row" style="margin-top: 16px;">
+        <button type="button"
+                id="test-ping-btn"
+                class="btn btn-ghost"
+                hx-post="/api/test-ping"
+                hx-swap="none"
+                hx-on::before-request="prepareTestPing(this)"
+                hx-on::after-request="handleTestPingResult(this, event)">
+            Test connection
+        </button>
+        <span id="test-ping-result" class="muted" style="font-size: 12px; align-self: center;"></span>
+    </div>
 </section>
 
 <section class="panel">
@@ -157,6 +170,33 @@ function handleAutostartResult(btn, event) {
         showToast(payload.enabled ? 'Autostart enabled' : 'Autostart disabled');
     } else {
         showToast(payload.error || 'Could not change autostart setting');
+    }
+}
+
+function prepareTestPing(btn) {
+    btn.disabled = true;
+    btn.textContent = 'Pinging…';
+    const out = document.getElementById('test-ping-result');
+    if (out) { out.textContent = ''; out.style.color = ''; }
+}
+
+function handleTestPingResult(btn, event) {
+    btn.disabled = false;
+    btn.textContent = 'Test connection';
+    const out = document.getElementById('test-ping-result');
+    if (!out) return;
+    let payload = {};
+    try { payload = JSON.parse(event.detail.xhr.responseText); } catch (e) {}
+    if (payload.ok) {
+        out.style.color = '';
+        out.textContent = '✓ ' + (payload.site_status || 'reachable')
+            + ' · ' + payload.rtt_ms + ' ms'
+            + (payload.site_version && payload.site_version !== 'unknown'
+                ? ' · v' + payload.site_version : '')
+            + (payload.tls_verified ? ' · TLS verified' : ' · TLS NOT verified');
+    } else {
+        out.style.color = 'var(--err, #c62828)';
+        out.textContent = '✗ ' + (payload.error || 'unreachable');
     }
 }
 

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -547,6 +547,66 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             {"status": "error", "error": f"Unexpected status '{remote_status}'"}
         )
 
+    @app.post("/api/test-ping")
+    def api_test_ping() -> JSONResponse:
+        """Smoke-probe the configured Mastio Site from the dashboard.
+
+        Closes Finding #5 from the 2026-04-29 dogfood: a freshly
+        enrolled operator had no in-dashboard way to ask "is this
+        actually working?" and had to drop into the MCP tool surface
+        (``hello_site``) to confirm. We replicate the same probe here
+        — ``GET <site>/health`` with the same TLS posture as the rest
+        of the connector — so the answer lives one click away from
+        the identity card.
+        """
+        if not has_identity(config.config_dir):
+            return JSONResponse(
+                {"ok": False, "error": "No identity loaded — enroll first."},
+                status_code=200,
+            )
+        if not config.site_url:
+            return JSONResponse(
+                {"ok": False, "error": "Site URL is not configured."},
+                status_code=200,
+            )
+
+        url = f"{config.site_url.rstrip('/')}/health"
+        started = time.perf_counter()
+        try:
+            resp = httpx.get(
+                url,
+                verify=config.verify_arg,
+                timeout=config.request_timeout_s,
+            )
+        except httpx.HTTPError as exc:
+            return JSONResponse({
+                "ok": False,
+                "site_url": config.site_url,
+                "error": f"Site unreachable: {exc}",
+            })
+
+        rtt_ms = round((time.perf_counter() - started) * 1000, 1)
+        if resp.status_code != 200:
+            return JSONResponse({
+                "ok": False,
+                "site_url": config.site_url,
+                "rtt_ms": rtt_ms,
+                "error": f"Site responded with HTTP {resp.status_code}",
+            })
+
+        try:
+            payload = resp.json()
+        except ValueError:
+            payload = {}
+        return JSONResponse({
+            "ok": True,
+            "site_url": config.site_url,
+            "rtt_ms": rtt_ms,
+            "site_status": payload.get("status", "unknown"),
+            "site_version": payload.get("version", "unknown"),
+            "tls_verified": config.verify_arg is not False,
+        })
+
     @app.post("/cancel")
     def cancel() -> Response:
         _clear_pending()

--- a/tests/connector/test_web_test_ping.py
+++ b/tests/connector/test_web_test_ping.py
@@ -1,0 +1,140 @@
+"""Tests for the /api/test-ping dashboard probe.
+
+The dogfood Finding #5 surfaced this: a freshly enrolled operator
+had no in-dashboard signal that "this actually works" — they had to
+drop into ``hello_site`` from an MCP-aware client to confirm. The
+endpoint replicates the same probe (``GET <site>/health``) so the
+answer is one click away from the identity card.
+
+Mock httpx so these tests never touch the network.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+import cullis_connector.web as _web
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import build_app
+
+
+@pytest.fixture
+def cfg(tmp_path) -> ConnectorConfig:
+    return ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://fake-mastio.test:9443",
+        verify_tls=True,
+    )
+
+
+@pytest.fixture
+def client_with_identity(cfg, monkeypatch) -> TestClient:
+    """Pretend an enrolled identity is on disk so test-ping doesn't
+    short-circuit on the no-identity guard."""
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+    return TestClient(build_app(cfg))
+
+
+@pytest.fixture
+def client_without_identity(cfg, monkeypatch) -> TestClient:
+    monkeypatch.setattr(_web, "has_identity", lambda _: False)
+    return TestClient(build_app(cfg))
+
+
+def _patch_health(monkeypatch, *, status_code: int, body: dict | str):
+    """Stub httpx.get so the probe sees the response we want."""
+    captured: dict[str, str] = {}
+
+    def _fake_get(url, *, verify, timeout):
+        captured["url"] = url
+        if isinstance(body, dict):
+            return httpx.Response(
+                status_code,
+                json=body,
+                request=httpx.Request("GET", url),
+            )
+        return httpx.Response(
+            status_code,
+            text=body,
+            request=httpx.Request("GET", url),
+        )
+
+    monkeypatch.setattr("cullis_connector.web.httpx.get", _fake_get)
+    return captured
+
+
+def test_test_ping_happy_path(client_with_identity, monkeypatch):
+    """Site at /health returns 200 + JSON → ok with rtt_ms + site fields."""
+    captured = _patch_health(
+        monkeypatch,
+        status_code=200,
+        body={"status": "ok", "version": "0.4.0"},
+    )
+    resp = client_with_identity.post("/api/test-ping")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is True
+    assert payload["site_status"] == "ok"
+    assert payload["site_version"] == "0.4.0"
+    assert payload["site_url"] == "https://fake-mastio.test:9443"
+    assert isinstance(payload["rtt_ms"], (int, float))
+    assert payload["tls_verified"] is True
+    assert captured["url"] == "https://fake-mastio.test:9443/health"
+
+
+def test_test_ping_returns_unreachable_on_httpx_error(
+    client_with_identity, monkeypatch,
+):
+    """Any HTTPError (DNS, TLS, connect refused) → ok=false + readable
+    error string. The dashboard surfaces this verbatim."""
+    def _raise(url, **_):
+        raise httpx.ConnectError(
+            "connection refused", request=httpx.Request("GET", url)
+        )
+
+    monkeypatch.setattr("cullis_connector.web.httpx.get", _raise)
+    resp = client_with_identity.post("/api/test-ping")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is False
+    assert "Site unreachable" in payload["error"]
+    assert "connection refused" in payload["error"]
+
+
+def test_test_ping_flags_non_200_response(client_with_identity, monkeypatch):
+    """Site responded but non-200 (e.g. 503 during boot) → ok=false +
+    rtt_ms still reported, so the operator can tell the network worked
+    but the upstream is not healthy."""
+    _patch_health(monkeypatch, status_code=503, body={"detail": "starting"})
+    resp = client_with_identity.post("/api/test-ping")
+    payload = resp.json()
+    assert payload["ok"] is False
+    assert "HTTP 503" in payload["error"]
+    assert "rtt_ms" in payload
+
+
+def test_test_ping_short_circuits_without_identity(client_without_identity):
+    """No identity → don't dial out; the probe is meaningful only once
+    enrollment completed. Returns ok=false with a guiding message."""
+    resp = client_without_identity.post("/api/test-ping")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["ok"] is False
+    assert "enroll" in payload["error"].lower()
+
+
+def test_test_ping_strips_trailing_slash_on_site_url(monkeypatch, tmp_path):
+    """``site_url`` with a trailing slash must not produce //health."""
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://fake-mastio.test:9443/",
+        verify_tls=True,
+    )
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+    client = TestClient(build_app(cfg))
+    captured = _patch_health(
+        monkeypatch, status_code=200, body={"status": "ok"}
+    )
+    client.post("/api/test-ping")
+    assert captured["url"] == "https://fake-mastio.test:9443/health"


### PR DESCRIPTION
## Summary

Closes Finding #5 from the 2026-04-29 dogfood. A freshly enrolled operator had no in-dashboard signal that the Site was reachable — they had to drop into the MCP tool surface (\`hello_site\`) from a client that already had Cullis wired up. That's an awkward chicken-and-egg moment mid-setup.

Adds a \"Test connection\" button under the identity card on \`/connected\` that does the same \`GET <site>/health\` probe \`hello_site\` does, with the same TLS posture, and surfaces RTT, site version, and TLS-verified flag inline.

## Scope

Deliberately small: only the **Site** smoke (operator → Mastio). **Peer-ping** (send oneshot to another agent + wait for echo) is a separate feature — would need a peer picker — out of scope for this UX gap.

## Changes

- ``cullis_connector/web.py``: ``POST /api/test-ping`` reusing ``hello_site`` semantics. Short-circuits with ok=false when no identity is loaded, so the button can't give a misleading green before enrollment.
- ``cullis_connector/templates/connected.html``: button + JS handler that renders ``✓ ok · 12.3 ms · v0.4.0 · TLS verified`` or ``✗ <reason>``.
- ``tests/connector/test_web_test_ping.py``: 5 cases — happy path, transport error, non-200 upstream, no-identity short-circuit, trailing-slash sanitization.

## Test plan

- [x] ``pytest tests/connector/ -k web`` — 18/18 pass
- [x] ``ruff check app/ agents/sdk.py tests/`` — clean
- [ ] Manual: hit \`/connected\` on a real Connector dashboard, click the button, watch RTT update and confirm both healthy + unhealthy paths render legibly