### PR TITLE
fix(policy): POLICY_DEFAULT_DECISION env for orgs without PDP webhook

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -103,6 +103,17 @@ class Settings(BaseSettings):
     policy_backend: str = "webhook"
     opa_url: str = ""  # e.g. "http://opa:8181"
     policy_enforcement: bool = True  # False = bypass all policy checks (demo mode)
+    # Fall-through decision when ``policy_enforcement=true`` AND the org
+    # involved has no PDP webhook configured. Default ``deny`` keeps the
+    # production fail-closed posture (an org without a webhook can't
+    # accidentally allow cross-org traffic). Operators running a sandbox
+    # or first-onboarding flow can flip to ``allow`` so cross-org A2A
+    # works before the PDP is wired. Distinct from
+    # ``policy_enforcement=false`` (which bypasses the dispatcher
+    # entirely): the dispatcher still runs and emits an audit row marking
+    # the decision as a default-fallback, so reviewers can grep for
+    # ``policy_default_allow`` after the fact. See issue #461.
+    policy_default_decision: str = "deny"  # "allow" | "deny"
     # SSRF escape hatch for the PDP webhook validator. When False (the
     # production default) the broker rejects any webhook URL that resolves
     # to a private/loopback/link-local/reserved IP. Set to True ONLY for
@@ -204,8 +215,31 @@ def validate_config(settings: "Settings") -> None:
     """
     is_production = settings.environment == "production"
 
+    # POLICY_DEFAULT_DECISION must be one of the two known values
+    # regardless of environment — typo guard. Production additionally
+    # refuses 'allow' (further down in the production-only block).
+    if settings.policy_default_decision not in ("allow", "deny"):
+        _startup_logger.critical(
+            "POLICY_DEFAULT_DECISION is %r — expected 'allow' or 'deny'.",
+            settings.policy_default_decision,
+        )
+        raise SystemExit(1)
+
     # ── Fatal checks (production only) ─────────────────────────────────────
     if is_production:
+        # Refuse 'allow' fall-through in production before checking the
+        # rest of the infra config — it's a security regression and we
+        # want the operator to see this signal even if database_url is
+        # also misconfigured. Issue #461.
+        if settings.policy_default_decision == "allow":
+            _startup_logger.critical(
+                "POLICY_DEFAULT_DECISION='allow' is not permitted in "
+                "production — orgs without a PDP webhook would bypass "
+                "all cross-org access checks. Configure webhook_url "
+                "per org instead. See issue #461.",
+            )
+            raise SystemExit(1)
+
         if not settings.database_url or settings.database_url.startswith("sqlite"):
             _startup_logger.critical(
                 "DATABASE_URL is not set or points to SQLite ('%s'). "
@@ -277,6 +311,16 @@ def validate_config(settings: "Settings") -> None:
             "Verify clients reach the broker via this exact URL — any "
             "mismatch will cause `Invalid DPoP proof: htu mismatch` 401s.",
             settings.broker_public_url,
+        )
+
+    # POLICY_DEFAULT_DECISION='allow' visibility — production already
+    # refused it above, dev/staging emits a loud warning so the deploy
+    # log shows the sandbox/demo flag clearly.
+    if not is_production and settings.policy_default_decision == "allow":
+        _startup_logger.warning(
+            "POLICY_DEFAULT_DECISION='allow' — orgs without a PDP webhook "
+            "will be granted cross-org access by default (sandbox/demo "
+            "mode). Audit rows tagged 'policy_default_allow'.",
         )
 
     if settings.vault_token == _INSECURE_VAULT_TOKEN:

--- a/app/policy/webhook.py
+++ b/app/policy/webhook.py
@@ -174,12 +174,38 @@ async def call_pdp_webhook(
     If webhook_url is None or the call fails, returns DENY (default-deny).
     """
     if not webhook_url:
+        from app.config import get_settings as _get_settings
+        default_decision = _get_settings().policy_default_decision
+        if default_decision == "allow":
+            # Sandbox/demo escape hatch (issue #461). Distinct from
+            # ``policy_enforcement=false``: the dispatcher still ran,
+            # this audit row marks the decision as a default-allow so
+            # operators can grep their chain for unconfigured orgs and
+            # wire webhooks before going to production.
+            _log.warning(
+                "PDP webhook not configured for org '%s' — POLICY_DEFAULT_DECISION='allow' fall-through",
+                org_id,
+            )
+            return WebhookDecision(
+                allowed=True,
+                reason=(
+                    f"policy_default_allow: org '{org_id}' has no PDP webhook "
+                    f"configured (POLICY_DEFAULT_DECISION=allow)"
+                ),
+                org_id=org_id,
+            )
         _log.warning(
             "PDP webhook not configured for org '%s' — default-deny", org_id
         )
         return WebhookDecision(
             allowed=False,
-            reason=f"Organization '{org_id}' has no PDP webhook configured — denied by default",
+            reason=(
+                f"policy_default_deny: organization '{org_id}' has no PDP webhook "
+                f"configured. Set 'webhook_url' on the org via "
+                f"PATCH /v1/registry/orgs/{org_id}, OR set "
+                f"POLICY_DEFAULT_DECISION=allow on the broker for sandbox/demo "
+                f"deploys (issue #461)."
+            ),
             org_id=org_id,
         )
 

--- a/tests/test_policy_default_decision.py
+++ b/tests/test_policy_default_decision.py
@@ -1,0 +1,145 @@
+"""POLICY_DEFAULT_DECISION fall-through for orgs without a PDP webhook.
+
+Issue #461. The webhook backend used to default-deny hard-coded when the
+org had no ``webhook_url``, leaving sandbox/demo deploys with no
+ergonomic path forward. The new ``policy_default_decision`` setting
+gates this fall-through:
+
+  - ``deny`` (default, prod-safe): same as before — denies with an
+    actionable error message.
+  - ``allow``: allows with an audit row tagged ``policy_default_allow``
+    so the chain shows orgs that haven't wired a real PDP yet.
+
+This test file pins the two paths and the audit reason string, plus
+the production refusal in ``validate_config``.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_default_deny_when_webhook_url_null(monkeypatch):
+    """Default ``policy_default_decision='deny'`` mirrors legacy
+    behaviour — no webhook → deny with an actionable hint."""
+    from app.config import get_settings
+    monkeypatch.delenv("POLICY_DEFAULT_DECISION", raising=False)
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    decision = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url=None,
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+    assert decision.allowed is False
+    assert "policy_default_deny" in decision.reason
+    # The error message must hand the operator both fix paths so they
+    # don't have to grep the codebase to figure out how to unblock.
+    assert "webhook_url" in decision.reason
+    assert "POLICY_DEFAULT_DECISION" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_default_allow_when_explicitly_opted_in(monkeypatch):
+    """``policy_default_decision='allow'`` lets unconfigured orgs through
+    with an audit-greppable reason."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "allow")
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    decision = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url=None,
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+    assert decision.allowed is True
+    assert "policy_default_allow" in decision.reason
+    assert "acme" in decision.reason
+
+
+@pytest.mark.asyncio
+async def test_configured_webhook_path_unaffected(monkeypatch):
+    """Setting ``policy_default_decision`` does NOT shadow real webhook
+    calls — the fall-through only fires when ``webhook_url is None``."""
+    import httpx
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "allow")
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"decision": "deny",
+                                          "reason": "explicit-pdp-deny"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    decision = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+    # Real webhook said deny — that wins, the env override is irrelevant.
+    assert decision.allowed is False
+    assert "explicit-pdp-deny" in decision.reason
+
+
+def test_validate_config_refuses_allow_in_production(monkeypatch):
+    """Production deploys must not silently allow unconfigured orgs.
+    ``validate_config`` exits hard if both ``ENVIRONMENT=production``
+    and ``POLICY_DEFAULT_DECISION=allow`` are set."""
+    from app.config import get_settings, validate_config
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "allow")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://stub")
+    monkeypatch.setenv("BROKER_PUBLIC_URL", "https://broker.example.com")
+    monkeypatch.setenv("ADMIN_SECRET", "production-secret-not-default")
+    get_settings.cache_clear()
+
+    settings = get_settings()
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+def test_validate_config_rejects_unknown_value(monkeypatch):
+    """Typo-guard — anything other than 'allow'/'deny' is a hard exit."""
+    from app.config import get_settings, validate_config
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "maybe")
+    monkeypatch.setenv("ADMIN_SECRET", "non-default-test-secret")
+    get_settings.cache_clear()
+
+    settings = get_settings()
+    with pytest.raises(SystemExit):
+        validate_config(settings)


### PR DESCRIPTION
Closes #461.

## Summary

- New `POLICY_DEFAULT_DECISION` env var gates the fall-through when an org has no `webhook_url`. Default `deny` (prod-safe), opt-in `allow` for sandbox/demo
- `validate_config` refuses `allow` in production (hard exit) and emits a loud WARNING in dev/staging
- 403 detail on default-deny now hands the operator both fix paths (`webhook_url` per org OR `POLICY_DEFAULT_DECISION` env), no codebase grep needed

## Why

Before this change `call_pdp_webhook` default-denied every cross-org call when the org had no PDP webhook configured. The only escape was `policy_enforcement=false`, which bypasses the dispatcher entirely (sledgehammer, no audit). Every new sandbox/demo/first-onboarding deploy hit this and had to either disable PDP wholesale or stand up a webhook before the first request worked.

The fix introduces an explicit middle ground: dispatcher still runs, audit row still gets written, but the fall-through decision is configurable and visible in the audit chain (`reason: policy_default_allow|policy_default_deny`).

## Out of scope

- `/v1/policy/rules` table is still not consulted by the dispatcher — that's issue #460, separate PR
- SDK federation CA fetch (#459), DPoP htu forward path (#458), multi-ingress BROKER_PUBLIC_URL (#462) are independent

## Test plan

- [x] Unit tests: `tests/test_policy_default_decision.py` covers all 4 paths (default-deny, default-allow opt-in, configured-webhook-unaffected, prod-refusal of allow, typo-guard)
- [x] Existing policy/webhook/PDP tests still pass: `pytest tests/ -k "policy or webhook or pdp or backend"` → 87 pass, 4 skipped
- [x] Existing oneshot/audit tests still pass: `pytest tests/test_oneshot_intra.py tests/test_audit_chain.py` → 33 pass
- [ ] `./smoke.sh full` (pre-merge gate per repo policy)
- [ ] Tier 1 nixosTest still green (run locally before merge)