### PR TITLE
fix(kms): CULLIS_LOCAL_KMS_DIR env override for read-only CWD

### DIFF
--- a/app/kms/admin_secret.py
+++ b/app/kms/admin_secret.py
@@ -44,9 +44,19 @@ _log = logging.getLogger("agent_trust.admin_secret")
 _cached_hash: str | None = None
 _cached_user_set: bool | None = None
 _VAULT_TIMEOUT = 10
-_LOCAL_HASH_PATH = pathlib.Path("certs/.admin_secret_hash")
-_LOCAL_USER_SET_PATH = pathlib.Path("certs/.admin_password_user_set")
-_LOCAL_BOOTSTRAP_TOKEN_PATH = pathlib.Path("certs/.admin_bootstrap_token")
+# Local KMS state directory. Defaults to ``certs/`` relative to the
+# process CWD (preserves the historical layout for repo-root and
+# Docker container deploys with WORKDIR=/app where ``certs/`` is a
+# writable mount). Override with ``CULLIS_LOCAL_KMS_DIR`` when the
+# CWD is read-only — most notably the NixOS test fixture where the
+# broker systemd unit runs with ``WorkingDirectory=<nix-store path>``,
+# so writes against a relative ``certs/`` blow up on first boot.
+_LOCAL_KMS_DIR = pathlib.Path(
+    os.environ.get("CULLIS_LOCAL_KMS_DIR") or "certs"
+)
+_LOCAL_HASH_PATH = _LOCAL_KMS_DIR / ".admin_secret_hash"
+_LOCAL_USER_SET_PATH = _LOCAL_KMS_DIR / ".admin_password_user_set"
+_LOCAL_BOOTSTRAP_TOKEN_PATH = _LOCAL_KMS_DIR / ".admin_bootstrap_token"
 _VAULT_BOOTSTRAP_TOKEN_FIELD = "admin_bootstrap_token"
 
 # Dummy hash for constant-time verification when no hash is available.

--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -356,6 +356,11 @@
           DATABASE_URL = "sqlite+aiosqlite:///${stateDir}/broker.sqlite";
           KMS_BACKEND = "local";
           OTEL_ENABLED = "false";
+          # ``app/kms/admin_secret.py`` defaults to ``certs/`` relative
+          # to the broker's CWD, which here is the read-only Nix store.
+          # Redirect to the writable state dir so first-boot mkdir of
+          # ``.admin_bootstrap_token`` succeeds.
+          CULLIS_LOCAL_KMS_DIR = certsDir;
         };
         serviceConfig = {
           Type = "simple";

--- a/tests/test_admin_secret_local_kms_dir.py
+++ b/tests/test_admin_secret_local_kms_dir.py
@@ -1,0 +1,84 @@
+"""``CULLIS_LOCAL_KMS_DIR`` env override for the local KMS state dir.
+
+The local backend writes ``.admin_secret_hash`` /
+``.admin_password_user_set`` / ``.admin_bootstrap_token`` to a
+filesystem path. Historically this was hard-coded to ``certs/`` (CWD-
+relative), which broke when the broker process ran with
+``WorkingDirectory`` set to a read-only Nix store path: ``mkdir
+certs/`` raised on first boot and the broker entered a restart loop.
+
+Issue surfaced by the NixOS Tier 1 test fixture in
+``tests/integration/cullis_network/lib/cullis-mastio.nix``. The fix is
+to read the directory from ``CULLIS_LOCAL_KMS_DIR`` with the legacy
+``certs`` default preserved for repo-root and Docker deploys.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import pathlib
+
+import pytest
+
+
+def test_default_path_is_relative_certs(monkeypatch):
+    """No env set → legacy ``certs/`` relative to cwd, as before."""
+    monkeypatch.delenv("CULLIS_LOCAL_KMS_DIR", raising=False)
+    from app.kms import admin_secret as mod
+    importlib.reload(mod)
+    assert mod._LOCAL_KMS_DIR == pathlib.Path("certs")
+    assert mod._LOCAL_HASH_PATH == pathlib.Path("certs/.admin_secret_hash")
+    assert mod._LOCAL_BOOTSTRAP_TOKEN_PATH == pathlib.Path(
+        "certs/.admin_bootstrap_token"
+    )
+
+
+def test_env_override_redirects_all_three_files(monkeypatch, tmp_path):
+    """All three local KMS files follow ``CULLIS_LOCAL_KMS_DIR``."""
+    monkeypatch.setenv("CULLIS_LOCAL_KMS_DIR", str(tmp_path / "kms-state"))
+    from app.kms import admin_secret as mod
+    importlib.reload(mod)
+    assert mod._LOCAL_KMS_DIR == tmp_path / "kms-state"
+    assert mod._LOCAL_HASH_PATH == tmp_path / "kms-state" / ".admin_secret_hash"
+    assert mod._LOCAL_USER_SET_PATH == (
+        tmp_path / "kms-state" / ".admin_password_user_set"
+    )
+    assert mod._LOCAL_BOOTSTRAP_TOKEN_PATH == (
+        tmp_path / "kms-state" / ".admin_bootstrap_token"
+    )
+
+
+def test_empty_env_falls_back_to_default(monkeypatch):
+    """Empty string env behaves like unset (the ``or`` shortcut)."""
+    monkeypatch.setenv("CULLIS_LOCAL_KMS_DIR", "")
+    from app.kms import admin_secret as mod
+    importlib.reload(mod)
+    assert mod._LOCAL_KMS_DIR == pathlib.Path("certs")
+
+
+def test_write_and_read_round_trip_under_override(monkeypatch, tmp_path):
+    """Smoke check — with the override pointing at a writable dir,
+    ``persist_admin_password_hash`` + ``load_admin_secret_hash`` round-
+    trip without ever touching ``certs/`` in the cwd. Guards the
+    NixOS read-only-cwd regression: under the old layout this test
+    would have to ``cd`` into a writable dir to even run."""
+    monkeypatch.setenv("CULLIS_LOCAL_KMS_DIR", str(tmp_path))
+    monkeypatch.setenv("KMS_BACKEND", "local")
+    monkeypatch.chdir("/")  # cwd intentionally not writable
+    from app.config import get_settings
+    get_settings.cache_clear()
+    from app.kms import admin_secret as mod
+    importlib.reload(mod)
+
+    import asyncio
+
+    async def _round_trip():
+        await mod.set_admin_secret_hash("$2b$12$fakehashfortests")
+        return await mod.get_admin_secret_hash()
+
+    rehash = asyncio.run(_round_trip())
+    assert rehash == "$2b$12$fakehashfortests"
+    # ``certs/`` was never created on the read-only cwd
+    assert not pathlib.Path("/certs").exists()
+    # The override path holds the file
+    assert (tmp_path / ".admin_secret_hash").exists()

--- a/tests/test_admin_secret_local_kms_dir.py
+++ b/tests/test_admin_secret_local_kms_dir.py
@@ -15,10 +15,7 @@ to read the directory from ``CULLIS_LOCAL_KMS_DIR`` with the legacy
 from __future__ import annotations
 
 import importlib
-import os
 import pathlib
-
-import pytest
 
 
 def test_default_path_is_relative_certs(monkeypatch):


### PR DESCRIPTION
## Summary

- ``app/kms/admin_secret.py`` now reads the local-KMS state directory from ``CULLIS_LOCAL_KMS_DIR`` with the legacy ``certs/`` (CWD-relative) default preserved
- NixOS Tier 1/Tier 2 fixture (``cullis-mastio.nix``) sets the env to the writable ``${stateDir}/certs`` so first-boot ``mkdir`` succeeds against a read-only Nix store CWD

## Why

Latent crash. The broker derived three local KMS files (``.admin_secret_hash`` / ``.admin_password_user_set`` / ``.admin_bootstrap_token``) from a hard-coded relative path ``certs/...``. This works when the process CWD is writable (repo root, Docker WORKDIR=/app), but breaks when the systemd unit's ``WorkingDirectory`` is a read-only Nix store. First boot's ``mkdir certs/`` raises on the read-only fs, broker enters a restart loop, the test fixture's ``wait_until_succeeds`` eventually times out.

The bug was hidden by a subtle interaction: ``cleanSourceWith`` in the test module captures whatever's in the source worktree at build time. A worktree with a stale ``certs/`` directory (left over from previous local builds) gets it materialised into the Nix store, where ``mkdir exist_ok=True`` becomes a no-op against the existing read-only entry → broker boots fine. A fresh worktree without ``certs/`` triggers the crash. Surface: same code, different worktree, different test outcome. Two parallel worktrees independently flagged this today.

## Backward compat

- Repo-root developers running ``python -m uvicorn app.main:app``: cwd has writable ``certs/`` (gitignored) → nothing changes
- Docker compose deploys (``reference/docker-compose.yml``): WORKDIR=/app with a writable certs/ volume → nothing changes
- NixOS systemd units pointing WorkingDirectory at the Nix store: now set ``CULLIS_LOCAL_KMS_DIR=/var/lib/cullis/certs`` and the broker writes to the writable state dir

## Test plan

- [x] ``pytest tests/test_admin_secret_local_kms_dir.py`` — new file, 4 cases (default-relative, env-override, empty-env-falls-back, write-read round-trip with read-only CWD)
- [x] ``pytest tests/ -k "admin_secret or admin_bootstrap or kms"`` — 104 pass, no regressions
- [ ] Tier 1 nixosTest from a fresh worktree (no ``certs/`` materialised) — should now boot deterministically