### PR TITLE
fix(security): close 4 dashboard XSS surfaces (badge_version + 3 copy buttons)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3136,7 +3136,18 @@ async def badge_version(request: Request):
     """HTMX fragment — single-pixel-thin banner that says "Update
     available: 0.3.0-rc3" and links to the modal with the copy-paste
     install command. Empty response when no update is pending so the
-    sidebar stays clean."""
+    sidebar stays clean.
+
+    M-dash-3 audit fix: every interpolated value is HTML-escaped
+    before reaching the response. ``release_url``, ``latest``, and
+    ``install_command`` come from the GitHub Releases API (or a tag
+    name that an attacker who compromises the GHCR repo could craft)
+    and used to be embedded raw in ``href=...`` / ``title=...`` /
+    text-content positions, giving a stored-XSS surface against any
+    operator viewing the dashboard.
+    """
+    import html as _html
+
     session = get_session(request)
     if not session.logged_in:
         return HTMLResponse("")
@@ -3146,11 +3157,14 @@ async def badge_version(request: Request):
     if not status.update_available or not status.install_command:
         return HTMLResponse("")
 
-    cmd = status.install_command
-    latest = status.latest or ""
-    current = status.current
+    # ``quote=True`` escapes ``"`` so attribute-context interpolations
+    # cannot break out into new attributes.
+    cmd = _html.escape(status.install_command, quote=True)
+    latest = _html.escape(status.latest or "", quote=True)
+    current = _html.escape(str(status.current), quote=True)
+    release_url = _html.escape(status.release_url or "", quote=True)
     return HTMLResponse(
-        f'<a href="{status.release_url}" target="_blank" rel="noopener" '
+        f'<a href="{release_url}" target="_blank" rel="noopener" '
         f'class="block px-3 py-2 rounded text-xs font-mono '
         f'bg-amber-500/20 text-amber-300 hover:bg-amber-500/30 transition" '
         f'title="Run ``{cmd}`` on the Mastio host to upgrade. '

--- a/mcp_proxy/dashboard/templates/downloads.html
+++ b/mcp_proxy/dashboard/templates/downloads.html
@@ -56,7 +56,7 @@
                         <code class="text-sm text-accent-400" style="font-family: 'JetBrains Mono', monospace;">{{ proxy_url }}</code>
                     </div>
                     <button type="button"
-                            onclick="navigator.clipboard.writeText('{{ proxy_url|e }}').then(function(){var b=event.target;var o=b.textContent;b.textContent='Copied';setTimeout(function(){b.textContent=o;},1600);})"
+                            onclick="navigator.clipboard.writeText({{ proxy_url|tojson }}).then(function(){var b=event.target;var o=b.textContent;b.textContent='Copied';setTimeout(function(){b.textContent=o;},1600);})"
                             class="px-3 py-1.5 text-[11px] uppercase tracking-wider font-semibold border border-gray-700 text-gray-300 rounded hover:bg-gray-800/60 hover:border-accent-400 hover:text-accent-400 transition"
                             style="font-family: 'Chakra Petch', sans-serif;">
                         Copy

--- a/mcp_proxy/dashboard/templates/link_broker.html
+++ b/mcp_proxy/dashboard/templates/link_broker.html
@@ -16,7 +16,7 @@
         <div class="flex items-center gap-3">
             <code class="text-sm text-white break-all flex-1" style="font-family: 'JetBrains Mono', monospace;">{{ org_id }}</code>
             <button type="button"
-                    onclick="navigator.clipboard.writeText('{{ org_id }}'); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
+                    onclick="navigator.clipboard.writeText({{ org_id|tojson }}); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
                     class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
                 Copy
             </button>

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -98,7 +98,7 @@
             <div class="flex items-center justify-between gap-3 mb-2">
                 <p class="text-[10px] text-gray-500 uppercase tracking-[0.2em]">Org ID (share with Court admin)</p>
                 <button type="button"
-                        onclick="navigator.clipboard.writeText('{{ org_id }}'); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
+                        onclick="navigator.clipboard.writeText({{ org_id|tojson }}); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
                         class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
                     Copy
                 </button>

--- a/tests/test_m_dash_badge_xss.py
+++ b/tests/test_m_dash_badge_xss.py
@@ -1,0 +1,136 @@
+"""
+M-dash-3 regression: ``/badge/version`` HTML-escapes every value it
+interpolates from the GitHub Releases API.
+
+The fragment used to embed ``release_url``, ``install_command``,
+``latest`` and ``current`` raw via f-string. An attacker who could
+publish a release tag with a crafted value (or compromise the GHCR
+repo) would land stored XSS against any operator viewing the
+dashboard. The fix HTML-escapes (``quote=True``) every interpolated
+field so attribute and text contexts both resist injection.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "m_dash_xss.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _admin_cookie(csrf_token: str = "csrf-xss-test") -> tuple[str, str]:
+    import json as _json
+    import time as _time
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, _sign
+    payload = _json.dumps(
+        {
+            "role": "admin",
+            "csrf_token": csrf_token,
+            "exp": int(_time.time()) + 3600,
+        },
+    )
+    return _COOKIE_NAME, _sign(payload)
+
+
+@pytest.mark.asyncio
+async def test_badge_version_escapes_release_url(proxy_app) -> None:
+    """A release URL containing a ``"`` would break out of the
+    ``href="..."`` attribute under the old f-string. After the fix
+    the value renders escaped as ``&quot;``."""
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    from mcp_proxy.version_check import UpdateStatus
+    crafted = UpdateStatus(
+        current="0.3.0",
+        latest="0.4.0",
+        update_available=True,
+        install_command="docker pull benign:0.4.0",
+        release_url='https://example.com/" onerror="alert(1)" data-x="',
+    )
+    async def _stub():
+        return crafted
+    with patch(
+        "mcp_proxy.version_check.check_for_updates", side_effect=_stub,
+    ):
+        resp = await client.get("/proxy/badge/version")
+
+    assert resp.status_code == 200
+    body = resp.text
+    # Raw quote+attribute injection must NOT appear.
+    assert ' onerror="alert(1)"' not in body
+    assert "&quot;" in body or "&#x22;" in body or "&#34;" in body, (
+        "release_url with embedded quote must be HTML-escaped in the output"
+    )
+
+
+@pytest.mark.asyncio
+async def test_badge_version_escapes_install_command(proxy_app) -> None:
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    from mcp_proxy.version_check import UpdateStatus
+    crafted = UpdateStatus(
+        current="0.3.0",
+        latest="0.4.0",
+        update_available=True,
+        install_command='" onmouseover="alert(2)" data-x="',
+        release_url="https://example.com/release",
+    )
+    async def _stub():
+        return crafted
+    with patch(
+        "mcp_proxy.version_check.check_for_updates", side_effect=_stub,
+    ):
+        resp = await client.get("/proxy/badge/version")
+
+    assert resp.status_code == 200
+    assert ' onmouseover="alert(2)"' not in resp.text
+
+
+@pytest.mark.asyncio
+async def test_badge_version_escapes_latest_text_node(proxy_app) -> None:
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    from mcp_proxy.version_check import UpdateStatus
+    crafted = UpdateStatus(
+        current="0.3.0",
+        latest="<script>alert(3)</script>",
+        update_available=True,
+        install_command="docker pull benign:0.4.0",
+        release_url="https://example.com/release",
+    )
+    async def _stub():
+        return crafted
+    with patch(
+        "mcp_proxy.version_check.check_for_updates", side_effect=_stub,
+    ):
+        resp = await client.get("/proxy/badge/version")
+
+    assert resp.status_code == 200
+    assert "<script>alert(3)</script>" not in resp.text
+    assert "&lt;script&gt;" in resp.text


### PR DESCRIPTION
## Summary

Audit lane5 flagged two distinct dashboard XSS shapes; this PR closes all four occurrences.

### 1. HTMX badge fragment — ``GET /proxy/badge/version``
The handler built its HTML reply via f-string interpolation of values that originate at the GitHub Releases API:
- ``release_url`` → ``href=...``
- ``install_command`` → ``title=...``
- ``latest`` / ``current`` → text content

An attacker who could publish a release tag with a crafted name (or compromise the GHCR repo) would land stored XSS against any operator viewing the dashboard. The fix HTML-escapes (``quote=True``) every interpolated field so attribute and text contexts both resist injection.

### 2. Copy-to-clipboard buttons (3 templates)
``link_broker.html``, ``overview.html`` and ``downloads.html`` passed Jinja values into a JS string literal inside ``onclick="navigator.clipboard.writeText('{{ var }}')"``. Jinja's HTML auto-escape is wrong for JS-context: ``\\``, ``'`` or U+2028 still break out of the string. ``downloads.html`` used ``|e`` which was the same shape of bug.

Switch each to ``{{ var|tojson }}`` which emits a JSON-safe quoted JS string literal (handles every escape and includes the surrounding quotes itself).

The org_id / proxy_url path is lower-impact (operator controls the env vars feeding them), but a misconfigured deploy or a hostile operator inserting a crafted org_id could turn it into stored XSS against future admins.

Closes **M-dash-3** (badge_version XSS) and the JS-context copy-button template XSS cluster from the 2026-04-30 audit.

## Test plan

- [x] `pytest tests/test_m_dash_badge_xss.py` (3 new regression tests pass — release_url quote injection blocked, install_command quote injection blocked, latest text-node escapes ``<script>``)
- [x] `pytest tests/ -k "dashboard or badge or version_check or downloads or link_broker or overview"` (206 passed, no regressions)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Side note

Other audit MEDIUMs investigated but not in this PR: ``DPoP ath dropped``, ``jti replay`` and ``X-Mastio-Edge deferred`` are by-design under ADR-014/network-isolation with rationale documented in source; ``HKDF salt=None`` doesn't add real security with fresh per-message ECDH IKM + per-protocol info string; ``RFQ bypass reach`` requires deeper Court schema change since reach lives on Mastio's `internal_agents`, not Court's `agents`. Each can be addressed in dedicated PRs if priority shifts.