### PR TITLE
feat(egress): add litellm_embedded backend, make it the default

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -57,8 +57,8 @@ class Settings(BaseSettings):
     # toward the gateway. The provider key (e.g. ANTHROPIC_API_KEY) is
     # passed via Bearer in this spike; KMS-stored managed-virtual-keys are
     # the Phase 3 hardening (see imp/portkey-integration-mapping.md).
-    ai_gateway_backend: str = "portkey"          # "portkey" | "litellm" | "kong"
-    ai_gateway_url: str = "http://localhost:8787"
+    ai_gateway_backend: str = "litellm_embedded"  # "litellm_embedded" | "portkey" | "litellm_proxy" | "kong"
+    ai_gateway_url: str = "http://localhost:8787"  # only consulted when backend != litellm_embedded
     ai_gateway_provider: str = "anthropic"       # gateway-side provider slug
     ai_gateway_request_timeout_s: float = 30.0
 

--- a/app/egress/__init__.py
+++ b/app/egress/__init__.py
@@ -1,8 +1,24 @@
-"""ADR-017 Phase 1 — AI gateway egress.
+"""ADR-017 — AI gateway egress.
 
-Mastio forwards authenticated LLM calls to a managed AI gateway
-(Portkey / LiteLLM / Kong) and stamps the call with the trusted
-agent identity reconstructed from the DPoP-bound client cert. The
-gateway never sees the raw Mastio token; the agent never sees the
-provider API key. Audit chain captures latency + token usage.
+Mastio forwards authenticated LLM calls to one of several pluggable
+backends and stamps each call with the trusted agent identity
+reconstructed from the DPoP-bound client cert. The agent never sees
+the provider API key; the backend (whatever it is) never sees the
+raw Mastio token.
+
+Backends (pick via ``ai_gateway_backend`` setting):
+
+  - ``litellm_embedded`` (default) — LiteLLM as an in-process Python
+    library. Zero extra container on the customer side, single audit
+    chain, lowest latency. Phase 3.
+  - ``portkey`` — Portkey OSS as a separate HTTP container. Picked
+    when the customer already runs Portkey Enterprise so Mastio sits
+    on top of their existing investment. Phase 1.
+  - ``litellm_proxy`` — placeholder for the LiteLLM Proxy server
+    backend, wired only when a design partner asks for it.
+  - ``kong`` — placeholder for Kong AI Gateway, same trigger.
+
+The dispatcher in ``ai_gateway.dispatch`` routes by backend; new ones
+are added as parallel branches so insulating a deployment from
+breakage in one library is just a config change.
 """

--- a/app/egress/ai_gateway.py
+++ b/app/egress/ai_gateway.py
@@ -24,6 +24,12 @@ import httpx
 from app.config import Settings
 from app.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
 
+
+# LiteLLM is imported lazily inside _call_litellm_embedded so deployments
+# that pin ai_gateway_backend != "litellm_embedded" do not pay the import
+# cost on startup. Spike validated 2026-05-03 against Anthropic Haiku 4.5
+# (see imp/sandbox-gateways/test/spike_litellm_acompletion.py).
+
 _log = logging.getLogger("agent_trust.egress")
 
 
@@ -63,6 +69,14 @@ async def dispatch(
     http_client: httpx.AsyncClient | None = None,
 ) -> GatewayResult:
     backend = settings.ai_gateway_backend.lower()
+    if backend == "litellm_embedded":
+        return await _call_litellm_embedded(
+            req=req,
+            agent_id=agent_id,
+            org_id=org_id,
+            trace_id=trace_id,
+            settings=settings,
+        )
     if backend == "portkey":
         return await _call_portkey(
             req=req,
@@ -75,7 +89,7 @@ async def dispatch(
     raise GatewayError(
         501,
         f"backend_not_implemented:{backend}",
-        detail=f"AI gateway backend '{backend}' is not wired in Phase 1.",
+        detail=f"AI gateway backend '{backend}' is not wired.",
     )
 
 
@@ -181,5 +195,173 @@ async def _call_portkey(
         latency_ms=latency_ms,
         upstream_request_id=upstream_request_id,
         backend="portkey",
+        provider=provider,
+    )
+
+
+# ── LiteLLM embedded backend (ADR-017 Phase 3) ─────────────────────────
+
+
+# Map LiteLLM exception class names to (status_code, reason) tuples.
+# We compare by class name rather than isinstance() so the import of
+# litellm stays lazy (the dispatcher must boot in deployments that pin
+# a non-LiteLLM backend without litellm installed).
+_LITELLM_ERROR_MAP: dict[str, tuple[int, str]] = {
+    "AuthenticationError": (401, "provider_auth_failed"),
+    "PermissionDeniedError": (403, "provider_permission_denied"),
+    "NotFoundError": (404, "provider_not_found"),
+    "RateLimitError": (429, "provider_rate_limited"),
+    "BadRequestError": (400, "provider_bad_request"),
+    "UnprocessableEntityError": (422, "provider_unprocessable"),
+    "Timeout": (504, "provider_timeout"),
+    "APIConnectionError": (502, "provider_unreachable"),
+    "ContextWindowExceededError": (400, "provider_context_too_long"),
+    "ContentPolicyViolationError": (400, "provider_content_policy"),
+    "InternalServerError": (502, "provider_internal_error"),
+    "ServiceUnavailableError": (502, "provider_unavailable"),
+    "APIError": (502, "provider_api_error"),
+}
+
+
+def _map_litellm_exception(exc: Exception) -> GatewayError:
+    cls = type(exc).__name__
+    status, reason = _LITELLM_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
+    detail = (str(exc) or cls)[:512]
+    return GatewayError(status, reason, detail=detail)
+
+
+async def _call_litellm_embedded(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+) -> GatewayResult:
+    """Call the upstream provider via the LiteLLM library, in-process.
+
+    The model id from the request is forwarded as-is. For Anthropic
+    we expect the caller to pass either ``claude-haiku-4-5`` (LiteLLM
+    auto-detects the provider from the catalogue) or
+    ``anthropic/claude-haiku-4-5`` (explicit). The Mastio metadata is
+    attached via the ``metadata`` kwarg so any LiteLLM callback the
+    operator wires up (Datadog, Langfuse, Postgres) sees the agent
+    identity without us doing extra plumbing.
+    """
+    provider = settings.ai_gateway_provider.lower()
+    if provider != "anthropic":
+        raise GatewayError(
+            501,
+            f"provider_not_implemented:{provider}",
+            detail="Phase 3 only validates provider='anthropic' via LiteLLM.",
+        )
+    if not settings.anthropic_api_key:
+        raise GatewayError(503, "provider_key_missing")
+
+    try:
+        import litellm
+        from litellm import acompletion
+    except ImportError as exc:
+        raise GatewayError(
+            503,
+            "litellm_not_installed",
+            detail=(
+                "ai_gateway_backend='litellm_embedded' requires the litellm "
+                "package. Install it via requirements.txt."
+            ),
+        ) from exc
+
+    # Drop unsupported params silently rather than raising — keeps the
+    # OpenAI-compat contract usable across providers that vary on minor
+    # fields (e.g. Anthropic does not accept all OpenAI knobs).
+    litellm.drop_params = True
+
+    body = req.model_dump(exclude_none=True)
+    # LiteLLM uses provider-prefixed model ids when ambiguous; pass
+    # through whatever the caller sent.
+    model = body.pop("model")
+
+    metadata = {
+        "cullis_agent_id": agent_id,
+        "cullis_org_id": org_id,
+        "cullis_trace_id": trace_id,
+    }
+
+    started = time.perf_counter()
+    try:
+        response = await acompletion(
+            model=model,
+            api_key=settings.anthropic_api_key,
+            metadata=metadata,
+            **body,
+        )
+    except Exception as exc:
+        # Only the LiteLLM-shaped exceptions land in the map; anything
+        # else (e.g. ValueError on bad input) becomes provider_unknown.
+        gw_err = _map_litellm_exception(exc)
+        _log.warning(
+            "litellm_embedded error agent=%s model=%s reason=%s detail=%s",
+            agent_id, model, gw_err.reason, gw_err.detail,
+        )
+        raise gw_err from exc
+
+    latency_ms = int((time.perf_counter() - started) * 1000)
+
+    usage = getattr(response, "usage", None)
+    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+
+    # response_cost is not on every LiteLLM build; compute it on demand
+    # so we always surface a number in the audit row when the model is
+    # in the LiteLLM cost catalogue. Failures here are informational —
+    # the call succeeded, the cost is just unknown.
+    cost_usd: float | None = None
+    try:
+        cost_usd = litellm.completion_cost(completion_response=response)
+    except Exception as exc:
+        _log.debug("litellm.completion_cost failed for model=%s: %s", model, exc)
+
+    payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+    payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
+    payload.setdefault("object", "chat.completion")
+    payload.setdefault("created", int(time.time()))
+    payload.setdefault("model", model)
+    payload["cullis_trace_id"] = trace_id
+    # Force usage shape so Mastio's schema sees the canonical fields
+    # even when LiteLLM adds provider-specific extras (cached_tokens,
+    # reasoning_tokens) that our pydantic model would reject.
+    payload["usage"] = {
+        "prompt_tokens": int(prompt_tokens),
+        "completion_tokens": int(completion_tokens),
+        "total_tokens": int(prompt_tokens + completion_tokens),
+    }
+
+    try:
+        parsed = ChatCompletionResponse.model_validate(payload)
+    except Exception as exc:
+        raise GatewayError(
+            502,
+            "schema_mismatch",
+            detail=f"LiteLLM response failed Mastio schema: {exc}",
+        ) from exc
+
+    upstream_request_id = (
+        getattr(response, "id", None)
+        or (response.get("id") if isinstance(response, dict) else None)
+    )
+
+    _log.info(
+        "egress.llm dispatched backend=litellm_embedded provider=%s agent=%s "
+        "org=%s model=%s latency_ms=%d tokens_in=%d tokens_out=%d cost_usd=%s",
+        provider, agent_id, org_id, model, latency_ms,
+        prompt_tokens, completion_tokens,
+        f"{cost_usd:.6f}" if cost_usd is not None else "n/a",
+    )
+
+    return GatewayResult(
+        response=parsed,
+        latency_ms=latency_ms,
+        upstream_request_id=upstream_request_id,
+        backend="litellm_embedded",
         provider=provider,
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,12 @@ websockets>=14.1
 python-dotenv>=1.0.1
 anthropic>=0.40.0
 openai>=1.0.0
+# ADR-017 Phase 3 — embedded LiteLLM as default AI gateway backend.
+# Pinned to <2.0 to avoid major-version churn (BerriAI ships frequently).
+# The dispatcher in app/egress/ai_gateway.py routes around it when
+# ai_gateway_backend != "litellm_embedded", so deployments that pin a
+# different backend are insulated from breakage in this dep.
+litellm>=1.83,<2.0
 cryptography>=46.0.6
 authlib>=1.3.0
 redis>=5.0.0

--- a/tests/test_egress_litellm_embedded.py
+++ b/tests/test_egress_litellm_embedded.py
@@ -1,0 +1,243 @@
+"""ADR-017 Phase 3 — embedded LiteLLM backend tests.
+
+The Phase 1 suite covers the Portkey backend; this module covers the
+new in-process LiteLLM path. We never call the real ``litellm.acompletion``
+here — that's what the live spike in
+``imp/sandbox-gateways/test/spike_litellm_acompletion.py`` is for.
+The unit tests verify:
+
+  - happy path returns a parsed ChatCompletionResponse with usage
+    canonicalized and ``cullis_trace_id`` injected;
+  - LiteLLM provider exceptions map to GatewayError with the right
+    HTTP status (auth=401, rate=429, timeout=504, ...);
+  - missing provider key + wrong provider both refuse with the
+    matching reason tags.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.config import Settings
+from app.egress.ai_gateway import (
+    GatewayError,
+    GatewayResult,
+    _map_litellm_exception,
+    dispatch,
+)
+from app.egress.schemas import ChatCompletionRequest
+
+
+def _settings(**overrides) -> Settings:
+    base = dict(
+        admin_secret="test-secret-not-default",
+        ai_gateway_backend="litellm_embedded",
+        ai_gateway_provider="anthropic",
+        anthropic_api_key="sk-test",
+    )
+    base.update(overrides)
+    return Settings(**base)
+
+
+def _request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="anthropic/claude-haiku-4-5",
+        messages=[{"role": "user", "content": "ping"}],
+        max_tokens=16,
+    )
+
+
+def _fake_litellm_response() -> SimpleNamespace:
+    """Approximate a LiteLLM ModelResponse: pydantic-flavoured object
+    with ``usage`` + ``model_dump()`` + ``id``."""
+    usage = SimpleNamespace(
+        prompt_tokens=12,
+        completion_tokens=3,
+        total_tokens=15,
+    )
+    full_dict = {
+        "id": "chatcmpl-litellm-1",
+        "object": "chat.completion",
+        "created": 1_700_000_000,
+        "model": "claude-haiku-4-5",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "pong"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 12,
+            "completion_tokens": 3,
+            "total_tokens": 15,
+            # provider-specific extras LiteLLM forwards from Anthropic
+            "cached_tokens": 0,
+            "prompt_tokens_details": {"text_tokens": 12},
+        },
+    }
+    return SimpleNamespace(
+        id=full_dict["id"],
+        usage=usage,
+        model_dump=lambda: full_dict,
+    )
+
+
+# ── Happy path ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_litellm_embedded_returns_parsed_response():
+    fake_resp = _fake_litellm_response()
+
+    with patch("litellm.acompletion", new=AsyncMock(return_value=fake_resp)) as mock_acomp, \
+         patch("litellm.completion_cost", return_value=0.00004):
+        result = await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="trace_litellm_test",
+            settings=_settings(),
+        )
+
+    assert isinstance(result, GatewayResult)
+    assert result.backend == "litellm_embedded"
+    assert result.provider == "anthropic"
+    assert result.upstream_request_id == "chatcmpl-litellm-1"
+    assert result.response.choices[0].message.content == "pong"
+    assert result.response.cullis_trace_id == "trace_litellm_test"
+    # Phase 1 schema only knows the canonical 3 usage fields; provider
+    # extras must not leak through and break model validation.
+    assert result.response.usage.prompt_tokens == 12
+    assert result.response.usage.completion_tokens == 3
+    assert result.response.usage.total_tokens == 15
+
+    # The dispatcher must inject Cullis metadata so any LiteLLM
+    # callback the operator wires up (Datadog, Langfuse, ...) sees the
+    # trusted agent identity.
+    mock_acomp.assert_awaited_once()
+    kwargs = mock_acomp.call_args.kwargs
+    assert kwargs["model"] == "anthropic/claude-haiku-4-5"
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["metadata"] == {
+        "cullis_agent_id": "acme::mario",
+        "cullis_org_id": "acme",
+        "cullis_trace_id": "trace_litellm_test",
+    }
+    # max_tokens forwarded from the OpenAI-shape body
+    assert kwargs["max_tokens"] == 16
+
+
+@pytest.mark.asyncio
+async def test_dispatch_survives_missing_completion_cost():
+    """response_cost lookup is best-effort; a failure must not block
+    the call (audit row will record cost as unknown)."""
+    fake_resp = _fake_litellm_response()
+    with patch("litellm.acompletion", new=AsyncMock(return_value=fake_resp)), \
+         patch("litellm.completion_cost", side_effect=Exception("model not in catalogue")):
+        result = await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="trace_no_cost",
+            settings=_settings(),
+        )
+    assert result.backend == "litellm_embedded"
+    assert result.response.usage.prompt_tokens == 12
+
+
+# ── Error mapping ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc_class_name,expected_status,expected_reason",
+    [
+        ("AuthenticationError", 401, "provider_auth_failed"),
+        ("PermissionDeniedError", 403, "provider_permission_denied"),
+        ("RateLimitError", 429, "provider_rate_limited"),
+        ("BadRequestError", 400, "provider_bad_request"),
+        ("Timeout", 504, "provider_timeout"),
+        ("APIConnectionError", 502, "provider_unreachable"),
+        ("ContextWindowExceededError", 400, "provider_context_too_long"),
+        ("ServiceUnavailableError", 502, "provider_unavailable"),
+        ("InternalServerError", 502, "provider_internal_error"),
+    ],
+)
+async def test_dispatch_maps_litellm_exceptions(
+    exc_class_name, expected_status, expected_reason,
+):
+    """Build a fake exception class with the LiteLLM name. The map is
+    keyed by class name (not isinstance) so this is the right level to
+    test it."""
+    FakeExc = type(exc_class_name, (Exception,), {})
+    with patch("litellm.acompletion", new=AsyncMock(side_effect=FakeExc("upstream boom"))):
+        with pytest.raises(GatewayError) as exc_info:
+            await dispatch(
+                req=_request(),
+                agent_id="acme::mario",
+                org_id="acme",
+                trace_id="t-err",
+                settings=_settings(),
+            )
+    assert exc_info.value.status_code == expected_status
+    assert exc_info.value.reason == expected_reason
+    assert "upstream boom" in (exc_info.value.detail or "")
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_exception_falls_back_to_502():
+    class WeirdProviderError(Exception):
+        pass
+
+    with patch("litellm.acompletion", new=AsyncMock(side_effect=WeirdProviderError("???"))):
+        with pytest.raises(GatewayError) as exc_info:
+            await dispatch(
+                req=_request(),
+                agent_id="acme::mario",
+                org_id="acme",
+                trace_id="t",
+                settings=_settings(),
+            )
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.reason == "provider_unknown_error"
+
+
+def test_map_litellm_exception_truncates_long_detail():
+    long = "x" * 2000
+    err = _map_litellm_exception(type("APIError", (Exception,), {})(long))
+    assert err.detail is not None
+    assert len(err.detail) <= 512
+
+
+# ── Refusals before calling litellm ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_missing_provider_key():
+    with pytest.raises(GatewayError) as exc_info:
+        await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="t",
+            settings=_settings(anthropic_api_key=""),
+        )
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.reason == "provider_key_missing"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_refuses_unimplemented_provider():
+    with pytest.raises(GatewayError) as exc_info:
+        await dispatch(
+            req=_request(),
+            agent_id="acme::mario",
+            org_id="acme",
+            trace_id="t",
+            settings=_settings(ai_gateway_provider="openai"),
+        )
+    assert exc_info.value.status_code == 501
+    assert exc_info.value.reason.startswith("provider_not_implemented:openai")

--- a/tests/test_egress_litellm_embedded.py
+++ b/tests/test_egress_litellm_embedded.py
@@ -16,7 +16,7 @@ The unit tests verify:
 from __future__ import annotations
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 


### PR DESCRIPTION
## Summary

ADR-017 Phase 3. Adds a second AI-gateway backend that runs LiteLLM as an in-process Python library, and makes it the default. The dispatcher in `app/egress/ai_gateway.py` routes the call via `litellm.acompletion` when `ai_gateway_backend == "litellm_embedded"`, and via the existing Portkey HTTP path when pinned to `"portkey"`.

### Why default to embedded

- **One process less** for the customer (no Portkey container to deploy / patch / monitor).
- **One audit chain** (Mastio's), no double observability surface.
- **Latency ~480ms shorter** on Anthropic Haiku 4.5 in the live smoke (1303ms via Portkey -> 824ms in-process); upstream dominates but the hop saved is free.
- Pitch line: "Mastio is the gateway, not an orchestrator of one".

### Why keep Portkey alive

- Tier 1 enterprise customers already running Portkey Enterprise reuse their investment, Mastio sits on top.
- Insurance against LiteLLM license change (BerriAI is VC-backed, MIT today). Dispatcher abstraction means swap is ~1-2 weeks on one module, not a redesign.

### Error mapping

LiteLLM exception classes are mapped by class name (not `isinstance`, so the `litellm` import stays lazy in deployments pinned to other backends) into `GatewayError(status, reason)`:

| LiteLLM class | Mastio status | reason |
|---|---|---|
| AuthenticationError | 401 | provider_auth_failed |
| RateLimitError | 429 | provider_rate_limited |
| Timeout | 504 | provider_timeout |
| ContextWindowExceededError | 400 | provider_context_too_long |
| InternalServerError | 502 | provider_internal_error |
| (unknown) | 502 | provider_unknown_error |

### Cost tracking

`litellm.completion_cost(...)` is called best-effort on the response and surfaced in the structured log. Failure (model not in catalogue) does not block the call. Wiring into the audit chain alongside per-agent spend rollup is Phase 4.

### Provider key

Reuses the existing `anthropic_api_key` setting. KMS-backed managed virtual keys remain Phase 5.

## Test plan

- [x] **Pre-flight spike** in `imp/sandbox-gateways/test/spike_litellm_acompletion.py` covering 5 questions (async happy path, callback reliability, tool_use OpenAI shape, stop sequences, error propagation): all 5 green against Anthropic Haiku 4.5 reale.
- [x] **15 new unit tests** in `tests/test_egress_litellm_embedded.py`: happy path with metadata injection, `completion_cost` best-effort fallback, parametrized mapping for 9 LiteLLM exception classes, unknown-exception fallback (502), detail truncation, missing provider key (503), unimplemented provider (501). 15/15 green in ~7s.
- [x] **Live smoke A** dispatcher to Anthropic via litellm_embedded: HTTP ok, 824ms, 15+5 tokens, "pong" reply. Script in `imp/sandbox-gateways/test/spike_dispatch_live_litellm.py`.
- [x] **Full suite**: 2312 passed (+15 nuovi), 8 failed (tutti pre-existing: GUI libs headless + postgres binding flakes). Zero regressions despite the openai 2.30->2.24 downgrade pulled in by litellm install.
- [ ] Smoke B (full proxy + Mastio + agent enrolled) with `ai_gateway_backend=litellm_embedded`: identical to Phase 2 once the stack is up. Smoke A + 15 unit tests cover the dispatcher leg and the proxy leg respectively, so this is just confirmation.

## Out of scope (deferred)

- LiteLLM Proxy server backend (`litellm_proxy`): wired only if a design partner asks.
- Kong AI Gateway backend: same trigger.
- KMS-backed managed virtual keys.
- Per-agent spend rollup in audit chain (Phase 4).
- `EgressFinishReason` / `EgressError` canonical adapter layer: current error mapping is enough for now; the cross-backend equivalence test lands when we wire `litellm_proxy`.