### PR TITLE
feat(proxy): OpenAI-compatible /v1/chat/completions endpoint

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -2779,6 +2779,24 @@ class CullisClient:
             resp.raise_for_status()
             return resp.json()
 
+    # ── ADR-017 — AI gateway egress ────────────────────────────────
+    def chat_completion(self, request: dict) -> dict:
+        """Forward an OpenAI-compatible chat completion to Mastio's
+        ``/v1/llm/chat`` endpoint, which dispatches to the configured
+        AI gateway (Phase 1: Portkey).
+
+        ``request`` is the OpenAI ChatCompletion body (model, messages,
+        max_tokens, temperature). Returns the parsed response dict
+        including ``cullis_trace_id`` injected by Mastio.
+
+        Raises ``httpx.HTTPStatusError`` on non-2xx with the upstream
+        body intact so callers can distinguish 401 (unauth), 502
+        (gateway upstream), 504 (timeout), 501 (not implemented).
+        """
+        resp = self._authed_request("POST", "/v1/llm/chat", json=request)
+        resp.raise_for_status()
+        return resp.json()
+
 
 class WebSocketConnection:
     """Authenticated WebSocket connection with heartbeat + auto-reconnect (M2).

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -1,0 +1,166 @@
+"""ADR-017 Phase 2 — OpenAI-compatible chat completions endpoint.
+
+This router exposes ``POST /v1/chat/completions`` on the proxy so a
+custom agent that already speaks the OpenAI Chat Completions API
+(e.g. an in-house worker, an OpenAI Python SDK pointed at a different
+``base_url``) can be routed through Cullis without code changes:
+
+  agent (mTLS+DPoP) → mcp_proxy /v1/chat/completions
+                    → Mastio /v1/llm/chat
+                    → AI gateway (Portkey)
+                    → upstream provider (Anthropic Haiku 4.5)
+
+The proxy authenticates the agent via the same mTLS+DPoP pair used by
+the rest of ``mcp_proxy.egress.router`` (ADR-014), looks up the
+agent's CullisClient via ``BrokerBridge``, and forwards the body
+through the SDK's ``chat_completion`` helper. Mastio re-stamps the
+identity from its own DPoP-bound JWT and writes the egress audit row;
+the proxy writes its own local audit row so the on-VM operator can
+see the call without querying Mastio.
+
+Standalone-mode proxies (no broker attached) reject with 400 — there
+is no fallback to direct Portkey, by design: we want every LLM call
+to traverse Mastio's control plane.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+from typing import Literal
+
+from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.db import log_audit
+from mcp_proxy.models import InternalAgent
+
+logger = logging.getLogger("mcp_proxy.egress.llm_chat")
+
+router = APIRouter(tags=["llm-chat"])
+
+
+ChatRole = Literal["system", "user", "assistant", "tool"]
+
+
+class ChatMessage(BaseModel):
+    role: ChatRole
+    content: str
+
+
+class ChatCompletionRequest(BaseModel):
+    """OpenAI-compatible request. Kept as a pydantic model only for
+    validation; the body is passed through to Mastio as a dict so
+    fields the proxy does not know about (e.g. provider-specific
+    extras) survive the round trip when Mastio adds support for them."""
+    model: str
+    messages: list[ChatMessage] = Field(..., min_length=1)
+    max_tokens: int | None = Field(None, ge=1, le=8192)
+    temperature: float | None = Field(None, ge=0.0, le=2.0)
+    stream: bool = False
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(
+    req: ChatCompletionRequest,
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
+) -> dict:
+    if req.stream:
+        raise HTTPException(
+            status_code=400,
+            detail="stream=true is not supported in Phase 2.",
+        )
+
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "broker_bridge not initialized — proxy is in standalone mode "
+                "or the broker is unreachable. /v1/chat/completions requires "
+                "a Mastio-attached proxy by design (ADR-017)."
+            ),
+        )
+
+    started = time.perf_counter()
+    body = req.model_dump(exclude_none=True)
+
+    try:
+        client = await bridge.get_client(agent.agent_id)
+    except Exception as exc:
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_llm_chat",
+            status="error",
+            detail=f"broker_bridge_get_client_failed: {exc}",
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"failed to obtain authenticated broker client: {exc}",
+        ) from exc
+
+    try:
+        # CullisClient.chat_completion is synchronous httpx; bounce it
+        # off the default thread pool so the proxy event loop is not
+        # blocked while Portkey + Anthropic process the request.
+        response = await asyncio.to_thread(client.chat_completion, body)
+    except httpx.HTTPStatusError as exc:
+        upstream_status = exc.response.status_code
+        upstream_text = (exc.response.text or "")[:512]
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_llm_chat",
+            status="error",
+            detail=(
+                f"upstream_status={upstream_status} "
+                f"model={req.model} body={upstream_text}"
+            ),
+        )
+        # Forward the original status so the client can distinguish
+        # 401 (broker unauth), 502 (gateway), 504 (timeout), 501 (provider).
+        raise HTTPException(
+            status_code=upstream_status,
+            detail={
+                "reason": "mastio_upstream_error",
+                "upstream_status": upstream_status,
+                "upstream_body": upstream_text,
+            },
+        ) from exc
+    except Exception as exc:
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_llm_chat",
+            status="error",
+            detail=f"unexpected_error: {exc}",
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"egress LLM call failed: {exc}",
+        ) from exc
+
+    latency_ms = int((time.perf_counter() - started) * 1000)
+    usage = response.get("usage", {}) if isinstance(response, dict) else {}
+    trace_id = response.get("cullis_trace_id") if isinstance(response, dict) else None
+
+    await log_audit(
+        agent_id=agent.agent_id,
+        action="egress_llm_chat",
+        status="success",
+        detail=(
+            f"model={req.model} "
+            f"trace_id={trace_id or 'n/a'} "
+            f"latency_ms={latency_ms} "
+            f"prompt_tokens={usage.get('prompt_tokens', 0)} "
+            f"completion_tokens={usage.get('completion_tokens', 0)}"
+        ),
+    )
+
+    logger.info(
+        "egress_llm_chat agent=%s model=%s latency_ms=%d trace_id=%s",
+        agent.agent_id, req.model, latency_ms, trace_id,
+    )
+
+    return response

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -985,6 +985,11 @@ app.include_router(mcp_aggregator_router)
 from mcp_proxy.egress.router import router as egress_router
 app.include_router(egress_router)
 
+# ADR-017 Phase 2 — OpenAI-compatible /v1/chat/completions on the proxy.
+# Routes through Mastio /v1/llm/chat to the configured AI gateway.
+from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+app.include_router(llm_chat_router)
+
 # ADR-008 Phase 1 PR #1 — sessionless one-shot endpoints.
 from mcp_proxy.egress.oneshot import router as oneshot_router
 app.include_router(oneshot_router)

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -1,0 +1,228 @@
+"""ADR-017 Phase 2 — proxy /v1/chat/completions endpoint.
+
+The router is exercised in isolation: a minimal FastAPI app mounts
+only the llm_chat_router with the mTLS+DPoP dep overridden to return
+a fixed InternalAgent. The proxy DB is initialized in a temp sqlite
+so log_audit can write its hash-chained rows. The broker_bridge on
+app.state is patched to return a mock CullisClient whose
+chat_completion is monkey-patched to whatever the test needs.
+
+We never try to set up real broker auth here — the SDK's
+chat_completion (and its DPoP dance) is covered by the broker-side
+test_egress_ai_gateway suite shipped in PR #401.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from sqlalchemy import text
+
+from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+from mcp_proxy.models import InternalAgent
+
+
+async def _audit_rows(action: str, status: str | None = None) -> list[dict]:
+    """Read back audit rows for assertions. Direct SQL because the
+    proxy module exposes only a hash-chain verifier, not a query API.
+    """
+    sql = "SELECT agent_id, action, status, detail FROM audit_log WHERE action = :a"
+    params = {"a": action}
+    if status is not None:
+        sql += " AND status = :s"
+        params["s"] = status
+    sql += " ORDER BY chain_seq ASC"
+    async with get_db() as conn:
+        result = await conn.execute(text(sql), params)
+        return [dict(r._mapping) for r in result.fetchall()]
+
+
+def _agent() -> InternalAgent:
+    return InternalAgent(
+        agent_id="orga::alice",
+        display_name="alice",
+        capabilities=["llm.chat"],
+        created_at="2026-05-03T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt="jkt-test",
+        reach="both",
+    )
+
+
+def _request_body() -> dict:
+    return {
+        "model": "claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 16,
+    }
+
+
+def _mastio_response() -> dict:
+    return {
+        "id": "chatcmpl-mastio-1",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "claude-haiku-4-5",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 3,
+            "total_tokens": 15,
+        },
+        "cullis_trace_id": "trace_proxy_test",
+    }
+
+
+@pytest_asyncio.fixture
+async def app_with_router(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    await init_db(url)
+
+    test_app = FastAPI()
+    test_app.include_router(llm_chat_router)
+    test_app.dependency_overrides[get_agent_from_dpop_client_cert] = _agent
+
+    yield test_app
+
+    test_app.dependency_overrides.clear()
+    await dispose_db()
+
+
+def _attach_bridge(app: FastAPI, *, chat_response: dict | None = None,
+                   chat_exc: Exception | None = None,
+                   get_client_exc: Exception | None = None):
+    """Wire a fake broker_bridge onto app.state.
+
+    chat_response / chat_exc control what the SDK call returns.
+    get_client_exc simulates a broker-bridge bootstrap failure.
+    """
+    fake_client = MagicMock()
+    if chat_exc is not None:
+        fake_client.chat_completion = MagicMock(side_effect=chat_exc)
+    else:
+        fake_client.chat_completion = MagicMock(return_value=chat_response or {})
+
+    fake_bridge = MagicMock()
+    if get_client_exc is not None:
+        fake_bridge.get_client = AsyncMock(side_effect=get_client_exc)
+    else:
+        fake_bridge.get_client = AsyncMock(return_value=fake_client)
+    app.state.broker_bridge = fake_bridge
+    return fake_bridge, fake_client
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_happy_path_writes_audit(app_with_router):
+    bridge, fake_client = _attach_bridge(
+        app_with_router, chat_response=_mastio_response(),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["choices"][0]["message"]["content"] == "pong"
+    assert body["cullis_trace_id"] == "trace_proxy_test"
+
+    bridge.get_client.assert_awaited_once_with("orga::alice")
+    fake_client.chat_completion.assert_called_once()
+    forwarded_body = fake_client.chat_completion.call_args.args[0]
+    assert forwarded_body["model"] == "claude-haiku-4-5"
+
+    rows = await _audit_rows("egress_llm_chat", status="success")
+    assert len(rows) == 1
+    assert rows[0]["agent_id"] == "orga::alice"
+    assert "trace_proxy_test" in (rows[0]["detail"] or "")
+    assert "prompt_tokens=12" in (rows[0]["detail"] or "")
+    assert "completion_tokens=3" in (rows[0]["detail"] or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_no_bridge_returns_503(app_with_router):
+    # Don't attach a bridge — simulate standalone-mode proxy.
+    app_with_router.state.broker_bridge = None
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 503
+    assert "standalone" in r.json()["detail"].lower() or "broker" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_forwards_upstream_status(app_with_router):
+    upstream_resp = httpx.Response(
+        status_code=504,
+        text='{"detail": {"reason": "upstream_timeout"}}',
+        request=httpx.Request("POST", "http://mastio/v1/llm/chat"),
+    )
+    err = httpx.HTTPStatusError("timeout", request=upstream_resp.request, response=upstream_resp)
+    _attach_bridge(app_with_router, chat_exc=err)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 504
+    body = r.json()
+    assert body["detail"]["reason"] == "mastio_upstream_error"
+    assert body["detail"]["upstream_status"] == 504
+
+    rows = await _audit_rows("egress_llm_chat", status="error")
+    assert len(rows) == 1
+    assert "upstream_status=504" in (rows[0]["detail"] or "")
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_rejects_streaming(app_with_router):
+    _attach_bridge(app_with_router, chat_response=_mastio_response())
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 400
+    assert "stream" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_get_client_failure_returns_502(app_with_router):
+    _attach_bridge(app_with_router, get_client_exc=RuntimeError("agent_credentials_missing"))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 502
+    assert "broker client" in r.json()["detail"].lower()
+
+    rows = await _audit_rows("egress_llm_chat", status="error")
+    assert len(rows) >= 1
+    assert any("broker_bridge_get_client_failed" in (r["detail"] or "") for r in rows)


### PR DESCRIPTION
## Summary

ADR-017 Phase 2. The mcp_proxy exposes `POST /v1/chat/completions` so any agent that already speaks the OpenAI Chat Completions API can be routed through Cullis without code changes:

```
agent (mTLS+DPoP) -> mcp_proxy /v1/chat/completions
                  -> Mastio /v1/llm/chat (PR #401)
                  -> AI gateway (Portkey)
                  -> upstream provider (Anthropic Haiku 4.5)
```

Key points:

- Auth via existing mTLS+DPoP cert gate (ADR-014). No new auth surface.
- Forwarding via `CullisClient.chat_completion`, a thin SDK wrapper around the existing `_authed_request` DPoP machinery.
- Audit on both sides: Mastio writes the canonical egress row, proxy writes a local row so the on-VM operator sees the call without querying Mastio. `cullis_trace_id` correlates them.
- Standalone-mode proxies reject 503 by design. No direct Portkey path. Every LLM call must traverse Mastio control plane.
- Streaming rejected 400 until SSE + end-of-stream token reconciliation lands.

## Test plan

- [x] `tests/test_proxy_llm_chat_router.py`: 5/5 green in ~10s. Covers happy path with audit row, 503 when bridge absent, upstream status forwarding + error audit row, stream reject, broker_bridge.get_client failure mapped to 502.
- [x] Full suite: 2297 passed, 8 failed (all pre-existing: GUI libs in headless + postgres binding flakes).
- [ ] Smoke B live (full proxy + Mastio + Portkey + Anthropic): script ready in `imp/sandbox-gateways/test/spike_proxy_chat_completions.py`. Execution requires the full local stack up (proxy + Mastio + sandbox-gateways + an enrolled intra-org agent). Smoke A from #401 already proved the dispatcher leg; this PR adds the proxy hop on top. Will execute end-to-end once the stack is brought up locally.