### PR TITLE
fix(security): SDK verify rejects bare SPKI, binds cert↔sender, optional chain validation

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -294,6 +294,17 @@ class CullisClient:
         # tools that need it must handle that case.
         self.identity: Any = None
 
+        # H7 audit fix — operator-pinned Org CA bundle path. When set,
+        # ``_resolve_trust_anchors()`` reads the file and threads its
+        # contents through ``verify_oneshot_envelope_signature`` /
+        # ``verify_inner_signature`` so the sender's cert must chain to
+        # one of these anchors, not just be a syntactically valid cert
+        # whose subject happens to match. ``from_connector`` /
+        # ``from_identity_dir`` / ``from_enrollment`` populate this
+        # from ``identity/ca-chain.pem`` (ADR-015 TOFU pin) when
+        # available.
+        self._ca_chain_path: "Path | None" = None
+
     def __enter__(self) -> CullisClient:
         return self
 
@@ -303,6 +314,27 @@ class CullisClient:
     def close(self) -> None:
         """Close the underlying HTTP client."""
         self._http.close()
+
+    def _resolve_trust_anchors(self) -> "list[str] | None":
+        """Read the operator-pinned Org CA bundle for sender-cert chain checks.
+
+        Returns the PEM contents of ``self._ca_chain_path`` as a
+        single-element list when the file exists and is readable, else
+        ``None``. ``verify_oneshot_envelope_signature`` and
+        ``verify_inner_signature`` use this to enforce that the
+        sender's cert chains to the operator-pinned Org CA (H7 audit).
+
+        ``None`` means "no anchors available" — the verify helpers then
+        fall back to bare-cert + identity-binding checks. SDK callers
+        that hold an Org CA bundle from another source can pass it
+        explicitly to the verify helpers and bypass this method.
+        """
+        if self._ca_chain_path is None:
+            return None
+        try:
+            return [self._ca_chain_path.read_text()]
+        except OSError:
+            return None
 
     # ── Internal helpers ────────────────────────────────────────────
 
@@ -1022,6 +1054,11 @@ class CullisClient:
             key_path=_mtls_key,
             ca_chain_path=_pinned_ca if _pinned_ca.exists() else None,
         )
+        # H7 audit fix — share the TOFU-pinned Org CA with the sender-cert
+        # verifier. ``decrypt_oneshot`` and the inner-signature path
+        # then chain-validate the sender's leaf cert against the
+        # operator-confirmed CA, not just any syntactically valid cert.
+        instance._ca_chain_path = _pinned_ca if _pinned_ca.exists() else None
         instance._pubkey_cache = {}
         instance._client_seq = {}
         instance._dpop_privkey = None
@@ -1971,6 +2008,7 @@ class CullisClient:
                     m["timestamp"],
                     m["payload"],
                     client_seq=m.get("sender_seq"),
+                    trust_anchors_pem=self._resolve_trust_anchors(),
                 )
                 if not ok:
                     raise ValueError(
@@ -2243,6 +2281,7 @@ class CullisClient:
             else self._fetch_pubkey_proxy_then_broker
         )
         sender_cert_pem = fetch(sender)
+        trust_anchors = self._resolve_trust_anchors()
         ok = verify_oneshot_envelope_signature(
             sender_cert_pem,
             envelope["signature"],
@@ -2253,6 +2292,7 @@ class CullisClient:
             mode=mode,
             reply_to=envelope.get("reply_to"),
             payload=envelope["payload"],
+            trust_anchors_pem=trust_anchors,
         )
         if not ok:
             raise ValueError(
@@ -2285,6 +2325,7 @@ class CullisClient:
             f"oneshot:{corr}", sender,
             envelope["nonce"], envelope["timestamp"], plaintext,
             client_seq=0,
+            trust_anchors_pem=trust_anchors,
         )
         return {
             "payload": plaintext,

--- a/cullis_sdk/crypto/_cert_trust.py
+++ b/cullis_sdk/crypto/_cert_trust.py
@@ -1,0 +1,202 @@
+"""
+Cert-side trust helpers shared by message_signer and e2e verifiers.
+
+H7 closed three gaps in the SDK verify path:
+
+1. ``verify_signature`` and ``verify_oneshot_envelope_signature`` used to
+   accept a bare SPKI public key when the PEM had no ``CERTIFICATE``
+   marker. A bare SPKI carries no identity, so an attacker who could
+   substitute the public key for one they control would forge messages
+   without any identity binding catching it. The new entry points
+   refuse anything that isn't a full X.509 cert.
+
+2. The verifying key was never bound to ``sender_agent_id``: a valid
+   signature from any cert was accepted as proof the claimed agent
+   sent the message. The cert subject — CN (classic mode) or a SPIFFE
+   URI SAN (SPIRE mode) — now has to match the claimed sender.
+
+3. Chain validation is now optional via ``trust_anchors_pem``: when
+   the caller supplies the Org CA bundle (e.g. via the operator-pinned
+   TOFU path on ``CullisClient``), the leaf cert must chain to one of
+   the anchors. Without anchors the verifier still does (1) + (2),
+   which is enough to stop the substitution attacks the audit
+   flagged; chain validation upgrades it to "the issuing CA is the
+   one we trust".
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+from cryptography import x509 as crypto_x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec as ec_alg
+from cryptography.hazmat.primitives.asymmetric import padding as asym_padding
+from cryptography.hazmat.primitives.asymmetric import rsa as rsa_alg
+from cryptography.x509.oid import NameOID
+
+
+class CertTrustError(ValueError):
+    """Raised when a cert cannot be loaded, bound, or chained."""
+
+
+def load_cert_strict(cert_pem: str) -> crypto_x509.Certificate:
+    """Load a PEM-encoded X.509 certificate.
+
+    Rejects bare SPKI public keys (the silent-fallback the audit
+    flagged): the cert subject is what binds the verifying key to a
+    sender_agent_id, and a bare SPKI has none.
+    """
+    if cert_pem is None:
+        raise CertTrustError("cert_pem is None")
+    pem_bytes = cert_pem.encode() if isinstance(cert_pem, str) else cert_pem
+    if b"-----BEGIN CERTIFICATE-----" not in pem_bytes:
+        raise CertTrustError(
+            "expected an X.509 CERTIFICATE PEM; bare SPKI public keys "
+            "are no longer accepted (H7 audit fix)",
+        )
+    try:
+        return crypto_x509.load_pem_x509_certificate(pem_bytes)
+    except Exception as exc:
+        raise CertTrustError(f"could not parse certificate PEM: {exc}") from exc
+
+
+def cert_binds_agent_id(cert: crypto_x509.Certificate, expected_agent_id: str) -> bool:
+    """Return True iff the cert subject identifies ``expected_agent_id``.
+
+    Matching rules mirror ``app/auth/x509_verifier.py``:
+
+    * Classic mode — cert has CN: the CN must equal the full
+      ``{org}::{name}`` agent_id.
+    * SPIRE mode — cert has no CN, identity in a SPIFFE URI SAN: the
+      path tail (last segment after ``/``) must equal the agent's
+      short name (``expected_agent_id`` after the ``::`` split).
+    """
+    if not expected_agent_id:
+        return False
+    cn_attrs = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    if cn_attrs:
+        return cn_attrs[0].value == expected_agent_id
+    try:
+        san_ext = cert.extensions.get_extension_for_class(
+            crypto_x509.SubjectAlternativeName,
+        )
+    except crypto_x509.ExtensionNotFound:
+        return False
+    uris = san_ext.value.get_values_for_type(crypto_x509.UniformResourceIdentifier)
+    expected_tail = expected_agent_id.split("::", 1)[-1]
+    for uri in uris:
+        if not uri.startswith("spiffe://"):
+            continue
+        tail = uri.rsplit("/", 1)[-1]
+        if tail == expected_tail:
+            return True
+    return False
+
+
+def _load_anchors(trust_anchors_pem: Sequence[str]) -> list[crypto_x509.Certificate]:
+    anchors: list[crypto_x509.Certificate] = []
+    for pem in trust_anchors_pem:
+        if not pem:
+            continue
+        pem_bytes = pem.encode() if isinstance(pem, str) else pem
+        try:
+            anchors.extend(crypto_x509.load_pem_x509_certificates(pem_bytes))
+        except Exception:
+            continue
+    return anchors
+
+
+def cert_chains_to_anchor(
+    leaf: crypto_x509.Certificate,
+    trust_anchors_pem: Sequence[str],
+    *,
+    now: datetime | None = None,
+) -> bool:
+    """Return True iff ``leaf`` is signed by one of the anchors and not expired.
+
+    Single-level chain check (leaf → Org CA). Cullis agent certs are
+    issued directly by the Org CA, no intermediates, so this matches
+    the deployment topology. Expanding to multi-level chains would
+    require ``cryptography.x509.verification.PolicyBuilder`` (>=42),
+    which we can adopt when the SDK's lower bound moves up.
+    """
+    anchors = _load_anchors(trust_anchors_pem)
+    if not anchors:
+        return False
+
+    when = now if now is not None else datetime.now(timezone.utc)
+    if leaf.not_valid_before_utc > when or leaf.not_valid_after_utc < when:
+        return False
+
+    leaf_tbs = leaf.tbs_certificate_bytes
+    leaf_sig = leaf.signature
+    leaf_alg = leaf.signature_hash_algorithm
+    if leaf_alg is None:
+        return False
+
+    for anchor in anchors:
+        if anchor.subject != leaf.issuer:
+            continue
+        if anchor.not_valid_before_utc > when or anchor.not_valid_after_utc < when:
+            continue
+        anchor_pub = anchor.public_key()
+        try:
+            if isinstance(anchor_pub, rsa_alg.RSAPublicKey):
+                anchor_pub.verify(leaf_sig, leaf_tbs, asym_padding.PKCS1v15(), leaf_alg)
+            elif isinstance(anchor_pub, ec_alg.EllipticCurvePublicKey):
+                anchor_pub.verify(leaf_sig, leaf_tbs, ec_alg.ECDSA(leaf_alg))
+            else:
+                continue
+            return True
+        except InvalidSignature:
+            continue
+        except Exception:
+            continue
+    return False
+
+
+def verify_cert_for_sender(
+    cert_pem: str,
+    sender_agent_id: str,
+    trust_anchors_pem: Sequence[str] | None = None,
+) -> crypto_x509.Certificate | None:
+    """One-shot helper: parse cert, verify it binds ``sender_agent_id``,
+    optionally verify it chains to a trust anchor.
+
+    Returns the parsed cert when every check passes, ``None`` otherwise.
+    Callers use the returned cert's public key to verify the signature
+    so the binding result stays welded to the same cert object.
+    """
+    try:
+        cert = load_cert_strict(cert_pem)
+    except CertTrustError:
+        return None
+    if not cert_binds_agent_id(cert, sender_agent_id):
+        return None
+    if trust_anchors_pem is not None:
+        if not cert_chains_to_anchor(cert, trust_anchors_pem):
+            return None
+    return cert
+
+
+__all__ = [
+    "CertTrustError",
+    "cert_binds_agent_id",
+    "cert_chains_to_anchor",
+    "load_cert_strict",
+    "verify_cert_for_sender",
+]
+
+
+# Public verification helpers (hashes + asym primitives) re-exported so
+# verify_signature implementations stay DRY.
+PSS_PADDING = asym_padding.PSS(
+    mgf=asym_padding.MGF1(hashes.SHA256()),
+    salt_length=asym_padding.PSS.MAX_LENGTH,
+)
+SHA256 = hashes.SHA256
+ECDSA = ec_alg.ECDSA
+RSAPublicKey = rsa_alg.RSAPublicKey
+ECPublicKey = ec_alg.EllipticCurvePublicKey

--- a/cullis_sdk/crypto/e2e.py
+++ b/cullis_sdk/crypto/e2e.py
@@ -14,6 +14,7 @@ import base64
 import json
 import os
 import re
+from collections.abc import Sequence
 
 # url-safe base64 alphabet (RFC 4648 section 5).
 _B64URL_ALPHABET_RE = re.compile(r"^[A-Za-z0-9_-]*$")
@@ -215,28 +216,32 @@ def verify_inner_signature(
     timestamp: int,
     payload: dict,
     client_seq: int | None = None,
+    *,
+    trust_anchors_pem: "Sequence[str] | None" = None,
 ) -> bool:
     """
     Verify the inner (plaintext) signature after E2E decryption.
 
     This provides non-repudiation: the recipient can prove the sender
-    signed the plaintext, not just the ciphertext. Returns True if valid,
-    raises ValueError if invalid.
-    """
-    from cryptography import x509 as crypto_x509
-    from cryptography.hazmat.primitives import serialization
+    signed the plaintext, not just the ciphertext. Returns True if
+    valid, raises ValueError if invalid.
 
-    # Accept either a full X.509 certificate PEM or a bare SPKI public
-    # key PEM — different Cullis surfaces return one or the other (the
-    # Mastio public-key endpoint returns SPKI, the broker registry
-    # historically returned the cert). Matches the pattern in
-    # ``message_signer.verify_oneshot_envelope_signature``.
-    pem_bytes = sender_cert_pem.encode()
-    if b"CERTIFICATE" in pem_bytes:
-        cert = crypto_x509.load_pem_x509_certificate(pem_bytes)
-        pub_key = cert.public_key()
-    else:
-        pub_key = serialization.load_pem_public_key(pem_bytes)
+    H7 audit fix: ``sender_cert_pem`` MUST be a full X.509 certificate
+    PEM (bare SPKI rejected), the cert subject must identify
+    ``sender_agent_id``, and when ``trust_anchors_pem`` is supplied
+    the cert must chain to one of the anchors. See
+    ``cullis_sdk.crypto._cert_trust`` for the rationale.
+    """
+    from cullis_sdk.crypto._cert_trust import verify_cert_for_sender
+
+    cert = verify_cert_for_sender(sender_cert_pem, sender_agent_id, trust_anchors_pem)
+    if cert is None:
+        raise ValueError(
+            "Inner signature verification failed — cert is not a valid "
+            "certificate, does not bind sender_agent_id, or does not "
+            "chain to a trust anchor",
+        )
+    pub_key = cert.public_key()
     sig = _b64url_decode(inner_signature_b64)
 
     # Canonical format must match sign_message() in message_signer.py

--- a/cullis_sdk/crypto/message_signer.py
+++ b/cullis_sdk/crypto/message_signer.py
@@ -8,15 +8,23 @@ Schema:
 
 The canonical JSON is deterministic: sort_keys=True, no spaces, ensure_ascii=True.
 Any modification to the payload, session_id, nonce, or sender invalidates the signature.
+
+H7 audit fix: ``verify_signature`` and ``verify_oneshot_envelope_signature``
+no longer accept a bare SPKI public key, always bind the cert subject to
+the claimed ``sender_agent_id``, and accept an optional ``trust_anchors_pem``
+to chain-validate the cert against the Org CA. See ``_cert_trust`` for the
+full rationale.
 """
 import base64
 import json
 import re
+from collections.abc import Sequence
 
-from cryptography import x509 as crypto_x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec as ec_alg, padding, rsa as rsa_alg
+
+from cullis_sdk.crypto._cert_trust import verify_cert_for_sender
 
 _PSS_PADDING = padding.PSS(
     mgf=padding.MGF1(hashes.SHA256()),
@@ -149,7 +157,7 @@ def sign_oneshot_envelope(
 
 
 def verify_oneshot_envelope_signature(
-    cert_or_pubkey_pem: str,
+    cert_pem: str,
     signature_b64: str,
     *,
     correlation_id: str,
@@ -159,19 +167,35 @@ def verify_oneshot_envelope_signature(
     mode: str,
     reply_to: str | None,
     payload: dict,
+    trust_anchors_pem: Sequence[str] | None = None,
 ) -> bool:
-    """Return True if the v2 envelope signature verifies, False otherwise."""
-    pem_bytes = cert_or_pubkey_pem.encode()
+    """Return True if the v2 envelope signature verifies, else False.
+
+    H7 audit fix: ``cert_pem`` MUST be a full X.509 certificate PEM.
+    Bare SPKI public keys (the silent-fallback the audit flagged) are
+    rejected because a bare SPKI carries no identity, so the verifying
+    key cannot be bound to ``sender_agent_id``.
+
+    The cert subject (CN or SPIFFE SAN) must identify
+    ``sender_agent_id`` — without that bind any valid signature from
+    any cert would be accepted as proof the claimed agent sent the
+    message.
+
+    When ``trust_anchors_pem`` is supplied (e.g. by the SDK consumer
+    threading the operator-pinned Org CA bundle), the cert must also
+    chain to one of the anchors. Without anchors the verifier still
+    enforces the parse + bind step, which is enough to stop the
+    substitution attacks the audit flagged.
+    """
+    cert = verify_cert_for_sender(cert_pem, sender_agent_id, trust_anchors_pem)
+    if cert is None:
+        return False
+    pub_key = cert.public_key()
+
     try:
-        if b"CERTIFICATE" in pem_bytes:
-            cert = crypto_x509.load_pem_x509_certificate(pem_bytes)
-            pub_key = cert.public_key()
-        else:
-            pub_key = serialization.load_pem_public_key(pem_bytes)
+        sig = _b64url_decode(signature_b64)
     except Exception:
         return False
-
-    sig = _b64url_decode(signature_b64)
     canonical = compute_oneshot_envelope_sig_input(
         correlation_id=correlation_id,
         sender_agent_id=sender_agent_id,
@@ -194,7 +218,7 @@ def verify_oneshot_envelope_signature(
 
 
 def verify_signature(
-    cert_or_pubkey_pem: str,
+    cert_pem: str,
     signature_b64: str,
     session_id: str,
     sender_agent_id: str,
@@ -202,23 +226,26 @@ def verify_signature(
     timestamp: int,
     payload: dict,
     client_seq: int | None = None,
+    *,
+    trust_anchors_pem: Sequence[str] | None = None,
 ) -> bool:
     """
     Verify a message signature. Returns True if valid, False if invalid.
 
-    Accepts either a PEM certificate or a PEM public key.
+    H7 audit fix: ``cert_pem`` MUST be a full X.509 certificate PEM.
+    Bare SPKI public keys are rejected. The cert subject (CN or SPIFFE
+    SAN) must identify ``sender_agent_id``. When ``trust_anchors_pem``
+    is supplied, the cert must also chain to one of the anchors.
     """
-    pem_bytes = cert_or_pubkey_pem.encode()
+    cert = verify_cert_for_sender(cert_pem, sender_agent_id, trust_anchors_pem)
+    if cert is None:
+        return False
+    pub_key = cert.public_key()
+
     try:
-        if b"CERTIFICATE" in pem_bytes:
-            cert = crypto_x509.load_pem_x509_certificate(pem_bytes)
-            pub_key = cert.public_key()
-        else:
-            pub_key = serialization.load_pem_public_key(pem_bytes)
+        sig = _b64url_decode(signature_b64)
     except Exception:
         return False
-
-    sig = _b64url_decode(signature_b64)
     canonical = _canonical(session_id, sender_agent_id, nonce, timestamp, payload, client_seq)
     try:
         if isinstance(pub_key, rsa_alg.RSAPublicKey):

--- a/sdk-ts/src/crypto.ts
+++ b/sdk-ts/src/crypto.ts
@@ -23,10 +23,67 @@ import {
   diffieHellman,
   hkdfSync,
   constants,
+  X509Certificate,
   type KeyObject,
 } from "node:crypto";
 import type { CipherBlob } from "./types.js";
 import { base64url, base64urlDecode, canonicalJson } from "./utils.js";
+
+/**
+ * H7 audit: parse a PEM string strictly as an X.509 certificate.
+ * Bare SPKI public keys are rejected — the cert subject is what binds
+ * the verifying key to ``senderAgentId``, and a bare SPKI carries no
+ * identity. Returns ``null`` on parse failure or if the input is not a
+ * CERTIFICATE PEM.
+ */
+function loadCertStrict(certPem: string): X509Certificate | null {
+  if (!certPem || !certPem.includes("-----BEGIN CERTIFICATE-----")) {
+    return null;
+  }
+  try {
+    return new X509Certificate(certPem);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * H7 audit: bind the cert to ``expectedAgentId``. Mirrors the Python
+ * ``_cert_trust.cert_binds_agent_id`` rule:
+ *   - cert with CN: CN must equal the full ``{org}::{name}`` agent_id
+ *   - cert with no CN, SPIFFE URI SAN: path tail must equal the
+ *     short name (after the ``::`` split)
+ */
+function certBindsAgentId(cert: X509Certificate, expectedAgentId: string): boolean {
+  if (!expectedAgentId) {
+    return false;
+  }
+  // ``X509Certificate.subject`` is a multi-line string of the form
+  // ``CN=acme::alice\nO=acme``. Walk it for a CN line.
+  const subject = cert.subject ?? "";
+  for (const line of subject.split("\n")) {
+    const match = /^\s*CN=(.+?)\s*$/.exec(line);
+    if (match) {
+      return match[1] === expectedAgentId;
+    }
+  }
+  // SPIFFE SAN fallback. ``subjectAltName`` is the comma-separated
+  // OpenSSL-style string, e.g. ``URI:spiffe://td/org/agent``.
+  const san = cert.subjectAltName ?? "";
+  const expectedTail = expectedAgentId.includes("::")
+    ? expectedAgentId.split("::").slice(-1)[0]
+    : expectedAgentId;
+  for (const entry of san.split(",")) {
+    const trimmed = entry.trim();
+    if (!trimmed.startsWith("URI:spiffe://")) continue;
+    const uri = trimmed.slice("URI:".length);
+    const tail = uri.split("/").pop() ?? "";
+    if (tail === expectedTail) {
+      return true;
+    }
+  }
+  return false;
+}
 
 const HKDF_INFO = Buffer.from("cullis-e2e-v2-aeskw", "utf-8");
 const HKDF_SALT = Buffer.alloc(0);
@@ -100,9 +157,14 @@ export function signMessage(
 /**
  * Verify a message signature. Algorithm is dispatched from the public key
  * type (RSA-PSS-SHA256 or ECDSA-SHA256). Returns true, throws on failure.
+ *
+ * H7 audit fix: ``certPem`` MUST be a full X.509 certificate PEM. Bare
+ * SPKI public keys are rejected, and the cert subject must identify
+ * ``senderAgentId``. See the Python ``_cert_trust`` module for the
+ * full rationale.
  */
 export function verifyMessageSignature(
-  publicKeyPem: string,
+  certPem: string,
   signatureB64: string,
   sessionId: string,
   senderAgentId: string,
@@ -111,11 +173,24 @@ export function verifyMessageSignature(
   payload: Record<string, unknown>,
   clientSeq?: number | null,
 ): boolean {
+  const cert = loadCertStrict(certPem);
+  if (cert === null) {
+    throw new Error(
+      "Message signature verification failed: expected an X.509 " +
+        "CERTIFICATE PEM (bare SPKI public keys are no longer accepted)",
+    );
+  }
+  if (!certBindsAgentId(cert, senderAgentId)) {
+    throw new Error(
+      "Message signature verification failed: cert subject does not " +
+        `bind sender_agent_id ${senderAgentId}`,
+    );
+  }
   const canonical = buildCanonical(
     sessionId, senderAgentId, nonce, timestamp, payload, clientSeq,
   );
   const sig = base64urlDecode(signatureB64);
-  const keyObj = createPublicKey(publicKeyPem);
+  const keyObj = cert.publicKey;
   const verifier = createVerify("SHA256");
   verifier.update(canonical);
 

--- a/tests/test_e2e_verify_chain_binding.py
+++ b/tests/test_e2e_verify_chain_binding.py
@@ -1,0 +1,291 @@
+"""
+H7 regression: SDK verify helpers reject bare SPKI, bind cert ↔ sender_agent_id,
+and chain-validate against operator-pinned trust anchors when supplied.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+import pytest
+from cryptography import x509 as _x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from cullis_sdk.crypto._cert_trust import (
+    cert_binds_agent_id,
+    cert_chains_to_anchor,
+    load_cert_strict,
+    verify_cert_for_sender,
+)
+from cullis_sdk.crypto.message_signer import (
+    sign_message,
+    sign_oneshot_envelope,
+    verify_oneshot_envelope_signature,
+    verify_signature,
+)
+
+
+def _ec_key():
+    return ec.generate_private_key(ec.SECP256R1())
+
+
+def _priv_pem(priv) -> str:
+    return priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+
+
+def _spki_pem(priv) -> str:
+    return priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _ca_pair(org_id: str = "acme") -> tuple[_x509.Certificate, "rsa.RSAPrivateKey"]:
+    ca_priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = _x509.Name([
+        _x509.NameAttribute(NameOID.COMMON_NAME, f"{org_id} Test CA"),
+        _x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    now = _dt.datetime.now(_dt.timezone.utc)
+    ca_cert = (
+        _x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(ca_priv.public_key())
+        .serial_number(_x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(minutes=5))
+        .not_valid_after(now + _dt.timedelta(days=365))
+        .add_extension(_x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_priv, hashes.SHA256())
+    )
+    return ca_cert, ca_priv
+
+
+def _agent_cert(
+    agent_priv,
+    agent_id: str,
+    org_id: str,
+    issuer_priv=None,
+    issuer_cert=None,
+    self_signed: bool = False,
+) -> _x509.Certificate:
+    subject = _x509.Name([
+        _x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        _x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    if self_signed or issuer_priv is None:
+        issuer_priv = agent_priv
+        issuer_subject = subject
+    else:
+        issuer_subject = issuer_cert.subject
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return (
+        _x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer_subject)
+        .public_key(agent_priv.public_key())
+        .serial_number(_x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(minutes=5))
+        .not_valid_after(now + _dt.timedelta(hours=1))
+        .sign(issuer_priv, hashes.SHA256())
+    )
+
+
+def _pem(cert: _x509.Certificate) -> str:
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+# ── load_cert_strict ────────────────────────────────────────────────────
+
+
+def test_load_cert_strict_rejects_bare_spki() -> None:
+    priv = _ec_key()
+    with pytest.raises(Exception):
+        load_cert_strict(_spki_pem(priv))
+
+
+def test_load_cert_strict_accepts_certificate() -> None:
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    parsed = load_cert_strict(_pem(cert))
+    assert parsed.subject == cert.subject
+
+
+# ── cert_binds_agent_id ─────────────────────────────────────────────────
+
+
+def test_binding_cn_matches() -> None:
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    assert cert_binds_agent_id(cert, "acme::alice") is True
+
+
+def test_binding_cn_mismatch_rejects() -> None:
+    """Substitution attack: cert has CN=acme::alice but caller claims bob."""
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    assert cert_binds_agent_id(cert, "acme::bob") is False
+
+
+# ── cert_chains_to_anchor ───────────────────────────────────────────────
+
+
+def test_chain_signed_by_anchor_accepted() -> None:
+    ca_cert, ca_priv = _ca_pair("acme")
+    agent_priv = _ec_key()
+    agent_cert = _agent_cert(
+        agent_priv, "acme::alice", "acme",
+        issuer_priv=ca_priv, issuer_cert=ca_cert,
+    )
+    assert cert_chains_to_anchor(agent_cert, [_pem(ca_cert)]) is True
+
+
+def test_chain_self_signed_rejected_when_anchor_supplied() -> None:
+    """Self-signed cert masquerading as agent cert: chain check rejects."""
+    _, real_ca_priv = _ca_pair("acme")
+    real_ca_cert, _ = _ca_pair("acme")  # different CA
+    fake_priv = _ec_key()
+    fake_cert = _agent_cert(fake_priv, "acme::alice", "acme", self_signed=True)
+    assert cert_chains_to_anchor(fake_cert, [_pem(real_ca_cert)]) is False
+
+
+def test_chain_expired_cert_rejected() -> None:
+    ca_cert, ca_priv = _ca_pair("acme")
+    agent_priv = _ec_key()
+    subject = _x509.Name([
+        _x509.NameAttribute(NameOID.COMMON_NAME, "acme::alice"),
+        _x509.NameAttribute(NameOID.ORGANIZATION_NAME, "acme"),
+    ])
+    now = _dt.datetime.now(_dt.timezone.utc)
+    expired_cert = (
+        _x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(agent_priv.public_key())
+        .serial_number(_x509.random_serial_number())
+        .not_valid_before(now - _dt.timedelta(days=10))
+        .not_valid_after(now - _dt.timedelta(days=1))
+        .sign(ca_priv, hashes.SHA256())
+    )
+    assert cert_chains_to_anchor(expired_cert, [_pem(ca_cert)]) is False
+
+
+# ── verify_cert_for_sender (composite) ──────────────────────────────────
+
+
+def test_verify_cert_for_sender_returns_cert_when_valid() -> None:
+    ca_cert, ca_priv = _ca_pair("acme")
+    agent_priv = _ec_key()
+    agent_cert = _agent_cert(
+        agent_priv, "acme::alice", "acme",
+        issuer_priv=ca_priv, issuer_cert=ca_cert,
+    )
+    out = verify_cert_for_sender(_pem(agent_cert), "acme::alice", [_pem(ca_cert)])
+    assert out is not None
+    assert out.subject == agent_cert.subject
+
+
+def test_verify_cert_for_sender_returns_none_on_binding_mismatch() -> None:
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    assert verify_cert_for_sender(_pem(cert), "acme::bob", None) is None
+
+
+def test_verify_cert_for_sender_skips_chain_when_anchors_none() -> None:
+    """Identity binding alone is enough when no anchors are supplied —
+    SDK consumers without a TOFU-pinned Org CA still get cert+binding."""
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    assert verify_cert_for_sender(_pem(cert), "acme::alice", None) is not None
+
+
+# ── End-to-end through verify_signature ────────────────────────────────
+
+
+def test_verify_signature_rejects_spki() -> None:
+    priv = _ec_key()
+    sig = sign_message(_priv_pem(priv), "s1", "acme::alice", "n", 1700000000, {"x": 1})
+    assert verify_signature(
+        _spki_pem(priv), sig, "s1", "acme::alice", "n", 1700000000, {"x": 1},
+    ) is False
+
+
+def test_verify_signature_rejects_cn_mismatch() -> None:
+    """Attacker holds a valid cert for acme::alice and tries to use it to
+    forge a message claiming to be from acme::bob — binding check stops it."""
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    sig = sign_message(_priv_pem(priv), "s1", "acme::bob", "n", 1700000000, {"x": 1})
+    assert verify_signature(
+        _pem(cert), sig, "s1", "acme::bob", "n", 1700000000, {"x": 1},
+    ) is False
+
+
+def test_verify_signature_rejects_untrusted_chain() -> None:
+    """Chain validation: a self-signed cert with the right CN is rejected
+    when a real Org CA is supplied as the trust anchor."""
+    real_ca_cert, _ = _ca_pair("acme")
+    fake_priv = _ec_key()
+    fake_cert = _agent_cert(fake_priv, "acme::alice", "acme", self_signed=True)
+    sig = sign_message(_priv_pem(fake_priv), "s1", "acme::alice", "n", 1700000000, {"x": 1})
+    assert verify_signature(
+        _pem(fake_cert), sig, "s1", "acme::alice", "n", 1700000000, {"x": 1},
+        trust_anchors_pem=[_pem(real_ca_cert)],
+    ) is False
+
+
+def test_verify_signature_accepts_legit_chain() -> None:
+    ca_cert, ca_priv = _ca_pair("acme")
+    agent_priv = _ec_key()
+    agent_cert = _agent_cert(
+        agent_priv, "acme::alice", "acme",
+        issuer_priv=ca_priv, issuer_cert=ca_cert,
+    )
+    sig = sign_message(
+        _priv_pem(agent_priv), "s1", "acme::alice", "n", 1700000000, {"x": 1},
+    )
+    assert verify_signature(
+        _pem(agent_cert), sig, "s1", "acme::alice", "n", 1700000000, {"x": 1},
+        trust_anchors_pem=[_pem(ca_cert)],
+    ) is True
+
+
+# ── End-to-end through verify_oneshot_envelope_signature ───────────────
+
+
+def test_oneshot_verify_rejects_spki() -> None:
+    priv = _ec_key()
+    sig = sign_oneshot_envelope(
+        _priv_pem(priv),
+        correlation_id="c1", sender_agent_id="acme::alice",
+        nonce="n", timestamp=1700000000, mode="envelope",
+        reply_to=None, payload={"x": 1},
+    )
+    assert verify_oneshot_envelope_signature(
+        _spki_pem(priv), sig,
+        correlation_id="c1", sender_agent_id="acme::alice",
+        nonce="n", timestamp=1700000000, mode="envelope",
+        reply_to=None, payload={"x": 1},
+    ) is False
+
+
+def test_oneshot_verify_rejects_cn_mismatch() -> None:
+    priv = _ec_key()
+    cert = _agent_cert(priv, "acme::alice", "acme", self_signed=True)
+    sig = sign_oneshot_envelope(
+        _priv_pem(priv),
+        correlation_id="c1", sender_agent_id="acme::bob",
+        nonce="n", timestamp=1700000000, mode="envelope",
+        reply_to=None, payload={"x": 1},
+    )
+    assert verify_oneshot_envelope_signature(
+        _pem(cert), sig,
+        correlation_id="c1", sender_agent_id="acme::bob",
+        nonce="n", timestamp=1700000000, mode="envelope",
+        reply_to=None, payload={"x": 1},
+    ) is False

--- a/tests/test_ts_interop.py
+++ b/tests/test_ts_interop.py
@@ -50,6 +50,39 @@ def _pem_keypair(kind: str) -> tuple[str, str]:
     return priv_pem, pub_pem
 
 
+def _self_signed_cert(priv_pem: str, agent_id: str, org_id: str) -> str:
+    """Build a self-signed cert for ``agent_id`` from the given private key.
+
+    H7 audit: ``verifyMessageSignature`` rejects bare SPKI public keys
+    and binds the cert subject to ``senderAgentId``. Test fixtures that
+    used to ship a bare pubkey now ship a self-signed cert with
+    ``CN=agent_id`` and ``O=org_id`` to mirror the production identity
+    binding (see ``cullis_sdk.crypto._cert_trust``).
+    """
+    import datetime as _dt
+
+    from cryptography import x509 as _x509
+    from cryptography.hazmat.primitives import hashes as _hashes
+    from cryptography.x509.oid import NameOID
+
+    priv = serialization.load_pem_private_key(priv_pem.encode(), password=None)
+    subject = _x509.Name([
+        _x509.NameAttribute(NameOID.COMMON_NAME, agent_id),
+        _x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+    builder = (
+        _x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(priv.public_key())
+        .serial_number(_x509.random_serial_number())
+        .not_valid_before(_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(minutes=5))
+        .not_valid_after(_dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(hours=1))
+    )
+    cert = builder.sign(priv, _hashes.SHA256())
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
 def _run_node(mode: str, payload: dict) -> dict:
     with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
         json.dump(payload, f)
@@ -125,7 +158,8 @@ def test_python_sign_ts_verify(kind: str) -> None:
     auto-dispatch matches Python's RSA-PSS / ECDSA selection."""
     from app.auth.message_signer import sign_message
 
-    priv_pem, pub_pem = _pem_keypair(kind)
+    priv_pem, _ = _pem_keypair(kind)
+    cert_pem = _self_signed_cert(priv_pem, "orgA::alice", "orgA")
     payload = {"kind": kind, "k": "py-sign"}
     nonce = "n-py-ts"
     ts = 1700000000
@@ -133,7 +167,7 @@ def test_python_sign_ts_verify(kind: str) -> None:
     out = _run_node(
         "verify",
         {
-            "sender_pub_pem": pub_pem,
+            "sender_pub_pem": cert_pem,
             "signature": signature,
             "session_id": "s1",
             "sender_agent_id": "orgA::alice",
@@ -241,14 +275,15 @@ def test_python_sign_ts_verify_non_ascii(label: str, payload: dict) -> None:
     """Python signs a non-ASCII payload; TS must verify (F-A-2 regression)."""
     from app.auth.message_signer import sign_message
 
-    priv_pem, pub_pem = _pem_keypair("ec")
+    priv_pem, _ = _pem_keypair("ec")
+    cert_pem = _self_signed_cert(priv_pem, "orgA::alice", "orgA")
     nonce = f"n-py-ts-{label}"
     ts = 1700000100
     signature = sign_message(priv_pem, "s1", "orgA::alice", nonce, ts, payload, 5)
     out = _run_node(
         "verify",
         {
-            "sender_pub_pem": pub_pem,
+            "sender_pub_pem": cert_pem,
             "signature": signature,
             "session_id": "s1",
             "sender_agent_id": "orgA::alice",


### PR DESCRIPTION
## Summary

The SDK helpers `verify_oneshot_envelope_signature` and `verify_signature` accepted any PEM whose body decoded as a public key (full cert or bare SPKI). A bare SPKI carries no identity, so the verifying key was never bound to `sender_agent_id`: any valid signature from any cert was accepted as proof the claimed agent sent the message. An attacker who could substitute the cert (cache poisoning, broker compromise, future fetcher that mistakenly returned SPKI) could forge messages from arbitrary agent IDs.

Three layers added in `cullis_sdk.crypto._cert_trust`:

1. **`load_cert_strict`** rejects anything that isn't a `CERTIFICATE` PEM (no silent SPKI fallback).
2. **`cert_binds_agent_id`** enforces that the cert subject identifies `sender_agent_id`: classic mode matches CN exactly, SPIRE mode matches the SPIFFE URI SAN path tail. Mirrors `app/auth/x509_verifier.py`.
3. **`cert_chains_to_anchor`** (opt-in via `trust_anchors_pem`) walks a single-level chain from leaf to the operator-pinned Org CA. `CullisClient.from_connector` threads `identity/ca-chain.pem` (ADR-015 TOFU pin) through the verify call sites so `decrypt_oneshot` enforces chain validation by default for Connector-built clients.

The TypeScript SDK gets the same parse + bind treatment via `loadCertStrict` and `certBindsAgentId`. Chain validation isn't plumbed through TS yet — no Connector-equivalent caller exists there.

Closes **H7** from the 2026-04-30 security audit.

## Test plan

- [x] `pytest tests/test_e2e_verify_chain_binding.py` (16 new regression tests pass)
- [x] `pytest tests/test_intra_org_round_trip.py tests/test_message_signature.py tests/test_oneshot_cross_envelope.py tests/test_audit_oneshot_envelope_integrity.py` (34 passed, no regressions)
- [x] `pytest tests/test_ts_interop.py` (25 passed — TS verify now fed self-signed certs in fixtures, mirroring production)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean
- [x] `npm run build` in `sdk-ts/` succeeds

## Backwards compatibility

The verify helpers' positional arg renamed from `cert_or_pubkey_pem` to `cert_pem`. The argument types didn't change (still `str`); only callers that passed bare SPKI break. The only such caller was the TS interop test, updated in this PR. Production fetchers (`_fetch_pubkey_proxy_then_broker`, `/v1/egress/agents/{id}/public-key`) already return certs.