### PR TITLE
fix(security): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -18,11 +18,16 @@ jobs:
 
       - name: Get PR commits
         id: get-pr-commits
-        uses: tim-actions/get-pr-commits@master
+        # Pinned to SHA (was @master) — audit 2026-04-30 C4. A third-party
+        # action that follows a moving branch lets the upstream maintainer
+        # ship arbitrary code into every PR run with secrets.GITHUB_TOKEN
+        # exposed.
+        uses: tim-actions/get-pr-commits@198af03565609bb4ed924d1260247b4881f09e7d  # v1.3.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check DCO
-        uses: tim-actions/dco@master
+        # Pinned to SHA — see note on get-pr-commits above.
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21  # v1.1.0
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Install Helm
         if: steps.filter.outputs.helm == 'true'
-        uses: azure/setup-helm@v4
+        # Pinned to SHA (was @v4 floating major) — audit 2026-04-30 lane 8 M5.
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: v3.16.2
 

--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -295,7 +295,8 @@ jobs:
           cat release-notes.md
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        # Pinned to SHA (was @v2 floating major) — audit 2026-04-30 lane 8 M5.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: "Cullis Connector ${{ github.ref_name }}"
@@ -330,7 +331,9 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to SHA (was @release/v1 moving alias) — audit 2026-04-30
+        # lane 8 M3. Most-exposed step in the entire release flow.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           # Switch to trusted publishing (OIDC) once the PyPI project

--- a/.github/workflows/release-mastio.yml
+++ b/.github/workflows/release-mastio.yml
@@ -138,7 +138,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: azure/setup-helm@v4
+      # Pinned to SHA (was @v4 floating major) — audit 2026-04-30 lane 8 M5.
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
         with:
           version: "v3.14.4"
 
@@ -297,7 +298,8 @@ jobs:
           cat release-notes.md
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        # Pinned to SHA (was @v2 floating major) — audit 2026-04-30 lane 8 M5.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: "Cullis Mastio ${{ github.ref_name }}"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -191,7 +191,8 @@ jobs:
           cat release-notes.md
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        # Pinned to SHA (was @v2 floating major) — audit 2026-04-30 lane 8 M5.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
         with:
           tag_name: ${{ github.ref_name }}
           name: "Cullis SDK ${{ github.ref_name }}"
@@ -227,7 +228,9 @@ jobs:
           path: dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        # Pinned to SHA (was @release/v1 moving alias) — audit 2026-04-30
+        # lane 8 M3. Most-exposed step in the entire release flow.
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           # Switch to trusted publishing (OIDC) once the PyPI project


### PR DESCRIPTION
## Summary

Closes audit findings **C4** + **M3** + **M5** from the 2026-04-30 security audit (memory \`project_security_audit_2026_04_30\`, lane 8).

- **C4** — \`tim-actions/get-pr-commits@master\` and \`tim-actions/dco@master\` follow a moving branch on a third-party org. A compromise or unfriendly maintainer could push arbitrary code into every PR run with \`secrets.GITHUB_TOKEN\` exposed.
- **M3** — \`pypa/gh-action-pypi-publish@release/v1\` is the most-exposed step in the release flow (publishes to PyPI). The \`release/v1\` alias is upstream-mutable.
- **M5** — \`softprops/action-gh-release@v2\` and \`azure/setup-helm@v4\` are floating major-version tags; upstream can ship any v2.x.y / v4.x.y.

## Pins applied

Each \`uses:\` line carries an inline comment with the resolved release tag for operator readability:

| Action | Old ref | Pinned SHA | Tag |
|---|---|---|---|
| \`tim-actions/get-pr-commits\` | \`@master\` | \`198af035\` | v1.3.1 |
| \`tim-actions/dco\` | \`@master\` | \`f2279e6e\` | v1.1.0 |
| \`pypa/gh-action-pypi-publish\` | \`@release/v1\` | \`cef22109\` | v1.14.0 |
| \`softprops/action-gh-release\` | \`@v2\` | \`3bb12739\` | v2.6.2 |
| \`azure/setup-helm\` | \`@v4\` | \`1a275c3b\` | v4.3.1 |

Same-major pins picked deliberately for \`softprops\` (v2.x) and \`azure/setup-helm\` (v4.x) to avoid silent major-version bumps. \`pypa/gh-action-pypi-publish\` stays inside the \`release/v1\` series.

## Out of scope

GitHub-owned actions (\`actions/checkout\`, \`actions/setup-python\`, \`actions/setup-node\`, \`actions/upload-artifact\`, \`actions/download-artifact\`) and well-maintained third parties (\`docker/*\`, \`dorny/paths-filter\`, \`helm/kind-action\`) are not pinned in this PR. They were not in the audit's must-pin list. Follow-up PR can extend coverage if desired.

## Test plan

- [x] \`python3 -c \"import yaml; ...\"\` — all 7 workflow files parse OK
- [ ] DCO check on this PR exercises the freshly-pinned \`tim-actions/*\` (will be visible in the Checks tab)
- [ ] Next \`mastio-v*\` / \`connector-v*\` / \`sdk-v*\` tag exercises the release path with the new pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)