### PR TITLE
docs(site): clarify connector onboarding flow

### DIFF
--- a/site/src/content/docs/install/connector.md
+++ b/site/src/content/docs/install/connector.md
@@ -3,7 +3,7 @@ title: "Install the Connector"
 description: "Download the Cullis Connector desktop release, install it on macOS, Linux, or Windows, and complete your first enrollment against your organization's Mastio."
 category: "Install"
 order: 10
-updated: "2026-04-23"
+updated: "2026-05-03"
 ---
 
 # Install the Connector
@@ -61,6 +61,27 @@ A `cullis-security/homebrew-tap` is on the roadmap but not yet published. In the
 
 ## 2. First enrollment
 
+You only enroll **once per machine**. The identity that lands at the end of this step is shared by every MCP client you'll wire up later — Cline, Cursor, Zed, Windsurf, Claude Desktop. Pick the path that fits you better; both produce the same artefacts under `~/.cullis/identity/`.
+
+### Option A — Dashboard wizard (recommended)
+
+The friendliest path on a fresh laptop. Start the dashboard and let the browser walk you through it:
+
+```bash
+cullis-connector dashboard
+# Connector dashboard running at http://127.0.0.1:7777
+```
+
+Open `http://127.0.0.1:7777`. If no identity exists yet, you land on a 3-step wizard:
+
+1. **Connect** — paste your Mastio URL (e.g. `https://cullis.acme.local:9443`) and optionally pin the CA fingerprint your admin gave you over a separate channel.
+2. **Approve** — the dashboard prints an approval URL for your admin. The page auto-refreshes while polling; no need to keep a terminal open.
+3. **Online** — once the admin approves, the dashboard switches to the Connected view with your agent id, org, and the IDE cards (see step 4).
+
+### Option B — CLI
+
+For headless setups (CI runners, remote servers, no display):
+
 ```bash
 cullis-connector enroll \
     --site-url https://cullis.acme.local \
@@ -69,15 +90,15 @@ cullis-connector enroll \
     --reason "New laptop, replacing the old MBP"
 ```
 
-What happens:
+What happens under the hood (same for both options):
 
 1. The Connector generates a fresh EC P-256 keypair under `~/.cullis/identity/`. The private key never leaves your machine.
 2. It POSTs the public key to `POST /v1/enrollments` on the Mastio. The Mastio replies with an enrollment session id and a challenge nonce (see [Connector device-code enrollment](../enroll/connector-device-code) for the challenge-response flow introduced in connector-v0.3.0).
-3. The CLI prints an approval URL — share it with your admin.
+3. The CLI / dashboard prints an approval URL — share it with your admin.
 4. The Connector polls every 3 seconds until the admin approves in the Mastio dashboard (`/proxy/enrollments`).
 5. On approval, the Connector completes a challenge-response handshake proving it still holds the private key, then writes `identity.pem`, `identity-key.pem`, and `agent.json` under `~/.cullis/identity/`.
 
-Expected terminal output (elided):
+Expected CLI output (elided):
 
 ```
 [cullis-connector] Generated fresh P-256 keypair (~/.cullis/identity/identity-key.pem)
@@ -92,14 +113,16 @@ Expected terminal output (elided):
 
 Time to approval depends on your admin; the default session TTL is 1 hour.
 
-## 3. Launch the dashboard
+## 3. Open the dashboard
+
+If you used the dashboard wizard in step 2, you're already on it. To re-open later:
 
 ```bash
 cullis-connector dashboard
 # Connector dashboard running at http://127.0.0.1:7777
 ```
 
-Open `http://127.0.0.1:7777` in your browser. The Overview tab shows your enrollment details (agent id, org, Mastio URL), a list of MCP resources you're bound to, and a link to wire up your MCP client.
+Open `http://127.0.0.1:7777` in your browser. The Connected view shows your enrollment details (agent id, org, Mastio URL), MCP resources you're bound to, and a card per detected MCP client.
 
 For a tray icon + native webview (no browser tab), use the optional desktop shell:
 
@@ -112,16 +135,37 @@ Platform notes:
 
 - **macOS / Windows 10+**: nothing extra to install.
 - **Linux**: install `gtk3` + `webkit2gtk` from your distro (`apt install libgtk-3-0 libwebkit2gtk-4.1-0`).
+- **NixOS**: the `desktop` shell currently fails on NixOS because `pystray` and `pywebview` can't bind to the system tray under the Nix store layout. Use `cullis-connector dashboard` (browser-based) instead.
 
-## 4. Wire up your MCP client
+## 4. How identity binds to your IDEs
 
-The dashboard's **Connected** tab has one-click cards for every MCP client the Connector auto-detects on your machine. For Claude Code CLI:
+Three things to internalise before you click around in step 5; none of them are optional reading.
+
+**One identity per machine, shared by every IDE.** The enrolment in step 2 creates *one* keypair + cert under `~/.cullis/identity/`. Every MCP client you wire up — Cline, Cursor, Zed, Windsurf, Claude Desktop, Claude Code CLI — invokes the same `cullis-connector serve` binary, which holds that single identity. From the network's point of view all of them are the same agent. There is no per-IDE enrolment.
+
+> If you genuinely need separate identities on the same laptop (e.g. a personal bot and a work bot), the Connector supports **profiles** — see [Multi-profile setup](https://github.com/cullis-security/cullis/blob/main/cullis_connector/README.md#multiple-profiles-on-the-same-machine). It is rarely what people want.
+
+**The Connector is model-agnostic.** Cullis exposes its tools (`list_agents`, `open_session`, `send_message`, …) over MCP. The MCP protocol doesn't care which LLM your client is talking to. So if you switch Cline from Claude to Gemini to a local Ollama model, the Cullis tools keep working. The identity is yours, not the model's. This is the whole point: Cullis is the trust + audit layer, not the AI.
+
+**Detected ≠ Configured.** The dashboard shows cards for every IDE it finds on disk:
+
+- **Configured** — the MCP entry for `cullis` is already in that IDE's config file. Nothing to do.
+- **Detected** — the IDE is installed but its config file doesn't mention Cullis yet. Click the card to write the entry.
+- **Not detected** — the IDE isn't installed (or, for Cline specifically, the VS Code extension `saoudrizwan.claude-dev` hasn't been installed yet — `code --install-extension saoudrizwan.claude-dev` and restart VS Code).
+
+The dashboard never writes to a client's config without an explicit click. Detection only tells you "I see this IDE installed", not "I patched it for you". If you launch a new IDE while the dashboard is open, refresh the page — detection re-runs on every page load.
+
+## 5. Wire up your MCP client
+
+In the dashboard's **Connected** view, click each IDE card you want to bind to Cullis. The Connector merges a `cullis` MCP entry into that IDE's config file (atomic write, backup of any pre-existing file goes to `~/.cullis/backups/`). **Restart the IDE** afterwards — most MCP clients only re-read their server list at startup.
+
+For Claude Code CLI specifically, the dashboard shells out to:
 
 ```bash
 claude mcp add cullis --scope user -- cullis-connector serve
 ```
 
-Manual config for clients that don't have a dashboard card — `~/.config/Claude/claude_desktop_config.json` (Claude Desktop), `~/.cursor/mcp.json` (Cursor), and similar paths:
+If your MCP client isn't auto-detected (custom build, unusual install path), use the **Other MCP client** card on the same view: it copies the JSON snippet to your clipboard so you can paste it into the right config file by hand. The snippet is:
 
 ```json
 {
@@ -134,9 +178,11 @@ Manual config for clients that don't have a dashboard card — `~/.config/Claude
 }
 ```
 
-Restart the MCP client. Your cullis tools (`list_agents`, `open_session`, `send_message`, etc.) should appear.
+Common file paths if you're patching by hand: `~/.config/Claude/claude_desktop_config.json` (Claude Desktop), `~/.cursor/mcp.json` (Cursor), `~/.codeium/windsurf/mcp_config.json` (Windsurf). Zed uses a different key — `context_servers`, not `mcpServers` — inside `~/.config/zed/settings.json`.
 
-## 5. Autostart on login (optional)
+Once you restart the client, your Cullis tools (`list_agents`, `open_session`, `send_message`, etc.) should appear in its tool list.
+
+## 6. Autostart on login (optional)
 
 ```bash
 cullis-connector install-autostart


### PR DESCRIPTION
## Summary

Tightens `docs/install/connector.md` based on a real first-run walkthrough that surfaced three things the doc was silent on, all of which are confusion points an early design partner is likely to hit.

- **Dashboard wizard promoted to Option A** for enrolment. The page used to show only the 5-flag CLI invocation; the friendlier 3-step `/setup` wizard wasn't even mentioned. CLI stays as Option B for headless setups.
- **New section "How identity binds to your IDEs"** that puts three facts up front before the user starts clicking IDE cards:
  - One identity per machine, shared by every IDE (no per-IDE enrolment).
  - The Connector is model-agnostic — switching the underlying LLM in the client doesn't break Cullis tools.
  - Detected vs Configured vs Not detected on the IDE cards mean three different things; Cline specifically requires `code --install-extension saoudrizwan.claude-dev` first.
- **NixOS callout** under "Open the dashboard": `cullis-connector desktop` (pystray + pywebview) doesn't work under the Nix store, fall back to the browser dashboard.

Also bumps `updated:` and renumbers Autostart 5 → 6 since a new section landed in front of it.

## Test plan

- [ ] `cd site && npm run build` succeeds (frontmatter + Markdown unchanged structurally)
- [ ] Render `cullis.io/docs/install/connector` locally; section numbering 1-6 is contiguous and the new "How identity binds to your IDEs" block reads as intended
- [ ] No broken anchors — the only new internal link is the existing GitHub README multi-profile section