### PR TITLE
feat(mcp_proxy): multi-role session + require_role helper for RBAC plugin

### DIFF
--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -34,13 +34,27 @@ _COOKIE_MAX_AGE = 8 * 3600  # 8 hours
 
 @dataclass
 class ProxyDashboardSession:
-    """Dashboard session payload."""
-    role: str  # "admin" only for now
+    """Dashboard session payload.
+
+    ``role`` is the primary display role used by templates / the UI badge.
+    ``roles`` is the full authorization tuple consulted by ``require_role``
+    (see ``mcp_proxy.rbac``). Default ``roles=()`` is filled to ``(role,)``
+    in ``__post_init__`` so single-role callers (community deploys, legacy
+    cookies issued before multi-role) keep working unchanged.
+    """
+    role: str
     csrf_token: str = ""
     logged_in: bool = True
+    roles: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.roles:
+            self.roles = (self.role,) if self.role else ()
 
 
-_NO_SESSION = ProxyDashboardSession(role="none", csrf_token="", logged_in=False)
+_NO_SESSION = ProxyDashboardSession(
+    role="none", csrf_token="", logged_in=False, roles=(),
+)
 
 _auto_key: str = ""
 
@@ -151,18 +165,40 @@ def get_session(request: Request) -> ProxyDashboardSession:
     if data.get("exp", 0) < time.time():
         return _NO_SESSION
 
+    raw_roles = data.get("roles")
+    parsed_roles: tuple[str, ...] = ()
+    if isinstance(raw_roles, list):
+        parsed_roles = tuple(str(r) for r in raw_roles if isinstance(r, str) and r)
+
     return ProxyDashboardSession(
         role=data.get("role", "none"),
         csrf_token=data.get("csrf_token", ""),
         logged_in=True,
+        roles=parsed_roles,
     )
 
 
-def set_session(response: Response, role: str = "admin") -> str:
-    """Set a signed session cookie on the response. Returns the CSRF token."""
+def set_session(
+    response: Response,
+    role: str = "admin",
+    roles: tuple[str, ...] | list[str] | None = None,
+) -> str:
+    """Set a signed session cookie on the response. Returns the CSRF token.
+
+    ``roles`` is the full set of authorization roles attached to the session.
+    When omitted, falls back to ``(role,)`` so single-role callers keep their
+    pre-existing behaviour. When provided, ``role`` remains the primary
+    display role; the dashboard UI shows it in the badge while
+    ``require_role`` checks against the wider ``roles`` tuple.
+    """
     csrf_token = os.urandom(16).hex()
+    if roles is None:
+        roles_tuple: tuple[str, ...] = (role,) if role else ()
+    else:
+        roles_tuple = tuple(str(r) for r in roles if r)
     payload = json.dumps({
         "role": role,
+        "roles": list(roles_tuple),
         "csrf_token": csrf_token,
         "exp": int(time.time()) + _COOKIE_MAX_AGE,
     })

--- a/mcp_proxy/rbac.py
+++ b/mcp_proxy/rbac.py
@@ -1,0 +1,73 @@
+"""Dashboard RBAC helpers — role-gated FastAPI dependencies.
+
+The community build only ever sees ``role="admin"`` (single-admin pattern
+preserved by ``mcp_proxy.dashboard.session``). When the enterprise plugin
+``rbac_multi_admin`` is loaded it mints sessions with a wider ``roles``
+tuple (admin / operator / viewer) and routes that opt into RBAC use
+``require_role`` to gate access.
+
+Two stable roles are defined here so handlers can reference them by name
+without reaching into plugin internals; additional roles introduced by
+plugins are accepted at runtime and matched verbatim.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from fastapi import HTTPException, Request
+
+from mcp_proxy.dashboard.session import ProxyDashboardSession, get_session
+
+ROLE_ADMIN = "admin"
+ROLE_OPERATOR = "operator"
+ROLE_VIEWER = "viewer"
+
+
+def has_role(session: ProxyDashboardSession, *roles: str) -> bool:
+    """True iff the session carries at least one of ``roles``."""
+    if not session.logged_in or not session.roles:
+        return False
+    allowed = set(roles)
+    return any(r in allowed for r in session.roles)
+
+
+def require_role(*allowed_roles: str):
+    """FastAPI dependency factory: 401 if logged out, 403 if role mismatch.
+
+    ``admin`` is implicitly accepted on every gate so the single-admin
+    community deploy never needs to opt into per-route role lists. When the
+    enterprise RBAC plugin is active, sessions minted without ``admin`` in
+    their ``roles`` tuple (operator / viewer) must match one of the
+    declared ``allowed_roles`` to pass.
+    """
+    if not allowed_roles:
+        raise ValueError("require_role needs at least one allowed role")
+    permitted = {ROLE_ADMIN, *allowed_roles}
+
+    def _dep(request: Request) -> ProxyDashboardSession:
+        session = get_session(request)
+        if not session.logged_in:
+            raise HTTPException(status_code=401, detail="login required")
+        if not any(r in permitted for r in session.roles):
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "error": "role_required",
+                    "allowed": sorted(allowed_roles),
+                },
+            )
+        return session
+
+    return _dep
+
+
+def filter_roles(roles: Iterable[str]) -> tuple[str, ...]:
+    """Drop empties + dedupe while preserving order. Used by plugins minting sessions."""
+    seen: set[str] = set()
+    kept: list[str] = []
+    for r in roles:
+        if not r or r in seen:
+            continue
+        seen.add(r)
+        kept.append(r)
+    return tuple(kept)

--- a/tests/test_proxy_rbac.py
+++ b/tests/test_proxy_rbac.py
@@ -1,0 +1,253 @@
+"""Tests for ``mcp_proxy.rbac`` and the multi-role extension to
+``ProxyDashboardSession``.
+
+Covers the back-compat surface (single-role cookies / single-role callers
+keep working unchanged) and the new ``roles`` tuple consumed by
+``require_role``. The enterprise plugin ``rbac_multi_admin`` lives in the
+private cullis-enterprise repo and tests the full DB-backed login flow;
+the unit tests here only exercise the core hook surface.
+"""
+from __future__ import annotations
+
+import json as _json
+import time as _time
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# ── ProxyDashboardSession back-compat ────────────────────────────────
+
+
+def test_session_default_roles_mirrors_role():
+    from mcp_proxy.dashboard.session import ProxyDashboardSession
+    s = ProxyDashboardSession(role="admin")
+    assert s.roles == ("admin",)
+
+
+def test_session_explicit_roles_kept():
+    from mcp_proxy.dashboard.session import ProxyDashboardSession
+    s = ProxyDashboardSession(role="operator", roles=("operator", "viewer"))
+    assert s.role == "operator"
+    assert s.roles == ("operator", "viewer")
+
+
+def test_session_empty_role_yields_empty_roles():
+    from mcp_proxy.dashboard.session import ProxyDashboardSession
+    s = ProxyDashboardSession(role="", logged_in=False)
+    assert s.roles == ()
+
+
+# ── Cookie round-trip back-compat ────────────────────────────────────
+
+
+def _signed_cookie(payload: dict) -> str:
+    from mcp_proxy.dashboard.session import _sign
+    return _sign(_json.dumps(payload))
+
+
+def test_legacy_cookie_without_roles_field_still_loads():
+    """Cookies issued before this change have no ``roles`` key. Reading them
+    must yield ``roles == (role,)`` so existing logged-in users don't lose
+    their session on rollout."""
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, get_session
+    from starlette.requests import Request
+
+    legacy_payload = {
+        "role": "admin",
+        "csrf_token": "abc",
+        "exp": int(_time.time()) + 3600,
+    }
+    cookie_value = _signed_cookie(legacy_payload)
+    scope = {
+        "type": "http",
+        "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+    }
+    req = Request(scope)
+    s = get_session(req)
+    assert s.logged_in is True
+    assert s.role == "admin"
+    assert s.roles == ("admin",)
+
+
+def test_new_cookie_with_roles_round_trips():
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, get_session
+    from starlette.requests import Request
+
+    payload = {
+        "role": "operator",
+        "roles": ["operator", "viewer"],
+        "csrf_token": "abc",
+        "exp": int(_time.time()) + 3600,
+    }
+    cookie_value = _signed_cookie(payload)
+    scope = {
+        "type": "http",
+        "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+    }
+    s = get_session(Request(scope))
+    assert s.logged_in is True
+    assert s.role == "operator"
+    assert s.roles == ("operator", "viewer")
+
+
+def test_set_session_default_back_compat(monkeypatch):
+    """``set_session(response, role='admin')`` (no ``roles``) must produce
+    a cookie that round-trips into ``roles=('admin',)`` — guarantees the
+    one production callsite in dashboard/router.py keeps working."""
+    from fastapi import Response
+    from mcp_proxy.dashboard.session import (
+        _COOKIE_NAME, get_session, set_session,
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+
+    response = Response()
+    set_session(response, role="admin")
+    cookie_header = response.headers["set-cookie"]
+    cookie_value = cookie_header.split(";", 1)[0].split("=", 1)[1]
+
+    from starlette.requests import Request
+    scope = {
+        "type": "http",
+        "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+    }
+    s = get_session(Request(scope))
+    assert s.role == "admin"
+    assert s.roles == ("admin",)
+    get_settings.cache_clear()
+
+
+def test_set_session_explicit_roles(monkeypatch):
+    from fastapi import Response
+    from mcp_proxy.dashboard.session import (
+        _COOKIE_NAME, get_session, set_session,
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+
+    response = Response()
+    set_session(response, role="viewer", roles=("viewer",))
+    cookie_value = response.headers["set-cookie"].split(";", 1)[0].split("=", 1)[1]
+
+    from starlette.requests import Request
+    scope = {
+        "type": "http",
+        "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+    }
+    s = get_session(Request(scope))
+    assert s.role == "viewer"
+    assert s.roles == ("viewer",)
+    get_settings.cache_clear()
+
+
+# ── require_role gate behaviour ──────────────────────────────────────
+
+
+def _app_with_role_gate(*roles: str) -> TestClient:
+    from mcp_proxy.rbac import require_role
+
+    app = FastAPI()
+
+    @app.get("/protected")
+    def protected(session=__import__(
+        "fastapi", fromlist=["Depends"],
+    ).Depends(require_role(*roles))):
+        return {"role": session.role, "roles": list(session.roles)}
+
+    return TestClient(app)
+
+
+def _login_client(client: TestClient, role: str, roles: tuple[str, ...] | None = None):
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, _sign
+    payload = {
+        "role": role,
+        "csrf_token": "csrf",
+        "exp": int(_time.time()) + 3600,
+    }
+    if roles is not None:
+        payload["roles"] = list(roles)
+    client.cookies.set(_COOKIE_NAME, _sign(_json.dumps(payload)))
+
+
+def test_require_role_admin_implicit(monkeypatch):
+    """Admin role passes every gate even without being declared."""
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    client = _app_with_role_gate("operator")
+    _login_client(client, role="admin")
+    r = client.get("/protected")
+    assert r.status_code == 200, r.text
+    assert r.json()["role"] == "admin"
+
+
+def test_require_role_unauth_returns_401(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    client = _app_with_role_gate("operator")
+    r = client.get("/protected")
+    assert r.status_code == 401
+
+
+def test_require_role_mismatch_returns_403(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    client = _app_with_role_gate("operator")
+    _login_client(client, role="viewer", roles=("viewer",))
+    r = client.get("/protected")
+    assert r.status_code == 403
+    assert r.json()["detail"]["error"] == "role_required"
+    assert r.json()["detail"]["allowed"] == ["operator"]
+
+
+def test_require_role_match_returns_200(monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    client = _app_with_role_gate("operator", "viewer")
+    _login_client(client, role="operator", roles=("operator",))
+    r = client.get("/protected")
+    assert r.status_code == 200
+    assert r.json()["roles"] == ["operator"]
+
+
+def test_require_role_empty_args_raises():
+    from mcp_proxy.rbac import require_role
+    with pytest.raises(ValueError):
+        require_role()
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def test_has_role_true_false():
+    from mcp_proxy.dashboard.session import ProxyDashboardSession
+    from mcp_proxy.rbac import has_role
+    s = ProxyDashboardSession(role="operator", roles=("operator", "viewer"))
+    assert has_role(s, "operator") is True
+    assert has_role(s, "viewer") is True
+    assert has_role(s, "admin") is False
+
+
+def test_has_role_logged_out_session():
+    from mcp_proxy.dashboard.session import ProxyDashboardSession
+    from mcp_proxy.rbac import has_role
+    s = ProxyDashboardSession(role="none", logged_in=False)
+    assert has_role(s, "admin") is False
+
+
+def test_filter_roles_dedup_preserves_order():
+    from mcp_proxy.rbac import filter_roles
+    assert filter_roles(["admin", "viewer", "admin", "", "operator", "viewer"]) == (
+        "admin", "viewer", "operator",
+    )


### PR DESCRIPTION
## Summary

- Extends `ProxyDashboardSession` with a `roles: tuple[str, ...]` field; `__post_init__` mirrors `(role,)` when callers omit it.
- `set_session(response, role, roles=None)` writes `roles` into the signed cookie; `get_session` reads the new key and falls back to `(role,)` for legacy cookies.
- New `mcp_proxy/rbac.py`: `ROLE_ADMIN / OPERATOR / VIEWER` constants, `require_role(*allowed)` FastAPI dependency factory, `has_role`, `filter_roles`. `admin` is implicitly accepted on every gate so single-admin community deploys never need to opt into per-route role lists.

## Why

Unblocks the cullis-enterprise `rbac_multi_admin` plugin (next PR on the private repo). The plugin will mint sessions with a wider tuple after a DB-backed `admin_users` lookup; admin-level enterprise routes will gate on `require_role("operator")` etc.

Single-role callers — the production `/proxy/login` handler in `dashboard/router.py:310`, the `saml_sso` ACS handler — keep their existing call signatures.

## Test plan

- [x] 15 new unit tests in `tests/test_proxy_rbac.py`:
  - `ProxyDashboardSession` default / explicit / empty role behaviour
  - Legacy cookie (no `roles` key) round-trips into `("admin",)` — guards rolling restart upgrade
  - New cookie with `roles` round-trips intact
  - `set_session` default + explicit roles
  - `require_role`: admin-implicit pass, 401 unauth, 403 mismatch, 200 match, empty-args raises
  - `has_role` true / false / logged-out
  - `filter_roles` dedupe + order preservation
- [x] Existing dashboard suites green (87 tests across `test_dashboard.py`, `test_proxy_dashboard_oidc.py`, `test_proxy_dashboard_mcp_resources.py`, `test_proxy_dashboard_mastio_key.py`, `test_dashboard_agents_reach.py`)
- [x] `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)