### PR TITLE
fix(security): register 6 missing rate-limit buckets + wire enrollment limiter

### DIFF
--- a/app/rate_limit/limiter.py
+++ b/app/rate_limit/limiter.py
@@ -56,6 +56,11 @@ class SlidingWindowLimiter:
         # Fail-open observability: count consecutive Redis failures so we can
         # log at WARNING without flooding logs (audit F-D-2).
         self._redis_failure_count: int = 0
+        # Buckets seen via check() that are not registered. Audit 2026-04-30
+        # found six call sites referencing buckets never registered, which
+        # made check() a silent no-op. Track first-sighting to log once per
+        # bucket without spamming.
+        self._unregistered_buckets: set[str] = set()
 
     def register(self, bucket: str, window_seconds: int, max_requests: int) -> None:
         """Register the configuration for a bucket. Called at startup."""
@@ -78,6 +83,13 @@ class SlidingWindowLimiter:
         """
         config = self._configs.get(bucket)
         if config is None:
+            if bucket not in self._unregistered_buckets:
+                self._unregistered_buckets.add(bucket)
+                _log.warning(
+                    "rate limiter bucket not registered, fail-open "
+                    "[bucket=%s] (this should be wired in limiter.py)",
+                    bucket,
+                )
             return
 
         self._select_backend()
@@ -232,3 +244,16 @@ rate_limiter.register("onboarding.rotate_mastio_pubkey",
                                           window_seconds=60,  max_requests=5)
 rate_limiter.register("broker.rfq",         window_seconds=60,  max_requests=5)
 rate_limiter.register("broker.rfq_respond", window_seconds=60,  max_requests=20)
+# Oneshot fan-out: sender, recipient inbound flood guard, inbox poll.
+# Audit 2026-04-30 C1 — these were referenced in oneshot_router.py but
+# never registered, so check() was a silent no-op.
+rate_limiter.register("broker.oneshot",         window_seconds=60, max_requests=60)
+rate_limiter.register("broker.oneshot_inbound", window_seconds=60, max_requests=120)
+rate_limiter.register("broker.oneshot_inbox",   window_seconds=60, max_requests=60)
+rate_limiter.register("broker.poll",            window_seconds=60, max_requests=60)
+# Onboarding anonymous inspect/attach paths. Inspect is read-only so a
+# slightly higher cap is fine; attach consumes invite-token state, so
+# match the join cadence (5/5min/IP).
+rate_limiter.register("onboarding.invite_inspect",
+                                                window_seconds=60,  max_requests=30)
+rate_limiter.register("onboarding.attach",      window_seconds=300, max_requests=5)

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -21,9 +21,10 @@ import hmac
 import json
 import logging
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Request, status
 from fastapi.responses import RedirectResponse
 
+from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     require_login,
@@ -42,6 +43,19 @@ from mcp_proxy.enrollment.schemas import (
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["enrollment"])
+
+# Per-IP budgets for the anonymous device-code endpoints. Audit 2026-04-30
+# C2 — these were unauthenticated and unrate-limited, letting any caller
+# flood the pending_enrollments table or enumerate /status timing.
+# ``start`` matches the broker ``onboarding.join`` cadence (5 per 5 min);
+# ``status`` allows ~1/sec polling, slightly above ``service.POLL_INTERVAL_S``.
+_ENROLLMENT_START_PER_MINUTE = 5
+_ENROLLMENT_STATUS_PER_MINUTE = 60
+
+
+def _client_ip(request: Request) -> str:
+    client = request.client
+    return client.host if client is not None else "unknown"
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -91,6 +105,15 @@ async def start_enrollment(
     payload: EnrollmentStartRequest,
     request: Request,
 ) -> EnrollmentStartResponse:
+    client_ip = _client_ip(request)
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}:enroll.start", _ENROLLMENT_START_PER_MINUTE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="enrollment rate limit exceeded",
+        )
+
     try:
         async with get_db() as conn:
             started = await service.start_enrollment(
@@ -127,7 +150,19 @@ async def start_enrollment(
     "/v1/enrollment/{session_id}/status",
     response_model=EnrollmentStatusResponse,
 )
-async def enrollment_status(session_id: str) -> EnrollmentStatusResponse:
+async def enrollment_status(
+    session_id: str,
+    request: Request,
+) -> EnrollmentStatusResponse:
+    client_ip = _client_ip(request)
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}:enroll.status", _ENROLLMENT_STATUS_PER_MINUTE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="enrollment status rate limit exceeded",
+        )
+
     try:
         async with get_db() as conn:
             record = await service.get_record(conn, session_id)

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -440,3 +440,74 @@ def _generate_self_signed_ca(org_id: str) -> tuple[str, str]:
     ).decode()
     cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
     return key_pem, cert_pem
+
+
+# ── Rate-limit tests (audit 2026-04-30 C2) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_http_start_rate_limits_after_budget(proxy_app, monkeypatch):
+    """6th /v1/enrollment/start from the same IP within 60s returns 429."""
+    _, client = proxy_app
+
+    import importlib
+
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+
+    enrollment_module = importlib.import_module("mcp_proxy.enrollment.router")
+    reset_agent_rate_limiter()
+    monkeypatch.setattr(enrollment_module, "_ENROLLMENT_START_PER_MINUTE", 5)
+
+    for _ in range(5):
+        resp = await client.post(
+            "/v1/enrollment/start",
+            json={
+                "pubkey_pem": _ec_pubkey_pem(),
+                "requester_name": "Mario",
+                "requester_email": "mario@acme.com",
+            },
+        )
+        assert resp.status_code == 201, resp.text
+
+    blocked = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": _ec_pubkey_pem(),
+            "requester_name": "Mario",
+            "requester_email": "mario@acme.com",
+        },
+    )
+    assert blocked.status_code == 429
+    reset_agent_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_http_status_rate_limits_after_budget(proxy_app, monkeypatch):
+    """61st /v1/enrollment/{id}/status from the same IP within 60s returns 429."""
+    _, client = proxy_app
+
+    import importlib
+
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+
+    enrollment_module = importlib.import_module("mcp_proxy.enrollment.router")
+    reset_agent_rate_limiter()
+    monkeypatch.setattr(enrollment_module, "_ENROLLMENT_STATUS_PER_MINUTE", 3)
+
+    started = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": _ec_pubkey_pem(),
+            "requester_name": "X",
+            "requester_email": "x@x.com",
+        },
+    )
+    session_id = started.json()["session_id"]
+
+    for _ in range(3):
+        resp = await client.get(f"/v1/enrollment/{session_id}/status")
+        assert resp.status_code == 200
+
+    blocked = await client.get(f"/v1/enrollment/{session_id}/status")
+    assert blocked.status_code == 429
+    reset_agent_rate_limiter()

--- a/tests/test_enrollment_dashboard.py
+++ b/tests/test_enrollment_dashboard.py
@@ -85,9 +85,15 @@ async def proxy_app(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
     monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
     from mcp_proxy.config import get_settings
 
     get_settings.cache_clear()
+    # Each test starts with a fresh rate-limit window. Several tests in this
+    # file POST /v1/enrollment/start multiple times as setup; without a
+    # reset the global module-level limiter accumulates across tests and
+    # later fixtures hit the 5/min budget.
+    reset_agent_rate_limiter()
 
     from mcp_proxy.main import app
 

--- a/tests/test_enrollment_dpop_jkt.py
+++ b/tests/test_enrollment_dpop_jkt.py
@@ -303,8 +303,10 @@ async def http_app(tmp_path, monkeypatch):
     monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "fb11-p3b")
     monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()
+    reset_agent_rate_limiter()
     from mcp_proxy.main import app
     yield app
     get_settings.cache_clear()

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -330,34 +330,29 @@ async def test_every_called_bucket_is_registered(bucket):
     )
 
 
-async def test_unknown_bucket_logs_warning_once():
-    """check() with an unregistered bucket logs a one-time warning, not silent."""
-    import logging
+async def test_unknown_bucket_logs_warning_once(monkeypatch):
+    """check() with an unregistered bucket logs a one-time warning, not silent.
+
+    Patches ``_log.warning`` directly: the ``agent_trust`` logger config in
+    CI varies (propagate flag, handler chain) and ``caplog`` has been
+    flaky on it before, see ``feedback_mcp_proxy_logger_caplog``.
+    """
+    from app.rate_limit import limiter as limiter_module
 
     limiter = SlidingWindowLimiter()
-    limiter._unregistered_buckets.clear()
+    captured: list[tuple] = []
 
-    captured: list[str] = []
+    def _capture_warning(msg, *args, **kwargs):
+        captured.append((msg % args) if args else msg)
 
-    class _ListHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record.getMessage())
+    monkeypatch.setattr(limiter_module._log, "warning", _capture_warning)
 
-    handler = _ListHandler(level=logging.WARNING)
-    logger = logging.getLogger("agent_trust")
-    logger.addHandler(handler)
-    prev_level = logger.level
-    logger.setLevel(logging.WARNING)
-    try:
-        await limiter.check("subject", "totally.unknown.bucket")
-        assert any(
-            "totally.unknown.bucket" in msg and "not registered" in msg
-            for msg in captured
-        ), f"expected warning, got {captured!r}"
+    await limiter.check("subject", "totally.unknown.bucket")
+    assert any(
+        "totally.unknown.bucket" in msg and "not registered" in msg
+        for msg in captured
+    ), f"expected warning, got {captured!r}"
 
-        before = len(captured)
-        await limiter.check("subject", "totally.unknown.bucket")
-        assert len(captured) == before, "second call should NOT log again"
-    finally:
-        logger.removeHandler(handler)
-        logger.setLevel(prev_level)
+    before = len(captured)
+    await limiter.check("subject", "totally.unknown.bucket")
+    assert len(captured) == before, "second call should NOT log again"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -291,3 +291,73 @@ async def test_failure_counter_resets_after_recovery():
     await limiter.check("subject-E", "test.bucket")  # succeeds → reset
 
     assert limiter._redis_failure_count == 0
+
+
+# ── Bucket registration coverage (audit 2026-04-30 C1) ────────────────
+
+
+@pytest.mark.parametrize(
+    "bucket",
+    [
+        # Pre-existing
+        "auth.token",
+        "broker.session",
+        "broker.message",
+        "dashboard.login",
+        "onboarding.join",
+        "onboarding.rotate_mastio_pubkey",
+        "broker.rfq",
+        "broker.rfq_respond",
+        # Audit 2026-04-30 C1: previously called but never registered
+        "broker.oneshot",
+        "broker.oneshot_inbound",
+        "broker.oneshot_inbox",
+        "broker.poll",
+        "onboarding.invite_inspect",
+        "onboarding.attach",
+    ],
+)
+async def test_every_called_bucket_is_registered(bucket):
+    """Every bucket name passed to rate_limiter.check() must be registered.
+
+    Before this test landed, six buckets (broker.oneshot family +
+    onboarding.invite_inspect/attach) were referenced in routers but never
+    registered, making rate_limiter.check() a silent no-op for them.
+    """
+    assert bucket in rate_limiter._configs, (
+        f"bucket {bucket!r} not registered in rate_limiter; check() would silently "
+        "fail-open on it"
+    )
+
+
+async def test_unknown_bucket_logs_warning_once():
+    """check() with an unregistered bucket logs a one-time warning, not silent."""
+    import logging
+
+    limiter = SlidingWindowLimiter()
+    limiter._unregistered_buckets.clear()
+
+    captured: list[str] = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    handler = _ListHandler(level=logging.WARNING)
+    logger = logging.getLogger("agent_trust")
+    logger.addHandler(handler)
+    prev_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        await limiter.check("subject", "totally.unknown.bucket")
+        assert any(
+            "totally.unknown.bucket" in msg and "not registered" in msg
+            for msg in captured
+        ), f"expected warning, got {captured!r}"
+
+        before = len(captured)
+        await limiter.check("subject", "totally.unknown.bucket")
+        assert len(captured) == before, "second call should NOT log again"
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)


### PR DESCRIPTION
## Summary

Closes audit findings **C1** + **C2** from the 2026-04-30 security audit (memory `project_security_audit_2026_04_30`).

- **C1** — `app/rate_limit/limiter.py` `check()` was a silent no-op for unregistered buckets. Six call sites referenced bucket names that were never registered: `broker.oneshot`, `broker.oneshot_inbound`, `broker.oneshot_inbox`, `broker.poll`, `onboarding.invite_inspect`, `onboarding.attach`. The SECURITY.md claim "rate limiting on all public endpoints" was effectively false on those paths.
- **C2** — Mastio `POST /v1/enrollment/start` and `GET /v1/enrollment/{id}/status` were unauthenticated and unrate-limited. Two independent audit lanes (lane 6 onboarding, lane 7 audit/rl/db) flagged this. An attacker could flood `pending_enrollments` or enumerate session_id timing.

## Changes

- Register the six missing buckets with sensible defaults (`broker.oneshot` family at 60-120/min/agent matching `broker.message`; onboarding paths matching the `onboarding.join` cadence).
- Make `check()` log a one-shot warning per unregistered bucket instead of returning silently. Future call sites that forget to register will surface in operator logs.
- Wire `get_agent_rate_limiter()` on the enrollment endpoints with per-IP budgets (5/min for `start`, 60/min for `status`).
- Tests pin every bucket-name passed to `rate_limiter.check()` against the registration table, so a future drop is caught at unit-test time. Plus integration tests that exercise the new 429 paths on enrollment.

## Test plan

- [x] `pytest tests/test_rate_limit.py` — 15/15 pass (including new parametric "every called bucket is registered" + "unknown-bucket logs warning once")
- [x] `pytest tests/test_enrollment.py` — 22/22 pass (including new `test_http_start_rate_limits_after_budget` + `test_http_status_rate_limits_after_budget`)
- [x] `pytest tests/test_oneshot_intra.py tests/test_oneshot_cross.py tests/test_onboarding.py` — 37/37 pass (no regressions on bucket consumers)
- [ ] Smoke against `./demo.sh` after merge to confirm the live path
- [ ] Manual POC: 6+ POSTs to `/v1/enrollment/start` from same IP get HTTP 429 on the 6th

🤖 Generated with [Claude Code](https://claude.com/claude-code)