### PR TITLE
fix(security): decouple at-rest secret KEK from Org CA private key

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -128,6 +128,15 @@ class Settings(BaseSettings):
     vault_token: str = ""
     vault_secret_path: str = "secret/data/broker"
 
+    # H8 audit fix — at-rest secret encryption uses a dedicated master
+    # key, NOT the broker CA private key. Local backend persists 32
+    # random bytes here on first boot (0600 perms). Vault backend
+    # stores the same material under the ``secret_encryption_key_b64``
+    # field of ``vault_secret_path`` and ignores this path. Operators
+    # MUST back this file up alongside the Org CA — losing it makes
+    # every enc:v2 stored secret unrecoverable.
+    secret_encryption_key_path: str = "certs/secret_encryption.key"
+
     # Audit hash chain TSA anchoring (issue #75). When enabled, a
     # background worker periodically timestamps each per-org chain head
     # with an external TSA so the broker operator cannot silently

--- a/app/kms/factory.py
+++ b/app/kms/factory.py
@@ -58,6 +58,7 @@ def _build_provider() -> KMSProvider:
         return LocalKMSProvider(
             key_path=settings.broker_ca_key_path,
             cert_path=settings.broker_ca_cert_path,
+            secret_encryption_key_path=settings.secret_encryption_key_path,
         )
 
     raise RuntimeError(

--- a/app/kms/local.py
+++ b/app/kms/local.py
@@ -5,6 +5,8 @@ Used for development, tests, and environments without a KMS backend.
 KMS_BACKEND=local (default when VAULT_ADDR is not set).
 """
 import logging
+import os
+import secrets
 from pathlib import Path
 
 from cryptography import x509 as crypto_x509
@@ -16,12 +18,27 @@ _log = logging.getLogger("agent_trust")
 class LocalKMSProvider:
     """Reads the broker CA private key and certificate from disk."""
 
-    def __init__(self, key_path: str, cert_path: str) -> None:
+    def __init__(
+        self,
+        key_path: str,
+        cert_path: str,
+        secret_encryption_key_path: str | None = None,
+    ) -> None:
         self._key_path = key_path
         self._cert_path = cert_path
+        # H8 audit fix — separate master key for at-rest secret
+        # encryption. Defaults to a sibling of the CA private key when
+        # the operator hasn't pinned a path, so a fresh deploy gets a
+        # working setup without extra config.
+        if secret_encryption_key_path is None:
+            secret_encryption_key_path = str(
+                Path(key_path).parent / "secret_encryption.key",
+            )
+        self._secret_encryption_key_path = secret_encryption_key_path
         # Cached values — loaded once on first access
         self._private_key_pem: str | None = None
         self._public_key_pem: str | None = None
+        self._secret_encryption_key: bytes | None = None
 
     async def get_broker_private_key_pem(self) -> str:
         if self._private_key_pem is None:
@@ -41,12 +58,73 @@ class LocalKMSProvider:
             _log.info("KMS[local] broker public key loaded from %s", self._cert_path)
         return self._public_key_pem
 
+    async def get_secret_encryption_key(self) -> bytes:
+        """Load or generate the 32-byte secret-encryption master key.
+
+        H8 audit fix: the master key is decoupled from the Org CA. On
+        first boot we generate 32 random bytes, write them to
+        ``secret_encryption.key`` with 0600 perms, and reuse that file
+        on subsequent boots. Operators wanting deterministic keys for
+        backup/restore can pre-populate the file (must be 32 bytes
+        binary or 64 hex chars).
+        """
+        if self._secret_encryption_key is not None:
+            return self._secret_encryption_key
+        path = Path(self._secret_encryption_key_path)
+        if path.exists():
+            raw = path.read_bytes().strip()
+            # Allow either raw 32-byte binary OR a 64-char hex string
+            # (operators commonly paste hex from `openssl rand -hex 32`).
+            if len(raw) == 32:
+                key = bytes(raw)
+            elif len(raw) == 64 and all(0x30 <= b <= 0x66 for b in raw):
+                try:
+                    key = bytes.fromhex(raw.decode("ascii"))
+                except ValueError:
+                    key = bytes(raw)
+            else:
+                raise RuntimeError(
+                    f"KMS[local] {path} must be 32 raw bytes or 64 hex "
+                    f"chars (got {len(raw)} bytes). Regenerate with "
+                    "`openssl rand -out secret_encryption.key 32`.",
+                )
+            _log.info("KMS[local] secret-encryption master key loaded from %s", path)
+        else:
+            key = secrets.token_bytes(32)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # Write atomically with restrictive perms — the master key
+            # has the same sensitivity as the broker CA private key.
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_bytes(key)
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+            _log.warning(
+                "KMS[local] generated new secret-encryption master key at %s "
+                "(0600). Back this up alongside the broker CA private key — "
+                "losing it makes every enc:v2 stored secret unrecoverable.",
+                path,
+            )
+        self._secret_encryption_key = key
+        return key
+
     async def encrypt_secret(self, plaintext: str) -> str:
-        from app.kms.secret_encrypt import encrypt_secret
-        pem = await self.get_broker_private_key_pem()
-        return encrypt_secret(pem, plaintext)
+        from app.kms.secret_encrypt import encrypt_secret_v2
+        master_key = await self.get_secret_encryption_key()
+        return encrypt_secret_v2(master_key, plaintext)
 
     async def decrypt_secret(self, stored: str) -> str:
-        from app.kms.secret_encrypt import decrypt_secret
+        """Decrypt a stored secret. Tries v2 (master-key derived) first
+        and falls back to v1 (legacy CA-derived) so existing data
+        keeps decrypting through the H8 cutover.
+        """
+        from app.kms.secret_encrypt import (
+            _ENC_PREFIX_V2,
+            decrypt_secret,
+            decrypt_secret_v2,
+        )
+        if stored.startswith(_ENC_PREFIX_V2):
+            master_key = await self.get_secret_encryption_key()
+            return decrypt_secret_v2(master_key, stored)
+        # Legacy enc:v1 or plaintext — keep using the CA private key.
         pem = await self.get_broker_private_key_pem()
         return decrypt_secret(pem, stored)

--- a/app/kms/provider.py
+++ b/app/kms/provider.py
@@ -18,6 +18,18 @@ class KMSProvider(Protocol):
         """Return the broker CA public key in PEM format."""
         ...
 
+    async def get_secret_encryption_key(self) -> bytes:
+        """Return the 32-byte master key used to derive at-rest secret KEKs.
+
+        H8 audit fix: the secret-encryption master key is decoupled from
+        the broker CA private key. Each backend manages its own
+        lifecycle (filesystem file, Vault KV field, cloud KMS-wrapped
+        material). On first call the backend may auto-generate it
+        (random 32 bytes) and persist it; subsequent calls return the
+        same bytes for the lifetime of the deployment until rotated.
+        """
+        ...
+
     async def encrypt_secret(self, plaintext: str) -> str:
         """Encrypt a secret string for storage at rest."""
         ...

--- a/app/kms/secret_encrypt.py
+++ b/app/kms/secret_encrypt.py
@@ -1,11 +1,22 @@
 """
-Symmetric secret encryption using a key derived from the broker private key.
+Symmetric secret encryption for at-rest values (OIDC client secrets, etc.).
 
-Uses HKDF-SHA256 to derive a 32-byte Fernet key from the broker RSA private
-key PEM, then Fernet (AES-128-CBC + HMAC-SHA256) for authenticated encryption.
+Two on-wire formats coexist:
 
-Encrypted values are prefixed with ``enc:v1:`` so legacy plaintext values
-can be detected and handled gracefully (transparent migration).
+* ``enc:v1:`` (legacy) — KEK derived via HKDF-SHA256 from the broker
+  CA private key PEM. Audit H8 flagged this for tying secret
+  encryption to the issuing CA's private key, so a CA key rotation
+  invalidates every stored secret and a CA compromise discloses every
+  stored secret. Reads still work for back-compat.
+* ``enc:v2:`` (new) — KEK derived via HKDF-SHA256 from a dedicated
+  32-byte master key the KMS provider manages. The master key has its
+  own lifecycle separate from the Org CA. Format:
+  ``enc:v2:<salt_hex>:<fernet_token>``.
+
+Both formats are Fernet-wrapped (AES-128-CBC + HMAC-SHA256). The
+``is_encrypted`` helper matches either prefix; ``decrypt_secret`` only
+handles the v1 path because callers without a master key can still
+read legacy values; ``decrypt_secret_v2`` handles the new path.
 """
 import base64
 import os
@@ -15,12 +26,17 @@ from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import hashes
 
 _ENC_PREFIX = "enc:v1:"
+_ENC_PREFIX_V2 = "enc:v2:"
 _HKDF_INFO = b"atn-secret-encryption-v1"
+_HKDF_INFO_V2 = b"atn-secret-encryption-v2"
 _SALT_LENGTH = 16
 
 
 def _derive_fernet_key(private_key_pem: str, salt: bytes | None = None) -> bytes:
-    """Derive a 32-byte Fernet key from the broker private key PEM via HKDF."""
+    """Derive a 32-byte Fernet key from the broker private key PEM via HKDF.
+
+    Legacy v1 path. Retained so existing ``enc:v1:`` ciphertexts decrypt.
+    """
     hkdf = HKDF(
         algorithm=hashes.SHA256(),
         length=32,
@@ -31,24 +47,68 @@ def _derive_fernet_key(private_key_pem: str, salt: bytes | None = None) -> bytes
     return base64.urlsafe_b64encode(derived)
 
 
+def _derive_fernet_key_v2(master_key: bytes, salt: bytes) -> bytes:
+    """Derive a Fernet key from the dedicated secret-encryption master key.
+
+    H8 audit fix: ``master_key`` is a 32-byte secret managed by the KMS
+    backend, decoupled from the Org CA private key. Its compromise
+    surface is limited to at-rest secrets, and rotating it does not
+    require re-issuing the CA.
+    """
+    if len(master_key) < 16:
+        raise ValueError(
+            "Secret-encryption master key must be at least 16 bytes "
+            "(got %d). Re-generate with `openssl rand 32`." % len(master_key),
+        )
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        info=_HKDF_INFO_V2,
+    )
+    derived = hkdf.derive(master_key)
+    return base64.urlsafe_b64encode(derived)
+
+
 def encrypt_secret(private_key_pem: str, plaintext: str) -> str:
-    """Encrypt a secret string, returning ``enc:v1:<salt_hex>:<fernet_token>``."""
+    """Encrypt with the legacy v1 KEK (CA-derived). Use ``encrypt_secret_v2``
+    for new code — the v1 path is kept only for tests that still feed a PEM.
+    """
     salt = os.urandom(_SALT_LENGTH)
     key = _derive_fernet_key(private_key_pem, salt=salt)
     token = Fernet(key).encrypt(plaintext.encode()).decode()
     return f"{_ENC_PREFIX}{salt.hex()}:{token}"
 
 
-def decrypt_secret(private_key_pem: str, stored: str) -> str:
-    """Decrypt a stored secret.
+def encrypt_secret_v2(master_key: bytes, plaintext: str) -> str:
+    """Encrypt with the dedicated secret-encryption master key (H8).
 
-    If the value does not carry the ``enc:v1:`` prefix it is assumed to be
-    legacy plaintext and returned as-is (transparent migration).
-
-    Supports both formats:
-      - ``enc:v1:<salt_hex>:<fernet_token>`` (new, salted)
-      - ``enc:v1:<fernet_token>`` (legacy, no salt — backward compat)
+    Returns ``enc:v2:<salt_hex>:<fernet_token>``. The 16-byte salt
+    randomises the per-secret KEK so two ciphertexts of the same
+    plaintext don't share the same KEK.
     """
+    salt = os.urandom(_SALT_LENGTH)
+    key = _derive_fernet_key_v2(master_key, salt=salt)
+    token = Fernet(key).encrypt(plaintext.encode()).decode()
+    return f"{_ENC_PREFIX_V2}{salt.hex()}:{token}"
+
+
+def decrypt_secret(private_key_pem: str, stored: str) -> str:
+    """Decrypt a v1 stored secret (legacy CA-derived KEK).
+
+    If the value does not carry the ``enc:v1:`` prefix it is assumed
+    to be legacy plaintext and returned as-is (transparent migration).
+    Refuses ``enc:v2:`` values — those require ``decrypt_secret_v2``.
+
+    Supports both v1 sub-formats:
+      - ``enc:v1:<salt_hex>:<fernet_token>`` (salted)
+      - ``enc:v1:<fernet_token>`` (pre-salt legacy)
+    """
+    if stored.startswith(_ENC_PREFIX_V2):
+        raise ValueError(
+            "decrypt_secret() only handles enc:v1; use decrypt_secret_v2() "
+            "with the secret-encryption master key for enc:v2 values",
+        )
     if not stored.startswith(_ENC_PREFIX):
         return stored  # legacy plaintext — return unchanged
     payload = stored[len(_ENC_PREFIX):]
@@ -72,6 +132,30 @@ def decrypt_secret(private_key_pem: str, stored: str) -> str:
             raise ValueError("Failed to decrypt secret — wrong key or corrupted data") from exc
 
 
+def decrypt_secret_v2(master_key: bytes, stored: str) -> str:
+    """Decrypt an ``enc:v2:`` secret with the dedicated master key (H8).
+
+    Refuses values without the v2 prefix so a typo doesn't silently
+    feed legacy v1 ciphertexts to the wrong key.
+    """
+    if not stored.startswith(_ENC_PREFIX_V2):
+        raise ValueError(
+            "decrypt_secret_v2() requires enc:v2 input; "
+            "got prefix-stripped value or legacy enc:v1",
+        )
+    payload = stored[len(_ENC_PREFIX_V2):]
+    parts = payload.split(":", 1)
+    if len(parts) != 2 or len(parts[0]) != _SALT_LENGTH * 2:
+        raise ValueError("malformed enc:v2 secret — expected <salt_hex>:<fernet_token>")
+    try:
+        salt = bytes.fromhex(parts[0])
+        token = parts[1]
+        key = _derive_fernet_key_v2(master_key, salt=salt)
+        return Fernet(key).decrypt(token.encode()).decode()
+    except (ValueError, InvalidToken) as exc:
+        raise ValueError("Failed to decrypt secret — wrong key or corrupted data") from exc
+
+
 def is_encrypted(stored: str) -> bool:
-    """Check if a stored value is encrypted."""
-    return stored.startswith(_ENC_PREFIX)
+    """Check if a stored value is encrypted (either v1 or v2 prefix)."""
+    return stored.startswith(_ENC_PREFIX) or stored.startswith(_ENC_PREFIX_V2)

--- a/app/kms/vault.py
+++ b/app/kms/vault.py
@@ -206,12 +206,112 @@ class VaultKMSProvider:
             _log.info("KMS[vault] broker public key fetched from %s", self._secret_path)
         return self._public_key_pem
 
+    async def get_secret_encryption_key(self) -> bytes:
+        """Load the 32-byte secret-encryption master key from Vault.
+
+        H8 audit fix: the master key for at-rest secret encryption is
+        decoupled from the broker CA private key. The Vault KV path
+        carries it as ``secret_encryption_key_b64`` (base64 of 32
+        random bytes). On a fresh deploy that hasn't seeded the field
+        yet we generate one locally and write it back to Vault under a
+        CAS round-trip so the next boot reads the same value.
+        """
+        if hasattr(self, "_secret_encryption_key") and self._secret_encryption_key is not None:
+            return self._secret_encryption_key
+
+        secret: dict | None = None
+        try:
+            secret = await self._fetch_secret()
+        except VaultSecretNotFound:
+            pass
+
+        if secret and "secret_encryption_key_b64" in secret:
+            import base64 as _b64
+            try:
+                key = _b64.b64decode(secret["secret_encryption_key_b64"])
+            except Exception as exc:
+                raise RuntimeError(
+                    f"Vault field 'secret_encryption_key_b64' is not valid "
+                    f"base64: {exc}",
+                ) from exc
+            if len(key) != 32:
+                raise RuntimeError(
+                    f"Vault field 'secret_encryption_key_b64' decoded to "
+                    f"{len(key)} bytes (expected 32)",
+                )
+            self._secret_encryption_key = key
+            _log.info("KMS[vault] secret-encryption master key loaded from %s", self._secret_path)
+            return key
+
+        # Field not seeded yet — generate locally + persist back to
+        # Vault so the next boot reads it from there.
+        import base64 as _b64
+        import secrets as _secrets
+
+        key = _secrets.token_bytes(32)
+        encoded = _b64.b64encode(key).decode("ascii")
+        ok = await self._write_field("secret_encryption_key_b64", encoded)
+        if not ok:
+            raise RuntimeError(
+                f"Vault path '{self._secret_path}' did not have "
+                "'secret_encryption_key_b64' and the write-back attempt "
+                "failed. Seed the field manually with `openssl rand 32 | "
+                "base64` before retrying.",
+            )
+        self._secret_encryption_key = key
+        _log.warning(
+            "KMS[vault] generated new secret-encryption master key and "
+            "persisted to %s. Back this Vault field up — losing it makes "
+            "every enc:v2 stored secret unrecoverable.",
+            self._secret_path,
+        )
+        return key
+
+    async def _write_field(self, field: str, value: str) -> bool:
+        """CAS write a single field into the existing Vault secret.
+
+        Used by ``get_secret_encryption_key`` to seed the master key on
+        first boot. Mirrors the merge-then-CAS pattern in
+        ``app.kms.admin_secret`` so concurrent writers don't lose data.
+        """
+        url = f"{self._vault_addr}/v1/{self._secret_path}"
+        headers = {"X-Vault-Token": self._vault_token, "Content-Type": "application/json"}
+        _ca_cert = os.environ.get("VAULT_CA_CERT", "")
+        _verify: bool | str = _ca_cert if _ca_cert else True
+        try:
+            async with httpx.AsyncClient(timeout=_VAULT_READ_TIMEOUT, verify=_verify) as client:
+                resp = await client.get(url, headers=headers)
+                if resp.status_code == 200:
+                    payload = resp.json()["data"]
+                    current = payload.get("data", {}) or {}
+                    version = payload.get("metadata", {}).get("version", 0)
+                    current[field] = value
+                    body: dict = {"options": {"cas": version}, "data": current}
+                else:
+                    body = {"data": {field: value}}
+                resp = await client.post(url, headers=headers, json=body)
+                return resp.status_code in (200, 204)
+        except Exception as exc:
+            _log.error("Vault write to %s failed: %s", self._secret_path, exc)
+            return False
+
     async def encrypt_secret(self, plaintext: str) -> str:
-        from app.kms.secret_encrypt import encrypt_secret
-        pem = await self.get_broker_private_key_pem()
-        return encrypt_secret(pem, plaintext)
+        from app.kms.secret_encrypt import encrypt_secret_v2
+        master_key = await self.get_secret_encryption_key()
+        return encrypt_secret_v2(master_key, plaintext)
 
     async def decrypt_secret(self, stored: str) -> str:
-        from app.kms.secret_encrypt import decrypt_secret
+        """Decrypt a stored secret. Tries v2 (master-key derived) first
+        and falls back to v1 (legacy CA-derived) so existing data
+        keeps decrypting through the H8 cutover.
+        """
+        from app.kms.secret_encrypt import (
+            _ENC_PREFIX_V2,
+            decrypt_secret,
+            decrypt_secret_v2,
+        )
+        if stored.startswith(_ENC_PREFIX_V2):
+            master_key = await self.get_secret_encryption_key()
+            return decrypt_secret_v2(master_key, stored)
         pem = await self.get_broker_private_key_pem()
         return decrypt_secret(pem, stored)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,9 +111,18 @@ def _inject_kms_provider():
     certs/broker-ca-key.pem from disk, which doesn't exist in CI.
     """
     from tests.cert_factory import init_broker_keys
-    from app.kms.secret_encrypt import encrypt_secret, decrypt_secret
+    from app.kms.secret_encrypt import (
+        _ENC_PREFIX_V2,
+        decrypt_secret,
+        decrypt_secret_v2,
+        encrypt_secret_v2,
+    )
 
     priv_pem, pub_pem = init_broker_keys()
+    # H8 audit — tests now exercise the v2 master-key path. A
+    # deterministic master key is fine for tests; production uses 32
+    # random bytes from the LocalKMS / Vault backend.
+    test_master_key = b"\x42" * 32
 
     class _EphemeralKMS:
         async def get_broker_private_key_pem(self) -> str:
@@ -122,10 +131,15 @@ def _inject_kms_provider():
         async def get_broker_public_key_pem(self) -> str:
             return pub_pem
 
+        async def get_secret_encryption_key(self) -> bytes:
+            return test_master_key
+
         async def encrypt_secret(self, plaintext: str) -> str:
-            return encrypt_secret(priv_pem, plaintext)
+            return encrypt_secret_v2(test_master_key, plaintext)
 
         async def decrypt_secret(self, stored: str) -> str:
+            if stored.startswith(_ENC_PREFIX_V2):
+                return decrypt_secret_v2(test_master_key, stored)
             return decrypt_secret(priv_pem, stored)
 
     import app.kms.factory as kms_mod

--- a/tests/test_h8_kek_decouple.py
+++ b/tests/test_h8_kek_decouple.py
@@ -1,0 +1,189 @@
+"""
+H8 regression: at-rest secret encryption uses a dedicated master key,
+not the broker CA private key.
+
+The audit flagged ``app/kms/secret_encrypt.py`` for deriving the KEK
+from the Org CA private key PEM. Two consequences: (1) rotating the CA
+breaks every encrypted secret, and (2) compromising the CA discloses
+every encrypted secret. The v2 path keeps the CA out of the secret-
+encryption path entirely; this file locks the property in.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from app.kms.local import LocalKMSProvider
+from app.kms.secret_encrypt import (
+    _ENC_PREFIX,
+    _ENC_PREFIX_V2,
+    decrypt_secret,
+    decrypt_secret_v2,
+    encrypt_secret,
+    encrypt_secret_v2,
+    is_encrypted,
+)
+
+# Throwaway CA private key — used only to drive the legacy v1 codepath
+# in tests; the v2 codepath never sees it.
+_DUMMY_PEM = "-----BEGIN RSA PRIVATE KEY-----\nMIIdummy1234567890\n-----END RSA PRIVATE KEY-----\n"
+
+
+# ── encrypt_secret_v2 / decrypt_secret_v2 ──────────────────────────────
+
+
+def test_v2_roundtrip() -> None:
+    master_key = os.urandom(32)
+    plaintext = "client-secret-9000"
+    ct = encrypt_secret_v2(master_key, plaintext)
+    assert ct.startswith(_ENC_PREFIX_V2)
+    assert plaintext not in ct
+    assert decrypt_secret_v2(master_key, ct) == plaintext
+
+
+def test_v2_wrong_master_key_fails() -> None:
+    ct = encrypt_secret_v2(os.urandom(32), "hello")
+    with pytest.raises(ValueError, match="Failed to decrypt"):
+        decrypt_secret_v2(os.urandom(32), ct)
+
+
+def test_v2_short_master_key_rejected() -> None:
+    """Catch operators who paste a 16-char string thinking it's the key."""
+    with pytest.raises(ValueError, match="at least 16 bytes"):
+        encrypt_secret_v2(b"short", "x")
+
+
+def test_v1_decrypt_refuses_v2_input() -> None:
+    """An enc:v2 ciphertext must not silently fall through to the v1 KEK."""
+    ct = encrypt_secret_v2(os.urandom(32), "x")
+    with pytest.raises(ValueError, match="enc:v2"):
+        decrypt_secret(_DUMMY_PEM, ct)
+
+
+def test_v2_decrypt_refuses_v1_input() -> None:
+    """An enc:v1 ciphertext must not silently feed the master key path."""
+    ct = encrypt_secret(_DUMMY_PEM, "x")
+    assert ct.startswith(_ENC_PREFIX)
+    with pytest.raises(ValueError, match="enc:v2"):
+        decrypt_secret_v2(os.urandom(32), ct)
+
+
+def test_is_encrypted_matches_both_prefixes() -> None:
+    assert is_encrypted(encrypt_secret(_DUMMY_PEM, "a"))
+    assert is_encrypted(encrypt_secret_v2(os.urandom(32), "a"))
+    assert not is_encrypted("plain text")
+
+
+# ── LocalKMSProvider master-key handling ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_local_kms_generates_master_key_on_first_boot(tmp_path: Path) -> None:
+    """First call creates the file with 32 random bytes and 0600 perms."""
+    cert_path = tmp_path / "ca.pem"
+    cert_path.write_text(
+        "-----BEGIN CERTIFICATE-----\nMIIdummy\n-----END CERTIFICATE-----\n",
+    )
+    key_path = tmp_path / "ca-key.pem"
+    key_path.write_text(_DUMMY_PEM)
+    secret_key_path = tmp_path / "secret_encryption.key"
+
+    kms = LocalKMSProvider(
+        key_path=str(key_path), cert_path=str(cert_path),
+        secret_encryption_key_path=str(secret_key_path),
+    )
+    assert not secret_key_path.exists()
+    key = await kms.get_secret_encryption_key()
+    assert len(key) == 32
+    assert secret_key_path.exists()
+    assert secret_key_path.stat().st_mode & 0o777 == 0o600
+    # Subsequent calls return the same value (cached + persisted).
+    assert await kms.get_secret_encryption_key() == key
+
+
+@pytest.mark.asyncio
+async def test_local_kms_master_key_is_independent_of_ca(tmp_path: Path) -> None:
+    """Encrypting under two LocalKMS instances with the SAME CA key but
+    different ``secret_encryption_key_path`` files must NOT interop —
+    proves the at-rest KEK no longer derives from the CA.
+    """
+    cert_path = tmp_path / "ca.pem"
+    cert_path.write_text(
+        "-----BEGIN CERTIFICATE-----\nMIIdummy\n-----END CERTIFICATE-----\n",
+    )
+    key_path = tmp_path / "ca-key.pem"
+    key_path.write_text(_DUMMY_PEM)
+    a_master = tmp_path / "a.key"
+    b_master = tmp_path / "b.key"
+
+    kms_a = LocalKMSProvider(
+        key_path=str(key_path), cert_path=str(cert_path),
+        secret_encryption_key_path=str(a_master),
+    )
+    kms_b = LocalKMSProvider(
+        key_path=str(key_path), cert_path=str(cert_path),
+        secret_encryption_key_path=str(b_master),
+    )
+    ct = await kms_a.encrypt_secret("alpha")
+    with pytest.raises(ValueError, match="Failed to decrypt"):
+        await kms_b.decrypt_secret(ct)
+
+
+@pytest.mark.asyncio
+async def test_local_kms_legacy_v1_still_decrypts(tmp_path: Path) -> None:
+    """Existing enc:v1 ciphertexts (CA-derived KEK) must keep decrypting
+    after the H8 cutover so deployments don't lose access to data."""
+    cert_path = tmp_path / "ca.pem"
+    cert_path.write_text(
+        "-----BEGIN CERTIFICATE-----\nMIIdummy\n-----END CERTIFICATE-----\n",
+    )
+    key_path = tmp_path / "ca-key.pem"
+    key_path.write_text(_DUMMY_PEM)
+    kms = LocalKMSProvider(
+        key_path=str(key_path), cert_path=str(cert_path),
+        secret_encryption_key_path=str(tmp_path / "se.key"),
+    )
+    legacy_ct = encrypt_secret(_DUMMY_PEM, "old-data")
+    assert legacy_ct.startswith(_ENC_PREFIX)
+    assert await kms.decrypt_secret(legacy_ct) == "old-data"
+
+
+@pytest.mark.asyncio
+async def test_local_kms_new_encrypts_emit_v2(tmp_path: Path) -> None:
+    cert_path = tmp_path / "ca.pem"
+    cert_path.write_text(
+        "-----BEGIN CERTIFICATE-----\nMIIdummy\n-----END CERTIFICATE-----\n",
+    )
+    key_path = tmp_path / "ca-key.pem"
+    key_path.write_text(_DUMMY_PEM)
+    kms = LocalKMSProvider(
+        key_path=str(key_path), cert_path=str(cert_path),
+        secret_encryption_key_path=str(tmp_path / "se.key"),
+    )
+    ct = await kms.encrypt_secret("new-data")
+    assert ct.startswith(_ENC_PREFIX_V2)
+    assert await kms.decrypt_secret(ct) == "new-data"
+
+
+@pytest.mark.asyncio
+async def test_local_kms_accepts_hex_master_key(tmp_path: Path) -> None:
+    """Operators commonly produce keys with `openssl rand -hex 32`. The
+    provider must accept either raw 32 bytes or 64 hex chars."""
+    cert_path = tmp_path / "ca.pem"
+    cert_path.write_text(
+        "-----BEGIN CERTIFICATE-----\nMIIdummy\n-----END CERTIFICATE-----\n",
+    )
+    key_path = tmp_path / "ca-key.pem"
+    key_path.write_text(_DUMMY_PEM)
+    secret_key_path = tmp_path / "se.key"
+    raw = bytes(range(32))
+    secret_key_path.write_text(raw.hex())
+
+    kms = LocalKMSProvider(
+        key_path=str(key_path), cert_path=str(cert_path),
+        secret_encryption_key_path=str(secret_key_path),
+    )
+    loaded = await kms.get_secret_encryption_key()
+    assert loaded == raw

--- a/tests/test_kms_encryption.py
+++ b/tests/test_kms_encryption.py
@@ -8,6 +8,7 @@ from app.kms.secret_encrypt import (
     decrypt_secret,
     is_encrypted,
     _ENC_PREFIX,
+    _ENC_PREFIX_V2,
 )
 
 # Use a deterministic "fake" PEM for testing — only the bytes matter for HKDF
@@ -78,12 +79,15 @@ def test_encrypt_same_value_produces_different_ciphertexts():
 
 @pytest.mark.asyncio
 async def test_kms_provider_encrypt_decrypt(client):
-    """KMS provider encrypt/decrypt methods work end-to-end."""
+    """KMS provider encrypt/decrypt methods work end-to-end. H8: v2 prefix."""
     from app.kms.factory import get_kms_provider
     kms = get_kms_provider()
     plaintext = "oidc-client-secret-via-kms"
     encrypted = await kms.encrypt_secret(plaintext)
-    assert encrypted.startswith(_ENC_PREFIX)
+    # H8 audit: providers always emit enc:v2 (master-key derived) for
+    # new ciphertexts. Decrypt still tolerates legacy enc:v1 from
+    # pre-cutover data.
+    assert encrypted.startswith(_ENC_PREFIX_V2)
     decrypted = await kms.decrypt_secret(encrypted)
     assert decrypted == plaintext
 


### PR DESCRIPTION
## Summary

The KEK that wraps OIDC client secrets and other at-rest values used to be HKDF-derived from the broker CA private key. Two failure modes:

- Rotating the Org CA invalidates every encrypted secret (HKDF input changed) — operators avoided rotation to keep data decryptable.
- Compromising the CA discloses every encrypted secret. The audit wanted these blast radii separate.

Switch to ``enc:v2:`` with a dedicated 32-byte master key per deployment:

- New ``KMSProvider.get_secret_encryption_key() -> bytes`` on the protocol.
- ``LocalKMSProvider`` reads/generates a sibling file (``secret_encryption.key``, 0600 perms, 32 random bytes on first boot). Accepts raw 32 bytes or 64 hex chars (``openssl rand -hex 32``).
- ``VaultKMSProvider`` stores the same material under ``secret_encryption_key_b64`` in the existing KV path; CAS-writes a freshly-generated key on first boot when the field is missing.
- ``encrypt_secret_v2(master_key, plaintext)`` and ``decrypt_secret_v2(master_key, stored)`` are the new HKDF-info-separated functions in ``app/kms/secret_encrypt.py``.

Reads are backwards-compatible: both providers try v2 first and fall back to the legacy CA-derived v1 path on enc:v1 ciphertexts, so existing data keeps decrypting through the cutover.

Closes **H8** from the 2026-04-30 audit.

## Test plan

- [x] `pytest tests/test_h8_kek_decouple.py` (11 new regression tests pass — v2 roundtrip, wrong-key fail, prefix mismatch refusal, master-key auto-generation, perms 0600, hex/raw handling, legacy v1 still decrypts, two LocalKMS instances with same CA + different master keys can't interop)
- [x] `pytest tests/test_kms_encryption.py tests/test_kms_vault_fallback.py tests/test_mastio_kms.py tests/test_secrets_hardening.py tests/test_audit_r2_t3.py` (71 passed)
- [x] Broader: `pytest tests/ -k "kms or secret or oidc or admin"` (195 passed)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Operator action

Existing local deployments: the ``secret_encryption.key`` file auto-generates on next boot. Back it up alongside the Org CA private key — losing it makes every enc:v2 stored secret unrecoverable.

Vault deployments: the ``secret_encryption_key_b64`` field auto-seeds in the broker KV path on next boot. Snapshot Vault as part of the existing CA backup procedure.