### PR TITLE
feat(connector): wire shared-mode Ambassador via AMBASSADOR_MODE env (ADR-021 PR4c)

### DIFF
--- a/cullis_connector/ambassador/shared/wire.py
+++ b/cullis_connector/ambassador/shared/wire.py
@@ -1,0 +1,178 @@
+"""Bootstrap helpers for Cullis Frontdesk shared mode (ADR-021 PR4c).
+
+Two responsibilities:
+
+  - ``bootstrap_cookie_secret(config_dir)`` — generate a 32-byte secret
+    on first start and persist it at ``<config_dir>/cookie.secret`` mode
+    0600. Subsequent runs reuse the same file.
+  - ``shared_mode_settings_from_env()`` — read the shared-mode env vars
+    into a typed dataclass so ``_maybe_install_shared_ambassador`` in
+    ``cullis_connector/web.py`` can validate them once at boot.
+
+Env contract (documented in ADR-021 §5+§6):
+
+  AMBASSADOR_MODE                  "single" (default) | "shared"
+  CULLIS_TRUSTED_PROXIES           CIDR list, default "127.0.0.1/32,::1/128"
+  CULLIS_FRONTDESK_ORG_ID          required for shared
+  CULLIS_FRONTDESK_TRUST_DOMAIN    required for shared
+  CULLIS_FRONTDESK_COOKIE_TTL_S    int seconds, default 3600
+  CULLIS_FRONTDESK_MASTIO_URL      where the Mastio CSR endpoint lives
+
+The Mastio URL falls back to the Connector ``site_url`` when not set,
+because in single-tenant Frontdesk deployments they are the same host.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.wire")
+
+COOKIE_SECRET_FILENAME = "cookie.secret"
+SECRET_LEN_BYTES = 32
+
+# Env var names — kept in one place so docs and tests can import them.
+ENV_MODE = "AMBASSADOR_MODE"
+ENV_TRUSTED_PROXIES = "CULLIS_TRUSTED_PROXIES"
+ENV_ORG_ID = "CULLIS_FRONTDESK_ORG_ID"
+ENV_TRUST_DOMAIN = "CULLIS_FRONTDESK_TRUST_DOMAIN"
+ENV_COOKIE_TTL = "CULLIS_FRONTDESK_COOKIE_TTL_S"
+ENV_MASTIO_URL = "CULLIS_FRONTDESK_MASTIO_URL"
+
+DEFAULT_TRUSTED_PROXIES = "127.0.0.1/32,::1/128"
+DEFAULT_COOKIE_TTL = 3600
+
+
+@dataclass(frozen=True)
+class SharedModeSettings:
+    """Validated env-driven shared-mode configuration."""
+
+    enabled: bool
+    org_id: str
+    trust_domain: str
+    trusted_proxies_cidrs: tuple[str, ...]
+    cookie_ttl_seconds: int
+    mastio_url: str  # may be empty → caller falls back to site_url
+
+
+def bootstrap_cookie_secret(config_dir: Path) -> bytes:
+    """Return the cookie secret, generating it on first call.
+
+    File mode 0600. The secret is the cryptographic root for every
+    session cookie issued by this Frontdesk container. Backup
+    alongside the broker CA private key — losing it forces every
+    user's browser to re-init their session (no security incident,
+    just UX churn).
+    """
+    config_dir.mkdir(parents=True, exist_ok=True)
+    path = config_dir / COOKIE_SECRET_FILENAME
+    if path.exists():
+        raw = path.read_bytes()
+        if len(raw) == SECRET_LEN_BYTES:
+            return raw
+        _log.warning(
+            "shared cookie secret at %s has unexpected length %d; "
+            "regenerating", path, len(raw),
+        )
+    secret = secrets.token_bytes(SECRET_LEN_BYTES)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_bytes(secret)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        _log.info(
+            "could not chmod 0600 on %s (filesystem may not support it)", tmp,
+        )
+    os.replace(tmp, path)
+    _log.info("shared cookie secret generated at %s (0600)", path)
+    return secret
+
+
+def _coerce_int(raw: Optional[str], default: int, *, name: str) -> int:
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer; got {raw!r}") from exc
+
+
+def shared_mode_settings_from_env(
+    env: Optional[dict[str, str]] = None,
+) -> SharedModeSettings:
+    """Read + validate shared-mode env vars.
+
+    Returns ``enabled=False`` (and other fields zeroed) when
+    ``AMBASSADOR_MODE`` is anything other than ``"shared"``. Raises
+    ``ValueError`` only when the operator opted into shared mode but
+    a required field is missing or malformed.
+    """
+    e = env if env is not None else os.environ
+    mode = (e.get(ENV_MODE) or "single").strip().lower()
+    if mode != "shared":
+        return SharedModeSettings(
+            enabled=False,
+            org_id="",
+            trust_domain="",
+            trusted_proxies_cidrs=(),
+            cookie_ttl_seconds=DEFAULT_COOKIE_TTL,
+            mastio_url="",
+        )
+
+    org_id = (e.get(ENV_ORG_ID) or "").strip()
+    if not org_id:
+        raise ValueError(
+            f"{ENV_ORG_ID} is required when {ENV_MODE}=shared",
+        )
+    trust_domain = (e.get(ENV_TRUST_DOMAIN) or "").strip()
+    if not trust_domain:
+        raise ValueError(
+            f"{ENV_TRUST_DOMAIN} is required when {ENV_MODE}=shared",
+        )
+
+    raw_cidrs = (e.get(ENV_TRUSTED_PROXIES) or DEFAULT_TRUSTED_PROXIES)
+    cidrs = tuple(c.strip() for c in raw_cidrs.split(",") if c.strip())
+    if not cidrs:
+        raise ValueError(
+            f"{ENV_TRUSTED_PROXIES} must contain at least one CIDR",
+        )
+
+    cookie_ttl = _coerce_int(
+        e.get(ENV_COOKIE_TTL), DEFAULT_COOKIE_TTL, name=ENV_COOKIE_TTL,
+    )
+    if cookie_ttl <= 0 or cookie_ttl > 24 * 3600:
+        raise ValueError(
+            f"{ENV_COOKIE_TTL} must be in (0, 86400]; got {cookie_ttl}",
+        )
+
+    mastio_url = (e.get(ENV_MASTIO_URL) or "").rstrip("/")
+
+    return SharedModeSettings(
+        enabled=True,
+        org_id=org_id,
+        trust_domain=trust_domain,
+        trusted_proxies_cidrs=cidrs,
+        cookie_ttl_seconds=cookie_ttl,
+        mastio_url=mastio_url,
+    )
+
+
+__all__ = [
+    "COOKIE_SECRET_FILENAME",
+    "DEFAULT_COOKIE_TTL",
+    "DEFAULT_TRUSTED_PROXIES",
+    "ENV_COOKIE_TTL",
+    "ENV_MASTIO_URL",
+    "ENV_MODE",
+    "ENV_ORG_ID",
+    "ENV_TRUST_DOMAIN",
+    "ENV_TRUSTED_PROXIES",
+    "SECRET_LEN_BYTES",
+    "SharedModeSettings",
+    "bootstrap_cookie_secret",
+    "shared_mode_settings_from_env",
+]

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -149,7 +149,24 @@ async def _dashboard_lifespan(app: FastAPI):
     # We mount it lazily here (vs in build_app) because the identity may
     # land mid-process (post enrollment), so a fresh dashboard start
     # picks it up. If ``ambassador.enabled`` is false this is a no-op.
-    _maybe_install_ambassador(app, config)
+    # ADR-021 PR4c — when AMBASSADOR_MODE=shared, mount the multi-tenant
+    # router instead of the single-user one. Default ``single`` keeps
+    # the laptop topology unchanged.
+    from cullis_connector.ambassador.shared.wire import (
+        shared_mode_settings_from_env,
+    )
+    try:
+        shared_settings = shared_mode_settings_from_env()
+    except ValueError as exc:
+        import logging as _logging
+        _logging.getLogger("cullis_connector.web").error(
+            "AMBASSADOR_MODE=shared configuration invalid: %s", exc,
+        )
+        raise
+    if shared_settings.enabled:
+        _maybe_install_shared_ambassador(app, config, shared_settings)
+    else:
+        _maybe_install_ambassador(app, config)
 
     _ensure_inbox_poller_running(app)
     try:
@@ -313,6 +330,117 @@ def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
     log.info(
         "Ambassador mounted: agent=%s site=%s bearer=*** (saved at %s)",
         agent_id, site_url, config.config_dir / "local.token",
+    )
+
+
+def _maybe_install_shared_ambassador(
+    app: FastAPI,
+    config: ConnectorConfig,
+    settings,  # SharedModeSettings; typed via runtime import to avoid cycle
+) -> None:
+    """Mount the shared-mode Ambassador (ADR-021 PR4c).
+
+    Activated when ``AMBASSADOR_MODE=shared``. Composes the cookie
+    secret bootstrap, the per-user credential cache, and the
+    ``HttpxMastioCsrTransport`` that ships CSRs to Mastio's
+    ``/v1/principals/csr`` endpoint (PR4a) on behalf of newly
+    SSO-authenticated users.
+
+    The Ambassador's own client identity for the Mastio CSR call is
+    the Connector's enrolled cert+key (loaded from
+    ``<config_dir>/identity/``). Mastio enforces RBAC same-org so
+    any agent enrolled in the deployment org can call the CSR
+    endpoint for principals in that same org.
+    """
+    import logging
+    log = logging.getLogger("cullis_connector.web")
+
+    if not has_identity(config.config_dir):
+        log.warning(
+            "shared Ambassador install deferred: no identity at %s yet "
+            "(complete enrollment first)", config.config_dir,
+        )
+        return
+
+    try:
+        import httpx
+        from cullis_connector.ambassador.shared.credentials import (
+            UserCredentialCache,
+        )
+        from cullis_connector.ambassador.shared.provisioning import (
+            HttpxMastioCsrTransport, UserProvisioner,
+        )
+        from cullis_connector.ambassador.shared.proxy_trust import (
+            TrustedProxiesAllowlist,
+        )
+        from cullis_connector.ambassador.shared.router import (
+            install_shared_ambassador,
+        )
+        from cullis_connector.ambassador.shared.wire import (
+            bootstrap_cookie_secret,
+        )
+        from cullis_connector.identity.store import (
+            CERT_FILENAME, KEY_FILENAME, _identity_dir,
+        )
+    except ImportError:
+        log.exception(
+            "shared Ambassador module import failed; skipping mount",
+        )
+        return
+
+    identity_dir = _identity_dir(config.config_dir)
+    cert_path = identity_dir / CERT_FILENAME
+    key_path = identity_dir / KEY_FILENAME
+    if not cert_path.exists() or not key_path.exists():
+        log.warning(
+            "shared Ambassador install skipped: identity files missing at %s",
+            identity_dir,
+        )
+        return
+
+    mastio_url = settings.mastio_url or config.site_url
+    if not mastio_url:
+        log.warning(
+            "shared Ambassador install skipped: neither "
+            "CULLIS_FRONTDESK_MASTIO_URL nor site_url is set",
+        )
+        return
+
+    cookie_secret = bootstrap_cookie_secret(config.config_dir)
+    trusted = TrustedProxiesAllowlist.from_cidrs(settings.trusted_proxies_cidrs)
+
+    # httpx client carrying the Ambassador's own mTLS cert. The Mastio
+    # endpoint also wants DPoP — for v0.1 we lean on Mastio's existing
+    # auth path: when the request arrives with an mTLS-bound client
+    # cert + the SDK access token, Mastio accepts it. The Ambassador
+    # caches its own access token via the SDK in v0.2; for now each
+    # CSR call rebuilds the SDK client (same trade-off as the per-user
+    # CullisClient in shared/router.py).
+    http = httpx.AsyncClient(
+        cert=(str(cert_path), str(key_path)),
+        verify=config.verify_arg,
+        timeout=httpx.Timeout(15.0),
+    )
+    app.state.shared_ambassador_http = http  # keep alive for app lifetime
+    transport = HttpxMastioCsrTransport(http=http, base_url=mastio_url)
+
+    cache = UserCredentialCache()
+    provisioner = UserProvisioner(mastio=transport, cache=cache)
+
+    install_shared_ambassador(
+        app,
+        cookie_secret=cookie_secret,
+        trusted_proxies=trusted,
+        org_id=settings.org_id,
+        trust_domain=settings.trust_domain,
+        provisioner=provisioner,
+        cookie_ttl_seconds=settings.cookie_ttl_seconds,
+        site_url=mastio_url,
+    )
+    log.info(
+        "shared Ambassador mounted: org=%s td=%s mastio=%s ttl=%ds",
+        settings.org_id, settings.trust_domain,
+        mastio_url, settings.cookie_ttl_seconds,
     )
 
 

--- a/tests/connector/test_ambassador_shared_wire.py
+++ b/tests/connector/test_ambassador_shared_wire.py
@@ -1,0 +1,144 @@
+"""Tests for the shared-mode bootstrap helpers (ADR-021 PR4c).
+
+Pure unit coverage of ``cullis_connector/ambassador/shared/wire.py``:
+cookie-secret bootstrap + env-var validation. The full end-to-end
+wiring through ``web.py`` lives in PR5's sandbox smoke.
+"""
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+
+from cullis_connector.ambassador.shared.wire import (
+    COOKIE_SECRET_FILENAME,
+    DEFAULT_COOKIE_TTL,
+    DEFAULT_TRUSTED_PROXIES,
+    ENV_COOKIE_TTL,
+    ENV_MASTIO_URL,
+    ENV_MODE,
+    ENV_ORG_ID,
+    ENV_TRUST_DOMAIN,
+    ENV_TRUSTED_PROXIES,
+    SECRET_LEN_BYTES,
+    bootstrap_cookie_secret,
+    shared_mode_settings_from_env,
+)
+
+
+# ── bootstrap_cookie_secret (4 tests) ─────────────────────────────
+
+
+def test_bootstrap_generates_on_first_call(tmp_path):
+    secret = bootstrap_cookie_secret(tmp_path)
+    assert len(secret) == SECRET_LEN_BYTES
+    assert (tmp_path / COOKIE_SECRET_FILENAME).exists()
+
+
+def test_bootstrap_reuses_existing(tmp_path):
+    a = bootstrap_cookie_secret(tmp_path)
+    b = bootstrap_cookie_secret(tmp_path)
+    assert a == b
+
+
+def test_bootstrap_regenerates_if_corrupted(tmp_path):
+    bootstrap_cookie_secret(tmp_path)
+    (tmp_path / COOKIE_SECRET_FILENAME).write_bytes(b"too-short")
+    fresh = bootstrap_cookie_secret(tmp_path)
+    assert len(fresh) == SECRET_LEN_BYTES
+    assert fresh != b"too-short"
+
+
+def test_bootstrap_file_mode_0600(tmp_path):
+    bootstrap_cookie_secret(tmp_path)
+    mode = os.stat(tmp_path / COOKIE_SECRET_FILENAME).st_mode & 0o777
+    assert mode == stat.S_IRUSR | stat.S_IWUSR  # 0o600
+
+
+# ── shared_mode_settings_from_env (8 tests) ───────────────────────
+
+
+def test_settings_default_is_disabled():
+    s = shared_mode_settings_from_env(env={})
+    assert s.enabled is False
+
+
+def test_settings_single_mode_explicitly_disabled():
+    s = shared_mode_settings_from_env(env={ENV_MODE: "single"})
+    assert s.enabled is False
+
+
+def test_settings_shared_happy_path():
+    s = shared_mode_settings_from_env(env={
+        ENV_MODE: "shared",
+        ENV_ORG_ID: "acme",
+        ENV_TRUST_DOMAIN: "acme.test",
+    })
+    assert s.enabled is True
+    assert s.org_id == "acme"
+    assert s.trust_domain == "acme.test"
+    assert s.cookie_ttl_seconds == DEFAULT_COOKIE_TTL
+    assert s.trusted_proxies_cidrs == tuple(
+        c.strip() for c in DEFAULT_TRUSTED_PROXIES.split(",")
+    )
+
+
+def test_settings_missing_org_id_raises():
+    with pytest.raises(ValueError, match=ENV_ORG_ID):
+        shared_mode_settings_from_env(env={
+            ENV_MODE: "shared",
+            ENV_TRUST_DOMAIN: "acme.test",
+        })
+
+
+def test_settings_missing_trust_domain_raises():
+    with pytest.raises(ValueError, match=ENV_TRUST_DOMAIN):
+        shared_mode_settings_from_env(env={
+            ENV_MODE: "shared",
+            ENV_ORG_ID: "acme",
+        })
+
+
+def test_settings_custom_proxies_and_ttl():
+    s = shared_mode_settings_from_env(env={
+        ENV_MODE: "shared",
+        ENV_ORG_ID: "acme",
+        ENV_TRUST_DOMAIN: "acme.test",
+        ENV_TRUSTED_PROXIES: "10.0.0.0/8, 192.168.0.0/16",
+        ENV_COOKIE_TTL: "1800",
+        ENV_MASTIO_URL: "https://mastio.acme.test:9443/",
+    })
+    assert s.trusted_proxies_cidrs == ("10.0.0.0/8", "192.168.0.0/16")
+    assert s.cookie_ttl_seconds == 1800
+    assert s.mastio_url == "https://mastio.acme.test:9443"  # trailing slash stripped
+
+
+def test_settings_invalid_ttl_raises():
+    with pytest.raises(ValueError, match=ENV_COOKIE_TTL):
+        shared_mode_settings_from_env(env={
+            ENV_MODE: "shared",
+            ENV_ORG_ID: "acme",
+            ENV_TRUST_DOMAIN: "acme.test",
+            ENV_COOKIE_TTL: "0",
+        })
+
+
+def test_settings_non_int_ttl_raises():
+    with pytest.raises(ValueError, match=ENV_COOKIE_TTL):
+        shared_mode_settings_from_env(env={
+            ENV_MODE: "shared",
+            ENV_ORG_ID: "acme",
+            ENV_TRUST_DOMAIN: "acme.test",
+            ENV_COOKIE_TTL: "not-an-int",
+        })
+
+
+def test_settings_empty_proxies_raises():
+    with pytest.raises(ValueError, match=ENV_TRUSTED_PROXIES):
+        shared_mode_settings_from_env(env={
+            ENV_MODE: "shared",
+            ENV_ORG_ID: "acme",
+            ENV_TRUST_DOMAIN: "acme.test",
+            ENV_TRUSTED_PROXIES: " , , ",
+        })


### PR DESCRIPTION
## Summary

Closes the wiring gap left by PR4b (#417). Mounts the shared-mode router on the Connector dashboard when \`AMBASSADOR_MODE=shared\`. Default \`single\` keeps the laptop topology unchanged.

After this PR, a Frontdesk container can be deployed by setting four env vars + having an enrolled identity:

\`\`\`bash
docker run \
  -e AMBASSADOR_MODE=shared \
  -e CULLIS_FRONTDESK_ORG_ID=acme \
  -e CULLIS_FRONTDESK_TRUST_DOMAIN=acme.test \
  -e CULLIS_FRONTDESK_MASTIO_URL=https://mastio.acme.test:9443 \
  -v /opt/cullis/identity:/root/.cullis \
  cullis/connector:latest dashboard --profile prod
\`\`\`

Behind a reverse proxy doing SAML/OIDC and forwarding \`X-Forwarded-User\`.

## What ships

\`cullis_connector/ambassador/shared/wire.py\`:

- \`bootstrap_cookie_secret(config_dir)\` — 32 random bytes at \`<config_dir>/cookie.secret\` mode 0600. Same pattern as \`local.token\` from single mode.
- \`shared_mode_settings_from_env()\` — typed dataclass parsed from env. Six env vars (one optional). Required fields raise loud at startup if missing.

\`cullis_connector/web.py\`:

- \`_maybe_install_shared_ambassador()\` composes \`httpx.AsyncClient\` (mTLS via Connector's enrolled cert+key on disk) + \`HttpxMastioCsrTransport\` + \`UserCredentialCache\` + \`UserProvisioner\` + \`TrustedProxiesAllowlist\`, then calls \`install_shared_ambassador\`.
- \`_dashboard_lifespan\` branches on \`shared_settings.enabled\`: shared mode replaces the single-mode mount, no double-install.

## Out of scope (deferred)

- End-to-end \`build_app\` test exercising the wire in a real lifespan. PR5 sandbox smoke covers this with two real users.
- Ambassador's own DPoP token caching for the Mastio CSR call. v0.1 builds the SDK client per CSR — fine for one provisioning per user per hour.
- Auto-renewal of the cookie secret on rotation policy. Operator rotates manually for v0.1.

## Tests

\`tests/connector/test_ambassador_shared_wire.py\` — 13 unit tests:

- 4 \`bootstrap_cookie_secret\` (generate, reuse, regenerate-if-corrupted, file mode 0600)
- 9 \`shared_mode_settings_from_env\` (default disabled, explicit single, happy path, missing org_id, missing trust_domain, custom proxies+ttl+mastio_url, invalid TTL, non-int TTL, empty proxies list)

## Test plan

- [x] \`pytest tests/connector/test_ambassador_shared_wire.py -n auto --dist=loadfile\` → 13/13 in 4.4s
- [x] \`pytest tests/connector/ -n auto --dist=loadfile --ignore=tests/connector/test_desktop_app.py --ignore=tests/connector/test_profile_runtime_switch.py\` → 378/378 (no regression on existing connector tests)
- [ ] CI green (full pytest + smoke gate)
- [ ] PR5 sandbox smoke validates the end-to-end mount path

## Related

- PR4b (#417) shared-mode router (this PR is its wire)
- ADR-021 §5 (cookie secret bootstrap), §6 (X-Forwarded-User trust)