### PR TITLE
feat(kms): UserPrincipalKMS Protocol + embedded backend (ADR-021 PR1)

### DIFF
--- a/app/kms/user_principal.py
+++ b/app/kms/user_principal.py
@@ -1,0 +1,173 @@
+"""UserPrincipalKMS abstraction — key material for human users.
+
+Distinct from the existing ``KMSProvider`` (``app/kms/provider.py``)
+which manages the broker's own CA and at-rest secret encryption.
+This Protocol manages per-user key material for ADR-020 user
+principals (``spiffe://<td>/<org>/user/<name>``).
+
+Lifecycle expected by callers:
+
+    1. ``has_principal(id)`` — if True, principal already provisioned;
+       proceed straight to ``sign``.
+    2. ``create_keypair(id, alg)`` — backend generates the keypair
+       internally (in-process for the embedded backend, server-side
+       for Vault Transit / AWS KMS / Azure KV). Returns the public
+       key so the caller can build a CSR from it.
+    3. Caller hands the CSR to Mastio (or any CA) for signing.
+    4. ``attach_certificate(id, cert_pem)`` — backend stores the cert
+       alongside the key material. The caller can now drop the cert
+       from its own working memory.
+    5. ``sign(id, payload)`` — backend signs ``payload`` with the
+       private key. For KMS-backed implementations the key never
+       leaves the KMS; for the embedded backend it is decrypted in
+       process for the duration of the call.
+    6. ``get_certificate(id)`` — returns the stored cert PEM (used
+       for cert thumbprint pinning, x5c headers, etc.).
+    7. ``revoke_principal(id)`` — marks the principal revoked; future
+       ``sign`` calls raise. The row remains for audit replay.
+
+The Protocol is deliberately narrow. There is no ``get_private_key``
+method, by design — even the embedded backend is structured so
+callers cannot accidentally exfiltrate private key material.
+
+This refines the API sketched in ``imp/adr-021-shared-mode-multi-user-kms.md``
+§1, which originally combined keypair generation and CSR-to-cert
+into a single ``provision_principal(csr_pem)`` call. The two-step
+split (``create_keypair`` then ``attach_certificate``) is cleaner
+because it puts the CA dependency (Mastio) outside the KMS contract:
+the KMS handles keys, Mastio handles certs.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+# Algorithm identifiers accepted by ``create_keypair`` and ``sign``.
+# v0.1 ships only ES256 (ECC P-256). RS256 will arrive in v0.2 if a
+# customer KMS only exposes RSA.
+ALG_ES256 = "ES256"
+SUPPORTED_ALGS = frozenset({ALG_ES256})
+
+
+class PrincipalNotFoundError(KeyError):
+    """Raised when an operation references an unknown ``principal_id``."""
+
+
+class PrincipalAlreadyExistsError(ValueError):
+    """Raised when ``create_keypair`` is called for an existing principal.
+
+    Re-provisioning requires an explicit ``revoke_principal`` first —
+    silent overwrite would mask key-rotation bugs.
+    """
+
+
+class PrincipalRevokedError(PermissionError):
+    """Raised when ``sign`` is invoked on a revoked principal."""
+
+
+class CertificateNotAttachedError(LookupError):
+    """Raised when ``get_certificate`` runs before ``attach_certificate``."""
+
+
+@dataclass(frozen=True)
+class ProvisioningResult:
+    """Outcome of ``create_keypair``.
+
+    Attributes:
+        public_key_pem: SubjectPublicKeyInfo PEM. Caller embeds this
+            in a CSR and ships it to the CA.
+        key_handle: Opaque backend-specific reference (e.g.
+            ``"embedded:acme/acme/user/mario"`` for the embedded
+            backend, ``"vault:transit/keys/cullis-user-..."`` for
+            Vault). Returned for log correlation only; callers must
+            not parse it.
+        alg: The algorithm identifier the backend used. Echoes back
+            what the caller asked for, for paranoia.
+    """
+
+    public_key_pem: str
+    key_handle: str
+    alg: str
+
+
+@runtime_checkable
+class UserPrincipalKMS(Protocol):
+    """Backend-agnostic key management for user principals."""
+
+    async def has_principal(self, principal_id: str) -> bool:
+        """Return True if this principal already has key material.
+
+        Returns True for both active and revoked principals — use
+        ``sign`` failure or a separate ``is_revoked`` check (future)
+        to distinguish.
+        """
+        ...
+
+    async def create_keypair(
+        self,
+        principal_id: str,
+        *,
+        alg: str = ALG_ES256,
+    ) -> ProvisioningResult:
+        """Generate a fresh keypair for ``principal_id``.
+
+        Raises:
+            PrincipalAlreadyExistsError: principal already provisioned.
+            ValueError: ``alg`` not in ``SUPPORTED_ALGS``.
+        """
+        ...
+
+    async def attach_certificate(
+        self,
+        principal_id: str,
+        cert_pem: str,
+    ) -> None:
+        """Store the CA-signed cert for ``principal_id``.
+
+        Re-attaching overrides the prior cert (cert rotation is a
+        normal operation). Raises ``PrincipalNotFoundError`` if
+        ``create_keypair`` has not run.
+        """
+        ...
+
+    async def get_certificate(self, principal_id: str) -> str:
+        """Return the stored cert PEM.
+
+        Raises:
+            PrincipalNotFoundError: no key material at all.
+            CertificateNotAttachedError: keys exist but no cert yet.
+        """
+        ...
+
+    async def sign(self, principal_id: str, payload: bytes) -> bytes:
+        """Sign ``payload`` with the principal's private key.
+
+        Returns raw signature bytes (DER for ECDSA, PKCS#1 v1.5 for
+        RSA — alg-dependent). DPoP / JWS callers re-encode as needed.
+
+        Raises:
+            PrincipalNotFoundError
+            PrincipalRevokedError
+        """
+        ...
+
+    async def revoke_principal(self, principal_id: str) -> None:
+        """Mark the principal revoked. Future ``sign`` raises.
+
+        Idempotent: revoking an already-revoked principal is a no-op.
+        Raises ``PrincipalNotFoundError`` if no key material exists.
+        """
+        ...
+
+
+__all__ = [
+    "ALG_ES256",
+    "SUPPORTED_ALGS",
+    "CertificateNotAttachedError",
+    "PrincipalAlreadyExistsError",
+    "PrincipalNotFoundError",
+    "PrincipalRevokedError",
+    "ProvisioningResult",
+    "UserPrincipalKMS",
+]

--- a/app/kms/user_principal_embedded.py
+++ b/app/kms/user_principal_embedded.py
@@ -1,0 +1,345 @@
+"""Embedded UserPrincipalKMS backend — SQLite + AES-256-GCM at rest.
+
+Fallback backend for deployments without a real KMS (small mid-market
+customers without Vault/AWS KMS/Azure KV, plus dev sandboxes and the
+test suite). Keys live in a SQLite file at ``<config_dir>/user_principals.db``,
+each private key wrapped with AES-256-GCM under a master key supplied
+through the environment.
+
+Security caveat (documented in ``imp/adr-021-shared-mode-multi-user-kms.md``
+§11 T2): a process compromise leaks the master key + the SQLite, which
+is full key exfiltration for every provisioned user. This backend is
+NOT recommended for compliance-sensitive deployments — Vault/AWS/Azure
+backends keep the private key server-side and limit blast radius.
+
+The master key MUST be supplied explicitly via ``CULLIS_USER_KMS_MASTER_KEY``
+(64 hex chars = 32 bytes). The backend refuses to auto-generate one,
+so the operator cannot accidentally ship with a default secret.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from app.kms.user_principal import (
+    ALG_ES256,
+    SUPPORTED_ALGS,
+    CertificateNotAttachedError,
+    PrincipalAlreadyExistsError,
+    PrincipalNotFoundError,
+    PrincipalRevokedError,
+    ProvisioningResult,
+)
+
+_log = logging.getLogger("agent_trust")
+
+# Env var name that supplies the wrapping key. Must be 64 hex chars
+# (32 bytes). Generate with ``openssl rand -hex 32``.
+ENV_MASTER_KEY = "CULLIS_USER_KMS_MASTER_KEY"
+
+# AES-GCM nonce length: 12 bytes is the recommended default.
+_NONCE_LEN = 12
+
+# Maximum principal_id length (matches the planned ``user_principals``
+# table column in PR2). 255 is generous for ``<td>/<org>/<type>/<name>``.
+_MAX_PRINCIPAL_ID_LEN = 255
+
+_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS user_principals_keys (
+    principal_id           TEXT PRIMARY KEY,
+    alg                    TEXT NOT NULL,
+    encrypted_private_key  BLOB NOT NULL,
+    public_key_pem         TEXT NOT NULL,
+    certificate_pem        TEXT,
+    created_at             TEXT NOT NULL,
+    revoked_at             TEXT
+);
+"""
+
+
+def _load_master_key() -> bytes:
+    """Read the master key from the environment.
+
+    Raises ``RuntimeError`` if the env var is missing or malformed.
+    """
+    raw = os.environ.get(ENV_MASTER_KEY, "").strip()
+    if not raw:
+        raise RuntimeError(
+            f"{ENV_MASTER_KEY} is required for the embedded "
+            "UserPrincipalKMS backend. Generate one with "
+            "`openssl rand -hex 32` and export it. The backend refuses "
+            "to auto-generate the master key so you can't accidentally "
+            "ship with a default secret.",
+        )
+    try:
+        key = bytes.fromhex(raw)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{ENV_MASTER_KEY} must be 64 hex chars; got non-hex input.",
+        ) from exc
+    if len(key) != 32:
+        raise RuntimeError(
+            f"{ENV_MASTER_KEY} must decode to 32 bytes (64 hex chars); "
+            f"got {len(key)} bytes.",
+        )
+    return key
+
+
+def _validate_principal_id(principal_id: str) -> None:
+    if not principal_id:
+        raise ValueError("principal_id must be a non-empty string")
+    if len(principal_id) > _MAX_PRINCIPAL_ID_LEN:
+        raise ValueError(
+            f"principal_id exceeds {_MAX_PRINCIPAL_ID_LEN} chars "
+            f"(got {len(principal_id)})",
+        )
+    if not principal_id.isascii() or not principal_id.isprintable():
+        raise ValueError("principal_id must be ASCII printable")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+class EmbeddedUserPrincipalKMS:
+    """SQLite + AES-256-GCM implementation of ``UserPrincipalKMS``.
+
+    Concurrency model: SQLite is sync. We wrap every operation in
+    ``asyncio.to_thread`` so the surrounding async code is not blocked.
+    Within the worker thread we open a fresh ``sqlite3.Connection`` per
+    operation — SQLite connections are not safe to share across
+    threads without explicit ``check_same_thread=False`` and locking.
+    File-level locking (SQLite's default) gives us serialization for
+    free at this scale (single-process, low-contention).
+    """
+
+    def __init__(self, db_path: str | Path, master_key: bytes | None = None) -> None:
+        self._db_path = Path(db_path)
+        if master_key is None:
+            master_key = _load_master_key()
+        if len(master_key) != 32:
+            raise ValueError(
+                "master_key must be exactly 32 bytes (got %d)" % len(master_key),
+            )
+        self._aead = AESGCM(master_key)
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Initialise schema synchronously at construction; subsequent
+        # async ops can rely on the table existing.
+        self._init_schema()
+
+    # ── schema / connection ────────────────────────────────────────
+
+    def _init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.executescript(_SCHEMA_SQL)
+        # Tighten file perms — same sensitivity as the broker CA key.
+        try:
+            os.chmod(self._db_path, 0o600)
+        except OSError:
+            _log.info(
+                "could not chmod 0600 on %s (filesystem may not support it)",
+                self._db_path,
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        # ``isolation_level=None`` puts us in autocommit; we issue
+        # explicit transactions for write paths via ``BEGIN``.
+        conn = sqlite3.connect(
+            self._db_path,
+            isolation_level=None,
+            timeout=5.0,
+        )
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA foreign_keys=ON;")
+        return conn
+
+    # ── crypto helpers ─────────────────────────────────────────────
+
+    def _wrap(self, plaintext: bytes, principal_id: str) -> bytes:
+        """AES-256-GCM seal. AAD binds the ciphertext to the principal_id
+        so a stolen ciphertext cannot be replayed under a different id.
+        """
+        nonce = os.urandom(_NONCE_LEN)
+        ct = self._aead.encrypt(nonce, plaintext, principal_id.encode("utf-8"))
+        return nonce + ct
+
+    def _unwrap(self, blob: bytes, principal_id: str) -> bytes:
+        if len(blob) < _NONCE_LEN + 16:
+            raise InvalidTag("ciphertext too short")
+        nonce = blob[:_NONCE_LEN]
+        ct = blob[_NONCE_LEN:]
+        return self._aead.decrypt(nonce, ct, principal_id.encode("utf-8"))
+
+    # ── Protocol implementation ────────────────────────────────────
+
+    async def has_principal(self, principal_id: str) -> bool:
+        _validate_principal_id(principal_id)
+        return await asyncio.to_thread(self._has_sync, principal_id)
+
+    def _has_sync(self, principal_id: str) -> bool:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM user_principals_keys WHERE principal_id = ?",
+                (principal_id,),
+            ).fetchone()
+        return row is not None
+
+    async def create_keypair(
+        self,
+        principal_id: str,
+        *,
+        alg: str = ALG_ES256,
+    ) -> ProvisioningResult:
+        _validate_principal_id(principal_id)
+        if alg not in SUPPORTED_ALGS:
+            raise ValueError(
+                f"alg '{alg}' not supported (v0.1 ships {sorted(SUPPORTED_ALGS)})",
+            )
+        return await asyncio.to_thread(self._create_keypair_sync, principal_id, alg)
+
+    def _create_keypair_sync(self, principal_id: str, alg: str) -> ProvisioningResult:
+        # ES256 = ECC P-256. RS256 will land alongside its first user.
+        priv = ec.generate_private_key(ec.SECP256R1())
+        priv_pem = priv.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )
+        pub_pem = priv.public_key().public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        ).decode("utf-8")
+
+        wrapped = self._wrap(priv_pem, principal_id)
+        created_at = _now_iso()
+
+        try:
+            with self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO user_principals_keys "
+                    "(principal_id, alg, encrypted_private_key, "
+                    " public_key_pem, certificate_pem, created_at, revoked_at) "
+                    "VALUES (?, ?, ?, ?, NULL, ?, NULL)",
+                    (principal_id, alg, wrapped, pub_pem, created_at),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise PrincipalAlreadyExistsError(
+                f"principal '{principal_id}' already provisioned; "
+                "revoke first to re-provision",
+            ) from exc
+
+        return ProvisioningResult(
+            public_key_pem=pub_pem,
+            key_handle=f"embedded:{principal_id}",
+            alg=alg,
+        )
+
+    async def attach_certificate(
+        self,
+        principal_id: str,
+        cert_pem: str,
+    ) -> None:
+        _validate_principal_id(principal_id)
+        if not cert_pem.strip():
+            raise ValueError("cert_pem must be a non-empty PEM string")
+        await asyncio.to_thread(
+            self._attach_certificate_sync, principal_id, cert_pem,
+        )
+
+    def _attach_certificate_sync(
+        self, principal_id: str, cert_pem: str,
+    ) -> None:
+        with self._connect() as conn:
+            cur = conn.execute(
+                "UPDATE user_principals_keys SET certificate_pem = ? "
+                "WHERE principal_id = ?",
+                (cert_pem, principal_id),
+            )
+            if cur.rowcount == 0:
+                raise PrincipalNotFoundError(principal_id)
+
+    async def get_certificate(self, principal_id: str) -> str:
+        _validate_principal_id(principal_id)
+        return await asyncio.to_thread(
+            self._get_certificate_sync, principal_id,
+        )
+
+    def _get_certificate_sync(self, principal_id: str) -> str:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT certificate_pem FROM user_principals_keys "
+                "WHERE principal_id = ?",
+                (principal_id,),
+            ).fetchone()
+        if row is None:
+            raise PrincipalNotFoundError(principal_id)
+        cert = row[0]
+        if cert is None:
+            raise CertificateNotAttachedError(principal_id)
+        return cert
+
+    async def sign(self, principal_id: str, payload: bytes) -> bytes:
+        _validate_principal_id(principal_id)
+        if not isinstance(payload, (bytes, bytearray)):
+            raise TypeError("payload must be bytes")
+        return await asyncio.to_thread(self._sign_sync, principal_id, bytes(payload))
+
+    def _sign_sync(self, principal_id: str, payload: bytes) -> bytes:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT encrypted_private_key, alg, revoked_at "
+                "FROM user_principals_keys WHERE principal_id = ?",
+                (principal_id,),
+            ).fetchone()
+        if row is None:
+            raise PrincipalNotFoundError(principal_id)
+        encrypted_pk, alg, revoked_at = row
+        if revoked_at is not None:
+            raise PrincipalRevokedError(principal_id)
+
+        priv_pem = self._unwrap(encrypted_pk, principal_id)
+        try:
+            priv = serialization.load_pem_private_key(priv_pem, password=None)
+        finally:
+            # Best-effort scrub of the in-process plaintext copy. Python
+            # bytes are immutable so this only zeroes the local name; the
+            # original buffer may linger in memory until GC. The KMS
+            # backends in PR3+ avoid this by never decrypting.
+            priv_pem = b"\x00" * len(priv_pem)
+            del priv_pem
+
+        if alg == ALG_ES256:
+            return priv.sign(payload, ec.ECDSA(hashes.SHA256()))
+        # Defensive: schema constrains alg, but be explicit.
+        raise ValueError(f"stored alg '{alg}' not supported by this backend")
+
+    async def revoke_principal(self, principal_id: str) -> None:
+        _validate_principal_id(principal_id)
+        await asyncio.to_thread(self._revoke_sync, principal_id)
+
+    def _revoke_sync(self, principal_id: str) -> None:
+        revoked_at = _now_iso()
+        with self._connect() as conn:
+            cur = conn.execute(
+                "UPDATE user_principals_keys "
+                "SET revoked_at = COALESCE(revoked_at, ?) "
+                "WHERE principal_id = ?",
+                (revoked_at, principal_id),
+            )
+            if cur.rowcount == 0:
+                raise PrincipalNotFoundError(principal_id)
+
+
+__all__ = [
+    "ENV_MASTER_KEY",
+    "EmbeddedUserPrincipalKMS",
+]

--- a/tests/test_user_principal_kms_embedded.py
+++ b/tests/test_user_principal_kms_embedded.py
@@ -1,0 +1,448 @@
+"""Tests for the embedded UserPrincipalKMS backend.
+
+Pure unit coverage of ``app/kms/user_principal_embedded.py`` — does
+not touch the broker app or the SQLAlchemy fixtures from conftest.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+from app.kms.user_principal import (
+    ALG_ES256,
+    CertificateNotAttachedError,
+    PrincipalAlreadyExistsError,
+    PrincipalNotFoundError,
+    PrincipalRevokedError,
+    ProvisioningResult,
+    UserPrincipalKMS,
+)
+from app.kms.user_principal_embedded import (
+    ENV_MASTER_KEY,
+    EmbeddedUserPrincipalKMS,
+)
+
+
+# 32 bytes of test entropy — fixed for determinism across runs.
+TEST_MASTER_KEY = bytes.fromhex(
+    "00112233445566778899aabbccddeeff" "00112233445566778899aabbccddeeff"
+)
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _make_kms(tmp_path) -> EmbeddedUserPrincipalKMS:
+    return EmbeddedUserPrincipalKMS(
+        db_path=tmp_path / "user_principals.db",
+        master_key=TEST_MASTER_KEY,
+    )
+
+
+def _verify_es256(public_pem: str, payload: bytes, signature: bytes) -> None:
+    """Verify an ES256 signature; raises if invalid."""
+    pub = serialization.load_pem_public_key(public_pem.encode())
+    pub.verify(signature, payload, ec.ECDSA(hashes.SHA256()))
+
+
+# ── master key handling (3 tests) ─────────────────────────────────
+
+
+def test_constructor_without_env_raises(tmp_path, monkeypatch):
+    monkeypatch.delenv(ENV_MASTER_KEY, raising=False)
+    with pytest.raises(RuntimeError, match=ENV_MASTER_KEY):
+        EmbeddedUserPrincipalKMS(db_path=tmp_path / "x.db")
+
+
+def test_constructor_master_key_wrong_length_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv(ENV_MASTER_KEY, "abcd")  # 2 bytes
+    with pytest.raises(RuntimeError, match="32 bytes"):
+        EmbeddedUserPrincipalKMS(db_path=tmp_path / "x.db")
+
+
+def test_constructor_master_key_non_hex_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv(ENV_MASTER_KEY, "z" * 64)
+    with pytest.raises(RuntimeError, match="hex"):
+        EmbeddedUserPrincipalKMS(db_path=tmp_path / "x.db")
+
+
+def test_explicit_master_key_bypasses_env(tmp_path, monkeypatch):
+    monkeypatch.delenv(ENV_MASTER_KEY, raising=False)
+    # No env var, but explicit master_key works fine.
+    kms = EmbeddedUserPrincipalKMS(
+        db_path=tmp_path / "x.db", master_key=TEST_MASTER_KEY,
+    )
+    assert kms is not None
+
+
+def test_explicit_master_key_wrong_length_raises(tmp_path):
+    with pytest.raises(ValueError, match="32 bytes"):
+        EmbeddedUserPrincipalKMS(
+            db_path=tmp_path / "x.db", master_key=b"\x00" * 16,
+        )
+
+
+# ── Protocol satisfaction (1 test) ─────────────────────────────────
+
+
+def test_implements_protocol(tmp_path):
+    kms = _make_kms(tmp_path)
+    # runtime_checkable Protocol — isinstance check verifies the
+    # concrete class exposes every method.
+    assert isinstance(kms, UserPrincipalKMS)
+
+
+# ── has_principal (2 tests) ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_has_principal_false_for_unknown(tmp_path):
+    kms = _make_kms(tmp_path)
+    assert await kms.has_principal("acme.test/acme/user/mario") is False
+
+
+@pytest.mark.asyncio
+async def test_has_principal_true_after_create(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    assert await kms.has_principal("acme.test/acme/user/mario") is True
+
+
+# ── create_keypair (4 tests) ───────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_keypair_returns_provisioning_result(tmp_path):
+    kms = _make_kms(tmp_path)
+    res = await kms.create_keypair("acme.test/acme/user/mario")
+    assert isinstance(res, ProvisioningResult)
+    assert res.alg == ALG_ES256
+    assert res.key_handle == "embedded:acme.test/acme/user/mario"
+    assert "BEGIN PUBLIC KEY" in res.public_key_pem
+
+
+@pytest.mark.asyncio
+async def test_create_keypair_twice_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    with pytest.raises(PrincipalAlreadyExistsError):
+        await kms.create_keypair("acme.test/acme/user/mario")
+
+
+@pytest.mark.asyncio
+async def test_create_keypair_unsupported_alg_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(ValueError, match="not supported"):
+        await kms.create_keypair("acme.test/acme/user/mario", alg="HS256")
+
+
+@pytest.mark.asyncio
+async def test_create_keypair_after_revoke_still_blocked(tmp_path):
+    """Re-provisioning a revoked principal still raises — caller must
+    delete + recreate via a different principal_id, or implement
+    explicit reset semantics in a higher layer.
+    """
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    await kms.revoke_principal("acme.test/acme/user/mario")
+    with pytest.raises(PrincipalAlreadyExistsError):
+        await kms.create_keypair("acme.test/acme/user/mario")
+
+
+# ── attach_certificate (4 tests) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_attach_certificate_happy_path(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    pem = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+    await kms.attach_certificate("acme.test/acme/user/mario", pem)
+    assert await kms.get_certificate("acme.test/acme/user/mario") == pem
+
+
+@pytest.mark.asyncio
+async def test_attach_certificate_unknown_principal_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(PrincipalNotFoundError):
+        await kms.attach_certificate(
+            "acme.test/acme/user/ghost",
+            "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        )
+
+
+@pytest.mark.asyncio
+async def test_attach_certificate_replaces_old(tmp_path):
+    """Cert rotation is a normal operation; reattach overwrites."""
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    old = "-----BEGIN CERTIFICATE-----\nold\n-----END CERTIFICATE-----\n"
+    new = "-----BEGIN CERTIFICATE-----\nnew\n-----END CERTIFICATE-----\n"
+    await kms.attach_certificate("acme.test/acme/user/mario", old)
+    await kms.attach_certificate("acme.test/acme/user/mario", new)
+    assert await kms.get_certificate("acme.test/acme/user/mario") == new
+
+
+@pytest.mark.asyncio
+async def test_attach_certificate_empty_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    with pytest.raises(ValueError, match="non-empty"):
+        await kms.attach_certificate("acme.test/acme/user/mario", "   ")
+
+
+# ── get_certificate (3 tests) ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_certificate_unknown_principal_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(PrincipalNotFoundError):
+        await kms.get_certificate("acme.test/acme/user/ghost")
+
+
+@pytest.mark.asyncio
+async def test_get_certificate_before_attach_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    with pytest.raises(CertificateNotAttachedError):
+        await kms.get_certificate("acme.test/acme/user/mario")
+
+
+@pytest.mark.asyncio
+async def test_get_certificate_after_attach(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    pem = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+    await kms.attach_certificate("acme.test/acme/user/mario", pem)
+    assert await kms.get_certificate("acme.test/acme/user/mario") == pem
+
+
+# ── sign (5 tests) ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_sign_produces_verifiable_signature(tmp_path):
+    kms = _make_kms(tmp_path)
+    res = await kms.create_keypair("acme.test/acme/user/mario")
+    payload = b"the quick brown fox"
+    sig = await kms.sign("acme.test/acme/user/mario", payload)
+    assert isinstance(sig, bytes)
+    # ECDSA DER signatures are 70-72 bytes typically; just sanity-check.
+    assert 64 <= len(sig) <= 80
+    # Decoding the DER does not raise → it's a well-formed signature.
+    decode_dss_signature(sig)
+    # And the signature verifies under the returned public key.
+    _verify_es256(res.public_key_pem, payload, sig)
+
+
+@pytest.mark.asyncio
+async def test_sign_unknown_principal_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(PrincipalNotFoundError):
+        await kms.sign("acme.test/acme/user/ghost", b"payload")
+
+
+@pytest.mark.asyncio
+async def test_sign_after_revoke_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    await kms.revoke_principal("acme.test/acme/user/mario")
+    with pytest.raises(PrincipalRevokedError):
+        await kms.sign("acme.test/acme/user/mario", b"payload")
+
+
+@pytest.mark.asyncio
+async def test_sign_str_payload_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    with pytest.raises(TypeError):
+        await kms.sign("acme.test/acme/user/mario", "string-not-bytes")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_sign_two_principals_independent(tmp_path):
+    kms = _make_kms(tmp_path)
+    res_m = await kms.create_keypair("acme.test/acme/user/mario")
+    res_a = await kms.create_keypair("acme.test/acme/user/anna")
+    payload = b"shared payload"
+    sig_m = await kms.sign("acme.test/acme/user/mario", payload)
+    sig_a = await kms.sign("acme.test/acme/user/anna", payload)
+    # Each signature verifies only under its own public key.
+    _verify_es256(res_m.public_key_pem, payload, sig_m)
+    _verify_es256(res_a.public_key_pem, payload, sig_a)
+    with pytest.raises(Exception):  # InvalidSignature
+        _verify_es256(res_m.public_key_pem, payload, sig_a)
+
+
+# ── revoke_principal (3 tests) ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_revoke_unknown_principal_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(PrincipalNotFoundError):
+        await kms.revoke_principal("acme.test/acme/user/ghost")
+
+
+@pytest.mark.asyncio
+async def test_revoke_idempotent(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    await kms.revoke_principal("acme.test/acme/user/mario")
+    # Second call must not raise.
+    await kms.revoke_principal("acme.test/acme/user/mario")
+
+
+@pytest.mark.asyncio
+async def test_revoke_one_does_not_affect_other(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    await kms.create_keypair("acme.test/acme/user/anna")
+    await kms.revoke_principal("acme.test/acme/user/mario")
+    # Anna can still sign.
+    sig = await kms.sign("acme.test/acme/user/anna", b"payload")
+    assert isinstance(sig, bytes)
+    # Mario cannot.
+    with pytest.raises(PrincipalRevokedError):
+        await kms.sign("acme.test/acme/user/mario", b"payload")
+
+
+# ── principal_id validation (3 tests) ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_principal_id_empty_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(ValueError, match="non-empty"):
+        await kms.has_principal("")
+
+
+@pytest.mark.asyncio
+async def test_principal_id_too_long_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    too_long = "a" * 256
+    with pytest.raises(ValueError, match="exceeds"):
+        await kms.has_principal(too_long)
+
+
+@pytest.mark.asyncio
+async def test_principal_id_non_ascii_raises(tmp_path):
+    kms = _make_kms(tmp_path)
+    with pytest.raises(ValueError, match="ASCII"):
+        await kms.has_principal("acme.test/acme/user/mariò")
+
+
+# ── encryption properties (3 tests) ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stored_blob_is_not_plaintext(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    # Open the SQLite directly and check the stored blob does not
+    # contain the unencrypted PKCS8 marker.
+    with sqlite3.connect(tmp_path / "user_principals.db") as conn:
+        row = conn.execute(
+            "SELECT encrypted_private_key FROM user_principals_keys "
+            "WHERE principal_id = ?",
+            ("acme.test/acme/user/mario",),
+        ).fetchone()
+    blob = row[0]
+    assert b"BEGIN PRIVATE KEY" not in blob
+    assert b"PRIVATE KEY" not in blob
+
+
+@pytest.mark.asyncio
+async def test_two_principals_have_different_nonces(tmp_path):
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    await kms.create_keypair("acme.test/acme/user/anna")
+    with sqlite3.connect(tmp_path / "user_principals.db") as conn:
+        rows = conn.execute(
+            "SELECT principal_id, encrypted_private_key "
+            "FROM user_principals_keys",
+        ).fetchall()
+    assert len(rows) == 2
+    nonces = [blob[:12] for _, blob in rows]
+    assert nonces[0] != nonces[1]
+
+
+@pytest.mark.asyncio
+async def test_aad_binding_prevents_cross_principal_replay(tmp_path):
+    """AAD binds the ciphertext to its principal_id. Swapping the
+    blob between two principals must fail to decrypt.
+    """
+    kms = _make_kms(tmp_path)
+    await kms.create_keypair("acme.test/acme/user/mario")
+    await kms.create_keypair("acme.test/acme/user/anna")
+    # Swap the encrypted_private_key blobs.
+    db = tmp_path / "user_principals.db"
+    with sqlite3.connect(db) as conn:
+        m_row = conn.execute(
+            "SELECT encrypted_private_key FROM user_principals_keys "
+            "WHERE principal_id = ?",
+            ("acme.test/acme/user/mario",),
+        ).fetchone()
+        a_row = conn.execute(
+            "SELECT encrypted_private_key FROM user_principals_keys "
+            "WHERE principal_id = ?",
+            ("acme.test/acme/user/anna",),
+        ).fetchone()
+        conn.execute(
+            "UPDATE user_principals_keys SET encrypted_private_key = ? "
+            "WHERE principal_id = ?",
+            (a_row[0], "acme.test/acme/user/mario"),
+        )
+        conn.execute(
+            "UPDATE user_principals_keys SET encrypted_private_key = ? "
+            "WHERE principal_id = ?",
+            (m_row[0], "acme.test/acme/user/anna"),
+        )
+    # Sign attempts must now raise InvalidTag (or its parent
+    # cryptography.exceptions.InvalidTag) — surfaces as Exception
+    # because we don't translate it.
+    with pytest.raises(Exception):
+        await kms.sign("acme.test/acme/user/mario", b"x")
+
+
+# ── persistence + perms (2 tests) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_persistence_across_instances(tmp_path):
+    """A second EmbeddedKMS instance pointed at the same DB sees prior
+    state and can sign with the existing keypair."""
+    kms1 = _make_kms(tmp_path)
+    res = await kms1.create_keypair("acme.test/acme/user/mario")
+    payload = b"persisted"
+    # Drop the first instance, open a new one.
+    del kms1
+    kms2 = _make_kms(tmp_path)
+    assert await kms2.has_principal("acme.test/acme/user/mario") is True
+    sig = await kms2.sign("acme.test/acme/user/mario", payload)
+    _verify_es256(res.public_key_pem, payload, sig)
+
+
+def test_db_file_has_tight_perms(tmp_path):
+    db_path = tmp_path / "user_principals.db"
+    EmbeddedUserPrincipalKMS(db_path=db_path, master_key=TEST_MASTER_KEY)
+    mode = os.stat(db_path).st_mode & 0o777
+    # Owner-only by default.
+    assert mode == 0o600
+
+
+# ── schema idempotency (1 test) ────────────────────────────────────
+
+
+def test_schema_idempotent_on_reinit(tmp_path):
+    db_path = tmp_path / "user_principals.db"
+    # Two instances pointing at the same DB must coexist without
+    # raising "table already exists".
+    EmbeddedUserPrincipalKMS(db_path=db_path, master_key=TEST_MASTER_KEY)
+    EmbeddedUserPrincipalKMS(db_path=db_path, master_key=TEST_MASTER_KEY)


### PR DESCRIPTION
## Summary

First brick of ADR-021 Cullis Frontdesk shared mode. Adds the abstraction Cullis needs to provision and manage **per-user key material** (distinct from the broker CA + at-rest secret encryption that the existing \`KMSProvider\` handles). Ships with the **embedded** backend (SQLite + AES-256-GCM) suitable for dev sandboxes, the test suite, and the fallback for deployments without a real KMS. Vault Transit / AWS KMS / Azure KV land in PR3+.

## Design

### Protocol (\`app/kms/user_principal.py\`)

Six methods, lifecycle-ordered:

\`\`\`python
class UserPrincipalKMS(Protocol):
    async def has_principal(self, principal_id: str) -> bool: ...
    async def create_keypair(self, principal_id: str, *, alg: str = "ES256") -> ProvisioningResult: ...
    async def attach_certificate(self, principal_id: str, cert_pem: str) -> None: ...
    async def get_certificate(self, principal_id: str) -> str: ...
    async def sign(self, principal_id: str, payload: bytes) -> bytes: ...
    async def revoke_principal(self, principal_id: str) -> None: ...
\`\`\`

The two-step provisioning (\`create_keypair\` + \`attach_certificate\`) is a refinement of the original ADR sketch (\`provision_principal(csr_pem)\`). The split keeps the CA dependency out of the KMS contract: the KMS handles keys, Mastio handles cert signing.

ES256 (ECC P-256) only in v0.1; RS256 lands with the first customer that needs it.

The Protocol is deliberately narrow: no \`get_private_key\`, no \`load_pem_from_disk\`. Even the embedded backend is structured so callers cannot exfiltrate private key material via the public API.

### Embedded backend (\`app/kms/user_principal_embedded.py\`)

- SQLite at \`<config_dir>/user_principals.db\`, schema:
  \`(principal_id PK, alg, encrypted_private_key BLOB, public_key_pem, certificate_pem, created_at, revoked_at)\`
- Each private key wrapped with **AES-256-GCM** under \`CULLIS_USER_KMS_MASTER_KEY\` (32 bytes hex, refused if unset so we cannot ship with a default secret).
- AAD on the GCM seal binds the ciphertext to its \`principal_id\` so a stolen blob cannot be replayed under a different id.
- DB file chmod 0600.
- Async API dispatched through \`asyncio.to_thread\` with one fresh \`sqlite3.Connection\` per call (SQLite connections are not safe to share across threads).
- Documented limitation in ADR-021 §11 T2: process compromise = master key + SQLite = full key exfiltration. The KMS-backed backends in PR3+ keep keys server-side.

## Tests

\`tests/test_user_principal_kms_embedded.py\` — 36 tests covering:

- master key handling (env required + length + hex + explicit override)
- Protocol satisfaction (\`isinstance\` against \`runtime_checkable\`)
- lifecycle happy paths (\`create_keypair\` → \`attach_certificate\` → \`get_certificate\` / \`sign\`)
- error classes (\`PrincipalNotFoundError\`, \`PrincipalAlreadyExistsError\`, \`PrincipalRevokedError\`, \`CertificateNotAttachedError\`)
- input validation (empty / too long / non-ASCII \`principal_id\`)
- encryption properties (stored blob is not plaintext, nonces unique per principal, AAD binding prevents cross-principal replay)
- persistence across instances (close + reopen)
- file perms (0600 on the SQLite)
- schema idempotency (two instances on the same DB)

## Test plan

- [x] \`pytest tests/test_user_principal_kms_embedded.py -n auto --dist=loadfile -v\` → 36/36 in 5.3s
- [ ] CI green (full pytest + smoke gate)
- [ ] Mental check: no \`F401\` unused imports (NixOS host doesn't run ruff)

## Related

- \`imp/adr-021-shared-mode-multi-user-kms.md\` (this PR is the §1 contract + §2 embedded backend)
- ADR-020 Phase 5 prerequisite (user principals lifecycle)
- ADR-019 Step 3 prerequisite (Ambassador shared mode in PR4)