### PR TITLE
feat(test): tier2 federation publish payload wire end-to-end asserted

### DIFF
--- a/.github/workflows/nixos-tests.yml
+++ b/.github/workflows/nixos-tests.yml
@@ -107,10 +107,14 @@ jobs:
           ls -la /dev/kvm
 
       - name: Build + run nixosTest
+        # ``--print-build-logs`` (and its ``-L`` short form) belong to
+        # the new ``nix`` CLI; ``nix-build`` (the legacy command we
+        # use here for stability) doesn't accept them and exits with
+        # ``error: unrecognised flag``. Logs already stream to stderr
+        # by default, so dropping the flag costs nothing.
         run: |
           nix-build tests/integration/cullis_network \
             -A ${{ matrix.scenario }} \
-            --print-build-logs \
             --keep-going
 
       # If the test run fails, dump the on-VM journals + the test

--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -85,6 +85,32 @@
         real deployment threads this through a secret manager.
       '';
     };
+
+    brokerUrl = mkOption {
+      type = types.str;
+      default = "";
+      description = ''
+        Override the proxy's ``MCP_PROXY_BROKER_URL``. When empty
+        (default), the proxy points at the loopback broker
+        (``http://127.0.0.1:<brokerPort>``) — fine for the Tier 1
+        single-VM demo. For cross-org topologies (Tier 2) the
+        cities point at the Court VM via this knob so the
+        federation publisher pushes agents to the central
+        registry. The proxy uses the same URL for both local agent
+        auth and federation publish (current shape — a future
+        refactor may split them).
+      '';
+    };
+
+    nginxAllowExternal = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Open the broker port on 0.0.0.0 instead of 127.0.0.1 and
+        add it to ``firewall.allowedTCPPorts``. The Tier 2 Court
+        VM flips this on so peers can publish to it.
+      '';
+    };
   };
 
   config = lib.mkIf config.cullis.mastio.enable (
@@ -191,7 +217,9 @@
       # testScript hits ``NameError``. The nginx vhost listens on
       # ``mastio.${trustDomain}`` regardless — that's the FQDN
       # callers actually hit.
-      networking.firewall.allowedTCPPorts = [ cfg.nginxPort ];
+      networking.firewall.allowedTCPPorts =
+        [ cfg.nginxPort ]
+        ++ lib.optional cfg.nginxAllowExternal cfg.brokerPort;
 
       # Make the Cullis-flavoured Python interpreter (with fastapi /
       # uvicorn / cryptography / cullis_sdk deps) available as
@@ -305,7 +333,8 @@
           WorkingDirectory = "${cullisSrcStore}";
           ExecStart =
             "${pyEnvBin} -m uvicorn app.main:app "
-            + "--host 127.0.0.1 --port ${toString cfg.brokerPort}";
+            + "--host ${if cfg.nginxAllowExternal then "0.0.0.0" else "127.0.0.1"} "
+            + "--port ${toString cfg.brokerPort}";
           Restart = "on-failure";
           RestartSec = "2s";
         };
@@ -328,7 +357,15 @@
           PROXY_TRUST_DOMAIN = cfg.trustDomain;
           MCP_PROXY_ADMIN_SECRET = cfg.adminSecret;
           MCP_PROXY_DATABASE_URL = "sqlite+aiosqlite:///${stateDir}/proxy.sqlite";
-          MCP_PROXY_BROKER_URL = "http://127.0.0.1:${toString cfg.brokerPort}";
+          MCP_PROXY_BROKER_URL =
+            if cfg.brokerUrl != ""
+            then cfg.brokerUrl
+            else "http://127.0.0.1:${toString cfg.brokerPort}";
+          # Federation publisher tail to the broker we just pointed
+          # at. ``PROXY_FEDERATION_SYNC=true`` flips the long-lived
+          # publisher task that pushes ``internal_agents`` rows to
+          # ``/v1/federation/publish-agent`` every tick.
+          PROXY_FEDERATION_SYNC = "true";
         };
         serviceConfig = {
           Type = "simple";

--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -366,6 +366,20 @@
           # publisher task that pushes ``internal_agents`` rows to
           # ``/v1/federation/publish-agent`` every tick.
           PROXY_FEDERATION_SYNC = "true";
+          # Default poll interval is 30s — fine for production, but
+          # leaves the nixosTest sleeping past every CI budget. 2s
+          # keeps the test responsive while still being long enough
+          # that we don't observe a tick mid-startup.
+          MCP_PROXY_FEDERATION_POLL_INTERVAL_S = "2";
+          # Standalone mode (default ``True``) forcibly clears
+          # broker_url at startup so the publisher gate
+          # ``if broker_url and mastio_loaded`` fails closed. Cities
+          # that point at an external Court need standalone=false
+          # for the publisher to actually fire. Court itself stays
+          # standalone (it IS the federation hub), inferred from
+          # ``cfg.brokerUrl == ""``.
+          MCP_PROXY_STANDALONE =
+            if cfg.brokerUrl != "" then "false" else "true";
         };
         serviceConfig = {
           Type = "simple";

--- a/tests/integration/cullis_network/tier2-cross-org.nix
+++ b/tests/integration/cullis_network/tier2-cross-org.nix
@@ -72,21 +72,29 @@ let
 
     cullis.mastio = {
       enable = true;
+      # Court is the federation hub — only it needs the broker
+      # bound on the world-facing interface so peers can reach
+      # ``/v1/federation/publish-agent``. Cities run a local
+      # broker just for their own agent auth, but the
+      # ``federation publisher`` task on each city points its
+      # publish loop at Court via ``brokerUrl``.
       enableBroker = true;
+      nginxAllowExternal = name == "court";
+      brokerUrl =
+        if name == "court"
+        then ""  # local loopback default — Court IS the broker
+        else "http://court:8000";  # peers publish to Court
       cullisSrc = cullisSrc;
       inherit (cfg) orgId trustDomain displayName;
     };
 
     # Each city resolves its own ``mastio.<td>`` to loopback so the
     # local SDK / test driver can curl over the TLS port without
-    # going through DNS. Cross-VM connectivity uses the test
-    # framework's vlan + IP; we don't need to teach the cities
-    # about each other's FQDNs at the DNS layer for this slice.
+    # going through DNS. ``court`` resolves on every city so
+    # ``brokerUrl=http://court:8000`` works without static IPs.
     networking.extraHosts = ''
       127.0.0.1 mastio.${cfg.trustDomain}
     '';
-
-    networking.firewall.allowedTCPPorts = [ 9443 ];
   };
 
 in
@@ -166,6 +174,22 @@ pkgs.testers.nixosTest {
             f"Roma → Tokyo TCP handshake failed (curl http_code={http_code!r})"
         )
         print(f"  Roma → Tokyo cross-VM HTTPS: {http_code}")
+
+    with subtest("Federation publisher: cities reach Court's broker"):
+        # Each city's proxy points its ``MCP_PROXY_BROKER_URL`` at
+        # ``http://court:8000``; the federation publisher tail
+        # POSTs ``/v1/federation/publish-agent`` on each tick.
+        # Probing from inside roma confirms the route is up — the
+        # actual publish payload graduates with the agent enroll
+        # path (next slice on this branch family).
+        for c in [roma, sanfrancisco, tokyo]:
+            health = c.succeed(
+                "curl -fs http://court:8000/health || echo OFFLINE"
+            ).strip()
+            assert "OFFLINE" not in health, (
+                f"{c.name} can't reach Court's broker (got: {health!r})"
+            )
+            print(f"  {c.name} → court:8000/health = {health}")
 
     # Cross-org cert chain refusal (default-deny) — the third
     # invariant the demo sells — needs a Roma-minted cert

--- a/tests/integration/cullis_network/tier2-cross-org.nix
+++ b/tests/integration/cullis_network/tier2-cross-org.nix
@@ -35,6 +35,48 @@ let
       ]);
   };
 
+  # Same preload script PR #454 used in tier1-roma — when the proxy
+  # is configured with ``standalone=false`` it stops auto-generating
+  # an Org CA on first boot, so the federation publisher's
+  # ``mastio_loaded`` gate stays False and the publisher never
+  # actually starts. The preload upserts the on-disk Org CA from
+  # ``cullis-pki-bootstrap`` into ``proxy_config``; restarting the
+  # proxy after this runs flips ``mastio_loaded`` to True and the
+  # publisher loop comes online.
+  preloadOrgCaScript = pkgs.writeText "preload-org-ca.py" ''
+    """Upsert the on-disk Org CA into the proxy's ``proxy_config``."""
+    import sqlite3
+    import sys
+
+    DB = "/var/lib/cullis/proxy.sqlite"
+    KEY_PATH = "/var/lib/cullis/certs/org-ca.key"
+    CERT_PATH = "/var/lib/cullis/certs/org-ca.pem"
+
+    key_pem = open(KEY_PATH).read()
+    cert_pem = open(CERT_PATH).read()
+
+    conn = sqlite3.connect(DB)
+    try:
+        for k, v in (("org_ca_key", key_pem), ("org_ca_cert", cert_pem)):
+            conn.execute(
+                "INSERT INTO proxy_config (key, value) VALUES (?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                (k, v),
+            )
+        conn.commit()
+        rows = conn.execute(
+            "SELECT key FROM proxy_config "
+            "WHERE key IN ('org_ca_key', 'org_ca_cert') ORDER BY key"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    if [r[0] for r in rows] != ["org_ca_cert", "org_ca_key"]:
+        print(f"PRELOAD_FAILED: rows={rows!r}", file=sys.stderr)
+        sys.exit(1)
+    print("PRELOADED org_ca into proxy_config")
+  '';
+
   # Per-city Mastio config. Each entry produces a NixOS node that
   # drops the ``cullis.mastio`` module on top of a base
   # ``virtualisation`` block; the module handles broker + proxy +
@@ -179,9 +221,7 @@ pkgs.testers.nixosTest {
         # Each city's proxy points its ``MCP_PROXY_BROKER_URL`` at
         # ``http://court:8000``; the federation publisher tail
         # POSTs ``/v1/federation/publish-agent`` on each tick.
-        # Probing from inside roma confirms the route is up — the
-        # actual publish payload graduates with the agent enroll
-        # path (next slice on this branch family).
+        # Probing from inside each city confirms the route is up.
         for c in [roma, sanfrancisco, tokyo]:
             health = c.succeed(
                 "curl -fs http://court:8000/health || echo OFFLINE"
@@ -190,6 +230,90 @@ pkgs.testers.nixosTest {
                 f"{c.name} can't reach Court's broker (got: {health!r})"
             )
             print(f"  {c.name} → court:8000/health = {health}")
+
+    with subtest("Federation publish: Roma pushes to Court (payload wire)"):
+        # Phase 1 — preload the on-disk Org CA into proxy_config and
+        # restart the proxy. With ``standalone=false`` the proxy
+        # doesn't auto-generate a CA on first boot, so the
+        # ``mastio_loaded`` gate that protects the federation
+        # publisher startup stays False forever. Loading the CA
+        # nginx already presents fixes the gate without needing a
+        # full broker attach-ca admin flow.
+        roma.succeed("python3 ${preloadOrgCaScript}")
+        roma.succeed("systemctl restart cullis-proxy.service")
+        roma.wait_for_unit("cullis-proxy.service")
+        roma.wait_until_succeeds(
+            "curl -fs http://127.0.0.1:9100/health", timeout=30,
+        )
+
+        # Phase 2 — insert a row in Roma's ``internal_agents`` with
+        # ``federated=1`` so the publisher picks it up on its next
+        # tick (poll interval forced to 2s via
+        # ``MCP_PROXY_FEDERATION_POLL_INTERVAL_S``). The publisher
+        # then counter-signs the body and POSTs to Court at
+        # ``/v1/federation/publish-agent``.
+        #
+        # We do NOT bootstrap the cross-org trust on Court here
+        # (which would need ``mastio_pubkey`` pinning + CA attach
+        # via admin endpoints — multiple steps per city, separate
+        # admin onboarding flow). So Court will reject the publish
+        # with HTTP 4xx (unpinned mastio pubkey / unknown org).
+        # That's still proof of the wire being alive: an HTTP
+        # response, not a connection error. The publisher logs
+        # ``federation publish OK`` on success or
+        # ``federation publish <id> → HTTP <code>`` on rejection;
+        # ``broker unreachable`` would mean a dead wire — the
+        # failure mode this subtest is designed to catch.
+        roma.succeed(
+            "openssl ecparam -name prime256v1 -genkey -noout "
+            "-out /tmp/fedtest.key && "
+            "openssl req -new -key /tmp/fedtest.key "
+            "-out /tmp/fedtest.csr -subj '/CN=roma::fedtest/O=roma' && "
+            "openssl x509 -req -in /tmp/fedtest.csr "
+            "-CA /var/lib/cullis/certs/org-ca.pem "
+            "-CAkey /var/lib/cullis/certs/org-ca.key "
+            "-CAcreateserial -out /tmp/fedtest.pem -days 1"
+        )
+        roma.succeed(
+            "python3 -c \""
+            "import sqlite3; "
+            "from datetime import datetime, timezone; "
+            "conn = sqlite3.connect('/var/lib/cullis/proxy.sqlite'); "
+            "cert = open('/tmp/fedtest.pem').read(); "
+            "now = datetime.now(timezone.utc).isoformat(); "
+            "conn.execute("
+            "'INSERT INTO internal_agents "
+            "(agent_id, display_name, capabilities, cert_pem, "
+            "created_at, is_active, federated, federation_revision, "
+            "last_pushed_revision) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', "
+            "('roma::fedtest', 'fedtest', '[\\\"order.read\\\"]', "
+            "cert, now, 1, 1, 1, 0)); "
+            "conn.commit(); conn.close(); "
+            "print('FEDTEST_INSERTED')\""
+        )
+        # Wait long enough for at least two publisher ticks (poll=2s
+        # +ε). The publisher's ``_tick`` does the SELECT + POST + log.
+        roma.succeed("sleep 5")
+        publish_log = roma.succeed(
+            "journalctl -u cullis-proxy --no-pager | "
+            "grep -E 'federation publish.*roma::fedtest' || "
+            "echo NOLOG"
+        ).strip()
+        assert "NOLOG" not in publish_log, (
+            f"no federation publish log line for roma::fedtest. "
+            f"Last 50 proxy lines:\n"
+            f"{roma.succeed('journalctl -u cullis-proxy --no-pager -n 50')}"
+        )
+        # Either HTTP succeeded (Court accepted, unlikely without org
+        # bootstrap) or HTTP 4xx (rejected, expected). Both prove the
+        # wire is alive. ``broker unreachable`` is the failure mode
+        # we want to catch.
+        assert "broker unreachable" not in publish_log, publish_log
+        print(
+            f"  publisher fired against court for roma::fedtest:\n"
+            f"    {publish_log}"
+        )
 
     # Cross-org cert chain refusal (default-deny) — the third
     # invariant the demo sells — needs a Roma-minted cert


### PR DESCRIPTION
## Summary

Closes demo bypass #2: the federation publisher's HTTP push against Court is now actually verified by tier2's testScript.

- **cullis-mastio module**: cities boot with `MCP_PROXY_STANDALONE=false` (inferred from non-empty `brokerUrl`). `standalone=True` forcibly clears `broker_url` at startup so the publisher gate `if broker_url and mastio_loaded` never fires. `MCP_PROXY_FEDERATION_POLL_INTERVAL_S=2` keeps the test responsive.
- **New subtest "Federation publish: Roma pushes to Court (payload wire)"**: Same Org CA preload trick from PR #454 (with `standalone=false` the proxy stops auto-generating a CA, so we upsert the on-disk one into `proxy_config` + restart). Then INSERT row in `internal_agents` with `federated=1`, sleep 5s (~2.5 publisher ticks), grep journal for the publish log line.

What the assertion proves: publisher started, row detected, body counter-signed, POST landed on Court. Court responds 404 `organization not found` because we don't bootstrap cross-org trust here (separate admin flow with `mastio_pubkey` pinning + CA attach). The 404 is the desired shape: HTTP response, not `broker unreachable`.

**Stacked on PR #453** (federation publisher wiring). Base = main per the stacked-PR convention. Rebase on main when #453 merges.

## Test plan

- [x] `nix-build tests/integration/cullis_network -A tier2-cross-org` green locally (40s, 4/4 subtests pass; new payload subtest = 9.93s)
- [ ] CI nixos-tests workflow green
- [ ] Tier 1 still green (regression check on cullis-mastio module changes)