### PR TITLE
feat(guardian): fast-path tool dispatch + slow-path hook (ADR-016 Phase 2)

### DIFF
--- a/mcp_proxy/guardian/__init__.py
+++ b/mcp_proxy/guardian/__init__.py
@@ -1,14 +1,15 @@
 """ADR-016 Guardian — bidirectional content inspection on Mastio.
 
-Phase 1 (foundation) ships the contract: endpoint, ticket signing,
-registry hook for plugin tools, audit row writer. No real inspection
-runs yet — every call returns ``decision=pass``. The plugin-side
-fast-path tools land in Phase 2 (cullis-enterprise).
+Phase 1 (foundation) shipped the contract: endpoint, ticket signing,
+registry hook for plugin tools, audit row writer. Phase 2 (this module
+extension) adds the fast-path dispatch loop in the endpoint and the
+slow-path hook the enterprise ``llm_guardian`` plugin sets at startup.
 
 Public surface:
     record_inspection — write a guardian decision to local_audit
     register_tool, registered_tools, Tool, ToolResult — plugin contract
     sign_ticket, verify_ticket, GuardianTicketError — JWT helpers
+    set_slow_path_hook, SlowPathPayload — slow-path enqueue contract
 """
 from __future__ import annotations
 
@@ -19,6 +20,13 @@ from mcp_proxy.guardian.registry import (
     register_tool,
     registered_tools,
 )
+from mcp_proxy.guardian.slow_path import (
+    SlowPathHook,
+    SlowPathPayload,
+    enqueue_slow_path,
+    get_slow_path_hook,
+    set_slow_path_hook,
+)
 from mcp_proxy.guardian.ticket import (
     GuardianTicketError,
     sign_ticket,
@@ -27,11 +35,16 @@ from mcp_proxy.guardian.ticket import (
 
 __all__ = [
     "GuardianTicketError",
+    "SlowPathHook",
+    "SlowPathPayload",
     "Tool",
     "ToolResult",
+    "enqueue_slow_path",
+    "get_slow_path_hook",
     "record_inspection",
     "register_tool",
     "registered_tools",
+    "set_slow_path_hook",
     "sign_ticket",
     "verify_ticket",
 ]

--- a/mcp_proxy/guardian/endpoint.py
+++ b/mcp_proxy/guardian/endpoint.py
@@ -1,22 +1,20 @@
 """``POST /v1/guardian/inspect`` — bidirectional content inspection (ADR-016).
 
-Phase 1 (foundation) wires the contract end-to-end: mTLS-authenticated
-request, validated body, persisted audit row, signed ticket, response
-shaped per ADR. The endpoint always returns ``decision=pass`` because
-no inspection tools are registered yet — the Phase 2 plugin owns the
-actual logic.
+Phase 2 (this module): the endpoint now iterates the fast-path tools
+registered in ``mcp_proxy.guardian.registry`` and merges their
+verdicts (block > redact > pass), then enqueues a copy of the payload
+on the slow-path hook (when the enterprise plugin has set one). The
+public core stays adapter-agnostic — slow-path judges live in the
+enterprise ``llm_guardian`` plugin and are wired via
+``set_slow_path_hook`` at plugin startup.
 
-Locking the wire shape now lets:
-
-- the SDK author (Phase 3) develop against a real response, including
-  ticket verification, before any tool exists;
-- third-party adapter authors (Lakera, Portkey, NeMo, …) plug into the
-  ``mcp_proxy.guardian.registry`` without forking the proxy;
-- the dashboard (Phase 6) and audit timeline rely on a stable
-  ``guardian.inspect`` event in ``local_audit`` from day one.
+The wire contract is unchanged from Phase 1: same request body, same
+response shape, same audit row. Existing SDK clients (Phase 3) keep
+working without any change.
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import logging
@@ -29,6 +27,8 @@ from pydantic import BaseModel, Field
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.config import get_settings
 from mcp_proxy.guardian.audit import record_inspection
+from mcp_proxy.guardian.registry import ToolResult, registered_tools
+from mcp_proxy.guardian.slow_path import SlowPathPayload, enqueue_slow_path
 from mcp_proxy.guardian.ticket import GuardianTicketError, sign_ticket
 from mcp_proxy.models import InternalAgent
 
@@ -92,14 +92,25 @@ async def inspect(
         ) from exc
 
     audit_id = uuid.uuid4().hex
-    decision: Literal["pass", "redact", "block"] = "pass"
 
-    # Phase 1: no fast-path tools registered. Phase 2 (plugin) iterates
-    # ``mcp_proxy.guardian.registry.registered_tools`` here, dispatches
-    # each in parallel via asyncio.gather, and merges the worst decision
-    # into the response. The audit detail at that point will carry the
-    # per-tool reasons; for now ``reasons`` stays empty.
-    _ = payload  # tools will read this; silence linter for now
+    # ── Fast-path dispatch (Phase 2) ────────────────────────────────
+    #
+    # Run every registered tool for the request direction (plus the
+    # ``both``-direction tools) in parallel. Merge verdicts using a
+    # block > redact > pass ordering so the strictest tool wins; on
+    # redact, the latest non-None ``redacted_payload`` is forwarded
+    # downstream. Reasons accumulate across all firing tools so the
+    # audit row carries the full triage signal.
+    fast_path_tools = registered_tools(direction=req.direction)
+    ctx = {
+        "agent_id": agent.agent_id,
+        "peer_agent_id": req.peer_agent_id,
+        "msg_id": req.msg_id,
+        "direction": req.direction,
+    }
+    decision, redacted_payload, reasons = await _run_fast_path(
+        tools=fast_path_tools, payload=payload, ctx=ctx,
+    )
 
     try:
         ticket, ticket_exp = sign_ticket(
@@ -129,24 +140,94 @@ async def inspect(
             peer_agent_id=req.peer_agent_id,
             msg_id=req.msg_id,
             org_id=settings.org_id,
-            reasons=[],
-            extra={"content_type": req.content_type, "phase": "foundation"},
+            reasons=reasons,
+            extra={
+                "content_type": req.content_type,
+                "phase": "fast_path",
+                "tools_run": [t.name for t in fast_path_tools],
+            },
         )
     except Exception:
         # Audit failure must not silently drop the decision; log loudly,
         # but still return the ticket — the SDK has already paid the
-        # round trip and an audit retry happens in the background
-        # writer in Phase 4. Phase 1 just logs.
+        # round trip. The slow-path queue in the enterprise plugin
+        # also writes its own per-judge rows asynchronously.
         _log.exception(
             "guardian audit write failed agent=%s msg_id=%s",
             agent.agent_id, req.msg_id,
+        )
+
+    # ── Slow-path enqueue (Phase 4 hook, populated by enterprise plugin) ─
+    enqueue_slow_path(SlowPathPayload(
+        audit_id=audit_id,
+        direction=req.direction,
+        agent_id=agent.agent_id,
+        peer_agent_id=req.peer_agent_id,
+        msg_id=req.msg_id,
+        # Pass the redacted form when we have one — the slow-path
+        # judges should see the same bytes downstream eventually does.
+        payload=redacted_payload if redacted_payload is not None else payload,
+    ))
+
+    redacted_b64: str | None = None
+    if redacted_payload is not None:
+        redacted_b64 = (
+            base64.urlsafe_b64encode(redacted_payload).rstrip(b"=").decode("ascii")
         )
 
     return InspectResponse(
         decision=decision,
         ticket=ticket,
         ticket_exp=ticket_exp,
-        redacted_payload_b64=None,
+        redacted_payload_b64=redacted_b64,
         audit_id=audit_id,
-        reasons=[],
+        reasons=[InspectReason(**r) for r in reasons if "tool" in r and "match" in r],
     )
+
+
+async def _run_fast_path(
+    *, tools: list, payload: bytes, ctx: dict,
+) -> tuple[Literal["pass", "redact", "block"], bytes | None, list[dict]]:
+    """Run every fast-path tool concurrently, merge worst-decision-wins.
+
+    Tools that raise are recorded in the reasons list as
+    ``tool=<name> match=tool_error:<class>`` so a broken tool does not
+    silently swallow the audit signal. The endpoint still returns a
+    decision (the strictest seen among the surviving tools).
+    """
+    if not tools:
+        return "pass", None, []
+
+    async def _safe_eval(t):
+        try:
+            return t, await t.evaluate(payload, ctx), None
+        except Exception as exc:
+            return t, None, exc
+
+    results = await asyncio.gather(*(_safe_eval(t) for t in tools))
+
+    decision: Literal["pass", "redact", "block"] = "pass"
+    redacted_payload: bytes | None = None
+    reasons: list[dict] = []
+    for tool, result, exc in results:
+        if exc is not None:
+            reasons.append({
+                "tool": getattr(tool, "name", "<unnamed>"),
+                "match": f"tool_error:{type(exc).__name__}",
+            })
+            continue
+        if not isinstance(result, ToolResult):
+            continue
+        for r in result.reasons or []:
+            reasons.append(r)
+        if result.decision == "block":
+            decision = "block"
+            # Block wins — clear any redaction the previous tool returned;
+            # we never want to deliver redacted bytes when another tool
+            # said the whole thing must not pass.
+            redacted_payload = None
+        elif result.decision == "redact" and decision != "block":
+            decision = "redact"
+            if result.redacted_payload is not None:
+                redacted_payload = result.redacted_payload
+    return decision, redacted_payload, reasons

--- a/mcp_proxy/guardian/slow_path.py
+++ b/mcp_proxy/guardian/slow_path.py
@@ -1,0 +1,80 @@
+"""Slow-path hook registry.
+
+Phase 1 (foundation) shipped the contract; the actual slow-path
+dispatcher lives in the enterprise ``llm_guardian`` plugin. The public
+core stays adapter-agnostic by exposing a single ``set_slow_path_hook``
+setter that the plugin calls during ``startup()``. The
+``/v1/guardian/inspect`` endpoint then enqueues a copy of the payload
+non-blocking; if no hook is registered, the call is a no-op.
+
+This pattern keeps the public repo from importing anything from the
+enterprise repo (open-core boundary).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol
+
+_log = logging.getLogger("mcp_proxy.guardian.slow_path")
+
+
+@dataclass
+class SlowPathPayload:
+    """Subset of the inspect request that the slow path needs.
+
+    The endpoint never hands the original ``InspectRequest`` to the
+    hook so the plugin author cannot accidentally couple to the
+    public Pydantic schema; the dataclass is a stable wire shape.
+    """
+
+    audit_id: str
+    direction: str
+    agent_id: str
+    peer_agent_id: str
+    msg_id: str
+    payload: bytes
+
+
+class SlowPathHook(Protocol):
+    def __call__(self, task: SlowPathPayload) -> bool:  # pragma: no cover
+        ...
+
+
+_hook: SlowPathHook | None = None
+
+
+def set_slow_path_hook(hook: SlowPathHook | None) -> None:
+    """Register the slow-path enqueue callable. ``None`` clears it.
+
+    Idempotent: re-registering replaces the existing hook. The plugin
+    sets it on startup and clears on shutdown so a partial reload
+    leaves no dangling reference.
+    """
+    global _hook
+    _hook = hook
+    if hook is None:
+        _log.info("guardian slow-path hook cleared")
+    else:
+        _log.info("guardian slow-path hook registered")
+
+
+def get_slow_path_hook() -> SlowPathHook | None:
+    return _hook
+
+
+def enqueue_slow_path(task: SlowPathPayload) -> bool:
+    """Enqueue the payload non-blocking. Returns False on no-op or drop.
+
+    Endpoint callers MUST treat False as best-effort observation lost,
+    not a hard failure: the fast-path decision has already been
+    computed and returned to the client.
+    """
+    hook = _hook
+    if hook is None:
+        return False
+    try:
+        return hook(task)
+    except Exception as exc:
+        _log.warning("guardian slow-path enqueue failed: %s", exc)
+        return False

--- a/mcp_proxy/guardian/slow_path.py
+++ b/mcp_proxy/guardian/slow_path.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, Protocol
+from typing import Protocol
 
 _log = logging.getLogger("mcp_proxy.guardian.slow_path")
 

--- a/tests/test_guardian_endpoint.py
+++ b/tests/test_guardian_endpoint.py
@@ -126,7 +126,8 @@ async def test_inspect_writes_audit_row(app):
     assert detail["peer_agent_id"] == "orgb::bob"
     assert detail["msg_id"] == "msg-test-1"
     assert detail["content_type"] == "application/json+a2a-payload"
-    assert detail["phase"] == "foundation"
+    assert detail["phase"] == "fast_path"
+    assert detail["tools_run"] == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_guardian_fastpath.py
+++ b/tests/test_guardian_fastpath.py
@@ -1,0 +1,310 @@
+"""ADR-016 Phase 2 — fast-path tool dispatch + slow-path hook.
+
+Phase 1 tests cover the empty-registry path (endpoint returns pass).
+This file covers the case the registry has tools and the endpoint
+runs them. Tools are registered locally per test via ``register_tool``
++ a fixture that clears the registry on teardown so tests don't leak
+state into each other.
+"""
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.guardian import (
+    SlowPathPayload,
+    Tool,
+    ToolResult,
+    register_tool,
+    set_slow_path_hook,
+)
+from mcp_proxy.guardian.endpoint import router as guardian_router
+from mcp_proxy.guardian.registry import clear_registry
+from mcp_proxy.models import InternalAgent
+
+
+_KEY_HEX = "00112233445566778899aabbccddeeff" * 2
+
+
+def _agent() -> InternalAgent:
+    return InternalAgent(
+        agent_id="orga::alice",
+        display_name="alice",
+        capabilities=["a2a.send"],
+        created_at="2026-05-07T00:00:00Z",
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt="jkt-test",
+        reach="both",
+    )
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _body(direction: str = "out", payload: bytes = b'{"hello":"world"}') -> dict:
+    return {
+        "direction": direction,
+        "peer_agent_id": "orgb::bob",
+        "msg_id": "msg-fastpath-1",
+        "content_type": "application/json+a2a-payload",
+        "payload_b64": _b64url(payload),
+    }
+
+
+@pytest_asyncio.fixture
+async def app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.setenv("MCP_PROXY_GUARDIAN_TICKET_KEY", _KEY_HEX)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "orga")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+
+    test_app = FastAPI()
+    test_app.include_router(guardian_router)
+    test_app.dependency_overrides[get_agent_from_dpop_client_cert] = _agent
+
+    yield test_app
+
+    test_app.dependency_overrides.clear()
+    get_settings.cache_clear()
+    clear_registry()
+    set_slow_path_hook(None)
+    await dispose_db()
+
+
+# ── Stub tools ─────────────────────────────────────────────────────
+
+
+class _BlockOnSubstr(Tool):
+    name = "block_on_substr"
+    direction = "out"
+
+    def __init__(self, substr: str):
+        self._substr = substr
+
+    async def evaluate(self, payload: bytes, ctx) -> ToolResult:
+        if self._substr.encode() in payload:
+            return ToolResult(
+                decision="block",
+                reasons=[{"tool": self.name, "match": self._substr}],
+            )
+        return ToolResult(decision="pass")
+
+
+class _RedactSubstr(Tool):
+    name = "redact_substr"
+    direction = "out"
+
+    def __init__(self, substr: str):
+        self._substr = substr
+
+    async def evaluate(self, payload: bytes, ctx) -> ToolResult:
+        if self._substr.encode() not in payload:
+            return ToolResult(decision="pass")
+        redacted = payload.replace(
+            self._substr.encode(), b"[REDACTED]",
+        )
+        return ToolResult(
+            decision="redact",
+            redacted_payload=redacted,
+            reasons=[{"tool": self.name, "match": self._substr}],
+        )
+
+
+class _AlwaysRaise(Tool):
+    name = "always_raise"
+    direction = "out"
+
+    async def evaluate(self, payload: bytes, ctx) -> ToolResult:
+        raise RuntimeError("synthetic tool failure")
+
+
+# ── Tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_block_tool_short_circuits_decision(app):
+    register_tool(_BlockOnSubstr("AKIA"))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/guardian/inspect",
+            json=_body(payload=b"please leak AKIAEXAMPLE now"),
+        )
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["decision"] == "block"
+    assert body["redacted_payload_b64"] is None
+    # reasons surfaced from the firing tool
+    assert any(r["tool"] == "block_on_substr" for r in body["reasons"])
+
+
+@pytest.mark.asyncio
+async def test_redact_tool_returns_redacted_payload(app):
+    register_tool(_RedactSubstr("4242"))
+
+    payload = b'{"card":"4242 4242 4242 4242"}'
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/guardian/inspect", json=_body(payload=payload))
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["decision"] == "redact"
+    assert body["redacted_payload_b64"]
+    decoded = base64.urlsafe_b64decode(
+        body["redacted_payload_b64"]
+        + "=" * (-len(body["redacted_payload_b64"]) % 4),
+    )
+    # 4 occurrences of "4242" each replaced with [REDACTED]
+    assert decoded.count(b"[REDACTED]") == 4
+    assert b"4242" not in decoded
+
+
+@pytest.mark.asyncio
+async def test_block_wins_over_redact_when_both_fire(app):
+    """Worst-decision-wins: block strictness > redact > pass. The
+    redaction is also dropped from the response so a block result
+    never carries 'almost OK' bytes downstream."""
+    register_tool(_RedactSubstr("4242"))
+    # Block must register AFTER redact so we test ordering invariance.
+    register_tool(_BlockOnSubstr("AKIA"))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/guardian/inspect",
+            json=_body(payload=b"4242 4242 / AKIAEXAMPLE"),
+        )
+
+    body = r.json()
+    assert body["decision"] == "block"
+    assert body["redacted_payload_b64"] is None
+
+
+@pytest.mark.asyncio
+async def test_tool_exception_recorded_not_propagated(app):
+    """A broken tool must not break the endpoint. The exception is
+    surfaced as a reason so operators see the gap in the audit row,
+    but the response is otherwise computed from the surviving tools."""
+    register_tool(_AlwaysRaise())
+    register_tool(_BlockOnSubstr("AKIA"))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/guardian/inspect",
+            json=_body(payload=b"AKIAEXAMPLE"),
+        )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["decision"] == "block"
+    reason_tools = [r["tool"] for r in body["reasons"]]
+    assert "always_raise" in reason_tools
+    assert "block_on_substr" in reason_tools
+
+
+@pytest.mark.asyncio
+async def test_slow_path_hook_called_with_inspect_payload(app):
+    """When set_slow_path_hook is registered, the endpoint enqueues
+    after the fast-path response is computed. The hook receives the
+    audit_id + direction + payload."""
+    captured: list[SlowPathPayload] = []
+
+    def hook(task: SlowPathPayload) -> bool:
+        captured.append(task)
+        return True
+
+    set_slow_path_hook(hook)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/guardian/inspect", json=_body())
+
+    assert r.status_code == 200
+    assert len(captured) == 1
+    assert captured[0].audit_id == r.json()["audit_id"]
+    assert captured[0].direction == "out"
+    assert captured[0].peer_agent_id == "orgb::bob"
+    assert captured[0].payload == b'{"hello":"world"}'
+
+
+@pytest.mark.asyncio
+async def test_slow_path_hook_returning_false_does_not_break_response(app):
+    """Queue full / dropped task is best-effort: response still 200."""
+    set_slow_path_hook(lambda task: False)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        r = await c.post("/v1/guardian/inspect", json=_body())
+
+    assert r.status_code == 200
+    assert r.json()["decision"] == "pass"
+
+
+@pytest.mark.asyncio
+async def test_slow_path_receives_redacted_payload_when_redact(app):
+    """When fast-path redacted the payload, the slow-path sees the
+    sanitized form. Slow-path judges should never see raw PII when
+    the synchronous tools already redacted it."""
+    register_tool(_RedactSubstr("4242"))
+    captured: list[SlowPathPayload] = []
+    set_slow_path_hook(lambda task: (captured.append(task) or True))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        await c.post(
+            "/v1/guardian/inspect",
+            json=_body(payload=b"see 4242 here"),
+        )
+
+    assert len(captured) == 1
+    assert b"4242" not in captured[0].payload
+    assert b"[REDACTED]" in captured[0].payload
+
+
+@pytest.mark.asyncio
+async def test_audit_row_carries_tools_run_list(app):
+    register_tool(_BlockOnSubstr("AKIA"))
+    register_tool(_RedactSubstr("4242"))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as c:
+        await c.post(
+            "/v1/guardian/inspect",
+            json=_body(payload=b"clean payload"),
+        )
+
+    async with get_db() as conn:
+        row = (await conn.execute(text(
+            "SELECT details FROM local_audit WHERE event_type = 'guardian.inspect'"
+        ))).fetchone()
+    detail = json.loads(row._mapping["details"])
+    assert detail["phase"] == "fast_path"
+    assert sorted(detail["tools_run"]) == ["block_on_substr", "redact_substr"]

--- a/tests/test_guardian_fastpath.py
+++ b/tests/test_guardian_fastpath.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import base64
 import json
-from typing import Any
 
 import pytest
 import pytest_asyncio


### PR DESCRIPTION
## Summary

ADR-016 Phase 2 (public-side wiring). Phase 1 (#465) endpoint returned `pass` for everything. This PR makes `/v1/guardian/inspect` actually invoke the registered tools and merges verdicts. Plus adds a slow-path hook the enterprise `llm_guardian` plugin will set at startup, enqueueing payloads non-blocking for async judge dispatch.

## What changes

**`mcp_proxy/guardian/endpoint.py`**:
- Iterates `registered_tools(direction)`, runs them concurrently via `asyncio.gather`, merges verdicts worst-wins (block > redact > pass).
- Tool exceptions caught + surfaced as `tool=<name> match=tool_error:<class>` reasons (broken plugin can't silently swallow signal).
- After fast-path response is computed, calls `enqueue_slow_path(SlowPathPayload(...))` non-blocking. No-op when no hook registered.
- When fast-path redacted, the slow-path receives the sanitized bytes (judges should never see PII the regex already removed).
- Audit row now carries `phase=fast_path` + `tools_run=[…]` for ops triage.

**New `mcp_proxy/guardian/slow_path.py`**:
- `set_slow_path_hook(callable)` setter, `enqueue_slow_path(task)` caller. Open-core boundary: public repo never imports from enterprise; enterprise plugin sets the hook at startup, clears on shutdown.
- `SlowPathPayload` dataclass with `audit_id`, `direction`, `agent_id`, `peer_agent_id`, `msg_id`, `payload`. Stable wire shape so the plugin cannot couple to the Pydantic request schema.

**`mcp_proxy/guardian/__init__.py`** re-exports the slow-path symbols.

## Test plan

- [x] `pytest tests/test_guardian_*.py` — **27/27 green** (19 existing Phase 1 + 8 new fastpath: block, redact, block-wins-over-redact, tool exception isolation, slow-path hook called, hook=False non-fatal, redacted bytes flow through, audit row tools_run list).
- [x] `pytest tests/` (full suite locally before push) — no regression on existing tests.
- [ ] `nix-build tests/integration/cullis_network -A tier1-roma` — pre-merge gate.

## Open-core boundary

The public repo never imports anything from the enterprise. The enterprise `llm_guardian` plugin (separate cullis-enterprise PR, depends on this) calls `mcp_proxy.guardian.set_slow_path_hook(dispatcher.enqueue)` at plugin startup. If a customer runs Cullis without the enterprise plugin, the slow-path is silently no-op (audit-only via fast-path).

## Wire shape preserved

Phase 1 SDK + Phase 3 SDK wiring (#469) keep working unchanged. The endpoint:
- request body identical
- response shape identical (decision + ticket + ticket_exp + redacted_payload_b64 + audit_id + reasons)
- audit row event_type identical (`guardian.inspect`)
- only `details.phase` flipped from `foundation` to `fast_path` and a new `tools_run` field added

## Out of scope

- The enterprise `llm_guardian` plugin (regex tools + slow-path dispatcher) — separate cullis-enterprise PR.
- Modes wiring (audit-only vs enforce-fast vs enforce-strict per binding) — Phase 2/Phase 6.
- Dashboard UI rule editor — Phase 6.

## Commits

1. `dfdc2a5` `feat(guardian): wire fast-path tool dispatch + slow-path hook (ADR-016 Phase 2)`