### PR TITLE
fix(security): HMAC sign + verify on /pdp/policy (X-ATN-Signature)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -99,6 +99,17 @@ class Settings(BaseSettings):
     # on the same private docker network as the broker.
     policy_webhook_allow_private_ips: bool = False
 
+    # Shared secret used to sign the X-ATN-Signature HMAC on outbound
+    # PDP webhook calls (audit 2026-04-30 lane 3 H3). When set, every
+    # ``call_pdp_webhook`` body is HMAC-SHA256-signed and the receiving
+    # PDP can verify the call originated from the broker. When unset
+    # (legacy deployments mid-rollout) the broker logs a warning at
+    # startup and skips signing — the receiver still has the option
+    # to fail-closed on its end. The dominant deployment shape is a
+    # single shared secret broker↔Mastio; multi-org per-secret is a
+    # follow-up.
+    policy_webhook_hmac_secret: str = ""
+
     # mTLS binding (RFC 8705 §3) — defense-in-depth at /auth/token.
     # When the broker sits behind a reverse proxy that terminates mTLS,
     # the proxy forwards the client certificate via an HTTP header. The

--- a/app/policy/webhook.py
+++ b/app/policy/webhook.py
@@ -25,7 +25,10 @@ Webhook contract:
             200 OK  { "decision": "deny", "reason": "..." }
             any non-200 or timeout → treated as DENY
 """
+import hashlib
+import hmac
 import ipaddress
+import json
 import logging
 import socket
 import time
@@ -201,6 +204,23 @@ async def call_pdp_webhook(
         "session_context":    session_context,
     }
 
+    # Audit 2026-04-30 lane 3 H3 — sign the body with the shared
+    # secret so the receiving PDP can verify the call originated
+    # from the broker. We hash the exact bytes we send on the wire,
+    # not ``payload`` re-serialised, to avoid sender/receiver
+    # canonicalisation drift. ``json.dumps`` defaults match httpx's
+    # ``json=`` serialisation closely enough that we serialise once
+    # and reuse the bytes for both the body and the signature.
+    body_bytes = json.dumps(payload).encode()
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    from app.config import get_settings as _get_settings
+    secret = _get_settings().policy_webhook_hmac_secret
+    if secret:
+        sig = hmac.new(
+            secret.encode(), body_bytes, hashlib.sha256,
+        ).hexdigest()
+        headers["X-ATN-Signature"] = sig
+
     t0 = time.monotonic()
     try:
         with tracer.start_as_current_span("pdp.webhook_call") as span:
@@ -223,7 +243,9 @@ async def call_pdp_webhook(
                 follow_redirects=False,
                 transport=transport,
             ) as client:
-                resp = await client.post(webhook_url, json=payload)
+                resp = await client.post(
+                    webhook_url, content=body_bytes, headers=headers,
+                )
 
             # Post-request safety check (belt and suspenders)
             _validate_response_ip(resp)

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -135,6 +135,16 @@ class ProxySettings(BaseSettings):
     # that keeps the system responsive.)
     rate_limit_per_minute: int = 1800
 
+    # Shared secret the proxy uses to verify the X-ATN-Signature HMAC
+    # on inbound /pdp/policy webhook calls (audit 2026-04-30 lane 3 H3).
+    # When set, every POST to /pdp/policy must carry a valid
+    # HMAC-SHA256 over the raw request body, keyed with this secret.
+    # When unset, the endpoint logs a warning at startup but still
+    # accepts unsigned calls — eases mid-rollout while operators
+    # configure the secret on both sides. Set the matching value on
+    # the broker via ``POLICY_WEBHOOK_HMAC_SECRET`` to enable.
+    pdp_webhook_hmac_secret: str = ""
+
     # ADR-013 layer 2 — global Mastio rate limit. Token bucket shared
     # across every request (not per-agent), so coordinated compromise
     # across many stolen credentials cannot outrun the aggregate cap.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -812,10 +812,30 @@ async def pdp_policy(request: Request):
     Evaluates rules from the dashboard Policies page (proxy_config DB).
     Default: allow all (empty rules = no restrictions).
     """
+    import hashlib
+    import hmac
     import json as _json
+    from fastapi import HTTPException
     from mcp_proxy.db import get_config
 
-    body = await request.json()
+    # Audit 2026-04-30 lane 3 H3 — verify the X-ATN-Signature HMAC over
+    # the raw body. Without this, any host that can reach the proxy on
+    # the PDP plane could (a) probe ``policy_rules`` via differential
+    # responses (which agents are blocked, allowed orgs, allowed caps)
+    # and (b) inject log lines via attacker-controlled
+    # ``initiator``/``target``/``context`` strings.
+    raw_body = await request.body()
+    expected_secret = settings.pdp_webhook_hmac_secret
+    if expected_secret:
+        provided = request.headers.get("x-atn-signature", "")
+        expected = hmac.new(
+            expected_secret.encode(), raw_body, hashlib.sha256,
+        ).hexdigest()
+        if not provided or not hmac.compare_digest(provided, expected):
+            _log.warning("pdp /policy rejected: bad or missing X-ATN-Signature")
+            raise HTTPException(status_code=401, detail="invalid signature")
+
+    body = _json.loads(raw_body)
     initiator = body.get("initiator_agent_id", "?")
     target = body.get("target_agent_id", "?")
     context = body.get("session_context", "?")

--- a/tests/test_pdp_webhook_hmac.py
+++ b/tests/test_pdp_webhook_hmac.py
@@ -1,0 +1,266 @@
+"""HMAC signing + verification on the PDP webhook channel.
+
+Audit 2026-04-30 lane 3 H3 — the broker → Mastio /pdp/policy call was
+unauthenticated, letting any host that could reach the proxy on the
+PDP plane probe ``policy_rules`` via differential responses and inject
+log lines via attacker-controlled ``initiator``/``target``/``context``
+strings.
+
+This test file pins both sides of the contract:
+  * broker side (``call_pdp_webhook``) attaches X-ATN-Signature when
+    ``policy_webhook_hmac_secret`` is set,
+  * proxy side (``/pdp/policy``) verifies it when
+    ``MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET`` is set, fail-closed on
+    mismatch / missing.
+
+When the secret is unset on either side the legacy unsigned path is
+preserved so deployments mid-rollout don't break — the audit finding
+is still partly mitigated because the receiver gets to enforce as
+soon as the operator configures it.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+# ── Broker-side: outbound signing ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_call_pdp_webhook_signs_when_secret_set(monkeypatch):
+    """When ``policy_webhook_hmac_secret`` is set the outbound call
+    carries ``X-ATN-Signature: hex(hmac_sha256(secret, body))``
+    and the body bytes match the signed bytes."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "shared-secret-xyz")
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        captured["body"] = bytes(request.content)
+        return httpx.Response(200, json={"decision": "allow"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    decision = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+
+    assert decision.allowed is True
+    assert "x-atn-signature" in captured["headers"]
+    expected = hmac.new(
+        b"shared-secret-xyz", captured["body"], hashlib.sha256,
+    ).hexdigest()
+    assert captured["headers"]["x-atn-signature"] == expected
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_call_pdp_webhook_unsigned_when_secret_unset(monkeypatch):
+    """Legacy backward-compat: when the secret is empty, no signature
+    header is attached (operators mid-rollout)."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200, json={"decision": "allow"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=[],
+        session_context="initiator",
+    )
+
+    assert "x-atn-signature" not in captured["headers"]
+    get_settings.cache_clear()
+
+
+# ── Proxy-side: inbound verification ────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_app_signed(tmp_path, monkeypatch):
+    """Proxy app booted with ``MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET`` set."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "shared-secret-xyz")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import importlib
+    import mcp_proxy.main as main_mod
+    importlib.reload(main_mod)
+    app = main_mod.app
+
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+
+    get_settings.cache_clear()
+
+
+def _sign(body: bytes, secret: str = "shared-secret-xyz") -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_pdp_policy_accepts_valid_signature(proxy_app_signed):
+    body = json.dumps({
+        "initiator_agent_id": "acme::alice",
+        "initiator_org_id": "acme",
+        "target_agent_id": "other-org::bob",
+        "target_org_id": "other-org",
+        "capabilities": [],
+        "session_context": "initiator",
+    }).encode()
+    resp = await proxy_app_signed.post(
+        "/pdp/policy",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-ATN-Signature": _sign(body),
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["decision"] in ("allow", "deny")
+
+
+@pytest.mark.asyncio
+async def test_pdp_policy_rejects_missing_signature(proxy_app_signed):
+    body = json.dumps({"initiator_agent_id": "x", "session_context": "initiator"}).encode()
+    resp = await proxy_app_signed.post(
+        "/pdp/policy",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 401
+    assert "signature" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_pdp_policy_rejects_wrong_signature(proxy_app_signed):
+    body = json.dumps({"initiator_agent_id": "x", "session_context": "initiator"}).encode()
+    resp = await proxy_app_signed.post(
+        "/pdp/policy",
+        content=body,
+        headers={
+            "Content-Type": "application/json",
+            "X-ATN-Signature": "deadbeef" * 8,
+        },
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_pdp_policy_rejects_tampered_body(proxy_app_signed):
+    """Sign body A, send body B → reject. The whole point of HMAC."""
+    body_signed = json.dumps({"initiator_agent_id": "alice", "session_context": "initiator"}).encode()
+    body_sent = json.dumps({"initiator_agent_id": "MALLORY", "session_context": "initiator"}).encode()
+    sig = _sign(body_signed)
+    resp = await proxy_app_signed.post(
+        "/pdp/policy",
+        content=body_sent,
+        headers={
+            "Content-Type": "application/json",
+            "X-ATN-Signature": sig,
+        },
+    )
+    assert resp.status_code == 401
+
+
+@pytest_asyncio.fixture
+async def proxy_app_unsigned(tmp_path, monkeypatch):
+    """Legacy compat: no secret set → unsigned calls accepted."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.delenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import importlib
+    import mcp_proxy.main as main_mod
+    importlib.reload(main_mod)
+    app = main_mod.app
+
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_pdp_policy_legacy_unsigned_accepted_when_secret_unset(proxy_app_unsigned):
+    body = json.dumps({"initiator_agent_id": "x", "session_context": "initiator"}).encode()
+    resp = await proxy_app_unsigned.post(
+        "/pdp/policy",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 200

--- a/tests/test_pdp_webhook_hmac.py
+++ b/tests/test_pdp_webhook_hmac.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
-from unittest.mock import patch
 
 import httpx
 import pytest


### PR DESCRIPTION
## Summary

Closes audit finding **H3** from the 2026-04-30 security audit (memory \`project_security_audit_2026_04_30\`, lane 3).

The broker → Mastio \`/pdp/policy\` webhook was unauthenticated. Any host that could reach the proxy on the PDP plane could:
- probe \`policy_rules\` via differential responses (which agents are blocked, allowed orgs, allowed caps)
- inject log lines via attacker-controlled \`initiator\`/\`target\`/\`context\` strings

The contract docstring in \`app/policy/webhook.py\` had documented \`X-ATN-Signature\` since v0 but called it "future, not yet enforced". This PR enforces it on both ends.

## Changes

**Broker side** (\`app/policy/webhook.py::call_pdp_webhook\`)
- New setting \`policy_webhook_hmac_secret\` (\`POLICY_WEBHOOK_HMAC_SECRET\`)
- When set, every outbound PDP call carries \`X-ATN-Signature: hex(hmac_sha256(secret, body))\`
- Body serialised once, reused for HTTP body + HMAC input → no canonicalisation drift

**Proxy side** (\`mcp_proxy/main.py::pdp_policy\`)
- New setting \`pdp_webhook_hmac_secret\` (\`MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET\`)
- When set, requires every \`/pdp/policy\` request to carry a valid signature
- \`hmac.compare_digest\` for constant-time compare
- 401 on missing or mismatched

**Mid-rollout compatibility:** either secret unset → legacy unsigned path. Receiver enforces as soon as operator configures the secret on both sides. Matches the codebase's ADR-013 layered defence pattern.

## Operator action required to enable

Set the same value on both sides:
\`\`\`bash
# Broker (Court)
export POLICY_WEBHOOK_HMAC_SECRET=<random-256-bit-secret>

# Proxy (Mastio)
export MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET=<same-value>
\`\`\`

Multi-org Mastios (one Court → many Mastios) want a follow-up that scopes the secret per webhook URL in the broker's PDP webhook table. Out of scope here — single-secret covers the dominant standalone Mastio shape.

## Test plan

- [x] \`pytest tests/test_pdp_webhook_hmac.py\` — 7/7 pass (signs, doesn't sign without secret, accepts valid, rejects missing/wrong/tampered, legacy compat)
- [x] \`pytest tests/test_policy.py tests/test_rfq.py tests/test_oneshot_cross.py\` — 47/47 pass (no regression on existing PDP-using paths)
- [ ] Manual smoke: set secret on both sides + cross-org session → succeeds
- [ ] Manual smoke: secret on proxy only + broker call → 401 surfaces in proxy logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)