### PR TITLE
chore(security): switch PyPI release to OIDC trusted publishing (C5)

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -307,13 +307,11 @@ jobs:
 
   # ── 6. PyPI upload ──────────────────────────────────────────────────
   #
-  # No `if:` on `secrets.PYPI_TOKEN`: the `secrets` context cannot be
-  # referenced in any `if:` expression when the workflow is invoked via
-  # `workflow_dispatch` (parser error: "Unrecognized named-value:
-  # 'secrets'"). The token is still consumed only via `with: password:
-  # ${{ secrets.PYPI_TOKEN }}` below — that form is always valid. If
-  # the secret is unset, the publish action fails with a clear error;
-  # provision PYPI_TOKEN as a repo secret to enable publishing.
+  # PyPI trusted publishing (OIDC). The PyPI project `cullis-connector`
+  # is configured with this repo + workflow as a trusted publisher, so
+  # the action mints a short-lived OIDC token at runtime instead of
+  # using a long-lived PYPI_TOKEN. `id-token: write` and the `pypi`
+  # environment together unlock the OIDC exchange.
   publish-pypi:
     name: Publish to PyPI
     needs: build-python
@@ -322,7 +320,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/cullis-connector
     permissions:
-      id-token: write  # for PyPI trusted publishing once configured
+      id-token: write  # required for PyPI trusted publishing OIDC exchange
     steps:
       - name: Download wheel + sdist
         uses: actions/download-artifact@v4
@@ -334,7 +332,3 @@ jobs:
         # Pinned to SHA (was @release/v1 moving alias) — audit 2026-04-30
         # lane 8 M3. Most-exposed step in the entire release flow.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          # Switch to trusted publishing (OIDC) once the PyPI project
-          # is configured; then `password` can be dropped.

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -204,13 +204,11 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
 
   # ── 4. Publish to PyPI ───────────────────────────────────────────────
-  # No `if:` on `secrets.PYPI_TOKEN`: the `secrets` context cannot be
-  # referenced in any `if:` expression when the workflow is invoked via
-  # `workflow_dispatch` (parser error: "Unrecognized named-value:
-  # 'secrets'"). The token is consumed via `with: password:
-  # ${{ secrets.PYPI_TOKEN }}` below — that form is always valid. If
-  # the secret is unset, the publish action fails with a clear error;
-  # provision PYPI_TOKEN as a repo secret to enable publishing.
+  # PyPI trusted publishing (OIDC). The PyPI project `cullis-sdk` is
+  # configured with this repo + workflow as a trusted publisher, so
+  # the action mints a short-lived OIDC token at runtime instead of
+  # using a long-lived PYPI_TOKEN. `id-token: write` and the `pypi`
+  # environment together unlock the OIDC exchange.
   publish-pypi:
     name: Publish to PyPI
     needs: build-python
@@ -219,7 +217,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/cullis-sdk
     permissions:
-      id-token: write  # for PyPI trusted publishing once configured
+      id-token: write  # required for PyPI trusted publishing OIDC exchange
     steps:
       - name: Download wheel + sdist
         uses: actions/download-artifact@v4
@@ -231,7 +229,3 @@ jobs:
         # Pinned to SHA (was @release/v1 moving alias) — audit 2026-04-30
         # lane 8 M3. Most-exposed step in the entire release flow.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          # Switch to trusted publishing (OIDC) once the PyPI project
-          # is configured; then `password` can be dropped.


### PR DESCRIPTION
## Summary

- Drop the long-lived \`PYPI_TOKEN\` secret from both \`release-sdk.yml\` and \`release-connector.yml\`.
- Both workflows already had \`id-token: write\` and the \`pypi\` environment configured, so removing \`password:\` is enough to switch \`pypa/gh-action-pypi-publish\` to the OIDC trusted-publisher exchange.
- Closes finding **C5** from the 2026-04-30 security audit (PyPI long-lived token).

## Pre-merge prerequisite (already done by maintainer)

PyPI trusted publishers must be configured for both projects:

- https://pypi.org/manage/project/cullis-sdk/settings/publishing/
  - Owner: \`cullis-security\` / Repo: \`cullis\` / Workflow: \`release-sdk.yml\` / Environment: \`pypi\`
- https://pypi.org/manage/project/cullis-connector/settings/publishing/
  - Owner: \`cullis-security\` / Repo: \`cullis\` / Workflow: \`release-connector.yml\` / Environment: \`pypi\`

If a project is misconfigured, the next \`*-vX.Y.Z\` tag will fail at the publish step with a clear \`invalid-publisher\` error from PyPI; revertible by re-adding \`password: \${{ secrets.PYPI_TOKEN }}\`.

## Test plan

- [ ] Tag a patch release of either package and confirm the publish step succeeds without \`PYPI_TOKEN\`.
- [ ] After the next successful publish, remove \`PYPI_TOKEN\` from repo secrets to enforce.