### PR TITLE
feat(packaging): frontdesk container bundle (ADR-019 Phase 7)

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -1,0 +1,102 @@
+# Cullis Frontdesk — multi-user container bundle
+
+Deploys Cullis Chat as a corporate web app, identity-aware via SSO. One container per N concurrent users, audit attributed per user. Implements ADR-019 rev 3 Phase 7.
+
+```
+[browser Mario] ──┐
+[browser Anna]  ──┼─→ [nginx :8080] ──→ [Cullis Chat SPA] ──→ [Connector :7777, AMBASSADOR_MODE=shared]
+[browser Luca]  ──┘     ↑                                        ↓ DPoP+mTLS, per-user keys via UserPrincipalKMS
+                        SSO: oauth2-proxy + IDP                  ↓
+                        injects X-Forwarded-User             [Cullis Mastio cloud]
+```
+
+## Prerequisites
+
+1. **A reachable Mastio.** The Connector enrolls against it and forwards requests to its proxy + audit chain. Stand one up with `packaging/mastio-bundle/` if you do not already have one.
+2. **An invite code** issued by your Mastio admin (`/v1/admin/invites` on the Mastio dashboard).
+3. **Docker Compose v2.20+** for the bundle, plus the cullis-connector image (built once or pulled from `ghcr.io/cullis-security/cullis-connector`).
+
+## One-shot enrollment
+
+The bundle does not enroll the Connector for you. Run this once before `docker compose up`:
+
+```bash
+docker run --rm -it \
+  -v $(pwd)/connector_data:/root/.cullis \
+  ghcr.io/cullis-security/cullis-connector:latest \
+  enroll \
+    --site https://mastio.acme.local:9443 \
+    --code <INVITE_CODE_FROM_MASTIO_ADMIN> \
+    --profile frontdesk
+```
+
+This writes the cert + key + config to the local `connector_data/` directory. The bundle mounts that directory into the Connector container; subsequent `docker compose up` calls reuse the same identity.
+
+If you wipe `connector_data/`, you must re-enroll.
+
+## Bring the bundle up
+
+```bash
+cp frontdesk.env.example frontdesk.env
+# Edit frontdesk.env: set CULLIS_FRONTDESK_ORG_ID and CULLIS_FRONTDESK_TRUST_DOMAIN
+# to match what you registered on the Mastio.
+
+docker compose --env-file frontdesk.env up -d
+```
+
+The bundle exposes nginx on the host port from `FRONTDESK_HTTP_PORT` (default `8080`).
+
+## Smoke test (dev fake-SSO)
+
+The dev nginx (`nginx/default.conf`) reads a `?user=` query string the first time you load the page, maps it to a fake email, and injects `X-Forwarded-User`. Three demo users are pre-mapped: `mario`, `anna`, `luca`.
+
+```bash
+# Terminal 1: tail Connector logs while you click around.
+docker compose logs -f connector
+
+# Browser tab A:
+open http://localhost:8080?user=mario   # establishes the cullis_session cookie
+                                         # and the badge shows "user · mario"
+
+# Browser tab B (incognito so the cookie is fresh):
+open http://localhost:8080?user=anna   # different cookie, different audit attribution
+```
+
+Each chat message is signed by a per-user agent key (provisioned via `UserPrincipalKMS`, ADR-021 PR4a) and lands in Mastio's audit chain attributed to `acme.test/acme/user/mario` (or `…/anna`). The two tabs never see each other's history.
+
+## Verify per-user audit attribution
+
+After running a chat in tab A and another in tab B, open the Mastio dashboard's audit log. Filter by `principal_type=user`. You should see one row per chat message, with the `principal_id` matching the user that sent it.
+
+If both rows show the same principal, the `X-Forwarded-User` header is not reaching the Ambassador. Common causes:
+
+| Symptom | Likely cause |
+|---|---|
+| Connector logs `untrusted proxy IP` | The docker bridge CIDR your host hands out is not in `CULLIS_TRUSTED_PROXIES`. Adjust the env var. |
+| Both users land as `unknown@frontdesk.dev` | nginx is not seeing the `?user=` query (it only triggers on the cookie-mint path). Open in incognito so each tab starts cookie-less. |
+| 502 from nginx | Connector cannot reach the Mastio. Check enrollment is good (`docker compose exec connector cullis-connector doctor`). |
+
+## Production: replace nginx with oauth2-proxy + IDP
+
+`nginx/default.conf` is dev-grade. The contracts the rest of the bundle relies on are exactly two:
+
+1. **Every** request reaching the SPA / Ambassador carries `X-Forwarded-User` set to the authenticated user (email or sub).
+2. The reverse proxy's source IP is in `CULLIS_TRUSTED_PROXIES` on the Connector.
+
+Any reverse proxy that performs SSO and injects that header works: oauth2-proxy + Dex, Keycloak gatekeeper, Istio with JWT, EnvoyAuthZ, AWS ALB with OIDC, Azure App Gateway with EntraID. The nginx config in this bundle exists only so a developer can dogfood the multi-user flow without standing up a full IDP.
+
+For oauth2-proxy specifically, the upstream config `--pass-user-headers=true` is what injects the header. Point oauth2-proxy at the Cullis Chat container (`cullis-chat:4321`) and route `/api/session/(init|logout)` directly to the Connector (`connector:7777`), exactly like the dev nginx does.
+
+## Tear down
+
+```bash
+docker compose down            # stop containers, keep connector_data volume
+docker compose down -v         # also wipe connector_data (forces re-enrollment)
+```
+
+## Known limitations
+
+- **No HTTPS in the bundle.** Production deployments terminate TLS at the corporate ingress (or at oauth2-proxy with a cert), upstream of nginx. The bundle binds `:80` on purpose.
+- **No autoscale.** Single Connector replica per bundle; the cookie secret lives on local disk so horizontal scale needs a shared secret store. Roadmap.
+- **Cookie secret rotation** is manual for now: stop the bundle, delete `connector_data/cookie.secret`, restart. Forces every browser to re-init the session, no security incident.
+- **The bundle does not bundle the Mastio.** Cleanly separates concerns; deploy Mastio with `packaging/mastio-bundle/` and point this bundle at it.

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -1,0 +1,121 @@
+# =============================================================================
+# Cullis Frontdesk — multi-user shared-mode container bundle (ADR-019 Phase 7)
+# =============================================================================
+#
+# Three services on a private docker network:
+#
+#   nginx          80   reverse proxy + (dev) fake-SSO injecting X-Forwarded-User
+#     ↓
+#   cullis-chat    4321 Astro SPA (chat UI)
+#     ↓
+#   connector      7777 cullis-connector dashboard + Ambassador (shared mode)
+#     ↓ DPoP+mTLS
+#   [Cullis Mastio cloud — out of scope for this bundle]
+#
+# Prerequisites:
+#
+#   1. A Mastio is reachable from this host (separate deploy, see
+#      packaging/mastio-bundle/).
+#   2. The Connector has been enrolled against that Mastio. Enrollment
+#      writes identity material to the ``connector_data`` volume; without
+#      it the Ambassador comes up but cannot reach Mastio.
+#
+#      One-shot enrollment (run once before ``docker compose up``):
+#
+#        docker run --rm -it \
+#          -v $(pwd)/connector_data:/root/.cullis \
+#          ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-latest} \
+#          enroll --site https://mastio.acme.local:9443 \
+#                 --code <INVITE_CODE_FROM_MASTIO_ADMIN> \
+#                 --profile frontdesk
+#
+# Usage:
+#
+#   cp frontdesk.env.example frontdesk.env       # then edit org_id, trust_domain
+#   docker compose --env-file frontdesk.env up -d
+#   open http://localhost:8080?user=mario        # demo user switch (dev only)
+#
+# Production: replace nginx with oauth2-proxy + your IDP. The
+# X-Forwarded-User header MUST come from a trusted proxy; the Connector
+# refuses requests whose source IP is not in CULLIS_TRUSTED_PROXIES.
+# =============================================================================
+
+services:
+
+  connector:
+    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-latest}
+    # ``dashboard`` mounts the Ambassador router via web.py lifespan when
+    # AMBASSADOR_MODE=shared (cullis_connector/web.py:152). Bind to all
+    # interfaces inside the container so nginx can reach it.
+    command: >
+      dashboard
+      --host 0.0.0.0
+      --port 7777
+      --no-open-browser
+      --profile ${CONNECTOR_PROFILE:-frontdesk}
+    expose:
+      - "7777"
+    environment:
+      # Shared mode wiring (ADR-021 PR4c). Required.
+      AMBASSADOR_MODE: shared
+      CULLIS_FRONTDESK_ORG_ID: ${CULLIS_FRONTDESK_ORG_ID}
+      CULLIS_FRONTDESK_TRUST_DOMAIN: ${CULLIS_FRONTDESK_TRUST_DOMAIN}
+      # Trust the docker bridge network so X-Forwarded-User from nginx is
+      # accepted. Default covers the bridge networks docker hands out by
+      # default (172.16.0.0/12). Tighten if you know your CIDR.
+      CULLIS_TRUSTED_PROXIES: ${CULLIS_TRUSTED_PROXIES:-127.0.0.1/32,::1/128,172.16.0.0/12}
+      CULLIS_FRONTDESK_COOKIE_TTL_S: ${CULLIS_FRONTDESK_COOKIE_TTL_S:-3600}
+      # Where Mastio's CSR endpoint lives. Falls back to site_url when empty.
+      CULLIS_FRONTDESK_MASTIO_URL: ${CULLIS_FRONTDESK_MASTIO_URL:-}
+      CULLIS_SITE_URL: ${CULLIS_SITE_URL:-}
+    volumes:
+      # Connector identity material (cert, key, profile config). Populated
+      # by the one-shot enrollment documented in the header comment.
+      - ${CONNECTOR_DATA_DIR:-./connector_data}:/root/.cullis
+    networks:
+      - frontdesk_net
+    restart: unless-stopped
+
+  cullis-chat:
+    # Build from source for now; future Phase 8.5 publishes
+    # ghcr.io/cullis-security/cullis-chat and we switch to image:.
+    build:
+      context: ../../frontend/cullis-chat
+      dockerfile: Dockerfile
+    expose:
+      - "4321"
+    environment:
+      # The SPA forwards Authorization+Cookie to this URL. Inside the
+      # bundle network the Ambassador is reachable as connector:7777.
+      CULLIS_AMBASSADOR_URL: http://connector:7777
+      # No local Bearer token in shared mode; the cookie is set by the
+      # Ambassador's /api/session/init via nginx routing (see nginx conf).
+      CULLIS_LOCAL_TOKEN: ${CULLIS_LOCAL_TOKEN:-shared-mode-no-bearer}
+      # Audit panel is for dashboards / admin surfaces, not end users.
+      PUBLIC_DEV_AUDIT_PANEL: ${PUBLIC_DEV_AUDIT_PANEL:-0}
+    depends_on:
+      - connector
+    networks:
+      - frontdesk_net
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "${FRONTDESK_HTTP_PORT:-8080}:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - cullis-chat
+    networks:
+      - frontdesk_net
+    restart: unless-stopped
+
+volumes:
+  # Persistent Connector identity. Survives `docker compose down`. Wipe
+  # only if you want to re-enroll the Connector from scratch.
+  connector_data:
+
+networks:
+  frontdesk_net:
+    driver: bridge

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -1,0 +1,57 @@
+# Cullis Frontdesk — env file for docker-compose (ADR-019 Phase 7).
+#
+# Copy to ``frontdesk.env`` and fill in the required values, then:
+#   docker compose --env-file frontdesk.env up -d
+
+# -- Required: shared-mode wiring ------------------------------------------
+
+# Org slug that all users behind this Frontdesk will be attributed to in
+# Mastio's audit chain. Must match the org slug registered in Mastio.
+CULLIS_FRONTDESK_ORG_ID=acme
+
+# SPIFFE trust domain for this Frontdesk deployment. Convention:
+# ``<org>.<environment>``, e.g. ``acme.test`` or ``acme.prod``. Used when
+# the Ambassador calls Mastio's CSR endpoint to mint per-user agent certs.
+CULLIS_FRONTDESK_TRUST_DOMAIN=acme.test
+
+# -- Optional: bundle behaviour --------------------------------------------
+
+# Which version of the cullis-connector image to pull. Pin a release tag
+# in production rather than ``latest``.
+# CONNECTOR_VERSION=0.3.6
+
+# Which Connector profile name to activate. The enrollment one-shot must
+# have used the same name (``--profile`` on ``cullis-connector enroll``).
+# CONNECTOR_PROFILE=frontdesk
+
+# Local directory holding the enrolled Connector identity (cert, key,
+# config). Created by the one-shot enrollment described in the compose
+# file's header comment. Default ``./connector_data`` keeps it next to
+# the bundle.
+# CONNECTOR_DATA_DIR=./connector_data
+
+# Override the docker bridge CIDR if your daemon hands out something other
+# than the default 172.16.0.0/12. Tighten this in production rather than
+# loosening it: a wide CIDR means anyone reachable on that network can
+# spoof ``X-Forwarded-User``.
+# CULLIS_TRUSTED_PROXIES=127.0.0.1/32,::1/128,172.16.0.0/12
+
+# Mastio CSR endpoint. Falls back to ``CULLIS_SITE_URL`` when empty,
+# which is the right default for single-tenant Frontdesk deployments.
+# CULLIS_FRONTDESK_MASTIO_URL=https://mastio.acme.local:9443
+
+# Connector site_url (Mastio reverse proxy). Read from the enrolled
+# profile's config when empty.
+# CULLIS_SITE_URL=https://mastio.acme.local:9443
+
+# Cookie TTL in seconds for the user session. Default 1h.
+# CULLIS_FRONTDESK_COOKIE_TTL_S=3600
+
+# Public host port the bundle binds to. Behind a corporate reverse proxy
+# this is the upstream port the proxy forwards to; on a developer laptop
+# this is the port you open in the browser.
+# FRONTDESK_HTTP_PORT=8080
+
+# Show the dev audit panel inside the SPA. Off by default — the audit
+# chain belongs to the Mastio admin dashboard, not the end user surface.
+# PUBLIC_DEV_AUDIT_PANEL=0

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -1,0 +1,83 @@
+# Cullis Frontdesk — dev nginx (ADR-019 Phase 7).
+#
+# Production: replace this whole file with an oauth2-proxy + your IDP
+# (Okta / Auth0 / Keycloak / EntraID / Google Workspace) sitting in front
+# of the SPA. The only contracts the rest of the bundle relies on are:
+#
+#   1. EVERY request reaching the SPA / Ambassador carries
+#      ``X-Forwarded-User`` set to the authenticated user (email or sub).
+#   2. The reverse proxy's source IP is in CULLIS_TRUSTED_PROXIES on the
+#      Connector (default 172.16.0.0/12 covers the docker bridge network).
+#
+# This dev nginx fakes step (1) with a ``?user=`` query-string switch the
+# first time you load the page. It is NOT a security boundary; it exists
+# only so a developer can dogfood the multi-user shared-mode flow without
+# standing up a full IDP. Never expose to the public internet.
+
+# Map the dev ?user= query to a fully-qualified principal email. The
+# default placeholder makes "no ?user=" the unsafe path: the Ambassador
+# will reject the unknown principal, surfacing the misconfig fast rather
+# than falling back to a random user.
+map $arg_user $forwarded_user {
+    default      "unknown@frontdesk.dev";
+    "mario"      "mario@acme.local";
+    "anna"       "anna@acme.local";
+    "luca"       "luca@beta.local";
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # Hide nginx version in error pages / Server header.
+    server_tokens off;
+
+    # ----- session/init and session/logout: bypass the SPA -----
+    #
+    # In shared mode the Ambassador (cullis_connector/ambassador/shared/
+    # router.py) issues the session cookie from X-Forwarded-User. We
+    # route those POSTs directly to the Connector so the Set-Cookie
+    # response reaches the browser without an SPA round-trip; the SPA's
+    # own /api/session/init.ts is single-mode-only and would not know
+    # how to mint the shared cookie.
+    location ~ ^/api/session/(init|logout)$ {
+        proxy_pass http://connector:7777$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-User $forwarded_user;
+    }
+
+    # ----- everything else: through the SPA -----
+    #
+    # /api/session/whoami stays here on purpose: the SPA's whoami.ts
+    # translates the Ambassador's cookie payload into the ADR-020
+    # principal shape that <IdentityBadge> expects. Routing whoami
+    # directly to the Ambassador would change the response shape and
+    # break the badge.
+    #
+    # /api/proxy/* (chat completions, models, MCP) goes via the SPA,
+    # which forwards Authorization + Cookie to the Ambassador. SSE
+    # streaming requires proxy_buffering off + a long read timeout.
+    location / {
+        proxy_pass http://cullis-chat:4321;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-User $forwarded_user;
+
+        # SSE chat streaming.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+
+        # Astro websocket / HMR (dev). Harmless in prod.
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Implements **ADR-019 rev 3 Phase 7**: Cullis Frontdesk as a multi-user container bundle. Three services on a private docker network:

```
[browser N users] → [nginx :8080, X-Forwarded-User injected]
                  → [Cullis Chat SPA :4321]
                  → [Connector :7777, AMBASSADOR_MODE=shared]
                  → DPoP+mTLS, per-user keys via UserPrincipalKMS
                  → [Cullis Mastio cloud — separate deploy]
```

The bundle does not start its own Mastio (clean separation of concerns: deploy one with `packaging/mastio-bundle/` and point this bundle at it).

## Files

- `packaging/frontdesk-bundle/docker-compose.yml` — three services (connector / cullis-chat / nginx)
- `packaging/frontdesk-bundle/nginx/default.conf` — dev fake-SSO via `?user=` query string mapping `mario`/`anna`/`luca` to fake principal emails. Routes `/api/session/(init|logout)` directly to the Connector to bypass the SPA's single-mode `init.ts`.
- `packaging/frontdesk-bundle/frontdesk.env.example` — required env (`CULLIS_FRONTDESK_ORG_ID`, `CULLIS_FRONTDESK_TRUST_DOMAIN`) plus operator knobs.
- `packaging/frontdesk-bundle/README.md` — ops guide: prerequisites, one-shot enrollment, bring-up, dev fake-SSO smoke (two browser tabs), production migration to oauth2-proxy + IDP, known limitations.

## Routing decision (worth a second look)

In shared mode the session cookie is minted by the Ambassador's `/api/session/init` route (`cullis_connector/ambassador/shared/router.py:139`) from the `X-Forwarded-User` header. The SPA's `frontend/cullis-chat/src/pages/api/session/init.ts` is **single-mode-only** (reads `readLocalToken()` from the Connector profile).

The dev nginx routes `/api/session/(init|logout)` **directly to the Connector**, bypassing the SPA. `/api/session/whoami` stays on the SPA path because the SPA translates the Ambassador's cookie payload into the ADR-020 principal shape that `<IdentityBadge>` expects. Routing whoami directly to the Ambassador would change the response shape and break the badge.

This was the cheapest way to ship Phase 7 with zero SPA changes. The cleaner long-term version is to teach `init.ts` to detect shared mode and proxy to the Ambassador with the header forwarded; deferred until we know whether the wizard-in-webview pattern is the keeper (ADR-019 Phase 11).

## Validated

- `docker compose config` parses clean.
- `nginx -t` parses clean inside the docker context (standalone test reports DNS lookup failure for upstream hostnames, expected outside the network).

## Out of scope, deferred

- Real `oauth2-proxy + Dex` opt-in override (`docker-compose.sso.yml`). Documented as the production migration path; not packaged to keep Phase 7 within the half-day budget.
- Automated smoke script for two-user audit attribution. Manual procedure documented; script-once the Mastio per-user audit query API stabilizes.
- Publishing `ghcr.io/cullis-security/cullis-chat` so the bundle can use `image:` instead of `build:`. Phase 8.5 follow-up.

## Test plan

- [ ] Stand up a Mastio (`packaging/mastio-bundle/`) and issue an invite code.
- [ ] One-shot enroll the Connector against the Mastio (commands in README).
- [ ] `docker compose up -d`, verify three containers healthy.
- [ ] Open `http://localhost:8080?user=mario` in incognito, observe the badge says `user · mario`, send a chat message.
- [ ] Open second incognito at `http://localhost:8080?user=anna`, observe the badge says `user · anna`, send a different chat.
- [ ] On the Mastio dashboard, filter audit log by `principal_type=user`. Two distinct principals (`acme.test/acme/user/mario` and `…/anna`) attributed to the two messages.
- [ ] `docker compose down -v` cleanly tears down.