### PR TITLE
feat(llm-gateway): Phase A floor + Phase 5 SSE streaming

### DIFF
--- a/app/auth/models.py
+++ b/app/auth/models.py
@@ -30,3 +30,10 @@ class TokenPayload(BaseModel):
     resource_id: str | None = None      # bound resource (e.g. rfq_id)
     payload_hash: str | None = None     # SHA-256 of authorized payload
     parent_jti: str | None = None       # links to originating access token
+    # ADR-020 typed principal. ``agent`` is the legacy default; ``user``
+    # / ``workload`` arrive on tokens minted for Frontdesk shared-mode
+    # users and SPIFFE workloads. Audit rows + per-principal aggregation
+    # key on this so a user and an agent with the same local name don't
+    # collide. Optional for back-compat with tokens issued by pre-ADR-020
+    # brokers in the upgrade window.
+    principal_type: str = "agent"

--- a/app/egress/ai_gateway.py
+++ b/app/egress/ai_gateway.py
@@ -43,6 +43,9 @@ class GatewayResult:
     upstream_request_id: str | None
     backend: str
     provider: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: float | None = None
 
 
 class GatewayError(Exception):
@@ -196,6 +199,9 @@ async def _call_portkey(
         upstream_request_id=upstream_request_id,
         backend="portkey",
         provider=provider,
+        prompt_tokens=int(parsed.usage.prompt_tokens or 0),
+        completion_tokens=int(parsed.usage.completion_tokens or 0),
+        cost_usd=None,
     )
 
 
@@ -364,4 +370,7 @@ async def _call_litellm_embedded(
         upstream_request_id=upstream_request_id,
         backend="litellm_embedded",
         provider=provider,
+        prompt_tokens=int(prompt_tokens),
+        completion_tokens=int(completion_tokens),
+        cost_usd=cost_usd,
     )

--- a/app/egress/router.py
+++ b/app/egress/router.py
@@ -60,8 +60,11 @@ async def chat_completion(
             result="error",
             agent_id=p.agent_id,
             org_id=p.org,
+            principal_type=p.principal_type,
             details={
                 "event": "llm.chat_completion",
+                "principal_id": p.agent_id,
+                "principal_type": p.principal_type,
                 "backend": settings.ai_gateway_backend,
                 "provider": settings.ai_gateway_provider,
                 "model": req.model,
@@ -81,8 +84,11 @@ async def chat_completion(
         result="ok",
         agent_id=p.agent_id,
         org_id=p.org,
+        principal_type=p.principal_type,
         details={
             "event": "llm.chat_completion",
+            "principal_id": p.agent_id,
+            "principal_type": p.principal_type,
             "backend": result.backend,
             "provider": result.provider,
             "model": result.response.model,

--- a/app/egress/router.py
+++ b/app/egress/router.py
@@ -61,6 +61,7 @@ async def chat_completion(
             agent_id=p.agent_id,
             org_id=p.org,
             details={
+                "event": "llm.chat_completion",
                 "backend": settings.ai_gateway_backend,
                 "provider": settings.ai_gateway_provider,
                 "model": req.model,
@@ -81,15 +82,18 @@ async def chat_completion(
         agent_id=p.agent_id,
         org_id=p.org,
         details={
+            "event": "llm.chat_completion",
             "backend": result.backend,
             "provider": result.provider,
             "model": result.response.model,
             "trace_id": trace_id,
             "upstream_request_id": result.upstream_request_id,
             "latency_ms": result.latency_ms,
-            "prompt_tokens": result.response.usage.prompt_tokens,
-            "completion_tokens": result.response.usage.completion_tokens,
-            "total_tokens": result.response.usage.total_tokens,
+            "prompt_tokens": result.prompt_tokens,
+            "completion_tokens": result.completion_tokens,
+            "total_tokens": result.prompt_tokens + result.completion_tokens,
+            "cost_usd": result.cost_usd,
+            "cache_hit": False,
         },
     )
 

--- a/mcp_proxy/auth/rate_limit.py
+++ b/mcp_proxy/auth/rate_limit.py
@@ -105,7 +105,105 @@ return 1
         return bool(allowed)
 
 
+class TokenSumLimiter(Protocol):
+    """Sliding-window sum of weighted entries (e.g. LLM token usage).
+
+    Unlike ``AgentRateLimiter`` which counts requests, this one tracks
+    a *quantity* added per request: pre-call ``peek`` reports the
+    current sum over the last window so the caller can decide to 429
+    before dispatching; post-call ``consume`` records the actual
+    weight (prompt + completion tokens) once known. Two concurrent
+    requests can each pass ``peek`` without seeing each other's
+    pending consumption — this is an MVP trade-off; for stricter
+    bounds add a reservation step.
+    """
+
+    async def peek(self, key: str) -> int:
+        """Return the current sum over the active window."""
+        ...
+
+    async def consume(self, key: str, amount: int) -> None:
+        """Record ``amount`` against ``key`` at the current timestamp."""
+        ...
+
+
+class InMemoryTokenSumLimiter:
+    """Per-process weighted sliding window. Async-safe within one loop."""
+
+    def __init__(self) -> None:
+        self._windows: dict[str, list[tuple[float, int]]] = {}
+        self._lock = asyncio.Lock()
+
+    async def peek(self, key: str) -> int:
+        cutoff = time.monotonic() - _WINDOW_SECONDS
+        async with self._lock:
+            entries = [(t, w) for t, w in self._windows.get(key, []) if t > cutoff]
+            self._windows[key] = entries
+            return sum(w for _, w in entries)
+
+    async def consume(self, key: str, amount: int) -> None:
+        if amount <= 0:
+            return
+        now = time.monotonic()
+        cutoff = now - _WINDOW_SECONDS
+        async with self._lock:
+            entries = [(t, w) for t, w in self._windows.get(key, []) if t > cutoff]
+            entries.append((now, int(amount)))
+            self._windows[key] = entries
+
+
+class RedisTokenSumLimiter:
+    """Redis sorted-set weighted sliding window.
+
+    Each entry is ``"<amount>:<uuid>"`` with score = epoch seconds.
+    ``peek`` evicts stale entries then sums the remaining amounts via
+    a Lua script (atomic read). ``consume`` ZADDs the new entry. The
+    set's TTL is reset on every consume so empty windows expire.
+    """
+
+    _PREFIX = "mcp_proxy:tokensum:"
+    _PEEK_LUA = """
+local key = KEYS[1]
+local cutoff = tonumber(ARGV[1])
+redis.call('ZREMRANGEBYSCORE', key, 0, cutoff)
+local entries = redis.call('ZRANGE', key, 0, -1)
+local total = 0
+for _, member in ipairs(entries) do
+    local sep = string.find(member, ':')
+    if sep then
+        total = total + tonumber(string.sub(member, 1, sep - 1))
+    end
+end
+return total
+"""
+
+    def __init__(self, redis_client) -> None:
+        self._redis = redis_client
+        self._peek_sha: str | None = None
+
+    async def peek(self, key: str) -> int:
+        cutoff = time.time() - _WINDOW_SECONDS
+        full_key = f"{self._PREFIX}{key}"
+        if self._peek_sha is None:
+            self._peek_sha = await self._redis.script_load(self._PEEK_LUA)
+        total = await self._redis.evalsha(
+            self._peek_sha, 1, full_key, str(cutoff),
+        )
+        return int(total or 0)
+
+    async def consume(self, key: str, amount: int) -> None:
+        if amount <= 0:
+            return
+        now = time.time()
+        full_key = f"{self._PREFIX}{key}"
+        member = f"{int(amount)}:{uuid.uuid4().hex}"
+        ttl = int(_WINDOW_SECONDS) + 10
+        await self._redis.zadd(full_key, {member: now})
+        await self._redis.expire(full_key, ttl)
+
+
 _limiter: AgentRateLimiter | None = None
+_token_sum_limiter: TokenSumLimiter | None = None
 
 
 def _init_limiter() -> AgentRateLimiter:
@@ -140,5 +238,27 @@ def get_agent_rate_limiter() -> AgentRateLimiter:
 
 def reset_agent_rate_limiter() -> None:
     """Reset the limiter (used by tests to force re-initialization)."""
-    global _limiter
+    global _limiter, _token_sum_limiter
     _limiter = None
+    _token_sum_limiter = None
+
+
+def _init_token_sum_limiter() -> TokenSumLimiter:
+    """Pick the best TokenSumLimiter backend, mirroring _init_limiter."""
+    from mcp_proxy.redis.pool import get_redis
+
+    redis = get_redis()
+    if redis is not None:
+        _log.info("Token-sum limiter: Redis")
+        return RedisTokenSumLimiter(redis)
+
+    _log.info("Token-sum limiter: in-memory")
+    return InMemoryTokenSumLimiter()
+
+
+def get_token_sum_limiter() -> TokenSumLimiter:
+    """Return the active token-sum limiter, initializing on first call."""
+    global _token_sum_limiter
+    if _token_sum_limiter is None:
+        _token_sum_limiter = _init_token_sum_limiter()
+    return _token_sum_limiter

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -144,6 +144,14 @@ class ProxySettings(BaseSettings):
     # that keeps the system responsive.)
     rate_limit_per_minute: int = 1800
 
+    # Phase A.3 — per-principal token budget on /v1/chat/completions.
+    # Sliding-window sum of (prompt_tokens + completion_tokens) over the
+    # last 60s, keyed on principal_id. Exhausted budget → 429 before the
+    # request reaches the upstream provider. Default 100k tok/min is
+    # generous for interactive use and modest for batch; tune per
+    # deployment via MCP_PROXY_LLM_TOKENS_PER_MINUTE.
+    llm_tokens_per_minute: int = 100_000
+
     # Shared secret the proxy uses to verify the X-ATN-Signature HMAC
     # on inbound /pdp/policy webhook calls (audit 2026-04-30 lane 3 H3).
     # When set, every POST to /pdp/policy must carry a valid

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -23,7 +23,7 @@ import logging
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Mapping
 
 from alembic import command
 from alembic.config import Config as AlembicConfig
@@ -352,6 +352,7 @@ async def log_audit(
     *,
     tool_name: str | None = None,
     detail: str | None = None,
+    details: Mapping[str, Any] | None = None,
     request_id: str | None = None,
     duration_ms: float | None = None,
 ) -> None:
@@ -363,8 +364,20 @@ async def log_audit(
     walks the chain and surfaces breaks; an attacker rewriting a
     row, dropping one, or splicing in a forgery has to recompute
     every subsequent hash without operator detection.
+
+    ``details`` lets callers attach a structured dict (e.g. LLM
+    cost/tokens). When passed it is serialised to canonical JSON and
+    stored in the same ``detail`` SQL column the legacy string uses,
+    so the chain hash semantics stay identical. Pass ``detail`` for
+    free-form human-readable strings, ``details`` for structured
+    data; if both arrive ``details`` wins.
     """
     from sqlalchemy.exc import IntegrityError
+
+    if details is not None:
+        detail = json.dumps(
+            dict(details), separators=(",", ":"), sort_keys=True, default=str,
+        )
 
     ts = datetime.now(timezone.utc).isoformat()
     async with _audit_chain_lock:

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -17,7 +17,8 @@ import json
 import logging
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import AsyncIterator
 
 import httpx
 
@@ -46,6 +47,35 @@ class GatewayResult:
     prompt_tokens: int = 0
     completion_tokens: int = 0
     cost_usd: float | None = None
+
+
+@dataclass
+class StreamingDispatch:
+    """Streaming counterpart of ``GatewayResult``.
+
+    The router drives ``aiter()`` to fan-out chunks as SSE frames; once
+    the stream drains, ``prompt_tokens`` / ``completion_tokens`` /
+    ``cost_usd`` / ``upstream_request_id`` carry the final values used
+    for the audit row and the per-principal token-budget consume. The
+    backend implementation populates them while iterating.
+    """
+
+    backend: str
+    provider: str
+    model: str
+    trace_id: str
+    _aiter_factory: object = None  # async generator factory, set by impl
+    started_at: float = field(default_factory=time.perf_counter)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: float | None = None
+    upstream_request_id: str | None = None
+    latency_ms: int = 0
+
+    def aiter(self) -> AsyncIterator[dict]:
+        if self._aiter_factory is None:
+            raise RuntimeError("StreamingDispatch.aiter called before backend wired it")
+        return self._aiter_factory()
 
 
 class GatewayError(Exception):
@@ -93,6 +123,41 @@ async def dispatch(
         501,
         f"backend_not_implemented:{backend}",
         detail=f"AI gateway backend '{backend}' is not wired.",
+    )
+
+
+async def dispatch_stream(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+) -> StreamingDispatch:
+    """Open a streaming dispatch.
+
+    Returns a ``StreamingDispatch`` whose ``aiter()`` yields OpenAI-shape
+    chunk dicts (``object=chat.completion.chunk``). The router converts
+    them to SSE frames. Token usage + cost land on the dispatch object
+    once the iterator drains, so the post-stream audit/rate-limit logic
+    can read them without inspecting the chunks itself.
+    """
+    backend = settings.ai_gateway_backend.lower()
+    if backend == "litellm_embedded":
+        return _build_litellm_stream(
+            req=req,
+            agent_id=agent_id,
+            org_id=org_id,
+            trace_id=trace_id,
+            settings=settings,
+        )
+    raise GatewayError(
+        501,
+        f"streaming_not_implemented_for_backend:{backend}",
+        detail=(
+            f"Streaming on backend '{backend}' is not wired. "
+            "Set ai_gateway_backend=litellm_embedded for stream=true."
+        ),
     )
 
 
@@ -374,3 +439,141 @@ async def _call_litellm_embedded(
         completion_tokens=int(completion_tokens),
         cost_usd=cost_usd,
     )
+
+
+def _build_litellm_stream(
+    *,
+    req: ChatCompletionRequest,
+    agent_id: str,
+    org_id: str,
+    trace_id: str,
+    settings: Settings,
+) -> StreamingDispatch:
+    """Build a ``StreamingDispatch`` backed by ``litellm.acompletion(stream=True)``.
+
+    The acompletion call itself happens lazily on first iteration; raise
+    here for the configuration-time errors (missing key, wrong provider,
+    litellm not installed) so the router can audit them as a non-stream
+    error before opening the SSE response.
+    """
+    provider = settings.ai_gateway_provider.lower()
+    if provider != "anthropic":
+        raise GatewayError(
+            501,
+            f"provider_not_implemented:{provider}",
+            detail="Streaming only validates provider='anthropic' via LiteLLM.",
+        )
+    if not settings.anthropic_api_key:
+        raise GatewayError(503, "provider_key_missing")
+
+    try:
+        import litellm
+        from litellm import acompletion
+    except ImportError as exc:
+        raise GatewayError(
+            503,
+            "litellm_not_installed",
+            detail=(
+                "ai_gateway_backend='litellm_embedded' requires the litellm "
+                "package. Install it via requirements.txt."
+            ),
+        ) from exc
+
+    litellm.drop_params = True
+
+    body = req.model_dump(exclude_none=True)
+    model = body.pop("model")
+    body.pop("stream", None)
+    # Ask the upstream for a final usage chunk so we can audit accurate
+    # token + cost numbers after the stream drains. Anthropic + OpenAI +
+    # most LiteLLM-routed providers honour this OpenAI-spec field.
+    stream_options = body.pop("stream_options", None) or {}
+    stream_options.setdefault("include_usage", True)
+
+    metadata = {
+        "cullis_agent_id": agent_id,
+        "cullis_org_id": org_id,
+        "cullis_trace_id": trace_id,
+    }
+
+    dispatch_obj = StreamingDispatch(
+        backend="litellm_embedded",
+        provider=provider,
+        model=model,
+        trace_id=trace_id,
+    )
+
+    async def _aiter() -> AsyncIterator[dict]:
+        try:
+            stream = await acompletion(
+                model=model,
+                api_key=settings.anthropic_api_key,
+                metadata=metadata,
+                stream=True,
+                stream_options=stream_options,
+                **body,
+            )
+        except Exception as exc:
+            raise _map_litellm_exception(exc) from exc
+
+        try:
+            async for chunk in stream:
+                payload = (
+                    chunk.model_dump() if hasattr(chunk, "model_dump")
+                    else dict(chunk)
+                )
+                payload.setdefault("object", "chat.completion.chunk")
+                payload.setdefault("model", model)
+                if dispatch_obj.upstream_request_id is None:
+                    upstream_id = payload.get("id")
+                    if upstream_id:
+                        dispatch_obj.upstream_request_id = upstream_id
+                # The final usage chunk has empty choices and a populated
+                # ``usage`` dict; harvest it for the audit row, normalise
+                # the shape so the SSE consumer always sees the canonical
+                # OpenAI usage fields.
+                usage = payload.get("usage")
+                if isinstance(usage, dict):
+                    pt = int(usage.get("prompt_tokens") or 0)
+                    ct = int(usage.get("completion_tokens") or 0)
+                    if pt or ct:
+                        dispatch_obj.prompt_tokens = pt
+                        dispatch_obj.completion_tokens = ct
+                        payload["usage"] = {
+                            "prompt_tokens": pt,
+                            "completion_tokens": ct,
+                            "total_tokens": pt + ct,
+                        }
+                yield payload
+        except GatewayError:
+            raise
+        except Exception as exc:
+            raise _map_litellm_exception(exc) from exc
+        finally:
+            dispatch_obj.latency_ms = int(
+                (time.perf_counter() - dispatch_obj.started_at) * 1000
+            )
+            if dispatch_obj.prompt_tokens or dispatch_obj.completion_tokens:
+                try:
+                    dispatch_obj.cost_usd = litellm.completion_cost(
+                        model=model,
+                        prompt_tokens=dispatch_obj.prompt_tokens,
+                        completion_tokens=dispatch_obj.completion_tokens,
+                    )
+                except Exception as exc:  # pragma: no cover — informational
+                    _log.debug(
+                        "litellm.completion_cost (stream) failed model=%s: %s",
+                        model, exc,
+                    )
+            _log.info(
+                "egress.llm streamed backend=litellm_embedded provider=%s "
+                "agent=%s org=%s model=%s latency_ms=%d tokens_in=%d "
+                "tokens_out=%d cost_usd=%s",
+                provider, agent_id, org_id, model, dispatch_obj.latency_ms,
+                dispatch_obj.prompt_tokens, dispatch_obj.completion_tokens,
+                f"{dispatch_obj.cost_usd:.6f}"
+                if dispatch_obj.cost_usd is not None else "n/a",
+            )
+
+    dispatch_obj._aiter_factory = _aiter
+    return dispatch_obj

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -554,15 +554,20 @@ def _build_litellm_stream(
                 (time.perf_counter() - dispatch_obj.started_at) * 1000
             )
             if dispatch_obj.prompt_tokens or dispatch_obj.completion_tokens:
+                # ``completion_cost`` wants a full response object; in the
+                # streaming path we've already drained it, so go through
+                # ``cost_per_token`` (returns the (input, output) USD
+                # tuple already multiplied by the token counts).
                 try:
-                    dispatch_obj.cost_usd = litellm.completion_cost(
+                    in_cost, out_cost = litellm.cost_per_token(
                         model=model,
                         prompt_tokens=dispatch_obj.prompt_tokens,
                         completion_tokens=dispatch_obj.completion_tokens,
                     )
+                    dispatch_obj.cost_usd = float(in_cost) + float(out_cost)
                 except Exception as exc:  # pragma: no cover — informational
                     _log.debug(
-                        "litellm.completion_cost (stream) failed model=%s: %s",
+                        "litellm.cost_per_token (stream) failed model=%s: %s",
                         model, exc,
                     )
             _log.info(

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -43,6 +43,9 @@ class GatewayResult:
     upstream_request_id: str | None
     backend: str
     provider: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: float | None = None
 
 
 class GatewayError(Exception):
@@ -196,6 +199,9 @@ async def _call_portkey(
         upstream_request_id=upstream_request_id,
         backend="portkey",
         provider=provider,
+        prompt_tokens=int(parsed.usage.prompt_tokens or 0),
+        completion_tokens=int(parsed.usage.completion_tokens or 0),
+        cost_usd=None,
     )
 
 
@@ -364,4 +370,7 @@ async def _call_litellm_embedded(
         upstream_request_id=upstream_request_id,
         backend="litellm_embedded",
         provider=provider,
+        prompt_tokens=int(prompt_tokens),
+        completion_tokens=int(completion_tokens),
+        cost_usd=cost_usd,
     )

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -20,17 +20,24 @@ serves AI gateway egress for its agents without federating.
 """
 from __future__ import annotations
 
+import json
 import logging
 import time
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import StreamingResponse
 
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.auth.rate_limit import get_token_sum_limiter
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
-from mcp_proxy.egress.ai_gateway import GatewayError, dispatch
+from mcp_proxy.egress.ai_gateway import (
+    GatewayError,
+    StreamingDispatch,
+    dispatch,
+    dispatch_stream,
+)
 from mcp_proxy.egress.schemas import ChatCompletionRequest
 from mcp_proxy.models import InternalAgent
 
@@ -49,13 +56,7 @@ async def chat_completions(
     req: ChatCompletionRequest,
     request: Request,
     agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
-) -> dict:
-    if req.stream:
-        raise HTTPException(
-            status_code=400,
-            detail="stream=true is not supported in Phase 2.",
-        )
-
+):
     settings = get_settings()
     trace_id = f"trace_{uuid.uuid4().hex[:16]}"
 
@@ -79,6 +80,7 @@ async def chat_completions(
                     "reason": "local_rate_limited_tokens",
                     "current_window_tokens": current_sum,
                     "limit_tokens_per_minute": settings.llm_tokens_per_minute,
+                    "stream": req.stream,
                 },
             )
             raise HTTPException(
@@ -90,6 +92,11 @@ async def chat_completions(
                     "limit_tokens_per_minute": settings.llm_tokens_per_minute,
                 },
             )
+
+    if req.stream:
+        return await _handle_stream(
+            req=req, agent=agent, settings=settings, trace_id=trace_id,
+        )
 
     started = time.perf_counter()
 
@@ -159,3 +166,145 @@ async def chat_completions(
     )
 
     return payload
+
+
+async def _handle_stream(
+    *,
+    req: ChatCompletionRequest,
+    agent: InternalAgent,
+    settings,
+    trace_id: str,
+) -> StreamingResponse:
+    """Open the upstream stream and fan it out as Server-Sent Events.
+
+    The handler is split out so the generator below can ``finally``-write
+    the audit row and consume the per-principal token budget regardless
+    of how the stream ends (success, upstream error mid-stream, client
+    disconnect). The ``data: [DONE]`` sentinel is appended only on the
+    happy path; on upstream error we emit a single ``data: {"error":...}``
+    frame so OpenAI-shaped clients see a terminal event.
+    """
+    try:
+        streamer: StreamingDispatch = await dispatch_stream(
+            req=req,
+            agent_id=agent.agent_id,
+            org_id=settings.org_id,
+            trace_id=trace_id,
+            settings=settings,
+        )
+    except GatewayError as exc:
+        await log_audit(
+            agent_id=agent.agent_id,
+            action="egress_llm_chat",
+            status="error",
+            details={
+                "event": "llm.chat_completion",
+                "principal_id": agent.agent_id,
+                "principal_type": agent.principal_type,
+                "backend": settings.ai_gateway_backend,
+                "provider": settings.ai_gateway_provider,
+                "model": req.model,
+                "trace_id": trace_id,
+                "reason": exc.reason,
+                "upstream_detail": exc.detail,
+                "stream": True,
+            },
+        )
+        raise HTTPException(
+            status_code=exc.status_code,
+            detail={"reason": exc.reason, "trace_id": trace_id},
+        ) from exc
+
+    async def sse():
+        terminated_with_error: GatewayError | None = None
+        try:
+            async for chunk in streamer.aiter():
+                # Inject the trace id on every chunk so a downstream
+                # audit/observability consumer can correlate even on a
+                # mid-stream client disconnect. The backend stays
+                # trace-id-agnostic.
+                chunk.setdefault("cullis_trace_id", trace_id)
+                yield f"data: {json.dumps(chunk)}\n\n"
+            yield "data: [DONE]\n\n"
+        except GatewayError as exc:
+            terminated_with_error = exc
+            err_frame = {
+                "error": {
+                    "type": exc.reason,
+                    "message": exc.detail or exc.reason,
+                    "trace_id": trace_id,
+                },
+            }
+            yield f"data: {json.dumps(err_frame)}\n\n"
+        finally:
+            if terminated_with_error is not None:
+                await log_audit(
+                    agent_id=agent.agent_id,
+                    action="egress_llm_chat",
+                    status="error",
+                    details={
+                        "event": "llm.chat_completion",
+                        "principal_id": agent.agent_id,
+                        "principal_type": agent.principal_type,
+                        "backend": streamer.backend,
+                        "provider": streamer.provider,
+                        "model": req.model,
+                        "trace_id": trace_id,
+                        "reason": terminated_with_error.reason,
+                        "upstream_detail": terminated_with_error.detail,
+                        "stream": True,
+                        "prompt_tokens": streamer.prompt_tokens,
+                        "completion_tokens": streamer.completion_tokens,
+                    },
+                )
+            else:
+                if settings.llm_tokens_per_minute > 0:
+                    weight = (
+                        int(streamer.prompt_tokens)
+                        + int(streamer.completion_tokens)
+                    )
+                    if weight > 0:
+                        await get_token_sum_limiter().consume(
+                            _token_bucket_key(agent), weight,
+                        )
+                await log_audit(
+                    agent_id=agent.agent_id,
+                    action="egress_llm_chat",
+                    status="success",
+                    duration_ms=float(streamer.latency_ms),
+                    details={
+                        "event": "llm.chat_completion",
+                        "principal_id": agent.agent_id,
+                        "principal_type": agent.principal_type,
+                        "backend": streamer.backend,
+                        "provider": streamer.provider,
+                        "model": req.model,
+                        "trace_id": trace_id,
+                        "upstream_request_id": streamer.upstream_request_id,
+                        "latency_ms": streamer.latency_ms,
+                        "prompt_tokens": streamer.prompt_tokens,
+                        "completion_tokens": streamer.completion_tokens,
+                        "cost_usd": streamer.cost_usd,
+                        "cache_hit": False,
+                        "stream": True,
+                    },
+                )
+                logger.info(
+                    "egress_llm_chat (stream) agent=%s backend=%s model=%s "
+                    "latency_ms=%d trace_id=%s",
+                    agent.agent_id, streamer.backend, req.model,
+                    streamer.latency_ms, trace_id,
+                )
+
+    return StreamingResponse(
+        sse(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            # Disable nginx response buffering so chunks reach the client
+            # as they are produced, not at end-of-response.
+            "X-Accel-Buffering": "no",
+            "X-Cullis-Trace": trace_id,
+        },
+    )

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -70,6 +70,8 @@ async def chat_completions(
             status="error",
             details={
                 "event": "llm.chat_completion",
+                "principal_id": agent.agent_id,
+                "principal_type": agent.principal_type,
                 "backend": settings.ai_gateway_backend,
                 "provider": settings.ai_gateway_provider,
                 "model": req.model,
@@ -94,6 +96,8 @@ async def chat_completions(
         duration_ms=float(latency_ms),
         details={
             "event": "llm.chat_completion",
+            "principal_id": agent.agent_id,
+            "principal_type": agent.principal_type,
             "backend": result.backend,
             "provider": result.provider,
             "model": req.model,

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -68,12 +68,15 @@ async def chat_completions(
             agent_id=agent.agent_id,
             action="egress_llm_chat",
             status="error",
-            detail=(
-                f"backend={settings.ai_gateway_backend} "
-                f"provider={settings.ai_gateway_provider} "
-                f"model={req.model} trace_id={trace_id} "
-                f"reason={exc.reason} upstream_detail={exc.detail}"
-            ),
+            details={
+                "event": "llm.chat_completion",
+                "backend": settings.ai_gateway_backend,
+                "provider": settings.ai_gateway_provider,
+                "model": req.model,
+                "trace_id": trace_id,
+                "reason": exc.reason,
+                "upstream_detail": exc.detail,
+            },
         )
         raise HTTPException(
             status_code=exc.status_code,
@@ -88,14 +91,20 @@ async def chat_completions(
         agent_id=agent.agent_id,
         action="egress_llm_chat",
         status="success",
-        detail=(
-            f"backend={result.backend} provider={result.provider} "
-            f"model={req.model} trace_id={trace_id} "
-            f"latency_ms={latency_ms} "
-            f"upstream_request_id={result.upstream_request_id or 'n/a'} "
-            f"prompt_tokens={payload.get('usage', {}).get('prompt_tokens', 0)} "
-            f"completion_tokens={payload.get('usage', {}).get('completion_tokens', 0)}"
-        ),
+        duration_ms=float(latency_ms),
+        details={
+            "event": "llm.chat_completion",
+            "backend": result.backend,
+            "provider": result.provider,
+            "model": req.model,
+            "trace_id": trace_id,
+            "upstream_request_id": result.upstream_request_id,
+            "latency_ms": latency_ms,
+            "prompt_tokens": result.prompt_tokens,
+            "completion_tokens": result.completion_tokens,
+            "cost_usd": result.cost_usd,
+            "cache_hit": False,
+        },
     )
 
     logger.info(

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -27,6 +27,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Request
 
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.auth.rate_limit import get_token_sum_limiter
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import log_audit
 from mcp_proxy.egress.ai_gateway import GatewayError, dispatch
@@ -36,6 +37,10 @@ from mcp_proxy.models import InternalAgent
 logger = logging.getLogger("mcp_proxy.egress.llm_chat")
 
 router = APIRouter(tags=["llm-chat"])
+
+
+def _token_bucket_key(agent: InternalAgent) -> str:
+    return f"principal:{agent.agent_id}:llm_tokens"
 
 
 @router.post("/v1/chat/completions")
@@ -53,6 +58,39 @@ async def chat_completions(
 
     settings = get_settings()
     trace_id = f"trace_{uuid.uuid4().hex[:16]}"
+
+    if settings.llm_tokens_per_minute > 0:
+        token_limiter = get_token_sum_limiter()
+        bucket_key = _token_bucket_key(agent)
+        current_sum = await token_limiter.peek(bucket_key)
+        if current_sum >= settings.llm_tokens_per_minute:
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_llm_chat",
+                status="error",
+                details={
+                    "event": "llm.chat_completion",
+                    "principal_id": agent.agent_id,
+                    "principal_type": agent.principal_type,
+                    "backend": settings.ai_gateway_backend,
+                    "provider": settings.ai_gateway_provider,
+                    "model": req.model,
+                    "trace_id": trace_id,
+                    "reason": "local_rate_limited_tokens",
+                    "current_window_tokens": current_sum,
+                    "limit_tokens_per_minute": settings.llm_tokens_per_minute,
+                },
+            )
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "reason": "local_rate_limited_tokens",
+                    "trace_id": trace_id,
+                    "current_window_tokens": current_sum,
+                    "limit_tokens_per_minute": settings.llm_tokens_per_minute,
+                },
+            )
+
     started = time.perf_counter()
 
     try:
@@ -88,6 +126,10 @@ async def chat_completions(
     latency_ms = int((time.perf_counter() - started) * 1000)
     payload = result.response.model_dump()
     payload.setdefault("cullis_trace_id", trace_id)
+
+    if settings.llm_tokens_per_minute > 0:
+        weight = int(result.prompt_tokens) + int(result.completion_tokens)
+        await get_token_sum_limiter().consume(_token_bucket_key(agent), weight)
 
     await log_audit(
         agent_id=agent.agent_id,

--- a/mcp_proxy/models.py
+++ b/mcp_proxy/models.py
@@ -69,6 +69,13 @@ class InternalAgent(BaseModel):
     # any forwarding; defaults to ``both`` so rows without the column
     # (pre-migration fixtures, legacy inserts) stay permissive.
     reach: str = "both"
+    # ADR-020 — typed principal mirrored from the client certificate /
+    # token claim. ``"agent"`` is the legacy default; ``"user"`` and
+    # ``"workload"`` widen the model to Frontdesk shared-mode users
+    # and SPIFFE workloads. Audit rows + per-principal aggregation
+    # key on this so a user named "daniele" never collides with an
+    # agent named "daniele".
+    principal_type: str = "agent"
 
 
 class AuditEntry(BaseModel):

--- a/tests/test_egress_ai_gateway.py
+++ b/tests/test_egress_ai_gateway.py
@@ -245,6 +245,9 @@ async def test_chat_completion_writes_audit_ok(client, authed_agent, db_session)
         upstream_request_id="pk_req_99",
         backend="portkey",
         provider="anthropic",
+        prompt_tokens=12,
+        completion_tokens=3,
+        cost_usd=None,
     )
 
     with patch.object(
@@ -283,12 +286,16 @@ async def test_chat_completion_writes_audit_ok(client, authed_agent, db_session)
     assert row.agent_id == "acme::mario"
     assert row.org_id == "acme"
     details = json.loads(row.details)
+    assert details["event"] == "llm.chat_completion"
     assert details["backend"] == "portkey"
     assert details["provider"] == "anthropic"
     assert details["model"] == "claude-haiku-4-5"
     assert details["latency_ms"] == 42
     assert details["prompt_tokens"] == 12
     assert details["completion_tokens"] == 3
+    assert details["total_tokens"] == 15
+    assert details["cost_usd"] is None
+    assert details["cache_hit"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_egress_ai_gateway.py
+++ b/tests/test_egress_ai_gateway.py
@@ -287,6 +287,8 @@ async def test_chat_completion_writes_audit_ok(client, authed_agent, db_session)
     assert row.org_id == "acme"
     details = json.loads(row.details)
     assert details["event"] == "llm.chat_completion"
+    assert details["principal_id"] == "acme::mario"
+    assert details["principal_type"] == "agent"
     assert details["backend"] == "portkey"
     assert details["provider"] == "anthropic"
     assert details["model"] == "claude-haiku-4-5"

--- a/tests/test_h4_audit_chain.py
+++ b/tests/test_h4_audit_chain.py
@@ -212,3 +212,92 @@ async def test_existing_audit_query_pattern_still_works(proxy_app):
 
     assert row is not None
     assert (row[0], row[1], row[2]) == ("alice", "t.invoke", "ok")
+
+
+# ── Phase A.1: structured details kwarg ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_audit_details_dict_serialised_to_canonical_json(proxy_app):
+    """``details`` is canonical JSON (sort_keys, no whitespace) so
+    downstream consumers can rely on byte-stable serialisation across
+    workers and Python versions."""
+    import json as _json
+
+    _, _ = proxy_app
+    from mcp_proxy.db import get_db, log_audit
+    from sqlalchemy import text
+
+    await log_audit(
+        agent_id="alice", action="egress_llm_chat", status="success",
+        details={
+            "event": "llm.chat_completion",
+            "model": "claude-haiku-4-5",
+            "prompt_tokens": 12,
+            "completion_tokens": 3,
+            "cost_usd": 0.000123,
+            "cache_hit": False,
+        },
+    )
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT detail FROM audit_log WHERE action = :a"),
+            {"a": "egress_llm_chat"},
+        )).first()
+
+    assert row is not None
+    raw = row[0]
+    assert raw.startswith("{") and raw.endswith("}")
+    parsed = _json.loads(raw)
+    assert parsed["model"] == "claude-haiku-4-5"
+    assert parsed["cost_usd"] == 0.000123
+    assert parsed["cache_hit"] is False
+    keys = list(parsed.keys())
+    assert keys == sorted(keys), "details must be serialised with sort_keys"
+
+
+@pytest.mark.asyncio
+async def test_log_audit_details_wins_over_detail_string(proxy_app):
+    """If both ``detail`` and ``details`` are passed the dict wins; this
+    keeps the call site single-source-of-truth and avoids two
+    representations diverging in the audit row."""
+    import json as _json
+
+    _, _ = proxy_app
+    from mcp_proxy.db import get_db, log_audit
+    from sqlalchemy import text
+
+    await log_audit(
+        agent_id="alice", action="t.invoke", status="ok",
+        detail="legacy human readable",
+        details={"x": 1, "y": "two"},
+    )
+
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text("SELECT detail FROM audit_log WHERE action = :a"),
+            {"a": "t.invoke"},
+        )).first()
+
+    parsed = _json.loads(row[0])
+    assert parsed == {"x": 1, "y": "two"}
+
+
+@pytest.mark.asyncio
+async def test_log_audit_details_chain_still_verifies(proxy_app):
+    """The hash chain treats ``detail`` (now JSON) the same as before:
+    ``verify_audit_chain`` must walk a mixed chain (legacy strings +
+    structured JSON rows) without breaks."""
+    _, _ = proxy_app
+    from mcp_proxy.db import log_audit, verify_audit_chain
+
+    await log_audit(agent_id="alice", action="t.invoke", status="ok",
+                    detail="legacy")
+    await log_audit(agent_id="alice", action="egress_llm_chat", status="success",
+                    details={"event": "llm.chat_completion", "cost_usd": 0.5})
+    await log_audit(agent_id="bob", action="t.invoke", status="ok",
+                    detail="legacy 2")
+
+    ok, broken, reason = await verify_audit_chain()
+    assert ok is True, f"chain broken at {broken}: {reason}"

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -12,6 +12,7 @@ chat completion in-process via litellm_embedded. No Court round trip.
 """
 from __future__ import annotations
 
+import json
 from unittest.mock import AsyncMock
 
 import pytest
@@ -92,6 +93,9 @@ def _gateway_result() -> GatewayResult:
         upstream_request_id="req_abc",
         backend="litellm_embedded",
         provider="anthropic",
+        prompt_tokens=12,
+        completion_tokens=3,
+        cost_usd=0.000123,
     )
 
 
@@ -156,9 +160,18 @@ async def test_chat_completions_happy_path_writes_audit(app_with_router, monkeyp
     rows = await _audit_rows("egress_llm_chat", status="success")
     assert len(rows) == 1
     assert rows[0]["agent_id"] == "orga::alice"
-    assert "backend=litellm_embedded" in (rows[0]["detail"] or "")
-    assert "prompt_tokens=12" in (rows[0]["detail"] or "")
-    assert "completion_tokens=3" in (rows[0]["detail"] or "")
+    detail = json.loads(rows[0]["detail"])
+    assert detail["event"] == "llm.chat_completion"
+    assert detail["backend"] == "litellm_embedded"
+    assert detail["provider"] == "anthropic"
+    assert detail["model"] == "claude-haiku-4-5"
+    assert detail["prompt_tokens"] == 12
+    assert detail["completion_tokens"] == 3
+    assert detail["cost_usd"] == 0.000123
+    assert detail["latency_ms"] >= 0
+    assert detail["upstream_request_id"] == "req_abc"
+    assert detail["cache_hit"] is False
+    assert detail["trace_id"].startswith("trace_")
 
 
 @pytest.mark.asyncio
@@ -202,8 +215,14 @@ async def test_chat_completions_gateway_error_surfaces_status(app_with_router, m
 
     rows = await _audit_rows("egress_llm_chat", status="error")
     assert len(rows) == 1
-    assert "reason=upstream_timeout" in (rows[0]["detail"] or "")
-    assert "backend=litellm_embedded" in (rows[0]["detail"] or "")
+    detail = json.loads(rows[0]["detail"])
+    assert detail["event"] == "llm.chat_completion"
+    assert detail["reason"] == "upstream_timeout"
+    assert detail["backend"] == "litellm_embedded"
+    assert detail["provider"] == "anthropic"
+    assert detail["model"] == "claude-haiku-4-5"
+    assert detail["upstream_detail"] == "provider 504 after 30s"
+    assert detail["trace_id"].startswith("trace_")
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -269,6 +269,122 @@ async def test_chat_completions_gateway_error_surfaces_status(app_with_router, m
 
 
 @pytest.mark.asyncio
+async def test_chat_completions_429_when_token_budget_exhausted(
+    app_with_router, monkeypatch,
+):
+    """When the principal's sliding-window token sum already meets or
+    exceeds llm_tokens_per_minute, the next call short-circuits with
+    HTTP 429 before reaching the upstream provider, and an audit row
+    is written with reason=local_rate_limited_tokens for ops triage."""
+    from mcp_proxy.auth.rate_limit import (
+        get_token_sum_limiter, reset_agent_rate_limiter,
+    )
+    from mcp_proxy.config import get_settings
+
+    reset_agent_rate_limiter()
+    monkeypatch.setenv("MCP_PROXY_LLM_TOKENS_PER_MINUTE", "100")
+    get_settings.cache_clear()
+
+    # Pre-fill the principal's bucket so the next call is over budget.
+    limiter = get_token_sum_limiter()
+    await limiter.consume("principal:orga::alice:llm_tokens", 100)
+
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 429, r.text
+    body = r.json()
+    assert body["detail"]["reason"] == "local_rate_limited_tokens"
+    assert body["detail"]["limit_tokens_per_minute"] == 100
+    assert body["detail"]["current_window_tokens"] >= 100
+
+    rows = await _audit_rows("egress_llm_chat", status="error")
+    assert len(rows) == 1
+    detail = json.loads(rows[0]["detail"])
+    assert detail["reason"] == "local_rate_limited_tokens"
+    assert detail["principal_id"] == "orga::alice"
+
+    reset_agent_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_consumes_tokens_post_call(
+    app_with_router, monkeypatch,
+):
+    """A successful call adds (prompt_tokens + completion_tokens) to
+    the principal's window so subsequent peeks see the new usage."""
+    from mcp_proxy.auth.rate_limit import (
+        get_token_sum_limiter, reset_agent_rate_limiter,
+    )
+
+    reset_agent_rate_limiter()
+    limiter = get_token_sum_limiter()
+    bucket = "principal:orga::alice:llm_tokens"
+    assert await limiter.peek(bucket) == 0
+
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 200, r.text
+    # _gateway_result returns prompt_tokens=12 + completion_tokens=3.
+    assert await limiter.peek(bucket) == 15
+
+    reset_agent_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_rate_limit_disabled_when_zero(
+    app_with_router, monkeypatch,
+):
+    """Setting llm_tokens_per_minute=0 disables the gate entirely; no
+    peek is invoked and no consume is recorded. Useful for benchmarks
+    or tightly-controlled pipelines that already cap upstream."""
+    from mcp_proxy.auth.rate_limit import (
+        get_token_sum_limiter, reset_agent_rate_limiter,
+    )
+    from mcp_proxy.config import get_settings
+
+    reset_agent_rate_limiter()
+    monkeypatch.setenv("MCP_PROXY_LLM_TOKENS_PER_MINUTE", "0")
+    get_settings.cache_clear()
+
+    limiter = get_token_sum_limiter()
+    bucket = "principal:orga::alice:llm_tokens"
+    # Pre-fill above any reasonable cap to prove it's ignored.
+    await limiter.consume(bucket, 999_999)
+
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 200, r.text
+    # Bucket unchanged: no consume happened either.
+    assert await limiter.peek(bucket) == 999_999
+
+    reset_agent_rate_limiter()
+
+
+@pytest.mark.asyncio
 async def test_chat_completions_rejects_streaming(app_with_router, monkeypatch):
     monkeypatch.setattr(
         router_module, "dispatch",

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -25,7 +25,7 @@ from sqlalchemy import text
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.db import dispose_db, get_db, init_db
 from mcp_proxy.egress import llm_chat_router as router_module
-from mcp_proxy.egress.ai_gateway import GatewayError, GatewayResult
+from mcp_proxy.egress.ai_gateway import GatewayError, GatewayResult, StreamingDispatch
 from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
 from mcp_proxy.egress.schemas import (
     ChatCompletionChoice,
@@ -384,11 +384,94 @@ async def test_chat_completions_rate_limit_disabled_when_zero(
     reset_agent_rate_limiter()
 
 
+def _parse_sse_frames(body: str) -> list[dict | str]:
+    """Split a raw SSE body into frame payloads.
+
+    Each ``data: ...\\n\\n`` becomes one entry: a parsed dict for JSON
+    payloads, the literal sentinel string ``[DONE]`` for the terminator.
+    Non-data lines (comments, ``event:``) are ignored — the gateway
+    never emits them, so any appearance is a regression.
+    """
+    frames: list[dict | str] = []
+    for raw in body.split("\n\n"):
+        line = raw.strip()
+        if not line:
+            continue
+        assert line.startswith("data: "), f"non-data SSE line: {line!r}"
+        payload = line[len("data: "):]
+        if payload == "[DONE]":
+            frames.append("[DONE]")
+        else:
+            frames.append(json.loads(payload))
+    return frames
+
+
+def _build_fake_streamer(
+    *,
+    chunks: list[dict],
+    prompt_tokens: int = 12,
+    completion_tokens: int = 3,
+    cost_usd: float | None = 0.000123,
+    upstream_request_id: str = "req_stream_1",
+    raise_mid: GatewayError | None = None,
+) -> "callable":
+    """Return an ``async`` ``dispatch_stream`` stub.
+
+    The returned callable matches the ``dispatch_stream`` signature and
+    yields the supplied chunks. The ``StreamingDispatch`` post-stream
+    fields are populated in the generator's ``finally`` so the router's
+    audit row sees the same numbers a real backend would write.
+    """
+
+    async def fake_dispatch_stream(**kwargs):
+        sd = StreamingDispatch(
+            backend="litellm_embedded",
+            provider="anthropic",
+            model=kwargs["req"].model,
+            trace_id=kwargs["trace_id"],
+        )
+
+        async def _aiter():
+            try:
+                for chunk in chunks:
+                    yield chunk
+                if raise_mid is not None:
+                    raise raise_mid
+            finally:
+                sd.prompt_tokens = prompt_tokens
+                sd.completion_tokens = completion_tokens
+                sd.cost_usd = cost_usd
+                sd.upstream_request_id = upstream_request_id
+                sd.latency_ms = 25
+
+        sd._aiter_factory = _aiter
+        return sd
+
+    return fake_dispatch_stream
+
+
 @pytest.mark.asyncio
-async def test_chat_completions_rejects_streaming(app_with_router, monkeypatch):
+async def test_chat_completions_streaming_happy_path(
+    app_with_router, monkeypatch,
+):
+    """stream=true returns text/event-stream, fans chunk dicts as SSE
+    frames, terminates with ``data: [DONE]``, and writes a single
+    success audit row with the stream's final token + cost numbers."""
+    chunks = [
+        {"id": "chatcmpl-stream-1", "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None},
+        ]},
+        {"id": "chatcmpl-stream-1", "choices": [
+            {"index": 0, "delta": {"content": "pong"}, "finish_reason": None},
+        ]},
+        {"id": "chatcmpl-stream-1", "choices": [
+            {"index": 0, "delta": {}, "finish_reason": "stop"},
+        ]},
+        {"id": "chatcmpl-stream-1", "choices": [],
+         "usage": {"prompt_tokens": 12, "completion_tokens": 3}},
+    ]
     monkeypatch.setattr(
-        router_module, "dispatch",
-        AsyncMock(return_value=_gateway_result()),
+        router_module, "dispatch_stream", _build_fake_streamer(chunks=chunks),
     )
 
     async with AsyncClient(
@@ -399,5 +482,206 @@ async def test_chat_completions_rejects_streaming(app_with_router, monkeypatch):
             json={**_request_body(), "stream": True},
         )
 
-    assert r.status_code == 400
-    assert "stream" in r.json()["detail"].lower()
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"].startswith("text/event-stream")
+    assert r.headers.get("x-cullis-trace", "").startswith("trace_")
+
+    frames = _parse_sse_frames(r.text)
+    assert frames[-1] == "[DONE]"
+    json_frames = [f for f in frames if isinstance(f, dict)]
+    assert len(json_frames) == 4
+    # cullis_trace_id is injected on every chunk so a downstream audit
+    # consumer can correlate even mid-stream.
+    for f in json_frames:
+        assert f["cullis_trace_id"].startswith("trace_")
+    # Content delta survived the round-trip.
+    deltas = [c["choices"][0]["delta"] for c in json_frames if c["choices"]]
+    assert {"content": "pong"} in deltas
+
+    rows = await _audit_rows("egress_llm_chat", status="success")
+    assert len(rows) == 1
+    detail = json.loads(rows[0]["detail"])
+    assert detail["stream"] is True
+    assert detail["prompt_tokens"] == 12
+    assert detail["completion_tokens"] == 3
+    assert detail["cost_usd"] == 0.000123
+    assert detail["upstream_request_id"] == "req_stream_1"
+    assert detail["backend"] == "litellm_embedded"
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_consumes_tokens_post_drain(
+    app_with_router, monkeypatch,
+):
+    """The per-principal token budget is consumed only after the stream
+    drains (the upstream usage chunk is the source of truth). A peek
+    before the request shows zero, after shows prompt + completion."""
+    from mcp_proxy.auth.rate_limit import (
+        get_token_sum_limiter, reset_agent_rate_limiter,
+    )
+
+    reset_agent_rate_limiter()
+    limiter = get_token_sum_limiter()
+    bucket = "principal:orga::alice:llm_tokens"
+    assert await limiter.peek(bucket) == 0
+
+    monkeypatch.setattr(
+        router_module, "dispatch_stream",
+        _build_fake_streamer(chunks=[
+            {"id": "x", "choices": [
+                {"index": 0, "delta": {"content": "hi"}, "finish_reason": None},
+            ]},
+            {"id": "x", "choices": [],
+             "usage": {"prompt_tokens": 7, "completion_tokens": 2}},
+        ], prompt_tokens=7, completion_tokens=2),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 200, r.text
+    # Drain happened — bucket reflects 7 + 2.
+    assert await limiter.peek(bucket) == 9
+
+    reset_agent_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_pre_flight_rate_limit(
+    app_with_router, monkeypatch,
+):
+    """The token-budget gate runs BEFORE the stream is opened, so an
+    over-budget principal gets a synchronous 429 (no SSE response). This
+    keeps the rejection cheap and surfacable to OpenAI-shape clients
+    that special-case the JSON body before flipping into SSE mode."""
+    from mcp_proxy.auth.rate_limit import (
+        get_token_sum_limiter, reset_agent_rate_limiter,
+    )
+    from mcp_proxy.config import get_settings
+
+    reset_agent_rate_limiter()
+    monkeypatch.setenv("MCP_PROXY_LLM_TOKENS_PER_MINUTE", "100")
+    get_settings.cache_clear()
+
+    await get_token_sum_limiter().consume(
+        "principal:orga::alice:llm_tokens", 100,
+    )
+
+    monkeypatch.setattr(
+        router_module, "dispatch_stream",
+        _build_fake_streamer(chunks=[]),  # never reached
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 429, r.text
+    assert r.headers["content-type"].startswith("application/json")
+
+    rows = await _audit_rows("egress_llm_chat", status="error")
+    assert len(rows) == 1
+    detail = json.loads(rows[0]["detail"])
+    assert detail["reason"] == "local_rate_limited_tokens"
+    assert detail["stream"] is True
+
+    reset_agent_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_upstream_error_mid_stream(
+    app_with_router, monkeypatch,
+):
+    """Once the SSE response is open, a mid-stream upstream failure can't
+    be turned back into HTTP 5xx. The handler emits one terminal SSE
+    frame ``data: {"error":...}`` so OpenAI-shape clients see a
+    terminator, then writes an error audit row with whatever tokens were
+    counted so ops can scope the cost of the partial call."""
+    chunks = [
+        {"id": "chatcmpl-err", "choices": [
+            {"index": 0, "delta": {"content": "partial"}, "finish_reason": None},
+        ]},
+    ]
+    monkeypatch.setattr(
+        router_module, "dispatch_stream",
+        _build_fake_streamer(
+            chunks=chunks,
+            prompt_tokens=5,
+            completion_tokens=1,
+            raise_mid=GatewayError(
+                502, "provider_internal_error", detail="upstream 500 mid-stream",
+            ),
+        ),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    # The HTTP status is already 200 by the time the body errors —
+    # this is the SSE contract.
+    assert r.status_code == 200
+    frames = _parse_sse_frames(r.text)
+    assert "[DONE]" not in frames
+    err_frame = frames[-1]
+    assert isinstance(err_frame, dict) and "error" in err_frame
+    assert err_frame["error"]["type"] == "provider_internal_error"
+    assert err_frame["error"]["trace_id"].startswith("trace_")
+
+    rows = await _audit_rows("egress_llm_chat", status="error")
+    assert len(rows) == 1
+    detail = json.loads(rows[0]["detail"])
+    assert detail["reason"] == "provider_internal_error"
+    assert detail["stream"] is True
+    # Token counters from the partial stream survive into the audit row
+    # so cost-attribution dashboards don't lose the burn.
+    assert detail["prompt_tokens"] == 5
+    assert detail["completion_tokens"] == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_setup_error_returns_json(
+    app_with_router, monkeypatch,
+):
+    """A configuration-time GatewayError raised by ``dispatch_stream``
+    BEFORE any chunk is yielded becomes a synchronous JSON HTTP error,
+    not an SSE frame — the SSE response was never opened."""
+
+    async def boom(**_kwargs):
+        raise GatewayError(
+            503, "provider_key_missing", detail="anthropic_api_key not set",
+        )
+
+    monkeypatch.setattr(router_module, "dispatch_stream", boom)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 503, r.text
+    assert r.headers["content-type"].startswith("application/json")
+    body = r.json()
+    assert body["detail"]["reason"] == "provider_key_missing"
+
+    rows = await _audit_rows("egress_llm_chat", status="error")
+    assert len(rows) == 1
+    detail = json.loads(rows[0]["detail"])
+    assert detail["reason"] == "provider_key_missing"
+    assert detail["stream"] is True

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -162,6 +162,8 @@ async def test_chat_completions_happy_path_writes_audit(app_with_router, monkeyp
     assert rows[0]["agent_id"] == "orga::alice"
     detail = json.loads(rows[0]["detail"])
     assert detail["event"] == "llm.chat_completion"
+    assert detail["principal_id"] == "orga::alice"
+    assert detail["principal_type"] == "agent"
     assert detail["backend"] == "litellm_embedded"
     assert detail["provider"] == "anthropic"
     assert detail["model"] == "claude-haiku-4-5"
@@ -172,6 +174,45 @@ async def test_chat_completions_happy_path_writes_audit(app_with_router, monkeyp
     assert detail["upstream_request_id"] == "req_abc"
     assert detail["cache_hit"] is False
     assert detail["trace_id"].startswith("trace_")
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_user_principal_recorded(app_with_router, monkeypatch):
+    """Frontdesk shared-mode flow: when the auth dep yields a user
+    principal (not an agent), the audit row reflects principal_type=user
+    so per-principal cost aggregation in Phase B can split user vs agent
+    spend without ambiguity."""
+    user_principal = InternalAgent(
+        agent_id="orga::user::daniele",
+        display_name="daniele",
+        capabilities=["llm.chat"],
+        created_at="2026-05-06T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt="jkt-user",
+        reach="both",
+        principal_type="user",
+    )
+    app_with_router.dependency_overrides[get_agent_from_dpop_client_cert] = (
+        lambda: user_principal
+    )
+    monkeypatch.setattr(
+        router_module, "dispatch",
+        AsyncMock(return_value=_gateway_result()),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/chat/completions", json=_request_body())
+
+    assert r.status_code == 200, r.text
+
+    rows = await _audit_rows("egress_llm_chat", status="success")
+    assert len(rows) == 1
+    detail = json.loads(rows[0]["detail"])
+    assert detail["principal_id"] == "orga::user::daniele"
+    assert detail["principal_type"] == "user"
 
 
 @pytest.mark.asyncio
@@ -217,6 +258,8 @@ async def test_chat_completions_gateway_error_surfaces_status(app_with_router, m
     assert len(rows) == 1
     detail = json.loads(rows[0]["detail"])
     assert detail["event"] == "llm.chat_completion"
+    assert detail["principal_id"] == "orga::alice"
+    assert detail["principal_type"] == "agent"
     assert detail["reason"] == "upstream_timeout"
     assert detail["backend"] == "litellm_embedded"
     assert detail["provider"] == "anthropic"

--- a/tests/test_rate_limit_token_sum.py
+++ b/tests/test_rate_limit_token_sum.py
@@ -1,0 +1,76 @@
+"""Phase A.3 — InMemoryTokenSumLimiter unit tests.
+
+Validates the weighted sliding-window contract: peek returns the sum
+of un-evicted weights, consume registers a new weight at the current
+timestamp, and expired entries (older than the window) are dropped on
+both operations. The Redis backend goes through the same Protocol but
+needs a live Redis to test; that lands in Phase A.4 dogfood.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from mcp_proxy.auth.rate_limit import InMemoryTokenSumLimiter
+
+
+@pytest.mark.asyncio
+async def test_peek_empty_returns_zero():
+    lim = InMemoryTokenSumLimiter()
+    assert await lim.peek("principal:alice:llm_tokens") == 0
+
+
+@pytest.mark.asyncio
+async def test_consume_then_peek_returns_sum():
+    lim = InMemoryTokenSumLimiter()
+    await lim.consume("k", 100)
+    await lim.consume("k", 250)
+    await lim.consume("k", 50)
+    assert await lim.peek("k") == 400
+
+
+@pytest.mark.asyncio
+async def test_consume_zero_or_negative_is_noop():
+    lim = InMemoryTokenSumLimiter()
+    await lim.consume("k", 0)
+    await lim.consume("k", -5)
+    assert await lim.peek("k") == 0
+
+
+@pytest.mark.asyncio
+async def test_keys_are_isolated():
+    lim = InMemoryTokenSumLimiter()
+    await lim.consume("alice", 100)
+    await lim.consume("bob", 200)
+    assert await lim.peek("alice") == 100
+    assert await lim.peek("bob") == 200
+    assert await lim.peek("carol") == 0
+
+
+@pytest.mark.asyncio
+async def test_window_eviction_drops_stale_entries(monkeypatch):
+    """Entries older than 60s drop out on the next peek/consume."""
+    lim = InMemoryTokenSumLimiter()
+
+    # Pin time.monotonic so we can move forward deterministically.
+    fake_now = [1000.0]
+    monkeypatch.setattr(
+        "mcp_proxy.auth.rate_limit.time.monotonic", lambda: fake_now[0],
+    )
+
+    await lim.consume("k", 100)
+    assert await lim.peek("k") == 100
+
+    # Advance just inside the window — still counts.
+    fake_now[0] += 30.0
+    await lim.consume("k", 50)
+    assert await lim.peek("k") == 150
+
+    # Advance past the window for the first entry only.
+    fake_now[0] += 31.0  # total +61s vs first entry
+    assert await lim.peek("k") == 50
+
+    # Advance past everything.
+    fake_now[0] += 60.0
+    assert await lim.peek("k") == 0

--- a/tests/test_rate_limit_token_sum.py
+++ b/tests/test_rate_limit_token_sum.py
@@ -8,8 +8,6 @@ needs a live Redis to test; that lands in Phase A.4 dogfood.
 """
 from __future__ import annotations
 
-import time
-
 import pytest
 
 from mcp_proxy.auth.rate_limit import InMemoryTokenSumLimiter


### PR DESCRIPTION
## Summary

Two stacked features on the native AI gateway (ADR-017):

**Phase A floor — per-principal observability + spending guardrail**
- `fb4277e` `log_audit` gains a structured `details` kwarg (canonical JSON, hash chain intact). `GatewayResult` carries `prompt_tokens` / `completion_tokens` / `cost_usd` first-class. Both LLM chat routers emit a `llm.chat_completion` event row with model + latency + tokens + cost + trace_id + cache_hit.
- `01d21be` Audit row carries `principal_id` + `principal_type` (ADR-020) so per-principal cost aggregation splits user vs agent vs workload spend without ambiguity.
- `a33b883` `TokenSumLimiter` tracks a 60s sliding sum of (prompt + completion) tokens per principal. Pre-call 429 when over budget, post-call consume records actual usage. `MCP_PROXY_LLM_TOKENS_PER_MINUTE` (default 100k, `=0` disables).

**Phase 5 — SSE streaming pass-through (`stream=true`)**
- `7b69d5f` Until this commit, `stream=true` was synchronously rejected with HTTP 400 and the Connector papered over it with a fake-stream wrapper. Now `dispatch_stream` returns a `StreamingDispatch` whose `aiter()` yields OpenAI-shape chunks via `litellm.acompletion(stream=True, stream_options={"include_usage": True})`. Router emits `data: {json}\n\n` frames + `data: [DONE]`. Mid-stream upstream errors emit a single `data: {"error":...}` terminator and an error audit row that preserves the partial token counts. Configuration-time errors stay synchronous JSON. Pre-flight token-budget gate is sync 429 (no SSE response).
- `9d8e0ef` Streaming cost via `litellm.cost_per_token` (the explicit "I have the totals" API). The completion_response is consumed by the time finally runs, so the non-stream path's `completion_cost(completion_response=)` doesn't apply.

## Differentiation hook (not feature parity)

Wherever Portkey writes `cost per virtual key`, Mastio writes `cost per principal` (with SPIFFE path, org, principal_type from ADR-020). The audit row schema is the leverage; UI / aggregation views land in Phase B without backend rework.

## Test plan
- [x] `pytest tests/test_proxy_llm_chat_router.py` — 12/12 green (7 Phase A + 5 streaming: happy path, post-drain consume, pre-flight 429, mid-stream upstream error, setup-error JSON).
- [x] `nix-build tests/integration/cullis_network -A tier1-roma` — green 25s on rebased branch.
- [x] **Live dogfood** against Anthropic Haiku 4.5 (`imp/dogfood_streaming.py`): 4 chunks, content "pong" delivered, prompt_tokens=13, completion_tokens=5, cost_usd=$3.8e-05, latency 937ms.
- [ ] Full unit suite + `./smoke.sh full` — deferred to pre-merge.

## Out of scope (Phase B / C / D)
- Admin UI cost dashboard per principal / per model (Phase B)
- Cache exact-match TTL 5min
- PII redaction regex opt-in
- Promotion of `principal_id` from JSON to a dedicated audit column (lands when an aggregation workload demands it)
- Portkey streaming (returns 501; default backend is `litellm_embedded`)
- Connector ambassador `fake_stream` → real pass-through refactor (separate PR; `cullis_connector/ambassador/streaming.py` already documents the migration)
- ADR-0023 LLM Gateway floor decisional doc (Phase D, post-merge)

## Race caveat

The pre-call peek on the token budget does not reserve quota; two concurrent requests can each pass the gate without seeing each other's pending consumption. Acceptable overshoot for the MVP floor; a reservation step lands when the budget overrun becomes operationally relevant.