### PR TITLE
fix(connector): save_identity preserves TOFU-pinned ca-chain.pem

### DIFF
--- a/cullis_connector/identity/store.py
+++ b/cullis_connector/identity/store.py
@@ -126,11 +126,18 @@ def save_identity(
         _write_atomic(
             identity_dir / CA_CHAIN_FILENAME, ca_chain_pem.encode(), mode=0o644
         )
-    else:
-        # Remove any stale chain so later loads don't mis-represent trust.
-        chain = identity_dir / CA_CHAIN_FILENAME
-        if chain.exists():
-            chain.unlink()
+    # Note: when ``ca_chain_pem`` is ``None`` we deliberately leave the
+    # file alone. ADR-015 introduced TOFU pinning, which writes
+    # ``ca-chain.pem`` from the dashboard's /setup/pin-ca handler
+    # BEFORE the enrollment exchange. The earlier "cleanup stale
+    # chain" branch here was deleting the operator-pinned PEM the
+    # moment ``api_status`` called ``save_identity`` post-approval,
+    # leaving the SDK's proxy http client with no trust store and
+    # every authenticated egress call failing
+    # CERTIFICATE_VERIFY_FAILED. If a caller actually needs to clear
+    # a stale chain, ``wipe_identity`` (full profile reset) is the
+    # right tool — save_identity must not be destructive on a field
+    # it didn't receive.
 
     _write_atomic(
         identity_dir / METADATA_FILENAME,

--- a/tests/connector/test_identity_store.py
+++ b/tests/connector/test_identity_store.py
@@ -111,7 +111,9 @@ def test_load_missing_identity_raises(tmp_path: Path):
         load_identity(tmp_path)
 
 
-def test_save_overwrites_stale_ca_chain(tmp_path: Path):
+def test_save_overwrites_chain_when_explicit_value_supplied(tmp_path: Path):
+    """When the caller passes a NEW ``ca_chain_pem`` value, the file
+    must be replaced (rotation path)."""
     key = generate_keypair()
     cert_pem = _self_signed_cert_pem(key)
     metadata = IdentityMetadata(
@@ -125,17 +127,51 @@ def test_save_overwrites_stale_ca_chain(tmp_path: Path):
         ca_chain_pem="chain-v1",
         metadata=metadata,
     )
-    assert (tmp_path / "identity" / CA_CHAIN_FILENAME).exists()
+    assert (tmp_path / "identity" / CA_CHAIN_FILENAME).read_text() == "chain-v1"
 
-    # Second save without chain must delete the stale file.
     save_identity(
         config_dir=tmp_path,
         cert_pem=cert_pem,
         private_key=key,
-        ca_chain_pem=None,
+        ca_chain_pem="chain-v2",
         metadata=metadata,
     )
-    assert not (tmp_path / "identity" / CA_CHAIN_FILENAME).exists()
+    assert (tmp_path / "identity" / CA_CHAIN_FILENAME).read_text() == "chain-v2"
+
+
+def test_save_preserves_tofu_pinned_chain_when_arg_is_none(tmp_path: Path):
+    """ADR-015 dogfood bug: the dashboard's /setup/pin-ca handler
+    writes ``ca-chain.pem`` BEFORE the enrollment exchange (TOFU
+    flow). ``api_status`` then calls ``save_identity(ca_chain_pem=
+    None)`` after admin approval — historically that would delete
+    the operator-pinned PEM, leaving the SDK with no trust store
+    and every authenticated egress call failing
+    CERTIFICATE_VERIFY_FAILED.
+
+    Pin the new contract: when the caller passes ``None``, we leave
+    whatever's on disk alone. Cleanup is the responsibility of a
+    full profile wipe, not save_identity."""
+    key = generate_keypair()
+    cert_pem = _self_signed_cert_pem(key)
+    metadata = IdentityMetadata(
+        agent_id="x", capabilities=[], site_url="", issued_at=""
+    )
+
+    # Simulate the dashboard pin: write the file before any save.
+    (tmp_path / "identity").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "identity" / CA_CHAIN_FILENAME).write_text("tofu-pinned-pem")
+
+    save_identity(
+        config_dir=tmp_path,
+        cert_pem=cert_pem,
+        private_key=key,
+        ca_chain_pem=None,  # post-approval path
+        metadata=metadata,
+    )
+
+    chain = tmp_path / "identity" / CA_CHAIN_FILENAME
+    assert chain.exists(), "save_identity wiped the TOFU-pinned chain"
+    assert chain.read_text() == "tofu-pinned-pem"
 
 
 def test_load_fixes_loose_key_permissions(tmp_path: Path):


### PR DESCRIPTION
## Summary

THE root cause behind the dogfood TLS issue. \`save_identity\`, called from \`api_status\` post-approval with \`ca_chain_pem=None\` (Phase 2c TODO never delivered the chain server-side), was actively DELETING the \`ca-chain.pem\` file the dashboard's \`/setup/pin-ca\` handler had just written via TOFU.

Sequence the operator hit:
1. Click "Pin this CA" → \`/setup/pin-ca\` writes \`identity/ca-chain.pem\` ✓
2. Submit form → wait → admin approves
3. \`/api/status\` hits the approved branch → \`save_identity(ca_chain_pem=None)\` → **deletes the file** ✗
4. SDK's proxy http client falls back to system CA store → every authenticated egress call → \`CERTIFICATE_VERIFY_FAILED\`
5. Both the pin click and the enrollment showed success — operator has no signal anything went wrong

## Fix

When \`ca_chain_pem\` is \`None\`, leave whatever's on disk alone. The "remove stale chain so later loads don't mis-represent trust" comment predates TOFU pinning (ADR-015) — back then \`None\` really meant "no chain", now it means "dashboard handled it out-of-band, don't touch".

Full profile wipe (\`rm -rf ~/.cullis/profiles/<X>\`) is the right tool for actually clearing a stale chain.

## Test plan

The previous test \`test_save_overwrites_stale_ca_chain\` was pinning the destructive behaviour. Split it:

- \`test_save_overwrites_chain_when_explicit_value_supplied\` — keeps the rotation path covered (chain-v1 → chain-v2)
- \`test_save_preserves_tofu_pinned_chain_when_arg_is_none\` — **new contract**: pin survives a save that didn't supply a chain. Would have caught this dogfood bug pre-ship.

- [x] \`pytest tests/connector/test_identity_store.py\` — 9/9 green
- [x] \`ruff check\` — clean

## Sister PR

#363 (SDK proxy client uses \`ca-chain.pem\`) is what unlocks the use of the file. Without it, this fix alone only makes the file survive — calls would still go through the system CA store. **Both should ship together.**