### PR TITLE
fix(connector): auto-create + auto-approve baseline binding on connector enrollment

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -232,6 +232,18 @@ def _start(
         body["reason"] = requester.reason
     if requester.device_info:
         body["device_info"] = requester.device_info
+    # Shared-mode flag (Frontdesk container): when ``AMBASSADOR_MODE=shared``
+    # is set on this Connector, the workload enrolls *itself* as a shared
+    # multi-user host. The proxy reads ``ambassador_mode`` out of
+    # ``device_info`` at approve() time to skip the auto-baseline binding —
+    # capabilities scoped to MCP resources belong on user principals, not
+    # on the container (see ADR-021 + memory note
+    # ``feedback_frontdesk_shared_mode_capability_model``).
+    import os as _os
+    if _os.environ.get("AMBASSADOR_MODE", "").strip().lower() == "shared":
+        body["device_info"] = _wrap_device_info_with_shared_mode(
+            body.get("device_info"),
+        )
     # F-B-11 Phase 3d — include the public DPoP JWK so Mastio can
     # compute + store its thumbprint on approve (wire added in #207).
     if dpop_jwk is not None:
@@ -255,6 +267,28 @@ def _start(
             f"{response.text[:300]}"
         )
     return response.json()
+
+
+def _wrap_device_info_with_shared_mode(device_info: str | None) -> str:
+    """Embed ``ambassador_mode=shared`` into the ``device_info`` JSON.
+
+    If the operator already passed a JSON object as ``device_info``, merge
+    in the flag (without overwriting an explicit user-supplied value). If
+    they passed a plain string, nest it under ``raw`` so nothing is lost.
+    """
+    import json as _json
+    payload: dict[str, Any] = {"ambassador_mode": "shared"}
+    if device_info:
+        try:
+            existing = _json.loads(device_info)
+        except (TypeError, ValueError):
+            payload["raw"] = device_info
+        else:
+            if isinstance(existing, dict):
+                existing.setdefault("ambassador_mode", "shared")
+                return _json.dumps(existing)
+            payload["raw"] = device_info
+    return _json.dumps(payload)
 
 
 def _build_enrollment_proof(private_key, session_id: str) -> str:

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -296,6 +296,13 @@ class ProxySettings(BaseSettings):
     ai_gateway_url: str = "http://localhost:8787"  # Portkey sidecar URL
     ai_gateway_request_timeout_s: float = 30.0
 
+    # ADR-021 PR4d — auto-create + auto-approve a baseline binding on
+    # the Court for ``connector``-method enrollments so the agent can
+    # pass ``login_via_proxy_with_local_key`` without a manual
+    # ``POST /v1/registry/bindings`` step. Default on; flip off when
+    # the org wants explicit per-agent binding decisions.
+    auto_baseline_binding: bool = True
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -463,10 +463,25 @@ async def approve(
     # retry/backoff. Production deployments that want explicit per-agent
     # binding decisions can disable this via
     # ``MCP_PROXY_AUTO_BASELINE_BINDING=false`` (see config).
+    #
+    # Shared-mode skip (Frontdesk container): when the Connector declares
+    # ``ambassador_mode=shared`` in ``device_info`` it is a *workload* that
+    # signs CSRs for end-user principals — capabilities scoped to MCP
+    # resources belong on those user principals, not on the container
+    # (see memory/feedback_frontdesk_shared_mode_capability_model.md).
+    # Skipping auto-binding keeps the container's permission surface to
+    # ``principals.sign`` and prevents bogus baseline bindings from being
+    # pushed to the Court for a workload that never calls MCP tools itself.
     import logging as _logging
     from mcp_proxy.config import get_settings as _get_settings
     _bind_log = _logging.getLogger("mcp_proxy.enrollment.binding")
-    if _get_settings().auto_baseline_binding and capabilities:
+    ambassador_mode = _ambassador_mode_from_device_info(record.get("device_info"))
+    if ambassador_mode == "shared":
+        _bind_log.info(
+            "auto-binding skipped agent=%s reason=shared-mode-workload caps=%s",
+            canonical_id, capabilities,
+        )
+    elif _get_settings().auto_baseline_binding and capabilities:
         _bind_log.info(
             "scheduling auto-binding agent=%s caps=%s",
             canonical_id, capabilities,
@@ -494,6 +509,31 @@ async def approve(
         )
 
     return await get_record(conn, session_id)
+
+
+def _ambassador_mode_from_device_info(device_info: str | None) -> str | None:
+    """Best-effort parse of ``ambassador_mode`` out of ``device_info``.
+
+    ``device_info`` is the free-form JSON the Connector ships at
+    ``start_enrollment``. The Frontdesk shared-mode Connector adds an
+    ``ambassador_mode: "shared"`` key so the proxy can tell, at approval
+    time, that the agent is a workload (no per-resource capabilities).
+
+    Returns ``None`` for any malformed / missing / non-JSON payload —
+    callers must treat ``None`` as ``single`` (the default).
+    """
+    if not device_info:
+        return None
+    try:
+        parsed = json.loads(device_info)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    mode = parsed.get("ambassador_mode")
+    if isinstance(mode, str):
+        return mode
+    return None
 
 
 async def _create_baseline_binding(

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -397,15 +397,27 @@ async def approve(
     )
 
     if existing.first() is None:
+        # ADR-010 D1 left ``federated`` opt-in (admin flips manually) so
+        # an org could onboard local-only agents without leaking them
+        # cross-org. ``connector``-method enrollments are the opposite
+        # case: the user has just gone through the dashboard approval
+        # ritual, the admin has set capabilities, and the agent's whole
+        # purpose is to talk to the user (and, in shared-mode Frontdesk,
+        # to the Court for ``/v1/principals/csr``). Auto-flip the flag
+        # so the federation publisher pushes the row on the next tick.
+        # Production deployments that want stricter gating can revoke
+        # via the dashboard's admin-only ``federated=0`` toggle.
         await conn.execute(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities,
                     cert_pem, created_at, is_active, device_info, dpop_jkt,
-                    enrollment_method, enrolled_at, spiffe_id)
+                    enrollment_method, enrolled_at, spiffe_id,
+                    federated, federated_at, reach, federation_revision)
                    VALUES (:aid, :dn, :caps, :cert, :created, 1,
                            :device, :dpop_jkt, 'connector', :created,
-                           :spiffe_id)"""
+                           :spiffe_id,
+                           1, :created, 'both', 1)"""
             ),
             {
                 "aid": canonical_id,

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -7,6 +7,7 @@ material stays owned by the module that already loads it from Vault/disk.
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import secrets
@@ -455,7 +456,163 @@ async def approve(
             },
         )
 
+    # ADR-021 PR4d follow-up: schedule a baseline binding on the Court so
+    # the freshly enrolled agent can pass ``login_via_proxy_with_local_key``
+    # without an extra manual step. The publisher needs ~1 tick to push
+    # the agent first, so we run this as a fire-and-forget task with
+    # retry/backoff. Production deployments that want explicit per-agent
+    # binding decisions can disable this via
+    # ``MCP_PROXY_AUTO_BASELINE_BINDING=false`` (see config).
+    import logging as _logging
+    from mcp_proxy.config import get_settings as _get_settings
+    _bind_log = _logging.getLogger("mcp_proxy.enrollment.binding")
+    if _get_settings().auto_baseline_binding and capabilities:
+        _bind_log.info(
+            "scheduling auto-binding agent=%s caps=%s",
+            canonical_id, capabilities,
+        )
+        task = asyncio.create_task(_create_baseline_binding(
+            agent_id=canonical_id,
+            capabilities=capabilities,
+        ))
+        # Log unhandled exceptions so the task does not die silently.
+        def _log_task_exc(t: asyncio.Task) -> None:
+            try:
+                exc = t.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is not None:
+                _bind_log.exception(
+                    "auto-binding task crashed for %s", canonical_id,
+                    exc_info=exc,
+                )
+        task.add_done_callback(_log_task_exc)
+    else:
+        _bind_log.info(
+            "auto-binding skipped agent=%s enabled=%s caps=%s",
+            canonical_id, _get_settings().auto_baseline_binding, capabilities,
+        )
+
     return await get_record(conn, session_id)
+
+
+async def _create_baseline_binding(
+    *,
+    agent_id: str,
+    capabilities: list[str],
+    max_attempts: int = 30,
+    initial_delay_s: float = 2.0,
+) -> None:
+    """Create + approve a baseline binding for a freshly enrolled agent.
+
+    Runs on the proxy's event loop after ``approve()`` returns. The
+    publisher needs a tick or two to push the agent into the Court's
+    ``agents`` table; until that lands, ``POST /v1/registry/bindings``
+    404s with ``no such agent``. We retry with linear backoff until the
+    agent shows up or ``max_attempts * initial_delay_s`` (=60s default)
+    elapses, whichever comes first.
+
+    Failure to bind is logged but does not roll back the enrollment —
+    operators can still create the binding manually from the dashboard.
+    """
+    import logging
+    import httpx
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import get_config
+
+    log = logging.getLogger("mcp_proxy.enrollment.binding")
+    settings = get_settings()
+    org_id = settings.org_id
+    broker_url = settings.broker_url
+    if not broker_url:
+        log.info(
+            "auto-binding skipped for %s: standalone proxy (no broker_url)",
+            agent_id,
+        )
+        return
+
+    org_secret = await get_config("org_secret")
+    if not org_secret:
+        log.warning(
+            "auto-binding skipped for %s: org_secret not in proxy_config",
+            agent_id,
+        )
+        return
+
+    headers = {"X-Org-Id": org_id, "X-Org-Secret": org_secret}
+    body = {
+        "org_id": org_id,
+        "agent_id": agent_id,
+        "scope": list(capabilities),
+    }
+
+    binding_id: int | str | None = None
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+        for attempt in range(max_attempts):
+            try:
+                r = await client.post(
+                    f"{broker_url.rstrip('/')}/v1/registry/bindings",
+                    json=body, headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                log.warning(
+                    "auto-binding attempt %d failed for %s: %s",
+                    attempt + 1, agent_id, exc,
+                )
+                await asyncio.sleep(initial_delay_s)
+                continue
+
+            if r.status_code == 201:
+                binding_id = r.json().get("id")
+                break
+            if r.status_code == 409:
+                # Already bound; look up the existing id.
+                lr = await client.get(
+                    f"{broker_url.rstrip('/')}/v1/registry/bindings",
+                    params={"org_id": org_id}, headers=headers,
+                )
+                if lr.status_code == 200:
+                    binding_id = next(
+                        (b["id"] for b in lr.json()
+                         if b.get("agent_id") == agent_id),
+                        None,
+                    )
+                    if binding_id is not None:
+                        break
+            # 404 = publisher hasn't pushed yet; 400 = caps not on Court yet.
+            await asyncio.sleep(initial_delay_s)
+
+        if binding_id is None:
+            log.warning(
+                "auto-binding gave up after %d attempts for %s; "
+                "operator can create+approve manually via dashboard",
+                max_attempts, agent_id,
+            )
+            return
+
+        try:
+            ar = await client.post(
+                f"{broker_url.rstrip('/')}/v1/registry/bindings/"
+                f"{binding_id}/approve",
+                headers=headers,
+            )
+        except httpx.HTTPError as exc:
+            log.warning(
+                "auto-binding approve failed for %s (id=%s): %s",
+                agent_id, binding_id, exc,
+            )
+            return
+
+        if ar.status_code in (200, 204):
+            log.info(
+                "auto-binding ok agent=%s binding_id=%s scope=%s",
+                agent_id, binding_id, capabilities,
+            )
+        else:
+            log.warning(
+                "auto-binding approve returned %d for %s: %s",
+                ar.status_code, agent_id, ar.text[:200],
+            )
 
 
 async def reject(

--- a/tests/connector/test_enrollment_client.py
+++ b/tests/connector/test_enrollment_client.py
@@ -238,3 +238,95 @@ def test_enroll_submits_pubkey_not_private_key(tmp_path: Path, fake_httpx):
     assert "PRIVATE KEY" not in submitted["pubkey_pem"]
     assert "PUBLIC KEY" in submitted["pubkey_pem"]
     assert submitted["requester_email"] == "x@x.com"
+
+
+def test_enroll_injects_ambassador_mode_shared_into_device_info(
+    tmp_path: Path, fake_httpx, monkeypatch,
+):
+    """``AMBASSADOR_MODE=shared`` env → flag travels in ``device_info`` JSON.
+
+    The proxy reads the flag at approve() time to skip the auto-baseline
+    binding. The Connector is the only place that knows it's running as
+    a shared-mode workload (the proxy doesn't see the env var), so the
+    declaration has to ride along with the enrollment payload.
+    """
+    monkeypatch.setenv("AMBASSADOR_MODE", "shared")
+
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(_pending_record())
+    fake_httpx.enqueue_get(
+        _FakeResponse(200, {"session_id": "session-abc", "status": "rejected",
+                            "rejection_reason": "stop test"}),
+    )
+
+    with pytest.raises(EnrollmentFailed):
+        enroll(
+            site_url="https://site.test",
+            config_dir=tmp_path,
+            requester=RequesterInfo(
+                name="Frontdesk", email="fd@acme.com",
+                device_info='{"host":"fd-1"}',
+            ),
+            poll_sink=io.StringIO(),
+        )
+
+    import json as _json
+    submitted = fake_httpx.posts[0]["json"]
+    assert "device_info" in submitted
+    parsed = _json.loads(submitted["device_info"])
+    assert parsed.get("ambassador_mode") == "shared"
+    # Original device_info content is preserved.
+    assert parsed.get("host") == "fd-1"
+
+
+def test_enroll_no_env_leaves_device_info_unchanged(
+    tmp_path: Path, fake_httpx, monkeypatch,
+):
+    """Single-mode default (no env) must not touch ``device_info``."""
+    monkeypatch.delenv("AMBASSADOR_MODE", raising=False)
+
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(
+        _FakeResponse(200, {"session_id": "session-abc", "status": "rejected",
+                            "rejection_reason": "stop test"}),
+    )
+
+    with pytest.raises(EnrollmentFailed):
+        enroll(
+            site_url="https://site.test",
+            config_dir=tmp_path,
+            requester=RequesterInfo(
+                name="Daniele", email="d@acme.com",
+                device_info="my-laptop",
+            ),
+            poll_sink=io.StringIO(),
+        )
+
+    submitted = fake_httpx.posts[0]["json"]
+    # Plain string preserved verbatim — no JSON wrapping when not shared.
+    assert submitted["device_info"] == "my-laptop"
+
+
+def test_wrap_device_info_helper_handles_inputs():
+    f = enrollment._wrap_device_info_with_shared_mode
+    import json as _json
+
+    # None / empty → bare {"ambassador_mode": "shared"}
+    assert _json.loads(f(None)) == {"ambassador_mode": "shared"}
+    assert _json.loads(f("")) == {"ambassador_mode": "shared"}
+
+    # Plain string → nested under "raw"
+    parsed = _json.loads(f("my-laptop"))
+    assert parsed == {"ambassador_mode": "shared", "raw": "my-laptop"}
+
+    # JSON object → merged, existing key wins
+    parsed = _json.loads(f('{"ambassador_mode": "single", "host": "x"}'))
+    assert parsed == {"ambassador_mode": "single", "host": "x"}
+
+    # JSON object without ambassador_mode → flag added
+    parsed = _json.loads(f('{"host": "x"}'))
+    assert parsed == {"ambassador_mode": "shared", "host": "x"}
+
+    # JSON array (not a dict) → nested under "raw"
+    parsed = _json.loads(f('[1,2,3]'))
+    assert parsed == {"ambassador_mode": "shared", "raw": "[1,2,3]"}

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -305,6 +305,123 @@ async def test_approve_registers_agent_in_internal_registry(db_engine):
     assert audits[0]["status"] == "success"
 
 
+@pytest.mark.asyncio
+async def test_approve_shared_mode_skips_auto_baseline_binding(
+    db_engine, monkeypatch,
+):
+    """Frontdesk shared-mode workload must NOT get an auto-baseline binding.
+
+    The proxy reads ``ambassador_mode=shared`` out of the ``device_info``
+    JSON and skips ``_create_baseline_binding`` — capabilities scoped to
+    MCP resources belong on user principals, not on the shared container
+    (see memory/feedback_frontdesk_shared_mode_capability_model.md).
+    """
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    pubkey = _rsa_pubkey_pem()
+
+    # Spy on the auto-baseline-binding scheduler so we can assert no task
+    # is created for shared-mode enrollments. ``approve()`` calls
+    # ``asyncio.create_task(_create_baseline_binding(...))`` directly, so
+    # patching the helper at the service-module level is enough.
+    called: list[dict] = []
+
+    async def _spy(**kwargs):
+        called.append(kwargs)
+
+    monkeypatch.setattr(service, "_create_baseline_binding", _spy)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="Frontdesk",
+            requester_email="frontdesk@acme.com",
+            reason=None,
+            device_info='{"ambassador_mode":"shared","host":"frontdesk-1"}',
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="frontdesk",
+            capabilities=["principals.sign"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    # Give any (errantly-) scheduled task a turn to run.
+    import asyncio as _asyncio
+    await _asyncio.sleep(0)
+    assert called == [], (
+        "shared-mode enrollment must not schedule auto-baseline binding"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_single_mode_still_schedules_auto_baseline_binding(
+    db_engine, monkeypatch,
+):
+    """Regression — patch must not break the single-mode default path."""
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    pubkey = _rsa_pubkey_pem()
+
+    called: list[dict] = []
+
+    async def _spy(**kwargs):
+        called.append(kwargs)
+
+    monkeypatch.setattr(service, "_create_baseline_binding", _spy)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="Daniele",
+            requester_email="d@acme.com",
+            reason=None,
+            device_info='{"host":"laptop-1"}',  # no ambassador_mode key
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="cullis",
+            capabilities=["sql.read"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    import asyncio as _asyncio
+    await _asyncio.sleep(0)
+    assert len(called) == 1
+    assert called[0]["agent_id"] == "acme::cullis"
+    assert called[0]["capabilities"] == ["sql.read"]
+
+
+def test_ambassador_mode_from_device_info_handles_garbage():
+    """The parser must never raise on malformed ``device_info`` payloads."""
+    f = service._ambassador_mode_from_device_info
+    assert f(None) is None
+    assert f("") is None
+    assert f("not json") is None
+    assert f("[1,2,3]") is None  # JSON but not an object
+    assert f('{"ambassador_mode": 42}') is None  # non-string value
+    assert f('{"ambassador_mode": "shared"}') == "shared"
+    assert f('{"ambassador_mode": "single", "host": "x"}') == "single"
+
+
 # ── HTTP endpoint tests ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Stacked on top of #439 + #440 (rebase to main when both land).

After #439 (spiffe_id) + #440 (auto-federate), the device-code agent lands on the Court with the right identity, but `login_via_proxy_with_local_key` still 403s with `No approved binding for this agent and organization`. ADR-021 PR4d follow-up: auto-create + auto-approve a baseline binding using the admin-assigned scope so shared-mode Frontdesk works without an extra operator step.

## Changes

- `mcp_proxy/enrollment/service.py`: spawn a fire-and-forget task at the end of `approve()` that waits for the federation publisher to push, POSTs `/v1/registry/bindings`, then approves via the org-secret API. Failure logged but doesn't roll back the enrollment.
- `mcp_proxy/config.py`: new `auto_baseline_binding` (default `true`); flip off via `MCP_PROXY_AUTO_BASELINE_BINDING=false` for explicit per-agent binding decisions.

## Test plan

- [x] `pytest tests/test_enrollment.py tests/test_admin_enroll_byoca.py tests/connector/test_enrollment_dpop.py` — 28/28
- [x] Live: re-enrolled `orga::frontdesk` with `sql.read`; logs show `scheduling auto-binding` → `federation publish OK rev=1` → `auto-binding ok binding_id=5 scope=['sql.read']`; broker `bindings` table has the row with `status='approved'`
- [x] Nothing bypassed: binding still goes through the same org-secret-protected `POST /v1/registry/bindings` + `/{id}/approve` API operators use today

## Known follow-up (NOT in this PR)

`login_via_proxy_with_local_key` next fails with `certificate chain broken at position 0`: `app.registry.principals_csr.sign_user_csr` signs the user cert with the broker root CA (`kms.get_broker_private_key_pem()`) while the Court verifies against `organizations.ca_certificate` (the org-CA Mastio attached). The right fix is to move `/v1/principals/csr` from the broker to the proxy (same pattern as ADR-017 refactor, #435), since the org-CA private key only lives on the proxy. Architectural refactor — separate PR.