### PR TITLE
docs(adr): ADR-016 LLM Guardian bidirectional inspection + rollout plan

### DIFF
--- a/docs/adrs/0016-llm-guardian-bidirectional.md
+++ b/docs/adrs/0016-llm-guardian-bidirectional.md
@@ -1,0 +1,164 @@
+# ADR-016 — LLM Guardian: bidirectional content inspection via SDK cooperation
+
+- **Status:** Proposed
+- **Date:** 2026-05-01
+- **Related:** ADR-006 (Trojan Horse standalone Mastio), ADR-011 (unified enrollment), ADR-013 (layered defence), ADR-014 (mTLS Connector ↔ Mastio)
+
+## Context
+
+Mastio is the per-org A2A proxy: every agent-to-agent message in the deployment passes through it. For **intra-org** traffic Mastio holds the key and can see plaintext, so it can apply policy (prompt-injection regex, PII redaction, etc.) inline. For **cross-org** traffic the message is end-to-end encrypted between sender SDK and receiver SDK; Mastio sees only the envelope. The brokerage (Court) sees even less — only metadata.
+
+This leaves an enforcement gap: the moment a customer connects two organisations via Cullis, the most security-relevant traffic (cross-org) becomes the one we cannot inspect at the proxy. Today's choices are:
+
+1. **Strip E2E** to let the proxy inspect cross-org messages. Defeats the point of the federated trust model and breaks the privacy promise to the counterparty org.
+2. **Move enforcement to the agent runtime**. Each agent vendor would need to integrate a content firewall library; in practice this won't happen consistently across an organisation's agent fleet, and audit becomes impossible (each agent emits its own log format).
+3. **Move enforcement to the SDK**. The SDK on each side already has the E2E key — it decrypts messages before handing them to the agent code, and encrypts agent output before sending. We make the SDK call the local Mastio for an inspection decision **after decrypting on receive** and **before encrypting on send**. Mastio sees plaintext only for the agent it owns; the counterparty key never leaves the counterparty SDK; E2E is preserved end-to-end.
+
+Option 3 is the only one that closes the cross-org gap without breaking E2E, and it folds the intra-org case in for free (the SDK calls the same endpoint regardless of whether the peer is intra- or cross-org).
+
+The other forcing constraint is **performance**. The 2026-04-23 nightly stress (`project_nightly_finding_dpop_concurrency`) showed the system is sensitive to per-message overhead: post-DPoP-fix throughput is ~35 rps with p99 ~497ms. A naive synchronous LLM-based content classifier in the hot path (200-500ms per call) would cut throughput by ~90%. Any inspection design must split fast deterministic checks (regex, role/scope, loop counters) from slow probabilistic checks (LLM-judge), and put only the fast set in the synchronous path.
+
+## Decision
+
+Adopt **SDK-mediated bidirectional inspection** with a **fast-path / slow-path** split.
+
+### 1. Cooperation flow
+
+```
+Sender side:
+  agent.send(msg)
+    → SDK.encrypt(msg) — held in buffer
+    → SDK.guardian_inspect(plaintext, direction=out, peer)
+       → Mastio /v1/guardian/inspect → decision + signed ticket
+    → if pass: SDK.send_to_mastio(ciphertext, ticket)
+    → if redact: SDK.encrypt(redacted) + send
+    → if block: raise GuardianBlocked(reason) → agent handles
+
+Receiver side:
+  Mastio.deliver(ciphertext) → SDK
+    → SDK.decrypt(ciphertext) — held in buffer
+    → SDK.guardian_inspect(plaintext, direction=in, peer)
+       → Mastio /v1/guardian/inspect → decision + signed ticket
+    → if pass: agent.on_message(plaintext, ticket)
+    → if redact: agent.on_message(redacted, ticket)
+    → if block: discard + audit, do not deliver
+```
+
+Mastio is the only component that holds the inspection rules; the SDK is a thin caller. Mastio is the only component that signs decisions; the agent runtime verifies the ticket before acting on the message (so a tampered SDK that skips the guardian call cannot deliver to a compliant agent).
+
+### 2. Endpoint
+
+`POST /v1/guardian/inspect` on Mastio. mTLS-authenticated with the calling agent's identity certificate (the same cert the SDK uses for `/v1/egress/*`). Body:
+
+```json
+{
+  "direction": "in" | "out",
+  "peer_agent_id": "string",
+  "msg_id": "uuid",
+  "content_type": "application/json+a2a-payload",
+  "payload_b64": "base64-encoded plaintext"
+}
+```
+
+Response:
+
+```json
+{
+  "decision": "pass" | "redact" | "block",
+  "ticket": "<JWT signed by Mastio's guardian key>",
+  "ticket_exp": 1730483200,
+  "redacted_payload_b64": "base64",
+  "audit_id": "ulid",
+  "reasons": [{"tool": "pii_egress", "match": "[REDACTED]"}]
+}
+```
+
+The ticket is a short-lived JWT (`exp = now + 30s`) that includes `agent_id`, `peer_agent_id`, `msg_id`, `direction`, `decision`, `audit_id`. Mastio signs with `MCP_PROXY_GUARDIAN_TICKET_KEY` (HMAC-SHA256 with a per-instance key). The receiving agent verifies before acting.
+
+### 3. Fast path / slow path split
+
+The endpoint runs **fast-path tools synchronously** and **slow-path tools asynchronously**. The HTTP response includes only fast-path decisions; slow-path findings land in audit ~seconds later and trigger the alerting pipeline if they fire.
+
+**Fast path (synchronous, target p50 < 10ms, p99 < 30ms):**
+
+| Tool | Technique | Direction | Notes |
+|---|---|---|---|
+| Prompt-injection regex | compiled patterns (jailbreak, system-override, role-flip) | in | Pattern set ships with plugin; operator extends via dashboard. |
+| Tool/capability escalation | allowlist by `(sender_role, peer_role, tool_name)` | in | Drops calls to tools outside the binding contract. |
+| Loop detection | hop counter + msg-id dedup (Redis, 60s window) | in | Refuses delivery if same msg loops > N times. |
+| PII patterns | regex (cards, SSN, emails, phones, MRN) | out | Redact-by-default; configurable. |
+| Secret leak | high-confidence regex (AWS keys, GCP SA, Stripe, JWT, PEM) | out | Block-by-default. |
+| Reach guard | binding lookup `(originator, peer, scope)` | both | Catches reflection attacks where A asks B to do cross-org work A doesn't have reach for. |
+
+**Slow path (asynchronous, audit-only in v1):**
+
+| Tool | Technique | Notes |
+|---|---|---|
+| LLM-judge | small classifier model (Llama Guard 1B locally, or Bedrock Guardrails / OpenAI Moderation API per operator choice) | Runs after the message has been delivered. Findings emit alerts but do not block. v2 may promote a subset to sync `enforce-strict` mode for high-risk binding lanes. |
+| Topic-policy classifier | domain-specific classifier (banking compliance, healthcare HIPAA, etc.) | Customer-trained; ships as optional add-on plugin. |
+
+Slow-path runs against a copy of the payload that the endpoint queues to a background worker pool (asyncio task queue, bounded). Because slow-path is audit-only the response time does not depend on it.
+
+### 4. Modes
+
+Per binding (default falls back to a global mode):
+
+- `disabled`: SDK does not call the endpoint. Zero overhead. Opt-in for customers without compliance requirement.
+- `audit-only`: All tools (fast + slow) run async, the endpoint returns `pass` immediately. Used for the first 2 weeks of every customer rollout to measure false-positive rate before turning on enforcement.
+- `enforce-fast`: Fast-path runs sync, slow-path runs async. Default for production.
+- `enforce-strict`: Fast-path + LLM-judge sync. Latency penalty 200-500ms. Reserved for explicitly opted-in high-risk lanes (e.g. cross-org bank-to-bank messages). Not the default.
+
+Modes are configurable via the dashboard or `MCP_PROXY_GUARDIAN_MODE` env (global).
+
+### 5. Idempotence cache
+
+The endpoint hashes the first 1KB of the payload (sha256) and caches `(payload_hash, direction, peer) → decision` for 1h in Redis. Repeated payloads in agent workflows (heartbeats, retries, polling) skip the full check. Expected hit rate 30-60% based on prior intra-org traffic samples. Cache lookup adds ~0.5ms.
+
+### 6. Trust model
+
+The SDK is the entry point but is not trusted. Two reinforcements:
+
+1. **Inspection ticket**: the receiving agent runtime verifies the JWT ticket signature (Mastio guardian key, distributed to agent processes via the same identity bundle that carries the org CA chain) and matches `msg_id` + `agent_id` + `direction`. A tampered SDK that returns a synthetic `pass` without calling Mastio cannot fabricate the signature.
+2. **mTLS-attested call**: the `/v1/guardian/inspect` request authenticates the SDK's agent cert. Mastio cross-checks that the agent identity matches the `peer_agent_id` claimed in the response routing. A rogue agent cannot ask the guardian to inspect on behalf of another agent.
+
+The threat model explicitly excludes a malicious agent runtime that strips ticket verification. That is the agent operator's responsibility (signed binaries, attested boot, SBOM gates) and not in scope for the guardian itself.
+
+### 7. Rollout safety gates
+
+Before any production cutover:
+
+1. Nightly stress with `enforce-fast` ON for 24h, no failures.
+2. End-to-end p99 latency < 1.3x baseline.
+3. Throughput rps > 0.75x baseline.
+4. Audit-only sweep on customer corpus shows fast-path false-positive rate < 5%.
+5. Each tool documented with a rule reference, a positive example (block), a negative example (legitimate traffic that must not block).
+
+If any gate fails, the customer remains in `audit-only` mode regardless of dashboard setting. The mode promotion to `enforce-fast` requires explicit operator confirmation in the dashboard with the gate report attached.
+
+## Consequences
+
+### Positive
+
+- Closes the cross-org content-inspection gap without breaking E2E.
+- Single source of truth for inspection rules (Mastio) regardless of intra/cross-org traffic shape.
+- Audit format unified across all enforcement actions (one log shape, one queryable timeline).
+- Customer can run audit-only forever for soft compliance use cases without paying enforcement latency cost.
+- Composable with the existing plugin architecture (`mcp_proxy.plugins`): each tool is a plugin that registers into `mcp_proxy.guardian.registry`.
+
+### Negative
+
+- SDK breaking change. Old SDK versions ignore the guardian endpoint; rollout requires SDK upgrade across the customer's agent fleet. Mitigated by feature flag (`MCP_PROXY_GUARDIAN_ENABLED=0` default in the SDK; customer opts in when ready).
+- Per-message overhead even in `enforce-fast` mode (~10ms p50, ~30ms p99). Acceptable for the agentic-workflow latency budget but visible.
+- Two extra round-trips per message (sender side + receiver side) in `enforce-fast`. Intra-org HTTPS keep-alive keeps these at 1-3ms each.
+- The trust model leans on the agent runtime to verify the ticket. Compromised runtime = bypass. We document this as a customer responsibility.
+- The slow-path adds infrastructure (async queue, alerting pipeline, model hosting if local Llama Guard). Operationally this is non-trivial; we ship it as an optional plugin so customers without LLM-judge requirements skip it.
+
+### Open questions deferred to implementation
+
+- Concrete LLM-judge model choice (Llama Guard 1B locally vs Bedrock Guardrails vs OpenAI Moderation). Decided in Phase 4 of the rollout plan after benchmarking on a representative corpus.
+- Distribution of the guardian ticket key to agent runtimes (separate bundle vs piggyback on org CA chain refresh). Resolved during Phase 1 implementation.
+- Dashboard UX for rule editing — visual builder vs YAML editor vs both. Decided when Phase 6 starts.
+
+## Implementation plan
+
+See `docs/plans/llm-guardian-rollout-2026-05.md` for the seven-phase rollout, dependencies, effort estimates, and CI gates.

--- a/docs/plans/llm-guardian-rollout-2026-05.md
+++ b/docs/plans/llm-guardian-rollout-2026-05.md
@@ -1,0 +1,210 @@
+# LLM Guardian rollout plan (May 2026)
+
+Companion to ADR-016. This document is the operational map: phase-by-phase deliverables, dependencies, parallelisation slots, risk register, and the immutable safety gates that govern promotion to enforcement mode.
+
+## Goals
+
+- Ship `enforce-fast` Guardian usable by the first design partner within ~3 weeks of the kickoff PR.
+- Add no more than 30% p99 latency overhead and no more than 25% throughput drop on the existing nightly stress baseline.
+- Keep the rollout opt-in per customer; no existing deployment changes behaviour without explicit operator action.
+- Preserve the ability to ship the audit-only signal (Phase 4 slow-path) even when the customer never promotes to `enforce-fast`.
+
+## Phase summary
+
+| # | Phase | Repo | Effort | Parallelisable | Blocks |
+|---|---|---|---|---|---|
+| 1 | ADR + endpoint scaffolding + SDK no-op hook | cullis (public) | ~1d | no | 2, 3, 6 |
+| 2 | `llm_guardian` plugin: fast-path tools + cache + modes | cullis-enterprise (private) | ~3d | with 3, 6 | 4, 5, 7 |
+| 3 | SDK cooperation flow (send + receive paths) | cullis (public) | ~1d | with 2, 6 | 5, 7 |
+| 4 | Slow-path async pipeline + LLM-judge plugin | cullis-enterprise (private) | ~2d | no | 7 |
+| 5 | Nightly stress lane + perf gate in CI | cullis (public) | ~1d | no | 7 |
+| 6 | Dashboard UI (rule editor, audit timeline, mode toggle) | cullis-enterprise (private) | ~2d | with 2, 3 | 7 |
+| 7 | Image rebuild, integration kit, customer runbook | cullis-enterprise (private) | ~1d | no | release |
+
+**Total wall-clock with parallelisation: ~9-10 days. Sequential: ~11 days.**
+
+## Phase detail
+
+### Phase 1 — Foundation (cullis public, ~1d)
+
+**Branch:** `feat/guardian-foundation`. **PR target:** main.
+
+Files added or extended:
+
+- `docs/adrs/0016-llm-guardian-bidirectional.md` (this PR brings it from Proposed to Accepted once reviewed).
+- `mcp_proxy/guardian/__init__.py`
+- `mcp_proxy/guardian/endpoint.py` — `POST /v1/guardian/inspect`, mTLS-authenticated, returns `pass` for everything (no logic yet). Supports the `direction`, `peer_agent_id`, `msg_id`, `payload_b64` body shape from the ADR. Always emits an `audit_id` and a signed ticket so the SDK side can be developed against a real response.
+- `mcp_proxy/guardian/registry.py` — `Tool` ABC + `register_tool(direction, mode, fn)`. Plugin entry point `cullis.guardian_tools` for downstream plugins.
+- `mcp_proxy/guardian/ticket.py` — JWT sign/verify with `MCP_PROXY_GUARDIAN_TICKET_KEY`, exp 30s, fields `agent_id`, `peer_agent_id`, `msg_id`, `direction`, `decision`, `audit_id`.
+- `mcp_proxy/guardian/audit.py` — `record(audit_id, decision, reasons[])` writes to a new `guardian_audit` table (alembic migration in this PR). Hash-chained (reuses the audit-chain helper coming out of security Sprint 4 if landed; otherwise plain append-only with a TODO).
+- `cullis_sdk/guardian/__init__.py`
+- `cullis_sdk/guardian/client.py` — `inspect_before_send(payload, peer)` and `inspect_before_deliver(payload, peer)`. NO-OP unless `MCP_PROXY_GUARDIAN_ENABLED=1`. When enabled, POSTs to the local Mastio guardian endpoint and returns the decision + ticket. Exposes `verify_ticket(jwt, expected_msg_id)` for the agent runtime to use before acting on a delivered message.
+- Tests:
+  - `tests/test_guardian_endpoint.py` — passthrough returns `pass`, ticket signs + verifies, mTLS auth required, unknown agent 401, malformed body 422.
+  - `tests/test_guardian_ticket.py` — sign + verify roundtrip, expired ticket rejected, wrong msg_id rejected, missing key 503.
+  - `tests/test_sdk_guardian_client.py` — NO-OP when disabled, posts when enabled (httpx mock), surfaces decision + ticket, raises `GuardianBlocked` on `decision=block`.
+
+**Deliverable:** end-to-end skeleton green in CI. The SDK can call the endpoint, get a `pass` decision, get a ticket, verify it. No real inspection happens yet but the contract is locked.
+
+### Phase 2 — Fast-path tools (cullis-enterprise, ~3d)
+
+**Branch:** `feat/mastio-llm-guardian`. **PR target:** main of cullis-enterprise.
+
+Plugin layout:
+
+```
+cullis_enterprise/mastio/llm_guardian/
+  __init__.py
+  plugin.py           # registers tools into mcp_proxy.guardian.registry
+  config.py           # CULLIS_GUARDIAN_* env loader, mode resolver per binding
+  cache.py            # sha256 idempotence cache (Redis when configured, in-memory dev fallback)
+  tools/
+    __init__.py
+    prompt_injection.py
+    tool_escalation.py
+    loop_detection.py
+    pii_egress.py
+    secret_leak.py
+    reach_guard.py
+  rules/
+    prompt_injection.yaml   # ships with starter pattern set
+    pii.yaml
+    secrets.yaml            # imports TruffleHog regex catalog
+```
+
+Each tool implements `Tool.evaluate(payload, ctx) -> ToolResult` where `ToolResult` carries `decision`, `redacted_payload`, `reasons`. The plugin's `startup` registers each tool in the appropriate fast-path direction. Mode resolution per binding consults the `binding_guardian_modes` table (new alembic migration here, in the public repo? — see open question below).
+
+Tests target ~40 cases: per-tool positive + negative + redaction, per-mode behaviour (audit-only returns pass, enforce-fast returns the tool decision), cache hit + miss, parallel `asyncio.gather` correctness, mode override per binding.
+
+### Phase 3 — SDK cooperation flow (cullis public, ~1d)
+
+**Branch:** `feat/sdk-guardian-cooperation`. **PR target:** main.
+
+Wires `cullis_sdk.guardian.client.inspect_before_send` into the existing send paths (`send_oneshot`, `reply`, `send_message`, internal `_send_envelope`). Wires `inspect_before_deliver` into the receive path (`receive_oneshot`, `await_response`, `_decrypt_envelope`).
+
+Introduces `cullis_sdk.guardian.GuardianBlocked` exception so the agent code can handle blocks distinctly from network errors. When mode is `redact`, the SDK substitutes the `redacted_payload` returned by Mastio before encrypting (send) or before delivering (receive).
+
+The agent runtime template (`cullis_sdk.runtime.Agent`) calls `verify_ticket` before invoking the user-provided `on_message` handler. Tests cover NO-OP path (env off), pass path, redact path, block path, ticket verification failure (rejects message even if SDK got `pass`).
+
+This is the breaking-change PR. Customers running pinned SDK versions are not affected (they keep ignoring the endpoint); customers on the latest SDK opt in via env var.
+
+### Phase 4 — Slow-path async pipeline (cullis-enterprise, ~2d)
+
+**Branch:** `feat/mastio-guardian-slow-path`. **PR target:** main.
+
+Adds:
+
+- `cullis_enterprise/mastio/llm_guardian/slow_path.py` — bounded asyncio task queue. The endpoint enqueues a copy of the payload after it has computed and returned the fast-path decision.
+- `cullis_enterprise/mastio/llm_guardian/judges/` — pluggable judge adapters: `llama_guard_local.py`, `bedrock_guardrails.py`, `openai_moderation.py`. Each implements `Judge.evaluate(payload, ctx) -> JudgeResult`. Customer picks via `CULLIS_GUARDIAN_JUDGE_BACKEND`.
+- `cullis_enterprise/mastio/llm_guardian/alerting.py` — when a slow-path tool fires, post to the configured webhook (Slack, PagerDuty, generic JSON POST). Includes the audit_id, the tool name, the matched reason, and a deeplink to the audit timeline.
+
+Decision on judge backend deferred to Phase 4 kickoff: benchmark all three on a 1000-message corpus, report latency + accuracy + cost, pick. The pluggable adapter shape lets customers swap later.
+
+### Phase 5 — Nightly + perf gate (cullis public, ~1d)
+
+**Branch:** `feat/nightly-guardian-lane`. **PR target:** main.
+
+Extends the existing nightly stress harness (the one that surfaced the DPoP concurrency stall) with a Guardian lane:
+
+- New compose stack `nightly/guardian/` with the plugin loaded, mode `enforce-fast`, 100% Redis cache hit rate baseline + 0% baseline + 50% baseline.
+- Three runs: 10 agents, 25 agents, 50 agents. Compares p50/p95/p99 latency and rps to the no-Guardian baseline.
+- CI assertion: nightly fails if p99 > 1.3x baseline OR rps < 0.75x baseline OR error rate > 1%.
+- Result published as a comment on the nightly run summary issue (existing pattern).
+
+This phase establishes the go/no-go signal for promoting any customer from `audit-only` to `enforce-fast`. Without a green nightly, the dashboard refuses the promotion (Phase 6 enforces this in UI).
+
+### Phase 6 — Dashboard UI (cullis-enterprise, ~2d)
+
+**Branch:** `feat/mastio-guardian-dashboard`. **PR target:** main of cullis-enterprise.
+
+Adds three pages under `/proxy/guardian/`:
+
+- **Modes**: per-binding mode toggle, global default, history of mode changes. Promotion to `enforce-fast` shows the latest nightly perf report and asks for confirmation.
+- **Rules**: starter rules ship read-only; operator extends via YAML editor (Monaco) or visual builder (form-based) for the simple cases. Live preview against pasted sample payloads.
+- **Audit timeline**: queryable view of guardian decisions, filter by tool, decision, agent, peer, time window. Each row links to the full payload (admin-only access, gated by RBAC `admin` role from PR #15).
+
+UI uses the existing dashboard template / asset pipeline. New tests: ~15 cases covering mode change persistence, rule validation, audit query filters, RBAC gates.
+
+### Phase 7 — Image, integration kit, runbook (cullis-enterprise, ~1d)
+
+**Branch:** `feat/mastio-guardian-release`. **PR target:** main of cullis-enterprise.
+
+- `Dockerfile` rebuilds with the `llm_guardian` plugin extras pre-installed.
+- `scripts/dogfood.sh` extends the smoke to issue a guardian-blocked message, a guardian-redacted message, a guardian-passed message; verify audit rows + ticket signing.
+- `docs/integration/guardian-quickstart.md` — operator-facing guide: enable the SDK env, pick a mode, monitor audit, promote to `enforce-fast`, customer-specific rules.
+- `docs/integration/guardian-customer-runbook.md` — incident runbook: false-positive triage, rule rollback, emergency disable (`MCP_PROXY_GUARDIAN_MODE=disabled` global override + audit annotation explaining why).
+- Release notes + changelog entries on both repos.
+
+## Dependencies
+
+```
+PR #378 #15 #16 (RBAC + SCIM, in review or recently merged)
+       │
+       ▼
+  Phase 1 (foundation)
+       │
+       ├─► Phase 2 (plugin tools)  ──┬─► Phase 4 (slow-path)
+       ├─► Phase 3 (SDK cooperation) ┤
+       └─► Phase 6 (dashboard UI)    │
+                                     ▼
+                                Phase 5 (nightly perf gate)
+                                     │
+                                     ▼
+                              Phase 7 (image + docs)
+```
+
+## Parallelisation slots
+
+After Phase 1 lands, three slots open:
+
+1. **Slot A — plugin author**: Phase 2 (fast-path tools). Largest piece.
+2. **Slot B — SDK author**: Phase 3 (cooperation flow).
+3. **Slot C — dashboard author**: Phase 6 (UI).
+
+Each slot can be a separate Claude Code session in a dedicated worktree:
+
+- Slot A: `/home/daenaihax/projects/cullis-enterprise-guardian-tools` on `feat/mastio-llm-guardian`.
+- Slot B: `/home/daenaihax/projects/agent-trust-sdk-guardian` on `feat/sdk-guardian-cooperation`.
+- Slot C: `/home/daenaihax/projects/cullis-enterprise-guardian-ui` on `feat/mastio-guardian-dashboard`.
+
+Slots A and C touch only `cullis-enterprise`; Slot B only `cullis` (public). No file collisions among the three. Slots A and B share the contract from Phase 1 but do not edit the same files. The security agent on Sprint 3+4 stays on `cullis` main repo touching `mcp_proxy/auth/`, `mcp_proxy/audit/`, `app/auth/`, `app/kms/`, `cullis_sdk/crypto/` — none overlap with `mcp_proxy/guardian/` or `cullis_sdk/guardian/`.
+
+## Risk register
+
+| ID | Risk | Probability | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | Performance regression beyond budget | medium | high | Phase 5 perf gate as CI hard fail. Phase 2 ships with the `audit-only` default; promotion gated by Phase 5 result. |
+| R2 | SDK breaking change strands old clients | medium | medium | Feature flag `MCP_PROXY_GUARDIAN_ENABLED` in SDK, default off. Customers pin and upgrade on their own cadence. |
+| R3 | LLM-judge model choice locks us in | low | medium | Pluggable adapter from Phase 4 day one. Three backends shipped (local, Bedrock, OpenAI). |
+| R4 | Trust assumption on agent runtime | low | medium | Documented in ADR; out-of-scope for v1. Phase 7 runbook flags it for the customer. |
+| R5 | Scope creep into v2 LLM-judge sync mode | high | medium | ADR explicitly says v1 is async-only for the slow path. `enforce-strict` is documented as a v1 mode but not implemented (returns 501 in v1). |
+| R6 | Idempotence cache cross-tenant contamination | low | high | Cache key includes `agent_id` and `peer_agent_id`. Per-org Redis namespace from existing convention. Phase 2 includes a dedicated test for cross-tenant isolation. |
+| R7 | Rule false-positive rate too high on first customer | medium | medium | Mandatory 2-week `audit-only` bake before any `enforce-fast` promotion. Phase 7 runbook documents the triage workflow. |
+
+## Immutable safety gates (pre-go-live)
+
+These cannot be bypassed by feature flag or operator override:
+
+1. Nightly with `enforce-fast` ON for 24h, no failures.
+2. p99 latency end-to-end < 1.3x baseline pre-Guardian.
+3. Throughput rps > 0.75x baseline.
+4. False-positive rate on customer audit-only sweep < 5%.
+5. Each tool ships with: rule reference, positive example (block), negative example (legitimate traffic that must not block).
+
+If any gate fails, mode promotion to `enforce-fast` is blocked at the dashboard level. The operator can still flip to `audit-only`. They cannot enable enforcement without all five gates green.
+
+## Open questions to resolve during implementation
+
+- **Q1**: where does the `binding_guardian_modes` table live — on the Mastio core (public) or the plugin (private)? Argument for core: dashboard for mode toggle is a UI on top of binding, which is core. Argument for plugin: keeps the public schema clean. **Default**: in the plugin; revisit if a community dashboard needs to read the mode.
+- **Q2**: ticket key distribution to agent runtimes. Same identity bundle as the org CA chain (rotated together) vs separate channel. **Default**: piggyback on identity bundle; rotate together; document the operational implication.
+- **Q3**: cache backend default. Redis is the production answer; in-memory works for single-Mastio dev. **Default**: in-memory dev fallback, Redis required for multi-replica deployments (already the existing pattern).
+- **Q4**: dashboard rule editor: visual builder, YAML, both. **Default**: YAML editor first (Monaco), visual builder deferred to v1.1 unless a design partner asks for it explicitly during the bake-time.
+- **Q5**: LLM-judge model choice (Llama Guard 1B local vs Bedrock Guardrails vs OpenAI Moderation). **Decision**: Phase 4 kickoff benchmark.
+
+## Out of scope for v1
+
+- `enforce-strict` mode actual implementation (returns 501 + clear error message; ADR documents it as v2).
+- Customer-trained classifiers beyond the off-the-shelf judges.
+- Multi-modal payload inspection (images, audio). v1 is text only.
+- Cross-Mastio rule sync (each Mastio carries its own rule set; federation of rules deferred).
+- Court-side guardian (cross-org metadata anomaly detection — that's the separate `cross_org_guardian` plugin in the Court Enterprise roadmap).


### PR DESCRIPTION
## Summary

Documents the LLM Guardian design (bidirectional content inspection via SDK cooperation, fast-path/slow-path split, four operating modes) and the seven-phase rollout plan with parallelisation slots, risk register, and immutable safety gates.

## Why

The Guardian closes the cross-org content inspection gap without breaking E2E: the SDK on each side decrypts/encrypts and calls the local Mastio for an inspection decision before delivering or sending. Same path covers intra-org. Performance budget locked in: fast-path sync only (regex + role + loop), LLM-judge async audit-only in v1 to keep the per-message overhead under 30ms p99.

## Documents

- \`docs/adrs/0016-llm-guardian-bidirectional.md\` — Status: Proposed. Promote to Accepted on merge.
- \`docs/plans/llm-guardian-rollout-2026-05.md\` — operational map: 7 phases, ~9-11d wall-clock, parallel slots, risk register R1-R7, immutable safety gates.

## Stacking with current work

- Builds on the multi-role session hook from #378 (merged) and the rbac_multi_admin / scim_2_0 plugins on the private repo (#15 #16).
- Phase 1 foundation PR is the next deliverable after this one merges; it brings up the endpoint stub + SDK no-op hook so Phases 2/3/6 can run in parallel slots.

## Out of scope for v1

- enforce-strict mode (returns 501 in v1, documented as v2)
- Multi-modal payload inspection (text only)
- Cross-Mastio rule sync
- Court-side guardian (separate cross_org_guardian plugin in Court Enterprise roadmap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
