### PR TITLE
fix(security): hash chain on mcp_proxy audit_log (H4 lane7)

### DIFF
--- a/mcp_proxy/alembic/versions/0023_audit_hash_chain.py
+++ b/mcp_proxy/alembic/versions/0023_audit_hash_chain.py
@@ -45,6 +45,13 @@ def _has_column(table_name: str, column_name: str) -> bool:
     return column_name in cols
 
 
+def _has_index(table_name: str, index_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    names = {ix["name"] for ix in inspector.get_indexes(table_name)}
+    return index_name in names
+
+
 def upgrade() -> None:
     with op.batch_alter_table("audit_log") as batch_op:
         if not _has_column("audit_log", "chain_seq"):
@@ -53,16 +60,24 @@ def upgrade() -> None:
             batch_op.add_column(sa.Column("prev_hash", sa.Text(), nullable=True))
         if not _has_column("audit_log", "row_hash"):
             batch_op.add_column(sa.Column("row_hash", sa.Text(), nullable=True))
-    op.create_index(
-        "idx_audit_log_chain_seq",
-        "audit_log",
-        ["chain_seq"],
-        unique=True,
-    )
+    # Idempotency: the legacy partial-seed path (see
+    # ``mcp_proxy/db.py:_run_migrations_sync``) calls
+    # ``metadata.create_all`` before stamping, and the post-0023
+    # ``AuditLogEntry`` declares the index in its ``__table_args__``.
+    # Without this guard the migration would CREATE INDEX on top of
+    # itself and fail with ``index ... already exists``.
+    if not _has_index("audit_log", "idx_audit_log_chain_seq"):
+        op.create_index(
+            "idx_audit_log_chain_seq",
+            "audit_log",
+            ["chain_seq"],
+            unique=True,
+        )
 
 
 def downgrade() -> None:
-    op.drop_index("idx_audit_log_chain_seq", table_name="audit_log")
+    if _has_index("audit_log", "idx_audit_log_chain_seq"):
+        op.drop_index("idx_audit_log_chain_seq", table_name="audit_log")
     with op.batch_alter_table("audit_log") as batch_op:
         if _has_column("audit_log", "row_hash"):
             batch_op.drop_column("row_hash")

--- a/mcp_proxy/alembic/versions/0023_audit_hash_chain.py
+++ b/mcp_proxy/alembic/versions/0023_audit_hash_chain.py
@@ -1,0 +1,72 @@
+"""Add hash chain columns to mcp_proxy audit_log — H4 lane7.
+
+Revision ID: 0023_audit_hash_chain
+Revises: 0022_drop_api_key_hash
+Create Date: 2026-05-01 00:00:00.000000
+
+The Mastio's audit_log was an append-only insert, but the rows had no
+forward integrity: an operator with DB write access could rewrite an
+old detail field, drop a row, or insert one between others, and the
+table itself would not reveal it. SECURITY.md claimed "append-only
+cryptographic audit log", which the Court enforces (per-org
+hash chain in app/db/audit.py) but the Mastio did not.
+
+This migration adds three nullable columns on ``audit_log``:
+
+- ``chain_seq INTEGER`` — monotonically increasing sequence per
+  Mastio. ``UNIQUE(chain_seq)`` so no two rows share a slot.
+- ``prev_hash TEXT`` — the row_hash of the previous entry in the
+  chain (``"genesis"`` for the first row).
+- ``row_hash TEXT`` — SHA-256 over a canonical encoding of
+  ``(chain_seq, timestamp, agent_id, action, tool_name, status,
+  detail, request_id, prev_hash)``.
+
+Existing rows stay nullable on these fields so the migration doesn't
+have to backfill historical data — verifying the chain skips
+pre-migration rows. New rows MUST populate all three; the application
+log_audit helper enforces that.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "0023_audit_hash_chain"
+down_revision: Union[str, Sequence[str], None] = "0022_drop_api_key_hash"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    cols = {c["name"] for c in inspector.get_columns(table_name)}
+    return column_name in cols
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("audit_log") as batch_op:
+        if not _has_column("audit_log", "chain_seq"):
+            batch_op.add_column(sa.Column("chain_seq", sa.Integer(), nullable=True))
+        if not _has_column("audit_log", "prev_hash"):
+            batch_op.add_column(sa.Column("prev_hash", sa.Text(), nullable=True))
+        if not _has_column("audit_log", "row_hash"):
+            batch_op.add_column(sa.Column("row_hash", sa.Text(), nullable=True))
+    op.create_index(
+        "idx_audit_log_chain_seq",
+        "audit_log",
+        ["chain_seq"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_audit_log_chain_seq", table_name="audit_log")
+    with op.batch_alter_table("audit_log") as batch_op:
+        if _has_column("audit_log", "row_hash"):
+            batch_op.drop_column("row_hash")
+        if _has_column("audit_log", "prev_hash"):
+            batch_op.drop_column("prev_hash")
+        if _has_column("audit_log", "chain_seq"):
+            batch_op.drop_column("chain_seq")

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -248,8 +248,67 @@ async def get_db() -> AsyncIterator[AsyncConnection]:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Audit log — APPEND-ONLY (no update, no delete)
+# Audit log — APPEND-ONLY (no update, no delete) + H4 hash chain
 # ─────────────────────────────────────────────────────────────────────────────
+
+import asyncio as _asyncio
+import hashlib as _hashlib
+
+# Per-process lock so two concurrent log_audit() calls don't race for
+# the same chain_seq. Multi-worker deployments rely on the
+# UNIQUE(chain_seq) constraint to reject the loser; the application
+# retries with the next seq.
+_audit_chain_lock = _asyncio.Lock()
+_AUDIT_CHAIN_GENESIS = "genesis"
+_AUDIT_CHAIN_MAX_RETRIES = 5
+
+
+def compute_audit_row_hash(
+    *,
+    chain_seq: int,
+    timestamp: str,
+    agent_id: str,
+    action: str,
+    tool_name: str | None,
+    status: str,
+    detail: str | None,
+    request_id: str | None,
+    prev_hash: str,
+) -> str:
+    """SHA-256 over a canonical encoding of every authoritative field.
+
+    Any tamper to the row — including changing tool_name from ``None``
+    to ``""`` — invalidates the hash. The encoding mirrors the Court
+    pattern in ``app/db/audit.py``: pipe-delimited with empty-string
+    sentinels for NULLs and a ``genesis`` literal for the head of the
+    chain.
+    """
+    canonical = (
+        f"{chain_seq}|{timestamp}|{agent_id}|{action}|"
+        f"{tool_name or ''}|{status}|{detail or ''}|"
+        f"{request_id or ''}|{prev_hash}"
+    )
+    return _hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+async def _audit_chain_head(conn) -> tuple[int, str]:
+    """Return ``(last_chain_seq, last_row_hash)``.
+
+    Pre-migration rows have ``chain_seq IS NULL`` and are ignored by
+    the chain — the first chained row gets ``chain_seq=1`` with
+    ``prev_hash=genesis``.
+    """
+    row = (await conn.execute(
+        text(
+            "SELECT chain_seq, row_hash FROM audit_log "
+            "WHERE chain_seq IS NOT NULL "
+            "ORDER BY chain_seq DESC LIMIT 1",
+        ),
+    )).first()
+    if row is None:
+        return 0, _AUDIT_CHAIN_GENESIS
+    return int(row[0]), str(row[1])
+
 
 async def log_audit(
     agent_id: str,
@@ -261,25 +320,135 @@ async def log_audit(
     request_id: str | None = None,
     duration_ms: float | None = None,
 ) -> None:
-    """Insert an immutable audit log entry."""
+    """Insert an immutable, hash-chained audit log entry.
+
+    Forward integrity: each row carries ``prev_hash`` (the previous
+    row's ``row_hash``) and a fresh ``row_hash`` over a canonical
+    encoding of all authoritative fields. ``verify_audit_chain``
+    walks the chain and surfaces breaks; an attacker rewriting a
+    row, dropping one, or splicing in a forgery has to recompute
+    every subsequent hash without operator detection.
+    """
+    from sqlalchemy.exc import IntegrityError
+
     ts = datetime.now(timezone.utc).isoformat()
-    async with get_db() as conn:
-        await conn.execute(
-            text(
-                """INSERT INTO audit_log (timestamp, agent_id, action, tool_name, status, detail, request_id, duration_ms)
-                   VALUES (:timestamp, :agent_id, :action, :tool_name, :status, :detail, :request_id, :duration_ms)"""
-            ),
-            {
-                "timestamp": ts,
-                "agent_id": agent_id,
-                "action": action,
-                "tool_name": tool_name,
-                "status": status,
-                "detail": detail,
-                "request_id": request_id,
-                "duration_ms": duration_ms,
-            },
+    async with _audit_chain_lock:
+        for _attempt in range(_AUDIT_CHAIN_MAX_RETRIES):
+            async with get_db() as conn:
+                last_seq, prev_hash = await _audit_chain_head(conn)
+                chain_seq = last_seq + 1
+                row_hash = compute_audit_row_hash(
+                    chain_seq=chain_seq,
+                    timestamp=ts,
+                    agent_id=agent_id,
+                    action=action,
+                    tool_name=tool_name,
+                    status=status,
+                    detail=detail,
+                    request_id=request_id,
+                    prev_hash=prev_hash,
+                )
+                try:
+                    await conn.execute(
+                        text(
+                            """INSERT INTO audit_log (
+                                   timestamp, agent_id, action, tool_name,
+                                   status, detail, request_id, duration_ms,
+                                   chain_seq, prev_hash, row_hash
+                               ) VALUES (
+                                   :timestamp, :agent_id, :action, :tool_name,
+                                   :status, :detail, :request_id, :duration_ms,
+                                   :chain_seq, :prev_hash, :row_hash
+                               )"""
+                        ),
+                        {
+                            "timestamp": ts,
+                            "agent_id": agent_id,
+                            "action": action,
+                            "tool_name": tool_name,
+                            "status": status,
+                            "detail": detail,
+                            "request_id": request_id,
+                            "duration_ms": duration_ms,
+                            "chain_seq": chain_seq,
+                            "prev_hash": prev_hash,
+                            "row_hash": row_hash,
+                        },
+                    )
+                    return
+                except IntegrityError:
+                    # UNIQUE(chain_seq) collision — another worker
+                    # claimed this seq. Reread the head and retry.
+                    continue
+        raise RuntimeError(
+            f"log_audit: could not append after {_AUDIT_CHAIN_MAX_RETRIES} "
+            "retries (chain_seq UNIQUE conflict). Confirm the audit_log "
+            "schema or look for a stuck worker.",
         )
+
+
+async def verify_audit_chain(
+    *, start_seq: int = 1, limit: int | None = None,
+) -> tuple[bool, int | None, str | None]:
+    """Walk the hash chain forward and report the first break.
+
+    Returns ``(ok, broken_seq, reason)``:
+      * ``(True, None, None)`` — every chained row verifies.
+      * ``(False, seq, reason)`` — the row at ``seq`` is the first
+        with a recomputed ``row_hash`` that disagrees with the stored
+        value, or whose ``prev_hash`` doesn't match the previous
+        row's ``row_hash``, or whose ``chain_seq`` skipped a slot.
+
+    Pre-migration rows (``chain_seq IS NULL``) are skipped.
+    """
+    async with get_db() as conn:
+        stmt = (
+            "SELECT chain_seq, prev_hash, row_hash, timestamp, agent_id, "
+            "action, tool_name, status, detail, request_id FROM audit_log "
+            "WHERE chain_seq IS NOT NULL AND chain_seq >= :start "
+            "ORDER BY chain_seq ASC"
+        )
+        params: dict[str, int] = {"start": start_seq}
+        if limit is not None:
+            stmt += " LIMIT :lim"
+            params["lim"] = limit
+        rows = (await conn.execute(text(stmt), params)).all()
+
+    expected_prev: str | None = None
+    expected_seq: int | None = None
+    for row in rows:
+        chain_seq = int(row[0])
+        prev_hash = str(row[1])
+        stored_hash = str(row[2])
+        if expected_seq is None:
+            # First row in the iteration — pin the expected seq to
+            # whatever the first chained row claims so we can detect
+            # gaps from this point forward without false-flagging
+            # legitimate truncation before ``start_seq``.
+            expected_seq = chain_seq
+            if start_seq == 1 and chain_seq == 1 and prev_hash != _AUDIT_CHAIN_GENESIS:
+                return False, chain_seq, "first row prev_hash != genesis"
+        else:
+            if chain_seq != expected_seq:
+                return False, chain_seq, f"chain_seq gap: expected {expected_seq}"
+            if expected_prev is not None and prev_hash != expected_prev:
+                return False, chain_seq, "prev_hash mismatch with previous row"
+        recomputed = compute_audit_row_hash(
+            chain_seq=chain_seq,
+            timestamp=str(row[3]),
+            agent_id=str(row[4]),
+            action=str(row[5]),
+            tool_name=row[6],
+            status=str(row[7]),
+            detail=row[8],
+            request_id=row[9],
+            prev_hash=prev_hash,
+        )
+        if recomputed != stored_hash:
+            return False, chain_seq, "row_hash mismatch — row tampered"
+        expected_prev = stored_hash
+        expected_seq = chain_seq + 1
+    return True, None, None
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -89,11 +89,21 @@ class AuditLogEntry(Base):
     detail = Column(Text, nullable=True)
     request_id = Column(Text, nullable=True)
     duration_ms = Column(String, nullable=True)  # REAL in SQLite — stored as text-safe numeric
+    # H4 lane7 audit fix — forward-integrity hash chain. ``chain_seq``
+    # is monotonically increasing per Mastio, ``prev_hash`` is the
+    # previous row's ``row_hash`` (or ``"genesis"`` for the first
+    # chained row), and ``row_hash`` is SHA-256 over a canonical
+    # encoding of every authoritative field. Pre-migration rows leave
+    # the columns NULL; verify_audit_chain() skips them.
+    chain_seq = Column(Integer, nullable=True)
+    prev_hash = Column(Text, nullable=True)
+    row_hash = Column(Text, nullable=True)
 
     __table_args__ = (
         Index("idx_audit_log_agent_id", "agent_id"),
         Index("idx_audit_log_timestamp", "timestamp"),
         Index("idx_audit_log_request_id", "request_id"),
+        Index("idx_audit_log_chain_seq", "chain_seq", unique=True),
     )
 
 

--- a/tests/test_h4_audit_chain.py
+++ b/tests/test_h4_audit_chain.py
@@ -1,0 +1,214 @@
+"""
+H4 lane7 regression: mcp_proxy ``audit_log`` carries a forward-integrity
+hash chain, like the Court does.
+
+The Mastio's audit table used to be a straight append — rows had a
+timestamp but no link backwards. SECURITY.md claimed an "append-only
+cryptographic audit log" which the Court enforces (per-org chain in
+``app/db/audit.py``) but the Mastio did not. An operator with DB
+write access could rewrite an old detail field, drop a row, or splice
+in a forged row, and the table itself wouldn't reveal it.
+
+This file locks in:
+
+- Every new row gets a monotonically-increasing ``chain_seq``, a
+  ``prev_hash`` linking to the previous row's ``row_hash``, and a
+  ``row_hash`` over a canonical encoding of every authoritative field.
+- ``verify_audit_chain()`` walks the chain and surfaces the first
+  break (recomputed hash mismatch, prev_hash mismatch, sequence gap).
+- Tampering with ANY field of an existing row makes verify fail at
+  that row's chain_seq.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "h4_audit.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+# ── Chain growth ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_audit_assigns_monotonic_chain_seq(proxy_app):
+    _, _ = proxy_app
+    from mcp_proxy.db import get_db, log_audit
+    from sqlalchemy import text
+
+    for i in range(3):
+        await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                        detail=f"row-{i}")
+
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT chain_seq, prev_hash, row_hash FROM audit_log "
+                "WHERE chain_seq IS NOT NULL ORDER BY chain_seq",
+            ),
+        )).all()
+
+    assert len(rows) == 3
+    assert [r[0] for r in rows] == [1, 2, 3]
+    assert rows[0][1] == "genesis"
+    assert rows[1][1] == rows[0][2]
+    assert rows[2][1] == rows[1][2]
+    # row_hash values are unique
+    assert len({r[2] for r in rows}) == 3
+
+
+@pytest.mark.asyncio
+async def test_verify_chain_returns_ok_on_clean_log(proxy_app):
+    _, _ = proxy_app
+    from mcp_proxy.db import log_audit, verify_audit_chain
+
+    for i in range(5):
+        await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                        detail=f"row-{i}")
+
+    ok, broken, reason = await verify_audit_chain()
+    assert ok is True, f"clean chain should verify (broken={broken} reason={reason})"
+
+
+# ── Tamper detection ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_verify_chain_catches_detail_tamper(proxy_app):
+    _, _ = proxy_app
+    from mcp_proxy.db import get_db, log_audit, verify_audit_chain
+    from sqlalchemy import text
+
+    for i in range(5):
+        await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                        detail=f"row-{i}")
+
+    # Rewrite row 3's detail without touching row_hash — the kind of
+    # mutation an operator with DB write access could do.
+    async with get_db() as conn:
+        await conn.execute(
+            text("UPDATE audit_log SET detail = 'rewritten' WHERE chain_seq = 3"),
+        )
+
+    ok, broken, reason = await verify_audit_chain()
+    assert ok is False
+    assert broken == 3
+    assert reason is not None and "row_hash mismatch" in reason
+
+
+@pytest.mark.asyncio
+async def test_verify_chain_catches_dropped_row(proxy_app):
+    _, _ = proxy_app
+    from mcp_proxy.db import get_db, log_audit, verify_audit_chain
+    from sqlalchemy import text
+
+    for i in range(5):
+        await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                        detail=f"row-{i}")
+
+    async with get_db() as conn:
+        await conn.execute(
+            text("DELETE FROM audit_log WHERE chain_seq = 3"),
+        )
+
+    ok, broken, reason = await verify_audit_chain()
+    assert ok is False
+    assert broken == 4
+    assert reason is not None and (
+        "chain_seq gap" in reason or "prev_hash mismatch" in reason
+    )
+
+
+@pytest.mark.asyncio
+async def test_verify_chain_catches_prev_hash_tamper(proxy_app):
+    """An attacker who recomputes row_hash for a tampered row but
+    forgets to fix the next row's prev_hash is caught at seq+1."""
+    _, _ = proxy_app
+    from mcp_proxy.db import (
+        compute_audit_row_hash, get_db, log_audit, verify_audit_chain,
+    )
+    from sqlalchemy import text
+
+    for i in range(5):
+        await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                        detail=f"row-{i}")
+
+    # Rewrite row 3's detail AND fix its row_hash to match — but
+    # leave row 4's prev_hash untouched. The chain walker should
+    # flag row 4 as the break point.
+    async with get_db() as conn:
+        row3 = (await conn.execute(
+            text(
+                "SELECT timestamp, agent_id, action, tool_name, status, "
+                "detail, request_id, prev_hash FROM audit_log WHERE chain_seq = 3",
+            ),
+        )).first()
+        new_hash = compute_audit_row_hash(
+            chain_seq=3,
+            timestamp=str(row3[0]),
+            agent_id=str(row3[1]),
+            action=str(row3[2]),
+            tool_name=row3[3],
+            status=str(row3[4]),
+            detail="rewritten",
+            request_id=row3[6],
+            prev_hash=str(row3[7]),
+        )
+        await conn.execute(
+            text(
+                "UPDATE audit_log SET detail = 'rewritten', row_hash = :h "
+                "WHERE chain_seq = 3",
+            ),
+            {"h": new_hash},
+        )
+
+    ok, broken, reason = await verify_audit_chain()
+    assert ok is False
+    assert broken == 4
+    assert reason is not None and "prev_hash mismatch" in reason
+
+
+# ── Existing log_audit callers keep working ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_existing_audit_query_pattern_still_works(proxy_app):
+    """Other code reads ``audit_log`` by ``timestamp`` + ``request_id``;
+    the new chain columns must not break those queries."""
+    _, _ = proxy_app
+    from mcp_proxy.db import get_db, log_audit
+    from sqlalchemy import text
+
+    await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                    request_id="req-abc")
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT agent_id, action, status FROM audit_log "
+                "WHERE request_id = :rid",
+            ),
+            {"rid": "req-abc"},
+        )).first()
+
+    assert row is not None
+    assert (row[0], row[1], row[2]) == ("alice", "t.invoke", "ok")

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0022_drop_api_key_hash",)]
+    assert rows == [("0023_audit_hash_chain",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0022_drop_api_key_hash",)]
+    assert version == [("0023_audit_hash_chain",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0022_drop_api_key_hash"
+HEAD_REVISION = "0023_audit_hash_chain"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0022_drop_api_key_hash"
+HEAD_REVISION = "0023_audit_hash_chain"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0022_drop_api_key_hash"
+HEAD_REVISION = "0023_audit_hash_chain"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

The Mastio's ``audit_log`` was append-only at the application level (no ``UPDATE`` / ``DELETE`` calls) but the rows had no forward integrity. An operator with DB write access could rewrite an old ``detail`` field, drop a row, or splice in a forgery without the table revealing it. ``SECURITY.md`` claimed "append-only cryptographic audit log", which the Court already enforces (per-org chain in ``app/db/audit.py``) but the Mastio did not.

Three new nullable columns on ``audit_log`` (alembic 0023):

- **``chain_seq``** — monotonic per Mastio, ``UNIQUE`` so no two rows share a slot.
- **``prev_hash``** — the previous row's ``row_hash``, or ``"genesis"`` for the head.
- **``row_hash``** — SHA-256 over a canonical encoding of every authoritative field plus ``prev_hash``.

``log_audit`` reads the chain head under a per-process lock, computes the new ``row_hash``, and inserts. Multi-worker collisions on ``UNIQUE(chain_seq)`` retry up to 5 times with the next slot. The new ``verify_audit_chain()`` helper walks the chain and surfaces the first break (recomputed hash mismatch, ``prev_hash`` mismatch, sequence gap).

Pre-migration rows leave the columns NULL and are skipped by the verifier — no destructive backfill. SECURITY.md's "append-only cryptographic audit log" claim is now true on the Mastio side as well as the Court side.

Closes **H4 lane7** from the 2026-04-30 audit.

## Test plan

- [x] `pytest tests/test_h4_audit_chain.py` (6 new regression tests pass — monotonic chain_seq, clean chain verifies, detail tamper caught, dropped row caught, prev_hash tamper caught, existing query patterns still work)
- [x] `pytest tests/ -k "audit"` (201 audit-related tests pass, no regressions)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Operational notes

- Existing data is preserved untouched. Pre-migration rows have ``chain_seq IS NULL``; the chain starts at ``seq=1`` from the next ``log_audit`` call after migration.
- Multi-worker deploys are safe via the ``UNIQUE(chain_seq)`` constraint; the loser of a race retries with the next slot.
- ``verify_audit_chain()`` is a free function for the dashboard / CLI to call. UI surface for it can ship in a follow-up.