### PR TITLE
feat(admin): list user + workload principals on Mastio (#476 #477)

### DIFF
--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -1,0 +1,304 @@
+"""Mastio admin API for user principals.
+
+Pairs with ``mcp_proxy/admin/agents.py`` and ``mcp_proxy/admin/mcp_resources.py``.
+Lets an org admin pre-create a user-principal row so the dashboard's
+Users tab renders before the user has touched the Frontdesk SSO flow.
+The CSR signing path on ``/v1/principals/csr`` upserts into the same
+table on every signature, so a user that *does* go through SSO first
+shows up automatically.
+
+Endpoints:
+- POST ``/v1/admin/users``   create a principal row (idempotent on conflict)
+- GET  ``/v1/admin/users``   list, optionally filtered by reach / surface / q
+
+Auth: ``X-Admin-Secret`` (same contract as ``/v1/admin/agents``).
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_db
+
+
+_log = logging.getLogger("mcp_proxy.admin.users")
+
+router = APIRouter(prefix="/v1/admin/users", tags=["admin"])
+
+
+# ── auth ────────────────────────────────────────────────────────────────
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+# ── models ──────────────────────────────────────────────────────────────
+
+
+_VALID_REACH = ("intra", "cross", "both")
+
+
+class UserCreateRequest(BaseModel):
+    user_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    display_name: str = Field("", max_length=256)
+    reach: str = Field("intra")
+    surface: Optional[str] = Field(None, max_length=64)
+
+
+class UserOut(BaseModel):
+    principal_id: str
+    user_name: str
+    display_name: Optional[str]
+    reach: str
+    surface: Optional[str]
+    last_active: Optional[str]
+    created_at: str
+
+
+class UserListResponse(BaseModel):
+    users: list[UserOut]
+    total: int
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _principal_id(org_id: str, user_name: str) -> str:
+    # Display form used by the SPA. Slash-form (the canonical
+    # ``<td>/<org>/user/<name>``) is internal-only; the dashboard speaks
+    # the ``::``-separated short id.
+    return f"{org_id}::user::{user_name}"
+
+
+# ── endpoints ───────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    response_model=UserOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def create_user(
+    body: UserCreateRequest, request: Request,
+) -> UserOut:
+    """Insert (or no-op on duplicate) a user-principal row.
+
+    Idempotent: re-posting the same ``user_name`` returns 201 with the
+    existing row; ``display_name`` / ``reach`` / ``surface`` are *not*
+    overwritten on conflict so admin pre-population can't blow away
+    a row a real Frontdesk SSO touch already filled in.
+    """
+    if body.reach not in _VALID_REACH:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"reach must be one of {_VALID_REACH}",
+        )
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None or not getattr(mgr, "ca_loaded", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized — Org CA not loaded",
+        )
+    pid = _principal_id(mgr.org_id, body.user_name)
+    now = _now_iso()
+    async with get_db() as conn:
+        existing = (await conn.execute(
+            text(
+                "SELECT principal_id, user_name, display_name, reach, "
+                "       surface, created_at, last_active_at "
+                "  FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": pid},
+        )).mappings().first()
+        if existing is None:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_user_principals (
+                        principal_id, user_name, display_name,
+                        reach, surface, created_at
+                    ) VALUES (
+                        :pid, :uname, :disp, :reach, :surface, :now
+                    )
+                    """
+                ),
+                {
+                    "pid": pid,
+                    "uname": body.user_name,
+                    "disp": body.display_name or None,
+                    "reach": body.reach,
+                    "surface": body.surface,
+                    "now": now,
+                },
+            )
+            return UserOut(
+                principal_id=pid,
+                user_name=body.user_name,
+                display_name=body.display_name or None,
+                reach=body.reach,
+                surface=body.surface,
+                last_active=None,
+                created_at=now,
+            )
+        return UserOut(
+            principal_id=existing["principal_id"],
+            user_name=existing["user_name"],
+            display_name=existing["display_name"],
+            reach=existing["reach"],
+            surface=existing["surface"],
+            last_active=existing["last_active_at"],
+            created_at=existing["created_at"],
+        )
+
+
+@router.get(
+    "",
+    response_model=UserListResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_users(
+    reach: Optional[str] = Query(None),
+    surface: Optional[str] = Query(None),
+    q: Optional[str] = Query(None, max_length=128),
+    limit: int = Query(200, ge=1, le=500),
+) -> UserListResponse:
+    if reach is not None and reach not in _VALID_REACH:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"reach must be one of {_VALID_REACH}",
+        )
+    sql = (
+        "SELECT principal_id, user_name, display_name, reach, surface, "
+        "       created_at, last_active_at "
+        "  FROM local_user_principals "
+    )
+    where: list[str] = []
+    params: dict[str, object] = {"limit": limit}
+    if reach is not None:
+        where.append("reach = :reach")
+        params["reach"] = reach
+    if surface is not None:
+        where.append("surface = :surface")
+        params["surface"] = surface
+    if q:
+        where.append(
+            "(LOWER(user_name) LIKE :q OR "
+            " LOWER(COALESCE(display_name, '')) LIKE :q)"
+        )
+        params["q"] = f"%{q.lower()}%"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY created_at DESC LIMIT :limit"
+    async with get_db() as conn:
+        rows = (await conn.execute(text(sql), params)).mappings().all()
+    items = [
+        UserOut(
+            principal_id=r["principal_id"],
+            user_name=r["user_name"],
+            display_name=r["display_name"],
+            reach=r["reach"],
+            surface=r["surface"],
+            last_active=r["last_active_at"],
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+    return UserListResponse(users=items, total=len(items))
+
+
+# ── populator helper ────────────────────────────────────────────────────
+
+
+async def upsert_from_csr(
+    *,
+    principal_id: str,
+    org_id: str,
+    cert_thumbprint: str,
+    surface_hint: Optional[str] = None,
+) -> None:
+    """Called by the CSR sign endpoint after a successful signature.
+
+    Idempotent insert (conflict → update last_active_at + cert_thumbprint
+    only). The caller hands in the canonical 4-component principal_id;
+    we re-key it to the ``::`` short form used by the dashboard.
+
+    Errors are swallowed and logged: the registry table is best-effort
+    UI metadata, never a blocker for the underlying CSR signing flow.
+    """
+    try:
+        # Convert <td>/<org>/user/<name> → <org>::user::<name>.
+        parts = principal_id.split("/")
+        if len(parts) != 4 or parts[2] != "user":
+            return
+        user_name = parts[3]
+        pid = _principal_id(org_id, user_name)
+        now = _now_iso()
+        async with get_db() as conn:
+            existing = (await conn.execute(
+                text(
+                    "SELECT principal_id FROM local_user_principals "
+                    " WHERE principal_id = :pid"
+                ),
+                {"pid": pid},
+            )).first()
+            if existing is None:
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO local_user_principals (
+                            principal_id, user_name, display_name,
+                            reach, surface, cert_thumbprint,
+                            created_at, last_active_at
+                        ) VALUES (
+                            :pid, :uname, NULL,
+                            'intra', :surface, :thumb,
+                            :now, :now
+                        )
+                        """
+                    ),
+                    {
+                        "pid": pid, "uname": user_name,
+                        "surface": surface_hint, "thumb": cert_thumbprint,
+                        "now": now,
+                    },
+                )
+            else:
+                await conn.execute(
+                    text(
+                        """
+                        UPDATE local_user_principals
+                           SET cert_thumbprint = :thumb,
+                               last_active_at  = :now,
+                               surface = COALESCE(surface, :surface)
+                         WHERE principal_id = :pid
+                        """
+                    ),
+                    {
+                        "pid": pid, "thumb": cert_thumbprint,
+                        "surface": surface_hint, "now": now,
+                    },
+                )
+    except Exception as exc:  # noqa: BLE001 — best-effort telemetry
+        _log.warning(
+            "upsert_from_csr failed for %s: %s", principal_id, exc,
+        )

--- a/mcp_proxy/admin/workloads.py
+++ b/mcp_proxy/admin/workloads.py
@@ -1,0 +1,237 @@
+"""Mastio admin API for workload principals (ADR-020 / ADR-019).
+
+Frontdesk shared-mode is the canonical workload: one container that
+hosts N user principals via SSO. Workloads stay intra-org by design —
+they never federate, and the Court federation registry has no view of
+them. This API powers the dashboard's Workloads tab on the *local*
+Mastio admin only.
+
+Endpoints:
+- POST ``/v1/admin/workloads``    create a workload row (idempotent)
+- GET  ``/v1/admin/workloads``    list, optional filter on runtime_status / q
+
+Auth: ``X-Admin-Secret``.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import text
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_db
+
+
+_log = logging.getLogger("mcp_proxy.admin.workloads")
+
+router = APIRouter(prefix="/v1/admin/workloads", tags=["admin"])
+
+
+_VALID_STATUS = ("running", "stopped", "unhealthy", "unknown")
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+class WorkloadCreateRequest(BaseModel):
+    workload_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    display_name: str = Field("", max_length=256)
+    image_digest: Optional[str] = Field(None, max_length=128)
+    runtime_status: str = Field("unknown")
+
+
+class WorkloadOut(BaseModel):
+    principal_id: str
+    workload_name: str
+    display_name: Optional[str]
+    image_digest: Optional[str]
+    runtime_status: str
+    hosted_principals_count: int
+    hosted_principals_sample: list[str]
+    last_active: Optional[str]
+    created_at: str
+
+
+class WorkloadListResponse(BaseModel):
+    workloads: list[WorkloadOut]
+    total: int
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _principal_id(org_id: str, workload_name: str) -> str:
+    return f"{org_id}::workload::{workload_name}"
+
+
+async def _hosted_principals(
+    conn, org_id: str,
+) -> tuple[int, list[str]]:
+    """Return (count, sample) of user principals on this Mastio.
+
+    The current shared-mode Frontdesk hosts every active user under
+    its single workload, so the dashboard view shows the count of
+    users this Mastio knows about as the workload's hosted count.
+    A future revision may track explicit container → user binding;
+    for now this matches the demo's mental model.
+    """
+    # Plain ``ORDER BY created_at DESC`` keeps the SQL portable across
+    # SQLite (sandbox) + Postgres (prod) without depending on
+    # ``NULLS LAST``.
+    rows = (await conn.execute(
+        text(
+            "SELECT principal_id FROM local_user_principals "
+            " ORDER BY created_at DESC LIMIT 5"
+        ),
+    )).mappings().all()
+    sample = [r["principal_id"] for r in rows]
+    total = (await conn.execute(
+        text("SELECT COUNT(*) AS n FROM local_user_principals"),
+    )).mappings().first()
+    return int(total["n"] if total else 0), sample
+
+
+@router.post(
+    "",
+    response_model=WorkloadOut,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def create_workload(
+    body: WorkloadCreateRequest, request: Request,
+) -> WorkloadOut:
+    if body.runtime_status not in _VALID_STATUS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"runtime_status must be one of {_VALID_STATUS}",
+        )
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None or not getattr(mgr, "ca_loaded", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized — Org CA not loaded",
+        )
+    pid = _principal_id(mgr.org_id, body.workload_name)
+    now = _now_iso()
+    async with get_db() as conn:
+        existing = (await conn.execute(
+            text(
+                "SELECT principal_id, workload_name, display_name, "
+                "       image_digest, runtime_status, "
+                "       created_at, last_active_at "
+                "  FROM local_workload_principals "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": pid},
+        )).mappings().first()
+        if existing is None:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_workload_principals (
+                        principal_id, workload_name, display_name,
+                        image_digest, runtime_status, created_at
+                    ) VALUES (
+                        :pid, :wname, :disp, :img, :status, :now
+                    )
+                    """
+                ),
+                {
+                    "pid": pid, "wname": body.workload_name,
+                    "disp": body.display_name or None,
+                    "img": body.image_digest,
+                    "status": body.runtime_status, "now": now,
+                },
+            )
+            count, sample = await _hosted_principals(conn, mgr.org_id)
+            return WorkloadOut(
+                principal_id=pid,
+                workload_name=body.workload_name,
+                display_name=body.display_name or None,
+                image_digest=body.image_digest,
+                runtime_status=body.runtime_status,
+                hosted_principals_count=count,
+                hosted_principals_sample=sample,
+                last_active=None,
+                created_at=now,
+            )
+        count, sample = await _hosted_principals(conn, mgr.org_id)
+        return WorkloadOut(
+            principal_id=existing["principal_id"],
+            workload_name=existing["workload_name"],
+            display_name=existing["display_name"],
+            image_digest=existing["image_digest"],
+            runtime_status=existing["runtime_status"],
+            hosted_principals_count=count,
+            hosted_principals_sample=sample,
+            last_active=existing["last_active_at"],
+            created_at=existing["created_at"],
+        )
+
+
+@router.get(
+    "",
+    response_model=WorkloadListResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_workloads(
+    runtime_status: Optional[str] = Query(None),
+    q: Optional[str] = Query(None, max_length=128),
+    limit: int = Query(200, ge=1, le=500),
+) -> WorkloadListResponse:
+    if runtime_status is not None and runtime_status not in _VALID_STATUS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"runtime_status must be one of {_VALID_STATUS}",
+        )
+    sql = (
+        "SELECT principal_id, workload_name, display_name, image_digest, "
+        "       runtime_status, created_at, last_active_at "
+        "  FROM local_workload_principals "
+    )
+    where: list[str] = []
+    params: dict[str, object] = {"limit": limit}
+    if runtime_status is not None:
+        where.append("runtime_status = :status")
+        params["status"] = runtime_status
+    if q:
+        where.append(
+            "(LOWER(workload_name) LIKE :q OR "
+            " LOWER(COALESCE(display_name, '')) LIKE :q)"
+        )
+        params["q"] = f"%{q.lower()}%"
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY created_at DESC LIMIT :limit"
+    async with get_db() as conn:
+        rows = (await conn.execute(text(sql), params)).mappings().all()
+        count, sample = await _hosted_principals(conn, "")
+    items = [
+        WorkloadOut(
+            principal_id=r["principal_id"],
+            workload_name=r["workload_name"],
+            display_name=r["display_name"],
+            image_digest=r["image_digest"],
+            runtime_status=r["runtime_status"],
+            hosted_principals_count=count,
+            hosted_principals_sample=sample,
+            last_active=r["last_active_at"],
+            created_at=r["created_at"],
+        )
+        for r in rows
+    ]
+    return WorkloadListResponse(workloads=items, total=len(items))

--- a/mcp_proxy/alembic/versions/0025_local_principals.py
+++ b/mcp_proxy/alembic/versions/0025_local_principals.py
@@ -1,0 +1,96 @@
+"""Mastio-local principal directories for users + workloads.
+
+Revision ID: 0025_local_principals
+Revises: 0024_bindings_principal_type
+Create Date: 2026-05-07 22:00:00.000000
+
+Adds two read-mostly tables on the Mastio so the admin dashboard can
+list user + workload principals with display metadata. The Frontdesk
+SSO flow (``/v1/principals/csr``) upserts into ``local_user_principals``
+on every signature, and the new ``POST /v1/admin/users`` /
+``POST /v1/admin/workloads`` endpoints pre-populate rows so the
+dashboard renders cleanly even before the first user logs in.
+
+These tables intentionally hold *display* metadata only — the source
+of truth for cert state remains the Org CA + audit log + the
+broker-side ``user_principals`` table that bridges SSO subject to
+principal_id. The Mastio table just lets the admin UI answer "who
+are my users?" without crossing the broker boundary.
+
+Workloads have no broker-side analogue — they are infra-local and
+never federate by default (memory note: workloads stay intra-org;
+Court federation registry is for users + agents). The table exists
+so the dashboard's Workloads tab has somewhere to read from.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0025_local_principals"
+down_revision: Union[str, Sequence[str], None] = "0024_bindings_principal_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_USERS = "local_user_principals"
+_WORKLOADS = "local_workload_principals"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _USERS not in existing:
+        op.create_table(
+            _USERS,
+            sa.Column("principal_id",   sa.Text(), primary_key=True),
+            sa.Column("user_name",      sa.Text(), nullable=False),
+            sa.Column("display_name",   sa.Text(), nullable=True),
+            # ADR-020 reach: intra | cross | both. Default intra so a
+            # newly seeded user that never sets a reach stays scoped.
+            sa.Column("reach",          sa.Text(), nullable=False,
+                      server_default="intra"),
+            # Free-form hint surfaced on the dashboard ("frontdesk",
+            # "cullis-chat", "cli"). NULL means unknown.
+            sa.Column("surface",        sa.Text(), nullable=True),
+            sa.Column("cert_thumbprint", sa.Text(), nullable=True),
+            sa.Column("created_at",     sa.Text(), nullable=False),
+            sa.Column("last_active_at", sa.Text(), nullable=True),
+        )
+        op.create_index(
+            "idx_local_user_principals_user_name",
+            _USERS, ["user_name"],
+        )
+
+    if _WORKLOADS not in existing:
+        op.create_table(
+            _WORKLOADS,
+            sa.Column("principal_id",   sa.Text(), primary_key=True),
+            sa.Column("workload_name",  sa.Text(), nullable=False),
+            sa.Column("display_name",   sa.Text(), nullable=True),
+            sa.Column("image_digest",   sa.Text(), nullable=True),
+            sa.Column("runtime_status", sa.Text(), nullable=False,
+                      server_default="unknown"),
+            sa.Column("created_at",     sa.Text(), nullable=False),
+            sa.Column("last_active_at", sa.Text(), nullable=True),
+        )
+        op.create_index(
+            "idx_local_workload_principals_name",
+            _WORKLOADS, ["workload_name"],
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _WORKLOADS in existing:
+        op.drop_index("idx_local_workload_principals_name", _WORKLOADS)
+        op.drop_table(_WORKLOADS)
+    if _USERS in existing:
+        op.drop_index("idx_local_user_principals_user_name", _USERS)
+        op.drop_table(_USERS)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -939,6 +939,14 @@ app.include_router(admin_mcp_resources_router)
 from mcp_proxy.admin.agents import router as admin_agents_router
 app.include_router(admin_agents_router)
 
+# ADR-020 / ADR-021 — user + workload principal admin lists for the
+# dashboard's Users / Workloads tabs. Workloads are intentionally
+# intra-org only (never federated to Court).
+from mcp_proxy.admin.users import router as admin_users_router
+from mcp_proxy.admin.workloads import router as admin_workloads_router
+app.include_router(admin_users_router)
+app.include_router(admin_workloads_router)
+
 # ADR-011 Phase 1b — BYOCA enrollment endpoint. ``/v1/admin/agents/enroll/byoca``
 # takes a caller-supplied cert/key pair, verifies the chain to the Mastio's
 # Org CA, and emits an API key + optional DPoP binding. Registered here,

--- a/mcp_proxy/registry/user_principals_router.py
+++ b/mcp_proxy/registry/user_principals_router.py
@@ -125,6 +125,15 @@ async def sign_csr(
         "principals.csr signed principal_id=%s thumbprint=%s not_after=%s",
         body.principal_id, thumbprint, not_after.isoformat(),
     )
+    # Best-effort: surface the user in the dashboard's Users tab. Errors
+    # are swallowed inside the helper — the user-facing flow is the
+    # cert response, not the directory upsert.
+    from mcp_proxy.admin.users import upsert_from_csr
+    await upsert_from_csr(
+        principal_id=body.principal_id,
+        org_id=token.org,
+        cert_thumbprint=thumbprint,
+    )
     return CsrSignResponse(
         cert_pem=cert_pem,
         cert_thumbprint=thumbprint,

--- a/tests/test_admin_users.py
+++ b/tests/test_admin_users.py
@@ -1,0 +1,185 @@
+"""Mastio admin API for user principals — POST + GET + auth + filters."""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── create ─────────────────────────────────────────────────────────────
+
+
+async def test_create_user_writes_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-create")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users",
+                headers=h,
+                json={
+                    "user_name": "claim-officer",
+                    "display_name": "Marco Conti",
+                    "reach": "intra",
+                    "surface": "cullis-chat",
+                },
+            )
+            assert r.status_code == 201, r.text
+            data = r.json()
+            assert data["principal_id"] == "users-create::user::claim-officer"
+            assert data["display_name"] == "Marco Conti"
+            assert data["reach"] == "intra"
+            assert data["surface"] == "cullis-chat"
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_idempotent_on_repost(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-idem")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "kenji", "display_name": "Kenji Watanabe"},
+            )
+            # Re-POST with a different display_name; existing row wins.
+            r = await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "kenji", "display_name": "Different"},
+            )
+            assert r.status_code == 201
+            assert r.json()["display_name"] == "Kenji Watanabe"
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_rejects_bad_reach(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-reach")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "x", "reach": "global"},
+            )
+            assert r.status_code == 400
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── list + filter ──────────────────────────────────────────────────────
+
+
+async def test_list_returns_created_users(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-list")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            for spec in (
+                {"user_name": "officer", "display_name": "Marco",
+                 "reach": "intra", "surface": "cullis-chat"},
+                {"user_name": "manager", "display_name": "Lucia",
+                 "reach": "both", "surface": "cullis-chat"},
+                {"user_name": "liaison", "display_name": "Kenji",
+                 "reach": "cross", "surface": "frontdesk"},
+            ):
+                await cli.post("/v1/admin/users", headers=h, json=spec)
+
+            r = await cli.get("/v1/admin/users", headers=h)
+            assert r.status_code == 200
+            data = r.json()
+            assert data["total"] == 3
+            names = {u["user_name"] for u in data["users"]}
+            assert names == {"officer", "manager", "liaison"}
+
+            # Reach filter.
+            r2 = await cli.get(
+                "/v1/admin/users?reach=cross", headers=h,
+            )
+            assert {u["user_name"] for u in r2.json()["users"]} == {"liaison"}
+
+            # Surface filter.
+            r3 = await cli.get(
+                "/v1/admin/users?surface=frontdesk", headers=h,
+            )
+            assert {u["user_name"] for u in r3.json()["users"]} == {"liaison"}
+
+            # q filter on display_name.
+            r4 = await cli.get(
+                "/v1/admin/users?q=lucia", headers=h,
+            )
+            assert {u["user_name"] for u in r4.json()["users"]} == {"manager"}
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── auth ───────────────────────────────────────────────────────────────
+
+
+async def test_auth_required(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-auth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get("/v1/admin/users")
+            assert r.status_code == 422  # header missing
+            r = await cli.get(
+                "/v1/admin/users",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+            assert r.status_code == 403
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── upsert from CSR sign ───────────────────────────────────────────────
+
+
+async def test_upsert_from_csr_creates_row(tmp_path, monkeypatch):
+    """``upsert_from_csr`` is the runtime helper the CSR endpoint calls
+    after a successful signature. Verifies the side-effect directly,
+    keeping the unit test below the HTTP layer because exercising the
+    full CSR path requires DPoP-bound auth fixtures the rest of the
+    suite already covers separately."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-csr")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.admin.users import upsert_from_csr
+            await upsert_from_csr(
+                principal_id="users-csr.cullis.test/users-csr/user/jane",
+                org_id="users-csr",
+                cert_thumbprint="sha256:" + "0" * 16,
+            )
+            h = await _headers()
+            r = await cli.get("/v1/admin/users", headers=h)
+            data = r.json()
+            assert data["total"] == 1
+            assert data["users"][0]["user_name"] == "jane"
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_admin_workloads.py
+++ b/tests/test_admin_workloads.py
@@ -1,0 +1,176 @@
+"""Mastio admin API for workload principals — POST + GET + auth + filters."""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── create ─────────────────────────────────────────────────────────────
+
+
+async def test_create_workload_writes_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "wl-create")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/workloads", headers=h,
+                json={
+                    "workload_name": "frontdesk-container",
+                    "display_name": "Asia-Pacific Frontdesk",
+                    "image_digest": "sha256:abc",
+                    "runtime_status": "running",
+                },
+            )
+            assert r.status_code == 201, r.text
+            data = r.json()
+            assert data["principal_id"] == "wl-create::workload::frontdesk-container"
+            assert data["display_name"] == "Asia-Pacific Frontdesk"
+            assert data["image_digest"] == "sha256:abc"
+            assert data["runtime_status"] == "running"
+            assert data["hosted_principals_count"] == 0
+            assert data["hosted_principals_sample"] == []
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_idempotent_on_repost(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "wl-idem")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/workloads", headers=h,
+                json={"workload_name": "fd",
+                      "display_name": "Original"},
+            )
+            r = await cli.post(
+                "/v1/admin/workloads", headers=h,
+                json={"workload_name": "fd", "display_name": "Different"},
+            )
+            assert r.status_code == 201
+            assert r.json()["display_name"] == "Original"
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_rejects_bad_status(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "wl-status")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/workloads", headers=h,
+                json={"workload_name": "x", "runtime_status": "exploded"},
+            )
+            assert r.status_code == 400
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── list + filter ──────────────────────────────────────────────────────
+
+
+async def test_list_returns_created_workloads(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "wl-list")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            for spec in (
+                {"workload_name": "fd-tokyo",
+                 "display_name": "Frontdesk Tokyo",
+                 "runtime_status": "running"},
+                {"workload_name": "fd-osaka",
+                 "display_name": "Frontdesk Osaka",
+                 "runtime_status": "stopped"},
+            ):
+                await cli.post("/v1/admin/workloads", headers=h, json=spec)
+
+            r = await cli.get("/v1/admin/workloads", headers=h)
+            data = r.json()
+            assert data["total"] == 2
+
+            r2 = await cli.get(
+                "/v1/admin/workloads?runtime_status=running", headers=h,
+            )
+            names = {w["workload_name"] for w in r2.json()["workloads"]}
+            assert names == {"fd-tokyo"}
+
+            r3 = await cli.get(
+                "/v1/admin/workloads?q=osaka", headers=h,
+            )
+            names = {w["workload_name"] for w in r3.json()["workloads"]}
+            assert names == {"fd-osaka"}
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_hosted_principals_count_reflects_users(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "wl-hosted")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            # Two users on this Mastio.
+            for name in ("alice", "bob"):
+                await cli.post(
+                    "/v1/admin/users", headers=h,
+                    json={"user_name": name, "display_name": name.title()},
+                )
+            await cli.post(
+                "/v1/admin/workloads", headers=h,
+                json={"workload_name": "fd",
+                      "display_name": "Frontdesk",
+                      "runtime_status": "running"},
+            )
+
+            r = await cli.get("/v1/admin/workloads", headers=h)
+            wl = r.json()["workloads"][0]
+            assert wl["hosted_principals_count"] == 2
+            assert len(wl["hosted_principals_sample"]) == 2
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── auth ───────────────────────────────────────────────────────────────
+
+
+async def test_auth_required(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "wl-auth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get("/v1/admin/workloads")
+            assert r.status_code == 422
+            r = await cli.get(
+                "/v1/admin/workloads",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+            assert r.status_code == 403
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0024_bindings_principal_type",)]
+    assert rows == [("0025_local_principals",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0024_bindings_principal_type",)]
+    assert version == [("0025_local_principals",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0024_bindings_principal_type"
+HEAD_REVISION = "0025_local_principals"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0024_bindings_principal_type"
+HEAD_REVISION = "0025_local_principals"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0024_bindings_principal_type"
+HEAD_REVISION = "0025_local_principals"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

- New Mastio-local tables ``local_user_principals`` + ``local_workload_principals`` (migration ``0025_local_principals``).
- ``POST /v1/admin/users`` + ``GET /v1/admin/users`` — idempotent create, list with ``reach`` / ``surface`` / ``q`` filters.
- ``POST /v1/admin/workloads`` + ``GET /v1/admin/workloads`` — same shape, with ``runtime_status`` / ``q`` filters and a ``hosted_principals_count`` derived from the local user table.
- ``/v1/principals/csr`` upserts into ``local_user_principals`` after each successful signature, so users that come in through Frontdesk SSO show up in the dashboard without an admin pre-population step.
- Workloads stay **intra-org by design** — Court federation registry has no view of them.

## Why

The insurance multi-surface demo (PR #475) needs a Mastio admin dashboard with Users / Agents / Workloads / Resources sections. Agents + resources have admin endpoints already; users + workloads did not. Without these the dashboard's Users / Workloads tabs would have to ship hardcoded fixtures forever.

## Closes
- #476 (``GET /v1/admin/users``)
- #477 (``GET /v1/admin/workloads``)

## Test plan
- ``pytest tests/test_admin_users.py tests/test_admin_workloads.py`` — 12 tests, all green locally
- ``pytest tests/test_principals_csr.py tests/test_user_principals_registry.py tests/test_h_csr_pop.py`` — regression check on the CSR + user-principals existing surface (43 tests, green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)