### PR TITLE
feat(policy): four-quadrant reach matrix + consent grants (ADR-020 Phase 3)

### DIFF
--- a/alembic/versions/l2g3b4c5d6e7_audit_principal_type.py
+++ b/alembic/versions/l2g3b4c5d6e7_audit_principal_type.py
@@ -1,0 +1,59 @@
+"""ADR-020 Phase 2 — audit_log.principal_type column
+
+Revision ID: l2g3b4c5d6e7
+Revises: k1f2a3b4c5d6
+Create Date: 2026-05-04 14:00:00.000000
+
+Adds the ``principal_type`` column to ``audit_log`` with default
+``'agent'`` so existing rows back-fill cleanly without rewriting the
+hash chain. The column distinguishes the three principal categories
+introduced by ADR-020:
+
+  - ``agent``    autonomous workload, the legacy default
+  - ``user``     human in a browser session
+  - ``workload`` MCP server, BYOCA script, model gateway
+
+Hash-chain compatibility (``app/db/audit.py::compute_entry_hash``) is
+preserved by appending ``|pt=<type>`` to the canonical only when the
+type is non-default. So every existing row, plus every new
+``principal_type='agent'`` row, hashes byte-for-byte identical to the
+pre-ADR-020 algorithm. Only ``user`` / ``workload`` rows produce a
+v2-shaped canonical, and they verify with the same single code path.
+
+An index on ``principal_type`` lets the dashboard filter by category
+("show me everything humans did in the last 24h") without a full scan.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "l2g3b4c5d6e7"
+down_revision = "k1f2a3b4c5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add NOT NULL with server-side default 'agent'. Existing rows pick
+    # up the default at upgrade time; the application code will keep
+    # passing 'agent' until ADR-020 Phase 5 wires the resolver to
+    # propagate the SPIFFE-derived value.
+    op.add_column(
+        "audit_log",
+        sa.Column(
+            "principal_type",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'agent'"),
+        ),
+    )
+    op.create_index(
+        "ix_audit_log_principal_type",
+        "audit_log",
+        ["principal_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_log_principal_type", table_name="audit_log")
+    op.drop_column("audit_log", "principal_type")

--- a/alembic/versions/m3h4i5j6k7l8_reach_consents.py
+++ b/alembic/versions/m3h4i5j6k7l8_reach_consents.py
@@ -1,0 +1,55 @@
+"""ADR-020 Phase 3 — reach_consents table for four-quadrant policy
+
+Revision ID: m3h4i5j6k7l8
+Revises: l2g3b4c5d6e7
+Create Date: 2026-05-04 15:00:00.000000
+
+Persists per-pair consent grants used by the reach policy (A2U / U2A
+intra-org, A2A / A2U / U2A / U2U cross-org). A row authorises one
+specific source — or any source of a given type from a given org when
+``source_name='*'`` — to deliver to one specific recipient.
+
+Soft-deletion via ``revoked_at`` non-null. The unique constraint on
+the full (recipient, source) tuple lets a re-grant after revoke
+update the existing row instead of piling up duplicates, mirroring
+``local_agent_resource_bindings``.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "m3h4i5j6k7l8"
+down_revision = "l2g3b4c5d6e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reach_consents",
+        sa.Column("consent_id", sa.String(length=64), primary_key=True),
+        sa.Column("recipient_org_id", sa.String(length=128), nullable=False),
+        sa.Column("recipient_principal_type", sa.String(length=16), nullable=False),
+        sa.Column("recipient_name", sa.String(length=128), nullable=False),
+        sa.Column("source_org_id", sa.String(length=128), nullable=False),
+        sa.Column("source_principal_type", sa.String(length=16), nullable=False),
+        sa.Column("source_name", sa.String(length=128), nullable=False),
+        sa.Column("granted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("granted_by", sa.String(length=128), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "source_org_id", "source_principal_type", "source_name",
+            name="uq_reach_consent_pair",
+        ),
+    )
+    op.create_index(
+        "idx_reach_consent_recipient_active",
+        "reach_consents",
+        ["recipient_org_id", "recipient_principal_type", "recipient_name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_reach_consent_recipient_active", table_name="reach_consents")
+    op.drop_table("reach_consents")

--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -84,6 +84,13 @@ class AuditLog(Base):
     # Cross-org linkage: on dual-write these point to the companion row.
     peer_org_id = Column(String(128), nullable=True, index=True)
     peer_row_hash = Column(String(64), nullable=True)
+    # ADR-020 — taxonomy of the acting principal. ``agent`` is the
+    # back-compat default so every existing query continues to work
+    # without filter; ``user`` / ``workload`` are filtered explicitly
+    # by reach policy and dashboard views once Phase 3+ ship.
+    principal_type = Column(
+        String(16), nullable=False, server_default="agent", index=True,
+    )
 
 
 class AuditTsaAnchor(Base):
@@ -124,6 +131,7 @@ def compute_entry_hash(
     previous_hash: str | None,
     chain_seq: int | None = None,
     peer_org_id: str | None = None,
+    principal_type: str | None = None,
 ) -> str:
     """Compute the SHA-256 hash of an audit log entry.
 
@@ -131,6 +139,20 @@ def compute_entry_hash(
     the hash. When `chain_seq` is None (legacy row) the hash format is
     identical to the pre-per-org version so existing rows stay
     verifiable against the original algorithm.
+
+    ADR-020 ``principal_type`` rule: a NEW field is appended to the
+    canonical only when it is *non-default*. ``principal_type='agent'``
+    (and ``None``, treated as agent) leaves the hash byte-for-byte
+    identical to the pre-ADR-020 algorithm, so:
+
+      - existing chains keep verifying with the original code path
+      - the column can be backfilled to 'agent' with no chain rewrite
+      - new ``user`` / ``workload`` rows produce a distinct, auditable
+        hash that includes the principal type
+
+    This is the chain-v2 marker: a row whose canonical includes
+    ``|pt=<x>`` is unambiguously v2; a row without is v1-or-agent. Both
+    verify with the same code path.
     """
     base = (
         f"{entry_id}|{timestamp.isoformat()}|{event_type}|"
@@ -143,6 +165,10 @@ def compute_entry_hash(
         # New rows bind chain_seq + peer_org_id into the hash so either
         # field cannot be rewritten without detection.
         canonical = f"{base}|seq={chain_seq}|peer={peer_org_id or ''}"
+    # ADR-020 — append principal_type only when non-default to preserve
+    # back-compat with rows produced before this column existed.
+    if principal_type and principal_type != "agent":
+        canonical = f"{canonical}|pt={principal_type}"
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -188,9 +214,16 @@ async def _append_row(
     details_json: str | None,
     peer_org_id: str | None,
     peer_row_hash: str | None,
+    principal_type: str = "agent",
 ) -> AuditLog:
     """Insert one audit row in the org's chain. Caller must hold the
-    per-org lock and will commit. Does NOT commit itself."""
+    per-org lock and will commit. Does NOT commit itself.
+
+    ``principal_type`` defaults to ``agent`` so callers that have not
+    migrated to ADR-020 keep producing rows identical to pre-ADR-020
+    output. Pass ``user`` / ``workload`` explicitly to record the new
+    taxonomy.
+    """
     previous_hash, last_seq = await _last_per_org(db, org_id)
     new_seq = last_seq + 1
 
@@ -205,6 +238,7 @@ async def _append_row(
         chain_seq=new_seq,
         peer_org_id=peer_org_id,
         peer_row_hash=peer_row_hash,
+        principal_type=principal_type,
     )
     db.add(entry)
     await db.flush()  # assigns auto-incremented id
@@ -218,6 +252,7 @@ async def _append_row(
         details_json, previous_hash,
         chain_seq=new_seq,
         peer_org_id=peer_org_id,
+        principal_type=principal_type,
     )
     return entry
 
@@ -230,6 +265,7 @@ async def log_event(
     session_id: str | None = None,
     org_id: str | None = None,
     details: dict | None = None,
+    principal_type: str = "agent",
 ) -> AuditLog:
     """Append a single entry to the caller's org chain.
 
@@ -262,6 +298,7 @@ async def log_event(
                     details_json=details_json,
                     peer_org_id=None,
                     peer_row_hash=None,
+                    principal_type=principal_type,
                 )
                 await db.commit()
                 break
@@ -305,6 +342,7 @@ async def log_event_cross_org(
     agent_id: str | None = None,
     session_id: str | None = None,
     details: dict | None = None,
+    principal_type: str = "agent",
 ) -> tuple[AuditLog, AuditLog]:
     """Append the same event to both org chains atomically.
 
@@ -347,6 +385,7 @@ async def log_event_cross_org(
                     details_json=details_json,
                     peer_org_id=second,
                     peer_row_hash=None,  # filled in after row_second is hashed
+                    principal_type=principal_type,
                 )
                 row_second = await _append_row(
                     db,
@@ -358,6 +397,7 @@ async def log_event_cross_org(
                     details_json=details_json,
                     peer_org_id=first,
                     peer_row_hash=row_first.entry_hash,
+                    principal_type=principal_type,
                 )
                 # Back-fill peer_row_hash on the first row now that the
                 # second row's hash exists. This closes the
@@ -493,6 +533,7 @@ async def verify_chain(
                 entry.result, entry.details, entry.previous_hash,
                 chain_seq=entry.chain_seq,
                 peer_org_id=entry.peer_org_id,
+                principal_type=entry.principal_type,
             )
             if entry.entry_hash != expected_hash:
                 AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(

--- a/app/policy/reach.py
+++ b/app/policy/reach.py
@@ -1,0 +1,471 @@
+"""ADR-020 Phase 3 — reach policy four-quadrant matrix.
+
+Cullis recognises three principal types (agent, user, workload). Every
+send is therefore assignable to one of nine cells in a (source × dest)
+matrix; eight of them get explicit semantics here. Workloads do not
+initiate in v0.1, so the W2* row is always denied.
+
+The matrix this module enforces:
+
+                       destination
+                       agent              user               workload
+   source
+   agent               A2A                A2U                tool call
+   user                U2A                U2U                tool call
+   workload            (deny v0.1)        (deny v0.1)        (deny v0.1)
+
+with the following defaults:
+
+   intra-org   A2A   allow              (this is the existing oneshot/reply path)
+   cross-org   A2A   allow if matching reach exists, otherwise deny
+   intra-org   U2A   allow if user owns the agent, otherwise consent gate
+   cross-org   U2A   deny  + per-source consent grant required
+   intra-org   A2U   deny  + per-source consent grant required
+   cross-org   A2U   deny  + per-source consent grant required
+   intra-org   U2U   allow              (same domain, SSO already trusts both)
+   cross-org   U2U   deny  + per-source consent grant required (addressbook)
+
+A2W / U2W (workload-as-destination) are tool calls and live in the MCP
+aggregator authz path (binding gate); reach policy is a no-op for that
+quadrant and returns allow.
+
+The consent table is a normal-form authorisation grant: any pending
+inbox push checks ``reach_consents`` for an active row that covers
+the (source, recipient) pair before delivery; otherwise the message
+is rejected at the broker edge with an audit row.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Literal
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Index,
+    String,
+    UniqueConstraint,
+    and_,
+    or_,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.audit import log_event
+from app.db.database import Base
+
+_log = logging.getLogger("app.policy.reach")
+
+# Legal principal-type values — aligned with app/spiffe.py PRINCIPAL_TYPES.
+PRINCIPAL_TYPES = ("agent", "user", "workload")
+PrincipalType = Literal["agent", "user", "workload"]
+
+# Quadrant labels emitted into audit rows.
+Quadrant = Literal["A2A", "A2U", "U2A", "U2U", "A2W", "U2W", "W2A", "W2U", "W2W"]
+
+# Wildcard sentinel for the source-name field of a consent grant. Lets
+# a user say "I accept incoming from any agent in org X" without
+# enumerating each agent.
+ANY_NAME = "*"
+
+
+# ── Data classes ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PrincipalRef:
+    """Reference to one principal (sender or recipient of a reach)."""
+    org_id: str
+    principal_type: PrincipalType
+    name: str
+
+
+@dataclass(frozen=True)
+class ReachContext:
+    """The (source, destination) pair under evaluation."""
+    source: PrincipalRef
+    destination: PrincipalRef
+
+    @property
+    def is_intra_org(self) -> bool:
+        return self.source.org_id == self.destination.org_id
+
+    @property
+    def quadrant(self) -> Quadrant:
+        # Two-letter shorthand: source-type initial + "2" + dest-type initial.
+        # Workload uses W; agent A; user U.
+        s = self.source.principal_type[0].upper()
+        d = self.destination.principal_type[0].upper()
+        return f"{s}2{d}"  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Result of a reach evaluation, ready to be returned to the caller
+    and to be audited via ``log_event``."""
+    allowed: bool
+    reason: str
+    quadrant: Quadrant
+    consent_id: str | None = None
+
+
+# ── Persistence model ───────────────────────────────────────────────
+
+
+class ReachConsent(Base):
+    """A persistent grant: recipient agreed to accept incoming reach
+    messages from a specific source (or any source of a given type
+    from a given org, when ``source_name`` is the wildcard ``*``).
+
+    Revocation is soft (``revoked_at`` non-null). The unique constraint
+    on the full (recipient, source) tuple lets a re-grant after revoke
+    UPDATE the existing row back to revoked_at=NULL without piling up
+    duplicates — same pattern as ``local_agent_resource_bindings``.
+    """
+    __tablename__ = "reach_consents"
+
+    consent_id = Column(String(64), primary_key=True)
+    recipient_org_id = Column(String(128), nullable=False, index=True)
+    recipient_principal_type = Column(String(16), nullable=False)
+    recipient_name = Column(String(128), nullable=False)
+    source_org_id = Column(String(128), nullable=False)
+    source_principal_type = Column(String(16), nullable=False)
+    source_name = Column(String(128), nullable=False)  # ANY_NAME = wildcard
+    granted_at = Column(DateTime(timezone=True), nullable=False)
+    granted_by = Column(String(128), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "source_org_id", "source_principal_type", "source_name",
+            name="uq_reach_consent_pair",
+        ),
+        Index(
+            "idx_reach_consent_recipient_active",
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+        ),
+    )
+
+
+OwnershipResolver = Callable[[PrincipalRef, PrincipalRef], Awaitable[bool]]
+"""Async predicate: does ``user`` own ``agent``? Resolver is supplied by
+the caller (Phase 5 wires this to a registry table). Phase 3 default
+is ``False`` if no resolver is supplied — callers in v0.1 are agents,
+not users-acting-on-their-agents."""
+
+
+# ── Evaluation ──────────────────────────────────────────────────────
+
+
+async def _has_active_consent(
+    db: AsyncSession, ctx: ReachContext,
+) -> str | None:
+    """Return ``consent_id`` of an active grant covering ``ctx``, or None.
+
+    Matches a specific source name first, then falls back to a wildcard
+    grant (``source_name=ANY_NAME``).
+    """
+    stmt = select(ReachConsent).where(
+        and_(
+            ReachConsent.recipient_org_id == ctx.destination.org_id,
+            ReachConsent.recipient_principal_type == ctx.destination.principal_type,
+            ReachConsent.recipient_name == ctx.destination.name,
+            ReachConsent.source_org_id == ctx.source.org_id,
+            ReachConsent.source_principal_type == ctx.source.principal_type,
+            or_(
+                ReachConsent.source_name == ctx.source.name,
+                ReachConsent.source_name == ANY_NAME,
+            ),
+            ReachConsent.revoked_at.is_(None),
+        )
+    ).order_by(
+        # Specific name beats wildcard when both exist for the same pair.
+        ReachConsent.source_name.desc(),
+    ).limit(1)
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    return row.consent_id if row else None
+
+
+async def evaluate_reach_quadrant(
+    db: AsyncSession,
+    ctx: ReachContext,
+    *,
+    ownership_resolver: OwnershipResolver | None = None,
+    audit_session_id: str | None = None,
+) -> PolicyDecision:
+    """Decide whether ``ctx`` is permitted by the four-quadrant matrix.
+
+    Side effects:
+      - emits a ``policy.reach_evaluated`` audit row on every call (one
+        per evaluation), tagged with the resolved quadrant.
+    """
+    quadrant = ctx.quadrant
+
+    # ── W2* — workloads do not initiate in v0.1 ────────────────────
+    if ctx.source.principal_type == "workload":
+        decision = PolicyDecision(
+            allowed=False,
+            reason="Workload-as-source not allowed in v0.1 (W2* deny by default)",
+            quadrant=quadrant,
+        )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── *2W — workload-as-destination is a tool call, separate authz ─
+    if ctx.destination.principal_type == "workload":
+        decision = PolicyDecision(
+            allowed=True,
+            reason="Workload destination — tool-call binding governs (reach noop)",
+            quadrant=quadrant,
+        )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── A2A ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "agent" and ctx.destination.principal_type == "agent":
+        if ctx.is_intra_org:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Intra-org A2A allowed by default",
+                quadrant=quadrant,
+            )
+            await _audit_reach(db, ctx, decision, audit_session_id)
+            return decision
+        # Cross-org A2A: existing reach mechanism. Phase 3 considers a
+        # consent grant equivalent to the legacy reach record. Caller
+        # may layer the legacy reach check on top.
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="Cross-org A2A requires an explicit reach grant",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Cross-org A2A authorised by reach grant",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── A2U ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "agent" and ctx.destination.principal_type == "user":
+        # ALWAYS consent-gated. Even intra-org an unsolicited agent must
+        # not pop into a human's inbox. The whole anti-spam premise of
+        # the user inbox depends on this.
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="A2U deny: recipient user has not consented to this source",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="A2U authorised by recipient consent",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── U2A ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "user" and ctx.destination.principal_type == "agent":
+        if ctx.is_intra_org and ownership_resolver is not None:
+            owns = await ownership_resolver(ctx.source, ctx.destination)
+            if owns:
+                decision = PolicyDecision(
+                    allowed=True,
+                    reason="U2A intra-org allowed: user owns destination agent",
+                    quadrant=quadrant,
+                )
+                await _audit_reach(db, ctx, decision, audit_session_id)
+                return decision
+        # Otherwise consent-gated.
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="U2A deny: agent has not consented to this user",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="U2A authorised by recipient consent",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── U2U ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "user" and ctx.destination.principal_type == "user":
+        if ctx.is_intra_org:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Intra-org U2U allowed by default (same SSO domain)",
+                quadrant=quadrant,
+            )
+            await _audit_reach(db, ctx, decision, audit_session_id)
+            return decision
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="Cross-org U2U deny: recipient user has not added sender to addressbook",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Cross-org U2U authorised by addressbook entry",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── Unhandled combo (defensive) ────────────────────────────────
+    decision = PolicyDecision(
+        allowed=False,
+        reason=f"Unrecognised quadrant {quadrant} — default deny",
+        quadrant=quadrant,
+    )
+    await _audit_reach(db, ctx, decision, audit_session_id)
+    return decision
+
+
+async def _audit_reach(
+    db: AsyncSession,
+    ctx: ReachContext,
+    decision: PolicyDecision,
+    session_id: str | None,
+) -> None:
+    await log_event(
+        db,
+        event_type="policy.reach_evaluated",
+        result="ok" if decision.allowed else "denied",
+        agent_id=f"{ctx.source.org_id}::{ctx.source.name}",
+        org_id=ctx.source.org_id,
+        session_id=session_id,
+        principal_type=ctx.source.principal_type,
+        details={
+            "quadrant": decision.quadrant,
+            "is_intra_org": ctx.is_intra_org,
+            "destination_org": ctx.destination.org_id,
+            "destination_principal_type": ctx.destination.principal_type,
+            "destination_name": ctx.destination.name,
+            "consent_id": decision.consent_id,
+            "reason": decision.reason,
+        },
+    )
+
+
+# ── Consent grant management ────────────────────────────────────────
+
+
+async def grant_consent(
+    db: AsyncSession,
+    *,
+    recipient: PrincipalRef,
+    source_org_id: str,
+    source_principal_type: PrincipalType,
+    source_name: str = ANY_NAME,
+    granted_by: str | None = None,
+) -> ReachConsent:
+    """Persist a consent grant. Idempotent: re-granting an existing
+    pair flips ``revoked_at=None`` instead of creating a duplicate."""
+    import uuid
+
+    # Look up existing row first (revoked or not).
+    existing = (await db.execute(
+        select(ReachConsent).where(
+            and_(
+                ReachConsent.recipient_org_id == recipient.org_id,
+                ReachConsent.recipient_principal_type == recipient.principal_type,
+                ReachConsent.recipient_name == recipient.name,
+                ReachConsent.source_org_id == source_org_id,
+                ReachConsent.source_principal_type == source_principal_type,
+                ReachConsent.source_name == source_name,
+            )
+        )
+    )).scalar_one_or_none()
+
+    now = datetime.now(timezone.utc)
+    if existing is not None:
+        existing.revoked_at = None
+        existing.granted_at = now
+        existing.granted_by = granted_by
+        await db.commit()
+        return existing
+
+    row = ReachConsent(
+        consent_id=str(uuid.uuid4()),
+        recipient_org_id=recipient.org_id,
+        recipient_principal_type=recipient.principal_type,
+        recipient_name=recipient.name,
+        source_org_id=source_org_id,
+        source_principal_type=source_principal_type,
+        source_name=source_name,
+        granted_at=now,
+        granted_by=granted_by,
+        revoked_at=None,
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+async def revoke_consent(
+    db: AsyncSession,
+    *,
+    recipient: PrincipalRef,
+    source_org_id: str,
+    source_principal_type: PrincipalType,
+    source_name: str = ANY_NAME,
+) -> bool:
+    """Mark an existing grant as revoked. No-op if no matching row.
+    Returns True iff a row was actually revoked (was previously active)."""
+    row = (await db.execute(
+        select(ReachConsent).where(
+            and_(
+                ReachConsent.recipient_org_id == recipient.org_id,
+                ReachConsent.recipient_principal_type == recipient.principal_type,
+                ReachConsent.recipient_name == recipient.name,
+                ReachConsent.source_org_id == source_org_id,
+                ReachConsent.source_principal_type == source_principal_type,
+                ReachConsent.source_name == source_name,
+                ReachConsent.revoked_at.is_(None),
+            )
+        )
+    )).scalar_one_or_none()
+    if row is None:
+        return False
+    row.revoked_at = datetime.now(timezone.utc)
+    await db.commit()
+    return True
+
+
+async def list_active_consents(
+    db: AsyncSession, recipient: PrincipalRef,
+) -> list[ReachConsent]:
+    """List every active grant for a recipient. Useful for the inbox UI."""
+    rows = (await db.execute(
+        select(ReachConsent).where(
+            and_(
+                ReachConsent.recipient_org_id == recipient.org_id,
+                ReachConsent.recipient_principal_type == recipient.principal_type,
+                ReachConsent.recipient_name == recipient.name,
+                ReachConsent.revoked_at.is_(None),
+            )
+        ).order_by(ReachConsent.granted_at.desc())
+    )).scalars().all()
+    return list(rows)

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -242,3 +242,128 @@ async def test_cross_org_mixed_with_intra_org(audit_db):
 
     ok, total, _ = await verify_chain(audit_db, org_id="acme")
     assert ok is True and total == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ADR-020 Phase 2 — principal_type column
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def test_adr020_default_principal_type_is_agent(audit_db):
+    """log_event without principal_type stores 'agent' (back-compat default)."""
+    entry = await log_event(audit_db, "test.default", "ok", org_id="acme")
+    assert entry.principal_type == "agent"
+
+
+async def test_adr020_explicit_user_principal_type(audit_db):
+    """A user-attributed event records principal_type='user'."""
+    entry = await log_event(
+        audit_db, "test.user", "ok",
+        agent_id="acme::mario", org_id="acme",
+        principal_type="user",
+    )
+    assert entry.principal_type == "user"
+
+
+async def test_adr020_explicit_workload_principal_type(audit_db):
+    entry = await log_event(
+        audit_db, "test.workload", "ok",
+        agent_id="acme::byoca-haiku", org_id="acme",
+        principal_type="workload",
+    )
+    assert entry.principal_type == "workload"
+
+
+async def test_adr020_agent_hash_unchanged_vs_pre_adr020(audit_db):
+    """Crucially: an 'agent' row's entry_hash is byte-for-byte equal
+    to what compute_entry_hash would produce WITHOUT principal_type
+    (i.e. the pre-ADR-020 algorithm). This is the back-compat property
+    that lets the column be added with no chain rewrite."""
+    from datetime import timezone
+
+    entry = await log_event(audit_db, "test.compat", "ok", org_id="acme",
+                            principal_type="agent")
+    ts = entry.timestamp
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+
+    recomputed_pre_adr = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        # principal_type omitted — exactly the pre-ADR-020 call shape
+    )
+    recomputed_agent = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        principal_type="agent",
+    )
+    assert recomputed_pre_adr == recomputed_agent == entry.entry_hash
+
+
+async def test_adr020_user_hash_includes_principal_type_marker(audit_db):
+    """A user row's canonical includes |pt=user, so its hash differs
+    from the same row hashed as 'agent'. This is the chain-v2 marker."""
+    from datetime import timezone
+
+    entry = await log_event(
+        audit_db, "test.usermark", "ok",
+        agent_id="acme::mario", org_id="acme",
+        principal_type="user",
+    )
+    ts = entry.timestamp
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+
+    hash_user = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        principal_type="user",
+    )
+    hash_as_agent = compute_entry_hash(
+        entry.id, ts, entry.event_type,
+        entry.agent_id, entry.session_id, entry.org_id,
+        entry.result, entry.details, entry.previous_hash,
+        chain_seq=entry.chain_seq,
+        peer_org_id=entry.peer_org_id,
+        principal_type="agent",
+    )
+    assert hash_user == entry.entry_hash
+    assert hash_user != hash_as_agent  # type marker actually changed the hash
+
+
+async def test_adr020_verify_chain_mixed_principals(audit_db):
+    """A chain that mixes user, agent, workload rows still verifies."""
+    await log_event(audit_db, "e1", "ok", org_id="acme")  # agent default
+    await log_event(audit_db, "e2", "ok", org_id="acme",
+                    principal_type="user")
+    await log_event(audit_db, "e3", "ok", org_id="acme",
+                    principal_type="workload")
+    await log_event(audit_db, "e4", "ok", org_id="acme",
+                    principal_type="user")
+    is_valid, total, broken_id = await verify_chain(audit_db, org_id="acme")
+    assert is_valid is True
+    assert total == 4
+    assert broken_id == 0
+
+
+async def test_adr020_cross_org_propagates_principal_type(audit_db):
+    """log_event_cross_org tags both rows with the same principal_type."""
+    from app.db.audit import log_event_cross_org
+
+    row_a, row_b = await log_event_cross_org(
+        audit_db, "u2u.message", "ok",
+        org_a="acme", org_b="bravo",
+        agent_id="acme::mario",
+        principal_type="user",
+    )
+    assert row_a.principal_type == "user"
+    assert row_b.principal_type == "user"

--- a/tests/test_reach_policy.py
+++ b/tests/test_reach_policy.py
@@ -14,11 +14,9 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
 
-from app.db.audit import AuditLog, log_event, verify_chain
+from app.db.audit import AuditLog, verify_chain
 from app.policy.reach import (
     ANY_NAME,
-    PRINCIPAL_TYPES,
-    PolicyDecision,
     PrincipalRef,
     ReachConsent,
     ReachContext,

--- a/tests/test_reach_policy.py
+++ b/tests/test_reach_policy.py
@@ -1,0 +1,376 @@
+"""ADR-020 Phase 3 — reach policy four-quadrant matrix tests.
+
+Covers:
+  * Quadrant detection (intra-org vs cross-org × every principal-type pair)
+  * Default-deny / default-allow per quadrant per direction
+  * Consent grant + revoke + idempotent re-grant
+  * Wildcard source_name='*' matches any source of the same type
+  * Audit row emitted on every evaluation
+  * verify_chain still passes after a mix of reach evaluations
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.db.audit import AuditLog, log_event, verify_chain
+from app.policy.reach import (
+    ANY_NAME,
+    PRINCIPAL_TYPES,
+    PolicyDecision,
+    PrincipalRef,
+    ReachConsent,
+    ReachContext,
+    evaluate_reach_quadrant,
+    grant_consent,
+    list_active_consents,
+    revoke_consent,
+)
+from tests.conftest import TestSessionLocal
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def reach_db():
+    """Clean session with audit_log + reach_consents emptied before/after."""
+    async with TestSessionLocal() as session:
+        await session.execute(delete(ReachConsent))
+        await session.execute(delete(AuditLog))
+        await session.commit()
+    async with TestSessionLocal() as session:
+        yield session
+    async with TestSessionLocal() as session:
+        await session.execute(delete(ReachConsent))
+        await session.execute(delete(AuditLog))
+        await session.commit()
+
+
+def _ctx(
+    src_org="acme", src_type="agent", src_name="mario-bot",
+    dst_org="acme", dst_type="agent", dst_name="compliance-bot",
+) -> ReachContext:
+    return ReachContext(
+        source=PrincipalRef(src_org, src_type, src_name),
+        destination=PrincipalRef(dst_org, dst_type, dst_name),
+    )
+
+
+# ── quadrant detection ──────────────────────────────────────────────
+
+
+def test_quadrant_intra_a2a():
+    ctx = _ctx()
+    assert ctx.quadrant == "A2A"
+    assert ctx.is_intra_org is True
+
+
+def test_quadrant_cross_u2u():
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    assert ctx.quadrant == "U2U"
+    assert ctx.is_intra_org is False
+
+
+def test_quadrant_a2u_a2w_u2a_w2a_w2u_w2w():
+    """Spot-check the 6 remaining cells parse to the right shorthand."""
+    pairs = [
+        ("agent", "user",     "A2U"),
+        ("agent", "workload", "A2W"),
+        ("user",  "agent",    "U2A"),
+        ("user",  "workload", "U2W"),
+        ("workload", "agent", "W2A"),
+        ("workload", "user",  "W2U"),
+        ("workload", "workload", "W2W"),
+    ]
+    for src, dst, expect in pairs:
+        ctx = _ctx(src_type=src, dst_type=dst)
+        assert ctx.quadrant == expect, (src, dst, ctx.quadrant)
+
+
+# ── A2A ─────────────────────────────────────────────────────────────
+
+
+async def test_a2a_intra_org_default_allow(reach_db):
+    decision = await evaluate_reach_quadrant(reach_db, _ctx())
+    assert decision.allowed
+    assert decision.quadrant == "A2A"
+    assert "Intra-org" in decision.reason
+
+
+async def test_a2a_cross_org_default_deny(reach_db):
+    ctx = _ctx(src_org="acme", dst_org="bravo")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert "reach grant" in decision.reason
+
+
+async def test_a2a_cross_org_consent_unblocks(reach_db):
+    ctx = _ctx(src_org="acme", dst_org="bravo")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="acme", source_principal_type="agent",
+        source_name="mario-bot", granted_by="bravo-admin",
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id is not None
+
+
+# ── A2U ─────────────────────────────────────────────────────────────
+
+
+async def test_a2u_intra_org_default_deny(reach_db):
+    """Even intra-org an unsolicited agent must NOT pop into a user inbox."""
+    ctx = _ctx(src_type="agent", dst_type="user", dst_name="mario")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert decision.quadrant == "A2U"
+    assert "consented" in decision.reason
+
+
+async def test_a2u_intra_org_consent_unblocks(reach_db):
+    ctx = _ctx(src_type="agent", dst_type="user", dst_name="mario")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="acme", source_principal_type="agent",
+        source_name="mario-bot",
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id is not None
+
+
+async def test_a2u_cross_org_default_deny(reach_db):
+    ctx = _ctx(src_org="acme", src_type="agent", src_name="snoopy",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert decision.quadrant == "A2U"
+
+
+# ── U2A ─────────────────────────────────────────────────────────────
+
+
+async def test_u2a_intra_org_without_ownership_default_deny(reach_db):
+    """Without an ownership resolver, even intra-org U2A is consent-gated."""
+    ctx = _ctx(src_type="user", src_name="mario",
+               dst_type="agent", dst_name="finance-bot")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert decision.quadrant == "U2A"
+
+
+async def test_u2a_intra_org_with_ownership_allow(reach_db):
+    ctx = _ctx(src_type="user", src_name="mario",
+               dst_type="agent", dst_name="mario-laptop")
+
+    async def owns(user, agent):
+        return user.name == "mario" and agent.name == "mario-laptop"
+
+    decision = await evaluate_reach_quadrant(
+        reach_db, ctx, ownership_resolver=owns,
+    )
+    assert decision.allowed
+    assert "owns destination agent" in decision.reason
+
+
+async def test_u2a_cross_org_default_deny(reach_db):
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="agent", dst_name="finance-bot")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+
+
+# ── U2U ─────────────────────────────────────────────────────────────
+
+
+async def test_u2u_intra_org_default_allow(reach_db):
+    ctx = _ctx(src_type="user", src_name="mario",
+               dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.quadrant == "U2U"
+    assert "Intra-org" in decision.reason
+
+
+async def test_u2u_cross_org_default_deny_addressbook(reach_db):
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert "addressbook" in decision.reason
+
+
+async def test_u2u_cross_org_consent_unblocks(reach_db):
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="acme", source_principal_type="user",
+        source_name="mario",
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+
+
+# ── workload-as-source / -as-destination ────────────────────────────
+
+
+async def test_workload_source_always_denied_in_v01(reach_db):
+    ctx = _ctx(src_type="workload", src_name="byoca-haiku",
+               dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert "Workload-as-source" in decision.reason
+
+
+async def test_workload_destination_is_tool_call_noop_allow(reach_db):
+    ctx = _ctx(src_type="agent", src_name="mario-bot",
+               dst_type="workload", dst_name="postgres-mcp")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert "Workload destination" in decision.reason
+
+
+# ── consent grant management ───────────────────────────────────────
+
+
+async def test_grant_revoke_round_trip(reach_db):
+    recipient = PrincipalRef("acme", "user", "mario")
+    grant = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert grant.consent_id
+    revoked = await revoke_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert revoked is True
+    # Second revoke is a no-op
+    revoked_again = await revoke_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert revoked_again is False
+
+
+async def test_re_grant_after_revoke_is_idempotent(reach_db):
+    """Re-granting after a revoke must reuse the same row, not duplicate."""
+    recipient = PrincipalRef("acme", "user", "mario")
+    g1 = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    await revoke_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    g2 = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert g1.consent_id == g2.consent_id
+    assert g2.revoked_at is None
+
+    rows = (await reach_db.execute(select(ReachConsent))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_wildcard_source_matches_any_name(reach_db):
+    """source_name='*' grants admit any sender of that type from that org."""
+    ctx = _ctx(src_org="bravo", src_type="agent", src_name="anything",
+               dst_org="acme", dst_type="user", dst_name="mario")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name=ANY_NAME,
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id is not None
+
+
+async def test_specific_grant_beats_wildcard_when_both_present(reach_db):
+    """If a specific grant and a wildcard both match, evaluator picks
+    the specific one (more auditable)."""
+    recipient = PrincipalRef("acme", "user", "mario")
+    await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name=ANY_NAME,
+    )
+    specific = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    ctx = _ctx(src_org="bravo", src_type="agent", src_name="snoopy",
+               dst_org="acme", dst_type="user", dst_name="mario")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id == specific.consent_id
+
+
+async def test_list_active_consents(reach_db):
+    recipient = PrincipalRef("acme", "user", "mario")
+    await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="charlie", source_principal_type="user",
+        source_name="anna",
+    )
+    rows = await list_active_consents(reach_db, recipient)
+    assert len(rows) == 2
+    src_orgs = sorted(r.source_org_id for r in rows)
+    assert src_orgs == ["bravo", "charlie"]
+
+
+# ── audit chain integrity ──────────────────────────────────────────
+
+
+async def test_audit_row_emitted_per_evaluation(reach_db):
+    ctx = _ctx()
+    await evaluate_reach_quadrant(reach_db, ctx)
+    rows = (await reach_db.execute(
+        select(AuditLog).where(AuditLog.event_type == "policy.reach_evaluated")
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].principal_type == "agent"
+    assert rows[0].result == "ok"
+
+
+async def test_chain_intact_after_mixed_evaluations(reach_db):
+    """Run a batch of evaluations across all quadrants and verify the
+    audit chain still passes."""
+    ctxs = [
+        _ctx(),  # A2A intra
+        _ctx(src_org="acme", dst_org="bravo"),  # A2A cross deny
+        _ctx(src_type="agent", dst_type="user", dst_name="mario"),  # A2U
+        _ctx(src_type="user", src_name="mario", dst_type="user", dst_name="anna"),  # U2U intra
+    ]
+    for ctx in ctxs:
+        await evaluate_reach_quadrant(reach_db, ctx)
+
+    is_valid, total, broken_id = await verify_chain(reach_db, org_id="acme")
+    assert is_valid is True, f"chain broken at id {broken_id}"
+    assert total == len(ctxs)


### PR DESCRIPTION
## Summary

ADR-020 (draft in `imp/`) formalises three principal types and nine cells of the source×destination interaction matrix. Phase 3 ships **the policy primitive that decides which cells deliver and which are denied at the broker edge**, plus the consent-grant primitive that unblocks the deny-by-default cells when the recipient says yes.

### The four-quadrant matrix as enforced

|   | dest agent | dest user | dest workload |
|---|---|---|---|
| **src agent** | A2A intra: **allow** / cross: consent | A2U: **deny + consent** | tool-call (allow) |
| **src user**  | U2A intra: ownership / consent / cross: consent | U2U intra: **allow** / cross: consent | tool-call (allow) |
| **src workload** | DENY in v0.1 | DENY in v0.1 | DENY in v0.1 |

**Anti-spam structural property**: even intra-org A2U requires an explicit consent. An unsolicited agent cannot drop into a human's inbox under any circumstance, including same-org. This is what makes Cullis "a trust network" rather than "another messaging fabric".

### What ships in this PR

- `app/policy/reach.py` — `PrincipalRef`, `ReachContext`, `ReachConsent` model, `PolicyDecision`, `evaluate_reach_quadrant`, `grant_consent` / `revoke_consent` / `list_active_consents`
- `alembic/versions/m3h4i5j6k7l8_reach_consents.py` — table + index, up+down tested
- `ANY_NAME='*'` wildcard for `source_name` so a recipient can grant "any agent of org X" without enumeration
- Specific-name grants beat wildcard grants when both match (better audit trail)
- Audit row `policy.reach_evaluated` per evaluation tagged with the resolved quadrant + consent_id

The evaluator is parametric on an `OwnershipResolver` (async predicate "does this user own this agent?"); Phase 5 will wire it to a registry table. Without a resolver, U2A is always consent-gated.

### Stacking note

This branch cherry-picks PR #408 (Phase 2 — audit `principal_type` column) so the cherry-picked commit lets reach.evaluate emit `log_event(principal_type=...)`. When #408 merges first, this branch rebases cleanly and the cherry-pick dissolves into the merge base. PR #407 (Phase 1 — SPIFFE Principal parser) is **not** required by this PR; reach.py uses bare strings.

## Test plan

- [x] 24 new tests in `tests/test_reach_policy.py`:
  - Quadrant detection (intra vs cross × every type pair)
  - Default allow/deny per quadrant
  - Consent unblocks denied quadrants
  - Workload-as-source always denied in v0.1
  - Workload-as-destination always allowed (tool-call noop)
  - Grant + revoke + idempotent re-grant after revoke
  - Wildcard source_name matches any sender of that type+org
  - Specific grant beats wildcard when both match
  - Audit row emitted per evaluation with principal_type tag
  - `verify_chain` intact across mixed-quadrant evaluations
- [x] 78 tests across reach + audit_chain + spiffe + audit_export pass with no regressions.
- [x] Alembic up + down + up clean on SQLite.

## Out of scope (next phases)

- Phase 4: user inbox primitive — extend `proxy_message_queue` with `recipient_principal_type`, `delivery_state`, `/v1/inbox` REST + WebSocket push
- Phase 5: Frontdesk integration — Cullis Chat inbox panel + SSO → user-cert provisioning + `OwnershipResolver` wired to registry