### PR TITLE
feat(mastio): KMS factory + LocalKMSProvider for Org CA persistence

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -26,6 +26,15 @@ class ProxySettings(BaseSettings):
 
     proxy_public_url: str = ""  # for DPoP htu validation
 
+    # KMS backend for the Org CA (and, in follow-up, Mastio leaf keys).
+    # ``local`` keeps the keys in proxy_config DB (current default,
+    # works for community + small deploys). Other values dispatch to
+    # cullis-enterprise plugins via the ``kms_factory`` plugin hook —
+    # e.g. ``aws`` / ``azure`` / ``gcp`` resolve to their respective
+    # cloud KMS providers when cullis-enterprise is installed and the
+    # license grants the matching feature.
+    kms_backend: str = "local"
+
     # Secrets backend
     secret_backend: str = "env"  # "env" | "vault"
     vault_addr: str = ""

--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -149,16 +149,24 @@ class AgentManager:
         )
 
     async def load_org_ca_from_config(self) -> bool:
-        """Try to load Org CA from proxy_config DB table (keys: org_ca_key, org_ca_cert).
+        """Try to load the Org CA via the configured KMS provider.
+
+        Default provider is :class:`mcp_proxy.kms.LocalKMSProvider` which
+        reads ``proxy_config[org_ca_key]`` and ``proxy_config[org_ca_cert]``
+        — same surface as before this method got refactored to route
+        through the KMS factory. cullis-enterprise plugins (cloud KMS,
+        Key Vault, etc.) plug in via ``MCP_PROXY_KMS_BACKEND`` + the
+        ``kms_factory`` plugin hook.
 
         Returns True if loaded successfully, False otherwise.
         """
-        ca_key_pem = await get_config("org_ca_key")
-        ca_cert_pem = await get_config("org_ca_cert")
-        if ca_key_pem and ca_cert_pem:
+        from mcp_proxy.kms import get_kms_provider
+        loaded = await get_kms_provider().load_org_ca()
+        if loaded is not None:
+            ca_key_pem, ca_cert_pem = loaded
             await self.load_org_ca(ca_key_pem, ca_cert_pem)
             return True
-        logger.warning("Org CA not found in proxy_config — agent cert issuance unavailable")
+        logger.warning("Org CA not found via KMS provider — agent cert issuance unavailable")
         return False
 
     async def generate_org_ca(
@@ -247,8 +255,12 @@ class AgentManager:
         ).decode()
         ca_cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
 
-        await set_config("org_ca_key", ca_key_pem)
-        await set_config("org_ca_cert", ca_cert_pem)
+        # Route through the KMS provider so enterprise backends (cloud
+        # KMS / Key Vault / Secrets Manager) get to persist this without
+        # touching agent_manager. The LocalKMSProvider default writes to
+        # proxy_config exactly like the prior inline calls did.
+        from mcp_proxy.kms import get_kms_provider
+        await get_kms_provider().store_org_ca(ca_key_pem, ca_cert_pem)
 
         self._org_ca_key = ca_key
         self._org_ca_cert = ca_cert

--- a/mcp_proxy/kms/__init__.py
+++ b/mcp_proxy/kms/__init__.py
@@ -1,0 +1,27 @@
+"""Mastio KMS abstraction.
+
+Wraps Org CA persistence behind a ``KMSProvider`` interface so cullis
+-enterprise plugins can route key storage through cloud KMS / Secrets
+Manager / Key Vault without touching ``agent_manager``.
+
+The default ``LocalKMSProvider`` keeps the keys in ``proxy_config``
+(historic behavior); enterprise providers are loaded via the plugin
+``kms_factory`` hook when ``MCP_PROXY_KMS_BACKEND`` resolves to
+something other than ``local``.
+
+Public surface:
+  * :class:`KMSProvider`            — protocol every backend implements.
+  * :class:`LocalKMSProvider`       — DB-backed default.
+  * :func:`get_kms_provider`        — module singleton resolver.
+  * :func:`reset_kms_provider`      — test-only cache invalidation.
+"""
+from mcp_proxy.kms.factory import get_kms_provider, reset_kms_provider
+from mcp_proxy.kms.local import LocalKMSProvider
+from mcp_proxy.kms.provider import KMSProvider
+
+__all__ = [
+    "KMSProvider",
+    "LocalKMSProvider",
+    "get_kms_provider",
+    "reset_kms_provider",
+]

--- a/mcp_proxy/kms/factory.py
+++ b/mcp_proxy/kms/factory.py
@@ -1,0 +1,74 @@
+"""KMS provider resolution — local default, plugins for everything else.
+
+Reads ``MCP_PROXY_KMS_BACKEND`` from settings. When it equals ``local``
+(the default), returns the in-tree :class:`LocalKMSProvider`. Any other
+value goes through the plugin registry's ``kms_factory(name)`` hook;
+the first plugin that returns a non-None factory wins. The factory
+callable is invoked with the active :class:`Settings` so the plugin can
+read its own config (region, key id, secret path).
+
+Module-level cache ensures every call site shares the same provider
+instance through the lifetime of the process. Tests use
+:func:`reset_kms_provider` to clear it.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from mcp_proxy.kms.local import LocalKMSProvider
+from mcp_proxy.kms.provider import KMSProvider
+
+_log = logging.getLogger("mcp_proxy.kms")
+_provider: Optional[KMSProvider] = None
+
+
+def reset_kms_provider() -> None:
+    """Test-only: drop the cached provider so the next ``get_kms_provider`` re-resolves."""
+    global _provider
+    _provider = None
+
+
+def get_kms_provider() -> KMSProvider:
+    """Return the active Mastio KMS provider, resolving once per process.
+
+    Resolution order:
+      1. ``MCP_PROXY_KMS_BACKEND`` == ``local`` (default) → :class:`LocalKMSProvider`.
+      2. Any other value → the plugin registry's ``kms_factory(backend)``
+         hook. First plugin that returns a non-None factory provides
+         the implementation.
+      3. Unknown backend with no plugin handler → :class:`RuntimeError`.
+    """
+    global _provider
+    if _provider is not None:
+        return _provider
+
+    from mcp_proxy.config import get_settings
+    settings = get_settings()
+    backend = (settings.kms_backend or "local").strip().lower()
+
+    if backend == "local":
+        _provider = LocalKMSProvider()
+        _log.info("KMS provider: local (proxy_config DB)")
+        return _provider
+
+    # Plugin-provided backend.
+    from mcp_proxy.plugins import get_registry
+    factory = get_registry().kms_factory(backend)
+    if factory is None:
+        raise RuntimeError(
+            f"MCP_PROXY_KMS_BACKEND={backend!r} but no plugin handles "
+            "this backend. Either install the matching cullis-enterprise "
+            "extra (e.g. ``pip install cullis-enterprise[cloud_kms_aws]``) "
+            "and license the feature, or set MCP_PROXY_KMS_BACKEND=local.",
+        )
+
+    provider = factory(settings)
+    if not isinstance(provider, KMSProvider):
+        raise RuntimeError(
+            f"plugin kms_factory({backend!r}) returned {type(provider)!r} "
+            "which does not satisfy the KMSProvider protocol",
+        )
+    _provider = provider
+    _log.info("KMS provider: %s (plugin-provided)", backend)
+    return _provider

--- a/mcp_proxy/kms/local.py
+++ b/mcp_proxy/kms/local.py
@@ -1,0 +1,26 @@
+"""``LocalKMSProvider`` — Org CA persisted in ``proxy_config``.
+
+This is the default Mastio path. It preserves the historic behavior
+where ``agent_manager`` reads ``org_ca_key`` / ``org_ca_cert`` from
+the local proxy_config table and writes them on first-boot generation.
+"""
+from __future__ import annotations
+
+from mcp_proxy.db import get_config, set_config
+
+
+class LocalKMSProvider:
+    """Default Mastio KMS provider — the Org CA lives in proxy_config."""
+
+    name = "local"
+
+    async def load_org_ca(self) -> tuple[str, str] | None:
+        key_pem = await get_config("org_ca_key")
+        cert_pem = await get_config("org_ca_cert")
+        if key_pem and cert_pem:
+            return key_pem, cert_pem
+        return None
+
+    async def store_org_ca(self, key_pem: str, cert_pem: str) -> None:
+        await set_config("org_ca_key", key_pem)
+        await set_config("org_ca_cert", cert_pem)

--- a/mcp_proxy/kms/provider.py
+++ b/mcp_proxy/kms/provider.py
@@ -1,0 +1,35 @@
+"""``KMSProvider`` protocol — Mastio Org CA persistence backend.
+
+Today the protocol is intentionally narrow: load + store the Org CA
+keypair as PEM strings. That is enough to route the keys through any
+cloud KMS, Secrets Manager, or HSM that exposes a "give me the wrapped
+private material" surface. A future Phase 2 will add a sign-only
+interface (``sign(message, hash_alg)``) for HSM-backed keys that
+never leave the device.
+
+Implementations live in :mod:`mcp_proxy.kms.local` (default) and in
+``cullis_enterprise.mastio.cloud_kms_*`` (proprietary providers).
+"""
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KMSProvider(Protocol):
+    """Persistence backend for the Mastio Org CA keypair."""
+
+    async def load_org_ca(self) -> tuple[str, str] | None:
+        """Return ``(key_pem, cert_pem)`` if the Org CA has been stored.
+
+        Returns ``None`` when the CA has never been generated (first
+        boot in standalone mode, or before the attach-ca flow on a
+        federated deploy).
+        """
+        ...
+
+    async def store_org_ca(self, key_pem: str, cert_pem: str) -> None:
+        """Persist a freshly generated Org CA keypair + cert.
+
+        Implementations must be idempotent on identical inputs and must
+        replace any earlier value atomically.
+        """
+        ...

--- a/tests/test_mastio_kms.py
+++ b/tests/test_mastio_kms.py
@@ -1,0 +1,149 @@
+"""Contract tests for the Mastio KMS abstraction.
+
+Cover both the in-tree LocalKMSProvider (current default behavior) and
+the plugin dispatch path used by cullis-enterprise cloud KMS providers.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from mcp_proxy import db as core_db
+from mcp_proxy import kms as core_kms
+from mcp_proxy import plugins as core_plugins
+from mcp_proxy.kms.factory import get_kms_provider, reset_kms_provider
+from mcp_proxy.kms.local import LocalKMSProvider
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_state(monkeypatch):
+    """Each test starts with a fresh in-memory DB + clean caches."""
+    reset_kms_provider()
+    core_plugins.reset_registry()
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "local")
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setenv("PROXY_SKIP_MIGRATIONS", "1")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await core_db.init_db("sqlite+aiosqlite:///:memory:")
+    yield
+    await core_db.dispose_db()
+    reset_kms_provider()
+    core_plugins.reset_registry()
+    get_settings.cache_clear()
+
+
+# ── LocalKMSProvider ───────────────────────────────────────────────────────
+
+
+async def test_local_provider_returns_none_when_unset():
+    provider = LocalKMSProvider()
+    assert await provider.load_org_ca() is None
+
+
+async def test_local_provider_round_trips_org_ca():
+    provider = LocalKMSProvider()
+    await provider.store_org_ca("KEY-PEM", "CERT-PEM")
+    loaded = await provider.load_org_ca()
+    assert loaded == ("KEY-PEM", "CERT-PEM")
+
+
+async def test_local_provider_overwrite():
+    provider = LocalKMSProvider()
+    await provider.store_org_ca("KEY-1", "CERT-1")
+    await provider.store_org_ca("KEY-2", "CERT-2")
+    loaded = await provider.load_org_ca()
+    assert loaded == ("KEY-2", "CERT-2")
+
+
+# ── factory ─────────────────────────────────────────────────────────────────
+
+
+async def test_factory_default_returns_local_provider():
+    provider = get_kms_provider()
+    assert isinstance(provider, LocalKMSProvider)
+
+
+async def test_factory_caches_singleton():
+    a = get_kms_provider()
+    b = get_kms_provider()
+    assert a is b
+
+
+async def test_factory_unknown_backend_raises_clearly(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "aws")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    reset_kms_provider()
+
+    with pytest.raises(RuntimeError, match="MCP_PROXY_KMS_BACKEND='aws'"):
+        get_kms_provider()
+
+
+async def test_factory_dispatches_to_plugin(monkeypatch):
+    """A plugin's kms_factory hook gets to provide an alternate backend."""
+
+    class FakeProvider:
+        name = "aws"
+
+        async def load_org_ca(self):
+            return ("FAKE-KEY", "FAKE-CERT")
+
+        async def store_org_ca(self, key_pem, cert_pem):
+            self.last_store = (key_pem, cert_pem)
+
+    class FakePlugin(core_plugins.Plugin):
+        name = "fake-aws-kms"
+        instance = FakeProvider()
+
+        def kms_factory(self, provider):
+            if provider == "aws":
+                return lambda settings: self.instance
+            return None
+
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "aws")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    reset_kms_provider()
+
+    fake_registry = core_plugins.PluginRegistry(plugins=[FakePlugin()])
+    monkeypatch.setattr(core_plugins, "_registry", fake_registry)
+
+    provider = get_kms_provider()
+    assert isinstance(provider, FakeProvider)
+    assert await provider.load_org_ca() == ("FAKE-KEY", "FAKE-CERT")
+
+
+async def test_factory_rejects_plugin_returning_non_provider(monkeypatch):
+    """A misbehaving plugin must be flagged loudly, not silently used."""
+
+    class BadPlugin(core_plugins.Plugin):
+        name = "bad"
+
+        def kms_factory(self, provider):
+            if provider == "aws":
+                return lambda settings: "not a provider"
+            return None
+
+    monkeypatch.setenv("MCP_PROXY_KMS_BACKEND", "aws")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    reset_kms_provider()
+
+    fake_registry = core_plugins.PluginRegistry(plugins=[BadPlugin()])
+    monkeypatch.setattr(core_plugins, "_registry", fake_registry)
+
+    with pytest.raises(RuntimeError, match="does not satisfy the KMSProvider protocol"):
+        get_kms_provider()
+
+
+# ── public-package surface ──────────────────────────────────────────────────
+
+
+def test_module_exports_are_stable():
+    """The cullis-enterprise plugins import these names — keep them stable."""
+    assert core_kms.KMSProvider is not None
+    assert core_kms.LocalKMSProvider is LocalKMSProvider
+    assert core_kms.get_kms_provider is get_kms_provider
+    assert core_kms.reset_kms_provider is reset_kms_provider

--- a/tests/test_mastio_kms.py
+++ b/tests/test_mastio_kms.py
@@ -5,8 +5,6 @@ the plugin dispatch path used by cullis-enterprise cloud KMS providers.
 """
 from __future__ import annotations
 
-import os
-
 import pytest
 
 from mcp_proxy import db as core_db


### PR DESCRIPTION
## Summary

Wraps Org CA load + store behind a `KMSProvider` protocol so cullis-enterprise plugins can route Mastio key persistence through cloud KMS / Secrets Manager / Key Vault without touching the egress agent manager. Default behavior unchanged: the new `LocalKMSProvider` reads the same `proxy_config[org_ca_key]` / `proxy_config[org_ca_cert]` rows that `agent_manager` did inline before this PR.

This is the public-repo half of the Cloud KMS feature. Once merged, `cullis_enterprise.mastio.cloud_kms_aws` / `_azure` / `_gcp` plugins hook the factory via the existing `kms_factory` plugin extension point.

## What lands

- **`mcp_proxy/kms/`** — new module
  - `provider.py` — `KMSProvider` Protocol: `load_org_ca()` / `store_org_ca()`. Narrow surface, enough to route through any backend that exposes wrapped private material. A future Phase 2 adds a sign-only interface for HSM-backed keys.
  - `local.py` — `LocalKMSProvider` wraps `mcp_proxy.db.get_config` / `set_config`. Same table, same keys.
  - `factory.py` — `get_kms_provider()` singleton: backend `local` (default) resolves to `LocalKMSProvider`; any other value goes through the plugin registry's `kms_factory(name)` hook. Unknown backend with no plugin handler raises a clear `RuntimeError` naming the missing extras install.
- **`mcp_proxy/config.py`** — `kms_backend: str = "local"` (env: `MCP_PROXY_KMS_BACKEND`).
- **`mcp_proxy/egress/agent_manager.py`** — `load_org_ca_from_config()` and `generate_org_ca()` route through the factory. Default code path unchanged.
- **`tests/test_mastio_kms.py`** — 9 contract tests.

## Test plan

- [x] `pytest tests/test_mastio_kms.py` — 9/9 pass
- [x] `pytest tests/test_proxy_standalone_e2e.py tests/test_attach_ca.py tests/test_mastio_plugin_system.py tests/test_court_plugin_system.py` — 53/53 pass (no regression on adjacent suites that exercise `agent_manager`)
- [ ] CI green