### PR TITLE
fix(connector): Frontdesk shared-mode CSR transport + nginx Host preservation

### DIFF
--- a/cullis_connector/ambassador/shared/provisioning.py
+++ b/cullis_connector/ambassador/shared/provisioning.py
@@ -21,10 +21,12 @@ via HTTPS only.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
+import threading
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol
+from typing import Any, Protocol
 
 import httpx
 from cryptography import x509
@@ -66,11 +68,13 @@ class MastioCsrTransport(Protocol):
 
 @dataclass(frozen=True)
 class HttpxMastioCsrTransport:
-    """Default Mastio transport built on an ``httpx.AsyncClient``.
+    """Legacy mTLS-only transport.
 
-    The client is supplied externally so the caller controls auth
-    headers (DPoP token + cert), TLS settings, and base URL. We do
-    not own its lifecycle.
+    Kept for tests + early-bring-up where the proxy still accepts
+    mTLS-only on /v1/principals/csr. ADR-021 PR4a tightened the
+    Court (and the proxy via reverse-proxy forwarding) to require
+    DPoP-bound JWT — production deployments must use
+    :class:`SdkMastioCsrTransport`.
     """
 
     http: httpx.AsyncClient
@@ -99,20 +103,146 @@ class HttpxMastioCsrTransport:
                 f"{resp.text[:512]}",
             )
         body = resp.json()
-        try:
-            cert_pem = body["cert_pem"]
-            not_after_iso = body["cert_not_after"]
-        except (KeyError, TypeError) as exc:
+        return _parse_csr_response(body)
+
+
+class SdkMastioCsrTransport:
+    """Production CSR transport using the cullis-sdk ``CullisClient``.
+
+    Authenticates the Frontdesk Connector against the broker (via the
+    Mastio reverse-proxy) with ``login_via_proxy_with_local_key``, the
+    device-code-friendly login that keeps the agent's private key on
+    the Connector and asks the Mastio to counter-sign the assertion
+    before the broker mints a DPoP-bound access token. The CSR call
+    then rides ``CullisClient._authed_request`` so every POST carries
+    ``Authorization: DPoP <token>`` + a fresh DPoP proof — exactly what
+    the Court's ADR-021 PR4a auth dependency requires.
+
+    Why not ``login_from_pem``: that path goes through the Mastio's
+    ADR-012 local issuer when ``MCP_PROXY_LOCAL_AUTH_ENABLED=true``;
+    its tokens are signed by the Mastio key and the Court rejects them
+    on /v1/principals/csr ("Token invalid or expired"). The
+    ``login_via_proxy_with_local_key`` path always rounds through the
+    Court so the token is broker-issued.
+
+    Lazy login: the first ``sign_csr`` call triggers a login. The token
+    is cached for ``RELOGIN_INTERVAL_S`` (10 min by default — below
+    Mastio's 30-min default ``jwt_access_token_expire_minutes``). On a
+    401 the transport invalidates the cached client and retries once.
+    """
+
+    RELOGIN_INTERVAL_S: float = 10 * 60
+
+    def __init__(
+        self,
+        *,
+        config_dir: Any,
+        base_url: str,
+        verify_tls: bool | str = True,
+    ) -> None:
+        self._config_dir = config_dir
+        self._base_url = base_url.rstrip("/")
+        self._verify_tls = verify_tls
+        self._client: Any = None
+        self._created_at: float = 0.0
+        self._lock = threading.Lock()
+
+    def _build(self) -> Any:
+        from cullis_sdk import CullisClient
+        import time
+
+        # ``from_connector`` reads cert + key + metadata.json from
+        # ``<config_dir>/identity/``; the SDK uses the metadata.site_url
+        # as the broker base. We override here so the Frontdesk
+        # ``CULLIS_FRONTDESK_MASTIO_URL`` (which may differ from the
+        # site_url written at enrollment) wins.
+        client = CullisClient.from_connector(
+            self._config_dir, verify_tls=self._verify_tls,
+        )
+        client.base = self._base_url
+        client.login_via_proxy_with_local_key()
+        self._client = client
+        self._created_at = time.monotonic()
+        _log.info(
+            "ambassador SDK login_via_proxy_with_local_key ok agent=%s site=%s",
+            getattr(client, "_proxy_agent_id", "?"), self._base_url,
+        )
+        return client
+
+    def _get(self) -> Any:
+        import time
+
+        with self._lock:
+            now = time.monotonic()
+            if (
+                self._client is None
+                or (now - self._created_at) > self.RELOGIN_INTERVAL_S
+            ):
+                self._build()
+            return self._client
+
+    def _invalidate(self) -> None:
+        with self._lock:
+            self._client = None
+            self._created_at = 0.0
+
+    def _post_csr_sync(self, principal_id: str, csr_pem: str) -> dict:
+        client = self._get()
+        resp = client._authed_request(
+            "POST", "/v1/principals/csr",
+            json={"principal_id": principal_id, "csr_pem": csr_pem},
+        )
+        if resp.status_code == 401:
+            # TOCTOU: token expired between cache check and request.
+            # Re-login once, retry.
+            self._invalidate()
+            client = self._get()
+            resp = client._authed_request(
+                "POST", "/v1/principals/csr",
+                json={"principal_id": principal_id, "csr_pem": csr_pem},
+            )
+        if resp.status_code != 201:
             raise MastioCsrError(
-                f"Mastio CSR response missing required fields: {body!r}",
-            ) from exc
+                f"Mastio /v1/principals/csr returned {resp.status_code}: "
+                f"{resp.text[:512]}",
+            )
+        return resp.json()
+
+    async def sign_csr(
+        self,
+        *,
+        principal_id: str,
+        csr_pem: str,
+    ) -> tuple[str, datetime]:
         try:
-            not_after = datetime.fromisoformat(not_after_iso)
-        except ValueError as exc:
+            body = await asyncio.to_thread(
+                self._post_csr_sync, principal_id, csr_pem,
+            )
+        except MastioCsrError:
+            raise
+        except Exception as exc:
             raise MastioCsrError(
-                f"Mastio CSR response has invalid not_after: {not_after_iso!r}",
+                f"transport failure calling Mastio /v1/principals/csr: {exc}",
             ) from exc
-        return cert_pem, not_after
+        return _parse_csr_response(body)
+
+
+def _parse_csr_response(body: dict) -> tuple[str, datetime]:
+    """Decode the JSON body of /v1/principals/csr into (cert_pem, not_after)."""
+    try:
+        cert_pem = body["cert_pem"]
+        not_after_iso = body["cert_not_after"]
+    except (KeyError, TypeError) as exc:
+        raise MastioCsrError(
+            f"Mastio CSR response missing required fields: {body!r}",
+        ) from exc
+    try:
+        not_after = datetime.fromisoformat(not_after_iso)
+    except ValueError as exc:
+        raise MastioCsrError(
+            f"Mastio CSR response has invalid not_after: {not_after_iso!r}",
+        ) from exc
+    return cert_pem, not_after
 
 
 def _generate_keypair_pem() -> tuple[str, ec.EllipticCurvePrivateKey]:
@@ -215,5 +345,6 @@ __all__ = [
     "HttpxMastioCsrTransport",
     "MastioCsrError",
     "MastioCsrTransport",
+    "SdkMastioCsrTransport",
     "UserProvisioner",
 ]

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -391,12 +391,11 @@ def _maybe_install_shared_ambassador(
         return
 
     try:
-        import httpx
         from cullis_connector.ambassador.shared.credentials import (
             UserCredentialCache,
         )
         from cullis_connector.ambassador.shared.provisioning import (
-            HttpxMastioCsrTransport, UserProvisioner,
+            SdkMastioCsrTransport, UserProvisioner,
         )
         from cullis_connector.ambassador.shared.proxy_trust import (
             TrustedProxiesAllowlist,
@@ -437,20 +436,24 @@ def _maybe_install_shared_ambassador(
     cookie_secret = bootstrap_cookie_secret(config.config_dir)
     trusted = TrustedProxiesAllowlist.from_cidrs(settings.trusted_proxies_cidrs)
 
-    # httpx client carrying the Ambassador's own mTLS cert. The Mastio
-    # endpoint also wants DPoP — for v0.1 we lean on Mastio's existing
-    # auth path: when the request arrives with an mTLS-bound client
-    # cert + the SDK access token, Mastio accepts it. The Ambassador
-    # caches its own access token via the SDK in v0.2; for now each
-    # CSR call rebuilds the SDK client (same trade-off as the per-user
-    # CullisClient in shared/router.py).
-    http = httpx.AsyncClient(
-        cert=(str(cert_path), str(key_path)),
-        verify=config.verify_arg,
-        timeout=httpx.Timeout(15.0),
+    # ADR-021 PR4a-followup: the Court's CSR endpoint requires a
+    # DPoP-bound JWT plus the mTLS cert. The previous HttpxMastioCsrTransport
+    # only attached the cert and 401'd on every login. SdkMastioCsrTransport
+    # uses cullis-sdk ``CullisClient`` to cache an access token + sign
+    # per-request DPoP proofs, refreshing on the token TTL boundary.
+    # ADR-021 PR4a-followup: the Court's CSR endpoint requires a broker-
+    # issued DPoP-bound JWT plus the mTLS cert. The previous
+    # HttpxMastioCsrTransport only attached the cert and 401'd on every
+    # call. SdkMastioCsrTransport drives ``CullisClient.from_connector`` +
+    # ``login_via_proxy_with_local_key`` so the broker token (not a
+    # Mastio-local ADR-012 token) authorises the CSR call, with a 10-min
+    # token cache + auto refresh.
+    transport = SdkMastioCsrTransport(
+        config_dir=config.config_dir,
+        base_url=mastio_url,
+        verify_tls=config.verify_arg,
     )
-    app.state.shared_ambassador_http = http  # keep alive for app lifetime
-    transport = HttpxMastioCsrTransport(http=http, base_url=mastio_url)
+    app.state.shared_ambassador_csr_transport = transport  # keep alive
 
     cache = UserCredentialCache()
     provisioner = UserProvisioner(mastio=transport, cache=cache)

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -75,7 +75,7 @@ server {
         }
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -90,7 +90,7 @@ server {
         }
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -113,7 +113,7 @@ server {
     location ~ ^/v1/(.*)$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -132,7 +132,7 @@ server {
     location ~ ^/(health|healthz|readyz|live)$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -143,7 +143,7 @@ server {
     location ~ ^/proxy(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -157,7 +157,7 @@ server {
     location ~ ^/pdp(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -168,7 +168,7 @@ server {
     location ~ ^/\.well-known(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -180,7 +180,7 @@ server {
     location = /pki/ca.crt {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
@@ -194,7 +194,7 @@ server {
     location ~ ^/static(/.*)?$ {
         proxy_pass http://mcp-proxy:9100;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -309,7 +309,7 @@ services:
       # never reaches the Court. Cross-org sends still route through
       # BrokerBridge's own per-agent Court login, so the envelope path
       # keeps working.
-      MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+      MCP_PROXY_LOCAL_AUTH_ENABLED: "false"
       # ADR-014 — first-boot writes Org CA + nginx server cert into the
       # shared volume so the mastio-nginx-a sidecar can serve TLS on
       # 9443 against the same CA the agents' certs chain to. SAN
@@ -612,7 +612,7 @@ services:
       # ADR-011 Phase 4b — see proxy-a rationale.
       PROXY_TRANSPORT_INTRA_ORG: "mtls-only"
       # ADR-012 — Mastio-local /v1/auth/token (see proxy-a rationale).
-      MCP_PROXY_LOCAL_AUTH_ENABLED: "true"
+      MCP_PROXY_LOCAL_AUTH_ENABLED: "false"
       # ADR-014 — see proxy-a rationale. SAN includes
       # ``mastio-nginx-b`` (the hostname agents resolve to).
       MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -106,6 +106,11 @@ async def app_with_router(tmp_path, monkeypatch):
     monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_BACKEND", "litellm_embedded")
     monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_PROVIDER", "anthropic")
     monkeypatch.setenv("MCP_PROXY_ORG_ID", "orga")
+    # ``get_settings`` is ``lru_cache``-wrapped — clear it so the test
+    # picks up the env we just set instead of whatever value a previous
+    # xdist worker memoised.
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
     await init_db(url)
 
     test_app = FastAPI()
@@ -115,6 +120,7 @@ async def app_with_router(tmp_path, monkeypatch):
     yield test_app
 
     test_app.dependency_overrides.clear()
+    get_settings.cache_clear()
     await dispose_db()
 
 


### PR DESCRIPTION
## Summary

Frontdesk shared-mode (ADR-019 Phase 7 + ADR-021 PR4a) couldn't provision a single user. Two coupled bugs:

1. **CSR transport had no auth** — `HttpxMastioCsrTransport` shipped only the mTLS cert, never logged in to the Court. The inline comment already pointed at "v0.2 caches access token via SDK" but never landed. New `SdkMastioCsrTransport` drives `CullisClient.from_connector` + `login_via_proxy_with_local_key` so each `POST /v1/principals/csr` carries a broker-issued DPoP-bound JWT + fresh DPoP proof. Token cached 10 min with TOCTOU re-login on 401.

2. **nginx Host dropped the port** — Mastio sidecar template used `$host` (strips port). htu reconstruction at the Court mismatched the SDK-signed proof. Switched to `$http_host`.

3. **Sandbox ADR-012 local-auth flag off** — when on, `/v1/auth/token` is intercepted by the Mastio and returns a Mastio-signed token; Court refuses it on `/v1/principals/csr`. Until local-auth learns to forward to Court for broker-issued claims, the sandbox keeps it off.

## Why depends on #436

This branch is stacked on top of `fix/frontdesk-dogfood-bundle` (#436). Will rebase to main after #436 merges.

## Test plan

- [x] `pytest` 64/64 on shared-ambassador + e2e + principals CSR (legacy `HttpxMastioCsrTransport` still works for tests)
- [x] Frontdesk container rebuilt → Connector logs show `login_via_proxy_with_local_key ok`
- [x] Direct CSR call reaches Court with broker token (no more "Token invalid or expired" / htu mismatch)
- [x] **Nothing bypassed**: TLS verify on (CA bundle), mTLS on, DPoP on, broker still mints cert via the same admin-secret-protected path

## Follow-ups (NOT in this PR)

- Device-code enrollment does not populate `internal_agents.spiffe_id` on the Mastio nor propagate the new agent into the `federation_events` feed → Court refuses `login_via_proxy_with_local_key` for a freshly enrolled Frontdesk Connector with `SPIFFE ID in SAN does not match the registered agent`.
- ADR-012 local-auth `/v1/auth/token` should forward to Court when the caller signals a need for broker-issued claims, so we can re-enable it without breaking shared-mode provisioning.