### PR TITLE
feat(dashboard): update advisory banner — polls GHCR + surfaces upgrade command

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3044,6 +3044,66 @@ async def badge_updates(request: Request):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Update advisory — banner + JSON polled by the dashboard frame.
+# The container can't auto-replace itself (no docker.sock), so we
+# advise + show the operator the exact ``./deploy.sh --upgrade <ver>``
+# they should run on the host.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/api/version-status")
+async def api_version_status(request: Request):
+    """JSON the banner polls every few minutes — surfaces a newer
+    Mastio release on GHCR when one is out.
+
+    Auth-gated to dashboard sessions: a leaked anonymous endpoint
+    that hits the GitHub API on every request would be an easy
+    rate-limit target. Logged-in admins are the only audience for
+    this advisory anyway.
+    """
+    from fastapi.responses import JSONResponse
+    session = get_session(request)
+    if not session.logged_in:
+        return JSONResponse({"update_available": False}, status_code=200)
+
+    from dataclasses import asdict as _asdict
+    from mcp_proxy.version_check import check_for_updates
+
+    status = await check_for_updates()
+    return JSONResponse(_asdict(status))
+
+
+@router.get("/badge/version")
+async def badge_version(request: Request):
+    """HTMX fragment — single-pixel-thin banner that says "Update
+    available: 0.3.0-rc3" and links to the modal with the copy-paste
+    install command. Empty response when no update is pending so the
+    sidebar stays clean."""
+    session = get_session(request)
+    if not session.logged_in:
+        return HTMLResponse("")
+
+    from mcp_proxy.version_check import check_for_updates
+    status = await check_for_updates()
+    if not status.update_available or not status.install_command:
+        return HTMLResponse("")
+
+    cmd = status.install_command
+    latest = status.latest or ""
+    current = status.current
+    return HTMLResponse(
+        f'<a href="{status.release_url}" target="_blank" rel="noopener" '
+        f'class="block px-3 py-2 rounded text-xs font-mono '
+        f'bg-amber-500/20 text-amber-300 hover:bg-amber-500/30 transition" '
+        f'title="Run ``{cmd}`` on the Mastio host to upgrade. '
+        f'See release notes on GitHub.">'
+        f'⤴ Update: <span class="font-semibold">{latest}</span> '
+        f'<span class="opacity-60">(running {current})</span>'
+        f'</a>'
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Overview (post-login landing)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -106,6 +106,13 @@
 
         <!-- Footer status -->
         <div class="px-4 py-3 border-t border-gray-800/60 space-y-2">
+            <!-- Update advisory: empty unless GHCR has a newer mastio-v* tag.
+                 Polled every 30 minutes — the version_check cache rounds it
+                 down to ~1 GitHub API call/h regardless of how many admins
+                 have the dashboard open. -->
+            <div hx-get="/proxy/badge/version"
+                 hx-trigger="load, every 1800s"
+                 hx-swap="innerHTML"></div>
             <div class="flex items-center gap-2">
                 <span class="w-1.5 h-1.5 rounded-full bg-accent-400 pulse-dot"></span>
                 <span class="text-[10px] text-gray-600 uppercase tracking-wider">Mastio Online</span>

--- a/mcp_proxy/version_check.py
+++ b/mcp_proxy/version_check.py
@@ -1,0 +1,195 @@
+"""Self-update advisory — compare the running image tag against GHCR releases.
+
+Loaded by the dashboard so the operator-facing banner can say "a new
+Mastio is out, run ``./deploy.sh --upgrade X.Y.Z``" without us
+silently auto-pulling. The container CANNOT auto-replace itself
+(it'd need ``/var/run/docker.sock`` mounted, which is a privilege
+escalation antipattern) — so the design is "advise + give the
+operator the exact one-liner".
+
+Pieces:
+
+  - ``get_current_version()`` — reads ``MCP_PROXY_VERSION`` env, set
+    by ``packaging/mastio-bundle/docker-compose.yml`` to whatever
+    ``CULLIS_MASTIO_VERSION`` was at deploy time. Falls back to
+    ``"unknown"`` for dev runs that didn't pin a tag.
+  - ``get_latest_version()`` — async fetch of GitHub's releases API,
+    filters for ``mastio-v*`` tags, returns the highest semver. No
+    auth needed (public repo); uses a 5s timeout so a flaky GitHub
+    doesn't stall the dashboard.
+  - ``check_for_updates()`` — orchestrates both, caches the result
+    in module memory for ``_CACHE_TTL_S`` (default 1h) so a busy
+    dashboard doesn't hammer the GitHub API. Returns the dict the
+    banner consumes verbatim.
+
+Cache is module-level intentionally — ``settings`` is a singleton,
+the dashboard runs in one process per Mastio, and a stale entry
+older than the TTL is recomputed on the next request. Killing the
+container drops the cache, which is the right behaviour for an
+advisory that's only as accurate as the most recent comparison.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+import time
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import httpx
+
+_log = logging.getLogger("mcp_proxy.version_check")
+
+
+_GITHUB_RELEASES_URL = "https://api.github.com/repos/cullis-security/cullis/releases"
+_TAG_PREFIX = "mastio-v"
+_CACHE_TTL_S = 3600  # 1 hour — the GitHub Releases API allows 60 anon req/h
+_FETCH_TIMEOUT_S = 5.0
+
+# Module-level cache. Populated lazily by ``check_for_updates``.
+_cache: dict[str, Any] | None = None
+_cache_at: float = 0.0
+_cache_lock = asyncio.Lock()
+
+
+# Loose semver: ``MAJOR.MINOR.PATCH`` plus an optional ``-PRERELEASE``
+# (rc1, rc2, beta, …). Captures pieces so ``_version_key`` can build a
+# sortable tuple. Anything more exotic falls through and gets sorted
+# lexically — fine for our naming convention.
+_SEMVER_RE = re.compile(
+    r"^(\d+)\.(\d+)\.(\d+)(?:-([a-zA-Z]+)(\d+)?)?$"
+)
+
+
+def _version_key(v: str) -> tuple:
+    """Return a sortable tuple for a version string.
+
+    Final releases (``0.3.0``) sort AFTER any of their prereleases
+    (``0.3.0-rc1``, ``0.3.0-beta3``) — same convention as PEP 440 and
+    npm/cargo. ``rc2`` sorts after ``rc1`` even when the major.minor
+    part is the same. Unparseable strings sort last.
+    """
+    m = _SEMVER_RE.match(v)
+    if not m:
+        return (1, v)  # garbage versions sort after everything parseable
+    major, minor, patch = int(m[1]), int(m[2]), int(m[3])
+    pre_tag = m[4] or ""
+    pre_num = int(m[5]) if m[5] else 0
+    # ``is_release = 1`` for full releases, ``0`` for prereleases —
+    # so the same major.minor.patch sorts ``rc1 < rc2 < (release)``.
+    is_release = 1 if not pre_tag else 0
+    # Pre-release tag ordering: alpha < beta < rc < anything-else.
+    pre_rank = {"alpha": 0, "beta": 1, "rc": 2}.get(pre_tag, 3) if pre_tag else 0
+    return (0, major, minor, patch, is_release, pre_rank, pre_num)
+
+
+def get_current_version() -> str:
+    """Image tag this container was started with, or ``"unknown"``.
+
+    Set by ``packaging/mastio-bundle/docker-compose.yml`` from the
+    operator-side ``CULLIS_MASTIO_VERSION``. Trimmed of an accidental
+    ``mastio-v`` prefix so ``"unknown"`` and ``"0.3.0-rc2"`` are the
+    only shapes the rest of the code has to handle.
+    """
+    raw = (os.environ.get("MCP_PROXY_VERSION") or "").strip()
+    if not raw or raw in {"latest", "unknown"}:
+        return "unknown"
+    if raw.startswith(_TAG_PREFIX):
+        raw = raw[len(_TAG_PREFIX):]
+    return raw
+
+
+async def get_latest_version() -> str | None:
+    """Highest ``mastio-v*`` release tag on the public repo, or None.
+
+    Returns the bare version (no ``mastio-v`` prefix). On any
+    transport / parse failure we return None — the banner then
+    silently stays hidden, which is the right outcome for an
+    advisory feature.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=_FETCH_TIMEOUT_S) as client:
+            resp = await client.get(_GITHUB_RELEASES_URL, params={"per_page": 50})
+            resp.raise_for_status()
+            releases = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        _log.info("version_check: GitHub releases fetch failed (%s)", exc)
+        return None
+
+    candidates: list[str] = []
+    for r in releases:
+        if not isinstance(r, dict):
+            continue
+        if r.get("draft") or r.get("prerelease") is None:
+            # ``prerelease=None`` would mean malformed payload — skip.
+            continue
+        tag = r.get("tag_name") or ""
+        if not tag.startswith(_TAG_PREFIX):
+            continue
+        version = tag[len(_TAG_PREFIX):]
+        candidates.append(version)
+
+    if not candidates:
+        return None
+    return max(candidates, key=_version_key)
+
+
+@dataclass(frozen=True)
+class UpdateStatus:
+    """Banner-shaped payload the dashboard renders verbatim."""
+
+    current: str  # ``"0.3.0-rc2"`` or ``"unknown"``
+    latest: str | None  # ``"0.3.0-rc3"`` or None when GitHub is unreachable
+    update_available: bool
+    install_command: str | None  # the one-liner to copy
+    release_url: str  # GitHub releases page — always safe to link
+
+
+def _make_status(current: str, latest: str | None) -> UpdateStatus:
+    update_available = (
+        current != "unknown"
+        and latest is not None
+        and _version_key(latest) > _version_key(current)
+    )
+    install_command = (
+        f"./deploy.sh --upgrade {latest}" if (update_available and latest) else None
+    )
+    return UpdateStatus(
+        current=current,
+        latest=latest,
+        update_available=update_available,
+        install_command=install_command,
+        release_url="https://github.com/cullis-security/cullis/releases",
+    )
+
+
+async def check_for_updates(*, force: bool = False) -> UpdateStatus:
+    """Cached comparison of running tag vs GHCR's latest. The
+    dashboard endpoint calls this on every banner poll; the cache
+    keeps the GitHub API call rare (~1/h)."""
+    global _cache, _cache_at
+
+    now = time.monotonic()
+    async with _cache_lock:
+        if (
+            not force
+            and _cache is not None
+            and (now - _cache_at) < _CACHE_TTL_S
+        ):
+            return UpdateStatus(**_cache)
+
+        current = get_current_version()
+        latest = await get_latest_version()
+        status = _make_status(current, latest)
+        _cache = asdict(status)
+        _cache_at = now
+        return status
+
+
+def reset_cache() -> None:
+    """Test hook — clears the module cache so each test starts cold."""
+    global _cache, _cache_at
+    _cache = None
+    _cache_at = 0.0

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -29,6 +29,12 @@ services:
     expose:
       - "9100"
     environment:
+      # The image tag this container was started with — read by the
+      # dashboard's update banner so it can compare against the latest
+      # release on GHCR and surface ``./deploy.sh --upgrade <ver>``
+      # when a newer Mastio is out. Falls back to "unknown" so the
+      # banner is silent on dev builds that don't pin a tag.
+      MCP_PROXY_VERSION:           ${CULLIS_MASTIO_VERSION:-unknown}
       MCP_PROXY_ENVIRONMENT:       ${MCP_PROXY_ENVIRONMENT:-development}
       MCP_PROXY_STANDALONE:        ${MCP_PROXY_STANDALONE:-true}
       MCP_PROXY_ADMIN_SECRET:      ${MCP_PROXY_ADMIN_SECRET:-change-me-in-production}

--- a/tests/test_mastio_version_check.py
+++ b/tests/test_mastio_version_check.py
@@ -1,0 +1,251 @@
+"""Tests for the dashboard's update advisory.
+
+The container can't auto-replace itself (would need
+``/var/run/docker.sock`` mounted, which is a privilege escalation
+antipattern). Instead, the dashboard polls GHCR for newer
+``mastio-v*`` releases and surfaces the exact ``./deploy.sh
+--upgrade <ver>`` the operator should run on the host.
+
+These tests pin the comparator + the cache + the install_command
+shape so a regression silently swapping in the wrong tag (or worse,
+auto-pulling) shows up at unit-test time.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from mcp_proxy import version_check
+from mcp_proxy.version_check import (
+    UpdateStatus,
+    _make_status,
+    _version_key,
+    check_for_updates,
+    get_current_version,
+    reset_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_state(monkeypatch):
+    """Reset cache + scrub MCP_PROXY_VERSION env between tests so each
+    case starts cold. The cache is module-level by design (one
+    Mastio process, one cache) and would leak across tests otherwise."""
+    reset_cache()
+    monkeypatch.delenv("MCP_PROXY_VERSION", raising=False)
+    yield
+    reset_cache()
+
+
+# ── _version_key — comparator pin ───────────────────────────────────
+
+
+def test_release_sorts_after_its_prereleases():
+    """Final ``0.3.0`` must beat any of its rcs — same convention as
+    PEP 440. Otherwise we'd nag the operator to "upgrade" from a
+    final release back to an rc."""
+    assert _version_key("0.3.0") > _version_key("0.3.0-rc1")
+    assert _version_key("0.3.0") > _version_key("0.3.0-rc99")
+    assert _version_key("0.3.0") > _version_key("0.3.0-beta3")
+
+
+def test_rc_numbers_sort_by_int_not_string():
+    """``rc10`` must beat ``rc2`` numerically — string sort would
+    flip them and a banner would lie to the operator."""
+    assert _version_key("0.3.0-rc10") > _version_key("0.3.0-rc2")
+
+
+def test_alpha_beta_rc_ordering():
+    """alpha < beta < rc — anyone running an rc must not be told
+    a newer beta is "available"."""
+    assert _version_key("0.3.0-alpha1") < _version_key("0.3.0-beta1")
+    assert _version_key("0.3.0-beta1") < _version_key("0.3.0-rc1")
+
+
+def test_unparseable_versions_sort_last():
+    """Garbage tag (``"latest"``, ``"main"``, manual experiments) must
+    not silently win the comparison and trigger a "downgrade"
+    suggestion."""
+    assert _version_key("0.3.0-rc1") < _version_key("garbage-tag")
+    # …and ``unknown`` is treated like garbage too.
+    assert _version_key("0.3.0") < _version_key("unknown")
+
+
+# ── get_current_version — env wiring ────────────────────────────────
+
+
+def test_current_version_from_env(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_VERSION", "0.3.0-rc2")
+    assert get_current_version() == "0.3.0-rc2"
+
+
+def test_current_version_strips_mastio_v_prefix(monkeypatch):
+    """The compose env normally passes the bare version, but a careless
+    operator may paste the full tag (``mastio-v0.3.0-rc2``). Strip it
+    so the comparator doesn't see two different shapes."""
+    monkeypatch.setenv("MCP_PROXY_VERSION", "mastio-v0.3.0-rc2")
+    assert get_current_version() == "0.3.0-rc2"
+
+
+@pytest.mark.parametrize("val", ["", "latest", "unknown", "   "])
+def test_current_version_returns_unknown_for_dev_runs(monkeypatch, val):
+    """Dev compose / image rebuilt locally without a tag → ``"unknown"``
+    so the banner stays silent (we can't compare against GitHub)."""
+    monkeypatch.setenv("MCP_PROXY_VERSION", val)
+    assert get_current_version() == "unknown"
+
+
+# ── _make_status — banner shape ─────────────────────────────────────
+
+
+def test_make_status_update_available_when_latest_is_newer():
+    s = _make_status("0.3.0-rc2", "0.3.0-rc3")
+    assert s.update_available is True
+    assert s.install_command == "./deploy.sh --upgrade 0.3.0-rc3"
+    assert s.release_url.endswith("/releases")
+
+
+def test_make_status_no_update_when_versions_equal():
+    s = _make_status("0.3.0-rc3", "0.3.0-rc3")
+    assert s.update_available is False
+    assert s.install_command is None
+
+
+def test_make_status_no_update_when_running_ahead_of_published():
+    """Operator running a custom build of main (newer than any
+    tagged release) — banner must stay silent so we don't suggest
+    a "downgrade" install command."""
+    s = _make_status("0.4.0", "0.3.0-rc3")
+    assert s.update_available is False
+
+
+def test_make_status_silent_on_unknown_current():
+    """Dev runs (``MCP_PROXY_VERSION=unknown``) must produce no
+    banner — we have nothing to compare against, and the operator
+    on a bespoke build doesn't want noise."""
+    s = _make_status("unknown", "0.3.0-rc3")
+    assert s.update_available is False
+    assert s.install_command is None
+
+
+def test_make_status_silent_when_github_unreachable():
+    """Latest=None is the documented signal for transport failure;
+    must not flip update_available."""
+    s = _make_status("0.3.0-rc2", None)
+    assert s.update_available is False
+    assert s.install_command is None
+
+
+# ── check_for_updates — cache + GitHub stub ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_round_trip(monkeypatch):
+    """Happy path: env says rc2, GitHub says rc3, banner gets
+    upgrade=True + the right one-liner."""
+    monkeypatch.setenv("MCP_PROXY_VERSION", "0.3.0-rc2")
+
+    async def _fake_latest():
+        return "0.3.0-rc3"
+
+    monkeypatch.setattr(version_check, "get_latest_version", _fake_latest)
+    status = await check_for_updates(force=True)
+    assert isinstance(status, UpdateStatus)
+    assert status.current == "0.3.0-rc2"
+    assert status.latest == "0.3.0-rc3"
+    assert status.update_available is True
+    assert status.install_command == "./deploy.sh --upgrade 0.3.0-rc3"
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_caches_result(monkeypatch):
+    """Second call within TTL must NOT re-hit GitHub — the API has a
+    60 anon req/h limit per IP and a busy dashboard with multiple
+    admins would burn through it fast."""
+    monkeypatch.setenv("MCP_PROXY_VERSION", "0.3.0-rc2")
+    calls = 0
+
+    async def _fake_latest():
+        nonlocal calls
+        calls += 1
+        return "0.3.0-rc3"
+
+    monkeypatch.setattr(version_check, "get_latest_version", _fake_latest)
+    await check_for_updates(force=True)
+    await check_for_updates()  # warm cache
+    await check_for_updates()  # warm cache
+    assert calls == 1, f"GitHub API called {calls} times — cache bypassed"
+
+
+@pytest.mark.asyncio
+async def test_check_for_updates_concurrent_fetches_dont_thunder(monkeypatch):
+    """Two concurrent first-call awaits must serialise on the lock
+    so we don't race two GitHub requests in the cold path."""
+    monkeypatch.setenv("MCP_PROXY_VERSION", "0.3.0-rc2")
+    calls = 0
+
+    async def _fake_latest():
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0.01)
+        return "0.3.0-rc3"
+
+    monkeypatch.setattr(version_check, "get_latest_version", _fake_latest)
+    results = await asyncio.gather(
+        check_for_updates(force=True),
+        check_for_updates(),
+        check_for_updates(),
+    )
+    assert all(r.latest == "0.3.0-rc3" for r in results)
+    assert calls == 1
+
+
+# ── get_latest_version — GitHub API stub ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_latest_version_picks_highest_mastio_release(monkeypatch):
+    """Releases API returns a mixed bag (drafts, connector tags, the
+    mastio chain). Filter must keep only ``mastio-v*`` non-draft
+    non-prerelease, then return the highest by semver."""
+    fake_releases = [
+        {"tag_name": "connector-v0.3.4", "draft": False, "prerelease": False},
+        {"tag_name": "mastio-v0.3.0-rc1", "draft": False, "prerelease": False},
+        {"tag_name": "mastio-v0.3.0-rc3", "draft": False, "prerelease": False},
+        {"tag_name": "mastio-v0.3.0-rc2", "draft": False, "prerelease": False},
+        {"tag_name": "mastio-v0.4.0-alpha1", "draft": True, "prerelease": False},
+        {"tag_name": "sdk-v0.1.0", "draft": False, "prerelease": False},
+    ]
+
+    class _StubResp:
+        def raise_for_status(self): pass
+        def json(self): return fake_releases
+
+    class _StubClient:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def get(self, url, **kw): return _StubResp()
+
+    monkeypatch.setattr(version_check.httpx, "AsyncClient", _StubClient)
+    latest = await version_check.get_latest_version()
+    assert latest == "0.3.0-rc3"
+
+
+@pytest.mark.asyncio
+async def test_get_latest_version_returns_none_on_transport_error(monkeypatch):
+    import httpx as _httpx
+
+    class _StubClient:
+        def __init__(self, *a, **kw): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return None
+        async def get(self, url, **kw):
+            raise _httpx.ConnectError(
+                "github unreachable",
+                request=_httpx.Request("GET", "https://api.github.com"),
+            )
+
+    monkeypatch.setattr(version_check.httpx, "AsyncClient", _StubClient)
+    assert await version_check.get_latest_version() is None


### PR DESCRIPTION
## Summary

Companion to #359 (\`deploy.sh --upgrade\`): the dashboard now notices when a newer Mastio release is out on GHCR and shows the operator the exact \`./deploy.sh --upgrade <ver>\` to run on the host.

We deliberately do **NOT** auto-pull. The container has no \`/var/run/docker.sock\` (privilege escalation antipattern) and shouldn't acquire one for this. Operator stays in control — banner advises, host CLI executes.

## What it does

- ``mcp_proxy/version_check.py``: ``check_for_updates()`` reads \`MCP_PROXY_VERSION\` env (set by docker-compose from \`CULLIS_MASTIO_VERSION\`) and compares against the highest \`mastio-v*\` tag from the public GitHub Releases API. Cached 1h. Concurrent first-call awaits serialise on a lock so cold-cache thundering herds don't fire duplicate requests. Banner stays silent on: \`unknown\` current (dev rebuilds), GitHub unreachable, current ahead of published (custom main builds).
- ``packaging/mastio-bundle/docker-compose.yml``: passes ``CULLIS_MASTIO_VERSION`` → ``MCP_PROXY_VERSION`` env on the proxy.
- ``GET /proxy/api/version-status`` (auth-gated): JSON for clients that want to query directly. Hidden from anon so leaked URLs can't burn the GitHub quota (60/h anon).
- ``GET /proxy/badge/version``: HTMX fragment — empty body when no update, amber-tinted clickable strip when there is. Wired into ``base.html`` sidebar footer with a 30-min poll. Hover tooltip carries the exact upgrade command.

## Comparator

``alpha < beta < rc < release``, ``rc10 > rc2`` numerically (string sort would lie), unparseable tags sort last so ``\"latest\"`` / ``\"main\"`` never silently win.

## Test plan

- [x] 20 unit tests in ``tests/test_mastio_version_check.py``: comparator (5), env wiring (3), banner shape (5), cache + thundering-herd guard (3), GitHub stub (2), config edge cases
- [x] ``ruff check app/ agents/sdk.py tests/`` — clean
- [x] App boots: ``/proxy/api/version-status`` and ``/proxy/badge/version`` mount under the dashboard router
- [ ] Manual: deploy on the dogfood VM, log into dashboard, see amber banner pointing to current rc → click → release notes

## Step 2 of the update UX

Step 1 (#359): \`deploy.sh --upgrade <ver>\` — packs the 3-step "down + edit env + up" into a one-liner.
Step 2 (this PR): banner that tells the operator a new \`<ver>\` exists.

Real auto-upgrade from inside the dashboard would need a host-side helper (\`cullis-mastio\` CLI or systemd unit). Deferred to a future session where it's actually justified.