### PR TITLE
feat(ambassador): single-mode session routes (ADR-019 Phase 8a)

### DIFF
--- a/cullis_connector/ambassador/auth.py
+++ b/cullis_connector/ambassador/auth.py
@@ -31,6 +31,13 @@ _AUTH_HEADER = "authorization"
 
 LOCAL_TOKEN_FILENAME = "local.token"
 
+# Name of the HttpOnly session cookie issued by ``POST /api/session/init``
+# in single mode. The Ambassador accepts either ``Authorization: Bearer
+# <token>`` or this cookie carrying the same local token. Two paths to
+# the same secret so a browser SPA can talk directly to the Ambassador
+# without an Astro server-side proxy in front (ADR-019 Phase 8).
+LOCAL_SESSION_COOKIE = "cullis_local_session"
+
 
 def ensure_local_token(config_dir: Path) -> str:
     """Return the local Bearer token, generating it on first call.
@@ -79,6 +86,19 @@ def require_loopback(request: Request) -> None:
 def require_bearer(expected_token: str):
     """Build a FastAPI dependency that validates the Bearer header.
 
+    Accepts the local token via either of two paths:
+
+      1. ``Authorization: Bearer <token>`` — the original path. Used by
+         Cursor / LibreChat / Claude Desktop and the SPA's server-side
+         proxy.
+      2. ``Cookie: cullis_local_session=<token>`` — the path used by a
+         browser SPA talking directly to the Ambassador, after
+         ``POST /api/session/init`` has minted the cookie. Lets the
+         Astro-static topology of ADR-019 Phase 8 collapse the
+         "browser → Astro server → Ambassador" hop.
+
+    The two paths carry the same secret. Both checks are constant-time.
+
     Returns a callable suitable for ``Depends(...)`` so each route can
     mount it without rebuilding the closure.
     """
@@ -87,13 +107,19 @@ def require_bearer(expected_token: str):
 
     def _checker(request: Request) -> None:
         raw = request.headers.get(_AUTH_HEADER, "")
-        if not raw.lower().startswith("bearer "):
-            raise HTTPException(
-                status_code=401,
-                detail="missing or non-Bearer Authorization header",
-            )
-        presented = raw.split(" ", 1)[1].strip()
-        if not secrets.compare_digest(presented, expected_token):
+        if raw.lower().startswith("bearer "):
+            presented = raw.split(" ", 1)[1].strip()
+            if secrets.compare_digest(presented, expected_token):
+                return
             raise HTTPException(status_code=401, detail="invalid Bearer token")
+
+        cookie_token = request.cookies.get(LOCAL_SESSION_COOKIE, "")
+        if cookie_token and secrets.compare_digest(cookie_token, expected_token):
+            return
+
+        raise HTTPException(
+            status_code=401,
+            detail="missing Authorization header or session cookie",
+        )
 
     return _checker

--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -31,6 +31,7 @@ from cullis_connector.ambassador.auth import require_bearer, require_loopback
 from cullis_connector.ambassador.client import AmbassadorClient
 from cullis_connector.ambassador.loop import run_tool_use_loop
 from cullis_connector.ambassador.models import ChatCompletionRequest
+from cullis_connector.ambassador.session_routes import router as session_router
 from cullis_connector.ambassador.streaming import (
     extract_assistant_text,
     fake_stream,
@@ -242,6 +243,11 @@ def install_ambassador(
         "require_local_only": require_local_only,
     }
     app.include_router(router)
+    # Session endpoints (init / whoami / logout). Lifted into a separate
+    # router so shared mode can mount its own session routes without
+    # colliding (the two modes share AMBASSADOR_MODE-gated lifespan
+    # logic in web.py, never run together).
+    app.include_router(session_router)
     _log.info(
         "ambassador installed: agent=%s site=%s models=%s",
         client.agent_id, getattr(client, "_site_url", ""), advertised_models,

--- a/cullis_connector/ambassador/session_routes.py
+++ b/cullis_connector/ambassador/session_routes.py
@@ -1,0 +1,200 @@
+"""Session endpoints for the single-mode Ambassador (ADR-019 Phase 8a).
+
+Adds ``/api/session/init``, ``/api/session/whoami`` and
+``/api/session/logout`` so a browser SPA served directly by the
+Connector (Astro static, no Astro server in front) can:
+
+  1. Mint an HttpOnly cookie from the Connector's local Bearer token,
+     then call ``/v1/chat/completions`` and friends with just the
+     cookie. ``require_bearer`` accepts either the cookie or the
+     legacy ``Authorization: Bearer`` header, so existing clients are
+     unaffected.
+  2. Read its own identity (``user · local`` in single mode) for the
+     IdentityBadge component without needing the SPA's server-side
+     translation that exists today.
+  3. Cleanly clear the cookie on logout.
+
+Shared mode (``AMBASSADOR_MODE=shared``) ships its own equivalent in
+``cullis_connector/ambassador/shared/router.py`` because it has very
+different semantics (session signed by a cookie secret, lookup of a
+per-user agent identity). The two routers do not share code on
+purpose: collapsing them would force shared-mode complexity into the
+single-mode path that today is "one Connector, one user, one Bearer".
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, Request, Response
+
+from cullis_connector.ambassador.auth import (
+    LOCAL_SESSION_COOKIE,
+    require_loopback,
+)
+
+_log = logging.getLogger("cullis_connector.ambassador.session_routes")
+
+# 30 minutes — matches the SPA's `SESSION_TTL_SECONDS` so users see
+# the same refresh cadence whether they go via the Astro server or
+# directly. Bumping requires a coordinated SPA change so the
+# client-side ``ensureSession`` cadence stays aligned.
+SESSION_TTL_SECONDS = 30 * 60
+
+router = APIRouter(tags=["ambassador-session"])
+
+
+def _enforce_loopback(request: Request) -> None:
+    """Apply ``require_loopback`` only when the Ambassador is configured to.
+
+    Mirrors the helper in ``router.py``: shares the same state key so
+    the ``--no-loopback-only`` operator override (test fixtures, CI)
+    affects every Ambassador surface uniformly.
+    """
+    state = getattr(request.app.state, "ambassador", None)
+    if state and state.get("require_local_only", True):
+        require_loopback(request)
+
+
+def _state(request: Request) -> dict[str, Any]:
+    """Pull the Ambassador's per-app state, set by ``install_ambassador``."""
+    state = getattr(request.app.state, "ambassador", None)
+    if not state:
+        # Should never happen in practice — install_ambassador runs in
+        # the lifespan before any request can reach this router. Keep
+        # the guard explicit to fail loud if wiring ever regresses.
+        raise RuntimeError("Ambassador not installed on this app")
+    return state
+
+
+@router.post("/api/session/init", dependencies=[Depends(_enforce_loopback)])
+def session_init(request: Request, response: Response) -> dict[str, Any]:
+    """Mint an HttpOnly session cookie carrying the local Bearer token.
+
+    The cookie value is the same secret that ``Authorization: Bearer
+    <token>`` carries today — two paths to one credential. The browser
+    cannot read the cookie (HttpOnly), only ride along on subsequent
+    same-origin requests.
+
+    Why ``Secure=False``: in topology L (laptop, single user) the
+    Ambassador binds to ``127.0.0.1`` only. Browsers refuse Secure
+    cookies on plain ``http://localhost`` origins on every major
+    browser (Chrome since ~2023, Firefox, Safari), so flagging the
+    cookie Secure here would make ``init`` succeed but every
+    subsequent request arrive cookie-less. Loopback is the security
+    boundary, not the cookie's Secure flag.
+    """
+    state = _state(request)
+    token = state["bearer_token"]
+    response.set_cookie(
+        LOCAL_SESSION_COOKIE,
+        value=token,
+        max_age=SESSION_TTL_SECONDS,
+        path="/",
+        httponly=True,
+        secure=False,  # see docstring
+        samesite="strict",
+    )
+    _log.info(
+        "session_init: minted cookie ttl=%ds for agent=%s",
+        SESSION_TTL_SECONDS, state.get("agent_id", "<unknown>"),
+    )
+    return {"ok": True, "ttl": SESSION_TTL_SECONDS}
+
+
+@router.post("/api/session/logout", dependencies=[Depends(_enforce_loopback)])
+def session_logout(response: Response) -> dict[str, Any]:
+    """Clear the session cookie. Idempotent: clears whether or not one is set."""
+    response.delete_cookie(LOCAL_SESSION_COOKIE, path="/")
+    return {"ok": True}
+
+
+@router.get("/api/session/whoami", dependencies=[Depends(_enforce_loopback)])
+def session_whoami(request: Request) -> dict[str, Any]:
+    """Return the resolved principal in the ADR-020 shape.
+
+    In single mode the answer is fixed: there is exactly one identity
+    served by this Connector, the active profile's agent. We surface
+    it as ``principal_type=user`` so the SPA's ``IdentityBadge``
+    renders ``user · <name>`` consistently with shared mode.
+
+    Auth: requires either the session cookie or the Bearer header.
+    Mirrors ``require_bearer`` semantics by hand because we need to
+    differentiate "no auth" (return a public placeholder so the badge
+    can show ``offline``) from "wrong token" (401). Both shared mode
+    and Cursor-style direct callers expect the same shape, so we keep
+    the response stable.
+    """
+    state = _state(request)
+    expected = state["bearer_token"]
+    presented = _extract_token(request)
+    if not presented:
+        return _placeholder_principal(reason="no_session")
+    if presented != expected:
+        # Wrong token: surface an explicit error rather than a
+        # placeholder, so a misconfigured client doesn't silently fall
+        # back to "looks like it works".
+        return _placeholder_principal(reason="invalid_token")
+
+    agent_id = state.get("agent_id", "")
+    org_id = state.get("org_id", "")
+    if "::" in agent_id:
+        # ``agent_id`` is ``<org>::<name>`` per CullisClient convention.
+        # The principal_id we surface is the SPIFFE-derived
+        # ``<trust-domain>/<org>/<principal-type>/<name>`` minus the
+        # ``spiffe://`` scheme; since single mode is laptop-only we use
+        # ``laptop`` as the trust-domain placeholder. Shared mode
+        # overrides this with the real Frontdesk trust domain.
+        _, name = agent_id.split("::", 1)
+    else:
+        name = agent_id or "local"
+    trust_domain = "laptop"
+    principal_type = "user"
+    principal_id = f"{trust_domain}/{org_id or 'local'}/{principal_type}/{name}"
+
+    return {
+        "ok": True,
+        "principal": {
+            "spiffe_id": f"spiffe://{principal_id}",
+            "principal_type": principal_type,
+            "name": name,
+            "org": org_id or "local",
+            "trust_domain": trust_domain,
+            "sub": name,
+            "source": "single",
+        },
+        # Stable across mode for clients that just want the bare facts.
+        "principal_id": principal_id,
+        "exp": int(time.time()) + SESSION_TTL_SECONDS,
+    }
+
+
+def _extract_token(request: Request) -> str:
+    """Pull the local Bearer from header or cookie, whichever is present."""
+    auth = request.headers.get("authorization", "")
+    if auth.lower().startswith("bearer "):
+        return auth.split(" ", 1)[1].strip()
+    return request.cookies.get(LOCAL_SESSION_COOKIE, "")
+
+
+def _placeholder_principal(*, reason: str) -> dict[str, Any]:
+    """Public-shape response when no valid auth is presented.
+
+    Returning 200 + a placeholder lets the SPA's IdentityBadge render
+    ``offline`` without crashing on the network error of a 401. The
+    ``ok=false`` field tells the badge to render the offline state.
+    """
+    return {
+        "ok": False,
+        "error": reason,
+        "principal": {
+            "spiffe_id": None,
+            "principal_type": "user",
+            "name": "local",
+            "org": "local",
+            "trust_domain": None,
+            "sub": "local",
+            "source": "single-fallback",
+        },
+    }

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -494,13 +494,19 @@ def build_app(config: ConnectorConfig) -> FastAPI:
 
     @app.middleware("http")
     async def _csrf_origin_guard(request: Request, call_next):  # type: ignore[no-untyped-def]
-        # ADR-019 — Ambassador endpoints under /v1/* run their own
-        # auth (loopback + Bearer) and cannot rely on Origin/Referer
-        # since OpenAI clients (Cullis Chat / Cursor / OpenWebUI) do
-        # not always emit those headers. Skip the dashboard CSRF
-        # guard for that prefix; the Ambassador router enforces
-        # 401 on missing/invalid Bearer.
-        if request.url.path.startswith("/v1/"):
+        # ADR-019 — Ambassador endpoints under /v1/* and /api/session/*
+        # run their own auth (loopback + Bearer/cookie) and cannot rely
+        # on Origin/Referer since OpenAI clients (Cullis Chat / Cursor /
+        # OpenWebUI) do not always emit those headers. The session
+        # endpoints in particular bootstrap the cookie that the rest of
+        # the SPA's calls authenticate with; gating them on a CSRF token
+        # the SPA does not yet have would deadlock the flow. Skip the
+        # dashboard CSRF guard for these prefixes; the Ambassador's
+        # session router enforces 401 on missing / invalid auth.
+        if (
+            request.url.path.startswith("/v1/")
+            or request.url.path.startswith("/api/session/")
+        ):
             return await call_next(request)
         if request.method in ("POST", "PUT", "DELETE", "PATCH"):
             authz = request.headers.get("authorization", "")

--- a/tests/connector/test_ambassador_session_routes.py
+++ b/tests/connector/test_ambassador_session_routes.py
@@ -17,7 +17,6 @@ real, the TestClient enters lifespan so ``install_ambassador`` runs.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/connector/test_ambassador_session_routes.py
+++ b/tests/connector/test_ambassador_session_routes.py
@@ -1,0 +1,321 @@
+"""ADR-019 Phase 8a — single-mode session endpoints on the Ambassador.
+
+Covers ``/api/session/init``, ``/api/session/whoami`` and
+``/api/session/logout`` plus the cookie path of ``require_bearer``:
+
+  * init mints an HttpOnly cookie carrying the local Bearer token
+  * logout clears the cookie idempotently
+  * whoami returns ADR-020 shape with bearer / cookie / nothing
+  * /v1/models accepts the session cookie alone (no Authorization)
+  * the legacy Bearer header path keeps working unchanged
+  * mismatching cookie value yields 401, not silent fallback
+
+Reuses the ``app`` / ``client`` / ``bearer`` fixtures style from
+``test_ambassador_router.py``: the SDK is faked, the Ambassador is
+real, the TestClient enters lifespan so ``install_ambassador`` runs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.ambassador.auth import LOCAL_SESSION_COOKIE
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity import generate_keypair, save_identity
+from cullis_connector.identity.store import IdentityMetadata
+from cullis_connector.web import build_app
+
+
+# ── helpers (copied from test_ambassador_router for fixture parity) ──
+
+
+def _self_signed_cert_pem(private_key, *, common_name: str) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.x509.oid import NameOID
+
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, common_name.split("::", 1)[0]),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=30))
+        .sign(private_key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _seed_identity(config_dir: Path, *, agent_id: str = "acme::frontdesk") -> None:
+    key = generate_keypair()
+    cert_pem = _self_signed_cert_pem(key, common_name=agent_id)
+    metadata = IdentityMetadata(
+        agent_id=agent_id,
+        capabilities=[],
+        site_url="https://mastio.test",
+        issued_at="2026-05-04T10:00:00+00:00",
+    )
+    save_identity(
+        config_dir=config_dir,
+        cert_pem=cert_pem,
+        private_key=key,
+        ca_chain_pem=None,
+        metadata=metadata,
+    )
+
+
+class FakeCullisClient:
+    """Minimal SDK fake — these tests do not exercise chat / mcp paths."""
+
+    @classmethod
+    def from_connector(cls, *args, **kwargs):
+        return cls()
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+    def list_inbox(self, *args, **kwargs):
+        return []
+
+    def discover(self, *args, **kwargs):
+        return []
+
+    def login_from_pem(self, *args, **kwargs) -> None:
+        pass
+
+    def list_mcp_tools(self) -> list[dict]:
+        return []
+
+    def chat_completion(self, body: dict) -> dict:
+        return {
+            "choices": [{
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+        }
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_sdk(monkeypatch):
+    monkeypatch.setattr("cullis_sdk.CullisClient", FakeCullisClient)
+
+
+@pytest.fixture
+def app(tmp_path: Path):
+    _seed_identity(tmp_path)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test",
+        verify_tls=False,
+    )
+    cfg.ambassador.require_local_only = False
+    return build_app(cfg)
+
+
+@pytest.fixture
+def client(app):
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def bearer(client, tmp_path: Path) -> str:
+    return (tmp_path / "local.token").read_text(encoding="utf-8").strip()
+
+
+# ── /api/session/init ───────────────────────────────────────────────
+
+
+def test_init_returns_ok_and_sets_cookie(client, bearer):
+    resp = client.post("/api/session/init")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["ttl"] == 30 * 60
+
+    set_cookie = resp.headers.get("set-cookie", "")
+    # The cookie value carries the same secret as the local Bearer.
+    assert LOCAL_SESSION_COOKIE in set_cookie
+    assert bearer in set_cookie
+    # HttpOnly is mandatory — the SPA never reads the value, only the
+    # browser carries it. SameSite=strict + path=/ are the topology L
+    # defaults; this assertion catches a regression that loosens any of
+    # them.
+    assert "HttpOnly" in set_cookie
+    assert "SameSite=strict" in set_cookie or "SameSite=Strict" in set_cookie
+    assert "Path=/" in set_cookie or "path=/" in set_cookie
+
+
+def test_init_is_idempotent_returns_same_token(client, bearer):
+    """Calling init twice keeps minting cookies with the same value.
+
+    Regression guard against a future change that rotates the local
+    token on every init — that would invalidate every existing cookie
+    on every browser tab refresh and silently break the SPA.
+    """
+    r1 = client.post("/api/session/init")
+    r2 = client.post("/api/session/init")
+    c1 = r1.headers.get("set-cookie", "")
+    c2 = r2.headers.get("set-cookie", "")
+    assert bearer in c1 and bearer in c2
+
+
+# ── /api/session/logout ─────────────────────────────────────────────
+
+
+def test_logout_clears_cookie(client):
+    resp = client.post("/api/session/logout")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+    set_cookie = resp.headers.get("set-cookie", "")
+    # Either an empty value or Max-Age=0 — both are valid clear signals.
+    assert LOCAL_SESSION_COOKIE in set_cookie
+    cleared = (
+        f'{LOCAL_SESSION_COOKIE}=""' in set_cookie
+        or f"{LOCAL_SESSION_COOKIE}=" in set_cookie and "Max-Age=0" in set_cookie
+    )
+    assert cleared, f"expected clear cookie, got: {set_cookie}"
+
+
+def test_logout_idempotent_when_no_session(client):
+    """Two consecutive logouts both succeed."""
+    assert client.post("/api/session/logout").status_code == 200
+    assert client.post("/api/session/logout").status_code == 200
+
+
+# ── cookie path of require_bearer ───────────────────────────────────
+
+
+def test_models_accepts_session_cookie_no_header(client, bearer):
+    """The original goal of Phase 8a: a browser SPA can hit /v1/* with
+    just the cookie, no Astro server in front.
+    """
+    resp = client.get(
+        "/v1/models",
+        cookies={LOCAL_SESSION_COOKIE: bearer},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["object"] == "list"
+
+
+def test_models_still_accepts_legacy_bearer_header(client, bearer):
+    """Regression: existing Bearer-only callers (Cursor, LibreChat) keep working."""
+    resp = client.get(
+        "/v1/models",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+
+
+def test_models_rejects_no_auth(client):
+    resp = client.get("/v1/models")
+    assert resp.status_code == 401
+
+
+def test_models_rejects_wrong_cookie_value(client):
+    """Wrong cookie token → 401, not a silent fallback to placeholder."""
+    resp = client.get(
+        "/v1/models",
+        cookies={LOCAL_SESSION_COOKIE: "definitely-not-the-real-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_models_rejects_wrong_bearer_header(client):
+    """Wrong Bearer header → 401, even if a valid cookie is also present.
+
+    Header-first ordering: a legacy client that sends an explicit
+    Authorization header expects it to be the source of truth. Falling
+    back to the cookie when the header is wrong would mask client bugs.
+    """
+    resp = client.get(
+        "/v1/models",
+        headers={"Authorization": "Bearer wrong-token"},
+        cookies={LOCAL_SESSION_COOKIE: "anything"},
+    )
+    assert resp.status_code == 401
+
+
+# ── /api/session/whoami ─────────────────────────────────────────────
+
+
+def test_whoami_no_session_returns_placeholder(client):
+    resp = client.get("/api/session/whoami")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"] == "no_session"
+    assert body["principal"]["name"] == "local"
+    assert body["principal"]["source"] == "single-fallback"
+
+
+def test_whoami_with_cookie_returns_full_principal(client, bearer):
+    resp = client.get(
+        "/api/session/whoami",
+        cookies={LOCAL_SESSION_COOKIE: bearer},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    p = body["principal"]
+    # The seeded agent_id is ``acme::frontdesk`` — the trust-domain is
+    # the single-mode placeholder ``laptop``, the org follows agent_id,
+    # principal_type is always ``user`` in single mode.
+    assert p["principal_type"] == "user"
+    assert p["name"] == "frontdesk"
+    assert p["org"] == "acme"
+    assert p["trust_domain"] == "laptop"
+    assert p["spiffe_id"] == "spiffe://laptop/acme/user/frontdesk"
+    assert body["principal_id"] == "laptop/acme/user/frontdesk"
+
+
+def test_whoami_with_bearer_header_returns_full_principal(client, bearer):
+    resp = client.get(
+        "/api/session/whoami",
+        headers={"Authorization": f"Bearer {bearer}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+
+
+def test_whoami_with_invalid_cookie_returns_placeholder(client):
+    resp = client.get(
+        "/api/session/whoami",
+        cookies={LOCAL_SESSION_COOKIE: "nope"},
+    )
+    # Whoami stays 200 even when wrong: the IdentityBadge needs a
+    # parseable response in every state. The error code is in the body.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["error"] == "invalid_token"
+
+
+# ── round-trip: init mints cookie, subsequent calls work ────────────
+
+
+def test_init_then_models_via_cookie_jar(client):
+    """End-to-end: POST /init, then the TestClient's cookie jar carries
+    the cookie back on the next GET."""
+    init = client.post("/api/session/init")
+    assert init.status_code == 200
+    # TestClient sticky cookies — no manual cookie= needed.
+    resp = client.get("/v1/models")
+    assert resp.status_code == 200


### PR DESCRIPTION
## What does this PR do?

Lays the Python foundation for collapsing the SPA's Astro server into the Connector FastAPI process (ADR-019 rev 3 Phase 8b). The SPA today owns three server-side routes (`session/init`, `session/whoami`, `proxy/[...path]`) that pass cookies + Bearer between the browser and the Ambassador. This PR moves the equivalent contract Python-side so a static SPA can talk to the Connector with no Astro-server hop in front.

Single mode now mirrors the shared mode surface that ADR-021 PR4c shipped on the same `/api/session/` prefix.

## New endpoints (single-mode router)

| Method | Path | Behavior |
|---|---|---|
| POST | `/api/session/init` | Mints `cullis_local_session` HttpOnly cookie carrying the local Bearer token (same secret that `ensure_local_token` already manages — two paths to one credential). Returns `{ok, ttl: 1800}`. |
| POST | `/api/session/logout` | Clears the cookie idempotently. |
| GET | `/api/session/whoami` | Returns the resolved principal in ADR-020 shape (`{spiffe_id, principal_type, name, org, trust_domain, sub, source}`). On missing / wrong auth: `{ok: false, error, principal: <placeholder>}` — 200 not 401, so `IdentityBadge` can render an offline state without crashing on a network error. |

## `require_bearer` extension

Extended to accept either:
1. `Authorization: Bearer <token>` (the original path; Cursor / LibreChat / Claude Desktop)
2. `Cookie: cullis_local_session=<token>` (the new path; browser SPA after `init` has minted the cookie)

**Header-first ordering** preserved: a wrong `Authorization` header returns 401 even if a valid cookie is also present, so legacy callers cannot silently fall through to a stale cookie.

## CSRF guard widening

`web.py:_csrf_origin_guard` exemption widened from `"/v1/"` to also cover `"/api/session/"`. The session endpoints bootstrap the cookie that the rest of the SPA's calls authenticate with, so gating them on a CSRF token the SPA has not minted yet would deadlock the flow. The shared mode router has the same property and already lived under this prefix without issue.

## SPA not touched

The Astro SPA's existing `frontend/cullis-chat/src/pages/api/session/*` and `api/proxy/[...path].ts` keep working. The new Python routes are a **parallel path** that unblocks Phase 8b's "Astro static build + FastAPI static-mount" collapse. After Phase 8b lands, the SPA's server-side routes can be deleted.

## Tests

14 new tests in `tests/connector/test_ambassador_session_routes.py`:

- init mints cookie with HttpOnly + SameSite=strict + Path=/
- init is idempotent (returns same token on repeat calls)
- logout clears the cookie (Max-Age=0 form)
- logout idempotent on no-session
- `/v1/models` works with cookie alone (no Authorization)
- `/v1/models` works with Bearer header (regression)
- `/v1/models` rejects no-auth (401)
- `/v1/models` rejects wrong cookie (401)
- `/v1/models` rejects wrong header even with valid cookie (header-first ordering)
- whoami without auth: placeholder + `ok=false`
- whoami with cookie: ADR-020-shaped principal
- whoami with bearer header: same shape
- whoami with invalid cookie: placeholder + `error: invalid_token`
- end-to-end: init then `/v1/models` via TestClient cookie jar

**Local results**: 27/27 ambassador tests pass, 407/411 connector tests pass. The 4 failing tests in `tests/connector/test_profile_runtime_switch.py` are **pre-existing** pystray-on-NixOS issues (memory `feedback_gui_libs_ci_headless`); verified by re-running on clean main with my changes stashed.

## Test plan

- [x] All new tests pass
- [x] No regressions in existing ambassador / shared-mode tests
- [x] Pre-existing test failures verified unchanged
- [ ] CI green (full suite under pytest-split, Postgres bindings, demo smoke)