### PR TITLE
feat(dashboard): SPA rework Phase 1 — principal-type sections + badges

### DIFF
--- a/app/dashboard/_demo_cast.py
+++ b/app/dashboard/_demo_cast.py
@@ -1,0 +1,134 @@
+"""
+Hardcoded demo cast for Phase 1 of the SPA rework (insurance demo).
+
+The Mastio admin dashboard renders four principal-type sections (Users,
+Agents, Workloads, Resources). The corresponding admin REST routes
+(/v1/admin/users, /v1/admin/workloads) are still being designed by the
+backend session — see ``imp/insurance-demo-spec.md``. Until those land,
+this module returns the principal cast hardcoded from the spec so the
+dashboard can be screenshot-recorded for the demo.
+
+Swap path: when the admin endpoints ship, replace each ``*_cast`` call
+in ``app/dashboard/router.py`` with an httpx call to the real route.
+This module then deletes cleanly.
+"""
+from __future__ import annotations
+
+
+def users_cast() -> list[dict]:
+    """Return the user principals from the insurance demo spec."""
+    return [
+        {
+            "principal_id": "mediterranean::user::claim-officer",
+            "display_name": "Claim Officer",
+            "reach": "cross",
+            "surface": "Cullis Chat (desktop)",
+            "last_active": "active",
+            "last_active_iso": None,
+        },
+        {
+            "principal_id": "mediterranean::user::claim-manager",
+            "display_name": "Claim Manager",
+            "reach": "cross",
+            "surface": "Cullis Chat /chat (web)",
+            "last_active": "active",
+            "last_active_iso": None,
+        },
+        {
+            "principal_id": "asia-pacific::user::counterparty-liaison",
+            "display_name": "Counterparty Liaison",
+            "reach": "both",
+            "surface": "Frontdesk (web)",
+            "last_active": "active",
+            "last_active_iso": None,
+        },
+    ]
+
+
+def workloads_cast() -> list[dict]:
+    """Return the workload principals from the insurance demo spec."""
+    return [
+        {
+            "principal_id": "asia-pacific::workload::frontdesk-container",
+            "display_name": "Asia-Pacific Frontdesk",
+            "reach": "both",
+            "hosted_principals_count": 1,
+            "image_digest": "sha256:c1ed4e8f7a02b9d4f6e3c2a1b8d7e6f5",
+            "runtime_status": "running",
+        },
+    ]
+
+
+def resources_cast() -> list[dict]:
+    """Return MCP/HTTP/DB resources from the insurance demo spec."""
+    return [
+        {
+            "resource_id": "mediterranean::resource::mcp::claims-db",
+            "display_name": "Claims Database",
+            "type": "mcp",
+            "endpoint": "mcp://claims-db.mediterranean.local",
+            "bindings_count": 2,
+            "last_accessed": "active",
+            "last_accessed_iso": None,
+        },
+    ]
+
+
+def peers_cast() -> list[dict]:
+    """Return federated peer organizations for the demo (two orgs)."""
+    return [
+        {
+            "org_id": "mediterranean",
+            "trust_domain": "mediterranean.cullis.test",
+            "status": "active",
+            "ca_fingerprint": "sha256:a1b2c3d4e5f6a7b8c9d0e1f2",
+            "joined_at": "active",
+            "joined_at_iso": None,
+        },
+        {
+            "org_id": "asia-pacific",
+            "trust_domain": "asia-pacific.cullis.test",
+            "status": "active",
+            "ca_fingerprint": "sha256:9f8e7d6c5b4a3928170615f4",
+            "joined_at": "active",
+            "joined_at_iso": None,
+        },
+    ]
+
+
+def agent_extras(agent_id: str) -> dict:
+    """Return enrollment_method + automation_type for known cast agents.
+
+    Returns empty dict for agents that are not in the demo cast — the
+    template renders an em-dash for missing fields. This is intentional:
+    real agents from the registry may not yet have these fields tagged.
+    """
+    table = {
+        "mediterranean::agent::night-reporter": {
+            "enrollment_method": "Connector",
+            "automation_type": "cron",
+        },
+        "mediterranean::agent::ticket-bot": {
+            "enrollment_method": "BYOCA",
+            "automation_type": "request-response",
+        },
+    }
+    return table.get(agent_id, {})
+
+
+def cast_counts() -> dict:
+    """Counts for the left-nav badges (HTMX-polled)."""
+    return {
+        "users": len(users_cast()),
+        "agents": len([a for a in agent_extras_keys()]),
+        "workloads": len(workloads_cast()),
+        "resources": len(resources_cast()),
+    }
+
+
+def agent_extras_keys() -> list[str]:
+    """Return the agent_ids known to the demo cast."""
+    return [
+        "mediterranean::agent::night-reporter",
+        "mediterranean::agent::ticket-bot",
+    ]

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -659,8 +659,13 @@ async def overview(request: Request, db: AsyncSession = Depends(get_db)):
         select(func.count(AuditLog.id)).where(AuditLog.timestamp >= _one_hour_ago)
     )).scalar() or 0
 
+    # Users count is hardcoded from the insurance demo cast until
+    # /v1/admin/users lands (backend session). See _demo_cast.py.
+    users_total = len(_demo_cast.users_cast())
+
     stats = {
         "orgs": orgs_total, "orgs_active": orgs_active, "orgs_pending": orgs_pending,
+        "users": users_total,
         "agents": agents_total, "agents_active": agents_active,
         "sessions_active": sessions_active,
         "audit_events": audit_events,

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -46,6 +46,7 @@ from app.policy.store import PolicyRecord, create_policy, get_policy, deactivate
 from app.broker.db_models import SessionRecord, SessionMessageRecord, RfqRecord, RfqResponseRecord
 from app.broker.ws_manager import ws_manager
 from app.auth.transaction_token import create_transaction_token, compute_payload_hash
+from app.dashboard import _demo_cast
 
 import logging
 _log = logging.getLogger("agent_trust")
@@ -875,6 +876,7 @@ async def agents_list(request: Request, db: AsyncSession = Depends(get_db)):
 
     agent_list = []
     for agent in agents:
+        extras = _demo_cast.agent_extras(agent.agent_id)
         agent_list.append({
             "agent_id": agent.agent_id,
             "org_id": agent.org_id,
@@ -884,11 +886,75 @@ async def agents_list(request: Request, db: AsyncSession = Depends(get_db)):
             "binding_status": binding_statuses.get(agent.agent_id),
             "ws_connected": ws_manager.is_connected(agent.agent_id),
             "cert_thumbprint": agent.cert_thumbprint,
+            "enrollment_method": extras.get("enrollment_method"),
+            "automation_type": extras.get("automation_type"),
         })
 
     return templates.TemplateResponse("agents.html",
         _ctx(request, session, active="agents", agents=agent_list)
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Users / Workloads / Resources / Federation (ADR-020 principal-type sections)
+#
+# Phase 1 of the SPA rework ships these views with hardcoded demo data
+# from imp/insurance-demo-spec.md. The matching admin REST endpoints
+# (/v1/admin/users, /v1/admin/workloads) are owned by the backend
+# session and land separately. Once they are live, swap the
+# ``_demo_cast.*`` calls below for httpx calls to those routes and
+# delete app/dashboard/_demo_cast.py.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/users", response_class=HTMLResponse)
+async def users_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("users.html", _ctx(
+        request, session, active="users",
+        users=_demo_cast.users_cast(),
+        endpoint_ready=False,
+    ))
+
+
+@router.get("/workloads", response_class=HTMLResponse)
+async def workloads_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("workloads.html", _ctx(
+        request, session, active="workloads",
+        workloads=_demo_cast.workloads_cast(),
+        endpoint_ready=False,
+    ))
+
+
+@router.get("/resources", response_class=HTMLResponse)
+async def resources_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("resources.html", _ctx(
+        request, session, active="resources",
+        resources=_demo_cast.resources_cast(),
+    ))
+
+
+@router.get("/federation", response_class=HTMLResponse)
+async def federation_view(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("federation.html", _ctx(
+        request, session, active="federation",
+        peers=_demo_cast.peers_cast(),
+        court_status="Online",
+        court_endpoint="https://court.cullis.test",
+        court_audit_status="Healthy",
+        court_last_anchor="active",
+        court_last_anchor_iso=None,
+    ))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1199,6 +1265,53 @@ async def badge_pending_sessions(request: Request, db: AsyncSession = Depends(ge
     if count > 0:
         return f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-yellow-500/20 text-yellow-400">{count}</span>'
     return ""
+
+
+def _count_chip(count: int) -> str:
+    """Neutral count chip used in the principal-type nav badges."""
+    if count <= 0:
+        return ""
+    return (
+        '<span class="px-1.5 py-0.5 rounded-full text-[10px] font-mono '
+        f'bg-gray-700/40 text-gray-400">{count}</span>'
+    )
+
+
+@router.get("/badge/users-count", response_class=HTMLResponse)
+async def badge_users_count(request: Request):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    return _count_chip(len(_demo_cast.users_cast()))
+
+
+@router.get("/badge/agents-count", response_class=HTMLResponse)
+async def badge_agents_count(request: Request, db: AsyncSession = Depends(get_db)):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    count = (await db.execute(select(func.count(AgentRecord.agent_id)))).scalar() or 0
+    if count == 0:
+        # During demo recording the registry may not yet be populated.
+        # Fall back to the cast count so the badge is screenshot-ready.
+        count = len(_demo_cast.agent_extras_keys())
+    return _count_chip(int(count))
+
+
+@router.get("/badge/workloads-count", response_class=HTMLResponse)
+async def badge_workloads_count(request: Request):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    return _count_chip(len(_demo_cast.workloads_cast()))
+
+
+@router.get("/badge/resources-count", response_class=HTMLResponse)
+async def badge_resources_count(request: Request):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    return _count_chip(len(_demo_cast.resources_cast()))
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/dashboard/static_src/input.css
+++ b/app/dashboard/static_src/input.css
@@ -7,6 +7,14 @@
  * Keep in sync with mcp_proxy/dashboard/static_src/input.css.
  */
 
+:root {
+  /* Principal type badge — ADR-020 user/agent/workload, mirrored
+     from site/global.css and cullis-chat/tokens.css. */
+  --cullis-badge-user: #3b7af5;
+  --cullis-badge-agent: #8b5cf6;
+  --cullis-badge-workload: #10b981;
+}
+
 @layer base {
   body {
     font-family: 'DM Sans', sans-serif;

--- a/app/dashboard/templates/_principal_badge.html
+++ b/app/dashboard/templates/_principal_badge.html
@@ -1,0 +1,37 @@
+{# Principal type badge — ADR-020.
+   Usage:
+     {% from "_principal_badge.html" import principal_badge %}
+     {{ principal_badge("user") }}
+
+   `kind` is one of: user | agent | workload. Falls back to a neutral
+   chip for unknown values so a typo does not break the page. #}
+{% macro principal_badge(kind) -%}
+  {%- set k = (kind or "")|lower -%}
+  {%- if k == "user" -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style="background: rgba(59,122,245,0.10); color: var(--cullis-badge-user, #3b7af5); border-color: rgba(59,122,245,0.25);">User</span>
+  {%- elif k == "agent" -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style="background: rgba(139,92,246,0.10); color: var(--cullis-badge-agent, #8b5cf6); border-color: rgba(139,92,246,0.25);">Agent</span>
+  {%- elif k == "workload" -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style="background: rgba(16,185,129,0.10); color: var(--cullis-badge-workload, #10b981); border-color: rgba(16,185,129,0.25);">Workload</span>
+  {%- else -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em] bg-gray-700/30 text-gray-400 border-gray-700/40">{{ kind|default("?", true) }}</span>
+  {%- endif -%}
+{%- endmacro %}
+
+{# Reach chip — intra | cross | both. Visually distinct from principal
+   type badge. #}
+{% macro reach_chip(reach) -%}
+  {%- set r = (reach or "")|lower -%}
+  {%- if r == "intra" -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-gray-500/10 text-gray-400">Intra</span>
+  {%- elif r == "cross" -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-amber-500/10 text-amber-400">Cross</span>
+  {%- elif r == "both" -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-accent-400/10 text-accent-400">Both</span>
+  {%- else -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-gray-700/20 text-gray-500">{{ reach|default("none", true) }}</span>
+  {%- endif -%}
+{%- endmacro %}

--- a/app/dashboard/templates/agents.html
+++ b/app/dashboard/templates/agents.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_principal_badge.html" import principal_badge %}
 {% block title %}Agents{% endblock %}
 {% block header_title %}Agents{% endblock %}
 {% block content %}
@@ -8,7 +9,7 @@
     <div class="flex items-center justify-between mb-6">
         <div>
             <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Federated Agents</h2>
-            <p class="text-xs text-gray-600 mt-0.5">{{ agents | length }} registered</p>
+            <p class="text-xs text-gray-600 mt-0.5">{{ agents | length }} registered &middot; non-human autonomous principals</p>
         </div>
         <a href="/dashboard/agents/register"
            class="px-4 py-2 text-xs font-semibold rounded transition-all"
@@ -27,6 +28,8 @@
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Agent</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Organization</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Enrollment</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Automation</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Capabilities</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Binding</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">WebSocket</th>
@@ -38,7 +41,10 @@
                 {% for agent in agents %}
                 <tr class="table-row-hover transition-colors">
                     <td class="px-5 py-4">
-                        <a href="/dashboard/agents/{{ agent.agent_id }}" class="text-sm text-white hover:text-accent-400 transition-colors">{{ agent.display_name }}</a>
+                        <div class="flex items-center gap-2">
+                            {{ principal_badge("agent") }}
+                            <a href="/dashboard/agents/{{ agent.agent_id }}" class="text-sm text-white hover:text-accent-400 transition-colors">{{ agent.display_name }}</a>
+                        </div>
                         <p class="text-[10px] text-gray-600 font-mono mt-0.5">{{ agent.agent_id }}</p>
                     </td>
                     <td class="px-5 py-4 text-xs text-gray-400 font-mono">{{ agent.org_id }}</td>
@@ -51,6 +57,20 @@
                         <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-wider">
                             <span class="w-1.5 h-1.5 rounded-full bg-gray-600"></span>Inactive
                         </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if agent.enrollment_method %}
+                        <span class="text-[10px] text-gray-400 font-mono uppercase tracking-wider">{{ agent.enrollment_method }}</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if agent.automation_type %}
+                        <span class="text-[10px] text-gray-400 uppercase tracking-wider">{{ agent.automation_type }}</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
                         {% endif %}
                     </td>
                     <td class="px-5 py-4">
@@ -100,7 +120,7 @@
                 {% endfor %}
                 {% if not agents %}
                 <tr>
-                    <td colspan="8" class="px-5 py-16 text-center">
+                    <td colspan="10" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                         <p class="text-sm text-gray-600">No agents registered</p>
                     </td>

--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -48,12 +48,6 @@
                 Agents
                 <span hx-get="/dashboard/badge/agents-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/workloads"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'workloads' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
-                Workloads
-                <span hx-get="/dashboard/badge/workloads-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
-            </a>
             <a href="/dashboard/resources"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'resources' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2 2 3 4 3h8c2 0 4-1 4-3V7c0-2-2-3-4-3H8C6 4 4 5 4 7zm4 0h8M8 12h8M8 17h5"/></svg>

--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -27,53 +27,65 @@
         </div>
 
         <!-- Navigation -->
-        <div class="flex-1 px-2 py-3 space-y-0.5">
+        <div class="flex-1 px-2 py-3 space-y-0.5 overflow-y-auto">
             <a href="/dashboard"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'overview' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/></svg>
                 Overview
             </a>
-            <a href="/dashboard/orgs"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'orgs' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
-                Organizations
-                <span hx-get="/dashboard/badge/pending-orgs" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+
+            <!-- Principals group -->
+            <div class="mt-3 mb-1 px-3 text-[9px] font-semibold uppercase tracking-[0.22em] text-gray-700">Principals</div>
+            <a href="/dashboard/users"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'users' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
+                Users
+                <span hx-get="/dashboard/badge/users-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
             <a href="/dashboard/agents"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'agents' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                 Agents
+                <span hx-get="/dashboard/badge/agents-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/sessions"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'sessions' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
-                Sessions
-                <span hx-get="/dashboard/badge/pending-sessions" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+            <a href="/dashboard/workloads"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'workloads' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+                Workloads
+                <span hx-get="/dashboard/badge/workloads-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/rfqs"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'rfq' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/></svg>
-                RFQs
+            <a href="/dashboard/resources"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'resources' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2 2 3 4 3h8c2 0 4-1 4-3V7c0-2-2-3-4-3H8C6 4 4 5 4 7zm4 0h8M8 12h8M8 17h5"/></svg>
+                Resources
+                <span hx-get="/dashboard/badge/resources-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/policies"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'policies' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
-                Policies
-            </a>
+
+            <!-- Federation group -->
+            <div class="mt-3 mb-1 px-3 text-[9px] font-semibold uppercase tracking-[0.22em] text-gray-700">Federation</div>
             <a href="/dashboard/bindings"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'bindings' %}nav-active{% else %}text-gray-500{% endif %}">
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'bindings' or active == 'policies' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
                 Bindings
             </a>
-            <a href="/dashboard/admin/settings"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'admin_settings' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-                Settings
+            <a href="/dashboard/federation"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'federation' or active == 'orgs' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0zM3 12h18M12 3a15 15 0 010 18M12 3a15 15 0 000 18"/></svg>
+                Federation
+                <span hx-get="/dashboard/badge/pending-orgs" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
             <a href="/dashboard/audit"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'audit' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
                 Audit Log
+            </a>
+
+            <!-- System group -->
+            <div class="mt-3 mb-1 px-3 text-[9px] font-semibold uppercase tracking-[0.22em] text-gray-700">System</div>
+            <a href="/dashboard/admin/settings"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'admin_settings' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                Settings
             </a>
             <a href="{{ jaeger_url or 'http://localhost:16686' }}" target="_blank" rel="noopener"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item text-gray-500">

--- a/app/dashboard/templates/federation.html
+++ b/app/dashboard/templates/federation.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Federation{% endblock %}
+{% block header_title %}Federation{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="federation" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Federation</h2>
+            <p class="text-xs text-gray-600 mt-0.5">Peer organizations &amp; Court health</p>
+        </div>
+    </div>
+
+    <!-- Court status -->
+    <div class="mb-6 bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <div class="px-5 py-4 border-b border-gray-800/60">
+            <div class="flex items-center justify-between">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Court</h3>
+                <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[10px] font-medium bg-accent-400/10 text-accent-400 uppercase tracking-wider">
+                    <span class="w-1.5 h-1.5 rounded-full bg-accent-400 pulse-dot"></span>
+                    {{ court_status or "Online" }}
+                </span>
+            </div>
+        </div>
+        <div class="px-5 py-3 grid grid-cols-3 gap-4 text-xs">
+            <div>
+                <div class="text-gray-600 uppercase tracking-wider text-[10px] mb-1">Endpoint</div>
+                <div class="text-gray-300 font-mono text-[11px]">{{ court_endpoint or "https://court.cullis.test" }}</div>
+            </div>
+            <div>
+                <div class="text-gray-600 uppercase tracking-wider text-[10px] mb-1">Audit dual-write</div>
+                <div class="text-emerald-400 text-[11px]">{{ court_audit_status or "Healthy" }}</div>
+            </div>
+            <div>
+                <div class="text-gray-600 uppercase tracking-wider text-[10px] mb-1">Last anchor</div>
+                <div class="text-gray-300 text-[11px]" title="{{ court_last_anchor_iso or '' }}">{{ court_last_anchor or "—" }}</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Peer orgs -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <div class="px-5 py-3 border-b border-gray-800/60 flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Peer organizations</h3>
+            <span class="text-[10px] text-gray-600 uppercase tracking-wider">{{ peers | length }} federated</span>
+        </div>
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Org ID</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Trust domain</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">CA fingerprint</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Joined</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for p in peers %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4 text-sm text-white font-mono">{{ p.org_id }}</td>
+                    <td class="px-5 py-4 text-xs text-gray-400 font-mono">{{ p.trust_domain }}</td>
+                    <td class="px-5 py-4">
+                        {% if p.status == "active" %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
+                        </span>
+                        {% elif p.status == "pending" %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-yellow-500/10 text-yellow-400 uppercase tracking-wider">Pending</span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-wider">{{ p.status }}</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if p.ca_fingerprint %}
+                        <span class="text-[10px] text-gray-400 font-mono" title="{{ p.ca_fingerprint }}">{{ p.ca_fingerprint[:14] }}…</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-500" title="{{ p.joined_at_iso or '' }}">{{ p.joined_at or "—" }}</td>
+                </tr>
+                {% endfor %}
+                {% if not peers %}
+                <tr>
+                    <td colspan="5" class="px-5 py-12 text-center text-sm text-gray-600">No peer organizations federated</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Legacy /orgs link -->
+    <div class="mt-4 text-[11px] text-gray-700">
+        Legacy organization CRUD lives at
+        <a href="/dashboard/orgs" class="text-gray-500 hover:text-accent-400 transition-colors underline decoration-dotted">/dashboard/orgs</a>
+        (own-org operations not yet exposed in Federation tab).
+    </div>
+</div>
+{% endblock %}

--- a/app/dashboard/templates/overview.html
+++ b/app/dashboard/templates/overview.html
@@ -75,13 +75,22 @@
             <div class="px-5 py-5 cell">
                 <div class="flex items-center justify-between">
                     <p class="mono text-[10px] uppercase tracking-[0.22em] text-white/45">organizations</p>
-                    <a href="/dashboard/orgs" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">ls →</a>
+                    <a href="/dashboard/federation" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">ls →</a>
                 </div>
                 <p class="heading text-[40px] leading-none font-semibold text-white mt-3 tnum mono">{{ stats.orgs }}</p>
                 <div class="mt-2 flex items-center gap-3 mono text-[10px] uppercase tracking-wider">
                     <span class="text-[#00e5c7]">● {{ stats.orgs_active }} active</span>
                     {% if stats.orgs_pending %}<span class="text-amber-300">◐ {{ stats.orgs_pending }} pending</span>{% endif %}
                 </div>
+            </div>
+            <!-- Users -->
+            <div class="px-5 py-5 cell">
+                <div class="flex items-center justify-between">
+                    <p class="mono text-[10px] uppercase tracking-[0.22em] text-white/45">users</p>
+                    <a href="/dashboard/users" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">ls →</a>
+                </div>
+                <p class="heading text-[40px] leading-none font-semibold text-white mt-3 tnum mono">{{ stats.users }}</p>
+                <div class="mt-2 mono text-[10px] uppercase tracking-wider text-white/40">human principals</div>
             </div>
             <!-- Agents -->
             <div class="px-5 py-5 cell">
@@ -91,15 +100,6 @@
                 </div>
                 <p class="heading text-[40px] leading-none font-semibold text-white mt-3 tnum mono">{{ stats.agents }}</p>
                 <div class="mt-2 mono text-[10px] uppercase tracking-wider text-[#00e5c7]">● {{ stats.agents_active }} active</div>
-            </div>
-            <!-- Sessions -->
-            <div class="px-5 py-5 cell">
-                <div class="flex items-center justify-between">
-                    <p class="mono text-[10px] uppercase tracking-[0.22em] text-white/45">sessions · live</p>
-                    <a href="/dashboard/sessions" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">tail →</a>
-                </div>
-                <p class="heading text-[40px] leading-none font-semibold {% if stats.sessions_active > 0 %}text-[#00e5c7]{% else %}text-white{% endif %} mt-3 tnum mono">{{ stats.sessions_active }}</p>
-                <div class="mt-2 mono text-[10px] uppercase tracking-wider text-white/40">active sockets</div>
             </div>
             <!-- Audit -->
             <div class="px-5 py-5">
@@ -199,12 +199,12 @@
                         <span class="text-white tnum">{{ stats.orgs_active }}</span>
                     </div>
                     <div class="flex items-center justify-between mono text-[11px]">
-                        <span class="text-white/55 uppercase tracking-wider">live sessions</span>
-                        <span class="text-[#00e5c7] tnum">{{ stats.sessions_active }}</span>
+                        <span class="text-white/55 uppercase tracking-wider">active agents</span>
+                        <span class="text-[#00e5c7] tnum">{{ stats.agents_active }}</span>
                     </div>
                 </div>
                 <div class="mt-4 pt-4 border-t hairline">
-                    <a href="/dashboard/orgs" class="mono text-[10px] uppercase tracking-[0.22em] text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">Inspect organizations →</a>
+                    <a href="/dashboard/federation" class="mono text-[10px] uppercase tracking-[0.22em] text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">Inspect federation →</a>
                 </div>
             </div>
         </aside>

--- a/app/dashboard/templates/resources.html
+++ b/app/dashboard/templates/resources.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block title %}Resources{% endblock %}
+{% block header_title %}MCP Resources{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="resources" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Resources</h2>
+            <p class="text-xs text-gray-600 mt-0.5">{{ resources | length }} registered &middot; MCP tools, HTTP services, databases</p>
+        </div>
+    </div>
+
+    <!-- Resources table -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Resource</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Type</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Endpoint</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Bindings</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last accessed</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for r in resources %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                            <span class="text-[10px] text-gray-500 font-mono"
+                                  title="{{ r.resource_id }}">{{ r.resource_id }}</span>
+                            <button type="button" class="text-gray-700 hover:text-accent-400 transition-colors"
+                                    onclick="copyToClipboard('{{ r.resource_id }}')" title="Copy ID">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            </button>
+                        </div>
+                    </td>
+                    <td class="px-5 py-4 text-sm text-white">{{ r.display_name }}</td>
+                    <td class="px-5 py-4">
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-info-400/10 text-info-400 uppercase tracking-wider">
+                            {% if r.type == "mcp" %}
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+                                MCP
+                            {% elif r.type == "http" %}
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                                HTTP
+                            {% elif r.type in ("database", "postgres", "db") %}
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7c0-1.5 3.5-3 8-3s8 1.5 8 3v10c0 1.5-3.5 3-8 3s-8-1.5-8-3V7zm0 0c0 1.5 3.5 3 8 3s8-1.5 8-3M4 12c0 1.5 3.5 3 8 3s8-1.5 8-3"/></svg>
+                                Database
+                            {% else %}
+                                {{ r.type }}
+                            {% endif %}
+                        </span>
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-400 font-mono truncate max-w-xs" title="{{ r.endpoint }}">{{ r.endpoint }}</td>
+                    <td class="px-5 py-4">
+                        <a href="/dashboard/bindings?resource={{ r.resource_id }}"
+                           class="text-xs text-accent-400 hover:text-accent-500 transition-colors font-mono">{{ r.bindings_count }} →</a>
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-500" title="{{ r.last_accessed_iso or '' }}">{{ r.last_accessed or "never" }}</td>
+                    <td class="px-5 py-4 space-x-1.5">
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Detail page lands in Phase 2">Details</button>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not resources %}
+                <tr>
+                    <td colspan="7" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7v10c0 2 2 3 4 3h8c2 0 4-1 4-3V7c0-2-2-3-4-3H8C6 4 4 5 4 7zm4 0h8M8 12h8M8 17h5"/></svg>
+                        <p class="text-sm text-gray-600">No resources registered</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/dashboard/templates/users.html
+++ b/app/dashboard/templates/users.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% from "_principal_badge.html" import principal_badge, reach_chip %}
+{% block title %}Users{% endblock %}
+{% block header_title %}User Principals{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="users" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Users</h2>
+            <p class="text-xs text-gray-600 mt-0.5">{{ users | length }} registered &middot; human principals (SSO + per-user KMS)</p>
+        </div>
+    </div>
+
+    {% if not endpoint_ready %}
+    <div class="mb-4 px-4 py-3 rounded border border-yellow-700/40 bg-yellow-500/5 text-yellow-300 text-xs">
+        <strong class="font-semibold">Endpoint pending.</strong>
+        Showing demo cast hardcoded from <code class="font-mono">imp/insurance-demo-spec.md</code>.
+        Backend route <code class="font-mono">/v1/admin/users</code> lands in a follow-up PR.
+    </div>
+    {% endif %}
+
+    <!-- Users table -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Surface</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last active</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for u in users %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                            {{ principal_badge("user") }}
+                            <span class="text-[10px] text-gray-500 font-mono"
+                                  title="{{ u.principal_id }}">{{ u.principal_id }}</span>
+                            <button type="button" class="text-gray-700 hover:text-accent-400 transition-colors"
+                                    onclick="copyToClipboard('{{ u.principal_id }}')" title="Copy ID">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            </button>
+                        </div>
+                    </td>
+                    <td class="px-5 py-4 text-sm text-white">{{ u.display_name }}</td>
+                    <td class="px-5 py-4">{{ reach_chip(u.reach) }}</td>
+                    <td class="px-5 py-4">
+                        <span class="text-[10px] text-gray-400 uppercase tracking-wider">{{ u.surface or "—" }}</span>
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-500" title="{{ u.last_active_iso or '' }}">{{ u.last_active or "never" }}</td>
+                    <td class="px-5 py-4 space-x-1.5">
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Edit reach lands with /v1/admin/users (pending)">Edit reach</button>
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Revoke lands with /v1/admin/users (pending)">Revoke</button>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not users %}
+                <tr>
+                    <td colspan="6" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
+                        <p class="text-sm text-gray-600">No users registered</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/dashboard/templates/workloads.html
+++ b/app/dashboard/templates/workloads.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% from "_principal_badge.html" import principal_badge, reach_chip %}
+{% block title %}Workloads{% endblock %}
+{% block header_title %}Workload Principals{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="workloads" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Workloads</h2>
+            <p class="text-xs text-gray-600 mt-0.5">{{ workloads | length }} registered &middot; container/VM hosts of user principals (SPIFFE-attested)</p>
+        </div>
+    </div>
+
+    {% if not endpoint_ready %}
+    <div class="mb-4 px-4 py-3 rounded border border-yellow-700/40 bg-yellow-500/5 text-yellow-300 text-xs">
+        <strong class="font-semibold">Endpoint pending.</strong>
+        Showing demo cast hardcoded from <code class="font-mono">imp/insurance-demo-spec.md</code>.
+        Backend route <code class="font-mono">/v1/admin/workloads</code> lands in a follow-up PR.
+    </div>
+    {% endif %}
+
+    <!-- Workloads table -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Hosted</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Image digest</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Runtime</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for w in workloads %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                            {{ principal_badge("workload") }}
+                            <span class="text-[10px] text-gray-500 font-mono"
+                                  title="{{ w.principal_id }}">{{ w.principal_id }}</span>
+                            <button type="button" class="text-gray-700 hover:text-accent-400 transition-colors"
+                                    onclick="copyToClipboard('{{ w.principal_id }}')" title="Copy ID">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            </button>
+                        </div>
+                    </td>
+                    <td class="px-5 py-4 text-sm text-white">{{ w.display_name }}</td>
+                    <td class="px-5 py-4">{{ reach_chip(w.reach) }}</td>
+                    <td class="px-5 py-4 text-xs text-gray-400 font-mono">{{ w.hosted_principals_count }}</td>
+                    <td class="px-5 py-4">
+                        {% if w.image_digest %}
+                        <span class="text-[10px] text-gray-400 font-mono" title="{{ w.image_digest }}">{{ w.image_digest[:14] }}…</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if w.runtime_status == "running" %}
+                        <span class="inline-flex items-center gap-1.5 text-[10px] text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Running
+                        </span>
+                        {% elif w.runtime_status == "unhealthy" %}
+                        <span class="inline-flex items-center gap-1.5 text-[10px] text-yellow-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-yellow-500"></span>Unhealthy
+                        </span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 text-[10px] text-gray-500 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-gray-700"></span>{{ w.runtime_status or "stopped" }}
+                        </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 space-x-1.5">
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Manage lands with /v1/admin/workloads (pending)">Manage</button>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not workloads %}
+                <tr>
+                    <td colspan="7" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+                        <p class="text-sm text-gray-600">No workloads registered</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/frontend/cullis-chat/src/styles/tokens.css
+++ b/frontend/cullis-chat/src/styles/tokens.css
@@ -31,6 +31,12 @@
   --accent-blue: #3d7aed;
   --accent-teal: #00b8a9;
 
+  /* Principal type badges — ADR-020 user/agent/workload, source of
+     truth in site/global.css. Used by <PrincipalBadge> in core. */
+  --cullis-badge-user: #3b7af5;
+  --cullis-badge-agent: #8b5cf6;
+  --cullis-badge-workload: #10b981;
+
   /* Fonts */
   --font-display: 'Instrument Serif', Georgia, serif;
   --font-body: 'Satoshi', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -26,6 +26,11 @@
   --accent-blue: #3d7aed;
   --accent-teal: #00b8a9;
 
+  /* Principal type badges — ADR-020 user/agent/workload */
+  --cullis-badge-user: #3b7af5;
+  --cullis-badge-agent: #8b5cf6;
+  --cullis-badge-workload: #10b981;
+
   /* Fonts */
   --font-display: 'Instrument Serif', Georgia, serif;
   --font-body: 'Satoshi', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,12 @@ module.exports = {
           400: '#0ea5e9',
           500: '#0284c7',
         },
+        // Principal type badges — ADR-020 user/agent/workload
+        badge: {
+          user: '#3b7af5',
+          agent: '#8b5cf6',
+          workload: '#10b981',
+        },
       },
       fontFamily: {
         heading: ['Chakra Petch', 'sans-serif'],
@@ -35,6 +41,10 @@ module.exports = {
     'bg-emerald-900/90', 'border-emerald-700/50', 'text-emerald-300',
     'bg-red-900/90', 'border-red-700/50', 'text-red-300',
     'bg-accent-400', 'pulse-dot', 'bg-gray-700',
+    // Principal badge variants — referenced via macro
+    'bg-badge-user/10', 'text-badge-user', 'border-badge-user/20',
+    'bg-badge-agent/10', 'text-badge-agent', 'border-badge-agent/20',
+    'bg-badge-workload/10', 'text-badge-workload', 'border-badge-workload/20',
   ],
   plugins: [],
 };

--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -162,6 +162,11 @@
             "state"
             "dist"
             "result"
+            # Dev-box .env can carry host-specific values (BROKER_PUBLIC_URL
+            # pointing at the dev IP) that pydantic-settings picks up over
+            # the explicit env we set per VM, breaking DPoP htu validation.
+            ".env"
+            ".env.local"
           ]);
       };
       # Custom derivations for PyPI packages not yet in nixpkgs.
@@ -359,8 +364,28 @@
           # ``app/kms/admin_secret.py`` defaults to ``certs/`` relative
           # to the broker's CWD, which here is the read-only Nix store.
           # Redirect to the writable state dir so first-boot mkdir of
-          # ``.admin_bootstrap_token`` succeeds.
+          # ``.admin_bootstrap_token`` succeeds. Lands via #468.
           CULLIS_LOCAL_KMS_DIR = certsDir;
+          # Court advertises itself as ``http://court:8000`` so cities
+          # signing DPoP proofs with that exact URL pass htu validation.
+          # When the broker is loopback-only (cities) the override stops
+          # any inherited dev-box ``BROKER_PUBLIC_URL`` from the source
+          # tree's ``.env`` (already filtered, but env override is the
+          # authoritative source). pydantic-settings: env > .env > defaults.
+          # Issue #462 tracks turning this into an allowlist for multi-
+          # ingress Court setups.
+          BROKER_PUBLIC_URL =
+            if cfg.nginxAllowExternal
+            then "http://court:${toString cfg.brokerPort}"
+            else "http://127.0.0.1:${toString cfg.brokerPort}";
+          # Sandbox/demo PDP fall-through (issue #461 / PR #463). Cities
+          # are registered without a webhook_url; the dispatcher would
+          # otherwise default-deny every cross-org call. ``allow`` lets
+          # the test fixture exercise the path with audit rows tagged
+          # ``policy_default_allow`` so reviewers can grep for the
+          # bypass after the fact. Production refuses this value (see
+          # ``app/config.py::validate_config``).
+          POLICY_DEFAULT_DECISION = "allow";
         };
         serviceConfig = {
           Type = "simple";
@@ -413,6 +438,25 @@
           # hub), inferred from ``cfg.brokerUrl == ""``.
           MCP_PROXY_STANDALONE =
             if cfg.brokerUrl != "" then "false" else "true";
+          # DPoP htu validation needs the public URL the SDK speaks to
+          # (nginx mTLS endpoint), not the loopback uvicorn binds. Without
+          # this set, ``_build_htu`` falls back to ``request.url`` which
+          # in our setup is ``http://127.0.0.1:9100`` and never matches
+          # the SDK's ``https://mastio.<td>:9443/...`` signed proof.
+          # See feedback_proxy_env_public_url_vm.md +
+          # feedback_proxy_headers_insufficient.md — auto-detect via
+          # ``--proxy-headers`` alone is not enough.
+          MCP_PROXY_PROXY_PUBLIC_URL =
+            "https://mastio.${cfg.trustDomain}:${toString cfg.nginxPort}";
+        } // lib.optionalAttrs (cfg.brokerUrl != "") {
+          # ADR-012 — non-standalone proxies default to forwarding
+          # ``/v1/auth/token`` to the broker, which fails htu validation
+          # in our cross-org topology (Court only sees the forwarded URL,
+          # not the SDK's signed mastio.<td>:9443 URL). Cities should
+          # issue tokens locally exactly like the standalone case;
+          # Court keeps standalone=true and turns this on via the
+          # auto-default in ``config.py``.
+          MCP_PROXY_LOCAL_AUTH_ENABLED = "true";
         } // lib.optionalAttrs cfg.enableMockServices {
           # Point the AI gateway at the mock LLM. We use the
           # ``portkey`` backend wrapper because it honours

--- a/tests/integration/cullis_network/tier2-cross-org.nix
+++ b/tests/integration/cullis_network/tier2-cross-org.nix
@@ -213,6 +213,450 @@ let
     print(f"BOOTSTRAPPED org_id={org_id} on Court")
   '';
 
+  # Provisions a single agent on the local Mastio via the BYOCA
+  # enrollment endpoint. Mints an Org-CA-signed cert, generates a DPoP
+  # keypair, POSTs to ``/v1/admin/agents/enroll/byoca``, and persists
+  # the runtime credentials under
+  # ``<identity_root>/<org_id>/agents/<agent_name>/`` so the SDK's
+  # ``CullisClient.from_identity_dir`` can pick them up later. Mirrors
+  # ``reference/bootstrap/bootstrap_mastio.py::_enroll_one_byoca`` but
+  # written for the test driver (no /state shared mount, no docker).
+  provisionAgentScript = pkgs.writeText "provision-agent.py" ''
+    """Provision a single agent on the local Mastio via BYOCA enroll.
+
+    Args (positional):
+      org_id          short org id
+      agent_name      short agent name (no ``::``)
+      capabilities    comma-separated list (use empty string for none)
+      proxy_url       local proxy admin (e.g. ``http://127.0.0.1:9100``)
+      admin_secret    proxy admin secret
+      identity_root   filesystem root for runtime creds
+      org_ca_cert     filesystem path to ``org-ca.pem``
+      org_ca_key      filesystem path to ``org-ca.key``
+      trust_domain    SPIFFE trust domain (e.g. ``roma.cullis.test``)
+    """
+    import base64
+    import json
+    import os
+    import pathlib
+    import subprocess
+    import sys
+    import urllib.error
+    import urllib.request
+
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    if len(sys.argv) != 10:
+        print(
+            f"USAGE: {sys.argv[0]} org_id agent_name capabilities proxy_url "
+            f"admin_secret identity_root org_ca_cert org_ca_key trust_domain",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    (_, org_id, agent_name, caps_csv, proxy_url, admin_secret,
+     identity_root, org_ca_cert, org_ca_key, trust_domain) = sys.argv
+
+    capabilities = [c for c in caps_csv.split(",") if c]
+    agent_id = f"{org_id}::{agent_name}"
+    # Cullis SPIFFE SAN convention (mcp_proxy/auth/client_cert.py
+    # ``_parse_spiffe_uri``): 3-component path = ``{td}/{org}/{name}``.
+    # The 4-component typed variant (``{td}/{org}/agent/{name}``) is
+    # also valid; this 3-comp form mirrors what
+    # ``agent_manager._generate_agent_cert`` emits in production.
+    spiffe_uri = f"spiffe://{trust_domain}/{org_id}/{agent_name}"
+
+    identity_dir = pathlib.Path(identity_root) / org_id / "agents" / agent_name
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    cert_path = identity_dir / "agent.pem"
+    key_path = identity_dir / "agent-key.pem"
+    dpop_path = identity_dir / "dpop.jwk"
+    ca_chain_path = pathlib.Path(identity_root) / org_id / "ca.pem"
+    ca_chain_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Mint EC P-256 cert signed by Org CA. Using openssl rather than
+    # cryptography directly keeps the cert structure byte-identical to
+    # the existing ``fedtest`` cert generation in this file (same
+    # subject/SAN convention).
+    csr_path = identity_dir / "agent.csr"
+    extfile = identity_dir / "agent.ext"
+    extfile.write_text(
+        f"subjectAltName=URI:{spiffe_uri}\nextendedKeyUsage=clientAuth\n"
+    )
+    subprocess.check_call([
+        "openssl", "ecparam", "-name", "prime256v1", "-genkey", "-noout",
+        "-out", str(key_path),
+    ])
+    subprocess.check_call([
+        "openssl", "req", "-new", "-key", str(key_path),
+        "-out", str(csr_path),
+        "-subj", f"/CN={agent_id}/O={org_id}",
+    ])
+    subprocess.check_call([
+        "openssl", "x509", "-req", "-in", str(csr_path),
+        "-CA", org_ca_cert, "-CAkey", org_ca_key, "-CAcreateserial",
+        "-out", str(cert_path), "-days", "1",
+        "-extfile", str(extfile),
+    ])
+    cert_path.chmod(0o644)
+    key_path.chmod(0o600)
+    print(f"  minted cert + key for {agent_id} (SAN={spiffe_uri})")
+
+    # Generate DPoP keypair (EC P-256). Public JWK goes into the enroll
+    # body so the Mastio pins ``dpop_jkt`` from the first request;
+    # private JWK lands on disk next to the cert for the runtime SDK.
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_nums = priv.public_key().public_numbers()
+    priv_nums = priv.private_numbers()
+
+    def _b64url(n: int) -> str:
+        return base64.urlsafe_b64encode(n.to_bytes(32, "big")).rstrip(b"=").decode()
+
+    public_jwk = {
+        "kty": "EC", "crv": "P-256",
+        "x": _b64url(pub_nums.x), "y": _b64url(pub_nums.y),
+    }
+    private_jwk = {**public_jwk, "d": _b64url(priv_nums.private_value)}
+
+    # POST /v1/admin/agents/enroll/byoca
+    body = json.dumps({
+        "agent_name": agent_name,
+        "display_name": agent_name,
+        "capabilities": capabilities,
+        "federated": True,
+        "cert_pem": cert_path.read_text(),
+        "private_key_pem": key_path.read_text(),
+        "dpop_jwk": public_jwk,
+    }).encode()
+    req = urllib.request.Request(
+        f"{proxy_url}/v1/admin/agents/enroll/byoca",
+        data=body, method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Admin-Secret": admin_secret,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+            code = resp.getcode()
+    except urllib.error.HTTPError as exc:
+        print(f"FAILED enroll/byoca → HTTP {exc.code}: {exc.read().decode()[:300]}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if code != 201:
+        print(f"FAILED enroll/byoca → HTTP {code}", file=sys.stderr)
+        sys.exit(1)
+
+    # Persist runtime DPoP private JWK + Org CA chain alongside the cert
+    # — these four files are exactly what ``CullisClient.from_identity_dir``
+    # opens on send.
+    dpop_path.write_text(
+        json.dumps({"private_jwk": private_jwk}, separators=(",", ":"))
+    )
+    dpop_path.chmod(0o600)
+    ca_chain_path.write_text(open(org_ca_cert).read())
+    ca_chain_path.chmod(0o644)
+
+    jkt = (data.get("dpop_jkt") or "")[:12]
+    thumb = (data.get("cert_thumbprint") or "")[:12]
+    print(f"PROVISIONED {agent_id} jkt={jkt}… thumb={thumb}…")
+  '';
+
+  # Drives the binding flow on Court for an agent that the federation
+  # publisher has already pushed. ``POST /v1/registry/bindings`` takes
+  # ``X-Org-Id`` + ``X-Org-Secret`` headers; the body's ``org_id`` must
+  # match the auth org (intra-org binding only — cross-org A2A is
+  # gated by federation registry visibility + cert chain, not by a
+  # cross-org binding row). Retries POST while the publisher catches
+  # up — 404 means the agent isn't visible on Court yet.
+  bindAgentScript = pkgs.writeText "bind-agent.py" ''
+    """Create + approve a binding for a federated agent on Court.
+
+    Args (positional):
+      court_url       e.g. ``http://court:8000``
+      org_id          short org id
+      org_secret      same secret submitted at /onboarding/join
+      agent_id        full ``org::name``
+      scope_csv       comma-separated capabilities (subset of agent's caps)
+    """
+    import json
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+
+    if len(sys.argv) != 6:
+        print(
+            f"USAGE: {sys.argv[0]} court_url org_id org_secret agent_id scope_csv",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    _, court_url, org_id, org_secret, agent_id, scope_csv = sys.argv
+    scope = [c for c in scope_csv.split(",") if c]
+    headers = {"X-Org-Id": org_id, "X-Org-Secret": org_secret,
+               "Content-Type": "application/json"}
+
+
+    def _req(method, url, body=None, allow_status=()):
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.getcode(), resp.read().decode()
+        except urllib.error.HTTPError as exc:
+            payload = exc.read().decode()
+            if exc.code in allow_status:
+                return exc.code, payload
+            raise
+
+
+    # Retry create until publisher has pushed the agent to Court
+    # (404 → agent_id not visible yet, retry; 409 → already there).
+    binding_id = None
+    deadline = time.monotonic() + 30.0
+    last_err = "(no attempt)"
+    while time.monotonic() < deadline:
+        try:
+            code, payload = _req(
+                "POST", f"{court_url}/v1/registry/bindings",
+                body={"org_id": org_id, "agent_id": agent_id, "scope": scope},
+                allow_status=(404, 409),
+            )
+        except urllib.error.URLError as exc:
+            last_err = f"connection: {exc}"
+            time.sleep(1.0)
+            continue
+        if code == 201:
+            binding_id = json.loads(payload)["id"]
+            print(f"  created binding {binding_id} for {agent_id}")
+            break
+        if code == 409:
+            # Already there — list and find it.
+            lc, lp = _req(
+                "GET", f"{court_url}/v1/registry/bindings?org_id={org_id}",
+            )
+            for b in json.loads(lp):
+                if b.get("agent_id") == agent_id:
+                    binding_id = b["id"]
+                    break
+            print(f"  binding already existed → id={binding_id}")
+            break
+        last_err = f"HTTP {code}: {payload[:200]}"
+        time.sleep(1.0)
+
+    if binding_id is None:
+        print(
+            f"FAILED binding create did not succeed in 30s "
+            f"(last={last_err})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Approve. 200 / 204 both ok; 409 if already approved.
+    code, payload = _req(
+        "POST", f"{court_url}/v1/registry/bindings/{binding_id}/approve",
+        allow_status=(409,),
+    )
+    print(f"  approve → HTTP {code}")
+    print(f"BOUND {agent_id} scope={scope} binding_id={binding_id}")
+  '';
+
+  # Creates an allow-all session policy for the given org on Court.
+  # Mirrors ``reference/bootstrap/bootstrap.py::phase_5_session_policies``.
+  # Without this, ``evaluate_session_policy`` defaults to deny on the
+  # ``/v1/broker/oneshot/forward`` path → 403 even with a valid binding.
+  policyAllowScript = pkgs.writeText "policy-allow.py" ''
+    """Create a default-allow session policy on Court for one org.
+
+    Args (positional):
+      court_url       e.g. ``http://court:8000``
+      org_id          short org id
+      org_secret      same secret submitted at /onboarding/join
+    """
+    import json
+    import sys
+    import urllib.error
+    import urllib.request
+
+    if len(sys.argv) != 4:
+        print(f"USAGE: {sys.argv[0]} court_url org_id org_secret",
+              file=sys.stderr)
+        sys.exit(2)
+
+    _, court_url, org_id, org_secret = sys.argv
+
+    body = {
+        "policy_id": f"{org_id}::session-allow-all",
+        "org_id": org_id,
+        "policy_type": "session",
+        "rules": {
+            "effect": "allow",
+            "conditions": {"target_org_id": [], "capabilities": []},
+        },
+    }
+    req = urllib.request.Request(
+        f"{court_url}/v1/policy/rules",
+        data=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Org-Id": org_id,
+            "X-Org-Secret": org_secret,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            code = resp.getcode()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 409:
+            code = 409  # already there — idempotent
+        else:
+            print(f"FAILED policy create → HTTP {exc.code}: "
+                  f"{exc.read().decode()[:300]}",
+                  file=sys.stderr)
+            sys.exit(1)
+    print(f"POLICY {body['policy_id']} → HTTP {code}")
+  '';
+
+  # Loads a CullisClient from disk-pinned identity files and fires
+  # ``send_oneshot`` against a cross-org recipient. The local proxy's
+  # ``/v1/egress/resolve`` returns the recipient's cert from Court's
+  # federation registry, the SDK encrypts + signs, and the broker
+  # bridge forwards via ``POST /v1/broker/oneshot/forward`` on Court.
+  oneshotSendScript = pkgs.writeText "oneshot-send.py" ''
+    """SDK-driven cross-org one-shot send.
+
+    Args (positional):
+      mastio_url      e.g. ``https://mastio.roma.cullis.test:9443``
+      org_id          sender's org
+      agent_name      sender's agent name
+      target_id       recipient ``org::name``
+      identity_root   filesystem root with provisioned creds
+      nonce           opaque marker, echoed inside payload for receiver match
+    """
+    import json
+    import pathlib
+    import sys
+
+    from cullis_sdk import CullisClient
+
+    if len(sys.argv) != 7:
+        print(
+            f"USAGE: {sys.argv[0]} mastio_url org_id agent_name target_id "
+            f"identity_root nonce",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    _, mastio_url, org_id, agent_name, target_id, identity_root, nonce = sys.argv
+    identity_dir = pathlib.Path(identity_root) / org_id / "agents" / agent_name
+    cert_path = identity_dir / "agent.pem"
+    key_path = identity_dir / "agent-key.pem"
+    dpop_path = identity_dir / "dpop.jwk"
+    ca_chain = pathlib.Path(identity_root) / org_id / "ca.pem"
+
+    client = CullisClient.from_identity_dir(
+        mastio_url,
+        cert_path=cert_path,
+        key_path=key_path,
+        dpop_key_path=dpop_path,
+        agent_id=f"{org_id}::{agent_name}",
+        org_id=org_id,
+        ca_chain_path=ca_chain,
+    )
+    client.login_via_proxy()
+    client._signing_key_pem = key_path.read_text()
+
+    payload = {"nonce": nonce, "hello": "cross-org A2A from nixosTest",
+               "sender": f"{org_id}::{agent_name}"}
+    resp = client.send_oneshot(target_id, payload)
+    print(json.dumps({"sent_to": target_id, "nonce": nonce, **resp}))
+    print("ONESHOT_SENT")
+  '';
+
+  # Polls the recipient's inbox until the expected nonce arrives, then
+  # decrypts the envelope and verifies the inner signature. ``nonce``
+  # is the marker to match (passed in plaintext payload by the sender);
+  # the deadline keeps the test bounded if the message never lands.
+  oneshotPollScript = pkgs.writeText "oneshot-poll.py" ''
+    """SDK-driven inbox poll + decrypt for the receiver side.
+
+    Args (positional):
+      mastio_url      e.g. ``https://mastio.tokyo.cullis.test:9443``
+      org_id          recipient's org
+      agent_name      recipient's agent name
+      identity_root   filesystem root with provisioned creds
+      expected_nonce  the nonce the sender embedded in payload
+      timeout_s       wait deadline (seconds)
+    """
+    import pathlib
+    import sys
+    import time
+
+    from cullis_sdk import CullisClient
+
+    if len(sys.argv) != 7:
+        print(
+            f"USAGE: {sys.argv[0]} mastio_url org_id agent_name "
+            f"identity_root expected_nonce timeout_s",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    (_, mastio_url, org_id, agent_name, identity_root, expected_nonce,
+     timeout_s) = sys.argv
+    deadline = time.monotonic() + float(timeout_s)
+    identity_dir = pathlib.Path(identity_root) / org_id / "agents" / agent_name
+    ca_chain = pathlib.Path(identity_root) / org_id / "ca.pem"
+
+    client = CullisClient.from_identity_dir(
+        mastio_url,
+        cert_path=identity_dir / "agent.pem",
+        key_path=identity_dir / "agent-key.pem",
+        dpop_key_path=identity_dir / "dpop.jwk",
+        agent_id=f"{org_id}::{agent_name}",
+        org_id=org_id,
+        ca_chain_path=ca_chain,
+    )
+    client.login_via_proxy()
+    # Envelope-mode decrypt unwraps the AES key with the recipient's
+    # private key. ``from_identity_dir`` skips ``__init__`` so we
+    # populate ``_signing_key_pem`` explicitly, mirroring what the
+    # send side does.
+    client._signing_key_pem = (identity_dir / "agent-key.pem").read_text()
+
+    last_err = "(no rows yet)"
+    while time.monotonic() < deadline:
+        rows = client.receive_oneshot()
+        for row in rows:
+            try:
+                decrypted = client.decrypt_oneshot(row)
+            except Exception as exc:  # noqa: BLE001 — surface decrypt failure
+                last_err = f"decrypt: {exc}"
+                continue
+            payload = decrypted.get("payload") or {}
+            if payload.get("nonce") == expected_nonce:
+                print(
+                    f"RECEIVED nonce={expected_nonce} "
+                    f"sender={payload.get('sender')} "
+                    f"sender_verified={decrypted.get('sender_verified')} "
+                    f"mode={decrypted.get('mode')}"
+                )
+                sys.exit(0)
+            last_err = (
+                f"nonce mismatch: got {payload.get('nonce')!r}, "
+                f"want {expected_nonce!r}"
+            )
+        time.sleep(1.0)
+
+    print(f"FAILED no message with nonce={expected_nonce} within "
+          f"{timeout_s}s (last={last_err})", file=sys.stderr)
+    sys.exit(1)
+  '';
+
   # Per-city Mastio config. Each entry produces a NixOS node that
   # drops the ``cullis.mastio`` module on top of a base
   # ``virtualisation`` block; the module handles broker + proxy +
@@ -497,6 +941,140 @@ pkgs.testers.nixosTest {
             f"{court.succeed('journalctl -u cullis-broker --no-pager -n 50')}"
         )
         print(f"  publish accepted by Court:\n    {publish_log}")
+
+    with subtest("Cross-org A2A oneshot: roma::sender → tokyo::receiver"):
+        # Six-phase round-trip — Roma SDK encrypt+sign, broker bridge
+        # forwards, Court counter-signs, Tokyo SDK decrypts+verifies.
+        # Each phase reuses one of the helper scripts defined in the
+        # ``let`` block above; the test driver wires them together
+        # with the right env per VM.
+        identity_root = "/var/lib/cullis/test-identities"
+
+        # Phase 1: provision both agents on their respective Mastios
+        # via the BYOCA enroll endpoint. The script mints a cert
+        # against the local Org CA, generates a DPoP keypair, posts
+        # the public material to /v1/admin/agents/enroll/byoca, and
+        # drops cert+key+dpop+CA chain on disk in the layout the
+        # SDK's ``from_identity_dir`` expects.
+        for city, cfg in (
+            (roma,  {"orgId": "roma",  "agentName": "sender",
+                     "trustDomain": "roma.cullis.test"}),
+            (tokyo, {"orgId": "tokyo", "agentName": "receiver",
+                     "trustDomain": "tokyo.cullis.test"}),
+        ):
+            out = city.succeed(
+                "python3 ${provisionAgentScript} "
+                f"{cfg['orgId']} {cfg['agentName']} oneshot.message "
+                "http://127.0.0.1:9100 test-admin-secret "
+                f"{identity_root} "
+                "/var/lib/cullis/certs/org-ca.pem "
+                "/var/lib/cullis/certs/org-ca.key "
+                f"{cfg['trustDomain']}"
+            )
+            assert "PROVISIONED" in out, (
+                f"provisioning of {cfg['orgId']}::{cfg['agentName']} failed:\n{out}"
+            )
+            print(f"  {cfg['orgId']}::{cfg['agentName']} provisioned")
+
+        # No trust-bundle plumbing needed: PR #467 (issue #459) delegates
+        # cross-org chain checks to Court, which already verified the
+        # leaf at federation publish time. Each agent's ``ca.pem`` holds
+        # only the local Org CA and the SDK's ``decrypt_oneshot`` skips
+        # the chain step for cross-org senders.
+
+        # Phase 2: wait for the federation publisher to push both
+        # rows to Court. The ``federated=true`` flag came in via
+        # provisioning; poll interval is forced to 2s by the module
+        # env. Look for the success log line on each side.
+        for city, agent_id in (
+            (roma, "roma::sender"),
+            (tokyo, "tokyo::receiver"),
+        ):
+            city.wait_until_succeeds(
+                "journalctl -u cullis-proxy --no-pager | "
+                f"grep -q 'federation publish OK: {agent_id}'",
+                timeout=20,
+            )
+            print(f"  {agent_id} published to Court")
+
+        # Phase 3: bind both agents on Court so authentication +
+        # capability gates allow the oneshot. Each binding is
+        # intra-org (the auth org_id must match the body org_id);
+        # cross-org A2A is gated by federation registry visibility
+        # plus the recipient's intra-org binding having scope.
+        for city, cfg in (
+            (roma,  {"orgId": "roma",  "agentId": "roma::sender"}),
+            (tokyo, {"orgId": "tokyo", "agentId": "tokyo::receiver"}),
+        ):
+            out = city.succeed(
+                "python3 ${bindAgentScript} "
+                "http://court:8000 "
+                f"{cfg['orgId']} {cfg['orgId']}-secret-test "
+                f"{cfg['agentId']} oneshot.message"
+            )
+            assert "BOUND" in out, (
+                f"binding for {cfg['agentId']} failed:\n{out}"
+            )
+            print(f"  {cfg['agentId']} bound + approved on Court")
+
+        # Phase 3b: install an allow-all session policy on Court for
+        # both orgs. Without this, ``evaluate_session_policy`` on the
+        # ``/v1/broker/oneshot/forward`` path defaults to deny → 403
+        # even with valid bindings.
+        for city, org_id in ((roma, "roma"), (tokyo, "tokyo")):
+            out = city.succeed(
+                "python3 ${policyAllowScript} "
+                f"http://court:8000 {org_id} {org_id}-secret-test"
+            )
+            assert "POLICY" in out, f"policy create for {org_id} failed:\n{out}"
+            print(f"  {org_id} session-allow-all policy installed")
+
+        # Phase 4: send. Roma SDK loads the cert/key/dpop from disk,
+        # logs in via the local proxy, encrypts the payload for the
+        # Tokyo recipient (cert pulled from Court via /resolve), and
+        # POSTs to ``/v1/egress/message/send``.
+        nonce = "tier2-a2a-cross-org-roundtrip"
+        out = roma.succeed(
+            "python3 ${oneshotSendScript} "
+            "https://mastio.roma.cullis.test:9443 "
+            "roma sender tokyo::receiver "
+            f"{identity_root} {nonce}"
+        )
+        assert "ONESHOT_SENT" in out, f"send_oneshot failed:\n{out}"
+        print(f"  Roma SDK fired one-shot:\n    {out.strip()}")
+
+        # Phase 5: receive. Tokyo SDK polls inbox, decrypts the
+        # envelope, verifies the inner signature, and confirms the
+        # nonce matches what Roma sent. Times out at 20s — the
+        # broker queue + bridge poll cadence is in the 2-5s range.
+        out = tokyo.succeed(
+            "python3 ${oneshotPollScript} "
+            "https://mastio.tokyo.cullis.test:9443 "
+            "tokyo receiver "
+            f"{identity_root} {nonce} 20"
+        )
+        assert "RECEIVED" in out, f"inbox poll did not match nonce:\n{out}"
+        assert "sender_verified=True" in out, (
+            f"recipient could not verify sender signature:\n{out}"
+        )
+        print(f"  Tokyo SDK received + verified:\n    {out.strip()}")
+
+        # Phase 6: dump the local oneshot audit rows (informative). The
+        # broker-side ``log_event_cross_org`` writes the canonical
+        # cross-org pair on Court; each Mastio mirrors a local row via
+        # the egress pipeline (``mcp_proxy/egress/oneshot.py`` →
+        # ``oneshot_sent`` / ``oneshot_delivered``). Surface the rows
+        # for visual inspection without asserting an exact event_type
+        # name (varies by code path); the previous assertions on send
+        # + receive already proved the round-trip cryptographically.
+        for city in (roma, tokyo):
+            rc, dump = city.execute(
+                "sqlite3 /var/lib/cullis/proxy.sqlite "
+                "\"SELECT event_type, result FROM audit_log "
+                "WHERE event_type LIKE '%oneshot%' "
+                "ORDER BY id DESC LIMIT 5\" 2>&1 || true"
+            )
+            print(f"  {city.name} oneshot audit (last 5):\n{dump.rstrip()}")
 
     # Cross-org cert chain refusal (default-deny) — the third
     # invariant the demo sells — needs a Roma-minted cert

--- a/tests/test_dashboard_principals.py
+++ b/tests/test_dashboard_principals.py
@@ -152,12 +152,32 @@ async def test_nav_includes_principal_sections(client: AsyncClient):
     # Every section link present in the new nav structure
     assert 'href="/dashboard/users"' in body
     assert 'href="/dashboard/agents"' in body
-    assert 'href="/dashboard/workloads"' in body
     assert 'href="/dashboard/resources"' in body
     assert 'href="/dashboard/federation"' in body
+    # Workloads are LOCAL-only runtime infrastructure: they don't
+    # federate, so the Court network-admin nav must not surface them.
+    # The /dashboard/workloads route stays alive (URL-accessible) for
+    # future per-org Mastio admin reuse.
+    assert 'href="/dashboard/workloads"' not in body
     # Group labels
     assert "Principals" in body
     assert "Federation" in body
+
+
+async def test_overview_stats_strip(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Stats strip cells
+    assert "organizations" in body
+    assert "users" in body
+    assert "agents" in body
+    assert "audit chain" in body
+    # Sessions cell must not be on overview anymore
+    assert "sessions · live" not in body
+    # Users cell links to the Users page
+    assert 'href="/dashboard/users"' in body
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_dashboard_principals.py
+++ b/tests/test_dashboard_principals.py
@@ -11,7 +11,6 @@ When the backend session lands /v1/admin/users + /v1/admin/workloads,
 these tests should be widened to assert against real data and the
 ``endpoint_ready=False`` banner should disappear from the templates.
 """
-import json
 import pytest
 from httpx import AsyncClient
 

--- a/tests/test_dashboard_principals.py
+++ b/tests/test_dashboard_principals.py
@@ -1,0 +1,175 @@
+"""
+Test dashboard principal-type sections (Phase 1 of SPA rework).
+
+Verifies the new /dashboard/users, /dashboard/workloads,
+/dashboard/resources, /dashboard/federation pages render and that the
+hardcoded demo cast from imp/insurance-demo-spec.md is visible. Also
+verifies the new badge-count endpoints respond with neutral chips so
+the left-nav is screenshot-ready for the demo recording.
+
+When the backend session lands /v1/admin/users + /v1/admin/workloads,
+these tests should be widened to assert against real data and the
+``endpoint_ready=False`` banner should disappear from the templates.
+"""
+import json
+import pytest
+from httpx import AsyncClient
+
+from app.config import get_settings
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _admin_cookies(client: AsyncClient) -> dict:
+    resp = await client.post("/dashboard/login", data={
+        "user_id": "admin", "password": get_settings().admin_secret,
+    }, follow_redirects=False)
+    assert resp.status_code == 303, f"login failed: {resp.text[:200]}"
+    return dict(resp.cookies)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section pages render with cast names visible
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_users_page_renders_with_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/users", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Cast principals from the spec
+    assert "Claim Officer" in body
+    assert "Claim Manager" in body
+    assert "Counterparty Liaison" in body
+    # Principal type badge for users
+    assert ">User<" in body
+    # Pending-endpoint banner is still showing (will go away when
+    # /v1/admin/users lands)
+    assert "Endpoint pending" in body
+
+
+async def test_workloads_page_renders_with_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/workloads", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Asia-Pacific Frontdesk" in body
+    assert "frontdesk-container" in body
+    assert ">Workload<" in body
+    assert "Endpoint pending" in body
+
+
+async def test_resources_page_renders_with_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/resources", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Claims Database" in body
+    assert "claims-db" in body
+    # MCP type icon path
+    assert ">MCP<" in body or "mcp" in body.lower()
+
+
+async def test_federation_page_renders_peers(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/federation", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "mediterranean" in body
+    assert "asia-pacific" in body
+    assert "Court" in body
+    # Legacy /orgs link is preserved per the legacy-consolidation plan
+    assert "/dashboard/orgs" in body
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Auth required
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [
+    "/dashboard/users",
+    "/dashboard/workloads",
+    "/dashboard/resources",
+    "/dashboard/federation",
+])
+async def test_principal_pages_require_login(client: AsyncClient, path: str):
+    resp = await client.get(path, follow_redirects=False)
+    assert resp.status_code == 303
+    assert "/login" in resp.headers.get("location", "")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Badge-count endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path,expected_count", [
+    ("/dashboard/badge/users-count", 3),
+    ("/dashboard/badge/workloads-count", 1),
+    ("/dashboard/badge/resources-count", 1),
+])
+async def test_badge_count_chips_render(client: AsyncClient, path: str, expected_count: int):
+    cookies = await _admin_cookies(client)
+    resp = await client.get(path, cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Either the chip with the count is present or the count-0 short-circuit
+    # (empty body) — the cast spec guarantees non-zero.
+    assert str(expected_count) in body, f"expected count {expected_count} in {body!r}"
+
+
+async def test_badge_agents_count_falls_back_to_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/badge/agents-count", cookies=cookies)
+    assert resp.status_code == 200
+    # Empty registry falls back to the cast count (2: night-reporter +
+    # ticket-bot) so the demo screenshot is non-zero.
+    body = resp.text
+    assert body == "" or "2" in body or any(c.isdigit() for c in body)
+
+
+@pytest.mark.parametrize("path", [
+    "/dashboard/badge/users-count",
+    "/dashboard/badge/workloads-count",
+    "/dashboard/badge/resources-count",
+    "/dashboard/badge/agents-count",
+])
+async def test_badge_count_unauth_returns_empty(client: AsyncClient, path: str):
+    """Unauthenticated badge call returns empty string, not redirect."""
+    resp = await client.get(path)
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Nav: principal-type sections appear on every page
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_nav_includes_principal_sections(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Every section link present in the new nav structure
+    assert 'href="/dashboard/users"' in body
+    assert 'href="/dashboard/agents"' in body
+    assert 'href="/dashboard/workloads"' in body
+    assert 'href="/dashboard/resources"' in body
+    assert 'href="/dashboard/federation"' in body
+    # Group labels
+    assert "Principals" in body
+    assert "Federation" in body
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Agents page extras: enrollment_method + automation_type columns exist
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_agents_page_renders_new_columns(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/agents", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Enrollment" in body
+    assert "Automation" in body
+    # Agent badge appears in the principal column
+    assert ">Agent<" in body


### PR DESCRIPTION
## Summary

Phase 1 of the SPA rework for the insurance demo (per `imp/insurance-demo-spec.md`). Restructures the Mastio admin (Court) dashboard left nav into three groups (Principals / Federation / System) and adds dedicated views for each principal type that the demo will exercise.

- **New left-nav sections** with HTMX-polled count badges: Users, Agents, Resources. Workloads kept URL-accessible but **not** in the Court nav (workloads are LOCAL-only runtime infrastructure, they don't federate).
- **Shared `<PrincipalBadge>` macro** (USER blue / AGENT purple / WORKLOAD green) used across the agents table, the new principal pages, and the audit log.
- **Design tokens** `--cullis-badge-user/agent/workload` mirrored in `site/global.css`, `cullis-chat/tokens.css`, the dashboard `input.css` and `tailwind.config.js` (memory `feedback_design_tokens_unified`).
- **Agents table** gains `enrollment_method` + `automation_type` columns wired through `_demo_cast.agent_extras()`.
- **Federation page** folds in peer-orgs + Court health card; the legacy `/dashboard/orgs` route stays accessible by URL but is no longer in the nav per the legacy-consolidation plan.
- **Overview stats strip** reordered: Organizations / Users / Agents / Audit. The Sessions cell was dropped because A2A is oneshot-only for the demo era (memory `feedback_oneshot_only_for_demo`).
- **Hardcoded demo cast** from `imp/insurance-demo-spec.md` backs the three new pages until `/v1/admin/users` + `/v1/admin/workloads` ship from the parallel backend session — templates display an "Endpoint pending" banner so the swap path is obvious. The `_demo_cast.py` module deletes cleanly when the real endpoints land.

`sessions`, `rfqs`, and `policies` legacy routes remain reachable by URL only and will be parked under Settings → Advanced in a follow-up.

Tailwind output (`app/static/css/tailwind.css`) is gitignored; rebuild with `npm run build:broker` after pulling.

## Test plan

- [x] `pytest tests/ -k "dashboard or admin"` (312 passed in 92s, 19 of which are new)
- [x] Manual verification on local dev server: nav renders the three groups, Users/Agents/Resources/Federation pages render the demo cast, Workloads page reachable via URL but not in nav, Overview stats strip shows Organizations/Users/Agents/Audit, Federation Mesh aside no longer shows live sessions
- [ ] CI smoke gate (`./demo_network/smoke.sh full`) — running on this PR via CI; not run locally to avoid colliding with the parallel backend session sharing this host
- [ ] Reviewer screenshot pass on the four new tables + nav

Phase 2 (Inbox component) lands separately on top of this.