### PR TITLE
release: cullis-connector 0.3.6

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -307,13 +307,11 @@ jobs:
 
   # ── 6. PyPI upload ──────────────────────────────────────────────────
   #
-  # No `if:` on `secrets.PYPI_TOKEN`: the `secrets` context cannot be
-  # referenced in any `if:` expression when the workflow is invoked via
-  # `workflow_dispatch` (parser error: "Unrecognized named-value:
-  # 'secrets'"). The token is still consumed only via `with: password:
-  # ${{ secrets.PYPI_TOKEN }}` below — that form is always valid. If
-  # the secret is unset, the publish action fails with a clear error;
-  # provision PYPI_TOKEN as a repo secret to enable publishing.
+  # PyPI trusted publishing (OIDC). The PyPI project `cullis-connector`
+  # is configured with this repo + workflow as a trusted publisher, so
+  # the action mints a short-lived OIDC token at runtime instead of
+  # using a long-lived PYPI_TOKEN. `id-token: write` and the `pypi`
+  # environment together unlock the OIDC exchange.
   publish-pypi:
     name: Publish to PyPI
     needs: build-python
@@ -322,7 +320,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/cullis-connector
     permissions:
-      id-token: write  # for PyPI trusted publishing once configured
+      id-token: write  # required for PyPI trusted publishing OIDC exchange
     steps:
       - name: Download wheel + sdist
         uses: actions/download-artifact@v4
@@ -334,7 +332,3 @@ jobs:
         # Pinned to SHA (was @release/v1 moving alias) — audit 2026-04-30
         # lane 8 M3. Most-exposed step in the entire release flow.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          # Switch to trusted publishing (OIDC) once the PyPI project
-          # is configured; then `password` can be dropped.

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -204,13 +204,11 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}
 
   # ── 4. Publish to PyPI ───────────────────────────────────────────────
-  # No `if:` on `secrets.PYPI_TOKEN`: the `secrets` context cannot be
-  # referenced in any `if:` expression when the workflow is invoked via
-  # `workflow_dispatch` (parser error: "Unrecognized named-value:
-  # 'secrets'"). The token is consumed via `with: password:
-  # ${{ secrets.PYPI_TOKEN }}` below — that form is always valid. If
-  # the secret is unset, the publish action fails with a clear error;
-  # provision PYPI_TOKEN as a repo secret to enable publishing.
+  # PyPI trusted publishing (OIDC). The PyPI project `cullis-sdk` is
+  # configured with this repo + workflow as a trusted publisher, so
+  # the action mints a short-lived OIDC token at runtime instead of
+  # using a long-lived PYPI_TOKEN. `id-token: write` and the `pypi`
+  # environment together unlock the OIDC exchange.
   publish-pypi:
     name: Publish to PyPI
     needs: build-python
@@ -219,7 +217,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/cullis-sdk
     permissions:
-      id-token: write  # for PyPI trusted publishing once configured
+      id-token: write  # required for PyPI trusted publishing OIDC exchange
     steps:
       - name: Download wheel + sdist
         uses: actions/download-artifact@v4
@@ -231,7 +229,3 @@ jobs:
         # Pinned to SHA (was @release/v1 moving alias) — audit 2026-04-30
         # lane 8 M3. Most-exposed step in the entire release flow.
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-          # Switch to trusted publishing (OIDC) once the PyPI project
-          # is configured; then `password` can be dropped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.3.6] — 2026-05-01
+
+### Security
+- **Dashboard CSRF / cross-origin guard** ([#371]): middleware checks
+  `Origin` and `Referer` on POST/PUT/DELETE/PATCH to the local
+  Connector dashboard, with a Bearer-token exemption for the
+  statusline integration. Mitigates DNS-rebinding attacks against
+  `127.0.0.1:7777` from a hostile webpage in the same browser.
+- **Proof-of-possession on enrollment status polling** ([#389]): the
+  `/enroll/status` polling loop now signs each request with the
+  enrollment keypair, so a network attacker who learns the
+  enrollment ID can no longer substitute their own approval result.
+- **Proof-of-possession on enrollment start** ([#393]): the initial
+  `/enroll/start` request is now also bound to the keypair, closing
+  the matching gap on the create side.
+
+### Changed
+- This is the first connector release published to PyPI via OIDC
+  trusted publishing instead of a long-lived `PYPI_TOKEN` (#394).
+
+[#371]: https://github.com/cullis-security/cullis/pull/371
+[#389]: https://github.com/cullis-security/cullis/pull/389
+[#393]: https://github.com/cullis-security/cullis/pull/393
+[#394]: https://github.com/cullis-security/cullis/pull/394
+
 ## [v0.3.5] — 2026-04-30
 
 ### Fixed

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.3.5"
+version = "0.3.6"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump \`cullis-connector\` to **0.3.6**. First release published to PyPI via OIDC trusted publishing (#394) instead of long-lived \`PYPI_TOKEN\`.

### Security fixes since 0.3.5

- **#371** Dashboard CSRF / cross-origin guard — Origin/Referer middleware on POST/PUT/DELETE/PATCH, mitigates DNS-rebinding from a hostile webpage in the same browser.
- **#389** Proof-of-possession on \`/enroll/status\` polling — signed requests prevent enrollment-ID substitution.
- **#393** Proof-of-possession on \`/enroll/start\` — same guarantee on the create side.

### Files changed

- \`cullis_connector/__init__.py\` — \`__version__\` 0.3.5 → 0.3.6
- \`packaging/pypi/pyproject.toml\` — version 0.3.5 → 0.3.6
- \`CHANGELOG.md\` — new \`v0.3.6\` section

### Release procedure (after merge)

1. \`git tag connector-v0.3.6 <merge-sha>\`
2. \`git push origin connector-v0.3.6\`
3. Watch \`release-connector\` workflow on Actions tab.
4. Verify \`pip install cullis-connector==0.3.6\` works.
5. If publish step succeeds: remove \`PYPI_TOKEN\` from repo secrets to fully close C5.

## Test plan

- [ ] CI green on this PR (build + version-match check).
- [ ] After merge + tag push: \`release-connector\` workflow completes all 6 jobs (test, build-python, smoke, GitHub Release, Docker, publish-pypi).
- [ ] Smoke: \`pip install cullis-connector==0.3.6 && cullis-connector --version\` in clean venv.