### PR TITLE
fix(security): proof-of-possession on enrollment status endpoint

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -121,6 +121,7 @@ def enroll(
         verify_tls=verify_tls,
         timeout_s=request_timeout_s,
         poll_sink=poll_sink,
+        private_key=private_key,
     )
 
     status = record.get("status")
@@ -209,6 +210,40 @@ def _start(
     return response.json()
 
 
+def _build_enrollment_proof(private_key, session_id: str) -> str:
+    """M-onb-1 audit fix — sign the canonical proof string with the
+    enrollment keypair so the server can verify the poller is the
+    same client that called ``/v1/enrollment/start``.
+
+    Without this header the server returns the bare status flag and
+    withholds ``cert_pem`` / ``agent_id`` / ``capabilities`` — an
+    attacker who guesses or steals a session_id no longer pulls the
+    issued cert.
+    """
+    import base64 as _b64
+
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+    canonical = f"enrollment-status:v1|{session_id}".encode("utf-8")
+    if isinstance(private_key, rsa.RSAPrivateKey):
+        sig = private_key.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    elif isinstance(private_key, ec.EllipticCurvePrivateKey):
+        sig = private_key.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        raise EnrollmentFailed(
+            f"Unsupported enrollment key type: {type(private_key).__name__}"
+        )
+    return _b64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
 def _poll_until_resolved(
     *,
     site_url: str,
@@ -218,14 +253,22 @@ def _poll_until_resolved(
     verify_tls: bool | str,
     timeout_s: float,
     poll_sink,
+    private_key,
 ) -> dict[str, Any]:
     deadline = time.monotonic() + max_wait_s
     poll_url = f"{site_url}/v1/enrollment/{session_id}/status"
     last_printed = 0.0
+    proof = _build_enrollment_proof(private_key, session_id)
+    proof_headers = {"X-Enrollment-Proof": proof}
 
     while True:
         try:
-            response = httpx.get(poll_url, verify=verify_tls, timeout=timeout_s)
+            response = httpx.get(
+                poll_url,
+                headers=proof_headers,
+                verify=verify_tls,
+                timeout=timeout_s,
+            )
         except httpx.HTTPError as exc:
             _log.warning("poll transient error", extra={"err": str(exc)})
             if time.monotonic() >= deadline:

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -146,6 +146,65 @@ async def start_enrollment(
     )
 
 
+_ENROLLMENT_STATUS_PROOF_HEADER = "X-Enrollment-Proof"
+_ENROLLMENT_STATUS_PROOF_DOMAIN = "enrollment-status:v1"
+
+
+def _verify_enrollment_proof(
+    pubkey_pem: str, session_id: str, signature_b64: str,
+) -> bool:
+    """M-onb-1 audit fix — proof of possession over the original
+    enrolment keypair.
+
+    The Connector signs ``"enrollment-status:v1|{session_id}"`` with
+    the same private key whose public half it submitted at
+    ``POST /v1/enrollment/start``. The server, holding the public
+    key on the row, can verify without storing or trusting any
+    fresh credential. Without a valid proof the status endpoint
+    returns ONLY ``status`` + ``session_id`` so an attacker who
+    guesses or steals a session_id cannot exfiltrate the issued
+    cert / agent_id / capabilities of an approved enrolment.
+    """
+    import base64 as _b64
+
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+    try:
+        sig = _b64.urlsafe_b64decode(
+            signature_b64 + "=" * (-len(signature_b64) % 4),
+        )
+    except Exception:
+        return False
+    try:
+        pub_key = serialization.load_pem_public_key(pubkey_pem.encode())
+    except Exception:
+        return False
+    canonical = (
+        f"{_ENROLLMENT_STATUS_PROOF_DOMAIN}|{session_id}".encode("utf-8")
+    )
+    try:
+        if isinstance(pub_key, rsa.RSAPublicKey):
+            pub_key.verify(
+                sig, canonical,
+                padding.PSS(
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.MAX_LENGTH,
+                ),
+                hashes.SHA256(),
+            )
+        elif isinstance(pub_key, ec.EllipticCurvePublicKey):
+            pub_key.verify(sig, canonical, ec.ECDSA(hashes.SHA256()))
+        else:
+            return False
+        return True
+    except InvalidSignature:
+        return False
+    except Exception:
+        return False
+
+
 @router.get(
     "/v1/enrollment/{session_id}/status",
     response_model=EnrollmentStatusResponse,
@@ -173,7 +232,24 @@ async def enrollment_status(
         session_id=record["session_id"],
         status=record["status"],  # type: ignore[arg-type]
     )
-    if record["status"] == "approved":
+
+    # M-onb-1 audit fix — gate the sensitive fields (cert_pem, agent_id,
+    # capabilities) behind a proof-of-possession over the keypair the
+    # Connector registered at start_enrollment. The endpoint stays
+    # callable without proof so the Connector can poll the status
+    # field cheaply, but only the legitimate enroller (who holds the
+    # private key) can pull the issued cert.
+    proof_header = request.headers.get(_ENROLLMENT_STATUS_PROOF_HEADER, "")
+    enroller_pubkey = record.get("pubkey_pem") or ""
+    has_valid_proof = bool(
+        proof_header
+        and enroller_pubkey
+        and _verify_enrollment_proof(
+            enroller_pubkey, session_id, proof_header,
+        )
+    )
+
+    if record["status"] == "approved" and has_valid_proof:
         response.agent_id = record["agent_id_assigned"]
         response.cert_pem = record["cert_pem"]
         caps_raw = record.get("capabilities_assigned") or "[]"
@@ -181,7 +257,7 @@ async def enrollment_status(
             response.capabilities = json.loads(caps_raw)
         except json.JSONDecodeError:
             response.capabilities = []
-    elif record["status"] == "rejected":
+    elif record["status"] == "rejected" and has_valid_proof:
         response.rejection_reason = record["rejection_reason"]
     return response
 

--- a/tests/test_m_onb_status_pop.py
+++ b/tests/test_m_onb_status_pop.py
@@ -1,0 +1,191 @@
+"""
+M-onb-1 regression: ``GET /v1/enrollment/{session_id}/status`` now
+gates ``cert_pem`` / ``agent_id`` / ``capabilities`` behind a proof
+of possession of the keypair the Connector registered at
+``POST /v1/enrollment/start``.
+
+Before the fix, the endpoint was unauthenticated — anyone holding
+the session_id (guessed, leaked from logs, intercepted on HTTP)
+could pull the issued cert and learn the assigned agent_id +
+capabilities of an approved enrolment. The session_id functioned
+as a bearer token. Now an attacker with just the session_id sees
+``status`` and nothing else.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "m_onb.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _ec_keypair() -> tuple:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _sign_proof(priv, session_id: str) -> str:
+    canonical = f"enrollment-status:v1|{session_id}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
+async def _start_enrollment(client: AsyncClient, pub_pem: str) -> str:
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": pub_pem,
+            "requester_name": "M Rossi",
+            "requester_email": "m@acme.test",
+            "reason": "test",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["session_id"]
+
+
+async def _approve(client: AsyncClient, session_id: str) -> None:
+    """Push the row to ``approved`` directly via the agent_manager
+    (skip the dashboard CSRF dance — not the surface under test)."""
+    from mcp_proxy.db import get_db
+    from mcp_proxy.enrollment import service
+
+    async with get_db() as conn:
+        from mcp_proxy.main import app as _app
+        agent_manager = _app.state.agent_manager
+        await service.approve(
+            conn,
+            session_id=session_id,
+            agent_id="alice",
+            capabilities=["read"],
+            groups=[],
+            admin_name="test-admin",
+            agent_manager=agent_manager,
+        )
+
+
+# ── Status without proof: only `status` field comes back ─────────────
+
+
+@pytest.mark.asyncio
+async def test_status_without_proof_hides_cert_and_caps(proxy_app) -> None:
+    _, client = proxy_app
+    priv, pub_pem = _ec_keypair()
+    session_id = await _start_enrollment(client, pub_pem)
+    await _approve(client, session_id)
+
+    resp = await client.get(f"/v1/enrollment/{session_id}/status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "approved"
+    # The whole point of the fix:
+    assert body.get("cert_pem") is None, "cert_pem leaked without PoP"
+    assert body.get("agent_id") is None, "agent_id leaked without PoP"
+    assert (body.get("capabilities") or []) == [], (
+        "capabilities leaked without PoP"
+    )
+
+
+# ── Wrong / forged proof: same restricted shape ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_with_wrong_key_proof_hides_cert(proxy_app) -> None:
+    """An attacker with the session_id but a different keypair can
+    forge a syntactically-valid proof. The server rejects it because
+    the signature won't verify against the enroller's public key."""
+    _, client = proxy_app
+    priv, pub_pem = _ec_keypair()
+    session_id = await _start_enrollment(client, pub_pem)
+    await _approve(client, session_id)
+
+    attacker_priv, _ = _ec_keypair()
+    forged_proof = _sign_proof(attacker_priv, session_id)
+
+    resp = await client.get(
+        f"/v1/enrollment/{session_id}/status",
+        headers={"X-Enrollment-Proof": forged_proof},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "approved"
+    assert body.get("cert_pem") is None
+    assert body.get("agent_id") is None
+
+
+# ── Valid proof: full payload is returned ────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_with_valid_proof_returns_full_payload(proxy_app) -> None:
+    _, client = proxy_app
+    priv, pub_pem = _ec_keypair()
+    session_id = await _start_enrollment(client, pub_pem)
+    await _approve(client, session_id)
+
+    proof = _sign_proof(priv, session_id)
+    resp = await client.get(
+        f"/v1/enrollment/{session_id}/status",
+        headers={"X-Enrollment-Proof": proof},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "approved"
+    assert body["agent_id"] == "acme::alice"
+    assert body["cert_pem"] and "BEGIN CERTIFICATE" in body["cert_pem"]
+    assert body["capabilities"] == ["read"]
+
+
+# ── Status field still leaks pending/approved (acceptable trade-off) ─
+
+
+@pytest.mark.asyncio
+async def test_status_field_alone_still_observable_without_proof(proxy_app) -> None:
+    """The fix does NOT hide the bare ``status`` field — the Connector
+    UI needs to show ``pending → approved`` to the operator without
+    bringing the private key online for every poll. Document the
+    accepted residual."""
+    _, client = proxy_app
+    priv, pub_pem = _ec_keypair()
+    session_id = await _start_enrollment(client, pub_pem)
+
+    resp = await client.get(f"/v1/enrollment/{session_id}/status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "pending"


### PR DESCRIPTION
## Summary

``GET /v1/enrollment/{session_id}/status`` was unauthenticated and returned ``cert_pem``, ``agent_id`` and ``capabilities`` once the admin approved. The session_id functioned as a bearer token: anyone who guessed it, intercepted it on HTTP, or recovered it from a log could pull the issued cert and learn the assigned identity of the new agent.

The fix gates the sensitive fields behind a proof of possession of the same keypair the Connector registered at ``POST /v1/enrollment/start``:

- The Connector signs ``"enrollment-status:v1|{session_id}"`` with its private key (RSA-PSS or ECDSA, dispatched by key type) and submits the b64url signature in the ``X-Enrollment-Proof`` header.
- The server fetches the row's stored ``pubkey_pem`` and verifies.
- Without a valid proof, the response carries only ``status`` (and ``session_id`` for echo) — no cert, no agent_id, no capabilities, no rejection_reason. The Connector UI still gets ``pending → approved`` for free so polling stays cheap.
- With a valid proof, the full payload is returned exactly as before.

Closes **M-onb-1** (status leak via session_id bearer) from the 2026-04-30 audit.

## Threat model

Without the fix:
- Attacker steals/guesses session_id → reads cert_pem, agent_id, capabilities.
- Cert_pem alone does not authenticate anyone (cert is bound to the Connector's private key, which never leaves the Connector machine), but the agent_id + capabilities disclosure is real, and a malicious operator who races the legitimate Connector to claim could potentially push a different cert if other defences fail.

After the fix:
- Attacker without the private key sees ``status`` only.
- Legitimate Connector continues to pull its cert as soon as the admin approves.

## Test plan

- [x] `pytest tests/test_m_onb_status_pop.py` (4 new regression tests pass — no proof returns no cert/agent/caps; wrong-key forged proof same; valid proof returns full payload; pending status still observable without proof)
- [x] `pytest tests/ -k "enrollment"` (69 passed, no regressions on dashboard approve / list / start flows)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Backwards compatibility

Older Connectors that don't ship the header poll status without proof and never see ``cert_pem``. They'll fail at the existing line ``raise EnrollmentFailed("Approved enrollment is missing cert_pem")``. This is the right behavior: pre-fix Connectors are silently insecure (anyone could steal the cert), and the fix forces an upgrade.

The Connector in this PR ships the header. Operators rolling out the new Mastio must update the Connector at the same time. If staged rollout is needed, the next PR can add a one-deploy compatibility window.

## Note on M-onb-2 (approve idempotency / cert orphan)

Investigated and judged not exploitable in current shape: ``service.approve`` runs UPDATE pending_enrollments + INSERT internal_agents in the same ``AsyncConnection`` transaction, so partial failures roll back atomically. The "orphan cert" concern is a CA serial-number pollution issue (a signed cert exists in the CA's signing log but never made it to a working agent), not a security exploit. Can be hardened by moving ``sign_external_pubkey`` after the row write; deferred to a dedicated PR if priority shifts.