### PR TITLE
feat(test): mock LLM + mock MCP postgres servers, tier1 demo path

### DIFF
--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -16,6 +16,14 @@
 { config, pkgs, lib, ... }:
 
 {
+  # Mock LLM + Mock MCP postgres servers, gated behind
+  # ``cullis.mastio.enableMockServices`` (default off). Imported
+  # unconditionally so callers get the option set even when they
+  # leave it disabled — the actual systemd units only land when
+  # ``cullis.mockServices.enable`` flips true via the wiring at
+  # the bottom of ``config = …``.
+  imports = [ ./mock-services.nix ];
+
   options.cullis.mastio = with lib; {
     enable = mkEnableOption "Cullis Mastio (broker + proxy + nginx)";
 
@@ -29,6 +37,19 @@
         ship as small derivations in ``lib/python-deps.nix`` next
         to this module. Flip off only when sharpening a test that
         doesn't need the broker.
+      '';
+    };
+
+    enableMockServices = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Stand up a tiny mock LLM (port 11434, OpenAI-compat) and a
+        mock MCP postgres backend (port 11435) on loopback inside
+        the VM so the testScript can drive a daniele@user → tool
+        use → MCP query flow without an Anthropic API key or a
+        real Postgres. Off by default — Tier 1 baseline doesn't
+        need it; the demo path flips it on.
       '';
     };
 
@@ -193,6 +214,16 @@
       # callers actually hit.
       networking.firewall.allowedTCPPorts = [ cfg.nginxPort ];
 
+      # Forward the mock-services toggle. ``cullis.mockServices``
+      # is defined in ``mock-services.nix`` (imported above);
+      # passing ``pythonEnv`` here lets the mock services reuse
+      # the same closure (fastapi + uvicorn + everything else)
+      # the broker / proxy already pulled in — no doubling.
+      cullis.mockServices = {
+        enable = cfg.enableMockServices;
+        inherit pythonEnv;
+      };
+
       # Make the Cullis-flavoured Python interpreter (with fastapi /
       # uvicorn / cryptography / cullis_sdk deps) available as
       # ``python3`` system-wide, plus the CLI tools the testScript
@@ -329,6 +360,19 @@
           MCP_PROXY_ADMIN_SECRET = cfg.adminSecret;
           MCP_PROXY_DATABASE_URL = "sqlite+aiosqlite:///${stateDir}/proxy.sqlite";
           MCP_PROXY_BROKER_URL = "http://127.0.0.1:${toString cfg.brokerPort}";
+        } // lib.optionalAttrs cfg.enableMockServices {
+          # Point the AI gateway at the mock LLM. We use the
+          # ``portkey`` backend wrapper because it honours
+          # ``ai_gateway_url`` directly (the ``litellm_embedded``
+          # branch baked-in routes upstream); the mock serves the
+          # exact same OpenAI-compat endpoint, so the headers
+          # Portkey adds are ignored harmlessly.
+          MCP_PROXY_AI_GATEWAY_BACKEND = "portkey";
+          MCP_PROXY_AI_GATEWAY_URL = "http://127.0.0.1:11434";
+          # Portkey's ``provider_key_missing`` guard rejects empty
+          # values, so feed it a sentinel — the mock never reads
+          # the bearer.
+          MCP_PROXY_ANTHROPIC_API_KEY = "mock-key-not-checked";
         };
         serviceConfig = {
           Type = "simple";

--- a/tests/integration/cullis_network/lib/mock-services.nix
+++ b/tests/integration/cullis_network/lib/mock-services.nix
@@ -1,0 +1,329 @@
+# Mock LLM + Mock MCP backend for the Tier 1 demo path.
+#
+# Real Anthropic / Postgres connections are out of scope for the
+# nixosTest sandbox (offline by design, no API keys in the closure).
+# Instead we stand up two tiny FastAPI services that play the role
+# of the upstream backends:
+#
+#   cullis-mock-llm        port 11434, OpenAI-compat
+#                          /v1/chat/completions returns a tool_use
+#                          call on the ``query`` tool first, then a
+#                          natural-language wrap-up once the
+#                          ``role=tool`` reply lands.
+#
+#   cullis-mock-mcp-postgres  port 11435, MCP HTTP transport
+#                             tools/list returns ``[{query}]``,
+#                             tools/call name=query echoes back
+#                             ``Mario Rossi: gdpr_training_completed=true``.
+#
+# The pair is what lets the testScript exercise the same daniele@user
+# → litellm → tool_use → MCP postgres flow PR #445 verified live on
+# the docker compose sandbox, but inside a kernel-isolated VM with no
+# outbound network.
+{ config, pkgs, lib, ... }:
+
+let
+  py = pkgs.python311;
+
+  mockLlmScript = pkgs.writeText "cullis-mock-llm.py" ''
+    """Mock LLM that mimics the slice of the OpenAI Chat Completions
+    API the Cullis litellm pipeline drives.
+
+    State machine (per request):
+      - First call (no tool messages) → return ``tool_calls`` with a
+        single ``query`` invocation against the Postgres MCP. This
+        triggers the tool_use loop in Cullis Chat / our test
+        harness.
+      - Follow-up call (has ``role=tool`` reply) → return a plain
+        text completion that quotes the tool result so the
+        testScript can assert on a deterministic payload.
+
+    Listens on 127.0.0.1:11434. No auth — the VM only exposes it
+    on loopback, the Mastio's litellm reaches it as a sibling
+    systemd unit.
+    """
+    from __future__ import annotations
+    import json
+    import os
+    import time
+    import uuid
+    from fastapi import FastAPI, Request
+
+    app = FastAPI(title="cullis-mock-llm")
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/v1/chat/completions")
+    async def chat(request: Request):
+        body = await request.json()
+        messages = body.get("messages", [])
+        # Detect whether we are on the second call (tool result has
+        # come back). The Cullis loop emits ``role=tool`` messages
+        # carrying the MCP output.
+        has_tool_reply = any(m.get("role") == "tool" for m in messages)
+        now = int(time.time())
+        cid = "chatcmpl-" + uuid.uuid4().hex[:16]
+
+        if has_tool_reply:
+            # Pull the last tool message and quote it so the
+            # testScript's assertion is deterministic.
+            tool_msgs = [m for m in messages if m.get("role") == "tool"]
+            tool_text = ""
+            for m in tool_msgs:
+                content = m.get("content")
+                if isinstance(content, str):
+                    tool_text = content
+                elif isinstance(content, list):
+                    for block in content:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            tool_text = block.get("text", "")
+                            break
+            return {
+                "id": cid,
+                "object": "chat.completion",
+                "created": now,
+                "model": body.get("model", "claude-haiku-4-5"),
+                "choices": [{
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": (
+                            "Result from the compliance database: "
+                            + tool_text
+                        ),
+                    },
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "total_tokens": 120,
+                },
+            }
+
+        # First call → emit a tool_calls message asking for the
+        # ``query`` tool. The arguments JSON mirrors what a real
+        # Haiku would emit when asked about Mario Rossi.
+        return {
+            "id": cid,
+            "object": "chat.completion",
+            "created": now,
+            "model": body.get("model", "claude-haiku-4-5"),
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_" + uuid.uuid4().hex[:12],
+                        "type": "function",
+                        "function": {
+                            "name": "query",
+                            "arguments": json.dumps({
+                                "sql": (
+                                    "SELECT name, gdpr_training_completed "
+                                    "FROM compliance_status "
+                                    "WHERE name = 'Mario Rossi'"
+                                ),
+                            }),
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {
+                "prompt_tokens": 50,
+                "completion_tokens": 30,
+                "total_tokens": 80,
+            },
+        }
+
+
+    if __name__ == "__main__":
+        import uvicorn
+        uvicorn.run(
+            "__main__:app",
+            host="127.0.0.1",
+            port=int(os.environ.get("PORT", "11434")),
+        )
+  '';
+
+  mockMcpScript = pkgs.writeText "cullis-mock-mcp-postgres.py" ''
+    """Mock MCP HTTP backend for the Postgres ``query`` tool.
+
+    Implements the slice of the Streamable-HTTP MCP transport the
+    proxy reverse-proxy forwarder hits in production:
+
+      POST /mcp   JSON-RPC 2.0
+        method=initialize    → server info + protocolVersion
+        method=tools/list    → [{name:"query", inputSchema:{...}}]
+        method=tools/call    → name=query → text echo of the
+                               compliance row daniele@user is
+                               authorised to read.
+
+    Listens on 127.0.0.1:11435. The Mastio's local registration
+    points at this URL via the seed step in cullis-mastio.nix.
+    """
+    from __future__ import annotations
+    from fastapi import FastAPI, Request
+    from fastapi.responses import JSONResponse
+
+    app = FastAPI(title="cullis-mock-mcp-postgres")
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/mcp")
+    async def mcp(request: Request):
+        body = await request.json()
+        method = body.get("method")
+        rid = body.get("id")
+        if method == "initialize":
+            return {
+                "jsonrpc": "2.0",
+                "id": rid,
+                "result": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "mock-postgres",
+                        "version": "0.1.0",
+                    },
+                },
+            }
+        if method == "tools/list":
+            return {
+                "jsonrpc": "2.0",
+                "id": rid,
+                "result": {
+                    "tools": [{
+                        "name": "query",
+                        "description": (
+                            "Run a read-only SQL query against the "
+                            "compliance_status demo table."
+                        ),
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "sql": {"type": "string"},
+                            },
+                            "required": ["sql"],
+                        },
+                    }],
+                },
+            }
+        if method == "tools/call":
+            params = body.get("params", {}) or {}
+            name = params.get("name")
+            if name != "query":
+                return JSONResponse({
+                    "jsonrpc": "2.0",
+                    "id": rid,
+                    "error": {
+                        "code": -32601,
+                        "message": f"Tool {name!r} not found",
+                    },
+                })
+            return {
+                "jsonrpc": "2.0",
+                "id": rid,
+                "result": {
+                    "content": [{
+                        "type": "text",
+                        "text": (
+                            "name=Mario Rossi, "
+                            "gdpr_training_completed=true"
+                        ),
+                    }],
+                    "isError": False,
+                },
+            }
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "id": rid,
+            "error": {
+                "code": -32601,
+                "message": f"Method {method!r} not supported",
+            },
+        })
+
+
+    if __name__ == "__main__":
+        import os
+        import uvicorn
+        uvicorn.run(
+            "__main__:app",
+            host="127.0.0.1",
+            port=int(os.environ.get("PORT", "11435")),
+        )
+  '';
+
+in
+{
+  options.cullis.mockServices = with lib; {
+    enable = mkEnableOption "Cullis mock LLM + mock MCP postgres";
+
+    pythonEnv = mkOption {
+      type = types.package;
+      description = ''
+        Python interpreter that already has fastapi + uvicorn in its
+        site-packages. The cullis.mastio module passes its
+        ``pythonEnv`` here so we don't double-build the closure.
+      '';
+    };
+
+    llmPort = mkOption {
+      type = types.port;
+      default = 11434;
+    };
+
+    mcpPort = mkOption {
+      type = types.port;
+      default = 11435;
+    };
+  };
+
+  config = lib.mkIf config.cullis.mockServices.enable (
+    let
+      cfg = config.cullis.mockServices;
+      pyBin = "${cfg.pythonEnv}/bin/python";
+    in
+    {
+      systemd.services.cullis-mock-llm = {
+        description = "Cullis mock LLM (OpenAI-compat /v1/chat/completions)";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        environment.PORT = toString cfg.llmPort;
+        serviceConfig = {
+          Type = "simple";
+          # Each script's ``__main__`` block hands itself to
+          # ``uvicorn.run("__main__:app", ...)``. Avoids the
+          # ``--app-dir`` + module-name dance that the Nix-store
+          # filename (``<hash>-cullis-mock-llm.py``, hyphens not
+          # legal in Python module names) makes painful.
+          ExecStart = "${pyBin} ${mockLlmScript}";
+          DynamicUser = true;
+          Restart = "on-failure";
+          RestartSec = "2s";
+        };
+      };
+
+      systemd.services.cullis-mock-mcp-postgres = {
+        description = "Cullis mock MCP HTTP backend (Postgres ``query``)";
+        wantedBy = [ "multi-user.target" ];
+        after = [ "network.target" ];
+        environment.PORT = toString cfg.mcpPort;
+        serviceConfig = {
+          Type = "simple";
+          ExecStart = "${pyBin} ${mockMcpScript}";
+          DynamicUser = true;
+          Restart = "on-failure";
+          RestartSec = "2s";
+        };
+      };
+    }
+  );
+}

--- a/tests/integration/cullis_network/tier1-roma.nix
+++ b/tests/integration/cullis_network/tier1-roma.nix
@@ -123,6 +123,12 @@ pkgs.testers.nixosTest {
 
     cullis.mastio = {
       enable = true;
+      enableBroker = true;
+      # Stand up the mock LLM (port 11434) + mock MCP postgres
+      # (port 11435) on loopback so the testScript can drive a
+      # daniele@user → tool_use → MCP query flow without an
+      # Anthropic API key or a real Postgres in the closure.
+      enableMockServices = true;
       cullisSrc = cullisSrc;
       orgId = "roma";
       trustDomain = "roma.cullis.test";
@@ -173,6 +179,61 @@ pkgs.testers.nixosTest {
         "curl -fs http://127.0.0.1:8000/health",
         timeout=30,
     )
+
+    # Mock LLM + Mock MCP postgres land under
+    # ``cullis-mock-llm.service`` + ``cullis-mock-mcp-postgres.service``
+    # whenever ``enableMockServices = true`` (Tier 1 demo path).
+    # Health-probe both before driving traffic through them so a
+    # systemd ordering glitch surfaces here, not as a vague 503
+    # mid-chat.
+    roma.wait_for_unit("cullis-mock-llm.service")
+    roma.wait_for_unit("cullis-mock-mcp-postgres.service")
+    roma.wait_until_succeeds(
+        "curl -fs http://127.0.0.1:11434/health", timeout=30,
+    )
+    roma.wait_until_succeeds(
+        "curl -fs http://127.0.0.1:11435/health", timeout=30,
+    )
+
+    with subtest("Mock LLM + MCP postgres reachable"):
+        # tools/list against the mock MCP returns the ``query`` tool.
+        out = roma.succeed(
+            "curl -fs -X POST http://127.0.0.1:11435/mcp "
+            "-H 'Content-Type: application/json' "
+            "-d '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}'"
+        )
+        assert '"name":"query"' in out, out
+
+        # Mock LLM smoke — first call should yield tool_calls.
+        out = roma.succeed(
+            "curl -fs -X POST http://127.0.0.1:11434/v1/chat/completions "
+            "-H 'Content-Type: application/json' "
+            "-d '{\"model\":\"claude-haiku-4-5\","
+            "\"messages\":[{\"role\":\"user\",\"content\":\"Mario Rossi\"}]}'"
+        )
+        assert '"tool_calls"' in out, out
+        assert '"name": "query"' in out or '\"name\":\"query\"' in out, out
+
+    with subtest("E2E demo: register MCP resource via admin API"):
+        # Drive the actual demo wire: register the mock MCP backend
+        # as an org resource on the proxy. From here a Cullis Chat
+        # client (or the SDK) could ``tools/list`` and ``tools/call``
+        # ``query`` against it — the chat-loop slice (binding +
+        # token + ``/v1/llm/chat``) graduates with the user-flow
+        # nginx mTLS triage tracked above.
+        admin_register = roma.succeed(
+            "curl -fsk -X POST "
+            "https://mastio.roma.cullis.test:9443/v1/admin/mcp-resources "
+            "-H 'X-Admin-Secret: test-admin-secret' "
+            "-H 'Content-Type: application/json' "
+            "-d '{\"name\":\"query\","
+            "\"endpoint_url\":\"http://127.0.0.1:11435/mcp\","
+            "\"description\":\"Mock postgres MCP — compliance_status\","
+            "\"required_capability\":\"sql.read\","
+            "\"allowed_domains\":[\"127.0.0.1\"]}'"
+        )
+        assert '"resource_id"' in admin_register, admin_register
+        print(f"  registered mock MCP resource: {admin_register[:120]}…")
 
     with subtest("Broker import surface (a2a-sdk derivation works)"):
         # ``app/main.py`` imports ``a2a-sdk``, ``opentelemetry``,


### PR DESCRIPTION
## Summary

- Two tiny FastAPI services (mock LLM port 11434, mock MCP postgres port 11435) on loopback inside the Tier 1 nixosTest VM. Together they let the testScript drive the *same* daniele@user → tool_use → MCP query flow PR #445 verified live on the docker compose sandbox, but with no outbound network and no Anthropic API key in the closure.
- New ``cullis.mastio.enableMockServices`` flag (default off). Tier 1 flips it on; the demo path is the test path.

## Wire

- ``lib/mock-services.nix`` — both scripts shipped as ``pkgs.writeText`` derivations and run via ``python <file>`` (each script's ``__main__`` block hands itself to ``uvicorn.run("__main__:app", …)``).
- ``cullis-mastio.nix`` imports the new module unconditionally, forwards ``cullis.mockServices.{enable, pythonEnv}`` so the mocks reuse the broker's python env (no double-build), and points the proxy's AI gateway at the mock when ``enableMockServices = true``.

## Live result

```
roma: cullis-mock-llm.service                  0.07s
roma: cullis-mock-mcp-postgres.service         0.06s
PASS Mock LLM + MCP postgres reachable         0.08s
PASS E2E demo: register MCP resource           0.07s
PASS Broker import surface                     1.05s
TOTAL VM run                                  20.18s
EXIT=0
```

## Deferred

Driver-side daniele@user → ``/v1/llm/chat`` call that actually rides the mock LLM + mock MCP through the agent auth + binding stack. Needs the nginx mTLS + ``copy_from_vm`` shuttle fixes the Tier 2 commit messages flagged. Once those land, the existing helper + the registered ``query`` resource stitch into a green E2E assertion (``response contains 'Mario Rossi'`` + audit row carries ``principal_type=user``).

## Stack / linked work

- Sits on main post-#451 (CI workflow). Sibling slice for the federation publisher (Tier 2 cross-org A2A) lands next.
- Once both mock services are merged and the user-flow nginx triage closes, the demo screencast can record a single nix-build run that covers Roma intra-org AND Tier 2 cross-continent — which is the pitch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)