### PR TITLE
fix(security): switch Org CA + agent leaf gen from RSA-2048 to EC P-256

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -83,7 +83,11 @@ class AgentManager:
     def __init__(self, org_id: str, trust_domain: str = "cullis.local"):
         self._org_id = org_id
         self._trust_domain = trust_domain
-        self._org_ca_key: rsa.RSAPrivateKey | None = None
+        # M-crypto-2 audit fix — Org CA generation defaults to EC P-256
+        # (see ``generate_self_signed_ca``) but legacy deployments may
+        # have an RSA Org CA on disk; the type annotation accepts both
+        # so loading legacy material doesn't trip a type guard.
+        self._org_ca_key: rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey | None = None
         self._org_ca_cert: x509.Certificate | None = None
         # ADR-009 Phase 1 — Mastio CA (intermediate). Persisted in
         # ``proxy_config.mastio_ca_{key,cert}``, loaded lazily at boot
@@ -197,7 +201,14 @@ class AgentManager:
         if self.ca_loaded:
             raise RuntimeError("Org CA already loaded — refusing to overwrite")
 
-        ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        # M-crypto-2 audit fix — Org CA is a 10-year root, so it must
+        # use a key size that survives its full lifetime under NIST
+        # SP 800-57 (≥3072-bit RSA or EC P-256). EC P-256 is also the
+        # SPIFFE/SPIRE convention and matches what the Mastio
+        # intermediate (``_mint_mastio_ca``) and leaf (``leaf_key``)
+        # already use. Verifiers stay dual-stack; legacy Org CAs
+        # issued under RSA-2048 keep working until they expire.
+        ca_key = ec.generate_private_key(ec.SECP256R1())
 
         if derive_org_id:
             pubkey_der = ca_key.public_key().public_bytes(
@@ -520,7 +531,7 @@ class AgentManager:
     # ── Certificate generation ──────────────────────────────────────
 
     def _generate_agent_cert(self, agent_name: str) -> tuple[str, str]:
-        """Generate RSA-2048 key + x509 cert for an internal agent.
+        """Generate EC P-256 key + x509 cert for an internal agent.
 
         Cert fields:
           - CN: {org_id}::{agent_name}
@@ -530,12 +541,19 @@ class AgentManager:
           - Valid 365 days
 
         Returns (cert_pem, key_pem).
+
+        M-crypto-2 audit fix: agent leaves are EC P-256, matching the
+        Mastio leaf (``leaf_key``) and DPoP keypair. RSA-2048 was
+        below NIST SP 800-57's ≥3072-bit recommendation for new keys.
+        Verifiers stay dual-stack so existing RSA-issued agents keep
+        working until their cert expires (1 year), then auto-renew
+        in EC at the next enrollment.
         """
         if not self.ca_loaded:
             raise RuntimeError("Org CA not loaded — call load_org_ca() first")
 
         # Generate agent key pair
-        agent_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        agent_key = ec.generate_private_key(ec.SECP256R1())
 
         agent_id = f"{self._org_id}::{agent_name}"
         spiffe_uri = f"spiffe://{self._trust_domain}/{self._org_id}/{agent_name}"

--- a/tests/test_adr009_phase1_mastio_pubkey.py
+++ b/tests/test_adr009_phase1_mastio_pubkey.py
@@ -283,16 +283,27 @@ async def test_mastio_leaf_chains_to_org_ca(tmp_path, monkeypatch):
     assert bc.ca is True
     assert bc.path_length == 0
 
-    # Verify the Org CA's signature over the Mastio CA.
-    org_ca.public_key().verify(
-        mastio_ca.signature,
-        mastio_ca.tbs_certificate_bytes,
-        padding=__import__(
-            "cryptography.hazmat.primitives.asymmetric.padding",
-            fromlist=["PKCS1v15"],
-        ).PKCS1v15(),
-        algorithm=mastio_ca.signature_hash_algorithm,
-    )
+    # Verify the Org CA's signature over the Mastio CA. M-crypto-2 made
+    # the Org CA EC P-256 by default (was RSA-2048), so the verify call
+    # must dispatch on key type — RSA-PSS/PKCS1v15 vs ECDSA.
+    from cryptography.hazmat.primitives.asymmetric import ec as _ec
+    from cryptography.hazmat.primitives.asymmetric import padding as _padding
+    from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+    org_pub = org_ca.public_key()
+    if isinstance(org_pub, _rsa.RSAPublicKey):
+        org_pub.verify(
+            mastio_ca.signature,
+            mastio_ca.tbs_certificate_bytes,
+            padding=_padding.PKCS1v15(),
+            algorithm=mastio_ca.signature_hash_algorithm,
+        )
+    else:
+        assert isinstance(org_pub, _ec.EllipticCurvePublicKey)
+        org_pub.verify(
+            mastio_ca.signature,
+            mastio_ca.tbs_certificate_bytes,
+            _ec.ECDSA(mastio_ca.signature_hash_algorithm),
+        )
 
     # Leaf SAN is spiffe://.../proxy/chain-org.
     san = leaf.extensions.get_extension_for_class(x509.SubjectAlternativeName).value

--- a/tests/test_m_crypto_2_ec_p256.py
+++ b/tests/test_m_crypto_2_ec_p256.py
@@ -1,0 +1,110 @@
+"""
+M-crypto-2 regression: Org CA + agent leaf cert generation defaults to
+EC P-256, not RSA.
+
+The audit flagged ``mcp_proxy/egress/agent_manager.py`` for shipping
+RSA-2048 by default. RSA-2048 carries 112-bit security strength under
+NIST SP 800-57, which is below the recommended floor for keys with a
+10-year (Org CA) or 1-year (agent leaf) lifetime starting in 2026. EC
+P-256 hits 128-bit strength with smaller keys, faster signatures, and
+matches the convention already used by the Mastio identity, the DPoP
+keypair, and the ECDH ephemeral.
+
+Existing RSA agents and Org CAs keep working because the verifier
+stays dual-stack; this file just locks in that NEW material is EC.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import rsa as _rsa
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "m_crypto.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _load_priv(pem: str):
+    return serialization.load_pem_private_key(pem.encode(), password=None)
+
+
+@pytest.mark.asyncio
+async def test_standalone_org_ca_is_ec_p256(proxy_app):
+    """Self-signed Org CA on first boot must be EC P-256, not RSA."""
+    from mcp_proxy.db import get_config
+    pem = await get_config("org_ca_key")
+    assert pem is not None, "standalone proxy did not persist Org CA"
+    key = _load_priv(pem)
+    assert isinstance(key, ec.EllipticCurvePrivateKey), (
+        f"Org CA must be EC under M-crypto-2 audit fix, got {type(key).__name__}"
+    )
+    assert isinstance(key.curve, ec.SECP256R1)
+    # And NOT RSA — explicit guard so a regression to RSA fails loudly.
+    assert not isinstance(key, _rsa.RSAPrivateKey)
+
+
+@pytest.mark.asyncio
+async def test_internal_agent_leaf_is_ec_p256(proxy_app):
+    """``_generate_agent_cert`` must produce EC P-256 leaves."""
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+    cert_pem, key_pem = mgr._generate_agent_cert("alice")
+    key = _load_priv(key_pem)
+    assert isinstance(key, ec.EllipticCurvePrivateKey)
+    assert isinstance(key.curve, ec.SECP256R1)
+    assert not isinstance(key, _rsa.RSAPrivateKey)
+
+
+@pytest.mark.asyncio
+async def test_agent_cert_signature_alg_is_ecdsa(proxy_app):
+    """Cert signature algorithm must be ecdsa-with-SHA256 (an EC Org CA
+    signs with ECDSA, not RSA-PKCS1v15)."""
+    from cryptography import x509 as _x509
+
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+    cert_pem, _ = mgr._generate_agent_cert("alice")
+    cert = _x509.load_pem_x509_certificate(cert_pem.encode())
+    # ECDSA with SHA-256 — OID 1.2.840.10045.4.3.2
+    assert cert.signature_algorithm_oid.dotted_string == "1.2.840.10045.4.3.2", (
+        f"agent cert must be ECDSA-signed under EC Org CA, got "
+        f"{cert.signature_algorithm_oid.dotted_string}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_cert_chains_under_ec_org_ca(proxy_app):
+    """Sanity: agent cert verifies against the EC Org CA via ECDSA."""
+    from cryptography import x509 as _x509
+
+    app, _ = proxy_app
+    mgr = app.state.agent_manager
+    cert_pem, _ = mgr._generate_agent_cert("alice")
+    cert = _x509.load_pem_x509_certificate(cert_pem.encode())
+    org_pub = mgr._org_ca_cert.public_key()
+    assert isinstance(org_pub, ec.EllipticCurvePublicKey)
+    # ECDSA verify path — raises on failure.
+    org_pub.verify(
+        cert.signature,
+        cert.tbs_certificate_bytes,
+        ec.ECDSA(cert.signature_hash_algorithm),
+    )

--- a/tests/test_proxy_standalone_ca.py
+++ b/tests/test_proxy_standalone_ca.py
@@ -61,9 +61,13 @@ async def test_standalone_ca_persisted_to_proxy_config(standalone_proxy):
     ca_cert_pem = await get_config("org_ca_cert")
     assert ca_key_pem and "BEGIN PRIVATE KEY" in ca_key_pem
     assert ca_cert_pem and "BEGIN CERTIFICATE" in ca_cert_pem
-    # Key is a valid RSA-2048
+    # M-crypto-2 audit: Org CA is now EC P-256 (was RSA-2048). Loading
+    # legacy RSA Org CAs from disk still works via the dual-stack
+    # verifier; this test exercises the freshly-minted path.
+    from cryptography.hazmat.primitives.asymmetric import ec as _ec
     key = serialization.load_pem_private_key(ca_key_pem.encode(), password=None)
-    assert key.key_size == 2048
+    assert isinstance(key, _ec.EllipticCurvePrivateKey)
+    assert isinstance(key.curve, _ec.SECP256R1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The two remaining ``rsa.generate_private_key(... key_size=2048)`` call sites in ``mcp_proxy/egress/agent_manager.py`` produced an RSA-2048 Org CA (10-year lifetime) and an RSA-2048 agent leaf (1-year). NIST SP 800-57 Rev 5 puts RSA-2048 at 112-bit security strength, below the recommended floor for keys with those lifetimes starting in 2026 (≥3072-bit RSA or EC P-256).

EC P-256 is what every other key in the proxy already uses: the Mastio identity, the Mastio CA intermediate (``_mint_mastio_ca``), the DPoP keypair, and the ECDH ephemeral. Standardising on it:
- Closes the audit MEDIUM ``M-crypto-2`` "RSA-2048 mix EC"
- Aligns with the SPIFFE/SPIRE convention the rest of the codebase follows
- Shrinks keys ~8x and signatures ~4x

## Backwards compatibility

Verifiers stay dual-stack — ``app/auth/message_signer.py`` and the SDK ``cullis_sdk.crypto`` already auto-dispatch RSA-PSS vs ECDSA from the public-key type. So:
- **Existing RSA agents and Org CAs keep working** until their cert expires
- **New material is EC P-256**
- **Legacy RSA rolls off naturally at the next renewal** (1y for agents, 10y for Org CA — operators will rotate the Org CA on a normal cycle)

The ``_org_ca_key`` type annotation widens to ``rsa.RSAPrivateKey | ec.EllipticCurvePrivateKey | None`` so ``load_org_ca`` can still parse a legacy RSA Org CA from disk.

## Test plan

- [x] `pytest tests/test_m_crypto_2_ec_p256.py` (4 new regression tests pass — Org CA is EC, agent leaf is EC, signature alg is ECDSA-SHA256, agent cert chains under ECDSA verify)
- [x] `pytest tests/ -k "egress or agent_manager or org_ca or generate_agent_cert or standalone or enrollment or x509 or pki"` (168 passed, 1 skipped)
- [x] Two existing tests fixed: `test_proxy_standalone_ca.py` assumed `key.key_size == 2048`; `test_adr009_phase1_mastio_pubkey` verified the chain with `RSAPublicKey.verify(padding=...)`. Both now dispatch on key type.
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Note on full RSA removal

This PR closes the **generation** half of the dual-stack story. Removing RSA from the **verifier** is intentionally NOT in scope — the project description in CLAUDE.md ships dual-stack as a feature for interop with enterprise PKIs that are still RSA-only. Removing it would close a real interop door.