### PR TITLE
feat(egress): add ai_gateway dispatcher + /v1/llm/chat router

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -51,6 +51,17 @@ class Settings(BaseSettings):
     injection_llm_judge_enabled: bool = True
     injection_llm_confidence_threshold: float = 0.7
 
+    # ADR-017 Phase 1 — AI gateway egress (LLM calls forwarded to a managed
+    # gateway like Portkey / LiteLLM / Kong). Mastio reconstructs the agent
+    # identity from the DPoP-bound cert and injects it as a trusted header
+    # toward the gateway. The provider key (e.g. ANTHROPIC_API_KEY) is
+    # passed via Bearer in this spike; KMS-stored managed-virtual-keys are
+    # the Phase 3 hardening (see imp/portkey-integration-mapping.md).
+    ai_gateway_backend: str = "portkey"          # "portkey" | "litellm" | "kong"
+    ai_gateway_url: str = "http://localhost:8787"
+    ai_gateway_provider: str = "anthropic"       # gateway-side provider slug
+    ai_gateway_request_timeout_s: float = 30.0
+
     # Redis — used for DPoP JTI store, rate limiting, and WebSocket pub/sub.
     # Empty string disables Redis; all components fall back to in-memory.
     redis_url: str = ""

--- a/app/egress/__init__.py
+++ b/app/egress/__init__.py
@@ -1,0 +1,8 @@
+"""ADR-017 Phase 1 — AI gateway egress.
+
+Mastio forwards authenticated LLM calls to a managed AI gateway
+(Portkey / LiteLLM / Kong) and stamps the call with the trusted
+agent identity reconstructed from the DPoP-bound client cert. The
+gateway never sees the raw Mastio token; the agent never sees the
+provider API key. Audit chain captures latency + token usage.
+"""

--- a/app/egress/ai_gateway.py
+++ b/app/egress/ai_gateway.py
@@ -1,0 +1,185 @@
+"""AI gateway dispatch (ADR-017 Phase 1).
+
+The dispatcher takes an OpenAI-compatible ChatCompletionRequest plus the
+trusted agent identity (already reconstructed from the DPoP-bound cert
+by the router) and forwards the call to the configured gateway. The
+agent identity is injected as both the gateway-native attribution
+header (e.g. x-portkey-metadata._user) and a canonical Cullis header
+(X-Cullis-Agent) propagated through to the upstream provider, so audit
+correlations work whether the dashboard speaks Cullis or gateway-native.
+
+Phase 1 supports Portkey only. LiteLLM and Kong land in Phase 2 once
+the smoke test confirms the contract.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+
+import httpx
+
+from app.config import Settings
+from app.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
+
+_log = logging.getLogger("agent_trust.egress")
+
+
+CULLIS_FORWARD_HEADERS = "X-Cullis-Agent,X-Cullis-Org,X-Cullis-Trace"
+
+
+@dataclass
+class GatewayResult:
+    response: ChatCompletionResponse
+    latency_ms: int
+    upstream_request_id: str | None
+    backend: str
+    provider: str
+
+
+class GatewayError(Exception):
+    """Raised on any non-recoverable failure talking to the gateway.
+
+    `status_code` is the HTTP code Mastio should return to its own
+    caller; `reason` is a short tag suitable for the audit row.
+    """
+
+    def __init__(self, status_code: int, reason: str, *, detail: str | None = None):
+        super().__init__(detail or reason)
+        self.status_code = status_code
+        self.reason = reason
+        self.detail = detail
+
+
+async def dispatch(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+    http_client: httpx.AsyncClient | None = None,
+) -> GatewayResult:
+    backend = settings.ai_gateway_backend.lower()
+    if backend == "portkey":
+        return await _call_portkey(
+            req=req,
+            agent_id=agent_id,
+            org_id=org_id,
+            trace_id=trace_id,
+            settings=settings,
+            http_client=http_client,
+        )
+    raise GatewayError(
+        501,
+        f"backend_not_implemented:{backend}",
+        detail=f"AI gateway backend '{backend}' is not wired in Phase 1.",
+    )
+
+
+async def _call_portkey(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+    http_client: httpx.AsyncClient | None,
+) -> GatewayResult:
+    provider = settings.ai_gateway_provider.lower()
+    if provider != "anthropic":
+        raise GatewayError(
+            501,
+            f"provider_not_implemented:{provider}",
+            detail="Phase 1 only validates provider='anthropic' against Portkey.",
+        )
+
+    if not settings.anthropic_api_key:
+        raise GatewayError(503, "provider_key_missing")
+
+    upstream_url = f"{settings.ai_gateway_url.rstrip('/')}/v1/chat/completions"
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {settings.anthropic_api_key}",
+        "x-portkey-provider": provider,
+        "x-portkey-trace-id": trace_id,
+        "x-portkey-forward-headers": CULLIS_FORWARD_HEADERS,
+        "x-portkey-metadata": json.dumps(
+            {"_user": agent_id, "org_id": org_id, "trace_id": trace_id},
+            separators=(",", ":"),
+        ),
+        "X-Cullis-Agent": agent_id,
+        "X-Cullis-Org": org_id,
+        "X-Cullis-Trace": trace_id,
+    }
+
+    body = req.model_dump(exclude_none=True)
+
+    started = time.perf_counter()
+    owns_client = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=settings.ai_gateway_request_timeout_s)
+    try:
+        try:
+            resp = await client.post(upstream_url, headers=headers, json=body)
+        except httpx.TimeoutException as exc:
+            raise GatewayError(504, "upstream_timeout", detail=str(exc)) from exc
+        except httpx.HTTPError as exc:
+            raise GatewayError(502, "upstream_unreachable", detail=str(exc)) from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    latency_ms = int((time.perf_counter() - started) * 1000)
+
+    if resp.status_code // 100 != 2:
+        # Surface the upstream body in the audit detail (capped) so
+        # operators can debug without re-running the call.
+        detail = resp.text[:512] if resp.text else None
+        raise GatewayError(
+            502,
+            f"upstream_status_{resp.status_code}",
+            detail=detail,
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise GatewayError(502, "malformed_upstream_body", detail=str(exc)) from exc
+
+    payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
+    payload.setdefault("object", "chat.completion")
+    payload.setdefault("created", int(time.time()))
+    payload.setdefault("model", req.model)
+    payload["cullis_trace_id"] = trace_id
+
+    try:
+        parsed = ChatCompletionResponse.model_validate(payload)
+    except Exception as exc:  # pydantic ValidationError or similar
+        raise GatewayError(
+            502,
+            "schema_mismatch",
+            detail=f"Upstream payload failed Mastio schema: {exc}",
+        ) from exc
+
+    upstream_request_id = (
+        resp.headers.get("x-portkey-request-id")
+        or resp.headers.get("x-request-id")
+    )
+
+    _log.info(
+        "egress.llm dispatched backend=portkey provider=%s agent=%s org=%s "
+        "model=%s latency_ms=%d tokens_in=%d tokens_out=%d",
+        provider, agent_id, org_id, parsed.model, latency_ms,
+        parsed.usage.prompt_tokens, parsed.usage.completion_tokens,
+    )
+
+    return GatewayResult(
+        response=parsed,
+        latency_ms=latency_ms,
+        upstream_request_id=upstream_request_id,
+        backend="portkey",
+        provider=provider,
+    )

--- a/app/egress/router.py
+++ b/app/egress/router.py
@@ -1,0 +1,96 @@
+"""POST /v1/llm/chat — DPoP-authenticated egress to the AI gateway.
+
+Mastio strips/ignores any client-supplied identity headers and re-stamps
+the call with the agent_id reconstructed from the DPoP-bound JWT. This
+is the trust boundary: a compromised connector cannot impersonate
+another agent on the gateway dashboard, because the gateway only ever
+sees the Mastio-injected `X-Cullis-Agent` (the connector's own header
+on the same name is overwritten in the dispatcher).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.config import get_settings
+from app.db.audit import log_event
+from app.db.database import get_db
+from app.egress.ai_gateway import GatewayError, dispatch
+from app.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
+
+_log = logging.getLogger("agent_trust.egress")
+
+router = APIRouter(prefix="/llm", tags=["llm-egress"])
+
+
+@router.post("/chat", response_model=ChatCompletionResponse)
+async def chat_completion(
+    req: ChatCompletionRequest,
+    p: TokenPayload = Depends(get_current_agent),
+    db: AsyncSession = Depends(get_db),
+) -> ChatCompletionResponse:
+    if req.stream:
+        # SSE forwarding lands in Phase 2 once the audit chain is wired
+        # to record streamed token totals at the end-of-stream marker.
+        raise HTTPException(
+            status_code=400,
+            detail="stream=true is not supported in Phase 1.",
+        )
+
+    settings = get_settings()
+    trace_id = f"trace_{uuid.uuid4().hex[:16]}"
+
+    try:
+        result = await dispatch(
+            req=req,
+            agent_id=p.agent_id,
+            org_id=p.org,
+            trace_id=trace_id,
+            settings=settings,
+        )
+    except GatewayError as exc:
+        await log_event(
+            db,
+            event_type="egress.llm.request",
+            result="error",
+            agent_id=p.agent_id,
+            org_id=p.org,
+            details={
+                "backend": settings.ai_gateway_backend,
+                "provider": settings.ai_gateway_provider,
+                "model": req.model,
+                "trace_id": trace_id,
+                "reason": exc.reason,
+                "upstream_detail": exc.detail,
+            },
+        )
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"reason": exc.reason, "trace_id": trace_id},
+        ) from exc
+
+    await log_event(
+        db,
+        event_type="egress.llm.request",
+        result="ok",
+        agent_id=p.agent_id,
+        org_id=p.org,
+        details={
+            "backend": result.backend,
+            "provider": result.provider,
+            "model": result.response.model,
+            "trace_id": trace_id,
+            "upstream_request_id": result.upstream_request_id,
+            "latency_ms": result.latency_ms,
+            "prompt_tokens": result.response.usage.prompt_tokens,
+            "completion_tokens": result.response.usage.completion_tokens,
+            "total_tokens": result.response.usage.total_tokens,
+        },
+    )
+
+    return result.response

--- a/app/egress/schemas.py
+++ b/app/egress/schemas.py
@@ -1,0 +1,52 @@
+"""OpenAI Chat Completion subset used by the egress endpoint.
+
+Kept intentionally minimal: enough for the spike (Portkey → Anthropic
+Haiku 4.5) without dragging in streaming / tool-use / function-calling
+which Phase 1 explicitly defers.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+ChatRole = Literal["system", "user", "assistant", "tool"]
+
+
+class ChatMessage(BaseModel):
+    role: ChatRole
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str = Field(..., description="Model id forwarded as-is to the gateway.")
+    messages: list[ChatMessage] = Field(..., min_length=1)
+    max_tokens: int | None = Field(None, ge=1, le=8192)
+    temperature: float | None = Field(None, ge=0.0, le=2.0)
+    # stream=true is rejected at the router until Phase 2 wires SSE through.
+    stream: bool = False
+
+
+class ChatCompletionUsage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ChatCompletionChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: str | None = None
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatCompletionChoice]
+    usage: ChatCompletionUsage = Field(default_factory=ChatCompletionUsage)
+    # Mastio-injected trace id propagated end-to-end so the caller can
+    # correlate its log with the gateway dashboard and the audit row.
+    cullis_trace_id: str

--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,7 @@ from app.broker.router import router as broker_router
 from app.policy.router import router as policy_router
 from app.onboarding.router import onboarding_router, admin_router
 from app.dashboard.router import router as dashboard_router
+from app.egress.router import router as egress_router
 
 settings = get_settings()
 
@@ -376,6 +377,7 @@ v1.include_router(broker_router)
 v1.include_router(policy_router)
 v1.include_router(onboarding_router)
 v1.include_router(admin_router)
+v1.include_router(egress_router)
 
 # ADR-001 Phase 4a — federation event stream for proxies to mirror
 # broker state (agent lifecycle, policies, bindings) via SSE.

--- a/tests/test_egress_ai_gateway.py
+++ b/tests/test_egress_ai_gateway.py
@@ -1,0 +1,352 @@
+"""ADR-017 Phase 1 — egress AI gateway dispatcher + /v1/llm/chat router.
+
+The dispatcher is exercised against a httpx MockTransport so we can
+assert the exact set of headers Mastio injects toward Portkey (the
+trust boundary requirement: agent identity comes from the DPoP-bound
+token, never from the client). The router is exercised with
+``dependency_overrides`` to skip the full DPoP/JWT dance — that path
+is covered by the auth suite. Here we only care that the router maps
+GatewayError to HTTP correctly and writes the right audit row.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.config import Settings
+from app.db.audit import AuditLog
+from app.egress import ai_gateway as ai_gateway_mod
+from app.egress.ai_gateway import (
+    CULLIS_FORWARD_HEADERS,
+    GatewayError,
+    GatewayResult,
+    dispatch,
+)
+from app.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
+from app.main import app
+
+
+def _settings(**overrides) -> Settings:
+    base = dict(
+        admin_secret="test-secret-not-default",
+        ai_gateway_backend="portkey",
+        ai_gateway_url="http://gw.test",
+        ai_gateway_provider="anthropic",
+        anthropic_api_key="sk-test",
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "ping"}],
+        max_tokens=16,
+    )
+
+
+def _portkey_payload() -> dict:
+    return {
+        "id": "chatcmpl-upstream-1",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "claude-haiku-4-5",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 3,
+            "total_tokens": 15,
+        },
+    }
+
+
+# ── Dispatcher ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_portkey_injects_trusted_headers_and_parses_response():
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json=_portkey_payload(),
+            headers={"x-portkey-request-id": "pk_req_42"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        result = await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="trace_abc",
+            settings=_settings(),
+            http_client=client,
+        )
+
+    assert isinstance(result, GatewayResult)
+    assert result.backend == "portkey"
+    assert result.provider == "anthropic"
+    assert result.upstream_request_id == "pk_req_42"
+    assert result.response.choices[0].message.content == "pong"
+    assert result.response.usage.prompt_tokens == 12
+    assert result.response.cullis_trace_id == "trace_abc"
+
+    # Trust-boundary assertions: Mastio must overwrite identity headers
+    # with values derived from the authenticated agent, regardless of
+    # what the client sent.
+    assert captured["url"] == "http://gw.test/v1/chat/completions"
+    h = captured["headers"]
+    assert h["authorization"] == "Bearer sk-test"
+    assert h["x-portkey-provider"] == "anthropic"
+    assert h["x-portkey-trace-id"] == "trace_abc"
+    assert h["x-portkey-forward-headers"] == CULLIS_FORWARD_HEADERS
+    assert h["x-cullis-agent"] == "acme::mario"
+    assert h["x-cullis-org"] == "acme"
+    assert h["x-cullis-trace"] == "trace_abc"
+    meta = json.loads(h["x-portkey-metadata"])
+    assert meta == {"_user": "acme::mario", "org_id": "acme", "trace_id": "trace_abc"}
+    # Body must be the OpenAI-compat request (no Mastio fields leaked).
+    assert captured["body"]["model"] == "claude-haiku-4-5"
+    assert captured["body"]["messages"][0]["content"] == "ping"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_portkey_upstream_5xx_raises_gateway_error():
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="upstream pool drained")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GatewayError) as exc_info:
+            await dispatch(
+                req=_request(),
+                agent_id="acme::mario",
+                org_id="acme",
+                trace_id="t1",
+                settings=_settings(),
+                http_client=client,
+            )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.reason == "upstream_status_503"
+    assert "drained" in (exc_info.value.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_portkey_malformed_body_raises_gateway_error():
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"not json")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(GatewayError) as exc_info:
+            await dispatch(
+                req=_request(),
+                agent_id="acme::mario",
+                org_id="acme",
+                trace_id="t1",
+                settings=_settings(),
+                http_client=client,
+            )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.reason == "malformed_upstream_body"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_portkey_missing_provider_key():
+    with pytest.raises(GatewayError) as exc_info:
+        await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="t1",
+            settings=_settings(anthropic_api_key=""),
+        )
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.reason == "provider_key_missing"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unimplemented_backend_returns_501():
+    with pytest.raises(GatewayError) as exc_info:
+        await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="t1",
+            settings=_settings(ai_gateway_backend="litellm"),
+        )
+    assert exc_info.value.status_code == 501
+    assert exc_info.value.reason == "backend_not_implemented:litellm"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unimplemented_provider_returns_501():
+    with pytest.raises(GatewayError) as exc_info:
+        await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="t1",
+            settings=_settings(ai_gateway_provider="openai"),
+        )
+    assert exc_info.value.status_code == 501
+    assert exc_info.value.reason.startswith("provider_not_implemented:openai")
+
+
+# ── Router ──────────────────────────────────────────────────────────────
+
+
+def _override_agent(agent_id: str = "acme::mario", org: str = "acme") -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.local/{org}/{agent_id.split('::')[-1]}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=1_000_000_000,
+        jti="jti-test",
+        scope=[],
+        cnf={"jkt": "test-jkt"},
+    )
+
+
+@pytest.fixture
+def authed_agent():
+    """Skip the DPoP/JWT dance for router-level tests."""
+    app.dependency_overrides[get_current_agent] = lambda: _override_agent()
+    yield
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_writes_audit_ok(client, authed_agent, db_session):
+    fake_result = GatewayResult(
+        response=ChatCompletionResponse.model_validate(
+            {**_portkey_payload(), "cullis_trace_id": "trace_xyz"}
+        ),
+        latency_ms=42,
+        upstream_request_id="pk_req_99",
+        backend="portkey",
+        provider="anthropic",
+    )
+
+    with patch.object(
+        ai_gateway_mod, "dispatch", new=AsyncMock(return_value=fake_result),
+    ):
+        # The router imports ``dispatch`` by name, so patch the binding
+        # in the router module too.
+        with patch("app.egress.router.dispatch", new=AsyncMock(return_value=fake_result)):
+            r = await client.post(
+                "/v1/llm/chat",
+                json={
+                    "model": "claude-haiku-4-5",
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "max_tokens": 16,
+                },
+            )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["choices"][0]["message"]["content"] == "pong"
+    assert body["cullis_trace_id"] == "trace_xyz"
+
+    # Filter by trace id — the in-memory test DB is session-scoped and
+    # accumulates rows across tests in this file.
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(AuditLog.event_type == "egress.llm.request")
+        )
+    ).scalars().all()
+    matching = [
+        r for r in rows if r.details and json.loads(r.details).get("upstream_request_id") == "pk_req_99"
+    ]
+    assert len(matching) == 1
+    row = matching[0]
+    assert row.result == "ok"
+    assert row.agent_id == "acme::mario"
+    assert row.org_id == "acme"
+    details = json.loads(row.details)
+    assert details["backend"] == "portkey"
+    assert details["provider"] == "anthropic"
+    assert details["model"] == "claude-haiku-4-5"
+    assert details["latency_ms"] == 42
+    assert details["prompt_tokens"] == 12
+    assert details["completion_tokens"] == 3
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_maps_gateway_error_and_logs_denied(
+    client, authed_agent, db_session,
+):
+    err = GatewayError(504, "upstream_timeout", detail="boom")
+    with patch("app.egress.router.dispatch", new=AsyncMock(side_effect=err)):
+        r = await client.post(
+            "/v1/llm/chat",
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "ping"}],
+            },
+        )
+    assert r.status_code == 504
+    body = r.json()
+    assert body["detail"]["reason"] == "upstream_timeout"
+
+    rows = (
+        await db_session.execute(
+            select(AuditLog).where(AuditLog.event_type == "egress.llm.request")
+        )
+    ).scalars().all()
+    error_rows = [
+        r for r in rows
+        if r.result == "error"
+        and r.details
+        and json.loads(r.details).get("upstream_detail") == "boom"
+    ]
+    assert len(error_rows) == 1
+    details = json.loads(error_rows[0].details)
+    assert details["reason"] == "upstream_timeout"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_rejects_streaming_phase1(client, authed_agent):
+    r = await client.post(
+        "/v1/llm/chat",
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "ping"}],
+            "stream": True,
+        },
+    )
+    assert r.status_code == 400
+    assert "stream" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_requires_dpop_auth(client):
+    # No dependency override here — the real DPoP gate runs and rejects.
+    r = await client.post(
+        "/v1/llm/chat",
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "ping"}],
+        },
+    )
+    assert r.status_code == 401
+    assert "DPoP" in r.text


### PR DESCRIPTION
## Summary

- ADR-017 Phase 1. Mastio forwards DPoP-authenticated chat completions to a managed AI gateway (Portkey in Phase 1) and stamps the call with the agent identity reconstructed from the bound cert. The gateway never sees the raw client headers, and the agent never sees the provider key.
- Audit chain captures latency + token usage per agent on every egress call (`event_type=egress.llm.request`).
- LiteLLM and Kong dispatchers raise `GatewayError(501)` until Phase 2 (paired with the Connector OpenAI-compat endpoint). Streaming is rejected (400) until SSE + end-of-stream token reconciliation lands. KMS-backed managed virtual keys are Phase 3.

## Test plan

- [x] `tests/test_egress_ai_gateway.py`: 10/10 green in ~4.5s. Covers dispatcher header injection (Authorization, x-portkey-provider, x-portkey-metadata._user, x-portkey-forward-headers, X-Cullis-Agent/Org/Trace), upstream 5xx, malformed body, missing provider key, unimplemented backend/provider, router DPoP gate, audit ok+error rows, stream reject.
- [x] `pytest tests/`: 2292 passed, 8 failed (all pre-existing: GUI libs in headless + postgres binding flakes).
- [x] Smoke A live: Mastio dispatcher to Portkey OSS to Anthropic Haiku 4.5, HTTP 200, 1.3s, 15+5 tokens, "pong" reply. Script in `imp/sandbox-gateways/test/spike_dispatch_live.py` (gitignored).
- [ ] Smoke B (full Mastio HTTP server + Connector client): Phase 2 once the Connector exposes `/v1/chat/completions`.