### PR TITLE
feat(spiffe): Principal + 3-component SPIFFE paths (ADR-020 Phase 1)

### DIFF
--- a/app/spiffe.py
+++ b/app/spiffe.py
@@ -2,16 +2,76 @@
 SPIFFE module — bidirectional mapping between internal agent_id and SPIFFE ID.
 
 Standard: https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE-ID.md
-Format:   spiffe://trust-domain/org/agent-name
 
-The internal format `org::agent-name` is the primary key in DB and logs.
-The SPIFFE ID is the standard format for identity in JWTs (claim `sub`)
-and x509 certificates (URI SAN).
+Two layouts coexist during the ADR-020 deprecation window:
+
+  Legacy (2-component path):
+      spiffe://trust-domain/org/<name>
+      → interpreted as principal_type=agent for backward compatibility.
+
+  ADR-020 (3-component path, principal-typed):
+      spiffe://trust-domain/org/<principal-type>/<name>
+      where <principal-type> ∈ { agent, user, workload }.
+
+The internal format `org::name` is unchanged in either layout. The
+``principal_type`` is a separate piece of metadata: derived from the
+SPIFFE path when issuing a new cert, recorded next to the agent_id in
+the registry, and surfaced in audit rows.
+
+ADR-020 introduces ``Principal`` (org_id, principal_type, name) +
+``principal_to_spiffe`` / ``spiffe_to_principal`` that round-trip the
+3-component layout. The legacy 2-component helpers
+(``agent_id_to_spiffe`` etc.) keep working for code paths that have
+not yet migrated; they always emit / accept the legacy layout and
+raise on a 3-component path.
 """
+from __future__ import annotations
+
 import re
+from dataclasses import dataclass
+from typing import Literal
 from urllib.parse import urlparse
 
 _SPIFFE_SCHEME = "spiffe"
+
+# ADR-020 — recognized principal types. The literal type is duck-checked
+# at parse time; new types must be added here AND in the audit /
+# policy layers.
+PRINCIPAL_TYPES = ("agent", "user", "workload")
+PrincipalType = Literal["agent", "user", "workload"]
+DEFAULT_PRINCIPAL_TYPE: PrincipalType = "agent"
+
+
+@dataclass(frozen=True)
+class Principal:
+    """A Cullis principal: the (org, type, name) triple that uniquely
+    identifies an agent, a user or a workload in the network.
+
+    ``agent_id`` is the legacy ``org::name`` text identifier; it does
+    NOT encode the principal type, which is carried separately. Two
+    principals with the same agent_id but different types are distinct
+    entities.
+    """
+    org_id: str
+    principal_type: PrincipalType
+    name: str
+
+    @property
+    def agent_id(self) -> str:
+        """Legacy text identifier. Same shape as before ADR-020."""
+        return f"{self.org_id}::{self.name}"
+
+    @property
+    def is_agent(self) -> bool:
+        return self.principal_type == "agent"
+
+    @property
+    def is_user(self) -> bool:
+        return self.principal_type == "user"
+
+    @property
+    def is_workload(self) -> bool:
+        return self.principal_type == "workload"
 
 # Trust domain: lowercase only, digits, hyphens, dots (no underscore per RFC)
 _TRUST_DOMAIN_RE = re.compile(r"^[a-z0-9]([a-z0-9\-\.]*[a-z0-9])?$")
@@ -96,6 +156,82 @@ def spiffe_to_internal_id(spiffe_id: str) -> str:
     """
     org_id, agent_name = spiffe_to_agent_id(spiffe_id)
     return f"{org_id}::{agent_name}"
+
+
+# ── ADR-020 — principal-typed helpers ─────────────────────────────────
+
+
+def _validate_principal_type(principal_type: str) -> None:
+    if principal_type not in PRINCIPAL_TYPES:
+        raise ValueError(
+            f"Unknown principal_type '{principal_type}' "
+            f"(expected one of {PRINCIPAL_TYPES})"
+        )
+
+
+def principal_to_spiffe(principal: Principal, trust_domain: str) -> str:
+    """Render a ``Principal`` as the ADR-020 3-component SPIFFE URI.
+
+    Example:
+        principal_to_spiffe(
+            Principal("acme", "user", "mario"),
+            "acme.test",
+        )
+        -> "spiffe://acme.test/acme/user/mario"
+    """
+    _validate_trust_domain(trust_domain)
+    _validate_principal_type(principal.principal_type)
+    _validate_path_component(principal.org_id, "org_id")
+    _validate_path_component(principal.name, "name")
+    return (
+        f"spiffe://{trust_domain}/{principal.org_id}"
+        f"/{principal.principal_type}/{principal.name}"
+    )
+
+
+def spiffe_to_principal(spiffe_id: str) -> Principal:
+    """Parse a SPIFFE URI into a ``Principal``.
+
+    Accepts both layouts:
+
+      - 3-component (ADR-020 native): ``spiffe://td/org/<type>/<name>``
+        returns ``Principal(org_id=org, principal_type=<type>, name=<name>)``.
+      - 2-component (legacy):         ``spiffe://td/org/<name>``
+        returns ``Principal(org_id=org, principal_type='agent', name=<name>)``.
+
+    Anything else (0, 1, 4+ segments) raises ValueError.
+    """
+    validate_spiffe_id(spiffe_id)
+    parsed = urlparse(spiffe_id)
+    parts = parsed.path.strip("/").split("/")
+    if len(parts) == 2:
+        org_id, name = parts
+        return Principal(
+            org_id=org_id,
+            principal_type=DEFAULT_PRINCIPAL_TYPE,
+            name=name,
+        )
+    if len(parts) == 3:
+        org_id, principal_type, name = parts
+        _validate_principal_type(principal_type)
+        return Principal(
+            org_id=org_id,
+            principal_type=principal_type,  # type: ignore[arg-type]
+            name=name,
+        )
+    raise ValueError(
+        f"SPIFFE path must have 2 (legacy) or 3 (ADR-020) components, "
+        f"got {len(parts)}: '{spiffe_id}'"
+    )
+
+
+def detect_principal_type(spiffe_id: str) -> PrincipalType:
+    """Convenience: return only the principal type for a SPIFFE URI.
+
+    Useful in code paths that already parse the SAN elsewhere and only
+    need the type for an audit / policy decision.
+    """
+    return spiffe_to_principal(spiffe_id).principal_type
 
 
 def parse_spiffe_san(spiffe_uri: str) -> tuple[str, str]:

--- a/tests/test_spiffe.py
+++ b/tests/test_spiffe.py
@@ -8,10 +8,15 @@ from httpx import AsyncClient
 import jwt as jose_jwt
 
 from app.spiffe import (
+    PRINCIPAL_TYPES,
+    Principal,
     agent_id_to_spiffe,
-    spiffe_to_agent_id,
+    detect_principal_type,
     internal_id_to_spiffe,
+    principal_to_spiffe,
+    spiffe_to_agent_id,
     spiffe_to_internal_id,
+    spiffe_to_principal,
     validate_spiffe_id,
 )
 from tests.cert_factory import make_agent_cert, make_assertion, get_org_ca_pem
@@ -329,3 +334,118 @@ async def test_registry_espone_agent_uri(client: AsyncClient, dpop):
     assert "agent_uri" in agent
     assert agent["agent_uri"].startswith("spiffe://")
     assert agent["agent_uri"] == f"spiffe://cullis.local/{org_id}/agent-1"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ADR-020 — principal-typed SPIFFE URIs (3-component path)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_adr020_principal_dataclass_helpers():
+    """Principal exposes is_user/is_agent/is_workload + agent_id."""
+    p_user = Principal("acme", "user", "mario")
+    assert p_user.is_user and not p_user.is_agent and not p_user.is_workload
+    assert p_user.agent_id == "acme::mario"
+
+    p_agent = Principal("acme", "agent", "mario-laptop")
+    assert p_agent.is_agent
+    assert p_agent.agent_id == "acme::mario-laptop"
+
+    p_wl = Principal("acme", "workload", "byoca-haiku")
+    assert p_wl.is_workload
+    assert p_wl.agent_id == "acme::byoca-haiku"
+
+
+def test_adr020_principal_to_spiffe_user():
+    uri = principal_to_spiffe(Principal("acme", "user", "mario"), "acme.test")
+    assert uri == "spiffe://acme.test/acme/user/mario"
+
+
+def test_adr020_principal_to_spiffe_agent():
+    uri = principal_to_spiffe(Principal("acme", "agent", "mario-laptop"), "acme.test")
+    assert uri == "spiffe://acme.test/acme/agent/mario-laptop"
+
+
+def test_adr020_principal_to_spiffe_workload():
+    uri = principal_to_spiffe(Principal("acme", "workload", "byoca-haiku"), "acme.test")
+    assert uri == "spiffe://acme.test/acme/workload/byoca-haiku"
+
+
+def test_adr020_spiffe_to_principal_round_trip():
+    """principal_to_spiffe / spiffe_to_principal must round-trip cleanly."""
+    for ptype in PRINCIPAL_TYPES:
+        original = Principal("acme", ptype, f"name-{ptype}")
+        uri = principal_to_spiffe(original, "trust.example.com")
+        parsed = spiffe_to_principal(uri)
+        assert parsed == original, (ptype, parsed)
+
+
+def test_adr020_spiffe_to_principal_legacy_2component_default_agent():
+    """Legacy path without principal segment is treated as principal_type=agent."""
+    p = spiffe_to_principal("spiffe://acme.test/acme/legacy-bot")
+    assert p == Principal("acme", "agent", "legacy-bot")
+    assert p.is_agent
+
+
+def test_adr020_spiffe_to_principal_rejects_unknown_principal_type():
+    with pytest.raises(ValueError, match="Unknown principal_type"):
+        spiffe_to_principal("spiffe://acme.test/acme/dragon/sneaky")
+
+
+def test_adr020_spiffe_to_principal_rejects_too_many_components():
+    """4+ path segments are not a valid SPIFFE layout in either flavor."""
+    with pytest.raises(ValueError, match="2 .legacy. or 3 .ADR-020. components"):
+        spiffe_to_principal("spiffe://acme.test/acme/agent/foo/extra")
+
+
+def test_adr020_spiffe_to_principal_rejects_empty_path():
+    with pytest.raises(ValueError):
+        spiffe_to_principal("spiffe://acme.test/")
+
+
+def test_adr020_principal_to_spiffe_rejects_unknown_type():
+    """Constructing the URI with a bogus type bombs at emit time too."""
+    bogus = Principal("acme", "dragon", "x")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Unknown principal_type"):
+        principal_to_spiffe(bogus, "acme.test")
+
+
+def test_adr020_detect_principal_type_new_style():
+    assert detect_principal_type("spiffe://acme.test/acme/user/mario") == "user"
+    assert detect_principal_type("spiffe://acme.test/acme/agent/bot") == "agent"
+    assert detect_principal_type("spiffe://acme.test/acme/workload/svc") == "workload"
+
+
+def test_adr020_detect_principal_type_legacy_defaults_to_agent():
+    assert detect_principal_type("spiffe://acme.test/acme/legacy-bot") == "agent"
+
+
+def test_adr020_legacy_helpers_unchanged_for_2component():
+    """Existing agent_id_to_spiffe / spiffe_to_agent_id must keep their
+    pre-ADR-020 contract: 2-component layout, no principal segment."""
+    uri = agent_id_to_spiffe("manufacturer", "sales-agent", "cullis.local")
+    assert uri == "spiffe://cullis.local/manufacturer/sales-agent"
+    org, name = spiffe_to_agent_id(uri)
+    assert (org, name) == ("manufacturer", "sales-agent")
+
+
+def test_adr020_legacy_spiffe_to_agent_id_still_rejects_3component():
+    """The legacy parser stays strict: principal-typed URIs must use the
+    new helper. We do NOT silently extend spiffe_to_agent_id, otherwise
+    a caller that expected 2 components could now get a wrong tuple."""
+    with pytest.raises(ValueError):
+        spiffe_to_agent_id("spiffe://cullis.local/acme/user/mario")
+
+
+def test_adr020_user_and_agent_can_coexist_for_same_human():
+    """A single human (Mario) may be both user/mario and agent/mario-laptop:
+    distinct principals, distinct SPIFFE IDs, same logical owner."""
+    user = Principal("acme", "user", "mario")
+    laptop = Principal("acme", "agent", "mario-laptop")
+    assert user != laptop
+    user_uri = principal_to_spiffe(user, "acme.test")
+    laptop_uri = principal_to_spiffe(laptop, "acme.test")
+    assert user_uri != laptop_uri
+    # Both round-trip independently.
+    assert spiffe_to_principal(user_uri) == user
+    assert spiffe_to_principal(laptop_uri) == laptop


### PR DESCRIPTION
## Summary

ADR-020 (draft in `imp/`) breaks the implicit binary "agent vs resource" model and introduces three principal types:

| Type | SPIFFE path |
|---|---|
| `user`     | `spiffe://<td>/<org>/user/<name>` |
| `agent`    | `spiffe://<td>/<org>/agent/<name>` |
| `workload` | `spiffe://<td>/<org>/workload/<name>` |

A single human can own multiple principals (e.g. `user/mario` in the browser + `agent/mario-laptop` running autonomously) with distinct SPIFFE IDs, distinct certs, and distinct audit attribution. This commit ships **only the parsing layer**: `Principal` dataclass + `principal_to_spiffe` / `spiffe_to_principal` / `detect_principal_type`. Audit principal_type column, reach policy four-quadrant matrix, user inbox primitive, and Frontdesk integration follow in later phases of ADR-020.

What's preserved unchanged:
- `agent_id_to_spiffe` / `spiffe_to_agent_id` keep their pre-ADR-020 contract: 2-component paths, raise on 3-component input. Code that hasn't migrated to `Principal` continues to work as-is.
- Legacy 2-component paths parse via `spiffe_to_principal` as `principal_type=agent` for back-compat.
- All existing SAN handling, JWT issuance, registry storage. Phase 2 will widen registry + audit; Phase 1 is parser-only.

This is the prerequisite for ADR-019 Step 2 (Cullis Chat SPA): the SPA's identity badge cannot show a correct principal type without a `principal_type` field flowing through. Land Phase 1 + Phase 2 before the SPA ships.

## Test plan

- [x] 14 new tests in `tests/test_spiffe.py` covering: each principal type's emit, round-trip for all three, legacy default-to-agent, unknown-type rejection, oversized path rejection (4+ components), empty path, legacy `spiffe_to_agent_id` still rejecting 3-component input, coexistence of user+agent for the same human.
- [x] 17 existing spiffe tests stay green.
- [x] 80/80 tests pass across spiffe + spiffe_resource_parsing + auth (the three callers of `app/spiffe.py`).

## Out of scope (next phases of ADR-020)

- Phase 2: alembic migration adding `principal_type` to audit + registry + hash chain v2 marker
- Phase 3: reach policy four-quadrant matrix (A2A / A2U / U2A / U2U with default-deny cross-org)
- Phase 4: user inbox primitive (extend `proxy_message_queue`, `/v1/inbox`, WebSocket push)
- Phase 5: Frontdesk integration (Cullis Chat inbox panel + SSO → user-cert provisioning)