### PR TITLE
fix(connector): auto-flip federated=1 on connector-method enrollment

### DIFF
--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -397,15 +397,27 @@ async def approve(
     )
 
     if existing.first() is None:
+        # ADR-010 D1 left ``federated`` opt-in (admin flips manually) so
+        # an org could onboard local-only agents without leaking them
+        # cross-org. ``connector``-method enrollments are the opposite
+        # case: the user has just gone through the dashboard approval
+        # ritual, the admin has set capabilities, and the agent's whole
+        # purpose is to talk to the user (and, in shared-mode Frontdesk,
+        # to the Court for ``/v1/principals/csr``). Auto-flip the flag
+        # so the federation publisher pushes the row on the next tick.
+        # Production deployments that want stricter gating can revoke
+        # via the dashboard's admin-only ``federated=0`` toggle.
         await conn.execute(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities,
                     cert_pem, created_at, is_active, device_info, dpop_jkt,
-                    enrollment_method, enrolled_at, spiffe_id)
+                    enrollment_method, enrolled_at, spiffe_id,
+                    federated, federated_at, reach, federation_revision)
                    VALUES (:aid, :dn, :caps, :cert, :created, 1,
                            :device, :dpop_jkt, 'connector', :created,
-                           :spiffe_id)"""
+                           :spiffe_id,
+                           1, :created, 'both', 1)"""
             ),
             {
                 "aid": canonical_id,


### PR DESCRIPTION
## Summary

Stacked on top of #439 (rebase to main when that lands).

ADR-010 D1 left `internal_agents.federated` opt-in. For `connector` device-code enrollments that's wrong: the admin has explicitly approved the agent through the dashboard, and shared-mode Frontdesk needs the agent to reach the Court (`/v1/principals/csr`) immediately. Without auto-flip the federation publisher never pushes, the Court never sees the agent, and `login_via_proxy_with_local_key` 403s with `No approved binding`.

Auto-flip `federated=1`, `federated_at=now`, `reach='both'`, `federation_revision=1` at the same `INSERT` that creates the row.

## Test plan

- [x] `pytest tests/test_enrollment.py tests/test_admin_enroll_byoca.py tests/connector/test_enrollment_dpop.py` — 28/28
- [x] Live: re-enrolled `orga::frontdesk` via device-code; publisher logged `federation publish OK rev=1 status=created` within 2s; agent in Court `agents` table with matching `cert_thumbprint`
- [x] Nothing bypassed