### PR TITLE
fix(security): CSRF / cross-origin guard on Connector dashboard

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -257,6 +257,70 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     templates.env.globals["active_profile"] = config.profile_name or ""
     app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
+    # ── CSRF / cross-origin guard ────────────────────────────────────────
+    #
+    # Audit 2026-04-30 lane 5 C1 — every state-changing endpoint on the
+    # dashboard (14 routes) had no CSRF token, no Origin/Referer check,
+    # and no SameSite cookie because the dashboard had no session at all.
+    # Any web page the operator visited could POST to ``/setup/pin-ca``
+    # and overwrite the TOFU-pinned Org CA, configure their IDE to spawn
+    # a malicious MCP server, etc. DNS rebinding to 127.0.0.1:7777
+    # amplifies the surface.
+    #
+    # Defence: reject every state-changing request whose ``Origin`` (or,
+    # as fallback, ``Referer``) does not match the dashboard's own host.
+    # Browsers attach ``Origin`` automatically on cross-origin POST and
+    # cannot be fooled by DNS rebinding because the header carries the
+    # name the page was loaded from, not the resolved IP.
+    #
+    # Exemption: requests carrying ``Authorization: Bearer ...`` skip the
+    # check. Bearer auth is the calling convention for non-browser
+    # callers (statusline scripts hit ``/status/inbox/seen`` with the
+    # token from ``statusline.token``); browsers never auto-attach
+    # ``Authorization``, so the bearer path is not a CSRF vector.
+
+    @app.middleware("http")
+    async def _csrf_origin_guard(request: Request, call_next):  # type: ignore[no-untyped-def]
+        if request.method in ("POST", "PUT", "DELETE", "PATCH"):
+            authz = request.headers.get("authorization", "")
+            if not authz.startswith("Bearer "):
+                expected_host = request.url.netloc
+                expected_origins = {
+                    f"http://{expected_host}",
+                    f"https://{expected_host}",
+                }
+                origin = request.headers.get("origin")
+                if origin is not None:
+                    if origin not in expected_origins:
+                        return JSONResponse(
+                            {"detail": "cross-origin request blocked"},
+                            status_code=403,
+                        )
+                else:
+                    referer = request.headers.get("referer", "")
+                    if referer:
+                        if not any(
+                            referer == o or referer.startswith(o + "/")
+                            for o in expected_origins
+                        ):
+                            return JSONResponse(
+                                {"detail": "cross-origin referer blocked"},
+                                status_code=403,
+                            )
+                    else:
+                        return JSONResponse(
+                            {
+                                "detail": (
+                                    "missing Origin and Referer; "
+                                    "browser POSTs must originate from the "
+                                    "dashboard. Programmatic callers should "
+                                    "use Authorization: Bearer."
+                                )
+                            },
+                            status_code=403,
+                        )
+        return await call_next(request)
+
     # ── Routes ────────────────────────────────────────────────────────────
 
     @app.get("/", response_class=HTMLResponse)

--- a/tests/connector/test_profiles_page.py
+++ b/tests/connector/test_profiles_page.py
@@ -43,7 +43,10 @@ def client_on_north(profile_tree, monkeypatch):
         verify_tls=False,
     )
     from cullis_connector.web import build_app
-    return TestClient(build_app(cfg))
+    tc = TestClient(build_app(cfg))
+    # Audit 2026-04-30 lane 5 C1 — same-origin Origin header required.
+    tc.headers["Origin"] = "http://testserver"
+    return tc
 
 
 def test_profiles_page_lists_profiles_and_flags_active(client_on_north):

--- a/tests/connector/test_status_inbox_endpoint.py
+++ b/tests/connector/test_status_inbox_endpoint.py
@@ -117,13 +117,21 @@ def test_status_inbox_rejects_wrong_token(app):
 
 def test_status_inbox_seen_rejects_missing_auth_cannot_reset_counter(app):
     """Without auth, a local attacker must NOT be able to ack the
-    dispatcher and hide unread messages from the user."""
+    dispatcher and hide unread messages from the user.
+
+    Two layers reject this request now (audit 2026-04-30 lane 5 C1):
+    the CSRF Origin guard returns 403 because the request has neither
+    a same-origin ``Origin`` nor a ``Bearer`` token; if it ever made it
+    past the middleware, the route-level bearer dependency would
+    return 401. Either is a hard rejection — what matters is that
+    ``fake.ack`` is never called.
+    """
     fake = MagicMock()
     fake.stop = AsyncMock(return_value=None)
     with TestClient(app) as client:
         app.state.inbox_dispatcher = fake
         r = client.post("/status/inbox/seen")
-    assert r.status_code == 401
+    assert r.status_code in (401, 403)
     fake.ack.assert_not_called()
 
 

--- a/tests/connector/test_web_csrf.py
+++ b/tests/connector/test_web_csrf.py
@@ -1,0 +1,175 @@
+"""CSRF / cross-origin guard for the Connector dashboard (audit
+2026-04-30 lane 5 C1).
+
+The dashboard at ``127.0.0.1:7777`` had no CSRF token, no Origin /
+Referer enforcement, and no SameSite cookie because it had no session
+at all. Any web page the operator visited could POST to
+``/setup/pin-ca`` and overwrite the TOFU-pinned Org CA, configure the
+user's IDE to spawn a malicious MCP server, etc. DNS rebinding to
+``127.0.0.1:7777`` amplifies the surface.
+
+The fix is a middleware that rejects every state-changing request whose
+``Origin`` (or, as fallback, ``Referer``) is not the dashboard's own
+host. Requests bearing ``Authorization: Bearer ...`` are exempted —
+they're the calling convention for non-browser callers (statusline
+scripts), and browsers never auto-attach ``Authorization``, so a
+bearer-bearing request is by definition not a CSRF vector.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import build_app
+
+
+@pytest.fixture
+def app(tmp_path):
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="http://mastio.test",
+        verify_tls=False,
+    )
+    return build_app(cfg)
+
+
+@pytest.fixture
+def client(app):
+    return TestClient(app)
+
+
+# ── Positive cases ───────────────────────────────────────────────────
+
+
+def test_post_with_matching_origin_passes_csrf_guard(client):
+    """A POST whose Origin matches the request host is allowed by the
+    middleware. The route's own logic may still 4xx for unrelated
+    reasons (missing form fields, etc.) but it MUST be reached."""
+    resp = client.post(
+        "/cancel",
+        headers={"Origin": "http://testserver"},
+    )
+    # /cancel returns 303 redirect on success; key invariant is that
+    # the middleware did NOT short-circuit with 403.
+    assert resp.status_code != 403
+
+
+def test_post_with_matching_referer_passes_csrf_guard(client):
+    """When ``Origin`` is absent, ``Referer`` is checked instead. A
+    referer pointing at the dashboard's own URL is accepted."""
+    resp = client.post(
+        "/cancel",
+        headers={"Referer": "http://testserver/waiting"},
+    )
+    assert resp.status_code != 403
+
+
+def test_post_with_bearer_auth_skips_csrf_guard(client):
+    """Bearer-authenticated requests are exempt. The route's own
+    bearer check / dispatcher availability check runs after the
+    middleware; key invariant is the middleware does NOT short-circuit
+    with 403."""
+    resp = client.post(
+        "/status/inbox/seen",
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert resp.status_code != 403, (
+        f"middleware should skip Bearer requests (got {resp.status_code})"
+    )
+
+
+# ── Negative cases ───────────────────────────────────────────────────
+
+
+def test_post_with_cross_origin_blocked(client):
+    """Origin header pointing at a different host triggers 403."""
+    resp = client.post(
+        "/cancel",
+        headers={"Origin": "https://evil.example.com"},
+    )
+    assert resp.status_code == 403
+    assert "cross-origin" in resp.json()["detail"].lower()
+
+
+def test_post_with_cross_origin_referer_blocked(client):
+    """Referer pointing at a different host triggers 403 when no
+    Origin is present."""
+    resp = client.post(
+        "/cancel",
+        headers={"Referer": "https://evil.example.com/page"},
+    )
+    assert resp.status_code == 403
+
+
+def test_post_with_no_origin_no_referer_no_bearer_blocked(client):
+    """No identifying header at all: 403. This is the curl / scripted
+    attack-without-browser path; legitimate non-browser callers must
+    use Bearer."""
+    resp = client.post("/cancel")
+    assert resp.status_code == 403
+
+
+def test_post_dns_rebinding_attack_blocked(client):
+    """DNS rebinding scenario: an attacker page on
+    ``http://attacker.example.com`` rebinds its DNS to ``127.0.0.1``
+    after page load and POSTs to the dashboard. The browser still
+    sends the original Origin (``http://attacker.example.com``)
+    because the ``Origin`` header reflects where the page was loaded
+    from, not where the request lands. Rejected."""
+    resp = client.post(
+        "/setup/pin-ca",
+        headers={"Origin": "http://attacker.example.com"},
+        data={
+            "site_url": "http://mastio.test",
+            "expected_fingerprint_sha256": "deadbeef" * 8,
+        },
+    )
+    assert resp.status_code == 403
+
+
+def test_get_requests_not_subject_to_origin_check(client):
+    """GET / HEAD / OPTIONS are not state-changing and are intentionally
+    not gated by the middleware."""
+    resp = client.get("/setup", headers={"Origin": "https://evil.example.com"})
+    # GET passes through; the route may redirect or render, but it
+    # MUST NOT 403 from the middleware.
+    assert resp.status_code != 403
+
+
+# ── State-changing endpoints sweep ───────────────────────────────────
+#
+# Spot-check that the middleware applies uniformly across the routes
+# the audit explicitly listed. We don't test every route exhaustively
+# (the route logic itself isn't what we're testing here), just that
+# they all reject a no-Origin request with 403.
+
+
+@pytest.mark.parametrize(
+    "method,path",
+    [
+        ("POST", "/setup"),
+        ("POST", "/setup/preview-ca"),
+        ("POST", "/setup/pin-ca"),
+        ("POST", "/cancel"),
+        ("POST", "/autostart/toggle"),
+        ("POST", "/configure/cursor"),
+        ("POST", "/mcp/admin-secret"),
+        ("POST", "/mcp/admin-secret/clear"),
+        ("POST", "/mcp/register"),
+        ("POST", "/mcp/abc-id/delete"),
+        ("POST", "/mcp/abc-id/bind-self"),
+        ("POST", "/profiles/create"),
+        ("POST", "/api/test-ping"),
+    ],
+)
+def test_state_changing_endpoint_rejects_missing_origin(client, method, path):
+    """Audit 2026-04-30 lane 5 C1 listed 14 mutating endpoints. All
+    must reject browser POSTs that lack a same-origin Origin header.
+    /status/inbox/seen is bearer-authenticated separately; covered in
+    the positive bearer-skip test above."""
+    resp = client.request(method, path)
+    assert resp.status_code == 403, (
+        f"{method} {path} should reject without Origin (got "
+        f"{resp.status_code})"
+    )

--- a/tests/connector/test_web_mcp.py
+++ b/tests/connector/test_web_mcp.py
@@ -51,7 +51,12 @@ def connector_client(connector_dir, monkeypatch):
         verify_tls=False,
     )
     app = build_app(cfg)
-    return TestClient(app)
+    tc = TestClient(app)
+    # Audit 2026-04-30 lane 5 C1 — dashboard rejects state-changing
+    # requests without a same-origin Origin header. ``TestClient`` uses
+    # ``http://testserver`` as base URL by default.
+    tc.headers["Origin"] = "http://testserver"
+    return tc
 
 
 def _mount_mastio(monkeypatch, handler):

--- a/tests/connector/test_web_test_ping.py
+++ b/tests/connector/test_web_test_ping.py
@@ -28,18 +28,26 @@ def cfg(tmp_path) -> ConnectorConfig:
     )
 
 
+def _origin_aware_client(cfg) -> TestClient:
+    """TestClient that pretends the request comes from the dashboard's
+    own origin (audit 2026-04-30 C1 — Origin header now required)."""
+    tc = TestClient(build_app(cfg))
+    tc.headers["Origin"] = "http://testserver"
+    return tc
+
+
 @pytest.fixture
 def client_with_identity(cfg, monkeypatch) -> TestClient:
     """Pretend an enrolled identity is on disk so test-ping doesn't
     short-circuit on the no-identity guard."""
     monkeypatch.setattr(_web, "has_identity", lambda _: True)
-    return TestClient(build_app(cfg))
+    return _origin_aware_client(cfg)
 
 
 @pytest.fixture
 def client_without_identity(cfg, monkeypatch) -> TestClient:
     monkeypatch.setattr(_web, "has_identity", lambda _: False)
-    return TestClient(build_app(cfg))
+    return _origin_aware_client(cfg)
 
 
 def _patch_health(monkeypatch, *, status_code: int, body: dict | str):
@@ -132,7 +140,7 @@ def test_test_ping_strips_trailing_slash_on_site_url(monkeypatch, tmp_path):
         verify_tls=True,
     )
     monkeypatch.setattr(_web, "has_identity", lambda _: True)
-    client = TestClient(build_app(cfg))
+    client = _origin_aware_client(cfg)
     captured = _patch_health(
         monkeypatch, status_code=200, body={"status": "ok"}
     )

--- a/tests/connector/test_web_tofu.py
+++ b/tests/connector/test_web_tofu.py
@@ -59,7 +59,13 @@ def cfg(tmp_path) -> ConnectorConfig:
 def client(cfg, monkeypatch) -> TestClient:
     import cullis_connector.web as _web
     monkeypatch.setattr(_web, "has_identity", lambda _: False)
-    return TestClient(build_app(cfg))
+    tc = TestClient(build_app(cfg))
+    # Audit 2026-04-30 lane 5 C1: dashboard now rejects state-changing
+    # requests without a same-origin ``Origin`` header. ``TestClient``
+    # uses ``http://testserver`` as the base URL, so a matching Origin
+    # makes these calls behave like a same-origin browser POST.
+    tc.headers["Origin"] = "http://testserver"
+    return tc
 
 
 def _patch_pki_endpoint(monkeypatch, status_code: int, body: str) -> list[str]:


### PR DESCRIPTION
## Summary

Closes audit finding **C3** from the 2026-04-30 security audit (memory \`project_security_audit_2026_04_30\`, lane 5).

The local Connector dashboard at \`127.0.0.1:7777\` had no CSRF token, no Origin/Referer check, and no SameSite cookie because it had no session at all. **14 mutating endpoints** were exposed:

\`/setup\`, \`/setup/preview-ca\`, \`/setup/pin-ca\`, \`/cancel\`, \`/autostart/toggle\`, \`/configure/{ide_id}\`, \`/mcp/admin-secret\`, \`/mcp/admin-secret/clear\`, \`/mcp/register\`, \`/mcp/{id}/delete\`, \`/mcp/{id}/bind-self\`, \`/profiles/create\`, \`/api/test-ping\`, \`/status/inbox/seen\`.

**Threat model:** any web page the operator visited could POST to \`/setup/pin-ca\` and overwrite the TOFU-pinned Org CA, configure their IDE to spawn a malicious MCP server, cancel a legitimate enrollment, etc. **DNS rebinding to 127.0.0.1:7777 amplifies the surface.**

## Defence

Tiny middleware that rejects every state-changing request (POST/PUT/DELETE/PATCH) whose \`Origin\` (or, as fallback, \`Referer\`) does not match the dashboard's own host. The browser attaches \`Origin\` automatically on cross-origin POST and **cannot be fooled by DNS rebinding** because the header carries the page's apparent origin name, not the resolved IP.

**Exemption:** requests carrying \`Authorization: Bearer ...\` skip the guard. Bearer auth is the calling convention for non-browser callers (statusline scripts hit \`/status/inbox/seen\` with the token from \`statusline.token\`); browsers never auto-attach \`Authorization\`, so the bearer path is not a CSRF vector.

## Tests

New \`tests/connector/test_web_csrf.py\` (21 tests):
- **Positive:** matching Origin, matching Referer, Bearer-auth exemption
- **Negative:** cross-origin Origin, cross-origin Referer, both missing, **DNS-rebinding scenario explicitly modelled**
- **Sweep:** parametrised over 13 of the 14 state-changing routes (the 14th, \`/status/inbox/seen\`, is bearer-authenticated and is covered by the bearer-skip case)

Pre-existing fixtures in \`test_web_tofu.py\`, \`test_web_mcp.py\`, \`test_web_test_ping.py\`, \`test_profiles_page.py\` updated to attach a same-origin \`Origin\` header.

Pre-existing fail in \`tests/connector/test_profile_runtime_switch.py\` (4 tests, MenuItem signature mismatch) is unrelated to this PR; verified failing on \`origin/main\` before the change.

## Test plan

- [x] \`pytest tests/connector/ --ignore=tests/connector/test_profile_runtime_switch.py\` — 320/320 pass
- [x] \`pytest tests/connector/test_web_csrf.py\` — 21/21 pass
- [ ] Manual smoke: \`cullis-connector dashboard\` open in browser, click through setup → still works
- [ ] Manual repro: from a malicious local-html page \`fetch('http://127.0.0.1:7777/setup/pin-ca', {method:'POST', body:...})\` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)