### PR TITLE
feat(connector): OpenAI-compat Ambassador (ADR-019 Step 1)

### DIFF
--- a/cullis_connector/ambassador/__init__.py
+++ b/cullis_connector/ambassador/__init__.py
@@ -1,0 +1,24 @@
+"""Connector Ambassador (ADR-019).
+
+OpenAI-compatible HTTP surface that translates Bearer-authenticated
+requests from a chat client (Cullis Chat, Cursor, OpenWebUI, ...) into
+DPoP+mTLS calls to the Cullis cloud (mcp_proxy + Mastio).
+
+This package adds three FastAPI endpoints to the Connector dashboard
+when ``config.ambassador.enabled`` is true:
+
+  POST /v1/chat/completions    — OpenAI ChatCompletion, with tool-use
+                                 loop dispatched server-side
+  POST /v1/mcp                  — JSON-RPC 2.0 MCP aggregator passthrough
+  GET  /v1/models               — list of models the Cullis cloud routes
+
+The Ambassador binds to 127.0.0.1 only and rejects any request whose
+``request.client.host`` is not loopback. The Bearer token is locally
+generated at first start and stored at
+``<config_dir>/local.token`` mode 0600. ADR-019 §6 (Security & threat
+model) documents the trust boundary in detail.
+"""
+
+from cullis_connector.ambassador.router import router
+
+__all__ = ["router"]

--- a/cullis_connector/ambassador/auth.py
+++ b/cullis_connector/ambassador/auth.py
@@ -1,0 +1,99 @@
+"""Bearer auth + loopback enforcement for the Ambassador.
+
+The Ambassador speaks Bearer to local clients and DPoP+mTLS to Cullis
+cloud. The Bearer is a random 32-byte token generated at first start
+and stored at ``<config_dir>/local.token`` mode 0600. Validation is
+constant-time (``secrets.compare_digest``).
+
+Loopback enforcement: every request whose ``request.client.host`` is
+not in ``{127.0.0.1, ::1}`` is rejected with 403. This is a belt-and-
+braces guard on top of the recommended bind ``--host 127.0.0.1``: if
+the operator overrides the bind to ``0.0.0.0``, the Ambassador still
+refuses non-loopback callers.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from pathlib import Path
+
+from fastapi import HTTPException, Request
+
+_log = logging.getLogger("cullis_connector.ambassador.auth")
+
+# Loopback IP addresses. ``::ffff:127.0.0.1`` is what some HTTP clients
+# advertise on dual-stack sockets — accept it explicitly.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "::ffff:127.0.0.1"})
+
+# Header name for the Bearer token. Standard OpenAI clients send
+# ``Authorization: Bearer <token>``.
+_AUTH_HEADER = "authorization"
+
+LOCAL_TOKEN_FILENAME = "local.token"
+
+
+def ensure_local_token(config_dir: Path) -> str:
+    """Return the local Bearer token, generating it on first call.
+
+    The file is created with mode 0600 (owner read+write only).
+    Subsequent calls read the existing file. The token is 32 random
+    bytes hex-encoded (64 ASCII chars).
+    """
+    token_path = config_dir / LOCAL_TOKEN_FILENAME
+    if token_path.exists():
+        token = token_path.read_text(encoding="utf-8").strip()
+        if token:
+            return token
+        _log.warning("local token file at %s is empty — regenerating", token_path)
+    token = secrets.token_hex(32)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    token_path.write_text(token + "\n", encoding="utf-8")
+    try:
+        token_path.chmod(0o600)
+    except OSError:
+        # Some filesystems (e.g. on Windows) ignore chmod. Logged at
+        # info, not warning, because the local trust boundary is the
+        # OS user not the file mode in those environments.
+        _log.info("could not chmod 0600 on %s (filesystem may not support it)", token_path)
+    _log.info("generated new local token at %s", token_path)
+    return token
+
+
+def require_loopback(request: Request) -> None:
+    """Raise 403 unless the inbound TCP peer is loopback.
+
+    Used as a FastAPI dependency on every Ambassador route.
+    """
+    host = request.client.host if request.client else None
+    if host not in _LOOPBACK_HOSTS:
+        _log.warning(
+            "rejecting non-loopback request from %s on %s %s",
+            host, request.method, request.url.path,
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="Ambassador only accepts loopback connections",
+        )
+
+
+def require_bearer(expected_token: str):
+    """Build a FastAPI dependency that validates the Bearer header.
+
+    Returns a callable suitable for ``Depends(...)`` so each route can
+    mount it without rebuilding the closure.
+    """
+    if not expected_token:
+        raise ValueError("expected_token must be a non-empty string")
+
+    def _checker(request: Request) -> None:
+        raw = request.headers.get(_AUTH_HEADER, "")
+        if not raw.lower().startswith("bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="missing or non-Bearer Authorization header",
+            )
+        presented = raw.split(" ", 1)[1].strip()
+        if not secrets.compare_digest(presented, expected_token):
+            raise HTTPException(status_code=401, detail="invalid Bearer token")
+
+    return _checker

--- a/cullis_connector/ambassador/client.py
+++ b/cullis_connector/ambassador/client.py
@@ -1,0 +1,98 @@
+"""Lazy CullisClient cache for the Ambassador.
+
+In single-user mode there is exactly one identity, so we keep one
+CullisClient alive for the lifetime of the dashboard process. The
+client is recreated when its access token nears expiry (re-login) or
+when an SDK call raises an auth error (defensive recreate).
+
+Multi-tenant mode (Step 3) replaces this singleton with a per-agent
+LRU cache keyed by ``agent_id``.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+_log = logging.getLogger("cullis_connector.ambassador.client")
+
+# Re-login this much before the access token expires. The SDK exposes
+# token expiry on the client object; v0.1 keeps it simple by recreating
+# every N seconds since last login. Fine-grained expiry handling is a
+# v0.2 polish.
+_RELOGIN_INTERVAL_S = 10 * 60  # 10 minutes
+
+
+class AmbassadorClient:
+    """Thread-safe singleton holder of an authenticated CullisClient.
+
+    The Ambassador reads ``site_url``, ``cert_path``, ``key_path``,
+    ``agent_id``, ``org_id`` from the Connector config and re-uses the
+    same SDK client across requests.
+    """
+
+    def __init__(
+        self,
+        *,
+        site_url: str,
+        agent_id: str,
+        org_id: str,
+        cert_pem: str,
+        key_pem: str,
+        verify_tls: bool | str = True,
+    ) -> None:
+        self._site_url = site_url
+        self._agent_id = agent_id
+        self._org_id = org_id
+        self._cert_pem = cert_pem
+        self._key_pem = key_pem
+        self._verify_tls = verify_tls
+        self._client: Any = None
+        self._created_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def _build(self) -> Any:
+        """Create + login a fresh CullisClient. Caller holds the lock."""
+        from cullis_sdk import CullisClient
+        import time
+
+        client = CullisClient(self._site_url, verify_tls=self._verify_tls)
+        client.login_from_pem(
+            self._agent_id, self._org_id, self._cert_pem, self._key_pem,
+        )
+        self._client = client
+        self._created_at = time.monotonic()
+        _log.info(
+            "ambassador SDK login ok agent=%s org=%s site=%s",
+            self._agent_id, self._org_id, self._site_url,
+        )
+        return client
+
+    def get(self) -> Any:
+        """Return a logged-in CullisClient, building or refreshing as needed."""
+        import time
+
+        with self._lock:
+            now = time.monotonic()
+            if self._client is None or (now - self._created_at) > _RELOGIN_INTERVAL_S:
+                self._build()
+            return self._client
+
+    def invalidate(self) -> None:
+        """Drop the cached client so the next ``get()`` re-logs in.
+
+        Called by the router on a 401 from the SDK so a stale token
+        does not break a long-running process.
+        """
+        with self._lock:
+            self._client = None
+            self._created_at = 0.0
+            _log.info("ambassador client cache invalidated")
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent_id
+
+    @property
+    def org_id(self) -> str:
+        return self._org_id

--- a/cullis_connector/ambassador/loop.py
+++ b/cullis_connector/ambassador/loop.py
@@ -1,0 +1,146 @@
+"""Server-side tool-use loop for the Ambassador.
+
+When a chat client (Cullis Chat etc.) sends a ChatCompletion request,
+the Ambassador discovers MCP tools the agent is bound to, attaches
+them to the LLM call as ``tools=[...]``, and dispatches any
+``tool_calls`` returned by the LLM through ``cullis_sdk.call_mcp_tool``
+before re-invoking the LLM. Loop terminates when the LLM stops
+returning tool_calls, or when ``max_iters`` is exhausted.
+
+This server-side loop spares clients from MCP awareness; they see a
+plain ChatCompletion ending in a final assistant content block.
+
+All work goes through the agent's authenticated CullisClient, so
+every LLM call and every tool call is audited in Mastio under the
+agent's identity.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+_log = logging.getLogger("cullis_connector.ambassador.loop")
+
+DEFAULT_MAX_ITERS = 8
+
+
+def _mcp_tool_to_openai(tool: dict) -> dict:
+    """MCP ``tools/list`` shape -> OpenAI ``tools[]`` shape."""
+    return {
+        "type": "function",
+        "function": {
+            "name": tool["name"],
+            "description": tool.get("description", ""),
+            "parameters": tool.get("inputSchema", {"type": "object"}),
+        },
+    }
+
+
+def _mcp_result_to_text(result: Any) -> str:
+    """Extract a single text blob from an MCP ``tools/call`` result."""
+    if not isinstance(result, dict):
+        return json.dumps(result, default=str)
+    content = result.get("content")
+    if not content:
+        return json.dumps(result, default=str)
+    parts: list[str] = []
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            parts.append(item.get("text", ""))
+        else:
+            parts.append(json.dumps(item, default=str))
+    return "\n".join(p for p in parts if p) or json.dumps(result, default=str)
+
+
+def run_tool_use_loop(
+    client: Any,
+    request_body: dict,
+    *,
+    max_iters: int = DEFAULT_MAX_ITERS,
+) -> tuple[dict, bool]:
+    """Drive an LLM tool-use loop through Cullis.
+
+    Args:
+        client: an authenticated ``CullisClient``.
+        request_body: the OpenAI ChatCompletion body the chat client sent.
+        max_iters: cap on LLM ↔ tool-call round trips.
+
+    Returns:
+        A tuple ``(final_response, truncated)``. ``final_response`` is the
+        last ChatCompletion JSON the LLM returned; ``truncated`` is True
+        iff the loop exited because of ``max_iters``.
+
+    Raises:
+        Whatever the SDK raises (httpx.HTTPStatusError on 4xx/5xx, etc).
+    """
+    body = dict(request_body)  # shallow copy; we mutate `messages`
+    messages: list[dict] = list(body.get("messages", []))
+
+    # Discover tools the agent is bound to. Empty list is fine: the LLM
+    # will simply produce a normal answer without tool_calls.
+    try:
+        mcp_tools = client.list_mcp_tools()
+    except Exception:
+        _log.exception("list_mcp_tools failed; proceeding without tools")
+        mcp_tools = []
+
+    if mcp_tools and "tools" not in body:
+        body["tools"] = [_mcp_tool_to_openai(t) for t in mcp_tools]
+
+    truncated = False
+    final_response: dict = {}
+
+    for iteration in range(max_iters):
+        body["messages"] = messages
+        _log.info(
+            "tool-use loop iter=%d agent=%s tools=%d msgs=%d",
+            iteration + 1,
+            getattr(client, "agent_id", "?"),
+            len(body.get("tools", []) or []),
+            len(messages),
+        )
+        final_response = client.chat_completion(body)
+        if not isinstance(final_response, dict):
+            return final_response, False
+
+        choices = final_response.get("choices") or []
+        if not choices:
+            return final_response, False
+        choice = choices[0]
+        msg = choice.get("message") or {}
+        tool_calls = msg.get("tool_calls") or []
+
+        if not tool_calls:
+            return final_response, False
+
+        # Append the assistant message (with tool_calls) verbatim, then
+        # dispatch each tool call and append a `role=tool` reply per id.
+        messages.append(msg)
+        for tc in tool_calls:
+            fn = tc.get("function") or {}
+            name = fn.get("name") or ""
+            args_raw = fn.get("arguments") or "{}"
+            try:
+                args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+            except json.JSONDecodeError:
+                _log.warning("tool_call args not valid JSON: %r", args_raw[:200])
+                args = {}
+            try:
+                result = client.call_mcp_tool(name, args)
+                text = _mcp_result_to_text(result)
+            except Exception as exc:  # broad: surface any tool error to the LLM
+                _log.exception("tool %s failed", name)
+                text = f"tool error: {exc}"
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.get("id", f"call_{iteration}_{name}"),
+                "content": text,
+            })
+
+    truncated = True
+    _log.warning(
+        "tool-use loop exhausted max_iters=%d, returning last response",
+        max_iters,
+    )
+    return final_response, truncated

--- a/cullis_connector/ambassador/models.py
+++ b/cullis_connector/ambassador/models.py
@@ -1,0 +1,64 @@
+"""Pydantic schemas for Ambassador endpoints.
+
+OpenAI ChatCompletion is the wire format. We accept ``content`` as
+either a string or a list of content blocks (multimodal-style) so
+clients like Cullis Chat / LibreChat / Cursor that emit different
+shapes all work without per-client hacks.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ChatMessage(BaseModel):
+    """OpenAI chat message — flexible content shape.
+
+    Accepted shapes for ``content``:
+      - ``str``: the typical case
+      - ``list[dict]``: multimodal (e.g. ``[{"type":"text","text":"..."}]``)
+      - ``None``: occasional case for assistant tool-call messages
+
+    Anything else passes through as-is to keep the schema permissive
+    against new client shapes.
+    """
+    model_config = ConfigDict(extra="allow")
+
+    role: str
+    content: Any | None = None
+    tool_calls: list[dict] | None = None
+    tool_call_id: str | None = None
+
+
+class ChatCompletionRequest(BaseModel):
+    """OpenAI ChatCompletion request body, permissive."""
+    model_config = ConfigDict(extra="allow")
+
+    model: str | None = None
+    messages: list[ChatMessage]
+    temperature: float | None = None
+    max_tokens: int | None = None
+    stream: bool | None = False
+    tools: list[dict] | None = None
+    tool_choice: Any | None = None
+
+
+def extract_text(content: Any) -> str:
+    """Flatten OpenAI ``content`` to a single string for routing decisions."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict):
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    parts.append(block["text"])
+                elif isinstance(block.get("content"), str):
+                    parts.append(block["content"])
+        return "\n".join(p for p in parts if p)
+    return str(content)

--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -1,0 +1,248 @@
+"""FastAPI router for the Connector Ambassador.
+
+Mounted on the Connector dashboard app when
+``config.ambassador.enabled`` is true. Exposes:
+
+  GET  /v1/ambassador/health   — unauthenticated, for liveness probes
+  GET  /v1/models              — Bearer-authed; lists Cullis-routed models
+  POST /v1/chat/completions    — Bearer-authed; OpenAI ChatCompletion
+                                 with server-side tool-use loop
+  POST /v1/mcp                 — Bearer-authed; JSON-RPC MCP passthrough
+
+All routes (except ``/v1/ambassador/health``) require:
+  - the request to come from a loopback peer (127.0.0.1 / ::1)
+  - a valid Bearer token matching the local ``local.token`` file
+
+Any 401 from the SDK invalidates the cached client so the next call
+re-logs in.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from cullis_connector.ambassador.auth import require_bearer, require_loopback
+from cullis_connector.ambassador.client import AmbassadorClient
+from cullis_connector.ambassador.loop import run_tool_use_loop
+from cullis_connector.ambassador.models import ChatCompletionRequest
+from cullis_connector.ambassador.streaming import (
+    extract_assistant_text,
+    fake_stream,
+)
+
+_log = logging.getLogger("cullis_connector.ambassador.router")
+
+router = APIRouter(tags=["ambassador"])
+
+
+# ── unauth liveness probe ───────────────────────────────────────────
+
+def _enforce_loopback(request: Request) -> None:
+    """Apply ``require_loopback`` only when the Ambassador is configured to."""
+    state = getattr(request.app.state, "ambassador", None)
+    if state and state.get("require_local_only", True):
+        require_loopback(request)
+
+
+@router.get("/v1/ambassador/health")
+def health(request: Request) -> dict:
+    """Liveness check. Loopback-only, no Bearer required."""
+    _enforce_loopback(request)
+    state = getattr(request.app.state, "ambassador", None)
+    if state is None:
+        return {"status": "ok", "agent_id": None, "site_url": None}
+    return {
+        "status": "ok",
+        "agent_id": state.get("agent_id"),
+        "site_url": state.get("site_url"),
+    }
+
+
+# ── /v1/models ──────────────────────────────────────────────────────
+
+def _get_state(request: Request) -> dict:
+    state = getattr(request.app.state, "ambassador", None)
+    if state is None:
+        raise HTTPException(503, "Ambassador not initialized on this app")
+    return state
+
+
+@router.get("/v1/models")
+def list_models(request: Request) -> dict:
+    _enforce_loopback(request)
+    state = _get_state(request)
+    require_bearer(state["bearer_token"])(request)
+    advertised = state["advertised_models"] or ["claude-haiku-4-5"]
+    return {
+        "object": "list",
+        "data": [
+            {
+                "id": m,
+                "object": "model",
+                "owned_by": "cullis",
+                "created": 0,
+            }
+            for m in advertised
+        ],
+    }
+
+
+# ── /v1/chat/completions ────────────────────────────────────────────
+
+def _completion_envelope(answer: str, model: str) -> dict:
+    return {
+        "id": f"chatcmpl-cullis-{uuid.uuid4().hex[:12]}",
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": answer},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    }
+
+
+@router.post("/v1/chat/completions")
+def chat_completions(req: ChatCompletionRequest, request: Request):
+    _enforce_loopback(request)
+    state = _get_state(request)
+    require_bearer(state["bearer_token"])(request)
+
+    client_holder: AmbassadorClient = state["client"]
+    body = req.model_dump(exclude_none=True)
+
+    try:
+        client = client_holder.get()
+    except Exception as exc:
+        _log.exception("ambassador SDK login failed")
+        raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
+
+    try:
+        response, truncated = run_tool_use_loop(client, body, max_iters=8)
+    except Exception as exc:
+        # Defensive: any auth-shaped error invalidates the cached
+        # client so the next request re-logs in fresh.
+        client_holder.invalidate()
+        _log.exception("tool-use loop failed")
+        raise HTTPException(502, f"Cullis cloud call failed: {exc}") from exc
+
+    model_out = body.get("model") or "claude-haiku-4-5"
+
+    if req.stream:
+        # v0.1 fake-stream: compute answer non-stream then fan out.
+        answer = extract_assistant_text(response)
+        headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+        if truncated:
+            headers["X-Cullis-Tool-Use-Truncated"] = "true"
+        return StreamingResponse(
+            fake_stream(answer, model=model_out),
+            media_type="text/event-stream",
+            headers=headers,
+        )
+
+    if truncated:
+        # Echo through; clients can detect via this custom header.
+        return JSONResponse(
+            response, headers={"X-Cullis-Tool-Use-Truncated": "true"}
+        )
+    return response
+
+
+# ── /v1/mcp passthrough ─────────────────────────────────────────────
+
+@router.post("/v1/mcp")
+async def mcp_passthrough(request: Request) -> JSONResponse:
+    """Forward a JSON-RPC MCP body verbatim to the Cullis proxy.
+
+    Useful for clients that want to drive the loop themselves (e.g.
+    Cursor in agent mode) instead of letting the Ambassador run it.
+    Bearer-authed and loopback-restricted just like the other routes.
+    """
+    _enforce_loopback(request)
+    state = _get_state(request)
+    require_bearer(state["bearer_token"])(request)
+
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(400, "invalid JSON body")
+    if not isinstance(body, dict):
+        raise HTTPException(400, "MCP body must be a JSON object")
+
+    method = body.get("method")
+    if method == "tools/list":
+        client = state["client"].get()
+        tools = await asyncio.to_thread(client.list_mcp_tools)
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "id": body.get("id"),
+            "result": {"tools": tools},
+        })
+    if method == "tools/call":
+        params = body.get("params") or {}
+        name = params.get("name")
+        arguments = params.get("arguments") or {}
+        if not isinstance(name, str) or not name:
+            raise HTTPException(400, "tools/call params.name required")
+        client = state["client"].get()
+        try:
+            result = await asyncio.to_thread(client.call_mcp_tool, name, arguments)
+        except Exception as exc:
+            return JSONResponse({
+                "jsonrpc": "2.0",
+                "id": body.get("id"),
+                "error": {"code": -32000, "message": str(exc)},
+            })
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "id": body.get("id"),
+            "result": result,
+        })
+
+    return JSONResponse({
+        "jsonrpc": "2.0",
+        "id": body.get("id"),
+        "error": {"code": -32601, "message": f"method {method!r} not supported by Ambassador"},
+    })
+
+
+# ── Wiring helper ───────────────────────────────────────────────────
+
+def install_ambassador(
+    app: Any,
+    *,
+    bearer_token: str,
+    client: AmbassadorClient,
+    advertised_models: list[str],
+    require_local_only: bool = True,
+) -> None:
+    """Stash Ambassador state on ``app.state.ambassador`` and mount the router.
+
+    Caller is the ``build_app`` factory in ``cullis_connector/web.py``.
+    Idempotent: if the router is already mounted, raise; we want a
+    loud signal not a silent double-mount.
+    """
+    if hasattr(app.state, "ambassador") and app.state.ambassador:
+        raise RuntimeError("Ambassador already installed on this app")
+    app.state.ambassador = {
+        "bearer_token": bearer_token,
+        "client": client,
+        "advertised_models": list(advertised_models),
+        "agent_id": client.agent_id,
+        "org_id": client.org_id,
+        "site_url": getattr(client, "_site_url", ""),
+        "require_local_only": require_local_only,
+    }
+    app.include_router(router)
+    _log.info(
+        "ambassador installed: agent=%s site=%s models=%s",
+        client.agent_id, getattr(client, "_site_url", ""), advertised_models,
+    )

--- a/cullis_connector/ambassador/streaming.py
+++ b/cullis_connector/ambassador/streaming.py
@@ -1,0 +1,77 @@
+"""Fake-stream SSE wrapper for v0.1 of the Ambassador.
+
+OpenAI clients (Cullis Chat, LibreChat, OpenWebUI, ...) almost always
+default to ``stream: true``. The Cullis cloud (``mcp_proxy
+/v1/chat/completions``, PR #402) does not yet support streaming and
+returns 400 on ``stream=true``. v0.1 bridges the gap by computing the
+answer non-stream and fanning it out as one SSE chunk so clients that
+require streaming see well-formed events.
+
+When ADR-017 lands real streaming on Mastio, this module is replaced
+with a pass-through that forwards upstream chunks verbatim.
+
+The OpenAI streaming envelope uses ``object=chat.completion.chunk``
+and emits ``data: {...}\\n\\n`` frames followed by a sentinel
+``data: [DONE]\\n\\n``. We mirror that exactly.
+"""
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from typing import Iterator
+
+
+def _frame(base: dict, delta: dict, finish_reason: str | None = None) -> str:
+    chunk = {
+        **base,
+        "choices": [{
+            "index": 0,
+            "delta": delta,
+            "finish_reason": finish_reason,
+        }],
+    }
+    return f"data: {json.dumps(chunk)}\n\n"
+
+
+def fake_stream(answer: str, *, model: str, completion_id: str | None = None) -> Iterator[str]:
+    """Emit an OpenAI-compatible single-chunk SSE for the given answer.
+
+    Args:
+        answer: the full assistant content that the loop produced.
+        model: model identifier to echo in the chunk envelope.
+        completion_id: optional explicit id; auto-generated otherwise.
+    """
+    cid = completion_id or f"chatcmpl-cullis-{uuid.uuid4().hex[:12]}"
+    base = {
+        "id": cid,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+    }
+
+    yield _frame(base, {"role": "assistant"})
+    yield _frame(base, {"content": answer})
+    yield _frame(base, {}, finish_reason="stop")
+    yield "data: [DONE]\n\n"
+
+
+def extract_assistant_text(response: dict) -> str:
+    """Pull the final assistant content out of a ChatCompletion response."""
+    if not isinstance(response, dict):
+        return ""
+    choices = response.get("choices") or []
+    if not choices:
+        return ""
+    msg = choices[0].get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        # OpenAI may return content as blocks for some models
+        parts = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "text":
+                parts.append(b.get("text", ""))
+        return "\n".join(p for p in parts if p)
+    return ""

--- a/cullis_connector/config.py
+++ b/cullis_connector/config.py
@@ -45,6 +45,33 @@ DEFAULT_CONFIG_FILENAME = "config.yaml"
 
 
 @dataclass
+class AmbassadorConfig:
+    """Connector Ambassador (ADR-019) settings.
+
+    The Ambassador exposes OpenAI-compatible endpoints on the same
+    FastAPI app as the dashboard so local chat clients (Cullis Chat,
+    Cursor, OpenWebUI, ...) can speak Bearer to localhost while
+    Cullis cloud keeps requiring DPoP+mTLS.
+    """
+
+    enabled: bool = True
+    """Mount /v1/chat/completions, /v1/mcp, /v1/models on the dashboard app."""
+
+    advertised_models: list[str] = field(
+        default_factory=lambda: [
+            "claude-haiku-4-5",
+            "claude-sonnet-4-6",
+            "claude-opus-4-7",
+        ]
+    )
+    """Models surfaced via /v1/models. Must be supported by Mastio's egress."""
+
+    require_local_only: bool = True
+    """Reject any non-loopback peer regardless of bind. Defence-in-depth
+    against the operator overriding ``--host`` to 0.0.0.0."""
+
+
+@dataclass
 class ConnectorConfig:
     """Resolved runtime configuration for the connector process."""
 
@@ -77,6 +104,9 @@ class ConnectorConfig:
 
     request_timeout_s: float = 10.0
     """HTTP request timeout for diagnostic and tool calls."""
+
+    ambassador: AmbassadorConfig = field(default_factory=AmbassadorConfig)
+    """ADR-019 — OpenAI-compatible Bearer surface for local chat clients."""
 
     @property
     def identity_dir(self) -> Path:

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -145,6 +145,12 @@ async def _dashboard_lifespan(app: FastAPI):
     # means to read ``identity/agent.key`` anyway.
     app.state.statusline_token = ensure_statusline_token(config.config_dir)
 
+    # ADR-019 — install the Ambassador if enabled and an identity exists.
+    # We mount it lazily here (vs in build_app) because the identity may
+    # land mid-process (post enrollment), so a fresh dashboard start
+    # picks it up. If ``ambassador.enabled`` is false this is a no-op.
+    _maybe_install_ambassador(app, config)
+
     _ensure_inbox_poller_running(app)
     try:
         yield
@@ -231,6 +237,85 @@ def _start_inbox_poller(config: ConnectorConfig) -> DashboardInboxPoller | None:
     return DashboardInboxPoller(client, poll_interval_s=interval_s)
 
 
+def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
+    """Mount Ambassador router if enabled and identity is on disk.
+
+    Silent no-op when ``ambassador.enabled`` is false or when there is
+    no identity yet (pre-enrollment dashboard). Logs the outcome
+    explicitly for operator visibility.
+    """
+    import logging
+    log = logging.getLogger("cullis_connector.web")
+
+    if not config.ambassador.enabled:
+        log.info("Ambassador disabled by config (ambassador.enabled=False)")
+        return
+    if not has_identity(config.config_dir):
+        log.info(
+            "Ambassador install deferred: no identity at %s yet",
+            config.config_dir,
+        )
+        return
+
+    try:
+        from cullis_connector.ambassador.auth import ensure_local_token
+        from cullis_connector.ambassador.client import AmbassadorClient
+        from cullis_connector.ambassador.router import install_ambassador
+        from cullis_connector.identity.store import load_identity
+    except ImportError:
+        log.exception("Ambassador module import failed; skipping mount")
+        return
+
+    bundle = load_identity(config.config_dir)
+    agent_id = bundle.metadata.agent_id
+    site_url = bundle.metadata.site_url or config.site_url
+    if "::" in agent_id:
+        org_id = agent_id.split("::", 1)[0]
+    else:
+        org_id = ""
+    if not site_url:
+        log.warning(
+            "Ambassador install skipped: site_url unknown "
+            "(metadata=%r config=%r)",
+            bundle.metadata.site_url, config.site_url,
+        )
+        return
+    if not agent_id:
+        log.warning("Ambassador install skipped: agent_id empty in identity")
+        return
+
+    bearer = ensure_local_token(config.config_dir)
+    # The SDK accepts the private key in PEM bytes via login_from_pem;
+    # serialise the in-memory PrivateKeyTypes object back to PEM here so
+    # we don't have to re-read the keyfile (which has the right perms).
+    from cryptography.hazmat.primitives import serialization
+    key_pem = bundle.private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    holder = AmbassadorClient(
+        site_url=site_url,
+        agent_id=agent_id,
+        org_id=org_id,
+        cert_pem=bundle.cert_pem,
+        key_pem=key_pem,
+        verify_tls=config.verify_arg,
+    )
+    install_ambassador(
+        app,
+        bearer_token=bearer,
+        client=holder,
+        advertised_models=config.ambassador.advertised_models,
+        require_local_only=config.ambassador.require_local_only,
+    )
+    log.info(
+        "Ambassador mounted: agent=%s site=%s bearer=*** (saved at %s)",
+        agent_id, site_url, config.config_dir / "local.token",
+    )
+
+
 def build_app(config: ConnectorConfig) -> FastAPI:
     """Return a FastAPI app bound to the given connector config.
 
@@ -281,6 +366,14 @@ def build_app(config: ConnectorConfig) -> FastAPI:
 
     @app.middleware("http")
     async def _csrf_origin_guard(request: Request, call_next):  # type: ignore[no-untyped-def]
+        # ADR-019 — Ambassador endpoints under /v1/* run their own
+        # auth (loopback + Bearer) and cannot rely on Origin/Referer
+        # since OpenAI clients (Cullis Chat / Cursor / OpenWebUI) do
+        # not always emit those headers. Skip the dashboard CSRF
+        # guard for that prefix; the Ambassador router enforces
+        # 401 on missing/invalid Bearer.
+        if request.url.path.startswith("/v1/"):
+            return await call_next(request)
         if request.method in ("POST", "PUT", "DELETE", "PATCH"):
             authz = request.headers.get("authorization", "")
             if not authz.startswith("Bearer "):

--- a/tests/connector/test_ambassador_router.py
+++ b/tests/connector/test_ambassador_router.py
@@ -19,8 +19,6 @@ FastAPI app built by ``cullis_connector.web.build_app``.
 """
 from __future__ import annotations
 
-import json
-import threading
 from pathlib import Path
 from typing import Any
 
@@ -426,7 +424,8 @@ def test_local_token_file_is_chmod_600(tmp_path: Path, client):
     token_path = tmp_path / "local.token"
     assert token_path.exists()
     # On Windows / some FS the perm bits are loose; only assert on POSIX.
-    import os, stat
+    import os
+    import stat
     if os.name == "posix":
         mode = stat.S_IMODE(token_path.stat().st_mode)
         assert mode == 0o600, f"local.token mode is {oct(mode)}, expected 0o600"

--- a/tests/connector/test_ambassador_router.py
+++ b/tests/connector/test_ambassador_router.py
@@ -1,0 +1,432 @@
+"""ADR-019 Step 1 — Connector Ambassador FastAPI router.
+
+Tests cover:
+
+  * Loopback enforcement (request.client.host)
+  * Bearer auth (correct, missing, wrong, malformed)
+  * /v1/models surface
+  * /v1/chat/completions happy path (no tools)
+  * /v1/chat/completions with tool-use loop
+  * /v1/chat/completions with stream=True (fake-stream)
+  * /v1/chat/completions max_iters truncation header
+  * /v1/mcp tools/list passthrough
+  * /v1/mcp tools/call passthrough
+  * /v1/ambassador/health unauth + agent_id reflected
+
+The Cullis SDK is replaced with a programmable fake so these are pure
+unit tests with no network. The whole path goes through the real
+FastAPI app built by ``cullis_connector.web.build_app``.
+"""
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity import (
+    generate_keypair,
+    save_identity,
+)
+from cullis_connector.identity.store import IdentityMetadata
+from cullis_connector.web import build_app
+
+
+# ── helpers ─────────────────────────────────────────────────────────
+
+
+def _self_signed_cert_pem(private_key, *, common_name: str) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.x509.oid import NameOID
+
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, common_name.split("::", 1)[0]),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=30))
+        .sign(private_key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _seed_identity(config_dir: Path, *, agent_id: str = "acme::frontdesk") -> None:
+    key = generate_keypair()
+    cert_pem = _self_signed_cert_pem(key, common_name=agent_id)
+    metadata = IdentityMetadata(
+        agent_id=agent_id,
+        capabilities=[],
+        site_url="https://mastio.test",
+        issued_at="2026-05-04T10:00:00+00:00",
+    )
+    save_identity(
+        config_dir=config_dir,
+        cert_pem=cert_pem,
+        private_key=key,
+        ca_chain_pem=None,
+        metadata=metadata,
+    )
+
+
+class FakeCullisClient:
+    """Programmable stand-in for cullis_sdk.CullisClient.
+
+    Test bodies push expected behaviours into the class-level shared
+    state, then read what the Ambassador called.
+    """
+
+    last_login: tuple = ()
+    chat_calls: list[dict] = []
+    list_tools_calls: int = 0
+    call_tool_calls: list[tuple] = []
+
+    chat_responses: list[dict] = []  # popped FIFO
+    tools_to_return: list[dict] = []
+    tool_results: dict[str, Any] = {}
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.last_login = ()
+        cls.chat_calls = []
+        cls.list_tools_calls = 0
+        cls.call_tool_calls = []
+        cls.chat_responses = []
+        cls.tools_to_return = []
+        cls.tool_results = {}
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._init_args = args
+        self._init_kwargs = kwargs
+
+    @classmethod
+    def from_connector(cls, *args, **kwargs):
+        """The dashboard's inbox poller calls this. Return a fresh fake."""
+        return cls()
+
+    def close(self) -> None:
+        pass
+
+    def list_inbox(self, *args, **kwargs):
+        return []
+
+    def discover(self, *args, **kwargs):
+        return []
+
+    def login_from_pem(self, agent_id, org_id, cert_pem, key_pem, **kw) -> None:
+        type(self).last_login = (agent_id, org_id, cert_pem[:30], key_pem[:30])
+
+    def chat_completion(self, body: dict) -> dict:
+        type(self).chat_calls.append(body)
+        if not type(self).chat_responses:
+            return {
+                "choices": [{
+                    "message": {"role": "assistant", "content": "default fake answer"},
+                    "finish_reason": "stop",
+                }],
+            }
+        return type(self).chat_responses.pop(0)
+
+    def list_mcp_tools(self) -> list[dict]:
+        type(self).list_tools_calls += 1
+        return list(type(self).tools_to_return)
+
+    def call_mcp_tool(self, name: str, arguments: dict) -> dict:
+        type(self).call_tool_calls.append((name, arguments))
+        if name in type(self).tool_results:
+            return type(self).tool_results[name]
+        return {"content": [{"type": "text", "text": f"tool {name} ok"}]}
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_sdk(monkeypatch):
+    FakeCullisClient.reset()
+    monkeypatch.setattr("cullis_sdk.CullisClient", FakeCullisClient)
+    yield
+    FakeCullisClient.reset()
+
+
+@pytest.fixture
+def app(tmp_path: Path):
+    _seed_identity(tmp_path)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test",
+        verify_tls=False,
+    )
+    # TestClient impersonates the host as ``testclient`` not 127.0.0.1,
+    # so the loopback enforcement would 403 every test request. Disable
+    # the check for unit tests (production deployments leave it on).
+    cfg.ambassador.require_local_only = False
+    return build_app(cfg)
+
+
+@pytest.fixture
+def client(app):
+    # The Ambassador is mounted in the dashboard's lifespan, so the
+    # TestClient must enter the context manager to trigger startup.
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def bearer(client, tmp_path: Path) -> str:
+    """Read local.token AFTER the lifespan has run (depends on client)."""
+    return (tmp_path / "local.token").read_text(encoding="utf-8").strip()
+
+
+# ── tests ───────────────────────────────────────────────────────────
+
+
+def test_health_works_without_bearer(client):
+    resp = client.get("/v1/ambassador/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["agent_id"] == "acme::frontdesk"
+    assert body["site_url"] == "https://mastio.test"
+
+
+def test_models_requires_bearer(client):
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+
+
+def test_models_lists_default_three(client, bearer):
+    resp = client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    ids = sorted(m["id"] for m in data)
+    assert "claude-haiku-4-5" in ids
+    assert len(ids) == 3
+
+
+def test_chat_completions_rejects_wrong_bearer(client):
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": "Bearer wrong-token"},
+        json={"model": "claude-haiku-4-5",
+              "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 401
+
+
+def test_chat_completions_rejects_missing_authorization(client):
+    resp = client.post(
+        "/v1/chat/completions",
+        json={"model": "claude-haiku-4-5",
+              "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert resp.status_code == 401
+
+
+def test_chat_completions_happy_path_no_tools(client, bearer):
+    FakeCullisClient.tools_to_return = []
+    FakeCullisClient.chat_responses = [{
+        "choices": [{
+            "message": {"role": "assistant", "content": "ciao Mario"},
+            "finish_reason": "stop",
+        }],
+    }]
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "ciao"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "ciao Mario"
+    # SDK was logged in once, chat called once, no tool dispatch
+    assert FakeCullisClient.last_login[0] == "acme::frontdesk"
+    assert FakeCullisClient.last_login[1] == "acme"
+    assert len(FakeCullisClient.chat_calls) == 1
+    assert FakeCullisClient.list_tools_calls == 1
+    assert FakeCullisClient.call_tool_calls == []
+
+
+def test_chat_completions_runs_tool_use_loop(client, bearer):
+    """LLM returns a tool_call; Ambassador dispatches it; LLM is
+    re-called with the tool result; final answer reaches the client."""
+    FakeCullisClient.tools_to_return = [{
+        "name": "query",
+        "description": "run sql",
+        "inputSchema": {"type": "object", "properties": {"sql": {"type": "string"}}},
+    }]
+    FakeCullisClient.tool_results = {
+        "query": {"content": [{"type": "text", "text": '[{"name":"Mario","ok":true}]'}]},
+    }
+    FakeCullisClient.chat_responses = [
+        # First call: LLM asks for the tool
+        {
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "query",
+                            "arguments": '{"sql":"SELECT name FROM compliance_status WHERE name ILIKE \'Mario%\'"}',
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        },
+        # Second call: LLM returns the final answer
+        {
+            "choices": [{
+                "message": {"role": "assistant", "content": "Mario ha completato il training."},
+                "finish_reason": "stop",
+            }],
+        },
+    ]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "Mario ha fatto il training?"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == "Mario ha completato il training."
+    # Tool loop ran exactly one tool dispatch.
+    assert len(FakeCullisClient.call_tool_calls) == 1
+    name, args = FakeCullisClient.call_tool_calls[0]
+    assert name == "query"
+    assert "compliance_status" in args["sql"]
+    # Two chat completions: one to ask tool, one to format answer.
+    assert len(FakeCullisClient.chat_calls) == 2
+
+
+def test_chat_completions_streaming_returns_sse(client, bearer):
+    FakeCullisClient.chat_responses = [{
+        "choices": [{
+            "message": {"role": "assistant", "content": "ciao streamed"},
+            "finish_reason": "stop",
+        }],
+    }]
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "stream": True,
+            "messages": [{"role": "user", "content": "ciao"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    body_text = resp.text
+    assert "data: " in body_text
+    assert "ciao streamed" in body_text
+    assert "data: [DONE]" in body_text
+
+
+def test_mcp_passthrough_tools_list(client, bearer):
+    FakeCullisClient.tools_to_return = [{
+        "name": "query",
+        "description": "run sql",
+        "inputSchema": {"type": "object"},
+    }]
+    resp = client.post(
+        "/v1/mcp",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["tools"][0]["name"] == "query"
+
+
+def test_mcp_passthrough_tools_call(client, bearer):
+    FakeCullisClient.tool_results = {
+        "query": {"content": [{"type": "text", "text": "ok"}]},
+    }
+    resp = client.post(
+        "/v1/mcp",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "jsonrpc": "2.0", "id": 7,
+            "method": "tools/call",
+            "params": {"name": "query", "arguments": {"sql": "SELECT 1"}},
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == 7
+    assert body["result"]["content"][0]["text"] == "ok"
+
+
+def test_mcp_passthrough_unknown_method(client, bearer):
+    resp = client.post(
+        "/v1/mcp",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/foobar"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"]["code"] == -32601
+
+
+def test_chat_completions_accepts_multimodal_content(client, bearer):
+    """LibreChat-style ``content`` array of blocks must not fail validation."""
+    FakeCullisClient.chat_responses = [{
+        "choices": [{
+            "message": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop",
+        }],
+    }]
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{
+                "role": "user",
+                "content": [{"type": "text", "text": "ciao"}],
+            }],
+        },
+    )
+    assert resp.status_code == 200
+
+
+def test_local_token_file_is_chmod_600(tmp_path: Path, client):
+    """The token file must be created with mode 0600.
+
+    Depends on ``client`` so the lifespan (which generates the file)
+    has fired before we inspect the filesystem.
+    """
+    token_path = tmp_path / "local.token"
+    assert token_path.exists()
+    # On Windows / some FS the perm bits are loose; only assert on POSIX.
+    import os, stat
+    if os.name == "posix":
+        mode = stat.S_IMODE(token_path.stat().st_mode)
+        assert mode == 0o600, f"local.token mode is {oct(mode)}, expected 0o600"


### PR DESCRIPTION
## Summary

First step toward Cullis Frontdesk (ADR-019 draft in `imp/`). The Connector dashboard now exposes an OpenAI-compatible HTTP surface on port 7777 so any local chat client (Cullis Chat once it lands, Cursor, OpenWebUI, ...) can speak Bearer to localhost while the Ambassador re-signs the request as DPoP+mTLS toward the Cullis cloud, preserving cryptographic identity at the cloud edge while letting Bearer-only clients participate.

New endpoints (Bearer + loopback enforced):
- `POST /v1/chat/completions` — OpenAI ChatCompletion, server-side tool-use loop
- `POST /v1/mcp` — JSON-RPC 2.0 passthrough (tools/list, tools/call)
- `GET /v1/models` — list of advertised Cullis-routed models
- `GET /v1/ambassador/health` — unauth liveness, reflects agent_id + site_url

Mechanics:
- `ambassador/auth.py` — local Bearer at `<config_dir>/local.token` (mode 0600, constant-time compare, loopback enforcement)
- `ambassador/client.py` — singleton CullisClient with periodic re-login + invalidate-on-error
- `ambassador/loop.py` — server-side tool-use loop (list bound MCP tools, attach as OpenAI tools[], dispatch, append, re-call, capped at max_iters=8)
- `ambassador/streaming.py` — fake-stream SSE wrapper for `stream=true` clients (replaced when ADR-017 lands real streaming)
- `ambassador/models.py` — permissive ChatCompletionRequest accepting string OR multimodal-array content shapes
- `ambassador/router.py` — FastAPI router + `install_ambassador` wiring
- `web.py` — `_maybe_install_ambassador` called from the dashboard lifespan; CSRF middleware exempts `/v1/*` (Ambassador has its own Bearer auth)
- `config.py` — new `AmbassadorConfig` dataclass

The Cullis cloud DPoP+mTLS guarantee is unchanged; this PR only adds a Bearer-authenticated trust zone strictly inside loopback or, in Step 3, behind a corporate reverse proxy. Threat model documented in `imp/adr-019-cullis-frontdesk.md` §6.

## Test plan

- [x] 13 new tests in `tests/connector/test_ambassador_router.py` cover:
  - Bearer accepted / rejected / missing / wrong
  - `/v1/models` lists 3 default models
  - chat completion happy path (no tools)
  - full tool-use loop (LLM emits tool_call → Ambassador dispatches → LLM re-called with tool result → final answer)
  - streaming SSE (`data: ... data: [DONE]`)
  - `/v1/mcp` tools/list + tools/call passthrough
  - unknown JSON-RPC method returns -32601
  - multimodal content shape (LibreChat-style blocks)
  - `local.token` file is mode 0600
- [x] Existing connector test suite stays green (333 passing; 4 pre-existing failures in `test_profile_runtime_switch.py` are pystray-related and reproduce on main with no Ambassador code in sight)
- [x] Manual smoke: import `cullis_connector.ambassador.router`, `cullis_connector.web._maybe_install_ambassador` succeed without error

## Out of scope (next PRs)

- Cullis Chat SPA (Step 2) — Astro frontend bundled with Connector daemon in `cullis/frontdesk:latest`
- Multi-user SSO mode (Step 3) — `X-Forwarded-User` header trust + `user_to_agent` mapping
- Local MCP bundles (Step 4) — filesystem + time, bind via dashboard
- WebAuthn passkey upgrade (Step 5)