### PR TITLE
fix(nightly): strict mTLS in workload + smoke clients

### DIFF
--- a/test/nightly/smoke.py
+++ b/test/nightly/smoke.py
@@ -33,18 +33,22 @@ def _probe(entry: dict) -> tuple[str, bool, str]:
     cert = agent_dir / "agent.pem"
     key = agent_dir / "agent-key.pem"
     dpop = agent_dir / "dpop.jwk"
+    ca_chain = STATE / org_id / "ca.pem"
 
-    for f in (cert, key, dpop):
+    for f in (cert, key, dpop, ca_chain):
         if not f.exists():
             return agent_id, False, f"missing {f.name}"
 
     mastio_url = MASTIO_URLS[org_id]
     try:
+        # ADR-014 strict mTLS: present client cert + verify server leaf
+        # against the per-org Org CA. Same path as production.
         client = CullisClient.from_identity_dir(
             mastio_url,
             cert_path=cert, key_path=key, dpop_key_path=dpop,
             agent_id=agent_id, org_id=org_id,
-            verify_tls=False,
+            verify_tls=True,
+            ca_chain_path=ca_chain,
             timeout=30.0,
         )
         peers = client.list_peers(limit=50)

--- a/test/nightly/workload/_common.py
+++ b/test/nightly/workload/_common.py
@@ -43,15 +43,26 @@ def load_client(agent_id: str) -> CullisClient:
     reads state from the local test/nightly/state/ bind mount.
 
     ADR-014 — TLS client cert authenticates against the per-org nginx
-    sidecar; ``verify_tls=False`` for the self-signed Org CA.
+    sidecar. Server cert verification uses the per-org Org CA at
+    ``state/<org>/ca.pem`` (the same root that signs the agent's leaf
+    AND the per-org nginx server leaf), so nightly runs through the
+    exact same mTLS path as a production deploy. No
+    ``verify_tls=False`` shortcut: a regression in client-cert
+    presentation now fails nightly loudly instead of silently falling
+    back to a no-cert TLS handshake.
     """
     org_id, agent_name = agent_id.split("::", 1)
     identity_dir = STATE / org_id / "agents" / agent_name
+    ca_chain_path = STATE / org_id / "ca.pem"
     for f in ("agent.pem", "agent-key.pem", "dpop.jwk"):
         if not (identity_dir / f).exists():
             raise SystemExit(
                 f"{identity_dir / f} missing — agent not enrolled"
             )
+    if not ca_chain_path.exists():
+        raise SystemExit(
+            f"{ca_chain_path} missing — bootstrap-mastio did not write Org CA"
+        )
 
     mastio_url = MASTIO_URLS[org_id]
     key_path = identity_dir / "agent-key.pem"
@@ -62,7 +73,8 @@ def load_client(agent_id: str) -> CullisClient:
         dpop_key_path=identity_dir / "dpop.jwk",
         agent_id=agent_id,
         org_id=org_id,
-        verify_tls=False,
+        verify_tls=True,
+        ca_chain_path=ca_chain_path,
         timeout=30.0,
     )
     # login_via_proxy mints a broker JWT so session APIs work.


### PR DESCRIPTION
## Summary

Closes the third (and last) outpost of the `verify_tls=False` shortcut that PR #386 ripped out of `_build_proxy_http_client`. Sandbox was fixed in #386, reference in #397, nightly was missed.

## Why nightly went silent

`test/nightly/workload/_common.py:65` and `test/nightly/smoke.py:47` still passed `verify_tls=False` to `CullisClient.from_identity_dir`. Pre-#386, that took the shortcut branch in `_build_proxy_http_client` that skipped `load_cert_chain` entirely — TLS handshakes against the per-org Mastio nginx sidecar went out without a client cert. After #386, the shortcut is gone; the same handshakes are now refused at the TLS layer because Mastio's nginx requires `ssl_verify_client on`. The next nightly run would have gone red across all N agents.

## What changed

Same pattern as PR #397 for `reference/`:

- **`test/nightly/workload/_common.py`** (`load_client`) — `verify_tls=True` + `ca_chain_path` from `state/<org>/ca.pem`. Loud `SystemExit` if the CA chain is missing rather than a silent no-cert handshake. Comment updated to spell out the strict-mTLS contract.
- **`test/nightly/smoke.py`** (`_probe`) — same. `ca.pem` added to the per-agent missing-files preflight so a half-bootstrapped state fails fast with a clear "missing ca.pem" message instead of an opaque TLS error.

## What stayed

- `test/nightly/bootstrap/bootstrap.py:450` keeps `httpx.Client(verify=False)`. It's the boot-time `/health` probe that runs **before** `bootstrap-mastio` writes `state/<org>/ca.pem`. No client cert presented, no data flows. Same reasoning as `reference/agent/agent.py:wait_for_http` in PR #397.
- The Org CA file is already produced by `bootstrap.py:_gen_org_ca` on every `nightly.sh full` (line 167), so no scaffolding needed on the bootstrap side.

## Test plan

- [ ] `cd test/nightly && ./nightly.sh down && ./nightly.sh full` boots without errors.
- [ ] `./nightly.sh smoke` reports N/N agents online (was rejecting at TLS handshake before this PR).
- [ ] `./nightly.sh go` for at least one minute of workload, then `./nightly.sh down` clean.
- [ ] Smoke + reference + sandbox golden paths still green (no shared code changed).