### PR TITLE
fix(security): proof of possession on enrollment start

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -99,6 +99,7 @@ def enroll(
         dpop_jwk=dpop_public_jwk,
         verify_tls=verify_tls,
         timeout_s=request_timeout_s,
+        private_key=private_key,
     )
     session_id = start_resp["session_id"]
     enroll_url = start_resp["enroll_url"]
@@ -169,6 +170,49 @@ def enroll(
 # ── Internals ────────────────────────────────────────────────────────────
 
 
+def _build_pop_signature(private_key, pubkey_pem: str) -> str:
+    """H-csr-pop audit fix — sign the canonical proof string with the
+    enrollment keypair so the server can verify the submitter
+    actually controls the matching private key.
+
+    Without this proof a hostile caller could submit *someone else's*
+    public key (observed in logs / leaked) and have the admin issue
+    a cert tied to it: useless to the attacker (they don't have the
+    private key), but a griefing / impersonation surface against the
+    real owner of the keypair.
+    """
+    import base64 as _b64
+    import hashlib as _hashlib
+
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec, padding, rsa
+
+    public_key = serialization.load_pem_public_key(pubkey_pem.encode())
+    der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    fingerprint = _hashlib.sha256(der).hexdigest()
+    canonical = f"enrollment-pop:v1|{fingerprint}".encode("utf-8")
+
+    if isinstance(private_key, rsa.RSAPrivateKey):
+        sig = private_key.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    elif isinstance(private_key, ec.EllipticCurvePrivateKey):
+        sig = private_key.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        raise EnrollmentFailed(
+            f"Unsupported enrollment key type: {type(private_key).__name__}"
+        )
+    return _b64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
 def _start(
     *,
     site_url: str,
@@ -177,6 +221,7 @@ def _start(
     verify_tls: bool | str,
     timeout_s: float,
     dpop_jwk: dict | None = None,
+    private_key=None,
 ) -> dict[str, Any]:
     body = {
         "pubkey_pem": pubkey_pem,
@@ -191,6 +236,8 @@ def _start(
     # compute + store its thumbprint on approve (wire added in #207).
     if dpop_jwk is not None:
         body["dpop_jwk"] = dpop_jwk
+    if private_key is not None:
+        body["pop_signature"] = _build_pop_signature(private_key, pubkey_pem)
 
     try:
         response = httpx.post(

--- a/mcp_proxy/enrollment/router.py
+++ b/mcp_proxy/enrollment/router.py
@@ -124,6 +124,7 @@ async def start_enrollment(
                 reason=payload.reason,
                 device_info=payload.device_info,
                 dpop_jwk=payload.dpop_jwk,
+                pop_signature=payload.pop_signature,
             )
     except service.EnrollmentError as exc:
         raise HTTPException(status_code=exc.http_status, detail=str(exc)) from exc

--- a/mcp_proxy/enrollment/schemas.py
+++ b/mcp_proxy/enrollment/schemas.py
@@ -51,6 +51,22 @@ class EnrollmentStartRequest(BaseModel):
             " endpoint (#206) or re-enrolls (audit F-B-11 Phase 3b)."
         ),
     )
+    pop_signature: str | None = Field(
+        None,
+        max_length=2048,
+        description=(
+            "H-csr-pop audit fix — base64url proof of possession over"
+            " the keypair whose public half is in ``pubkey_pem``. The"
+            " Connector signs ``\"enrollment-pop:v1|<pubkey-sha256-hex>\"``"
+            " (RSA-PSS or ECDSA, dispatched by key type) and submits"
+            " the signature here. The server verifies before persisting,"
+            " so an attacker cannot enroll a stolen / observed public"
+            " key whose private half they don't control. Optional for"
+            " a transition window — pre-fix Connectors still enroll"
+            " but the server logs a WARNING. Will become required in"
+            " a follow-up release."
+        ),
+    )
 
 
 class EnrollmentStartResponse(BaseModel):

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -156,6 +156,65 @@ def _validate_and_compute_dpop_jkt(dpop_jwk: dict | None) -> str | None:
         ) from exc
 
 
+_ENROLLMENT_POP_DOMAIN = "enrollment-pop:v1"
+
+
+def _verify_pop_signature(
+    pubkey_pem: str, fingerprint: str, signature_b64: str,
+) -> bool:
+    """H-csr-pop audit — proof of possession over the enrollment keypair.
+
+    The Connector signs ``"enrollment-pop:v1|<fingerprint>"`` with
+    its private key and submits the signature in ``pop_signature``.
+    The server verifies before persisting the row. A failed verify
+    raises ``EnrollmentError`` (400). Domain-separated by the
+    ``enrollment-pop:v1`` prefix and bound to the pubkey fingerprint
+    so the proof is non-replayable across keys.
+    """
+    import base64 as _b64
+
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives import hashes as _hashes
+    from cryptography.hazmat.primitives.asymmetric import (
+        ec as _ec,
+        padding as _padding,
+        rsa as _rsa,
+    )
+
+    try:
+        sig = _b64.urlsafe_b64decode(
+            signature_b64 + "=" * (-len(signature_b64) % 4),
+        )
+    except Exception:
+        return False
+    try:
+        pub_key = serialization.load_pem_public_key(pubkey_pem.encode())
+    except Exception:
+        return False
+    canonical = (
+        f"{_ENROLLMENT_POP_DOMAIN}|{fingerprint}".encode("utf-8")
+    )
+    try:
+        if isinstance(pub_key, _rsa.RSAPublicKey):
+            pub_key.verify(
+                sig, canonical,
+                _padding.PSS(
+                    mgf=_padding.MGF1(_hashes.SHA256()),
+                    salt_length=_padding.PSS.MAX_LENGTH,
+                ),
+                _hashes.SHA256(),
+            )
+        elif isinstance(pub_key, _ec.EllipticCurvePublicKey):
+            pub_key.verify(sig, canonical, _ec.ECDSA(_hashes.SHA256()))
+        else:
+            return False
+        return True
+    except InvalidSignature:
+        return False
+    except Exception:
+        return False
+
+
 async def start_enrollment(
     conn: AsyncConnection,
     *,
@@ -165,6 +224,7 @@ async def start_enrollment(
     reason: str | None,
     device_info: str | None,
     dpop_jwk: dict | None = None,
+    pop_signature: str | None = None,
 ) -> StartedEnrollment:
     """Create a new pending enrollment.
 
@@ -189,6 +249,30 @@ async def start_enrollment(
     dpop_jkt = _validate_and_compute_dpop_jkt(dpop_jwk)
 
     fingerprint = _pubkey_fingerprint(pubkey_pem)
+
+    # H-csr-pop audit fix — verify proof-of-possession over the
+    # submitted public key. A pre-fix Connector that doesn't ship
+    # ``pop_signature`` is allowed through with a WARNING during the
+    # transition window so existing fleets keep working; a follow-up
+    # PR makes it required once Connector rollout is confirmed.
+    if pop_signature:
+        if not _verify_pop_signature(pubkey_pem, fingerprint, pop_signature):
+            raise EnrollmentError(
+                "pop_signature does not verify against pubkey_pem — "
+                "the submitter does not control the corresponding "
+                "private key (H-csr-pop audit).",
+                http_status=400,
+            )
+    else:
+        import logging
+        logging.getLogger("mcp_proxy.enrollment").warning(
+            "start_enrollment: legacy Connector submitted pubkey_pem "
+            "without pop_signature (fingerprint=%s). Accepted under "
+            "the transition window; a future release will make the "
+            "PoP signature required.",
+            fingerprint,
+        )
+
     session_id = secrets.token_urlsafe(24)
     now = _now()
     expires_at = now + ENROLLMENT_TTL

--- a/tests/test_h_csr_pop.py
+++ b/tests/test_h_csr_pop.py
@@ -1,0 +1,170 @@
+"""
+H-csr-pop regression: ``POST /v1/enrollment/start`` verifies a proof
+of possession over the submitted ``pubkey_pem``.
+
+Pre-fix, the start endpoint accepted any public key with no proof
+the caller controlled the matching private key. An attacker who
+observed someone else's public key (logs, public artifacts, leaked
+backups) could submit it under a different requester identity and
+have the admin issue a cert tied to it. The cert would be unusable
+to the attacker (they have no private key), but it gave a griefing
+/ impersonation surface against the real owner of the keypair.
+
+The fix: the Connector signs ``"enrollment-pop:v1|<sha256-fp>"``
+with the enrollment private key and submits the signature in
+``pop_signature``. The server verifies before persisting.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+
+import pytest
+import pytest_asyncio
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "h_csr_pop.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _ec_keypair() -> tuple:
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _fingerprint(pub_pem: str) -> str:
+    pub = serialization.load_pem_public_key(pub_pem.encode())
+    der = pub.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(der).hexdigest()
+
+
+def _sign_pop(priv, pub_pem: str) -> str:
+    fp = _fingerprint(pub_pem)
+    canonical = f"enrollment-pop:v1|{fp}".encode("utf-8")
+    if isinstance(priv, ec.EllipticCurvePrivateKey):
+        sig = priv.sign(canonical, ec.ECDSA(hashes.SHA256()))
+    else:
+        sig = priv.sign(
+            canonical,
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH,
+            ),
+            hashes.SHA256(),
+        )
+    return base64.urlsafe_b64encode(sig).decode("ascii").rstrip("=")
+
+
+# ── Valid PoP: enrollment created ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_with_valid_pop_creates_pending(proxy_app) -> None:
+    _, client = proxy_app
+    priv, pub_pem = _ec_keypair()
+    proof = _sign_pop(priv, pub_pem)
+
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": pub_pem,
+            "requester_name": "Alice",
+            "requester_email": "a@acme.test",
+            "pop_signature": proof,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["status"] == "pending"
+
+
+# ── Wrong key signed PoP: 400 ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_with_wrong_key_pop_rejected(proxy_app) -> None:
+    """An attacker submits Alice's public key with a PoP signed by
+    a different private key. The server's verify must reject."""
+    _, client = proxy_app
+    _, alice_pub = _ec_keypair()
+    bob_priv, _ = _ec_keypair()
+    forged_proof = _sign_pop(bob_priv, alice_pub)
+
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": alice_pub,
+            "requester_name": "Eve (impersonating)",
+            "requester_email": "eve@evil.test",
+            "pop_signature": forged_proof,
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "pop_signature" in resp.text
+
+
+# ── Garbage PoP: 400 ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_with_garbage_pop_rejected(proxy_app) -> None:
+    _, client = proxy_app
+    _, pub_pem = _ec_keypair()
+
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": pub_pem,
+            "requester_name": "Alice",
+            "requester_email": "a@acme.test",
+            "pop_signature": "not-a-real-signature-just-noise",
+        },
+    )
+    assert resp.status_code == 400
+
+
+# ── Missing PoP: still works during transition (with warning) ────────
+
+
+@pytest.mark.asyncio
+async def test_start_without_pop_accepted_during_transition(proxy_app) -> None:
+    """Pre-fix Connectors that don't ship pop_signature still enroll
+    during the transition window. The server logs a WARNING but
+    accepts the row so existing fleets don't break on upgrade."""
+    _, client = proxy_app
+    _, pub_pem = _ec_keypair()
+
+    resp = await client.post(
+        "/v1/enrollment/start",
+        json={
+            "pubkey_pem": pub_pem,
+            "requester_name": "LegacyConnector",
+            "requester_email": "legacy@acme.test",
+        },
+    )
+    assert resp.status_code == 201


### PR DESCRIPTION
## Summary

``POST /v1/enrollment/start`` accepted any ``pubkey_pem`` with no proof the caller controlled the matching private key. An attacker who observed someone else's public key (logs, public artifacts, leaked backups) could submit it under a different requester identity and have the admin issue a cert tied to it. The cert is useless to the attacker directly, but it's a griefing / impersonation surface against the real owner of the keypair and pollutes the admin queue.

The fix: the Connector signs ``"enrollment-pop:v1|<pubkey-sha256-hex>"`` with its enrollment private key (RSA-PSS or ECDSA, dispatched by key type) and submits the b64url signature in the new ``pop_signature`` field. The server fetches the pubkey, verifies the signature, and rejects with HTTP 400 before persisting the row.

Closes the **H-csr-pop** audit finding from the 2026-04-30 audit.

## Backwards compatibility

``pop_signature`` is currently optional with a transition window:
- Pre-fix Connectors keep enrolling and the server logs a WARNING noting the legacy submission.
- A follow-up release will flip it to required once Connector rollout is confirmed.

This mirrors the M-onb-1 pattern (status-endpoint PoP) — same shape of fix, complementary surface.

## Test plan

- [x] `pytest tests/test_h_csr_pop.py` (4 new regression tests pass — valid PoP creates pending, wrong-key forged PoP rejected with 400, garbage PoP rejected, legacy missing-PoP path still accepts during transition)
- [x] `pytest tests/ -k "enrollment"` (69 passed, no regressions on existing enrollment flows)
- [x] CI ruff (`ruff check app/ agents/sdk.py tests/ --select E,F,W --ignore E501,E402`) clean

## Why both M-onb-1 and H-csr-pop matter

The two PoPs cover different points of the lifecycle:
- **H-csr-pop** (this PR) — proves the *enroller* controls the keypair at submission. Stops impersonation at intake.
- **M-onb-1** (PR #389) — proves the *poller* is the same enroller before pulling the issued cert. Stops session_id-bearer leaks.

Together they make the enrollment flow end-to-end auth'd against the keypair the Connector generated locally.