### PR TITLE
feat: end-to-end user-principal flow (Frontdesk shared-mode → MCP)

### DIFF
--- a/app/auth/jwt.py
+++ b/app/auth/jwt.py
@@ -84,11 +84,18 @@ async def create_access_token(
     scope: list[str] | None = None,
     settings: Settings | None = None,
     dpop_jkt: str = "",
+    principal_type: str = "agent",
+    trust_domain: str | None = None,
 ) -> tuple[str, int]:
     """
     Create an RS256 JWT signed with the broker's private key.
     dpop_jkt must be the JWK thumbprint of the agent's DPoP key (RFC 9449 §6).
     Returns (token, expires_in_seconds).
+
+    ``trust_domain`` overrides ``settings.trust_domain`` when the
+    caller has resolved the org's federated trust domain (per-org
+    domains are common in multi-tenant deploys; the SPIFFE ``sub``
+    claim must match the cert SAN the verifier just authenticated).
     """
     if settings is None:
         settings = get_settings()
@@ -102,7 +109,26 @@ async def create_access_token(
     expire = now + timedelta(minutes=settings.jwt_access_token_expire_minutes)
     jti = str(uuid.uuid4())
 
-    spiffe_id = internal_id_to_spiffe(agent_id, settings.trust_domain)
+    effective_td = trust_domain or settings.trust_domain
+    # ADR-020 — agent_id can be the legacy 2-segment ``{org}::{name}`` or
+    # the typed 3-segment ``{org}::{type}::{name}`` for user / workload
+    # principals. Build a SPIFFE URI that matches the cert SAN format
+    # the verifier emitted so ``sub`` round-trips correctly.
+    if principal_type == "agent":
+        spiffe_id = internal_id_to_spiffe(agent_id, effective_td)
+    else:
+        # ``{org}::{type}::{name}`` → ``spiffe://td/{org}/{type}/{name}``
+        parts = agent_id.split("::", 2)
+        if len(parts) != 3:
+            raise ValueError(
+                f"typed agent_id must be ``{{org}}::{{type}}::{{name}}``: "
+                f"got {agent_id!r}",
+            )
+        org_part, type_part, name_part = parts
+        spiffe_id = (
+            f"spiffe://{effective_td}"
+            f"/{org_part}/{type_part}/{name_part}"
+        )
 
     payload = {
         "iss": _TOKEN_ISSUER,
@@ -111,6 +137,7 @@ async def create_access_token(
         "agent_id": agent_id,    # internal format org::agent — DB primary key
         "org": org_id,
         "scope": scope or [],
+        "principal_type": principal_type,
         "iat": int(now.timestamp()),
         "exp": int(expire.timestamp()),
         "jti": jti,

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -93,29 +93,30 @@ async def issue_token(
         span.set_attribute("agent.id", agent_id)
         span.set_attribute("org.id", org_id)
         span.set_attribute("principal.type", principal_type)
-        # ADR-020 — user/workload principals do not authenticate via this
-        # legacy ``/v1/auth/token`` endpoint. The verifier now recognises
-        # their SPIFFE SAN so the caller fails fast with a precise 4xx
-        # instead of a confusing "agent not found" 401 from the registry
-        # lookup below. The dedicated user-principal flow lives on the
-        # dedicated routes (e.g. ``/v1/inbox`` directly via mTLS, or the
-        # post-PR4d user token endpoint when it lands).
-        if principal_type != "agent":
-            AUTH_DENY_COUNTER.add(1, {"reason": "principal_type_not_agent"})
+        # ADR-020 — workload principals don't have a token flow yet (they
+        # call /v1/principals/csr to mint user certs and forward the user
+        # cert downstream — they never need their own access token). User
+        # principals reuse this endpoint with a relaxed agents lookup (see
+        # below): the user_principals table is the registry, scope is
+        # empty (user-binding lives on the proxy via
+        # ``local_agent_resource_bindings`` keyed by principal_type=user),
+        # and the JWT carries ``principal_type='user'`` so the proxy
+        # aggregator filters MCP tools / audit rows correctly.
+        if principal_type == "workload":
+            AUTH_DENY_COUNTER.add(1, {"reason": "principal_type_workload"})
             await log_event(
                 db, "auth.token_request", "denied",
                 agent_id=agent_id, org_id=org_id,
                 details={
-                    "reason": "principal_type_not_agent",
+                    "reason": "workload principals do not have a token flow",
                     "principal_type": principal_type,
                 },
             )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
-                    f"/v1/auth/token is only for agent principals; got "
-                    f"principal_type={principal_type!r}. Use the dedicated "
-                    f"endpoints for {principal_type} principals."
+                    "/v1/auth/token does not apply to workload principals; "
+                    "workloads use /v1/principals/csr to mint user certs."
                 ),
             )
 
@@ -141,29 +142,67 @@ async def issue_token(
             )
             raise
 
-        # ── Agent checks ─────────────────────────────────────────────────────
-        agent = await get_agent_by_id(db, agent_id)
-        if agent is None or agent.org_id != org_id:
-            AUTH_DENY_COUNTER.add(1, {"reason": "agent_not_found"})
-            await log_event(
-                db, "auth.token_request", "denied",
-                agent_id=agent_id, org_id=org_id,
-                details={"reason": "agent not found or org mismatch"},
+        # ── Registry lookup ──────────────────────────────────────────────────
+        if principal_type == "user":
+            # User principals live in ``user_principals`` (ADR-021 PR2)
+            # if the Frontdesk has already provisioned them, but the
+            # current Frontdesk only writes to the *proxy* via
+            # ``/v1/principals/csr`` and does not round-trip the row up
+            # to the Court. For revocation semantics we *should* check
+            # the row when present (allows admins to disable a user) but
+            # *must* permit absence so the demo flow works before the
+            # provisioner is wired end-to-end. Cert validity already
+            # gates this: the verifier walks the chain back to the org
+            # CA so a cert without an active row is still cryptographically
+            # bound to the user that owns the KMS-held key.
+            from app.registry.user_principals import get_by_principal_id
+            from app.registry.org_store import get_org_by_id
+            org_row = await get_org_by_id(db, org_id)
+            trust_domain = (
+                (org_row.trust_domain if org_row else None)
+                or settings.trust_domain
             )
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Agent not found or org mismatch")
+            full_principal_id = (
+                f"{trust_domain}/{org_id}/user/{agent_id.split('::', 2)[-1]}"
+            )
+            user_view = await get_by_principal_id(db, full_principal_id)
+            if user_view is not None and not user_view.is_active:
+                AUTH_DENY_COUNTER.add(1, {"reason": "user_principal_revoked"})
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="User principal revoked",
+                )
+            agent = None  # bypass agent-only branches below
+        else:
+            agent = await get_agent_by_id(db, agent_id)
+            if agent is None or agent.org_id != org_id:
+                AUTH_DENY_COUNTER.add(1, {"reason": "agent_not_found"})
+                await log_event(
+                    db, "auth.token_request", "denied",
+                    agent_id=agent_id, org_id=org_id,
+                    details={"reason": "agent not found or org mismatch"},
+                )
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Agent not found or org mismatch")
 
-        if not agent.is_active:
-            AUTH_DENY_COUNTER.add(1, {"reason": "agent_inactive"})
-            await log_event(
-                db, "auth.token_request", "denied",
-                agent_id=agent_id, org_id=org_id,
-                details={"reason": "agent inactive"},
-            )
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Agent not active")
+            if not agent.is_active:
+                AUTH_DENY_COUNTER.add(1, {"reason": "agent_inactive"})
+                await log_event(
+                    db, "auth.token_request", "denied",
+                    agent_id=agent_id, org_id=org_id,
+                    details={"reason": "agent inactive"},
+                )
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Agent not active")
 
         # ── Verify approved binding ──────────────────────────────────────────
-        binding = await get_approved_binding(db, org_id, agent_id)
-        if not binding:
+        # User principals: scoped binding lives on the proxy
+        # (``local_agent_resource_bindings`` keyed by principal_type=user).
+        # The Court issues an empty-scope token and trusts the proxy's
+        # MCP aggregator to filter tools by (principal_id, principal_type).
+        if principal_type == "user":
+            binding = None
+        else:
+            binding = await get_approved_binding(db, org_id, agent_id)
+        if principal_type != "user" and not binding:
             AUTH_DENY_COUNTER.add(1, {"reason": "no_binding"})
             await log_event(
                 db, "auth.token_request", "denied",
@@ -183,7 +222,11 @@ async def issue_token(
         # SPIFFE URI match instead (ADR-003 §2.3). The cert_pem still needs
         # to be current on the server side so outbound-message signature
         # verification in the broker can locate it.
-        if svid_mode:
+        if principal_type == "user":
+            # User cert lives in user_principals (KMS-attached); the
+            # ``agents`` cert refresh path doesn't apply.
+            pass
+        elif svid_mode:
             await refresh_agent_cert_svid(db, agent_id, cert_pem, cert_thumbprint)
         elif not svid_mode:
             pinned_ok = await update_agent_cert(db, agent_id, cert_pem, cert_thumbprint)
@@ -201,8 +244,28 @@ async def issue_token(
                     detail="Certificate thumbprint mismatch — use the rotate-cert endpoint to update",
                 )
 
+        scope = binding.scope if binding is not None else []
+        # Resolve the org's federated trust_domain so the SPIFFE ``sub``
+        # in the issued token matches the cert SAN the verifier just
+        # authenticated. Falls back to the broker default for legacy
+        # rows that haven't been migrated.
+        token_trust_domain: str | None = None
+        if principal_type == "user":
+            # Already loaded ``org_row`` above for the user-principals
+            # lookup; reuse it instead of a second round-trip.
+            token_trust_domain = (
+                (org_row.trust_domain if org_row is not None else None)
+            )
+        else:
+            from app.registry.org_store import get_org_by_id as _get_org
+            _org = await _get_org(db, org_id)
+            token_trust_domain = (
+                (_org.trust_domain if _org is not None else None)
+            )
         token, expires_in = await create_access_token(
-            agent_id, org_id, scope=binding.scope, dpop_jkt=dpop_jkt
+            agent_id, org_id, scope=scope, dpop_jkt=dpop_jkt,
+            principal_type=principal_type,
+            trust_domain=token_trust_domain,
         )
 
         AUTH_SUCCESS_COUNTER.add(1, {"org_id": org_id})

--- a/cullis_connector/ambassador/shared/router.py
+++ b/cullis_connector/ambassador/shared/router.py
@@ -278,18 +278,27 @@ async def list_models(
 def _build_user_client(state: SharedAmbassadorState, cred: UserCredentials):
     """Construct a CullisClient logged in with the user's cert+key.
 
-    v0.1 builds fresh per request (~100ms login). v0.2 will cache
-    these clients keyed on principal_id with TTL matching the cert,
-    behind a tiny adapter so this function stays the entry point.
+    Uses :meth:`CullisClient.from_user_principal_pem` so the user's
+    cert is presented at the TLS handshake — required by the Mastio
+    nginx ``location ~ ^/v1/(egress|agents|audit|llm|chat)`` mTLS gate
+    that fronts the AI gateway. The factory derives the canonical
+    typed ``agent_id`` (``{org}::user::{name}``) from the 4-segment
+    principal_id so the JWT ``sub`` lines up with the broker
+    x509_verifier's SPIFFE-SAN parse (no 401 'sub mismatch').
+
+    v0.1 builds fresh per request (~100ms login + tempfile setup).
+    v0.2 will cache these clients keyed on principal_id with TTL
+    matching the cert, behind a tiny adapter so this function stays
+    the entry point.
     """
     from cullis_sdk import CullisClient
-    parts = cred.principal_id.split("/")
-    if len(parts) != 4:
-        raise HTTPException(500, "malformed principal_id in credentials")
-    _td, org, _ptype, name = parts
-    agent_id = f"{org}::{name}"
-    client = CullisClient(state.site_url)
-    client.login_from_pem(agent_id, org, cred.cert_pem, cred.key_pem)
+    client = CullisClient.from_user_principal_pem(
+        state.site_url,
+        principal_id=cred.principal_id,
+        cert_pem=cred.cert_pem,
+        key_pem=cred.key_pem,
+    )
+    client.login_via_proxy_with_local_key()
     return client
 
 

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -18,6 +18,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import os
 import sys
 import time
 import uuid
@@ -314,6 +315,17 @@ class CullisClient:
     def close(self) -> None:
         """Close the underlying HTTP client."""
         self._http.close()
+        # ADR-021 PR4c — wipe the per-process tmpdir that holds a
+        # user-principal cert + key when ``from_user_principal_pem``
+        # was used. Best-effort: any error during cleanup is logged
+        # and swallowed so close() stays exception-safe.
+        tmpdir = getattr(self, "_user_principal_tmpdir", None)
+        if tmpdir is not None:
+            try:
+                import shutil
+                shutil.rmtree(tmpdir, ignore_errors=True)
+            finally:
+                self._user_principal_tmpdir = None
 
     def _resolve_trust_anchors(self) -> "list[str] | None":
         """Read the operator-pinned Org CA bundle for sender-cert chain checks.
@@ -1152,6 +1164,128 @@ class CullisClient:
                 )
 
         log("sdk", f"Loaded Connector identity {agent_id} from {identity_dir}")
+        return instance
+
+    # ── ADR-021 PR4c — user-principal client (in-memory cert+key) ───
+
+    @classmethod
+    def from_user_principal_pem(
+        cls,
+        site_url: str,
+        *,
+        principal_id: str,
+        cert_pem: str,
+        key_pem: str,
+        ca_chain_pem: str | None = None,
+        timeout: float = 10.0,
+        enable_dpop: bool = True,
+        verify_tls: bool | None = None,
+    ) -> CullisClient:
+        """Build a CullisClient bound to a Frontdesk-minted user principal.
+
+        Counterpart to :meth:`from_connector`, but for the shared-mode
+        Frontdesk Ambassador (ADR-021 PR4c) where the per-user cert and
+        KMS-released key live entirely in memory: nothing on disk, the
+        cert lifecycle is the SSO session lifecycle, and the lookup key
+        is the 4-segment ``<td>/<org>/<type>/<name>`` principal_id.
+
+        ``cert_pem`` + ``key_pem`` are the user's freshly-signed
+        ADR-020 typed-principal cert (CN/O empty, SPIFFE SAN
+        ``spiffe://<td>/<org>/user/<name>``) and the matching private
+        key the embedded KMS just released. The factory persists them
+        to a per-process temp dir so httpx + nginx can use them at the
+        TLS handshake — the temp files inherit the current umask and
+        are removed on ``close()`` / GC. The cert lives at most as long
+        as the cached :class:`UserCredentials` row in the Ambassador.
+
+        ``principal_id`` must be the 4-segment form. The factory derives
+        the canonical typed ``agent_id`` (``{org}::user::{name}`` for
+        users / workloads, ``{org}::{name}`` for plain agents) so JWT
+        ``sub`` and the broker x509_verifier's parse line up exactly.
+
+        Caller is expected to invoke
+        :meth:`login_via_proxy_with_local_key` afterwards to mint a
+        DPoP-bound access token. Building the client and minting the
+        token are kept separate so the ambassador can probe identity
+        before paying the full login round-trip.
+        """
+        import tempfile
+
+        parts = principal_id.split("/")
+        if len(parts) != 4:
+            raise ValueError(
+                "principal_id must be ``<td>/<org>/<type>/<name>``; "
+                f"got {principal_id!r}",
+            )
+        _td, org_id, ptype, name = parts
+        if ptype not in ("agent", "user", "workload"):
+            raise ValueError(
+                f"principal_id has unknown type segment {ptype!r}; "
+                "expected one of agent / user / workload",
+            )
+        if ptype == "agent":
+            agent_id = f"{org_id}::{name}"
+        else:
+            agent_id = f"{org_id}::{ptype}::{name}"
+
+        if verify_tls is None:
+            verify_tls = site_url.startswith("https://")
+
+        # Persist cert + key + CA bundle to a temp dir so httpx's SSL
+        # context can load them at the handshake. Tracked on the
+        # instance so ``close()`` cleans them up; nothing else needs
+        # them after the client is constructed.
+        tmp = tempfile.mkdtemp(prefix="cullis-user-")
+        cert_path = Path(tmp) / "cert.pem"
+        key_path = Path(tmp) / "key.pem"
+        cert_path.write_text(cert_pem)
+        key_path.write_text(key_pem)
+        os.chmod(key_path, 0o600)
+        ca_path: Path | None = None
+        if ca_chain_pem:
+            ca_path = Path(tmp) / "ca-chain.pem"
+            ca_path.write_text(ca_chain_pem)
+
+        instance = cls.__new__(cls)
+        instance.base = site_url.rstrip("/")
+        instance._verify_tls = verify_tls
+        instance.token = None
+        instance._label = agent_id
+        instance.server_role = None
+        instance._signing_key_pem = key_pem
+        instance._cert_pem = cert_pem
+        instance._http = _build_proxy_http_client(
+            verify_tls=verify_tls,
+            timeout=timeout,
+            cert_path=cert_path,
+            key_path=key_path,
+            ca_chain_path=ca_path,
+        )
+        instance._ca_chain_path = ca_path
+        instance._pubkey_cache = {}
+        instance._client_seq = {}
+        instance._dpop_privkey = None
+        instance._dpop_pubkey_jwk = None
+        instance._dpop_nonce = None
+        instance._egress_dpop_key = None
+        instance._egress_dpop_nonce = None
+        instance._proxy_agent_id = agent_id
+        instance._proxy_org_id = org_id
+        instance._use_egress_for_sessions = True
+        instance.identity = None
+        # Track the temp dir so ``close()`` / ``__del__`` can wipe the
+        # cert + key off disk. The temp files are mode 600 + key 600,
+        # but the on-disk dwell-time still wants to be minimised.
+        instance._user_principal_tmpdir = tmp
+
+        if enable_dpop:
+            from cullis_sdk.dpop import DpopKey
+            instance._egress_dpop_key = DpopKey.generate()
+
+        log(
+            "sdk",
+            f"Loaded user-principal identity {agent_id} (principal_id={principal_id})",
+        )
         return instance
 
     # ── SPIFFE Workload API bootstrap ───────────────────────────────

--- a/mcp_proxy/auth/challenge_response.py
+++ b/mcp_proxy/auth/challenge_response.py
@@ -344,40 +344,51 @@ async def sign_challenged_assertion(
             ),
         )
 
-    # Cert pin — ``internal_agents.cert_pem`` is the row the operator
-    # enrolled. A valid chain-of-trust cert that doesn't match the
-    # pinned one is rejected (defence against silent re-issuance).
-    db_row = await db_get_agent(agent.agent_id)
-    if db_row is None or not db_row.get("is_active", True):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="agent not registered or deactivated",
-        )
-    pinned_pem = db_row.get("cert_pem")
-    if not pinned_pem:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="agent has no pinned cert_pem on record",
-        )
-    try:
-        pinned_cert = x509.load_pem_x509_certificate(pinned_pem.encode())
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="pinned cert_pem is malformed",
-        ) from exc
-    from cryptography.hazmat.primitives import serialization as _ser
-    pinned_der = pinned_cert.public_bytes(_ser.Encoding.DER)
-    leaf_der = leaf.public_bytes(_ser.Encoding.DER)
-    if pinned_der != leaf_der:
-        _log.info(
-            "login challenge rejected for %s: leaf cert != pinned",
-            agent.agent_id,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="leaf certificate does not match pinned internal_agents.cert_pem",
-        )
+    # ADR-020 — typed principals (user / workload) skip the cert pin
+    # check (see the matching branch in ``client_cert.py``): their certs
+    # rotate every ~1h via ``/v1/principals/csr`` and the registry never
+    # writes a pinned ``cert_pem`` for them. The chain walk + SPIFFE SAN
+    # match enforced upstream by nginx ``ssl_verify_client`` is the
+    # security gate; pinning a one-hour leaf would just force every
+    # fresh login through a registry write the provisioner doesn't issue.
+    is_typed_principal = (
+        "::user::" in agent.agent_id or "::workload::" in agent.agent_id
+    )
+    if not is_typed_principal:
+        # Cert pin — ``internal_agents.cert_pem`` is the row the operator
+        # enrolled. A valid chain-of-trust cert that doesn't match the
+        # pinned one is rejected (defence against silent re-issuance).
+        db_row = await db_get_agent(agent.agent_id)
+        if db_row is None or not db_row.get("is_active", True):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="agent not registered or deactivated",
+            )
+        pinned_pem = db_row.get("cert_pem")
+        if not pinned_pem:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="agent has no pinned cert_pem on record",
+            )
+        try:
+            pinned_cert = x509.load_pem_x509_certificate(pinned_pem.encode())
+        except Exception as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="pinned cert_pem is malformed",
+            ) from exc
+        from cryptography.hazmat.primitives import serialization as _ser
+        pinned_der = pinned_cert.public_bytes(_ser.Encoding.DER)
+        leaf_der = leaf.public_bytes(_ser.Encoding.DER)
+        if pinned_der != leaf_der:
+            _log.info(
+                "login challenge rejected for %s: leaf cert != pinned",
+                agent.agent_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="leaf certificate does not match pinned internal_agents.cert_pem",
+            )
 
     # Counter-sign — reuse the ADR-009 Phase 2 primitive. When the
     # mastio identity isn't loaded yet (legacy deploys pre-ADR-009),

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -103,11 +103,24 @@ def _parse_spiffe_uri(uri: str) -> Optional[tuple[str, str]]:
     if not uri.startswith("spiffe://"):
         return None
     rest = uri[len("spiffe://"):]
-    # rest = "<trust_domain>/<org_id>/<agent_name>"
-    parts = rest.split("/", 2)
-    if len(parts) != 3:
+    # ADR-020 — accept both legacy 2-component (``<td>/<org>/<name>``)
+    # and typed 3-component (``<td>/<org>/<type>/<name>``) paths.
+    parts = rest.split("/")
+    if len(parts) == 3:
+        _td, org_id, agent_name = parts
+    elif len(parts) == 4:
+        _td, org_id, ptype, name = parts
+        if ptype not in ("agent", "user", "workload"):
+            return None
+        if ptype == "agent":
+            agent_name = name
+        else:
+            # Encode the typed identity into the canonical agent_id form
+            # used as the registry key (``{org}::{type}::{name}``). The
+            # caller will look this up in ``internal_agents`` directly.
+            agent_name = f"{ptype}::{name}"
+    else:
         return None
-    _trust_domain, org_id, agent_name = parts
     if not org_id or not agent_name:
         return None
     return org_id, agent_name
@@ -280,31 +293,41 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
             detail="agent unknown or inactive",
         )
 
-    # Pin the presented cert against the stored one. A renewal that
-    # rotated cert_pem in the DB but left the old cert in the wild
-    # would fail this — that's the desired behaviour: revocation by
-    # row-level update propagates to the next request without waiting
-    # for CA rotation.
-    stored_digest = _pem_der_digest(agent_data.get("cert_pem"))
-    if not stored_digest:
-        _log.error(
-            "internal_agents.cert_pem unparseable for %s — refusing auth",
-            canonical_id,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="agent cert pin unavailable",
-        )
-    if not hmac.compare_digest(_cert_der_digest(cert), stored_digest):
-        _log.warning(
-            "client cert pin mismatch for %s — presented cert is not "
-            "the one this Mastio issued.",
-            canonical_id,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="client cert does not match the registered identity",
-        )
+    # ADR-020 — typed principals (user / workload) skip the cert-pin step.
+    # Their certs rotate every ~1h via ``/v1/principals/csr`` and are not
+    # persisted in ``internal_agents`` (the registry is a *workload*
+    # registry; user principals live in their own table). Identity is
+    # already gated upstream by the nginx mTLS chain walk + the SPIFFE
+    # SAN match the chain enforces, so re-pinning the rotating leaf
+    # would force every fresh login through a registry write the
+    # provisioner doesn't issue.
+    is_typed_principal = "::user::" in canonical_id or "::workload::" in canonical_id
+    if not is_typed_principal:
+        # Pin the presented cert against the stored one. A renewal that
+        # rotated cert_pem in the DB but left the old cert in the wild
+        # would fail this — that's the desired behaviour: revocation by
+        # row-level update propagates to the next request without waiting
+        # for CA rotation.
+        stored_digest = _pem_der_digest(agent_data.get("cert_pem"))
+        if not stored_digest:
+            _log.error(
+                "internal_agents.cert_pem unparseable for %s — refusing auth",
+                canonical_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="agent cert pin unavailable",
+            )
+        if not hmac.compare_digest(_cert_der_digest(cert), stored_digest):
+            _log.warning(
+                "client cert pin mismatch for %s — presented cert is not "
+                "the one this Mastio issued.",
+                canonical_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="client cert does not match the registered identity",
+            )
 
     settings = get_settings()
     if not await get_agent_rate_limiter().check(

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -144,13 +144,30 @@ def _validate_public_key(csr: x509.CertificateSigningRequest) -> None:
 
 
 def _build_subject(principal_id: str, org_id: str) -> x509.Name:
-    return x509.Name([
-        x509.NameAttribute(NameOID.COMMON_NAME, principal_id[:64]),
-        x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
-    ])
+    """ADR-020 — typed-principal certs ship as SVID-style (empty subject,
+    identity in the SPIFFE SAN URI only).
+
+    Putting the 4-component principal_id in CN/O sends the broker's
+    ``x509_verifier`` down the legacy CN/O parse branch which then tries
+    to coerce ``orga.test/orga/user/daniele`` into the
+    ``org::agent-name`` internal format and 500s. The SPIFFE SAN we add
+    later carries the full identity, and the verifier's SVID branch
+    parses it cleanly via ``spiffe_to_principal`` (PR #443). Agent certs
+    keep CN/O via the ``sign_external_pubkey`` path; this helper is
+    user / workload only.
+    """
+    return x509.Name([])
 
 
 def _build_issuer(org_id: str) -> x509.Name:
+    """Fallback issuer name when the proxy can't read the Org CA cert.
+
+    Real signing path uses the actual Org CA cert's subject (see
+    ``sign_user_csr``) so the cert's ``Issuer`` field rfc4514-equals
+    the CA's ``Subject`` and nginx ``ssl_verify_client`` walks the
+    chain cleanly. This helper is only kept for the test fakes that
+    construct certs without an AgentManager around.
+    """
     return x509.Name([
         x509.NameAttribute(NameOID.COMMON_NAME, "Cullis Mastio Broker CA"),
         x509.NameAttribute(NameOID.ORGANIZATION_NAME, org_id),
@@ -209,6 +226,17 @@ async def sign_user_csr(
     ca_key = agent_manager._org_ca_key  # type: ignore[attr-defined]
     if ca_key is None:
         raise RuntimeError("Org CA key missing despite ca_loaded=True")
+    # Use the *real* Org CA cert subject as the issuer so the resulting
+    # cert chains cleanly through nginx's ``ssl_verify_client``. The
+    # fallback ``_build_issuer`` would emit a synthetic
+    # ``CN=Cullis Mastio Broker CA, O=<org>`` Name that does NOT match
+    # the registered org_ca subject; OpenSSL then refuses the chain
+    # with "unable to get issuer cert" and nginx returns the generic
+    # 400 SSL certificate error page. Caught dogfooding 2026-05-06.
+    ca_cert = agent_manager._org_ca_cert  # type: ignore[attr-defined]
+    issuer_name = ca_cert.subject if ca_cert is not None else _build_issuer(
+        expected_org,
+    )
 
     now = datetime.now(timezone.utc)
     not_before = now - CLOCK_SKEW
@@ -217,7 +245,7 @@ async def sign_user_csr(
     cert = (
         x509.CertificateBuilder()
         .subject_name(_build_subject(principal_id, expected_org))
-        .issuer_name(_build_issuer(expected_org))
+        .issuer_name(issuer_name)
         .public_key(csr.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(not_before)

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -65,7 +65,18 @@ async def run(
         )
 
     # 2. Capability check
-    if not tool_registry.has_capability(tool_name, agent.scope):
+    # ADR-020 — typed principals (user / workload) authorise via the
+    # ``local_agent_resource_bindings`` table on the proxy, NOT via the
+    # broker-issued JWT scope. The aggregator (``_handle_tools_call``)
+    # has already verified an active binding for ``(agent_id,
+    # principal_type, resource_id)`` before reaching here, so the
+    # legacy scope-based capability gate is redundant for typed
+    # principals and would fail closed (the broker's user-token flow
+    # ships an empty scope).
+    principal_type = getattr(agent, "principal_type", "agent")
+    if principal_type == "agent" and not tool_registry.has_capability(
+        tool_name, agent.scope,
+    ):
         duration_ms = _elapsed_ms(t0)
         _log.warning(
             "Agent '%s' lacks capability '%s' for tool '%s'",

--- a/nginx/mastio/mastio.conf
+++ b/nginx/mastio/mastio.conf
@@ -69,7 +69,7 @@ server {
     # PR-C dropped that path. /v1/auth/token stays anonymous (it
     # validates a client_assertion JWT, not a TLS cert) — see the
     # /v1/* catch-all below.
-    location ~ ^/v1/(egress|agents|audit)(/.*)?$ {
+    location ~ ^/v1/(egress|agents|audit|llm|chat)(/.*)?$ {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }

--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -32,8 +32,10 @@ WORKDIR /src
 COPY . /src
 
 RUN python -m pip install --upgrade pip build \
+ && bash packaging/pypi-sdk/build.sh \
  && bash packaging/pypi/build.sh \
  && mkdir -p /dist \
+ && mv dist/cullis_sdk-*.whl /dist/ \
  && mv dist/cullis_connector-*.whl /dist/
 
 # ── Stage 2: runtime ────────────────────────────────────────────────────
@@ -54,9 +56,18 @@ COPY --from=builder /dist/*.whl /tmp/
 # ``dashboard`` ImportErrors. The plain ``serve`` (MCP stdio) and
 # ``enroll`` paths do not need the extra but it costs ~25 MiB and keeps
 # the image single-purpose.
-RUN WHEEL=$(ls /tmp/cullis_connector-*.whl) \
- && pip install "${WHEEL}[dashboard]" \
- && rm "${WHEEL}"
+#
+# We install the locally-built ``cullis-sdk`` wheel BEFORE the
+# connector wheel (and pin pip to the local copy) so the ADR-021 PR4c
+# user-principal factory + ADR-017 ``chat_completion`` ship in the
+# image. Without this step pip would fall back to the published
+# ``cullis-sdk>=0.1.2`` which predates both features and the Frontdesk
+# shared-mode chat path 401s on every request.
+RUN SDK_WHEEL=$(ls /tmp/cullis_sdk-*.whl) \
+ && CONN_WHEEL=$(ls /tmp/cullis_connector-*.whl) \
+ && pip install "${SDK_WHEEL}" \
+ && pip install "${CONN_WHEEL}[dashboard]" \
+ && rm "${SDK_WHEEL}" "${CONN_WHEEL}"
 
 USER cullis
 WORKDIR /home/cullis

--- a/tests/test_auth_svid.py
+++ b/tests/test_auth_svid.py
@@ -182,23 +182,23 @@ async def test_svid_no_san_rejected(client: AsyncClient, dpop):
 # ── ADR-020 — 3-component principal SPIFFE format ──────────────────────────
 
 
-async def test_user_principal_svid_token_endpoint_returns_400(
+async def test_user_principal_svid_token_endpoint_issues_token(
     client: AsyncClient, dpop,
 ):
-    """User principal cert (``spiffe://td/org/user/<name>``) is recognised
-    by the verifier but rejected by ``/v1/auth/token`` with a precise 400.
+    """User principal cert (``spiffe://td/org/user/<name>``) round-trips
+    through ``/v1/auth/token`` and gets a DPoP-bound JWT with
+    ``principal_type=user``.
 
-    Pre-fix this 500'd somewhere downstream because the verifier collapsed
-    the 3-component path into a fake agent_id and the registry lookup
-    blew up. The dedicated user-principal flow lives elsewhere; the
-    legacy ``/v1/auth/token`` endpoint stays agent-only on purpose.
+    Pre-fix this 500'd because the verifier collapsed the 3-component
+    path into a fake agent_id. PR #443 + the typed-token flow added
+    the user-principal lookup that issues an empty-scope token (the
+    proxy's ``local_agent_resource_bindings`` is the authz source for
+    user MCP access — see ADR-020). Workload principals stay rejected
+    on this endpoint by design (separate test below).
     """
     await _prime_nonce(client, dpop)
     org_id = "userp-orga"
     trust_domain = "userp-orga.test"
-    # We register a placeholder agent under the same org so the
-    # trust-domain → org resolution succeeds; the user principal is
-    # NOT in the agents table by design.
     await _register_agent(
         client, f"{org_id}::placeholder", org_id, trust_domain=trust_domain,
     )
@@ -215,8 +215,17 @@ async def test_user_principal_svid_token_endpoint_returns_400(
         json={"client_assertion": assertion},
         headers={"DPoP": dpop.proof("POST", "/v1/auth/token")},
     )
-    assert resp.status_code == 400, resp.text
-    assert "principal_type" in resp.text
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    token = body["access_token"]
+
+    # Decode without verification to check the typed claims survived.
+    import jwt as _jwt
+    payload = _jwt.decode(token, options={"verify_signature": False})
+    assert payload["principal_type"] == "user"
+    assert payload["agent_id"] == f"{org_id}::user::daniele"
+    assert payload["sub"] == spiffe
+    assert payload["scope"] == []  # binding-driven authz; no broker scope
 
 
 async def test_workload_principal_svid_token_endpoint_returns_400(


### PR DESCRIPTION
## Summary

- Closes the Frontdesk shared-mode user-principal flow end-to-end. After ADR-020/ADR-021 (#439-#444) the schema and SPIFFE recognition were in place, but the **wire** path from a daniele@user click in Cullis Chat to the postgres MCP query never connected — every component fell back closed at a different boundary.
- This PR fixes seven coordinated gaps that the 2026-05-06 dogfood surfaced in sequence (each was 'the next 401/500 in line').
- After merge: daniele@user → Frontdesk → Anthropic → MCP postgres → returns Mario Rossi's GDPR row. mario@user → Frontdesk → no tool listed (binding isolation working). Audit chain has separate rows per principal_type.

See ADR-020 + ADR-021 + memory ``feedback_frontdesk_shared_mode_capability_model``.

## What changed (7 gaps)

1. **Cert subject** — typed-principal certs now ship SVID-style (empty subject), so the broker x509_verifier reaches its 3-component SPIFFE branch instead of trying to coerce ``orga.test/orga/user/daniele`` into ``org::agent-name``.
2. **Cert issuer** — copy the real Org CA cert subject onto the leaf so ``nginx ssl_verify_client`` doesn't return the generic *400 The SSL certificate error*.
3. **nginx mTLS gate** — ``^/v1/(egress|agents|audit)`` extended to include ``llm`` and ``chat`` so the AI gateway endpoint sees the user cert.
4. **Proxy auth deps** — ``client_cert.py`` parses the 4-component ADR-020 SPIFFE path and folds the type into ``agent_id``; both ``client_cert.py`` and ``challenge_response.py`` skip the cert pin for typed principals (their certs rotate every ~1h, the registry never persists the rotating leaf).
5. **Broker /v1/auth/token** — accepts ``principal_type=user``, looks up ``user_principals`` (revocation gate), skips the agent-binding requirement (per-resource binding lives on the proxy), and issues an empty-scope DPoP-bound token. Workload principals stay rejected on this endpoint by design (they sign user CSRs, not their own tokens).
6. **Token payload** — JWT carries ``principal_type`` and a SPIFFE ``sub`` that matches the cert SAN (3-segment agent / 4-segment typed). Per-org ``trust_domain`` plumbed through.
7. **SDK + Connector + image build** — new ``CullisClient.from_user_principal_pem(...)`` factory takes in-memory cert+key, configures httpx with the cert at the TLS handshake; ``_build_user_client`` in the shared Ambassador uses it. ``packaging/docker/Dockerfile`` builds the local ``cullis-sdk`` wheel alongside the connector wheel so the published 0.1.2 (which predates ADR-017 + ADR-021) doesn't sneak back in.

Bonus: ``mcp_proxy/tools/executor.py`` skips the legacy capability check for typed principals — the binding existence in ``local_agent_resource_bindings(principal_type)`` is the authz source of truth for them.

## Test plan

- [x] ``pytest tests/test_auth_svid.py tests/test_proxy_mcp_aggregator.py tests/test_proxy_admin_mcp_resources.py tests/test_proxy_migrations.py -n auto --dist=loadfile`` — 48/48 green.
- [x] ``pytest tests/test_auth.py tests/test_auth_chain.py tests/test_auth_ec.py tests/test_auth_token_deprecation.py tests/test_mtls_binding.py tests/test_dashboard_bindings.py tests/test_proxy_dashboard_mcp_resources.py -n auto --dist=loadfile`` — 69/69 green (wider regression).
- [x] **Live E2E** on the official_sandbox NixOS stack: daniele@user query MCP postgres returns the row; mario@user without binding sees no tool; audit log carries per-principal rows.
- [ ] CI matrix.
- [ ] Merge + sandbox dogfood with ``./demo.sh full``.

## Live demo output

```
$ curl http://localhost:8080/api/session/init?user=daniele -c /tmp/d.txt
$ curl -b /tmp/d.txt http://localhost:8080/v1/chat/completions -d '{...query Mario Rossi...}'
{ ... "content": "Mario Rossi: gdpr_training_completed=true" ... }

$ docker exec sandbox-proxy-a-1 sqlite3 /data/mcp_proxy.db \
    "SELECT agent_id, action, status FROM audit_log WHERE agent_id LIKE '%user::%' ORDER BY id DESC LIMIT 3"
orga::user::daniele|tool_execute|success
orga::user::daniele|egress_llm_chat|success
orga::user::mario|egress_llm_chat|success
```

Mario sees a chatbot with no tools (LLM responds *"I don't have access to a query tool"*) — the per-principal binding isolation Cullis sells.

## Memory / linked work

- Stack predecessors: #439 → #440 → #441 → #442 + #443 + #444. This PR is the wire layer that makes them demonstrable.
- Memory entry to update: ``project_scenario3_remaining_gaps`` → close all 3+7 gaps; ``feedback_frontdesk_shared_mode_capability_model`` already covers the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)