### PR TITLE
fix(reference): align with production mTLS, drop verify_tls=False shortcut

### DIFF
--- a/reference/agent/agent.py
+++ b/reference/agent/agent.py
@@ -47,9 +47,12 @@ def _record(nonce: str) -> None:
 
 
 def wait_for_http(url: str, timeout: float = 60.0) -> bool:
-    # ADR-014 — Mastio's https endpoint behind the per-org nginx
-    # sidecar uses a self-signed Org CA, so verify=False (matches the
-    # SDK's ``verify_tls=False``).
+    # Boot-time /health probe runs BEFORE the per-org Org CA file is
+    # guaranteed on disk (bootstrap-mastio writes ca.pem alongside the
+    # agent identity). verify=False is intentional here and does not
+    # weaken the runtime auth path: no client cert is presented and no
+    # data flows. Real traffic goes through CullisClient with
+    # verify_tls=True + ca_chain_path (see _auth_identity_dir).
     import httpx
     deadline = time.monotonic() + timeout
     with httpx.Client(verify=False, timeout=2.0) as client:
@@ -140,21 +143,33 @@ def _auth_identity_dir(mastio_url: str, identity_dir: str, self_id: str) -> Cull
     ``/state/{org}/agents/{name}/``: ``agent.pem`` (cert) +
     ``agent-key.pem`` (private key) + ``dpop.jwk`` (egress proof key).
 
-    ``verify_tls=False`` because the reference deployment's Org CA is
-    self-signed.
+    Server cert verification uses the per-org Org CA at
+    ``/state/{org}/ca.pem`` (the same root that signs the agent's leaf
+    AND the per-org nginx server leaf), so reference runs through the
+    exact same mTLS path as a production deploy. No
+    ``verify_tls=False`` shortcut: a regression in client-cert
+    presentation now fails reference loudly instead of silently
+    falling back to a no-cert TLS handshake.
     """
     cert_path = pathlib.Path(identity_dir) / "agent.pem"
     key_path = pathlib.Path(identity_dir) / "agent-key.pem"
     dpop_key_path = pathlib.Path(identity_dir) / "dpop.jwk"
+    org_id = self_id.split("::", 1)[0]
+    ca_chain_path = pathlib.Path("/state") / org_id / "ca.pem"
     deadline = time.monotonic() + 60
     while time.monotonic() < deadline:
-        if cert_path.exists() and key_path.exists() and dpop_key_path.exists():
+        if (
+            cert_path.exists()
+            and key_path.exists()
+            and dpop_key_path.exists()
+            and ca_chain_path.exists()
+        ):
             break
         time.sleep(0.5)
     else:
         raise RuntimeError(
             f"[{self_id}] missing identity material under {identity_dir} "
-            "(need agent.pem, agent-key.pem, dpop.jwk) — "
+            f"(need agent.pem, agent-key.pem, dpop.jwk, {ca_chain_path}) — "
             "did bootstrap-mastio + bootstrap run?"
         )
     client = CullisClient.from_identity_dir(
@@ -163,8 +178,9 @@ def _auth_identity_dir(mastio_url: str, identity_dir: str, self_id: str) -> Cull
         key_path=key_path,
         dpop_key_path=dpop_key_path,
         agent_id=self_id,
-        org_id=self_id.split("::", 1)[0],
-        verify_tls=False,
+        org_id=org_id,
+        verify_tls=True,
+        ca_chain_path=ca_chain_path,
     )
     # Session APIs (``list_sessions`` / ``open_session`` / ``send``)
     # require a broker JWT. ``login_via_proxy`` asks the Mastio to mint

--- a/reference/agent/llm_agent.py
+++ b/reference/agent/llm_agent.py
@@ -178,17 +178,20 @@ def _load_prompt() -> str:
 
 
 def _wait_identity(timeout_s: float = 60.0) -> None:
-    """Block until bootstrap + bootstrap-mastio have written cert+key+dpop.jwk."""
+    """Block until bootstrap + bootstrap-mastio have written
+    cert+key+dpop.jwk plus the per-org Org CA chain at /state/<org>/ca.pem."""
     deadline = time.monotonic() + timeout_s
     cert = IDENTITY_DIR / "agent.pem"
     key = IDENTITY_DIR / "agent-key.pem"
     dpop = IDENTITY_DIR / "dpop.jwk"
+    ca_chain = pathlib.Path("/state") / ORG_ID / "ca.pem"
     while time.monotonic() < deadline:
-        if cert.exists() and key.exists() and dpop.exists():
+        if cert.exists() and key.exists() and dpop.exists() and ca_chain.exists():
             return
         time.sleep(0.5)
     raise SystemExit(
-        f"identity not provisioned at {IDENTITY_DIR} after {timeout_s:.0f}s"
+        f"identity not provisioned at {IDENTITY_DIR} (or ca chain at "
+        f"{ca_chain}) after {timeout_s:.0f}s"
     )
 
 
@@ -196,12 +199,16 @@ def _load_client() -> CullisClient:
     """Build a CullisClient from the on-disk credentials.
 
     ADR-014 — TLS client cert authenticates against the per-org nginx
-    sidecar on ``https://proxy-X:9443``. ``verify_tls=False`` because
-    the reference deployment's Org CA is self-signed.
+    sidecar on ``https://mastio-nginx-X:9443``. Server cert
+    verification uses the per-org Org CA at ``/state/<org>/ca.pem``
+    (the same root that signs the agent's leaf AND the per-org nginx
+    server leaf), so reference runs through the exact same mTLS path
+    as a production deploy.
     """
     _wait_identity()
     cert_path = IDENTITY_DIR / "agent.pem"
     key_path = IDENTITY_DIR / "agent-key.pem"
+    ca_chain_path = pathlib.Path("/state") / ORG_ID / "ca.pem"
     client = CullisClient.from_identity_dir(
         BROKER_URL,
         cert_path=cert_path,
@@ -209,7 +216,8 @@ def _load_client() -> CullisClient:
         dpop_key_path=IDENTITY_DIR / "dpop.jwk",
         agent_id=SELF_ID,
         org_id=ORG_ID,
-        verify_tls=False,
+        verify_tls=True,
+        ca_chain_path=ca_chain_path,
     )
     client.login_via_proxy()
     # send_oneshot signs each envelope with the agent's private key for

--- a/reference/docker-compose.yml
+++ b/reference/docker-compose.yml
@@ -317,7 +317,7 @@ services:
       # includes ``proxy-a`` (the alias agents resolve over
       # orga-internal) and ``localhost`` (smoke + dev curl from host).
       MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"
-      MCP_PROXY_NGINX_SAN: "proxy-a,localhost"
+      MCP_PROXY_NGINX_SAN: "mastio-nginx-a,proxy-a,localhost"
     volumes:
       - proxy-a-data:/data
       - mastio-a-nginx-certs:/var/lib/mastio/nginx-certs:rw
@@ -597,7 +597,7 @@ services:
       MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
       # ADR-014 — see proxy-a rationale.
       MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"
-      MCP_PROXY_NGINX_SAN: "proxy-b,localhost"
+      MCP_PROXY_NGINX_SAN: "mastio-nginx-b,proxy-b,localhost"
     volumes:
       - proxy-b-data:/data
       - mastio-b-nginx-certs:/var/lib/mastio/nginx-certs:rw

--- a/reference/scenarios/_identity.py
+++ b/reference/scenarios/_identity.py
@@ -19,16 +19,22 @@ def load_enrolled_client(
     org_id: str,
     agent_name: str,
     identity_root: str | Path = "/state",
-    verify_tls: bool = False,
+    verify_tls: bool = True,
 ) -> CullisClient:
     identity_dir = Path(identity_root) / org_id / "agents" / agent_name
     cert_path = identity_dir / "agent.pem"
     key_path = identity_dir / "agent-key.pem"
     dpop_key_path = identity_dir / "dpop.jwk"
-    if not cert_path.exists() or not key_path.exists() or not dpop_key_path.exists():
+    ca_chain_path = Path(identity_root) / org_id / "ca.pem"
+    if (
+        not cert_path.exists()
+        or not key_path.exists()
+        or not dpop_key_path.exists()
+        or not ca_chain_path.exists()
+    ):
         raise RuntimeError(
             f"enrolled identity missing under {identity_dir} "
-            f"(expected agent.pem + agent-key.pem + dpop.jwk) — "
+            f"(expected agent.pem + agent-key.pem + dpop.jwk + {ca_chain_path}) — "
             "is bootstrap-mastio done?"
         )
     client = CullisClient.from_identity_dir(
@@ -39,6 +45,7 @@ def load_enrolled_client(
         agent_id=f"{org_id}::{agent_name}",
         org_id=org_id,
         verify_tls=verify_tls,
+        ca_chain_path=ca_chain_path,
     )
     # Mirror the runtime wiring in agent.py ``_auth_identity_dir``:
     #   • ``login_via_proxy`` mints a broker JWT so ``_authed_request``

--- a/reference/scenarios/inject.sh
+++ b/reference/scenarios/inject.sh
@@ -51,10 +51,12 @@ _inject_intra_orga() {
 import pathlib
 from cullis_sdk import CullisClient
 ID = pathlib.Path("/state/orga/agents/alice-byoca")
+CA = pathlib.Path("/state/orga/ca.pem")
 c = CullisClient.from_identity_dir("https://mastio-nginx-a:9443",
     cert_path=ID/"agent.pem", key_path=ID/"agent-key.pem",
     dpop_key_path=ID/"dpop.jwk",
-    agent_id="orga::alice-byoca", org_id="orga", verify_tls=False)
+    agent_id="orga::alice-byoca", org_id="orga",
+    verify_tls=True, ca_chain_path=CA)
 c.login_via_proxy()
 c._signing_key_pem = (ID/"agent-key.pem").read_text()
 r = c.send_oneshot("orga::alice-spiffe",
@@ -69,10 +71,12 @@ _inject_intra_orgb() {
 import pathlib
 from cullis_sdk import CullisClient
 ID = pathlib.Path("/state/orgb/agents/bob-byoca")
+CA = pathlib.Path("/state/orgb/ca.pem")
 c = CullisClient.from_identity_dir("https://mastio-nginx-b:9443",
     cert_path=ID/"agent.pem", key_path=ID/"agent-key.pem",
     dpop_key_path=ID/"dpop.jwk",
-    agent_id="orgb::bob-byoca", org_id="orgb", verify_tls=False)
+    agent_id="orgb::bob-byoca", org_id="orgb",
+    verify_tls=True, ca_chain_path=CA)
 c.login_via_proxy()
 c._signing_key_pem = (ID/"agent-key.pem").read_text()
 r = c.send_oneshot("orgb::bob-spiffe",
@@ -87,10 +91,12 @@ _inject_cross_org() {
 import pathlib
 from cullis_sdk import CullisClient
 ID = pathlib.Path("/state/orga/agents/alice-connector")
+CA = pathlib.Path("/state/orga/ca.pem")
 c = CullisClient.from_identity_dir("https://mastio-nginx-a:9443",
     cert_path=ID/"agent.pem", key_path=ID/"agent-key.pem",
     dpop_key_path=ID/"dpop.jwk",
-    agent_id="orga::alice-connector", org_id="orga", verify_tls=False)
+    agent_id="orga::alice-connector", org_id="orga",
+    verify_tls=True, ca_chain_path=CA)
 c.login_via_proxy()
 c._signing_key_pem = (ID/"agent-key.pem").read_text()
 r = c.send_oneshot("orgb::bob-connector",


### PR DESCRIPTION
## Summary

Mirrors PR #386 for the reference deployment. Reference had the same \`verify_tls=False\` shortcut that masked a 2-day mTLS regression in sandbox last week. Same pattern, same fix.

### What was wrong

The reference scenarios + runtime + LLM agent + injectors all passed \`verify_tls=False\` to \`CullisClient.from_identity_dir\` because the per-org Mastio nginx sidecar's leaf cert was signed by the per-org Org CA (not in the system trust store). PR #365 then routed that branch through a shortcut in \`_build_proxy_http_client\` that skips \`load_cert_chain\` entirely, so any reference smoke would silently start TLS handshakes **without** presenting the client cert.

This masked exactly the kind of regression #386 caught the hard way in sandbox: nginx returns 401 on every \`/v1/auth/sign-assertion\` + \`/v1/egress/*\` call, all agents go into restart loop, and no one notices because \`./demo.sh full\` never gets run between the breakage and the customer install.

### What changed (5 files)

| File | Change |
|---|---|
| \`reference/scenarios/_identity.py\` | default \`verify_tls=True\`, load \`/state/<org>/ca.pem\` as \`ca_chain_path\`, fail loudly if absent |
| \`reference/agent/agent.py\` | same in \`_auth_identity_dir\`; bootstrap \`/health\` probe stays \`verify=False\` (no cert, no data, comment updated) |
| \`reference/agent/llm_agent.py\` | \`_wait_identity\` also waits for \`/state/<ORG_ID>/ca.pem\`; \`_load_client\` passes \`verify_tls=True\` + \`ca_chain_path\` |
| \`reference/scenarios/inject.sh\` | three inline injector blocks (intra-orga, intra-orgb, cross-org) gain \`ca_chain_path=CA\` and \`verify_tls=True\` |
| \`reference/docker-compose.yml\` | \`MCP_PROXY_NGINX_SAN\` now includes \`mastio-nginx-{a,b}\`, the docker-compose service name agents resolve via \`BROKER_URL\` |

### Validation status

- [x] Python AST parse on all 3 .py files
- [x] \`bash -n\` on inject.sh
- [x] \`docker compose config --quiet\` on docker-compose.yml
- [x] **End-to-end \`./demo.sh full\` validated locally**:
  - All 26 containers up healthy on first boot, no agent restart loop
  - All 6 LLM agents (alice/bob × byoca/spiffe/connector) healthy
  - \`scenarios/inject.sh\` intra-orgb returned msg_id (oneshot envelope round-trip OK)
  - \`scenarios/inject.sh -c\` cross-org returned msg_id (counter-sig + envelope OK)
  - \`reference/smoke.sh\` 15/15 PASS / 0 FAIL: 6 agents healthy, 6 identity files OK, 3 enrollment methods (BYOCA + SPIFFE + Connector device-code) all exercised

Reference is **not** covered by CI smoke (smoke.yml only runs sandbox via demo_network), but the local dogfood proves strict mTLS reggge end-to-end. Safe to merge.

### Follow-up

Nightly stress lane in \`cullis-enterprise\` (private) inherits sandbox stack — needs the same audit + fix if it copied any \`verify_tls=False\` from the pre-#386 sandbox.