### PR TITLE
feat(spa): wire IdentityBadge to shared-mode whoami + 3 UX fixes

### DIFF
--- a/frontend/cullis-chat/mock/ambassador.mjs
+++ b/frontend/cullis-chat/mock/ambassador.mjs
@@ -64,23 +64,23 @@ function pickFixture(messages) {
 const FIXTURES = {
   plain: {
     answer:
-      "Ciao. Sono **Cullis Chat**, l'interfaccia di Cullis Frontdesk. " +
-      "Posso rispondere a domande operative sui dati della tua organizzazione " +
-      "tramite i tool MCP collegati. Prova a chiedermi qualcosa sulle compliance, " +
-      'sulle sessioni attive, o sui training GDPR.',
+      "Hi. I'm **Cullis Chat**, the Cullis Frontdesk interface. " +
+      "I can answer operational questions about your organisation's data " +
+      "through the connected MCP tools. Try asking me about compliance, " +
+      'active sessions, or GDPR training.',
     tools: [],
   },
   tool: {
     answer:
-      "Sì. **Anna Bianchi** ha completato il training GDPR il *2025-09-12* (fonte: " +
-      "tabella `gdpr_training_records` sul DB compliance).\n\n" +
+      "Yes. **Anna Bianchi** completed her GDPR training on *2025-09-12* (source: " +
+      "the `gdpr_training_records` table in the compliance DB).\n\n" +
       "```sql\n" +
       "select employee, completion_date\n" +
       "  from gdpr_training_records\n" +
       "  where employee = 'Anna Bianchi';\n" +
       "```\n\n" +
-      'Lo scan completo dei dipendenti dell\'unità Sales mostra **3 ritardatari** ' +
-      'oltre la scadenza di 12 mesi. Posso aprirti il dettaglio se vuoi.',
+      "A full scan across the Sales team shows **3 employees** past " +
+      'the 12-month deadline. I can pull up the details if you want.',
     tools: [
       { name: 'postgres.query', latency_ms: 286 },
     ],
@@ -101,14 +101,14 @@ const FIXTURES = {
   },
   sessions: {
     answer:
-      'Risultano **4 sessioni attive** nelle ultime 24h:\n\n' +
-      '| Agente | Org | Apertura | Stato |\n' +
+      '**4 active sessions** in the last 24h:\n\n' +
+      '| Agent | Org | Opened | State |\n' +
       '|---|---|---|---|\n' +
       '| `payments-bot` | acme | 2026-05-04 09:12 | live |\n' +
       '| `procurement-bot` | acme | 2026-05-04 10:48 | live |\n' +
       '| `risk-monitor` | acme | 2026-05-04 11:03 | live |\n' +
       '| `mario-laptop` | acme | 2026-05-04 12:21 | idle |\n\n' +
-      'Ogni riga è ancorata a un trace_id verificabile in audit chain.',
+      'Each row is anchored to a trace_id verifiable in the audit chain.',
     tools: [
       { name: 'mastio.list_sessions', latency_ms: 142 },
     ],

--- a/frontend/cullis-chat/mock/ambassador.mjs
+++ b/frontend/cullis-chat/mock/ambassador.mjs
@@ -152,12 +152,27 @@ const server = createServer(async (req, res) => {
   }
 
   if (req.method === 'GET' && pathname === '/v1/whoami') {
+    // Single mode legacy shape — kept for back-compat. Shared mode
+    // uses /api/session/whoami (below) with the cookie-payload shape.
     jsonResponse(res, 200, {
       spiffe_id: 'spiffe://demo.test/demo/user/mario',
       principal_type: 'user',
       name: 'mario',
       org: 'demo',
       trust_domain: 'demo.test',
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && pathname === '/api/session/whoami') {
+    // ADR-021 shared-mode shape: cookie payload as the Ambassador
+    // hands it back. The Astro `/api/session/whoami` route translates
+    // this into the ADR-020 principal shape the IdentityBadge wants.
+    jsonResponse(res, 200, {
+      principal_id: 'demo.test/demo/user/mario',
+      sub: 'mario@demo.test',
+      org: 'demo',
+      exp: Math.floor(Date.now() / 1000) + 3600,
     });
     return;
   }

--- a/frontend/cullis-chat/src/components/IdentityBadge.tsx
+++ b/frontend/cullis-chat/src/components/IdentityBadge.tsx
@@ -5,7 +5,12 @@ import type { Principal } from '../lib/types';
 
 /**
  * Live identity badge in the TopBar. Reads the principal from
- * `/api/session/whoami` (which forwards to Ambassador `/v1/whoami`).
+ * the local Astro `/api/session/whoami` route, which forwards to
+ * the Ambassador's shared-mode `/api/session/whoami` endpoint and
+ * translates the cookie-payload shape into the ADR-020 principal
+ * shape we render here. Single mode falls through to a "local"
+ * placeholder so the badge still shows something useful.
+ *
  * v0.1 shape (ADR-020): principal_type display em + name.
  */
 export default function IdentityBadge() {

--- a/frontend/cullis-chat/src/components/SidebarLeft.astro
+++ b/frontend/cullis-chat/src/components/SidebarLeft.astro
@@ -12,6 +12,9 @@
 <aside class="sidebar-left" aria-label="Conversation history">
   <header class="sl-head">
     <span class="eyebrow">conversations</span>
+    <a class="sl-new" href="/" aria-label="Start a new chat" title="New chat">
+      <span aria-hidden="true">+</span> new
+    </a>
   </header>
 
   <div class="sl-empty">
@@ -39,6 +42,31 @@
   .sl-head {
     padding: 1.25rem 1.25rem 0.9rem;
     border-bottom: 1px solid var(--border-subtle);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  /* "+ new" — full-page navigation to / so React island state resets
+     cleanly. v0.1 has no server-side history; v0.5 will swap this for
+     a real "spawn new conversation" action that also persists. */
+  .sl-new {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: 0.25rem 0.55rem;
+    border: 1px solid var(--border-medium);
+    border-left: 2px solid var(--accent-cyan);
+    transition: color var(--t-base) ease, border-color var(--t-base) ease;
+  }
+
+  .sl-new:hover, .sl-new:focus-visible {
+    color: var(--accent-cyan);
+    border-color: var(--accent-cyan);
   }
 
   .sl-empty {

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -154,6 +154,15 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     opacity: 0.7;
   }
 
+  /* Native <option> rendering ignores the parent <select> background
+     in Chromium/WebKit, leaving the dropdown panel white-on-white on
+     dark themes. Force the option styling explicitly. Firefox honours
+     this; Safari uses the system theme regardless and we accept that. */
+  :global(.model-picker option) {
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+  }
+
   /* Right — status + identity badge */
   .topbar-right {
     display: flex;

--- a/frontend/cullis-chat/src/pages/api/session/whoami.ts
+++ b/frontend/cullis-chat/src/pages/api/session/whoami.ts
@@ -7,13 +7,13 @@ export const prerender = false;
 /**
  * GET /api/session/whoami
  *
- * Returns the current principal as resolved by the Ambassador. The SPA
- * uses this to populate the IdentityBadge in the TopBar.
+ * Returns the current principal for the IdentityBadge in the TopBar.
  *
- * Implementation: read the Bearer cookie, forward to `/v1/whoami` on
- * the Ambassador, return the result verbatim. No token leaves the server.
+ * In **shared mode** (ADR-021) the Ambassador exposes
+ * `/api/session/whoami` with the cookie payload shape
+ * `{ principal_id, sub, org, exp }`. We translate it to the ADR-020
+ * shape the IdentityBadge consumes:
  *
- * Shape (ADR-020):
  *   {
  *     spiffe_id: "spiffe://acme.test/acme/user/mario",
  *     principal_type: "user" | "agent" | "workload",
@@ -22,11 +22,45 @@ export const prerender = false;
  *     trust_domain: "acme.test"
  *   }
  *
- * If the Ambassador does not yet expose /v1/whoami (Step 1 PR #406 is
- * principal-type-agnostic), we fall back to a minimal local-mode shape
- * inferred from the configured profile name.
+ * In **single mode** the Ambassador has no whoami endpoint (it's a
+ * one-user dashboard, identity is the Connector profile). We return
+ * a local-shaped payload so the badge still renders.
  */
-export const GET: APIRoute = async ({ cookies }) => {
+type SharedWhoami = {
+  principal_id: string;
+  sub: string;
+  org: string;
+  exp: number;
+};
+
+function principalFromSharedPayload(body: SharedWhoami) {
+  // principal_id is `<trust-domain>/<org>/<principal-type>/<name>`
+  const parts = body.principal_id.split('/');
+  if (parts.length === 4) {
+    const [trust_domain, org, principal_type, name] = parts;
+    return {
+      spiffe_id: `spiffe://${body.principal_id}`,
+      principal_type,
+      name,
+      org,
+      trust_domain,
+      sub: body.sub,
+      source: 'shared',
+    };
+  }
+  // Malformed principal_id — surface what we have rather than crash.
+  return {
+    spiffe_id: null,
+    principal_type: 'user',
+    name: body.sub,
+    org: body.org,
+    trust_domain: null,
+    sub: body.sub,
+    source: 'shared-fallback',
+  };
+}
+
+export const GET: APIRoute = async ({ cookies, request }) => {
   const token = cookies.get(SESSION_COOKIE)?.value;
   if (!token) {
     return new Response(JSON.stringify({ ok: false, error: 'no_session' }), {
@@ -35,15 +69,34 @@ export const GET: APIRoute = async ({ cookies }) => {
     });
   }
 
+  // Forward the browser's cookies to the Ambassador so the
+  // shared-mode `cullis_session` cookie reaches the server. The
+  // Bearer is the local-token for single mode (kept for back-compat).
+  const fwdHeaders: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+  };
+  const fwdCookie = request.headers.get('cookie');
+  if (fwdCookie) {
+    fwdHeaders.Cookie = fwdCookie;
+  }
+
   try {
-    const upstream = await fetch(`${AMBASSADOR_URL}/v1/whoami`, {
+    const upstream = await fetch(`${AMBASSADOR_URL}/api/session/whoami`, {
       method: 'GET',
-      headers: { Authorization: `Bearer ${token}` },
+      headers: fwdHeaders,
     });
 
-    if (upstream.status === 404) {
-      // Ambassador does not expose /v1/whoami yet — return a local shape
-      // so the badge can still render something useful.
+    if (upstream.ok) {
+      const body = (await upstream.json()) as SharedWhoami;
+      return new Response(
+        JSON.stringify({ ok: true, principal: principalFromSharedPayload(body) }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+
+    if (upstream.status === 401 || upstream.status === 404) {
+      // Single mode (no /api/session/whoami) or no shared cookie set.
+      // Fall back to a local shape so the badge still renders.
       return new Response(
         JSON.stringify({
           ok: true,


### PR DESCRIPTION
## What does this PR do?

Four small SPA changes on top of ADR-019 v0.1 / ADR-021 shared mode.

### 1. `feat(spa): wire IdentityBadge to shared-mode /api/session/whoami` (Task #6)

Main commit. The Astro proxy was calling Ambassador `/v1/whoami`, which exists in neither single nor shared mode, so every shared-mode user fell back to the `user · local` placeholder.

Shared mode (ADR-021 PR4b) exposes `/api/session/whoami` returning the cookie payload `{ principal_id, sub, org, exp }`. The proxy now:
1. Forwards browser cookies (so `cullis_session` reaches Ambassador) alongside the legacy Bearer header.
2. Translates the shared-mode payload into the ADR-020 principal shape `IdentityBadge` consumes (`spiffe_id`, `principal_type`, `name`, `org`, `trust_domain`).
3. Falls back to the existing `local` placeholder on 401/404 so single mode still renders.

`mock/ambassador.mjs` gains an `/api/session/whoami` handler so Playwright exercises the new path. `/v1/whoami` is left in place for back-compat.

### 2. `feat(spa): + new chat button in sidebar header`

v0.1 has no server-side conversation history (ADR-019 §4 → v0.5), so the only way to start fresh was a manual reload. Added a small monospace `+ new` link in the sidebar header that navigates to `/`. Full-page nav resets the React island, clears the surface, keeps the cookie session and model preference. v0.5 will swap this for a real spawn-conversation that also persists.

### 3. `fix(spa): readable model picker dropdown options on dark theme`

Native `<option>` rendering ignores parent `<select>` background in Chromium/WebKit, so the dropdown was white-on-white on the dark theme. Forced via a global rule on `.model-picker option`. Firefox honours it; Safari uses the system theme regardless and we accept that.

### 4. `i18n(spa-mock): translate fixture answers to English`

The mock Ambassador shipped its three demo answers in Italian, which made the dev surface noticeable for non-Italian speakers and pinned the demo video / screenshots to one language. Plain, tool, and sessions fixtures now in English (xss was already English). Logic, fixture keys, and trigger regex unchanged.

## Checklist

- [x] Code is in English (comments, logs, docstrings)
- [x] Build green (`npm run build` in `frontend/cullis-chat`)
- [x] No secrets or credentials in the code
- [ ] Tests added for new functionality (mock-only changes; Playwright path exercised but no new test case)