### PR TITLE
feat(spa): wire IdentityBadge to shared-mode /api/session/whoami (Task #6)

### DIFF
--- a/frontend/cullis-chat/mock/ambassador.mjs
+++ b/frontend/cullis-chat/mock/ambassador.mjs
@@ -152,12 +152,27 @@ const server = createServer(async (req, res) => {
   }
 
   if (req.method === 'GET' && pathname === '/v1/whoami') {
+    // Single mode legacy shape — kept for back-compat. Shared mode
+    // uses /api/session/whoami (below) with the cookie-payload shape.
     jsonResponse(res, 200, {
       spiffe_id: 'spiffe://demo.test/demo/user/mario',
       principal_type: 'user',
       name: 'mario',
       org: 'demo',
       trust_domain: 'demo.test',
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && pathname === '/api/session/whoami') {
+    // ADR-021 shared-mode shape: cookie payload as the Ambassador
+    // hands it back. The Astro `/api/session/whoami` route translates
+    // this into the ADR-020 principal shape the IdentityBadge wants.
+    jsonResponse(res, 200, {
+      principal_id: 'demo.test/demo/user/mario',
+      sub: 'mario@demo.test',
+      org: 'demo',
+      exp: Math.floor(Date.now() / 1000) + 3600,
     });
     return;
   }

--- a/frontend/cullis-chat/src/components/IdentityBadge.tsx
+++ b/frontend/cullis-chat/src/components/IdentityBadge.tsx
@@ -5,7 +5,12 @@ import type { Principal } from '../lib/types';
 
 /**
  * Live identity badge in the TopBar. Reads the principal from
- * `/api/session/whoami` (which forwards to Ambassador `/v1/whoami`).
+ * the local Astro `/api/session/whoami` route, which forwards to
+ * the Ambassador's shared-mode `/api/session/whoami` endpoint and
+ * translates the cookie-payload shape into the ADR-020 principal
+ * shape we render here. Single mode falls through to a "local"
+ * placeholder so the badge still shows something useful.
+ *
  * v0.1 shape (ADR-020): principal_type display em + name.
  */
 export default function IdentityBadge() {

--- a/frontend/cullis-chat/src/pages/api/session/whoami.ts
+++ b/frontend/cullis-chat/src/pages/api/session/whoami.ts
@@ -7,13 +7,13 @@ export const prerender = false;
 /**
  * GET /api/session/whoami
  *
- * Returns the current principal as resolved by the Ambassador. The SPA
- * uses this to populate the IdentityBadge in the TopBar.
+ * Returns the current principal for the IdentityBadge in the TopBar.
  *
- * Implementation: read the Bearer cookie, forward to `/v1/whoami` on
- * the Ambassador, return the result verbatim. No token leaves the server.
+ * In **shared mode** (ADR-021) the Ambassador exposes
+ * `/api/session/whoami` with the cookie payload shape
+ * `{ principal_id, sub, org, exp }`. We translate it to the ADR-020
+ * shape the IdentityBadge consumes:
  *
- * Shape (ADR-020):
  *   {
  *     spiffe_id: "spiffe://acme.test/acme/user/mario",
  *     principal_type: "user" | "agent" | "workload",
@@ -22,11 +22,45 @@ export const prerender = false;
  *     trust_domain: "acme.test"
  *   }
  *
- * If the Ambassador does not yet expose /v1/whoami (Step 1 PR #406 is
- * principal-type-agnostic), we fall back to a minimal local-mode shape
- * inferred from the configured profile name.
+ * In **single mode** the Ambassador has no whoami endpoint (it's a
+ * one-user dashboard, identity is the Connector profile). We return
+ * a local-shaped payload so the badge still renders.
  */
-export const GET: APIRoute = async ({ cookies }) => {
+type SharedWhoami = {
+  principal_id: string;
+  sub: string;
+  org: string;
+  exp: number;
+};
+
+function principalFromSharedPayload(body: SharedWhoami) {
+  // principal_id is `<trust-domain>/<org>/<principal-type>/<name>`
+  const parts = body.principal_id.split('/');
+  if (parts.length === 4) {
+    const [trust_domain, org, principal_type, name] = parts;
+    return {
+      spiffe_id: `spiffe://${body.principal_id}`,
+      principal_type,
+      name,
+      org,
+      trust_domain,
+      sub: body.sub,
+      source: 'shared',
+    };
+  }
+  // Malformed principal_id — surface what we have rather than crash.
+  return {
+    spiffe_id: null,
+    principal_type: 'user',
+    name: body.sub,
+    org: body.org,
+    trust_domain: null,
+    sub: body.sub,
+    source: 'shared-fallback',
+  };
+}
+
+export const GET: APIRoute = async ({ cookies, request }) => {
   const token = cookies.get(SESSION_COOKIE)?.value;
   if (!token) {
     return new Response(JSON.stringify({ ok: false, error: 'no_session' }), {
@@ -35,15 +69,34 @@ export const GET: APIRoute = async ({ cookies }) => {
     });
   }
 
+  // Forward the browser's cookies to the Ambassador so the
+  // shared-mode `cullis_session` cookie reaches the server. The
+  // Bearer is the local-token for single mode (kept for back-compat).
+  const fwdHeaders: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const fwdCookie = request.headers.get('cookie');
+  if (fwdCookie) {
+    fwdHeaders.Cookie = fwdCookie;
+  }
+
   try {
-    const upstream = await fetch(`${AMBASSADOR_URL}/v1/whoami`, {
+    const upstream = await fetch(`${AMBASSADOR_URL}/api/session/whoami`, {
       method: 'GET',
-      headers: { Authorization: `Bearer ${token}` },
+      headers: fwdHeaders,
     });
 
-    if (upstream.status === 404) {
-      // Ambassador does not expose /v1/whoami yet — return a local shape
-      // so the badge can still render something useful.
+    if (upstream.ok) {
+      const body = (await upstream.json()) as SharedWhoami;
+      return new Response(
+        JSON.stringify({ ok: true, principal: principalFromSharedPayload(body) }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (upstream.status === 401 || upstream.status === 404) {
+      // Single mode (no /api/session/whoami) or no shared cookie set.
+      // Fall back to a local shape so the badge still renders.
       return new Response(
         JSON.stringify({
           ok: true,


### PR DESCRIPTION
## Summary

Closes Task #6. The SPA's Astro proxy at \`/api/session/whoami\` was calling Ambassador \`/v1/whoami\` — an endpoint that does **not** exist in either single mode or shared mode. The IdentityBadge silently fell back to a \`user · local\` placeholder for every shared-mode user, which would have been the most visible regression in the demo video.

## Fix

Shared mode (ADR-021 PR4b) exposes \`/api/session/whoami\` returning the cookie payload shape:

\`\`\`json
{ "principal_id": "acme.test/acme/user/mario",
  "sub": "mario@acme.it",
  "org": "acme",
  "exp": 1730000000 }
\`\`\`

The Astro route now:

1. Forwards the browser cookies (so \`cullis_session\` reaches the Ambassador) alongside the legacy Bearer.
2. Translates the shared-mode payload into the ADR-020 principal shape the badge consumes:
   \`\`\`json
   { "spiffe_id": "spiffe://acme.test/acme/user/mario",
     "principal_type": "user",
     "name": "mario",
     "org": "acme",
     "trust_domain": "acme.test",
     "source": "shared" }
   \`\`\`
3. On 401/404 falls through to the existing \`local\` placeholder so single mode still renders the badge.

## Mock + tests

\`mock/ambassador.mjs\` gains an \`/api/session/whoami\` handler so the Playwright suite exercises the new path. \`/v1/whoami\` is kept for back-compat in case anything else hits it.

## Test plan

- [x] \`npm run build\` → green (no TS errors)
- [ ] CI Playwright suite green
- [ ] Manual recording sandbox: confirm IdentityBadge renders \`user · mario\` for Mario and \`user · anna\` for Anna's incognito tab