### PR TITLE
feat(registry): user_principals table + by-sso lookup (ADR-021 PR2)

### DIFF
--- a/alembic/versions/o5j6k7l8m9n0_user_principals.py
+++ b/alembic/versions/o5j6k7l8m9n0_user_principals.py
@@ -1,0 +1,55 @@
+"""ADR-021 PR2 — user_principals table
+
+Revision ID: o5j6k7l8m9n0
+Revises: n4i5j6k7l8m9
+Create Date: 2026-05-04 18:00:00.000000
+
+Mapping table for user-principal provisioning. One row per
+provisioned user, keyed by SPIFFE-style ``principal_id``
+(``<td>/<org>/user/<name>``). UNIQUE on ``(org_id, sso_subject)``
+so a single SSO subject cannot be silently re-provisioned under
+two principal_ids.
+
+Cert columns are nullable until the Ambassador finishes the CSR
+roundtrip and calls ``attach_certificate``. ``revoked_at`` flips
+the row to a tombstone state without deleting it (audit replay
+needs the historical mapping).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "o5j6k7l8m9n0"
+down_revision = "n4i5j6k7l8m9"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_principals",
+        sa.Column("principal_id", sa.String(length=255), primary_key=True),
+        sa.Column("org_id", sa.String(length=128), nullable=False),
+        sa.Column("sso_subject", sa.String(length=255), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=True),
+        sa.Column("cert_thumbprint", sa.String(length=64), nullable=True),
+        sa.Column("cert_not_after", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("kms_backend", sa.String(length=32), nullable=False),
+        sa.Column("kms_key_handle", sa.String(length=255), nullable=False),
+        sa.Column("provisioned_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_active_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "org_id", "sso_subject", name="uq_user_principals_org_sso",
+        ),
+    )
+    op.create_index(
+        "idx_user_principals_lookup",
+        "user_principals",
+        ["org_id", "sso_subject"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_principals_lookup", table_name="user_principals")
+    op.drop_table("user_principals")

--- a/app/main.py
+++ b/app/main.py
@@ -392,6 +392,10 @@ v1.include_router(oneshot_router)
 from app.inbox.router import router as inbox_router
 v1.include_router(inbox_router)
 
+# ADR-021 PR2 — user principal SSO mapping lookup.
+from app.registry.user_principals_router import router as user_principals_router
+v1.include_router(user_principals_router)
+
 # ADR-002 Phase 2a — A2A protocol adapter (read-only AgentCard + directory).
 # Gated on settings.a2a_adapter (default False) so existing deployments
 # see no surface change.

--- a/app/registry/user_principals.py
+++ b/app/registry/user_principals.py
@@ -1,0 +1,312 @@
+"""User principal mapping (ADR-021 PR2).
+
+Bridges SSO identity (``mario@acme.it``) to a Cullis principal id
+(``acme.test/acme/user/mario``) and tracks provisioning state. The
+Cullis Frontdesk Ambassador (PR4) calls this layer at the start of
+every authenticated session:
+
+    1. ``GET /v1/principals/by-sso?org=acme&subject=mario@acme.it``
+    2. if 404 → provision via the KMS (PR1) and ``create()`` here
+    3. if 200 → use the returned ``principal_id`` directly
+
+The table is the source of truth for "is this user already
+provisioned?". The KMS holds the keys; this table holds the
+metadata + the link to the KMS key handle.
+
+Cert columns are nullable until the Ambassador completes the CSR
+roundtrip (``KMS.create_keypair`` → Mastio CSR signing →
+``KMS.attach_certificate`` → ``attach_cert()`` here). A row with
+NULL ``cert_thumbprint`` means provisioning is mid-flight.
+
+``revoked_at`` flips the row to a tombstone instead of deleting it
+so audit replay can resolve the historical SSO→principal mapping.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    Column, DateTime, Index, String, UniqueConstraint, select, update,
+)
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.database import Base
+
+_log = logging.getLogger("agent_trust")
+
+
+# ── Model ──────────────────────────────────────────────────────────
+
+
+class UserPrincipalRecord(Base):
+    """SQLAlchemy model for the ``user_principals`` table.
+
+    See ``alembic/versions/o5j6k7l8m9n0_user_principals.py`` for the
+    canonical schema. Kept legacy ``Column`` style for symmetry with
+    the surrounding registry modules.
+    """
+
+    __tablename__ = "user_principals"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "sso_subject", name="uq_user_principals_org_sso",
+        ),
+        Index(
+            "idx_user_principals_lookup",
+            "org_id", "sso_subject",
+        ),
+    )
+
+    principal_id     = Column(String(255), primary_key=True)
+    org_id           = Column(String(128), nullable=False)
+    sso_subject      = Column(String(255), nullable=False)
+    display_name     = Column(String(255), nullable=True)
+    cert_thumbprint  = Column(String(64),  nullable=True)
+    cert_not_after   = Column(DateTime(timezone=True), nullable=True)
+    kms_backend      = Column(String(32),  nullable=False)
+    kms_key_handle   = Column(String(255), nullable=False)
+    provisioned_at   = Column(
+        DateTime(timezone=True), nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    last_active_at   = Column(DateTime(timezone=True), nullable=True)
+    revoked_at       = Column(DateTime(timezone=True), nullable=True)
+
+
+# ── Errors ─────────────────────────────────────────────────────────
+
+
+class DuplicatePrincipalError(ValueError):
+    """Raised when a ``(org_id, sso_subject)`` collision is detected
+    or when ``principal_id`` is reused."""
+
+
+# ── DTO ────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class UserPrincipalView:
+    """Read-only projection used by the router and external callers.
+
+    The SQLAlchemy model is intentionally not exposed across module
+    boundaries: it carries hidden state (the session) that callers
+    should not depend on. ``UserPrincipalView`` is a plain dataclass
+    safe to serialise.
+    """
+
+    principal_id: str
+    org_id: str
+    sso_subject: str
+    display_name: Optional[str]
+    cert_thumbprint: Optional[str]
+    cert_not_after: Optional[datetime]
+    kms_backend: str
+    kms_key_handle: str
+    provisioned_at: datetime
+    last_active_at: Optional[datetime]
+    revoked_at: Optional[datetime]
+
+    @property
+    def is_active(self) -> bool:
+        return self.revoked_at is None
+
+    @property
+    def is_provisioned(self) -> bool:
+        """True once a cert has been attached."""
+        return self.cert_thumbprint is not None
+
+
+def _to_view(row: UserPrincipalRecord) -> UserPrincipalView:
+    return UserPrincipalView(
+        principal_id=row.principal_id,
+        org_id=row.org_id,
+        sso_subject=row.sso_subject,
+        display_name=row.display_name,
+        cert_thumbprint=row.cert_thumbprint,
+        cert_not_after=row.cert_not_after,
+        kms_backend=row.kms_backend,
+        kms_key_handle=row.kms_key_handle,
+        provisioned_at=row.provisioned_at,
+        last_active_at=row.last_active_at,
+        revoked_at=row.revoked_at,
+    )
+
+
+# ── CRUD ───────────────────────────────────────────────────────────
+
+
+async def create(
+    session: AsyncSession,
+    *,
+    principal_id: str,
+    org_id: str,
+    sso_subject: str,
+    kms_backend: str,
+    kms_key_handle: str,
+    display_name: Optional[str] = None,
+) -> UserPrincipalView:
+    """Insert a fresh user principal row.
+
+    Raises ``DuplicatePrincipalError`` on either of:
+      - ``principal_id`` collision (PK)
+      - ``(org_id, sso_subject)`` collision (UNIQUE)
+
+    Cert fields stay NULL until ``attach_cert`` is called.
+    """
+    if not principal_id or not org_id or not sso_subject:
+        raise ValueError(
+            "principal_id, org_id, sso_subject are all required",
+        )
+    if not kms_backend or not kms_key_handle:
+        raise ValueError("kms_backend and kms_key_handle are required")
+
+    record = UserPrincipalRecord(
+        principal_id=principal_id,
+        org_id=org_id,
+        sso_subject=sso_subject,
+        display_name=display_name,
+        kms_backend=kms_backend,
+        kms_key_handle=kms_key_handle,
+        provisioned_at=datetime.now(timezone.utc),
+    )
+    session.add(record)
+    try:
+        await session.flush()
+    except IntegrityError as exc:
+        await session.rollback()
+        raise DuplicatePrincipalError(
+            f"principal_id={principal_id!r} or "
+            f"(org_id={org_id!r}, sso_subject={sso_subject!r}) already exists",
+        ) from exc
+    return _to_view(record)
+
+
+async def get_by_principal_id(
+    session: AsyncSession, principal_id: str,
+) -> Optional[UserPrincipalView]:
+    """Return the row for an exact principal_id, or None."""
+    if not principal_id:
+        return None
+    row = (
+        await session.execute(
+            select(UserPrincipalRecord).where(
+                UserPrincipalRecord.principal_id == principal_id,
+            ),
+        )
+    ).scalar_one_or_none()
+    return _to_view(row) if row else None
+
+
+async def get_by_sso(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    sso_subject: str,
+) -> Optional[UserPrincipalView]:
+    """Look up a principal by its SSO identity within an org.
+
+    This is the hot path for the Ambassador on every authenticated
+    request. The composite UNIQUE on ``(org_id, sso_subject)``
+    guarantees at most one row.
+    """
+    if not org_id or not sso_subject:
+        return None
+    row = (
+        await session.execute(
+            select(UserPrincipalRecord).where(
+                UserPrincipalRecord.org_id == org_id,
+                UserPrincipalRecord.sso_subject == sso_subject,
+            ),
+        )
+    ).scalar_one_or_none()
+    return _to_view(row) if row else None
+
+
+async def attach_cert(
+    session: AsyncSession,
+    *,
+    principal_id: str,
+    cert_thumbprint: str,
+    cert_not_after: datetime,
+) -> Optional[UserPrincipalView]:
+    """Attach the cert metadata after the CSR roundtrip completes.
+
+    Re-attaching is a normal cert rotation; the call is idempotent
+    on the column values. Returns the updated view, or ``None`` if
+    the principal does not exist.
+    """
+    if not cert_thumbprint or len(cert_thumbprint) > 64:
+        raise ValueError("cert_thumbprint must be 1-64 chars")
+    cur = await session.execute(
+        update(UserPrincipalRecord)
+        .where(UserPrincipalRecord.principal_id == principal_id)
+        .values(
+            cert_thumbprint=cert_thumbprint,
+            cert_not_after=cert_not_after,
+        ),
+    )
+    if cur.rowcount == 0:
+        return None
+    await session.flush()
+    return await get_by_principal_id(session, principal_id)
+
+
+async def mark_revoked(
+    session: AsyncSession,
+    principal_id: str,
+) -> Optional[UserPrincipalView]:
+    """Set ``revoked_at`` to now if not already set. Idempotent.
+
+    Returns the updated view, or ``None`` if the principal does not
+    exist. The row is NOT deleted — historical SSO→principal mapping
+    must remain queryable for audit replay.
+    """
+    now = datetime.now(timezone.utc)
+    cur = await session.execute(
+        update(UserPrincipalRecord)
+        .where(
+            UserPrincipalRecord.principal_id == principal_id,
+            UserPrincipalRecord.revoked_at.is_(None),
+        )
+        .values(revoked_at=now),
+    )
+    # rowcount 0 either means the principal does not exist OR it was
+    # already revoked. Distinguish via a follow-up read.
+    view = await get_by_principal_id(session, principal_id)
+    return view
+
+
+async def update_last_active(
+    session: AsyncSession,
+    principal_id: str,
+    *,
+    when: Optional[datetime] = None,
+) -> None:
+    """Touch the ``last_active_at`` timestamp.
+
+    Idempotent and silent on missing principal — telemetry should
+    never raise.
+    """
+    ts = when or datetime.now(timezone.utc)
+    await session.execute(
+        update(UserPrincipalRecord)
+        .where(UserPrincipalRecord.principal_id == principal_id)
+        .values(last_active_at=ts),
+    )
+
+
+__all__ = [
+    "DuplicatePrincipalError",
+    "UserPrincipalRecord",
+    "UserPrincipalView",
+    "attach_cert",
+    "create",
+    "get_by_principal_id",
+    "get_by_sso",
+    "mark_revoked",
+    "update_last_active",
+]

--- a/app/registry/user_principals.py
+++ b/app/registry/user_principals.py
@@ -266,7 +266,7 @@ async def mark_revoked(
     must remain queryable for audit replay.
     """
     now = datetime.now(timezone.utc)
-    cur = await session.execute(
+    await session.execute(
         update(UserPrincipalRecord)
         .where(
             UserPrincipalRecord.principal_id == principal_id,
@@ -274,10 +274,10 @@ async def mark_revoked(
         )
         .values(revoked_at=now),
     )
-    # rowcount 0 either means the principal does not exist OR it was
-    # already revoked. Distinguish via a follow-up read.
-    view = await get_by_principal_id(session, principal_id)
-    return view
+    # The UPDATE is a no-op on missing or already-revoked principals.
+    # A follow-up read disambiguates: missing → None, revoked → view
+    # whose revoked_at preserves the original timestamp.
+    return await get_by_principal_id(session, principal_id)
 
 
 async def update_last_active(

--- a/app/registry/user_principals_router.py
+++ b/app/registry/user_principals_router.py
@@ -1,0 +1,107 @@
+"""REST endpoints for the user_principals mapping (ADR-021 PR2).
+
+The Cullis Frontdesk Ambassador (PR4) is the primary caller. On
+every authenticated user request it needs to map an SSO subject
+back to its Cullis principal_id; this endpoint is the lookup.
+
+PR2 ships only the ``GET /v1/principals/by-sso`` lookup. Provisioning
+endpoints (POST + cert-attach) will land alongside the Ambassador
+in PR4 — that PR drives both ends of the API and shape choices.
+
+Authentication uses the existing ``Depends(get_current_agent)``
+DPoP-bound JWT. RBAC: the caller may only look up principals in
+its own ``org_id``. Cross-org SSO lookups are forbidden because
+SSO subjects are per-org PII; cross-org user federation has its
+own discovery story (deferred to ADR-020 v0.5).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.db.database import get_db
+from app.registry.user_principals import (
+    UserPrincipalView,
+    get_by_sso,
+)
+
+_log = logging.getLogger("agent_trust")
+
+router = APIRouter(prefix="/principals", tags=["principals"])
+
+
+class UserPrincipalResponse(BaseModel):
+    """Public projection of a UserPrincipalRecord.
+
+    ``kms_key_handle`` is included because the Ambassador uses it
+    for log correlation; it is opaque, not a secret.
+    """
+
+    principal_id: str = Field(...)
+    org_id: str = Field(...)
+    sso_subject: str = Field(...)
+    display_name: Optional[str] = Field(default=None)
+    cert_thumbprint: Optional[str] = Field(default=None)
+    cert_not_after: Optional[datetime] = Field(default=None)
+    kms_backend: str = Field(...)
+    kms_key_handle: str = Field(...)
+    provisioned_at: datetime = Field(...)
+    last_active_at: Optional[datetime] = Field(default=None)
+    revoked_at: Optional[datetime] = Field(default=None)
+    is_active: bool = Field(...)
+    is_provisioned: bool = Field(...)
+
+
+def _to_response(view: UserPrincipalView) -> UserPrincipalResponse:
+    return UserPrincipalResponse(
+        principal_id=view.principal_id,
+        org_id=view.org_id,
+        sso_subject=view.sso_subject,
+        display_name=view.display_name,
+        cert_thumbprint=view.cert_thumbprint,
+        cert_not_after=view.cert_not_after,
+        kms_backend=view.kms_backend,
+        kms_key_handle=view.kms_key_handle,
+        provisioned_at=view.provisioned_at,
+        last_active_at=view.last_active_at,
+        revoked_at=view.revoked_at,
+        is_active=view.is_active,
+        is_provisioned=view.is_provisioned,
+    )
+
+
+@router.get("/by-sso", response_model=UserPrincipalResponse)
+async def lookup_by_sso(
+    org: str = Query(..., min_length=1, max_length=128, description="Org id"),
+    subject: str = Query(
+        ..., min_length=1, max_length=255,
+        description="SSO subject (e.g. 'mario@acme.it')",
+    ),
+    db: AsyncSession = Depends(get_db),
+    token: TokenPayload = Depends(get_current_agent),
+) -> UserPrincipalResponse:
+    """Look up a user principal by SSO subject within an org.
+
+    404 if no mapping exists. 403 if the caller's org differs from
+    the requested ``org`` (cross-org SSO lookups are forbidden).
+    """
+    if token.org != org:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="cannot look up SSO subjects in a different org",
+        )
+
+    view = await get_by_sso(db, org_id=org, sso_subject=subject)
+    if view is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"no principal mapped to sso_subject={subject!r} in org={org!r}",
+        )
+    return _to_response(view)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ from app.auth.transaction_db import TransactionTokenRecord as _TT  # noqa — re
 from app.broker.notifications import Notification as _Notification  # noqa — registra in Base.metadata
 from app.broker.federation import FederationEvent as _FederationEvent  # noqa — registra in Base.metadata
 from app.onboarding.invite_store import InviteToken as _InviteToken  # noqa — registra in Base.metadata
+from app.registry.user_principals import UserPrincipalRecord as _UPR  # noqa — registra in Base.metadata
 from app.rate_limit.limiter import rate_limiter
 
 # Admin headers for endpoints that now require admin auth

--- a/tests/test_user_principals_registry.py
+++ b/tests/test_user_principals_registry.py
@@ -1,0 +1,405 @@
+"""Tests for ``app/registry/user_principals.py`` + the by-sso endpoint
+(ADR-021 PR2).
+
+Two layers:
+  - CRUD tests against an in-memory SQLite session (db_session fixture
+    from conftest)
+  - Endpoint tests against the FastAPI app, with the auth dependency
+    overridden so we don't need a full DPoP token roundtrip
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.main import app
+from app.registry.user_principals import (
+    DuplicatePrincipalError,
+    UserPrincipalRecord,
+    attach_cert,
+    create,
+    get_by_principal_id,
+    get_by_sso,
+    mark_revoked,
+    update_last_active,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def upd_db(db_session):
+    """Truncate user_principals around each test for isolation."""
+    await db_session.execute(delete(UserPrincipalRecord))
+    await db_session.commit()
+    yield db_session
+    await db_session.execute(delete(UserPrincipalRecord))
+    await db_session.commit()
+
+
+# ── create (4 tests) ──────────────────────────────────────────────
+
+
+async def test_create_happy_path(upd_db):
+    view = await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="embedded:acme.test/acme/user/mario",
+        display_name="Mario Rossi",
+    )
+    await upd_db.commit()
+    assert view.principal_id == "acme.test/acme/user/mario"
+    assert view.org_id == "acme"
+    assert view.sso_subject == "mario@acme.it"
+    assert view.display_name == "Mario Rossi"
+    assert view.kms_backend == "embedded"
+    assert view.cert_thumbprint is None
+    assert view.is_active is True
+    assert view.is_provisioned is False  # cert not attached yet
+
+
+async def test_create_duplicate_principal_id_raises(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    await upd_db.commit()
+    with pytest.raises(DuplicatePrincipalError):
+        await create(
+            upd_db,
+            principal_id="acme.test/acme/user/mario",  # same PK
+            org_id="acme",
+            sso_subject="someone-else@acme.it",
+            kms_backend="embedded",
+            kms_key_handle="h2",
+        )
+
+
+async def test_create_duplicate_org_sso_raises(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    await upd_db.commit()
+    with pytest.raises(DuplicatePrincipalError):
+        await create(
+            upd_db,
+            principal_id="acme.test/acme/user/mario-2",  # different PK
+            org_id="acme",
+            sso_subject="mario@acme.it",  # same (org, sso)
+            kms_backend="embedded",
+            kms_key_handle="h2",
+        )
+
+
+async def test_create_missing_field_raises(upd_db):
+    with pytest.raises(ValueError):
+        await create(
+            upd_db,
+            principal_id="acme.test/acme/user/mario",
+            org_id="",  # empty
+            sso_subject="mario@acme.it",
+            kms_backend="embedded",
+            kms_key_handle="h1",
+        )
+
+
+# ── lookup (4 tests) ──────────────────────────────────────────────
+
+
+async def test_get_by_principal_id_existing(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    view = await get_by_principal_id(upd_db, "acme.test/acme/user/mario")
+    assert view is not None
+    assert view.sso_subject == "mario@acme.it"
+
+
+async def test_get_by_principal_id_missing_returns_none(upd_db):
+    assert await get_by_principal_id(upd_db, "acme.test/acme/user/ghost") is None
+
+
+async def test_get_by_sso_existing(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    view = await get_by_sso(upd_db, org_id="acme", sso_subject="mario@acme.it")
+    assert view is not None
+    assert view.principal_id == "acme.test/acme/user/mario"
+
+
+async def test_get_by_sso_missing_returns_none(upd_db):
+    view = await get_by_sso(
+        upd_db, org_id="acme", sso_subject="ghost@acme.it",
+    )
+    assert view is None
+
+
+# ── attach_cert (4 tests) ─────────────────────────────────────────
+
+
+async def test_attach_cert_happy_path(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+    view = await attach_cert(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        cert_thumbprint="a" * 64,
+        cert_not_after=not_after,
+    )
+    assert view is not None
+    assert view.cert_thumbprint == "a" * 64
+    assert view.is_provisioned is True
+
+
+async def test_attach_cert_missing_principal_returns_none(upd_db):
+    not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+    view = await attach_cert(
+        upd_db,
+        principal_id="acme.test/acme/user/ghost",
+        cert_thumbprint="a" * 64,
+        cert_not_after=not_after,
+    )
+    assert view is None
+
+
+async def test_attach_cert_idempotent_rotation(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+    await attach_cert(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        cert_thumbprint="a" * 64,
+        cert_not_after=not_after,
+    )
+    new_after = datetime.now(timezone.utc) + timedelta(hours=2)
+    view = await attach_cert(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        cert_thumbprint="b" * 64,
+        cert_not_after=new_after,
+    )
+    assert view is not None
+    assert view.cert_thumbprint == "b" * 64
+
+
+async def test_attach_cert_too_long_thumbprint_raises(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    with pytest.raises(ValueError, match="64"):
+        await attach_cert(
+            upd_db,
+            principal_id="acme.test/acme/user/mario",
+            cert_thumbprint="a" * 65,
+            cert_not_after=datetime.now(timezone.utc),
+        )
+
+
+# ── revoke / activity (4 tests) ───────────────────────────────────
+
+
+async def test_mark_revoked_sets_revoked_at(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    view = await mark_revoked(upd_db, "acme.test/acme/user/mario")
+    assert view is not None
+    assert view.revoked_at is not None
+    assert view.is_active is False
+
+
+async def test_mark_revoked_idempotent(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    first = await mark_revoked(upd_db, "acme.test/acme/user/mario")
+    second = await mark_revoked(upd_db, "acme.test/acme/user/mario")
+    assert first is not None and second is not None
+    # The timestamp must NOT advance on the second revoke.
+    assert first.revoked_at == second.revoked_at
+
+
+async def test_mark_revoked_missing_principal_returns_none(upd_db):
+    view = await mark_revoked(upd_db, "acme.test/acme/user/ghost")
+    assert view is None
+
+
+async def test_update_last_active_silent_on_missing(upd_db):
+    # Must not raise even when the principal doesn't exist.
+    await update_last_active(upd_db, "acme.test/acme/user/ghost")
+
+
+async def test_update_last_active_touches_column(upd_db):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    when = datetime.now(timezone.utc)
+    await update_last_active(upd_db, "acme.test/acme/user/mario", when=when)
+    view = await get_by_principal_id(upd_db, "acme.test/acme/user/mario")
+    assert view is not None
+    assert view.last_active_at is not None
+
+
+# ── /v1/principals/by-sso endpoint (5 tests) ──────────────────────
+
+
+def _override_token(*, agent_id: str, org: str) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{org}/agent/{agent_id.split('::', 1)[-1]}",
+        agent_id=agent_id,
+        org=org,
+        exp=2_000_000_000,
+        iat=1_700_000_000,
+        jti="test-jti",
+        scope=[],
+        cnf={"jkt": "x" * 43},
+    )
+
+
+@pytest_asyncio.fixture
+async def auth_as_acme(upd_db):
+    """Override get_current_agent so endpoint tests don't need DPoP."""
+    app.dependency_overrides[get_current_agent] = (
+        lambda: _override_token(agent_id="acme::frontdesk", org="acme")
+    )
+    yield
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest_asyncio.fixture
+async def auth_as_globex(upd_db):
+    app.dependency_overrides[get_current_agent] = (
+        lambda: _override_token(agent_id="globex::frontdesk", org="globex")
+    )
+    yield
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+async def test_by_sso_endpoint_200(upd_db, client, auth_as_acme):
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+        display_name="Mario Rossi",
+    )
+    await upd_db.commit()
+
+    r = await client.get(
+        "/v1/principals/by-sso",
+        params={"org": "acme", "subject": "mario@acme.it"},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["principal_id"] == "acme.test/acme/user/mario"
+    assert data["sso_subject"] == "mario@acme.it"
+    assert data["display_name"] == "Mario Rossi"
+    assert data["is_active"] is True
+    assert data["is_provisioned"] is False  # no cert yet
+
+
+async def test_by_sso_endpoint_404(upd_db, client, auth_as_acme):
+    r = await client.get(
+        "/v1/principals/by-sso",
+        params={"org": "acme", "subject": "ghost@acme.it"},
+    )
+    assert r.status_code == 404
+
+
+async def test_by_sso_endpoint_403_cross_org(upd_db, client, auth_as_globex):
+    # Caller is globex agent; trying to read acme mappings.
+    await create(
+        upd_db,
+        principal_id="acme.test/acme/user/mario",
+        org_id="acme",
+        sso_subject="mario@acme.it",
+        kms_backend="embedded",
+        kms_key_handle="h1",
+    )
+    await upd_db.commit()
+
+    r = await client.get(
+        "/v1/principals/by-sso",
+        params={"org": "acme", "subject": "mario@acme.it"},
+    )
+    assert r.status_code == 403
+
+
+async def test_by_sso_endpoint_422_missing_subject(upd_db, client, auth_as_acme):
+    r = await client.get(
+        "/v1/principals/by-sso",
+        params={"org": "acme"},
+    )
+    assert r.status_code == 422
+
+
+async def test_by_sso_endpoint_422_missing_org(upd_db, client, auth_as_acme):
+    r = await client.get(
+        "/v1/principals/by-sso",
+        params={"subject": "mario@acme.it"},
+    )
+    assert r.status_code == 422


### PR DESCRIPTION
## Summary

Second brick of ADR-021 Cullis Frontdesk shared mode. Adds the **mapping table + lookup endpoint** the Ambassador (PR4) will hit on every authenticated user request to translate an SSO subject (\`mario@acme.it\`) into a Cullis principal_id (\`acme.test/acme/user/mario\`).

Independent of PR1 at the import level (PR1 is the KMS Protocol; PR2 is the DB mapping). The two compose in PR4: the Ambassador first asks PR2 \"do we already have a principal for this SSO subject?\", and if not it asks PR1 to mint keys and PR2 to register the new mapping.

## Schema

\`alembic/versions/o5j6k7l8m9n0_user_principals.py\`:

\`\`\`sql
CREATE TABLE user_principals (
    principal_id        VARCHAR(255) PRIMARY KEY,
    org_id              VARCHAR(128) NOT NULL,
    sso_subject         VARCHAR(255) NOT NULL,
    display_name        VARCHAR(255),
    cert_thumbprint     VARCHAR(64),
    cert_not_after      TIMESTAMP WITH TIME ZONE,
    kms_backend         VARCHAR(32)  NOT NULL,
    kms_key_handle      VARCHAR(255) NOT NULL,
    provisioned_at      TIMESTAMP WITH TIME ZONE NOT NULL,
    last_active_at      TIMESTAMP WITH TIME ZONE,
    revoked_at          TIMESTAMP WITH TIME ZONE,
    UNIQUE (org_id, sso_subject)
);
CREATE INDEX idx_user_principals_lookup ON user_principals (org_id, sso_subject);
\`\`\`

Cert columns are nullable until the Ambassador completes the CSR roundtrip and calls \`attach_cert\`. \`revoked_at\` flips a row to a tombstone instead of deleting it — audit replay needs the historical SSO→principal mapping.

## CRUD module

\`app/registry/user_principals.py\` exposes:

- \`create()\` — insert; raises \`DuplicatePrincipalError\` on either PK or \`(org, sso)\` collision
- \`get_by_principal_id()\`
- \`get_by_sso()\` — hot path for the Ambassador
- \`attach_cert()\` — idempotent (covers cert rotation); returns None on missing principal
- \`mark_revoked()\` — idempotent; preserves the original revoked_at timestamp on a second call
- \`update_last_active()\` — silent on missing principal (telemetry should never raise)

Returns frozen \`UserPrincipalView\` dataclasses across module boundaries to avoid leaking SQLAlchemy session state.

## Endpoint

\`GET /v1/principals/by-sso?org=&subject=\`:

- 200 with the principal projection (includes \`is_active\`, \`is_provisioned\`)
- 404 if no mapping
- 403 if caller's \`token.org\` differs from the requested \`org\` — SSO subjects are per-org PII; cross-org user federation has its own discovery story (deferred to ADR-020 v0.5)
- 422 if \`org\` or \`subject\` query params are missing

Auth: existing \`Depends(get_current_agent)\` DPoP-bound JWT. PR4 will tighten RBAC to the Ambassador workload identity specifically; v0.1 trusts any same-org agent.

## Tests

\`tests/test_user_principals_registry.py\` — 22 tests:

- 16 CRUD: happy paths, duplicate errors, missing-field validation, cert rotation, revocation idempotency, last_active touch
- 6 endpoint: 200 / 404 / 403 (cross-org) / 2× 422 (missing params)

## Test plan

- [x] \`pytest tests/test_user_principals_registry.py -n auto --dist=loadfile -v\` → 22/22 in 4.5s
- [x] Full local suite: 2423 passed, 8 pre-existing NixOS/headless failures (connector GUI libs + postgres integration), no new regressions
- [ ] CI green (full pytest + smoke gate)

## Related

- \`imp/adr-021-shared-mode-multi-user-kms.md\` §8 (the table schema this PR materializes)
- ADR-020 Phase 5 prerequisite
- PR1 (#413) UserPrincipalKMS Protocol — composes in PR4