### PR TITLE
feat(demo): insurance multi-surface demo backend scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ drafts/
 # generate_certs.py is INTENTIONALLY tracked — it is a runtime dependency
 # of deploy_broker.sh (invoked on a fresh clone to bootstrap the broker CA).
 run.sh
+# Specific scenario orchestration scripts are checked-in (the top-level
+# run.sh is the dev-machine entry point and stays gitignored).
+!reference/scenarios/insurance-demo/run.sh
 reset.sh
 CLAUDE.md
 .claude/

--- a/reference/scenarios/insurance-demo/README.md
+++ b/reference/scenarios/insurance-demo/README.md
@@ -8,8 +8,8 @@ Insurance claims escalation scenario.
 
 Two orgs (English-only, role-named):
 
-  Mediterranean Insurance    org_id=roma,  td=roma.cullis.test
-  Asia-Pacific Insurance     org_id=tokyo, td=tokyo.cullis.test
+  Mediterranean Insurance    org_id=mediterranean,  td=mediterranean.cullis.test
+  Asia-Pacific Insurance     org_id=asia-pacific, td=asia-pacific.cullis.test
 
 Plus `court` as federation hub.
 
@@ -17,13 +17,13 @@ Five principals + 1 workload + 1 resource:
 
 | Backend ID | Type | Surface |
 |---|---|---|
-| `roma::user::claim-officer` | user | Cullis Chat (single-user desktop) |
-| `roma::user::claim-manager` | user | Cullis Chat dashboard `/chat` |
-| `roma::agent::night-reporter` | agent | none (cron-style script) |
-| `roma::agent::ticket-bot` | agent | none (request-response script) |
-| `tokyo::user::counterparty-liaison` | user | Frontdesk (multi-user web) |
-| `tokyo::workload::frontdesk-container` | workload | n/a (visible in admin) |
-| `roma::resource::mcp::claims-db` | resource | postgres MCP server |
+| `mediterranean::user::claim-officer` | user | Cullis Chat (single-user desktop) |
+| `mediterranean::user::claim-manager` | user | Cullis Chat dashboard `/chat` |
+| `mediterranean::agent::night-reporter` | agent | none (cron-style script) |
+| `mediterranean::agent::ticket-bot` | agent | none (request-response script) |
+| `asia-pacific::user::counterparty-liaison` | user | Frontdesk (multi-user web) |
+| `asia-pacific::workload::frontdesk-container` | workload | n/a (visible in admin) |
+| `mediterranean::resource::mcp::claims-db` | resource | postgres MCP server |
 
 Full UI/SPA contract: `imp/insurance-demo-spec.md`
 
@@ -36,7 +36,7 @@ Full UI/SPA contract: `imp/insurance-demo-spec.md`
 3. `claim-manager` (user, Cullis Chat /chat) decides cross-company action,
    asks `ticket-bot` to generate a formal ticket. **U2A intra-org.**
 4. `ticket-bot` returns ticket ID. **A2U intra-org return.**
-5. `claim-manager` sends request to `counterparty-liaison` at Tokyo,
+5. `claim-manager` sends request to `counterparty-liaison` at Asia-Pacific,
    referencing ticket. **U2U cross-org.**
 6. `counterparty-liaison` (user, Frontdesk) receives in inbox, reads, replies.
 
@@ -63,16 +63,16 @@ Quadrants ADR-020 covered: A2U, U2U intra, U2A, U2U cross-org. Missing: A2A
   ./demo.sh full                                  # base reference up
   cd scenarios/insurance-demo
   ./run.sh seed                                   # provision principals + claims
-  ./run.sh frontdesk                              # bring up Tokyo Frontdesk
+  ./run.sh frontdesk                              # bring up Asia-Pacific Frontdesk
   ./run.sh trigger-night-reporter                 # manual A2U trigger
   ./run.sh urls                                   # print recording-ready URLs
 
 Then browser:
   Cullis Chat (claim-officer):   http://localhost:9100/chat
   Cullis Chat (claim-manager):   http://localhost:9100/chat?user=manager  (or alt port)
-  Frontdesk Tokyo:               http://localhost:8090?user=liaison
-  Mastio Roma admin:             http://localhost:9100/admin
-  Mastio Tokyo admin:            http://localhost:9200/admin
+  Asia-Pacific Frontdesk:               http://localhost:8090?user=liaison
+  Mediterranean Mastio admin:             http://localhost:9100/admin
+  Asia-Pacific Mastio admin:            http://localhost:9200/admin
 
 ## Cleanup
 
@@ -85,7 +85,7 @@ Then browser:
     ../../../imp/official_sandbox/.env | cut -d= -f2-)
 
   ./run.sh seed   # picks it up from env, configures litellm_embedded
-                  # on Roma proxy AI gateway
+                  # on Mediterranean proxy AI gateway
 
 The bots use Haiku 4.5 for cost; Cullis Chat user-facing path uses whatever
 the user's session config has set.

--- a/reference/scenarios/insurance-demo/README.md
+++ b/reference/scenarios/insurance-demo/README.md
@@ -1,0 +1,91 @@
+# Insurance demo — multi-surface cross-org A2A
+
+Three-surface demo (Cullis Chat consumer / Frontdesk enterprise / Mastio
+admin dashboard) showing 5 principals exchanging messages across two orgs.
+Insurance claims escalation scenario.
+
+## Cast
+
+Two orgs (English-only, role-named):
+
+  Mediterranean Insurance    org_id=roma,  td=roma.cullis.test
+  Asia-Pacific Insurance     org_id=tokyo, td=tokyo.cullis.test
+
+Plus `court` as federation hub.
+
+Five principals + 1 workload + 1 resource:
+
+| Backend ID | Type | Surface |
+|---|---|---|
+| `roma::user::claim-officer` | user | Cullis Chat (single-user desktop) |
+| `roma::user::claim-manager` | user | Cullis Chat dashboard `/chat` |
+| `roma::agent::night-reporter` | agent | none (cron-style script) |
+| `roma::agent::ticket-bot` | agent | none (request-response script) |
+| `tokyo::user::counterparty-liaison` | user | Frontdesk (multi-user web) |
+| `tokyo::workload::frontdesk-container` | workload | n/a (visible in admin) |
+| `roma::resource::mcp::claims-db` | resource | postgres MCP server |
+
+Full UI/SPA contract: `imp/insurance-demo-spec.md`
+
+## Workflow
+
+1. Overnight: `night-reporter` (agent) queries `claims-db` for cross-company-flagged
+   cases, sends summary to `claim-officer` inbox. **A2U intra-org.**
+2. Morning: `claim-officer` (user, Cullis Chat) reads, picks the most urgent,
+   escalates to `claim-manager`. **U2U intra-org.**
+3. `claim-manager` (user, Cullis Chat /chat) decides cross-company action,
+   asks `ticket-bot` to generate a formal ticket. **U2A intra-org.**
+4. `ticket-bot` returns ticket ID. **A2U intra-org return.**
+5. `claim-manager` sends request to `counterparty-liaison` at Tokyo,
+   referencing ticket. **U2U cross-org.**
+6. `counterparty-liaison` (user, Frontdesk) receives in inbox, reads, replies.
+
+Quadrants ADR-020 covered: A2U, U2U intra, U2A, U2U cross-org. Missing: A2A
+(intentional — demo clarity over completeness).
+
+## Files
+
+  README.md            this file
+  seed/
+    seed.py            provision the 5 principals + 1 workload + claims-db
+    claims.sql         insurance claims fixture (cross-company flag, urgency,
+                       region, etc.) seeded into the postgres MCP server
+  bots/
+    night_reporter.py  agent script — overnight scheduled run
+    ticket_bot.py      agent script — request-response loop
+  compose.frontdesk.yml  overlay adding Frontdesk container to reference
+  run.sh               orchestration — bring up reference + frontdesk overlay,
+                       run seeds, optional manual triggers
+
+## Running the demo
+
+  cd reference
+  ./demo.sh full                                  # base reference up
+  cd scenarios/insurance-demo
+  ./run.sh seed                                   # provision principals + claims
+  ./run.sh frontdesk                              # bring up Tokyo Frontdesk
+  ./run.sh trigger-night-reporter                 # manual A2U trigger
+  ./run.sh urls                                   # print recording-ready URLs
+
+Then browser:
+  Cullis Chat (claim-officer):   http://localhost:9100/chat
+  Cullis Chat (claim-manager):   http://localhost:9100/chat?user=manager  (or alt port)
+  Frontdesk Tokyo:               http://localhost:8090?user=liaison
+  Mastio Roma admin:             http://localhost:9100/admin
+  Mastio Tokyo admin:            http://localhost:9200/admin
+
+## Cleanup
+
+  ./run.sh down                                   # tears down frontdesk overlay
+  cd ../.. && ./demo.sh down                      # tears down reference
+
+## Anthropic API key
+
+  export ANTHROPIC_API_KEY=$(grep ^ANTHROPIC_API_KEY \
+    ../../../imp/official_sandbox/.env | cut -d= -f2-)
+
+  ./run.sh seed   # picks it up from env, configures litellm_embedded
+                  # on Roma proxy AI gateway
+
+The bots use Haiku 4.5 for cost; Cullis Chat user-facing path uses whatever
+the user's session config has set.

--- a/reference/scenarios/insurance-demo/README.md
+++ b/reference/scenarios/insurance-demo/README.md
@@ -13,6 +13,17 @@ Two orgs (English-only, role-named):
 
 Plus `court` as federation hub.
 
+Personas (the humans behind the user principals — Mediterranean side
+Italian, Asia-Pacific side Japanese; mirrors the realistic insurance
+scenario where a Roma–Napoli accident involves a Japanese-insured
+counterparty, see claim INC-2026-0501 in `seed/claims.sql`):
+
+  - `claim-officer`         → Marco Conti       (Italian, junior)
+  - `claim-manager`         → Lucia Bianchi     (Italian, senior)
+  - `counterparty-liaison`  → Kenji Watanabe    (Japanese, partner)
+
+Bots have no human face — they are just `Night Reporter` and `Ticket Bot`.
+
 Five principals + 1 workload + 1 resource:
 
 | Backend ID | Type | Surface |

--- a/reference/scenarios/insurance-demo/bots/night_reporter.py
+++ b/reference/scenarios/insurance-demo/bots/night_reporter.py
@@ -1,16 +1,16 @@
 """Night Reporter — overnight scheduled agent for the insurance demo.
 
-Identity: ``roma::agent::night-reporter``
+Identity: ``mediterranean::agent::night-reporter``
 Reach:    intra-org only
 Scope:    claims-db.read + oneshot.message
 
 What it does (one tick):
 
-  1. Authenticate to Roma's Mastio with the cert/key minted by ``seed.py``
-  2. Query the ``roma::resource::mcp::claims-db`` MCP server for claims
+  1. Authenticate to Mediterranean's Mastio with the cert/key minted by ``seed.py``
+  2. Query the ``mediterranean::resource::mcp::claims-db`` MCP server for claims
      where ``cross_company_flag = TRUE`` AND ``status = 'open'``
   3. Build a short summary (count, top 3 by amount, urgency breakdown)
-  4. Send a one-shot message to ``roma::user::claim-officer`` with the
+  4. Send a one-shot message to ``mediterranean::user::claim-officer`` with the
      summary as payload (intra-org A2U, ADR-008 envelope)
   5. Log + exit (idempotent — replay-safe via correlation_id)
 
@@ -40,7 +40,7 @@ from cullis_sdk import CullisClient
 
 HERE = pathlib.Path(__file__).resolve().parent
 STATE_DIR = (HERE.parents[2] / "state" / "insurance-demo" / "agents" / "night-reporter").resolve()
-RECIPIENT = "roma::user::claim-officer"
+RECIPIENT = "mediterranean::user::claim-officer"
 MASTIO_URL = os.environ.get("CULLIS_PROXY_A_URL", "https://localhost:9100")
 
 
@@ -81,7 +81,7 @@ def _build_summary(claims: list[dict]) -> dict:
 
 
 def _query_claims(client: CullisClient) -> list[dict]:
-    """Call the ``roma::resource::mcp::claims-db`` MCP server through the
+    """Call the ``mediterranean::resource::mcp::claims-db`` MCP server through the
     SDK helper. Returns a list of claim rows (dict). Falls back to a
     canned fixture if the MCP server is unreachable so the demo doesn't
     hard-fail on a network blip during recording."""
@@ -89,7 +89,7 @@ def _query_claims(client: CullisClient) -> list[dict]:
         # SDK MCP helpers landed in ADR-017 Phase 3 (memory:
         # project_session_2026_05_04_adr017_live.md).
         result = client.call_mcp_tool(
-            resource_id="roma::resource::mcp::claims-db",
+            resource_id="mediterranean::resource::mcp::claims-db",
             tool_name="query_claims",
             arguments={
                 "where": "cross_company_flag = TRUE AND status = 'open'",
@@ -139,8 +139,8 @@ def run_once(verbose: bool = False) -> int:
         MASTIO_URL,
         cert_path=cert,
         key_path=key,
-        agent_id="roma::agent::night-reporter",
-        org_id="roma",
+        agent_id="mediterranean::agent::night-reporter",
+        org_id="mediterranean",
         verify_tls=False,  # dev / sandbox — Org CA self-signed
     )
     client.login_via_proxy()

--- a/reference/scenarios/insurance-demo/bots/night_reporter.py
+++ b/reference/scenarios/insurance-demo/bots/night_reporter.py
@@ -1,0 +1,190 @@
+"""Night Reporter — overnight scheduled agent for the insurance demo.
+
+Identity: ``roma::agent::night-reporter``
+Reach:    intra-org only
+Scope:    claims-db.read + oneshot.message
+
+What it does (one tick):
+
+  1. Authenticate to Roma's Mastio with the cert/key minted by ``seed.py``
+  2. Query the ``roma::resource::mcp::claims-db`` MCP server for claims
+     where ``cross_company_flag = TRUE`` AND ``status = 'open'``
+  3. Build a short summary (count, top 3 by amount, urgency breakdown)
+  4. Send a one-shot message to ``roma::user::claim-officer`` with the
+     summary as payload (intra-org A2U, ADR-008 envelope)
+  5. Log + exit (idempotent — replay-safe via correlation_id)
+
+Run modes:
+
+  python night_reporter.py --once             # single tick, exit
+  python night_reporter.py --schedule '0 22 * * *'   # cron string, daemon
+  python night_reporter.py --demo             # demo mode: skips schedule,
+                                                runs once, prints what it
+                                                sent for the recording
+
+In production this lives behind a systemd timer; in the demo recording the
+operator triggers it manually via ``run.sh trigger-night-reporter``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import time
+import uuid
+
+from cullis_sdk import CullisClient
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+STATE_DIR = (HERE.parents[2] / "state" / "insurance-demo" / "agents" / "night-reporter").resolve()
+RECIPIENT = "roma::user::claim-officer"
+MASTIO_URL = os.environ.get("CULLIS_PROXY_A_URL", "https://localhost:9100")
+
+
+def _build_summary(claims: list[dict]) -> dict:
+    if not claims:
+        return {
+            "kind":        "night-report",
+            "generated_at": int(time.time()),
+            "summary":      "No cross-company-flagged open claims this run.",
+            "claim_count":  0,
+            "claims":       [],
+        }
+    by_urgency = {"high": 0, "normal": 0, "low": 0}
+    for c in claims:
+        by_urgency[c.get("urgency", "normal")] = by_urgency.get(c.get("urgency", "normal"), 0) + 1
+    top3 = sorted(claims, key=lambda c: c.get("estimated_amount_eur", 0), reverse=True)[:3]
+    return {
+        "kind":         "night-report",
+        "generated_at":  int(time.time()),
+        "summary": (
+            f"{len(claims)} cross-company claims open. "
+            f"Urgency: high={by_urgency['high']}, normal={by_urgency['normal']}, "
+            f"low={by_urgency['low']}. Top 3 by exposure attached."
+        ),
+        "claim_count":  len(claims),
+        "by_urgency":   by_urgency,
+        "top3":         [
+            {
+                "claim_id":  c["claim_id"],
+                "amount_eur": c["estimated_amount_eur"],
+                "region":    c["region"],
+                "counterparty_insurer": c["counterparty_insurer"],
+                "urgency":   c["urgency"],
+            }
+            for c in top3
+        ],
+    }
+
+
+def _query_claims(client: CullisClient) -> list[dict]:
+    """Call the ``roma::resource::mcp::claims-db`` MCP server through the
+    SDK helper. Returns a list of claim rows (dict). Falls back to a
+    canned fixture if the MCP server is unreachable so the demo doesn't
+    hard-fail on a network blip during recording."""
+    try:
+        # SDK MCP helpers landed in ADR-017 Phase 3 (memory:
+        # project_session_2026_05_04_adr017_live.md).
+        result = client.call_mcp_tool(
+            resource_id="roma::resource::mcp::claims-db",
+            tool_name="query_claims",
+            arguments={
+                "where": "cross_company_flag = TRUE AND status = 'open'",
+                "order_by": "estimated_amount_eur DESC",
+                "limit": 20,
+            },
+        )
+        return result.get("rows", [])
+    except Exception as exc:
+        print(f"[night-reporter] MCP query failed ({exc}) — using canned fixture",
+              file=sys.stderr)
+        # Canned fixture mirrors claims.sql cross-company rows
+        return [
+            {"claim_id": "INC-2026-0501", "estimated_amount_eur": 18500,
+             "region": "Lazio",     "counterparty_insurer": "Asia-Pacific Insurance",
+             "urgency": "high"},
+            {"claim_id": "INC-2026-0502", "estimated_amount_eur": 42000,
+             "region": "Lombardia", "counterparty_insurer": "Asia-Pacific Insurance",
+             "urgency": "high"},
+            {"claim_id": "INC-2026-0503", "estimated_amount_eur": 7800,
+             "region": "Campania",  "counterparty_insurer": "Asia-Pacific Insurance",
+             "urgency": "high"},
+        ]
+
+
+def _send(client: CullisClient, payload: dict) -> dict:
+    """Fire the summary as a one-shot to claim-officer. Sets
+    correlation_id deterministically so two same-day runs idempotent."""
+    corr_id = f"night-report-{time.strftime('%Y%m%d')}"
+    return client.send_oneshot(
+        recipient_id=RECIPIENT,
+        payload=payload,
+        correlation_id=corr_id,
+        ttl_seconds=86400,
+    )
+
+
+def run_once(verbose: bool = False) -> int:
+    cert = STATE_DIR / "agent.pem"
+    key  = STATE_DIR / "agent-key.pem"
+    if not (cert.exists() and key.exists()):
+        print(f"[night-reporter] missing identity at {STATE_DIR} — "
+              "did you run ./run.sh seed?", file=sys.stderr)
+        return 2
+
+    client = CullisClient.from_identity_dir(
+        MASTIO_URL,
+        cert_path=cert,
+        key_path=key,
+        agent_id="roma::agent::night-reporter",
+        org_id="roma",
+        verify_tls=False,  # dev / sandbox — Org CA self-signed
+    )
+    client.login_via_proxy()
+    client._signing_key_pem = key.read_text()
+
+    claims = _query_claims(client)
+    payload = _build_summary(claims)
+    if verbose:
+        print(json.dumps(payload, indent=2))
+    resp = _send(client, payload)
+    print(f"[night-reporter] sent → {RECIPIENT} "
+          f"correlation_id={resp.get('correlation_id')} "
+          f"msg_id={resp.get('msg_id')} status={resp.get('status')}")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--once", action="store_true",
+                   help="single tick then exit (default)")
+    p.add_argument("--demo", action="store_true",
+                   help="demo mode: same as --once but verbose")
+    p.add_argument("--schedule", default=None,
+                   help="cron string (loops forever — production deploy)")
+    args = p.parse_args()
+
+    if args.schedule:
+        try:
+            from croniter import croniter
+        except ImportError:
+            print("[night-reporter] --schedule requires croniter "
+                  "(pip install croniter)", file=sys.stderr)
+            return 2
+        from datetime import datetime
+        cron = croniter(args.schedule, datetime.now())
+        while True:
+            nxt = cron.get_next(datetime)
+            wait = (nxt - datetime.now()).total_seconds()
+            if wait > 0:
+                time.sleep(wait)
+            run_once(verbose=False)
+
+    return run_once(verbose=args.demo)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/scenarios/insurance-demo/bots/ticket_bot.py
+++ b/reference/scenarios/insurance-demo/bots/ticket_bot.py
@@ -1,14 +1,14 @@
 """Ticket Bot — request-response agent for the insurance demo.
 
-Identity: ``roma::agent::ticket-bot``
+Identity: ``mediterranean::agent::ticket-bot``
 Reach:    intra-org only
 Scope:    claims-db.write + oneshot.message
 
 What it does (event loop):
 
-  1. Authenticate to Roma's Mastio with the cert/key minted by ``seed.py``
+  1. Authenticate to Mediterranean's Mastio with the cert/key minted by ``seed.py``
   2. Poll the inbox for incoming requests addressed to this agent
-     (typically from ``roma::user::claim-manager``)
+     (typically from ``mediterranean::user::claim-manager``)
   3. For each request, parse the natural-language claim context, generate
      a deterministic ticket ID (``TKT-YYYY-MM-DD-NNN``), persist a
      formal record into the claims-db (status=under-review, ticket_ref
@@ -85,7 +85,7 @@ def _process_request(client: CullisClient, msg: dict) -> dict | None:
     # Persist into the claims DB via the MCP server.
     try:
         client.call_mcp_tool(
-            resource_id="roma::resource::mcp::claims-db",
+            resource_id="mediterranean::resource::mcp::claims-db",
             tool_name="exec_sql",
             arguments={
                 "statement": (
@@ -122,8 +122,8 @@ def run_once(verbose: bool = False) -> int:
         MASTIO_URL,
         cert_path=cert,
         key_path=key,
-        agent_id="roma::agent::ticket-bot",
-        org_id="roma",
+        agent_id="mediterranean::agent::ticket-bot",
+        org_id="mediterranean",
         verify_tls=False,
     )
     client.login_via_proxy()

--- a/reference/scenarios/insurance-demo/bots/ticket_bot.py
+++ b/reference/scenarios/insurance-demo/bots/ticket_bot.py
@@ -1,0 +1,186 @@
+"""Ticket Bot — request-response agent for the insurance demo.
+
+Identity: ``roma::agent::ticket-bot``
+Reach:    intra-org only
+Scope:    claims-db.write + oneshot.message
+
+What it does (event loop):
+
+  1. Authenticate to Roma's Mastio with the cert/key minted by ``seed.py``
+  2. Poll the inbox for incoming requests addressed to this agent
+     (typically from ``roma::user::claim-manager``)
+  3. For each request, parse the natural-language claim context, generate
+     a deterministic ticket ID (``TKT-YYYY-MM-DD-NNN``), persist a
+     formal record into the claims-db (status=under-review, ticket_ref
+     populated), and reply to the sender with the ticket ID + URL
+  4. Continue polling until SIGINT
+
+Run modes:
+
+  python ticket_bot.py --once                # process one inbox message, exit
+  python ticket_bot.py --watch               # daemon, polls forever
+  python ticket_bot.py --demo                # one-shot for the recording
+
+This is the U2A return path: claim-manager (user) asks ticket-bot (agent)
+to formalise a claim, ticket-bot writes to the DB and answers back. Both
+sides intra-org. Zero cross-org traffic from this bot.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+import time
+
+from cullis_sdk import CullisClient
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+STATE_DIR = (HERE.parents[2] / "state" / "insurance-demo" / "agents" / "ticket-bot").resolve()
+MASTIO_URL = os.environ.get("CULLIS_PROXY_A_URL", "https://localhost:9100")
+POLL_INTERVAL_S = 3.0
+
+
+def _next_ticket_id() -> str:
+    """``TKT-YYYY-MM-DD-NNN`` — counter persisted to a file so two runs
+    in the same day don't collide."""
+    counter_path = STATE_DIR / "ticket-counter"
+    today = time.strftime("%Y-%m-%d")
+    if counter_path.exists():
+        try:
+            saved_date, saved_n = counter_path.read_text().strip().split(":")
+            n = int(saved_n) + 1 if saved_date == today else 1
+        except Exception:
+            n = 1
+    else:
+        n = 1
+    counter_path.write_text(f"{today}:{n}")
+    return f"TKT-{today}-{n:03d}"
+
+
+def _process_request(client: CullisClient, msg: dict) -> dict | None:
+    """Decrypt the incoming request, generate a ticket, persist it,
+    return the reply payload. Returns None if the message is not a
+    valid request (skip + ack). """
+    try:
+        decrypted = client.decrypt_oneshot(msg)
+    except Exception as exc:
+        print(f"[ticket-bot] decrypt failed for msg {msg.get('msg_id')}: {exc}",
+              file=sys.stderr)
+        return None
+    payload = decrypted.get("payload") or {}
+
+    # Expected request shape (from claim-manager):
+    #   {"action": "create_ticket", "claim_id": "INC-2026-0501",
+    #    "context": "..."}
+    if payload.get("action") != "create_ticket":
+        return None
+
+    ticket_id = _next_ticket_id()
+    claim_id = payload.get("claim_id", "unknown")
+    context = payload.get("context", "")
+
+    # Persist into the claims DB via the MCP server.
+    try:
+        client.call_mcp_tool(
+            resource_id="roma::resource::mcp::claims-db",
+            tool_name="exec_sql",
+            arguments={
+                "statement": (
+                    "UPDATE claims SET status = 'under-review', "
+                    "notes = COALESCE(notes,'') || ' [ticket=' || $1 || ']' "
+                    "WHERE claim_id = $2"
+                ),
+                "params": [ticket_id, claim_id],
+            },
+        )
+    except Exception as exc:
+        print(f"[ticket-bot] DB update failed ({exc}) — replying anyway",
+              file=sys.stderr)
+
+    return {
+        "kind":          "ticket-created",
+        "ticket_id":     ticket_id,
+        "claim_id":      claim_id,
+        "url":           f"https://claims.local/tickets/{ticket_id}",
+        "context_echo":  context[:200],
+        "created_at":    int(time.time()),
+    }
+
+
+def run_once(verbose: bool = False) -> int:
+    cert = STATE_DIR / "agent.pem"
+    key  = STATE_DIR / "agent-key.pem"
+    if not (cert.exists() and key.exists()):
+        print(f"[ticket-bot] missing identity at {STATE_DIR} — "
+              "did you run ./run.sh seed?", file=sys.stderr)
+        return 2
+
+    client = CullisClient.from_identity_dir(
+        MASTIO_URL,
+        cert_path=cert,
+        key_path=key,
+        agent_id="roma::agent::ticket-bot",
+        org_id="roma",
+        verify_tls=False,
+    )
+    client.login_via_proxy()
+    client._signing_key_pem = key.read_text()
+
+    rows = client.receive_oneshot()
+    if not rows:
+        if verbose:
+            print("[ticket-bot] inbox empty")
+        return 0
+
+    handled = 0
+    for msg in rows:
+        reply = _process_request(client, msg)
+        if reply is None:
+            continue
+        sender = msg["sender_agent_id"]
+        resp = client.send_oneshot(
+            recipient_id=sender,
+            payload=reply,
+            reply_to=msg["correlation_id"],
+            ttl_seconds=300,
+        )
+        print(f"[ticket-bot] ticket {reply['ticket_id']} → {sender} "
+              f"(reply_to={msg['correlation_id']})")
+        if verbose:
+            print(json.dumps(reply, indent=2))
+        handled += 1
+    return 0 if handled or not rows else 0
+
+
+def watch() -> int:
+    print("[ticket-bot] watching inbox… (Ctrl+C to stop)")
+    while True:
+        try:
+            run_once(verbose=False)
+        except KeyboardInterrupt:
+            print("\n[ticket-bot] stopping")
+            return 0
+        except Exception as exc:
+            print(f"[ticket-bot] error in tick: {exc}", file=sys.stderr)
+        time.sleep(POLL_INTERVAL_S)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--once",  action="store_true",
+                   help="single inbox sweep then exit")
+    p.add_argument("--demo",  action="store_true",
+                   help="demo mode: --once + verbose")
+    p.add_argument("--watch", action="store_true",
+                   help="daemon — poll inbox forever")
+    args = p.parse_args()
+    if args.watch:
+        return watch()
+    return run_once(verbose=args.demo)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/scenarios/insurance-demo/compose.frontdesk.yml
+++ b/reference/scenarios/insurance-demo/compose.frontdesk.yml
@@ -1,0 +1,128 @@
+# Frontdesk overlay for the insurance demo.
+#
+# Adds a Frontdesk container in shared mode wired to the Asia-Pacific
+# Mastio (proxy-b) of the reference stack. Mirrors the structure in
+# packaging/frontdesk-bundle/docker-compose.yml but renamed + rewired
+# to live alongside the reference services rather than alongside the
+# packaging stack.
+#
+# Three internal services on a private bridge net:
+#
+#   nginx-frontdesk-asia-pacific  80   reverse proxy + dev fake-SSO
+#     ↓
+#   chat-frontdesk-asia-pacific   8080 Astro SPA static
+#     ↓
+#   connector-frontdesk-asia-pacific 7777 Connector dashboard + Ambassador
+#     ↓ DPoP+mTLS (joins orgb-internal to reach mastio-nginx-b:9443)
+#
+# Use:
+#
+#   cd reference/scenarios/insurance-demo
+#   ./run.sh seed             # provisions the user principal
+#   ./run.sh frontdesk-prep   # bootstraps the connector identity (one-shot)
+#   ./run.sh frontdesk        # docker compose -f reference/docker-compose.yml
+#                             #                -f compose.frontdesk.yml up -d
+#
+# Open http://localhost:8090?user=kenji to act as Kenji Watanabe.
+#
+# Expected env (defaults set so the demo runs without overrides):
+#
+#   FRONTDESK_AP_HTTP_PORT          host port for Frontdesk web (default 8090)
+#   FRONTDESK_AP_ORG_ID             default asia-pacific
+#   FRONTDESK_AP_TRUST_DOMAIN       default asia-pacific.cullis.test
+#   FRONTDESK_AP_MASTIO_URL         default https://mastio-nginx-b:9443
+#                                   (reachable through the orgb-internal
+#                                    network this overlay joins)
+
+services:
+
+  connector-frontdesk-asia-pacific:
+    build:
+      context: ../../../packaging/frontdesk-bundle
+      dockerfile: Dockerfile.connector
+      args:
+        CONNECTOR_VERSION: ${CONNECTOR_VERSION:-latest}
+    command: >
+      dashboard
+      --host 0.0.0.0
+      --port 7777
+      --no-open-browser
+      --profile frontdesk-asia-pacific
+    expose: ["7777"]
+    environment:
+      AMBASSADOR_MODE: shared
+      CULLIS_FRONTDESK_ORG_ID:        ${FRONTDESK_AP_ORG_ID:-asia-pacific}
+      CULLIS_FRONTDESK_TRUST_DOMAIN:  ${FRONTDESK_AP_TRUST_DOMAIN:-asia-pacific.cullis.test}
+      CULLIS_TRUSTED_PROXIES:         ${FRONTDESK_AP_TRUSTED_PROXIES:-127.0.0.1/32,::1/128,172.16.0.0/12}
+      CULLIS_FRONTDESK_COOKIE_TTL_S:  3600
+      CULLIS_FRONTDESK_MASTIO_URL:    ${FRONTDESK_AP_MASTIO_URL:-https://mastio-nginx-b:9443}
+      CULLIS_SITE_URL:                ${FRONTDESK_AP_MASTIO_URL:-https://mastio-nginx-b:9443}
+      # The Asia-Pacific Mastio's nginx serves a self-signed Org CA cert.
+      # Mount mastio-b-nginx-certs/org-ca.crt and trust it.
+      SSL_CERT_FILE:                  /etc/cullis/ca-bundle.pem
+      REQUESTS_CA_BUNDLE:             /etc/cullis/ca-bundle.pem
+    volumes:
+      # Connector identity material. Pre-populated by ``run.sh frontdesk-prep``.
+      - frontdesk-asia-pacific-connector-data:/home/cullis/.cullis
+      # Trust anchor for proxy-b's self-signed Org CA.
+      - mastio-b-nginx-certs:/etc/cullis-certs:ro
+      # Bash entrypoint copies the trust anchor into the location
+      # SSL_CERT_FILE points at. Plain symlink would suffice but volume
+      # mounts are cleaner.
+    entrypoint: >
+      sh -c "cp /etc/cullis-certs/org-ca.crt /etc/cullis/ca-bundle.pem &&
+             exec /usr/local/bin/cullis-connector $$@"
+    networks:
+      frontdesk-asia-pacific-net:
+      orgb-internal:
+        aliases: [connector-frontdesk-asia-pacific]
+    restart: unless-stopped
+
+  chat-frontdesk-asia-pacific:
+    build:
+      context: ../../../frontend/cullis-chat
+      dockerfile: Dockerfile
+    expose: ["8080"]
+    depends_on:
+      - connector-frontdesk-asia-pacific
+    networks:
+      - frontdesk-asia-pacific-net
+    restart: unless-stopped
+
+  nginx-frontdesk-asia-pacific:
+    image: nginx:1.27-alpine
+    ports:
+      - "${FRONTDESK_AP_HTTP_PORT:-8090}:80"
+    volumes:
+      # The packaging/frontdesk-bundle ships an nginx config tuned to its
+      # service hostnames (connector + cullis-chat). We point it at a
+      # demo-specific copy so the upstreams resolve to our renamed
+      # services. ``run.sh frontdesk-prep`` materialises this from the
+      # bundle config + service-name patches.
+      - ./nginx/frontdesk-asia-pacific.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - chat-frontdesk-asia-pacific
+    networks:
+      - frontdesk-asia-pacific-net
+    restart: unless-stopped
+
+
+volumes:
+  frontdesk-asia-pacific-connector-data:
+  # ``mastio-b-nginx-certs`` is the same volume mastio-nginx-b mounts. Re-
+  # using it lets us pick up the proxy-b Org CA without copy gymnastics.
+  # External flag tells docker compose this volume is created by the
+  # parent compose (reference/docker-compose.yml).
+  mastio-b-nginx-certs:
+    external: true
+    name: cullis-reference-mastio-b-nginx-certs
+
+
+networks:
+  frontdesk-asia-pacific-net:
+    driver: bridge
+  # Reuses the network created by the reference compose. Joining it lets
+  # connector-frontdesk-asia-pacific reach mastio-nginx-b:9443 by hostname.
+  orgb-internal:
+    external: true
+    name: cullis-reference-orgb-internal

--- a/reference/scenarios/insurance-demo/nginx/frontdesk-asia-pacific.conf
+++ b/reference/scenarios/insurance-demo/nginx/frontdesk-asia-pacific.conf
@@ -1,0 +1,125 @@
+# Cullis Frontdesk — dev nginx (ADR-019 Phase 7).
+#
+# Production: replace this whole file with an oauth2-proxy + your IDP
+# (Okta / Auth0 / Keycloak / EntraID / Google Workspace) sitting in front
+# of the SPA. The only contracts the rest of the bundle relies on are:
+#
+#   1. EVERY request reaching the SPA / Ambassador carries
+#      ``X-Forwarded-User`` set to the authenticated user (email or sub).
+#   2. The reverse proxy's source IP is in CULLIS_TRUSTED_PROXIES on the
+#      Connector (default 172.16.0.0/12 covers the docker bridge network).
+#
+# This dev nginx fakes step (1) with a ``?user=`` query-string switch the
+# first time you load the page. It is NOT a security boundary; it exists
+# only so a developer can dogfood the multi-user shared-mode flow without
+# standing up a full IDP. Never expose to the public internet.
+
+# Map the dev ?user= query to a fully-qualified principal email. The
+# default placeholder makes "no ?user=" the unsafe path: the Ambassador
+# will reject the unknown principal, surfacing the misconfig fast rather
+# than falling back to a random user.
+# Insurance-demo persona map. Cross-check imp/insurance-demo-spec.md
+# for the canonical persona ↔ principal mapping.
+map $arg_user $forwarded_user {
+    default      "unknown@frontdesk.dev";
+    "kenji"      "kenji.watanabe@asia-pacific.cullis.test";
+    "watanabe"   "kenji.watanabe@asia-pacific.cullis.test";
+}
+
+server {
+    listen 80 default_server;
+    server_name _;
+
+    # Hide nginx version in error pages / Server header.
+    server_tokens off;
+
+    # Docker's embedded DNS — required because the proxy_pass URLs use
+    # variables (``$request_uri``), which forces nginx to resolve the
+    # upstream hostname per request rather than at start. Without an
+    # explicit resolver nginx errors with "no resolver defined" and
+    # surfaces 502 to the client.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 3s;
+
+    # ----- security headers (ADR-019 Phase 8b-2b) -----
+    #
+    # Set on every response. The SPA in static mode no longer carries
+    # the per-request CSP nonce middleware that pre-Phase-8b's Astro
+    # server had; the policy here applies to the prerendered HTML and
+    # to the proxied /api + /v1 responses.
+    #
+    # ``script-src 'unsafe-inline'`` is a deliberate pragmatic choice
+    # while we ship Phase 8b-2b: Astro's bootstrap inline scripts and
+    # our two custom inline blocks (TopBar audit toggle, ChatLayout
+    # pre-paint hydrate) need either nonce, hash, or unsafe-inline. The
+    # nonce path requires an Astro middleware (gone) or a server-side
+    # injector. Auto-hash via Astro's experimental CSP is the right
+    # follow-up; tracked separately.
+    add_header Content-Security-Policy
+        "default-src 'self'; \
+         script-src 'self' 'unsafe-inline'; \
+         style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; \
+         font-src 'self' https://fonts.gstatic.com https://api.fontshare.com https://cdn.fontshare.com data:; \
+         img-src 'self' data:; \
+         connect-src 'self'; \
+         object-src 'none'; \
+         base-uri 'self'; \
+         frame-ancestors 'none'; \
+         form-action 'self'" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "same-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    # ----- /api/session/*: bypass the SPA, straight to the Ambassador -----
+    #
+    # init mints the cookie from X-Forwarded-User (shared mode) or the
+    # local Bearer (single mode); whoami reads it back; logout clears
+    # it. All three live on the Connector after ADR-019 Phase 8a + 8b-2a;
+    # the SPA's old Astro server-side equivalents are gone (Phase 8b-2b).
+    location /api/session/ {
+        proxy_pass http://connector-frontdesk-asia-pacific:7777$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-User $forwarded_user;
+    }
+
+    # ----- /v1/*: bypass the SPA, direct to the Ambassador -----
+    #
+    # ``require_bearer`` on the Ambassador accepts the cookie minted by
+    # /api/session/init, so the SPA can hit /v1/chat/completions,
+    # /v1/models, /v1/mcp, /v1/ambassador/health directly. SSE streaming
+    # wiring (proxy_buffering off, long read timeout) inlined here.
+    location /v1/ {
+        proxy_pass http://connector-frontdesk-asia-pacific:7777$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-User $forwarded_user;
+        # SSE chat streaming.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+    }
+
+    # ----- everything else: static SPA via the cullis-chat container -----
+    #
+    # The cullis-chat container ships nginx-static (port 8080) serving
+    # the prerendered Astro output. No Astro server in this topology;
+    # the SPA's own /api/* routes were deleted in Phase 8b-2b along
+    # with switching the Astro config to ``output: 'static'``.
+    location / {
+        proxy_pass http://chat-frontdesk-asia-pacific:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/reference/scenarios/insurance-demo/run.sh
+++ b/reference/scenarios/insurance-demo/run.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Insurance demo orchestration.
+#
+#   run.sh seed                      provision the cast on top of reference
+#   run.sh frontdesk                 bring up Asia-Pacific Frontdesk container overlay
+#   run.sh trigger-night-reporter    one-tick A2U from the overnight bot
+#   run.sh start-ticket-bot          background daemon for U2A request/response
+#   run.sh stop-ticket-bot           kill the daemon
+#   run.sh urls                      print recording-ready URLs
+#   run.sh down                      tear down frontdesk overlay
+#   run.sh status                    diagnostic — show component health
+#   run.sh prep-ca                   copy Mediterranean Org CA out of reference state
+#                                    volume to local disk (one-shot)
+#
+# Prerequisites:
+#   1. ``cd reference && ./demo.sh full`` already ran successfully
+#   2. ``imp/official_sandbox/.env`` has ANTHROPIC_API_KEY (gitignored)
+#   3. ``cullis-connector`` SDK installed in the active venv
+#
+# Memory:
+#   - feedback_dogfood_before_demo.md — always end-to-end smoke before
+#     declaring a demo "ready"
+#   - feedback_internal_docs_local.md — the bots, seed, and overlay live
+#     here in scenarios/insurance-demo/, not in scripts/ (public)
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REFERENCE_DIR="$(cd "$HERE/../.." && pwd)"
+REPO_ROOT="$(cd "$HERE/../../.." && pwd)"
+STATE_DIR="$REPO_ROOT/state/insurance-demo"
+ANTHROPIC_ENV_FILE="$REPO_ROOT/imp/official_sandbox/.env"
+PIDS_DIR="$STATE_DIR/pids"
+
+mkdir -p "$STATE_DIR" "$PIDS_DIR"
+
+BOLD='\033[1m'; CYAN='\033[36m'; GREEN='\033[32m'; YELLOW='\033[33m'; RED='\033[31m'; RESET='\033[0m'
+
+_h()    { echo -e "\n${BOLD}${CYAN}═══ $1 ═══${RESET}\n"; }
+_ok()   { echo -e "  ${GREEN}✓${RESET} $1"; }
+_warn() { echo -e "  ${YELLOW}⚠${RESET} $1"; }
+_fail() { echo -e "  ${RED}✗${RESET} $1"; }
+
+_load_env() {
+    if [ -f "$ANTHROPIC_ENV_FILE" ]; then
+        export ANTHROPIC_API_KEY="$(grep '^ANTHROPIC_API_KEY=' "$ANTHROPIC_ENV_FILE" | cut -d= -f2- | tr -d '"')"
+    fi
+}
+
+# ── Subcommands ─────────────────────────────────────────────────────────
+
+cmd_prep_ca() {
+    _h "Copying Mediterranean Org CA from reference state volume"
+    # The reference compose's bootstrap container persists Org CAs into
+    # the bootstrap-state volume. Copy them out for our seed.py to mint
+    # agent certs against.
+    local container
+    container=$(docker compose -f "$REFERENCE_DIR/docker-compose.yml" ps -q bootstrap | head -1)
+    if [ -z "$container" ]; then
+        _warn "bootstrap container not running — starting transiently"
+        docker compose -f "$REFERENCE_DIR/docker-compose.yml" up -d bootstrap || true
+        container=$(docker compose -f "$REFERENCE_DIR/docker-compose.yml" ps -q bootstrap | head -1)
+    fi
+    if [ -z "$container" ]; then
+        _fail "no bootstrap container available; cannot extract CA"
+        exit 1
+    fi
+    docker cp "$container:/state/mediterranean/ca-cert.pem" "$STATE_DIR/mediterranean-ca.pem"
+    docker cp "$container:/state/mediterranean/ca-key.pem"  "$STATE_DIR/mediterranean-ca.key"
+    chmod 600 "$STATE_DIR/mediterranean-ca.key"
+    _ok "Mediterranean Org CA at $STATE_DIR/mediterranean-ca.{pem,key}"
+}
+
+cmd_seed() {
+    _load_env
+    _h "Seeding insurance-demo cast"
+    if [ ! -f "$STATE_DIR/mediterranean-ca.pem" ]; then
+        _warn "Mediterranean Org CA missing — running prep-ca first"
+        cmd_prep_ca
+    fi
+    python3 "$HERE/seed/seed.py"
+}
+
+cmd_frontdesk() {
+    _h "Bringing up Asia-Pacific Frontdesk container"
+    if [ ! -f "$HERE/compose.frontdesk.yml" ]; then
+        _warn "compose.frontdesk.yml not present yet — manual scaffold pending"
+        _warn "use ../packaging/frontdesk-bundle/ as the source for now:"
+        _warn "  cd $REPO_ROOT/packaging/frontdesk-bundle"
+        _warn "  cp frontdesk.env.example frontdesk.env"
+        _warn "  edit frontdesk.env: set CULLIS_FRONTDESK_ORG_ID=asia-pacific"
+        _warn "  docker compose --env-file frontdesk.env up -d"
+        return 0
+    fi
+    docker compose -f "$REFERENCE_DIR/docker-compose.yml" \
+                   -f "$HERE/compose.frontdesk.yml" up -d frontdesk-asia-pacific
+    _ok "frontdesk-asia-pacific up — http://localhost:8090"
+}
+
+cmd_trigger_night_reporter() {
+    _load_env
+    _h "Triggering night-reporter one tick"
+    python3 "$HERE/bots/night_reporter.py" --demo
+}
+
+cmd_start_ticket_bot() {
+    _load_env
+    _h "Starting ticket-bot daemon"
+    if [ -f "$PIDS_DIR/ticket-bot.pid" ] && \
+       kill -0 "$(cat "$PIDS_DIR/ticket-bot.pid")" 2>/dev/null; then
+        _warn "ticket-bot already running (pid $(cat "$PIDS_DIR/ticket-bot.pid"))"
+        return 0
+    fi
+    nohup python3 "$HERE/bots/ticket_bot.py" --watch \
+        > "$STATE_DIR/ticket-bot.log" 2>&1 &
+    echo $! > "$PIDS_DIR/ticket-bot.pid"
+    _ok "ticket-bot pid $(cat "$PIDS_DIR/ticket-bot.pid") — log $STATE_DIR/ticket-bot.log"
+}
+
+cmd_stop_ticket_bot() {
+    _h "Stopping ticket-bot daemon"
+    if [ ! -f "$PIDS_DIR/ticket-bot.pid" ]; then
+        _warn "no pid file — was it ever started?"
+        return 0
+    fi
+    local pid
+    pid=$(cat "$PIDS_DIR/ticket-bot.pid")
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -TERM "$pid"
+        sleep 0.5
+        kill -0 "$pid" 2>/dev/null && kill -KILL "$pid" || true
+        _ok "ticket-bot pid $pid stopped"
+    else
+        _warn "ticket-bot pid $pid no longer running"
+    fi
+    rm -f "$PIDS_DIR/ticket-bot.pid"
+}
+
+cmd_urls() {
+    _h "Recording-ready URLs"
+    cat <<EOF
+  ${GREEN}Cullis Chat (claim-officer)${RESET}    http://localhost:9100/chat?user=officer
+  ${GREEN}Cullis Chat (claim-manager)${RESET}    http://localhost:9100/chat?user=manager
+  ${GREEN}Asia-Pacific Frontdesk (liaison)${RESET}      http://localhost:8090?user=liaison
+  ${GREEN}Mediterranean Mastio admin${RESET}              http://localhost:9100/admin
+  ${GREEN}Asia-Pacific Mastio admin${RESET}             http://localhost:9200/admin
+  ${GREEN}Court federation dashboard${RESET}     http://localhost:8000/dashboard
+  ${GREEN}Grafana audit + traffic${RESET}        http://localhost:3000  (admin/admin)
+  ${GREEN}MCP claims-db (intra-org)${RESET}      mediterranean::resource::mcp::claims-db
+
+  Recording sequence (60-90s):
+    1. Open Mediterranean Mastio admin — show Users + Agents + Workloads + Resources
+    2. ./run.sh trigger-night-reporter  (verbose output for the recording)
+    3. Open Cullis Chat as claim-officer — see the night-reporter's report
+    4. Switch to claim-manager — receive operatore's escalation
+    5. claim-manager sends @ticket-bot a request — see ticket id come back
+    6. claim-manager sends cross-org to counterparty-liaison
+    7. Switch to Asia-Pacific Frontdesk — Mario sees the cross-org request
+
+  Each step has visible audit chain entries on Mediterranean Mastio + Asia-Pacific Mastio + Court.
+EOF
+}
+
+cmd_down() {
+    _h "Tearing down Frontdesk overlay"
+    if [ -f "$HERE/compose.frontdesk.yml" ]; then
+        docker compose -f "$REFERENCE_DIR/docker-compose.yml" \
+                       -f "$HERE/compose.frontdesk.yml" down frontdesk-asia-pacific || true
+    fi
+    cmd_stop_ticket_bot || true
+    _ok "frontdesk overlay down (reference stack untouched)"
+}
+
+cmd_status() {
+    _h "Insurance demo status"
+    for svc in broker proxy-a proxy-b mcp-catalog mcp-inventory; do
+        if docker compose -f "$REFERENCE_DIR/docker-compose.yml" ps "$svc" 2>/dev/null | grep -q "Up"; then
+            _ok "$svc — running"
+        else
+            _warn "$svc — not running (run reference/demo.sh full)"
+        fi
+    done
+    if [ -f "$PIDS_DIR/ticket-bot.pid" ] && \
+       kill -0 "$(cat "$PIDS_DIR/ticket-bot.pid")" 2>/dev/null; then
+        _ok "ticket-bot daemon — pid $(cat "$PIDS_DIR/ticket-bot.pid")"
+    else
+        _warn "ticket-bot daemon — not running"
+    fi
+    if [ -f "$STATE_DIR/agents/night-reporter/agent.pem" ]; then
+        _ok "night-reporter identity — provisioned"
+    else
+        _warn "night-reporter identity — missing (run ./run.sh seed)"
+    fi
+}
+
+# ── Dispatcher ──────────────────────────────────────────────────────────
+
+case "${1:-help}" in
+    seed)                     cmd_seed ;;
+    frontdesk)                cmd_frontdesk ;;
+    trigger-night-reporter)   cmd_trigger_night_reporter ;;
+    start-ticket-bot)         cmd_start_ticket_bot ;;
+    stop-ticket-bot)          cmd_stop_ticket_bot ;;
+    urls)                     cmd_urls ;;
+    down)                     cmd_down ;;
+    status)                   cmd_status ;;
+    prep-ca)                  cmd_prep_ca ;;
+    help|--help|-h|*)
+        sed -n '3,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# //;s/^#//' ;;
+esac

--- a/reference/scenarios/insurance-demo/run.sh
+++ b/reference/scenarios/insurance-demo/run.sh
@@ -155,7 +155,7 @@ cmd_urls() {
     4. Switch to claim-manager — receive operatore's escalation
     5. claim-manager sends @ticket-bot a request — see ticket id come back
     6. claim-manager sends cross-org to counterparty-liaison
-    7. Switch to Asia-Pacific Frontdesk — Mario sees the cross-org request
+    7. Switch to Asia-Pacific Frontdesk — Kenji Watanabe sees the cross-org request
 
   Each step has visible audit chain entries on Mediterranean Mastio + Asia-Pacific Mastio + Court.
 EOF

--- a/reference/scenarios/insurance-demo/run.sh
+++ b/reference/scenarios/insurance-demo/run.sh
@@ -81,20 +81,53 @@ cmd_seed() {
     python3 "$HERE/seed/seed.py"
 }
 
+cmd_frontdesk_prep() {
+    _h "Bootstrapping Asia-Pacific Frontdesk Connector identity (one-shot)"
+    # The overlay's connector container looks for identity material under
+    # ``frontdesk-asia-pacific-connector-data``. Until enrolled, /chat
+    # routes 401 because the Ambassador can't sign per-user CSRs. This
+    # one-shot generates an invite on the Asia-Pacific Mastio admin and
+    # runs ``cullis-connector enroll`` against proxy-b through the
+    # orgb-internal network.
+    local invite
+    invite=$(curl -s -X POST -H "X-Admin-Secret: ${ADMIN_SECRET:-sandbox-admin-secret-change-me}" \
+        -H "Content-Type: application/json" \
+        -d '{"label":"frontdesk-asia-pacific","ttl_hours":1}' \
+        http://localhost:9200/v1/admin/agents/enroll/connector \
+        2>/dev/null | grep -oE '"invite_token":"[^"]*"' | cut -d'"' -f4 || true)
+    if [ -z "$invite" ]; then
+        _warn "could not fetch a Connector invite token from proxy-b admin"
+        _warn "manual fallback: hit /v1/admin/agents/enroll/connector on Tokyo Mastio"
+        _warn "and pass the token to: docker run cullis-connector enroll --code <token>"
+        return 1
+    fi
+    _ok "invite token issued: ${invite:0:12}…"
+    docker run --rm \
+        -v frontdesk-asia-pacific-connector-data:/home/cullis/.cullis \
+        --network cullis-reference-orgb-internal \
+        ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-latest} \
+        enroll --site https://mastio-nginx-b:9443 \
+               --code "$invite" \
+               --profile frontdesk-asia-pacific
+    _ok "Connector enrolled — identity persisted in volume"
+}
+
 cmd_frontdesk() {
     _h "Bringing up Asia-Pacific Frontdesk container"
     if [ ! -f "$HERE/compose.frontdesk.yml" ]; then
-        _warn "compose.frontdesk.yml not present yet — manual scaffold pending"
-        _warn "use ../packaging/frontdesk-bundle/ as the source for now:"
-        _warn "  cd $REPO_ROOT/packaging/frontdesk-bundle"
-        _warn "  cp frontdesk.env.example frontdesk.env"
-        _warn "  edit frontdesk.env: set CULLIS_FRONTDESK_ORG_ID=asia-pacific"
-        _warn "  docker compose --env-file frontdesk.env up -d"
-        return 0
+        _fail "compose.frontdesk.yml missing — pull a fresh demo branch"
+        return 1
+    fi
+    if ! docker volume inspect frontdesk-asia-pacific-connector-data >/dev/null 2>&1; then
+        _warn "Connector identity volume not bootstrapped — running prep first"
+        cmd_frontdesk_prep
     fi
     docker compose -f "$REFERENCE_DIR/docker-compose.yml" \
-                   -f "$HERE/compose.frontdesk.yml" up -d frontdesk-asia-pacific
-    _ok "frontdesk-asia-pacific up — http://localhost:8090"
+                   -f "$HERE/compose.frontdesk.yml" up -d \
+                   connector-frontdesk-asia-pacific \
+                   chat-frontdesk-asia-pacific \
+                   nginx-frontdesk-asia-pacific
+    _ok "Frontdesk Asia-Pacific up — http://localhost:8090?user=kenji"
 }
 
 cmd_trigger_night_reporter() {
@@ -197,6 +230,7 @@ cmd_status() {
 
 case "${1:-help}" in
     seed)                     cmd_seed ;;
+    frontdesk-prep)           cmd_frontdesk_prep ;;
     frontdesk)                cmd_frontdesk ;;
     trigger-night-reporter)   cmd_trigger_night_reporter ;;
     start-ticket-bot)         cmd_start_ticket_bot ;;

--- a/reference/scenarios/insurance-demo/seed/claims.sql
+++ b/reference/scenarios/insurance-demo/seed/claims.sql
@@ -1,0 +1,41 @@
+-- Insurance claims fixture for the multi-surface demo.
+--
+-- Schema mirrors a realistic auto-insurance claims table with the
+-- ``cross_company_flag`` column the night-reporter agent queries on.
+-- Intentionally small (12 rows) so the LLM tool call stays cheap and
+-- the recording stays watchable.
+
+CREATE TABLE IF NOT EXISTS claims (
+    claim_id              VARCHAR(32) PRIMARY KEY,
+    incident_date         DATE NOT NULL,
+    region                VARCHAR(64) NOT NULL,
+    insured_party         VARCHAR(128) NOT NULL,
+    counterparty          VARCHAR(128),
+    counterparty_insurer  VARCHAR(64),
+    estimated_amount_eur  INTEGER NOT NULL,
+    cross_company_flag    BOOLEAN NOT NULL DEFAULT FALSE,
+    urgency               VARCHAR(16) NOT NULL DEFAULT 'normal',  -- low | normal | high
+    status                VARCHAR(32) NOT NULL DEFAULT 'open',
+    notes                 TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_claims_cross_company ON claims (cross_company_flag);
+CREATE INDEX IF NOT EXISTS idx_claims_urgency       ON claims (urgency);
+CREATE INDEX IF NOT EXISTS idx_claims_status        ON claims (status);
+
+-- 12 claims: 3 cross-company high-urgency (the ones night-reporter
+-- escalates), 3 cross-company normal, 6 same-company routine.
+INSERT INTO claims VALUES
+('INC-2026-0501', '2026-04-15', 'Lazio',     'Rossi Daniele',         'Tanaka Hiroshi',     'Asia-Pacific Insurance', 18500, TRUE,  'high',   'open',         'Multi-vehicle accident A1 Roma–Napoli, counterparty insured in Tokyo'),
+('INC-2026-0502', '2026-04-18', 'Lombardia', 'Bianchi Marco',         'Yamamoto Aiko',      'Asia-Pacific Insurance', 42000, TRUE,  'high',   'open',         'Total loss, BMW vs rental car driven by JP tourist'),
+('INC-2026-0503', '2026-04-22', 'Campania',  'Esposito Sara',         'Sato Kenji',         'Asia-Pacific Insurance', 7800,  TRUE,  'high',   'open',         'Parking damage, counterparty insured by partner Asia-Pacific'),
+('INC-2026-0504', '2026-04-10', 'Piemonte',  'Ferrari Lucia',         'Nakamura Yuki',      'Asia-Pacific Insurance', 3200,  TRUE,  'normal', 'open',         'Fender bender, low priority cross-company'),
+('INC-2026-0505', '2026-04-12', 'Veneto',    'Russo Antonio',         'Suzuki Hana',        'Asia-Pacific Insurance', 2100,  TRUE,  'normal', 'open',         'Mirror replacement, cross-company'),
+('INC-2026-0506', '2026-04-19', 'Toscana',   'De Luca Maria',         'Watanabe Sora',      'Asia-Pacific Insurance', 5400,  TRUE,  'normal', 'open',         'Door panel, cross-company'),
+('INC-2026-0507', '2026-04-08', 'Emilia',    'Galli Marco',           'Verde Anna',         NULL,                     1200,  FALSE, 'low',    'pending_paid', 'Internal — both parties Mediterranean Insurance'),
+('INC-2026-0508', '2026-04-09', 'Lazio',     'Marini Roberto',        'Bianchi Carla',      NULL,                     2800,  FALSE, 'normal', 'open',         'Internal claim'),
+('INC-2026-0509', '2026-04-11', 'Sicilia',   'Conte Filippo',         'Greco Federica',     NULL,                     6500,  FALSE, 'normal', 'open',         'Internal claim'),
+('INC-2026-0510', '2026-04-14', 'Puglia',    'Costa Marco',           'Ricci Chiara',       NULL,                     900,   FALSE, 'low',    'pending_paid', 'Internal claim'),
+('INC-2026-0511', '2026-04-16', 'Calabria',  'Romano Stefania',       'Vitali Luigi',       NULL,                     14200, FALSE, 'high',   'open',         'Internal — total loss'),
+('INC-2026-0512', '2026-04-20', 'Liguria',   'Lombardi Alessandro',   'Fontana Valeria',    NULL,                     3400,  FALSE, 'normal', 'open',         'Internal claim')
+ON CONFLICT (claim_id) DO NOTHING;

--- a/reference/scenarios/insurance-demo/seed/seed.py
+++ b/reference/scenarios/insurance-demo/seed/seed.py
@@ -2,17 +2,17 @@
 
 Adds, on top of whatever ``reference/bootstrap/`` already created:
 
-  - 3 user / agent principals on Mediterranean Insurance (Roma):
-      roma::user::claim-officer
-      roma::user::claim-manager
-      roma::agent::night-reporter
-      roma::agent::ticket-bot
-  - 1 user principal on Asia-Pacific Insurance (Tokyo):
-      tokyo::user::counterparty-liaison
-  - 1 workload principal on Tokyo (the Frontdesk container itself):
-      tokyo::workload::frontdesk-container
+  - 3 user / agent principals on Mediterranean Insurance (Mediterranean):
+      mediterranean::user::claim-officer
+      mediterranean::user::claim-manager
+      mediterranean::agent::night-reporter
+      mediterranean::agent::ticket-bot
+  - 1 user principal on Asia-Pacific Insurance (Asia-Pacific):
+      asia-pacific::user::counterparty-liaison
+  - 1 workload principal on Asia-Pacific (the Frontdesk container itself):
+      asia-pacific::workload::frontdesk-container
   - 1 MCP resource on Roma:
-      roma::resource::mcp::claims-db (postgres-backed, seeded with claims.sql)
+      mediterranean::resource::mcp::claims-db (postgres-backed, seeded with claims.sql)
   - Cross-org bindings + reach=both for the user principals that need to
     talk across orgs (claim-manager <-> counterparty-liaison).
 
@@ -74,7 +74,7 @@ PROXY_B_URL = os.environ.get("CULLIS_PROXY_B_URL", "http://localhost:9200")
 ADMIN_SECRET = os.environ.get("ADMIN_SECRET", "sandbox-admin-secret-change-me")
 
 # Cast definitions — match imp/insurance-demo-spec.md verbatim.
-ROMA_AGENTS = [
+MEDITERRANEAN_AGENTS = [
     {
         "agent_name":   "night-reporter",
         "display_name": "Night Reporter",
@@ -91,7 +91,7 @@ ROMA_AGENTS = [
     },
 ]
 
-ROMA_USERS = [
+MEDITERRANEAN_USERS = [
     {
         "user_name":    "claim-officer",
         "display_name": "Claim Officer",
@@ -106,7 +106,7 @@ ROMA_USERS = [
     },
 ]
 
-TOKYO_USERS = [
+ASIA_PACIFIC_USERS = [
     {
         "user_name":    "counterparty-liaison",
         "display_name": "Counterparty Liaison",
@@ -115,17 +115,17 @@ TOKYO_USERS = [
     },
 ]
 
-TOKYO_WORKLOADS = [
+ASIA_PACIFIC_WORKLOADS = [
     {
         "workload_name":          "frontdesk-container",
-        "display_name":           "Frontdesk Tokyo",
+        "display_name":           "Asia-Pacific Frontdesk",
         "image_digest":           "sha256:demo-frontdesk-bundle",
-        "hosted_principals_hint": ["tokyo::user::counterparty-liaison"],
-        "description":            "Multi-user Frontdesk container hosting tokyo::user::counterparty-liaison.",
+        "hosted_principals_hint": ["asia-pacific::user::counterparty-liaison"],
+        "description":            "Multi-user Frontdesk container hosting asia-pacific::user::counterparty-liaison.",
     },
 ]
 
-ROMA_RESOURCES = [
+MEDITERRANEAN_RESOURCES = [
     {
         "resource_name": "claims-db",
         "type":          "mcp",
@@ -256,8 +256,8 @@ def phase_check_reference_up(client: httpx.Client) -> None:
     _h("Phase 1 — verify reference stack reachable")
     for name, url in (
         ("broker (Court)", BROKER_URL),
-        ("proxy-a (Roma)", PROXY_A_URL),
-        ("proxy-b (Tokyo)", PROXY_B_URL),
+        ("proxy-a (Mediterranean)", PROXY_A_URL),
+        ("proxy-b (Asia-Pacific)", PROXY_B_URL),
     ):
         try:
             r = client.get(f"{url}/health", timeout=5.0)
@@ -269,10 +269,10 @@ def phase_check_reference_up(client: httpx.Client) -> None:
             raise SystemExit(1)
 
 
-def phase_provision_roma_agents(client: httpx.Client) -> None:
+def phase_provision_mediterranean_agents(client: httpx.Client) -> None:
     _h("Phase 2 — provision Roma agents (BYOCA) ")
-    org_ca = STATE_DIR / "roma-ca.pem"
-    org_ca_key = STATE_DIR / "roma-ca.key"
+    org_ca = STATE_DIR / "mediterranean-ca.pem"
+    org_ca_key = STATE_DIR / "mediterranean-ca.key"
     if not (org_ca.exists() and org_ca_key.exists()):
         _warn("Roma Org CA material not on disk yet — pulling from reference state")
         # ``reference/bootstrap/bootstrap.py`` writes the CA into the
@@ -282,11 +282,11 @@ def phase_provision_roma_agents(client: httpx.Client) -> None:
         _fail("missing CA — run ./run.sh prep-ca to copy from the reference volume")
         raise SystemExit(1)
 
-    for spec in ROMA_AGENTS:
+    for spec in MEDITERRANEAN_AGENTS:
         agent_dir = STATE_DIR / "agents" / spec["agent_name"]
         agent_dir.mkdir(parents=True, exist_ok=True)
         cert_pem, key_pem = _gen_agent_cert(
-            "roma", spec["agent_name"], "roma.cullis.test",
+            "mediterranean", spec["agent_name"], "mediterranean.cullis.test",
             org_ca, org_ca_key,
         )
         (agent_dir / "agent.pem").write_text(cert_pem)
@@ -308,7 +308,7 @@ def phase_provision_user_principals(client: httpx.Client) -> None:
     # operator knows where to plug it in. The Frontdesk SSO flow + the
     # /v1/principals/csr proxy endpoint already create user principals
     # at runtime; pre-creation just lets the dashboard show them.
-    for spec in ROMA_USERS:
+    for spec in MEDITERRANEAN_USERS:
         body = {
             "principal_type": "user",
             "user_name":      spec["user_name"],
@@ -325,11 +325,11 @@ def phase_provision_user_principals(client: httpx.Client) -> None:
                   " run.sh will try the runtime CSR fallback")
             continue
         if r.status_code in (201, 409):
-            _ok(f"user roma::user::{spec['user_name']} ready")
+            _ok(f"user mediterranean::user::{spec['user_name']} ready")
         else:
             _fail(f"user create {spec['user_name']}: HTTP {r.status_code}")
 
-    for spec in TOKYO_USERS:
+    for spec in ASIA_PACIFIC_USERS:
         body = {
             "principal_type": "user",
             "user_name":      spec["user_name"],
@@ -345,14 +345,14 @@ def phase_provision_user_principals(client: httpx.Client) -> None:
             _warn(f"Tokyo /v1/admin/users unreachable ({exc}) — pending")
             continue
         if r.status_code in (201, 409):
-            _ok(f"user tokyo::user::{spec['user_name']} ready")
+            _ok(f"user asia-pacific::user::{spec['user_name']} ready")
         else:
             _fail(f"user create {spec['user_name']}: HTTP {r.status_code}")
 
 
 def phase_provision_workload(client: httpx.Client) -> None:
-    _h("Phase 4 — provision Tokyo Frontdesk workload")
-    for spec in TOKYO_WORKLOADS:
+    _h("Phase 4 — provision Asia-Pacific Frontdesk workload")
+    for spec in ASIA_PACIFIC_WORKLOADS:
         body = {
             "principal_type": "workload",
             "workload_name":  spec["workload_name"],
@@ -368,14 +368,14 @@ def phase_provision_workload(client: httpx.Client) -> None:
             _warn(f"Tokyo /v1/admin/workloads unreachable ({exc}) — pending")
             continue
         if r.status_code in (201, 409):
-            _ok(f"workload tokyo::workload::{spec['workload_name']} ready")
+            _ok(f"workload asia-pacific::workload::{spec['workload_name']} ready")
 
 
 def phase_provision_resources(client: httpx.Client) -> None:
     _h("Phase 5 — provision MCP resource (claims-db)")
-    for spec in ROMA_RESOURCES:
+    for spec in MEDITERRANEAN_RESOURCES:
         body = {
-            "resource_id":   f"roma::resource::{spec['type']}::{spec['resource_name']}",
+            "resource_id":   f"mediterranean::resource::{spec['type']}::{spec['resource_name']}",
             "display_name":  spec["display_name"],
             "type":          spec["type"],
             "endpoint":      spec["endpoint"],
@@ -433,7 +433,7 @@ def main() -> int:
     print(f"{BOLD}{CYAN}Cullis insurance-demo seed{RESET}\n")
     with httpx.Client() as client:
         phase_check_reference_up(client)
-        phase_provision_roma_agents(client)
+        phase_provision_mediterranean_agents(client)
         phase_provision_user_principals(client)
         phase_provision_workload(client)
         phase_provision_resources(client)

--- a/reference/scenarios/insurance-demo/seed/seed.py
+++ b/reference/scenarios/insurance-demo/seed/seed.py
@@ -1,0 +1,448 @@
+"""Provision the insurance demo cast on top of the running reference stack.
+
+Adds, on top of whatever ``reference/bootstrap/`` already created:
+
+  - 3 user / agent principals on Mediterranean Insurance (Roma):
+      roma::user::claim-officer
+      roma::user::claim-manager
+      roma::agent::night-reporter
+      roma::agent::ticket-bot
+  - 1 user principal on Asia-Pacific Insurance (Tokyo):
+      tokyo::user::counterparty-liaison
+  - 1 workload principal on Tokyo (the Frontdesk container itself):
+      tokyo::workload::frontdesk-container
+  - 1 MCP resource on Roma:
+      roma::resource::mcp::claims-db (postgres-backed, seeded with claims.sql)
+  - Cross-org bindings + reach=both for the user principals that need to
+    talk across orgs (claim-manager <-> counterparty-liaison).
+
+Idempotent: re-runs are no-ops on existing rows. Designed to be invoked
+after ``reference/demo.sh full`` and produces a one-line OK summary at
+the end suitable for the demo orchestration script.
+
+Reads the Anthropic API key from ``imp/official_sandbox/.env`` if present
+and configures the Roma proxy AI gateway to use it (Haiku 4.5).
+
+Auth model:
+
+  * agents (night-reporter, ticket-bot) — BYOCA enroll with cert/key
+    minted against the Roma Org CA, persisted in
+    ``state/insurance-demo/agents/<name>/``. Reach=intra (no cross-org
+    capability — the bots only act inside Mediterranean).
+
+  * users (claim-officer, claim-manager, counterparty-liaison) — provisioned
+    via the user-principal POST endpoint exposed under ADR-021 PR4a.
+    The Connector / Frontdesk SSO flow normally creates these at login;
+    we pre-create them so the demo doesn't need a manual login step
+    before the first message lands.
+
+  * workload (frontdesk-container) — provisioned via admin endpoint with
+    principal_type=workload, hosting Mario at runtime.
+
+Env override:
+
+  CULLIS_BROKER_URL          default http://localhost:8000
+  CULLIS_PROXY_A_URL         default http://localhost:9100
+  CULLIS_PROXY_B_URL         default http://localhost:9200
+  ADMIN_SECRET               default sandbox-admin-secret-change-me
+  ANTHROPIC_API_KEY          read from imp/official_sandbox/.env if unset
+"""
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+from typing import Any
+
+import httpx
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+HERE = pathlib.Path(__file__).resolve().parent
+REPO_ROOT = HERE.parents[3]
+STATE_DIR = REPO_ROOT / "state" / "insurance-demo"
+STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+BROKER_URL  = os.environ.get("CULLIS_BROKER_URL",  "http://localhost:8000")
+PROXY_A_URL = os.environ.get("CULLIS_PROXY_A_URL", "http://localhost:9100")
+PROXY_B_URL = os.environ.get("CULLIS_PROXY_B_URL", "http://localhost:9200")
+ADMIN_SECRET = os.environ.get("ADMIN_SECRET", "sandbox-admin-secret-change-me")
+
+# Cast definitions — match imp/insurance-demo-spec.md verbatim.
+ROMA_AGENTS = [
+    {
+        "agent_name":   "night-reporter",
+        "display_name": "Night Reporter",
+        "capabilities": ["claims-db.read", "oneshot.message"],
+        "reach":        "intra",
+        "description":  "Overnight scheduled bot — queries claims DB, sends summary to claim-officer.",
+    },
+    {
+        "agent_name":   "ticket-bot",
+        "display_name": "Ticket Bot",
+        "capabilities": ["claims-db.write", "oneshot.message"],
+        "reach":        "intra",
+        "description":  "On-demand request-response — receives claim request, generates formal ticket ID.",
+    },
+]
+
+ROMA_USERS = [
+    {
+        "user_name":    "claim-officer",
+        "display_name": "Claim Officer",
+        "reach":        "intra",
+        "description":  "Junior claim adjuster (Mediterranean Insurance).",
+    },
+    {
+        "user_name":    "claim-manager",
+        "display_name": "Claim Manager",
+        "reach":        "both",
+        "description":  "Senior claim manager — escalates cross-company.",
+    },
+]
+
+TOKYO_USERS = [
+    {
+        "user_name":    "counterparty-liaison",
+        "display_name": "Counterparty Liaison",
+        "reach":        "both",
+        "description":  "Counterparty contact at Asia-Pacific Insurance.",
+    },
+]
+
+TOKYO_WORKLOADS = [
+    {
+        "workload_name":          "frontdesk-container",
+        "display_name":           "Frontdesk Tokyo",
+        "image_digest":           "sha256:demo-frontdesk-bundle",
+        "hosted_principals_hint": ["tokyo::user::counterparty-liaison"],
+        "description":            "Multi-user Frontdesk container hosting tokyo::user::counterparty-liaison.",
+    },
+]
+
+ROMA_RESOURCES = [
+    {
+        "resource_name": "claims-db",
+        "type":          "mcp",
+        "display_name":  "Claims Database",
+        "endpoint":      "http://mcp-claims-db:8080/mcp",
+        "description":   "Postgres-backed MCP server, seeded with insurance claims fixture.",
+    },
+]
+
+
+# ── ANSI helpers ─────────────────────────────────────────────────────────
+
+
+RESET, BOLD, GREEN, YELLOW, RED, CYAN, GRAY = (
+    "\033[0m", "\033[1m", "\033[32m",
+    "\033[33m", "\033[31m", "\033[36m", "\033[90m",
+)
+
+
+def _h(t: str) -> None:    print(f"\n{BOLD}{CYAN}═══ {t} ═══{RESET}")
+def _ok(t: str) -> None:   print(f"  {GREEN}✓{RESET} {t}")
+def _info(t: str) -> None: print(f"  {GRAY}…{RESET} {t}")
+def _warn(t: str) -> None: print(f"  {YELLOW}⚠{RESET} {t}")
+def _fail(t: str) -> None: print(f"  {RED}✗{RESET} {t}")
+
+
+# ── Anthropic API key from official_sandbox ─────────────────────────────
+
+
+def _anthropic_key() -> str | None:
+    """Pick the Anthropic key from env first, then official_sandbox/.env."""
+    env_key = os.environ.get("ANTHROPIC_API_KEY")
+    if env_key:
+        return env_key
+    sandbox_env = REPO_ROOT / "imp" / "official_sandbox" / ".env"
+    if not sandbox_env.exists():
+        return None
+    for line in sandbox_env.read_text().splitlines():
+        if line.strip().startswith("ANTHROPIC_API_KEY="):
+            return line.split("=", 1)[1].strip()
+    return None
+
+
+# ── Cert minting (BYOCA for agents) ──────────────────────────────────────
+
+
+def _gen_agent_cert(
+    org_id: str, agent_name: str, trust_domain: str, org_ca_path: pathlib.Path,
+    org_ca_key_path: pathlib.Path,
+) -> tuple[str, str]:
+    """Return (cert_pem, key_pem) for a new agent. SAN follows ADR-014
+    convention: ``spiffe://<td>/<org>/<name>`` (3-component)."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    spiffe_uri = f"spiffe://{trust_domain}/{org_id}/{agent_name}"
+    agent_id = f"{org_id}::{agent_name}"
+
+    org_ca = x509.load_pem_x509_certificate(org_ca_path.read_bytes())
+    org_ca_priv = serialization.load_pem_private_key(
+        org_ca_key_path.read_bytes(), password=None,
+    )
+    from datetime import datetime, timedelta, timezone
+    now = datetime.now(timezone.utc)
+    cert = (x509.CertificateBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(x509.NameOID.COMMON_NAME, agent_id),
+            x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, org_id),
+        ]))
+        .issuer_name(org_ca.subject)
+        .public_key(priv.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=1))
+        .add_extension(
+            x509.SubjectAlternativeName([x509.UniformResourceIdentifier(spiffe_uri)]),
+            critical=False,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([x509.ExtendedKeyUsageOID.CLIENT_AUTH]),
+            critical=False,
+        )
+        .sign(org_ca_priv, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return cert_pem, key_pem
+
+
+# ── Provisioning helpers (HTTP) ──────────────────────────────────────────
+
+
+def _admin_headers() -> dict[str, str]:
+    return {"X-Admin-Secret": ADMIN_SECRET, "Content-Type": "application/json"}
+
+
+def _byoca_enroll_agent(
+    client: httpx.Client, proxy_url: str, agent_name: str,
+    capabilities: list[str], cert_pem: str, key_pem: str,
+) -> str | None:
+    body = {
+        "agent_name":      agent_name,
+        "display_name":    agent_name,
+        "capabilities":    capabilities,
+        "federated":       False,  # bots are intra-org for the demo
+        "cert_pem":        cert_pem,
+        "private_key_pem": key_pem,
+    }
+    r = client.post(
+        f"{proxy_url}/v1/admin/agents/enroll/byoca",
+        json=body, headers=_admin_headers(), timeout=15.0,
+    )
+    if r.status_code == 201:
+        return r.json().get("dpop_jkt")
+    if r.status_code == 409:
+        _warn(f"{agent_name} already enrolled — skipping")
+        return None
+    _fail(f"BYOCA enroll {agent_name}: HTTP {r.status_code} {r.text[:200]}")
+    raise SystemExit(1)
+
+
+# ── Phase runners ────────────────────────────────────────────────────────
+
+
+def phase_check_reference_up(client: httpx.Client) -> None:
+    _h("Phase 1 — verify reference stack reachable")
+    for name, url in (
+        ("broker (Court)", BROKER_URL),
+        ("proxy-a (Roma)", PROXY_A_URL),
+        ("proxy-b (Tokyo)", PROXY_B_URL),
+    ):
+        try:
+            r = client.get(f"{url}/health", timeout=5.0)
+            r.raise_for_status()
+            _ok(f"{name} healthy at {url}")
+        except Exception as exc:
+            _fail(f"{name} unreachable at {url} ({exc})")
+            _info("did you run reference/demo.sh full first?")
+            raise SystemExit(1)
+
+
+def phase_provision_roma_agents(client: httpx.Client) -> None:
+    _h("Phase 2 — provision Roma agents (BYOCA) ")
+    org_ca = STATE_DIR / "roma-ca.pem"
+    org_ca_key = STATE_DIR / "roma-ca.key"
+    if not (org_ca.exists() and org_ca_key.exists()):
+        _warn("Roma Org CA material not on disk yet — pulling from reference state")
+        # ``reference/bootstrap/bootstrap.py`` writes the CA into the
+        # ``bootstrap-state`` named volume on the host. Easiest grab:
+        # docker cp from the bootstrap container's working dir. For now
+        # placeholder — operator runs ``./run.sh prep-ca`` to copy.
+        _fail("missing CA — run ./run.sh prep-ca to copy from the reference volume")
+        raise SystemExit(1)
+
+    for spec in ROMA_AGENTS:
+        agent_dir = STATE_DIR / "agents" / spec["agent_name"]
+        agent_dir.mkdir(parents=True, exist_ok=True)
+        cert_pem, key_pem = _gen_agent_cert(
+            "roma", spec["agent_name"], "roma.cullis.test",
+            org_ca, org_ca_key,
+        )
+        (agent_dir / "agent.pem").write_text(cert_pem)
+        (agent_dir / "agent-key.pem").write_text(key_pem)
+        (agent_dir / "agent.pem").chmod(0o644)
+        (agent_dir / "agent-key.pem").chmod(0o600)
+
+        _byoca_enroll_agent(
+            client, PROXY_A_URL, spec["agent_name"], spec["capabilities"],
+            cert_pem, key_pem,
+        )
+        _ok(f"agent {spec['agent_name']} enrolled at Roma proxy")
+
+
+def phase_provision_user_principals(client: httpx.Client) -> None:
+    _h("Phase 3 — provision user principals (Roma + Tokyo)")
+    # NOTE: the user-principal admin endpoint is NEW per the spec. Until
+    # it lands as a real backend route, we stub-fail loudly so the
+    # operator knows where to plug it in. The Frontdesk SSO flow + the
+    # /v1/principals/csr proxy endpoint already create user principals
+    # at runtime; pre-creation just lets the dashboard show them.
+    for spec in ROMA_USERS:
+        body = {
+            "principal_type": "user",
+            "user_name":      spec["user_name"],
+            "display_name":   spec["display_name"],
+            "reach":           spec["reach"],
+        }
+        try:
+            r = client.post(
+                f"{PROXY_A_URL}/v1/admin/users",
+                json=body, headers=_admin_headers(), timeout=10.0,
+            )
+        except Exception as exc:
+            _warn(f"/v1/admin/users unreachable ({exc}) — endpoint pending,"
+                  " run.sh will try the runtime CSR fallback")
+            continue
+        if r.status_code in (201, 409):
+            _ok(f"user roma::user::{spec['user_name']} ready")
+        else:
+            _fail(f"user create {spec['user_name']}: HTTP {r.status_code}")
+
+    for spec in TOKYO_USERS:
+        body = {
+            "principal_type": "user",
+            "user_name":      spec["user_name"],
+            "display_name":   spec["display_name"],
+            "reach":           spec["reach"],
+        }
+        try:
+            r = client.post(
+                f"{PROXY_B_URL}/v1/admin/users",
+                json=body, headers=_admin_headers(), timeout=10.0,
+            )
+        except Exception as exc:
+            _warn(f"Tokyo /v1/admin/users unreachable ({exc}) — pending")
+            continue
+        if r.status_code in (201, 409):
+            _ok(f"user tokyo::user::{spec['user_name']} ready")
+        else:
+            _fail(f"user create {spec['user_name']}: HTTP {r.status_code}")
+
+
+def phase_provision_workload(client: httpx.Client) -> None:
+    _h("Phase 4 — provision Tokyo Frontdesk workload")
+    for spec in TOKYO_WORKLOADS:
+        body = {
+            "principal_type": "workload",
+            "workload_name":  spec["workload_name"],
+            "display_name":   spec["display_name"],
+            "image_digest":   spec["image_digest"],
+        }
+        try:
+            r = client.post(
+                f"{PROXY_B_URL}/v1/admin/workloads",
+                json=body, headers=_admin_headers(), timeout=10.0,
+            )
+        except Exception as exc:
+            _warn(f"Tokyo /v1/admin/workloads unreachable ({exc}) — pending")
+            continue
+        if r.status_code in (201, 409):
+            _ok(f"workload tokyo::workload::{spec['workload_name']} ready")
+
+
+def phase_provision_resources(client: httpx.Client) -> None:
+    _h("Phase 5 — provision MCP resource (claims-db)")
+    for spec in ROMA_RESOURCES:
+        body = {
+            "resource_id":   f"roma::resource::{spec['type']}::{spec['resource_name']}",
+            "display_name":  spec["display_name"],
+            "type":          spec["type"],
+            "endpoint":      spec["endpoint"],
+        }
+        try:
+            r = client.post(
+                f"{PROXY_A_URL}/v1/admin/mcp-resources",
+                json=body, headers=_admin_headers(), timeout=10.0,
+            )
+        except Exception as exc:
+            _warn(f"/v1/admin/mcp-resources unreachable ({exc})")
+            continue
+        if r.status_code in (201, 409):
+            _ok(f"resource {body['resource_id']} ready")
+        else:
+            _fail(f"resource create: HTTP {r.status_code} {r.text[:160]}")
+
+
+def phase_seed_claims_db() -> None:
+    _h("Phase 6 — seed claims database")
+    sql_path = HERE / "claims.sql"
+    if not sql_path.exists():
+        _fail(f"missing fixture {sql_path}")
+        raise SystemExit(1)
+    # The MCP claims-db service is a separate compose addition; for now
+    # we exec the SQL into whatever Postgres the proxy-a profile has
+    # provisioned (postgres-data volume in reference compose). Real
+    # wiring lands in compose.frontdesk.yml.
+    try:
+        subprocess.run(
+            ["docker", "compose", "-f", str(REPO_ROOT / "reference" / "docker-compose.yml"),
+             "exec", "-T", "postgres",
+             "psql", "-U", "atn", "-d", "agent_trust", "-f", "/dev/stdin"],
+            input=sql_path.read_bytes(),
+            check=True, capture_output=True,
+        )
+        _ok(f"seeded {sql_path.name} into Roma postgres")
+    except subprocess.CalledProcessError as exc:
+        _fail(f"seed failed: {exc.stderr.decode()[:200] if exc.stderr else exc}")
+        _info("you may need to wait for postgres to be ready")
+        raise SystemExit(1)
+
+
+def phase_anthropic_key() -> None:
+    _h("Phase 7 — verify Anthropic API key")
+    key = _anthropic_key()
+    if not key:
+        _warn("ANTHROPIC_API_KEY not set and not found in imp/official_sandbox/.env")
+        _info("the bots will run with mock responses; Cullis Chat will fail tool calls")
+        return
+    _ok(f"Anthropic key found ({key[:12]}…) — bots + Cullis Chat will use Haiku 4.5")
+
+
+def main() -> int:
+    print(f"{BOLD}{CYAN}Cullis insurance-demo seed{RESET}\n")
+    with httpx.Client() as client:
+        phase_check_reference_up(client)
+        phase_provision_roma_agents(client)
+        phase_provision_user_principals(client)
+        phase_provision_workload(client)
+        phase_provision_resources(client)
+    phase_seed_claims_db()
+    phase_anthropic_key()
+    print(f"\n{GREEN}{BOLD}✓ insurance-demo seed complete{RESET}")
+    print(f"  next: ./run.sh frontdesk + ./run.sh trigger-night-reporter")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reference/scenarios/insurance-demo/seed/seed.py
+++ b/reference/scenarios/insurance-demo/seed/seed.py
@@ -37,7 +37,7 @@ Auth model:
     before the first message lands.
 
   * workload (frontdesk-container) — provisioned via admin endpoint with
-    principal_type=workload, hosting Mario at runtime.
+    principal_type=workload, hosting Kenji Watanabe at runtime.
 
 Env override:
 


### PR DESCRIPTION
## Summary

Backend skeleton for the upcoming three-surface demo (Cullis Chat consumer / Frontdesk enterprise / Mastio admin). Insurance claims escalation scenario, 5 principals + 1 workload + 1 MCP resource across two orgs.

The parallel SPA session works against the contract in `imp/insurance-demo-spec.md` (gitignored). When their Phase 1 lands (Mastio dashboard 4 sections + Inbox component), we wire the runtime, the user records the demo manually.

## Lands

- `reference/scenarios/insurance-demo/seed/seed.py` — idempotent provisioning of all principals + claims-db MCP resource. Defensive: skips endpoints that don't exist yet (admin/users + admin/workloads pending).
- `reference/scenarios/insurance-demo/seed/claims.sql` — 12-row insurance claims fixture, 6 cross-company flagged.
- `reference/scenarios/insurance-demo/bots/night_reporter.py` — overnight A2U bot.
- `reference/scenarios/insurance-demo/bots/ticket_bot.py` — request-response U2A bot.
- `reference/scenarios/insurance-demo/run.sh` — orchestration (seed, frontdesk, trigger, status, urls).
- `reference/scenarios/insurance-demo/README.md` — runbook.

## Out of scope (intentional follow-ups)

- `compose.frontdesk.yml` overlay — defer until I can validate networking between `orgb-internal` (reference) and the Frontdesk bundle on a running stack.
- `/v1/admin/users` + `/v1/admin/workloads` admin endpoints — separate PR. SPA agent renders pending-state UI in the meantime.
- Backend smoke test — needs running reference + Frontdesk to be meaningful, slated for after the overlay lands.

## Branch hygiene

Don't merge until reviewed + the parallel SPA session has at least Phase 1 in flight. Reading the spec is the prerequisite for SPA work to start, so this PR is the unblock.