### PR TITLE
feat(test): tier2 federation publisher wired (cities to Court broker)

### DIFF
--- a/.github/workflows/nixos-tests.yml
+++ b/.github/workflows/nixos-tests.yml
@@ -107,10 +107,14 @@ jobs:
           ls -la /dev/kvm
 
       - name: Build + run nixosTest
+        # ``--print-build-logs`` (and its ``-L`` short form) belong to
+        # the new ``nix`` CLI; ``nix-build`` (the legacy command we
+        # use here for stability) doesn't accept them and exits with
+        # ``error: unrecognised flag``. Logs already stream to stderr
+        # by default, so dropping the flag costs nothing.
         run: |
           nix-build tests/integration/cullis_network \
             -A ${{ matrix.scenario }} \
-            --print-build-logs \
             --keep-going
 
       # If the test run fails, dump the on-VM journals + the test

--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -85,6 +85,32 @@
         real deployment threads this through a secret manager.
       '';
     };
+
+    brokerUrl = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Override the proxy's ``MCP_PROXY_BROKER_URL``. When empty
+        (default), the proxy points at the loopback broker
+        (``http://127.0.0.1:<brokerPort>``) — fine for the Tier 1
+        single-VM demo. For cross-org topologies (Tier 2) the
+        cities point at the Court VM via this knob so the
+        federation publisher pushes agents to the central
+        registry. The proxy uses the same URL for both local agent
+        auth and federation publish (current shape — a future
+        refactor may split them).
+      '';
+    };
+
+    nginxAllowExternal = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Open the broker port on 0.0.0.0 instead of 127.0.0.1 and
+        add it to ``firewall.allowedTCPPorts``. The Tier 2 Court
+        VM flips this on so peers can publish to it.
+      '';
+    };
   };
 
   config = lib.mkIf config.cullis.mastio.enable (
@@ -191,7 +217,9 @@
       # testScript hits ``NameError``. The nginx vhost listens on
       # ``mastio.${trustDomain}`` regardless — that's the FQDN
       # callers actually hit.
-      networking.firewall.allowedTCPPorts = [ cfg.nginxPort ];
+      networking.firewall.allowedTCPPorts =
+        [ cfg.nginxPort ]
+        ++ lib.optional cfg.nginxAllowExternal cfg.brokerPort;
 
       # Make the Cullis-flavoured Python interpreter (with fastapi /
       # uvicorn / cryptography / cullis_sdk deps) available as
@@ -305,7 +333,8 @@
           WorkingDirectory = "${cullisSrcStore}";
           ExecStart =
             "${pyEnvBin} -m uvicorn app.main:app "
-            + "--host 127.0.0.1 --port ${toString cfg.brokerPort}";
+            + "--host ${if cfg.nginxAllowExternal then "0.0.0.0" else "127.0.0.1"} "
+            + "--port ${toString cfg.brokerPort}";
           Restart = "on-failure";
           RestartSec = "2s";
         };
@@ -328,7 +357,15 @@
           PROXY_TRUST_DOMAIN = cfg.trustDomain;
           MCP_PROXY_ADMIN_SECRET = cfg.adminSecret;
           MCP_PROXY_DATABASE_URL = "sqlite+aiosqlite:///${stateDir}/proxy.sqlite";
-          MCP_PROXY_BROKER_URL = "http://127.0.0.1:${toString cfg.brokerPort}";
+          MCP_PROXY_BROKER_URL =
+            if cfg.brokerUrl != ""
+            then cfg.brokerUrl
+            else "http://127.0.0.1:${toString cfg.brokerPort}";
+          # Federation publisher tail to the broker we just pointed
+          # at. ``PROXY_FEDERATION_SYNC=true`` flips the long-lived
+          # publisher task that pushes ``internal_agents`` rows to
+          # ``/v1/federation/publish-agent`` every tick.
+          PROXY_FEDERATION_SYNC = "true";
         };
         serviceConfig = {
           Type = "simple";

--- a/tests/integration/cullis_network/tier2-cross-org.nix
+++ b/tests/integration/cullis_network/tier2-cross-org.nix
@@ -72,21 +72,29 @@ let
 
     cullis.mastio = {
       enable = true;
+      # Court is the federation hub — only it needs the broker
+      # bound on the world-facing interface so peers can reach
+      # ``/v1/federation/publish-agent``. Cities run a local
+      # broker just for their own agent auth, but the
+      # ``federation publisher`` task on each city points its
+      # publish loop at Court via ``brokerUrl``.
       enableBroker = true;
+      nginxAllowExternal = name == "court";
+      brokerUrl =
+        if name == "court"
+        then ""  # local loopback default — Court IS the broker
+        else "http://court:8000";  # peers publish to Court
       cullisSrc = cullisSrc;
       inherit (cfg) orgId trustDomain displayName;
     };
 
     # Each city resolves its own ``mastio.<td>`` to loopback so the
     # local SDK / test driver can curl over the TLS port without
-    # going through DNS. Cross-VM connectivity uses the test
-    # framework's vlan + IP; we don't need to teach the cities
-    # about each other's FQDNs at the DNS layer for this slice.
+    # going through DNS. ``court`` resolves on every city so
+    # ``brokerUrl=http://court:8000`` works without static IPs.
     networking.extraHosts = ''
       127.0.0.1 mastio.${cfg.trustDomain}
     '';
-
-    networking.firewall.allowedTCPPorts = [ 9443 ];
   };
 
 in
@@ -166,6 +174,22 @@ pkgs.testers.nixosTest {
             f"Roma → Tokyo TCP handshake failed (curl http_code={http_code!r})"
         )
         print(f"  Roma → Tokyo cross-VM HTTPS: {http_code}")
+
+    with subtest("Federation publisher: cities reach Court's broker"):
+        # Each city's proxy points its ``MCP_PROXY_BROKER_URL`` at
+        # ``http://court:8000``; the federation publisher tail
+        # POSTs ``/v1/federation/publish-agent`` on each tick.
+        # Probing from inside roma confirms the route is up — the
+        # actual publish payload graduates with the agent enroll
+        # path (next slice on this branch family).
+        for c in [roma, sanfrancisco, tokyo]:
+            health = c.succeed(
+                "curl -fs http://court:8000/health || echo OFFLINE"
+            ).strip()
+            assert "OFFLINE" not in health, (
+                f"{c.name} can't reach Court's broker (got: {health!r})"
+            )
+            print(f"  {c.name} → court:8000/health = {health}")
 
     # Cross-org cert chain refusal (default-deny) — the third
     # invariant the demo sells — needs a Roma-minted cert


### PR DESCRIPTION
## Summary

- Each city (roma/sf/tokyo) points `MCP_PROXY_BROKER_URL=http://court:8000` with `PROXY_FEDERATION_SYNC=true`; Court binds the broker on `0.0.0.0` with firewall open.
- Two new `cullis-mastio` module options: `brokerUrl` (override proxy's broker pointer) and `nginxAllowExternal` (bind on 0.0.0.0 + open port).
- New `testScript` subtest "Federation publisher: cities reach Court's broker" probes `/health` on Court from each peer.

Sibling to #449 (Tier 2 scaffold) and #452 (mock LLM in VMs). The actual publish payload ships when the agent enroll path lands on this branch family. Topology + route are now asserted.

## Test plan

- [x] `nix-build tests/integration/cullis_network -A tier2-cross-org` green locally (32s, all four subtests pass)
- [ ] CI nixos-tests workflow green on push
- [ ] Tier 1 still green (regression check on the cullis-mastio module changes)