### PR TITLE
fix(security): replace ECDH XOR key wrap with AES-KW (RFC 3394)

### DIFF
--- a/app/e2e_crypto.py
+++ b/app/e2e_crypto.py
@@ -29,6 +29,7 @@ def _b64url_decode(s: str) -> bytes:
 from cryptography.hazmat.primitives.asymmetric import ec, padding as asym_padding, rsa
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
 
 
 def _encrypt_aes_key_rsa(pubkey, aes_key: bytes) -> dict:
@@ -45,15 +46,21 @@ def _encrypt_aes_key_rsa(pubkey, aes_key: bytes) -> dict:
 
 
 def _encrypt_aes_key_ec(pubkey, aes_key: bytes) -> dict:
-    """Wrap AES key with ECDH + HKDF."""
+    """Wrap AES key with ECDH + HKDF + AES-KW (RFC 3394).
+
+    The HKDF-derived 256-bit KEK is consumed by AES Key Wrap, which is a
+    deterministic AEAD designed for wrapping symmetric keys. The wrapped
+    output is 8 bytes longer than the input (40 bytes for a 32-byte key)
+    and any single-bit tamper is detected by the integrity check during
+    unwrap (raises ``InvalidUnwrap``).
+    """
     ephemeral_key = ec.generate_private_key(pubkey.curve)
     shared_secret = ephemeral_key.exchange(ec.ECDH(), pubkey)
-    derived_key = HKDF(
+    kek = HKDF(
         algorithm=hashes.SHA256(), length=32,
-        salt=None, info=b"cullis-e2e-v1",
+        salt=None, info=b"cullis-e2e-v2-aeskw",
     ).derive(shared_secret)
-    # XOR the AES key with the derived key
-    encrypted_key = bytes(a ^ b for a, b in zip(aes_key, derived_key))
+    encrypted_key = aes_key_wrap(kek, aes_key)
     ephemeral_pub_bytes = ephemeral_key.public_key().public_bytes(
         serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo,
     )
@@ -125,16 +132,21 @@ def _decrypt_aes_key_rsa(privkey, cipher_blob: dict) -> bytes:
 
 
 def _decrypt_aes_key_ec(privkey, cipher_blob: dict) -> bytes:
-    """Unwrap AES key with ECDH + HKDF."""
+    """Unwrap AES key with ECDH + HKDF + AES-KW (RFC 3394).
+
+    AES key unwrap raises ``cryptography.hazmat.primitives.keywrap.InvalidUnwrap``
+    on any tamper to the wrapped key bytes; the caller propagates as a
+    decryption failure.
+    """
     encrypted_key = _b64url_decode(cipher_blob["encrypted_key"])
     ephemeral_pub_pem = _b64url_decode(cipher_blob["ephemeral_pubkey"])
     ephemeral_pub = serialization.load_pem_public_key(ephemeral_pub_pem)
     shared_secret = privkey.exchange(ec.ECDH(), ephemeral_pub)
-    derived_key = HKDF(
+    kek = HKDF(
         algorithm=hashes.SHA256(), length=32,
-        salt=None, info=b"cullis-e2e-v1",
+        salt=None, info=b"cullis-e2e-v2-aeskw",
     ).derive(shared_secret)
-    return bytes(a ^ b for a, b in zip(encrypted_key, derived_key))
+    return aes_key_unwrap(kek, encrypted_key)
 
 
 def decrypt_from_agent(

--- a/cullis_sdk/crypto/e2e.py
+++ b/cullis_sdk/crypto/e2e.py
@@ -49,6 +49,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec, padding as asym_padding, rsa
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.keywrap import aes_key_unwrap, aes_key_wrap
 
 
 def _encrypt_aes_key_rsa(pubkey, aes_key: bytes) -> dict:
@@ -65,14 +66,21 @@ def _encrypt_aes_key_rsa(pubkey, aes_key: bytes) -> dict:
 
 
 def _encrypt_aes_key_ec(pubkey, aes_key: bytes) -> dict:
-    """Wrap AES key with ECDH + HKDF."""
+    """Wrap AES key with ECDH + HKDF + AES-KW (RFC 3394).
+
+    The HKDF-derived 256-bit KEK is consumed by AES Key Wrap, which is a
+    deterministic AEAD designed for wrapping symmetric keys. The wrapped
+    output is 8 bytes longer than the input (40 bytes for a 32-byte key)
+    and any single-bit tamper is detected by the integrity check during
+    unwrap (raises ``InvalidUnwrap``).
+    """
     ephemeral_key = ec.generate_private_key(pubkey.curve)
     shared_secret = ephemeral_key.exchange(ec.ECDH(), pubkey)
-    derived_key = HKDF(
+    kek = HKDF(
         algorithm=hashes.SHA256(), length=32,
-        salt=None, info=b"cullis-e2e-v1",
+        salt=None, info=b"cullis-e2e-v2-aeskw",
     ).derive(shared_secret)
-    encrypted_key = bytes(a ^ b for a, b in zip(aes_key, derived_key))
+    encrypted_key = aes_key_wrap(kek, aes_key)
     ephemeral_pub_bytes = ephemeral_key.public_key().public_bytes(
         serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo,
     )
@@ -144,16 +152,21 @@ def _decrypt_aes_key_rsa(privkey, cipher_blob: dict) -> bytes:
 
 
 def _decrypt_aes_key_ec(privkey, cipher_blob: dict) -> bytes:
-    """Unwrap AES key with ECDH + HKDF."""
+    """Unwrap AES key with ECDH + HKDF + AES-KW (RFC 3394).
+
+    AES key unwrap raises ``cryptography.hazmat.primitives.keywrap.InvalidUnwrap``
+    on any tamper to the wrapped key bytes; the caller propagates as a
+    decryption failure.
+    """
     encrypted_key = _b64url_decode(cipher_blob["encrypted_key"])
     ephemeral_pub_pem = _b64url_decode(cipher_blob["ephemeral_pubkey"])
     ephemeral_pub = serialization.load_pem_public_key(ephemeral_pub_pem)
     shared_secret = privkey.exchange(ec.ECDH(), ephemeral_pub)
-    derived_key = HKDF(
+    kek = HKDF(
         algorithm=hashes.SHA256(), length=32,
-        salt=None, info=b"cullis-e2e-v1",
+        salt=None, info=b"cullis-e2e-v2-aeskw",
     ).derive(shared_secret)
-    return bytes(a ^ b for a, b in zip(encrypted_key, derived_key))
+    return aes_key_unwrap(kek, encrypted_key)
 
 
 def decrypt_from_agent(

--- a/sdk-ts/src/crypto.ts
+++ b/sdk-ts/src/crypto.ts
@@ -3,7 +3,7 @@
  *
  * Encryption: AES-256-GCM (data)
  *   + RSA-OAEP-SHA256 (key wrapping, RSA recipients)
- *   + ECDH ephemeral + HKDF-SHA256 (key wrapping, EC recipients)
+ *   + ECDH ephemeral + HKDF-SHA256 + AES-KW (key wrapping, EC recipients)
  * Signing:    RSA-PSS-SHA256 (RSA keys) or ECDSA-SHA256 (EC keys)
  *
  * This mirrors app/e2e_crypto.py and app/auth/message_signer.py exactly,
@@ -28,8 +28,10 @@ import {
 import type { CipherBlob } from "./types.js";
 import { base64url, base64urlDecode, canonicalJson } from "./utils.js";
 
-const HKDF_INFO = Buffer.from("cullis-e2e-v1", "utf-8");
+const HKDF_INFO = Buffer.from("cullis-e2e-v2-aeskw", "utf-8");
 const HKDF_SALT = Buffer.alloc(0);
+// RFC 3394 default IV for AES Key Wrap.
+const AES_KW_DEFAULT_IV = Buffer.from("A6A6A6A6A6A6A6A6", "hex");
 
 // ── Message Signing (RSA-PSS-SHA256) ──────────────────────────────
 
@@ -141,18 +143,7 @@ export function verifyMessageSignature(
   return true;
 }
 
-// ── E2E Encryption (AES-256-GCM + RSA-OAEP or ECDH+HKDF) ────────
-
-function xorBuffers(a: Buffer, b: Buffer): Buffer {
-  if (a.length !== b.length) {
-    throw new Error("xor length mismatch");
-  }
-  const out = Buffer.alloc(a.length);
-  for (let i = 0; i < a.length; i++) {
-    out[i] = a[i]! ^ b[i]!;
-  }
-  return out;
-}
+// ── E2E Encryption (AES-256-GCM + RSA-OAEP or ECDH+HKDF+AES-KW) ──
 
 function wrapAesKeyRsa(
   recipientPubKey: KeyObject,
@@ -183,10 +174,11 @@ function wrapAesKeyEc(
     privateKey: ephemeral.privateKey,
     publicKey: recipientPubKey,
   });
-  const derived = Buffer.from(
+  const kek = Buffer.from(
     hkdfSync("sha256", sharedSecret, HKDF_SALT, HKDF_INFO, 32),
   );
-  const encryptedKey = xorBuffers(aesKey, derived);
+  const wrap = createCipheriv("aes256-wrap", kek, AES_KW_DEFAULT_IV);
+  const encryptedKey = Buffer.concat([wrap.update(aesKey), wrap.final()]);
   const ephemeralPubPem = ephemeral.publicKey
     .export({ type: "spki", format: "pem" })
     .toString();
@@ -226,11 +218,12 @@ function unwrapAesKeyEc(
     privateKey: recipientPrivKey,
     publicKey: ephemeralPub,
   });
-  const derived = Buffer.from(
+  const kek = Buffer.from(
     hkdfSync("sha256", sharedSecret, HKDF_SALT, HKDF_INFO, 32),
   );
   const encryptedKey = base64urlDecode(blob.encrypted_key);
-  return xorBuffers(encryptedKey, derived);
+  const unwrap = createDecipheriv("aes256-wrap", kek, AES_KW_DEFAULT_IV);
+  return Buffer.concat([unwrap.update(encryptedKey), unwrap.final()]);
 }
 
 
@@ -240,7 +233,7 @@ function unwrapAesKeyEc(
  * Schema: AES-256-GCM encrypts {payload, inner_signature} as JSON.
  * The AES key is wrapped with the recipient's public key:
  *   - RSA keys: RSA-OAEP-SHA256
- *   - EC keys:  ephemeral ECDH + HKDF-SHA256 (info="cullis-e2e-v1"), XOR wrap
+ *   - EC keys:  ephemeral ECDH + HKDF-SHA256 (info="cullis-e2e-v2-aeskw") + AES-KW (RFC 3394)
  * AAD binds the ciphertext to the session context.
  */
 export function encryptForAgent(

--- a/tests/test_e2e_aeskw_tamper.py
+++ b/tests/test_e2e_aeskw_tamper.py
@@ -1,0 +1,74 @@
+"""
+H6 regression: ECDH key wrap is AES-KW (RFC 3394), not malleable XOR.
+
+The pre-fix scheme XOR'd the AES data key with an HKDF-derived key per
+message. Single-bit tampering of ``encrypted_key`` produced a different
+AES key on the recipient side and the outer AES-GCM tag rejected the
+ciphertext, so end-to-end confidentiality was preserved by accident, but
+the wrap step itself had no integrity. AES-KW provides authenticated
+key wrap and rejects tampering during unwrap with ``InvalidUnwrap``.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.keywrap import InvalidUnwrap
+
+from app.e2e_crypto import decrypt_from_agent, encrypt_for_agent
+
+
+def _ec_keypair() -> tuple[str, str]:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv_pem, pub_pem
+
+
+def test_ecdh_wrapped_key_is_40_bytes() -> None:
+    _, pub_pem = _ec_keypair()
+    blob = encrypt_for_agent(
+        pub_pem, {"hello": "world"}, "inner-sig", "sess", "orgA::sender",
+    )
+    assert "ephemeral_pubkey" in blob, "EC wrap must include ephemeral pubkey"
+    wrapped = base64.urlsafe_b64decode(blob["encrypted_key"] + "==")
+    assert len(wrapped) == 40, (
+        "AES-KW wrap of a 32-byte key must be 40 bytes (RFC 3394). "
+        "32 bytes would mean XOR wrap is back."
+    )
+
+
+def test_ecdh_tampered_wrapped_key_raises_invalid_unwrap() -> None:
+    priv_pem, pub_pem = _ec_keypair()
+    blob = encrypt_for_agent(
+        pub_pem, {"x": 1}, "inner-sig", "sess", "orgA::sender",
+    )
+    # Flip one bit of the wrapped key.
+    raw = bytearray(base64.urlsafe_b64decode(blob["encrypted_key"] + "=="))
+    raw[0] ^= 0x01
+    blob["encrypted_key"] = base64.urlsafe_b64encode(bytes(raw)).decode().rstrip("=")
+    with pytest.raises(InvalidUnwrap):
+        decrypt_from_agent(priv_pem, blob, "sess", "orgA::sender")
+
+
+def test_ecdh_roundtrip_preserves_payload() -> None:
+    priv_pem, pub_pem = _ec_keypair()
+    payload = {"order_id": 42, "items": ["a", "b"]}
+    blob = encrypt_for_agent(
+        pub_pem, payload, "inner-sig", "sess-roundtrip", "orgA::sender",
+        client_seq=7,
+    )
+    decoded, sig = decrypt_from_agent(
+        priv_pem, blob, "sess-roundtrip", "orgA::sender", client_seq=7,
+    )
+    assert decoded == payload
+    assert sig == "inner-sig"


### PR DESCRIPTION
## Summary

- Replace malleable XOR key wrap in the ECDH E2E path with AES Key Wrap (RFC 3394).
- Bump HKDF info from `cullis-e2e-v1` to `cullis-e2e-v2-aeskw` so the algorithm change is explicit and cross-version key reuse cannot happen.
- Mirror the fix across `app/e2e_crypto.py`, the in-tree `cullis_sdk` (auto-vendored into `packaging/pypi-sdk/`), and the TypeScript SDK.
- Add `tests/test_e2e_aeskw_tamper.py` to lock in the integrity property: any single-bit tamper to `encrypted_key` raises `InvalidUnwrap`, and the wrapped key length is 40 bytes (32 + 8 integrity).

Closes **H6** from the 2026-04-30 security audit.

## Why

XOR has no integrity. A flipped bit in `encrypted_key` flipped the same bit in the AES data key on the recipient side. The outer AES-GCM tag still rejected the tampered ciphertext so confidentiality held by accident, but the wrap step itself never authenticated, and standards reviewers flagged it as malleable. AES-KW is the IETF-standard primitive for wrapping symmetric keys with a symmetric KEK and adds a 64-bit integrity check.

## Test plan

- [x] `pytest tests/test_message_signature.py tests/test_oneshot_cross_envelope.py tests/test_audit_oneshot_envelope_integrity.py` (32 passed)
- [x] `pytest tests/test_ts_interop.py` Python ↔ Node interop in both directions, both EC and RSA recipients (25 passed)
- [x] New `tests/test_e2e_aeskw_tamper.py` (3 passed): wrapped key is 40 bytes, tamper raises `InvalidUnwrap`, roundtrip preserves payload
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Backwards compatibility

The HKDF info bump is a hard break: messages encrypted under the old scheme cannot be decrypted by the new code and vice versa. There is no deployed fleet to rotate yet, so this is the right time. The wire format (field names) is unchanged; only the byte length of `encrypted_key` grew from 32 to 40.