### PR TITLE
fix(security): helm chart org rename + dashboard cookie/break-glass MEDIUMs

### DIFF
--- a/deploy/helm/cullis/README.md
+++ b/deploy/helm/cullis/README.md
@@ -212,7 +212,7 @@ spec:
 | `nameOverride` | `""` | Override chart name (per release). |
 | `fullnameOverride` | `""` | Override fully qualified name. |
 | `imagePullSecrets` | `[]` | Image pull secrets applied to every pod. |
-| `broker.image.repository` | `ghcr.io/daenaihax/cullis` | Broker image repo. |
+| `broker.image.repository` | `ghcr.io/cullis-security/cullis` | Broker image repo. |
 | `broker.image.tag` | `""` | Image tag (defaults to chart `appVersion`). |
 | `broker.image.pullPolicy` | `IfNotPresent` | Image pull policy. |
 | `broker.replicaCount` | `2` | Static replica count when HPA disabled. |

--- a/deploy/helm/cullis/values.yaml
+++ b/deploy/helm/cullis/values.yaml
@@ -24,7 +24,7 @@ imagePullSecrets: []
 broker:
   image:
     # -- Container image repository for the broker.
-    repository: ghcr.io/daenaihax/cullis
+    repository: ghcr.io/cullis-security/cullis
     # -- Image tag. When empty the chart appVersion is used.
     tag: ""
     # -- Image pull policy.

--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -178,6 +178,26 @@ def get_session(request: Request) -> ProxyDashboardSession:
     )
 
 
+def _should_set_secure_cookie() -> bool:
+    """Decide the ``Secure`` flag for the dashboard session cookie.
+
+    M-dash audit fix: the previous heuristic looked only at
+    ``proxy_public_url.startswith("https")``. If the operator forgot
+    to set the env var, or pointed it at an internal HTTP URL while
+    the dashboard sits behind an HTTPS-terminating reverse proxy, the
+    cookie shipped without ``Secure`` and could leak over HTTP. The
+    new rule pins ``Secure=True`` whenever ``environment=production``
+    regardless of the URL hint, and falls back to the URL heuristic
+    only in development where HTTP-only loopback is the norm.
+    """
+    from mcp_proxy.config import get_settings as _proxy_settings
+    settings = _proxy_settings()
+    if settings.environment == "production":
+        return True
+    pub_url = settings.proxy_public_url
+    return pub_url.startswith("https") if pub_url else False
+
+
 def set_session(
     response: Response,
     role: str = "admin",
@@ -203,9 +223,7 @@ def set_session(
         "exp": int(time.time()) + _COOKIE_MAX_AGE,
     })
     signed = _sign(payload)
-    from mcp_proxy.config import get_settings as _proxy_settings
-    _pub_url = _proxy_settings().proxy_public_url
-    _use_secure = _pub_url.startswith("https") if _pub_url else False
+    _use_secure = _should_set_secure_cookie()
     response.set_cookie(
         _COOKIE_NAME, signed,
         max_age=_COOKIE_MAX_AGE,
@@ -218,10 +236,9 @@ def set_session(
 
 def clear_session(response: Response) -> None:
     """Delete the session cookie."""
-    from mcp_proxy.config import get_settings as _proxy_settings
-    _pub_url = _proxy_settings().proxy_public_url
-    _use_secure = _pub_url.startswith("https") if _pub_url else False
-    response.delete_cookie(_COOKIE_NAME, samesite="lax", secure=_use_secure)
+    response.delete_cookie(
+        _COOKIE_NAME, samesite="lax", secure=_should_set_secure_cookie(),
+    )
 
 
 def require_login(request: Request) -> ProxyDashboardSession | RedirectResponse:
@@ -260,15 +277,12 @@ def set_oidc_state(response: Response, flow_state: dict) -> None:
     payload_data["exp"] = int(time.time()) + _OIDC_STATE_MAX_AGE
     payload = json.dumps(payload_data)
     signed = _sign(payload)
-    from mcp_proxy.config import get_settings as _proxy_settings
-    _pub_url = _proxy_settings().proxy_public_url
-    _use_secure = _pub_url.startswith("https") if _pub_url else False
     response.set_cookie(
         _OIDC_STATE_COOKIE, signed,
         max_age=_OIDC_STATE_MAX_AGE,
         httponly=True,
         samesite="lax",
-        secure=_use_secure,
+        secure=_should_set_secure_cookie(),
     )
 
 
@@ -291,11 +305,8 @@ def get_oidc_state(request: Request) -> dict | None:
 
 def clear_oidc_state(response: Response) -> None:
     """Delete the OIDC state cookie."""
-    from mcp_proxy.config import get_settings as _proxy_settings
-    _pub_url = _proxy_settings().proxy_public_url
-    _use_secure = _pub_url.startswith("https") if _pub_url else False
     response.delete_cookie(
-        _OIDC_STATE_COOKIE, samesite="lax", secure=_use_secure,
+        _OIDC_STATE_COOKIE, samesite="lax", secure=_should_set_secure_cookie(),
     )
 
 
@@ -361,6 +372,9 @@ async def verify_admin_password(plaintext: str) -> bool:
 # ─────────────────────────────────────────────────────────────────────────────
 
 
+_force_local_password_audited: bool = False
+
+
 async def is_local_password_login_enabled() -> bool:
     """Return True when /proxy/login is allowed to accept a password.
 
@@ -372,9 +386,43 @@ async def is_local_password_login_enabled() -> bool:
 
     The toggle is consulted on every request; no caching — the admin
     must be able to flip it off and see the form vanish immediately.
+
+    M-dash audit fix: when the env break-glass is the deciding factor
+    AND the stored flag says disabled, the override gets a one-shot
+    audit row (``auth.local_password.break_glass``) so a Mastio admin
+    auditing post-incident can see when SSO-only hardening was bypassed.
+    The flag is per-process; a worker restart re-emits the row, which
+    is the right cadence — anyone triaging an incident wants to know
+    the override is active right now.
     """
     from mcp_proxy.config import get_settings
     if get_settings().force_local_password:
+        global _force_local_password_audited
+        if not _force_local_password_audited:
+            _force_local_password_audited = True
+            try:
+                from mcp_proxy.db import get_config, log_audit
+                stored = await get_config(LOCAL_PASSWORD_ENABLED_KEY)
+                # Only audit when the env IS overriding a "disabled"
+                # DB toggle. When the DB toggle is also enabled (or
+                # unset) the env adds nothing surprising and the
+                # noise hides real break-glass events.
+                if stored == "0":
+                    await log_audit(
+                        agent_id="admin",
+                        action="auth.local_password.break_glass",
+                        status="active",
+                        detail=(
+                            "MCP_PROXY_FORCE_LOCAL_PASSWORD=1 env override "
+                            "is restoring password login while the DB "
+                            "toggle says disabled. Unset the env var when "
+                            "SSO is back to re-enable hardening."
+                        ),
+                    )
+            except Exception:
+                # Audit best-effort: a DB outage during break-glass
+                # must not block the operator from logging in.
+                _force_local_password_audited = False
         return True
 
     from mcp_proxy.db import get_config

--- a/tests/test_m_dash_break_glass_and_cookie.py
+++ b/tests/test_m_dash_break_glass_and_cookie.py
@@ -1,0 +1,168 @@
+"""
+M-dash regression: dashboard hardening for the SSO-only hardening
+toggle and the session cookie ``Secure`` flag.
+
+1. The ``MCP_PROXY_FORCE_LOCAL_PASSWORD`` env break-glass used to
+   silently override the DB-stored "local password disabled" flag.
+   No audit trail. Now the override emits a one-shot
+   ``auth.local_password.break_glass`` audit row when it's actually
+   reversing a DB-disabled state, so a post-incident reviewer can
+   see when SSO-only was bypassed.
+
+2. The session cookie ``Secure`` flag was decided from a heuristic
+   on ``proxy_public_url.startswith("https")``. If the operator left
+   the env var unset (or pointed it at an internal HTTP URL while
+   nginx terminates HTTPS), the cookie shipped without ``Secure``
+   and could leak over HTTP. Now production forces ``Secure=True``.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "m_dash.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.delenv("MCP_PROXY_FORCE_LOCAL_PASSWORD", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    # Reset the per-process flag so each test starts from a clean
+    # "not yet audited" state.
+    import mcp_proxy.dashboard.session as _ses
+    _ses._force_local_password_audited = False
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+    _ses._force_local_password_audited = False
+
+
+# ── Break-glass audit ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_break_glass_audited_when_db_says_disabled(
+    proxy_app, monkeypatch,
+) -> None:
+    monkeypatch.setenv("MCP_PROXY_FORCE_LOCAL_PASSWORD", "1")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import set_config
+    await set_config("local_password_enabled", "0")
+
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
+    assert await is_local_password_login_enabled() is True
+
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT status, detail FROM audit_log "
+                "WHERE action = 'auth.local_password.break_glass'",
+            ),
+        )).all()
+    assert len(rows) == 1, "break-glass override must emit exactly one audit row"
+    status, detail = rows[0]
+    assert status == "active"
+    assert detail is not None and "MCP_PROXY_FORCE_LOCAL_PASSWORD" in detail
+
+
+@pytest.mark.asyncio
+async def test_break_glass_silent_when_db_already_enabled(
+    proxy_app, monkeypatch,
+) -> None:
+    """Env override + DB toggle both 'enabled' = no override happening,
+    no audit noise. Triaging post-incident wants to spot REAL break-glass
+    events, not see one for every prod boot where the env is set
+    redundantly."""
+    monkeypatch.setenv("MCP_PROXY_FORCE_LOCAL_PASSWORD", "1")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    # DB unset (default = enabled) — env doesn't change anything.
+
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
+    assert await is_local_password_login_enabled() is True
+
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT 1 FROM audit_log "
+                "WHERE action = 'auth.local_password.break_glass'",
+            ),
+        )).all()
+    assert rows == [], "redundant env override must not pollute the audit log"
+
+
+@pytest.mark.asyncio
+async def test_break_glass_audit_is_one_shot(proxy_app, monkeypatch) -> None:
+    """Multiple consults inside one process emit at most one audit row."""
+    monkeypatch.setenv("MCP_PROXY_FORCE_LOCAL_PASSWORD", "1")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import set_config
+    await set_config("local_password_enabled", "0")
+
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
+    for _ in range(5):
+        await is_local_password_login_enabled()
+
+    from mcp_proxy.db import get_db
+    from sqlalchemy import text
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT 1 FROM audit_log "
+                "WHERE action = 'auth.local_password.break_glass'",
+            ),
+        )).all()
+    assert len(rows) == 1
+
+
+# ── Cookie Secure flag ───────────────────────────────────────────────
+
+
+def test_cookie_secure_forced_in_production(monkeypatch) -> None:
+    """``Secure`` must be ``True`` in production regardless of
+    ``proxy_public_url``. Operators forgetting to set the URL hint
+    while nginx terminates HTTPS in front used to ship cookies
+    without ``Secure``.
+    """
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "")
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.dashboard.session import _should_set_secure_cookie
+    assert _should_set_secure_cookie() is True
+    get_settings.cache_clear()
+
+
+def test_cookie_secure_follows_url_in_dev(monkeypatch) -> None:
+    """In development the URL heuristic still applies — local HTTP
+    loopback is the norm and forcing Secure would break dev login."""
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "development")
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "http://localhost:7777")
+    get_settings.cache_clear()
+    from mcp_proxy.dashboard.session import _should_set_secure_cookie
+    assert _should_set_secure_cookie() is False
+
+    monkeypatch.setenv("MCP_PROXY_PROXY_PUBLIC_URL", "https://mastio.example")
+    get_settings.cache_clear()
+    assert _should_set_secure_cookie() is True
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary

Three audit MEDIUMs in one PR — supply-chain pin and dashboard hardening, all small surface area.

### 1. Helm chart broker image repository
``deploy/helm/cullis/values.yaml`` + the rendered ``deploy/helm/cullis/README.md`` still pointed at ``ghcr.io/daenaihax/cullis``, the pre-rebrand personal namespace. Canonical location is ``ghcr.io/cullis-security/cullis``. The old namespace is a takeover surface — anyone who registers ``daenaihax`` on a future GHCR clone (or if the personal account ever lapses) could ship a malicious image to operators that pinned chart defaults.

### 2. Dashboard cookie ``Secure`` flag
``mcp_proxy/dashboard/session.py`` derived ``Secure`` from a heuristic on ``proxy_public_url.startswith("https")``. If the operator forgot the env var, or pointed it at an internal HTTP URL while nginx terminated HTTPS in front, the session cookie shipped without ``Secure`` and could leak to a downgrade attacker.

The new ``_should_set_secure_cookie()`` helper:
- Pins ``True`` whenever ``environment=production``, regardless of URL hint
- Falls back to the URL heuristic only in development where loopback HTTP is the norm

Four call sites consolidated (set_session, clear_session, set_oidc_state, clear_oidc_state).

### 3. ``MCP_PROXY_FORCE_LOCAL_PASSWORD`` break-glass audit
The env override silently re-enabled password sign-in over a DB toggle that disabled it (SSO-only hardening). No audit trail meant a post-incident reviewer couldn't tell when SSO-only was bypassed.

``is_local_password_login_enabled`` now emits a one-shot ``auth.local_password.break_glass`` row when the env IS the deciding factor (DB says disabled), and stays silent when the env override is redundant (DB also enabled). Best-effort: a DB outage during break-glass must not block login.

Closes **M-supply-1** (helm chart org), **M-dash-1** (cookie heuristic), **M-dash-2** (break-glass audit) from the 2026-04-30 audit.

## Test plan

- [x] `pytest tests/test_m_dash_break_glass_and_cookie.py` (5 new regression tests pass — break-glass audited when DB-disabled, silent when DB-enabled, one-shot per process, cookie Secure forced in production, follows URL in dev)
- [x] `pytest tests/test_proxy_local_password_toggle.py tests/test_h9_login_lockout.py tests/test_proxy_dashboard_mcp_resources.py` (34 passed, no regressions on related dashboard surfaces)
- [x] `pytest tests/ -k "session or cookie or oidc or password or login or dashboard"` (336 passed; 3 unrelated failures are pre-existing — test_e2e requires sequential run order, test_postgres_integration is in the known-failures memo)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Operational notes

- Operators that pinned the chart at the old namespace should update their values when upgrading. The image at the new namespace is the same content; CI publishes both for a release if needed.
- The cookie change is invisible to most prod operators (HTTPS already pinned via URL); it tightens the failure mode of forgetting the URL env.
- The break-glass audit will surface in dashboards reading the audit log; expect zero rows under steady state (env unset OR DB enabled), and one row per process when an operator deliberately runs the break-glass.