### PR TITLE
fix(site): align deployment + download pages with reality

### DIFF
--- a/site/src/content/docs/install/connector.md
+++ b/site/src/content/docs/install/connector.md
@@ -37,7 +37,7 @@ Each zip ships the platform-specific binary plus an `install.sh` / `install.comm
 # Linux example — adjust filename for your platform
 sudo mv cullis-connector-linux-x86_64 /usr/local/bin/cullis-connector
 cullis-connector --version
-# cullis-connector 0.3.2
+# cullis-connector 0.3.6
 ```
 
 > macOS Intel and Linux on ARM are not currently published as standalone binaries. Use **option B (`pip install`)** on those platforms.

--- a/site/src/content/docs/install/mastio-kubernetes.md
+++ b/site/src/content/docs/install/mastio-kubernetes.md
@@ -122,9 +122,9 @@ curl -H "Host: broker.your-org.com" http://<INGRESS-IP>/readyz
 The Mastio is stateless from the Court's perspective and uses its own small SQLite database. Point it at the Court's public base URL + JWKS URL:
 
 ```bash
-helm install cullis-proxy deploy/helm/cullis-proxy/ \
+helm install cullis-mastio deploy/helm/cullis-mastio/ \
     --namespace cullis \
-    --values deploy/helm/cullis-proxy/values-dev.yaml \
+    --values deploy/helm/cullis-mastio/values-dev.yaml \
     --set ingress.host=proxy.your-org.com \
     --wait --timeout 5m
 ```

--- a/site/src/pages/deployment.astro
+++ b/site/src/pages/deployment.astro
@@ -287,8 +287,8 @@ import Layout from '../layouts/Layout.astro';
       <div class="install-grid">
         <article class="install-card reveal" data-delay="1">
           <div class="install-head">
-            <div class="install-label">For developers</div>
-            <h3>Docker Compose</h3>
+            <div class="install-label">For evaluation</div>
+            <h3>Sandbox demo</h3>
           </div>
           <pre><code>git clone https://github.com/cullis-security/cullis
 cd cullis
@@ -308,43 +308,48 @@ cd cullis
 
         <article class="install-card featured reveal" data-delay="2">
           <div class="install-head">
-            <div class="install-label">For production</div>
-            <h3>Kubernetes · Helm</h3>
+            <div class="install-label">For a single host</div>
+            <h3>Self-host · Compose</h3>
           </div>
-          <pre><code>helm repo add cullis https://cullis.io/charts
-helm install mastio cullis/mastio \
-  --set org.name=acme \
-  --set ingress.host=mastio.acme.internal</code></pre>
+          <pre><code>git clone https://github.com/cullis-security/cullis
+cd cullis
+./deploy_broker.sh --prod-acme \
+  --domain mastio.acme.com \
+  --email ops@acme.com</code></pre>
           <p>
-            Helm chart handles Org CA bootstrap, Vault KV v2 integration,
-            Postgres for audit, OpenTelemetry wiring, and OIDC admin login.
-            Standalone by default; <code>attach-ca</code> post-install.
+            Wraps a production Docker Compose stack with three TLS profiles —
+            self-signed dev, Let's Encrypt ACME, or bring-your-own CA. nginx,
+            Vault, Postgres, and the Mastio come up wired together. First-boot
+            wizard at <code>/proxy/first-boot</code>.
           </p>
           <ul class="install-specs">
-            <li><span class="k">Time</span><span>~10 min first boot</span></li>
-            <li><span class="k">Requires</span><span>K8s 1.28+ · Vault · Postgres</span></li>
-            <li><span class="k">Best for</span><span>production</span></li>
+            <li><span class="k">Time</span><span>~5 min first boot</span></li>
+            <li><span class="k">Requires</span><span>Docker + Compose v2 · DNS · TLS</span></li>
+            <li><span class="k">Best for</span><span>single-VM production</span></li>
           </ul>
         </article>
 
         <article class="install-card reveal" data-delay="3">
           <div class="install-head">
-            <div class="install-label">For edge / lightweight</div>
-            <h3>Single binary</h3>
+            <div class="install-label">For Kubernetes</div>
+            <h3>Helm chart</h3>
           </div>
-          <pre><code>curl -L https://cullis.io/get | sh
-cullis-mastio init --standalone
-cullis-mastio start</code></pre>
+          <pre><code>git clone https://github.com/cullis-security/cullis
+helm install cullis-mastio \
+  ./cullis/deploy/helm/cullis-mastio \
+  --namespace cullis --create-namespace \
+  --set ingress.host=mastio.acme.internal</code></pre>
           <p>
-            A statically-linked binary, SQLite for audit, filesystem KMS.
-            Zero external dependencies. Ideal for edge deployments, air-gapped
-            datacenters, or regulatory environments where every dependency is
-            a compliance question.
+            Chart in the repo at <code>deploy/helm/cullis-mastio/</code>. Wires
+            Org CA bootstrap, Vault KV v2, Postgres for audit, ingress, and HPA.
+            <code>values-dev.yaml</code> for kind/k3d evaluation;
+            <code>values.yaml</code> for production. Pre-1.0 — fork and harden
+            for your environment.
           </p>
           <ul class="install-specs">
-            <li><span class="k">Time</span><span>&lt; 30 seconds</span></li>
-            <li><span class="k">Requires</span><span>Linux · nothing else</span></li>
-            <li><span class="k">Best for</span><span>edge, air-gapped</span></li>
+            <li><span class="k">Time</span><span>~10 min first boot</span></li>
+            <li><span class="k">Requires</span><span>K8s 1.28+ · Helm 3.14+</span></li>
+            <li><span class="k">Best for</span><span>multi-node clusters</span></li>
           </ul>
         </article>
       </div>

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -1,11 +1,13 @@
 ---
 import Layout from '../layouts/Layout.astro';
 
-// `releases/latest/download/<file>` is GitHub's stable redirect: it always
-// resolves to the latest published (non-prerelease) Connector release. No
-// need to bump this on every tag — push a new release and the site picks
-// it up automatically.
-const BASE = 'https://github.com/cullis-security/cullis/releases/latest/download';
+// Pinned to the current Connector tag. Bump on every Connector release.
+// We can't use `releases/latest/download/<file>` because GitHub's "latest"
+// flag is shared across Connector / SDK / Mastio tags in this repo and
+// often resolves to a non-Connector release.
+const CONNECTOR_VERSION = '0.3.6';
+const CONNECTOR_TAG = `connector-v${CONNECTOR_VERSION}`;
+const BASE = `https://github.com/cullis-security/cullis/releases/download/${CONNECTOR_TAG}`;
 
 const platforms = [
   {
@@ -44,8 +46,8 @@ const platforms = [
         </aside>
         <div>
           <div class="eyebrow reveal" data-delay="1">
-            <span class="eyebrow-number">Latest release</span>
-            <a class="v-badge" href="https://github.com/cullis-security/cullis/releases/latest">view on GitHub →</a>
+            <span class="eyebrow-number">{CONNECTOR_TAG}</span>
+            <a class="v-badge" href={`https://github.com/cullis-security/cullis/releases/tag/${CONNECTOR_TAG}`}>view on GitHub →</a>
           </div>
           <h1 class="reveal" data-delay="2">
             Get the <em>Connector</em>.
@@ -122,9 +124,11 @@ const platforms = [
           <pre><code>pip install cullis-connector</code></pre>
           <p>Wheel and source tarball published on every release. Use it to embed the Connector in a Python process, write integration tests, or build your own CLI on top.</p>
           <div class="dev-links">
-            <a href={`${BASE}/cullis_connector-0.1.0-py3-none-any.whl`} download>wheel</a>
+            <a href={`${BASE}/cullis_connector-${CONNECTOR_VERSION}-py3-none-any.whl`} download>wheel</a>
             <span class="sep">·</span>
-            <a href={`${BASE}/cullis_connector-0.1.0.tar.gz`} download>sdist</a>
+            <a href={`${BASE}/cullis_connector-${CONNECTOR_VERSION}.tar.gz`} download>sdist</a>
+            <span class="sep">·</span>
+            <a href="https://pypi.org/project/cullis-connector/" target="_blank" rel="noopener">PyPI</a>
           </div>
         </article>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,7 +8,7 @@ import Layout from '../layouts/Layout.astro';
     <div class="container hero-container">
       <aside class="hero-marginalia reveal">
         <div class="scribble">CLLS-0001</div>
-        <div class="folio">v 0.2.0 · <em>preview</em></div>
+        <div class="folio">research preview · <em>pre-1.0</em></div>
         <div class="marginalia">
           Cryptographic infrastructure for artificial agents — identity,
           authorization, and tamper-evident audit across organizations


### PR DESCRIPTION
## Summary

The `/deployment` and `/download` pages on cullis.io shipped commands that didn't exist or pointed at 404s. A visitor copy-pasting from either page hit a wall. This PR makes both pages match what's actually shipped.

## What was broken

**`/deployment` — three install cards, three lies**
- `helm repo add cullis https://cullis.io/charts` — no chart repo is served from that URL (cullis.io returns the SPA 404 fallback).
- `curl -L https://cullis.io/get | sh` — no install script at `/get`.
- `cullis-mastio init --standalone` — there is no single-binary Mastio. It's a Docker Compose stack.

**`/download` — Latest-release link points at the wrong product**
- `BASE = releases/latest/download/<file>` resolves via GitHub's "latest" flag, which now points at `sdk-v0.1.3` (created after `connector-v0.3.6`). Every `cullis-connector-*.zip` / standalone binary link 404'd.
- Wheel + sdist links hardcoded to version `0.1.0` (current is `0.3.6`).

**Stale version strings**
- Hero on `/` shows `v 0.2.0 · preview` (Connector is at 0.3.6, Mastio at 0.3.0-rc3).
- `docs/install/connector.md` example output: `cullis-connector 0.3.2`.

**Wrong Helm chart path**
- `docs/install/mastio-kubernetes.md` installs `deploy/helm/cullis-proxy/`. That path doesn't exist; the chart is `deploy/helm/cullis-mastio/`.

## What this PR does

- `/deployment` install grid rewritten to **Sandbox demo** (`./sandbox/demo.sh full`), **Self-host Compose** (`./deploy_broker.sh --prod-acme`), **Helm chart** (`helm install ./deploy/helm/cullis-mastio`). All three commands exist in the repo today.
- `/download` pins to `connector-v0.3.6` via `CONNECTOR_VERSION`; bump on each Connector release. Added a PyPI link next to wheel/sdist as a more durable channel.
- Hero `v 0.2.0 · preview` → `research preview · pre-1.0` (no version, no rot).
- `docs/install/connector.md` expected output bumped 0.3.2 → 0.3.6.
- `docs/install/mastio-kubernetes.md` chart path `cullis-proxy` → `cullis-mastio`.

## Verified

- `npm run build` clean, 25 pages rendered.
- `curl -sIL` against the new `connector-v0.3.6` asset URLs: all 302 → 200, content-length matches release.

## Follow-up

The pin in `download.astro` will need a manual bump on every Connector release. The structural fix is to mark Connector — not SDK — as the repo's "Latest release" on GitHub (`gh release edit connector-vX.Y.Z --latest`), then revert to `releases/latest/download/`. Out of scope here.

## Test plan

- [ ] Visit `/deployment` — three cards match what `git clone` actually gives you.
- [ ] Visit `/download`, click each macOS / Windows / Linux installer + standalone binary — all six should download (not 404).
- [ ] Click wheel + sdist on `/download` — should download `cullis_connector-0.3.6-*` artifacts.
- [ ] Visit `/docs/install/mastio-kubernetes`, verify Mastio install command shows `cullis-mastio` (not `cullis-proxy`).