### PR TITLE
fix(security): bind /v1/auth/token sub to client cert + preserve LOCAL_TOKEN reach

### DIFF
--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -214,6 +214,13 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
         is_active=bool(record.get("is_active", True)),
         cert_pem=record.get("cert_pem"),
         dpop_jkt=record.get("dpop_jkt"),
+        # Audit 2026-04-30 lane 1 H2 — preserve the DB-stored reach.
+        # Without this, the InternalAgent default ("both") shadows
+        # an intra-only or cross-only setting whenever the egress
+        # path runs through Bearer LOCAL_TOKEN, silently relaxing
+        # reach. The mTLS path (client_cert.py:333) already does
+        # this correctly; mirror it here for parity.
+        reach=record.get("reach") or "both",
     )
 
 

--- a/mcp_proxy/auth/local_token.py
+++ b/mcp_proxy/auth/local_token.py
@@ -33,6 +33,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
 from fastapi import APIRouter, HTTPException, Request, status
 from pydantic import BaseModel, Field
 
+from mcp_proxy.auth.client_cert import _identity_from_cert
 from mcp_proxy.auth.local_issuer import LOCAL_AUDIENCE, LOCAL_SCOPE, LocalIssuer
 from mcp_proxy.db import get_config
 
@@ -210,6 +211,27 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
     agent_id = claims.get("sub")
     if not agent_id or not isinstance(agent_id, str):
         raise _unauthorized("assertion missing sub")
+
+    # Audit 2026-04-30 lane 1 H1 — bind ``sub`` to the leaf cert's
+    # canonical identity. Without this check, any agent holding a
+    # valid Org-CA-signed cert (i.e. any enrolled Connector) can sign
+    # an assertion claiming ``sub: <other-agent>`` and have the Mastio
+    # mint a LOCAL_TOKEN for that identity, bypassing every
+    # cert-pin defence the rest of ADR-014 PR-B carefully built. The
+    # Court's verifier (app/auth/x509_verifier.py:403) already
+    # enforces this; we mirror it on the Mastio side.
+    try:
+        cert_org, cert_agent = _identity_from_cert(leaf)
+    except HTTPException as exc:
+        _log.info("local /auth/token rejected: cert identity unparseable: %s", exc.detail)
+        raise _unauthorized("cert identity unparseable") from exc
+    canonical_agent_id = f"{cert_org}::{cert_agent}"
+    if agent_id != canonical_agent_id:
+        _log.warning(
+            "local /auth/token rejected: sub %s does not match cert %s",
+            agent_id, canonical_agent_id,
+        )
+        raise _unauthorized("sub does not match client cert")
 
     ttl = _resolve_ttl(request)
     token = issuer.issue(agent_id=agent_id, ttl_seconds=ttl)

--- a/tests/test_proxy_local_agent_dep.py
+++ b/tests/test_proxy_local_agent_dep.py
@@ -346,3 +346,109 @@ async def test_expired_grace_kid_is_rejected(app_with_flag_on):
     # DPoP (no DPoP header present) → 401 DPoP realm.
     assert resp.status_code == 401
     assert "dpop" in resp.headers.get("WWW-Authenticate", "").lower()
+
+
+# ── Audit 2026-04-30 lane 1 H2 — preserve reach on LOCAL_TOKEN egress ─
+
+
+@pytest.mark.asyncio
+async def test_local_token_egress_preserves_intra_reach(tmp_path, monkeypatch):
+    """Audit 2026-04-30 lane 1 H2 — LOCAL_TOKEN egress dep must NOT
+    drop the DB-stored ``reach`` field. Before the fix,
+    ``_maybe_local_internal_agent`` built ``InternalAgent(...)`` with
+    no ``reach=`` kwarg, so the model default ``"both"`` shadowed an
+    intra-only agent and reach_guard.py:119 silently relaxed reach.
+    """
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    from datetime import datetime, timezone
+
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_internal_agent
+
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "1")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.db as db_mod
+    importlib.reload(db_mod)
+    await db_mod.init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    # Create the agent with reach="intra" — the value that must
+    # survive the LOCAL_TOKEN dep round-trip. ``create_agent`` doesn't
+    # take a ``reach`` kwarg (set via dashboard later), so we patch it
+    # in directly.
+    await db_mod.create_agent(
+        agent_id="orga::intra-only",
+        display_name="intra-only",
+        capabilities=[],
+    )
+    from sqlalchemy import text as _sql_text
+    async with db_mod.get_db() as conn:
+        await conn.execute(
+            _sql_text("UPDATE internal_agents SET reach='intra' WHERE agent_id=:aid"),
+            {"aid": "orga::intra-only"},
+        )
+
+    # Mint key + LocalIssuer.
+    key = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    kid = compute_kid(pub_pem)
+    now = datetime.now(timezone.utc)
+    await db_mod.insert_mastio_key(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem,
+        created_at=now.isoformat(), activated_at=now.isoformat(),
+    )
+    active = MastioKey(
+        kid=kid, pubkey_pem=pub_pem, privkey_pem=priv_pem, cert_pem=None,
+        created_at=now, activated_at=now, deprecated_at=None, expires_at=None,
+    )
+    issuer = LocalIssuer(org_id="orga", active_key=active)
+    keystore = LocalKeyStore()
+
+    token = issuer.issue("orga::intra-only", ttl_seconds=60).token
+
+    # Mock minimal Request so the dep can run.
+    class _State:
+        pass
+
+    class _AppState:
+        local_issuer = issuer
+        local_keystore = keystore
+
+    class _App:
+        state = _AppState()
+
+    class _Headers(dict):
+        def get(self, key, default=None):  # type: ignore[override]
+            return super().get(key.lower(), default)
+
+    class _Request:
+        app = _App()
+        headers = _Headers({"authorization": f"Bearer {token}"})
+        client = None
+        method = "POST"
+        url = type("U", (), {"path": "/v1/egress/test"})()
+
+    agent = await _maybe_local_internal_agent(_Request())
+
+    assert agent is not None
+    assert agent.agent_id == "orga::intra-only"
+    assert agent.reach == "intra", (
+        f"reach must be preserved from DB; got {agent.reach!r} "
+        "(audit H2 — silent reach relaxation regressed)"
+    )
+
+    get_settings.cache_clear()
+    await db_mod.dispose_db()

--- a/tests/test_proxy_local_token.py
+++ b/tests/test_proxy_local_token.py
@@ -247,6 +247,28 @@ async def test_local_token_never_hits_the_court(flag_on_proxy):
     assert resp.status_code == 200
 
 
+@pytest.mark.asyncio
+async def test_local_token_rejects_sub_not_matching_cert(flag_on_proxy):
+    """Audit 2026-04-30 lane 1 H1 — IDOR via sub-spoofing.
+
+    Mint a leaf cert for ``acme::alice`` and sign an assertion claiming
+    ``sub: acme::bob``. Without the cert-binding check, the Mastio
+    would mint a LOCAL_TOKEN for bob's identity, letting alice
+    impersonate any other agent in the same org. Must return 401.
+    """
+    ctx = flag_on_proxy
+    leaf_key_pem, _, x5c = _issue_leaf(
+        ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice"
+    )
+    # Cert says alice, assertion says bob — mismatch.
+    assertion = _build_assertion("acme::bob", leaf_key_pem, x5c)
+    resp = await ctx["client"].post(
+        "/v1/auth/token", json={"client_assertion": assertion}
+    )
+    assert resp.status_code == 401, resp.text
+    assert "cert" in resp.json()["detail"].lower()
+
+
 @pytest_asyncio.fixture
 async def flag_off_proxy(tmp_path, monkeypatch):
     """Proxy app with the flag *off*. /v1/auth/token must fall through to


### PR DESCRIPTION
## Summary

Closes audit findings **H1** + **H2** from the 2026-04-30 security audit (memory \`project_security_audit_2026_04_30\`, lane 1). Both live on the Mastio's local auth path; same file area, same review surface, single PR.

### H1 — \`/v1/auth/token\` IDOR via sub-spoofing

\`issue_local_token\` extracted \`sub\` from the assertion body and called \`LocalIssuer.issue(agent_id=...)\` without binding \`sub\` to the leaf cert's identity. **Any agent holding a valid Org-CA-signed cert** (i.e. any enrolled Connector) could sign an assertion claiming \`sub: <other-agent-in-same-org>\`, get a LOCAL_TOKEN minted for that identity, then call \`/v1/egress/*\` via the LOCAL_TOKEN short-circuit, **impersonating any other agent in the same org**. Bypasses every cert-pin defence the rest of ADR-014 PR-B carefully built.

The Court's verifier (\`app/auth/x509_verifier.py:403\`) already enforces \`sub == canonical_agent_id_from_cert\`. This PR mirrors the check on the Mastio: extract \`(org, agent_name)\` from the leaf via \`_identity_from_cert\` (SPIFFE SAN preferred, CN fallback), build the canonical \`{org}::{agent}\`, reject 401 on mismatch.

### H2 — LOCAL_TOKEN egress drops \`reach\`, defaults to \`"both"\`

\`_maybe_local_internal_agent\` built \`InternalAgent(...)\` from the DB record but omitted \`reach=record.get("reach")\`. Combined with \`reach_guard.py:119\` defaulting to \`"both"\`, an agent with \`reach="intra"\` who authenticated via Bearer LOCAL_TOKEN got reach **silently relaxed**. The mTLS path (\`client_cert.py:333\`) does this correctly. One-line fix: \`reach=record.get("reach") or "both"\`.

## Test plan

- [x] \`pytest tests/test_proxy_local_token.py tests/test_proxy_local_agent_dep.py tests/test_proxy_reach_guard.py tests/test_dashboard_agents_reach.py\` — 35/35 pass
- [x] **New** \`test_local_token_rejects_sub_not_matching_cert\` — leaf for alice + assertion claiming bob → 401 with "cert" in detail
- [x] **New** \`test_local_token_egress_preserves_intra_reach\` — DB-stored reach="intra" survives the LOCAL_TOKEN egress dep round-trip
- [ ] Manual smoke against \`./demo.sh\` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)