### PR TITLE
fix(federation): /agents/{id}/public-key returns full cert_pem

### DIFF
--- a/app/federation/read.py
+++ b/app/federation/read.py
@@ -165,7 +165,15 @@ async def get_federated_agent_public_key(
         serialization.Encoding.PEM,
         serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode()
-    return AgentPublicKeyResponse(agent_id=agent_id, public_key_pem=public_key_pem)
+    # Issue #470 — return the full X.509 cert too. SDK consumers post-H7
+    # need the cert (not just the SPKI) to bind the public key to the
+    # agent identity. Legacy callers reading ``public_key_pem`` are
+    # untouched.
+    return AgentPublicKeyResponse(
+        agent_id=agent_id,
+        public_key_pem=public_key_pem,
+        cert_pem=agent.cert_pem,
+    )
 
 
 @router.get("/agents/{agent_id}", response_model=AgentResponse)

--- a/app/registry/models.py
+++ b/app/registry/models.py
@@ -46,3 +46,13 @@ class AgentListResponse(BaseModel):
 class AgentPublicKeyResponse(BaseModel):
     agent_id: str
     public_key_pem: str
+    # Issue #470 — the H7 audit fix on the SDK rejects bare SPKI for
+    # signature verification. Carrying the full X.509 cert alongside
+    # ``public_key_pem`` lets ``CullisClient.decrypt_oneshot`` chain
+    # the cert to the agent identity (cert_binds_agent_id) without
+    # losing the public key the legacy callers still consume from
+    # ``public_key_pem``. Optional for backward compat: a federated
+    # agent created before this field existed has ``cert_pem=None``,
+    # in which case the SDK falls back to the bare key (loses cert
+    # identity binding but preserves the legacy contract).
+    cert_pem: str | None = None

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -1816,9 +1816,17 @@ class CullisClient:
         return [AgentInfo.from_dict(p) for p in resp.json().get("peers", [])]
 
     def get_agent_public_key(self, agent_id: str, force_refresh: bool = False) -> str:
-        """Retrieve agent PEM public key from the broker (TTL-cached).
+        """Retrieve the agent's full X.509 cert PEM from the broker (TTL-cached).
 
         ADR-010 Phase 6a: reads from the ``/v1/federation/`` namespace.
+
+        Issue #470 — the response carries both ``cert_pem`` (full X.509)
+        and ``public_key_pem`` (bare SPKI). Prefer ``cert_pem`` since
+        the H7 audit fix on the verify helpers rejects bare SPKI; fall
+        back to ``public_key_pem`` only if the broker is older and
+        doesn't populate the cert field, in which case the consumer
+        loses the cert-to-identity binding step but the legacy contract
+        keeps working.
         """
         if not force_refresh and agent_id in self._pubkey_cache:
             pubkey_pem, fetched_at = self._pubkey_cache[agent_id]
@@ -1827,7 +1835,8 @@ class CullisClient:
         path = f"/v1/federation/agents/{agent_id}/public-key"
         resp = self._authed_request("GET", path)
         resp.raise_for_status()
-        pubkey_pem = resp.json()["public_key_pem"]
+        body = resp.json()
+        pubkey_pem = body.get("cert_pem") or body["public_key_pem"]
         self._pubkey_cache[agent_id] = (pubkey_pem, time.time())
         return pubkey_pem
 

--- a/tests/test_federation_public_key_cert_pem.py
+++ b/tests/test_federation_public_key_cert_pem.py
@@ -16,8 +16,8 @@ from cryptography import x509 as crypto_x509
 from cryptography.hazmat.primitives import serialization
 from httpx import AsyncClient
 
-from tests.cert_factory import get_org_ca_pem, make_agent_cert
-from tests.conftest import ADMIN_HEADERS, seed_court_agent
+from tests.cert_factory import make_agent_cert
+from tests.conftest import seed_court_agent
 from tests.test_federation_read import _setup
 
 
@@ -56,9 +56,7 @@ async def test_public_key_response_carries_full_cert_pem(
     token = await _setup(
         client, "fr-cert-a", "fr-cert-a::caller", ["cap.read"], dpop,
     )
-    cert_pem = await _seed_agent_with_cert(
-        "fr-cert-a", "fr-cert-a::peer",
-    )
+    await _seed_agent_with_cert("fr-cert-a", "fr-cert-a::peer")
 
     resp = await client.get(
         "/v1/federation/agents/fr-cert-a::peer/public-key",

--- a/tests/test_federation_public_key_cert_pem.py
+++ b/tests/test_federation_public_key_cert_pem.py
@@ -1,0 +1,115 @@
+"""``GET /v1/federation/agents/{id}/public-key`` returns ``cert_pem``.
+
+Issue #470. The endpoint historically extracted the SPKI from the
+stored cert and returned only ``public_key_pem``. SDK consumers
+post-H7 audit fix reject bare SPKI; they need the full X.509 to bind
+the public key to the agent identity.
+
+The fix carries ``cert_pem`` alongside the legacy ``public_key_pem``,
+so the SDK reads ``cert_pem`` (and falls back to ``public_key_pem``
+when an older broker doesn't populate the cert).
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography import x509 as crypto_x509
+from cryptography.hazmat.primitives import serialization
+from httpx import AsyncClient
+
+from tests.cert_factory import get_org_ca_pem, make_agent_cert
+from tests.conftest import ADMIN_HEADERS, seed_court_agent
+from tests.test_federation_read import _setup
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_agent_with_cert(org_id: str, agent_id: str) -> str:
+    """Create an internal_agents row with a valid Org-CA-signed cert.
+    Returns the cert PEM."""
+    from app.registry.store import register_agent, update_agent_cert, compute_cert_thumbprint
+    from tests.conftest import TestSessionLocal
+
+    _, cert = make_agent_cert(agent_id, org_id)
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    thumb = compute_cert_thumbprint(cert_pem)
+
+    async with TestSessionLocal() as session:
+        await register_agent(
+            session,
+            agent_id=agent_id, org_id=org_id,
+            display_name=agent_id, capabilities=["cap.read"],
+            metadata={},
+        )
+        await update_agent_cert(
+            session, agent_id=agent_id,
+            cert_pem=cert_pem, thumbprint=thumb,
+        )
+    return cert_pem
+
+
+async def test_public_key_response_carries_full_cert_pem(
+    client: AsyncClient, dpop,
+):
+    """Same-org fetch returns both ``cert_pem`` (X.509) and the legacy
+    ``public_key_pem`` (SPKI). SDK consumers post-H7 use the cert."""
+    token = await _setup(
+        client, "fr-cert-a", "fr-cert-a::caller", ["cap.read"], dpop,
+    )
+    cert_pem = await _seed_agent_with_cert(
+        "fr-cert-a", "fr-cert-a::peer",
+    )
+
+    resp = await client.get(
+        "/v1/federation/agents/fr-cert-a::peer/public-key",
+        headers=dpop.headers(
+            "GET", "/v1/federation/agents/fr-cert-a::peer/public-key", token,
+        ),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Both fields present
+    assert "public_key_pem" in body
+    assert body["public_key_pem"].startswith("-----BEGIN PUBLIC KEY-----")
+    assert "cert_pem" in body
+    assert body["cert_pem"] is not None
+    assert body["cert_pem"].startswith("-----BEGIN CERTIFICATE-----")
+
+    # ``cert_pem`` parses as a real X.509 — the SDK's
+    # ``load_cert_strict`` (H7 audit) accepts it
+    parsed = crypto_x509.load_pem_x509_certificate(body["cert_pem"].encode())
+    cn_attrs = parsed.subject.get_attributes_for_oid(
+        crypto_x509.NameOID.COMMON_NAME,
+    )
+    assert cn_attrs and cn_attrs[0].value == "fr-cert-a::peer"
+
+    # And the SPKI extracted from the cert matches what the legacy
+    # field returned, so old callers reading ``public_key_pem`` keep
+    # working byte-identical.
+    expected_spki = parsed.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    assert body["public_key_pem"] == expected_spki
+
+
+async def test_public_key_404_when_cert_missing(client: AsyncClient, dpop):
+    """No cert pinned yet → 404 unchanged. Backward compat with the
+    pre-issue contract."""
+    token = await _setup(
+        client, "fr-cert-b", "fr-cert-b::caller", ["cap.read"], dpop,
+    )
+    await seed_court_agent(
+        agent_id="fr-cert-b::no-cert",
+        org_id="fr-cert-b",
+        display_name="no-cert",
+        capabilities=["cap.read"],
+    )
+    resp = await client.get(
+        "/v1/federation/agents/fr-cert-b::no-cert/public-key",
+        headers=dpop.headers(
+            "GET", "/v1/federation/agents/fr-cert-b::no-cert/public-key", token,
+        ),
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
Closes #470.

## Summary

- ``GET /v1/federation/agents/{id}/public-key`` now returns ``cert_pem`` (full X.509) alongside the legacy ``public_key_pem`` (bare SPKI)
- ``cullis_sdk/client.py::get_agent_public_key`` prefers ``cert_pem`` and falls back to ``public_key_pem`` for older-broker compat
- Existing callers of ``public_key_pem`` keep working byte-identical

## Why

The H7 audit fix on the SDK rejects bare SPKI for envelope signature verification (the verifier needs the full cert to bind the public key to the agent identity). Court's federation read endpoint predated H7 and silently dropped the cert. Cross-org A2A receive failed end-to-end with ``CertTrustError: expected an X.509 CERTIFICATE PEM``.

Surfaced today by the NixOS Tier 2 cross-org A2A oneshot test (parked branch ``feat/nixos-tier2-a2a-oneshot``). Single-VM and intra-org tests don't hit this path because they read ``cert_pem`` from ``internal_agents`` directly.

## Test plan

- [x] New test ``tests/test_federation_public_key_cert_pem.py`` — happy-path returns both fields, 404 on no-cert preserved
- [x] ``pytest tests/ -k "federation or oneshot_cross or audit_oneshot"`` — 110 pass, no regressions
- [ ] Tier 1 nixosTest still green (the test exercises only intra-org but shares the SDK)
- [ ] Once merged, Tier 2 cross-org A2A oneshot can complete end-to-end