### PR TITLE
feat(sdk,proxy): MCP aggregator helpers + 3-backend smoke

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -2797,6 +2797,59 @@ class CullisClient:
         resp.raise_for_status()
         return resp.json()
 
+    # ── ADR-007 — MCP aggregator (proxy-side only) ─────────────────
+    def list_mcp_tools(self) -> list[dict]:
+        """List the MCP tools the authenticated agent can call.
+
+        Calls ``POST /v1/mcp`` JSON-RPC ``tools/list`` on the proxy.
+        The proxy filters to backends the agent has an active binding
+        for, so the returned list is already authorization-scoped.
+
+        Requires ``self.base`` to point at the **mcp_proxy** (not
+        Mastio directly): the aggregator endpoint lives there. Returns
+        the raw ``tools`` array from the JSON-RPC ``result``.
+        """
+        resp = self._authed_request(
+            "POST", "/v1/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if "error" in body:
+            raise RuntimeError(f"tools/list error: {body['error']}")
+        return body.get("result", {}).get("tools", [])
+
+    def call_mcp_tool(self, name: str, arguments: dict | None = None) -> dict:
+        """Invoke an MCP tool by name through the proxy aggregator.
+
+        The proxy validates the caller's binding, audits the call,
+        injects the configured auth header from the SecretProvider
+        and forwards JSON-RPC ``tools/call`` to the upstream MCP
+        server. Returns the raw ``result`` object (typically with
+        ``content`` array and ``isError`` flag).
+
+        Raises ``RuntimeError`` on JSON-RPC error (binding missing,
+        upstream unreachable, schema mismatch).
+        """
+        resp = self._authed_request(
+            "POST", "/v1/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments or {}},
+            },
+        )
+        resp.raise_for_status()
+        body = resp.json()
+        if "error" in body:
+            err = body["error"]
+            raise RuntimeError(
+                f"tools/call error code={err.get('code')} "
+                f"message={err.get('message')!r}"
+            )
+        return body.get("result", {})
+
 
 class WebSocketConnection:
     """Authenticated WebSocket connection with heartbeat + auto-reconnect (M2).

--- a/tests/test_proxy_mcp_aggregator.py
+++ b/tests/test_proxy_mcp_aggregator.py
@@ -628,3 +628,41 @@ async def test_audit_hash_chain_intact_after_resource_calls(
 
     ok, broken_at = await verify_local_chain("acme")
     assert ok, f"hash chain broken at seq={broken_at}"
+
+
+# ── Three-backend smoke (github / slack / postgres) ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_three_backends_visible_after_seed_and_binding(
+    proxy_db, clean_registry, app_client,
+):
+    """The sandbox-mcp setup registers three backends with distinct
+    auth_type and capability values. Once the agent is bound to all
+    three, tools/list must surface them as a single set the proxy
+    presents to the agent."""
+    backends = [
+        ("res-gh", "github", "bearer", "github.write"),
+        ("res-sl", "slack", "bearer", "slack.post"),
+        ("res-pg", "postgres", "api_key", "sql.read"),
+    ]
+    for rid, name, auth_type, cap in backends:
+        await _seed_resource(
+            resource_id=rid, name=name,
+            endpoint_url=f"http://mock-mcp:9100/{name}",
+            auth_type=auth_type,
+            required_capability=cap,
+            allowed_domains='["mock-mcp:9100"]',
+        )
+        await _seed_binding(agent_id="acme::buyer", resource_id=rid)
+
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 100, "method": "tools/list",
+    }).json()
+    names = sorted(t["name"] for t in body["result"]["tools"])
+    assert "github" in names
+    assert "slack" in names
+    assert "postgres" in names


### PR DESCRIPTION
## Summary

ADR-007 Phase 1 follow-up. Adds SDK ergonomics on top of the existing `mcp_proxy /v1/mcp` aggregator and a smoke test that mirrors the sandbox-mcp setup (github / slack / postgres backends).

## Why

The aggregator is wired since PR-3 of Phase 1 (forwarder + binding + audit chain). What was missing is a thin SDK surface so a custom Python agent (LangChain worker, in-house script, demo) can run a tool_use loop without hand-rolling JSON-RPC envelopes:

```python
client = CullisClient.from_identity_dir(proxy_url, cert_path=..., key_path=...)
client.login_from_pem(...)

for tool in client.list_mcp_tools():           # binding-filtered
    print(tool["name"], tool["description"])

result = client.call_mcp_tool(
    "github",
    arguments={"action": "create_issue", "owner": "acme", "repo": "x", "title": "..."},
)
```

The proxy untouched. SDK gains two methods. One test added.

## Test plan

- [x] `tests/test_proxy_mcp_aggregator.py::test_three_backends_visible_after_seed_and_binding`: seeds three backends with distinct `auth_type` (bearer / bearer / api_key) and capability (`github.write`, `slack.post`, `sql.read`), binds an agent to all three, asserts `tools/list` returns the union.
- [x] Full file suite: 21/21 in `test_proxy_mcp_aggregator.py` green.
- [x] Full suite: 2313 passed, 8 failed (all pre-existing: GUI libs in headless + postgres binding flakes). Zero regressions.
- [x] Live mock smoke (manual): `imp/sandbox-mcp/` mock MCP server up, JSON-RPC `tools/list` + `tools/call` against `/github`, `/slack`, `/postgres` returns expected shape with auth header echoed back.

## Out of scope (deferred)

- Live smoke against real GitHub / Slack / Postgres MCP servers: requires a PAT, a Slack bot token and a Postgres DSN. The sandbox README documents the swap (replace mock with sparfenyuk `mcp-proxy` PyPI package bridging the official npm packages, no SDK / proxy code change).
- `langchain-cullis` adapter (`CullisChatModel` + tool wrapper): targeted when a design partner asks for LangChain explicitly.
- AI gateway settings UI on the proxy dashboard: separate PR.
- 1-click MCP catalog wizard (preset for github / slack / postgres / linear): UX polish PR after design partner feedback.