### PR TITLE
fix(auth): broker x509_verifier accepts ADR-020 user/workload SPIFFE

### DIFF
--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -86,11 +86,38 @@ async def issue_token(
         dpop_jkt = await verify_dpop_proof(dpop, htm="POST", htu=htu, access_token=None)
 
         # ── Verify certificate and signature ─────────────────────────────────
-        agent_id, org_id, cert_pem, cert_thumbprint, svid_mode = await verify_client_assertion(
+        (agent_id, org_id, cert_pem, cert_thumbprint, svid_mode,
+         principal_type) = await verify_client_assertion(
             body.client_assertion, db, request=request,
         )
         span.set_attribute("agent.id", agent_id)
         span.set_attribute("org.id", org_id)
+        span.set_attribute("principal.type", principal_type)
+        # ADR-020 — user/workload principals do not authenticate via this
+        # legacy ``/v1/auth/token`` endpoint. The verifier now recognises
+        # their SPIFFE SAN so the caller fails fast with a precise 4xx
+        # instead of a confusing "agent not found" 401 from the registry
+        # lookup below. The dedicated user-principal flow lives on the
+        # dedicated routes (e.g. ``/v1/inbox`` directly via mTLS, or the
+        # post-PR4d user token endpoint when it lands).
+        if principal_type != "agent":
+            AUTH_DENY_COUNTER.add(1, {"reason": "principal_type_not_agent"})
+            await log_event(
+                db, "auth.token_request", "denied",
+                agent_id=agent_id, org_id=org_id,
+                details={
+                    "reason": "principal_type_not_agent",
+                    "principal_type": principal_type,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"/v1/auth/token is only for agent principals; got "
+                    f"principal_type={principal_type!r}. Use the dedicated "
+                    f"endpoints for {principal_type} principals."
+                ),
+            )
 
         # ── ADR-009 — mastio counter-signature (strict, always on) ───────────
         # After Phase 4 there is no legacy path: an org without a pinned

--- a/app/auth/x509_verifier.py
+++ b/app/auth/x509_verifier.py
@@ -34,7 +34,6 @@ from app.spiffe import (
     PrincipalType,
     internal_id_to_spiffe,
     parse_spiffe_san,
-    principal_to_spiffe,
     spiffe_to_principal,
 )
 from app.telemetry import tracer

--- a/app/auth/x509_verifier.py
+++ b/app/auth/x509_verifier.py
@@ -29,7 +29,14 @@ from app.auth.jti_blacklist import check_and_consume_jti
 from app.auth.revocation import check_cert_not_revoked
 from app.registry.org_store import get_org_by_id, get_org_by_trust_domain
 from app.config import get_settings
-from app.spiffe import internal_id_to_spiffe, parse_spiffe_san
+from app.spiffe import (
+    DEFAULT_PRINCIPAL_TYPE,
+    PrincipalType,
+    internal_id_to_spiffe,
+    parse_spiffe_san,
+    principal_to_spiffe,
+    spiffe_to_principal,
+)
 from app.telemetry import tracer
 from app.telemetry_metrics import X509_VERIFY_DURATION_HISTOGRAM
 
@@ -190,20 +197,32 @@ async def verify_client_assertion(
     assertion: str,
     db: AsyncSession,
     request: Request | None = None,
-) -> tuple[str, str, str, str, bool]:
+) -> tuple[str, str, str, str, bool, PrincipalType]:
     """
-    Verify a client_assertion JWT and return (agent_id, org_id, cert_pem,
-    cert_thumbprint, svid_mode).
-    cert_pem is the agent certificate extracted from x5c — it is saved in DB
-    by the auth router to allow verification of message signatures.
-    cert_thumbprint is the SHA-256 hex digest of the DER-encoded certificate.
-    svid_mode is True iff identity was resolved via SPIFFE URI SAN + chain
-    walk (no CN/O present); callers use it to skip per-cert pinning since
-    SPIRE-style SVIDs rotate far too fast for thumbprint-level stickiness.
+    Verify a client_assertion JWT and return ``(agent_id, org_id, cert_pem,
+    cert_thumbprint, svid_mode, principal_type)``.
 
-    When ``request`` is provided and ``mtls_binding`` is enabled in settings,
-    also enforces RFC 8705-style confirmation that the mTLS client cert
-    forwarded by the reverse proxy matches the cert in x5c.
+    ``cert_pem`` is the agent certificate extracted from x5c — it is saved
+    in DB by the auth router to allow verification of message signatures.
+    ``cert_thumbprint`` is the SHA-256 hex digest of the DER-encoded cert.
+    ``svid_mode`` is True iff identity was resolved via SPIFFE URI SAN +
+    chain walk (no CN/O present); callers use it to skip per-cert pinning
+    since SPIRE-style SVIDs rotate far too fast for thumbprint-level
+    stickiness.
+
+    ``principal_type`` is the ADR-020 principal type derived from the
+    SPIFFE SAN — ``"agent"`` (default / 2-component path), ``"user"``,
+    or ``"workload"``. Classic CN/O certs always report ``"agent"`` so
+    pre-ADR-020 callers see no behaviour change. When ``principal_type``
+    is ``"user"`` or ``"workload"``, ``agent_id`` carries the canonical
+    typed key ``{org}::{type}::{name}`` so the broker's auth router can
+    fan out to the correct registry table (``user_principals`` for
+    ``user``) without ever colliding with an agent that happens to share
+    a name with a user.
+
+    When ``request`` is provided and ``mtls_binding`` is enabled in
+    settings, also enforces RFC 8705-style confirmation that the mTLS
+    client cert forwarded by the reverse proxy matches the cert in x5c.
 
     Raises HTTPException 401/403 if verification fails.
     """
@@ -249,6 +268,7 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
     #       derive agent_id from the path's last segment.
     svid_mode = False
     svid_spiffe_uri: str | None = None
+    principal_type: PrincipalType = DEFAULT_PRINCIPAL_TYPE
     cn_attrs = agent_cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
     org_attrs = agent_cert.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)
     if cn_attrs and org_attrs:
@@ -268,6 +288,11 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
                 detail="Cert missing CN/O and no SPIFFE SAN URI present",
             )
         svid_spiffe_uri = spiffe_sans[0]
+        # ADR-020 — accept both 2-component (legacy SVID, e.g. SPIRE
+        # ``spiffe://td/workload/agent-a``) and 3-component (typed
+        # principal ``spiffe://td/org/<type>/<name>``) SPIFFE paths.
+        # ``parse_spiffe_san`` returns the raw path; the principal-typed
+        # parse below handles the type whitelist for 3-component URIs.
         try:
             trust_domain, spiffe_path = parse_spiffe_san(svid_spiffe_uri)
         except ValueError:
@@ -280,9 +305,50 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
                 status.HTTP_403_FORBIDDEN,
                 detail=f"No organization registered for trust domain '{trust_domain}'",
             )
-        agent_name = spiffe_path.rsplit("/", 1)[-1]
-        agent_id = f"{org.org_id}::{agent_name}"
         org_id = org.org_id
+        path_parts = spiffe_path.split("/")
+        if len(path_parts) == 2:
+            # Legacy 2-component: ``<freeform>/<agent-name>``. The first
+            # segment historically carried whatever workload/namespace the
+            # caller wanted (often literally "workload" for SPIRE SVIDs)
+            # and is intentionally NOT bound to the org_id. agent_id is
+            # ``{org}::{last segment}`` — same shape clients already index
+            # into ``agents.agent_id``.
+            agent_id = f"{org_id}::{path_parts[-1]}"
+            principal_type = DEFAULT_PRINCIPAL_TYPE
+        else:
+            # 3-component (or longer) — interpret as ADR-020 typed principal.
+            # ``spiffe_to_principal`` raises on anything outside the
+            # agent/user/workload whitelist or on path lengths != 3.
+            try:
+                principal = spiffe_to_principal(svid_spiffe_uri)
+            except ValueError as exc:
+                raise HTTPException(
+                    status.HTTP_401_UNAUTHORIZED,
+                    detail=f"SPIFFE SAN principal parse failed: {exc}",
+                )
+            # Org consistency: the SPIFFE org segment must match the org
+            # we just resolved by trust_domain. Refuse cross-org SAN
+            # smuggling for any caller using the typed format.
+            if principal.org_id != org_id:
+                raise HTTPException(
+                    status.HTTP_403_FORBIDDEN,
+                    detail=(
+                        f"SPIFFE SAN org '{principal.org_id}' does not match "
+                        f"trust-domain-resolved org '{org_id}'"
+                    ),
+                )
+            principal_type = principal.principal_type
+            # Canonical agent_id: keep ``{org}::{name}`` for ``agent`` so
+            # the existing ``agents`` row keying is unchanged, and use
+            # ``{org}::{type}::{name}`` for user / workload so the auth
+            # router can fan out to the right registry without a flag,
+            # and a user named "daniele" can never collide with an agent
+            # named "daniele".
+            if principal_type == "agent":
+                agent_id = f"{org_id}::{principal.name}"
+            else:
+                agent_id = f"{org_id}::{principal_type}::{principal.name}"
         svid_mode = True
 
     # ── 4. Load org CA from DB and verify it is a true CA ────────────────────
@@ -394,7 +460,9 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
     settings = get_settings()
     if svid_mode and svid_spiffe_uri is not None:
         # In SVID mode the SPIFFE URI IS the authoritative identity;
-        # accept it (and the internal agent_id) as sub/iss.
+        # accept it (and the internal agent_id) as sub/iss. For user /
+        # workload principals (3-component path) the JWT carries the
+        # full typed URI; for legacy 2-component agents nothing changes.
         expected_spiffe = svid_spiffe_uri
     else:
         org_td = org.trust_domain or settings.trust_domain
@@ -485,5 +553,6 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
     cert_pem = agent_cert.public_bytes(serialization.Encoding.PEM).decode()
     _span.set_attribute("cert.thumbprint", cert_thumbprint)
     _span.set_attribute("auth.svid_mode", svid_mode)
+    _span.set_attribute("auth.principal_type", principal_type)
     X509_VERIFY_DURATION_HISTOGRAM.record((_time.monotonic() - _t0) * 1000)
-    return agent_id, org_id, cert_pem, cert_thumbprint, svid_mode
+    return agent_id, org_id, cert_pem, cert_thumbprint, svid_mode, principal_type

--- a/tests/test_auth_svid.py
+++ b/tests/test_auth_svid.py
@@ -177,3 +177,147 @@ async def test_svid_no_san_rejected(client: AsyncClient, dpop):
         headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
     )
     assert resp.status_code == 401
+
+
+# ── ADR-020 — 3-component principal SPIFFE format ──────────────────────────
+
+
+async def test_user_principal_svid_token_endpoint_returns_400(
+    client: AsyncClient, dpop,
+):
+    """User principal cert (``spiffe://td/org/user/<name>``) is recognised
+    by the verifier but rejected by ``/v1/auth/token`` with a precise 400.
+
+    Pre-fix this 500'd somewhere downstream because the verifier collapsed
+    the 3-component path into a fake agent_id and the registry lookup
+    blew up. The dedicated user-principal flow lives elsewhere; the
+    legacy ``/v1/auth/token`` endpoint stays agent-only on purpose.
+    """
+    await _prime_nonce(client, dpop)
+    org_id = "userp-orga"
+    trust_domain = "userp-orga.test"
+    # We register a placeholder agent under the same org so the
+    # trust-domain → org resolution succeeds; the user principal is
+    # NOT in the agents table by design.
+    await _register_agent(
+        client, f"{org_id}::placeholder", org_id, trust_domain=trust_domain,
+    )
+
+    assertion, spiffe = make_svid_assertion(
+        agent_name="daniele",
+        ca_org_id=org_id,
+        trust_domain=trust_domain,
+        spiffe_path=f"{org_id}/user/daniele",
+    )
+    assert spiffe == f"spiffe://{trust_domain}/{org_id}/user/daniele"
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 400, resp.text
+    assert "principal_type" in resp.text
+
+
+async def test_workload_principal_svid_token_endpoint_returns_400(
+    client: AsyncClient, dpop,
+):
+    """Same fast-fail for ``workload`` principals."""
+    await _prime_nonce(client, dpop)
+    org_id = "wlp-orga"
+    trust_domain = "wlp-orga.test"
+    await _register_agent(
+        client, f"{org_id}::placeholder", org_id, trust_domain=trust_domain,
+    )
+
+    assertion, _ = make_svid_assertion(
+        agent_name="frontdesk",
+        ca_org_id=org_id,
+        trust_domain=trust_domain,
+        spiffe_path=f"{org_id}/workload/frontdesk",
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 400, resp.text
+
+
+async def test_3component_agent_principal_accepted(
+    client: AsyncClient, dpop,
+):
+    """3-component path with ``principal_type=agent`` resolves identically
+    to the legacy 2-component agent SVID — same agent_id shape, same
+    behaviour at ``/v1/auth/token``."""
+    await _prime_nonce(client, dpop)
+    org_id = "ag3-orga"
+    trust_domain = "ag3-orga.test"
+    agent_id = f"{org_id}::sales-agent"
+    await _register_agent(client, agent_id, org_id, trust_domain=trust_domain)
+
+    assertion, _ = make_svid_assertion(
+        agent_name="sales-agent",
+        ca_org_id=org_id,
+        trust_domain=trust_domain,
+        spiffe_path=f"{org_id}/agent/sales-agent",
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+async def test_3component_org_segment_mismatch_rejected(
+    client: AsyncClient, dpop,
+):
+    """SPIFFE SAN's org segment does not match the trust-domain-resolved
+    org → 403. Closes the SAN-smuggling gap that 2-component legacy SVIDs
+    intentionally allowed for SPIRE-shape paths."""
+    await _prime_nonce(client, dpop)
+    org_id = "real-orga"
+    trust_domain = "real-orga.test"
+    await _register_agent(
+        client, f"{org_id}::placeholder", org_id, trust_domain=trust_domain,
+    )
+
+    assertion, _ = make_svid_assertion(
+        agent_name="bob",
+        ca_org_id=org_id,  # signed by THIS org's CA
+        trust_domain=trust_domain,
+        spiffe_path="other-org/user/bob",  # SAN claims a DIFFERENT org
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 403, resp.text
+    assert "does not match" in resp.text.lower()
+
+
+async def test_3component_unknown_principal_type_rejected(
+    client: AsyncClient, dpop,
+):
+    """Made-up principal type (e.g. ``service``) → 401 with parse error."""
+    await _prime_nonce(client, dpop)
+    org_id = "ut-orga"
+    trust_domain = "ut-orga.test"
+    await _register_agent(
+        client, f"{org_id}::placeholder", org_id, trust_domain=trust_domain,
+    )
+
+    assertion, _ = make_svid_assertion(
+        agent_name="x",
+        ca_org_id=org_id,
+        trust_domain=trust_domain,
+        spiffe_path=f"{org_id}/service/x",  # 'service' not in whitelist
+    )
+    resp = await client.post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
+    )
+    assert resp.status_code == 401, resp.text


### PR DESCRIPTION
## Summary

- The broker x509_verifier learns the ADR-020 3-component SPIFFE format (``spiffe://td/<org>/<type>/<name>``) so user-principal certs minted by the Frontdesk shared-mode KMS round-trip cleanly through the auth pipeline.
- The legacy 2-component form keeps its existing semantics (SPIRE SVIDs unchanged); the new branch adds an org-consistency check and threads a typed ``principal_type`` through the return tuple.
- ``/v1/auth/token`` fast-fails user / workload principals with a precise 400 instead of the misleading "Agent not found" 401 from the registry lookup that follows.

Why this matters: the 2026-05-06 dogfood for Scenario 3 (Frontdesk multi-user → Mastio → MCP) ran into a 500 on the broker because the verifier collapsed ``spiffe://orga.test/orga/user/daniele`` into a malformed agent_id, then ``app.spiffe.internal_id_to_spiffe`` raised ``Invalid agent_id format`` while the audit row was being written. ADR-020 rev 3 is what the design partner sees — the broker had to learn the new shape end-to-end.

See ADR-020 §"Principal type encoding" + memory note ``feedback_frontdesk_shared_mode_capability_model``.

## What changed

- ``app/auth/x509_verifier.py``
  - 2-component path: unchanged (legacy SPIRE shape kept intact, no org binding on the first segment).
  - 3-component path: parsed via ``spiffe_to_principal``; org segment must match the org we resolved by trust_domain; ``principal_type`` derived from the SAN.
  - ``agent_id`` shape: ``{org}::{name}`` for ``agent``, ``{org}::{type}::{name}`` for ``user`` / ``workload`` (so a user named "daniele" never collides with an agent named "daniele" in audit / lookup paths).
  - Return tuple: 5 → 6 fields (``principal_type`` appended).
- ``app/auth/router.py`` — ``/v1/auth/token`` fast-fails non-``agent`` principals with 400 + precise audit reason.
- ``tests/test_auth_svid.py`` — five new regression tests.

## Test plan

- [x] ``pytest tests/test_auth_svid.py tests/test_auth.py tests/test_auth_ec.py tests/test_auth_chain.py tests/test_auth_token_deprecation.py tests/test_mtls_binding.py -n auto --dist=loadfile`` — 49/49 green.
- [ ] CI matrix.
- [ ] Smoke once the proxy-side PRs land: Daniele user cert from Frontdesk reaches the broker without 500; Scenario 3 unblocks.

## Memory / linked work

- Stack predecessors: #439 (proxy SPIFFE persist) → #440 (auto-federate) → #441 (auto-binding + shared-mode skip) → #442 (CSR signing on the proxy). This PR is independent — it touches broker code only — and can land in any order relative to the stack, but the demo isn't whole until both sides are merged.
- Remaining gap for Scenario 3: schema ``local_principal_resource_bindings`` with ``principal_type`` column + aggregator update (~1h).

🤖 Generated with [Claude Code](https://claude.com/claude-code)