### PR TITLE
fix(mastio): deploy.sh --upgrade must compose down before pre-flight

### DIFF
--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -233,6 +233,14 @@ if [[ -n "$UPGRADE_TO" ]]; then
     ok "proxy.env: CULLIS_MASTIO_VERSION=${UPGRADE_TO}"
     # Export so this very run sees the new pin without a re-source.
     export CULLIS_MASTIO_VERSION="$UPGRADE_TO"
+    # Stop the running stack BEFORE the port pre-flight below — without
+    # this, the port-9443 check sees our own existing nginx sidecar
+    # bound to it and refuses to continue. Volumes (DB + mastio-nginx
+    # certs) are preserved by ``compose down``, so the upgrade comes
+    # back up with the same Org CA + admin secret + enrolled agents.
+    $COMPOSE $COMPOSE_FILES --env-file proxy.env down 2>/dev/null \
+        || $COMPOSE $COMPOSE_FILES down
+    ok "Stopped existing stack — preparing rc${UPGRADE_TO} bring-up"
 fi
 
 # ── Pre-flight: host port not already in use ───────────────────────────────


### PR DESCRIPTION
## Summary

Found dogfooding rc3 the moment the image landed on GHCR: the \`--upgrade\` path shipped in #359 doesn't actually complete because the host port pre-flight refuses to start when 9443 is "already in use" — and the thing using it is **our own running mastio-nginx sidecar** from the previous tag.

\`./deploy.sh --upgrade 0.3.0-rc3\` errored with \`Refusing to start — fix the port conflict first.\` and I had to fall back to the old three-step workaround (\`--down\` then \`--pull\`). Exactly the friction --upgrade was supposed to remove.

## Fix

Add the missing \`compose down\` to the \`--upgrade\` branch, before the port pre-flight. Volumes (\`mcp_proxy_data\` DB, \`mastio_nginx_certs\` leaf+CA) are preserved by compose-down so the new image comes up with the same admin secret, enrolled agents, and TLS material.

Pre-flight stays in place so an unrelated service blocking 9443 on a non-upgrade run still gets the clear message.

## Test plan

- [x] \`bash -n deploy.sh\` — syntax clean
- [x] Manual: pulled rc3 image, ran the workaround successfully — proves the volumes survive compose-down + the rest of the upgrade flow works once the port is freed
- [ ] Next dogfood rc4 → ``./deploy.sh --upgrade 0.3.0-rc4`` should now actually work end-to-end