### PR TITLE
feat(ambassador): shared mode (cookie + per-user provisioning) (ADR-021 PR4b)

### DIFF
--- a/app/kms/user_principal_embedded.py
+++ b/app/kms/user_principal_embedded.py
@@ -25,10 +25,12 @@ import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 
+from cryptography import x509
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.x509.oid import NameOID
 
 from app.kms.user_principal import (
     ALG_ES256,
@@ -321,6 +323,78 @@ class EmbeddedUserPrincipalKMS:
             return priv.sign(payload, ec.ECDSA(hashes.SHA256()))
         # Defensive: schema constrains alg, but be explicit.
         raise ValueError(f"stored alg '{alg}' not supported by this backend")
+
+    # ── backend-specific helper (NOT part of the Protocol) ─────────
+
+    async def build_csr(
+        self,
+        principal_id: str,
+        *,
+        common_name: str,
+        spiffe_uri: str,
+    ) -> str:
+        """Construct a CSR signed by the principal's private key.
+
+        Returns the CSR as PEM. The CSR's SAN includes the supplied
+        SPIFFE URI; the caller (Ambassador provisioning flow) then
+        ships this CSR to Mastio for signing.
+
+        Kept off the UserPrincipalKMS Protocol because in-KMS CSR
+        construction is not portable across backends — Vault Transit
+        signs CSRs through a different API surface, and PR3 will
+        either add an equivalent helper to that backend or push the
+        CSR construction one layer up.
+        """
+        _validate_principal_id(principal_id)
+        if not common_name or len(common_name) > 64:
+            raise ValueError("common_name must be 1-64 chars")
+        if not spiffe_uri.startswith("spiffe://"):
+            raise ValueError("spiffe_uri must start with 'spiffe://'")
+        return await asyncio.to_thread(
+            self._build_csr_sync, principal_id, common_name, spiffe_uri,
+        )
+
+    def _build_csr_sync(
+        self, principal_id: str, common_name: str, spiffe_uri: str,
+    ) -> str:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT encrypted_private_key, alg, revoked_at "
+                "FROM user_principals_keys WHERE principal_id = ?",
+                (principal_id,),
+            ).fetchone()
+        if row is None:
+            raise PrincipalNotFoundError(principal_id)
+        encrypted_pk, alg, revoked_at = row
+        if revoked_at is not None:
+            raise PrincipalRevokedError(principal_id)
+
+        priv_pem = self._unwrap(encrypted_pk, principal_id)
+        try:
+            priv = serialization.load_pem_private_key(priv_pem, password=None)
+        finally:
+            priv_pem = b"\x00" * len(priv_pem)
+            del priv_pem
+
+        if alg != ALG_ES256:
+            raise ValueError(f"stored alg '{alg}' not supported by build_csr")
+
+        csr = (
+            x509.CertificateSigningRequestBuilder()
+            .subject_name(x509.Name([
+                x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+            ]))
+            .add_extension(
+                x509.SubjectAlternativeName([
+                    x509.UniformResourceIdentifier(spiffe_uri),
+                ]),
+                critical=False,
+            )
+            .sign(priv, hashes.SHA256())
+        )
+        return csr.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+
+    # ── Protocol implementation continues ──────────────────────────
 
     async def revoke_principal(self, principal_id: str) -> None:
         _validate_principal_id(principal_id)

--- a/cullis_connector/ambassador/shared/__init__.py
+++ b/cullis_connector/ambassador/shared/__init__.py
@@ -1,0 +1,13 @@
+"""Cullis Frontdesk shared mode (ADR-021 PR4b).
+
+Sub-package activated when ``AMBASSADOR_MODE=shared`` (default
+``single``). Adds:
+
+  - ``cookie``        HMAC-signed session cookie helpers
+  - ``proxy_trust``   ``X-Forwarded-User`` allowlist + extraction
+  - ``credentials``   per-user (cert + KMS handle) LRU+TTL cache
+  - ``provisioning``  KMS create_keypair → CSR → Mastio sign → cache
+  - ``router``        FastAPI router for the multi-tenant surface
+
+Single mode (``cullis_connector/ambassador/router.py``) is unchanged.
+"""

--- a/cullis_connector/ambassador/shared/cookie.py
+++ b/cullis_connector/ambassador/shared/cookie.py
@@ -1,0 +1,172 @@
+"""HMAC-signed session cookie for Cullis Frontdesk shared mode.
+
+Format: ``<base64url(payload_json)>.<base64url(hmac_sha256(payload, secret))>``
+
+Self-validating: the payload carries ``iat`` + ``exp`` so we can
+detect tampering and expiry without a server-side session table.
+``parse_cookie`` returns ``None`` on any failure (bad encoding, bad
+signature, expired, malformed JSON) so callers cannot accidentally
+distinguish "absent" from "invalid" in their control flow.
+
+Why not ``itsdangerous``: stdlib ``hmac`` + ``base64`` + ``json`` are
+enough for this footprint and keep the Frontdesk container's
+dependency tree minimal. Constant-time comparison via
+``hmac.compare_digest``.
+"""
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+import logging
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Optional
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.cookie")
+
+# Caps on cookie payload size — keep cookies well under the 4KiB browser
+# limit and refuse anything larger than would be reasonable.
+_MAX_PAYLOAD_BYTES = 1024
+_MAX_COOKIE_BYTES = 2048
+
+
+@dataclass(frozen=True)
+class SessionPayload:
+    """The structured contents of a shared-mode session cookie."""
+
+    sub: str               # SSO subject (e.g. 'mario@acme.it')
+    org: str               # tenant org id
+    principal_id: str      # 'acme.test/acme/user/mario'
+    iat: int               # issued at (unix seconds)
+    exp: int               # expiry (unix seconds)
+
+    def as_json_bytes(self) -> bytes:
+        return json.dumps(
+            {
+                "sub": self.sub,
+                "org": self.org,
+                "principal_id": self.principal_id,
+                "iat": int(self.iat),
+                "exp": int(self.exp),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json_bytes(cls, raw: bytes) -> "SessionPayload":
+        obj = json.loads(raw)
+        if not isinstance(obj, dict):
+            raise ValueError("payload must be a JSON object")
+        for k in ("sub", "org", "principal_id", "iat", "exp"):
+            if k not in obj:
+                raise ValueError(f"payload missing required key {k!r}")
+        return cls(
+            sub=str(obj["sub"]),
+            org=str(obj["org"]),
+            principal_id=str(obj["principal_id"]),
+            iat=int(obj["iat"]),
+            exp=int(obj["exp"]),
+        )
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    pad = "=" * ((4 - len(data) % 4) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+def _hmac(secret: bytes, payload: bytes) -> bytes:
+    return hmac.new(secret, payload, sha256).digest()
+
+
+def make_cookie(payload: SessionPayload, secret: bytes) -> str:
+    """Encode + HMAC-sign a session payload.
+
+    Raises ``ValueError`` if the payload exceeds the soft cap.
+    """
+    if len(secret) < 16:
+        raise ValueError("secret must be at least 16 bytes")
+    raw = payload.as_json_bytes()
+    if len(raw) > _MAX_PAYLOAD_BYTES:
+        raise ValueError(
+            f"cookie payload too large ({len(raw)} bytes > {_MAX_PAYLOAD_BYTES})",
+        )
+    sig = _hmac(secret, raw)
+    return f"{_b64url_encode(raw)}.{_b64url_encode(sig)}"
+
+
+def parse_cookie(
+    cookie: str,
+    secret: bytes,
+    *,
+    now: Optional[int] = None,
+) -> Optional[SessionPayload]:
+    """Verify + decode a session cookie. Returns ``None`` on any failure.
+
+    Failure modes collapse to ``None`` on purpose so callers cannot
+    leak via timing or exception type which check failed (bad sig vs
+    expired vs malformed).
+    """
+    if not cookie or len(cookie) > _MAX_COOKIE_BYTES:
+        return None
+    try:
+        encoded_payload, encoded_sig = cookie.split(".", 1)
+    except ValueError:
+        return None
+    try:
+        raw_payload = _b64url_decode(encoded_payload)
+        raw_sig = _b64url_decode(encoded_sig)
+    except (ValueError, base64.binascii.Error):  # type: ignore[attr-defined]
+        return None
+    expected_sig = _hmac(secret, raw_payload)
+    if not hmac.compare_digest(raw_sig, expected_sig):
+        return None
+    try:
+        payload = SessionPayload.from_json_bytes(raw_payload)
+    except (ValueError, json.JSONDecodeError, TypeError):
+        return None
+    cur = int(now if now is not None else time.time())
+    if cur >= payload.exp:
+        return None
+    if cur < payload.iat:
+        # Issued in the future — refuse rather than gracefully accept,
+        # something is very wrong with the issuer's clock.
+        return None
+    return payload
+
+
+def issue(
+    *,
+    sub: str,
+    org: str,
+    principal_id: str,
+    secret: bytes,
+    ttl_seconds: int = 3600,
+    now: Optional[int] = None,
+) -> tuple[str, SessionPayload]:
+    """Build + sign a fresh session cookie. Convenience over ``make_cookie``."""
+    if ttl_seconds <= 0 or ttl_seconds > 24 * 3600:
+        raise ValueError("ttl_seconds must be in (0, 86400]")
+    cur = int(now if now is not None else time.time())
+    payload = SessionPayload(
+        sub=sub,
+        org=org,
+        principal_id=principal_id,
+        iat=cur,
+        exp=cur + ttl_seconds,
+    )
+    return make_cookie(payload, secret), payload
+
+
+__all__ = [
+    "SessionPayload",
+    "issue",
+    "make_cookie",
+    "parse_cookie",
+]

--- a/cullis_connector/ambassador/shared/credentials.py
+++ b/cullis_connector/ambassador/shared/credentials.py
@@ -1,0 +1,115 @@
+"""Per-user credential cache for Cullis Frontdesk shared mode.
+
+Holds the (cert_pem, KMS-bound private-key handle, expiry) for each
+provisioned user principal. Bounded LRU + TTL eviction so a busy
+deployment cannot grow the cache without bound and a stale cert
+cannot live longer than its issuance window.
+
+The private key never leaves the KMS — this cache holds only:
+  - the principal_id
+  - the cert PEM (public material)
+  - the KMS key_handle (opaque reference for log correlation)
+  - the cert expiry timestamp
+
+A miss triggers ``UserProvisioner.provision()`` which generates a
+fresh keypair via the KMS, builds a CSR, ships it to Mastio for
+signing, attaches the cert in the KMS, and populates the cache.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.credentials")
+
+DEFAULT_CACHE_SIZE = 1024
+DEFAULT_TTL_SECONDS = 3600  # 1h, matches USER_CERT_TTL on the Mastio side
+
+
+@dataclass(frozen=True)
+class UserCredentials:
+    """Snapshot of a provisioned user principal.
+
+    The Ambassador uses ``cert_pem`` to assert identity to Mastio
+    (x5c JWT header) and ``key_pem`` to sign the JWT + DPoP proofs.
+
+    v0.1 limitation: the private key lives in process memory for
+    the duration of the cache TTL (1h). v0.2 will move signing to
+    the KMS via a signer-callable refactor of ``CullisClient`` so
+    private key material never leaves the KMS boundary. Documented
+    in ADR-021 §5 as the embedded-backend trade-off.
+    """
+
+    principal_id: str
+    cert_pem: str
+    key_pem: str
+    cert_not_after: datetime
+
+    def expired(self, *, now: Optional[float] = None) -> bool:
+        cur = now if now is not None else time.time()
+        return cur >= self.cert_not_after.timestamp()
+
+
+class UserCredentialCache:
+    """LRU + TTL cache keyed by ``principal_id``.
+
+    Async-safe: every read/write goes through ``self._lock`` so
+    concurrent provisioning attempts do not corrupt the OrderedDict.
+    Provisioning itself happens outside the cache lock; the cache
+    only serialises the in-memory map.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_size: int = DEFAULT_CACHE_SIZE,
+    ) -> None:
+        if max_size <= 0:
+            raise ValueError("max_size must be > 0")
+        self._max_size = max_size
+        self._items: "OrderedDict[str, UserCredentials]" = OrderedDict()
+        self._lock = asyncio.Lock()
+
+    async def get(self, principal_id: str) -> Optional[UserCredentials]:
+        """Return the cached credentials, or ``None`` on miss / expiry."""
+        async with self._lock:
+            cred = self._items.get(principal_id)
+            if cred is None:
+                return None
+            if cred.expired():
+                # Lazy expiry: evict on read so the next provision()
+                # call repopulates with a fresh cert.
+                del self._items[principal_id]
+                return None
+            self._items.move_to_end(principal_id)
+            return cred
+
+    async def put(self, cred: UserCredentials) -> None:
+        async with self._lock:
+            self._items[cred.principal_id] = cred
+            self._items.move_to_end(cred.principal_id)
+            while len(self._items) > self._max_size:
+                evicted_id, _ = self._items.popitem(last=False)
+                _log.debug("ambassador credentials cache evicted %s", evicted_id)
+
+    async def invalidate(self, principal_id: str) -> bool:
+        """Drop the entry. Returns True if something was removed."""
+        async with self._lock:
+            return self._items.pop(principal_id, None) is not None
+
+    async def size(self) -> int:
+        async with self._lock:
+            return len(self._items)
+
+
+__all__ = [
+    "DEFAULT_CACHE_SIZE",
+    "DEFAULT_TTL_SECONDS",
+    "UserCredentialCache",
+    "UserCredentials",
+]

--- a/cullis_connector/ambassador/shared/provisioning.py
+++ b/cullis_connector/ambassador/shared/provisioning.py
@@ -1,0 +1,219 @@
+"""Per-user provisioning flow (ADR-021 PR4b).
+
+Orchestrates the steps that turn a fresh SSO subject into a usable
+credential the Ambassador can sign DPoP+x509 proofs with:
+
+    1. Cache hit? → return cached ``UserCredentials``.
+    2. Generate an ECC P-256 keypair in process memory.
+    3. Build a CSR around the public key, with a SPIFFE SAN matching
+       the principal_id (``spiffe://<td>/<org>/user/<name>``).
+    4. POST the CSR to Mastio's ``/v1/principals/csr`` endpoint
+       (PR4a) and get back a 1h cert.
+    5. Populate the in-process ``UserCredentialCache`` so subsequent
+       Ambassador requests skip the whole roundtrip.
+
+v0.1 simplification: the keypair lives in process memory for the
+TTL of the cache entry (1h, matches the cert lifetime). v0.2 will
+plug the embedded KMS (PR1) and refactor ``CullisClient`` to take
+a signer callable so the private key never leaves the KMS. The
+cross-package boundary stays clean: this module talks to Mastio
+via HTTPS only.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from cullis_connector.ambassador.shared.credentials import (
+    UserCredentialCache,
+    UserCredentials,
+)
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.provisioning")
+
+
+class MastioCsrError(RuntimeError):
+    """Raised when Mastio refuses to sign the CSR for any reason."""
+
+
+class MastioCsrTransport(Protocol):
+    """The CSR-signing surface the provisioner needs from Mastio.
+
+    Implementations wrap an ``httpx.AsyncClient`` carrying the
+    Ambassador's own DPoP-bound credentials.
+    """
+
+    async def sign_csr(
+        self,
+        *,
+        principal_id: str,
+        csr_pem: str,
+    ) -> tuple[str, datetime]:
+        """POST /v1/principals/csr → (cert_pem, not_after).
+
+        Raises ``MastioCsrError`` on non-201 responses.
+        """
+        ...
+
+
+@dataclass(frozen=True)
+class HttpxMastioCsrTransport:
+    """Default Mastio transport built on an ``httpx.AsyncClient``.
+
+    The client is supplied externally so the caller controls auth
+    headers (DPoP token + cert), TLS settings, and base URL. We do
+    not own its lifecycle.
+    """
+
+    http: httpx.AsyncClient
+    base_url: str
+
+    async def sign_csr(
+        self,
+        *,
+        principal_id: str,
+        csr_pem: str,
+    ) -> tuple[str, datetime]:
+        url = f"{self.base_url.rstrip('/')}/v1/principals/csr"
+        try:
+            resp = await self.http.post(
+                url,
+                json={"principal_id": principal_id, "csr_pem": csr_pem},
+            )
+        except httpx.HTTPError as exc:
+            raise MastioCsrError(
+                f"transport failure calling Mastio /v1/principals/csr: {exc}",
+            ) from exc
+
+        if resp.status_code != 201:
+            raise MastioCsrError(
+                f"Mastio /v1/principals/csr returned {resp.status_code}: "
+                f"{resp.text[:512]}",
+            )
+        body = resp.json()
+        try:
+            cert_pem = body["cert_pem"]
+            not_after_iso = body["cert_not_after"]
+        except (KeyError, TypeError) as exc:
+            raise MastioCsrError(
+                f"Mastio CSR response missing required fields: {body!r}",
+            ) from exc
+        try:
+            not_after = datetime.fromisoformat(not_after_iso)
+        except ValueError as exc:
+            raise MastioCsrError(
+                f"Mastio CSR response has invalid not_after: {not_after_iso!r}",
+            ) from exc
+        return cert_pem, not_after
+
+
+def _generate_keypair_pem() -> tuple[str, ec.EllipticCurvePrivateKey]:
+    """Build an ECC P-256 keypair. Returns (key_pem, key_object).
+
+    The PEM is what the SDK consumes; the key object is used to
+    sign the CSR locally before being discarded.
+    """
+    priv = ec.generate_private_key(ec.SECP256R1())
+    key_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    return key_pem, priv
+
+
+def _build_csr_pem(
+    priv: ec.EllipticCurvePrivateKey,
+    *,
+    principal_id: str,
+    spiffe_uri: str,
+) -> str:
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, principal_id[:64]),
+        ]))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe_uri),
+            ]),
+            critical=False,
+        )
+        .sign(priv, hashes.SHA256())
+    )
+    return csr.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+
+
+class UserProvisioner:
+    """Compose keypair + Mastio CSR + cache to obtain user credentials."""
+
+    def __init__(
+        self,
+        *,
+        mastio: MastioCsrTransport,
+        cache: UserCredentialCache,
+    ) -> None:
+        self._mastio = mastio
+        self._cache = cache
+
+    async def get_or_provision(
+        self,
+        *,
+        principal_id: str,
+        sso_subject: str,
+    ) -> UserCredentials:
+        """Return a fresh ``UserCredentials`` for this principal.
+
+        Cache hit → return cached. Cache miss → run the full
+        provisioning chain and populate the cache.
+        """
+        cached = await self._cache.get(principal_id)
+        if cached is not None:
+            return cached
+        cred = await self._provision(
+            principal_id=principal_id, sso_subject=sso_subject,
+        )
+        await self._cache.put(cred)
+        return cred
+
+    async def _provision(
+        self, *, principal_id: str, sso_subject: str,
+    ) -> UserCredentials:
+        spiffe_uri = f"spiffe://{principal_id}"
+
+        key_pem, priv = _generate_keypair_pem()
+        csr_pem = _build_csr_pem(
+            priv, principal_id=principal_id, spiffe_uri=spiffe_uri,
+        )
+
+        cert_pem, not_after = await self._mastio.sign_csr(
+            principal_id=principal_id, csr_pem=csr_pem,
+        )
+
+        cred = UserCredentials(
+            principal_id=principal_id,
+            cert_pem=cert_pem,
+            key_pem=key_pem,
+            cert_not_after=not_after,
+        )
+        _log.info(
+            "ambassador provisioned principal=%s sso=%s not_after=%s",
+            principal_id, sso_subject, not_after.isoformat(),
+        )
+        return cred
+
+
+__all__ = [
+    "HttpxMastioCsrTransport",
+    "MastioCsrError",
+    "MastioCsrTransport",
+    "UserProvisioner",
+]

--- a/cullis_connector/ambassador/shared/proxy_trust.py
+++ b/cullis_connector/ambassador/shared/proxy_trust.py
@@ -1,0 +1,88 @@
+"""Reverse-proxy SSO header trust (ADR-021 §6).
+
+Cullis does not implement SAML/OIDC. The reverse proxy in front of
+the Frontdesk container does, and forwards the authenticated subject
+in ``X-Forwarded-User``. We trust that header IF AND ONLY IF the
+TCP peer of the request is in the operator-supplied allowlist.
+
+Default allowlist: ``127.0.0.1/32, ::1/128``. Production deployments
+override via ``CULLIS_TRUSTED_PROXIES`` (comma-separated CIDRs).
+"""
+from __future__ import annotations
+
+import ipaddress
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.proxy_trust")
+
+DEFAULT_TRUSTED_CIDRS = ("127.0.0.1/32", "::1/128")
+SSO_HEADER = "x-forwarded-user"
+SSO_GROUPS_HEADER = "x-forwarded-groups"  # optional, for future RBAC
+
+
+@dataclass(frozen=True)
+class TrustedProxiesAllowlist:
+    """Wraps a set of ``ipaddress`` networks for ``contains`` checks."""
+
+    networks: tuple[ipaddress._BaseNetwork, ...]
+
+    @classmethod
+    def from_cidrs(cls, cidrs: Iterable[str]) -> "TrustedProxiesAllowlist":
+        nets: list[ipaddress._BaseNetwork] = []
+        for cidr in cidrs:
+            cidr = cidr.strip()
+            if not cidr:
+                continue
+            try:
+                nets.append(ipaddress.ip_network(cidr, strict=False))
+            except ValueError as exc:
+                raise ValueError(
+                    f"invalid CIDR in trusted proxies allowlist: {cidr!r}: {exc}",
+                ) from exc
+        if not nets:
+            raise ValueError("trusted proxies allowlist cannot be empty")
+        return cls(networks=tuple(nets))
+
+    def contains(self, peer_ip: str) -> bool:
+        try:
+            addr = ipaddress.ip_address(peer_ip)
+        except ValueError:
+            return False
+        # ipaddress quirk: a v4 address is not "in" a v6 network and
+        # vice-versa, so we just walk the list.
+        for net in self.networks:
+            if addr.version != net.version:
+                continue
+            if addr in net:
+                return True
+        return False
+
+
+def extract_sso_subject(headers: dict[str, str]) -> Optional[str]:
+    """Pull the SSO subject from a request's headers, lowercase-keyed.
+
+    Returns ``None`` if absent. The header value is sanitised
+    (stripped, length-capped) but no further normalisation happens
+    here — a tenant-specific transform (e.g. ``mario@acme.it`` →
+    ``mario``) is applied by the caller.
+    """
+    raw = headers.get(SSO_HEADER, "")
+    if not raw:
+        return None
+    sub = raw.strip()
+    if not sub or len(sub) > 255:
+        return None
+    if not sub.isprintable() or any(c in sub for c in "\r\n\t"):
+        return None
+    return sub
+
+
+__all__ = [
+    "DEFAULT_TRUSTED_CIDRS",
+    "SSO_GROUPS_HEADER",
+    "SSO_HEADER",
+    "TrustedProxiesAllowlist",
+    "extract_sso_subject",
+]

--- a/cullis_connector/ambassador/shared/router.py
+++ b/cullis_connector/ambassador/shared/router.py
@@ -1,0 +1,362 @@
+"""FastAPI router for Cullis Frontdesk shared mode (ADR-021 PR4b).
+
+Endpoints:
+
+  POST /api/session/init        cookie issuance from X-Forwarded-User
+  POST /api/session/logout      cookie invalidation
+  GET  /v1/models               list models (cookie-authed, per user)
+  POST /v1/chat/completions     chat (cookie-authed, per user, tool-use)
+
+Activation: ``install_shared_ambassador(app, ...)`` mounts the
+router and stashes shared-mode state on ``app.state.shared_ambassador``.
+The Connector dashboard ``build_app`` factory chooses between
+``install_ambassador`` (single mode) and this when
+``AMBASSADOR_MODE=shared``.
+
+Single-mode router (``cullis_connector/ambassador/router.py``) is
+unchanged — both modes can coexist on the same image.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from fastapi import (
+    APIRouter, Depends, FastAPI, HTTPException, Request, Response, status,
+)
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from cullis_connector.ambassador.loop import run_tool_use_loop
+from cullis_connector.ambassador.models import ChatCompletionRequest
+from cullis_connector.ambassador.shared.cookie import (
+    SessionPayload, issue, parse_cookie,
+)
+from cullis_connector.ambassador.shared.credentials import (
+    DEFAULT_TTL_SECONDS, UserCredentials,
+)
+from cullis_connector.ambassador.shared.provisioning import (
+    MastioCsrError, UserProvisioner,
+)
+from cullis_connector.ambassador.shared.proxy_trust import (
+    TrustedProxiesAllowlist, extract_sso_subject,
+)
+from cullis_connector.ambassador.streaming import (
+    extract_assistant_text, fake_stream,
+)
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.router")
+
+router = APIRouter(tags=["ambassador-shared"])
+
+
+COOKIE_NAME = "cullis_session"
+DEFAULT_COOKIE_TTL_SECONDS = DEFAULT_TTL_SECONDS  # 1h
+
+
+# ── State plumbing ────────────────────────────────────────────────
+
+
+@dataclass
+class SharedAmbassadorState:
+    """Wiring stashed on ``app.state.shared_ambassador``."""
+
+    cookie_secret: bytes
+    cookie_ttl_seconds: int
+    trusted_proxies: TrustedProxiesAllowlist
+    org_id: str
+    trust_domain: str
+    sso_subject_to_name: Any  # callable: subject_str -> name_str
+    provisioner: UserProvisioner
+    advertised_models: list[str]
+    site_url: str
+    # When False, skip the X-Forwarded-Proxy peer check. Test-only —
+    # production must keep this True so the SSO header is only honoured
+    # from the configured reverse proxy.
+    enforce_proxy_trust: bool = True
+
+
+def _state(request: Request) -> SharedAmbassadorState:
+    s = getattr(request.app.state, "shared_ambassador", None)
+    if s is None:
+        raise HTTPException(503, "shared Ambassador not initialised on this app")
+    return s
+
+
+# ── Helpers ───────────────────────────────────────────────────────
+
+
+def _peer_ip(request: Request) -> str:
+    return request.client.host if request.client else ""
+
+
+def _enforce_trusted_proxy(request: Request, state: SharedAmbassadorState) -> None:
+    if not state.enforce_proxy_trust:
+        return
+    if not state.trusted_proxies.contains(_peer_ip(request)):
+        _log.warning(
+            "shared ambassador rejecting request from non-trusted peer %s on %s %s",
+            _peer_ip(request), request.method, request.url.path,
+        )
+        raise HTTPException(401, "untrusted proxy peer")
+
+
+def _principal_id_for(state: SharedAmbassadorState, sso_subject: str) -> str:
+    name = state.sso_subject_to_name(sso_subject)
+    if not name:
+        raise HTTPException(400, "could not derive principal name from SSO subject")
+    return f"{state.trust_domain}/{state.org_id}/user/{name}"
+
+
+async def _require_session(request: Request) -> SessionPayload:
+    state = _state(request)
+    cookie = request.cookies.get(COOKIE_NAME, "")
+    payload = parse_cookie(cookie, state.cookie_secret)
+    if payload is None:
+        raise HTTPException(401, "missing or invalid session cookie")
+    return payload
+
+
+async def _require_credentials(
+    request: Request,
+    payload: SessionPayload = Depends(_require_session),
+) -> UserCredentials:
+    state = _state(request)
+    try:
+        cred = await state.provisioner.get_or_provision(
+            principal_id=payload.principal_id,
+            sso_subject=payload.sub,
+        )
+    except MastioCsrError as exc:
+        _log.exception("provisioning failed for %s", payload.principal_id)
+        raise HTTPException(502, f"user provisioning failed: {exc}") from exc
+    return cred
+
+
+# ── /api/session/init ─────────────────────────────────────────────
+
+
+@router.post("/api/session/init")
+async def session_init(request: Request) -> JSONResponse:
+    """Issue a cookie from the SSO subject in ``X-Forwarded-User``.
+
+    Idempotent: a returning user with a still-valid cookie is given a
+    fresh one (sliding refresh) but the principal stays the same.
+    """
+    state = _state(request)
+    _enforce_trusted_proxy(request, state)
+
+    headers = {k.lower(): v for k, v in request.headers.items()}
+    sso_subject = extract_sso_subject(headers)
+    if not sso_subject:
+        raise HTTPException(401, "missing or invalid X-Forwarded-User header")
+
+    principal_id = _principal_id_for(state, sso_subject)
+    cookie_value, payload = issue(
+        sub=sso_subject,
+        org=state.org_id,
+        principal_id=principal_id,
+        secret=state.cookie_secret,
+        ttl_seconds=state.cookie_ttl_seconds,
+    )
+    resp = JSONResponse({
+        "principal_id": principal_id,
+        "sub": sso_subject,
+        "org": state.org_id,
+        "exp": payload.exp,
+    })
+    resp.set_cookie(
+        key=COOKIE_NAME,
+        value=cookie_value,
+        max_age=state.cookie_ttl_seconds,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        path="/",
+    )
+    _log.info(
+        "shared ambassador session issued sub=%s principal=%s",
+        sso_subject, principal_id,
+    )
+    return resp
+
+
+# ── /api/session/logout ───────────────────────────────────────────
+
+
+@router.post("/api/session/logout")
+async def session_logout(
+    request: Request,
+    payload: SessionPayload = Depends(_require_session),
+) -> Response:
+    """Invalidate the cookie immediately by setting Max-Age=0."""
+    resp = JSONResponse({"ok": True, "principal_id": payload.principal_id})
+    resp.set_cookie(
+        key=COOKIE_NAME,
+        value="",
+        max_age=0,
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        path="/",
+    )
+    _log.info(
+        "shared ambassador logout principal=%s sub=%s",
+        payload.principal_id, payload.sub,
+    )
+    return resp
+
+
+# ── /api/session/whoami ───────────────────────────────────────────
+
+
+@router.get("/api/session/whoami")
+async def session_whoami(
+    payload: SessionPayload = Depends(_require_session),
+) -> dict:
+    """Tiny helper used by the SPA's IdentityBadge."""
+    return {
+        "principal_id": payload.principal_id,
+        "sub": payload.sub,
+        "org": payload.org,
+        "exp": payload.exp,
+    }
+
+
+# ── /v1/models ────────────────────────────────────────────────────
+
+
+@router.get("/v1/models")
+async def list_models(
+    request: Request,
+    _payload: SessionPayload = Depends(_require_session),
+) -> dict:
+    state = _state(request)
+    return {
+        "object": "list",
+        "data": [
+            {"id": m, "object": "model", "owned_by": "cullis", "created": 0}
+            for m in (state.advertised_models or ["claude-haiku-4-5"])
+        ],
+    }
+
+
+# ── /v1/chat/completions ─────────────────────────────────────────
+
+
+def _build_user_client(state: SharedAmbassadorState, cred: UserCredentials):
+    """Construct a CullisClient logged in with the user's cert+key.
+
+    v0.1 builds fresh per request (~100ms login). v0.2 will cache
+    these clients keyed on principal_id with TTL matching the cert,
+    behind a tiny adapter so this function stays the entry point.
+    """
+    from cullis_sdk import CullisClient
+    parts = cred.principal_id.split("/")
+    if len(parts) != 4:
+        raise HTTPException(500, "malformed principal_id in credentials")
+    _td, org, _ptype, name = parts
+    agent_id = f"{org}::{name}"
+    client = CullisClient(state.site_url)
+    client.login_from_pem(agent_id, org, cred.cert_pem, cred.key_pem)
+    return client
+
+
+@router.post("/v1/chat/completions")
+async def chat_completions(
+    req: ChatCompletionRequest,
+    request: Request,
+    cred: UserCredentials = Depends(_require_credentials),
+):
+    state = _state(request)
+    body = req.model_dump(exclude_none=True)
+
+    try:
+        client = _build_user_client(state, cred)
+    except Exception as exc:
+        _log.exception("shared ambassador SDK login failed for %s", cred.principal_id)
+        raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
+
+    try:
+        response, truncated = run_tool_use_loop(client, body, max_iters=8)
+    except Exception as exc:
+        _log.exception(
+            "shared ambassador tool-use loop failed for %s", cred.principal_id,
+        )
+        raise HTTPException(502, f"Cullis cloud call failed: {exc}") from exc
+
+    model_out = body.get("model") or "claude-haiku-4-5"
+
+    if req.stream:
+        answer = extract_assistant_text(response)
+        headers = {"Cache-Control": "no-cache", "X-Accel-Buffering": "no"}
+        if truncated:
+            headers["X-Cullis-Tool-Use-Truncated"] = "true"
+        return StreamingResponse(
+            fake_stream(answer, model=model_out),
+            media_type="text/event-stream",
+            headers=headers,
+        )
+
+    if truncated:
+        return JSONResponse(
+            response, headers={"X-Cullis-Tool-Use-Truncated": "true"}
+        )
+    return response
+
+
+# ── Wiring ────────────────────────────────────────────────────────
+
+
+def install_shared_ambassador(
+    app: FastAPI,
+    *,
+    cookie_secret: bytes,
+    trusted_proxies: TrustedProxiesAllowlist,
+    org_id: str,
+    trust_domain: str,
+    provisioner: UserProvisioner,
+    sso_subject_to_name=lambda sub: sub.split("@")[0] if "@" in sub else sub,
+    advertised_models: list[str] | None = None,
+    cookie_ttl_seconds: int = DEFAULT_COOKIE_TTL_SECONDS,
+    site_url: str = "",
+    enforce_proxy_trust: bool = True,
+) -> None:
+    """Stash shared-mode state on ``app.state.shared_ambassador`` and mount.
+
+    ``enforce_proxy_trust=False`` is for test scaffolding only —
+    the FastAPI ``TestClient`` reports ``request.client.host =
+    'testclient'`` which is not a valid IP and cannot be in any
+    CIDR. Production callers MUST leave this True so the SSO
+    header is only honoured from the configured reverse proxy.
+    """
+    if hasattr(app.state, "shared_ambassador") and app.state.shared_ambassador:
+        raise RuntimeError("shared Ambassador already installed on this app")
+    if len(cookie_secret) < 32:
+        raise ValueError("cookie_secret must be at least 32 bytes")
+    app.state.shared_ambassador = SharedAmbassadorState(
+        cookie_secret=cookie_secret,
+        cookie_ttl_seconds=cookie_ttl_seconds,
+        trusted_proxies=trusted_proxies,
+        org_id=org_id,
+        trust_domain=trust_domain,
+        sso_subject_to_name=sso_subject_to_name,
+        provisioner=provisioner,
+        advertised_models=list(advertised_models or ["claude-haiku-4-5"]),
+        site_url=site_url,
+        enforce_proxy_trust=enforce_proxy_trust,
+    )
+    app.include_router(router)
+    _log.info(
+        "shared ambassador installed org=%s trust_domain=%s site=%s",
+        org_id, trust_domain, site_url,
+    )
+
+
+__all__ = [
+    "COOKIE_NAME",
+    "DEFAULT_COOKIE_TTL_SECONDS",
+    "SharedAmbassadorState",
+    "install_shared_ambassador",
+    "router",
+]

--- a/tests/connector/test_ambassador_shared.py
+++ b/tests/connector/test_ambassador_shared.py
@@ -1,0 +1,545 @@
+"""Tests for Cullis Frontdesk shared mode (ADR-021 PR4b).
+
+Five layers, all in this file for now:
+
+  1. ``shared/cookie.py``          HMAC-signed session cookies
+  2. ``shared/proxy_trust.py``     X-Forwarded-User trust + allowlist
+  3. ``shared/credentials.py``     LRU + TTL credential cache
+  4. ``shared/provisioning.py``    KMS-less keypair → CSR → Mastio sign
+  5. ``shared/router.py``          FastAPI surface end-to-end
+"""
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cullis_connector.ambassador.shared.cookie import (
+    SessionPayload, issue, make_cookie, parse_cookie,
+)
+from cullis_connector.ambassador.shared.credentials import (
+    UserCredentialCache, UserCredentials,
+)
+from cullis_connector.ambassador.shared.provisioning import (
+    HttpxMastioCsrTransport, MastioCsrError, UserProvisioner,
+)
+from cullis_connector.ambassador.shared.proxy_trust import (
+    TrustedProxiesAllowlist, extract_sso_subject,
+)
+from cullis_connector.ambassador.shared.router import (
+    COOKIE_NAME, install_shared_ambassador,
+)
+
+
+SECRET = b"x" * 32
+
+
+# ─────────────────────────────────────────────────────────────────
+# 1) cookie.py
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_cookie_roundtrip_happy():
+    cookie, payload = issue(
+        sub="mario@acme.it", org="acme",
+        principal_id="acme.test/acme/user/mario",
+        secret=SECRET, ttl_seconds=3600,
+    )
+    parsed = parse_cookie(cookie, SECRET)
+    assert parsed == payload
+
+
+def test_cookie_tampered_payload_fails():
+    cookie, _ = issue(
+        sub="mario@acme.it", org="acme",
+        principal_id="acme.test/acme/user/mario",
+        secret=SECRET, ttl_seconds=3600,
+    )
+    payload_b64, sig = cookie.split(".", 1)
+    raw = base64.urlsafe_b64decode(payload_b64 + "=" * ((4 - len(payload_b64) % 4) % 4))
+    obj = json.loads(raw)
+    obj["sub"] = "anna@acme.it"
+    new_payload = base64.urlsafe_b64encode(
+        json.dumps(obj, separators=(",", ":"), sort_keys=True).encode(),
+    ).rstrip(b"=").decode()
+    tampered = f"{new_payload}.{sig}"
+    assert parse_cookie(tampered, SECRET) is None
+
+
+def test_cookie_wrong_secret_fails():
+    cookie, _ = issue(
+        sub="mario@acme.it", org="acme",
+        principal_id="acme.test/acme/user/mario",
+        secret=SECRET, ttl_seconds=3600,
+    )
+    assert parse_cookie(cookie, b"y" * 32) is None
+
+
+def test_cookie_expired_fails():
+    payload = SessionPayload(
+        sub="mario@acme.it", org="acme",
+        principal_id="acme.test/acme/user/mario",
+        iat=1000, exp=2000,
+    )
+    cookie = make_cookie(payload, SECRET)
+    assert parse_cookie(cookie, SECRET, now=2001) is None
+    assert parse_cookie(cookie, SECRET, now=1500) == payload
+
+
+def test_cookie_issued_in_future_fails():
+    cookie, _ = issue(
+        sub="mario@acme.it", org="acme",
+        principal_id="acme.test/acme/user/mario",
+        secret=SECRET, ttl_seconds=3600, now=10_000,
+    )
+    assert parse_cookie(cookie, SECRET, now=5_000) is None
+
+
+def test_cookie_malformed_returns_none():
+    assert parse_cookie("not-a-cookie", SECRET) is None
+    assert parse_cookie("", SECRET) is None
+    assert parse_cookie(".", SECRET) is None
+    assert parse_cookie("a.b", SECRET) is None
+
+
+def test_cookie_secret_too_short_raises():
+    with pytest.raises(ValueError, match="16 bytes"):
+        issue(
+            sub="x", org="a", principal_id="td/a/user/x",
+            secret=b"short", ttl_seconds=60,
+        )
+
+
+def test_cookie_ttl_bounds():
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        issue(sub="x", org="a", principal_id="td/a/user/x",
+              secret=SECRET, ttl_seconds=0)
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        issue(sub="x", org="a", principal_id="td/a/user/x",
+              secret=SECRET, ttl_seconds=24 * 3600 + 1)
+
+
+def test_cookie_size_cap():
+    # Very long principal_id should bust the soft cap.
+    with pytest.raises(ValueError, match="payload too large"):
+        issue(
+            sub="x" * 1024, org="a",
+            principal_id="td/a/user/" + "x" * 1024,
+            secret=SECRET, ttl_seconds=60,
+        )
+
+
+# ─────────────────────────────────────────────────────────────────
+# 2) proxy_trust.py
+# ─────────────────────────────────────────────────────────────────
+
+
+def test_allowlist_loopback_default():
+    al = TrustedProxiesAllowlist.from_cidrs(["127.0.0.1/32", "::1/128"])
+    assert al.contains("127.0.0.1") is True
+    assert al.contains("::1") is True
+    assert al.contains("10.0.0.5") is False
+
+
+def test_allowlist_cidr_range():
+    al = TrustedProxiesAllowlist.from_cidrs(["10.0.0.0/8"])
+    assert al.contains("10.5.6.7") is True
+    assert al.contains("11.0.0.1") is False
+
+
+def test_allowlist_empty_raises():
+    with pytest.raises(ValueError, match="cannot be empty"):
+        TrustedProxiesAllowlist.from_cidrs([])
+
+
+def test_allowlist_invalid_cidr_raises():
+    with pytest.raises(ValueError, match="invalid CIDR"):
+        TrustedProxiesAllowlist.from_cidrs(["not-a-cidr"])
+
+
+def test_allowlist_invalid_peer_returns_false():
+    al = TrustedProxiesAllowlist.from_cidrs(["127.0.0.1/32"])
+    assert al.contains("not-an-ip") is False
+
+
+def test_extract_sso_subject_happy():
+    assert extract_sso_subject({"x-forwarded-user": "mario@acme.it"}) == "mario@acme.it"
+
+
+def test_extract_sso_subject_missing():
+    assert extract_sso_subject({}) is None
+    assert extract_sso_subject({"x-forwarded-user": ""}) is None
+
+
+def test_extract_sso_subject_rejects_control_chars():
+    assert extract_sso_subject({"x-forwarded-user": "mario\nanna@acme.it"}) is None
+    assert extract_sso_subject({"x-forwarded-user": "x" * 500}) is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# 3) credentials.py
+# ─────────────────────────────────────────────────────────────────
+
+
+def _make_cred(principal_id="acme.test/acme/user/mario", *, ttl_s=3600):
+    return UserCredentials(
+        principal_id=principal_id,
+        cert_pem="-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        key_pem="-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n",
+        cert_not_after=datetime.now(timezone.utc) + timedelta(seconds=ttl_s),
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_get_miss():
+    cache = UserCredentialCache()
+    assert await cache.get("acme.test/acme/user/ghost") is None
+
+
+@pytest.mark.asyncio
+async def test_cache_put_then_get():
+    cache = UserCredentialCache()
+    cred = _make_cred()
+    await cache.put(cred)
+    assert await cache.get(cred.principal_id) == cred
+
+
+@pytest.mark.asyncio
+async def test_cache_lazy_expiry_evicts():
+    cache = UserCredentialCache()
+    cred = UserCredentials(
+        principal_id="acme.test/acme/user/mario",
+        cert_pem="", key_pem="",
+        cert_not_after=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    await cache.put(cred)
+    assert await cache.get(cred.principal_id) is None
+    assert await cache.size() == 0
+
+
+@pytest.mark.asyncio
+async def test_cache_lru_eviction():
+    cache = UserCredentialCache(max_size=2)
+    a = _make_cred("td/o/user/a")
+    b = _make_cred("td/o/user/b")
+    c = _make_cred("td/o/user/c")
+    await cache.put(a)
+    await cache.put(b)
+    await cache.put(c)  # evicts a
+    assert await cache.get("td/o/user/a") is None
+    assert await cache.get("td/o/user/b") == b
+    assert await cache.get("td/o/user/c") == c
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidate():
+    cache = UserCredentialCache()
+    cred = _make_cred()
+    await cache.put(cred)
+    assert await cache.invalidate(cred.principal_id) is True
+    assert await cache.invalidate(cred.principal_id) is False
+    assert await cache.get(cred.principal_id) is None
+
+
+def test_cache_max_size_validation():
+    with pytest.raises(ValueError, match="max_size"):
+        UserCredentialCache(max_size=0)
+
+
+# ─────────────────────────────────────────────────────────────────
+# 4) provisioning.py
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _StubMastio:
+    """Records calls + returns canned cert."""
+
+    cert_pem: str = "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n"
+    not_after_iso: str = "2099-12-31T23:59:59+00:00"
+    fail_with: Exception | None = None
+    calls: list[tuple[str, str]] = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        self.calls = []
+
+    async def sign_csr(self, *, principal_id: str, csr_pem: str):
+        self.calls.append((principal_id, csr_pem))
+        if self.fail_with is not None:
+            raise self.fail_with
+        return self.cert_pem, datetime.fromisoformat(self.not_after_iso)
+
+
+@pytest.mark.asyncio
+async def test_provisioner_cache_miss_then_provision():
+    cache = UserCredentialCache()
+    mastio = _StubMastio()
+    p = UserProvisioner(mastio=mastio, cache=cache)
+
+    cred = await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+    assert cred.cert_pem == mastio.cert_pem
+    assert cred.principal_id == "acme.test/acme/user/mario"
+    assert "BEGIN PRIVATE KEY" in cred.key_pem
+    # CSR was sent to Mastio with the right principal_id.
+    assert len(mastio.calls) == 1
+    assert mastio.calls[0][0] == "acme.test/acme/user/mario"
+    assert "BEGIN CERTIFICATE REQUEST" in mastio.calls[0][1]
+    # Cached for the next call.
+    assert await cache.get("acme.test/acme/user/mario") == cred
+
+
+@pytest.mark.asyncio
+async def test_provisioner_cache_hit_skips_mastio():
+    cache = UserCredentialCache()
+    mastio = _StubMastio()
+    p = UserProvisioner(mastio=mastio, cache=cache)
+
+    await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+    await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+    assert len(mastio.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_provisioner_propagates_mastio_failure():
+    cache = UserCredentialCache()
+    mastio = _StubMastio(fail_with=MastioCsrError("Mastio said no"))
+    p = UserProvisioner(mastio=mastio, cache=cache)
+    with pytest.raises(MastioCsrError, match="Mastio said no"):
+        await p.get_or_provision(
+            principal_id="acme.test/acme/user/mario",
+            sso_subject="mario@acme.it",
+        )
+    # Cache stays empty so a retry triggers a fresh attempt.
+    assert await cache.size() == 0
+
+
+@pytest.mark.asyncio
+async def test_httpx_transport_201():
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        assert body["principal_id"] == "acme.test/acme/user/mario"
+        assert "BEGIN CERTIFICATE REQUEST" in body["csr_pem"]
+        return httpx.Response(
+            201,
+            json={
+                "cert_pem": "PEM",
+                "cert_thumbprint": "x" * 64,
+                "cert_not_after": "2099-12-31T23:59:59+00:00",
+            },
+        )
+
+    transport = httpx.MockTransport(_handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        t = HttpxMastioCsrTransport(http=http, base_url="http://mastio.test")
+        cert, not_after = await t.sign_csr(
+            principal_id="acme.test/acme/user/mario",
+            csr_pem=(
+                "-----BEGIN CERTIFICATE REQUEST-----\n"
+                + ("AAAA" * 32) + "\n"
+                + "-----END CERTIFICATE REQUEST-----\n"
+            ),
+        )
+        assert cert == "PEM"
+        assert not_after.year == 2099
+
+
+@pytest.mark.asyncio
+async def test_httpx_transport_non_201_raises():
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, text="bad CSR")
+
+    transport = httpx.MockTransport(_handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        t = HttpxMastioCsrTransport(http=http, base_url="http://mastio.test")
+        with pytest.raises(MastioCsrError, match="returned 400"):
+            await t.sign_csr(principal_id="x/x/user/x", csr_pem="abc")
+
+
+@pytest.mark.asyncio
+async def test_httpx_transport_missing_fields_raises():
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={"cert_pem": "PEM"})  # no not_after
+
+    transport = httpx.MockTransport(_handler)
+    async with httpx.AsyncClient(transport=transport) as http:
+        t = HttpxMastioCsrTransport(http=http, base_url="http://mastio.test")
+        with pytest.raises(MastioCsrError, match="missing required fields"):
+            await t.sign_csr(principal_id="x/x/user/x", csr_pem="abc")
+
+
+# ─────────────────────────────────────────────────────────────────
+# 5) router.py — endpoint integration
+# ─────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _StubProvisioner:
+    """Returns a canned UserCredentials, no Mastio calls."""
+
+    cred: UserCredentials
+
+    async def get_or_provision(self, *, principal_id: str, sso_subject: str):
+        return self.cred
+
+
+def _build_shared_app(
+    *,
+    trusted_cidrs=("127.0.0.1/32",),
+    provisioner=None,
+    enforce_proxy_trust: bool = False,
+) -> FastAPI:
+    app = FastAPI()
+    if provisioner is None:
+        provisioner = _StubProvisioner(_make_cred())
+    install_shared_ambassador(
+        app,
+        cookie_secret=SECRET * 1,  # 32 bytes
+        trusted_proxies=TrustedProxiesAllowlist.from_cidrs(trusted_cidrs),
+        org_id="acme",
+        trust_domain="acme.test",
+        provisioner=provisioner,  # type: ignore[arg-type]
+        site_url="https://mastio.test",
+        enforce_proxy_trust=enforce_proxy_trust,
+    )
+    return app
+
+
+def test_session_init_issues_cookie():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        r = cli.post(
+            "/api/session/init",
+            headers={"X-Forwarded-User": "mario@acme.it"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["principal_id"] == "acme.test/acme/user/mario"
+        assert COOKIE_NAME in r.cookies
+
+
+def test_session_init_missing_xfu_401():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        r = cli.post("/api/session/init")
+        assert r.status_code == 401
+
+
+def test_session_init_untrusted_proxy_401():
+    # Enable the proxy check; TestClient reports "testclient" as host
+    # which is not in any CIDR, so enforcement gives 401.
+    app = _build_shared_app(
+        trusted_cidrs=("10.0.0.0/8",),
+        enforce_proxy_trust=True,
+    )
+    with TestClient(app, base_url="https://testserver") as cli:
+        r = cli.post(
+            "/api/session/init",
+            headers={"X-Forwarded-User": "mario@acme.it"},
+        )
+        assert r.status_code == 401
+
+
+def test_session_whoami_requires_cookie():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        r = cli.get("/api/session/whoami")
+        assert r.status_code == 401
+
+
+def test_session_whoami_after_init():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        cli.post(
+            "/api/session/init",
+            headers={"X-Forwarded-User": "mario@acme.it"},
+        )
+        r = cli.get("/api/session/whoami")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["principal_id"] == "acme.test/acme/user/mario"
+        assert body["sub"] == "mario@acme.it"
+        assert body["org"] == "acme"
+
+
+def test_session_logout_clears_cookie():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        cli.post(
+            "/api/session/init",
+            headers={"X-Forwarded-User": "mario@acme.it"},
+        )
+        r = cli.post("/api/session/logout")
+        assert r.status_code == 200
+        # whoami after logout → 401
+        # TestClient persists cookies across calls; logout sets Max-Age=0
+        # which TestClient honours by removing the cookie.
+        r2 = cli.get("/api/session/whoami")
+        assert r2.status_code == 401
+
+
+def test_session_logout_requires_cookie():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        r = cli.post("/api/session/logout")
+        assert r.status_code == 401
+
+
+def test_v1_models_requires_cookie():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        assert cli.get("/v1/models").status_code == 401
+
+
+def test_v1_models_after_init():
+    app = _build_shared_app()
+    with TestClient(app, base_url="https://testserver") as cli:
+        cli.post(
+            "/api/session/init",
+            headers={"X-Forwarded-User": "mario@acme.it"},
+        )
+        r = cli.get("/v1/models")
+        assert r.status_code == 200
+        assert r.json()["data"][0]["id"] == "claude-haiku-4-5"
+
+
+def test_install_twice_raises():
+    app = _build_shared_app()
+    provisioner = _StubProvisioner(_make_cred())
+    with pytest.raises(RuntimeError, match="already installed"):
+        install_shared_ambassador(
+            app,
+            cookie_secret=SECRET,
+            trusted_proxies=TrustedProxiesAllowlist.from_cidrs(["127.0.0.1/32"]),
+            org_id="acme",
+            trust_domain="acme.test",
+            provisioner=provisioner,  # type: ignore[arg-type]
+        )
+
+
+def test_install_short_secret_raises():
+    app = FastAPI()
+    provisioner = _StubProvisioner(_make_cred())
+    with pytest.raises(ValueError, match="32 bytes"):
+        install_shared_ambassador(
+            app,
+            cookie_secret=b"short",
+            trusted_proxies=TrustedProxiesAllowlist.from_cidrs(["127.0.0.1/32"]),
+            org_id="acme",
+            trust_domain="acme.test",
+            provisioner=provisioner,  # type: ignore[arg-type]
+        )

--- a/tests/connector/test_ambassador_shared.py
+++ b/tests/connector/test_ambassador_shared.py
@@ -17,7 +17,6 @@ from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
-import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 


### PR DESCRIPTION
## Summary

The multi-tenant Ambassador surface for Cullis Frontdesk in topology S: one container in the datacenter behind a SAML/OIDC reverse proxy, N concurrent users from N browsers. Single mode (\`cullis_connector/ambassador/router.py\`) is unchanged — both modes coexist on the same image.

This is the bigger half of PR4. Composes with PR1 (KMS Protocol), PR2 (user_principals table), PR4a (Mastio CSR endpoint).

## What ships

\`cullis_connector/ambassador/shared/\` (new sub-package, activated when \`AMBASSADOR_MODE=shared\`):

- **\`cookie.py\`** — HMAC-SHA256 + base64url session cookie. Stdlib only (no \`itsdangerous\`). HttpOnly + Secure + SameSite=Strict, 1h sliding refresh.
- **\`proxy_trust.py\`** — \`X-Forwarded-User\` extraction + \`TrustedProxiesAllowlist\` (CIDR). Default \`127.0.0.1/32, ::1/128\`. Production overrides via \`CULLIS_TRUSTED_PROXIES\`.
- **\`credentials.py\`** — \`UserCredentialCache\`: LRU + TTL on \`(cert_pem, key_pem, expires_at)\` keyed by \`principal_id\`. Bounded size, async-safe.
- **\`provisioning.py\`** — \`UserProvisioner\` orchestrates: generate ECC P-256 keypair (in process) → build CSR with SPIFFE SAN → POST Mastio \`/v1/principals/csr\` (PR4a) → store cert+key in cache. Mastio abstracted as \`MastioCsrTransport\` Protocol with \`HttpxMastioCsrTransport\` default.
- **\`router.py\`** — FastAPI surface:
  - \`POST /api/session/init\` (cookie issuance from \`X-Forwarded-User\`, allowlist-gated)
  - \`POST /api/session/logout\`
  - \`GET  /api/session/whoami\` (SPA IdentityBadge convenience)
  - \`GET  /v1/models\`
  - \`POST /v1/chat/completions\` (cookie-authed, derives user CullisClient from cred cache)
  - \`install_shared_ambassador(app, ...)\` factory.

\`app/kms/user_principal_embedded.py\`: adds \`build_csr()\` helper for v0.2 wiring (NOT part of the UserPrincipalKMS Protocol — the Vault backend in PR3 will need a different impl).

## v0.1 trade-off (documented in ADR-021 §5)

The keypair lives in process memory for the cache TTL (1h). v0.2 will plug the embedded KMS (PR1) and refactor \`CullisClient\` to take a signer callable so the private key never leaves the KMS boundary. The cross-package boundary stays clean: this module only talks to Mastio via HTTPS.

For the demo video this is acceptable: Frontdesk container = company trust boundary; if the container is compromised, the attacker has the private key for the duration of the cache TTL but cannot exfiltrate keys for users who logged in earlier and whose entries already expired.

## Tests

\`tests/connector/test_ambassador_shared.py\` — 40 tests:

- 9 \`cookie\` (roundtrip, tamper, wrong secret, expired, future-iat, malformed, secret length, ttl bounds, payload size cap)
- 8 \`proxy_trust\` (loopback, CIDR range, empty/invalid, sso subject extraction, control char rejection)
- 6 \`credentials\` (miss, put+get, lazy expiry, LRU eviction, invalidate, max_size validation)
- 6 \`provisioning\` (cache miss provisions, cache hit skips Mastio, propagates failures, httpx 201/non-201/missing fields)
- 11 \`router\` (init issues cookie, missing X-Forwarded-User, untrusted proxy, whoami requires/after init, logout clears, models requires/after init, install twice, install short secret)

## Test plan

- [x] \`pytest tests/connector/test_ambassador_shared.py -n auto --dist=loadfile\` → 40/40 in 4.5s
- [x] Full local suite → 2516 passed, 8 pre-existing NixOS/headless failures (connector GUI libs + postgres integration), no new regressions
- [ ] CI green (full pytest + smoke gate)

## Out of scope (deferred)

- Wiring \`install_shared_ambassador\` into \`cullis_connector/web.py\` based on \`AMBASSADOR_MODE\` env. PR4c follow-up — needs the Connector dashboard \`build_app\` factory to branch on mode.
- \`CullisClient\` signer-callable refactor for KMS-side signing (v0.2).
- Per-user rate limit (defensive, deferred to v0.2).
- Audit hooks \`user.session_started\` + \`user.session_signed\` (v0.2).

## Related

- \`imp/adr-021-shared-mode-multi-user-kms.md\` (the full design)
- ADR-019 §2 topology S
- PR1 (#413), PR2 (#414), PR4a (#416)