### PR TITLE
fix(security): reach gate on egress discover + tools/invoke + public-key

### DIFF
--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -1081,6 +1081,13 @@ async def get_agent_public_key(
             cert_pem=row["cert_pem"],
         )
 
+    # Audit 2026-04-30 lane 3 M2 — reach gate. The cross-org branch
+    # was reachable for agents whose reach is ``intra``, giving them
+    # a key-fetch primer for a path the send/session paths would
+    # later refuse. Mirror the gate that ``/resolve``, ``/peers``,
+    # ``/sessions`` already enforce: ``check_reach`` raises 403 here.
+    check_reach(agent, target_org, settings.org_id or "")
+
     # Cross-org: mirror ``/resolve``'s contract — when no bridge is
     # configured (pure standalone proxy) return cert_pem=None rather
     # than 400, so callers that tolerate a missing cert (e.g. mtls-only
@@ -1261,6 +1268,24 @@ async def discover_agents(
     agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
 ):
     """Discover remote agents on the network."""
+    # Audit 2026-04-30 lane 3 H5 — discover always queries the Court
+    # (cross-org by definition). An ``intra``-only agent must NOT
+    # surface a ready-made cross-org agent list. Filter to empty
+    # (matches ``/peers`` reach gate) rather than 403, so the SDK's
+    # ``discover_agents`` stays uniform across reach modes.
+    caller_reach = (getattr(agent, "reach", None) or "both").lower()
+    if caller_reach == "intra":
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_discover",
+            status="success",
+            detail=(
+                f"capabilities={body.capabilities} q={body.q} "
+                "results=0 reason=reach=intra"
+            ),
+        )
+        return {"agents": [], "count": 0}
+
     bridge = _get_bridge(request)
     try:
         agents = await bridge.discover_agents(
@@ -1344,6 +1369,16 @@ async def invoke_remote_tool(
                 status_code=400,
                 detail="Cannot determine recipient from session metadata",
             )
+
+        # Audit 2026-04-30 lane 3 H5 — reach gate. ``open_session`` and
+        # ``send`` already gate by reach (router.py:261, :528) but
+        # ``tools/invoke`` did not, so an agent whose reach was tightened
+        # to ``intra`` after holding a cross-org session could still push
+        # tool_calls through it. Derive target_org from the canonical
+        # ``org::name`` recipient and reuse ``check_reach`` for parity.
+        _settings = get_settings()
+        recipient_target_org = resolve_target_org(recipient)
+        check_reach(agent, recipient_target_org, _settings.org_id or "")
 
         await bridge.send_message(
             agent.agent_id,

--- a/tests/test_proxy_egress_pubkey.py
+++ b/tests/test_proxy_egress_pubkey.py
@@ -260,3 +260,131 @@ async def test_pubkey_rate_limit_shared_with_egress_budget(
         monkeypatch.delenv("MCP_PROXY_RATE_LIMIT_PER_MINUTE", raising=False)
         get_settings.cache_clear()
         reset_agent_rate_limiter()
+
+
+# ── Audit 2026-04-30 lane 3 M2 — reach gate on cross-org public-key ─
+
+
+async def _set_caller_reach(agent_id: str, reach: str) -> None:
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE internal_agents SET reach=:r WHERE agent_id=:aid"),
+            {"r": reach, "aid": agent_id},
+        )
+
+
+@pytest.mark.asyncio
+async def test_pubkey_cross_org_blocked_when_caller_reach_is_intra(proxy_app):
+    """Audit 2026-04-30 lane 3 M2 — an ``intra``-only agent must NOT
+    fetch cross-org peer public keys, even though the call is
+    nominally read-only. Without the gate, intra agents can pre-cache
+    cross-org keys ahead of paths that would later refuse send.
+    """
+    app, client = proxy_app
+    caller_headers = await _provision_caller("acme::intra-bot")
+    await _set_caller_reach("acme::intra-bot", "intra")
+
+    class _StubBridge:
+        async def get_peer_public_key(self, caller_agent_id, target):
+            raise AssertionError("bridge MUST NOT be reached for reach=intra")
+
+    app.state.broker_bridge = _StubBridge()
+    try:
+        resp = await client.get(
+            "/v1/egress/agents/other-org::bob/public-key",
+            headers=caller_headers,
+        )
+    finally:
+        app.state.broker_bridge = None
+
+    assert resp.status_code == 403, resp.text
+    assert "reach" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_pubkey_cross_org_allowed_when_caller_reach_is_both(proxy_app):
+    """Default reach=both keeps the cross-org cert fetch working."""
+    app, client = proxy_app
+    caller_headers = await _provision_caller("acme::both-bot")
+    # reach default is "both"; explicit set just to pin the contract.
+    await _set_caller_reach("acme::both-bot", "both")
+
+    class _StubBridge:
+        async def get_peer_public_key(self, caller_agent_id, target):
+            return "-----BEGIN CERTIFICATE-----\nCROSS\n-----END CERTIFICATE-----"
+
+    app.state.broker_bridge = _StubBridge()
+    try:
+        resp = await client.get(
+            "/v1/egress/agents/other-org::bob/public-key",
+            headers=caller_headers,
+        )
+    finally:
+        app.state.broker_bridge = None
+    assert resp.status_code == 200, resp.text
+    assert "CROSS" in resp.json()["cert_pem"]
+
+
+# ── Audit 2026-04-30 lane 3 H5 — discover reach gate ────────────────
+
+
+@pytest.mark.asyncio
+async def test_discover_returns_empty_when_caller_reach_is_intra(proxy_app):
+    """Audit 2026-04-30 lane 3 H5 — discover always queries the Court
+    (cross-org by definition). An intra-only agent must NOT receive a
+    ready-made cross-org agent list."""
+    app, client = proxy_app
+    caller_headers = await _provision_caller("acme::intra-disc")
+    await _set_caller_reach("acme::intra-disc", "intra")
+
+    class _StubBridge:
+        async def discover_agents(self, *args, **kwargs):
+            raise AssertionError("bridge MUST NOT be reached for reach=intra")
+
+    app.state.broker_bridge = _StubBridge()
+    try:
+        resp = await client.post(
+            "/v1/egress/discover",
+            headers=caller_headers,
+            json={"capabilities": ["cap.read"]},
+        )
+    finally:
+        app.state.broker_bridge = None
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agents"] == []
+    assert body["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_discover_calls_bridge_when_caller_reach_is_both(proxy_app):
+    """reach=both: discover delegates to the broker bridge as before."""
+    app, client = proxy_app
+    caller_headers = await _provision_caller("acme::both-disc")
+    await _set_caller_reach("acme::both-disc", "both")
+
+    seen: list[str] = []
+
+    class _StubBridge:
+        async def discover_agents(self, agent_id, *, capabilities=None, q=None):
+            seen.append(agent_id)
+            return [{"agent_id": "other-org::peer", "capabilities": ["cap.read"]}]
+
+    app.state.broker_bridge = _StubBridge()
+    try:
+        resp = await client.post(
+            "/v1/egress/discover",
+            headers=caller_headers,
+            json={"capabilities": ["cap.read"]},
+        )
+    finally:
+        app.state.broker_bridge = None
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["agents"][0]["agent_id"] == "other-org::peer"
+    assert seen == ["acme::both-disc"]


### PR DESCRIPTION
## Summary

Closes audit findings **H5** + **M2** from the 2026-04-30 security audit (memory \`project_security_audit_2026_04_30\`, lane 3). Three reach gaps on the proxy egress surface; same file, single PR.

### H5 — \`POST /v1/egress/discover\`

Discover always queries the Court (cross-org by definition). An \`intra\`-only agent must NOT receive a ready-made cross-org agent list. Filter to empty (matches the existing \`/peers\` reach gate) rather than 403, so the SDK's \`discover_agents\` stays uniform across reach modes.

### H5 — \`POST /v1/egress/tools/invoke\`

\`open_session\` and \`send\` already gate by reach (\`router.py:261, :528\`) but \`tools/invoke\` did not, so an agent whose reach was tightened to \`intra\` after holding a cross-org session could still push tool_calls through it. Derive \`target_org\` from the canonical \`org::name\` recipient and reuse \`check_reach\` for parity (raises 403 on deny).

### M2 — \`GET /v1/egress/agents/{id}/public-key\` (cross-org branch)

The cross-org branch was reachable for \`intra\`-only agents, giving them a key-fetch primer for a path the send/session paths would later refuse. Mirror the gate that \`/resolve\`, \`/peers\`, \`/sessions\` already enforce.

## Test plan

- [x] \`pytest tests/test_proxy_egress_pubkey.py tests/test_proxy_reach_guard.py tests/test_proxy_local_token.py tests/test_proxy_local_agent_dep.py\` — 44/44 pass
- [x] **New** 4 integration tests covering both reach=intra deny and reach=both happy paths for \`/discover\` + \`/public-key\` (the bridge-must-not-be-reached invariant is asserted via \`AssertionError\` in stub)
- [ ] Manual smoke after merge: dogfood with reach=intra agent + \`discover_agents\` SDK call → empty list
- [ ] Same with \`hello_site\` followed by intra-restrict + cross peer pubkey fetch → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)