### PR TITLE
release: cullis-sdk 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.1.3] — 2026-05-01 (cullis-sdk)
+
+### Security
+- **ECDH key wrap upgraded from XOR to AES-KW (RFC 3394)** ([#377]):
+  the one-shot end-to-end encryption envelope now wraps the per-message
+  key with AES-KW instead of an HKDF-derived XOR mask. HKDF `info`
+  is bumped to `cullis-oneshot-v2-aeskw` and the wrapped key is now
+  40 bytes (was 32). Cross-language interop with `sdk-ts` is
+  preserved.
+- **`verify_oneshot` rejects bare-SPKI senders, binds cert↔sender,
+  optional chain trust** ([#379]): a new `cullis_sdk/crypto/_cert_trust.py`
+  module enforces three checks on the sender's identity certificate:
+  the cert must not be a bare SPKI, its CN/SPIFFE SAN must match the
+  declared `sender_agent_id`, and (when `trust_anchors_pem` is
+  provided) it must chain to a known anchor. `CullisClient.from_connector`
+  now passes the Org CA from `identity/ca-chain.pem` as the anchor by
+  default.
+- **`ca_chain_path` threaded through every constructor** ([#381]):
+  `from_enrollment`, `from_identity_dir`, `_do_enroll`,
+  `enroll_via_byoca`, `enroll_via_spiffe`, and `from_api_key_file` all
+  accept a new `ca_chain_path` kwarg, which is now routed through
+  `_build_proxy_http_client` for both the bootstrap GET/POST and the
+  runtime client. This closes a gap where some bootstrap paths were
+  silently using the system CA bundle instead of the TOFU-pinned chain.
+
+### Changed
+- This is the second SDK release published to PyPI via OIDC trusted
+  publishing instead of a long-lived `PYPI_TOKEN` (#394 enabled OIDC
+  for both SDK + Connector workflows; connector v0.3.6 was the first
+  to validate the path end-to-end).
+
+[#377]: https://github.com/cullis-security/cullis/pull/377
+[#379]: https://github.com/cullis-security/cullis/pull/379
+[#381]: https://github.com/cullis-security/cullis/pull/381
+
 ## [v0.3.6] — 2026-05-01
 
 ### Security

--- a/cullis_sdk/__init__.py
+++ b/cullis_sdk/__init__.py
@@ -37,4 +37,4 @@ __all__ = [
     "log_msg",
 ]
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/packaging/pypi-sdk/pyproject.toml
+++ b/packaging/pypi-sdk/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "Python SDK for Cullis — federated agent-trust network. E2E-encrypted agent↔agent messaging, x509 mutual auth, DPoP-bound tokens."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bump \`cullis-sdk\` to **0.1.3**. Second package published to PyPI via OIDC trusted publishing (after connector 0.3.6 validated the path).

### Security fixes since 0.1.2 (all from audit Sprint 3, 2026-04-30)

- **#377** ECDH key wrap upgraded XOR → AES-KW (RFC 3394) on one-shot envelope. HKDF \`info\` v2-aeskw, wrapped key 40B (was 32B). \`sdk-ts\` interop preserved.
- **#379** \`verify_oneshot\` rejects bare-SPKI senders, binds cert ↔ \`sender_agent_id\` via CN/SPIFFE SAN, optional chain trust via new \`trust_anchors_pem\` arg.
- **#381** \`ca_chain_path\` threaded through \`from_enrollment\`, \`from_identity_dir\`, \`_do_enroll\`, \`enroll_via_byoca\`, \`enroll_via_spiffe\`, \`from_api_key_file\`, plus \`_build_proxy_http_client\`.

### Files changed

- \`cullis_sdk/__init__.py\` — \`__version__\` 0.1.2 → 0.1.3
- \`packaging/pypi-sdk/pyproject.toml\` — version 0.1.2 → 0.1.3
- \`CHANGELOG.md\` — new \`v0.1.3\` SDK section above v0.3.6 connector

### Release procedure (after merge)

1. \`git tag sdk-v0.1.3 <merge-sha>\`
2. \`git push origin sdk-v0.1.3\`
3. Watch \`release-sdk\` workflow.
4. Verify \`pip install cullis-sdk==0.1.3\` works.

## Test plan

- [ ] CI green on this PR (build + version-match).
- [ ] After tag push: \`release-sdk\` workflow completes (test, build-python, smoke wheel, GitHub Release, publish-pypi).
- [ ] Smoke: \`pip install cullis-sdk==0.1.3 && python -c "import cullis_sdk; print(cullis_sdk.__version__)"\` in clean venv.