### PR TITLE
fix(sdk): route session ops through egress for proxy-bound clients (#9)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -222,6 +222,17 @@ class CullisClient:
         # detect which role is in front of it without a config change.
         self.server_role: str | None = None
 
+        # Dogfood Finding #9 (2026-04-29): when the SDK is built
+        # against a Mastio proxy (``from_connector`` / proxy-bound
+        # factories), session ops route through ``/v1/egress/sessions*``
+        # rather than ``/v1/broker/sessions*``. The egress router is
+        # the local mini-broker for intra-org sessions in standalone
+        # and falls through to the broker bridge for cross-org — the
+        # broker paths only worked when a Court was reachable, so they
+        # 503'd on every standalone Mastio. Direct-broker factories
+        # leave this False so they keep talking to ``/v1/broker``.
+        self._use_egress_for_sessions: bool = False
+
         # Opaque identity bundle attached by the caller after
         # construction. Connector callers set this to the loaded
         # ``cullis_connector.identity.IdentityBundle`` so helpers like
@@ -378,6 +389,8 @@ class CullisClient:
         instance._egress_dpop_nonce = None
         instance._proxy_agent_id = config["agent_id"]
         instance._proxy_org_id = config["org_id"]
+        # Dogfood Finding #9 — proxy-bound: see __init__.
+        instance._use_egress_for_sessions = True
         # Mirror __init__: callers may attach the on-disk identity bundle
         # afterwards (see ``canonical_recipient`` in cullis_connector).
         instance.identity = None
@@ -553,6 +566,8 @@ class CullisClient:
         instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
+        # Dogfood Finding #9 — proxy-bound: see __init__.
+        instance._use_egress_for_sessions = True
         # ``_update_nonce`` reads ``self.server_role`` on every response;
         # since we skip ``__init__`` above (the ``cls.__new__(cls)`` route
         # that other factories also use), the attribute must exist.
@@ -810,6 +825,8 @@ class CullisClient:
         instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
+        # Dogfood Finding #9 — proxy-bound: see __init__.
+        instance._use_egress_for_sessions = True
         instance.server_role = None
         instance.identity = None
 
@@ -956,6 +973,10 @@ class CullisClient:
         instance._egress_dpop_nonce = None
         instance._proxy_agent_id = agent_id
         instance._proxy_org_id = org_id
+        # Dogfood Finding #9 — proxy-bound: route session ops through
+        # /v1/egress/sessions* (handles intra-org locally, falls
+        # through to broker bridge for cross-org).
+        instance._use_egress_for_sessions = True
         # Mirror __init__: callers may attach the on-disk identity bundle
         # afterwards (see ``canonical_recipient`` in cullis_connector).
         instance.identity = None
@@ -1534,7 +1555,22 @@ class CullisClient:
 
     def open_session(self, target_agent_id: str, target_org_id: str,
                      capabilities: list[str]) -> str:
-        """Open a new session with a target agent. Returns session_id."""
+        """Open a new session with a target agent. Returns session_id.
+
+        Proxy-bound clients (``from_connector``, ``from_enrollment``,
+        ``from_identity_dir``) route through ``/v1/egress/sessions`` —
+        the proxy's local mini-broker handles intra-org and falls
+        through to the broker bridge for cross-org. Direct-broker
+        clients keep using ``/v1/broker/sessions``.
+        """
+        if self._use_egress_for_sessions:
+            resp = self._egress_http("post", "/v1/egress/sessions", json={
+                "target_agent_id": target_agent_id,
+                "target_org_id": target_org_id,
+                "capabilities": capabilities,
+            })
+            resp.raise_for_status()
+            return resp.json()["session_id"]
         path = "/v1/broker/sessions"
         resp = self._authed_request("POST", path, json={
             "target_agent_id": target_agent_id,
@@ -1546,28 +1582,64 @@ class CullisClient:
 
     def accept_session(self, session_id: str) -> None:
         """Accept a pending session."""
+        if self._use_egress_for_sessions:
+            resp = self._egress_http(
+                "post", f"/v1/egress/sessions/{session_id}/accept"
+            )
+            resp.raise_for_status()
+            return
         path = f"/v1/broker/sessions/{session_id}/accept"
         resp = self._authed_request("POST", path)
         resp.raise_for_status()
 
     def reject_session(self, session_id: str) -> None:
-        """Reject a pending session."""
+        """Reject a pending session.
+
+        The egress router has no dedicated reject endpoint — it folds
+        rejection into ``/close`` (the local store treats both as a
+        terminal state with the same semantics for the initiator).
+        Direct-broker clients still get the reject path so the broker
+        can distinguish 'rejected by target' from 'closed'.
+        """
+        if self._use_egress_for_sessions:
+            resp = self._egress_http(
+                "post", f"/v1/egress/sessions/{session_id}/close"
+            )
+            resp.raise_for_status()
+            return
         path = f"/v1/broker/sessions/{session_id}/reject"
         resp = self._authed_request("POST", path)
         resp.raise_for_status()
 
     def close_session(self, session_id: str) -> None:
         """Close an active session."""
+        if self._use_egress_for_sessions:
+            resp = self._egress_http(
+                "post", f"/v1/egress/sessions/{session_id}/close"
+            )
+            resp.raise_for_status()
+            return
         path = f"/v1/broker/sessions/{session_id}/close"
         resp = self._authed_request("POST", path)
         resp.raise_for_status()
 
     def list_sessions(self, status: str | None = None) -> list[SessionInfo]:
-        """List sessions, optionally filtered by status."""
-        path = "/v1/broker/sessions"
+        """List sessions, optionally filtered by status.
+
+        The egress shape wraps the list in ``{"sessions": [...]}`` and
+        the broker shape returns a flat list — unwrap on the egress
+        side so callers see the same return type.
+        """
         params = {}
         if status:
             params["status"] = status
+        if self._use_egress_for_sessions:
+            resp = self._egress_http("get", "/v1/egress/sessions", params=params)
+            resp.raise_for_status()
+            body = resp.json()
+            sessions = body.get("sessions", []) if isinstance(body, dict) else body
+            return [SessionInfo.from_dict(s) for s in sessions]
+        path = "/v1/broker/sessions"
         resp = self._authed_request("GET", path, params=params)
         resp.raise_for_status()
         return [SessionInfo.from_dict(s) for s in resp.json()]
@@ -1622,6 +1694,37 @@ class CullisClient:
             self._signing_key_pem, session_id, sender_agent_id,
             nonce, timestamp, cipher_blob, client_seq=client_seq,
         )
+
+        if self._use_egress_for_sessions:
+            # Egress envelope mode: cert-as-identity, no outer signature
+            # (mTLS provides transport integrity to the proxy; the
+            # ``inner_sig`` baked into ``cipher_blob`` provides E2E
+            # non-repudiation for the recipient).
+            body: dict[str, Any] = {
+                "session_id": session_id,
+                "payload": cipher_blob,
+                "recipient_agent_id": recipient_agent_id,
+                "mode": "envelope",
+            }
+            if ttl_seconds is not None:
+                body["ttl_seconds"] = ttl_seconds
+            if idempotency_key is not None:
+                body["idempotency_key"] = idempotency_key
+            for attempt in range(3):
+                try:
+                    resp = self._egress_http("post", "/v1/egress/send", json=body)
+                    resp.raise_for_status()
+                    try:
+                        return resp.json()
+                    except Exception:
+                        return {"status": "accepted", "session_id": session_id}
+                except (httpx.ConnectError, httpx.TimeoutException):
+                    if attempt < 2:
+                        print(f"[{self._label}] Proxy unreachable — retry in 2s...", flush=True)
+                        time.sleep(2)
+                    else:
+                        raise ConnectionError(f"[{self._label}] Proxy unreachable after 3 attempts.")
+            raise ConnectionError(f"[{self._label}] Proxy send failed unexpectedly.")
 
         envelope = {
             "session_id": session_id,
@@ -2279,6 +2382,8 @@ class CullisClient:
         safe to continue; the broker has already moved on). Raises on
         transport failures so the caller can retry.
         """
+        if self._use_egress_for_sessions:
+            return self.ack_via_proxy(session_id, msg_id)
         path = f"/v1/broker/sessions/{session_id}/messages/{msg_id}/ack"
         resp = self._authed_request("POST", path)
         if resp.status_code == 204:
@@ -2317,7 +2422,39 @@ class CullisClient:
         return msg
 
     def poll(self, session_id: str, after: int = -1, poll_interval: int = 2) -> list[InboxMessage]:
-        """Poll for new messages in a session. Returns decrypted messages."""
+        """Poll for new messages in a session. Returns decrypted messages.
+
+        Egress poll wraps the list in ``{"messages": [...], "count": N,
+        "scope": ...}`` and, in envelope mode, serialises the cipher
+        blob to a JSON string under ``payload_ciphertext``. Reverse
+        both shape diffs so callers see the same ``list[InboxMessage]``
+        as the broker path.
+        """
+        if self._use_egress_for_sessions:
+            for attempt in range(5):
+                try:
+                    resp = self._egress_http(
+                        "get", f"/v1/egress/messages/{session_id}",
+                        params={"after": after},
+                    )
+                    resp.raise_for_status()
+                    body = resp.json()
+                    raw = body.get("messages", []) if isinstance(body, dict) else body
+                    result: list[InboxMessage] = []
+                    for m in raw:
+                        unwrapped = self._unwrap_egress_message(m, session_id)
+                        decrypted = self.decrypt_payload(unwrapped, session_id=session_id)
+                        result.append(InboxMessage.from_dict(decrypted))
+                    return result
+                except httpx.HTTPStatusError:
+                    raise
+                except (httpx.ConnectError, httpx.TimeoutException):
+                    if attempt < 4:
+                        time.sleep(poll_interval)
+                    else:
+                        raise ConnectionError(f"[{self._label}] Proxy unreachable.")
+            return []
+
         path = f"/v1/broker/sessions/{session_id}/messages"
         for attempt in range(5):
             try:
@@ -2338,6 +2475,30 @@ class CullisClient:
                 else:
                     raise ConnectionError(f"[{self._label}] Broker unreachable.")
         return []
+
+    @staticmethod
+    def _unwrap_egress_message(m: dict, session_id: str) -> dict:
+        """Translate an egress poll-response row into the broker shape
+        ``decrypt_payload`` already understands.
+
+        Egress envelope rows carry the cipher dict serialised as JSON
+        under ``payload_ciphertext``; broker rows carry it as a dict
+        under ``payload``. mtls-only rows already have ``payload`` as
+        a dict — leave those alone, they decrypt as plaintext.
+        """
+        out = dict(m)
+        out.setdefault("session_id", session_id)
+        if out.get("mode") == "envelope" and "payload_ciphertext" in out:
+            try:
+                import json as _json
+                out["payload"] = _json.loads(out["payload_ciphertext"])
+            except (ValueError, TypeError):
+                # Leave as-is — decrypt_payload will fail closed if it
+                # can't parse the structure, which is the right outcome
+                # for a malformed wire frame.
+                pass
+            out.pop("payload_ciphertext", None)
+        return out
 
     # ── WebSocket ───────────────────────────────────────────────────
 

--- a/tests/test_sdk_session_egress_routing.py
+++ b/tests/test_sdk_session_egress_routing.py
@@ -1,0 +1,278 @@
+"""Tests for ADR-006 §2.2 extension — SDK session ops route to egress.
+
+Closes Finding #9 from the 2026-04-29 dogfood: with no Court attached,
+``client.open_session`` (and the rest of the session API) used to call
+``/v1/broker/sessions*``, which the proxy reverse-proxy forwarder
+returned 503 for whenever ``broker_url`` was ``None`` (i.e. every
+standalone Mastio).
+
+The SDK now flips ``_use_egress_for_sessions`` to True for every
+proxy-bound factory (``from_connector``, ``from_enrollment``,
+``from_identity_dir``, ``from_api_key_file`` flow) so the same calls
+hit ``/v1/egress/sessions*`` — the proxy's local mini-broker handles
+intra-org locally and falls through to the broker bridge for cross-
+org. Direct-broker clients (``CullisClient(broker_url=…)``) leave the
+flag at False so they keep talking to ``/v1/broker``.
+
+These tests verify the path dispatch by mocking the http client and
+asserting which URL each method calls. They DO NOT exercise crypto —
+``test_proxy_local_sessions.py`` already covers the server-side
+end-to-end.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from cullis_sdk import CullisClient
+
+
+def _make_client(*, use_egress: bool) -> CullisClient:
+    """A CullisClient with crypto + http stubs that just record calls.
+
+    Skips ``__init__`` (matching the factory pattern) and sets only the
+    attributes the session methods touch. Tests that need the full
+    init path use ``CullisClient.from_*`` directly.
+    """
+    instance = CullisClient.__new__(CullisClient)
+    instance.base = "https://fake-mastio.test:9443"
+    instance._verify_tls = True
+    instance._http = _RecordingHttp()
+    instance.token = None
+    instance._label = "test-agent"
+    instance._signing_key_pem = None
+    instance._pubkey_cache = {}
+    instance._client_seq = {}
+    instance._dpop_privkey = None
+    instance._dpop_pubkey_jwk = None
+    instance._dpop_nonce = None
+    instance._egress_dpop_key = None
+    instance._egress_dpop_nonce = None
+    instance.server_role = None
+    instance.identity = None
+    instance._use_egress_for_sessions = use_egress
+    instance._proxy_agent_id = "acme::test-agent"
+    instance._proxy_org_id = "acme"
+    return instance
+
+
+class _RecordingHttp:
+    """Minimal httpx.Client stand-in: records the URL+method+kwargs of
+    each call and returns a 200 with a configurable JSON body."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+        self.responses: dict[str, Any] = {}  # method+path → JSON body
+        self.default_body: Any = {"status": "ok"}
+
+    def _resp(self, method: str, url: str, **kwargs) -> httpx.Response:
+        self.calls.append((method, url, kwargs))
+        body = self.responses.get(f"{method.upper()} {url}", self.default_body)
+        return httpx.Response(
+            200, json=body, request=httpx.Request(method.upper(), url),
+        )
+
+    def get(self, url, **kw): return self._resp("get", url, **kw)
+    def post(self, url, **kw): return self._resp("post", url, **kw)
+    def put(self, url, **kw): return self._resp("put", url, **kw)
+    def delete(self, url, **kw): return self._resp("delete", url, **kw)
+
+
+@pytest.fixture
+def disable_dpop_signing(monkeypatch):
+    """The egress path goes through ``proxy_headers`` which would try
+    to mint a DPoP proof — short-circuit it to a no-op for these
+    routing tests, since we only care about *which URL* gets hit."""
+    monkeypatch.setattr(
+        CullisClient, "proxy_headers", lambda self, method, url: {},
+    )
+
+
+# ── from_connector wires the flag to True ───────────────────────────
+
+
+def test_from_connector_sets_egress_routing_flag(tmp_path):
+    """The whole point of Finding #9: every Connector identity must
+    route session ops through the egress surface."""
+    identity = tmp_path / "identity"
+    identity.mkdir()
+    (identity / "metadata.json").write_text(
+        '{"agent_id":"acme::cullis","site_url":"http://fake-mastio.test"}'
+    )
+    client = CullisClient.from_connector(tmp_path, verify_tls=False)
+    assert client._use_egress_for_sessions is True
+
+
+def test_default_constructor_keeps_broker_routing():
+    """Direct-broker clients (no proxy) MUST keep talking to
+    /v1/broker/sessions — they have no proxy in front of them so the
+    egress paths don't exist on the wire."""
+    client = CullisClient(broker_url="https://broker.test", verify_tls=False)
+    assert client._use_egress_for_sessions is False
+
+
+# ── Egress path dispatch ─────────────────────────────────────────────
+
+
+def test_open_session_via_egress_uses_capabilities_field(disable_dpop_signing):
+    client = _make_client(use_egress=True)
+    client._http.responses["POST https://fake-mastio.test:9443/v1/egress/sessions"] = {
+        "session_id": "abc-123", "status": "opened",
+    }
+    sid = client.open_session("acme::peer", "acme", ["cap.read"])
+    assert sid == "abc-123"
+    method, url, kwargs = client._http.calls[-1]
+    assert method == "post"
+    assert url.endswith("/v1/egress/sessions")
+    body = kwargs["json"]
+    assert body == {
+        "target_agent_id": "acme::peer",
+        "target_org_id": "acme",
+        # Egress uses ``capabilities``, NOT ``requested_capabilities``.
+        "capabilities": ["cap.read"],
+    }
+
+
+def test_accept_session_via_egress(disable_dpop_signing):
+    client = _make_client(use_egress=True)
+    client.accept_session("abc-123")
+    method, url, _ = client._http.calls[-1]
+    assert method == "post"
+    assert url.endswith("/v1/egress/sessions/abc-123/accept")
+
+
+def test_close_session_via_egress(disable_dpop_signing):
+    client = _make_client(use_egress=True)
+    client.close_session("abc-123")
+    method, url, _ = client._http.calls[-1]
+    assert method == "post"
+    assert url.endswith("/v1/egress/sessions/abc-123/close")
+
+
+def test_reject_session_via_egress_folds_into_close(disable_dpop_signing):
+    """Egress has no /reject endpoint — the SDK folds reject → close so
+    the local store treats both terminal states equivalently."""
+    client = _make_client(use_egress=True)
+    client.reject_session("abc-123")
+    method, url, _ = client._http.calls[-1]
+    assert method == "post"
+    assert url.endswith("/v1/egress/sessions/abc-123/close")
+
+
+def test_list_sessions_via_egress_unwraps_payload(disable_dpop_signing):
+    client = _make_client(use_egress=True)
+    client._http.responses["GET https://fake-mastio.test:9443/v1/egress/sessions"] = {
+        "sessions": [
+            {"session_id": "s1", "status": "active",
+             "initiator_agent_id": "acme::a", "target_agent_id": "acme::b",
+             "capabilities": []},
+        ],
+    }
+    sessions = client.list_sessions(status="active")
+    assert len(sessions) == 1
+    assert sessions[0].session_id == "s1"
+    method, url, kwargs = client._http.calls[-1]
+    assert method == "get"
+    assert url.endswith("/v1/egress/sessions")
+    assert kwargs["params"] == {"status": "active"}
+
+
+def test_ack_message_via_egress(disable_dpop_signing):
+    """``ack_message`` on a proxy-bound client must use the egress
+    sessions/{id}/messages/{msg}/ack path (the same one
+    ``ack_via_proxy`` already used)."""
+    client = _make_client(use_egress=True)
+    # The egress ack returns 204; we patch the response shape.
+    def _post(url, **kw):
+        client._http.calls.append(("post", url, kw))
+        return httpx.Response(
+            204, request=httpx.Request("POST", url),
+        )
+    client._http.post = _post
+    ok = client.ack_message("abc-123", "msg-1")
+    assert ok is True
+    method, url, _ = client._http.calls[-1]
+    assert url.endswith("/v1/egress/sessions/abc-123/messages/msg-1/ack")
+
+
+# ── Broker path dispatch (regression guard for direct-broker SDKs) ──
+
+
+def test_open_session_direct_broker_uses_requested_capabilities():
+    """Pre-existing direct-broker SDKs MUST keep using the broker path
+    and the historical ``requested_capabilities`` field name. The flag
+    defaults to False so this is the default behaviour."""
+    client = _make_client(use_egress=False)
+    client._http.responses["POST https://fake-mastio.test:9443/v1/broker/sessions"] = {
+        "session_id": "abc-123", "status": "pending",
+    }
+    # Patch _authed_request because direct-broker uses it (DPoP/token).
+    captured: dict = {}
+
+    def _fake_authed(method, path, **kw):
+        captured["method"] = method
+        captured["path"] = path
+        captured["kwargs"] = kw
+        return httpx.Response(
+            200, json={"session_id": "abc-123", "status": "pending"},
+            request=httpx.Request(method, path),
+        )
+
+    client._authed_request = _fake_authed  # type: ignore[method-assign]
+    client.open_session("acme::peer", "acme", ["cap.read"])
+    assert captured["path"] == "/v1/broker/sessions"
+    body = captured["kwargs"]["json"]
+    assert body == {
+        "target_agent_id": "acme::peer",
+        "target_org_id": "acme",
+        "requested_capabilities": ["cap.read"],
+    }
+
+
+# ── Egress poll body unwrap ─────────────────────────────────────────
+
+
+def test_unwrap_egress_message_envelope_to_broker_shape():
+    """The egress GET /messages serialises the cipher dict to JSON
+    under ``payload_ciphertext`` — ``decrypt_payload`` expects it as a
+    dict under ``payload``. The unwrap helper must bridge them."""
+    egress_row = {
+        "msg_id": "m1",
+        "session_id": "s1",
+        "sender_agent_id": "acme::a",
+        "mode": "envelope",
+        "payload_ciphertext": '{"ciphertext":"abc","encrypted_key":"def","iv":"xyz"}',
+    }
+    out = CullisClient._unwrap_egress_message(egress_row, "s1")
+    assert out["payload"] == {"ciphertext": "abc", "encrypted_key": "def", "iv": "xyz"}
+    assert "payload_ciphertext" not in out
+
+
+def test_unwrap_egress_message_passes_mtls_only_through():
+    """mtls-only rows already carry ``payload`` as a dict — unwrap
+    must not touch them or crypto verifier downstream gets nothing
+    to decrypt against."""
+    row = {
+        "msg_id": "m1",
+        "session_id": "s1",
+        "sender_agent_id": "acme::a",
+        "mode": "mtls-only",
+        "payload": {"text": "hi"},
+        "signature": "sig",
+        "nonce": "n",
+        "timestamp": 1,
+    }
+    out = CullisClient._unwrap_egress_message(row, "s1")
+    assert out["payload"] == {"text": "hi"}
+    assert out["signature"] == "sig"
+
+
+def test_unwrap_egress_message_fills_in_session_id_when_missing():
+    """Some egress rows omit session_id; the SDK already knows it
+    (the caller passed it to ``poll``), so backfill it on the unwrap
+    path so ``decrypt_payload`` never sees ``session_id=''``."""
+    row = {"msg_id": "m1", "sender_agent_id": "x", "mode": "envelope"}
+    out = CullisClient._unwrap_egress_message(row, "s1-fallback")
+    assert out["session_id"] == "s1-fallback"


### PR DESCRIPTION
## Summary

Closes Finding #9 from the 2026-04-29 dogfood. ``client.open_session`` (and the rest of the session API) called ``/v1/broker/sessions*``, which the proxy reverse-proxy forwarder turned into a 503 whenever ``broker_url`` was ``None`` — i.e. **on every standalone Mastio**. The local mini-broker (``LocalSessionStore`` + ``local_messages`` + ``LocalConnectionManager``) was already wired and exposed at ``/v1/egress/sessions*``; the SDK just wasn't reaching it.

## Root cause

The broker paths predated ADR-001's intra-org proxy routing and never got migrated when the local store landed. ``send_oneshot`` already used the egress path (and worked in standalone), but session ops still pointed at the broker.

## What changed

Add ``_use_egress_for_sessions`` to ``CullisClient``. Every proxy-bound factory — ``from_connector``, ``from_enrollment``, ``from_identity_dir``, ``from_api_key_file`` — flips it to True so session calls now hit ``/v1/egress/sessions*``. The egress router already handles intra-org locally and falls through to the broker bridge for cross-org, so federation deploys keep working unchanged. Direct-broker SDKs (``CullisClient(broker_url=…)``) leave the flag at False and keep using ``/v1/broker/sessions``.

Methods adapted: open / accept / close / reject / list / send / poll / ack_message. Shape diffs handled at the SDK boundary so callers see no API change:

| Op | Diff handled |
|----|---|
| open | rename ``requested_capabilities`` → ``capabilities`` |
| reject | egress has no /reject; fold into /close |
| list | unwrap ``{\"sessions\": [...]}`` envelope |
| send | drop outer ``signature``/``nonce``/``timestamp``/``client_seq`` (mTLS to proxy gives transport integrity; ``inner_signature`` baked into the ciphertext still gives E2E non-repudiation). Body adds ``recipient_agent_id`` + ``mode: \"envelope\"``. |
| poll | unwrap ``{\"messages\": [...], \"count\": N, \"scope\": ...}`` + JSON-parse ``payload_ciphertext`` back into the dict shape ``decrypt_payload`` understands |
| ack_message | forwards to the existing ``ack_via_proxy`` |

## Test plan

- [x] 12 SDK-level routing tests pin every method against the correct URL + body shape, plus regression guards for direct-broker clients
- [x] ``pytest tests/test_proxy_local_sessions.py`` — existing 18 integration tests of /v1/egress/sessions* still pass (server side unchanged)
- [x] ``pytest tests/test_audit_r2_t2.py tests/test_audit_oneshot_envelope_integrity.py tests/test_m3_router_integration.py`` — 53 direct-broker tests still pass (regression check that ``_use_egress_for_sessions=False`` path is intact)
- [x] ``pytest tests/test_e2e.py`` — 10/10 pass
- [x] ``ruff check app/ agents/sdk.py tests/`` — clean
- [ ] Manual: open a session cullis → system on the dogfood VM, send messages, verify the use case from the dogfood memory (multi-turn problem-solving dialogue) actually works end-to-end