### PR TITLE
feat(audit): principal_type column with hash-chain back-compat (ADR-020 Phase 2)

### DIFF
--- a/alembic/versions/l2g3b4c5d6e7_audit_principal_type.py
+++ b/alembic/versions/l2g3b4c5d6e7_audit_principal_type.py
@@ -1,0 +1,59 @@
+"""ADR-020 Phase 2 — audit_log.principal_type column
+
+Revision ID: l2g3b4c5d6e7
+Revises: k1f2a3b4c5d6
+Create Date: 2026-05-04 14:00:00.000000
+
+Adds the ``principal_type`` column to ``audit_log`` with default
+``'agent'`` so existing rows back-fill cleanly without rewriting the
+hash chain. The column distinguishes the three principal categories
+introduced by ADR-020:
+
+  - ``agent``    autonomous workload, the legacy default
+  - ``user``     human in a browser session
+  - ``workload`` MCP server, BYOCA script, model gateway
+
+Hash-chain compatibility (``app/db/audit.py::compute_entry_hash``) is
+preserved by appending ``|pt=<type>`` to the canonical only when the
+type is non-default. So every existing row, plus every new
+``principal_type='agent'`` row, hashes byte-for-byte identical to the
+pre-ADR-020 algorithm. Only ``user`` / ``workload`` rows produce a
+v2-shaped canonical, and they verify with the same single code path.
+
+An index on ``principal_type`` lets the dashboard filter by category
+("show me everything humans did in the last 24h") without a full scan.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "l2g3b4c5d6e7"
+down_revision = "k1f2a3b4c5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add NOT NULL with server-side default 'agent'. Existing rows pick
+    # up the default at upgrade time; the application code will keep
+    # passing 'agent' until ADR-020 Phase 5 wires the resolver to
+    # propagate the SPIFFE-derived value.
+    op.add_column(
+        "audit_log",
+        sa.Column(
+            "principal_type",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'agent'"),
+        ),
+    )
+    op.create_index(
+        "ix_audit_log_principal_type",
+        "audit_log",
+        ["principal_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_log_principal_type", table_name="audit_log")
+    op.drop_column("audit_log", "principal_type")

--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -84,6 +84,13 @@ class AuditLog(Base):
     # Cross-org linkage: on dual-write these point to the companion row.
     peer_org_id = Column(String(128), nullable=True, index=True)
     peer_row_hash = Column(String(64), nullable=True)
+    # ADR-020 — taxonomy of the acting principal. ``agent`` is the
+    # back-compat default so every existing query continues to work
+    # without filter; ``user`` / ``workload`` are filtered explicitly
+    # by reach policy and dashboard views once Phase 3+ ship.
+    principal_type = Column(
+        String(16), nullable=False, server_default="agent", index=True,
+    )
 
 
 class AuditTsaAnchor(Base):
@@ -124,6 +131,7 @@ def compute_entry_hash(
     previous_hash: str | None,
     chain_seq: int | None = None,
     peer_org_id: str | None = None,
+    principal_type: str | None = None,
 ) -> str:
     """Compute the SHA-256 hash of an audit log entry.
 
@@ -131,6 +139,20 @@ def compute_entry_hash(
     the hash. When `chain_seq` is None (legacy row) the hash format is
     identical to the pre-per-org version so existing rows stay
     verifiable against the original algorithm.
+
+    ADR-020 ``principal_type`` rule: a NEW field is appended to the
+    canonical only when it is *non-default*. ``principal_type='agent'``
+    (and ``None``, treated as agent) leaves the hash byte-for-byte
+    identical to the pre-ADR-020 algorithm, so:
+
+      - existing chains keep verifying with the original code path
+      - the column can be backfilled to 'agent' with no chain rewrite
+      - new ``user`` / ``workload`` rows produce a distinct, auditable
+        hash that includes the principal type
+
+    This is the chain-v2 marker: a row whose canonical includes
+    ``|pt=<x>`` is unambiguously v2; a row without is v1-or-agent. Both
+    verify with the same code path.
     """
     base = (
         f"{entry_id}|{timestamp.isoformat()}|{event_type}|"
@@ -143,6 +165,10 @@ def compute_entry_hash(
         # New rows bind chain_seq + peer_org_id into the hash so either
         # field cannot be rewritten without detection.
         canonical = f"{base}|seq={chain_seq}|peer={peer_org_id or ''}"
+    # ADR-020 — append principal_type only when non-default to preserve
+    # back-compat with rows produced before this column existed.
+    if principal_type and principal_type != "agent":
+        canonical = f"{canonical}|pt={principal_type}"
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -188,9 +214,16 @@ async def _append_row(
     details_json: str | None,
     peer_org_id: str | None,
     peer_row_hash: str | None,
+    principal_type: str = "agent",
 ) -> AuditLog:
     """Insert one audit row in the org's chain. Caller must hold the
-    per-org lock and will commit. Does NOT commit itself."""
+    per-org lock and will commit. Does NOT commit itself.
+
+    ``principal_type`` defaults to ``agent`` so callers that have not
+    migrated to ADR-020 keep producing rows identical to pre-ADR-020
+    output. Pass ``user`` / ``workload`` explicitly to record the new
+    taxonomy.
+    """
     previous_hash, last_seq = await _last_per_org(db, org_id)
     new_seq = last_seq + 1
 
@@ -205,6 +238,7 @@ async def _append_row(
         chain_seq=new_seq,
         peer_org_id=peer_org_id,
         peer_row_hash=peer_row_hash,
+        principal_type=principal_type,
     )
     db.add(entry)
     await db.flush()  # assigns auto-incremented id
@@ -218,6 +252,7 @@ async def _append_row(
         details_json, previous_hash,
         chain_seq=new_seq,
         peer_org_id=peer_org_id,
+        principal_type=principal_type,
     )
     return entry
 
@@ -230,6 +265,7 @@ async def log_event(
     session_id: str | None = None,
     org_id: str | None = None,
     details: dict | None = None,
+    principal_type: str = "agent",
 ) -> AuditLog:
     """Append a single entry to the caller's org chain.
 
@@ -262,6 +298,7 @@ async def log_event(
                     details_json=details_json,
                     peer_org_id=None,
                     peer_row_hash=None,
+                    principal_type=principal_type,
                 )
                 await db.commit()
                 break
@@ -305,6 +342,7 @@ async def log_event_cross_org(
     agent_id: str | None = None,
     session_id: str | None = None,
     details: dict | None = None,
+    principal_type: str = "agent",
 ) -> tuple[AuditLog, AuditLog]:
     """Append the same event to both org chains atomically.
 
@@ -347,6 +385,7 @@ async def log_event_cross_org(
                     details_json=details_json,
                     peer_org_id=second,
                     peer_row_hash=None,  # filled in after row_second is hashed
+                    principal_type=principal_type,
                 )
                 row_second = await _append_row(
                     db,
@@ -358,6 +397,7 @@ async def log_event_cross_org(
                     details_json=details_json,
                     peer_org_id=first,
                     peer_row_hash=row_first.entry_hash,
+                    principal_type=principal_type,
                 )
                 # Back-fill peer_row_hash on the first row now that the
                 # second row's hash exists. This closes the
@@ -493,6 +533,7 @@ async def verify_chain(
                 entry.result, entry.details, entry.previous_hash,
                 chain_seq=entry.chain_seq,
                 peer_org_id=entry.peer_org_id,
+                principal_type=entry.principal_type,
             )
             if entry.entry_hash != expected_hash:
                 AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -242,3 +242,128 @@ async def test_cross_org_mixed_with_intra_org(audit_db):
 
     ok, total, _ = await verify_chain(audit_db, org_id="acme")
     assert ok is True and total == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ADR-020 Phase 2 — principal_type column
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def test_adr020_default_principal_type_is_agent(audit_db):
+    """log_event without principal_type stores 'agent' (back-compat default)."""
+    entry = await log_event(audit_db, "test.default", "ok", org_id="acme")
+    assert entry.principal_type == "agent"
+
+
+async def test_adr020_explicit_user_principal_type(audit_db):
+    """A user-attributed event records principal_type='user'."""
+    entry = await log_event(
+        audit_db, "test.user", "ok",
+        agent_id="acme::mario", org_id="acme",
+        principal_type="user",
+    )
+    assert entry.principal_type == "user"
+
+
+async def test_adr020_explicit_workload_principal_type(audit_db):
+    entry = await log_event(
+        audit_db, "test.workload", "ok",
+        agent_id="acme::byoca-haiku", org_id="acme",
+        principal_type="workload",
+    )
+    assert entry.principal_type == "workload"
+
+
+async def test_adr020_agent_hash_unchanged_vs_pre_adr020(audit_db):
+    """Crucially: an 'agent' row's entry_hash is byte-for-byte equal
+    to what compute_entry_hash would produce WITHOUT principal_type
+    (i.e. the pre-ADR-020 algorithm). This is the back-compat property
+    that lets the column be added with no chain rewrite."""
+    from datetime import timezone
+
+    entry = await log_event(audit_db, "test.compat", "ok", org_id="acme",
+                            principal_type="agent")
+    ts = entry.timestamp
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+
+    recomputed_pre_adr = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        # principal_type omitted — exactly the pre-ADR-020 call shape
+    )
+    recomputed_agent = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        principal_type="agent",
+    )
+    assert recomputed_pre_adr == recomputed_agent == entry.entry_hash
+
+
+async def test_adr020_user_hash_includes_principal_type_marker(audit_db):
+    """A user row's canonical includes |pt=user, so its hash differs
+    from the same row hashed as 'agent'. This is the chain-v2 marker."""
+    from datetime import timezone
+
+    entry = await log_event(
+        audit_db, "test.usermark", "ok",
+        agent_id="acme::mario", org_id="acme",
+        principal_type="user",
+    )
+    ts = entry.timestamp
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+
+    hash_user = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        principal_type="user",
+    )
+    hash_as_agent = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        principal_type="agent",
+    )
+    assert hash_user == entry.entry_hash
+    assert hash_user != hash_as_agent  # type marker actually changed the hash
+
+
+async def test_adr020_verify_chain_mixed_principals(audit_db):
+    """A chain that mixes user, agent, workload rows still verifies."""
+    await log_event(audit_db, "e1", "ok", org_id="acme")  # agent default
+    await log_event(audit_db, "e2", "ok", org_id="acme",
+                    principal_type="user")
+    await log_event(audit_db, "e3", "ok", org_id="acme",
+                    principal_type="workload")
+    await log_event(audit_db, "e4", "ok", org_id="acme",
+                    principal_type="user")
+    is_valid, total, broken_id = await verify_chain(audit_db, org_id="acme")
+    assert is_valid is True
+    assert total == 4
+    assert broken_id == 0
+
+
+async def test_adr020_cross_org_propagates_principal_type(audit_db):
+    """log_event_cross_org tags both rows with the same principal_type."""
+    from app.db.audit import log_event_cross_org
+
+    row_a, row_b = await log_event_cross_org(
+        audit_db, "u2u.message", "ok",
+        org_a="acme", org_b="bravo",
+        agent_id="acme::mario",
+        principal_type="user",
+    )
+    assert row_a.principal_type == "user"
+    assert row_b.principal_type == "user"


### PR DESCRIPTION
## Summary

The audit log now records the principal taxonomy introduced by ADR-020 (user / agent / workload). The column has `server_default='agent'` so every existing row backfills cleanly and the application code keeps behaving identically until ADR-020 Phase 5 wires the SPIFFE-derived value through.

Hash-chain backward compatibility is the non-trivial property: `compute_entry_hash` appends `|pt=<type>` to the canonical **only when the type is non-default**. As a result:

- existing chains keep verifying with the original code path (no rewrite, no recompute)
- `principal_type='agent'` rows hash byte-for-byte identical to the pre-ADR-020 algorithm
- `principal_type='user'` / `'workload'` rows include the chain-v2 marker in their hash and verify with the same single code path

`verify_chain` reads `entry.principal_type` and re-passes it to `compute_entry_hash` so mixed chains (some agent, some user, some workload) verify cleanly. `log_event` and `log_event_cross_org` accept an optional `principal_type` kwarg (default `'agent'`).

Migration `l2g3b4c5d6e7` adds the column NOT NULL DEFAULT 'agent' and an index on it; downgrade drops both. Up + down + up tested locally on SQLite.

## Test plan

- [x] 7 new tests in `tests/test_audit_chain.py`:
  - `default_principal_type_is_agent`
  - `explicit_user_principal_type` / `explicit_workload_principal_type`
  - **`agent_hash_unchanged_vs_pre_adr020`** (the back-compat property — agent rows hash identically to pre-ADR-020)
  - **`user_hash_includes_principal_type_marker`** (chain-v2 marker visible only on non-agent rows)
  - `verify_chain_mixed_principals` (a chain mixing all three types verifies)
  - `cross_org_propagates_principal_type`
- [x] 22/22 `tests/test_audit_chain.py` green.
- [x] 65/65 across the wider audit suite green: `test_audit_chain.py + test_audit_race_safety.py + test_audit_export.py + test_audit_export_tsa.py + test_audit_oneshot_envelope_integrity.py + test_audit_api.py + test_h4_audit_chain.py`.
- [x] Alembic up + down + up clean on SQLite.
- [x] No regressions in 80 tests across `test_spiffe.py + test_spiffe_resource_parsing.py + test_auth.py` (the chain hashing path is referenced by these via the audit module).

## Independence from PR #407 (Phase 1)

Phase 2 is **standalone**. It does not import or use the `Principal` parser from PR #407 — at this layer the column is a free-form string with a server default. Phase 5 will wire the SPIFFE-derived `principal_type` through, at which point Phase 1's parser becomes the canonical source.

## Out of scope (next phases of ADR-020)

- Phase 3: reach policy four-quadrant matrix (A2A / A2U / U2A / U2U with default-deny cross-org)
- Phase 4: user inbox primitive (extend `proxy_message_queue`, `/v1/inbox`, WebSocket push)
- Phase 5: Frontdesk integration (Cullis Chat inbox panel + SSO → user-cert provisioning, where the SPIFFE-derived principal_type starts flowing into log_event calls)