### PR TITLE
fix(dashboard): Court login form overflow on wide viewports

### DIFF
--- a/app/dashboard/templates/login.html
+++ b/app/dashboard/templates/login.html
@@ -78,10 +78,10 @@
     <span class="w-1.5 h-1.5 rounded-full bg-[#00e5c7]"></span> transport: tls 1.3
 </div>
 
-<main class="w-full max-w-[920px] relative z-10 grid grid-cols-1 lg:grid-cols-[1.05fr_1fr] gap-8 px-6">
+<main class="w-full max-w-[920px] min-w-0 relative z-10 grid grid-cols-1 lg:grid-cols-[1.05fr_1fr] gap-8 px-6">
 
     <!-- Left: protocol banner -->
-    <section class="flex flex-col justify-between py-4 rise d1">
+    <section class="flex flex-col justify-between py-4 rise d1 min-w-0">
         <div>
             <div class="flex items-center gap-3 mb-8">
                 <img src="/static/cullis-mark.svg" alt="" style="height:42px;width:auto;filter:drop-shadow(0 0 14px rgba(0,229,199,0.35));">
@@ -117,7 +117,7 @@
     </section>
 
     <!-- Right: auth card -->
-    <section class="rise d2">
+    <section class="rise d2 min-w-0">
         <div class="relative border hairline rounded-md bg-[#070c14]/80 backdrop-blur-sm p-7" style="box-shadow: 0 30px 80px -40px rgba(0,229,199,0.18), inset 0 1px 0 rgba(255,255,255,0.03);">
 
             <!-- Header strip -->


### PR DESCRIPTION
## Symptom

On viewports wider than ~1100px the Court admin login renders with the auth card overflowing past the right edge: the AUTHENTICATE button is full-bleed huge, the password field extends off-screen, the bottom marquee status tape leaks horizontally. At first glance the form's narrow visible portion looks like an intentional retro-terminal cropping effect — it isn't, the right side is just gone past the viewport.

## Cause

The main container is a CSS grid:

\`\`\`html
<main class="... grid grid-cols-1 lg:grid-cols-[1.05fr_1fr] gap-8 px-6">
\`\`\`

The right column hosts a horizontal marquee (\`whitespace-nowrap\` + many \`<span>\` in a flex row) inside an \`overflow-hidden\` wrapper.

CSS grid items default to \`min-width: auto\`, which means a child whose intrinsic content is wider than the track will stretch the track itself — \`fr\` does not override that. The marquee's intrinsic width is huge (it's the same content repeated twice for a seamless animation loop), so the right grid track grew to fit it, dragging the form + button + footer past the viewport. The wrapper's \`overflow-hidden\` was effectively a no-op because the wrapper itself was sized to the content.

## Fix

Add \`min-w-0\` to both grid items and to the \`<main>\`:

\`\`\`diff
-<main class="w-full max-w-[920px] relative z-10 grid ...">
+<main class="w-full max-w-[920px] min-w-0 relative z-10 grid ...">
-    <section class="flex flex-col justify-between py-4 rise d1">
+    <section class="flex flex-col justify-between py-4 rise d1 min-w-0">
-    <section class="rise d2">
+    <section class="rise d2 min-w-0">
\`\`\`

\`min-w-0\` lets the \`fr\` track shrink back to its share. The marquee wrapper's \`overflow-hidden\` then actually clips, because its column is properly bounded.

## Test plan

- [ ] CI green
- [ ] Manual: spin sandbox, hit Court login at wide viewport (~1500px), confirm form+button+marquee all fit inside the auth card; password field is the visible-cropped narrow input it was supposed to be
- [ ] Manual: viewport <\`lg\` breakpoint stacks columns (mobile path) is unaffected