### PR TITLE
feat(frontend): gate audit panel behind PUBLIC_DEV_AUDIT_PANEL env

### DIFF
--- a/frontend/cullis-chat/README.md
+++ b/frontend/cullis-chat/README.md
@@ -13,12 +13,14 @@ as DPoP+mTLS and emits it to the Cullis cloud (proxy + Mastio).
 
 ## v0.1 surface
 
-- 3-pane layout: empty sidebar (history lands in v0.5), chat main, audit panel
+- 3-pane layout: empty sidebar (history lands in v0.5), chat main, optional dev audit panel
 - Streaming SSE chat over `/v1/chat/completions` (OpenAI-compatible)
 - Tool-use indicators inline ("calling postgres.query...")
-- Audit panel right with `trace_id`, latency, tool calls per assistant message
 - Identity badge with `principal_type` per ADR-020 (`user · mario`)
 - Model picker fed by `/v1/models`
+- Dev-only audit panel (right rail) gated by `PUBLIC_DEV_AUDIT_PANEL=1`. In
+  production the audit chain belongs to the CISO/admin dashboard (Mastio),
+  not to the end-user surface. Default off.
 - No login (topology L: security boundary is the OS process; topology S adds
   reverse-proxy SSO upstream, see ADR-019 §2)
 
@@ -42,6 +44,14 @@ npm run dev             # Astro dev on :4321
 
 # Open http://localhost:4321
 ```
+
+To exercise the dev audit panel locally:
+
+```bash
+PUBLIC_DEV_AUDIT_PANEL=1 npm run dev
+```
+
+The Playwright config sets this automatically for the e2e suite.
 
 ## Build
 

--- a/frontend/cullis-chat/playwright.config.ts
+++ b/frontend/cullis-chat/playwright.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
       env: {
         CULLIS_LOCAL_TOKEN: 'test-token',
         CULLIS_AMBASSADOR_URL: `http://127.0.0.1:${MOCK_PORT}`,
+        // The audit panel is dev-only (production hides it). Tests
+        // exercise it, so enable it explicitly here.
+        PUBLIC_DEV_AUDIT_PANEL: '1',
       },
       stdout: 'pipe',
       stderr: 'pipe',

--- a/frontend/cullis-chat/src/components/ChatApp.tsx
+++ b/frontend/cullis-chat/src/components/ChatApp.tsx
@@ -8,6 +8,11 @@ import { ChatWindow } from './ChatWindow';
 import { AuditPanel } from './AuditPanel';
 import '../styles/chat-window.css';
 
+// In production the audit chain belongs to the CISO/admin dashboard,
+// not to the end-user chat surface. The inline panel is dev-only and
+// gated by an Astro public env var. Default off.
+const AUDIT_PANEL_ENABLED = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
+
 interface ChatState {
   messages: ChatMessage[];
   status: 'idle' | 'sending';
@@ -232,15 +237,18 @@ export default function ChatApp() {
 
   // Initial collapse state from localStorage. The TopBar toggle script
   // mutates the data-attribute on this element directly; we just seed it.
-  const collapsed = readCollapsedFromLocalStorage();
+  // Only relevant when the audit panel is enabled.
+  const collapsed = AUDIT_PANEL_ENABLED ? readCollapsedFromLocalStorage() : false;
+
+  const className = AUDIT_PANEL_ENABLED ? 'chat-app' : 'chat-app chat-app--no-audit';
 
   return (
     <ChatContext.Provider value={value}>
-      <div className="chat-app" data-audit-collapsed={collapsed ? 'true' : 'false'}>
+      <div className={className} data-audit-collapsed={collapsed ? 'true' : 'false'}>
         <section className="chat-main" aria-label="Chat">
           <ChatWindow />
         </section>
-        <AuditPanel />
+        {AUDIT_PANEL_ENABLED ? <AuditPanel /> : null}
       </div>
     </ChatContext.Provider>
   );

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -10,6 +10,8 @@
 
 import IdentityBadge from './IdentityBadge.tsx';
 import ModelPicker from './ModelPicker.tsx';
+
+const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
 ---
 
 <header class="topbar">
@@ -30,15 +32,17 @@ import ModelPicker from './ModelPicker.tsx';
       <span class="status-label">connected</span>
     </span>
     <IdentityBadge client:load />
-    <button
-      type="button"
-      class="audit-toggle"
-      aria-label="Toggle audit panel"
-      data-action="toggle-audit"
-    >
-      <span class="folio">audit</span>
-      <span class="audit-toggle-icon" aria-hidden="true">▦</span>
-    </button>
+    {auditToggleEnabled && (
+      <button
+        type="button"
+        class="audit-toggle"
+        aria-label="Toggle audit panel"
+        data-action="toggle-audit"
+      >
+        <span class="folio">audit</span>
+        <span class="audit-toggle-icon" aria-hidden="true">▦</span>
+      </button>
+    )}
   </div>
 </header>
 

--- a/frontend/cullis-chat/src/env.d.ts
+++ b/frontend/cullis-chat/src/env.d.ts
@@ -7,3 +7,16 @@ declare namespace App {
     cspNonce: string;
   }
 }
+
+interface ImportMetaEnv {
+  /**
+   * When set to '1', renders the inline audit panel + topbar toggle.
+   * Default off: in production the audit chain belongs to the CISO
+   * dashboard (Mastio admin UI), not to the end-user chat surface.
+   */
+  readonly PUBLIC_DEV_AUDIT_PANEL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/frontend/cullis-chat/src/styles/globals.css
+++ b/frontend/cullis-chat/src/styles/globals.css
@@ -85,6 +85,13 @@ body {
   pointer-events: none;
 }
 
+/* Production mode (PUBLIC_DEV_AUDIT_PANEL unset): the audit pane is
+ * not rendered at all. Collapse the layout to a single column so the
+ * chat surface fills the available width. */
+.chat-app--no-audit {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 /* Subtle grid background CONFINED to the main pane (sidebar + audit
  * stay flat surface for legibility — different from the site, where
  * the grid is global). */


### PR DESCRIPTION
## Summary

Hide the inline audit chain panel + topbar toggle by default. Render only when `PUBLIC_DEV_AUDIT_PANEL=1`.

**Why**: in production the audit chain belongs to the CISO/admin dashboard (Mastio admin UI), not to the end-user chat surface. Mario is a regular employee, not a security analyst; an inline hash chain confuses the target user and dilutes the *one install, 1000 users, audit individual* pitch. The component stays in the codebase as a dev/debug aid (and as material for demo screenshots).

**What changes**:
- `ChatApp.tsx` reads `import.meta.env.PUBLIC_DEV_AUDIT_PANEL`. Off → no `<AuditPanel />` render, root gets `chat-app--no-audit` class.
- `TopBar.astro` skips the audit toggle button when off.
- `globals.css` adds `.chat-app--no-audit { grid-template-columns: minmax(0, 1fr); }`.
- `env.d.ts` declares `ImportMetaEnv.PUBLIC_DEV_AUDIT_PANEL`.
- `playwright.config.ts` sets `PUBLIC_DEV_AUDIT_PANEL=1` in the dev server env so the existing `audit-panel.spec.ts` keeps passing without modification.
- README documents the flag.

## Test plan

- [x] `npm run build` clean (no TS errors)
- [ ] CI Playwright suite green (audit-panel spec uses the env-on dev server)
- [ ] Local `npm run dev` (no env) renders chat without right rail and without audit toggle
- [ ] Local `PUBLIC_DEV_AUDIT_PANEL=1 npm run dev` renders the audit panel + toggle as before

## Related

- Discussion in session 2026-05-04 part 4 (planning ADR-021)
- Material for the demo video: chat surface stays clean for the user-shot, audit shown separately on a CISO dashboard view