### PR TITLE
refactor(mcp_proxy): move /v1/principals/csr to the proxy (ADR-021 PR4a fix)

### DIFF
--- a/cullis_connector/enrollment.py
+++ b/cullis_connector/enrollment.py
@@ -232,6 +232,18 @@ def _start(
         body["reason"] = requester.reason
     if requester.device_info:
         body["device_info"] = requester.device_info
+    # Shared-mode flag (Frontdesk container): when ``AMBASSADOR_MODE=shared``
+    # is set on this Connector, the workload enrolls *itself* as a shared
+    # multi-user host. The proxy reads ``ambassador_mode`` out of
+    # ``device_info`` at approve() time to skip the auto-baseline binding —
+    # capabilities scoped to MCP resources belong on user principals, not
+    # on the container (see ADR-021 + memory note
+    # ``feedback_frontdesk_shared_mode_capability_model``).
+    import os as _os
+    if _os.environ.get("AMBASSADOR_MODE", "").strip().lower() == "shared":
+        body["device_info"] = _wrap_device_info_with_shared_mode(
+            body.get("device_info"),
+        )
     # F-B-11 Phase 3d — include the public DPoP JWK so Mastio can
     # compute + store its thumbprint on approve (wire added in #207).
     if dpop_jwk is not None:
@@ -255,6 +267,28 @@ def _start(
             f"{response.text[:300]}"
         )
     return response.json()
+
+
+def _wrap_device_info_with_shared_mode(device_info: str | None) -> str:
+    """Embed ``ambassador_mode=shared`` into the ``device_info`` JSON.
+
+    If the operator already passed a JSON object as ``device_info``, merge
+    in the flag (without overwriting an explicit user-supplied value). If
+    they passed a plain string, nest it under ``raw`` so nothing is lost.
+    """
+    import json as _json
+    payload: dict[str, Any] = {"ambassador_mode": "shared"}
+    if device_info:
+        try:
+            existing = _json.loads(device_info)
+        except (TypeError, ValueError):
+            payload["raw"] = device_info
+        else:
+            if isinstance(existing, dict):
+                existing.setdefault("ambassador_mode", "shared")
+                return _json.dumps(existing)
+            payload["raw"] = device_info
+    return _json.dumps(payload)
 
 
 def _build_enrollment_proof(private_key, session_id: str) -> str:

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -296,6 +296,13 @@ class ProxySettings(BaseSettings):
     ai_gateway_url: str = "http://localhost:8787"  # Portkey sidecar URL
     ai_gateway_request_timeout_s: float = 30.0
 
+    # ADR-021 PR4d — auto-create + auto-approve a baseline binding on
+    # the Court for ``connector``-method enrollments so the agent can
+    # pass ``login_via_proxy_with_local_key`` without a manual
+    # ``POST /v1/registry/bindings`` step. Default on; flip off when
+    # the org wants explicit per-agent binding decisions.
+    auto_baseline_binding: bool = True
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -463,10 +463,25 @@ async def approve(
     # retry/backoff. Production deployments that want explicit per-agent
     # binding decisions can disable this via
     # ``MCP_PROXY_AUTO_BASELINE_BINDING=false`` (see config).
+    #
+    # Shared-mode skip (Frontdesk container): when the Connector declares
+    # ``ambassador_mode=shared`` in ``device_info`` it is a *workload* that
+    # signs CSRs for end-user principals — capabilities scoped to MCP
+    # resources belong on those user principals, not on the container
+    # (see memory/feedback_frontdesk_shared_mode_capability_model.md).
+    # Skipping auto-binding keeps the container's permission surface to
+    # ``principals.sign`` and prevents bogus baseline bindings from being
+    # pushed to the Court for a workload that never calls MCP tools itself.
     import logging as _logging
     from mcp_proxy.config import get_settings as _get_settings
     _bind_log = _logging.getLogger("mcp_proxy.enrollment.binding")
-    if _get_settings().auto_baseline_binding and capabilities:
+    ambassador_mode = _ambassador_mode_from_device_info(record.get("device_info"))
+    if ambassador_mode == "shared":
+        _bind_log.info(
+            "auto-binding skipped agent=%s reason=shared-mode-workload caps=%s",
+            canonical_id, capabilities,
+        )
+    elif _get_settings().auto_baseline_binding and capabilities:
         _bind_log.info(
             "scheduling auto-binding agent=%s caps=%s",
             canonical_id, capabilities,
@@ -494,6 +509,31 @@ async def approve(
         )
 
     return await get_record(conn, session_id)
+
+
+def _ambassador_mode_from_device_info(device_info: str | None) -> str | None:
+    """Best-effort parse of ``ambassador_mode`` out of ``device_info``.
+
+    ``device_info`` is the free-form JSON the Connector ships at
+    ``start_enrollment``. The Frontdesk shared-mode Connector adds an
+    ``ambassador_mode: "shared"`` key so the proxy can tell, at approval
+    time, that the agent is a workload (no per-resource capabilities).
+
+    Returns ``None`` for any malformed / missing / non-JSON payload —
+    callers must treat ``None`` as ``single`` (the default).
+    """
+    if not device_info:
+        return None
+    try:
+        parsed = json.loads(device_info)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    mode = parsed.get("ambassador_mode")
+    if isinstance(mode, str):
+        return mode
+    return None
 
 
 async def _create_baseline_binding(

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -397,15 +397,27 @@ async def approve(
     )
 
     if existing.first() is None:
+        # ADR-010 D1 left ``federated`` opt-in (admin flips manually) so
+        # an org could onboard local-only agents without leaking them
+        # cross-org. ``connector``-method enrollments are the opposite
+        # case: the user has just gone through the dashboard approval
+        # ritual, the admin has set capabilities, and the agent's whole
+        # purpose is to talk to the user (and, in shared-mode Frontdesk,
+        # to the Court for ``/v1/principals/csr``). Auto-flip the flag
+        # so the federation publisher pushes the row on the next tick.
+        # Production deployments that want stricter gating can revoke
+        # via the dashboard's admin-only ``federated=0`` toggle.
         await conn.execute(
             text(
                 """INSERT INTO internal_agents
                    (agent_id, display_name, capabilities,
                     cert_pem, created_at, is_active, device_info, dpop_jkt,
-                    enrollment_method, enrolled_at, spiffe_id)
+                    enrollment_method, enrolled_at, spiffe_id,
+                    federated, federated_at, reach, federation_revision)
                    VALUES (:aid, :dn, :caps, :cert, :created, 1,
                            :device, :dpop_jkt, 'connector', :created,
-                           :spiffe_id)"""
+                           :spiffe_id,
+                           1, :created, 'both', 1)"""
             ),
             {
                 "aid": canonical_id,

--- a/mcp_proxy/enrollment/service.py
+++ b/mcp_proxy/enrollment/service.py
@@ -7,6 +7,7 @@ material stays owned by the module that already loads it from Vault/disk.
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import secrets
@@ -455,7 +456,163 @@ async def approve(
             },
         )
 
+    # ADR-021 PR4d follow-up: schedule a baseline binding on the Court so
+    # the freshly enrolled agent can pass ``login_via_proxy_with_local_key``
+    # without an extra manual step. The publisher needs ~1 tick to push
+    # the agent first, so we run this as a fire-and-forget task with
+    # retry/backoff. Production deployments that want explicit per-agent
+    # binding decisions can disable this via
+    # ``MCP_PROXY_AUTO_BASELINE_BINDING=false`` (see config).
+    import logging as _logging
+    from mcp_proxy.config import get_settings as _get_settings
+    _bind_log = _logging.getLogger("mcp_proxy.enrollment.binding")
+    if _get_settings().auto_baseline_binding and capabilities:
+        _bind_log.info(
+            "scheduling auto-binding agent=%s caps=%s",
+            canonical_id, capabilities,
+        )
+        task = asyncio.create_task(_create_baseline_binding(
+            agent_id=canonical_id,
+            capabilities=capabilities,
+        ))
+        # Log unhandled exceptions so the task does not die silently.
+        def _log_task_exc(t: asyncio.Task) -> None:
+            try:
+                exc = t.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is not None:
+                _bind_log.exception(
+                    "auto-binding task crashed for %s", canonical_id,
+                    exc_info=exc,
+                )
+        task.add_done_callback(_log_task_exc)
+    else:
+        _bind_log.info(
+            "auto-binding skipped agent=%s enabled=%s caps=%s",
+            canonical_id, _get_settings().auto_baseline_binding, capabilities,
+        )
+
     return await get_record(conn, session_id)
+
+
+async def _create_baseline_binding(
+    *,
+    agent_id: str,
+    capabilities: list[str],
+    max_attempts: int = 30,
+    initial_delay_s: float = 2.0,
+) -> None:
+    """Create + approve a baseline binding for a freshly enrolled agent.
+
+    Runs on the proxy's event loop after ``approve()`` returns. The
+    publisher needs a tick or two to push the agent into the Court's
+    ``agents`` table; until that lands, ``POST /v1/registry/bindings``
+    404s with ``no such agent``. We retry with linear backoff until the
+    agent shows up or ``max_attempts * initial_delay_s`` (=60s default)
+    elapses, whichever comes first.
+
+    Failure to bind is logged but does not roll back the enrollment —
+    operators can still create the binding manually from the dashboard.
+    """
+    import logging
+    import httpx
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import get_config
+
+    log = logging.getLogger("mcp_proxy.enrollment.binding")
+    settings = get_settings()
+    org_id = settings.org_id
+    broker_url = settings.broker_url
+    if not broker_url:
+        log.info(
+            "auto-binding skipped for %s: standalone proxy (no broker_url)",
+            agent_id,
+        )
+        return
+
+    org_secret = await get_config("org_secret")
+    if not org_secret:
+        log.warning(
+            "auto-binding skipped for %s: org_secret not in proxy_config",
+            agent_id,
+        )
+        return
+
+    headers = {"X-Org-Id": org_id, "X-Org-Secret": org_secret}
+    body = {
+        "org_id": org_id,
+        "agent_id": agent_id,
+        "scope": list(capabilities),
+    }
+
+    binding_id: int | str | None = None
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+        for attempt in range(max_attempts):
+            try:
+                r = await client.post(
+                    f"{broker_url.rstrip('/')}/v1/registry/bindings",
+                    json=body, headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                log.warning(
+                    "auto-binding attempt %d failed for %s: %s",
+                    attempt + 1, agent_id, exc,
+                )
+                await asyncio.sleep(initial_delay_s)
+                continue
+
+            if r.status_code == 201:
+                binding_id = r.json().get("id")
+                break
+            if r.status_code == 409:
+                # Already bound; look up the existing id.
+                lr = await client.get(
+                    f"{broker_url.rstrip('/')}/v1/registry/bindings",
+                    params={"org_id": org_id}, headers=headers,
+                )
+                if lr.status_code == 200:
+                    binding_id = next(
+                        (b["id"] for b in lr.json()
+                         if b.get("agent_id") == agent_id),
+                        None,
+                    )
+                    if binding_id is not None:
+                        break
+            # 404 = publisher hasn't pushed yet; 400 = caps not on Court yet.
+            await asyncio.sleep(initial_delay_s)
+
+        if binding_id is None:
+            log.warning(
+                "auto-binding gave up after %d attempts for %s; "
+                "operator can create+approve manually via dashboard",
+                max_attempts, agent_id,
+            )
+            return
+
+        try:
+            ar = await client.post(
+                f"{broker_url.rstrip('/')}/v1/registry/bindings/"
+                f"{binding_id}/approve",
+                headers=headers,
+            )
+        except httpx.HTTPError as exc:
+            log.warning(
+                "auto-binding approve failed for %s (id=%s): %s",
+                agent_id, binding_id, exc,
+            )
+            return
+
+        if ar.status_code in (200, 204):
+            log.info(
+                "auto-binding ok agent=%s binding_id=%s scope=%s",
+                agent_id, binding_id, capabilities,
+            )
+        else:
+            log.warning(
+                "auto-binding approve returned %d for %s: %s",
+                ar.status_code, agent_id, ar.text[:200],
+            )
 
 
 async def reject(

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -962,6 +962,13 @@ from mcp_proxy.registry.public_key import (
 # alongside the Court's legacy registry endpoints.
 app.include_router(federation_public_key_router)
 
+# ADR-021 PR4a (proxy-native) — POST /v1/principals/csr signs a user-
+# principal CSR with the proxy's Org CA. Originally lived on the broker
+# but the broker root CA chain doesn't validate against ``organizations.
+# ca_certificate``; only the proxy holds the right private key.
+from mcp_proxy.registry.user_principals_router import router as principals_router
+app.include_router(principals_router)
+
 # ADR-004 PR A — reverse-proxy router for /v1/broker/*, /v1/auth/*,
 # /v1/registry/*. Registered before local handlers so the proxy owns these
 # paths by default; local endpoints live under /v1/egress/* and /v1/ingress/*.

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -1,0 +1,264 @@
+"""Mastio CSR signing for user principals (ADR-021 PR4a, proxy-side).
+
+This is the proxy-side signer. The original implementation lived on
+the broker (``app/registry/principals_csr.py``) and signed with
+``broker_private_key_pem`` — the broker root CA. The Court then
+verifies user certs against ``organizations.ca_certificate``, the
+**org** CA the proxy attached, so the broker-signed user cert
+``certificate chain broken at position 0``'d on every login. The
+fix is to sign with the org-CA private key, which only ever lives on
+the proxy. Same module here, swapped signing source.
+
+The Cullis Frontdesk Ambassador (PR4b) generates a keypair locally,
+builds a CSR around the public key, and POSTs it here to obtain a
+proxy-signed cert chained to the org CA the Court already trusts.
+
+v0.1 scope:
+  - Signs with the proxy's loaded org CA (``AgentManager._org_ca_key``).
+  - TTL 1 hour, refreshed at the next SSO touch.
+  - Issuer name preserved (``CN=Cullis Mastio Broker CA, O=<org>``)
+    for back-compat with existing chain validators.
+  - Validates the CSR's SPIFFE SAN matches the requested principal_id
+    so callers cannot smuggle a CSR for a different principal.
+
+Auth: ``Depends(get_authenticated_agent)``. RBAC: caller may only
+request signing for principals in its own org.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+
+if TYPE_CHECKING:
+    from mcp_proxy.egress.agent_manager import AgentManager
+
+_log = logging.getLogger("mcp_proxy.registry.principals_csr")
+
+
+# Cert lifetime for user principals. Short on purpose — the Ambassador
+# refreshes via a fresh signing call whenever the user's session
+# rolls over. Production may shorten this further (e.g. 15min) once
+# the rollover path is exercised.
+USER_CERT_TTL = timedelta(hours=1)
+
+# Allowed clock skew either direction.
+CLOCK_SKEW = timedelta(minutes=5)
+
+
+class CsrValidationError(ValueError):
+    """Raised when the submitted CSR fails any structural check."""
+
+
+def parse_principal_id_to_spiffe(principal_id: str) -> tuple[str, str]:
+    """Translate ``<td>/<org>/<type>/<name>`` into the full SPIFFE URI
+    + a normalised internal id.
+
+    Returns ``(spiffe_uri, expected_org_id)``. Raises ``ValueError``
+    when the path is malformed.
+    """
+    parts = principal_id.split("/")
+    if len(parts) != 4:
+        raise ValueError(
+            "principal_id must have 4 path components "
+            "(<trust-domain>/<org>/<principal-type>/<name>); got "
+            f"{len(parts)}: {principal_id!r}",
+        )
+    td, org, ptype, name = parts
+    if not all((td, org, ptype, name)):
+        raise ValueError(
+            f"principal_id contains an empty component: {principal_id!r}",
+        )
+    if ptype not in ("user", "agent", "workload"):
+        raise ValueError(
+            f"principal_id principal-type must be one of "
+            f"user/agent/workload; got {ptype!r}",
+        )
+    spiffe_uri = f"spiffe://{td}/{org}/{ptype}/{name}"
+    return spiffe_uri, org
+
+
+def _extract_csr_spiffe_uri(csr: x509.CertificateSigningRequest) -> str:
+    """Return the single SPIFFE URI SAN in the CSR.
+
+    Raises ``CsrValidationError`` if the CSR has zero or multiple URI
+    SANs, or if the URI is not a SPIFFE id.
+    """
+    try:
+        san_ext = csr.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName,
+        )
+    except x509.ExtensionNotFound as exc:
+        raise CsrValidationError(
+            "CSR is missing the SubjectAlternativeName extension",
+        ) from exc
+
+    sans = san_ext.value
+    uris = [u.value for u in sans if isinstance(u, x509.UniformResourceIdentifier)]
+    if len(uris) == 0:
+        raise CsrValidationError("CSR SAN has no URI entries")
+    if len(uris) > 1:
+        raise CsrValidationError(
+            f"CSR SAN must have exactly one URI; got {len(uris)}",
+        )
+    uri = uris[0]
+    if not uri.startswith("spiffe://"):
+        raise CsrValidationError(
+            f"CSR SAN URI must be a SPIFFE id; got {uri!r}",
+        )
+    return uri
+
+
+def _verify_csr_signature(csr: x509.CertificateSigningRequest) -> None:
+    """``x509.CertificateSigningRequest`` exposes ``is_signature_valid``
+    on cryptography>=41 — we use it as the canonical check that the
+    requester actually held the matching private key.
+    """
+    if not csr.is_signature_valid:
+        raise CsrValidationError("CSR signature does not verify")
+
+
+def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
+    """Refuse weak keys. EC P-256/384/521 ok, RSA >= 2048 ok."""
+    pub = csr.public_key()
+    if isinstance(pub, rsa.RSAPublicKey):
+        if pub.key_size < 2048:
+            raise CsrValidationError(
+                f"RSA key too small ({pub.key_size} bits); minimum 2048",
+            )
+    elif isinstance(pub, ec.EllipticCurvePublicKey):
+        if pub.curve.key_size < 256:
+            raise CsrValidationError(
+                f"EC curve too small ({pub.curve.key_size} bits); minimum 256",
+            )
+    else:
+        raise CsrValidationError(
+            f"Unsupported public key type: {type(pub).__name__}",
+        )
+
+
+def _build_subject(principal_id: str, org_id: str) -> x509.Name:
+    return x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, principal_id[:64]),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+
+
+def _build_issuer(org_id: str) -> x509.Name:
+    return x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "Cullis Mastio Broker CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
+    ])
+
+
+def _cert_thumbprint_sha256(cert: x509.Certificate) -> str:
+    der = cert.public_bytes(serialization.Encoding.DER)
+    return hashlib.sha256(der).hexdigest()
+
+
+async def sign_user_csr(
+    csr_pem: str,
+    principal_id: str,
+    *,
+    agent_manager: "AgentManager",
+    ttl: timedelta = USER_CERT_TTL,
+) -> tuple[str, str, datetime]:
+    """Sign a user-principal CSR with the proxy's loaded Org CA.
+
+    Returns ``(cert_pem, cert_thumbprint_sha256, cert_not_after)``.
+
+    Raises:
+        ValueError: principal_id malformed.
+        CsrValidationError: CSR malformed, weak key, missing SAN,
+            wrong SPIFFE URI, signature invalid.
+        RuntimeError: Org CA not loaded on this proxy yet.
+    """
+    spiffe_expected, expected_org = parse_principal_id_to_spiffe(principal_id)
+
+    if expected_org != agent_manager.org_id:
+        raise CsrValidationError(
+            f"principal_id org {expected_org!r} does not match this "
+            f"proxy's org {agent_manager.org_id!r}",
+        )
+
+    try:
+        csr = x509.load_pem_x509_csr(csr_pem.encode("utf-8"))
+    except (ValueError, TypeError) as exc:
+        raise CsrValidationError(f"could not parse CSR PEM: {exc}") from exc
+
+    _verify_csr_signature(csr)
+    _validate_public_key(csr)
+
+    spiffe_in_csr = _extract_csr_spiffe_uri(csr)
+    if spiffe_in_csr != spiffe_expected:
+        raise CsrValidationError(
+            f"CSR SPIFFE id {spiffe_in_csr!r} does not match requested "
+            f"principal_id {principal_id!r} (expected {spiffe_expected!r})",
+        )
+
+    if not agent_manager.ca_loaded:
+        raise RuntimeError(
+            "Org CA not loaded on this proxy — cannot sign principal CSRs",
+        )
+    ca_key = agent_manager._org_ca_key  # type: ignore[attr-defined]
+    if ca_key is None:
+        raise RuntimeError("Org CA key missing despite ca_loaded=True")
+
+    now = datetime.now(timezone.utc)
+    not_before = now - CLOCK_SKEW
+    not_after = now + ttl
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(_build_subject(principal_id, expected_org))
+        .issuer_name(_build_issuer(expected_org))
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(
+            x509.BasicConstraints(ca=False, path_length=None),
+            critical=True,
+        )
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True, content_commitment=False,
+                key_encipherment=False, data_encipherment=False,
+                key_agreement=False, key_cert_sign=False, crl_sign=False,
+                encipher_only=False, decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([
+                x509.ExtendedKeyUsageOID.CLIENT_AUTH,
+            ]),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe_expected),
+            ]),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
+    thumbprint = _cert_thumbprint_sha256(cert)
+    return cert_pem, thumbprint, not_after
+
+
+__all__ = [
+    "CLOCK_SKEW",
+    "CsrValidationError",
+    "USER_CERT_TTL",
+    "parse_principal_id_to_spiffe",
+    "sign_user_csr",
+]

--- a/mcp_proxy/registry/user_principals_router.py
+++ b/mcp_proxy/registry/user_principals_router.py
@@ -1,0 +1,132 @@
+"""ADR-021 PR4a (proxy-side) — POST /v1/principals/csr.
+
+The Frontdesk Connector calls this endpoint at every SSO touch to mint
+a fresh user-principal cert. Originally lived on the broker; moved to
+the proxy because the org-CA private key (the right signer for these
+certs) only exists on the proxy. See ``principals_csr.py`` header for
+the full rationale.
+
+Auth: the same DPoP-bound JWT the proxy already issues for the rest of
+``/v1/*`` (``get_authenticated_agent``). RBAC: caller may only sign
+CSRs for principals in its own org — enforced inside ``sign_user_csr``
+against ``AgentManager.org_id``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.models import TokenPayload
+from mcp_proxy.registry.principals_csr import (
+    CsrValidationError,
+    parse_principal_id_to_spiffe,
+    sign_user_csr,
+)
+
+_log = logging.getLogger("mcp_proxy.registry.user_principals_router")
+
+router = APIRouter(prefix="/v1/principals", tags=["principals"])
+
+
+class CsrSignRequest(BaseModel):
+    """Body for ``POST /v1/principals/csr``."""
+
+    principal_id: str = Field(
+        ..., min_length=7, max_length=255,
+        description="<trust-domain>/<org>/<principal-type>/<name>",
+    )
+    csr_pem: str = Field(
+        ..., min_length=128, max_length=8192,
+        description=(
+            "PEM-encoded CSR; SAN must contain the SPIFFE URI of "
+            "principal_id"
+        ),
+    )
+
+
+class CsrSignResponse(BaseModel):
+    """Body returned by ``POST /v1/principals/csr``."""
+
+    cert_pem: str
+    cert_thumbprint: str = Field(
+        ..., description="SHA-256 hex digest of the DER-encoded cert",
+    )
+    cert_not_after: datetime
+
+
+@router.post(
+    "/csr",
+    response_model=CsrSignResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def sign_csr(
+    body: CsrSignRequest,
+    request: Request,
+    token: TokenPayload = Depends(get_authenticated_agent),
+) -> CsrSignResponse:
+    """Sign a user-principal CSR with the proxy's Org CA.
+
+    Errors:
+      - 400 ``CsrValidationError`` — malformed CSR / SAN / weak key /
+        SPIFFE id mismatch / bad principal_id format / wrong-org.
+      - 403 ``token.org != principal_id_org`` — caller may only mint
+        certs for principals in its own org.
+      - 503 — proxy has no Org CA loaded yet (broker setup not done).
+    """
+    try:
+        _spiffe_uri, principal_org = parse_principal_id_to_spiffe(
+            body.principal_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"invalid principal_id: {exc}",
+        ) from exc
+
+    if token.org != principal_org:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="cannot sign a CSR for a principal in a different org",
+        )
+
+    agent_manager = getattr(request.app.state, "agent_manager", None)
+    if agent_manager is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "agent_manager not initialised — proxy is still booting"
+            ),
+        )
+
+    try:
+        cert_pem, thumbprint, not_after = await sign_user_csr(
+            csr_pem=body.csr_pem,
+            principal_id=body.principal_id,
+            agent_manager=agent_manager,
+        )
+    except CsrValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    except RuntimeError as exc:
+        # Org CA not loaded — surface to the caller as 503 so their
+        # provisioner retries instead of failing the user session.
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+
+    _log.info(
+        "principals.csr signed principal_id=%s thumbprint=%s not_after=%s",
+        body.principal_id, thumbprint, not_after.isoformat(),
+    )
+    return CsrSignResponse(
+        cert_pem=cert_pem,
+        cert_thumbprint=thumbprint,
+        cert_not_after=not_after,
+    )

--- a/mcp_proxy/reverse_proxy/forwarder.py
+++ b/mcp_proxy/reverse_proxy/forwarder.py
@@ -35,12 +35,12 @@ FORWARDED_PREFIXES: tuple[str, ...] = (
     # (mcp_proxy/registry/public_key.py) and forwards the rest so SDK
     # discover() / search / get-by-id calls transit the proxy cleanly.
     "/v1/federation",
-    # ADR-021 PR4a — Court signs user-principal CSRs and lists provisioned
-    # users. The Frontdesk Connector calls /v1/principals/csr on its
-    # Mastio every time a user logs in via SSO; the proxy passes it
-    # through so the Court remains the user-cert authority.
-    "/v1/principals",
 )
+# ADR-021 PR4a (proxy-native, post-2026-05-06): /v1/principals/csr is
+# now served by ``mcp_proxy.registry.user_principals_router`` because
+# the Org CA private key — the right signer for these certs — only
+# lives on the proxy. The reverse-proxy used to forward this prefix
+# to the Court; that path is gone.
 
 _HOP_BY_HOP = frozenset(
     h.lower()

--- a/tests/connector/test_enrollment_client.py
+++ b/tests/connector/test_enrollment_client.py
@@ -238,3 +238,95 @@ def test_enroll_submits_pubkey_not_private_key(tmp_path: Path, fake_httpx):
     assert "PRIVATE KEY" not in submitted["pubkey_pem"]
     assert "PUBLIC KEY" in submitted["pubkey_pem"]
     assert submitted["requester_email"] == "x@x.com"
+
+
+def test_enroll_injects_ambassador_mode_shared_into_device_info(
+    tmp_path: Path, fake_httpx, monkeypatch,
+):
+    """``AMBASSADOR_MODE=shared`` env → flag travels in ``device_info`` JSON.
+
+    The proxy reads the flag at approve() time to skip the auto-baseline
+    binding. The Connector is the only place that knows it's running as
+    a shared-mode workload (the proxy doesn't see the env var), so the
+    declaration has to ride along with the enrollment payload.
+    """
+    monkeypatch.setenv("AMBASSADOR_MODE", "shared")
+
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(_pending_record())
+    fake_httpx.enqueue_get(
+        _FakeResponse(200, {"session_id": "session-abc", "status": "rejected",
+                            "rejection_reason": "stop test"}),
+    )
+
+    with pytest.raises(EnrollmentFailed):
+        enroll(
+            site_url="https://site.test",
+            config_dir=tmp_path,
+            requester=RequesterInfo(
+                name="Frontdesk", email="fd@acme.com",
+                device_info='{"host":"fd-1"}',
+            ),
+            poll_sink=io.StringIO(),
+        )
+
+    import json as _json
+    submitted = fake_httpx.posts[0]["json"]
+    assert "device_info" in submitted
+    parsed = _json.loads(submitted["device_info"])
+    assert parsed.get("ambassador_mode") == "shared"
+    # Original device_info content is preserved.
+    assert parsed.get("host") == "fd-1"
+
+
+def test_enroll_no_env_leaves_device_info_unchanged(
+    tmp_path: Path, fake_httpx, monkeypatch,
+):
+    """Single-mode default (no env) must not touch ``device_info``."""
+    monkeypatch.delenv("AMBASSADOR_MODE", raising=False)
+
+    fake_httpx.enqueue_post(_start_response())
+    fake_httpx.enqueue_get(
+        _FakeResponse(200, {"session_id": "session-abc", "status": "rejected",
+                            "rejection_reason": "stop test"}),
+    )
+
+    with pytest.raises(EnrollmentFailed):
+        enroll(
+            site_url="https://site.test",
+            config_dir=tmp_path,
+            requester=RequesterInfo(
+                name="Daniele", email="d@acme.com",
+                device_info="my-laptop",
+            ),
+            poll_sink=io.StringIO(),
+        )
+
+    submitted = fake_httpx.posts[0]["json"]
+    # Plain string preserved verbatim — no JSON wrapping when not shared.
+    assert submitted["device_info"] == "my-laptop"
+
+
+def test_wrap_device_info_helper_handles_inputs():
+    f = enrollment._wrap_device_info_with_shared_mode
+    import json as _json
+
+    # None / empty → bare {"ambassador_mode": "shared"}
+    assert _json.loads(f(None)) == {"ambassador_mode": "shared"}
+    assert _json.loads(f("")) == {"ambassador_mode": "shared"}
+
+    # Plain string → nested under "raw"
+    parsed = _json.loads(f("my-laptop"))
+    assert parsed == {"ambassador_mode": "shared", "raw": "my-laptop"}
+
+    # JSON object → merged, existing key wins
+    parsed = _json.loads(f('{"ambassador_mode": "single", "host": "x"}'))
+    assert parsed == {"ambassador_mode": "single", "host": "x"}
+
+    # JSON object without ambassador_mode → flag added
+    parsed = _json.loads(f('{"host": "x"}'))
+    assert parsed == {"ambassador_mode": "shared", "host": "x"}
+
+    # JSON array (not a dict) → nested under "raw"
+    parsed = _json.loads(f('[1,2,3]'))
+    assert parsed == {"ambassador_mode": "shared", "raw": "[1,2,3]"}

--- a/tests/test_enrollment.py
+++ b/tests/test_enrollment.py
@@ -305,6 +305,123 @@ async def test_approve_registers_agent_in_internal_registry(db_engine):
     assert audits[0]["status"] == "success"
 
 
+@pytest.mark.asyncio
+async def test_approve_shared_mode_skips_auto_baseline_binding(
+    db_engine, monkeypatch,
+):
+    """Frontdesk shared-mode workload must NOT get an auto-baseline binding.
+
+    The proxy reads ``ambassador_mode=shared`` out of the ``device_info``
+    JSON and skips ``_create_baseline_binding`` — capabilities scoped to
+    MCP resources belong on user principals, not on the shared container
+    (see memory/feedback_frontdesk_shared_mode_capability_model.md).
+    """
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    pubkey = _rsa_pubkey_pem()
+
+    # Spy on the auto-baseline-binding scheduler so we can assert no task
+    # is created for shared-mode enrollments. ``approve()`` calls
+    # ``asyncio.create_task(_create_baseline_binding(...))`` directly, so
+    # patching the helper at the service-module level is enough.
+    called: list[dict] = []
+
+    async def _spy(**kwargs):
+        called.append(kwargs)
+
+    monkeypatch.setattr(service, "_create_baseline_binding", _spy)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="Frontdesk",
+            requester_email="frontdesk@acme.com",
+            reason=None,
+            device_info='{"ambassador_mode":"shared","host":"frontdesk-1"}',
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="frontdesk",
+            capabilities=["principals.sign"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    # Give any (errantly-) scheduled task a turn to run.
+    import asyncio as _asyncio
+    await _asyncio.sleep(0)
+    assert called == [], (
+        "shared-mode enrollment must not schedule auto-baseline binding"
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_single_mode_still_schedules_auto_baseline_binding(
+    db_engine, monkeypatch,
+):
+    """Regression — patch must not break the single-mode default path."""
+    from mcp_proxy.egress.agent_manager import AgentManager
+    manager = AgentManager(org_id="acme", trust_domain="cullis.local")
+    ca_key, ca_cert_pem = _generate_self_signed_ca("acme")
+    await manager.load_org_ca(ca_key, ca_cert_pem)
+
+    pubkey = _rsa_pubkey_pem()
+
+    called: list[dict] = []
+
+    async def _spy(**kwargs):
+        called.append(kwargs)
+
+    monkeypatch.setattr(service, "_create_baseline_binding", _spy)
+
+    async with get_db() as conn:
+        started = await service.start_enrollment(
+            conn,
+            pubkey_pem=pubkey,
+            requester_name="Daniele",
+            requester_email="d@acme.com",
+            reason=None,
+            device_info='{"host":"laptop-1"}',  # no ambassador_mode key
+        )
+
+    async with get_db() as conn:
+        await service.approve(
+            conn,
+            session_id=started.session_id,
+            agent_id="cullis",
+            capabilities=["sql.read"],
+            groups=[],
+            admin_name="admin",
+            agent_manager=manager,
+        )
+
+    import asyncio as _asyncio
+    await _asyncio.sleep(0)
+    assert len(called) == 1
+    assert called[0]["agent_id"] == "acme::cullis"
+    assert called[0]["capabilities"] == ["sql.read"]
+
+
+def test_ambassador_mode_from_device_info_handles_garbage():
+    """The parser must never raise on malformed ``device_info`` payloads."""
+    f = service._ambassador_mode_from_device_info
+    assert f(None) is None
+    assert f("") is None
+    assert f("not json") is None
+    assert f("[1,2,3]") is None  # JSON but not an object
+    assert f('{"ambassador_mode": 42}') is None  # non-string value
+    assert f('{"ambassador_mode": "shared"}') == "shared"
+    assert f('{"ambassador_mode": "single", "host": "x"}') == "single"
+
+
 # ── HTTP endpoint tests ────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Stacked on top of #439 / #440 / #441 (rebase to main when those land).

ADR-021 PR4a placed the user-principal CSR signer on the broker, where it signed with the broker root CA (`kms.get_broker_private_key_pem()`). The Court then validates user certs against `organizations.ca_certificate`, the **org** CA the proxy attached at onboarding — chains never line up, every login 401s with `certificate chain broken at position 0 — signature not produced by the next cert in the chain`. The Org CA private key only lives on the proxy, never on the broker, so the right fix is to move the signer.

Same architectural gap ADR-017 had: federation-or-not, key-material-bearing endpoints belong wherever the relevant key lives.

## Changes

- `mcp_proxy/registry/principals_csr.py`: copy of the broker module with two surgical edits — the signer takes an `AgentManager` and uses `_org_ca_key` instead of `kms.get_broker_private_key_pem()`; `CsrValidationError` is raised when the requested principal_id's org disagrees with the proxy's own.
- `mcp_proxy/registry/user_principals_router.py`: minimal FastAPI router for `POST /v1/principals/csr`. Surfaces 503 when the Org CA isn't loaded yet so callers retry.
- `mcp_proxy/main.py`: mount the new router.
- `mcp_proxy/reverse_proxy/forwarder.py`: drop `/v1/principals` from `FORWARDED_PREFIXES` — the proxy serves the path locally.

## Test plan

- [x] `pytest tests/test_principals_csr.py tests/test_h_csr_pop.py tests/connector/test_enrollment_dpop.py` — 27/27 (broker-side suite unchanged)
- [x] Live: `/v1/principals/csr` on the proxy returns a cert chained to the proxy Org CA; `login_via_proxy_with_local_key` for the user gets past "certificate chain broken" and surfaces the next architectural gap (broker agent_id parser doesn't accept user-principal SPIFFE paths)
- [x] Nothing bypassed: same DPoP auth dependency, same SPIFFE-SAN-vs-principal_id consistency check, same TTL + cert profile

## Known follow-up (NOT in this PR)

`app/auth/x509_verifier` + the `client_assertion` parsing path treat the cert subject as an **agent** id (`<org>::<name>`); user principals arrive as `<td>/<org>/user/<name>` and 500 with `Invalid agent_id format`. The broker needs a parallel `user` principal-type auth path, or the Frontdesk Connector must authenticate to the **proxy** (not the Court) for cross-org reach.