### PR TITLE
ci: pin tests/test_e2e.py to shard 1 to avoid split-induced order breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,11 +110,30 @@ jobs:
         env:
           OTEL_ENABLED: "false"
           DATABASE_URL: "sqlite+aiosqlite://"
+        # ``tests/test_e2e.py`` is order-dependent (module-level _state
+        # dict shared across step1..step10). pytest-split's
+        # duration-based distribution scatters those steps across shards
+        # whenever the suite's overall timing shifts (e.g. a PR adds
+        # tests). When step1 lands in one shard and step5 in another,
+        # step5 can't read state step1 wrote and the suite fails with
+        # "State 'session_id' not found — tests must run in order".
+        # Excluded here and re-run as a single block in shard 1.
         run: |
           pytest tests/ \
               --tb=short \
               --ignore=tests/test_postgres_integration.py \
+              --ignore=tests/test_e2e.py \
               --splits 3 --group ${{ matrix.split-group }}
+
+      - name: Run tests/test_e2e.py (order-dependent, no split)
+        if: matrix.split-group == 1
+        env:
+          OTEL_ENABLED: "false"
+          DATABASE_URL: "sqlite+aiosqlite://"
+        # Pinned to shard 1 so the ordered step1..step10 chain runs
+        # inside a single pytest invocation. ~30s extra in shard 1.
+        run: |
+          pytest tests/test_e2e.py --tb=short
 
       - name: Anti-flaky concurrency gate (10× rotation race tests)
         if: matrix.split-group == 1


### PR DESCRIPTION
## Summary

Surfaced by PR #413 + PR #414: every PR that shifts the suite's overall timing risks scattering the ordered steps of \`tests/test_e2e.py\` across pytest-split shards. When that happens \`step5\` runs in a shard that never saw \`step1\` write the module-level state, and the suite fails with:

\`\`\`
AssertionError: State 'session_id' not found — tests must run in order
\`\`\`

The root bug is structural in \`tests/test_e2e.py\` (module-level \`_state = {}\` shared across \`test_step1\`..\`test_step10\`). Refactoring the file is out of scope for this PR — the fix here is to stop the split from breaking the chain in the meantime.

## What changes

- Add \`--ignore=tests/test_e2e.py\` to the sharded pytest invocation
- New step \`Run tests/test_e2e.py (order-dependent, no split)\` pinned to \`shard 1\`, runs the file as a single \`pytest\` invocation
- ~30s extra in shard 1; no change to total wall time because shard 1 currently finishes first

## Test plan

- [ ] CI green on this PR (would've already failed before the fix)
- [ ] Once merged, rebase #413 + #414 onto main and confirm both go green

## Follow-up (not this PR)

Refactor \`tests/test_e2e.py\` to stop relying on module-level state. Each step should set up its own preconditions (or use a session-scoped fixture that wires the chain). Once that lands, this CI workaround can be removed.