### PR TITLE
feat(mastio): plugin registry + license verifier skeleton

### DIFF
--- a/mcp_proxy/license.py
+++ b/mcp_proxy/license.py
@@ -1,0 +1,181 @@
+"""Mastio license verifier — offline JWT (RS256) gate for paid features.
+
+Validates an offline-signed license token and exposes ``has_feature`` /
+``require_feature`` for the plugin layer + protected endpoints.
+
+Design choices:
+  * RS256 with a public key embedded in the binary — no phone-home, no
+    network call to validate. Operators can supply their own pubkey via
+    ``CULLIS_LICENSE_PUBKEY_PATH`` (typical for staging or self-issued
+    test keys; production deals will swap the embedded key with the
+    customer-distribution one before the first contract).
+  * Token is read from ``CULLIS_LICENSE_KEY`` (raw JWT) or from the file
+    pointed to by ``CULLIS_LICENSE_PATH``. Missing or invalid token =
+    community tier (no paid features).
+  * ``has_feature`` is the non-blocking accessor (returns False on
+    community); ``require_feature(name)`` is a FastAPI dependency
+    factory that raises HTTPException(402) when a paid feature is hit
+    without entitlement.
+
+The placeholder embedded key never matches a real-world signature; the
+public repo deliberately ships in "community-only" mode until an
+operator points the override env at a real key.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import jwt as jose_jwt
+from fastapi import HTTPException
+
+_log = logging.getLogger("mcp_proxy.license")
+
+
+_PLACEHOLDER_MARKER = "CULLIS_PLACEHOLDER_PUBKEY"
+_DEV_PUBKEY_PEM = (
+    f"-----BEGIN PUBLIC KEY-----\n{_PLACEHOLDER_MARKER}\n-----END PUBLIC KEY-----\n"
+).encode()
+
+
+@dataclass(frozen=True)
+class LicenseClaims:
+    tier: str = "community"
+    org: str = ""
+    exp: int = 0
+    features: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def is_community(self) -> bool:
+        return self.tier == "community"
+
+    def has(self, feature: str) -> bool:
+        return feature in self.features
+
+
+_COMMUNITY = LicenseClaims()
+_cached: LicenseClaims | None = None
+
+
+def _load_pubkey() -> bytes | None:
+    override = os.environ.get("CULLIS_LICENSE_PUBKEY_PATH")
+    if override:
+        try:
+            return Path(override).read_bytes()
+        except OSError as exc:
+            _log.warning("license pubkey override %s unreadable: %s", override, exc)
+            return None
+
+    if _PLACEHOLDER_MARKER in _DEV_PUBKEY_PEM.decode("ascii", errors="replace"):
+        # Public repo ships without a real key. Any submitted license
+        # would fail signature verification anyway; short-circuit so the
+        # log line is honest about why we are running community.
+        return None
+    return _DEV_PUBKEY_PEM
+
+
+def _read_token() -> str | None:
+    raw = os.environ.get("CULLIS_LICENSE_KEY")
+    if raw and raw.strip():
+        return raw.strip()
+    path = os.environ.get("CULLIS_LICENSE_PATH")
+    if path:
+        try:
+            return Path(path).read_text().strip() or None
+        except OSError as exc:
+            _log.warning("license file %s unreadable: %s", path, exc)
+    return None
+
+
+def _verify(token: str, pubkey: bytes) -> LicenseClaims | None:
+    try:
+        payload: dict[str, Any] = jose_jwt.decode(
+            token,
+            pubkey,
+            algorithms=["RS256"],
+            options={"require": ["exp"]},
+        )
+    except jose_jwt.ExpiredSignatureError:
+        _log.error("license expired")
+        return None
+    except jose_jwt.InvalidTokenError as exc:
+        _log.error("license invalid: %s", exc)
+        return None
+
+    raw_features = payload.get("features", [])
+    if not isinstance(raw_features, list):
+        raw_features = []
+    return LicenseClaims(
+        tier=str(payload.get("tier", "enterprise")),
+        org=str(payload.get("org", "")),
+        exp=int(payload.get("exp", 0)),
+        features=frozenset(str(f) for f in raw_features),
+    )
+
+
+def load_license() -> LicenseClaims:
+    """Read + verify the license; cached after the first successful call."""
+    global _cached
+    if _cached is not None:
+        return _cached
+
+    token = _read_token()
+    if not token:
+        _cached = _COMMUNITY
+        _log.info("license: community (no token configured)")
+        return _cached
+
+    pubkey = _load_pubkey()
+    if not pubkey:
+        _log.warning(
+            "license token present but no real pubkey configured "
+            "(set CULLIS_LICENSE_PUBKEY_PATH) — falling back to community",
+        )
+        _cached = _COMMUNITY
+        return _cached
+
+    claims = _verify(token, pubkey)
+    if claims is None:
+        _cached = _COMMUNITY
+        return _cached
+
+    _cached = claims
+    _log.info(
+        "license: tier=%s org=%s features=%d exp=%s",
+        claims.tier,
+        claims.org,
+        len(claims.features),
+        time.strftime("%Y-%m-%d", time.gmtime(claims.exp)) if claims.exp else "unset",
+    )
+    return _cached
+
+
+def reset_cache() -> None:
+    """Test-only: drop cached claims so the next ``load_license`` re-reads env."""
+    global _cached
+    _cached = None
+
+
+def has_feature(feature: str) -> bool:
+    return load_license().has(feature)
+
+
+def require_feature(feature: str):
+    """FastAPI dependency factory that 402s when ``feature`` is not licensed."""
+
+    def _dep() -> None:
+        if not has_feature(feature):
+            raise HTTPException(
+                status_code=402,
+                detail={
+                    "error": "license_required",
+                    "feature": feature,
+                    "tier": load_license().tier,
+                },
+            )
+
+    return _dep

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -486,12 +486,24 @@ async def lifespan(app: FastAPI):
     else:
         _log.info("anomaly detector disabled (mode=off)")
 
+    # Enterprise plugin startup hooks. Discovered + license-filtered at
+    # module import; here we let each plugin allocate its own resources
+    # (e.g. SAML SP keypair load, audit-export S3 client). Failures are
+    # logged inside the registry and never block core boot.
+    from mcp_proxy.plugins import get_registry as _get_plugin_registry
+    await _get_plugin_registry().run_startup(app)
+
     _log.info(
         "MCP Proxy started (host=%s, port=%d, env=%s)",
         settings.host, settings.port, settings.environment,
     )
 
     yield
+
+    # Stop enterprise plugins before tearing down core services so
+    # they can flush state (audit watermarks, SAML sessions) while
+    # engine + redis are still up.
+    await _get_plugin_registry().run_shutdown(app)
 
     # Cleanup — stop the latency tracker first so the background probe
     # doesn't race with engine dispose.
@@ -750,6 +762,20 @@ _log.info(
 # and /.well-known/ so observability never hides under load.
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Enterprise plugin middlewares. Registered before the global rate
+# limit so Starlette's LIFO order runs the rate limiter FIRST on every
+# inbound request — plugin middlewares only see traffic that already
+# passed admission control.
+from mcp_proxy.plugins import get_registry as _get_plugin_registry_for_middlewares
+
+_plugin_registry = _get_plugin_registry_for_middlewares()
+_plugin_registry.add_middlewares(app)
+if _plugin_registry.plugins:
+    _log.info(
+        "enterprise middlewares registered: %s",
+        [p.name for p in _plugin_registry.plugins],
+    )
+
 from mcp_proxy.middleware.global_rate_limit import (
     GlobalRateLimitMiddleware,
     TokenBucket,
@@ -990,6 +1016,16 @@ app.include_router(downloads_router)
 # Parte 1) — admin list / apply / rollback under /proxy/updates.
 from mcp_proxy.dashboard.updates_router import router as updates_router
 app.include_router(updates_router)
+
+# Enterprise plugin routers. Mounted after every core router so a
+# plugin can never shadow a core endpoint by registering a conflicting
+# path; FastAPI keeps registration order on routing.
+_plugin_registry.mount_routers(app)
+if _plugin_registry.plugins:
+    _log.info(
+        "enterprise routers mounted from plugins: %s",
+        [p.name for p in _plugin_registry.plugins],
+    )
 
 # Static assets for the dashboard (compiled Tailwind CSS + bundled htmx).
 # Shake-out P0-09 + P1-10: serve /static/css/tailwind.css and /static/vendor/htmx.min.js

--- a/mcp_proxy/plugins.py
+++ b/mcp_proxy/plugins.py
@@ -1,0 +1,166 @@
+"""Mastio plugin registry — extension point for the cullis-enterprise package.
+
+Discovers plugins via Python entry points (group ``cullis.mastio_plugins``)
+and exposes 5 hook surfaces. Empty registry is the supported default: when
+no entry points are installed (community deploys) the proxy boots
+identically to a no-plugin build.
+
+Hook surfaces:
+  * ``routers()``         — list[APIRouter] mounted after core routers.
+  * ``middlewares()``     — list[(cls, kwargs)] added to the FastAPI app.
+  * ``kms_factory(name)`` — optional callable for a KMS provider name; the
+                            first plugin that returns non-None wins.
+  * ``startup(app)``      — coroutine awaited at lifespan startup, after
+                            core init has placed services on ``app.state``.
+  * ``shutdown(app)``     — coroutine awaited at lifespan shutdown, before
+                            core teardown disposes the engine + redis pool.
+
+Plugins override only the hooks they need; defaults are no-ops. Each plugin
+may declare ``requires_feature``: when set, ``filter_by_license`` drops the
+plugin from the active registry if the running license does not grant that
+feature.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any, Callable, Optional, Sequence
+
+from fastapi import APIRouter, FastAPI
+
+_log = logging.getLogger("mcp_proxy.plugins")
+
+ENTRY_POINT_GROUP = "cullis.mastio_plugins"
+
+
+class Plugin:
+    """Base class for Mastio enterprise plugins.
+
+    Subclasses override only the hooks they implement. ``name`` is used in
+    log lines; ``requires_feature`` (when set) gates the plugin on a license
+    flag.
+    """
+
+    name: str = "unnamed"
+    requires_feature: str | None = None
+
+    def routers(self) -> Sequence[APIRouter]:
+        return ()
+
+    def middlewares(self) -> Sequence[tuple[type, dict]]:
+        return ()
+
+    def kms_factory(self, provider: str) -> Optional[Callable[..., Any]]:
+        return None
+
+    async def startup(self, app: FastAPI) -> None:
+        return None
+
+    async def shutdown(self, app: FastAPI) -> None:
+        return None
+
+
+@dataclass
+class PluginRegistry:
+    plugins: list[Plugin] = field(default_factory=list)
+
+    @classmethod
+    def discover(cls, group: str = ENTRY_POINT_GROUP) -> "PluginRegistry":
+        registry = cls()
+        try:
+            eps = entry_points().select(group=group)
+        except Exception as exc:
+            _log.warning("plugin discovery failed: %s", exc)
+            return registry
+
+        for ep in eps:
+            try:
+                obj = ep.load()
+            except Exception as exc:
+                _log.error("failed to load plugin entry-point %s: %s", ep.name, exc)
+                continue
+            try:
+                plugin = obj() if isinstance(obj, type) else obj
+            except Exception as exc:
+                _log.error("failed to instantiate plugin %s: %s", ep.name, exc)
+                continue
+            if not isinstance(plugin, Plugin):
+                _log.error(
+                    "entry-point %s did not return a Plugin instance (got %r) — skipping",
+                    ep.name, type(plugin),
+                )
+                continue
+            registry.plugins.append(plugin)
+            _log.info(
+                "plugin loaded: %s (requires_feature=%s)",
+                plugin.name, plugin.requires_feature,
+            )
+        return registry
+
+    def filter_by_license(
+        self, has_feature: Callable[[str], bool],
+    ) -> "PluginRegistry":
+        kept: list[Plugin] = []
+        for plugin in self.plugins:
+            if plugin.requires_feature is None or has_feature(plugin.requires_feature):
+                kept.append(plugin)
+            else:
+                _log.warning(
+                    "plugin %s skipped: feature %s not in license",
+                    plugin.name, plugin.requires_feature,
+                )
+        return PluginRegistry(plugins=kept)
+
+    def mount_routers(self, app: FastAPI) -> None:
+        for plugin in self.plugins:
+            for router in plugin.routers():
+                app.include_router(router)
+
+    def add_middlewares(self, app: FastAPI) -> None:
+        for plugin in self.plugins:
+            for cls_, kwargs in plugin.middlewares():
+                app.add_middleware(cls_, **kwargs)
+
+    def kms_factory(self, provider: str) -> Optional[Callable[..., Any]]:
+        for plugin in self.plugins:
+            factory = plugin.kms_factory(provider)
+            if factory is not None:
+                return factory
+        return None
+
+    async def run_startup(self, app: FastAPI) -> None:
+        for plugin in self.plugins:
+            try:
+                await plugin.startup(app)
+            except Exception as exc:
+                _log.error("plugin %s startup failed: %s", plugin.name, exc)
+
+    async def run_shutdown(self, app: FastAPI) -> None:
+        for plugin in reversed(self.plugins):
+            try:
+                await plugin.shutdown(app)
+            except Exception as exc:
+                _log.warning("plugin %s shutdown raised: %s", plugin.name, exc)
+
+
+_registry: PluginRegistry | None = None
+
+
+def get_registry() -> PluginRegistry:
+    """Return the discovered + license-filtered plugin registry.
+
+    First call discovers entry points and applies the license gate;
+    subsequent calls reuse the cached instance. Tests may use
+    :func:`reset_registry` to force re-discovery.
+    """
+    global _registry
+    if _registry is None:
+        from mcp_proxy.license import has_feature
+        _registry = PluginRegistry.discover().filter_by_license(has_feature)
+    return _registry
+
+
+def reset_registry() -> None:
+    global _registry
+    _registry = None

--- a/tests/test_mastio_plugin_system.py
+++ b/tests/test_mastio_plugin_system.py
@@ -1,0 +1,328 @@
+"""Contract tests for the Mastio plugin + license skeleton.
+
+The PR is enterprise-shaped but ships in the public repo: every test here
+asserts that the core boots identically when no plugin is installed.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+import jwt as jose_jwt
+
+from mcp_proxy import license as mp_license
+from mcp_proxy import plugins as mp_plugins
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _gen_keypair() -> tuple[bytes, bytes]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub
+
+
+def _mint_license(
+    priv_pem: bytes,
+    *,
+    features: list[str],
+    tier: str = "enterprise",
+    org: str = "test-org",
+    exp_offset: int = 3600,
+) -> str:
+    now = int(time.time())
+    return jose_jwt.encode(
+        {"tier": tier, "org": org, "features": features, "exp": now + exp_offset},
+        priv_pem,
+        algorithm="RS256",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with a fresh license cache and plugin registry."""
+    mp_license.reset_cache()
+    mp_plugins.reset_registry()
+    monkeypatch.delenv("CULLIS_LICENSE_KEY", raising=False)
+    monkeypatch.delenv("CULLIS_LICENSE_PATH", raising=False)
+    monkeypatch.delenv("CULLIS_LICENSE_PUBKEY_PATH", raising=False)
+    yield
+    mp_license.reset_cache()
+    mp_plugins.reset_registry()
+
+
+# ── license: community fallback ────────────────────────────────────────────
+
+
+def test_no_token_returns_community():
+    claims = mp_license.load_license()
+    assert claims.is_community
+    assert claims.features == frozenset()
+    assert mp_license.has_feature("anything") is False
+
+
+def test_invalid_token_falls_back_to_community(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    _, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", "not.a.valid.jwt")
+
+    claims = mp_license.load_license()
+    assert claims.is_community
+
+
+def test_expired_token_falls_back_to_community(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["saml_sso"], exp_offset=-60)
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", token)
+
+    claims = mp_license.load_license()
+    assert claims.is_community
+
+
+def test_token_present_but_no_real_pubkey_falls_back_to_community(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Public repo ships with a placeholder pubkey — verification disabled.
+
+    Until an operator points ``CULLIS_LICENSE_PUBKEY_PATH`` at a real key
+    the proxy must keep running on community even with a token in env.
+    """
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", "anything")
+    claims = mp_license.load_license()
+    assert claims.is_community
+
+
+# ── license: valid token ───────────────────────────────────────────────────
+
+
+def test_valid_token_grants_listed_features(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["saml_sso", "audit_export_s3"])
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", token)
+
+    claims = mp_license.load_license()
+    assert claims.is_community is False
+    assert claims.tier == "enterprise"
+    assert claims.org == "test-org"
+    assert mp_license.has_feature("saml_sso") is True
+    assert mp_license.has_feature("audit_export_s3") is True
+    assert mp_license.has_feature("scim_sync") is False
+
+
+def test_token_loaded_from_path(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["llm_firewall"])
+    token_path = tmp_path / "license.jwt"
+    token_path.write_text(token)
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_PATH", str(token_path))
+
+    assert mp_license.has_feature("llm_firewall") is True
+
+
+def test_require_feature_returns_402_without_license():
+    from fastapi import Depends
+
+    app = FastAPI()
+
+    @app.get("/protected", dependencies=[Depends(mp_license.require_feature("saml_sso"))])
+    def protected():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        resp = client.get("/protected")
+        assert resp.status_code == 402
+        body = resp.json()
+        assert body["detail"]["error"] == "license_required"
+        assert body["detail"]["feature"] == "saml_sso"
+        assert body["detail"]["tier"] == "community"
+
+
+def test_require_feature_passes_with_valid_license(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    from fastapi import Depends
+    from fastapi.testclient import TestClient
+
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["saml_sso"])
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", token)
+
+    app = FastAPI()
+
+    @app.get("/protected", dependencies=[Depends(mp_license.require_feature("saml_sso"))])
+    def protected():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        resp = client.get("/protected")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+
+# ── plugin registry ────────────────────────────────────────────────────────
+
+
+def test_empty_registry_is_a_noop():
+    reg = mp_plugins.PluginRegistry()
+    app = FastAPI()
+    initial_routes = len(app.routes)
+    reg.mount_routers(app)
+    reg.add_middlewares(app)
+    assert reg.kms_factory("aws") is None
+    assert len(app.routes) == initial_routes
+
+
+def test_plugin_routers_mount_in_order():
+    class _R1(mp_plugins.Plugin):
+        name = "r1"
+
+        def routers(self):
+            r = APIRouter()
+            r.add_api_route("/_test/r1", lambda: {"ok": "r1"})
+            return [r]
+
+    class _R2(mp_plugins.Plugin):
+        name = "r2"
+
+        def routers(self):
+            r = APIRouter()
+            r.add_api_route("/_test/r2", lambda: {"ok": "r2"})
+            return [r]
+
+    reg = mp_plugins.PluginRegistry(plugins=[_R1(), _R2()])
+    app = FastAPI()
+    reg.mount_routers(app)
+    paths = [r.path for r in app.routes if hasattr(r, "path")]
+    assert "/_test/r1" in paths
+    assert "/_test/r2" in paths
+
+
+def test_filter_by_license_drops_ungated_plugins():
+    class _Free(mp_plugins.Plugin):
+        name = "free"
+
+    class _Paid(mp_plugins.Plugin):
+        name = "paid"
+        requires_feature = "saml_sso"
+
+    reg = mp_plugins.PluginRegistry(plugins=[_Free(), _Paid()])
+    filtered = reg.filter_by_license(lambda f: False)
+    assert [p.name for p in filtered.plugins] == ["free"]
+
+    filtered_paid = reg.filter_by_license(lambda f: f == "saml_sso")
+    assert {p.name for p in filtered_paid.plugins} == {"free", "paid"}
+
+
+def test_kms_factory_first_hit_wins():
+    class _A(mp_plugins.Plugin):
+        name = "a"
+
+        def kms_factory(self, provider):
+            return ("a", provider) if provider == "aws" else None
+
+    class _B(mp_plugins.Plugin):
+        name = "b"
+
+        def kms_factory(self, provider):
+            return ("b", provider)
+
+    reg = mp_plugins.PluginRegistry(plugins=[_A(), _B()])
+    assert reg.kms_factory("aws") == ("a", "aws")
+    assert reg.kms_factory("azure") == ("b", "azure")
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_does_not_break_other_plugins(caplog):
+    calls: list[str] = []
+
+    class _OK(mp_plugins.Plugin):
+        name = "ok"
+
+        async def startup(self, app):
+            calls.append("ok-start")
+
+        async def shutdown(self, app):
+            calls.append("ok-stop")
+
+    class _Boom(mp_plugins.Plugin):
+        name = "boom"
+
+        async def startup(self, app):
+            raise RuntimeError("nope")
+
+    reg = mp_plugins.PluginRegistry(plugins=[_Boom(), _OK()])
+    app = FastAPI()
+    await reg.run_startup(app)
+    await reg.run_shutdown(app)
+    assert "ok-start" in calls
+    assert "ok-stop" in calls
+
+
+def test_discovery_skips_non_plugin_entrypoint(monkeypatch: pytest.MonkeyPatch):
+    """A misregistered entry point must not crash discovery."""
+
+    class _NotAPlugin:
+        pass
+
+    class _FakeEntryPoint:
+        name = "bogus"
+
+        def load(self):
+            return _NotAPlugin
+
+    class _FakeEntryPoints:
+        def select(self, group: str):
+            return [_FakeEntryPoint()] if group == mp_plugins.ENTRY_POINT_GROUP else []
+
+    monkeypatch.setattr(mp_plugins, "entry_points", lambda: _FakeEntryPoints())
+    reg = mp_plugins.PluginRegistry.discover()
+    assert reg.plugins == []
+
+
+# ── core app boots identically without plugins ─────────────────────────────
+
+
+def test_core_app_imports_without_plugins():
+    """No entry points installed = main.py imports clean and registry is empty."""
+    from mcp_proxy.plugins import get_registry
+
+    mp_plugins.reset_registry()
+    reg = get_registry()
+    assert reg.plugins == []


### PR DESCRIPTION
## Summary

Bootstrap PR for the `cullis-enterprise` package. Mastio core gains a no-op plugin extension surface and an offline JWT (RS256) license check. With no entry points installed (community deploys), the registry is empty and the proxy boots identically to a no-plugin build.

This is **Fase 0.1** of the enterprise rebuild plan — pure infra, no behavior change to the core. Next PR mirrors the same pattern on `app/` for Court.

## What lands

- **`mcp_proxy/plugins.py`** — `Plugin` base class with 5 hooks (`routers`, `middlewares`, `kms_factory`, `startup`, `shutdown`). `PluginRegistry.discover()` loads entry points from group `cullis.mastio_plugins`. `filter_by_license()` gates each plugin on its `requires_feature` flag.
- **`mcp_proxy/license.py`** — reads `CULLIS_LICENSE_KEY` / `CULLIS_LICENSE_PATH`, verifies RS256 against an embedded placeholder pubkey (override via `CULLIS_LICENSE_PUBKEY_PATH`). `has_feature()` accessor and `require_feature(name)` FastAPI dependency that 402s on miss. Missing / invalid / expired tokens → community tier.
- **`mcp_proxy/main.py`** — three small wiring points:
  - plugin middlewares registered before the global rate limit (admission control stays in front)
  - plugin routers mounted after every core router (cannot shadow core endpoints)
  - startup / shutdown hooks called in lifespan, between core init and core teardown
- **`tests/test_mastio_plugin_system.py`** — 15 contract tests covering license community fallback (4 paths), valid token parsing, `require_feature` 402/200, registry mount / filter / kms fan-out, startup-failure isolation, malformed entry-point skip, empty-registry no-op.

## Fail-closed by default

The public repo ships with a placeholder pubkey marker — even a license token in env cannot unlock features unless `CULLIS_LICENSE_PUBKEY_PATH` points at a real key. `test_token_present_but_no_real_pubkey_falls_back_to_community` pins this.

## Test plan

- [x] `pytest tests/test_mastio_plugin_system.py` — 15/15 pass
- [x] `pytest tests/test_proxy_local_token.py tests/test_proxy_standalone_e2e.py` — 26/26 pass (no regression on adjacent suites)
- [x] `python -c "from mcp_proxy.main import app"` — boots clean, 139 routes, zero plugins loaded
- [ ] CI green
- [ ] `./demo_network/smoke.sh full` (run locally before merge if CI passes — additive PR, but smoke is the standing pre-merge gate for `mcp_proxy/` changes)