### PR TITLE
fix(connector): persist spiffe_id on device-code enrollment + AgentManager.trust_domain

### DIFF
--- a/mcp_proxy/egress/agent_manager.py
+++ b/mcp_proxy/egress/agent_manager.py
@@ -289,6 +289,10 @@ class AgentManager:
     def org_id(self) -> str:
         return self._org_id
 
+    @property
+    def trust_domain(self) -> str:
+        return self._trust_domain
+
     def derive_org_id_from_ca(self) -> str | None:
         """SHA-256(pubkey DER)[:16] of the currently loaded Org CA.
 

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -383,15 +383,29 @@ async def approve(
         text("SELECT 1 FROM internal_agents WHERE agent_id = :aid"),
         {"aid": canonical_id},
     )
+    # SPIFFE URI ``sign_external_pubkey`` just embedded into the cert SAN
+    # — store it on the row so the Court's CSR auth dep
+    # (``app.registry.user_principals_router.sign_csr`` /
+    # ``app.auth.x509_verifier``) can match the assertion's cert SAN to
+    # ``agents.spiffe_id`` after federation propagation. Without this,
+    # device-code-enrolled Connectors hit ``SPIFFE ID in SAN does not
+    # match the registered agent`` on every cross-org call.
+    name_part = canonical_id.split("::", 1)[1]
+    spiffe_id = (
+        f"spiffe://{agent_manager.trust_domain}/"
+        f"{agent_manager.org_id}/{name_part}"
+    )
+
     if existing.first() is None:
         await conn.execute(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities,
                     cert_pem, created_at, is_active, device_info, dpop_jkt,
-                    enrollment_method, enrolled_at)
+                    enrollment_method, enrolled_at, spiffe_id)
                    VALUES (:aid, :dn, :caps, :cert, :created, 1,
-                           :device, :dpop_jkt, 'connector', :created)"""
+                           :device, :dpop_jkt, 'connector', :created,
+                           :spiffe_id)"""
             ),
             {
                 "aid": canonical_id,
@@ -408,6 +422,7 @@ async def approve(
                 # egress dep's grace path accepts them until operators
                 # flip to required mode (Phase 6).
                 "dpop_jkt": record.get("dpop_jkt"),
+                "spiffe_id": spiffe_id,
             },
         )
         await conn.execute(

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -281,6 +281,13 @@ services:
       MCP_PROXY_ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
       MCP_PROXY_AI_GATEWAY_BACKEND: "litellm_embedded"
       MCP_PROXY_AI_GATEWAY_PROVIDER: "anthropic"
+      # Trust domain pinned to match bootstrap-mastio's BYOCA enrollments
+      # (``orga.test``) so device-code agents land on the same SPIFFE
+      # namespace ``spiffe://orga.test/orga/<name>`` the Court expects.
+      # Without this the proxy default (``cullis.local``) shows up in
+      # SAN URIs and the Court rejects the Connector with
+      # ``SPIFFE ID in SAN does not match the registered agent``.
+      PROXY_TRUST_DOMAIN: "orga.test"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orga"
       MCP_PROXY_ALLOWED_ORIGINS:   "http://localhost:9100"

--- a/tests/test_proxy_device_info.py
+++ b/tests/test_proxy_device_info.py
@@ -98,10 +98,14 @@ async def _proxy_db(tmp_path, monkeypatch):
 
 
 class _FakeAgentManager:
-    """Minimal stand-in for AgentManager. ``approve`` only needs
-    ``ca_loaded`` + ``sign_external_pubkey`` to run."""
+    """Minimal stand-in for AgentManager. ``approve`` reads ``ca_loaded``,
+    ``sign_external_pubkey``, ``org_id`` and ``trust_domain`` (the last
+    two added when device-code approval started persisting ``spiffe_id``
+    on ``internal_agents``)."""
 
     ca_loaded = True
+    org_id = "testorg"
+    trust_domain = "testorg.test"
 
     def sign_external_pubkey(self, *, pubkey_pem: str, agent_name: str) -> str:
         # Not a real cert — approve() only stores it on the row.


### PR DESCRIPTION
## Summary

ADR-021 PR4a's `/v1/principals/csr` requires that the calling Connector chain its assertion against an `internal_agents` row whose `spiffe_id` matches the cert's SPIFFE SAN. Device-code enrollment was writing `spiffe_id=NULL`, so freshly enrolled Frontdesk Connectors hit `SPIFFE ID in SAN does not match the registered agent` on every CSR call.

## Changes

- `mcp_proxy/egress/agent_manager.py`: expose `trust_domain` as a property.
- `mcp_proxy/enrollment/service.py`: at approve-time compute the SPIFFE URI (`spiffe://<trust_domain>/<org_id>/<agent_name>`) exactly as `sign_external_pubkey` embeds it, and persist it on the new row.
- `sandbox/docker-compose.yml`: pin `PROXY_TRUST_DOMAIN=orga.test` so the proxy emits the same trust domain as `bootstrap-mastio`'s BYOCA enrollments. Without this the proxy default (`cullis.local`) shows up in SAN URIs and the Court refuses freshly federated agents.

## Test plan

- [x] `pytest tests/connector/` — 409/409 (excl. 4 known flakes in `test_profile_runtime_switch.py`)
- [x] `pytest tests/test_admin_enroll_byoca.py tests/test_enrollment.py tests/test_enrollment_dpop_jkt.py` — 33/33
- [x] Live in `imp/official_sandbox/`: device-code enrollment now writes `spiffe_id=spiffe://orga.test/orga/frontdesk`; with the federation flag flipped the agent reaches the Court `agents` table with matching `cert_thumbprint`
- [x] Nothing bypassed: TLS verify on, mTLS on, DPoP on, capability + binding gates intact

## Follow-ups (NOT in this PR)

1. **Device-code agents stay `federated=0` until an admin flips it.** Needs a dashboard / config knob to auto-flip on `connector`-method approve.
2. **Default capabilities + auto-binding for shared-mode agents.** Today the operator manually `POST /v1/registry/bindings` + `approve`. ADR-021 PR4d should auto-create + auto-approve a baseline binding for `connector`-method enrollments.
3. **`/v1/principals/csr` cert-chain validation.** Current behaviour rejects with `certificate chain broken at position 0`. Likely the proxy and Court are minting against different Org CAs; needs an end-to-end audit of the user-provisioning chain.