### PR TITLE
feat(ambassador): unify whoami response shape (ADR-019 Phase 8b-2a)

### DIFF
--- a/cullis_connector/ambassador/shared/router.py
+++ b/cullis_connector/ambassador/shared/router.py
@@ -214,8 +214,39 @@ async def session_logout(
 async def session_whoami(
     payload: SessionPayload = Depends(_require_session),
 ) -> dict:
-    """Tiny helper used by the SPA's IdentityBadge."""
+    """Resolve the authenticated principal in ADR-020 wrapped shape.
+
+    Matches single mode (cullis_connector/ambassador/session_routes.py)
+    after Phase 8b-2a — both modes now return ``{ok, principal: <ADR-020
+    shape>, principal_id, sub, org, exp}`` so the SPA's IdentityBadge
+    consumes one wire shape regardless of where the Ambassador runs.
+
+    Top-level ``principal_id``, ``sub``, ``org``, ``exp`` are preserved
+    for back-compat with callers (incl. Frontdesk smoke tests) that read
+    them directly. The ``principal`` subobject is the additive piece.
+    """
+    parts = payload.principal_id.split("/")
+    if len(parts) == 4:
+        trust_domain, org, principal_type, name = parts
+    else:
+        # Malformed principal_id: surface what we have. Should not
+        # happen in practice (init validates the shape) but is a
+        # defensive fallback so the badge still renders.
+        trust_domain = ""
+        org = payload.org
+        principal_type = "user"
+        name = payload.sub
     return {
+        "ok": True,
+        "principal": {
+            "spiffe_id": f"spiffe://{payload.principal_id}",
+            "principal_type": principal_type,
+            "name": name,
+            "org": org,
+            "trust_domain": trust_domain,
+            "sub": payload.sub,
+            "source": "shared",
+        },
         "principal_id": payload.principal_id,
         "sub": payload.sub,
         "org": payload.org,

--- a/frontend/cullis-chat/mock/ambassador.mjs
+++ b/frontend/cullis-chat/mock/ambassador.mjs
@@ -172,10 +172,21 @@ const server = createServer(async (req, res) => {
   }
 
   if (req.method === 'GET' && pathname === '/api/session/whoami') {
-    // ADR-021 shared-mode shape: cookie payload as the Ambassador
-    // hands it back. The Astro `/api/session/whoami` route translates
-    // this into the ADR-020 principal shape the IdentityBadge wants.
+    // ADR-019 Phase 8b-2a unified shape: both single and shared modes
+    // now emit the wrapped ADR-020 ``principal`` subobject alongside
+    // the legacy top-level fields. The SPA's IdentityBadge consumes
+    // the wrapped shape directly with no client-side translation.
     jsonResponse(res, 200, {
+      ok: true,
+      principal: {
+        spiffe_id: 'spiffe://demo.test/demo/user/mario',
+        principal_type: 'user',
+        name: 'mario',
+        org: 'demo',
+        trust_domain: 'demo.test',
+        sub: 'mario@demo.test',
+        source: 'shared',
+      },
       principal_id: 'demo.test/demo/user/mario',
       sub: 'mario@demo.test',
       org: 'demo',

--- a/frontend/cullis-chat/src/lib/api.ts
+++ b/frontend/cullis-chat/src/lib/api.ts
@@ -59,15 +59,13 @@ export async function initSession(): Promise<{ ok: boolean; ttl: number }> {
   return jsonFetch('/api/session/init', { method: 'POST', body: '{}' });
 }
 
-/** GET /api/session/whoami — fetches the resolved principal. */
-export async function whoami(): Promise<{ ok: true; principal: Principal } | Principal> {
-  // The server returns either {ok, principal} (fallback) or the principal
-  // shape directly (forwarded from Ambassador /v1/whoami). Normalise.
-  const raw = await jsonFetch<unknown>('/api/session/whoami');
-  if (raw && typeof raw === 'object' && 'principal' in (raw as Record<string, unknown>)) {
-    return raw as { ok: true; principal: Principal };
-  }
-  return raw as Principal;
+/** GET /api/session/whoami — fetches the resolved principal.
+ *
+ * After Phase 8b-2a both single and shared mode return the same
+ * ADR-020 wrapped shape, so this is now a pure passthrough.
+ */
+export async function whoami(): Promise<{ ok: boolean; principal: Principal }> {
+  return jsonFetch<{ ok: boolean; principal: Principal }>('/api/session/whoami');
 }
 
 /** GET /v1/models — direct to Ambassador via session cookie auth. */

--- a/frontend/cullis-chat/src/pages/api/session/whoami.ts
+++ b/frontend/cullis-chat/src/pages/api/session/whoami.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { AMBASSADOR_URL, SESSION_COOKIE } from '../../../lib/server/config';
+import { AMBASSADOR_URL } from '../../../lib/server/config';
 import { logEvent } from '../../../lib/server/logger';
 
 export const prerender = false;
@@ -7,74 +7,23 @@ export const prerender = false;
 /**
  * GET /api/session/whoami
  *
- * Returns the current principal for the IdentityBadge in the TopBar.
+ * Pure passthrough to the Ambassador. After ADR-019 Phase 8b-2a both
+ * single mode (cullis_connector/ambassador/session_routes.py) and
+ * shared mode (cullis_connector/ambassador/shared/router.py) return
+ * the same ADR-020 wrapped shape:
  *
- * In **shared mode** (ADR-021) the Ambassador exposes
- * `/api/session/whoami` with the cookie payload shape
- * `{ principal_id, sub, org, exp }`. We translate it to the ADR-020
- * shape the IdentityBadge consumes:
+ *   { ok, principal: { spiffe_id, principal_type, name, org,
+ *                      trust_domain, sub, source },
+ *     principal_id, sub, org, exp }
  *
- *   {
- *     spiffe_id: "spiffe://acme.test/acme/user/mario",
- *     principal_type: "user" | "agent" | "workload",
- *     name: "mario",
- *     org: "acme",
- *     trust_domain: "acme.test"
- *   }
- *
- * In **single mode** the Ambassador has no whoami endpoint (it's a
- * one-user dashboard, identity is the Connector profile). We return
- * a local-shaped payload so the badge still renders.
+ * The SPA's `lib/api.ts:whoami()` consumes that wrapped shape directly
+ * — no translation here. This Astro route stays only to pass cookies
+ * through in the dev `npm run dev` topology and the Frontdesk
+ * container Phase 7 nginx config; Phase 8b-2 will remove it entirely
+ * along with switching Astro to static.
  */
-type SharedWhoami = {
-  principal_id: string;
-  sub: string;
-  org: string;
-  exp: number;
-};
-
-function principalFromSharedPayload(body: SharedWhoami) {
-  // principal_id is `<trust-domain>/<org>/<principal-type>/<name>`
-  const parts = body.principal_id.split('/');
-  if (parts.length === 4) {
-    const [trust_domain, org, principal_type, name] = parts;
-    return {
-      spiffe_id: `spiffe://${body.principal_id}`,
-      principal_type,
-      name,
-      org,
-      trust_domain,
-      sub: body.sub,
-      source: 'shared',
-    };
-  }
-  // Malformed principal_id — surface what we have rather than crash.
-  return {
-    spiffe_id: null,
-    principal_type: 'user',
-    name: body.sub,
-    org: body.org,
-    trust_domain: null,
-    sub: body.sub,
-    source: 'shared-fallback',
-  };
-}
-
-export const GET: APIRoute = async ({ cookies, request }) => {
-  const token = cookies.get(SESSION_COOKIE)?.value;
-  if (!token) {
-    return new Response(JSON.stringify({ ok: false, error: 'no_session' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
-  // Forward the browser's cookies to the Ambassador so the
-  // shared-mode `cullis_session` cookie reaches the server. The
-  // Bearer is the local-token for single mode (kept for back-compat).
-  const fwdHeaders: Record<string, string> = {
-    Authorization: `Bearer ${token}`,
-  };
+export const GET: APIRoute = async ({ request }) => {
+  const fwdHeaders: Record<string, string> = {};
   const fwdCookie = request.headers.get('cookie');
   if (fwdCookie) {
     fwdHeaders.Cookie = fwdCookie;
@@ -85,34 +34,6 @@ export const GET: APIRoute = async ({ cookies, request }) => {
       method: 'GET',
       headers: fwdHeaders,
     });
-
-    if (upstream.ok) {
-      const body = (await upstream.json()) as SharedWhoami;
-      return new Response(
-        JSON.stringify({ ok: true, principal: principalFromSharedPayload(body) }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      );
-    }
-
-    if (upstream.status === 401 || upstream.status === 404) {
-      // Single mode (no /api/session/whoami) or no shared cookie set.
-      // Fall back to a local shape so the badge still renders.
-      return new Response(
-        JSON.stringify({
-          ok: true,
-          principal: {
-            spiffe_id: null,
-            principal_type: 'user',
-            name: 'local',
-            org: 'local',
-            trust_domain: null,
-            source: 'fallback',
-          },
-        }),
-        { status: 200, headers: { 'Content-Type': 'application/json' } },
-      );
-    }
-
     const body = await upstream.text();
     return new Response(body, {
       status: upstream.status,

--- a/frontend/cullis-chat/src/pages/api/session/whoami.ts
+++ b/frontend/cullis-chat/src/pages/api/session/whoami.ts
@@ -1,5 +1,5 @@
 import type { APIRoute } from 'astro';
-import { AMBASSADOR_URL } from '../../../lib/server/config';
+import { AMBASSADOR_URL, SESSION_COOKIE } from '../../../lib/server/config';
 import { logEvent } from '../../../lib/server/logger';
 
 export const prerender = false;
@@ -7,7 +7,7 @@ export const prerender = false;
 /**
  * GET /api/session/whoami
  *
- * Pure passthrough to the Ambassador. After ADR-019 Phase 8b-2a both
+ * Cookie-forward to the Ambassador. After ADR-019 Phase 8b-2a both
  * single mode (cullis_connector/ambassador/session_routes.py) and
  * shared mode (cullis_connector/ambassador/shared/router.py) return
  * the same ADR-020 wrapped shape:
@@ -16,13 +16,23 @@ export const prerender = false;
  *                      trust_domain, sub, source },
  *     principal_id, sub, org, exp }
  *
- * The SPA's `lib/api.ts:whoami()` consumes that wrapped shape directly
- * — no translation here. This Astro route stays only to pass cookies
- * through in the dev `npm run dev` topology and the Frontdesk
- * container Phase 7 nginx config; Phase 8b-2 will remove it entirely
- * along with switching Astro to static.
+ * No payload translation here — the SPA's ``lib/api.ts:whoami()``
+ * consumes the wrapped shape directly. The "no cookie" early-return
+ * stays so unauth callers see a stable ``{ok:false, error:"no_session"}``
+ * 401 instead of whatever the upstream's missing-auth response happens
+ * to look like (single mode returns 200+placeholder, shared mode 401
+ * with a different body). Phase 8b-2 will remove this Astro route
+ * entirely along with switching Astro to static; the contract then
+ * lives on the Ambassador only.
  */
-export const GET: APIRoute = async ({ request }) => {
+export const GET: APIRoute = async ({ cookies, request }) => {
+  if (!cookies.get(SESSION_COOKIE)?.value) {
+    return new Response(JSON.stringify({ ok: false, error: 'no_session' }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
   const fwdHeaders: Record<string, string> = {};
   const fwdCookie = request.headers.get('cookie');
   if (fwdCookie) {

--- a/tests/test_frontdesk_shared_e2e.py
+++ b/tests/test_frontdesk_shared_e2e.py
@@ -135,6 +135,11 @@ def test_two_users_get_distinct_cookies(frontdesk_app):
 
 
 def test_whoami_returns_per_user_principal(frontdesk_app):
+    """Whoami response carries both the legacy top-level fields (for
+    back-compat) and the ADR-020 wrapped ``principal`` subobject so
+    that single mode and shared mode now share one wire shape (Phase
+    8b-2a). The SPA's IdentityBadge can read the same fields whether
+    it's running on a laptop installer or behind SSO in Frontdesk."""
     app, _ = frontdesk_app
     with TestClient(app, base_url="https://testserver") as cli:
         cli.post(
@@ -144,9 +149,20 @@ def test_whoami_returns_per_user_principal(frontdesk_app):
         r = cli.get("/api/session/whoami")
         assert r.status_code == 200
         body = r.json()
+        # Top-level (back-compat).
         assert body["principal_id"] == "acme.test/acme/user/mario"
         assert body["sub"] == "mario@acme.it"
         assert body["org"] == "acme"
+        # ADR-020 wrapped shape (additive).
+        assert body["ok"] is True
+        p = body["principal"]
+        assert p["spiffe_id"] == "spiffe://acme.test/acme/user/mario"
+        assert p["principal_type"] == "user"
+        assert p["name"] == "mario"
+        assert p["org"] == "acme"
+        assert p["trust_domain"] == "acme.test"
+        assert p["sub"] == "mario@acme.it"
+        assert p["source"] == "shared"
 
 
 def test_logout_clears_then_unauthorised(frontdesk_app):


### PR DESCRIPTION
## What does this PR do?

Aligns shared mode `/api/session/whoami` to the same ADR-020 wrapped shape that single mode shipped in Phase 8a (PR #428). Two modes, two wire shapes, one client-side translator → one unified shape, no client translator.

## Before (shared mode)

```json
{
  "principal_id": "acme.test/acme/user/mario",
  "sub": "mario@acme.it",
  "org": "acme",
  "exp": 12345
}
```

## After (both modes)

```json
{
  "ok": true,
  "principal": {
    "spiffe_id": "spiffe://acme.test/acme/user/mario",
    "principal_type": "user",
    "name": "mario",
    "org": "acme",
    "trust_domain": "acme.test",
    "sub": "mario@acme.it",
    "source": "shared"
  },
  "principal_id": "acme.test/acme/user/mario",
  "sub": "mario@acme.it",
  "org": "acme",
  "exp": 12345
}
```

Top-level `principal_id`, `sub`, `org`, `exp` are **preserved** so existing callers (Frontdesk e2e tests, Mastio audit tooling that reads top-level) keep working. The wrapped `principal` subobject is **purely additive**.

## Why

The SPA's `whoami.ts` owned the flat→wrapped translation as a workaround for shared mode's flat shape. After this PR:

- `frontend/cullis-chat/src/lib/api.ts:whoami()` is a pure passthrough
- `src/pages/api/session/whoami.ts` becomes a thin cookie-forward (no shape transform)

Phase 8b-2b will delete the Astro `whoami.ts` route entirely along with switching Astro to static. This PR is the prerequisite that makes the deletion safe.

## Files

- `cullis_connector/ambassador/shared/router.py`: rebuild whoami response to the wrapped shape; unwrap `principal_id` into `trust_domain`/`org`/`principal_type`/`name`; tag `source: "shared"` so consumers can tell the modes apart.
- `frontend/cullis-chat/src/lib/api.ts`: drop the dual-shape normalisation in `whoami()`.
- `frontend/cullis-chat/src/pages/api/session/whoami.ts`: drop the flat→wrapped translator; pure cookie-forward to upstream (will be deleted in 8b-2b).
- `tests/test_frontdesk_shared_e2e.py`: assert the new wrapped fields alongside the legacy top-level ones.

## Verification

- 61 ambassador + Frontdesk shared e2e tests pass.
- `npm run build` clean.

## Test plan

- [ ] CI green (Python tests + e2e Playwright suite + smoke)
- [ ] Manual smoke against Frontdesk: badge displays correctly for two distinct SSO users