### PR TITLE
fix(connector): close Phase 8c visual gaps surfaced by dogfood smoke

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -513,6 +513,23 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     # like connected.html link to /chat/ once enrollment is complete.
     chat_dist = _resolve_chat_dist()
     if chat_dist is not None:
+        # Pre-mount gate: a user who navigates to /chat or /chat/ before
+        # enrollment would otherwise get the prerendered SPA, which then
+        # fails on its first /api/session/init call with a 404 (the
+        # Ambassador router is only mounted by the lifespan after
+        # has_identity is true). Surface the missing step explicitly by
+        # redirecting to /setup. Asset paths under /chat/_astro/ and
+        # other deep links keep flowing through to StaticFiles so an
+        # already-loaded SPA tab can refresh assets without a redirect
+        # ping-pong.
+        @app.middleware("http")
+        async def _chat_identity_gate(request, call_next):  # type: ignore[no-untyped-def]
+            path = request.url.path
+            if path == "/chat" or path == "/chat/":
+                if not has_identity(config.config_dir):
+                    return RedirectResponse("/setup", status_code=303)
+            return await call_next(request)
+
         app.mount(
             "/chat",
             StaticFiles(directory=str(chat_dist), html=True),

--- a/frontend/cullis-chat/astro.config.mjs
+++ b/frontend/cullis-chat/astro.config.mjs
@@ -14,8 +14,27 @@ import react from '@astrojs/react';
 //     the Connector container (packaging/frontdesk-bundle/).
 //   - Desktop installer (Phase 8c): FastAPI mounts dist/ at /chat and
 //     serves the same /v1/* /api/* on the same origin.
+// ``ASTRO_BASE`` env var lets the same source build for two topologies:
+//
+//   - Frontdesk container (packaging/frontdesk-bundle/): nginx serves
+//     the SPA at ``/`` so the default ``base: '/'`` produces asset
+//     URLs like ``/_astro/app.js`` that resolve against the bundle's
+//     root.
+//   - Desktop installer (Phase 8c): FastAPI mounts the SPA under
+//     ``/chat/`` (the ``/`` route is the Connector dashboard). Asset
+//     URLs need to live under ``/chat/_astro/...`` or the browser 404s
+//     the entire CSS+JS payload and renders an unstyled page.
+//
+// scripts/build-spa.sh sets ``ASTRO_BASE=/chat`` before invoking npm
+// run build for the Connector-staged copy. The Frontdesk Dockerfile
+// keeps the default. API fetches in lib/api.ts use absolute paths
+// (``/api/session/init`` etc) so they always hit the origin root,
+// regardless of base.
+const ASTRO_BASE = process.env.ASTRO_BASE || '/';
+
 export default defineConfig({
   output: 'static',
+  base: ASTRO_BASE,
   integrations: [react()],
   server: {
     port: 4321,

--- a/frontend/cullis-chat/src/components/SidebarLeft.astro
+++ b/frontend/cullis-chat/src/components/SidebarLeft.astro
@@ -12,7 +12,7 @@
 <aside class="sidebar-left" aria-label="Conversation history">
   <header class="sl-head">
     <span class="eyebrow">conversations</span>
-    <a class="sl-new" href="/" aria-label="Start a new chat" title="New chat">
+    <a class="sl-new" href={import.meta.env.BASE_URL} aria-label="Start a new chat" title="New chat">
       <span aria-hidden="true">+</span> new
     </a>
   </header>

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -15,8 +15,8 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
 ---
 
 <header class="topbar">
-  <a class="brand" href="/" aria-label="Cullis Chat home">
-    <img src="/cullis-mark.svg" alt="" width="26" height="26" />
+  <a class="brand" href={import.meta.env.BASE_URL} aria-label="Cullis Chat home">
+    <img src={`${import.meta.env.BASE_URL}cullis-mark.svg`} alt="" width="26" height="26" />
     <span class="wordmark">
       Cullis <span class="brand-tail">Chat</span>
     </span>

--- a/frontend/cullis-chat/src/layouts/ChatLayout.astro
+++ b/frontend/cullis-chat/src/layouts/ChatLayout.astro
@@ -33,7 +33,7 @@ const {
     <meta name="description" content={description} />
     <meta name="referrer" content="same-origin" />
     <title>{title}</title>
-    <link rel="icon" type="image/svg+xml" href="/cullis-mark.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}cullis-mark.svg`} />
   </head>
   <body class="app-shell">
     <TopBar />

--- a/scripts/build-spa.sh
+++ b/scripts/build-spa.sh
@@ -32,8 +32,15 @@ fi
 echo "==> npm ci (deterministic install) in ${SPA_DIR}"
 ( cd "${SPA_DIR}" && npm ci --include=dev )
 
-echo "==> npm run build"
-( cd "${SPA_DIR}" && npm run build )
+# ASTRO_BASE=/chat/: the Connector mounts the SPA at /chat (web.py),
+# Astro must emit asset URLs under that prefix or the browser 404s the
+# entire CSS/JS payload. Trailing slash matters because we concatenate
+# ``${BASE_URL}cullis-mark.svg`` in the templates — Astro exposes
+# ``import.meta.env.BASE_URL`` exactly as configured, no normalisation.
+# The Frontdesk container Dockerfile leaves ASTRO_BASE unset so its
+# default-/-rooted nginx serve still works.
+echo "==> npm run build (ASTRO_BASE=/chat/)"
+( cd "${SPA_DIR}" && ASTRO_BASE=/chat/ npm run build )
 
 if [[ ! -f "${DIST_DIR}/index.html" ]]; then
     echo "ERROR: build did not produce index.html in ${DIST_DIR}" >&2

--- a/tests/connector/test_cullis_chat_mount.py
+++ b/tests/connector/test_cullis_chat_mount.py
@@ -140,6 +140,23 @@ def app_with_chat(tmp_path: Path, monkeypatch):
     return build_app(cfg)
 
 
+@pytest.fixture
+def app_with_chat_no_identity(tmp_path: Path, monkeypatch):
+    """SPA dist exists but no enrollment yet — the gate should redirect
+    /chat traffic to /setup so the user does not see the SPA's
+    session_init 404 banner before completing enrollment."""
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test",
+        verify_tls=False,
+    )
+    cfg.ambassador.require_local_only = False
+    dist = tmp_path / "fake-spa-dist"
+    _make_fake_dist(dist)
+    monkeypatch.setenv("CULLIS_CHAT_DIST", str(dist))
+    return build_app(cfg)
+
+
 def test_chat_not_mounted_when_no_dist(app_no_chat):
     with TestClient(app_no_chat, follow_redirects=False) as cli:
         # /chat is not mounted at all — 404 from the dashboard router.
@@ -188,3 +205,37 @@ def test_connected_template_hides_chat_button_when_not_mounted(app_no_chat):
         resp = cli.get("/connected")
         assert resp.status_code == 200
         assert "Open Cullis Chat" not in resp.text
+
+
+def test_chat_gate_redirects_to_setup_when_no_identity(app_with_chat_no_identity):
+    """SPA mounted but no enrollment: /chat and /chat/ both redirect
+    to /setup so the user lands on the wizard instead of seeing the
+    SPA's ``session_init: HTTP 404`` banner before there is anything
+    for the cookie to authenticate against."""
+    with TestClient(app_with_chat_no_identity, follow_redirects=False) as cli:
+        for path in ("/chat", "/chat/"):
+            resp = cli.get(path)
+            assert resp.status_code == 303, f"{path}: {resp.status_code}"
+            assert resp.headers["location"] == "/setup"
+
+
+def test_chat_gate_does_not_block_static_assets_when_no_identity(
+    app_with_chat_no_identity,
+):
+    """Asset paths under /chat/_astro/ stay reachable so an already-
+    loaded SPA tab (rare but possible during enrollment if the user
+    keeps the chat tab open) can still pull JS/CSS chunks without a
+    redirect ping-pong."""
+    with TestClient(app_with_chat_no_identity, follow_redirects=False) as cli:
+        # The fake dist fixture writes _astro/app.js under the dist root.
+        resp = cli.get("/chat/_astro/app.js")
+        assert resp.status_code == 200
+        assert "fixture" in resp.text
+
+
+def test_chat_gate_passes_through_when_identity_exists(app_with_chat):
+    """The original mount-on path still works once enrollment is done."""
+    with TestClient(app_with_chat, follow_redirects=False) as cli:
+        resp = cli.get("/chat/")
+        assert resp.status_code == 200
+        assert "cullis-chat fixture" in resp.text


### PR DESCRIPTION
## What does this PR do?

Two follow-ups to ADR-019 Phase 8c (PR #432) found by manual smoke against a freshly-started Connector (no enrollment, no Mastio).

### 1. ASTRO_BASE: SPA renders unstyled when mounted at /chat

The Astro static build emitted asset URLs as `/_astro/index.css` etc. (root-rooted). When the Connector mounts the SPA at `/chat/` via FastAPI's StaticFiles, the browser requests those at `<origin>/_astro/...` — paths that do not exist under the mount, so every CSS+JS chunk 404s and the page renders as unstyled HTML.

Fix: the `ASTRO_BASE` env var feeds into Astro's `base` config so the same source builds for two topologies:

| Topology | `ASTRO_BASE` | Asset URLs |
|---|---|---|
| Frontdesk container (nginx serves SPA at `/`) | unset (default `/`) | `/_astro/...` |
| Desktop installer (FastAPI mounts at `/chat`) | `/chat/` | `/chat/_astro/...` |

`scripts/build-spa.sh` now sets `ASTRO_BASE=/chat/` before invoking `npm run build`. The Frontdesk Dockerfile leaves it unset.

`public/`-served assets (the cullis-mark.svg logo, favicon) needed manual treatment because Astro's `base` does not rewrite hardcoded `/cullis-mark.svg` strings; updated TopBar.astro, ChatLayout.astro, SidebarLeft.astro to use `${import.meta.env.BASE_URL}cullis-mark.svg` so they resolve against the configured base.

### 2. Gate /chat behind enrollment, redirect to /setup if missing

Without enrollment, the Ambassador router is not mounted (lifespan in `web.py:148-169`), so the SPA's `ensureSession()` 404s on `/api/session/init` and the user sees a "session_init: HTTP 404" banner inside an otherwise-pristine SPA UI. Confusing.

Added a small middleware that intercepts GET `/chat` and `/chat/` when no identity exists and redirects to `/setup`. Asset paths under `/chat/_astro/` stay reachable (an already-loaded SPA tab can still refresh chunks without ping-pong).

## Files

- `frontend/cullis-chat/astro.config.mjs`: `base: process.env.ASTRO_BASE || '/'`.
- `scripts/build-spa.sh`: export `ASTRO_BASE=/chat/` before build.
- `frontend/cullis-chat/src/components/TopBar.astro`: `${BASE_URL}` for cullis-mark + brand link.
- `frontend/cullis-chat/src/components/SidebarLeft.astro`: `${BASE_URL}` for `+ new` link.
- `frontend/cullis-chat/src/layouts/ChatLayout.astro`: `${BASE_URL}` for favicon link.
- `cullis_connector/web.py`: `_chat_identity_gate` middleware.
- `tests/connector/test_cullis_chat_mount.py`: 3 new tests for the gate.

## Verification

- `bash scripts/build-spa.sh` produces a dist/ where every internal href/src is `/chat/...`.
- `python -m cullis_connector dashboard --port 7780` + `curl http://127.0.0.1:7780/chat/` → 303 to /setup when no identity.
- All 9 mount tests pass; broader connector regression clean.

## Manual smoke checklist

- [ ] Visit `http://127.0.0.1:7780/chat/` without enrollment → lands on /setup
- [ ] Complete enrollment flow → root redirects to /chat/ → SPA renders with full styling
- [ ] No 404s in DevTools Network tab on the styled SPA