### PR TITLE
feat(inbox): user inbox primitive with reach gate (ADR-020 Phase 4)

### DIFF
--- a/alembic/versions/m3h4i5j6k7l8_reach_consents.py
+++ b/alembic/versions/m3h4i5j6k7l8_reach_consents.py
@@ -1,0 +1,55 @@
+"""ADR-020 Phase 3 — reach_consents table for four-quadrant policy
+
+Revision ID: m3h4i5j6k7l8
+Revises: l2g3b4c5d6e7
+Create Date: 2026-05-04 15:00:00.000000
+
+Persists per-pair consent grants used by the reach policy (A2U / U2A
+intra-org, A2A / A2U / U2A / U2U cross-org). A row authorises one
+specific source — or any source of a given type from a given org when
+``source_name='*'`` — to deliver to one specific recipient.
+
+Soft-deletion via ``revoked_at`` non-null. The unique constraint on
+the full (recipient, source) tuple lets a re-grant after revoke
+update the existing row instead of piling up duplicates, mirroring
+``local_agent_resource_bindings``.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "m3h4i5j6k7l8"
+down_revision = "l2g3b4c5d6e7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "reach_consents",
+        sa.Column("consent_id", sa.String(length=64), primary_key=True),
+        sa.Column("recipient_org_id", sa.String(length=128), nullable=False),
+        sa.Column("recipient_principal_type", sa.String(length=16), nullable=False),
+        sa.Column("recipient_name", sa.String(length=128), nullable=False),
+        sa.Column("source_org_id", sa.String(length=128), nullable=False),
+        sa.Column("source_principal_type", sa.String(length=16), nullable=False),
+        sa.Column("source_name", sa.String(length=128), nullable=False),
+        sa.Column("granted_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("granted_by", sa.String(length=128), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "source_org_id", "source_principal_type", "source_name",
+            name="uq_reach_consent_pair",
+        ),
+    )
+    op.create_index(
+        "idx_reach_consent_recipient_active",
+        "reach_consents",
+        ["recipient_org_id", "recipient_principal_type", "recipient_name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_reach_consent_recipient_active", table_name="reach_consents")
+    op.drop_table("reach_consents")

--- a/alembic/versions/n4i5j6k7l8m9_user_inbox.py
+++ b/alembic/versions/n4i5j6k7l8m9_user_inbox.py
@@ -1,0 +1,70 @@
+"""ADR-020 Phase 4 — user_inbox_messages table
+
+Revision ID: n4i5j6k7l8m9
+Revises: m3h4i5j6k7l8
+Create Date: 2026-05-04 16:00:00.000000
+
+Adds the user_inbox_messages table that backs the ``/v1/inbox`` REST
++ WebSocket endpoints. Distinct from ``proxy_message_queue`` which
+is session-bound A2A; this table is for stand-alone inbox-style
+deliveries (A2U, U2U, U2A) and stores plaintext body for v0.1.
+
+The table is created from scratch by this migration; downgrade
+drops it. No data migration is required because no caller writes
+to it before this migration.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "n4i5j6k7l8m9"
+down_revision = "m3h4i5j6k7l8"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_inbox_messages",
+        sa.Column("msg_id", sa.String(length=64), primary_key=True),
+        sa.Column("sender_org_id", sa.String(length=128), nullable=False),
+        sa.Column("sender_principal_type", sa.String(length=16), nullable=False),
+        sa.Column("sender_name", sa.String(length=128), nullable=False),
+        sa.Column("recipient_org_id", sa.String(length=128), nullable=False),
+        sa.Column("recipient_principal_type", sa.String(length=16), nullable=False),
+        sa.Column("recipient_name", sa.String(length=128), nullable=False),
+        sa.Column("subject", sa.String(length=256), nullable=True),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column(
+            "delivery_state", sa.String(length=24),
+            nullable=False, server_default=sa.text("'queued'"),
+        ),
+        sa.Column("consent_id", sa.String(length=64), nullable=True),
+        sa.Column("enqueued_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ttl_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=256), nullable=True),
+        sa.UniqueConstraint(
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "idempotency_key",
+            name="uq_user_inbox_idempotency",
+        ),
+    )
+    op.create_index(
+        "idx_user_inbox_recipient_pending",
+        "user_inbox_messages",
+        ["recipient_org_id", "recipient_principal_type", "recipient_name", "delivery_state"],
+    )
+    op.create_index(
+        "idx_user_inbox_ttl",
+        "user_inbox_messages",
+        ["ttl_expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_inbox_ttl", table_name="user_inbox_messages")
+    op.drop_index("idx_user_inbox_recipient_pending", table_name="user_inbox_messages")
+    op.drop_table("user_inbox_messages")

--- a/app/broker/db_models.py
+++ b/app/broker/db_models.py
@@ -174,3 +174,78 @@ class RfqResponseRecord(Base):
     responder_org_id    = Column(String(128), nullable=False)
     response_payload    = Column(Text, nullable=False)              # JSON
     received_at         = Column(DateTime(timezone=True), nullable=False)
+
+
+class UserInboxMessage(Base):
+    """ADR-020 Phase 4 — durable user inbox.
+
+    Holds messages addressed to a *user* (or, transitively, to any
+    principal that wants Slack-like inbox semantics). Distinct from
+    ``ProxyMessageQueueRecord`` which is bound to live A2A sessions:
+
+      - no ``session_id`` — inbox messages are stand-alone, not part
+        of a multi-turn session
+      - plaintext ``body`` for v0.1 (E2E encryption is a Phase 5
+        candidate; the cloud edge is the trust boundary today)
+      - ``delivery_state`` distinguishes online (WS push at the moment
+        of write) from offline (recipient absent, drained by a later
+        ``GET /v1/inbox``) — a property the legacy queue does not need
+
+    Reach policy (``app/policy/reach.py``) is consulted at enqueue time;
+    a row only lands here when ``evaluate_reach_quadrant`` returns
+    allow. The ``consent_id`` links to the grant that authorised the
+    delivery, so an audit trail can prove not just "the message was
+    accepted" but "the message was accepted under THIS consent".
+    """
+
+    __tablename__ = "user_inbox_messages"
+    __table_args__ = (
+        UniqueConstraint(
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "idempotency_key",
+            name="uq_user_inbox_idempotency",
+        ),
+        Index(
+            "idx_user_inbox_recipient_pending",
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "delivery_state",
+        ),
+        Index("idx_user_inbox_ttl", "ttl_expires_at"),
+    )
+
+    msg_id               = Column(String(64), primary_key=True)
+
+    # Sender identification (full principal triple).
+    sender_org_id            = Column(String(128), nullable=False, index=True)
+    sender_principal_type    = Column(String(16), nullable=False)
+    sender_name              = Column(String(128), nullable=False)
+
+    # Recipient identification (full principal triple).
+    recipient_org_id         = Column(String(128), nullable=False, index=True)
+    recipient_principal_type = Column(String(16), nullable=False)
+    recipient_name           = Column(String(128), nullable=False)
+
+    # Payload. v0.1 stores plaintext; E2E encryption candidate for v0.5.
+    subject              = Column(String(256), nullable=True)
+    body                 = Column(Text, nullable=False)
+
+    # Delivery lifecycle: queued | delivered_offline | delivered_online |
+    # archived | expired.
+    delivery_state       = Column(
+        String(24), nullable=False, default="queued", index=True,
+    )
+
+    # Reach grant that authorised this delivery. ``None`` for cells whose
+    # default is allow (intra-org A2A, intra-org U2U, ownership U2A).
+    consent_id           = Column(String(64), nullable=True)
+
+    # Lifecycle timestamps.
+    enqueued_at          = Column(DateTime(timezone=True), nullable=False,
+                                  default=lambda: datetime.now(timezone.utc))
+    delivered_at         = Column(DateTime(timezone=True), nullable=True)
+    archived_at          = Column(DateTime(timezone=True), nullable=True)
+    expired_at           = Column(DateTime(timezone=True), nullable=True)
+    ttl_expires_at       = Column(DateTime(timezone=True), nullable=False)
+
+    # Idempotency under retries from a flapping sender.
+    idempotency_key      = Column(String(256), nullable=True)

--- a/app/inbox/__init__.py
+++ b/app/inbox/__init__.py
@@ -1,0 +1,37 @@
+"""ADR-020 Phase 4 — user inbox primitive.
+
+Stand-alone messaging surface for the four-quadrant matrix:
+
+  - A2U: an agent drops a message in a user's inbox (consent-gated)
+  - U2A: a user sends to an agent (intra-org with ownership, otherwise consent)
+  - U2U: a human sends to another human (intra-org allow, cross-org addressbook)
+
+The store layer (``store.py``) writes to ``user_inbox_messages`` after
+``app/policy/reach.py:evaluate_reach_quadrant`` returns allow. The
+router layer (``router.py``) exposes:
+
+  GET   /v1/inbox?since=&limit=     list messages for the caller
+  POST  /v1/inbox/<msg_id>/ack      mark delivered
+  POST  /v1/inbox/<msg_id>/archive  soft hide (UI hint, no chain effect)
+
+WebSocket push (``/v1/inbox/stream``) lands in a follow-up — Phase 4
+ships the durable side first so offline drain works on day one.
+"""
+
+from app.inbox.store import (
+    DeliveryState,
+    InboxDelivery,
+    enqueue,
+    fetch_for_recipient,
+    mark_delivered,
+    mark_archived,
+)
+
+__all__ = [
+    "DeliveryState",
+    "InboxDelivery",
+    "enqueue",
+    "fetch_for_recipient",
+    "mark_delivered",
+    "mark_archived",
+]

--- a/app/inbox/router.py
+++ b/app/inbox/router.py
@@ -1,0 +1,235 @@
+"""ADR-020 Phase 4 — REST surface for the user inbox.
+
+Endpoints:
+
+  POST  /v1/inbox/send                 enqueue a message to a recipient
+  GET   /v1/inbox?since=&limit=        list messages addressed to the
+                                       authenticated principal
+  POST  /v1/inbox/{msg_id}/ack         mark delivered (offline drain)
+  POST  /v1/inbox/{msg_id}/archive     soft hide
+
+Authentication is the existing DPoP-bound JWT
+(``app.auth.jwt.get_current_agent``). The token's ``sub`` SPIFFE URI
+is parsed into a ``Principal`` (ADR-020 Phase 1) so the principal type
+gates the right inbox: ``user/mario`` GETs Mario's inbox, ``agent/X``
+GETs the agent's notification queue.
+
+The router does NOT implement WebSocket push — that lands in a
+follow-up. Phase 4 Phase A ships durability so offline drain works
+on day one; online push is sugar for the SPA later.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.db.database import get_db
+from app.inbox.store import (
+    DeliveryState,
+    ReachDeniedError,
+    enqueue,
+    fetch_for_recipient,
+    mark_archived,
+    mark_delivered,
+)
+from app.policy.reach import PrincipalRef
+from app.spiffe import spiffe_to_principal
+
+_log = logging.getLogger("app.inbox.router")
+
+router = APIRouter(prefix="/inbox", tags=["inbox"])
+
+
+def _caller_principal(token: TokenPayload) -> PrincipalRef:
+    """Convert the authenticated token into a ``PrincipalRef``.
+
+    Uses the SPIFFE URI in ``sub`` (ADR-020 Phase 1 parser handles
+    both legacy 2-component and new 3-component layouts; legacy
+    paths default to ``principal_type=agent``). Falls back to the
+    internal ``agent_id`` only if SPIFFE parsing fails.
+    """
+    try:
+        principal = spiffe_to_principal(token.sub)
+        return PrincipalRef(
+            org_id=principal.org_id,
+            principal_type=principal.principal_type,
+            name=principal.name,
+        )
+    except ValueError:
+        # Defensive fallback: tokens issued before ADR-020 may carry
+        # an non-SPIFFE-shaped ``sub``. Use the org/name from the
+        # internal agent_id and assume agent.
+        if "::" in token.agent_id:
+            org, name = token.agent_id.split("::", 1)
+        else:
+            org, name = token.org, token.agent_id
+        return PrincipalRef(org_id=org, principal_type="agent", name=name)
+
+
+# ── Send ───────────────────────────────────────────────────────────
+
+
+class InboxSendRequest(BaseModel):
+    """Request body for ``POST /v1/inbox/send``."""
+    recipient_org_id: str = Field(..., min_length=1, max_length=128)
+    recipient_principal_type: str = Field(..., min_length=1, max_length=16)
+    recipient_name: str = Field(..., min_length=1, max_length=128)
+    body: str = Field(..., max_length=64 * 1024)
+    subject: str | None = Field(None, max_length=256)
+    idempotency_key: str | None = Field(None, max_length=256)
+
+
+class InboxSendResponse(BaseModel):
+    msg_id: str
+    inserted: bool
+    quadrant: str
+
+
+@router.post("/send", response_model=InboxSendResponse, status_code=status.HTTP_201_CREATED)
+async def send_message(
+    payload: InboxSendRequest,
+    db: AsyncSession = Depends(get_db),
+    token: TokenPayload = Depends(get_current_agent),
+) -> InboxSendResponse:
+    """Enqueue a message addressed to a Cullis principal."""
+    sender = _caller_principal(token)
+    recipient = PrincipalRef(
+        org_id=payload.recipient_org_id,
+        principal_type=payload.recipient_principal_type,  # type: ignore[arg-type]
+        name=payload.recipient_name,
+    )
+    try:
+        delivery = await enqueue(
+            db,
+            sender=sender,
+            recipient=recipient,
+            subject=payload.subject,
+            body=payload.body,
+            idempotency_key=payload.idempotency_key,
+        )
+    except ReachDeniedError as exc:
+        _log.info(
+            "inbox send denied: quadrant=%s reason=%s",
+            exc.decision.quadrant, exc.decision.reason,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "reason": exc.decision.reason,
+                "quadrant": exc.decision.quadrant,
+            },
+        )
+
+    return InboxSendResponse(
+        msg_id=delivery.msg_id,
+        inserted=delivery.inserted,
+        quadrant=delivery.decision.quadrant,
+    )
+
+
+# ── List ───────────────────────────────────────────────────────────
+
+
+class InboxItem(BaseModel):
+    msg_id: str
+    sender_org_id: str
+    sender_principal_type: str
+    sender_name: str
+    subject: str | None
+    body: str
+    delivery_state: str
+    consent_id: str | None
+    enqueued_at: str
+    delivered_at: str | None
+    ttl_expires_at: str
+
+
+def _to_item(row: Any) -> InboxItem:
+    return InboxItem(
+        msg_id=row.msg_id,
+        sender_org_id=row.sender_org_id,
+        sender_principal_type=row.sender_principal_type,
+        sender_name=row.sender_name,
+        subject=row.subject,
+        body=row.body,
+        delivery_state=row.delivery_state,
+        consent_id=row.consent_id,
+        enqueued_at=row.enqueued_at.isoformat(),
+        delivered_at=row.delivered_at.isoformat() if row.delivered_at else None,
+        ttl_expires_at=row.ttl_expires_at.isoformat(),
+    )
+
+
+@router.get("", response_model=list[InboxItem])
+async def list_inbox(
+    since: str | None = None,
+    limit: int = 50,
+    include_archived: bool = False,
+    db: AsyncSession = Depends(get_db),
+    token: TokenPayload = Depends(get_current_agent),
+) -> list[InboxItem]:
+    """Return messages addressed to the authenticated principal."""
+    recipient = _caller_principal(token)
+    rows = await fetch_for_recipient(
+        db,
+        recipient=recipient,
+        since_msg_id=since,
+        limit=limit,
+        include_archived=include_archived,
+    )
+    return [_to_item(r) for r in rows]
+
+
+# ── Ack / Archive ──────────────────────────────────────────────────
+
+
+async def _require_recipient(
+    db: AsyncSession, msg_id: str, caller: PrincipalRef,
+) -> None:
+    """Reject 404 if msg doesn't exist OR caller is not its recipient."""
+    from app.broker.db_models import UserInboxMessage
+    from sqlalchemy import select, and_
+
+    row = (await db.execute(
+        select(UserInboxMessage).where(UserInboxMessage.msg_id == msg_id)
+    )).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "message not found")
+    if (
+        row.recipient_org_id != caller.org_id
+        or row.recipient_principal_type != caller.principal_type
+        or row.recipient_name != caller.name
+    ):
+        # Don't leak existence to non-recipients: 404, not 403.
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "message not found")
+
+
+@router.post("/{msg_id}/ack")
+async def ack(
+    msg_id: str,
+    online: bool = False,
+    db: AsyncSession = Depends(get_db),
+    token: TokenPayload = Depends(get_current_agent),
+) -> dict:
+    caller = _caller_principal(token)
+    await _require_recipient(db, msg_id, caller)
+    flipped = await mark_delivered(db, msg_id=msg_id, online=online)
+    return {"acked": flipped, "msg_id": msg_id}
+
+
+@router.post("/{msg_id}/archive")
+async def archive(
+    msg_id: str,
+    db: AsyncSession = Depends(get_db),
+    token: TokenPayload = Depends(get_current_agent),
+) -> dict:
+    caller = _caller_principal(token)
+    await _require_recipient(db, msg_id, caller)
+    archived = await mark_archived(db, msg_id=msg_id)
+    return {"archived": archived, "msg_id": msg_id}

--- a/app/inbox/router.py
+++ b/app/inbox/router.py
@@ -31,7 +31,6 @@ from app.auth.jwt import get_current_agent
 from app.auth.models import TokenPayload
 from app.db.database import get_db
 from app.inbox.store import (
-    DeliveryState,
     ReachDeniedError,
     enqueue,
     fetch_for_recipient,

--- a/app/inbox/router.py
+++ b/app/inbox/router.py
@@ -194,7 +194,7 @@ async def _require_recipient(
 ) -> None:
     """Reject 404 if msg doesn't exist OR caller is not its recipient."""
     from app.broker.db_models import UserInboxMessage
-    from sqlalchemy import select, and_
+    from sqlalchemy import select
 
     row = (await db.execute(
         select(UserInboxMessage).where(UserInboxMessage.msg_id == msg_id)

--- a/app/inbox/store.py
+++ b/app/inbox/store.py
@@ -19,7 +19,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Awaitable, Callable, Optional
+from typing import Optional
 
 from sqlalchemy import and_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert

--- a/app/inbox/store.py
+++ b/app/inbox/store.py
@@ -1,0 +1,248 @@
+"""User inbox storage layer (ADR-020 Phase 4).
+
+Wraps ``UserInboxMessage`` with a small async API:
+
+  - ``enqueue``                 reach-policy gate + persist
+  - ``fetch_for_recipient``     drain pending / cursor pagination
+  - ``mark_delivered``          ack
+  - ``mark_archived``           soft hide
+
+The reach gate is the load-bearing part: every enqueue calls
+``evaluate_reach_quadrant`` and refuses to write the row when the
+quadrant is denied. The denial is itself audited by the reach
+evaluator; the store does NOT swallow it silently.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Awaitable, Callable, Optional
+
+from sqlalchemy import and_, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.broker.db_models import UserInboxMessage
+from app.policy.reach import (
+    OwnershipResolver,
+    PolicyDecision,
+    PrincipalRef,
+    ReachContext,
+    evaluate_reach_quadrant,
+)
+
+_log = logging.getLogger("app.inbox.store")
+
+# TTL defaults per recipient principal type (ADR-020 §5).
+_DEFAULT_TTL_SECONDS = {
+    "user": 7 * 24 * 3600,      # 7 days
+    "agent": 30 * 60,           # 30 minutes (mirrors A2A behaviour)
+    "workload": 5 * 60,         # 5 minutes (workloads should be online)
+}
+
+
+class DeliveryState(str, Enum):
+    """Discrete states a row passes through. Stored as VARCHAR for SQL
+    legibility; the enum is the canonical source of values."""
+    QUEUED = "queued"
+    DELIVERED_OFFLINE = "delivered_offline"
+    DELIVERED_ONLINE = "delivered_online"
+    ARCHIVED = "archived"
+    EXPIRED = "expired"
+
+
+@dataclass(frozen=True)
+class InboxDelivery:
+    """Outcome of an enqueue: row written + reach decision attached."""
+    msg_id: str
+    inserted: bool
+    decision: PolicyDecision
+
+
+class ReachDeniedError(RuntimeError):
+    """Raised when ``evaluate_reach_quadrant`` rejects the send.
+
+    Carries the decision so callers (e.g. the router) can surface
+    quadrant + reason to the audit log without re-evaluating.
+    """
+
+    def __init__(self, decision: PolicyDecision):
+        super().__init__(decision.reason)
+        self.decision = decision
+
+
+# ── Enqueue ─────────────────────────────────────────────────────────
+
+
+async def enqueue(
+    db: AsyncSession,
+    *,
+    sender: PrincipalRef,
+    recipient: PrincipalRef,
+    body: str,
+    subject: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    idempotency_key: Optional[str] = None,
+    ownership_resolver: OwnershipResolver | None = None,
+) -> InboxDelivery:
+    """Reach-gate then persist a message in the recipient's inbox.
+
+    Always emits a reach evaluation audit row (via
+    ``evaluate_reach_quadrant``). On allow, writes a
+    ``UserInboxMessage`` row with ``delivery_state='queued'`` and
+    returns ``inserted=True``. On a duplicate ``idempotency_key`` for
+    the same recipient, returns the existing ``msg_id`` and
+    ``inserted=False`` (no audit duplication, no second row).
+
+    Raises ``ReachDeniedError`` when the quadrant is denied. The
+    caller is expected to surface a 403 (or analogous error) to its
+    own client; the audit row already records the denial.
+    """
+    ctx = ReachContext(source=sender, destination=recipient)
+    decision = await evaluate_reach_quadrant(
+        db, ctx, ownership_resolver=ownership_resolver,
+    )
+    if not decision.allowed:
+        raise ReachDeniedError(decision)
+
+    if ttl_seconds is None:
+        ttl_seconds = _DEFAULT_TTL_SECONDS.get(recipient.principal_type, 30 * 60)
+    now = datetime.now(timezone.utc)
+    msg_id = str(uuid.uuid4())
+
+    values = dict(
+        msg_id=msg_id,
+        sender_org_id=sender.org_id,
+        sender_principal_type=sender.principal_type,
+        sender_name=sender.name,
+        recipient_org_id=recipient.org_id,
+        recipient_principal_type=recipient.principal_type,
+        recipient_name=recipient.name,
+        subject=subject,
+        body=body,
+        delivery_state=DeliveryState.QUEUED.value,
+        consent_id=decision.consent_id,
+        enqueued_at=now,
+        ttl_expires_at=now + timedelta(seconds=ttl_seconds),
+        idempotency_key=idempotency_key,
+    )
+
+    if idempotency_key is None:
+        db.add(UserInboxMessage(**values))
+        await db.commit()
+        return InboxDelivery(msg_id=msg_id, inserted=True, decision=decision)
+
+    dialect_name = db.bind.dialect.name if db.bind else "sqlite"
+    if dialect_name == "postgresql":
+        stmt = pg_insert(UserInboxMessage).values(**values)
+        stmt = stmt.on_conflict_do_nothing(constraint="uq_user_inbox_idempotency")
+    else:
+        stmt = sqlite_insert(UserInboxMessage).values(**values)
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=[
+                "recipient_org_id", "recipient_principal_type",
+                "recipient_name", "idempotency_key",
+            ],
+        )
+    result = await db.execute(stmt)
+    await db.commit()
+
+    if result.rowcount > 0:
+        return InboxDelivery(msg_id=msg_id, inserted=True, decision=decision)
+
+    existing = (await db.execute(
+        select(UserInboxMessage.msg_id).where(
+            and_(
+                UserInboxMessage.recipient_org_id == recipient.org_id,
+                UserInboxMessage.recipient_principal_type == recipient.principal_type,
+                UserInboxMessage.recipient_name == recipient.name,
+                UserInboxMessage.idempotency_key == idempotency_key,
+            )
+        )
+    )).scalar_one()
+    return InboxDelivery(msg_id=existing, inserted=False, decision=decision)
+
+
+# ── Fetch / list ────────────────────────────────────────────────────
+
+
+async def fetch_for_recipient(
+    db: AsyncSession,
+    *,
+    recipient: PrincipalRef,
+    since_msg_id: str | None = None,
+    limit: int = 50,
+    include_archived: bool = False,
+) -> list[UserInboxMessage]:
+    """Return messages for a recipient, ordered by enqueued_at asc.
+
+    Cursor pagination via ``since_msg_id``: caller passes the last
+    msg_id received, server returns rows strictly after it. ``limit``
+    is capped at 200 to keep the response bounded.
+    """
+    capped = min(max(1, limit), 200)
+    where = [
+        UserInboxMessage.recipient_org_id == recipient.org_id,
+        UserInboxMessage.recipient_principal_type == recipient.principal_type,
+        UserInboxMessage.recipient_name == recipient.name,
+    ]
+    if not include_archived:
+        where.append(UserInboxMessage.delivery_state != DeliveryState.ARCHIVED.value)
+
+    if since_msg_id is not None:
+        cursor = (await db.execute(
+            select(UserInboxMessage.enqueued_at).where(
+                UserInboxMessage.msg_id == since_msg_id,
+            )
+        )).scalar_one_or_none()
+        if cursor is not None:
+            where.append(UserInboxMessage.enqueued_at > cursor)
+
+    rows = (await db.execute(
+        select(UserInboxMessage)
+        .where(and_(*where))
+        .order_by(UserInboxMessage.enqueued_at.asc())
+        .limit(capped)
+    )).scalars().all()
+    return list(rows)
+
+
+# ── State transitions ──────────────────────────────────────────────
+
+
+async def mark_delivered(
+    db: AsyncSession, *, msg_id: str, online: bool = False,
+) -> bool:
+    """Flip a queued row to delivered. Idempotent: re-acking is no-op."""
+    target_state = (
+        DeliveryState.DELIVERED_ONLINE.value if online
+        else DeliveryState.DELIVERED_OFFLINE.value
+    )
+    now = datetime.now(timezone.utc)
+    result = await db.execute(
+        update(UserInboxMessage)
+        .where(
+            UserInboxMessage.msg_id == msg_id,
+            UserInboxMessage.delivery_state == DeliveryState.QUEUED.value,
+        )
+        .values(delivery_state=target_state, delivered_at=now)
+    )
+    await db.commit()
+    return (result.rowcount or 0) > 0
+
+
+async def mark_archived(db: AsyncSession, *, msg_id: str) -> bool:
+    """Soft-hide a row (UI hint, no chain effect). Idempotent."""
+    now = datetime.now(timezone.utc)
+    result = await db.execute(
+        update(UserInboxMessage)
+        .where(UserInboxMessage.msg_id == msg_id)
+        .where(UserInboxMessage.delivery_state != DeliveryState.ARCHIVED.value)
+        .values(delivery_state=DeliveryState.ARCHIVED.value, archived_at=now)
+    )
+    await db.commit()
+    return (result.rowcount or 0) > 0

--- a/app/main.py
+++ b/app/main.py
@@ -388,6 +388,10 @@ v1.include_router(federation_router)
 from app.broker.oneshot_router import router as oneshot_router
 v1.include_router(oneshot_router)
 
+# ADR-020 Phase 4 — user inbox REST surface.
+from app.inbox.router import router as inbox_router
+v1.include_router(inbox_router)
+
 # ADR-002 Phase 2a — A2A protocol adapter (read-only AgentCard + directory).
 # Gated on settings.a2a_adapter (default False) so existing deployments
 # see no surface change.

--- a/app/policy/reach.py
+++ b/app/policy/reach.py
@@ -1,0 +1,471 @@
+"""ADR-020 Phase 3 — reach policy four-quadrant matrix.
+
+Cullis recognises three principal types (agent, user, workload). Every
+send is therefore assignable to one of nine cells in a (source × dest)
+matrix; eight of them get explicit semantics here. Workloads do not
+initiate in v0.1, so the W2* row is always denied.
+
+The matrix this module enforces:
+
+                       destination
+                       agent              user               workload
+   source
+   agent               A2A                A2U                tool call
+   user                U2A                U2U                tool call
+   workload            (deny v0.1)        (deny v0.1)        (deny v0.1)
+
+with the following defaults:
+
+   intra-org   A2A   allow              (this is the existing oneshot/reply path)
+   cross-org   A2A   allow if matching reach exists, otherwise deny
+   intra-org   U2A   allow if user owns the agent, otherwise consent gate
+   cross-org   U2A   deny  + per-source consent grant required
+   intra-org   A2U   deny  + per-source consent grant required
+   cross-org   A2U   deny  + per-source consent grant required
+   intra-org   U2U   allow              (same domain, SSO already trusts both)
+   cross-org   U2U   deny  + per-source consent grant required (addressbook)
+
+A2W / U2W (workload-as-destination) are tool calls and live in the MCP
+aggregator authz path (binding gate); reach policy is a no-op for that
+quadrant and returns allow.
+
+The consent table is a normal-form authorisation grant: any pending
+inbox push checks ``reach_consents`` for an active row that covers
+the (source, recipient) pair before delivery; otherwise the message
+is rejected at the broker edge with an audit row.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Awaitable, Callable, Literal
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Index,
+    String,
+    UniqueConstraint,
+    and_,
+    or_,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.audit import log_event
+from app.db.database import Base
+
+_log = logging.getLogger("app.policy.reach")
+
+# Legal principal-type values — aligned with app/spiffe.py PRINCIPAL_TYPES.
+PRINCIPAL_TYPES = ("agent", "user", "workload")
+PrincipalType = Literal["agent", "user", "workload"]
+
+# Quadrant labels emitted into audit rows.
+Quadrant = Literal["A2A", "A2U", "U2A", "U2U", "A2W", "U2W", "W2A", "W2U", "W2W"]
+
+# Wildcard sentinel for the source-name field of a consent grant. Lets
+# a user say "I accept incoming from any agent in org X" without
+# enumerating each agent.
+ANY_NAME = "*"
+
+
+# ── Data classes ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class PrincipalRef:
+    """Reference to one principal (sender or recipient of a reach)."""
+    org_id: str
+    principal_type: PrincipalType
+    name: str
+
+
+@dataclass(frozen=True)
+class ReachContext:
+    """The (source, destination) pair under evaluation."""
+    source: PrincipalRef
+    destination: PrincipalRef
+
+    @property
+    def is_intra_org(self) -> bool:
+        return self.source.org_id == self.destination.org_id
+
+    @property
+    def quadrant(self) -> Quadrant:
+        # Two-letter shorthand: source-type initial + "2" + dest-type initial.
+        # Workload uses W; agent A; user U.
+        s = self.source.principal_type[0].upper()
+        d = self.destination.principal_type[0].upper()
+        return f"{s}2{d}"  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    """Result of a reach evaluation, ready to be returned to the caller
+    and to be audited via ``log_event``."""
+    allowed: bool
+    reason: str
+    quadrant: Quadrant
+    consent_id: str | None = None
+
+
+# ── Persistence model ───────────────────────────────────────────────
+
+
+class ReachConsent(Base):
+    """A persistent grant: recipient agreed to accept incoming reach
+    messages from a specific source (or any source of a given type
+    from a given org, when ``source_name`` is the wildcard ``*``).
+
+    Revocation is soft (``revoked_at`` non-null). The unique constraint
+    on the full (recipient, source) tuple lets a re-grant after revoke
+    UPDATE the existing row back to revoked_at=NULL without piling up
+    duplicates — same pattern as ``local_agent_resource_bindings``.
+    """
+    __tablename__ = "reach_consents"
+
+    consent_id = Column(String(64), primary_key=True)
+    recipient_org_id = Column(String(128), nullable=False, index=True)
+    recipient_principal_type = Column(String(16), nullable=False)
+    recipient_name = Column(String(128), nullable=False)
+    source_org_id = Column(String(128), nullable=False)
+    source_principal_type = Column(String(16), nullable=False)
+    source_name = Column(String(128), nullable=False)  # ANY_NAME = wildcard
+    granted_at = Column(DateTime(timezone=True), nullable=False)
+    granted_by = Column(String(128), nullable=True)
+    revoked_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+            "source_org_id", "source_principal_type", "source_name",
+            name="uq_reach_consent_pair",
+        ),
+        Index(
+            "idx_reach_consent_recipient_active",
+            "recipient_org_id", "recipient_principal_type", "recipient_name",
+        ),
+    )
+
+
+OwnershipResolver = Callable[[PrincipalRef, PrincipalRef], Awaitable[bool]]
+"""Async predicate: does ``user`` own ``agent``? Resolver is supplied by
+the caller (Phase 5 wires this to a registry table). Phase 3 default
+is ``False`` if no resolver is supplied — callers in v0.1 are agents,
+not users-acting-on-their-agents."""
+
+
+# ── Evaluation ──────────────────────────────────────────────────────
+
+
+async def _has_active_consent(
+    db: AsyncSession, ctx: ReachContext,
+) -> str | None:
+    """Return ``consent_id`` of an active grant covering ``ctx``, or None.
+
+    Matches a specific source name first, then falls back to a wildcard
+    grant (``source_name=ANY_NAME``).
+    """
+    stmt = select(ReachConsent).where(
+        and_(
+            ReachConsent.recipient_org_id == ctx.destination.org_id,
+            ReachConsent.recipient_principal_type == ctx.destination.principal_type,
+            ReachConsent.recipient_name == ctx.destination.name,
+            ReachConsent.source_org_id == ctx.source.org_id,
+            ReachConsent.source_principal_type == ctx.source.principal_type,
+            or_(
+                ReachConsent.source_name == ctx.source.name,
+                ReachConsent.source_name == ANY_NAME,
+            ),
+            ReachConsent.revoked_at.is_(None),
+        )
+    ).order_by(
+        # Specific name beats wildcard when both exist for the same pair.
+        ReachConsent.source_name.desc(),
+    ).limit(1)
+    row = (await db.execute(stmt)).scalar_one_or_none()
+    return row.consent_id if row else None
+
+
+async def evaluate_reach_quadrant(
+    db: AsyncSession,
+    ctx: ReachContext,
+    *,
+    ownership_resolver: OwnershipResolver | None = None,
+    audit_session_id: str | None = None,
+) -> PolicyDecision:
+    """Decide whether ``ctx`` is permitted by the four-quadrant matrix.
+
+    Side effects:
+      - emits a ``policy.reach_evaluated`` audit row on every call (one
+        per evaluation), tagged with the resolved quadrant.
+    """
+    quadrant = ctx.quadrant
+
+    # ── W2* — workloads do not initiate in v0.1 ────────────────────
+    if ctx.source.principal_type == "workload":
+        decision = PolicyDecision(
+            allowed=False,
+            reason="Workload-as-source not allowed in v0.1 (W2* deny by default)",
+            quadrant=quadrant,
+        )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── *2W — workload-as-destination is a tool call, separate authz ─
+    if ctx.destination.principal_type == "workload":
+        decision = PolicyDecision(
+            allowed=True,
+            reason="Workload destination — tool-call binding governs (reach noop)",
+            quadrant=quadrant,
+        )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── A2A ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "agent" and ctx.destination.principal_type == "agent":
+        if ctx.is_intra_org:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Intra-org A2A allowed by default",
+                quadrant=quadrant,
+            )
+            await _audit_reach(db, ctx, decision, audit_session_id)
+            return decision
+        # Cross-org A2A: existing reach mechanism. Phase 3 considers a
+        # consent grant equivalent to the legacy reach record. Caller
+        # may layer the legacy reach check on top.
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="Cross-org A2A requires an explicit reach grant",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Cross-org A2A authorised by reach grant",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── A2U ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "agent" and ctx.destination.principal_type == "user":
+        # ALWAYS consent-gated. Even intra-org an unsolicited agent must
+        # not pop into a human's inbox. The whole anti-spam premise of
+        # the user inbox depends on this.
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="A2U deny: recipient user has not consented to this source",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="A2U authorised by recipient consent",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── U2A ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "user" and ctx.destination.principal_type == "agent":
+        if ctx.is_intra_org and ownership_resolver is not None:
+            owns = await ownership_resolver(ctx.source, ctx.destination)
+            if owns:
+                decision = PolicyDecision(
+                    allowed=True,
+                    reason="U2A intra-org allowed: user owns destination agent",
+                    quadrant=quadrant,
+                )
+                await _audit_reach(db, ctx, decision, audit_session_id)
+                return decision
+        # Otherwise consent-gated.
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="U2A deny: agent has not consented to this user",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="U2A authorised by recipient consent",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── U2U ────────────────────────────────────────────────────────
+    if ctx.source.principal_type == "user" and ctx.destination.principal_type == "user":
+        if ctx.is_intra_org:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Intra-org U2U allowed by default (same SSO domain)",
+                quadrant=quadrant,
+            )
+            await _audit_reach(db, ctx, decision, audit_session_id)
+            return decision
+        consent_id = await _has_active_consent(db, ctx)
+        if consent_id is None:
+            decision = PolicyDecision(
+                allowed=False,
+                reason="Cross-org U2U deny: recipient user has not added sender to addressbook",
+                quadrant=quadrant,
+            )
+        else:
+            decision = PolicyDecision(
+                allowed=True,
+                reason="Cross-org U2U authorised by addressbook entry",
+                quadrant=quadrant,
+                consent_id=consent_id,
+            )
+        await _audit_reach(db, ctx, decision, audit_session_id)
+        return decision
+
+    # ── Unhandled combo (defensive) ────────────────────────────────
+    decision = PolicyDecision(
+        allowed=False,
+        reason=f"Unrecognised quadrant {quadrant} — default deny",
+        quadrant=quadrant,
+    )
+    await _audit_reach(db, ctx, decision, audit_session_id)
+    return decision
+
+
+async def _audit_reach(
+    db: AsyncSession,
+    ctx: ReachContext,
+    decision: PolicyDecision,
+    session_id: str | None,
+) -> None:
+    await log_event(
+        db,
+        event_type="policy.reach_evaluated",
+        result="ok" if decision.allowed else "denied",
+        agent_id=f"{ctx.source.org_id}::{ctx.source.name}",
+        org_id=ctx.source.org_id,
+        session_id=session_id,
+        principal_type=ctx.source.principal_type,
+        details={
+            "quadrant": decision.quadrant,
+            "is_intra_org": ctx.is_intra_org,
+            "destination_org": ctx.destination.org_id,
+            "destination_principal_type": ctx.destination.principal_type,
+            "destination_name": ctx.destination.name,
+            "consent_id": decision.consent_id,
+            "reason": decision.reason,
+        },
+    )
+
+
+# ── Consent grant management ────────────────────────────────────────
+
+
+async def grant_consent(
+    db: AsyncSession,
+    *,
+    recipient: PrincipalRef,
+    source_org_id: str,
+    source_principal_type: PrincipalType,
+    source_name: str = ANY_NAME,
+    granted_by: str | None = None,
+) -> ReachConsent:
+    """Persist a consent grant. Idempotent: re-granting an existing
+    pair flips ``revoked_at=None`` instead of creating a duplicate."""
+    import uuid
+
+    # Look up existing row first (revoked or not).
+    existing = (await db.execute(
+        select(ReachConsent).where(
+            and_(
+                ReachConsent.recipient_org_id == recipient.org_id,
+                ReachConsent.recipient_principal_type == recipient.principal_type,
+                ReachConsent.recipient_name == recipient.name,
+                ReachConsent.source_org_id == source_org_id,
+                ReachConsent.source_principal_type == source_principal_type,
+                ReachConsent.source_name == source_name,
+            )
+        )
+    )).scalar_one_or_none()
+
+    now = datetime.now(timezone.utc)
+    if existing is not None:
+        existing.revoked_at = None
+        existing.granted_at = now
+        existing.granted_by = granted_by
+        await db.commit()
+        return existing
+
+    row = ReachConsent(
+        consent_id=str(uuid.uuid4()),
+        recipient_org_id=recipient.org_id,
+        recipient_principal_type=recipient.principal_type,
+        recipient_name=recipient.name,
+        source_org_id=source_org_id,
+        source_principal_type=source_principal_type,
+        source_name=source_name,
+        granted_at=now,
+        granted_by=granted_by,
+        revoked_at=None,
+    )
+    db.add(row)
+    await db.commit()
+    return row
+
+
+async def revoke_consent(
+    db: AsyncSession,
+    *,
+    recipient: PrincipalRef,
+    source_org_id: str,
+    source_principal_type: PrincipalType,
+    source_name: str = ANY_NAME,
+) -> bool:
+    """Mark an existing grant as revoked. No-op if no matching row.
+    Returns True iff a row was actually revoked (was previously active)."""
+    row = (await db.execute(
+        select(ReachConsent).where(
+            and_(
+                ReachConsent.recipient_org_id == recipient.org_id,
+                ReachConsent.recipient_principal_type == recipient.principal_type,
+                ReachConsent.recipient_name == recipient.name,
+                ReachConsent.source_org_id == source_org_id,
+                ReachConsent.source_principal_type == source_principal_type,
+                ReachConsent.source_name == source_name,
+                ReachConsent.revoked_at.is_(None),
+            )
+        )
+    )).scalar_one_or_none()
+    if row is None:
+        return False
+    row.revoked_at = datetime.now(timezone.utc)
+    await db.commit()
+    return True
+
+
+async def list_active_consents(
+    db: AsyncSession, recipient: PrincipalRef,
+) -> list[ReachConsent]:
+    """List every active grant for a recipient. Useful for the inbox UI."""
+    rows = (await db.execute(
+        select(ReachConsent).where(
+            and_(
+                ReachConsent.recipient_org_id == recipient.org_id,
+                ReachConsent.recipient_principal_type == recipient.principal_type,
+                ReachConsent.recipient_name == recipient.name,
+                ReachConsent.revoked_at.is_(None),
+            )
+        ).order_by(ReachConsent.granted_at.desc())
+    )).scalars().all()
+    return list(rows)

--- a/tests/test_reach_policy.py
+++ b/tests/test_reach_policy.py
@@ -14,11 +14,9 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import delete, select
 
-from app.db.audit import AuditLog, log_event, verify_chain
+from app.db.audit import AuditLog, verify_chain
 from app.policy.reach import (
     ANY_NAME,
-    PRINCIPAL_TYPES,
-    PolicyDecision,
     PrincipalRef,
     ReachConsent,
     ReachContext,

--- a/tests/test_reach_policy.py
+++ b/tests/test_reach_policy.py
@@ -1,0 +1,376 @@
+"""ADR-020 Phase 3 — reach policy four-quadrant matrix tests.
+
+Covers:
+  * Quadrant detection (intra-org vs cross-org × every principal-type pair)
+  * Default-deny / default-allow per quadrant per direction
+  * Consent grant + revoke + idempotent re-grant
+  * Wildcard source_name='*' matches any source of the same type
+  * Audit row emitted on every evaluation
+  * verify_chain still passes after a mix of reach evaluations
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.db.audit import AuditLog, log_event, verify_chain
+from app.policy.reach import (
+    ANY_NAME,
+    PRINCIPAL_TYPES,
+    PolicyDecision,
+    PrincipalRef,
+    ReachConsent,
+    ReachContext,
+    evaluate_reach_quadrant,
+    grant_consent,
+    list_active_consents,
+    revoke_consent,
+)
+from tests.conftest import TestSessionLocal
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def reach_db():
+    """Clean session with audit_log + reach_consents emptied before/after."""
+    async with TestSessionLocal() as session:
+        await session.execute(delete(ReachConsent))
+        await session.execute(delete(AuditLog))
+        await session.commit()
+    async with TestSessionLocal() as session:
+        yield session
+    async with TestSessionLocal() as session:
+        await session.execute(delete(ReachConsent))
+        await session.execute(delete(AuditLog))
+        await session.commit()
+
+
+def _ctx(
+    src_org="acme", src_type="agent", src_name="mario-bot",
+    dst_org="acme", dst_type="agent", dst_name="compliance-bot",
+) -> ReachContext:
+    return ReachContext(
+        source=PrincipalRef(src_org, src_type, src_name),
+        destination=PrincipalRef(dst_org, dst_type, dst_name),
+    )
+
+
+# ── quadrant detection ──────────────────────────────────────────────
+
+
+def test_quadrant_intra_a2a():
+    ctx = _ctx()
+    assert ctx.quadrant == "A2A"
+    assert ctx.is_intra_org is True
+
+
+def test_quadrant_cross_u2u():
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    assert ctx.quadrant == "U2U"
+    assert ctx.is_intra_org is False
+
+
+def test_quadrant_a2u_a2w_u2a_w2a_w2u_w2w():
+    """Spot-check the 6 remaining cells parse to the right shorthand."""
+    pairs = [
+        ("agent", "user",     "A2U"),
+        ("agent", "workload", "A2W"),
+        ("user",  "agent",    "U2A"),
+        ("user",  "workload", "U2W"),
+        ("workload", "agent", "W2A"),
+        ("workload", "user",  "W2U"),
+        ("workload", "workload", "W2W"),
+    ]
+    for src, dst, expect in pairs:
+        ctx = _ctx(src_type=src, dst_type=dst)
+        assert ctx.quadrant == expect, (src, dst, ctx.quadrant)
+
+
+# ── A2A ─────────────────────────────────────────────────────────────
+
+
+async def test_a2a_intra_org_default_allow(reach_db):
+    decision = await evaluate_reach_quadrant(reach_db, _ctx())
+    assert decision.allowed
+    assert decision.quadrant == "A2A"
+    assert "Intra-org" in decision.reason
+
+
+async def test_a2a_cross_org_default_deny(reach_db):
+    ctx = _ctx(src_org="acme", dst_org="bravo")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert "reach grant" in decision.reason
+
+
+async def test_a2a_cross_org_consent_unblocks(reach_db):
+    ctx = _ctx(src_org="acme", dst_org="bravo")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="acme", source_principal_type="agent",
+        source_name="mario-bot", granted_by="bravo-admin",
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id is not None
+
+
+# ── A2U ─────────────────────────────────────────────────────────────
+
+
+async def test_a2u_intra_org_default_deny(reach_db):
+    """Even intra-org an unsolicited agent must NOT pop into a user inbox."""
+    ctx = _ctx(src_type="agent", dst_type="user", dst_name="mario")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert decision.quadrant == "A2U"
+    assert "consented" in decision.reason
+
+
+async def test_a2u_intra_org_consent_unblocks(reach_db):
+    ctx = _ctx(src_type="agent", dst_type="user", dst_name="mario")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="acme", source_principal_type="agent",
+        source_name="mario-bot",
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id is not None
+
+
+async def test_a2u_cross_org_default_deny(reach_db):
+    ctx = _ctx(src_org="acme", src_type="agent", src_name="snoopy",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert decision.quadrant == "A2U"
+
+
+# ── U2A ─────────────────────────────────────────────────────────────
+
+
+async def test_u2a_intra_org_without_ownership_default_deny(reach_db):
+    """Without an ownership resolver, even intra-org U2A is consent-gated."""
+    ctx = _ctx(src_type="user", src_name="mario",
+               dst_type="agent", dst_name="finance-bot")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert decision.quadrant == "U2A"
+
+
+async def test_u2a_intra_org_with_ownership_allow(reach_db):
+    ctx = _ctx(src_type="user", src_name="mario",
+               dst_type="agent", dst_name="mario-laptop")
+
+    async def owns(user, agent):
+        return user.name == "mario" and agent.name == "mario-laptop"
+
+    decision = await evaluate_reach_quadrant(
+        reach_db, ctx, ownership_resolver=owns,
+    )
+    assert decision.allowed
+    assert "owns destination agent" in decision.reason
+
+
+async def test_u2a_cross_org_default_deny(reach_db):
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="agent", dst_name="finance-bot")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+
+
+# ── U2U ─────────────────────────────────────────────────────────────
+
+
+async def test_u2u_intra_org_default_allow(reach_db):
+    ctx = _ctx(src_type="user", src_name="mario",
+               dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.quadrant == "U2U"
+    assert "Intra-org" in decision.reason
+
+
+async def test_u2u_cross_org_default_deny_addressbook(reach_db):
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert "addressbook" in decision.reason
+
+
+async def test_u2u_cross_org_consent_unblocks(reach_db):
+    ctx = _ctx(src_org="acme", src_type="user", src_name="mario",
+               dst_org="bravo", dst_type="user", dst_name="anna")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="acme", source_principal_type="user",
+        source_name="mario",
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+
+
+# ── workload-as-source / -as-destination ────────────────────────────
+
+
+async def test_workload_source_always_denied_in_v01(reach_db):
+    ctx = _ctx(src_type="workload", src_name="byoca-haiku",
+               dst_type="user", dst_name="anna")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert not decision.allowed
+    assert "Workload-as-source" in decision.reason
+
+
+async def test_workload_destination_is_tool_call_noop_allow(reach_db):
+    ctx = _ctx(src_type="agent", src_name="mario-bot",
+               dst_type="workload", dst_name="postgres-mcp")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert "Workload destination" in decision.reason
+
+
+# ── consent grant management ───────────────────────────────────────
+
+
+async def test_grant_revoke_round_trip(reach_db):
+    recipient = PrincipalRef("acme", "user", "mario")
+    grant = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert grant.consent_id
+    revoked = await revoke_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert revoked is True
+    # Second revoke is a no-op
+    revoked_again = await revoke_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert revoked_again is False
+
+
+async def test_re_grant_after_revoke_is_idempotent(reach_db):
+    """Re-granting after a revoke must reuse the same row, not duplicate."""
+    recipient = PrincipalRef("acme", "user", "mario")
+    g1 = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    await revoke_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    g2 = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    assert g1.consent_id == g2.consent_id
+    assert g2.revoked_at is None
+
+    rows = (await reach_db.execute(select(ReachConsent))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_wildcard_source_matches_any_name(reach_db):
+    """source_name='*' grants admit any sender of that type from that org."""
+    ctx = _ctx(src_org="bravo", src_type="agent", src_name="anything",
+               dst_org="acme", dst_type="user", dst_name="mario")
+    await grant_consent(
+        reach_db,
+        recipient=ctx.destination,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name=ANY_NAME,
+    )
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id is not None
+
+
+async def test_specific_grant_beats_wildcard_when_both_present(reach_db):
+    """If a specific grant and a wildcard both match, evaluator picks
+    the specific one (more auditable)."""
+    recipient = PrincipalRef("acme", "user", "mario")
+    await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name=ANY_NAME,
+    )
+    specific = await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    ctx = _ctx(src_org="bravo", src_type="agent", src_name="snoopy",
+               dst_org="acme", dst_type="user", dst_name="mario")
+    decision = await evaluate_reach_quadrant(reach_db, ctx)
+    assert decision.allowed
+    assert decision.consent_id == specific.consent_id
+
+
+async def test_list_active_consents(reach_db):
+    recipient = PrincipalRef("acme", "user", "mario")
+    await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="bravo", source_principal_type="agent",
+        source_name="snoopy",
+    )
+    await grant_consent(
+        reach_db, recipient=recipient,
+        source_org_id="charlie", source_principal_type="user",
+        source_name="anna",
+    )
+    rows = await list_active_consents(reach_db, recipient)
+    assert len(rows) == 2
+    src_orgs = sorted(r.source_org_id for r in rows)
+    assert src_orgs == ["bravo", "charlie"]
+
+
+# ── audit chain integrity ──────────────────────────────────────────
+
+
+async def test_audit_row_emitted_per_evaluation(reach_db):
+    ctx = _ctx()
+    await evaluate_reach_quadrant(reach_db, ctx)
+    rows = (await reach_db.execute(
+        select(AuditLog).where(AuditLog.event_type == "policy.reach_evaluated")
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].principal_type == "agent"
+    assert rows[0].result == "ok"
+
+
+async def test_chain_intact_after_mixed_evaluations(reach_db):
+    """Run a batch of evaluations across all quadrants and verify the
+    audit chain still passes."""
+    ctxs = [
+        _ctx(),  # A2A intra
+        _ctx(src_org="acme", dst_org="bravo"),  # A2A cross deny
+        _ctx(src_type="agent", dst_type="user", dst_name="mario"),  # A2U
+        _ctx(src_type="user", src_name="mario", dst_type="user", dst_name="anna"),  # U2U intra
+    ]
+    for ctx in ctxs:
+        await evaluate_reach_quadrant(reach_db, ctx)
+
+    is_valid, total, broken_id = await verify_chain(reach_db, org_id="acme")
+    assert is_valid is True, f"chain broken at id {broken_id}"
+    assert total == len(ctxs)

--- a/tests/test_user_inbox.py
+++ b/tests/test_user_inbox.py
@@ -1,0 +1,505 @@
+"""ADR-020 Phase 4 — user inbox primitive tests.
+
+Covers store.py end-to-end:
+  * enqueue gates on reach (denied raises ReachDeniedError, audit
+    row already written by the reach evaluator)
+  * enqueue persists with consent_id when a grant authorised it
+  * idempotency: same (recipient, idempotency_key) collapses
+  * fetch_for_recipient ordering, pagination, archive filter
+  * mark_delivered transition (online vs offline) + idempotent
+  * mark_archived idempotent
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+from app.broker.db_models import UserInboxMessage
+from app.db.audit import AuditLog
+from app.inbox import (
+    DeliveryState,
+    enqueue,
+    fetch_for_recipient,
+    mark_archived,
+    mark_delivered,
+)
+from app.inbox.store import ReachDeniedError
+from app.policy.reach import (
+    PrincipalRef,
+    ReachConsent,
+    grant_consent,
+)
+from tests.conftest import TestSessionLocal
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def inbox_db():
+    """Clean session with inbox + reach + audit emptied before/after."""
+    async with TestSessionLocal() as session:
+        await session.execute(delete(UserInboxMessage))
+        await session.execute(delete(ReachConsent))
+        await session.execute(delete(AuditLog))
+        await session.commit()
+    async with TestSessionLocal() as session:
+        yield session
+    async with TestSessionLocal() as session:
+        await session.execute(delete(UserInboxMessage))
+        await session.execute(delete(ReachConsent))
+        await session.execute(delete(AuditLog))
+        await session.commit()
+
+
+def _user(name: str, org: str = "acme") -> PrincipalRef:
+    return PrincipalRef(org, "user", name)
+
+
+def _agent(name: str, org: str = "acme") -> PrincipalRef:
+    return PrincipalRef(org, "agent", name)
+
+
+# ── enqueue: reach gate ─────────────────────────────────────────────
+
+
+async def test_enqueue_a2u_denied_raises(inbox_db):
+    """A2U intra-org without consent must NOT land a row."""
+    with pytest.raises(ReachDeniedError) as excinfo:
+        await enqueue(
+            inbox_db,
+            sender=_agent("snoopy"),
+            recipient=_user("mario"),
+            body="hello",
+        )
+    assert "consented" in excinfo.value.decision.reason
+    rows = (await inbox_db.execute(select(UserInboxMessage))).scalars().all()
+    assert rows == []
+
+
+async def test_enqueue_a2u_consent_unblocks(inbox_db):
+    sender = _agent("snoopy")
+    recipient = _user("mario")
+    grant = await grant_consent(
+        inbox_db,
+        recipient=recipient,
+        source_org_id=sender.org_id,
+        source_principal_type="agent",
+        source_name="snoopy",
+    )
+    delivery = await enqueue(
+        inbox_db,
+        sender=sender, recipient=recipient,
+        subject="ciao Mario",
+        body="hai un report da rivedere",
+    )
+    assert delivery.inserted is True
+    assert delivery.decision.allowed
+    row = (await inbox_db.execute(select(UserInboxMessage))).scalar_one()
+    assert row.subject == "ciao Mario"
+    assert row.delivery_state == DeliveryState.QUEUED.value
+    assert row.consent_id == grant.consent_id
+
+
+async def test_enqueue_u2u_intra_org_default_allow(inbox_db):
+    delivery = await enqueue(
+        inbox_db,
+        sender=_user("mario"), recipient=_user("anna"),
+        body="ho una domanda",
+    )
+    assert delivery.inserted
+    rows = (await inbox_db.execute(select(UserInboxMessage))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].sender_principal_type == "user"
+    assert rows[0].recipient_principal_type == "user"
+
+
+async def test_enqueue_u2u_cross_org_default_deny(inbox_db):
+    with pytest.raises(ReachDeniedError):
+        await enqueue(
+            inbox_db,
+            sender=_user("mario", "acme"),
+            recipient=_user("anna", "bravo"),
+            body="cross-org without addressbook",
+        )
+
+
+async def test_enqueue_u2a_with_ownership_resolver(inbox_db):
+    async def owns(user, agent):
+        return user.name == "mario" and agent.name == "mario-laptop"
+
+    delivery = await enqueue(
+        inbox_db,
+        sender=_user("mario"),
+        recipient=_agent("mario-laptop"),
+        body="agente sveglia",
+        ownership_resolver=owns,
+    )
+    assert delivery.inserted
+    assert delivery.decision.allowed
+
+
+# ── idempotency ─────────────────────────────────────────────────────
+
+
+async def test_enqueue_idempotency_collapses_duplicates(inbox_db):
+    sender = _user("mario")
+    recipient = _user("anna")
+    d1 = await enqueue(
+        inbox_db, sender=sender, recipient=recipient,
+        body="msg 1", idempotency_key="abc-123",
+    )
+    d2 = await enqueue(
+        inbox_db, sender=sender, recipient=recipient,
+        body="msg 1 retry", idempotency_key="abc-123",
+    )
+    assert d1.inserted is True
+    assert d2.inserted is False
+    assert d1.msg_id == d2.msg_id
+
+    rows = (await inbox_db.execute(select(UserInboxMessage))).scalars().all()
+    assert len(rows) == 1
+
+
+async def test_enqueue_no_idempotency_key_creates_distinct_rows(inbox_db):
+    sender = _user("mario")
+    recipient = _user("anna")
+    d1 = await enqueue(inbox_db, sender=sender, recipient=recipient, body="m1")
+    d2 = await enqueue(inbox_db, sender=sender, recipient=recipient, body="m2")
+    assert d1.msg_id != d2.msg_id
+    rows = (await inbox_db.execute(select(UserInboxMessage))).scalars().all()
+    assert len(rows) == 2
+
+
+# ── fetch ───────────────────────────────────────────────────────────
+
+
+async def test_fetch_for_recipient_orders_by_enqueued_at(inbox_db):
+    recipient = _user("mario")
+    for sender_name, body in [("anna", "first"), ("bob", "second"), ("anna", "third")]:
+        await enqueue(
+            inbox_db, sender=_user(sender_name), recipient=recipient, body=body,
+        )
+    rows = await fetch_for_recipient(inbox_db, recipient=recipient)
+    bodies = [r.body for r in rows]
+    assert bodies == ["first", "second", "third"]
+
+
+async def test_fetch_for_recipient_cursor_pagination(inbox_db):
+    recipient = _user("mario")
+    sent = []
+    for body in ["a", "b", "c", "d"]:
+        d = await enqueue(
+            inbox_db, sender=_user("anna"), recipient=recipient, body=body,
+        )
+        sent.append(d.msg_id)
+
+    page1 = await fetch_for_recipient(inbox_db, recipient=recipient, limit=2)
+    assert [r.body for r in page1] == ["a", "b"]
+
+    cursor = page1[-1].msg_id
+    page2 = await fetch_for_recipient(
+        inbox_db, recipient=recipient, since_msg_id=cursor, limit=10,
+    )
+    assert [r.body for r in page2] == ["c", "d"]
+
+
+async def test_fetch_for_recipient_excludes_archived_by_default(inbox_db):
+    recipient = _user("mario")
+    d1 = await enqueue(inbox_db, sender=_user("anna"), recipient=recipient, body="a")
+    d2 = await enqueue(inbox_db, sender=_user("anna"), recipient=recipient, body="b")
+    await mark_archived(inbox_db, msg_id=d1.msg_id)
+
+    visible = await fetch_for_recipient(inbox_db, recipient=recipient)
+    assert [r.body for r in visible] == ["b"]
+
+    with_archive = await fetch_for_recipient(
+        inbox_db, recipient=recipient, include_archived=True,
+    )
+    assert sorted(r.body for r in with_archive) == ["a", "b"]
+
+
+async def test_fetch_for_recipient_filters_by_full_principal(inbox_db):
+    """Two users in same org, name disambiguates."""
+    mario = _user("mario")
+    anna = _user("anna")
+    await enqueue(inbox_db, sender=_user("bob"), recipient=mario, body="for mario")
+    await enqueue(inbox_db, sender=_user("bob"), recipient=anna, body="for anna")
+
+    mario_inbox = await fetch_for_recipient(inbox_db, recipient=mario)
+    assert [r.body for r in mario_inbox] == ["for mario"]
+    anna_inbox = await fetch_for_recipient(inbox_db, recipient=anna)
+    assert [r.body for r in anna_inbox] == ["for anna"]
+
+
+# ── mark_delivered / mark_archived ─────────────────────────────────
+
+
+async def test_mark_delivered_offline(inbox_db):
+    d = await enqueue(
+        inbox_db, sender=_user("anna"), recipient=_user("mario"), body="hi",
+    )
+    flipped = await mark_delivered(inbox_db, msg_id=d.msg_id, online=False)
+    assert flipped is True
+
+    row = (await inbox_db.execute(
+        select(UserInboxMessage).where(UserInboxMessage.msg_id == d.msg_id)
+    )).scalar_one()
+    assert row.delivery_state == DeliveryState.DELIVERED_OFFLINE.value
+    assert row.delivered_at is not None
+
+
+async def test_mark_delivered_online_then_idempotent(inbox_db):
+    d = await enqueue(
+        inbox_db, sender=_user("anna"), recipient=_user("mario"), body="hi",
+    )
+    first = await mark_delivered(inbox_db, msg_id=d.msg_id, online=True)
+    second = await mark_delivered(inbox_db, msg_id=d.msg_id, online=True)
+    assert first is True
+    # Second call is a no-op (already not in QUEUED state).
+    assert second is False
+
+
+async def test_mark_archived_idempotent(inbox_db):
+    d = await enqueue(
+        inbox_db, sender=_user("anna"), recipient=_user("mario"), body="hi",
+    )
+    first = await mark_archived(inbox_db, msg_id=d.msg_id)
+    second = await mark_archived(inbox_db, msg_id=d.msg_id)
+    assert first is True
+    assert second is False
+
+
+# ── audit chain integrity ──────────────────────────────────────────
+
+
+async def test_audit_row_emitted_on_denied_enqueue(inbox_db):
+    """Even a denied send leaves an audit trace via reach evaluator."""
+    with pytest.raises(ReachDeniedError):
+        await enqueue(
+            inbox_db,
+            sender=_agent("snoopy"),
+            recipient=_user("mario"),
+            body="spam",
+        )
+    rows = (await inbox_db.execute(
+        select(AuditLog).where(AuditLog.event_type == "policy.reach_evaluated")
+    )).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].result == "denied"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# REST router (with DPoP/JWT overridden out)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+from httpx import AsyncClient, ASGITransport
+
+from app.main import app
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+
+
+def _fake_token(*, agent_id: str, org: str, principal_type: str = "user") -> TokenPayload:
+    name = agent_id.split("::", 1)[-1]
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{org}/{principal_type}/{name}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=1_000_000_000,
+        jti=f"jti-{agent_id}",
+        scope=[],
+        cnf={"jkt": "fake-jkt"},
+    )
+
+
+@pytest.fixture
+def authed_user(request):
+    """Override get_current_agent with a user/mario principal.
+
+    Marker ``@pytest.mark.user_principal('acme', 'mario')`` lets a test
+    swap to a different fake user.
+    """
+    org = "acme"
+    name = "mario"
+    marker = request.node.get_closest_marker("user_principal")
+    if marker is not None:
+        org, name = marker.args
+    token = _fake_token(agent_id=f"{org}::{name}", org=org, principal_type="user")
+    app.dependency_overrides[get_current_agent] = lambda: token
+    yield token
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest.fixture
+def authed_agent_principal():
+    """Override with an agent (not user) principal — for A2U send tests."""
+    token = _fake_token(agent_id="acme::snoopy", org="acme", principal_type="agent")
+    app.dependency_overrides[get_current_agent] = lambda: token
+    yield token
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest_asyncio.fixture
+async def http_client():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+
+
+# ── /v1/inbox/send ─────────────────────────────────────────────────
+
+
+async def test_router_send_u2u_intra_org_201(http_client, authed_user, inbox_db):
+    resp = await http_client.post("/v1/inbox/send", json={
+        "recipient_org_id": "acme",
+        "recipient_principal_type": "user",
+        "recipient_name": "anna",
+        "subject": "ciao",
+        "body": "domanda?",
+    })
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["inserted"] is True
+    assert body["quadrant"] == "U2U"
+
+    # The row exists in the DB.
+    rows = (await inbox_db.execute(select(UserInboxMessage))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].sender_name == "mario"
+    assert rows[0].recipient_name == "anna"
+
+
+async def test_router_send_a2u_without_consent_403(http_client, authed_agent_principal, inbox_db):
+    resp = await http_client.post("/v1/inbox/send", json={
+        "recipient_org_id": "acme",
+        "recipient_principal_type": "user",
+        "recipient_name": "mario",
+        "body": "spam",
+    })
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["quadrant"] == "A2U"
+
+
+async def test_router_send_idempotent(http_client, authed_user, inbox_db):
+    payload = {
+        "recipient_org_id": "acme",
+        "recipient_principal_type": "user",
+        "recipient_name": "anna",
+        "body": "msg",
+        "idempotency_key": "abc-1",
+    }
+    r1 = await http_client.post("/v1/inbox/send", json=payload)
+    r2 = await http_client.post("/v1/inbox/send", json=payload)
+    assert r1.status_code == 201
+    assert r2.status_code == 201
+    assert r1.json()["msg_id"] == r2.json()["msg_id"]
+    assert r1.json()["inserted"] is True
+    assert r2.json()["inserted"] is False
+
+
+# ── GET /v1/inbox ─────────────────────────────────────────────────
+
+
+async def test_router_list_returns_messages_for_caller(http_client, authed_user, inbox_db):
+    # Seed one message addressed to mario directly via the store.
+    mario = _user("mario")
+    await enqueue(inbox_db, sender=_user("anna"), recipient=mario, body="for you")
+    # And one for anna (must NOT show up).
+    await enqueue(
+        inbox_db, sender=_user("mario"), recipient=_user("anna"), body="elsewhere",
+    )
+
+    resp = await http_client.get("/v1/inbox")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["body"] == "for you"
+    assert items[0]["delivery_state"] == "queued"
+
+
+async def test_router_list_pagination(http_client, authed_user, inbox_db):
+    mario = _user("mario")
+    sent = []
+    for body in ["a", "b", "c", "d"]:
+        d = await enqueue(inbox_db, sender=_user("anna"), recipient=mario, body=body)
+        sent.append(d.msg_id)
+
+    page1 = (await http_client.get("/v1/inbox?limit=2")).json()
+    assert [it["body"] for it in page1] == ["a", "b"]
+
+    cursor = page1[-1]["msg_id"]
+    page2 = (await http_client.get(f"/v1/inbox?since={cursor}&limit=10")).json()
+    assert [it["body"] for it in page2] == ["c", "d"]
+
+
+async def test_router_list_isolation_between_users(http_client, authed_user, inbox_db):
+    """Anna's messages are not visible to mario via the router."""
+    await enqueue(
+        inbox_db, sender=_user("bob"), recipient=_user("anna"), body="for anna only",
+    )
+    resp = await http_client.get("/v1/inbox")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── ack / archive ──────────────────────────────────────────────────
+
+
+async def test_router_ack(http_client, authed_user, inbox_db):
+    d = await enqueue(
+        inbox_db, sender=_user("anna"), recipient=_user("mario"), body="hi",
+    )
+    resp = await http_client.post(f"/v1/inbox/{d.msg_id}/ack?online=true")
+    assert resp.status_code == 200
+    assert resp.json()["acked"] is True
+
+    row = (await inbox_db.execute(
+        select(UserInboxMessage).where(UserInboxMessage.msg_id == d.msg_id)
+    )).scalar_one()
+    assert row.delivery_state == "delivered_online"
+
+
+async def test_router_ack_unknown_msg_404(http_client, authed_user, inbox_db):
+    resp = await http_client.post("/v1/inbox/does-not-exist/ack")
+    assert resp.status_code == 404
+
+
+async def test_router_ack_not_recipient_404(http_client, authed_user, inbox_db):
+    """Calling ack for a message not addressed to the caller → 404 (no leak)."""
+    d = await enqueue(
+        inbox_db, sender=_user("bob"), recipient=_user("anna"), body="for anna",
+    )
+    resp = await http_client.post(f"/v1/inbox/{d.msg_id}/ack")
+    assert resp.status_code == 404
+
+
+async def test_router_archive(http_client, authed_user, inbox_db):
+    d = await enqueue(
+        inbox_db, sender=_user("anna"), recipient=_user("mario"), body="hi",
+    )
+    resp = await http_client.post(f"/v1/inbox/{d.msg_id}/archive")
+    assert resp.status_code == 200
+    assert resp.json()["archived"] is True
+
+    row = (await inbox_db.execute(
+        select(UserInboxMessage).where(UserInboxMessage.msg_id == d.msg_id)
+    )).scalar_one()
+    assert row.delivery_state == "archived"
+
+
+async def test_router_archive_excluded_from_list_default(http_client, authed_user, inbox_db):
+    mario = _user("mario")
+    d = await enqueue(inbox_db, sender=_user("anna"), recipient=mario, body="visible")
+    archived = await enqueue(
+        inbox_db, sender=_user("anna"), recipient=mario, body="hidden",
+    )
+    await mark_archived(inbox_db, msg_id=archived.msg_id)
+
+    visible = (await http_client.get("/v1/inbox")).json()
+    assert len(visible) == 1
+    assert visible[0]["body"] == "visible"
+
+    with_archive = (await http_client.get("/v1/inbox?include_archived=true")).json()
+    assert sorted(it["body"] for it in with_archive) == ["hidden", "visible"]

--- a/tests/test_user_inbox.py
+++ b/tests/test_user_inbox.py
@@ -207,7 +207,7 @@ async def test_fetch_for_recipient_cursor_pagination(inbox_db):
 async def test_fetch_for_recipient_excludes_archived_by_default(inbox_db):
     recipient = _user("mario")
     d1 = await enqueue(inbox_db, sender=_user("anna"), recipient=recipient, body="a")
-    d2 = await enqueue(inbox_db, sender=_user("anna"), recipient=recipient, body="b")
+    await enqueue(inbox_db, sender=_user("anna"), recipient=recipient, body="b")
     await mark_archived(inbox_db, msg_id=d1.msg_id)
 
     visible = await fetch_for_recipient(inbox_db, recipient=recipient)
@@ -491,7 +491,7 @@ async def test_router_archive(http_client, authed_user, inbox_db):
 
 async def test_router_archive_excluded_from_list_default(http_client, authed_user, inbox_db):
     mario = _user("mario")
-    d = await enqueue(inbox_db, sender=_user("anna"), recipient=mario, body="visible")
+    await enqueue(inbox_db, sender=_user("anna"), recipient=mario, body="visible")
     archived = await enqueue(
         inbox_db, sender=_user("anna"), recipient=mario, body="hidden",
     )


### PR DESCRIPTION
## Summary

Phase 3 introduced the four-quadrant reach matrix and the consent-grant primitive. Phase 4 connects them to a **durable storage surface** that backs A2U / U2A / U2U deliveries, plus the REST endpoints the SPA / clients call to drain and ack the inbox. This completes the user inbox primitive described in ADR-020 §5.

### What's new

- **`user_inbox_messages` table** — stand-alone (no `session_id`), full principal triple on both ends (`org`, `type`, `name`), plaintext body for v0.1 (E2E encryption is v0.5 candidate; the cloud edge is the trust boundary today), `delivery_state` enum (`queued` | `delivered_offline` | `delivered_online` | `archived` | `expired`), per-principal-type TTL defaults (7 days users, 30 min agents, 5 min workloads), full idempotency on `(recipient, idempotency_key)`.

- **`app/inbox/store.py`** — `enqueue` / `fetch_for_recipient` / `mark_delivered` / `mark_archived`. Every `enqueue` calls `evaluate_reach_quadrant` first and refuses to write a row when the quadrant is denied. The denial is audited by the reach evaluator (no double-audit). On allow, the row stores `consent_id` so the audit trail proves which grant authorised the delivery.

- **`app/inbox/router.py`** — REST surface:

| Method | Path | Behaviour |
|---|---|---|
| POST | `/v1/inbox/send` | enqueue, 201 on insert, **403 with quadrant + reason** on reach denial |
| GET | `/v1/inbox?since=&limit=` | list caller's messages, cursor-paginated, archive excluded by default |
| POST | `/v1/inbox/{msg_id}/ack` | mark delivered, `online=true` for WS push, idempotent |
| POST | `/v1/inbox/{msg_id}/archive` | soft hide, idempotent |

The router resolves the caller principal via `spiffe_to_principal` on the JWT's `sub` (ADR-020 Phase 1, already merged in #407), falling back to `agent_id` + `principal_type=agent` for legacy tokens. Same DPoP+JWT auth as every other v1 endpoint.

**404 (not 403)** when a non-recipient tries to ack/archive a foreign message — never leak existence of others' inboxes.

WebSocket `/v1/inbox/stream` is reserved for a follow-up: Phase 4 ships **durability** so offline drain works on day one; online push is sugar for the SPA later.

### Stacking

Cherry-picks PR #409 (Phase 3 reach policy) so this branch is independently testable. When #408 + #409 merge upstream, the cherry-picks dissolve into the merge base. Phase 1 (#407) is already on main.

## Test plan

- [x] 26 new tests in `tests/test_user_inbox.py`:
  - **15 on store**: A2U denial without consent / allowed with consent / U2U intra allow / U2U cross deny / U2A with ownership_resolver / idempotency / no-key distinct rows / fetch ordering / cursor pagination / archive filter / mark_delivered offline+online idempotent / mark_archived idempotent / audit row emitted on denied enqueue.
  - **11 on router**: 201 on U2U send / 403 on A2U without consent (with quadrant in detail) / idempotent send returns same `msg_id` / list returns only caller's messages / pagination / cross-user isolation / ack online flips state / 404 unknown msg / 404 not-recipient (no leak) / archive flips state / archive excluded from list by default.
- [x] `111/111` green across `test_user_inbox.py` + `test_reach_policy.py` + `test_audit_chain.py` + `test_spiffe.py` (no regressions).
- [x] Migration up + down + up clean on SQLite.

## Out of scope (next phase)

- Phase 5: Frontdesk integration — Cullis Chat inbox panel + SSO → user-cert provisioning + `OwnershipResolver` wired to a registry table (currently always returns False without a resolver).
- WebSocket `/v1/inbox/stream` for online push.
- E2E encryption of the body (v0.5).
- Cross-org U2U addressbook UI for granting and revoking consents.