### PR TITLE
feat(connector): restyle dashboard tokens to cullis.io design system

### DIFF
--- a/cullis_connector/static/style.css
+++ b/cullis_connector/static/style.css
@@ -30,16 +30,20 @@
   --success:        #3ee089;
   --warning:        #f0a500;
 
-  /* Typography — dashboard registry (Chakra Petch brand lockup + DM Sans body + JetBrains Mono)
-     plus Instrument Serif editorial accent to bridge the site tone. */
-  --font-display:   'Chakra Petch', sans-serif;
+  /* Typography — aligned with cullis.io site + Cullis Chat SPA tokens
+     (ADR-019 rev 3 Phase 6.5, 2026-05-05). Display = Instrument Serif,
+     body = Satoshi, mono = DM Mono. Chakra Petch demoted to logo lockup
+     only via --font-brand (used by .brand-name). --font-editorial kept as
+     alias for backward compat with classes that explicitly request it. */
+  --font-display:   'Instrument Serif', Georgia, serif;
   --font-editorial: 'Instrument Serif', Georgia, serif;
-  --font-body:      'DM Sans', system-ui, sans-serif;
-  --font-mono:      'JetBrains Mono', 'Fira Code', monospace;
+  --font-body:      'Satoshi', system-ui, sans-serif;
+  --font-mono:      'DM Mono', 'SF Mono', Menlo, monospace;
+  --font-brand:     'Chakra Petch', sans-serif;
 
-  --radius-sm: 4px;
-  --radius-md: 6px;
-  --radius-lg: 10px;
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
 
   --shadow-glow: 0 0 24px rgba(0, 229, 199, 0.12);
 }
@@ -137,7 +141,7 @@ body::after {
 }
 
 .brand-name {
-  font-family: var(--font-display);
+  font-family: var(--font-brand);
   font-weight: 600;
   font-size: 14px;
   letter-spacing: 0.18em;
@@ -152,7 +156,7 @@ body::after {
 }
 
 .brand-role-chip {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.22em;
@@ -195,7 +199,7 @@ body::after {
   border-radius: var(--radius-sm);
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--border-subtle);
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -305,7 +309,7 @@ body::after {
 }
 
 .step-label {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -360,7 +364,7 @@ body::after {
 }
 
 .panel-eyebrow {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.22em;
   text-transform: uppercase;
@@ -396,7 +400,7 @@ body::after {
 .field { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
 
 .field-label {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -443,7 +447,7 @@ body::after {
   gap: 8px;
   padding: 11px 20px;
   border-radius: var(--radius-sm);
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 12px;
   font-weight: 600;
   letter-spacing: 0.12em;
@@ -669,7 +673,7 @@ body::after {
 }
 
 .urlbox-eyebrow {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -698,7 +702,7 @@ body::after {
   border: 1px solid var(--border-default);
   background: transparent;
   color: var(--text-secondary);
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   text-transform: uppercase;
   cursor: pointer;
   transition: all 150ms ease;
@@ -773,7 +777,7 @@ body::after {
 .identity-row:last-child { border-bottom: none; }
 
 .identity-k {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 10px;
   letter-spacing: 0.18em;
   text-transform: uppercase;
@@ -826,7 +830,7 @@ body::after {
 }
 
 .ide-card-name {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 12px;
   letter-spacing: 0.1em;
   font-weight: 600;
@@ -852,7 +856,7 @@ body::after {
 .toggle-meta { flex: 1; min-width: 0; }
 
 .toggle-title {
-    font-family: var(--font-display);
+    font-family: var(--font-mono);
     font-size: 14px;
     font-weight: 600;
     color: var(--text-primary);
@@ -1000,7 +1004,7 @@ body::after {
 }
 
 .profile-name {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 16px;
   font-weight: 600;
   color: var(--text-primary);
@@ -1008,7 +1012,7 @@ body::after {
 }
 
 .profile-badge {
-  font-family: var(--font-display);
+  font-family: var(--font-mono);
   font-size: 9px;
   font-weight: 600;
   letter-spacing: 0.22em;

--- a/cullis_connector/templates/base.html
+++ b/cullis_connector/templates/base.html
@@ -6,7 +6,8 @@
     <title>{% block title %}Connector{% endblock %} — Cullis Connector</title>
     <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
     <link rel="stylesheet" href="/static/style.css">
-    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+    <link href="https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap" rel="stylesheet">
     <script src="/static/htmx.min.js" defer></script>
 </head>
 <body>


### PR DESCRIPTION
## What does this PR do?

ADR-019 rev 3 **Phase 6.5**. Brings the Connector dashboard at `:7777` into visual alignment with cullis.io and the Cullis Chat SPA.

Pre-condition for Phase 8 (Cullis Chat desktop installer): the installer wraps the Connector dashboard webview as the first-launch enrollment wizard, so the dashboard must look like the post-enrollment chat surface or the user sees two stylistically different apps at first launch.

## What was misaligned

| Surface | Display | Body | Mono | Radius |
|---|---|---|---|---|
| cullis.io site | Instrument Serif | Satoshi | DM Mono | 0 |
| Cullis Chat SPA | Instrument Serif | Satoshi | DM Mono | 0 |
| **Connector dashboard (before)** | Chakra Petch | DM Sans | JetBrains Mono | 4-10 px |
| **Connector dashboard (this PR)** | Instrument Serif | Satoshi | DM Mono | 0 |

The palette `#050508 + #00e5c7` was already shared across the three surfaces; only fonts and radius diverged.

## Changes

- `cullis_connector/static/style.css` `:root`: typography tokens swapped, radius all to 0, new `--font-brand: 'Chakra Petch'` for logo lockup only.
- All `var(--font-display)` usages in UI chrome (chips, badges, eyebrows, labels) switched to `var(--font-mono)`. Instrument Serif as a serif is for headings and italic accents; uppercase letterspaced labels use DM Mono per the cullis.io pattern (see `.btn`, `.scribble`, `.folio` in `site/src/styles/global.css`).
- `.brand-name` (the "Cullis" logo lockup) explicitly switched to `var(--font-brand)` so Chakra Petch survives in the one place that needs its personality.
- `cullis_connector/templates/base.html` font imports updated: drop DM Sans + JetBrains Mono, add DM Mono (Google) + Satoshi (Fontshare). Mirrors `frontend/cullis-chat/src/styles/tokens.css`.

Markup of the 6 Jinja templates (`base`, `setup`, `waiting`, `connected`, `mcp`, `profiles`) is untouched. Pure token swap. The `.toggle-switch border-radius: 12px` is left as-is because it is a functional UX pill shape, not a stylistic radius.

## Test plan

- [ ] Launch dashboard locally (`python -m cullis_connector dashboard --port 7777`), open `http://127.0.0.1:7777`
- [ ] Verify each template renders without layout regressions: `/setup`, `/waiting`, `/connected`, `/profiles`, `/mcp`
- [ ] Visual diff vs cullis.io and Cullis Chat SPA: same fonts, same zero-radius, same palette
- [ ] No console errors (font load, CSS parse)
- [ ] htmx interactions still work (button clicks, form submissions)

## Followups out of scope

- Phase 11: port `/setup`, `/waiting`, `/connected` into the Astro SPA so the Connector exposes only JSON. Single-stack frontend. Deferred until post-installer real-user feedback shows whether the wizard-in-webview pattern is a keeper.