### PR TITLE
feat(court): /dashboard/bindings — approve / revoke / edit scope from UI

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -39,7 +39,8 @@ from app.registry.org_store import (
     update_org_ca_cert, set_org_status, set_org_sealed,
 )
 from app.registry.binding_store import (
-    BindingRecord, create_binding, approve_binding, revoke_binding, get_binding_by_org_agent,
+    BindingRecord, create_binding, approve_binding, revoke_binding,
+    get_binding_by_org_agent, get_binding, list_all_bindings, update_binding_scope,
 )
 from app.policy.store import PolicyRecord, create_policy, get_policy, deactivate_policy
 from app.broker.db_models import SessionRecord, SessionMessageRecord, RfqRecord, RfqResponseRecord
@@ -2791,3 +2792,185 @@ async def policy_deactivate(request: Request, policy_id: str, db: AsyncSession =
                         details={"policy_id": policy_id, "source": "dashboard"})
 
     return RedirectResponse(url="/dashboard/policies", status_code=303)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Bindings — registry of approved org ↔ agent grants (cross-org)
+#
+# A binding is the per-org authorization to let an external agent call into
+# this org. Three knobs the network admin needs at a glance:
+#   • status: pending / approved / revoked (lifecycle)
+#   • scope:  subset of the agent's declared capabilities that this org
+#             actually concedes — can be tighter than what the agent offers
+#   • org_id ↔ agent_id pair: bindings are directional, so A↔B requires two
+#             separate rows; revoking one keeps the other live, which is
+#             how an operator pins one-way traffic
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/bindings", response_class=HTMLResponse)
+async def bindings_list(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    status_filter: str | None = None,
+):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    bindings = await list_all_bindings(db, status_filter=status_filter)
+
+    # Hydrate each row with the underlying agent's capabilities so the
+    # scope editor can render a multi-select with the legal options.
+    from app.registry.store import get_agent_by_id
+    enriched = []
+    for b in bindings:
+        agent = await get_agent_by_id(db, b.agent_id)
+        enriched.append({
+            "id": b.id,
+            "org_id": b.org_id,
+            "agent_id": b.agent_id,
+            "status": b.status,
+            "scope": b.scope,
+            "approved_by": b.approved_by,
+            "approved_at": b.approved_at,
+            "created_at": b.created_at,
+            "agent_capabilities": list(agent.capabilities) if agent else [],
+            "agent_org_id": agent.org_id if agent else None,
+        })
+
+    counts = {
+        "pending":  sum(1 for b in bindings if b.status == "pending"),
+        "approved": sum(1 for b in bindings if b.status == "approved"),
+        "revoked":  sum(1 for b in bindings if b.status == "revoked"),
+    }
+
+    return templates.TemplateResponse(
+        "bindings.html",
+        _ctx(
+            request, session, active="bindings",
+            bindings=enriched,
+            counts=counts,
+            current_filter=status_filter or "",
+        ),
+    )
+
+
+@router.post("/bindings/{binding_id}/approve", response_class=HTMLResponse)
+async def bindings_approve(
+    request: Request, binding_id: int, db: AsyncSession = Depends(get_db),
+):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    binding = await get_binding(db, binding_id)
+    if not binding:
+        raise HTTPException(status_code=404, detail="Binding not found")
+
+    approved = await approve_binding(
+        db, binding_id, approved_by="dashboard-network-admin",
+    )
+    if approved is None:
+        return RedirectResponse(url="/dashboard/bindings", status_code=303)
+
+    await log_event(
+        db, "binding.approved", "ok",
+        agent_id=binding.agent_id, org_id=binding.org_id,
+        details={"binding_id": binding_id, "source": "dashboard"},
+    )
+    return RedirectResponse(url="/dashboard/bindings", status_code=303)
+
+
+@router.post("/bindings/{binding_id}/revoke", response_class=HTMLResponse)
+async def bindings_revoke(
+    request: Request, binding_id: int, db: AsyncSession = Depends(get_db),
+):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    binding = await get_binding(db, binding_id)
+    if not binding:
+        raise HTTPException(status_code=404, detail="Binding not found")
+
+    revoked = await revoke_binding(db, binding_id)
+    if revoked is None:
+        return RedirectResponse(url="/dashboard/bindings", status_code=303)
+
+    # Mirror the API path side effects: close active sessions + drop ws.
+    from app.broker.session import get_session_store
+    from app.broker.persistence import save_session
+    from app.broker.ws_manager import ws_manager
+
+    store = get_session_store()
+    closed = store.close_all_for_agent(revoked.agent_id)
+    for s in closed:
+        await save_session(db, s)
+    if ws_manager.is_connected(revoked.agent_id):
+        await ws_manager.disconnect(revoked.agent_id)
+
+    await log_event(
+        db, "binding.revoked", "ok",
+        agent_id=revoked.agent_id, org_id=revoked.org_id,
+        details={
+            "binding_id": binding_id, "source": "dashboard",
+            "sessions_closed": len(closed),
+        },
+    )
+    return RedirectResponse(url="/dashboard/bindings", status_code=303)
+
+
+@router.post("/bindings/{binding_id}/scope", response_class=HTMLResponse)
+async def bindings_update_scope(
+    request: Request, binding_id: int, db: AsyncSession = Depends(get_db),
+):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    binding = await get_binding(db, binding_id)
+    if not binding:
+        raise HTTPException(status_code=404, detail="Binding not found")
+
+    form = await request.form()
+    raw_scope = form.getlist("scope")
+    new_scope = [s.strip() for s in raw_scope if s.strip()]
+
+    # Subset check against the agent's declared capabilities — same gate
+    # the API enforces on POST /v1/registry/bindings.
+    from app.registry.store import get_agent_by_id
+    agent = await get_agent_by_id(db, binding.agent_id)
+    if agent is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Agent {binding.agent_id} not found — cannot validate scope",
+        )
+    agent_caps = set(agent.capabilities)
+    invalid = [s for s in new_scope if s not in agent_caps]
+    if invalid:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Scope {invalid} not in agent capabilities: "
+                f"{sorted(agent_caps)}"
+            ),
+        )
+
+    await update_binding_scope(db, binding_id, new_scope)
+    await log_event(
+        db, "binding.scope_updated", "ok",
+        agent_id=binding.agent_id, org_id=binding.org_id,
+        details={
+            "binding_id": binding_id,
+            "old_scope": binding.scope,
+            "new_scope": new_scope,
+            "source": "dashboard",
+        },
+    )
+    return RedirectResponse(url="/dashboard/bindings", status_code=303)

--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -60,6 +60,11 @@
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
                 Policies
             </a>
+            <a href="/dashboard/bindings"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'bindings' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
+                Bindings
+            </a>
             <a href="/dashboard/admin/settings"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'admin_settings' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>

--- a/app/dashboard/templates/bindings.html
+++ b/app/dashboard/templates/bindings.html
@@ -1,0 +1,162 @@
+{% extends "base.html" %}
+{% block title %}Bindings{% endblock %}
+{% block header_title %}Org ↔ Agent Bindings{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="bindings" class="max-w-7xl">
+
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Bindings</h2>
+            <p class="text-xs text-gray-600 mt-0.5">
+                {{ bindings | length }} total
+                <span class="text-emerald-400">{{ counts.approved }} approved</span> ·
+                <span class="text-amber-400">{{ counts.pending }} pending</span> ·
+                <span class="text-gray-500">{{ counts.revoked }} revoked</span>
+            </p>
+        </div>
+        <div class="flex items-center gap-2">
+            <a href="/dashboard/bindings"
+               class="px-3 py-1.5 text-[10px] uppercase tracking-wider rounded border {% if not current_filter %}border-accent-400 text-accent-400 bg-accent-400/10{% else %}border-gray-700 text-gray-500{% endif %}">All</a>
+            <a href="/dashboard/bindings?status_filter=approved"
+               class="px-3 py-1.5 text-[10px] uppercase tracking-wider rounded border {% if current_filter == 'approved' %}border-emerald-400 text-emerald-400 bg-emerald-500/10{% else %}border-gray-700 text-gray-500{% endif %}">Approved</a>
+            <a href="/dashboard/bindings?status_filter=pending"
+               class="px-3 py-1.5 text-[10px] uppercase tracking-wider rounded border {% if current_filter == 'pending' %}border-amber-400 text-amber-400 bg-amber-500/10{% else %}border-gray-700 text-gray-500{% endif %}">Pending</a>
+            <a href="/dashboard/bindings?status_filter=revoked"
+               class="px-3 py-1.5 text-[10px] uppercase tracking-wider rounded border {% if current_filter == 'revoked' %}border-red-400 text-red-400 bg-red-500/10{% else %}border-gray-700 text-gray-500{% endif %}">Revoked</a>
+        </div>
+    </div>
+
+    <div class="bg-surface-900/40 border border-gray-800/40 rounded-lg p-4 mb-6 text-xs text-gray-400">
+        <p>
+            A binding is the per-org grant: <span class="text-white font-mono">org_id</span> approves
+            <span class="text-white font-mono">agent_id</span> with a specific
+            <span class="text-white">scope</span> (subset of capabilities the agent declared).
+            Bindings are <span class="text-white">directional</span>; A↔B requires two rows.
+            Revoke one verso to pin one-way traffic.
+        </p>
+    </div>
+
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">ID</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Granting Org</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Caller Agent</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Scope</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Approved By</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for b in bindings %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <span class="text-xs font-mono text-gray-500">#{{ b.id }}</span>
+                    </td>
+                    <td class="px-5 py-4">
+                        <span class="text-xs font-mono text-white">{{ b.org_id }}</span>
+                    </td>
+                    <td class="px-5 py-4">
+                        <span class="text-xs font-mono text-white">{{ b.agent_id }}</span>
+                        {% if b.agent_org_id and b.agent_org_id != b.org_id %}
+                        <span class="ml-1 text-[10px] text-gray-600">(from {{ b.agent_org_id }})</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        <div class="flex flex-wrap gap-1 max-w-md">
+                        {% for cap in b.scope %}
+                            <span class="px-1.5 py-0.5 rounded text-[10px] font-mono bg-info-400/10 text-info-400">{{ cap }}</span>
+                        {% endfor %}
+                        {% if not b.scope %}
+                            <span class="text-[10px] text-gray-600 uppercase tracking-wider">empty (no capabilities granted)</span>
+                        {% endif %}
+                        </div>
+                        {% if b.agent_capabilities %}
+                        <details class="mt-2">
+                            <summary class="text-[10px] text-gray-600 cursor-pointer hover:text-gray-400 uppercase tracking-wider">edit scope</summary>
+                            <form method="post" action="/dashboard/bindings/{{ b.id }}/scope" class="mt-2 p-3 bg-surface-950/60 rounded border border-gray-800/40">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-2">capabilities declared by {{ b.agent_id }}</p>
+                                <div class="flex flex-wrap gap-2 mb-3">
+                                    {% for cap in b.agent_capabilities %}
+                                    <label class="inline-flex items-center gap-1.5 text-xs cursor-pointer">
+                                        <input type="checkbox" name="scope" value="{{ cap }}"
+                                               {% if cap in b.scope %}checked{% endif %}
+                                               class="accent-accent-400">
+                                        <span class="font-mono text-gray-300">{{ cap }}</span>
+                                    </label>
+                                    {% endfor %}
+                                </div>
+                                <button type="submit"
+                                        class="px-3 py-1 text-[10px] uppercase tracking-wider rounded bg-accent-400/10 text-accent-400 border border-accent-400/40 hover:bg-accent-400/20">
+                                    Save scope
+                                </button>
+                            </form>
+                        </details>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if b.status == 'approved' %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Approved
+                        </span>
+                        {% elif b.status == 'pending' %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-amber-500"></span>Pending
+                        </span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-red-600"></span>Revoked
+                        </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if b.approved_by %}
+                        <span class="text-[11px] text-gray-400">{{ b.approved_by }}</span>
+                        {% if b.approved_at %}
+                        <div class="text-[10px] text-gray-600">{{ b.approved_at.strftime('%Y-%m-%d %H:%M') if b.approved_at.strftime else b.approved_at }}</div>
+                        {% endif %}
+                        {% else %}
+                        <span class="text-[10px] text-gray-600">-</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                        {% if b.status == 'pending' or b.status == 'revoked' %}
+                            <form method="post" action="/dashboard/bindings/{{ b.id }}/approve" class="inline"
+                                  onsubmit="return confirm('Approve binding {{ b.org_id }} ← {{ b.agent_id }}?')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <button type="submit"
+                                        class="px-2.5 py-1 text-[10px] uppercase tracking-wider border border-emerald-500/40 text-emerald-400 rounded hover:bg-emerald-500/10 transition-colors">Approve</button>
+                            </form>
+                        {% endif %}
+                        {% if b.status == 'approved' %}
+                            <form method="post" action="/dashboard/bindings/{{ b.id }}/revoke" class="inline"
+                                  onsubmit="return confirm('Revoke binding {{ b.org_id }} ← {{ b.agent_id }}?\nThis closes active sessions for this agent and invalidates their tokens.')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <button type="submit"
+                                        class="px-2.5 py-1 text-[10px] uppercase tracking-wider border border-red-500/40 text-red-400 rounded hover:bg-red-500/10 transition-colors">Revoke</button>
+                            </form>
+                        {% endif %}
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not bindings %}
+                <tr><td colspan="7" class="px-5 py-16 text-center">
+                    <p class="text-sm text-gray-600">
+                        {% if current_filter %}
+                            No bindings with status <span class="text-white font-mono">{{ current_filter }}</span>.
+                        {% else %}
+                            No bindings registered yet.
+                        {% endif %}
+                    </p>
+                </td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/registry/binding_store.py
+++ b/app/registry/binding_store.py
@@ -158,3 +158,33 @@ async def list_bindings(db: AsyncSession, org_id: str) -> list[BindingRecord]:
         select(BindingRecord).where(BindingRecord.org_id == org_id)
     )
     return list(result.scalars().all())
+
+
+async def list_all_bindings(
+    db: AsyncSession, status_filter: str | None = None,
+) -> list[BindingRecord]:
+    """Return every binding across orgs. Network-admin only — used by the
+    Court dashboard to render a full registry view; regular org-scoped
+    callers must use ``list_bindings(org_id=...)`` to stay tenant-bound."""
+    stmt = select(BindingRecord).order_by(BindingRecord.created_at.desc())
+    if status_filter:
+        stmt = stmt.where(BindingRecord.status == status_filter)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def update_binding_scope(
+    db: AsyncSession, binding_id: int, scope: list[str],
+) -> BindingRecord | None:
+    """Update an existing binding's scope subset. Caller is responsible
+    for validating that ``scope`` is a subset of the agent's declared
+    capabilities — the binding store does not re-fetch the agent here so
+    the same helper works whether the caller has the agent record loaded
+    or not. Returns the refreshed binding or None if missing."""
+    binding = await get_binding(db, binding_id)
+    if not binding:
+        return None
+    binding.scope_json = json.dumps(scope)
+    await db.commit()
+    await db.refresh(binding)
+    return binding

--- a/tests/test_dashboard_bindings.py
+++ b/tests/test_dashboard_bindings.py
@@ -1,0 +1,277 @@
+"""Tests for the network-admin /dashboard/bindings page (Court).
+
+Covers list rendering + filters, approve, revoke, and scope edit (with
+the subset-of-capabilities guard). Auth uses the same admin password
+helper the rest of the dashboard suite uses.
+
+The session-scope ``setup_db`` fixture never tears the schema down
+between tests, so every test in this module uses a uuid suffix on
+agent_ids to avoid UNIQUE(agent_id) collisions with the shared DB.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.config import get_settings
+from tests.conftest import seed_court_agent
+
+
+def _uniq(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+pytestmark = pytest.mark.asyncio
+
+
+def _extract_csrf(cookies: dict) -> str:
+    cookie = cookies.get("cullis_session", "")
+    if not cookie:
+        return ""
+    if cookie.startswith('"') and cookie.endswith('"'):
+        cookie = cookie[1:-1]
+    import codecs
+    try:
+        cookie = codecs.decode(cookie, "unicode_escape")
+    except Exception:
+        pass
+    if "." not in cookie:
+        return ""
+    payload_str = cookie.rsplit(".", 1)[0]
+    try:
+        return json.loads(payload_str).get("csrf_token", "")
+    except (json.JSONDecodeError, TypeError):
+        return ""
+
+
+async def _admin_ctx(client: AsyncClient) -> tuple[dict, str]:
+    resp = await client.post(
+        "/dashboard/login",
+        data={"user_id": "admin", "password": get_settings().admin_secret},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    cookies = dict(resp.cookies)
+    return cookies, _extract_csrf(cookies)
+
+
+async def _make_binding(
+    org_id: str,
+    agent_id: str,
+    scope: list[str],
+    status: str = "pending",
+) -> int:
+    """Insert a binding directly via the store. Returns the new id."""
+    from tests.conftest import TestSessionLocal
+    from app.registry.binding_store import create_binding, approve_binding, revoke_binding
+
+    async with TestSessionLocal() as session:
+        b = await create_binding(session, org_id, agent_id, scope)
+        if status == "approved":
+            await approve_binding(session, b.id, approved_by="seed-helper")
+        elif status == "revoked":
+            await revoke_binding(session, b.id)
+        return b.id
+
+
+# ── list page ──────────────────────────────────────────────────────
+
+
+async def test_bindings_page_renders_empty(client: AsyncClient):
+    cookies, _ = await _admin_ctx(client)
+    resp = await client.get("/dashboard/bindings", cookies=cookies)
+    assert resp.status_code == 200
+    assert "Bindings" in resp.text
+    assert "No bindings registered" in resp.text
+
+
+async def test_bindings_page_lists_seeded_rows(client: AsyncClient):
+    aid = _uniq("orga::agent")
+    await seed_court_agent(aid, "orga", capabilities=["order.read", "order.write"])
+    bid = await _make_binding(
+        org_id="orgb", agent_id=aid,
+        scope=["order.read"], status="approved",
+    )
+    cookies, _ = await _admin_ctx(client)
+    resp = await client.get("/dashboard/bindings", cookies=cookies)
+    assert resp.status_code == 200
+    assert aid in resp.text
+    assert "order.read" in resp.text
+    assert "Approved" in resp.text
+    assert f"#{bid}" in resp.text
+
+
+async def test_bindings_filter_by_status(client: AsyncClient):
+    approved_aid = _uniq("orga::agent-app")
+    pending_aid = _uniq("orga::agent-pen")
+    await seed_court_agent(approved_aid, "orga", capabilities=["x.y"])
+    await _make_binding("orgb", approved_aid, ["x.y"], status="approved")
+    await seed_court_agent(pending_aid, "orga", capabilities=["x.y"])
+    await _make_binding("orgb", pending_aid, ["x.y"], status="pending")
+
+    cookies, _ = await _admin_ctx(client)
+    resp = await client.get(
+        "/dashboard/bindings?status_filter=pending", cookies=cookies,
+    )
+    assert resp.status_code == 200
+    assert pending_aid in resp.text
+    assert approved_aid not in resp.text
+
+
+# ── approve ────────────────────────────────────────────────────────
+
+
+async def test_approve_pending_binding(client: AsyncClient):
+    aid = _uniq("orga::agent")
+    await seed_court_agent(aid, "orga", capabilities=["x.y"])
+    bid = await _make_binding("orgb", aid, ["x.y"], status="pending")
+
+    cookies, csrf = await _admin_ctx(client)
+    resp = await client.post(
+        f"/dashboard/bindings/{bid}/approve",
+        data={"csrf_token": csrf},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from tests.conftest import TestSessionLocal
+    from app.registry.binding_store import get_binding
+    async with TestSessionLocal() as s:
+        b = await get_binding(s, bid)
+        assert b.status == "approved"
+        assert b.approved_by == "dashboard-network-admin"
+
+
+async def test_approve_requires_csrf(client: AsyncClient):
+    aid = _uniq("orga::agent")
+    await seed_court_agent(aid, "orga", capabilities=["x.y"])
+    bid = await _make_binding("orgb", aid, ["x.y"], status="pending")
+
+    cookies, _ = await _admin_ctx(client)
+    resp = await client.post(
+        f"/dashboard/bindings/{bid}/approve",
+        data={"csrf_token": "wrong"},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+async def test_approve_unknown_binding_404(client: AsyncClient):
+    cookies, csrf = await _admin_ctx(client)
+    resp = await client.post(
+        "/dashboard/bindings/99999/approve",
+        data={"csrf_token": csrf},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 404
+
+
+# ── revoke ─────────────────────────────────────────────────────────
+
+
+async def test_revoke_approved_binding(client: AsyncClient):
+    aid = _uniq("orga::agent")
+    await seed_court_agent(aid, "orga", capabilities=["x.y"])
+    bid = await _make_binding("orgb", aid, ["x.y"], status="approved")
+
+    cookies, csrf = await _admin_ctx(client)
+    resp = await client.post(
+        f"/dashboard/bindings/{bid}/revoke",
+        data={"csrf_token": csrf},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from tests.conftest import TestSessionLocal
+    from app.registry.binding_store import get_binding
+    async with TestSessionLocal() as s:
+        b = await get_binding(s, bid)
+        assert b.status == "revoked"
+
+
+# ── scope edit ─────────────────────────────────────────────────────
+
+
+async def test_scope_edit_subset_succeeds(client: AsyncClient):
+    aid = _uniq("orga::agent")
+    await seed_court_agent(
+        aid, "orga",
+        capabilities=["order.read", "order.write", "order.delete"],
+    )
+    bid = await _make_binding(
+        "orgb", aid,
+        scope=["order.read", "order.write"], status="approved",
+    )
+
+    cookies, csrf = await _admin_ctx(client)
+    resp = await client.post(
+        f"/dashboard/bindings/{bid}/scope",
+        data={"csrf_token": csrf, "scope": ["order.read"]},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from tests.conftest import TestSessionLocal
+    from app.registry.binding_store import get_binding
+    async with TestSessionLocal() as s:
+        b = await get_binding(s, bid)
+        assert b.scope == ["order.read"]
+
+
+async def test_scope_edit_rejects_non_subset(client: AsyncClient):
+    """Trying to grant a capability the agent never declared is 400."""
+    aid = _uniq("orga::agent")
+    await seed_court_agent(aid, "orga", capabilities=["order.read"])
+    bid = await _make_binding(
+        "orgb", aid, scope=["order.read"], status="approved",
+    )
+
+    cookies, csrf = await _admin_ctx(client)
+    resp = await client.post(
+        f"/dashboard/bindings/{bid}/scope",
+        data={"csrf_token": csrf, "scope": ["order.read", "order.delete"]},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    assert "order.delete" in resp.json()["detail"]
+
+
+async def test_scope_edit_to_empty(client: AsyncClient):
+    """An empty scope is legal — the binding stays but the agent loses
+    every concession until the operator re-approves a real scope."""
+    aid = _uniq("orga::agent")
+    await seed_court_agent(aid, "orga", capabilities=["order.read"])
+    bid = await _make_binding(
+        "orgb", aid, scope=["order.read"], status="approved",
+    )
+    cookies, csrf = await _admin_ctx(client)
+    resp = await client.post(
+        f"/dashboard/bindings/{bid}/scope",
+        data={"csrf_token": csrf},
+        cookies=cookies,
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from tests.conftest import TestSessionLocal
+    from app.registry.binding_store import get_binding
+    async with TestSessionLocal() as s:
+        b = await get_binding(s, bid)
+        assert b.scope == []
+
+
+# ── auth gate ─────────────────────────────────────────────────────
+
+
+async def test_unauthenticated_redirects_to_login(client: AsyncClient):
+    resp = await client.get("/dashboard/bindings", follow_redirects=False)
+    assert resp.status_code == 303
+    assert "/dashboard/login" in resp.headers.get("location", "")

--- a/tests/test_dashboard_bindings.py
+++ b/tests/test_dashboard_bindings.py
@@ -80,6 +80,19 @@ async def _make_binding(
 
 
 async def test_bindings_page_renders_empty(client: AsyncClient):
+    """Render check on a freshly-cleared bindings table.
+
+    The session-scope ``setup_db`` fixture means earlier shards may have
+    seeded rows that survive into this test. Truncate first so the
+    'no bindings registered' empty state is what we actually render.
+    """
+    from sqlalchemy import delete
+    from app.registry.binding_store import BindingRecord
+    from tests.conftest import TestSessionLocal
+    async with TestSessionLocal() as s:
+        await s.execute(delete(BindingRecord))
+        await s.commit()
+
     cookies, _ = await _admin_ctx(client)
     resp = await client.get("/dashboard/bindings", cookies=cookies)
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Adds the **Bindings** page on the Court dashboard for the network admin. Until now binding lifecycle (approve / revoke / scope) was only reachable via the \`/v1/registry/bindings\` API, so operators couldn't see who's approved or change scope without curl. The page makes the model visible and adds an explicit scope editor.

## What you can finally do from the UI

The classic example **A → B yes, B → A no** is now three clicks:

1. Open \`/dashboard/bindings\`
2. Find the row \`org_id=orga, agent_id=orgb::agent-b\` and hit Revoke
3. agent-b → orga immediately 403 (\`get_approved_binding\` returns None); agent-a → orgb keeps working — that binding wasn't touched

Same flow for tightening scope: click *edit scope*, untick the capabilities you don't want to grant, save. Subset guard is the same one the API enforces on \`POST /v1/registry/bindings\`.

## UI details

- Sidebar nav entry under Policies (link icon).
- Table: granting org, caller agent (with home-org tag when cross-org), scope chips, status badge (approved/pending/revoked), approver + timestamp, action buttons.
- Status filter pills: All / Approved / Pending / Revoked.
- Inline scope editor in a \`<details>\` element: multi-checkbox over the agent's declared capabilities, save POSTs only the checked subset.
- Approve / Revoke use \`confirm()\`; Revoke message warns about active-session closure to mirror the API side effect.

## Backend changes

- \`app/registry/binding_store.py\`: new \`list_all_bindings(status_filter)\` for the network-admin global view + \`update_binding_scope()\` helper. Existing \`list_bindings(org_id)\` stays for the per-tenant API path.
- \`app/dashboard/router.py\`: four endpoints under \`/dashboard/bindings\` — GET list, POST \`{id}/approve\`, POST \`{id}/revoke\`, POST \`{id}/scope\`. All gate on \`require_login\` + CSRF.
- Revoke mirrors the API: closes active sessions for the agent, disconnects ws, invalidates tokens via the same \`revoke_binding\` store helper, audit log.

## Test plan

- [x] 11 tests in \`tests/test_dashboard_bindings.py\`:
  - list rendering empty + populated, status filter
  - approve happy path, CSRF guard (403), 404 on unknown id
  - revoke happy path
  - scope edit subset / non-subset (400) / empty
  - unauthenticated redirect to login
- [x] \`ruff check\` clean
- [x] No regression on existing dashboard suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
