### PR TITLE
fix(security): drop XFF spoof on /pki/ca.crt + JWKS, perm-check Org CA key

### DIFF
--- a/app/kms/local.py
+++ b/app/kms/local.py
@@ -42,9 +42,71 @@ class LocalKMSProvider:
 
     async def get_broker_private_key_pem(self) -> str:
         if self._private_key_pem is None:
-            self._private_key_pem = Path(self._key_path).read_text()
+            path = Path(self._key_path)
+            self._check_key_file_perms(path)
+            self._private_key_pem = path.read_text()
             _log.info("KMS[local] broker private key loaded from %s", self._key_path)
         return self._private_key_pem
+
+    @staticmethod
+    def _check_key_file_perms(path: Path) -> None:
+        """Refuse to load the Org CA private key from a world/group-readable file.
+
+        H-kms-perms audit fix: the broker CA private key signs every
+        agent cert and JWT the Mastio issues; its compromise blasts
+        the entire Org's trust. A POSIX file with mode ``0644`` (or
+        anything with bits set in ``0o077``) lets every local process
+        on the host read it — the file system stops being a defence.
+
+        Production deployments fail-closed: refuse to read and raise.
+        Development can opt out via
+        ``MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS=1`` for shared-fs
+        scenarios where the operator accepts the trade-off.
+        """
+        import os
+        try:
+            mode = path.stat().st_mode & 0o777
+        except OSError as exc:
+            raise RuntimeError(
+                f"Cannot stat Org CA private key at {path}: {exc}",
+            ) from exc
+
+        loose_bits = mode & 0o077
+        if loose_bits == 0:
+            return
+
+        env_override = os.environ.get(
+            "MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS", "",
+        ).lower() in ("1", "true", "yes")
+
+        msg = (
+            f"Org CA private key {path} has loose POSIX perms {oct(mode)}. "
+            "Tighten with `chmod 0600 %s` so only the Mastio process "
+            "user can read it. Loose perms let any local process steal "
+            "the key that signs every Org cert."
+        ) % path
+
+        from app.config import get_settings as _get_settings
+        settings = _get_settings()
+        is_production = getattr(settings, "environment", "") == "production"
+
+        if env_override:
+            _log.warning(
+                "%s — MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS=1 override "
+                "in effect, accepting the trade-off.", msg,
+            )
+            return
+        if is_production:
+            _log.critical(msg)
+            raise RuntimeError(
+                f"Refusing to load Org CA private key with loose perms "
+                f"{oct(mode)} in production. Set "
+                "MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS=1 to override "
+                "(not recommended).",
+            )
+        _log.warning(
+            "%s — proceeding because environment != production.", msg,
+        )
 
     async def get_broker_public_key_pem(self) -> str:
         if self._public_key_pem is None:

--- a/mcp_proxy/auth/jwks_local.py
+++ b/mcp_proxy/auth/jwks_local.py
@@ -49,16 +49,22 @@ _JWKS_RATE_LIMIT_PER_MINUTE = 30
 
 
 def _client_ip(request: Request) -> str:
-    """Best-effort IP extraction for the rate-limit subject.
+    """Return the rate-limit subject for this request.
 
-    Honours ``X-Forwarded-For`` (first hop) when the proxy is behind
-    a trusted edge, falls back to the socket peer. Same precedence
-    as ``app.rate_limit.limiter.get_client_ip`` — kept local because
-    ``mcp_proxy`` does not import from ``app/``.
+    H-xff audit fix: the previous implementation read the first
+    entry from ``X-Forwarded-For`` directly, which is fully
+    attacker-controlled when nginx is bypassed (host port exposed,
+    misconfigured deploy) or when nginx forwards the upstream XFF
+    as-is. An attacker could spray ``X-Forwarded-For: 1.2.3.4`` with
+    a different value per request and never trip the JWKS limiter.
+
+    The deployed shape runs uvicorn behind nginx with
+    ``--proxy-headers --forwarded-allow-ips=<nginx>`` so
+    ``ProxyHeadersMiddleware`` rewrites ``request.client`` from the
+    last trusted XFF hop. Using ``request.client.host`` directly
+    matches ``app.rate_limit.limiter.get_client_ip`` and the
+    post-H9 dashboard login handler.
     """
-    xff = request.headers.get("x-forwarded-for")
-    if xff:
-        return xff.split(",")[0].strip()
     client = request.client
     return client.host if client is not None else "unknown"
 

--- a/mcp_proxy/pki/public.py
+++ b/mcp_proxy/pki/public.py
@@ -44,9 +44,22 @@ _PKI_CA_RATE_LIMIT_PER_MINUTE = 30
 
 
 def _client_ip(request: Request) -> str:
-    xff = request.headers.get("x-forwarded-for")
-    if xff:
-        return xff.split(",")[0].strip()
+    """Return the rate-limit subject for this request.
+
+    H-xff audit fix: the previous implementation read the first
+    entry from ``X-Forwarded-For`` directly, which is fully
+    attacker-controlled when nginx is bypassed (host port exposed,
+    misconfigured deploy) or when nginx forwards the upstream
+    XFF as-is. An attacker could spray ``X-Forwarded-For: 1.2.3.4``
+    with a different value per request and never trip the limiter.
+
+    The deployed shape runs uvicorn behind nginx with
+    ``--proxy-headers --forwarded-allow-ips=<nginx>`` so
+    ``ProxyHeadersMiddleware`` rewrites ``request.client`` from the
+    last trusted XFF hop. Using ``request.client.host`` directly
+    is the same pattern as ``app.rate_limit.limiter.get_client_ip``
+    and the dashboard login handler post-H9.
+    """
     client = request.client
     return client.host if client is not None else "unknown"
 

--- a/tests/test_h_xff_and_kms_perms.py
+++ b/tests/test_h_xff_and_kms_perms.py
@@ -123,7 +123,11 @@ async def test_local_kms_warns_on_loose_perms_in_dev(
     with caplog.at_level(logging.WARNING, logger="agent_trust"):
         pem = await kms.get_broker_private_key_pem()
     assert "BEGIN RSA PRIVATE KEY" in pem
-    assert any("loose POSIX perms" in r.message for r in caplog.records)
+    # ``LogRecord.message`` is unset until ``getMessage()`` substitutes
+    # the %-args; use the substituted form so the assertion sees the
+    # post-format text.
+    rendered = [r.getMessage() for r in caplog.records]
+    assert any("loose POSIX perms" in m for m in rendered), rendered
     get_settings.cache_clear()
 
 

--- a/tests/test_h_xff_and_kms_perms.py
+++ b/tests/test_h_xff_and_kms_perms.py
@@ -1,0 +1,193 @@
+"""
+H-xff + H-kms-perms regression: rate-limit IP attribution can no
+longer be spoofed via ``X-Forwarded-For``, and ``LocalKMSProvider``
+refuses to load an Org CA private key with loose POSIX perms in
+production.
+
+Three audit findings closed in one batch:
+
+* ``mcp_proxy/pki/public.py:_client_ip`` — used to read the first
+  hop of ``X-Forwarded-For`` directly. Attacker-controlled when
+  nginx is bypassed (host port exposed) or forwards upstream XFF
+  unchecked. Now reads ``request.client.host`` only.
+* ``mcp_proxy/auth/jwks_local.py:_client_ip`` — same shape.
+* ``app/kms/local.py:LocalKMSProvider`` — used to read the Org CA
+  private key without checking file mode. A world-readable key on
+  a shared host let any local process steal the trust anchor of
+  every Org cert. Now refuses ``0o077`` mode bits in production
+  unless the operator opts out.
+"""
+from __future__ import annotations
+
+import os
+import stat as _stat
+
+import pytest
+
+
+# ── XFF spoof: pki/public.py ─────────────────────────────────────────
+
+
+def test_pki_public_client_ip_ignores_xff_header() -> None:
+    """Crafted XFF header must NOT be the rate-limit subject."""
+    from mcp_proxy.pki.public import _client_ip
+
+    class _Client:
+        host = "10.0.0.1"
+
+    class _Req:
+        headers = {"x-forwarded-for": "203.0.113.5"}
+        client = _Client()
+
+    assert _client_ip(_Req()) == "10.0.0.1"
+
+
+def test_pki_public_client_ip_returns_unknown_without_client() -> None:
+    from mcp_proxy.pki.public import _client_ip
+
+    class _Req:
+        headers = {"x-forwarded-for": "203.0.113.5"}
+        client = None
+
+    assert _client_ip(_Req()) == "unknown"
+
+
+# ── XFF spoof: auth/jwks_local.py ────────────────────────────────────
+
+
+def test_jwks_local_client_ip_ignores_xff_header() -> None:
+    from mcp_proxy.auth.jwks_local import _client_ip
+
+    class _Client:
+        host = "10.0.0.7"
+
+    class _Req:
+        headers = {"x-forwarded-for": "203.0.113.99"}
+        client = _Client()
+
+    assert _client_ip(_Req()) == "10.0.0.7"
+
+
+# ── LocalKMSProvider perm check ──────────────────────────────────────
+
+
+def _write_key_file(path, mode: int) -> None:
+    path.write_text(
+        "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n"
+    )
+    os.chmod(path, mode)
+
+
+@pytest.mark.asyncio
+async def test_local_kms_accepts_0600(tmp_path) -> None:
+    """The happy path: 0600 perms load without complaint."""
+    from app.kms.local import LocalKMSProvider
+
+    key = tmp_path / "ca.key"
+    cert = tmp_path / "ca.crt"
+    cert.write_text(
+        "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+    )
+    _write_key_file(key, 0o600)
+
+    kms = LocalKMSProvider(
+        key_path=str(key), cert_path=str(cert),
+        secret_encryption_key_path=str(tmp_path / "se.key"),
+    )
+    pem = await kms.get_broker_private_key_pem()
+    assert "BEGIN RSA PRIVATE KEY" in pem
+
+
+@pytest.mark.asyncio
+async def test_local_kms_warns_on_loose_perms_in_dev(
+    tmp_path, monkeypatch, caplog,
+) -> None:
+    """Development mode: warn loudly but still load."""
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.delenv("MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS", raising=False)
+    from app.config import get_settings
+    get_settings.cache_clear()
+
+    from app.kms.local import LocalKMSProvider
+
+    key = tmp_path / "ca.key"
+    cert = tmp_path / "ca.crt"
+    cert.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+    _write_key_file(key, 0o644)
+
+    kms = LocalKMSProvider(
+        key_path=str(key), cert_path=str(cert),
+        secret_encryption_key_path=str(tmp_path / "se.key"),
+    )
+    import logging
+    with caplog.at_level(logging.WARNING, logger="agent_trust"):
+        pem = await kms.get_broker_private_key_pem()
+    assert "BEGIN RSA PRIVATE KEY" in pem
+    assert any("loose POSIX perms" in r.message for r in caplog.records)
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_local_kms_refuses_loose_perms_in_production(
+    tmp_path, monkeypatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ADMIN_SECRET", "test-secret-not-default")
+    monkeypatch.setenv("DASHBOARD_SIGNING_KEY", "x" * 32)
+    monkeypatch.delenv("MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS", raising=False)
+    from app.config import get_settings
+    get_settings.cache_clear()
+
+    from app.kms.local import LocalKMSProvider
+
+    key = tmp_path / "ca.key"
+    cert = tmp_path / "ca.crt"
+    cert.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+    _write_key_file(key, 0o644)
+
+    kms = LocalKMSProvider(
+        key_path=str(key), cert_path=str(cert),
+        secret_encryption_key_path=str(tmp_path / "se.key"),
+    )
+    with pytest.raises(RuntimeError, match="loose perms"):
+        await kms.get_broker_private_key_pem()
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_local_kms_env_override_skips_check(
+    tmp_path, monkeypatch,
+) -> None:
+    """Operators who knowingly run on a shared filesystem can opt
+    out via the env override even in production."""
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("ADMIN_SECRET", "test-secret-not-default")
+    monkeypatch.setenv("DASHBOARD_SIGNING_KEY", "x" * 32)
+    monkeypatch.setenv("MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS", "1")
+    from app.config import get_settings
+    get_settings.cache_clear()
+
+    from app.kms.local import LocalKMSProvider
+
+    key = tmp_path / "ca.key"
+    cert = tmp_path / "ca.crt"
+    cert.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+    _write_key_file(key, 0o644)
+
+    kms = LocalKMSProvider(
+        key_path=str(key), cert_path=str(cert),
+        secret_encryption_key_path=str(tmp_path / "se.key"),
+    )
+    pem = await kms.get_broker_private_key_pem()
+    assert "BEGIN RSA PRIVATE KEY" in pem
+    get_settings.cache_clear()
+
+
+def test_loose_perm_bit_predicate() -> None:
+    """Sanity check on the bitmask used to detect group/world access."""
+    assert (0o600 & 0o077) == 0
+    assert (0o640 & 0o077) != 0  # group readable
+    assert (0o604 & 0o077) != 0  # world readable
+    assert (0o644 & 0o077) != 0  # both
+    assert _stat.S_IRGRP & 0o077
+    assert _stat.S_IROTH & 0o077

--- a/tests/test_h_xff_and_kms_perms.py
+++ b/tests/test_h_xff_and_kms_perms.py
@@ -100,34 +100,41 @@ async def test_local_kms_accepts_0600(tmp_path) -> None:
 
 @pytest.mark.asyncio
 async def test_local_kms_warns_on_loose_perms_in_dev(
-    tmp_path, monkeypatch, caplog,
+    tmp_path, monkeypatch,
 ) -> None:
-    """Development mode: warn loudly but still load."""
+    """Development mode: warn loudly but still load. Capture via a
+    monkeypatch on ``_log.warning`` because caplog's logger
+    propagation depends on root config that the conftest may
+    override; the direct patch is robust regardless."""
     monkeypatch.setenv("ENVIRONMENT", "development")
     monkeypatch.delenv("MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS", raising=False)
     from app.config import get_settings
     get_settings.cache_clear()
 
-    from app.kms.local import LocalKMSProvider
+    from app.kms import local as local_kms
+
+    captured: list[str] = []
+
+    def _capture(msg, *args, **kwargs):
+        try:
+            captured.append(msg % args if args else msg)
+        except TypeError:
+            captured.append(str(msg))
+
+    monkeypatch.setattr(local_kms._log, "warning", _capture)
 
     key = tmp_path / "ca.key"
     cert = tmp_path / "ca.crt"
     cert.write_text("-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
     _write_key_file(key, 0o644)
 
-    kms = LocalKMSProvider(
+    kms = local_kms.LocalKMSProvider(
         key_path=str(key), cert_path=str(cert),
         secret_encryption_key_path=str(tmp_path / "se.key"),
     )
-    import logging
-    with caplog.at_level(logging.WARNING, logger="agent_trust"):
-        pem = await kms.get_broker_private_key_pem()
+    pem = await kms.get_broker_private_key_pem()
     assert "BEGIN RSA PRIVATE KEY" in pem
-    # ``LogRecord.message`` is unset until ``getMessage()`` substitutes
-    # the %-args; use the substituted form so the assertion sees the
-    # post-format text.
-    rendered = [r.getMessage() for r in caplog.records]
-    assert any("loose POSIX perms" in m for m in rendered), rendered
+    assert any("loose POSIX perms" in m for m in captured), captured
     get_settings.cache_clear()
 
 


### PR DESCRIPTION
## Summary

Three audit HIGH-altri in one batch — small-surface fixes that follow patterns already used elsewhere in the codebase.

### 1. ``mcp_proxy/pki/public.py:_client_ip`` — XFF spoof
The rate-limit subject for the anonymous ``GET /pki/ca.crt`` endpoint used to read the first hop of ``X-Forwarded-For`` directly. Attacker-controlled when nginx is bypassed (host port exposed, misconfigured deploy) or when an upstream proxy forwards XFF unchecked. An attacker spraying ``X-Forwarded-For: 1.2.3.4`` with a different IP per request would never trip the limiter.

Drop the XFF read; rely on ``request.client.host`` rewritten by uvicorn's ``ProxyHeadersMiddleware`` (running with ``--proxy-headers --forwarded-allow-ips=<nginx>``). Same pattern as ``app.rate_limit.limiter.get_client_ip`` and the post-H9 dashboard login handler.

### 2. ``mcp_proxy/auth/jwks_local.py:_client_ip`` — XFF spoof
Same shape, same fix.

### 3. ``app/kms/local.py:LocalKMSProvider`` — no-perm-check on CA key
Loaded the Org CA private key (the trust anchor for every Org cert) without checking POSIX mode. Mode ``0644`` (or any bit in ``0o077``) lets every local process on the host read the file.

The new ``_check_key_file_perms`` helper:
- refuses to load on loose perms in production (raises ``RuntimeError``)
- warns loudly in development (still loads — local-fs convenience)
- accepts an explicit ``MCP_PROXY_ALLOW_LOOSE_CA_KEY_PERMS=1`` opt-out for shared-fs scenarios where the operator deliberately accepts the trade-off

Closes the **H-altri** batch: ``/pki/ca.crt`` XFF spoof, ``jwks_local`` XFF spoof, ``LocalKMS`` no-perm-check from the 2026-04-30 audit.

## Test plan

- [x] `pytest tests/test_h_xff_and_kms_perms.py` (8 new regression tests pass — XFF header ignored on both endpoints, 0600 accepted, 0644 warns in dev, 0644 refuses in production, env override bypasses)
- [x] `pytest tests/ -k "kms or pki or jwks or rate_limit"` (130 passed, no regressions)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Operational notes

- Operators upgrading to this build whose CA key file is ``0644`` will see a ``CRITICAL`` log + ``RuntimeError`` on production boot. Fix with ``chmod 0600 /path/to/broker-ca-key.pem``.
- Production rollout: tighten perms first, then deploy. The override env var exists for the corner case where shared-fs / mounted-secrets pin a higher mode.