### PR TITLE
chore(release): bump cullis-sdk 0.1.2 + cullis-connector 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.3.5] — 2026-04-30
+
+### Fixed
+- **Client cert is now actually presented at the nginx mTLS gate**
+  (monorepo #365). httpx 0.28 silently drops the client cert when
+  ``verify=<path-string>`` is combined with ``cert=(crt, key)``. The
+  SDK's egress + proxy clients now build an ``ssl.SSLContext``
+  explicitly and pass it via ``verify=ctx``, restoring the cert at
+  the TLS handshake. Symptom this closes: ``discover_agents`` /
+  ``send_oneshot`` / ``open_session`` returning 401 from
+  ``/v1/(egress|agents|audit)`` while ``hello_site`` (TLS-only)
+  succeeded.
+- **TOFU-pinned ``ca-chain.pem`` is preserved across re-enrollments**
+  (monorepo #364). ``save_identity`` previously overwrote the pinned
+  chain with whatever the bootstrap response carried, which broke
+  the SDK's verifier on the next call. The pin is now stable for the
+  lifetime of the identity.
+- **Proxy http client uses the TOFU-pinned ``ca-chain.pem``**
+  (monorepo #363). The SDK now points at the same chain the rest of
+  the connector trusts, instead of the system bundle that doesn't
+  know the Org CA.
+
+### Compat
+- Requires ``cullis-sdk>=0.1.2`` for the rebuilt SSLContext path.
+  Older SDK installs continue to 401 against the nginx mTLS gate.
+
 ## [v0.3.4] — 2026-04-28
 
 ### Fixed

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 __all__ = ["__version__"]

--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "log_msg",
 ]
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
 readme = "README_PKG.md"
 requires-python = ">=3.10"

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.3.4"
+version = "0.3.5"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"
@@ -60,7 +60,7 @@ dependencies = [
     # without dragging in the connector's MCP server stack. 0.3.1 shipped
     # without this line; `pip install cullis-connector` succeeded but every
     # subcommand died on `ModuleNotFoundError: cullis_sdk`.
-    "cullis-sdk>=0.1.1",
+    "cullis-sdk>=0.1.2",
     "mcp>=1.0",
     "httpx>=0.24.0",
     "cryptography>=41.0.0",


### PR DESCRIPTION
## Summary

- Ships the TLS-chain fixes from #362, #363, #364, #365 as proper PyPI artifacts.
- The wheel currently on PyPI tagged `0.3.4` was published from the SHA **before** those four fixes landed, so a fresh `pip install cullis-connector` still 401s on every `/v1/(egress|agents|audit)` call — `httpx 0.28` silently drops the client cert at the nginx mTLS gate when `verify=<path>` is combined with `cert=(crt, key)`. Caught dogfooding 2026-04-30 against the standalone Mastio after a VM restart.
- Bumps:
  - `cullis-sdk` 0.1.1 → 0.1.2 (carries #363 + #365)
  - `cullis-connector` 0.3.4 → 0.3.5 (carries #364) and pins `cullis-sdk>=0.1.2` so the rebuilt SSLContext path is mandatory.

## Release order

Same as #340 — install order matters because `cullis-connector` declares `cullis-sdk>=0.1.2`:

1. Merge this PR.
2. Tag `sdk-v0.1.2` → triggers `release-sdk.yml`.
3. **Wait** for PyPI to publish `cullis-sdk-0.1.2`.
4. Tag `connector-v0.3.5` → triggers `release-connector.yml`.

## Test plan

- [ ] CI green on the PR (build matrix on both pyproject files).
- [ ] After `sdk-v0.1.2` ships: `pip download cullis-sdk==0.1.2` from a clean venv.
- [ ] After `connector-v0.3.5` ships: `pipx install --force cullis-connector`, restart the MCP server, then run `discover_agents` against a standalone Mastio and confirm 200 instead of 401.
- [ ] Smoke `cullis-connector --version` reports `0.3.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)