### PR TITLE
fix(connector,frontdesk): dashboard deps + Frontdesk bundle dogfood gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dist/
 build/
 *.egg-info/
 /sandbox/.env
+
+# Frontdesk Connector identity material (per-deployment, never committed)
+packaging/frontdesk-bundle/connector_data/
+packaging/frontdesk-bundle/frontdesk.env

--- a/mcp_proxy/reverse_proxy/forwarder.py
+++ b/mcp_proxy/reverse_proxy/forwarder.py
@@ -35,6 +35,11 @@ FORWARDED_PREFIXES: tuple[str, ...] = (
     # (mcp_proxy/registry/public_key.py) and forwards the rest so SDK
     # discover() / search / get-by-id calls transit the proxy cleanly.
     "/v1/federation",
+    # ADR-021 PR4a — Court signs user-principal CSRs and lists provisioned
+    # users. The Frontdesk Connector calls /v1/principals/csr on its
+    # Mastio every time a user logs in via SSO; the proxy passes it
+    # through so the Court remains the user-cert authority.
+    "/v1/principals",
 )
 
 _HOP_BY_HOP = frozenset(

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -48,7 +48,15 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN useradd --create-home --uid 10001 --shell /bin/false cullis
 
 COPY --from=builder /dist/*.whl /tmp/
-RUN pip install /tmp/cullis_connector-*.whl && rm /tmp/cullis_connector-*.whl
+# Install with the ``dashboard`` extra so ``cullis-connector dashboard``
+# (and the Frontdesk shared-mode embedded server) work out of the box —
+# without it FastAPI/Starlette/Jinja2/python-multipart are missing and
+# ``dashboard`` ImportErrors. The plain ``serve`` (MCP stdio) and
+# ``enroll`` paths do not need the extra but it costs ~25 MiB and keeps
+# the image single-purpose.
+RUN WHEEL=$(ls /tmp/cullis_connector-*.whl) \
+ && pip install "${WHEEL}[dashboard]" \
+ && rm "${WHEEL}"
 
 USER cullis
 WORKDIR /home/cullis

--- a/packaging/frontdesk-bundle/Dockerfile.connector
+++ b/packaging/frontdesk-bundle/Dockerfile.connector
@@ -1,0 +1,19 @@
+# Frontdesk Connector image — wraps the official cullis-connector
+# with the FastAPI/Starlette stack required by ``dashboard`` mode.
+#
+# Bug: the published ``ghcr.io/cullis-security/cullis-connector:latest``
+# image installs the cullis-connector wheel without the FastAPI extras,
+# so ``cullis-connector dashboard`` ImportErrors on ``fastapi``. This
+# Dockerfile lifts the missing deps in. Real fix lives in the
+# cullis-connector packaging (split ``[dashboard]`` extra and ship it
+# in the GHCR image).
+ARG CONNECTOR_BASE=cullis-connector:local
+FROM ${CONNECTOR_BASE}
+
+USER root
+RUN pip install --no-cache-dir \
+    "fastapi>=0.115.6,<1.0.0" \
+    "starlette>=0.40.0,<1.0.0" \
+    "python-multipart>=0.0.20" \
+    "jinja2>=3.1.0"
+USER cullis

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -43,7 +43,11 @@
 services:
 
   connector:
-    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile.connector
+      args:
+        CONNECTOR_VERSION: ${CONNECTOR_VERSION:-latest}
     # ``dashboard`` mounts the Ambassador router via web.py lifespan when
     # AMBASSADOR_MODE=shared (cullis_connector/web.py:152). Bind to all
     # interfaces inside the container so nginx can reach it.
@@ -68,12 +72,34 @@ services:
       # Where Mastio's CSR endpoint lives. Falls back to site_url when empty.
       CULLIS_FRONTDESK_MASTIO_URL: ${CULLIS_FRONTDESK_MASTIO_URL:-}
       CULLIS_SITE_URL: ${CULLIS_SITE_URL:-}
+      # Trust anchor for the Mastio TLS handshake. Production uses the
+      # corporate PKI; the sandbox/ ships a self-signed Org-CA so we
+      # mount it as a CA bundle here. Honoured by Python's ssl module
+      # (cullis-connector + the Mastio CSR client both pick it up).
+      SSL_CERT_FILE: ${CULLIS_FRONTDESK_CA_BUNDLE:-/etc/cullis/ca-bundle.pem}
+      REQUESTS_CA_BUNDLE: ${CULLIS_FRONTDESK_CA_BUNDLE:-/etc/cullis/ca-bundle.pem}
     volumes:
       # Connector identity material (cert, key, profile config). Populated
       # by the one-shot enrollment documented in the header comment.
-      - ${CONNECTOR_DATA_DIR:-./connector_data}:/root/.cullis
+      # The cullis-connector image runs as user ``cullis`` whose home is
+      # ``/home/cullis`` — mount the bind directory there so identity
+      # writes survive container recreation.
+      - ${CONNECTOR_DATA_DIR:-./connector_data}:/home/cullis/.cullis
+      # CA bundle for Mastio TLS verification. Path inside the container
+      # is referenced by SSL_CERT_FILE / REQUESTS_CA_BUNDLE.
+      - ${CULLIS_FRONTDESK_CA_BUNDLE_HOST:-../../imp/official_sandbox/certs/cullis-bundle.pem}:/etc/cullis/ca-bundle.pem:ro
+    # In dev with the Mastio published on the docker host (rather than a
+    # routable hostname), the Connector reaches it via host.docker.internal.
+    # Production deployments route over a real DNS name; this entry is a
+    # no-op there.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       - frontdesk_net
+      # Join the sandbox's orga-internal network so the Connector can
+      # reach mastio-nginx-a:9443 by hostname. official_sandbox-only:
+      # production has the Mastio behind a real DNS / routable IP.
+      - sandbox-orga
     restart: unless-stopped
 
   cullis-chat:
@@ -116,3 +142,8 @@ volumes:
 networks:
   frontdesk_net:
     driver: bridge
+  # External network owned by the sandbox/ compose. The Frontdesk
+  # connector joins it to reach mastio-nginx-a:9443 by hostname.
+  sandbox-orga:
+    name: cullis-sandbox-orga
+    external: true

--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -20,6 +20,7 @@
 # than falling back to a random user.
 map $arg_user $forwarded_user {
     default      "unknown@frontdesk.dev";
+    "daniele"    "daniele@acme.local";
     "mario"      "mario@acme.local";
     "anna"       "anna@acme.local";
     "luca"       "luca@beta.local";
@@ -31,6 +32,14 @@ server {
 
     # Hide nginx version in error pages / Server header.
     server_tokens off;
+
+    # Docker's embedded DNS — required because the proxy_pass URLs use
+    # variables (``$request_uri``), which forces nginx to resolve the
+    # upstream hostname per request rather than at start. Without an
+    # explicit resolver nginx errors with "no resolver defined" and
+    # surfaces 502 to the client.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 3s;
 
     # ----- security headers (ADR-019 Phase 8b-2b) -----
     #


### PR DESCRIPTION
## Summary

Five gaps surfaced while dogfooding Frontdesk shared-mode (ADR-019 Phase 7 + ADR-021) end-to-end against `sandbox/`. Each one was the kind of papercut a customer hits on first try; rolling them up keeps the trail auditable.

1. **`cullis-connector:latest` GHCR image misses `[dashboard]` extra** — `dashboard` mode ImportErrors on `fastapi` at startup. The extra already exists in `packaging/pypi/pyproject.toml`, just not installed in `packaging/docker/Dockerfile`. Fixed with `pip install '<wheel>[dashboard]'`.
2. **Frontdesk volume mount path** — bundle mounted `connector_data` at `/root/.cullis`, but image runtime user is `cullis` with `$HOME=/home/cullis`. Identity was written to ephemeral container layer and lost every recreate. Mount moved to `/home/cullis/.cullis`.
3. **nginx `no resolver defined`** — variable in `proxy_pass` URL forces per-request DNS resolution; without an explicit resolver nginx 502'd. Added Docker embedded DNS (127.0.0.11).
4. **mcp_proxy didn't forward `/v1/principals` to Court** — ADR-021 PR4a put the user-principal CSR signer on Court. The proxy's reverse-proxy was missing `/v1/principals` in `FORWARDED_PREFIXES`, so the Frontdesk Connector's `POST /v1/principals/csr` 404'd at the proxy. Forwarded.
5. **Frontdesk Connector needs CA bundle + sandbox network for dev** — production has real DNS + PKI; sandbox uses self-signed Org-CA + internal docker hostname. Bundle now joins external `cullis-sandbox-orga` network, mounts a CA bundle at `/etc/cullis/ca-bundle.pem`, points `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` at it. TLS verify stays on (no `--no-verify-tls` shortcuts).

`Dockerfile.connector` override added so the bundle builds the Connector from source until the GHCR image is rebuilt with `[dashboard]`.

## Notes

- `daniele` added to the dev fake-SSO map alongside mario/anna/luca.
- `connector_data/` and `frontdesk.env` gitignored.
- The next gap (Connector shared-mode `/v1/principals/csr` provisioning lacks DPoP auth) is **out of scope** — separate PR follows.

## Test plan

- [x] Rebuilt `cullis-connector:local`; `pip list` shows fastapi 0.136 / starlette / Jinja2 / python-multipart
- [x] `docker compose --env-file frontdesk.env up -d` brings bundle up healthy with identity persisted across recreate
- [x] `POST /api/session/init?user=daniele` mints cookie; `GET /v1/models` returns 200
- [x] `POST /v1/chat/completions` reaches Mastio (TLS verify ON, CA bundle mounted)
- [x] No security checks bypassed: TLS verify on, mTLS required by Mastio, Origin/CSRF guard intact