### PR TITLE
feat(registry): POST /v1/principals/csr Mastio CSR signing for users (ADR-021 PR4a)

### DIFF
--- a/app/registry/principals_csr.py
+++ b/app/registry/principals_csr.py
@@ -1,0 +1,255 @@
+"""Mastio CSR signing for user principals (ADR-021 PR4a).
+
+The Cullis Frontdesk Ambassador (PR4b) generates a keypair via the
+KMS, builds a CSR around the public key, and POSTs it here to obtain
+a Mastio-signed certificate. The signed cert is then stored back in
+the KMS via ``attach_certificate`` and registered in the
+``user_principals`` table via ``attach_cert`` (PR2).
+
+v0.1 scope:
+  - Signs with the broker CA key (the same key already used to sign
+    agent certs in standalone / managed mode). Single-org deployments
+    treat broker CA == org CA.
+  - TTL 1 hour. Sliding renewal happens at the next SSO touch in the
+    Ambassador, so 1h is plenty for chat sessions and bounds the blast
+    radius of a leaked cert.
+  - Issuer name hardcoded as ``CN=Cullis Mastio Broker CA, O=<org>``.
+    Future BYOCA enterprise deployments will need a different signer
+    that delegates to the org's KMS — that's a follow-up beyond v0.1.
+  - Validates the CSR's SPIFFE SAN matches the requested principal_id
+    so callers cannot smuggle a CSR for a different principal.
+
+Auth: ``Depends(get_current_agent)``. RBAC: caller may only request
+signing for principals in its own org. The Ambassador's workload
+cert satisfies both requirements when shared mode is deployed.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from app.kms.factory import get_kms_provider
+from app.spiffe import spiffe_to_principal
+
+_log = logging.getLogger("agent_trust")
+
+
+# Cert lifetime for user principals. Short on purpose — the Ambassador
+# refreshes via a fresh signing call whenever the user's session
+# rolls over. Production may shorten this further (e.g. 15min) once
+# the rollover path is exercised.
+USER_CERT_TTL = timedelta(hours=1)
+
+# Allowed clock skew either direction.
+CLOCK_SKEW = timedelta(minutes=5)
+
+
+class CsrValidationError(ValueError):
+    """Raised when the submitted CSR fails any structural check."""
+
+
+def parse_principal_id_to_spiffe(principal_id: str) -> tuple[str, str]:
+    """Translate ``<td>/<org>/<type>/<name>`` into the full SPIFFE URI
+    + a normalised internal id.
+
+    Returns ``(spiffe_uri, expected_org_id)``. Raises ``ValueError``
+    when the path is malformed.
+    """
+    parts = principal_id.split("/")
+    if len(parts) != 4:
+        raise ValueError(
+            "principal_id must have 4 path components "
+            "(<trust-domain>/<org>/<principal-type>/<name>); got "
+            f"{len(parts)}: {principal_id!r}",
+        )
+    td, org, ptype, name = parts
+    if not all((td, org, ptype, name)):
+        raise ValueError(
+            f"principal_id contains an empty component: {principal_id!r}",
+        )
+    if ptype not in ("user", "agent", "workload"):
+        raise ValueError(
+            f"principal_id principal-type must be one of "
+            f"user/agent/workload; got {ptype!r}",
+        )
+    spiffe_uri = f"spiffe://{td}/{org}/{ptype}/{name}"
+    return spiffe_uri, org
+
+
+def _extract_csr_spiffe_uri(csr: x509.CertificateSigningRequest) -> str:
+    """Return the single SPIFFE URI SAN in the CSR.
+
+    Raises ``CsrValidationError`` if the CSR has zero or multiple URI
+    SANs, or if the URI is not a SPIFFE id.
+    """
+    try:
+        san_ext = csr.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName,
+        )
+    except x509.ExtensionNotFound as exc:
+        raise CsrValidationError(
+            "CSR is missing the SubjectAlternativeName extension",
+        ) from exc
+
+    sans = san_ext.value
+    uris = [u.value for u in sans if isinstance(u, x509.UniformResourceIdentifier)]
+    if len(uris) == 0:
+        raise CsrValidationError("CSR SAN has no URI entries")
+    if len(uris) > 1:
+        raise CsrValidationError(
+            f"CSR SAN must have exactly one URI; got {len(uris)}",
+        )
+    uri = uris[0]
+    if not uri.startswith("spiffe://"):
+        raise CsrValidationError(
+            f"CSR SAN URI must be a SPIFFE id; got {uri!r}",
+        )
+    return uri
+
+
+def _verify_csr_signature(csr: x509.CertificateSigningRequest) -> None:
+    """``x509.CertificateSigningRequest`` exposes ``is_signature_valid``
+    on cryptography>=41 — we use it as the canonical check that the
+    requester actually held the matching private key.
+    """
+    if not csr.is_signature_valid:
+        raise CsrValidationError("CSR signature does not verify")
+
+
+def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
+    """Refuse weak keys. EC P-256/384/521 ok, RSA >= 2048 ok."""
+    pub = csr.public_key()
+    if isinstance(pub, rsa.RSAPublicKey):
+        if pub.key_size < 2048:
+            raise CsrValidationError(
+                f"RSA key too small ({pub.key_size} bits); minimum 2048",
+            )
+    elif isinstance(pub, ec.EllipticCurvePublicKey):
+        if pub.curve.key_size < 256:
+            raise CsrValidationError(
+                f"EC curve too small ({pub.curve.key_size} bits); minimum 256",
+            )
+    else:
+        raise CsrValidationError(
+            f"Unsupported public key type: {type(pub).__name__}",
+        )
+
+
+def _build_subject(principal_id: str, org_id: str) -> x509.Name:
+    return x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, principal_id[:64]),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+
+
+def _build_issuer(org_id: str) -> x509.Name:
+    return x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "Cullis Mastio Broker CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+
+
+def _cert_thumbprint_sha256(cert: x509.Certificate) -> str:
+    der = cert.public_bytes(serialization.Encoding.DER)
+    return hashlib.sha256(der).hexdigest()
+
+
+async def sign_user_csr(
+    csr_pem: str,
+    principal_id: str,
+    *,
+    ttl: timedelta = USER_CERT_TTL,
+) -> tuple[str, str, datetime]:
+    """Sign a user-principal CSR with the broker CA.
+
+    Returns ``(cert_pem, cert_thumbprint_sha256, cert_not_after)``.
+
+    Raises:
+        ValueError: principal_id malformed.
+        CsrValidationError: CSR malformed, weak key, missing SAN,
+            wrong SPIFFE URI, signature invalid.
+    """
+    spiffe_expected, expected_org = parse_principal_id_to_spiffe(principal_id)
+
+    try:
+        csr = x509.load_pem_x509_csr(csr_pem.encode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        raise CsrValidationError(f"could not parse CSR PEM: {exc}") from exc
+
+    _verify_csr_signature(csr)
+    _validate_public_key(csr)
+
+    spiffe_in_csr = _extract_csr_spiffe_uri(csr)
+    if spiffe_in_csr != spiffe_expected:
+        raise CsrValidationError(
+            f"CSR SPIFFE id {spiffe_in_csr!r} does not match requested "
+            f"principal_id {principal_id!r} (expected {spiffe_expected!r})",
+        )
+
+    # Catch malformed paths early so signing failures surface as 400.
+    spiffe_to_principal(spiffe_expected)
+
+    kms = get_kms_provider()
+    ca_key_pem = await kms.get_broker_private_key_pem()
+    ca_key = serialization.load_pem_private_key(
+        ca_key_pem.encode("utf-8"), password=None,
+    )
+
+    now = datetime.now(timezone.utc)
+    not_before = now - CLOCK_SKEW
+    not_after = now + ttl
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(_build_subject(principal_id, expected_org))
+        .issuer_name(_build_issuer(expected_org))
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=False, crl_sign=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([
+                x509.ExtendedKeyUsageOID.CLIENT_AUTH,
+            ]),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe_expected),
+            ]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    thumbprint = _cert_thumbprint_sha256(cert)
+    return cert_pem, thumbprint, not_after
+
+
+__all__ = [
+    "CLOCK_SKEW",
+    "CsrValidationError",
+    "USER_CERT_TTL",
+    "parse_principal_id_to_spiffe",
+    "sign_user_csr",
+]

--- a/app/registry/user_principals_router.py
+++ b/app/registry/user_principals_router.py
@@ -1,18 +1,17 @@
-"""REST endpoints for the user_principals mapping (ADR-021 PR2).
+"""REST endpoints for the user_principals mapping (ADR-021 PR2 + PR4a).
 
-The Cullis Frontdesk Ambassador (PR4) is the primary caller. On
-every authenticated user request it needs to map an SSO subject
-back to its Cullis principal_id; this endpoint is the lookup.
+The Cullis Frontdesk Ambassador (PR4b) is the primary caller. Two
+phases per user session:
 
-PR2 ships only the ``GET /v1/principals/by-sso`` lookup. Provisioning
-endpoints (POST + cert-attach) will land alongside the Ambassador
-in PR4 — that PR drives both ends of the API and shape choices.
+  * Lookup (PR2): ``GET /v1/principals/by-sso`` — given an SSO
+    subject, return the principal_id if already provisioned.
+  * Provisioning (PR4a): ``POST /v1/principals/csr`` — given a CSR
+    built around a fresh KMS-generated public key, return a Mastio-
+    signed cert. The Ambassador then attaches it to the KMS and
+    registers the (sso, principal_id) mapping via the registry CRUD.
 
-Authentication uses the existing ``Depends(get_current_agent)``
-DPoP-bound JWT. RBAC: the caller may only look up principals in
-its own ``org_id``. Cross-org SSO lookups are forbidden because
-SSO subjects are per-org PII; cross-org user federation has its
-own discovery story (deferred to ADR-020 v0.5).
+Authentication: ``Depends(get_current_agent)`` DPoP-bound JWT. RBAC:
+the caller may only operate on principals in its own ``org_id``.
 """
 from __future__ import annotations
 
@@ -27,6 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth.jwt import get_current_agent
 from app.auth.models import TokenPayload
 from app.db.database import get_db
+from app.registry.principals_csr import (
+    CsrValidationError,
+    parse_principal_id_to_spiffe,
+    sign_user_csr,
+)
 from app.registry.user_principals import (
     UserPrincipalView,
     get_by_sso,
@@ -105,3 +109,85 @@ async def lookup_by_sso(
             detail=f"no principal mapped to sso_subject={subject!r} in org={org!r}",
         )
     return _to_response(view)
+
+
+# ── /v1/principals/csr (ADR-021 PR4a) ────────────────────────────────
+
+
+class CsrSignRequest(BaseModel):
+    """Body for ``POST /v1/principals/csr``."""
+
+    principal_id: str = Field(
+        ..., min_length=7, max_length=255,
+        description="<trust-domain>/<org>/<principal-type>/<name>",
+    )
+    csr_pem: str = Field(
+        ..., min_length=128, max_length=8192,
+        description="PEM-encoded CSR; SAN must contain the SPIFFE URI of principal_id",
+    )
+
+
+class CsrSignResponse(BaseModel):
+    """Body returned by ``POST /v1/principals/csr``."""
+
+    cert_pem: str
+    cert_thumbprint: str = Field(
+        ..., description="SHA-256 hex digest of the DER-encoded cert",
+    )
+    cert_not_after: datetime
+
+
+@router.post(
+    "/csr",
+    response_model=CsrSignResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def sign_csr(
+    body: CsrSignRequest,
+    token: TokenPayload = Depends(get_current_agent),
+) -> CsrSignResponse:
+    """Sign a user-principal CSR with the Mastio broker CA.
+
+    The cert is short-lived (1h, see ``USER_CERT_TTL``). The Ambassador
+    refreshes by calling this endpoint again at the next SSO touch.
+
+    Errors:
+      - 400 ``CsrValidationError`` — malformed CSR / SAN / weak key /
+        SPIFFE id mismatch / bad principal_id format.
+      - 403 ``token.org != principal_id_org`` — caller may only mint
+        certs for principals in its own org.
+    """
+    try:
+        _spiffe_uri, principal_org = parse_principal_id_to_spiffe(body.principal_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"invalid principal_id: {exc}",
+        ) from exc
+
+    if token.org != principal_org:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="cannot sign a CSR for a principal in a different org",
+        )
+
+    try:
+        cert_pem, thumbprint, not_after = await sign_user_csr(
+            csr_pem=body.csr_pem,
+            principal_id=body.principal_id,
+        )
+    except CsrValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    _log.info(
+        "principals.csr signed principal_id=%s thumbprint=%s not_after=%s",
+        body.principal_id, thumbprint, not_after.isoformat(),
+    )
+    return CsrSignResponse(
+        cert_pem=cert_pem,
+        cert_thumbprint=thumbprint,
+        cert_not_after=not_after,
+    )

--- a/tests/test_principals_csr.py
+++ b/tests/test_principals_csr.py
@@ -1,0 +1,283 @@
+"""Tests for the Mastio CSR signing endpoint (ADR-021 PR4a).
+
+Two layers:
+  - Unit tests on ``sign_user_csr()`` in ``app/registry/principals_csr.py``
+  - HTTP tests on ``POST /v1/principals/csr`` with auth dependency
+    overridden (same pattern as PR2).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+from app.auth.jwt import get_current_agent
+from app.auth.models import TokenPayload
+from app.main import app
+from app.registry.principals_csr import (
+    CsrValidationError,
+    parse_principal_id_to_spiffe,
+    sign_user_csr,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ────────────────────────────────────────────────────────
+
+
+def _make_csr(
+    spiffe_uri: str | None,
+    *,
+    cn: str = "principal",
+    key_type: str = "ec",
+    key_size: int = 256,
+    extra_uris: list[str] | None = None,
+) -> tuple[x509.CertificateSigningRequest, str]:
+    """Build a CSR + return PEM. ``spiffe_uri`` None = no SAN extension."""
+    if key_type == "ec":
+        if key_size == 256:
+            curve = ec.SECP256R1()
+        elif key_size == 384:
+            curve = ec.SECP384R1()
+        elif key_size == 192:
+            curve = ec.SECT163K1()  # weak curve sentinel for negative test
+        else:
+            raise ValueError("test only ships ec 192/256/384")
+        priv = ec.generate_private_key(curve)
+        sig_alg = hashes.SHA256()
+    elif key_type == "rsa":
+        priv = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
+        sig_alg = hashes.SHA256()
+    else:
+        raise ValueError(key_type)
+
+    builder = x509.CertificateSigningRequestBuilder().subject_name(
+        x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)]),
+    )
+
+    sans: list[x509.GeneralName] = []
+    if spiffe_uri is not None:
+        sans.append(x509.UniformResourceIdentifier(spiffe_uri))
+    if extra_uris:
+        sans.extend(x509.UniformResourceIdentifier(u) for u in extra_uris)
+    if sans:
+        builder = builder.add_extension(
+            x509.SubjectAlternativeName(sans), critical=False,
+        )
+
+    csr = builder.sign(priv, sig_alg)
+    pem = csr.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    return csr, pem
+
+
+# ── parse_principal_id_to_spiffe (4 tests) ─────────────────────────
+
+
+def test_parse_principal_id_happy():
+    spiffe, org = parse_principal_id_to_spiffe("acme.test/acme/user/mario")
+    assert spiffe == "spiffe://acme.test/acme/user/mario"
+    assert org == "acme"
+
+
+def test_parse_principal_id_wrong_segment_count_raises():
+    with pytest.raises(ValueError, match="4 path components"):
+        parse_principal_id_to_spiffe("acme.test/acme/mario")
+
+
+def test_parse_principal_id_empty_segment_raises():
+    with pytest.raises(ValueError, match="empty component"):
+        parse_principal_id_to_spiffe("acme.test//user/mario")
+
+
+def test_parse_principal_id_unknown_type_raises():
+    with pytest.raises(ValueError, match="user/agent/workload"):
+        parse_principal_id_to_spiffe("acme.test/acme/badtype/mario")
+
+
+# ── sign_user_csr unit (8 tests) ───────────────────────────────────
+
+
+async def test_sign_user_csr_happy_ec_p256():
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    cert_pem, thumbprint, not_after = await sign_user_csr(
+        csr_pem, "acme.test/acme/user/mario",
+    )
+    assert "BEGIN CERTIFICATE" in cert_pem
+    assert len(thumbprint) == 64  # sha256 hex
+    assert not_after > datetime.now(timezone.utc)
+    # Parse the returned cert and check its SAN.
+    cert = x509.load_pem_x509_certificate(cert_pem.encode())
+    san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    uris = [u.value for u in san if isinstance(u, x509.UniformResourceIdentifier)]
+    assert uris == ["spiffe://acme.test/acme/user/mario"]
+    # Cert is not a CA
+    bc = cert.extensions.get_extension_for_class(x509.BasicConstraints).value
+    assert bc.ca is False
+    # Issuer organisation is the org_id
+    issuer_org = next(
+        a.value for a in cert.issuer if a.oid == NameOID.ORGANIZATION_NAME
+    )
+    assert issuer_org == "acme"
+
+
+async def test_sign_user_csr_happy_rsa_2048():
+    _, csr_pem = _make_csr(
+        "spiffe://acme.test/acme/user/mario", key_type="rsa", key_size=2048,
+    )
+    cert_pem, thumbprint, _ = await sign_user_csr(
+        csr_pem, "acme.test/acme/user/mario",
+    )
+    assert "BEGIN CERTIFICATE" in cert_pem
+    assert len(thumbprint) == 64
+
+
+async def test_sign_user_csr_wrong_principal_id_raises():
+    """CSR has SAN for mario, caller asks signing for anna → reject."""
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    with pytest.raises(CsrValidationError, match="does not match"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/anna")
+
+
+async def test_sign_user_csr_no_san_raises():
+    _, csr_pem = _make_csr(spiffe_uri=None)  # no SAN extension at all
+    with pytest.raises(CsrValidationError, match="missing the SubjectAlternativeName"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+async def test_sign_user_csr_multiple_uri_sans_raises():
+    _, csr_pem = _make_csr(
+        "spiffe://acme.test/acme/user/mario",
+        extra_uris=["spiffe://acme.test/acme/agent/extra"],
+    )
+    with pytest.raises(CsrValidationError, match="exactly one URI"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+async def test_sign_user_csr_non_spiffe_uri_raises():
+    _, csr_pem = _make_csr("https://attacker.example/")
+    with pytest.raises(CsrValidationError, match="SPIFFE id"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+async def test_sign_user_csr_weak_rsa_raises():
+    _, csr_pem = _make_csr(
+        "spiffe://acme.test/acme/user/mario", key_type="rsa", key_size=1024,
+    )
+    with pytest.raises(CsrValidationError, match="too small"):
+        await sign_user_csr(csr_pem, "acme.test/acme/user/mario")
+
+
+async def test_sign_user_csr_malformed_pem_raises():
+    with pytest.raises(CsrValidationError, match="could not parse"):
+        await sign_user_csr("not a pem", "acme.test/acme/user/mario")
+
+
+# ── /v1/principals/csr endpoint (5 tests) ──────────────────────────
+
+
+def _override_token(*, agent_id: str, org: str) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{org}/agent/{agent_id.split('::', 1)[-1]}",
+        agent_id=agent_id,
+        org=org,
+        exp=2_000_000_000,
+        iat=1_700_000_000,
+        jti="test-jti",
+        scope=[],
+        cnf={"jkt": "x" * 43},
+    )
+
+
+@pytest_asyncio.fixture
+async def auth_as_acme():
+    app.dependency_overrides[get_current_agent] = (
+        lambda: _override_token(agent_id="acme::frontdesk", org="acme")
+    )
+    yield
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+@pytest_asyncio.fixture
+async def auth_as_globex():
+    app.dependency_overrides[get_current_agent] = (
+        lambda: _override_token(agent_id="globex::frontdesk", org="globex")
+    )
+    yield
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+async def test_csr_endpoint_201(client, auth_as_acme):
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/user/mario",
+            "csr_pem": csr_pem,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert "BEGIN CERTIFICATE" in body["cert_pem"]
+    assert len(body["cert_thumbprint"]) == 64
+
+
+async def test_csr_endpoint_400_malformed_csr(client, auth_as_acme):
+    # Padded so the body passes Pydantic min_length=128 and the
+    # malformed-PEM check happens in the handler, returning 400.
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/user/mario",
+            "csr_pem": (
+                "-----BEGIN CERTIFICATE REQUEST-----\n"
+                + ("garbageQ" * 16) + "\n"
+                + "-----END CERTIFICATE REQUEST-----\n"
+            ),
+        },
+    )
+    assert r.status_code == 400, r.text
+    detail = r.json()["detail"].lower()
+    assert "csr" in detail or "parse" in detail
+
+
+async def test_csr_endpoint_400_principal_id_malformed(client, auth_as_acme):
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/badtype/mario",
+            "csr_pem": csr_pem,
+        },
+    )
+    assert r.status_code == 400
+
+
+async def test_csr_endpoint_403_cross_org(client, auth_as_globex):
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/user/mario",
+            "csr_pem": csr_pem,
+        },
+    )
+    assert r.status_code == 403
+
+
+async def test_csr_endpoint_400_san_mismatch(client, auth_as_acme):
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/anna")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/user/mario",
+            "csr_pem": csr_pem,
+        },
+    )
+    assert r.status_code == 400
+    assert "does not match" in r.json()["detail"]


### PR DESCRIPTION
## Summary

Third brick of ADR-021 (smaller half of the Ambassador work). Adds the Mastio endpoint the Cullis Frontdesk Ambassador will hit to obtain a signed cert for a freshly-provisioned user principal.

The Ambassador (PR4b) loop becomes:

1. \`KMS.create_keypair(principal_id)\` (PR1) → public key
2. Build CSR locally with the public key + SPIFFE SAN
3. **\`POST /v1/principals/csr\`** with the CSR → Mastio-signed cert PEM (this PR)
4. \`KMS.attach_certificate(principal_id, cert_pem)\` (PR1)
5. \`registry.attach_cert(...)\` (PR2) → row updated with thumbprint + not_after

PR4b will land all of the above wired into the Ambassador.

## Design

- **Signs with the broker CA** (\`KMS.get_broker_private_key_pem()\`), the same key that already signs agent certs in standalone / managed mode. Single-org deployments treat broker CA == org CA.
- **TTL 1 hour** for user certs (\`USER_CERT_TTL\`). Sliding renewal happens at the next SSO touch in the Ambassador.
- **Validation**: SAN must have exactly one SPIFFE URI, matching the requested \`principal_id\`; CSR signature must verify; RSA ≥ 2048, EC ≥ 256.
- **Cert profile**: \`BasicConstraints CA=false (critical)\`, \`KeyUsage digitalSignature (critical)\`, \`ExtendedKeyUsage clientAuth\`, SAN with the SPIFFE URI.
- **Issuer**: hardcoded \`CN=Cullis Mastio Broker CA, O=<org>\`. v0.1 simplification — BYOCA enterprise will need a different signer that delegates to the org's KMS.

## Auth + RBAC

- \`Depends(get_current_agent)\` (existing DPoP-bound JWT)
- Caller may only sign for principals in its own org. The Ambassador's workload cert satisfies this in shared mode.

## Errors

- 400 — CSR validation errors (malformed PEM, no SAN, wrong SPIFFE URI, weak key, signature invalid, malformed principal_id)
- 403 — cross-org sign attempts
- 201 + \`{cert_pem, cert_thumbprint, cert_not_after}\` on success

## Tests

\`tests/test_principals_csr.py\` — 17 tests:

- 4 \`parse_principal_id_to_spiffe\` (happy + 3 errors)
- 8 \`sign_user_csr\` unit (EC P-256, RSA-2048, wrong principal, no SAN, multiple URIs, non-SPIFFE URI, weak RSA, malformed PEM)
- 5 endpoint (201 / 400 malformed / 400 bad principal_id / 403 cross-org / 400 SAN mismatch)

## Test plan

- [x] \`pytest tests/test_principals_csr.py -n auto --dist=loadfile\` → 17/17 in 4.5s
- [ ] CI green (full pytest + smoke gate)

## Related

- \`imp/adr-021-shared-mode-multi-user-kms.md\` (the CSR roundtrip the Ambassador will drive in PR4b)
- PR1 (#413) UserPrincipalKMS Protocol — composes via the broker key load
- PR2 (#414) user_principals registry — composes via \`attach_cert\` after sign