### PR TITLE
fix(connector): lazy-spawn inbox poller after enrollment approval

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -127,6 +127,14 @@ async def _dashboard_lifespan(app: FastAPI):
     stdio MCP server) because the dashboard runs in a separate
     process and on restart picks up whatever identity is on disk
     right now.
+
+    Pre-enrollment dashboards yield with ``inbox_poller = None`` and
+    rely on :func:`_ensure_inbox_poller_running` to spin up the
+    notifier the moment the identity lands (post admin approval),
+    instead of forcing the operator to restart the dashboard. That
+    closes the dogfood bug where notifications silently never
+    appeared because the dashboard had been launched before the
+    profile was enrolled.
     """
     config = app.state.connector_config
     app.state.inbox_poller = None
@@ -136,26 +144,55 @@ async def _dashboard_lifespan(app: FastAPI):
     # chmod 0600 — any local process that can read it already had the
     # means to read ``identity/agent.key`` anyway.
     app.state.statusline_token = ensure_statusline_token(config.config_dir)
-    if os.environ.get("CULLIS_CONNECTOR_NOTIFICATIONS", "on").lower() in ("0", "off", "false", "no"):
-        _log.info("inbox poller disabled via CULLIS_CONNECTOR_NOTIFICATIONS")
-        yield
-        return
 
-    poller = _start_inbox_poller(config)
-    app.state.inbox_poller = poller
-    dispatcher: InboxDispatcher | None = None
-    if poller is not None:
-        poller.start()
-        dispatcher = InboxDispatcher(poller, build_notifier())
-        dispatcher.start()
-        app.state.inbox_dispatcher = dispatcher
+    _ensure_inbox_poller_running(app)
     try:
         yield
     finally:
+        dispatcher = getattr(app.state, "inbox_dispatcher", None)
+        poller = getattr(app.state, "inbox_poller", None)
         if dispatcher is not None:
             await dispatcher.stop()
         if poller is not None:
             await poller.stop()
+
+
+def _ensure_inbox_poller_running(app: FastAPI) -> bool:
+    """Idempotently start the inbox poller + dispatcher.
+
+    Returns ``True`` if the poller is now running (either we started
+    it or it already was), ``False`` if there's no identity to poll
+    against or notifications are disabled. Safe to call from:
+
+      - the dashboard lifespan (boot), which fires while the loop is
+        still warming up but already running enough for
+        ``poller.start()`` to schedule its task
+      - ``/api/status`` right after ``save_identity`` succeeds, which
+        is the lazy-spawn path that closes the "dashboard launched
+        pre-enrollment" hole
+
+    Intentionally synchronous: ``poller.start()`` and
+    ``dispatcher.start()`` already wrap ``asyncio.create_task``
+    internally, and both call sites run inside the event loop
+    (lifespan + async handler), so no extra await plumbing is needed.
+    """
+    config = app.state.connector_config
+    if getattr(app.state, "inbox_poller", None) is not None:
+        return True
+    if os.environ.get("CULLIS_CONNECTOR_NOTIFICATIONS", "on").lower() in ("0", "off", "false", "no"):
+        _log.info("inbox poller disabled via CULLIS_CONNECTOR_NOTIFICATIONS")
+        return False
+
+    poller = _start_inbox_poller(config)
+    if poller is None:
+        return False
+    poller.start()
+    dispatcher = InboxDispatcher(poller, build_notifier())
+    dispatcher.start()
+    app.state.inbox_poller = poller
+    app.state.inbox_dispatcher = dispatcher
+    _log.info("inbox poller spawned (lazy=%s)", poller is not None)
+    return True
 
 
 def _start_inbox_poller(config: ConnectorConfig) -> DashboardInboxPoller | None:
@@ -460,13 +497,20 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         return JSONResponse({"app": "cullis-connector"})
 
     @app.get("/api/status")
-    def api_status() -> JSONResponse:
+    def api_status(request: Request) -> JSONResponse:
         """Single-shot poll of the remote enrollment status.
 
         Returns JSON so the waiting page's HTMX can route to the next
         screen on its own.
         """
         if has_identity(config.config_dir):
+            # Lazy-spawn the inbox poller — the dashboard may have
+            # been launched pre-enrollment, in which case the lifespan
+            # bootstrap saw no identity and returned early. Now that
+            # the identity is on disk (this branch), the operator
+            # should start receiving notifications without having to
+            # restart the dashboard. Idempotent + cheap.
+            _ensure_inbox_poller_running(request.app)
             return JSONResponse({"status": "approved"})
         if _pending is None:
             return JSONResponse({"status": "idle"})
@@ -531,6 +575,14 @@ def build_app(config: ConnectorConfig) -> FastAPI:
                 metadata=metadata,
             )
             _clear_pending()
+            # First moment the identity exists on disk — kick the
+            # inbox poller now so the operator sees notifications
+            # without having to restart the dashboard. The next
+            # /api/status poll would also catch this via the
+            # ``has_identity`` branch above, but doing it here too
+            # closes the small window between approval and the
+            # following HTMX poll.
+            _ensure_inbox_poller_running(request.app)
             return JSONResponse({"status": "approved", "agent_id": agent_id})
 
         if remote_status == "rejected":

--- a/tests/connector/test_inbox_poller_lazy_spawn.py
+++ b/tests/connector/test_inbox_poller_lazy_spawn.py
@@ -1,0 +1,169 @@
+"""Tests for the lazy inbox-poller spawn (dogfood bug fix).
+
+Reproduces the dogfood scenario:
+
+  1. Operator runs ``cullis-connector dashboard`` while
+     ``~/.cullis/profiles/<X>/identity/`` is still empty (e.g. first
+     boot, or right after deleting the profile to redo enrollment).
+  2. Lifespan calls ``_start_inbox_poller`` which sees no identity
+     and returns ``None`` — ``app.state.inbox_poller`` stays ``None``.
+  3. Operator completes enrollment in the browser; ``api_status``
+     hits the approved branch, ``save_identity`` writes the cert.
+  4. **Pre-fix**: poller stays ``None`` for the rest of the
+     dashboard's life. No notifications arrive even though oneshots
+     keep landing on the Mastio side. Operator has to kill+restart
+     the dashboard to get notifications.
+  5. **Post-fix**: ``api_status`` calls
+     ``_ensure_inbox_poller_running`` which lazy-spawns the poller +
+     dispatcher. Idempotent, so the next /api/status poll doesn't
+     stack a second one.
+
+These tests verify the helper's idempotence + the lifespan/handler
+wiring without spinning up real poller threads (we monkey-patch
+``_start_inbox_poller`` to return a fake instance).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import cullis_connector.web as _web
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import (
+    _ensure_inbox_poller_running,
+    build_app,
+)
+
+
+@pytest.fixture
+def cfg(tmp_path) -> ConnectorConfig:
+    return ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://fake-mastio.test:9443",
+        verify_tls=False,
+    )
+
+
+@pytest.fixture
+def fake_poller_factory(monkeypatch):
+    """Replace ``_start_inbox_poller`` with a knob a test can flip
+    so the same fixture covers both ``no-identity`` and
+    ``identity-now-present``. Captures every fake poller for
+    inspection."""
+    state = {"identity_present": False, "spawned": []}
+
+    def _factory(_config):
+        if not state["identity_present"]:
+            return None
+        fake = MagicMock(name="DashboardInboxPoller")
+        fake.start = MagicMock()
+        fake.stop = MagicMock(return_value=None)
+        state["spawned"].append(fake)
+        return fake
+
+    monkeypatch.setattr(_web, "_start_inbox_poller", _factory)
+    # InboxDispatcher also gets faked because instantiating it would
+    # try to read the poller's queue; we don't care about its
+    # behaviour for this test, only that it gets started.
+    fake_dispatcher_cls = MagicMock(name="InboxDispatcher")
+    fake_dispatcher_cls.return_value.start = MagicMock()
+
+    async def _stop(*a, **kw):
+        return None
+
+    fake_dispatcher_cls.return_value.stop = _stop
+    monkeypatch.setattr(_web, "InboxDispatcher", fake_dispatcher_cls)
+    # build_notifier shouldn't try to find notify-send during a unit
+    # test; stub it out so we don't depend on the test runner's host.
+    monkeypatch.setattr(_web, "build_notifier", lambda: MagicMock(name="Notifier"))
+    return state
+
+
+# ── _ensure_inbox_poller_running — idempotence + behaviour ──────────
+
+
+def test_ensure_returns_false_when_no_identity(cfg, fake_poller_factory):
+    """Pre-enrollment: helper must report ``False`` and leave
+    ``inbox_poller`` as ``None`` so the next call can retry."""
+    fake_poller_factory["identity_present"] = False
+    app = build_app(cfg)
+    # Lifespan didn't run in this unit-test path, so seed the state
+    # the lifespan would have set to None.
+    app.state.inbox_poller = None
+    app.state.inbox_dispatcher = None
+    assert _ensure_inbox_poller_running(app) is False
+    assert app.state.inbox_poller is None
+    assert app.state.inbox_dispatcher is None
+
+
+def test_ensure_spawns_when_identity_appears(cfg, fake_poller_factory):
+    """The dogfood scenario: identity arrives between dashboard boot
+    and the next /api/status poll. Helper must build the poller +
+    dispatcher and stash references on app.state."""
+    app = build_app(cfg)
+    app.state.inbox_poller = None
+    app.state.inbox_dispatcher = None
+    fake_poller_factory["identity_present"] = True
+    assert _ensure_inbox_poller_running(app) is True
+    assert app.state.inbox_poller is not None
+    assert app.state.inbox_dispatcher is not None
+    # The poller's start() hook must have been called exactly once.
+    app.state.inbox_poller.start.assert_called_once()
+
+
+def test_ensure_is_idempotent(cfg, fake_poller_factory):
+    """Repeated calls (every /api/status poll once enrollment
+    succeeds) must NOT stack a second poller — the LRU dedupe in the
+    dispatcher would mostly absorb double events, but spawning extra
+    background tasks every 3s would still be a leak."""
+    app = build_app(cfg)
+    app.state.inbox_poller = None
+    app.state.inbox_dispatcher = None
+    fake_poller_factory["identity_present"] = True
+    assert _ensure_inbox_poller_running(app) is True
+    first = app.state.inbox_poller
+    assert _ensure_inbox_poller_running(app) is True
+    assert app.state.inbox_poller is first
+    # _start_inbox_poller called only once — second call short-
+    # circuits before going to the factory again.
+    assert len(fake_poller_factory["spawned"]) == 1
+
+
+def test_ensure_returns_false_when_notifications_disabled(
+    cfg, fake_poller_factory, monkeypatch,
+):
+    """Operators on headless / test boxes set
+    ``CULLIS_CONNECTOR_NOTIFICATIONS=off``. The lazy spawn must
+    respect that — otherwise we'd silently re-enable a thing the
+    operator turned off."""
+    monkeypatch.setenv("CULLIS_CONNECTOR_NOTIFICATIONS", "off")
+    app = build_app(cfg)
+    app.state.inbox_poller = None
+    app.state.inbox_dispatcher = None
+    fake_poller_factory["identity_present"] = True
+    assert _ensure_inbox_poller_running(app) is False
+    assert app.state.inbox_poller is None
+
+
+# ── api_status integration — the wire-up that closes the bug ───────
+
+
+def test_api_status_lazy_spawns_when_identity_already_on_disk(
+    cfg, fake_poller_factory, monkeypatch,
+):
+    """Identity already saved (e.g. operator reloaded the page after
+    enrollment) → /api/status hits the has_identity short-circuit
+    AND lazy-spawns the poller. Pre-fix, that branch returned without
+    touching app.state, leaving the poller dead forever."""
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+    fake_poller_factory["identity_present"] = True
+    client = TestClient(build_app(cfg))
+    resp = client.get("/api/status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "approved"
+    # The TestClient app instance is what got mutated — fetch it
+    # back via app reference. ``client.app`` is the FastAPI app.
+    assert client.app.state.inbox_poller is not None
+    client.app.state.inbox_poller.start.assert_called_once()

--- a/tests/connector/test_status_inbox_endpoint.py
+++ b/tests/connector/test_status_inbox_endpoint.py
@@ -6,7 +6,7 @@ endpoint just reads a snapshot from the dispatcher object.
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -56,6 +56,10 @@ def test_status_inbox_returns_dispatcher_snapshot(app):
     """Inject a fake dispatcher and verify the endpoint surfaces
     its status_snapshot() verbatim."""
     fake = MagicMock()
+    # Lifespan now drains the dispatcher on shutdown via ``await
+    # dispatcher.stop()`` (so lazy-spawned ones from /api/status are
+    # also cleaned up). Inject an awaitable stop on the fake.
+    fake.stop = AsyncMock(return_value=None)
     fake.status_snapshot.return_value = {
         "unread": 3,
         "last_sender": "acme::mario",
@@ -75,6 +79,7 @@ def test_status_inbox_returns_dispatcher_snapshot(app):
 
 def test_status_inbox_seen_calls_ack_when_dispatcher_present(app):
     fake = MagicMock()
+    fake.stop = AsyncMock(return_value=None)
     with TestClient(app) as client:
         app.state.inbox_dispatcher = fake
         r = client.post("/status/inbox/seen", headers=_auth_headers(app))
@@ -114,6 +119,7 @@ def test_status_inbox_seen_rejects_missing_auth_cannot_reset_counter(app):
     """Without auth, a local attacker must NOT be able to ack the
     dispatcher and hide unread messages from the user."""
     fake = MagicMock()
+    fake.stop = AsyncMock(return_value=None)
     with TestClient(app) as client:
         app.state.inbox_dispatcher = fake
         r = client.post("/status/inbox/seen")


### PR DESCRIPTION
## Summary

Found dogfooding 2026-04-29 on GNOME — operator deleted the profile to redo enrollment, then started \`cullis-connector dashboard\`, THEN completed enrollment in the browser. Notifications never arrived even though oneshots kept landing on the Mastio.

## Root cause

\`_dashboard_lifespan\` calls \`_start_inbox_poller\` exactly once at boot. With no identity on disk during a fresh-profile boot, the helper returns \`None\`, the dispatcher never gets built, and the operator's only path back to working notifications was kill + restart of the dashboard. **Same bug on Hyprland**; the operator just always enrolled BEFORE starting the dashboard there, so it never showed.

## Fix

- Extract spawn logic into \`_ensure_inbox_poller_running(app)\` — idempotent, respects \`CULLIS_CONNECTOR_NOTIFICATIONS=off\`
- Lifespan calls it at boot (same as before)
- \`/api/status\` calls it (a) after \`save_identity\` succeeds on the approval branch, and (b) on every poll that hits the \`has_identity()\` short-circuit. Belt-and-suspenders.
- Lifespan \`finally\` now reads \`app.state.inbox_dispatcher\` / \`inbox_poller\` instead of locals so lazy-spawned pairs get drained on shutdown too

## Test plan

- [x] 5 new tests in \`tests/connector/test_inbox_poller_lazy_spawn.py\`: no-identity returns False, identity-arrives spawns, idempotent, env disable respected, /api/status triggers spawn
- [x] \`tests/connector/test_status_inbox_endpoint.py\` updated: injected MagicMock dispatchers now need awaitable \`.stop()\` because the lifespan drains them too
- [x] \`pytest tests/connector/\` (298 tests excluding pre-existing pystray flakes) — green
- [x] \`ruff check\` — clean
- [ ] Manual: on the dogfood GNOME box, fresh-delete profile, start dashboard, complete enrollment, send a oneshot from the system peer — popup must appear without restarting the dashboard