### PR TITLE
feat(connector): bundle Cullis Chat SPA in PyInstaller binary + tray polish (ADR-019 Phase 8d)

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -216,6 +216,25 @@ jobs:
         with:
           python-version: "3.11"
 
+      # ADR-019 Phase 8d — the PyInstaller spec ships
+      # ``cullis_connector/static`` wholesale, so the SPA dist needs to
+      # be staged into ``cullis_connector/static/cullis-chat/`` BEFORE
+      # PyInstaller runs. ``scripts/build-spa.sh`` does the npm build
+      # and copies the dist into place. Skip if the SPA isn't part of
+      # this release (the script no-ops if ``frontend/cullis-chat/`` is
+      # missing — the script errors out by design when it can't find
+      # the SPA, so the workflow surfaces a missing-frontend regression
+      # at release time rather than producing a /chat-less binary).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: frontend/cullis-chat/package-lock.json
+
+      - name: Build Cullis Chat SPA + stage into the connector package
+        shell: bash
+        run: bash scripts/build-spa.sh
+
       - name: Build binary
         shell: bash  # works on windows-latest (Git Bash)
         run: bash packaging/pyinstaller/build.sh

--- a/cullis-connector.spec
+++ b/cullis-connector.spec
@@ -10,6 +10,14 @@
 # Templates and static files must ship as data files — Jinja2Templates
 # and StaticFiles read them off disk at runtime relative to
 # cullis_connector/__file__.
+#
+# The ``cullis_connector/static`` entry covers two surfaces:
+#   - dashboard CSS + favicon (always present in the source tree)
+#   - the Cullis Chat SPA dist at ``cullis_connector/static/cullis-chat/``,
+#     which only exists if ``scripts/build-spa.sh`` was run before
+#     PyInstaller (ADR-019 Phase 8d). The release CI workflow does this
+#     automatically; local builds need to invoke the script first or the
+#     resulting binary will log "cullis-chat SPA not mounted" at boot.
 datas = [
     ("cullis_connector/templates", "cullis_connector/templates"),
     ("cullis_connector/static", "cullis_connector/static"),

--- a/cullis_connector/desktop_app.py
+++ b/cullis_connector/desktop_app.py
@@ -211,8 +211,18 @@ def _build_menu(
     on_quit: Callable[[], None],
     *,
     profiles_submenu=None,
+    open_chat: Callable[[], None] | None = None,
 ):
-    """Tray menu: Open Dashboard / Open Inbox / [Profiles ▸] / Quit.
+    """Tray menu: [Open Cullis Chat] / Open Dashboard / Open Inbox /
+    [Profiles ▸] / Quit.
+
+    ADR-019 Phase 8d — when the Cullis Chat SPA is mounted at /chat
+    (resolved at boot by ``cullis_connector.web._resolve_chat_dist``)
+    the menu surfaces it as the default action. Clicking the tray
+    icon opens chat directly; "Open Dashboard" stays available for
+    admin / maintenance flows. When the SPA is not bundled (no dist/
+    found), the chat entry is omitted so users do not click a dead
+    link.
 
     Pause-notifications remains a deliberate follow-up (M3.1b) — the
     top-level surface stays small so the first packaged binary is
@@ -220,17 +230,35 @@ def _build_menu(
     """
     import pystray
 
-    items = [
-        pystray.MenuItem(
-            "Open Dashboard",
-            lambda icon, item: open_dashboard(),
-            default=True,
-        ),
+    items: list = []
+    if open_chat is not None:
+        items.append(
+            pystray.MenuItem(
+                "Open Cullis Chat",
+                lambda icon, item: open_chat(),
+                default=True,
+            )
+        )
+        items.append(
+            pystray.MenuItem(
+                "Open Connector Dashboard",
+                lambda icon, item: open_dashboard(),
+            )
+        )
+    else:
+        items.append(
+            pystray.MenuItem(
+                "Open Dashboard",
+                lambda icon, item: open_dashboard(),
+                default=True,
+            )
+        )
+    items.append(
         pystray.MenuItem(
             "Open Inbox",
             lambda icon, item: open_inbox(),
-        ),
-    ]
+        )
+    )
     if profiles_submenu is not None:
         items.append(
             pystray.MenuItem("Profiles", profiles_submenu)
@@ -288,8 +316,18 @@ def run_desktop_app(
 
     window.events.closing += _on_closing
 
+    # ADR-019 Phase 8d — discover at boot whether the Cullis Chat SPA
+    # is bundled with this Connector. The resolver (web.py) is the same
+    # logic the dashboard uses to decide its mount, so the tray menu and
+    # the dashboard agree about /chat availability.
+    from cullis_connector.web import _resolve_chat_dist
+    chat_available = _resolve_chat_dist() is not None
+
     def _open_dashboard() -> None:
-        window.load_url(f"{base_url}/")
+        # /connected for explicit "show me the admin dashboard". When chat
+        # is bundled, /connected stays the admin surface; the new "Open
+        # Cullis Chat" menu item drives the consumer chat path.
+        window.load_url(f"{base_url}/connected" if chat_available else f"{base_url}/")
         window.show()
 
     def _open_inbox() -> None:
@@ -298,6 +336,13 @@ def run_desktop_app(
 
     def _open_profiles() -> None:
         window.load_url(f"{base_url}/profiles")
+        window.show()
+
+    def _open_chat() -> None:
+        # /chat redirects to /setup when no identity (gate added in
+        # the Phase 8c follow-up), so a pre-enrollment user clicking
+        # "Open Cullis Chat" lands on the wizard.
+        window.load_url(f"{base_url}/chat/")
         window.show()
 
     import pystray
@@ -352,6 +397,7 @@ def run_desktop_app(
         _open_inbox,
         _quit_all,
         profiles_submenu=profiles_submenu,
+        open_chat=_open_chat if chat_available else None,
     )
     icon.run_detached()
 


### PR DESCRIPTION
## What does this PR do?

Closes the loop on the desktop-installer foundation that Phase 8c (PR #432) laid. After this PR, the standalone PyInstaller binary ships with the Cullis Chat SPA inside it, the tray menu surfaces "Open Cullis Chat" as the default action, and the existing dashboard stays accessible for admin / maintenance flows.

Stacked on PR #433 in spirit (same dogfood-driven cleanup arc), but technically separate — this PR's diff does not touch the SPA source or the chat-redirect gate, so it can land independently.

## Files

- **`.github/workflows/release-connector.yml`**: the `build-binaries` matrix now sets up Node 22, runs `scripts/build-spa.sh` (npm build + stage into `cullis_connector/static/cullis-chat/`), then invokes `packaging/pyinstaller/build.sh` as before. PyInstaller's existing `--add-data cullis_connector/static` flag picks up the staged SPA wholesale; **no spec-level change needed for bundling**.

- **`cullis-connector.spec`**: comment against the `cullis_connector/static` `datas` entry calling out the SPA dependency on `scripts/build-spa.sh`. A contributor running pyinstaller locally without the script would silently produce a /chat-less binary; the comment + the GHA workflow keep that from happening for releases.

- **`cullis_connector/desktop_app.py`**:
  - `run_desktop_app` calls `web._resolve_chat_dist()` once at boot to detect whether the SPA is bundled with this Connector (env override / staged dir / repo dev fallback — same resolver the dashboard uses, so the tray and dashboard agree).
  - `_build_menu` accepts an optional `open_chat` callable. When set, the tray surfaces "Open Cullis Chat" as the **default action** and demotes "Open Connector Dashboard" to admin / maintenance. When SPA is not bundled, the chat entry is omitted so users do not click a 404.
  - "Open Connector Dashboard" routes to `/connected` explicitly when chat is bundled, so the dashboard stays one click away even though `/` now redirects to `/chat/` post-enrollment (Phase 8c).

## Behavior matrix

| State | Tray default click | Tray menu lists |
|---|---|---|
| SPA bundled, identity present | `/chat/` (chat UI) | Open Cullis Chat / Open Connector Dashboard / Open Inbox / Profiles / Quit |
| SPA bundled, no identity | `/chat/` → gate from PR #433 redirects to `/setup` | same |
| SPA not bundled | `/` → `/setup` or `/connected` per existing logic | Open Dashboard / Open Inbox / Profiles / Quit |

## Verification

- 406 connector tests pass (the 4 pre-existing `test_profile_runtime_switch.py` failures are pystray-on-NixOS issues, see memory `feedback_gui_libs_ci_headless`).
- `bash scripts/build-spa.sh && bash packaging/pyinstaller/build.sh` from a source checkout produces a binary that has the SPA at `<MEIPASS>/cullis_connector/static/cullis-chat/` (PyInstaller's existing data-bundling path).
- Tray-menu wiring is exercised at boot only and not unit-tested (pystray imports crash in headless CI runners; visual smoke + the GHA build matrix is the validation gate).

## Test plan

- [ ] CI green (release-connector workflow won't run on PRs — this is gated on tag push, so the build-binaries matrix change is implicitly tested only at release time)
- [ ] Manual smoke from a tag push: download the macOS / Linux / Windows artefacts, run, confirm SPA loads at `/chat/` after enrollment
- [ ] Tray menu click on "Open Cullis Chat" lands in the SPA; click on "Open Connector Dashboard" lands at `/connected`

## Out of scope, deferred to Phase 8e

- Native installers (`.dmg` / `.msi` / `.AppImage` / `.deb`)
- Code signing (Apple Developer ID + Windows EV cert)
- Auto-update — deferred to v0.2 of the installer per ADR-019 rev 3