### PR TITLE
feat(proxy): forwarder speaks Streamable HTTP MCP transport

### DIFF
--- a/mcp_proxy/tools/mcp_resource_forwarder.py
+++ b/mcp_proxy/tools/mcp_resource_forwarder.py
@@ -22,6 +22,7 @@ Contract:
 """
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from typing import Any
@@ -36,6 +37,12 @@ from mcp_proxy.tools.registry import ToolDefinition
 _log = logging.getLogger("mcp_proxy.tools.mcp_resource_forwarder")
 
 DEFAULT_FORWARD_TIMEOUT = 15.0  # seconds — fail fast, no retry
+
+# Streamable HTTP MCP transport (2025-03 spec) requires the client to
+# advertise both JSON and SSE. Stateless servers reply with a single
+# JSON object; stateful or streaming servers may push SSE frames. We
+# accept both and only ever read the first JSON message.
+_MCP_ACCEPT = "application/json, text/event-stream"
 
 
 async def _build_auth_header(
@@ -77,6 +84,35 @@ async def _build_auth_header(
         return {"X-API-Key": secret}
     _log.warning("Unknown auth_type=%r — forwarding without auth header", auth_type)
     return {}
+
+
+def _decode_mcp_response(resp: httpx.Response) -> dict | None:
+    """Return the first JSON-RPC message in the response, or None if malformed.
+
+    Streamable HTTP MCP servers may answer with either:
+      - ``Content-Type: application/json`` and a single JSON-RPC object, or
+      - ``Content-Type: text/event-stream`` and one or more ``data: {...}``
+        SSE frames. The spec guarantees the first ``data:`` line for a
+        JSON-RPC reply contains the full envelope; we read only that.
+    """
+    ctype = resp.headers.get("content-type", "").lower()
+    if "text/event-stream" in ctype:
+        for line in resp.text.splitlines():
+            if line.startswith("data:"):
+                payload = line[len("data:"):].strip()
+                if not payload:
+                    continue
+                try:
+                    parsed = json.loads(payload)
+                except ValueError:
+                    return None
+                return parsed if isinstance(parsed, dict) else None
+        return None
+    try:
+        parsed = resp.json()
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 async def forward_to_mcp_resource(
@@ -124,12 +160,13 @@ async def forward_to_mcp_resource(
     }
 
     transport = WhitelistedTransport(allowed_domains=tool_def.allowed_domains)
+    request_headers = {"Accept": _MCP_ACCEPT, **auth_header}
     try:
         async with httpx.AsyncClient(
             transport=transport,
             timeout=DEFAULT_FORWARD_TIMEOUT,
         ) as client:
-            resp = await client.post(endpoint, json=payload, headers=auth_header)
+            resp = await client.post(endpoint, json=payload, headers=request_headers)
     except (httpx.TimeoutException, httpx.ConnectError) as exc:
         await append_local_audit(
             event_type="resource_call",
@@ -163,9 +200,8 @@ async def forward_to_mcp_resource(
             f"MCP resource returned HTTP {resp.status_code}"
         )
 
-    try:
-        data = resp.json()
-    except ValueError as exc:
+    data = _decode_mcp_response(resp)
+    if data is None:
         await append_local_audit(
             event_type="resource_call",
             result="error",
@@ -173,7 +209,7 @@ async def forward_to_mcp_resource(
             org_id=ctx.org_id,
             details={**audit_details, "error": "malformed_json"},
         )
-        raise ToolExecutionError("MCP resource returned non-JSON body") from exc
+        raise ToolExecutionError("MCP resource returned non-JSON body")
 
     if isinstance(data, dict) and "error" in data:
         err = data["error"] if isinstance(data["error"], dict) else {"message": str(data["error"])}

--- a/tests/test_proxy_mcp_aggregator.py
+++ b/tests/test_proxy_mcp_aggregator.py
@@ -666,3 +666,116 @@ async def test_three_backends_visible_after_seed_and_binding(
     assert "github" in names
     assert "slack" in names
     assert "postgres" in names
+
+
+# ── Streamable HTTP forwarder behavior ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_forwarder_sends_streamable_http_accept_header(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    """Forwarder must advertise both JSON and SSE so Streamable HTTP
+    MCP servers (e.g. sparfenyuk mcp-proxy) accept the POST."""
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["accept"] = request.headers.get("accept")
+        return httpx.Response(
+            200, json={"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+        )
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-shttp", name="shttp-svc",
+        endpoint_url="http://shttp-svc:8080/mcp",
+        allowed_domains='["shttp-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-shttp")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "shttp-svc", "arguments": {}},
+    })
+
+    accept = captured.get("accept", "")
+    assert "application/json" in accept
+    assert "text/event-stream" in accept
+
+
+@pytest.mark.asyncio
+async def test_forwarder_decodes_sse_framed_response(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    """When the upstream replies with text/event-stream (single data:
+    frame), the forwarder must extract the JSON-RPC envelope from it."""
+    sse_body = (
+        'event: message\n'
+        'data: {"jsonrpc":"2.0","id":1,"result":'
+        '{"content":[{"type":"text","text":"sse-hello"}],"isError":false}}\n'
+        '\n'
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=sse_body.encode("utf-8"),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-sse", name="sse-svc",
+        endpoint_url="http://sse-svc:8080/mcp",
+        allowed_domains='["sse-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-sse")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "sse-svc", "arguments": {}},
+    }).json()
+
+    assert body["result"]["isError"] is False
+    text_out = body["result"]["content"][0]["text"]
+    assert "sse-hello" in text_out
+
+
+@pytest.mark.asyncio
+async def test_forwarder_rejects_malformed_sse_body(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    """A text/event-stream body with no parseable data: line is treated
+    as malformed and bubbles up as an error result."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"event: ping\n\n",
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-sse-bad", name="sse-bad-svc",
+        endpoint_url="http://sse-bad:8080/mcp",
+        allowed_domains='["sse-bad:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-sse-bad")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    body = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "sse-bad-svc", "arguments": {}},
+    }).json()
+
+    assert "error" in body
+    assert "non-JSON" in body["error"]["message"] or "malformed" in body["error"]["message"].lower()


### PR DESCRIPTION
## Summary

- The MCP resource forwarder now sets `Accept: application/json, text/event-stream` on the outbound POST so Streamable HTTP MCP servers (the 2025-03 spec, used by `sparfenyuk/mcp-proxy --stateless` to bridge npm `@modelcontextprotocol/server-*` packages) accept the request instead of replying `406 Not Acceptable`.
- Response decoding handles both content types: a plain JSON body keeps the existing path; a `text/event-stream` body is parsed by reading the first `data:` line of the SSE frame. Stateless servers reply with one frame per JSON-RPC envelope, which is exactly what `tools/list` and `tools/call` need.

This unlocks a live smoke against real upstream MCP servers (postgres, github, slack) in `imp/sandbox-mcp/`. Existing mock-mcp tests, which serve plain JSON, are unaffected and continue to pass.

Local-mode (the only loaded path here) keeps the same DPoP, binding, and audit semantics — only the upstream HTTP envelope changes.

## Test plan

- [x] 21 pre-existing tests in `tests/test_proxy_mcp_aggregator.py` still pass (mock-mcp path unchanged).
- [x] 3 new tests cover the Streamable HTTP path:
  - `test_forwarder_sends_streamable_http_accept_header` — asserts both media types in `Accept`.
  - `test_forwarder_decodes_sse_framed_response` — happy path `text/event-stream` with single `data:` JSON-RPC frame.
  - `test_forwarder_rejects_malformed_sse_body` — SSE body with no parseable `data:` line bubbles up as `non-JSON`.
- [x] Manual smoke against a live `sparfenyuk/mcp-proxy --stateless` bridging `@modelcontextprotocol/server-postgres`: `tools/list` and `tools/call query` round-trip a real `compliance_status` query.