### PR TITLE
fix(security): rate-limit + per-IP lockout on Mastio /proxy/login

### DIFF
--- a/mcp_proxy/dashboard/login_lockout.py
+++ b/mcp_proxy/dashboard/login_lockout.py
@@ -1,0 +1,152 @@
+"""
+Per-IP brute-force lockout for the Mastio dashboard ``/proxy/login`` form.
+
+Audit H9: the login handler had no rate-limit, no lockout, and no
+back-off, so an attacker on the same network could trial passwords at
+HTTP-stack speed. The bcrypt cost slows each attempt down somewhat,
+but ~10 guesses per second on commodity hardware is still enough to
+chew through a short or pattern-based admin password before anyone
+notices.
+
+Two layers, both keyed on the client IP:
+
+1. **Rate limit** — caps the burst rate at 10 attempts/min/IP via the
+   existing ``get_agent_rate_limiter()`` (Redis-backed when available,
+   in-memory per-worker otherwise). Lets a forgetful operator retry
+   without locking themselves out, but stops a fast scripted spray.
+
+2. **Lockout** — after 5 consecutive failures the IP is blocked for
+   15 minutes. Successful logins reset the counter; the lockout
+   window itself uses absolute timestamps so a restart doesn't
+   accidentally reset state mid-attack (in-memory) or persists in
+   Redis (multi-worker).
+
+Both layers are advisory rather than authentication: even if the
+attacker bypasses the lockout (different IP, header spoof through a
+broken reverse proxy), bcrypt + the audit log on every failure still
+protect the credential. The point is to put friction on automation
+and make the audit trail noisy enough to notice.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Protocol
+
+_log = logging.getLogger("mcp_proxy")
+
+# Tuned for the dashboard threat model: an admin password change is
+# rare, so 5 misses inside the cooldown is overwhelmingly likely to
+# be an attack rather than a confused operator. 15 min matches the
+# OWASP ASVS L1 baseline for account-lockout duration.
+LOCKOUT_THRESHOLD = 5
+LOCKOUT_WINDOW_SECONDS = 15 * 60
+LOCKOUT_DURATION_SECONDS = 15 * 60
+LOGIN_RATE_PER_MINUTE = 10
+
+
+class LoginLockoutStore(Protocol):
+    async def record_failure(self, ip: str) -> tuple[int, float | None]:
+        """Increment the failure counter and return ``(count, locked_until)``.
+
+        ``locked_until`` is a wall-clock UNIX timestamp when the IP
+        becomes unlocked, or ``None`` when the IP is still under the
+        threshold.
+        """
+        ...
+
+    async def record_success(self, ip: str) -> None:
+        """Clear failure state for a successful login."""
+        ...
+
+    async def is_locked(self, ip: str) -> float | None:
+        """Return the unlock time when the IP is currently locked, else ``None``."""
+        ...
+
+
+class _InMemoryStore:
+    """Per-worker in-memory store. Sufficient for single-worker
+    deployments; multi-worker needs the Redis-backed variant or each
+    worker's lockout window is independent (degrading the threshold
+    by a factor of N)."""
+
+    def __init__(self) -> None:
+        # ip -> list[float] of recent failure timestamps within the
+        # rolling lockout window. The list is trimmed on each access.
+        self._failures: dict[str, list[float]] = {}
+        # ip -> wall-clock unlock time
+        self._locked_until: dict[str, float] = {}
+        self._lock = asyncio.Lock()
+
+    async def record_failure(self, ip: str) -> tuple[int, float | None]:
+        now = time.time()
+        cutoff = now - LOCKOUT_WINDOW_SECONDS
+        async with self._lock:
+            recent = [t for t in self._failures.get(ip, []) if t > cutoff]
+            recent.append(now)
+            self._failures[ip] = recent
+            if len(recent) >= LOCKOUT_THRESHOLD:
+                unlock_at = now + LOCKOUT_DURATION_SECONDS
+                self._locked_until[ip] = unlock_at
+                # Leaving the failure list intact means a single mistake
+                # after the lockout expires won't reset the counter —
+                # only an explicit success does. Closes a partial-bypass
+                # where an attacker spaces guesses just past the window.
+                return len(recent), unlock_at
+            return len(recent), None
+
+    async def record_success(self, ip: str) -> None:
+        async with self._lock:
+            self._failures.pop(ip, None)
+            self._locked_until.pop(ip, None)
+
+    async def is_locked(self, ip: str) -> float | None:
+        now = time.time()
+        async with self._lock:
+            unlock_at = self._locked_until.get(ip)
+            if unlock_at is None:
+                return None
+            if unlock_at <= now:
+                # Expired lockout: clear it and the failure history so
+                # the next legitimate attempt starts fresh.
+                self._locked_until.pop(ip, None)
+                self._failures.pop(ip, None)
+                return None
+            return unlock_at
+
+
+_store: LoginLockoutStore | None = None
+
+
+def get_login_lockout_store() -> LoginLockoutStore:
+    """Return the active store, initialising on first call.
+
+    Mirrors the pattern in ``auth/rate_limit.py`` — Redis when
+    available, in-memory otherwise. The Redis adapter is intentionally
+    not implemented yet; multi-worker deployments must run with one
+    worker until a Redis-backed variant lands. Single-Mastio default
+    deploy is single-worker.
+    """
+    global _store
+    if _store is None:
+        _store = _InMemoryStore()
+        _log.info("Dashboard login lockout: in-memory")
+    return _store
+
+
+def reset_login_lockout_for_tests() -> None:
+    """Test-only helper: drop the singleton so each test starts fresh."""
+    global _store
+    _store = None
+
+
+__all__ = [
+    "LOCKOUT_DURATION_SECONDS",
+    "LOCKOUT_THRESHOLD",
+    "LOCKOUT_WINDOW_SECONDS",
+    "LOGIN_RATE_PER_MINUTE",
+    "LoginLockoutStore",
+    "get_login_lockout_store",
+    "reset_login_lockout_for_tests",
+]

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -250,6 +250,19 @@ async def login_page(request: Request):
     })
 
 
+def _login_client_ip(request: Request) -> str:
+    """Best-effort client IP for the login handler.
+
+    Uses the immediate transport peer rather than ``X-Forwarded-For``:
+    nginx in front of the Mastio handles trusted-proxy resolution and
+    rewrites ``request.client`` accordingly, while in dev / direct
+    deployments ``X-Forwarded-For`` is attacker-controlled and would
+    let any client mint a fresh "IP" per request to dodge the lockout.
+    """
+    client = request.client
+    return client.host if client is not None else "unknown"
+
+
 @router.post("/login")
 async def login_submit(request: Request):
     # State guard: if no password is set, you can't sign in — go register first.
@@ -275,6 +288,47 @@ async def login_submit(request: Request):
             "password_enabled": False,
         }, status_code=403)
 
+    # H9 audit fix — per-IP lockout + rate-limit before bcrypt.
+    from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
+    from mcp_proxy.dashboard.login_lockout import (
+        LOGIN_RATE_PER_MINUTE,
+        get_login_lockout_store,
+    )
+    from mcp_proxy.db import log_audit
+
+    client_ip = _login_client_ip(request)
+    lockout_store = get_login_lockout_store()
+
+    locked_until = await lockout_store.is_locked(client_ip)
+    if locked_until is not None:
+        await log_audit(
+            agent_id="admin",
+            action="auth.login",
+            status="denied",
+            detail=f"ip-locked-until {int(locked_until)} ip={client_ip}",
+        )
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": (
+                "Too many failed attempts from this address. Try again later "
+                "or reset the admin password from the local CLI."
+            ),
+        }, status_code=429)
+
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}:dashboard.login", LOGIN_RATE_PER_MINUTE,
+    ):
+        await log_audit(
+            agent_id="admin",
+            action="auth.login",
+            status="denied",
+            detail=f"rate-limited ip={client_ip}",
+        )
+        return templates.TemplateResponse("login.html", {
+            "request": request,
+            "error": "Too many login attempts. Slow down and try again in a minute.",
+        }, status_code=429)
+
     form = await request.form()
     password = str(form.get("password", ""))
 
@@ -287,23 +341,27 @@ async def login_submit(request: Request):
     if not await verify_admin_password(password):
         # Audit the failure but keep the message vague (don't leak whether the
         # account exists, the username is wrong, etc.).
-        from mcp_proxy.db import log_audit
+        fail_count, locked_until = await lockout_store.record_failure(client_ip)
+        detail = f"invalid password ip={client_ip} consecutive_fails={fail_count}"
+        if locked_until is not None:
+            detail += f" locked-until={int(locked_until)}"
         await log_audit(
             agent_id="admin",
             action="auth.login",
             status="error",
-            detail="invalid password",
+            detail=detail,
         )
         return templates.TemplateResponse("login.html", {
             "request": request,
             "error": "Invalid password.",
         }, status_code=401)
 
-    from mcp_proxy.db import log_audit
+    await lockout_store.record_success(client_ip)
     await log_audit(
         agent_id="admin",
         action="auth.login",
         status="success",
+        detail=f"ip={client_ip}",
     )
 
     response = RedirectResponse(url=await _post_login_redirect(), status_code=303)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,36 @@ def reset_rate_limiter():
 
 
 @pytest.fixture(autouse=True)
+def reset_mcp_proxy_rate_state():
+    """Reset the mcp_proxy per-agent rate limiter + dashboard login
+    lockout singletons between tests.
+
+    H9 audit fix: ``mcp_proxy/dashboard/router.py:/proxy/login`` now
+    consults ``get_agent_rate_limiter()`` and ``get_login_lockout_store()``
+    on every POST. Both are process-global singletons; without this
+    fixture, accumulated state from one test (rate-limit window or
+    lockout counter) bleeds into the next and unrelated tests get a
+    spurious 429 from the login form.
+
+    Imports are inline so the fixture stays a no-op when the proxy
+    package isn't on the import path (broker-only test slices in
+    minimal CI shards). Both reset helpers are safe to call when the
+    singleton hasn't been initialised yet.
+    """
+    try:
+        from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+        from mcp_proxy.dashboard.login_lockout import reset_login_lockout_for_tests
+    except ImportError:
+        yield
+        return
+    reset_agent_rate_limiter()
+    reset_login_lockout_for_tests()
+    yield
+    reset_agent_rate_limiter()
+    reset_login_lockout_for_tests()
+
+
+@pytest.fixture(autouse=True)
 def reset_admin_secret_cache():
     """Reset the module-level admin secret cache between tests.
 

--- a/tests/test_h9_login_lockout.py
+++ b/tests/test_h9_login_lockout.py
@@ -1,0 +1,214 @@
+"""
+H9 regression: per-IP rate-limit + lockout on the Mastio dashboard
+``/proxy/login`` form.
+
+The handler used to bcrypt-compare every request with no per-IP
+gating, no failure counter, and no back-off. Audit H9 flagged the
+obvious brute-force surface — bcrypt buys time per guess, not per
+million guesses. This file locks in the new safeguards:
+
+- 10 attempts/min/IP rate cap before bcrypt fires
+- 5 consecutive failures within 15 min lock the IP for 15 min
+- Successful login resets the counter
+- Audit row on lock, on rate-limit, on each failure (with counter), on success
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "h9_lockout.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_FORCE_LOCAL_PASSWORD", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    # Reset the lockout + rate limiter singletons so each test runs clean.
+    from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+    from mcp_proxy.dashboard.login_lockout import reset_login_lockout_for_tests
+    reset_agent_rate_limiter()
+    reset_login_lockout_for_tests()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+    reset_agent_rate_limiter()
+    reset_login_lockout_for_tests()
+
+
+async def _set_admin_password(pw: str = "correct-horse-battery-staple") -> None:
+    from mcp_proxy.dashboard.session import set_admin_password
+    await set_admin_password(pw)
+
+
+# ── Lockout after 5 consecutive failures ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lockout_after_threshold_failures(proxy_app):
+    _, client = proxy_app
+    await _set_admin_password()
+
+    # 5 wrong guesses each return 401 — at the 5th the lockout is armed.
+    for _ in range(5):
+        resp = await client.post(
+            "/proxy/login",
+            data={"password": "wrong-guess"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401, resp.text
+
+    # 6th attempt — even with the right password — must be blocked.
+    resp = await client.post(
+        "/proxy/login",
+        data={"password": "correct-horse-battery-staple"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 429, resp.text
+    assert "too many failed attempts" in resp.text.lower()
+
+
+# ── Successful login resets the counter ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_success_resets_failure_counter(proxy_app):
+    _, client = proxy_app
+    await _set_admin_password()
+
+    # 4 failures — under the threshold.
+    for _ in range(4):
+        resp = await client.post(
+            "/proxy/login",
+            data={"password": "wrong"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401
+
+    # Right password — success.
+    resp = await client.post(
+        "/proxy/login",
+        data={"password": "correct-horse-battery-staple"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    # 4 more failures — still under the threshold (counter was reset).
+    for _ in range(4):
+        resp = await client.post(
+            "/proxy/login",
+            data={"password": "wrong"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401, "success did not reset failure counter"
+
+
+# ── Rate limit before bcrypt ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_caps_attempts_per_minute(proxy_app, monkeypatch):
+    _, client = proxy_app
+    await _set_admin_password()
+
+    # Drop the rate-limit ceiling far enough below the lockout
+    # threshold that this test exercises the rate-limit path.
+    from mcp_proxy.dashboard import login_lockout, router as dashboard_router
+    monkeypatch.setattr(login_lockout, "LOGIN_RATE_PER_MINUTE", 2)
+    monkeypatch.setattr(dashboard_router, "LOGIN_RATE_PER_MINUTE", 2, raising=False)
+    # ``router`` imports the constant lazily inside the handler, so the
+    # monkeypatch on ``login_lockout`` is what the handler reads.
+
+    # First two attempts return 401 (bad password) — under the cap.
+    for _ in range(2):
+        resp = await client.post(
+            "/proxy/login",
+            data={"password": "wrong"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 401
+
+    # Third attempt — over the per-minute cap — returns 429 without
+    # touching bcrypt. Use the right password to prove the cap fires
+    # before the password check.
+    resp = await client.post(
+        "/proxy/login",
+        data={"password": "correct-horse-battery-staple"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 429, resp.text
+    assert "too many login attempts" in resp.text.lower()
+
+
+# ── Audit log records lockout, rate-limit, fails, and success ────────
+
+
+@pytest.mark.asyncio
+async def test_audit_records_failures_with_counter(proxy_app):
+    _, client = proxy_app
+    await _set_admin_password()
+
+    for _ in range(3):
+        await client.post(
+            "/proxy/login",
+            data={"password": "wrong"},
+            follow_redirects=False,
+        )
+
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT status, detail FROM audit_log "
+                "WHERE action = 'auth.login' ORDER BY timestamp",
+            ),
+        )).all()
+
+    failures = [r for r in rows if r[0] == "error"]
+    assert len(failures) == 3, [tuple(r) for r in rows]
+    # The detail string must carry the per-IP failure counter so the
+    # audit reader can spot escalating brute-force without recomputing
+    # state from scratch.
+    assert "consecutive_fails=1" in failures[0][1]
+    assert "consecutive_fails=2" in failures[1][1]
+    assert "consecutive_fails=3" in failures[2][1]
+
+
+@pytest.mark.asyncio
+async def test_audit_records_success_with_ip(proxy_app):
+    _, client = proxy_app
+    await _set_admin_password()
+
+    resp = await client.post(
+        "/proxy/login",
+        data={"password": "correct-horse-battery-staple"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT status, detail FROM audit_log "
+                "WHERE action = 'auth.login' ORDER BY timestamp DESC LIMIT 1",
+            ),
+        )).first()
+    assert row is not None
+    status, detail = row
+    assert status == "success"
+    assert detail is not None and "ip=" in detail


### PR DESCRIPTION
## Summary

The Mastio dashboard login handler ran straight through to bcrypt on every POST — no rate-limit, no lockout, no back-off. Bcrypt buys time per guess, not per million guesses; at HTTP-stack speed an attacker on the same network could brute-force a short or pattern-based admin password before anyone noticed.

Two layers, both keyed on the client IP, both fire BEFORE the bcrypt compare so the timing side-channel stays silent:

- **Rate limit** (10 attempts/min/IP) via the existing ``get_agent_rate_limiter()`` (Redis-backed when available, in-memory per-worker otherwise). Bucket key: ``ip:<host>:dashboard.login``.
- **Lockout** (5 consecutive failures inside 15 min → IP blocked for 15 min). New ``mcp_proxy/dashboard/login_lockout.py`` module; in-memory single-worker store with a ``LoginLockoutStore`` Protocol so a Redis variant can drop in later.

A successful login resets the counter; an expired lockout clears the failure history. Audit log now records the per-attempt failure counter (``consecutive_fails=N``) and the IP on every event so the operator triaging brute-force doesn't have to recompute state from scratch.

Closes **H9** from the 2026-04-30 audit.

## Test plan

- [x] `pytest tests/test_h9_login_lockout.py` (5 new tests pass — lockout after 5 fails, success resets counter, rate limit caps before bcrypt, audit records counter, audit records IP on success)
- [x] `pytest tests/test_proxy_local_password_toggle.py tests/test_enrollment_dashboard.py` (22 passed, no regressions to the existing toggle / enrollment dashboard tests)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Off-limits files respected

- ``mcp_proxy/dashboard/session.py`` (RBAC plugin in flight) — untouched
- ``mcp_proxy/rbac.py`` — untouched
- ``app/dashboard/session.py`` — untouched

The new file ``mcp_proxy/dashboard/login_lockout.py`` is fresh code; the only change to existing surface is the ``/proxy/login`` POST handler in ``mcp_proxy/dashboard/router.py``.