### PR TITLE
feat(court): plugin registry + license verifier skeleton

### DIFF
--- a/app/license.py
+++ b/app/license.py
@@ -1,0 +1,180 @@
+"""Court license verifier — offline JWT (RS256) gate for paid features.
+
+Mirrors :mod:`mcp_proxy.license`: same token format, same env vars, same
+fail-closed default. Court reads the same ``CULLIS_LICENSE_KEY`` /
+``CULLIS_LICENSE_PATH`` so a single license JWT is enough to unlock both
+sides of a Mastio + Court enterprise stack.
+
+Design choices:
+  * RS256 with a public key embedded in the binary — no phone-home, no
+    network call to validate. Operators can supply their own pubkey via
+    ``CULLIS_LICENSE_PUBKEY_PATH`` (typical for staging or self-issued
+    test keys; production deals will swap the embedded key with the
+    customer-distribution one before the first contract).
+  * Token is read from ``CULLIS_LICENSE_KEY`` (raw JWT) or from the file
+    pointed to by ``CULLIS_LICENSE_PATH``. Missing or invalid token =
+    community tier (no paid features).
+  * ``has_feature`` is the non-blocking accessor (returns False on
+    community); ``require_feature(name)`` is a FastAPI dependency factory
+    that raises HTTPException(402) when a paid feature is hit without
+    entitlement.
+
+The placeholder embedded key never matches a real-world signature; the
+public repo deliberately ships in "community-only" mode until an operator
+points the override env at a real key.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import jwt as jose_jwt
+from fastapi import HTTPException
+
+_log = logging.getLogger("app.license")
+
+
+_PLACEHOLDER_MARKER = "CULLIS_PLACEHOLDER_PUBKEY"
+_DEV_PUBKEY_PEM = (
+    f"-----BEGIN PUBLIC KEY-----\n{_PLACEHOLDER_MARKER}\n-----END PUBLIC KEY-----\n"
+).encode()
+
+
+@dataclass(frozen=True)
+class LicenseClaims:
+    tier: str = "community"
+    org: str = ""
+    exp: int = 0
+    features: frozenset[str] = field(default_factory=frozenset)
+
+    @property
+    def is_community(self) -> bool:
+        return self.tier == "community"
+
+    def has(self, feature: str) -> bool:
+        return feature in self.features
+
+
+_COMMUNITY = LicenseClaims()
+_cached: LicenseClaims | None = None
+
+
+def _load_pubkey() -> bytes | None:
+    override = os.environ.get("CULLIS_LICENSE_PUBKEY_PATH")
+    if override:
+        try:
+            return Path(override).read_bytes()
+        except OSError as exc:
+            _log.warning("license pubkey override %s unreadable: %s", override, exc)
+            return None
+
+    if _PLACEHOLDER_MARKER in _DEV_PUBKEY_PEM.decode("ascii", errors="replace"):
+        return None
+    return _DEV_PUBKEY_PEM
+
+
+def _read_token() -> str | None:
+    raw = os.environ.get("CULLIS_LICENSE_KEY")
+    if raw and raw.strip():
+        return raw.strip()
+    path = os.environ.get("CULLIS_LICENSE_PATH")
+    if path:
+        try:
+            return Path(path).read_text().strip() or None
+        except OSError as exc:
+            _log.warning("license file %s unreadable: %s", path, exc)
+    return None
+
+
+def _verify(token: str, pubkey: bytes) -> LicenseClaims | None:
+    try:
+        payload: dict[str, Any] = jose_jwt.decode(
+            token,
+            pubkey,
+            algorithms=["RS256"],
+            options={"require": ["exp"]},
+        )
+    except jose_jwt.ExpiredSignatureError:
+        _log.error("license expired")
+        return None
+    except jose_jwt.InvalidTokenError as exc:
+        _log.error("license invalid: %s", exc)
+        return None
+
+    raw_features = payload.get("features", [])
+    if not isinstance(raw_features, list):
+        raw_features = []
+    return LicenseClaims(
+        tier=str(payload.get("tier", "enterprise")),
+        org=str(payload.get("org", "")),
+        exp=int(payload.get("exp", 0)),
+        features=frozenset(str(f) for f in raw_features),
+    )
+
+
+def load_license() -> LicenseClaims:
+    """Read + verify the license; cached after the first successful call."""
+    global _cached
+    if _cached is not None:
+        return _cached
+
+    token = _read_token()
+    if not token:
+        _cached = _COMMUNITY
+        _log.info("license: community (no token configured)")
+        return _cached
+
+    pubkey = _load_pubkey()
+    if not pubkey:
+        _log.warning(
+            "license token present but no real pubkey configured "
+            "(set CULLIS_LICENSE_PUBKEY_PATH) — falling back to community",
+        )
+        _cached = _COMMUNITY
+        return _cached
+
+    claims = _verify(token, pubkey)
+    if claims is None:
+        _cached = _COMMUNITY
+        return _cached
+
+    _cached = claims
+    _log.info(
+        "license: tier=%s org=%s features=%d exp=%s",
+        claims.tier,
+        claims.org,
+        len(claims.features),
+        time.strftime("%Y-%m-%d", time.gmtime(claims.exp)) if claims.exp else "unset",
+    )
+    return _cached
+
+
+def reset_cache() -> None:
+    """Test-only: drop cached claims so the next ``load_license`` re-reads env."""
+    global _cached
+    _cached = None
+
+
+def has_feature(feature: str) -> bool:
+    return load_license().has(feature)
+
+
+def require_feature(feature: str):
+    """FastAPI dependency factory that 402s when ``feature`` is not licensed."""
+
+    def _dep() -> None:
+        if not has_feature(feature):
+            raise HTTPException(
+                status_code=402,
+                detail={
+                    "error": "license_required",
+                    "feature": feature,
+                    "tier": load_license().tier,
+                },
+            )
+
+    return _dep

--- a/app/main.py
+++ b/app/main.py
@@ -211,7 +211,19 @@ async def lifespan(app: FastAPI):
         from app.audit.tsa_worker import start_worker_task
         tsa_task, tsa_stop = start_worker_task(settings)
 
+    # Enterprise plugin startup hooks. Discovered + license-filtered at
+    # module import; here we let each plugin allocate its own resources
+    # (e.g. SAML SP, TSA worker overrides). Failures are logged inside
+    # the registry and never block core boot.
+    from app.plugins import get_registry as _get_plugin_registry
+    await _get_plugin_registry().run_startup(app)
+
     yield
+
+    # Stop enterprise plugins before tearing down core services so they
+    # can flush state (audit watermarks, TSA queues) while engine +
+    # redis are still up.
+    await _get_plugin_registry().run_shutdown(app)
 
     # ── Drain phase ──────────────────────────────────────────────────────────
     # If a signal was received, give the load balancer a few seconds to
@@ -304,6 +316,20 @@ else:
     )
 
 
+# Enterprise plugin middlewares. Registered before `security_headers` /
+# CORS so Starlette's LIFO order runs core admission first; plugins
+# only see traffic that already passed the core middleware stack.
+from app.plugins import get_registry as _get_plugin_registry_for_middlewares
+
+_court_plugin_registry = _get_plugin_registry_for_middlewares()
+_court_plugin_registry.add_middlewares(app)
+if _court_plugin_registry.plugins:
+    logger.info(
+        "enterprise middlewares registered: %s",
+        [p.name for p in _court_plugin_registry.plugins],
+    )
+
+
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
     response = await call_next(request)
@@ -379,6 +405,16 @@ app.include_router(federation_router)
 # dropped in Phase 6a-4; these endpoints are now the only read path.
 from app.federation.read import router as federation_read_router
 app.include_router(federation_read_router)
+
+# Enterprise plugin routers. Mounted after every core router so a plugin
+# can never shadow a core endpoint by registering a conflicting path;
+# FastAPI keeps registration order on routing.
+_court_plugin_registry.mount_routers(app)
+if _court_plugin_registry.plugins:
+    logger.info(
+        "enterprise routers mounted from plugins: %s",
+        [p.name for p in _court_plugin_registry.plugins],
+    )
 
 # ── Static files ─────────────────────────────────────────────────────────────
 app.mount("/static", StaticFiles(directory="app/static"), name="static")

--- a/app/plugins.py
+++ b/app/plugins.py
@@ -1,0 +1,167 @@
+"""Court plugin registry — extension point for the cullis-enterprise package.
+
+Mirrors :mod:`mcp_proxy.plugins` for the Court (broker) side. Discovers
+plugins via Python entry points (group ``cullis.court_plugins``) and
+exposes 5 hook surfaces. Empty registry is the supported default: when
+no entry points are installed (community deploys) Court boots
+identically to a no-plugin build.
+
+Hook surfaces:
+  * ``routers()``         — list[APIRouter] mounted after core routers.
+  * ``middlewares()``     — list[(cls, kwargs)] added to the FastAPI app.
+  * ``kms_factory(name)`` — optional callable for a KMS provider name; the
+                            first plugin that returns non-None wins.
+  * ``startup(app)``      — coroutine awaited at lifespan startup, after
+                            core init.
+  * ``shutdown(app)``     — coroutine awaited at lifespan shutdown, before
+                            core teardown.
+
+Plugins override only the hooks they need; defaults are no-ops. Each plugin
+may declare ``requires_feature``: when set, ``filter_by_license`` drops the
+plugin from the active registry if the running license does not grant that
+feature.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+from typing import Any, Callable, Optional, Sequence
+
+from fastapi import APIRouter, FastAPI
+
+_log = logging.getLogger("app.plugins")
+
+ENTRY_POINT_GROUP = "cullis.court_plugins"
+
+
+class Plugin:
+    """Base class for Court enterprise plugins.
+
+    Subclasses override only the hooks they implement. ``name`` is used in
+    log lines; ``requires_feature`` (when set) gates the plugin on a license
+    flag.
+    """
+
+    name: str = "unnamed"
+    requires_feature: str | None = None
+
+    def routers(self) -> Sequence[APIRouter]:
+        return ()
+
+    def middlewares(self) -> Sequence[tuple[type, dict]]:
+        return ()
+
+    def kms_factory(self, provider: str) -> Optional[Callable[..., Any]]:
+        return None
+
+    async def startup(self, app: FastAPI) -> None:
+        return None
+
+    async def shutdown(self, app: FastAPI) -> None:
+        return None
+
+
+@dataclass
+class PluginRegistry:
+    plugins: list[Plugin] = field(default_factory=list)
+
+    @classmethod
+    def discover(cls, group: str = ENTRY_POINT_GROUP) -> "PluginRegistry":
+        registry = cls()
+        try:
+            eps = entry_points().select(group=group)
+        except Exception as exc:
+            _log.warning("plugin discovery failed: %s", exc)
+            return registry
+
+        for ep in eps:
+            try:
+                obj = ep.load()
+            except Exception as exc:
+                _log.error("failed to load plugin entry-point %s: %s", ep.name, exc)
+                continue
+            try:
+                plugin = obj() if isinstance(obj, type) else obj
+            except Exception as exc:
+                _log.error("failed to instantiate plugin %s: %s", ep.name, exc)
+                continue
+            if not isinstance(plugin, Plugin):
+                _log.error(
+                    "entry-point %s did not return a Plugin instance (got %r) — skipping",
+                    ep.name, type(plugin),
+                )
+                continue
+            registry.plugins.append(plugin)
+            _log.info(
+                "plugin loaded: %s (requires_feature=%s)",
+                plugin.name, plugin.requires_feature,
+            )
+        return registry
+
+    def filter_by_license(
+        self, has_feature: Callable[[str], bool],
+    ) -> "PluginRegistry":
+        kept: list[Plugin] = []
+        for plugin in self.plugins:
+            if plugin.requires_feature is None or has_feature(plugin.requires_feature):
+                kept.append(plugin)
+            else:
+                _log.warning(
+                    "plugin %s skipped: feature %s not in license",
+                    plugin.name, plugin.requires_feature,
+                )
+        return PluginRegistry(plugins=kept)
+
+    def mount_routers(self, app: FastAPI) -> None:
+        for plugin in self.plugins:
+            for router in plugin.routers():
+                app.include_router(router)
+
+    def add_middlewares(self, app: FastAPI) -> None:
+        for plugin in self.plugins:
+            for cls_, kwargs in plugin.middlewares():
+                app.add_middleware(cls_, **kwargs)
+
+    def kms_factory(self, provider: str) -> Optional[Callable[..., Any]]:
+        for plugin in self.plugins:
+            factory = plugin.kms_factory(provider)
+            if factory is not None:
+                return factory
+        return None
+
+    async def run_startup(self, app: FastAPI) -> None:
+        for plugin in self.plugins:
+            try:
+                await plugin.startup(app)
+            except Exception as exc:
+                _log.error("plugin %s startup failed: %s", plugin.name, exc)
+
+    async def run_shutdown(self, app: FastAPI) -> None:
+        for plugin in reversed(self.plugins):
+            try:
+                await plugin.shutdown(app)
+            except Exception as exc:
+                _log.warning("plugin %s shutdown raised: %s", plugin.name, exc)
+
+
+_registry: PluginRegistry | None = None
+
+
+def get_registry() -> PluginRegistry:
+    """Return the discovered + license-filtered plugin registry.
+
+    First call discovers entry points and applies the license gate;
+    subsequent calls reuse the cached instance. Tests may use
+    :func:`reset_registry` to force re-discovery.
+    """
+    global _registry
+    if _registry is None:
+        from app.license import has_feature
+        _registry = PluginRegistry.discover().filter_by_license(has_feature)
+    return _registry
+
+
+def reset_registry() -> None:
+    global _registry
+    _registry = None

--- a/tests/test_court_plugin_system.py
+++ b/tests/test_court_plugin_system.py
@@ -1,0 +1,337 @@
+"""Contract tests for the Court plugin + license skeleton.
+
+Mirrors :mod:`tests.test_mastio_plugin_system` against the Court
+(``app/``) side. The PR is enterprise-shaped but ships in the public
+repo: every test here asserts that the core boots identically when no
+plugin is installed.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import APIRouter, Depends, FastAPI
+from fastapi.testclient import TestClient
+import jwt as jose_jwt
+
+from app import license as ap_license
+from app import plugins as ap_plugins
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def _gen_keypair() -> tuple[bytes, bytes]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub
+
+
+def _mint_license(
+    priv_pem: bytes,
+    *,
+    features: list[str],
+    tier: str = "enterprise",
+    org: str = "test-org",
+    exp_offset: int = 3600,
+) -> str:
+    now = int(time.time())
+    return jose_jwt.encode(
+        {"tier": tier, "org": org, "features": features, "exp": now + exp_offset},
+        priv_pem,
+        algorithm="RS256",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch):
+    """Each test starts with a fresh license cache and plugin registry."""
+    ap_license.reset_cache()
+    ap_plugins.reset_registry()
+    monkeypatch.delenv("CULLIS_LICENSE_KEY", raising=False)
+    monkeypatch.delenv("CULLIS_LICENSE_PATH", raising=False)
+    monkeypatch.delenv("CULLIS_LICENSE_PUBKEY_PATH", raising=False)
+    yield
+    ap_license.reset_cache()
+    ap_plugins.reset_registry()
+
+
+# ── license: community fallback ────────────────────────────────────────────
+
+
+def test_no_token_returns_community():
+    claims = ap_license.load_license()
+    assert claims.is_community
+    assert claims.features == frozenset()
+    assert ap_license.has_feature("anything") is False
+
+
+def test_invalid_token_falls_back_to_community(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    _, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", "not.a.valid.jwt")
+
+    claims = ap_license.load_license()
+    assert claims.is_community
+
+
+def test_expired_token_falls_back_to_community(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["tsa_anchoring"], exp_offset=-60)
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", token)
+
+    claims = ap_license.load_license()
+    assert claims.is_community
+
+
+def test_token_present_but_no_real_pubkey_falls_back_to_community(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", "anything")
+    claims = ap_license.load_license()
+    assert claims.is_community
+
+
+# ── license: valid token ───────────────────────────────────────────────────
+
+
+def test_valid_token_grants_listed_features(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(
+        priv, features=["tsa_anchoring", "cross_org_guardian"],
+    )
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", token)
+
+    claims = ap_license.load_license()
+    assert claims.is_community is False
+    assert claims.tier == "enterprise"
+    assert claims.org == "test-org"
+    assert ap_license.has_feature("tsa_anchoring") is True
+    assert ap_license.has_feature("cross_org_guardian") is True
+    assert ap_license.has_feature("multi_tenant_isolation") is False
+
+
+def test_token_loaded_from_path(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["sla_federation_monitor"])
+    token_path = tmp_path / "license.jwt"
+    token_path.write_text(token)
+
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_PATH", str(token_path))
+
+    assert ap_license.has_feature("sla_federation_monitor") is True
+
+
+def test_require_feature_returns_402_without_license():
+    app = FastAPI()
+
+    @app.get(
+        "/protected",
+        dependencies=[Depends(ap_license.require_feature("tsa_anchoring"))],
+    )
+    def protected():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        resp = client.get("/protected")
+        assert resp.status_code == 402
+        body = resp.json()
+        assert body["detail"]["error"] == "license_required"
+        assert body["detail"]["feature"] == "tsa_anchoring"
+        assert body["detail"]["tier"] == "community"
+
+
+def test_require_feature_passes_with_valid_license(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "license.pub"
+    pub_path.write_bytes(pub)
+    token = _mint_license(priv, features=["tsa_anchoring"])
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", token)
+
+    app = FastAPI()
+
+    @app.get(
+        "/protected",
+        dependencies=[Depends(ap_license.require_feature("tsa_anchoring"))],
+    )
+    def protected():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        resp = client.get("/protected")
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+
+# ── plugin registry ────────────────────────────────────────────────────────
+
+
+def test_empty_registry_is_a_noop():
+    reg = ap_plugins.PluginRegistry()
+    app = FastAPI()
+    initial_routes = len(app.routes)
+    reg.mount_routers(app)
+    reg.add_middlewares(app)
+    assert reg.kms_factory("aws") is None
+    assert len(app.routes) == initial_routes
+
+
+def test_plugin_routers_mount_in_order():
+    class _R1(ap_plugins.Plugin):
+        name = "r1"
+
+        def routers(self):
+            r = APIRouter()
+            r.add_api_route("/_test/court_r1", lambda: {"ok": "r1"})
+            return [r]
+
+    class _R2(ap_plugins.Plugin):
+        name = "r2"
+
+        def routers(self):
+            r = APIRouter()
+            r.add_api_route("/_test/court_r2", lambda: {"ok": "r2"})
+            return [r]
+
+    reg = ap_plugins.PluginRegistry(plugins=[_R1(), _R2()])
+    app = FastAPI()
+    reg.mount_routers(app)
+    paths = [r.path for r in app.routes if hasattr(r, "path")]
+    assert "/_test/court_r1" in paths
+    assert "/_test/court_r2" in paths
+
+
+def test_filter_by_license_drops_ungated_plugins():
+    class _Free(ap_plugins.Plugin):
+        name = "free"
+
+    class _Paid(ap_plugins.Plugin):
+        name = "paid"
+        requires_feature = "tsa_anchoring"
+
+    reg = ap_plugins.PluginRegistry(plugins=[_Free(), _Paid()])
+    filtered = reg.filter_by_license(lambda f: False)
+    assert [p.name for p in filtered.plugins] == ["free"]
+
+    filtered_paid = reg.filter_by_license(lambda f: f == "tsa_anchoring")
+    assert {p.name for p in filtered_paid.plugins} == {"free", "paid"}
+
+
+def test_kms_factory_first_hit_wins():
+    class _A(ap_plugins.Plugin):
+        name = "a"
+
+        def kms_factory(self, provider):
+            return ("a", provider) if provider == "aws" else None
+
+    class _B(ap_plugins.Plugin):
+        name = "b"
+
+        def kms_factory(self, provider):
+            return ("b", provider)
+
+    reg = ap_plugins.PluginRegistry(plugins=[_A(), _B()])
+    assert reg.kms_factory("aws") == ("a", "aws")
+    assert reg.kms_factory("azure") == ("b", "azure")
+
+
+@pytest.mark.asyncio
+async def test_startup_failure_does_not_break_other_plugins():
+    calls: list[str] = []
+
+    class _OK(ap_plugins.Plugin):
+        name = "ok"
+
+        async def startup(self, app):
+            calls.append("ok-start")
+
+        async def shutdown(self, app):
+            calls.append("ok-stop")
+
+    class _Boom(ap_plugins.Plugin):
+        name = "boom"
+
+        async def startup(self, app):
+            raise RuntimeError("nope")
+
+    reg = ap_plugins.PluginRegistry(plugins=[_Boom(), _OK()])
+    app = FastAPI()
+    await reg.run_startup(app)
+    await reg.run_shutdown(app)
+    assert "ok-start" in calls
+    assert "ok-stop" in calls
+
+
+def test_discovery_skips_non_plugin_entrypoint(monkeypatch: pytest.MonkeyPatch):
+    """A misregistered entry point must not crash discovery."""
+
+    class _NotAPlugin:
+        pass
+
+    class _FakeEntryPoint:
+        name = "bogus"
+
+        def load(self):
+            return _NotAPlugin
+
+    class _FakeEntryPoints:
+        def select(self, group: str):
+            return [_FakeEntryPoint()] if group == ap_plugins.ENTRY_POINT_GROUP else []
+
+    monkeypatch.setattr(ap_plugins, "entry_points", lambda: _FakeEntryPoints())
+    reg = ap_plugins.PluginRegistry.discover()
+    assert reg.plugins == []
+
+
+# ── core app boots identically without plugins ─────────────────────────────
+
+
+def test_core_app_imports_without_plugins():
+    """No entry points installed = main.py imports clean and registry is empty."""
+    from app.plugins import get_registry
+
+    ap_plugins.reset_registry()
+    reg = get_registry()
+    assert reg.plugins == []
+
+
+def test_court_uses_distinct_entry_point_group():
+    """Court's group must NOT collide with Mastio's — they are vended separately."""
+    from mcp_proxy.plugins import ENTRY_POINT_GROUP as MASTIO_GROUP
+
+    assert ap_plugins.ENTRY_POINT_GROUP == "cullis.court_plugins"
+    assert MASTIO_GROUP == "cullis.mastio_plugins"
+    assert ap_plugins.ENTRY_POINT_GROUP != MASTIO_GROUP


### PR DESCRIPTION
## Summary

Mirror of #367 on the Court (broker) side. Adds a no-op plugin surface and offline JWT (RS256) license check on `app/`, sharing the same `CULLIS_LICENSE_*` env contract so a single license JWT unlocks both Mastio and Court when both are deployed.

This is **Fase 0.2** of the enterprise rebuild plan. Pure infra, zero behavior change to community deploys.

## What lands

- **`app/plugins.py`** — `Plugin` base class with 5 hooks. Entry-point group `cullis.court_plugins` (distinct from Mastio's `cullis.mastio_plugins` so the `cullis-enterprise` package vends each side independently).
- **`app/license.py`** — identical token format and env-var contract as `mcp_proxy/license.py`. Same JWT loaded by both sides.
- **`app/main.py`** — three small wiring points:
  - plugin middlewares registered before `security_headers` / CORS (LIFO keeps core admission in front)
  - plugin routers mounted after every core router (cannot shadow core endpoints)
  - startup / shutdown hooks called in lifespan, between core init and core teardown
- **`tests/test_court_plugin_system.py`** — 16 contract tests, including a guard that asserts Court and Mastio entry-point groups stay distinct.

## Fail-closed by default

Same placeholder-pubkey marker as Mastio: even a license token in env cannot unlock features unless `CULLIS_LICENSE_PUBKEY_PATH` points at a real key.

## Test plan

- [x] `pytest tests/test_court_plugin_system.py tests/test_mastio_plugin_system.py` — 31/31 pass
- [x] `pytest tests/test_attach_ca.py tests/test_audit_chain.py` — 23/23 pass (no regression on adjacent suites)
- [x] `python -c "from app.main import app"` — boots clean, 121 routes, zero plugins loaded
- [ ] CI green