### PR TITLE
feat(mcp_proxy): native AI gateway on Mastio (ADR-017 refactor)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ cullis_connector/static/cullis-chat/
 dist/
 build/
 *.egg-info/
+/sandbox/.env

--- a/cullis_connector/ambassador/loop.py
+++ b/cullis_connector/ambassador/loop.py
@@ -75,6 +75,12 @@ def run_tool_use_loop(
         Whatever the SDK raises (httpx.HTTPStatusError on 4xx/5xx, etc).
     """
     body = dict(request_body)  # shallow copy; we mutate `messages`
+    # ADR-017 Phase 2: Mastio /v1/llm/chat doesn't yet support SSE
+    # streaming. The SPA always asks for stream=true; we collapse the
+    # request to non-stream here and the outer router (router.py) wraps
+    # the final answer back into a fake_stream SSE response. Removed
+    # when Mastio Phase 3 wires real SSE pass-through.
+    body["stream"] = False
     messages: list[dict] = list(body.get("messages", []))
 
     # Discover tools the agent is bound to. Empty list is fine: the LLM

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -286,6 +286,16 @@ class ProxySettings(BaseSettings):
     # PROXY_LOCAL_AUTH.
     local_auth_enabled: bool = False
 
+    # ADR-017 native AI gateway on Mastio. When the Mastio runs litellm
+    # in-process (default: ``litellm_embedded``), every chat completion
+    # is dispatched without a Court round trip. Set ``backend=portkey``
+    # to delegate to a Portkey gateway sidecar instead.
+    anthropic_api_key: str = ""
+    ai_gateway_backend: str = "litellm_embedded"  # litellm_embedded | portkey
+    ai_gateway_provider: str = "anthropic"
+    ai_gateway_url: str = "http://localhost:8787"  # Portkey sidecar URL
+    ai_gateway_request_timeout_s: float = 30.0
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -1,0 +1,367 @@
+"""AI gateway dispatch (ADR-017 Phase 1).
+
+The dispatcher takes an OpenAI-compatible ChatCompletionRequest plus the
+trusted agent identity (already reconstructed from the DPoP-bound cert
+by the router) and forwards the call to the configured gateway. The
+agent identity is injected as both the gateway-native attribution
+header (e.g. x-portkey-metadata._user) and a canonical Cullis header
+(X-Cullis-Agent) propagated through to the upstream provider, so audit
+correlations work whether the dashboard speaks Cullis or gateway-native.
+
+Phase 1 supports Portkey only. LiteLLM and Kong land in Phase 2 once
+the smoke test confirms the contract.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+
+import httpx
+
+from mcp_proxy.config import ProxySettings as Settings
+from mcp_proxy.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
+
+
+# LiteLLM is imported lazily inside _call_litellm_embedded so deployments
+# that pin ai_gateway_backend != "litellm_embedded" do not pay the import
+# cost on startup. Spike validated 2026-05-03 against Anthropic Haiku 4.5
+# (see imp/sandbox-gateways/test/spike_litellm_acompletion.py).
+
+_log = logging.getLogger("agent_trust.egress")
+
+
+CULLIS_FORWARD_HEADERS = "X-Cullis-Agent,X-Cullis-Org,X-Cullis-Trace"
+
+
+@dataclass
+class GatewayResult:
+    response: ChatCompletionResponse
+    latency_ms: int
+    upstream_request_id: str | None
+    backend: str
+    provider: str
+
+
+class GatewayError(Exception):
+    """Raised on any non-recoverable failure talking to the gateway.
+
+    `status_code` is the HTTP code Mastio should return to its own
+    caller; `reason` is a short tag suitable for the audit row.
+    """
+
+    def __init__(self, status_code: int, reason: str, *, detail: str | None = None):
+        super().__init__(detail or reason)
+        self.status_code = status_code
+        self.reason = reason
+        self.detail = detail
+
+
+async def dispatch(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+    http_client: httpx.AsyncClient | None = None,
+) -> GatewayResult:
+    backend = settings.ai_gateway_backend.lower()
+    if backend == "litellm_embedded":
+        return await _call_litellm_embedded(
+            req=req,
+            agent_id=agent_id,
+            org_id=org_id,
+            trace_id=trace_id,
+            settings=settings,
+        )
+    if backend == "portkey":
+        return await _call_portkey(
+            req=req,
+            agent_id=agent_id,
+            org_id=org_id,
+            trace_id=trace_id,
+            settings=settings,
+            http_client=http_client,
+        )
+    raise GatewayError(
+        501,
+        f"backend_not_implemented:{backend}",
+        detail=f"AI gateway backend '{backend}' is not wired.",
+    )
+
+
+async def _call_portkey(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+    http_client: httpx.AsyncClient | None,
+) -> GatewayResult:
+    provider = settings.ai_gateway_provider.lower()
+    if provider != "anthropic":
+        raise GatewayError(
+            501,
+            f"provider_not_implemented:{provider}",
+            detail="Phase 1 only validates provider='anthropic' against Portkey.",
+        )
+
+    if not settings.anthropic_api_key:
+        raise GatewayError(503, "provider_key_missing")
+
+    upstream_url = f"{settings.ai_gateway_url.rstrip('/')}/v1/chat/completions"
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {settings.anthropic_api_key}",
+        "x-portkey-provider": provider,
+        "x-portkey-trace-id": trace_id,
+        "x-portkey-forward-headers": CULLIS_FORWARD_HEADERS,
+        "x-portkey-metadata": json.dumps(
+            {"_user": agent_id, "org_id": org_id, "trace_id": trace_id},
+            separators=(",", ":"),
+        ),
+        "X-Cullis-Agent": agent_id,
+        "X-Cullis-Org": org_id,
+        "X-Cullis-Trace": trace_id,
+    }
+
+    body = req.model_dump(exclude_none=True)
+
+    started = time.perf_counter()
+    owns_client = http_client is None
+    client = http_client or httpx.AsyncClient(timeout=settings.ai_gateway_request_timeout_s)
+    try:
+        try:
+            resp = await client.post(upstream_url, headers=headers, json=body)
+        except httpx.TimeoutException as exc:
+            raise GatewayError(504, "upstream_timeout", detail=str(exc)) from exc
+        except httpx.HTTPError as exc:
+            raise GatewayError(502, "upstream_unreachable", detail=str(exc)) from exc
+    finally:
+        if owns_client:
+            await client.aclose()
+
+    latency_ms = int((time.perf_counter() - started) * 1000)
+
+    if resp.status_code // 100 != 2:
+        # Surface the upstream body in the audit detail (capped) so
+        # operators can debug without re-running the call.
+        detail = resp.text[:512] if resp.text else None
+        raise GatewayError(
+            502,
+            f"upstream_status_{resp.status_code}",
+            detail=detail,
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise GatewayError(502, "malformed_upstream_body", detail=str(exc)) from exc
+
+    payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
+    payload.setdefault("object", "chat.completion")
+    payload.setdefault("created", int(time.time()))
+    payload.setdefault("model", req.model)
+    payload["cullis_trace_id"] = trace_id
+
+    try:
+        parsed = ChatCompletionResponse.model_validate(payload)
+    except Exception as exc:  # pydantic ValidationError or similar
+        raise GatewayError(
+            502,
+            "schema_mismatch",
+            detail=f"Upstream payload failed Mastio schema: {exc}",
+        ) from exc
+
+    upstream_request_id = (
+        resp.headers.get("x-portkey-request-id")
+        or resp.headers.get("x-request-id")
+    )
+
+    _log.info(
+        "egress.llm dispatched backend=portkey provider=%s agent=%s org=%s "
+        "model=%s latency_ms=%d tokens_in=%d tokens_out=%d",
+        provider, agent_id, org_id, parsed.model, latency_ms,
+        parsed.usage.prompt_tokens, parsed.usage.completion_tokens,
+    )
+
+    return GatewayResult(
+        response=parsed,
+        latency_ms=latency_ms,
+        upstream_request_id=upstream_request_id,
+        backend="portkey",
+        provider=provider,
+    )
+
+
+# ── LiteLLM embedded backend (ADR-017 Phase 3) ─────────────────────────
+
+
+# Map LiteLLM exception class names to (status_code, reason) tuples.
+# We compare by class name rather than isinstance() so the import of
+# litellm stays lazy (the dispatcher must boot in deployments that pin
+# a non-LiteLLM backend without litellm installed).
+_LITELLM_ERROR_MAP: dict[str, tuple[int, str]] = {
+    "AuthenticationError": (401, "provider_auth_failed"),
+    "PermissionDeniedError": (403, "provider_permission_denied"),
+    "NotFoundError": (404, "provider_not_found"),
+    "RateLimitError": (429, "provider_rate_limited"),
+    "BadRequestError": (400, "provider_bad_request"),
+    "UnprocessableEntityError": (422, "provider_unprocessable"),
+    "Timeout": (504, "provider_timeout"),
+    "APIConnectionError": (502, "provider_unreachable"),
+    "ContextWindowExceededError": (400, "provider_context_too_long"),
+    "ContentPolicyViolationError": (400, "provider_content_policy"),
+    "InternalServerError": (502, "provider_internal_error"),
+    "ServiceUnavailableError": (502, "provider_unavailable"),
+    "APIError": (502, "provider_api_error"),
+}
+
+
+def _map_litellm_exception(exc: Exception) -> GatewayError:
+    cls = type(exc).__name__
+    status, reason = _LITELLM_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
+    detail = (str(exc) or cls)[:512]
+    return GatewayError(status, reason, detail=detail)
+
+
+async def _call_litellm_embedded(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+) -> GatewayResult:
+    """Call the upstream provider via the LiteLLM library, in-process.
+
+    The model id from the request is forwarded as-is. For Anthropic
+    we expect the caller to pass either ``claude-haiku-4-5`` (LiteLLM
+    auto-detects the provider from the catalogue) or
+    ``anthropic/claude-haiku-4-5`` (explicit). The Mastio metadata is
+    attached via the ``metadata`` kwarg so any LiteLLM callback the
+    operator wires up (Datadog, Langfuse, Postgres) sees the agent
+    identity without us doing extra plumbing.
+    """
+    provider = settings.ai_gateway_provider.lower()
+    if provider != "anthropic":
+        raise GatewayError(
+            501,
+            f"provider_not_implemented:{provider}",
+            detail="Phase 3 only validates provider='anthropic' via LiteLLM.",
+        )
+    if not settings.anthropic_api_key:
+        raise GatewayError(503, "provider_key_missing")
+
+    try:
+        import litellm
+        from litellm import acompletion
+    except ImportError as exc:
+        raise GatewayError(
+            503,
+            "litellm_not_installed",
+            detail=(
+                "ai_gateway_backend='litellm_embedded' requires the litellm "
+                "package. Install it via requirements.txt."
+            ),
+        ) from exc
+
+    # Drop unsupported params silently rather than raising — keeps the
+    # OpenAI-compat contract usable across providers that vary on minor
+    # fields (e.g. Anthropic does not accept all OpenAI knobs).
+    litellm.drop_params = True
+
+    body = req.model_dump(exclude_none=True)
+    # LiteLLM uses provider-prefixed model ids when ambiguous; pass
+    # through whatever the caller sent.
+    model = body.pop("model")
+
+    metadata = {
+        "cullis_agent_id": agent_id,
+        "cullis_org_id": org_id,
+        "cullis_trace_id": trace_id,
+    }
+
+    started = time.perf_counter()
+    try:
+        response = await acompletion(
+            model=model,
+            api_key=settings.anthropic_api_key,
+            metadata=metadata,
+            **body,
+        )
+    except Exception as exc:
+        # Only the LiteLLM-shaped exceptions land in the map; anything
+        # else (e.g. ValueError on bad input) becomes provider_unknown.
+        gw_err = _map_litellm_exception(exc)
+        _log.warning(
+            "litellm_embedded error agent=%s model=%s reason=%s detail=%s",
+            agent_id, model, gw_err.reason, gw_err.detail,
+        )
+        raise gw_err from exc
+
+    latency_ms = int((time.perf_counter() - started) * 1000)
+
+    usage = getattr(response, "usage", None)
+    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+
+    # response_cost is not on every LiteLLM build; compute it on demand
+    # so we always surface a number in the audit row when the model is
+    # in the LiteLLM cost catalogue. Failures here are informational —
+    # the call succeeded, the cost is just unknown.
+    cost_usd: float | None = None
+    try:
+        cost_usd = litellm.completion_cost(completion_response=response)
+    except Exception as exc:
+        _log.debug("litellm.completion_cost failed for model=%s: %s", model, exc)
+
+    payload = response.model_dump() if hasattr(response, "model_dump") else dict(response)
+    payload.setdefault("id", f"chatcmpl-{uuid.uuid4().hex[:24]}")
+    payload.setdefault("object", "chat.completion")
+    payload.setdefault("created", int(time.time()))
+    payload.setdefault("model", model)
+    payload["cullis_trace_id"] = trace_id
+    # Force usage shape so Mastio's schema sees the canonical fields
+    # even when LiteLLM adds provider-specific extras (cached_tokens,
+    # reasoning_tokens) that our pydantic model would reject.
+    payload["usage"] = {
+        "prompt_tokens": int(prompt_tokens),
+        "completion_tokens": int(completion_tokens),
+        "total_tokens": int(prompt_tokens + completion_tokens),
+    }
+
+    try:
+        parsed = ChatCompletionResponse.model_validate(payload)
+    except Exception as exc:
+        raise GatewayError(
+            502,
+            "schema_mismatch",
+            detail=f"LiteLLM response failed Mastio schema: {exc}",
+        ) from exc
+
+    upstream_request_id = (
+        getattr(response, "id", None)
+        or (response.get("id") if isinstance(response, dict) else None)
+    )
+
+    _log.info(
+        "egress.llm dispatched backend=litellm_embedded provider=%s agent=%s "
+        "org=%s model=%s latency_ms=%d tokens_in=%d tokens_out=%d cost_usd=%s",
+        provider, agent_id, org_id, model, latency_ms,
+        prompt_tokens, completion_tokens,
+        f"{cost_usd:.6f}" if cost_usd is not None else "n/a",
+    )
+
+    return GatewayResult(
+        response=parsed,
+        latency_ms=latency_ms,
+        upstream_request_id=upstream_request_id,
+        backend="litellm_embedded",
+        provider=provider,
+    )

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -1,40 +1,36 @@
-"""ADR-017 Phase 2 — OpenAI-compatible chat completions endpoint.
+"""ADR-017 Phase 4 — native AI gateway on Mastio.
 
-This router exposes ``POST /v1/chat/completions`` on the proxy so a
-custom agent that already speaks the OpenAI Chat Completions API
-(e.g. an in-house worker, an OpenAI Python SDK pointed at a different
-``base_url``) can be routed through Cullis without code changes:
+Architecture (post-2026-05-06 fix): the Mastio is the AI gateway egress
+point for its agents. No Court round trip:
 
-  agent (mTLS+DPoP) → mcp_proxy /v1/chat/completions
-                    → Mastio /v1/llm/chat
-                    → AI gateway (Portkey)
+  agent (mTLS+DPoP) → Mastio /v1/chat/completions
+                    → mcp_proxy.egress.ai_gateway.dispatch
+                    → litellm_embedded (in-process)
                     → upstream provider (Anthropic Haiku 4.5)
 
-The proxy authenticates the agent via the same mTLS+DPoP pair used by
+The Mastio authenticates the agent via the same mTLS+DPoP pair used by
 the rest of ``mcp_proxy.egress.router`` (ADR-014), looks up the
-agent's CullisClient via ``BrokerBridge``, and forwards the body
-through the SDK's ``chat_completion`` helper. Mastio re-stamps the
-identity from its own DPoP-bound JWT and writes the egress audit row;
-the proxy writes its own local audit row so the on-VM operator can
-see the call without querying Mastio.
+agent's identity (already trusted from the cert), and dispatches the
+chat completion in-process via the LiteLLM library. Mastio writes a
+local audit row; cross-org dual-write to Court is a federation concern
+(future PR), not a precondition for the gateway to work.
 
-Standalone-mode proxies (no broker attached) reject with 400 — there
-is no fallback to direct Portkey, by design: we want every LLM call
-to traverse Mastio's control plane.
+Court is never required for LLM calls. The Mastio runs standalone and
+serves AI gateway egress for its agents without federating.
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 import time
+import uuid
 
-import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
-from typing import Literal
 
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
+from mcp_proxy.egress.ai_gateway import GatewayError, dispatch
+from mcp_proxy.egress.schemas import ChatCompletionRequest
 from mcp_proxy.models import InternalAgent
 
 logger = logging.getLogger("mcp_proxy.egress.llm_chat")
@@ -42,27 +38,8 @@ logger = logging.getLogger("mcp_proxy.egress.llm_chat")
 router = APIRouter(tags=["llm-chat"])
 
 
-ChatRole = Literal["system", "user", "assistant", "tool"]
-
-
-class ChatMessage(BaseModel):
-    role: ChatRole
-    content: str
-
-
-class ChatCompletionRequest(BaseModel):
-    """OpenAI-compatible request. Kept as a pydantic model only for
-    validation; the body is passed through to Mastio as a dict so
-    fields the proxy does not know about (e.g. provider-specific
-    extras) survive the round trip when Mastio adds support for them."""
-    model: str
-    messages: list[ChatMessage] = Field(..., min_length=1)
-    max_tokens: int | None = Field(None, ge=1, le=8192)
-    temperature: float | None = Field(None, ge=0.0, le=2.0)
-    stream: bool = False
-
-
 @router.post("/v1/chat/completions")
+@router.post("/v1/llm/chat")
 async def chat_completions(
     req: ChatCompletionRequest,
     request: Request,
@@ -74,93 +51,56 @@ async def chat_completions(
             detail="stream=true is not supported in Phase 2.",
         )
 
-    bridge = getattr(request.app.state, "broker_bridge", None)
-    if bridge is None:
-        raise HTTPException(
-            status_code=503,
-            detail=(
-                "broker_bridge not initialized — proxy is in standalone mode "
-                "or the broker is unreachable. /v1/chat/completions requires "
-                "a Mastio-attached proxy by design (ADR-017)."
-            ),
-        )
-
+    settings = get_settings()
+    trace_id = f"trace_{uuid.uuid4().hex[:16]}"
     started = time.perf_counter()
-    body = req.model_dump(exclude_none=True)
 
     try:
-        client = await bridge.get_client(agent.agent_id)
-    except Exception as exc:
-        await log_audit(
+        result = await dispatch(
+            req=req,
             agent_id=agent.agent_id,
-            action="egress_llm_chat",
-            status="error",
-            detail=f"broker_bridge_get_client_failed: {exc}",
+            org_id=settings.org_id,
+            trace_id=trace_id,
+            settings=settings,
         )
-        raise HTTPException(
-            status_code=502,
-            detail=f"failed to obtain authenticated broker client: {exc}",
-        ) from exc
-
-    try:
-        # CullisClient.chat_completion is synchronous httpx; bounce it
-        # off the default thread pool so the proxy event loop is not
-        # blocked while Portkey + Anthropic process the request.
-        response = await asyncio.to_thread(client.chat_completion, body)
-    except httpx.HTTPStatusError as exc:
-        upstream_status = exc.response.status_code
-        upstream_text = (exc.response.text or "")[:512]
+    except GatewayError as exc:
         await log_audit(
             agent_id=agent.agent_id,
             action="egress_llm_chat",
             status="error",
             detail=(
-                f"upstream_status={upstream_status} "
-                f"model={req.model} body={upstream_text}"
+                f"backend={settings.ai_gateway_backend} "
+                f"provider={settings.ai_gateway_provider} "
+                f"model={req.model} trace_id={trace_id} "
+                f"reason={exc.reason} upstream_detail={exc.detail}"
             ),
         )
-        # Forward the original status so the client can distinguish
-        # 401 (broker unauth), 502 (gateway), 504 (timeout), 501 (provider).
         raise HTTPException(
-            status_code=upstream_status,
-            detail={
-                "reason": "mastio_upstream_error",
-                "upstream_status": upstream_status,
-                "upstream_body": upstream_text,
-            },
-        ) from exc
-    except Exception as exc:
-        await log_audit(
-            agent_id=agent.agent_id,
-            action="egress_llm_chat",
-            status="error",
-            detail=f"unexpected_error: {exc}",
-        )
-        raise HTTPException(
-            status_code=502,
-            detail=f"egress LLM call failed: {exc}",
+            status_code=exc.status_code,
+            detail={"reason": exc.reason, "trace_id": trace_id},
         ) from exc
 
     latency_ms = int((time.perf_counter() - started) * 1000)
-    usage = response.get("usage", {}) if isinstance(response, dict) else {}
-    trace_id = response.get("cullis_trace_id") if isinstance(response, dict) else None
+    payload = result.response.model_dump()
+    payload.setdefault("cullis_trace_id", trace_id)
 
     await log_audit(
         agent_id=agent.agent_id,
         action="egress_llm_chat",
         status="success",
         detail=(
-            f"model={req.model} "
-            f"trace_id={trace_id or 'n/a'} "
+            f"backend={result.backend} provider={result.provider} "
+            f"model={req.model} trace_id={trace_id} "
             f"latency_ms={latency_ms} "
-            f"prompt_tokens={usage.get('prompt_tokens', 0)} "
-            f"completion_tokens={usage.get('completion_tokens', 0)}"
+            f"upstream_request_id={result.upstream_request_id or 'n/a'} "
+            f"prompt_tokens={payload.get('usage', {}).get('prompt_tokens', 0)} "
+            f"completion_tokens={payload.get('usage', {}).get('completion_tokens', 0)}"
         ),
     )
 
     logger.info(
-        "egress_llm_chat agent=%s model=%s latency_ms=%d trace_id=%s",
-        agent.agent_id, req.model, latency_ms, trace_id,
+        "egress_llm_chat agent=%s backend=%s model=%s latency_ms=%d trace_id=%s",
+        agent.agent_id, result.backend, req.model, latency_ms, trace_id,
     )
 
-    return response
+    return payload

--- a/mcp_proxy/egress/schemas.py
+++ b/mcp_proxy/egress/schemas.py
@@ -1,0 +1,67 @@
+"""OpenAI Chat Completion subset used by the egress endpoint.
+
+Kept intentionally minimal: enough for the spike (Portkey → Anthropic
+Haiku 4.5) without dragging in streaming / tool-use / function-calling
+which Phase 1 explicitly defers.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+ChatRole = Literal["system", "user", "assistant", "tool"]
+
+
+class ChatMessage(BaseModel):
+    role: ChatRole
+    # OpenAI tool-use messages can carry list-of-blocks content (tool_use,
+    # tool_result, text). Accept both shapes; the dispatcher passes them
+    # through to LiteLLM which knows how to format per provider.
+    content: str | list[dict] | None = None
+    # Tool-use round-trip plumbing (OpenAI-compat). When the model
+    # returns tool_calls we echo them back in the next turn; the result
+    # comes in as role=tool with tool_call_id.
+    tool_calls: list[dict] | None = None
+    tool_call_id: str | None = None
+    name: str | None = None
+
+
+class ChatCompletionRequest(BaseModel):
+    model: str = Field(..., description="Model id forwarded as-is to the gateway.")
+    messages: list[ChatMessage] = Field(..., min_length=1)
+    max_tokens: int | None = Field(None, ge=1, le=8192)
+    temperature: float | None = Field(None, ge=0.0, le=2.0)
+    # stream=true is rejected at the router until Phase 2 wires SSE through.
+    stream: bool = False
+    # OpenAI-compatible tool-use plumbing. The Connector ambassador
+    # discovers MCP tools via list_mcp_tools() and attaches them here so
+    # the LLM can choose to invoke one. We forward as-is to LiteLLM
+    # (which translates to provider-native tool/function calling shape).
+    tools: list[dict] | None = None
+    tool_choice: str | dict | None = None
+
+
+class ChatCompletionUsage(BaseModel):
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+
+
+class ChatCompletionChoice(BaseModel):
+    index: int
+    message: ChatMessage
+    finish_reason: str | None = None
+
+
+class ChatCompletionResponse(BaseModel):
+    id: str
+    object: str = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatCompletionChoice]
+    usage: ChatCompletionUsage = Field(default_factory=ChatCompletionUsage)
+    # Mastio-injected trace id propagated end-to-end so the caller can
+    # correlate its log with the gateway dashboard and the audit row.
+    cullis_trace_id: str

--- a/mcp_proxy/requirements-proxy.txt
+++ b/mcp_proxy/requirements-proxy.txt
@@ -20,3 +20,7 @@ authlib>=1.3.0
 # MCP_PROXY_REDIS_URL set), but the Python package must be present for
 # the import path in mcp_proxy.redis.pool to resolve (audit F-B-12).
 redis>=5.0.0
+# ADR-017 native AI gateway on Mastio (architectural fix: Court is
+# federation-only, AI gateway egress runs in-process on Mastio).
+# Required when MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded.
+litellm>=1.50.0

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -65,6 +65,44 @@ def _make_handler(tool_def: ToolDefinition):
     return _h
 
 
+async def _fetch_upstream_schema(endpoint_url: str, tool_name: str) -> dict | None:
+    """Best-effort fetch of the upstream MCP server's inputSchema for ``tool_name``.
+
+    The DB stores only the resource description + endpoint; the actual
+    tool signature lives on the upstream MCP server (e.g. postgres-mcp
+    advertises ``{sql: string}``). Without this, the proxy aggregator
+    advertises an empty inputSchema and the LLM has no idea how to
+    invoke the tool.
+    """
+    import httpx as _httpx
+    try:
+        async with _httpx.AsyncClient(timeout=3.0) as client:
+            r = await client.post(
+                endpoint_url,
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            )
+            if r.status_code != 200:
+                _log.warning(
+                    "upstream tools/list returned %d for %s",
+                    r.status_code, endpoint_url,
+                )
+                return None
+            data = r.json()
+            for t in (data.get("result", {}) or {}).get("tools", []):
+                if t.get("name") == tool_name:
+                    return t.get("inputSchema")
+            return None
+    except Exception as exc:
+        _log.warning(
+            "upstream schema fetch failed for %s: %s", endpoint_url, exc,
+        )
+        return None
+
+
 def _parse_allowed_domains(raw: str | None) -> list[str]:
     """Decode the JSON-encoded allowed_domains column.
 
@@ -131,13 +169,21 @@ async def load_resources_into_registry(registry: ToolRegistry) -> int:
             skipped_conflict += 1
             continue
 
+        # Fetch upstream input schema so the LLM sees the real tool
+        # signature (sql / SQL string / etc.) instead of an empty object.
+        # Best-effort: if the upstream MCP server is not yet up at boot,
+        # fall back to None and the LLM gets the empty schema. Future PR:
+        # lazy + cached refresh on demand.
+        upstream_schema = await _fetch_upstream_schema(
+            row["endpoint_url"], name,
+        )
         tool_def = ToolDefinition(
             name=name,
             description=row["description"] or "",
             required_capability=row["required_capability"] or "",
             allowed_domains=_parse_allowed_domains(row["allowed_domains"]),
             handler=_noop_placeholder,  # replaced below; must be a callable
-            parameters_schema=None,
+            parameters_schema=upstream_schema,
             resource_id=row["resource_id"],
             endpoint_url=row["endpoint_url"],
         )

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -22,6 +22,12 @@ networks:
   public-wan:
     name: cullis-sandbox-wan
     driver: bridge
+  # External network owned by imp/sandbox-mcp/ compose (the MCP servers
+  # bundle). proxy-a joins this so it can reach the Postgres / GitHub /
+  # Slack MCP containers by hostname. official_sandbox setup detail.
+  mcp-sandbox:
+    name: cullis-mcp-sandbox
+    external: true
 
 volumes:
   broker-ca:
@@ -101,6 +107,15 @@ services:
       # demo point look broken: the cookie kept validating across
       # reboots because the signature stayed good.
       KMS_BACKEND: "local"
+      # ADR-017 Phase 1 — AI gateway egress. Court runs litellm_embedded
+      # by default, which routes /v1/llm/chat to Anthropic when the key
+      # is present. Without the key the dispatcher 503s and Cullis Chat /
+      # any agent doing chat_completion fails. Pulled from host env so
+      # the sandbox-mcp .env (existing dogfood key) is reused without
+      # secret duplication.
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      AI_GATEWAY_BACKEND: "litellm_embedded"
+      AI_GATEWAY_PROVIDER: "anthropic"
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
       # ADR-004 PR B — proxy-only topology. Agents now reach the broker
@@ -259,6 +274,13 @@ services:
       # actually signed.
       MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-a:9443"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
+      # ADR-017 native AI gateway on Mastio (post-2026-05-06 architectural
+      # fix): the Mastio dispatches LLM calls itself via litellm_embedded.
+      # No Court egress hop. Required for standalone Mastio + intra-org
+      # agents to consume LLM through Cullis without federating.
+      MCP_PROXY_ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
+      MCP_PROXY_AI_GATEWAY_BACKEND: "litellm_embedded"
+      MCP_PROXY_AI_GATEWAY_PROVIDER: "anthropic"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
       MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9100"
@@ -303,6 +325,12 @@ services:
     volumes:
       - proxy-a-data:/data
       - mastio-a-nginx-certs:/var/lib/mastio/nginx-certs:rw
+    extra_hosts:
+      # Lets the proxy reach MCP servers exposed on the host (e.g.
+      # postgres-mcp from imp/sandbox-mcp/ on host port 8003). Without
+      # this, MCP resources registered with hostname ``host.docker.internal``
+      # 503 on tools/call.
+      - "host.docker.internal:host-gateway"
     networks:
       orga-internal:
         # ``mcp-proxy`` is the upstream name nginx/mastio/mastio.conf
@@ -312,6 +340,12 @@ services:
         aliases: [proxy-a, mcp-proxy]
       public-wan:
         aliases: [proxy-a]
+      # MCP servers from imp/sandbox-mcp/ live on a separate compose
+      # network. Joining it from here lets the proxy reach
+      # ``cullis-sb-postgres-mcp:8080`` etc. without exposing them on
+      # the host. official_sandbox-only — production deploys put the
+      # MCP servers on the same swarm/k8s network as the proxy.
+      mcp-sandbox: {}
     expose: ["9100"]
     ports: ["9100:9100"]
     healthcheck:

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -1,21 +1,19 @@
-"""ADR-017 Phase 2 — proxy /v1/chat/completions endpoint.
+"""ADR-017 Phase 4 — proxy /v1/chat/completions native AI gateway.
 
-The router is exercised in isolation: a minimal FastAPI app mounts
-only the llm_chat_router with the mTLS+DPoP dep overridden to return
-a fixed InternalAgent. The proxy DB is initialized in a temp sqlite
-so log_audit can write its hash-chained rows. The broker_bridge on
-app.state is patched to return a mock CullisClient whose
-chat_completion is monkey-patched to whatever the test needs.
+The router is exercised in isolation: a minimal FastAPI app mounts only
+the llm_chat_router with the mTLS+DPoP dep overridden to return a fixed
+InternalAgent. The proxy DB is initialized in a temp sqlite so log_audit
+can write its hash-chained rows. The litellm dispatcher is patched at
+``mcp_proxy.egress.llm_chat_router.dispatch`` so we never touch the
+network or pay the LiteLLM import cost.
 
-We never try to set up real broker auth here — the SDK's
-chat_completion (and its DPoP dance) is covered by the broker-side
-test_egress_ai_gateway suite shipped in PR #401.
+Phase 4 dropped BrokerBridge from the path: the Mastio dispatches the
+chat completion in-process via litellm_embedded. No Court round trip.
 """
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
-import httpx
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
@@ -25,14 +23,20 @@ from sqlalchemy import text
 
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.egress import llm_chat_router as router_module
+from mcp_proxy.egress.ai_gateway import GatewayError, GatewayResult
 from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+from mcp_proxy.egress.schemas import (
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionUsage,
+    ChatMessage,
+)
 from mcp_proxy.models import InternalAgent
 
 
 async def _audit_rows(action: str, status: str | None = None) -> list[dict]:
-    """Read back audit rows for assertions. Direct SQL because the
-    proxy module exposes only a hash-chain verifier, not a query API.
-    """
     sql = "SELECT agent_id, action, status, detail FROM audit_log WHERE action = :a"
     params = {"a": action}
     if status is not None:
@@ -65,26 +69,30 @@ def _request_body() -> dict:
     }
 
 
-def _mastio_response() -> dict:
-    return {
-        "id": "chatcmpl-mastio-1",
-        "object": "chat.completion",
-        "created": 1_700_000_000,
-        "model": "claude-haiku-4-5",
-        "choices": [
-            {
-                "index": 0,
-                "message": {"role": "assistant", "content": "pong"},
-                "finish_reason": "stop",
-            }
+def _gateway_result() -> GatewayResult:
+    response = ChatCompletionResponse(
+        id="chatcmpl-mastio-1",
+        created=1_700_000_000,
+        model="claude-haiku-4-5",
+        choices=[
+            ChatCompletionChoice(
+                index=0,
+                message=ChatMessage(role="assistant", content="pong"),
+                finish_reason="stop",
+            )
         ],
-        "usage": {
-            "prompt_tokens": 12,
-            "completion_tokens": 3,
-            "total_tokens": 15,
-        },
-        "cullis_trace_id": "trace_proxy_test",
-    }
+        usage=ChatCompletionUsage(
+            prompt_tokens=12, completion_tokens=3, total_tokens=15,
+        ),
+        cullis_trace_id="trace_proxy_test",
+    )
+    return GatewayResult(
+        response=response,
+        latency_ms=42,
+        upstream_request_id="req_abc",
+        backend="litellm_embedded",
+        provider="anthropic",
+    )
 
 
 @pytest_asyncio.fixture
@@ -92,6 +100,12 @@ async def app_with_router(tmp_path, monkeypatch):
     db_file = tmp_path / "proxy.sqlite"
     url = f"sqlite+aiosqlite:///{db_file}"
     monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    # AI gateway settings — required for the router; never reach LiteLLM
+    # because dispatch() is patched per-test.
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_BACKEND", "litellm_embedded")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_PROVIDER", "anthropic")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "orga")
     await init_db(url)
 
     test_app = FastAPI()
@@ -104,34 +118,19 @@ async def app_with_router(tmp_path, monkeypatch):
     await dispose_db()
 
 
-def _attach_bridge(app: FastAPI, *, chat_response: dict | None = None,
-                   chat_exc: Exception | None = None,
-                   get_client_exc: Exception | None = None):
-    """Wire a fake broker_bridge onto app.state.
-
-    chat_response / chat_exc control what the SDK call returns.
-    get_client_exc simulates a broker-bridge bootstrap failure.
-    """
-    fake_client = MagicMock()
-    if chat_exc is not None:
-        fake_client.chat_completion = MagicMock(side_effect=chat_exc)
-    else:
-        fake_client.chat_completion = MagicMock(return_value=chat_response or {})
-
-    fake_bridge = MagicMock()
-    if get_client_exc is not None:
-        fake_bridge.get_client = AsyncMock(side_effect=get_client_exc)
-    else:
-        fake_bridge.get_client = AsyncMock(return_value=fake_client)
-    app.state.broker_bridge = fake_bridge
-    return fake_bridge, fake_client
-
-
 @pytest.mark.asyncio
-async def test_chat_completions_happy_path_writes_audit(app_with_router):
-    bridge, fake_client = _attach_bridge(
-        app_with_router, chat_response=_mastio_response(),
-    )
+async def test_chat_completions_happy_path_writes_audit(app_with_router, monkeypatch):
+    captured: dict = {}
+
+    async def fake_dispatch(*, req: ChatCompletionRequest, agent_id: str,
+                            org_id: str, trace_id: str, settings):
+        captured["agent_id"] = agent_id
+        captured["org_id"] = org_id
+        captured["trace_id"] = trace_id
+        captured["model"] = req.model
+        return _gateway_result()
+
+    monkeypatch.setattr(router_module, "dispatch", fake_dispatch)
 
     async with AsyncClient(
         transport=ASGITransport(app=app_with_router), base_url="http://test",
@@ -143,42 +142,47 @@ async def test_chat_completions_happy_path_writes_audit(app_with_router):
     assert body["choices"][0]["message"]["content"] == "pong"
     assert body["cullis_trace_id"] == "trace_proxy_test"
 
-    bridge.get_client.assert_awaited_once_with("orga::alice")
-    fake_client.chat_completion.assert_called_once()
-    forwarded_body = fake_client.chat_completion.call_args.args[0]
-    assert forwarded_body["model"] == "claude-haiku-4-5"
+    assert captured["agent_id"] == "orga::alice"
+    assert captured["org_id"] == "orga"
+    assert captured["model"] == "claude-haiku-4-5"
+    assert captured["trace_id"].startswith("trace_")
 
     rows = await _audit_rows("egress_llm_chat", status="success")
     assert len(rows) == 1
     assert rows[0]["agent_id"] == "orga::alice"
-    assert "trace_proxy_test" in (rows[0]["detail"] or "")
+    assert "backend=litellm_embedded" in (rows[0]["detail"] or "")
     assert "prompt_tokens=12" in (rows[0]["detail"] or "")
     assert "completion_tokens=3" in (rows[0]["detail"] or "")
 
 
 @pytest.mark.asyncio
-async def test_chat_completions_no_bridge_returns_503(app_with_router):
-    # Don't attach a bridge — simulate standalone-mode proxy.
-    app_with_router.state.broker_bridge = None
+async def test_chat_completions_alias_v1_llm_chat(app_with_router, monkeypatch):
+    """ADR-017 Phase 4: SDK back-compat. The Connector SDK calls
+    /v1/llm/chat (broker path); the proxy serves it via the same handler
+    so device-code agents work without an SDK upgrade."""
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
 
     async with AsyncClient(
         transport=ASGITransport(app=app_with_router), base_url="http://test",
     ) as c:
-        r = await c.post("/v1/chat/completions", json=_request_body())
+        r = await c.post("/v1/llm/chat", json=_request_body())
 
-    assert r.status_code == 503
-    assert "standalone" in r.json()["detail"].lower() or "broker" in r.json()["detail"].lower()
+    assert r.status_code == 200, r.text
+    assert r.json()["choices"][0]["message"]["content"] == "pong"
 
 
 @pytest.mark.asyncio
-async def test_chat_completions_forwards_upstream_status(app_with_router):
-    upstream_resp = httpx.Response(
-        status_code=504,
-        text='{"detail": {"reason": "upstream_timeout"}}',
-        request=httpx.Request("POST", "http://mastio/v1/llm/chat"),
-    )
-    err = httpx.HTTPStatusError("timeout", request=upstream_resp.request, response=upstream_resp)
-    _attach_bridge(app_with_router, chat_exc=err)
+async def test_chat_completions_gateway_error_surfaces_status(app_with_router, monkeypatch):
+    """A GatewayError carries the upstream HTTP status (e.g. 504 timeout,
+    502 unreachable) so callers can distinguish failure modes. Audit row
+    is written with reason + provider for ops."""
+    async def boom(**_kwargs):
+        raise GatewayError(504, "upstream_timeout", detail="provider 504 after 30s")
+
+    monkeypatch.setattr(router_module, "dispatch", boom)
 
     async with AsyncClient(
         transport=ASGITransport(app=app_with_router), base_url="http://test",
@@ -187,17 +191,21 @@ async def test_chat_completions_forwards_upstream_status(app_with_router):
 
     assert r.status_code == 504
     body = r.json()
-    assert body["detail"]["reason"] == "mastio_upstream_error"
-    assert body["detail"]["upstream_status"] == 504
+    assert body["detail"]["reason"] == "upstream_timeout"
+    assert body["detail"]["trace_id"].startswith("trace_")
 
     rows = await _audit_rows("egress_llm_chat", status="error")
     assert len(rows) == 1
-    assert "upstream_status=504" in (rows[0]["detail"] or "")
+    assert "reason=upstream_timeout" in (rows[0]["detail"] or "")
+    assert "backend=litellm_embedded" in (rows[0]["detail"] or "")
 
 
 @pytest.mark.asyncio
-async def test_chat_completions_rejects_streaming(app_with_router):
-    _attach_bridge(app_with_router, chat_response=_mastio_response())
+async def test_chat_completions_rejects_streaming(app_with_router, monkeypatch):
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
 
     async with AsyncClient(
         transport=ASGITransport(app=app_with_router), base_url="http://test",
@@ -209,20 +217,3 @@ async def test_chat_completions_rejects_streaming(app_with_router):
 
     assert r.status_code == 400
     assert "stream" in r.json()["detail"].lower()
-
-
-@pytest.mark.asyncio
-async def test_chat_completions_get_client_failure_returns_502(app_with_router):
-    _attach_bridge(app_with_router, get_client_exc=RuntimeError("agent_credentials_missing"))
-
-    async with AsyncClient(
-        transport=ASGITransport(app=app_with_router), base_url="http://test",
-    ) as c:
-        r = await c.post("/v1/chat/completions", json=_request_body())
-
-    assert r.status_code == 502
-    assert "broker client" in r.json()["detail"].lower()
-
-    rows = await _audit_rows("egress_llm_chat", status="error")
-    assert len(rows) >= 1
-    assert any("broker_bridge_get_client_failed" in (r["detail"] or "") for r in rows)


### PR DESCRIPTION
## Summary

- Move ADR-017 AI gateway egress from Court (broker) into the Mastio (mcp_proxy). litellm_embedded runs in-process; Court is no longer in the LLM path. Standalone Mastios become functional for chat completions and device-code agents stop 502'ing.
- Aggregator now serves the upstream MCP tool's real `inputSchema` instead of an empty object, so an LLM offered a registered MCP tool actually knows how to invoke it.
- Connector ambassador collapses `stream=true` to non-stream before dispatch (the outer router already wraps the answer back into the SPA's expected SSE shape).

## Why

ADR-017 Phase 2 routed every chat completion through the Court via `BrokerBridge.get_client(agent_id)`. That call needs the agent's private key to do `login_from_pem`, which is fine for BYOCA (admin imports the key) but **impossible for device-code agents**, where the private key never leaves the device by design. Court was also conceptually wrong here: it's the federation broker (cross-org session establishment), not an AI traffic proxy.

Discovered while dogfooding the end-to-end Cullis Chat path (`imp/official_sandbox/`): device-code Connector → Mastio → 502. The fix splits the concerns: Mastio dispatches LLM in-process, Court keeps doing federation. Cross-org dual-write of audit rows remains a separate pending PR.

## Changes

- `mcp_proxy/egress/ai_gateway.py` + `schemas.py`: new. Dispatcher + OpenAI pydantic models. litellm imported lazily.
- `mcp_proxy/egress/llm_chat_router.py`: rewrite. `dispatch()` direct, no broker_bridge. `/v1/llm/chat` alias kept for SDK back-compat. Tools fields forwarded.
- `mcp_proxy/egress/schemas.py`: `ChatMessage` gained `tool_calls` / `tool_call_id` / `name`; `ChatCompletionRequest` gained `tools` / `tool_choice`. Without these the LLM never saw the MCP tools (silent pydantic drop).
- `mcp_proxy/config.py`: `ProxySettings` fields `anthropic_api_key`, `ai_gateway_backend` (default `litellm_embedded`), `ai_gateway_provider` (default `anthropic`), `ai_gateway_url`, `ai_gateway_request_timeout_s`.
- `mcp_proxy/requirements-proxy.txt`: `litellm>=1.50.0`.
- `mcp_proxy/tools/resource_loader.py`: `_fetch_upstream_schema` populates `parameters_schema` from upstream MCP `tools/list` at boot. Was hardcoded to `None`.
- `cullis_connector/ambassador/loop.py`: `body["stream"] = False` before dispatch. The SPA's expected SSE response is rebuilt by the outer router via `fake_stream`.
- `sandbox/docker-compose.yml`: proxy-a env carries the new AI gateway vars; joins external `cullis-mcp-sandbox` network so MCP containers from `imp/sandbox-mcp/` are reachable; `extra_hosts: host-gateway`.
- `tests/test_proxy_llm_chat_router.py`: rewrite. Patches `dispatch()` rather than the deleted `broker_bridge`. Covers happy path, `/v1/llm/chat` alias, `GatewayError` status surfacing, stream rejection.

## Test plan

- [x] `pytest tests/test_proxy_llm_chat_router.py` — 4 passed
- [x] `pytest tests/` — only 2 pre-existing postgres flakes (`test_pg_session_and_signed_messages`, `test_pg_nonce_replay_blocked`) per memory `feedback_ci_known_failures`
- [x] `bash demo_network/smoke.sh full` — exit 0
- [x] End-to-end dogfood: device-code Connector → Mastio → litellm → Anthropic Haiku → tool_use → postgres-mcp → answer
- [x] Audit row written, agent_id correct, prompt_tokens / completion_tokens captured
- [x] No security checks bypassed: TLS verify on (CA bundle), mTLS on, DPoP on, capability gate on, binding gate on

## Notes

- `imp/official_sandbox/` is gitignored (per repo convention): the dogfood playground that surfaced this PR. Lessons + 13 distinct bugs are documented there for follow-up.
- `MCP_PROXY_ANTHROPIC_API_KEY` env in `sandbox/docker-compose.yml` is dev-only. Production keeps using `secret_backend=vault`.
- Hot-reload of `tool_registry` after admin POST/DELETE on `/v1/admin/mcp-resources` is still a manual restart — separate follow-up PR.