### PR TITLE
fix(security): gate /v1/federation/agents/search direct-lookup by binding

### DIFF
--- a/app/federation/read.py
+++ b/app/federation/read.py
@@ -106,6 +106,26 @@ async def search_federated_agents(
         exclude_org_id=exclude,
         trust_domain=settings.trust_domain,
     )
+
+    # Audit 2026-04-30 lane 3 H4 — direct-lookup (``agent_id`` or
+    # ``agent_uri``) bypasses the ``exclude_org_id`` filter, so any
+    # authenticated agent can resolve any cross-org agent's full
+    # record at the Court without an approved binding. Mirror the
+    # gate that ``GET /agents/{id}`` and ``GET /agents/{id}/public-key``
+    # already enforce: drop cross-org results whose owning org has no
+    # approved binding with the caller. Filter silently — same shape
+    # as "search found nothing".
+    if is_direct and agents:
+        gated: list = []
+        for a in agents:
+            if a.org_id == current_agent.org:
+                gated.append(a)
+                continue
+            binding = await get_approved_binding(db, a.org_id, a.agent_id)
+            if binding:
+                gated.append(a)
+        agents = gated
+
     return AgentListResponse(
         agents=[_as_agent_response(a, settings.trust_domain) for a in agents],
         total=len(agents),

--- a/tests/test_federation_read.py
+++ b/tests/test_federation_read.py
@@ -129,6 +129,71 @@ async def test_search_requires_at_least_one_filter(client: AsyncClient, dpop):
     assert resp.status_code == 422
 
 
+async def test_search_direct_lookup_cross_org_without_binding_filtered(
+    client: AsyncClient, dpop,
+):
+    """Audit 2026-04-30 lane 3 H4 — direct-id lookup at /agents/search
+    must enforce the same binding gate as /agents/{id} and
+    /agents/{id}/public-key. A caller with no approved binding for the
+    target org gets an empty list, NOT the agent record.
+    """
+    token = await _setup(
+        client, "fr-srch-caller", "fr-srch-caller::agent",
+        ["cap.read"], dpop,
+    )
+    # Target org bootstrapped WITHOUT a binding to the caller.
+    await client.post("/v1/registry/orgs", json={
+        "org_id": "fr-srch-target", "display_name": "target",
+        "secret": "fr-srch-target-secret",
+    }, headers=ADMIN_HEADERS)
+    await client.post(
+        "/v1/registry/orgs/fr-srch-target/certificate",
+        json={"ca_certificate": get_org_ca_pem("fr-srch-target")},
+        headers={
+            "x-org-id": "fr-srch-target",
+            "x-org-secret": "fr-srch-target-secret",
+        },
+    )
+    await seed_court_agent(
+        agent_id="fr-srch-target::leak",
+        org_id="fr-srch-target",
+        display_name="leak",
+        capabilities=["cap.read"],
+    )
+
+    resp = await client.get(
+        "/v1/federation/agents/search",
+        params={"agent_id": "fr-srch-target::leak"},
+        headers=dpop.headers("GET", "/v1/federation/agents/search", token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    ids = [a["agent_id"] for a in body["agents"]]
+    assert "fr-srch-target::leak" not in ids, (
+        "audit H4 — direct-id lookup must NOT leak a cross-org agent "
+        "without an approved binding"
+    )
+    assert body["total"] == 0
+
+
+async def test_search_direct_lookup_same_org_still_returns(
+    client: AsyncClient, dpop,
+):
+    """Same-org direct lookup must keep working — the binding gate is
+    cross-org only."""
+    token = await _setup(
+        client, "fr-srch-self", "fr-srch-self::agent", ["cap.read"], dpop,
+    )
+    resp = await client.get(
+        "/v1/federation/agents/search",
+        params={"agent_id": "fr-srch-self::agent", "include_own_org": True},
+        headers=dpop.headers("GET", "/v1/federation/agents/search", token),
+    )
+    assert resp.status_code == 200
+    ids = [a["agent_id"] for a in resp.json()["agents"]]
+    assert "fr-srch-self::agent" in ids
+
+
 # ── public-key ──────────────────────────────────────────────────────────
 
 async def test_public_key_same_org(client: AsyncClient, dpop):


### PR DESCRIPTION
## Summary

Closes audit finding **H4** from the 2026-04-30 security audit (memory \`project_security_audit_2026_04_30\`, lane 3).

When \`agent_id\` or \`agent_uri\` was supplied to \`/v1/federation/agents/search\`, the handler set \`is_direct=True\` and \`exclude_org_id=None\`, then \`search_agents\` returned the agent regardless of org. The sibling endpoints \`GET /v1/federation/agents/{id}\` and \`GET /v1/federation/agents/{id}/public-key\` enforce a binding check on the same shape (\`app/federation/read.py:130, :163\`); **the search direct-lookup branch did not**.

**Impact:** any authenticated Mastio agent could resolve any cross-org agent's full record (agent_id, org_id, capabilities, metadata) at the Court without an approved binding. Reconnaissance primitive — broad \`pattern=otherorg::*\` is excluded by default but a single direct \`agent_id\` check was not.

## Fix

After \`search_agents\` returns, when the call is direct-lookup, filter cross-org results to only those with an approved binding. Filter silently — same shape as "search found nothing", consistent with search semantics. The 403 path stays on the singular \`/agents/{id}\` endpoint where the caller asked specifically by name.

## Test plan

- [x] \`pytest tests/test_federation_read.py\` — 13/13 pass
- [x] **New** \`test_search_direct_lookup_cross_org_without_binding_filtered\` — cross-org \`agent_id\` query without binding returns \`total: 0\`
- [x] **New** \`test_search_direct_lookup_same_org_still_returns\` — same-org direct lookup keeps working
- [ ] Manual smoke after merge: cross-org search via SDK \`discover_agents\` + verify binding gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)