### PR TITLE
feat(connector): mount Cullis Chat SPA at /chat (ADR-019 Phase 8c)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,11 @@ packaging/pypi-sdk/LICENSE-APACHE-2.0
 packaging/pypi-sdk/NOTICE
 packaging/pypi-sdk/CHANGELOG.md
 
+# Cullis Chat SPA static — built artefact, not source. Copied here by
+# scripts/build-spa.sh before packaging the Connector wheel (ADR-019
+# Phase 8c). Reproducible from frontend/cullis-chat/.
+cullis_connector/static/cullis-chat/
+
 # Python build outputs
 dist/
 build/

--- a/cullis_connector/templates/connected.html
+++ b/cullis_connector/templates/connected.html
@@ -62,6 +62,11 @@
     </div>
 
     <div class="btn-row" style="margin-top: 16px;">
+        {% if cullis_chat_mounted %}
+        <a href="/chat/" class="btn btn-primary">
+            Open Cullis Chat →
+        </a>
+        {% endif %}
         <button type="button"
                 id="test-ping-btn"
                 class="btn btn-ghost"

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -73,6 +73,34 @@ _log = logging.getLogger("cullis_connector.web")
 _TEMPLATES_DIR = Path(__file__).parent / "templates"
 _STATIC_DIR = Path(__file__).parent / "static"
 
+# ADR-019 Phase 8c — locations to look for the Cullis Chat SPA build.
+# Searched in order; first match wins. ``CULLIS_CHAT_DIST`` env var
+# beats both. If none exist, /chat is not mounted (logged once at boot).
+_CHAT_BUNDLED_DIR = _STATIC_DIR / "cullis-chat"
+_CHAT_REPO_DEV_DIR = (
+    Path(__file__).parent.parent / "frontend" / "cullis-chat" / "dist"
+)
+
+
+def _resolve_chat_dist() -> Path | None:
+    """Return the directory holding the built Cullis Chat SPA, or None.
+
+    A directory counts as a valid SPA build if it contains an
+    ``index.html`` at its root. We check that explicitly so an empty
+    or half-built directory does not silently mount and serve 404s for
+    every asset.
+    """
+    candidates: list[Path] = []
+    env_path = os.environ.get("CULLIS_CHAT_DIST")
+    if env_path:
+        candidates.append(Path(env_path))
+    candidates.append(_CHAT_BUNDLED_DIR)
+    candidates.append(_CHAT_REPO_DEV_DIR)
+    for candidate in candidates:
+        if candidate.is_dir() and (candidate / "index.html").is_file():
+            return candidate
+    return None
+
 
 # ── Pending-enrollment in-memory state ───────────────────────────────────
 #
@@ -470,6 +498,39 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     templates.env.globals["active_profile"] = config.profile_name or ""
     app.mount("/static", StaticFiles(directory=str(_STATIC_DIR)), name="static")
 
+    # ADR-019 Phase 8c — mount the Cullis Chat SPA static build at /chat
+    # if a built dist/ is reachable. Resolution order:
+    #
+    #   1. CULLIS_CHAT_DIST env var (operator override, useful in dev when
+    #      the SPA is built somewhere unusual)
+    #   2. cullis_connector/static/cullis-chat/ (production wheel layout —
+    #      the build pipeline copies frontend/cullis-chat/dist there before
+    #      packaging; pyproject.toml's force-include picks it up)
+    #   3. <repo>/frontend/cullis-chat/dist/ (dev layout, when running from
+    #      a source checkout)
+    #
+    # html=True so a bare GET /chat/ serves /chat/index.html. Templates
+    # like connected.html link to /chat/ once enrollment is complete.
+    chat_dist = _resolve_chat_dist()
+    if chat_dist is not None:
+        app.mount(
+            "/chat",
+            StaticFiles(directory=str(chat_dist), html=True),
+            name="cullis_chat",
+        )
+        _log.info("cullis-chat SPA mounted at /chat from %s", chat_dist)
+    else:
+        _log.info(
+            "cullis-chat SPA not mounted: no dist/ found; "
+            "build the SPA (npm run build in frontend/cullis-chat) or "
+            "set CULLIS_CHAT_DIST to enable /chat"
+        )
+    # Templates check this to decide whether to render the "Open Cullis
+    # Chat" button on /connected. Stashed on app.state too so the
+    # desktop wrapper can navigate to /chat post-enrollment.
+    templates.env.globals["cullis_chat_mounted"] = chat_dist is not None
+    app.state.cullis_chat_mounted = chat_dist is not None
+
     # ── CSRF / cross-origin guard ────────────────────────────────────────
     #
     # Audit 2026-04-30 lane 5 C1 — every state-changing endpoint on the
@@ -552,8 +613,18 @@ def build_app(config: ConnectorConfig) -> FastAPI:
 
     @app.get("/", response_class=HTMLResponse)
     def root() -> Response:
-        """Dispatch to the correct screen based on current state."""
+        """Dispatch to the correct screen based on current state.
+
+        When identity is present AND the Cullis Chat SPA is mounted at
+        /chat (ADR-019 Phase 8c), the root sends users straight to the
+        chat surface — that is the consumer-facing destination of the
+        desktop installer. The /connected dashboard is still reachable
+        directly (or via the tray menu in the desktop wrapper) for
+        admin / maintenance flows.
+        """
         if has_identity(config.config_dir):
+            if getattr(app.state, "cullis_chat_mounted", False):
+                return RedirectResponse("/chat/", status_code=303)
             return RedirectResponse("/connected", status_code=303)
         if _pending is not None:
             return RedirectResponse("/waiting", status_code=303)

--- a/scripts/build-spa.sh
+++ b/scripts/build-spa.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# scripts/build-spa.sh — build the Cullis Chat SPA and stage it for
+# packaging. ADR-019 Phase 8c.
+#
+# After this script:
+#   - frontend/cullis-chat/dist/         contains the prerendered SPA
+#                                        (used by the Frontdesk container's
+#                                        cullis-chat Dockerfile)
+#   - cullis_connector/static/cullis-chat/  contains the same dist
+#                                        (used by the Connector wheel; the
+#                                        FastAPI app mounts it at /chat)
+#
+# Run before:
+#   - publishing the Connector wheel (so pip-installed users get /chat)
+#   - building the PyInstaller bundle for the desktop installer
+#   - dogfooding /chat from a source checkout
+#
+# Idempotent: re-runs replace the staged copy.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPA_DIR="${REPO_ROOT}/frontend/cullis-chat"
+DIST_DIR="${SPA_DIR}/dist"
+STAGE_DIR="${REPO_ROOT}/cullis_connector/static/cullis-chat"
+
+if [[ ! -f "${SPA_DIR}/package.json" ]]; then
+    echo "ERROR: SPA package.json not found at ${SPA_DIR}" >&2
+    exit 1
+fi
+
+echo "==> npm ci (deterministic install) in ${SPA_DIR}"
+( cd "${SPA_DIR}" && npm ci --include=dev )
+
+echo "==> npm run build"
+( cd "${SPA_DIR}" && npm run build )
+
+if [[ ! -f "${DIST_DIR}/index.html" ]]; then
+    echo "ERROR: build did not produce index.html in ${DIST_DIR}" >&2
+    exit 1
+fi
+
+echo "==> staging dist into ${STAGE_DIR}"
+rm -rf "${STAGE_DIR}"
+mkdir -p "$(dirname "${STAGE_DIR}")"
+cp -R "${DIST_DIR}" "${STAGE_DIR}"
+
+echo "==> done. Connector now mounts /chat from ${STAGE_DIR}"

--- a/tests/connector/test_cullis_chat_mount.py
+++ b/tests/connector/test_cullis_chat_mount.py
@@ -1,0 +1,190 @@
+"""ADR-019 Phase 8c — Cullis Chat SPA mount in the Connector.
+
+The Connector FastAPI mounts the prerendered SPA at /chat when a built
+dist/ is reachable. Resolution order:
+
+  1. CULLIS_CHAT_DIST env var
+  2. cullis_connector/static/cullis-chat/  (production wheel layout)
+  3. <repo>/frontend/cullis-chat/dist/      (dev source layout)
+
+Tests cover:
+
+  * No dist anywhere → /chat is not mounted, ``/`` falls back to
+    /connected when identity exists, /setup otherwise.
+  * dist via env var → /chat serves index.html, ``/`` redirects to /chat.
+  * Templates global ``cullis_chat_mounted`` reflects the mount state
+    so connected.html can conditionally render the "Open Cullis Chat"
+    button.
+
+The dist used here is a tiny fixture (one index.html, one CSS, one JS
+chunk). It does not exercise the real SPA — that is the job of the
+Playwright suite under ``frontend/cullis-chat/tests/e2e/``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity import generate_keypair, save_identity
+from cullis_connector.identity.store import IdentityMetadata
+from cullis_connector.web import build_app
+
+
+def _self_signed_cert_pem(private_key, *, common_name: str) -> str:
+    from datetime import datetime, timedelta, timezone
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.x509.oid import NameOID
+
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, common_name),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, common_name.split("::", 1)[0]),
+    ])
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(private_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=30))
+        .sign(private_key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _seed_identity(config_dir: Path, *, agent_id: str = "acme::frontdesk") -> None:
+    key = generate_keypair()
+    cert_pem = _self_signed_cert_pem(key, common_name=agent_id)
+    save_identity(
+        config_dir=config_dir,
+        cert_pem=cert_pem,
+        private_key=key,
+        ca_chain_pem=None,
+        metadata=IdentityMetadata(
+            agent_id=agent_id,
+            capabilities=[],
+            site_url="https://mastio.test",
+            issued_at="2026-05-04T10:00:00+00:00",
+        ),
+    )
+
+
+def _make_fake_dist(target: Path) -> None:
+    """Create a minimal SPA-like dist tree: index.html + one asset."""
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "index.html").write_text(
+        '<!doctype html><html><head><meta charset="utf-8">'
+        "<title>Cullis Chat</title></head><body>"
+        '<div id="root">cullis-chat fixture</div></body></html>',
+        encoding="utf-8",
+    )
+    assets = target / "_astro"
+    assets.mkdir(exist_ok=True)
+    (assets / "app.js").write_text("/* fixture */", encoding="utf-8")
+
+
+class _NoChatDistEnv:
+    """Force the SPA resolver to find nothing.
+
+    Repository-relative dev fallback can survive monkeypatching of
+    ``CULLIS_CHAT_DIST`` (it does not look at env vars). We point the
+    env var at a guaranteed-empty directory under tmp_path AND null
+    the bundled / repo-dev candidates by monkeypatching the module
+    constants. Both must be set or one of them resolves the path
+    despite our intent.
+    """
+
+
+@pytest.fixture
+def app_no_chat(tmp_path: Path, monkeypatch):
+    _seed_identity(tmp_path)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test",
+        verify_tls=False,
+    )
+    cfg.ambassador.require_local_only = False
+    # Point to an empty dir (no index.html) so the resolver rejects it.
+    empty = tmp_path / "no-spa-here"
+    empty.mkdir()
+    monkeypatch.setenv("CULLIS_CHAT_DIST", str(empty))
+    # Null the other candidates by pointing them at non-existent paths.
+    monkeypatch.setattr(
+        "cullis_connector.web._CHAT_BUNDLED_DIR", tmp_path / "no-bundled"
+    )
+    monkeypatch.setattr(
+        "cullis_connector.web._CHAT_REPO_DEV_DIR", tmp_path / "no-repo-dev"
+    )
+    return build_app(cfg)
+
+
+@pytest.fixture
+def app_with_chat(tmp_path: Path, monkeypatch):
+    _seed_identity(tmp_path)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test",
+        verify_tls=False,
+    )
+    cfg.ambassador.require_local_only = False
+    # Build a fake dist and point CULLIS_CHAT_DIST at it.
+    dist = tmp_path / "fake-spa-dist"
+    _make_fake_dist(dist)
+    monkeypatch.setenv("CULLIS_CHAT_DIST", str(dist))
+    return build_app(cfg)
+
+
+def test_chat_not_mounted_when_no_dist(app_no_chat):
+    with TestClient(app_no_chat, follow_redirects=False) as cli:
+        # /chat is not mounted at all — 404 from the dashboard router.
+        resp = cli.get("/chat/")
+        assert resp.status_code == 404
+
+        # Without the mount, /  falls back to the dashboard /connected
+        # (identity is seeded by the fixture).
+        root = cli.get("/")
+        assert root.status_code == 303
+        assert root.headers["location"] == "/connected"
+
+
+def test_chat_mounted_serves_index(app_with_chat):
+    with TestClient(app_with_chat, follow_redirects=False) as cli:
+        # /chat/ serves the SPA's index.html.
+        resp = cli.get("/chat/")
+        assert resp.status_code == 200
+        assert "cullis-chat fixture" in resp.text
+        assert resp.headers["content-type"].startswith("text/html")
+
+
+def test_chat_assets_resolve(app_with_chat):
+    with TestClient(app_with_chat, follow_redirects=False) as cli:
+        resp = cli.get("/chat/_astro/app.js")
+        assert resp.status_code == 200
+        assert "fixture" in resp.text
+
+
+def test_root_redirects_to_chat_when_mounted_and_identity(app_with_chat):
+    with TestClient(app_with_chat, follow_redirects=False) as cli:
+        root = cli.get("/")
+        assert root.status_code == 303
+        assert root.headers["location"] == "/chat/"
+
+
+def test_connected_template_shows_chat_button_when_mounted(app_with_chat):
+    with TestClient(app_with_chat) as cli:
+        resp = cli.get("/connected")
+        assert resp.status_code == 200
+        assert "Open Cullis Chat" in resp.text
+
+
+def test_connected_template_hides_chat_button_when_not_mounted(app_no_chat):
+    with TestClient(app_no_chat) as cli:
+        resp = cli.get("/connected")
+        assert resp.status_code == 200
+        assert "Open Cullis Chat" not in resp.text


### PR DESCRIPTION
## What does this PR do?

Lays the foundation for the desktop installer. The Connector FastAPI now serves the prerendered Cullis Chat SPA at `/chat` when a built `dist/` is reachable. After this PR, a single Connector process can serve the enrollment wizard (Jinja templates), the chat UI (Astro static), and the Ambassador API surface — exactly the topology the desktop installer (Phase 8d-e) bundles.

## Resolution order at boot

1. `CULLIS_CHAT_DIST` env var (operator override, dev-friendly)
2. `cullis_connector/static/cullis-chat/` (production wheel layout — `pyproject.toml`'s force-include already ships this path; `scripts/build-spa.sh` populates it)
3. `<repo>/frontend/cullis-chat/dist/` (dev source checkout layout)

A directory only counts as a valid SPA build if it contains `index.html` at its root, so a half-built or empty dir does not silently mount and serve 404s for every asset.

## Behaviour

| Path | When SPA mounted | When not mounted |
|---|---|---|
| `GET /` (with identity) | 303 → `/chat/` | 303 → `/connected` (unchanged) |
| `GET /` (no identity) | 303 → `/setup` | 303 → `/setup` (unchanged) |
| `GET /chat/` | 200, prerendered index.html | 404 |
| `GET /chat/_astro/<hashed>` | 200, JS/CSS chunks | 404 |
| `/connected` dashboard | "Open Cullis Chat →" button visible | button hidden |

## Files

- `cullis_connector/web.py`: `_resolve_chat_dist()` helper + the mount call; root redirect chooses `/chat` when identity AND mount; `templates.env.globals['cullis_chat_mounted']` and `app.state.cullis_chat_mounted` expose the boot decision.
- `cullis_connector/templates/connected.html`: conditional `Open Cullis Chat →` CTA on the post-enrollment screen.
- `scripts/build-spa.sh`: `npm ci && npm run build` then copy `frontend/cullis-chat/dist/` → `cullis_connector/static/cullis-chat/`. Run before publishing the wheel or dogfooding `/chat` from source.
- `.gitignore`: exclude the staged build artefact (it is reproducible from source).
- `tests/connector/test_cullis_chat_mount.py`: 6 tests covering mount on/off, `/chat` index + assets, root redirect, `/connected` CTA visibility. Uses a fake `dist/` fixture; does not exercise the real SPA (Playwright covers that).

## Verification

- 6/6 new tests pass.
- 413/413 connector + Frontdesk e2e tests pass (no regressions).

## Test plan

- [ ] CI green (Python tests + e2e Playwright + smoke).
- [ ] Manual smoke from a source checkout: `bash scripts/build-spa.sh` then `python -m cullis_connector dashboard --port 7780 --no-open-browser`. Open `http://127.0.0.1:7780/chat/` — SPA renders.
- [ ] Same flow with `CULLIS_CHAT_DIST=/tmp/empty` env var: `/chat` returns 404, log line says no dist found.

## Out of scope, deferred

- PyInstaller `.spec` updates so the frozen Connector binary embeds the SPA. Phase 8d.
- `desktop_app.py` polish (explicit tray menu items for `/chat` vs `/connected`). The existing webview already navigates to `/`, which now redirects to `/chat` post-enrollment, so the desktop wrapper works end-to-end without code changes.
- Auto-update for the desktop installer. Phase 8e.
- Strict CSP via Astro experimental auto-hash. Tracked separately.