### PR TITLE
fix(demo): smoke pre-record fixes — 7 bug across insurance-demo

### DIFF
--- a/reference/scenarios/insurance-demo/README.md
+++ b/reference/scenarios/insurance-demo/README.md
@@ -6,12 +6,20 @@ Insurance claims escalation scenario.
 
 ## Cast
 
-Two orgs (English-only, role-named):
+Two orgs. Display name (the brand the user sees) lives separately from
+the backend ``org_id`` so we can reuse the reference stack without
+re-bootstrapping with new IDs:
 
-  Mediterranean Insurance    org_id=mediterranean,  td=mediterranean.cullis.test
-  Asia-Pacific Insurance     org_id=asia-pacific, td=asia-pacific.cullis.test
+  Display name              Backend org_id    Trust domain
+  ─────────────────────────────────────────────────────────
+  Mediterranean Insurance   orga              orga.test
+  Asia-Pacific Insurance    orgb              orgb.test
 
-Plus `court` as federation hub.
+Principal IDs in audit logs and on the wire use the backend ``org_id``
+(``orga::user::claim-officer``). The dashboard maps ``orga`` →
+"Mediterranean Insurance" at the display layer.
+
+Plus ``court`` as federation hub.
 
 Personas (the humans behind the user principals — Mediterranean side
 Italian, Asia-Pacific side Japanese; mirrors the realistic insurance
@@ -28,13 +36,13 @@ Five principals + 1 workload + 1 resource:
 
 | Backend ID | Type | Surface |
 |---|---|---|
-| `mediterranean::user::claim-officer` | user | Cullis Chat (single-user desktop) |
-| `mediterranean::user::claim-manager` | user | Cullis Chat dashboard `/chat` |
-| `mediterranean::agent::night-reporter` | agent | none (cron-style script) |
-| `mediterranean::agent::ticket-bot` | agent | none (request-response script) |
-| `asia-pacific::user::counterparty-liaison` | user | Frontdesk (multi-user web) |
-| `asia-pacific::workload::frontdesk-container` | workload | n/a (visible in admin) |
-| `mediterranean::resource::mcp::claims-db` | resource | postgres MCP server |
+| `orga::user::claim-officer` | user | Cullis Chat (single-user desktop) |
+| `orga::user::claim-manager` | user | Cullis Chat dashboard `/chat` |
+| `orga::agent::night-reporter` | agent | none (cron-style script) |
+| `orga::agent::ticket-bot` | agent | none (request-response script) |
+| `orgb::user::counterparty-liaison` | user | Frontdesk (multi-user web) |
+| `orgb::workload::frontdesk-container` | workload | n/a (visible in admin) |
+| `orga::resource::mcp::claims-db` | resource | postgres MCP server |
 
 Full UI/SPA contract: `imp/insurance-demo-spec.md`
 

--- a/reference/scenarios/insurance-demo/bots/night_reporter.py
+++ b/reference/scenarios/insurance-demo/bots/night_reporter.py
@@ -1,16 +1,16 @@
 """Night Reporter — overnight scheduled agent for the insurance demo.
 
-Identity: ``mediterranean::agent::night-reporter``
+Identity: ``orga::agent::night-reporter``
 Reach:    intra-org only
 Scope:    claims-db.read + oneshot.message
 
 What it does (one tick):
 
   1. Authenticate to Mediterranean's Mastio with the cert/key minted by ``seed.py``
-  2. Query the ``mediterranean::resource::mcp::claims-db`` MCP server for claims
+  2. Query the ``orga::resource::mcp::claims-db`` MCP server for claims
      where ``cross_company_flag = TRUE`` AND ``status = 'open'``
   3. Build a short summary (count, top 3 by amount, urgency breakdown)
-  4. Send a one-shot message to ``mediterranean::user::claim-officer`` with the
+  4. Send a one-shot message to ``orga::user::claim-officer`` with the
      summary as payload (intra-org A2U, ADR-008 envelope)
   5. Log + exit (idempotent — replay-safe via correlation_id)
 
@@ -39,9 +39,16 @@ from cullis_sdk import CullisClient
 
 
 HERE = pathlib.Path(__file__).resolve().parent
-STATE_DIR = (HERE.parents[2] / "state" / "insurance-demo" / "agents" / "night-reporter").resolve()
-RECIPIENT = "mediterranean::user::claim-officer"
-MASTIO_URL = os.environ.get("CULLIS_PROXY_A_URL", "https://localhost:9100")
+# parents: [0]=bots, [1]=insurance-demo, [2]=scenarios, [3]=reference, [4]=repo root.
+# seed.py writes agent identity material under <repo-root>/state/insurance-demo/.
+STATE_DIR = (HERE.parents[3] / "state" / "insurance-demo" / "agents" / "night-reporter").resolve()
+RECIPIENT = "orga::user::claim-officer"
+# mTLS endpoint (mastio-nginx-a sidecar). The plain HTTP :9100 is
+# admin-only — agent traffic must hit nginx :9443 to satisfy DPoP htu
+# matching + Org CA mTLS handshake.
+MASTIO_URL = os.environ.get(
+    "MASTIO_NGINX_A_URL", "https://localhost:9443",
+)
 
 
 def _build_summary(claims: list[dict]) -> dict:
@@ -81,7 +88,7 @@ def _build_summary(claims: list[dict]) -> dict:
 
 
 def _query_claims(client: CullisClient) -> list[dict]:
-    """Call the ``mediterranean::resource::mcp::claims-db`` MCP server through the
+    """Call the ``orga::resource::mcp::claims-db`` MCP server through the
     SDK helper. Returns a list of claim rows (dict). Falls back to a
     canned fixture if the MCP server is unreachable so the demo doesn't
     hard-fail on a network blip during recording."""
@@ -89,7 +96,7 @@ def _query_claims(client: CullisClient) -> list[dict]:
         # SDK MCP helpers landed in ADR-017 Phase 3 (memory:
         # project_session_2026_05_04_adr017_live.md).
         result = client.call_mcp_tool(
-            resource_id="mediterranean::resource::mcp::claims-db",
+            resource_id="orga::resource::mcp::claims-db",
             tool_name="query_claims",
             arguments={
                 "where": "cross_company_flag = TRUE AND status = 'open'",
@@ -130,18 +137,26 @@ def _send(client: CullisClient, payload: dict) -> dict:
 def run_once(verbose: bool = False) -> int:
     cert = STATE_DIR / "agent.pem"
     key  = STATE_DIR / "agent-key.pem"
+    # STATE_DIR = …/state/insurance-demo/agents/night-reporter
+    # parents[1] = …/state/insurance-demo (where prep-ca dropped orga-ca.pem)
+    org_ca = STATE_DIR.parents[1] / "orga-ca.pem"
     if not (cert.exists() and key.exists()):
         print(f"[night-reporter] missing identity at {STATE_DIR} — "
               "did you run ./run.sh seed?", file=sys.stderr)
         return 2
 
+    # NOTE: ``verify_tls=False`` in the SDK silently drops the client
+    # cert (httpx 0.28 incompat — see _build_proxy_http_client). nginx
+    # then 401s. Pin verify_tls=True + ca_chain_path so the client cert
+    # is actually presented at the TLS handshake.
     client = CullisClient.from_identity_dir(
         MASTIO_URL,
         cert_path=cert,
         key_path=key,
-        agent_id="mediterranean::agent::night-reporter",
-        org_id="mediterranean",
-        verify_tls=False,  # dev / sandbox — Org CA self-signed
+        agent_id="orga::night-reporter",
+        org_id="orga",
+        verify_tls=True,
+        ca_chain_path=org_ca,
     )
     client.login_via_proxy()
     client._signing_key_pem = key.read_text()

--- a/reference/scenarios/insurance-demo/bots/ticket_bot.py
+++ b/reference/scenarios/insurance-demo/bots/ticket_bot.py
@@ -1,6 +1,6 @@
 """Ticket Bot — request-response agent for the insurance demo.
 
-Identity: ``mediterranean::agent::ticket-bot``
+Identity: ``orga::agent::ticket-bot``
 Reach:    intra-org only
 Scope:    claims-db.write + oneshot.message
 
@@ -8,7 +8,7 @@ What it does (event loop):
 
   1. Authenticate to Mediterranean's Mastio with the cert/key minted by ``seed.py``
   2. Poll the inbox for incoming requests addressed to this agent
-     (typically from ``mediterranean::user::claim-manager``)
+     (typically from ``orga::user::claim-manager``)
   3. For each request, parse the natural-language claim context, generate
      a deterministic ticket ID (``TKT-YYYY-MM-DD-NNN``), persist a
      formal record into the claims-db (status=under-review, ticket_ref
@@ -38,8 +38,13 @@ from cullis_sdk import CullisClient
 
 
 HERE = pathlib.Path(__file__).resolve().parent
-STATE_DIR = (HERE.parents[2] / "state" / "insurance-demo" / "agents" / "ticket-bot").resolve()
-MASTIO_URL = os.environ.get("CULLIS_PROXY_A_URL", "https://localhost:9100")
+# parents: [0]=bots, [1]=insurance-demo, [2]=scenarios, [3]=reference, [4]=repo root.
+STATE_DIR = (HERE.parents[3] / "state" / "insurance-demo" / "agents" / "ticket-bot").resolve()
+# See night_reporter.py — agent traffic must hit the nginx sidecar at
+# :9443 (HTTPS), not the admin port :9100 (plain HTTP).
+MASTIO_URL = os.environ.get(
+    "MASTIO_NGINX_A_URL", "https://localhost:9443",
+)
 POLL_INTERVAL_S = 3.0
 
 
@@ -85,7 +90,7 @@ def _process_request(client: CullisClient, msg: dict) -> dict | None:
     # Persist into the claims DB via the MCP server.
     try:
         client.call_mcp_tool(
-            resource_id="mediterranean::resource::mcp::claims-db",
+            resource_id="orga::resource::mcp::claims-db",
             tool_name="exec_sql",
             arguments={
                 "statement": (
@@ -113,18 +118,23 @@ def _process_request(client: CullisClient, msg: dict) -> dict | None:
 def run_once(verbose: bool = False) -> int:
     cert = STATE_DIR / "agent.pem"
     key  = STATE_DIR / "agent-key.pem"
+    # See night_reporter.py — STATE_DIR.parents[1] = state/insurance-demo.
+    org_ca = STATE_DIR.parents[1] / "orga-ca.pem"
     if not (cert.exists() and key.exists()):
         print(f"[ticket-bot] missing identity at {STATE_DIR} — "
               "did you run ./run.sh seed?", file=sys.stderr)
         return 2
 
+    # See night_reporter.py — ``verify_tls=False`` silently drops the
+    # client cert in the SDK's httpx layer.
     client = CullisClient.from_identity_dir(
         MASTIO_URL,
         cert_path=cert,
         key_path=key,
-        agent_id="mediterranean::agent::ticket-bot",
-        org_id="mediterranean",
-        verify_tls=False,
+        agent_id="orga::ticket-bot",
+        org_id="orga",
+        verify_tls=True,
+        ca_chain_path=org_ca,
     )
     client.login_via_proxy()
     client._signing_key_pem = key.read_text()

--- a/reference/scenarios/insurance-demo/compose.frontdesk.yml
+++ b/reference/scenarios/insurance-demo/compose.frontdesk.yml
@@ -29,7 +29,7 @@
 #
 #   FRONTDESK_AP_HTTP_PORT          host port for Frontdesk web (default 8090)
 #   FRONTDESK_AP_ORG_ID             default asia-pacific
-#   FRONTDESK_AP_TRUST_DOMAIN       default asia-pacific.cullis.test
+#   FRONTDESK_AP_TRUST_DOMAIN       default orgb.test
 #   FRONTDESK_AP_MASTIO_URL         default https://mastio-nginx-b:9443
 #                                   (reachable through the orgb-internal
 #                                    network this overlay joins)
@@ -52,7 +52,7 @@ services:
     environment:
       AMBASSADOR_MODE: shared
       CULLIS_FRONTDESK_ORG_ID:        ${FRONTDESK_AP_ORG_ID:-asia-pacific}
-      CULLIS_FRONTDESK_TRUST_DOMAIN:  ${FRONTDESK_AP_TRUST_DOMAIN:-asia-pacific.cullis.test}
+      CULLIS_FRONTDESK_TRUST_DOMAIN:  ${FRONTDESK_AP_TRUST_DOMAIN:-orgb.test}
       CULLIS_TRUSTED_PROXIES:         ${FRONTDESK_AP_TRUSTED_PROXIES:-127.0.0.1/32,::1/128,172.16.0.0/12}
       CULLIS_FRONTDESK_COOKIE_TTL_S:  3600
       CULLIS_FRONTDESK_MASTIO_URL:    ${FRONTDESK_AP_MASTIO_URL:-https://mastio-nginx-b:9443}

--- a/reference/scenarios/insurance-demo/nginx/frontdesk-asia-pacific.conf
+++ b/reference/scenarios/insurance-demo/nginx/frontdesk-asia-pacific.conf
@@ -22,8 +22,8 @@
 # for the canonical persona ↔ principal mapping.
 map $arg_user $forwarded_user {
     default      "unknown@frontdesk.dev";
-    "kenji"      "kenji.watanabe@asia-pacific.cullis.test";
-    "watanabe"   "kenji.watanabe@asia-pacific.cullis.test";
+    "kenji"      "kenji.watanabe@orgb.test";
+    "watanabe"   "kenji.watanabe@orgb.test";
 }
 
 server {

--- a/reference/scenarios/insurance-demo/run.sh
+++ b/reference/scenarios/insurance-demo/run.sh
@@ -9,7 +9,7 @@
 #   run.sh urls                      print recording-ready URLs
 #   run.sh down                      tear down frontdesk overlay
 #   run.sh status                    diagnostic — show component health
-#   run.sh prep-ca                   copy Mediterranean Org CA out of reference state
+#   run.sh prep-ca                   copy orga Org CA out of reference state
 #                                    volume to local disk (one-shot)
 #
 # Prerequisites:
@@ -50,10 +50,11 @@ _load_env() {
 # ── Subcommands ─────────────────────────────────────────────────────────
 
 cmd_prep_ca() {
-    _h "Copying Mediterranean Org CA from reference state volume"
+    _h "Copying orga (Mediterranean Insurance) Org CA from reference state volume"
     # The reference compose's bootstrap container persists Org CAs into
-    # the bootstrap-state volume. Copy them out for our seed.py to mint
-    # agent certs against.
+    # the bootstrap-state volume at ``/state/{org_id}/ca.pem`` +
+    # ``ca-key.pem``. Copy them out for our seed.py to mint agent
+    # certs against.
     local container
     container=$(docker compose -f "$REFERENCE_DIR/docker-compose.yml" ps -q bootstrap | head -1)
     if [ -z "$container" ]; then
@@ -65,17 +66,17 @@ cmd_prep_ca() {
         _fail "no bootstrap container available; cannot extract CA"
         exit 1
     fi
-    docker cp "$container:/state/mediterranean/ca-cert.pem" "$STATE_DIR/mediterranean-ca.pem"
-    docker cp "$container:/state/mediterranean/ca-key.pem"  "$STATE_DIR/mediterranean-ca.key"
-    chmod 600 "$STATE_DIR/mediterranean-ca.key"
-    _ok "Mediterranean Org CA at $STATE_DIR/mediterranean-ca.{pem,key}"
+    docker cp "$container:/state/orga/ca.pem"     "$STATE_DIR/orga-ca.pem"
+    docker cp "$container:/state/orga/ca-key.pem" "$STATE_DIR/orga-ca.key"
+    chmod 600 "$STATE_DIR/orga-ca.key"
+    _ok "orga Org CA at $STATE_DIR/orga-ca.{pem,key}"
 }
 
 cmd_seed() {
     _load_env
     _h "Seeding insurance-demo cast"
-    if [ ! -f "$STATE_DIR/mediterranean-ca.pem" ]; then
-        _warn "Mediterranean Org CA missing — running prep-ca first"
+    if [ ! -f "$STATE_DIR/orga-ca.pem" ]; then
+        _warn "orga Org CA missing — running prep-ca first"
         cmd_prep_ca
     fi
     python3 "$HERE/seed/seed.py"
@@ -90,7 +91,7 @@ cmd_frontdesk_prep() {
     # runs ``cullis-connector enroll`` against proxy-b through the
     # orgb-internal network.
     local invite
-    invite=$(curl -s -X POST -H "X-Admin-Secret: ${ADMIN_SECRET:-sandbox-admin-secret-change-me}" \
+    invite=$(curl -s -X POST -H "X-Admin-Secret: ${PROXY_B_ADMIN_SECRET:-sandbox-proxy-admin-b}" \
         -H "Content-Type: application/json" \
         -d '{"label":"frontdesk-asia-pacific","ttl_hours":1}' \
         http://localhost:9200/v1/admin/agents/enroll/connector \
@@ -179,7 +180,7 @@ cmd_urls() {
   ${GREEN}Asia-Pacific Mastio admin${RESET}             http://localhost:9200/admin
   ${GREEN}Court federation dashboard${RESET}     http://localhost:8000/dashboard
   ${GREEN}Grafana audit + traffic${RESET}        http://localhost:3000  (admin/admin)
-  ${GREEN}MCP claims-db (intra-org)${RESET}      mediterranean::resource::mcp::claims-db
+  ${GREEN}MCP claims-db (intra-org)${RESET}      orga::resource::mcp::claims-db
 
   Recording sequence (60-90s):
     1. Open Mediterranean Mastio admin — show Users + Agents + Workloads + Resources

--- a/reference/scenarios/insurance-demo/seed/seed.py
+++ b/reference/scenarios/insurance-demo/seed/seed.py
@@ -3,16 +3,16 @@
 Adds, on top of whatever ``reference/bootstrap/`` already created:
 
   - 3 user / agent principals on Mediterranean Insurance (Mediterranean):
-      mediterranean::user::claim-officer
-      mediterranean::user::claim-manager
-      mediterranean::agent::night-reporter
-      mediterranean::agent::ticket-bot
+      orga::user::claim-officer
+      orga::user::claim-manager
+      orga::agent::night-reporter
+      orga::agent::ticket-bot
   - 1 user principal on Asia-Pacific Insurance (Asia-Pacific):
-      asia-pacific::user::counterparty-liaison
+      orgb::user::counterparty-liaison
   - 1 workload principal on Asia-Pacific (the Frontdesk container itself):
-      asia-pacific::workload::frontdesk-container
+      orgb::workload::frontdesk-container
   - 1 MCP resource on Roma:
-      mediterranean::resource::mcp::claims-db (postgres-backed, seeded with claims.sql)
+      orga::resource::mcp::claims-db (postgres-backed, seeded with claims.sql)
   - Cross-org bindings + reach=both for the user principals that need to
     talk across orgs (claim-manager <-> counterparty-liaison).
 
@@ -44,7 +44,9 @@ Env override:
   CULLIS_BROKER_URL          default http://localhost:8000
   CULLIS_PROXY_A_URL         default http://localhost:9100
   CULLIS_PROXY_B_URL         default http://localhost:9200
-  ADMIN_SECRET               default sandbox-admin-secret-change-me
+  PROXY_A_ADMIN_SECRET       default sandbox-proxy-admin-a (Mastio A)
+  PROXY_B_ADMIN_SECRET       default sandbox-proxy-admin-b (Mastio B)
+  COURT_ADMIN_SECRET         default sandbox-admin-secret-change-me
   ANTHROPIC_API_KEY          read from imp/official_sandbox/.env if unset
 """
 from __future__ import annotations
@@ -71,7 +73,18 @@ STATE_DIR.mkdir(parents=True, exist_ok=True)
 BROKER_URL  = os.environ.get("CULLIS_BROKER_URL",  "http://localhost:8000")
 PROXY_A_URL = os.environ.get("CULLIS_PROXY_A_URL", "http://localhost:9100")
 PROXY_B_URL = os.environ.get("CULLIS_PROXY_B_URL", "http://localhost:9200")
-ADMIN_SECRET = os.environ.get("ADMIN_SECRET", "sandbox-admin-secret-change-me")
+# Per-proxy admin secrets — match reference/docker-compose.yml. The Court
+# (broker) uses its own secret for org-onboarding admin; the per-proxy
+# secrets gate the Mastio admin surface (/v1/admin/agents, users, etc.).
+PROXY_A_ADMIN_SECRET = os.environ.get(
+    "PROXY_A_ADMIN_SECRET", "sandbox-proxy-admin-a",
+)
+PROXY_B_ADMIN_SECRET = os.environ.get(
+    "PROXY_B_ADMIN_SECRET", "sandbox-proxy-admin-b",
+)
+COURT_ADMIN_SECRET = os.environ.get(
+    "COURT_ADMIN_SECRET", "sandbox-admin-secret-change-me",
+)
 
 # Cast definitions — match imp/insurance-demo-spec.md verbatim.
 MEDITERRANEAN_AGENTS = [
@@ -120,8 +133,8 @@ ASIA_PACIFIC_WORKLOADS = [
         "workload_name":          "frontdesk-container",
         "display_name":           "Asia-Pacific Frontdesk",
         "image_digest":           "sha256:demo-frontdesk-bundle",
-        "hosted_principals_hint": ["asia-pacific::user::counterparty-liaison"],
-        "description":            "Multi-user Frontdesk container hosting asia-pacific::user::counterparty-liaison.",
+        "hosted_principals_hint": ["orgb::user::counterparty-liaison"],
+        "description":            "Multi-user Frontdesk container hosting orgb::user::counterparty-liaison.",
     },
 ]
 
@@ -220,8 +233,15 @@ def _gen_agent_cert(
 # ── Provisioning helpers (HTTP) ──────────────────────────────────────────
 
 
-def _admin_headers() -> dict[str, str]:
-    return {"X-Admin-Secret": ADMIN_SECRET, "Content-Type": "application/json"}
+def _admin_headers(proxy_url: str) -> dict[str, str]:
+    """Pick the right admin secret based on which proxy we're calling."""
+    if proxy_url == PROXY_A_URL:
+        secret = PROXY_A_ADMIN_SECRET
+    elif proxy_url == PROXY_B_URL:
+        secret = PROXY_B_ADMIN_SECRET
+    else:
+        secret = COURT_ADMIN_SECRET
+    return {"X-Admin-Secret": secret, "Content-Type": "application/json"}
 
 
 def _byoca_enroll_agent(
@@ -238,7 +258,7 @@ def _byoca_enroll_agent(
     }
     r = client.post(
         f"{proxy_url}/v1/admin/agents/enroll/byoca",
-        json=body, headers=_admin_headers(), timeout=15.0,
+        json=body, headers=_admin_headers(proxy_url), timeout=15.0,
     )
     if r.status_code == 201:
         return r.json().get("dpop_jkt")
@@ -269,10 +289,10 @@ def phase_check_reference_up(client: httpx.Client) -> None:
             raise SystemExit(1)
 
 
-def phase_provision_mediterranean_agents(client: httpx.Client) -> None:
-    _h("Phase 2 — provision Roma agents (BYOCA) ")
-    org_ca = STATE_DIR / "mediterranean-ca.pem"
-    org_ca_key = STATE_DIR / "mediterranean-ca.key"
+def phase_provision_orga_agents(client: httpx.Client) -> None:
+    _h("Phase 2 — provision orga (Mediterranean) agents (BYOCA) ")
+    org_ca = STATE_DIR / "orga-ca.pem"
+    org_ca_key = STATE_DIR / "orga-ca.key"
     if not (org_ca.exists() and org_ca_key.exists()):
         _warn("Roma Org CA material not on disk yet — pulling from reference state")
         # ``reference/bootstrap/bootstrap.py`` writes the CA into the
@@ -285,14 +305,26 @@ def phase_provision_mediterranean_agents(client: httpx.Client) -> None:
     for spec in MEDITERRANEAN_AGENTS:
         agent_dir = STATE_DIR / "agents" / spec["agent_name"]
         agent_dir.mkdir(parents=True, exist_ok=True)
+        cert_path = agent_dir / "agent.pem"
+        key_path  = agent_dir / "agent-key.pem"
+        # Idempotency: if the cert+key already exist on disk we trust
+        # they match the BYOCA-enrolled row in the proxy DB. Re-minting
+        # on a re-run produces a NEW cert that the DB doesn't know about
+        # (BYOCA returns 409 without updating), and the next mTLS
+        # handshake fails with "client cert does not match the
+        # registered identity".
+        if cert_path.exists() and key_path.exists():
+            _ok(f"agent {spec['agent_name']} already provisioned "
+                f"({cert_path.name} on disk) — skipping mint+enroll")
+            continue
         cert_pem, key_pem = _gen_agent_cert(
-            "mediterranean", spec["agent_name"], "mediterranean.cullis.test",
+            "orga", spec["agent_name"], "orga.test",
             org_ca, org_ca_key,
         )
-        (agent_dir / "agent.pem").write_text(cert_pem)
-        (agent_dir / "agent-key.pem").write_text(key_pem)
-        (agent_dir / "agent.pem").chmod(0o644)
-        (agent_dir / "agent-key.pem").chmod(0o600)
+        cert_path.write_text(cert_pem)
+        key_path.write_text(key_pem)
+        cert_path.chmod(0o644)
+        key_path.chmod(0o600)
 
         _byoca_enroll_agent(
             client, PROXY_A_URL, spec["agent_name"], spec["capabilities"],
@@ -318,14 +350,14 @@ def phase_provision_user_principals(client: httpx.Client) -> None:
         try:
             r = client.post(
                 f"{PROXY_A_URL}/v1/admin/users",
-                json=body, headers=_admin_headers(), timeout=10.0,
+                json=body, headers=_admin_headers(PROXY_A_URL), timeout=10.0,
             )
         except Exception as exc:
             _warn(f"/v1/admin/users unreachable ({exc}) — endpoint pending,"
                   " run.sh will try the runtime CSR fallback")
             continue
         if r.status_code in (201, 409):
-            _ok(f"user mediterranean::user::{spec['user_name']} ready")
+            _ok(f"user orga::user::{spec['user_name']} ready")
         else:
             _fail(f"user create {spec['user_name']}: HTTP {r.status_code}")
 
@@ -339,13 +371,13 @@ def phase_provision_user_principals(client: httpx.Client) -> None:
         try:
             r = client.post(
                 f"{PROXY_B_URL}/v1/admin/users",
-                json=body, headers=_admin_headers(), timeout=10.0,
+                json=body, headers=_admin_headers(PROXY_B_URL), timeout=10.0,
             )
         except Exception as exc:
             _warn(f"Tokyo /v1/admin/users unreachable ({exc}) — pending")
             continue
         if r.status_code in (201, 409):
-            _ok(f"user asia-pacific::user::{spec['user_name']} ready")
+            _ok(f"user orgb::user::{spec['user_name']} ready")
         else:
             _fail(f"user create {spec['user_name']}: HTTP {r.status_code}")
 
@@ -362,34 +394,38 @@ def phase_provision_workload(client: httpx.Client) -> None:
         try:
             r = client.post(
                 f"{PROXY_B_URL}/v1/admin/workloads",
-                json=body, headers=_admin_headers(), timeout=10.0,
+                json=body, headers=_admin_headers(PROXY_B_URL), timeout=10.0,
             )
         except Exception as exc:
             _warn(f"Tokyo /v1/admin/workloads unreachable ({exc}) — pending")
             continue
         if r.status_code in (201, 409):
-            _ok(f"workload asia-pacific::workload::{spec['workload_name']} ready")
+            _ok(f"workload orgb::workload::{spec['workload_name']} ready")
 
 
 def phase_provision_resources(client: httpx.Client) -> None:
     _h("Phase 5 — provision MCP resource (claims-db)")
     for spec in MEDITERRANEAN_RESOURCES:
+        # Contract: mcp_proxy/admin/mcp_resources.py::MCPResourceCreate
+        # — fields are ``name`` + ``endpoint_url``, NOT resource_id /
+        # endpoint. The proxy mints the resource_id (uuid4) on insert.
         body = {
-            "resource_id":   f"mediterranean::resource::{spec['type']}::{spec['resource_name']}",
-            "display_name":  spec["display_name"],
-            "type":          spec["type"],
-            "endpoint":      spec["endpoint"],
+            "name":         spec["resource_name"],
+            "endpoint_url": spec["endpoint"],
+            "description":  spec.get("description") or spec["display_name"],
+            "auth_type":    "none",
         }
         try:
             r = client.post(
                 f"{PROXY_A_URL}/v1/admin/mcp-resources",
-                json=body, headers=_admin_headers(), timeout=10.0,
+                json=body, headers=_admin_headers(PROXY_A_URL), timeout=10.0,
             )
         except Exception as exc:
             _warn(f"/v1/admin/mcp-resources unreachable ({exc})")
             continue
         if r.status_code in (201, 409):
-            _ok(f"resource {body['resource_id']} ready")
+            _ok(f"resource {spec['resource_name']} ready "
+                f"(resource_id={r.json().get('resource_id', '?')[:8]})")
         else:
             _fail(f"resource create: HTTP {r.status_code} {r.text[:160]}")
 
@@ -433,7 +469,7 @@ def main() -> int:
     print(f"{BOLD}{CYAN}Cullis insurance-demo seed{RESET}\n")
     with httpx.Client() as client:
         phase_check_reference_up(client)
-        phase_provision_mediterranean_agents(client)
+        phase_provision_orga_agents(client)
         phase_provision_user_principals(client)
         phase_provision_workload(client)
         phase_provision_resources(client)


### PR DESCRIPTION
## Summary

Live smoke against ``reference/demo.sh full`` uncovered seven concrete bugs in the insurance-demo scenario shipped in PR #475. All fixes are local to ``reference/scenarios/insurance-demo/``.

| # | Bug | Status |
|---|---|---|
| 1 | ``ADMIN_SECRET`` singleton → per-proxy reference compose | fixed |
| 2 | bot URL defaulted to HTTP admin port instead of HTTPS nginx mTLS | fixed |
| 3 | org_id ``mediterranean``/``asia-pacific`` ≠ reference ``orga``/``orgb`` | fixed (rename + display map) |
| 4 | ``/v1/admin/mcp-resources`` body schema (``name`` + ``endpoint_url``) | fixed |
| 5 | bot ``STATE_DIR`` resolved to ``reference/state`` not repo root ``state`` | fixed |
| 6 | BYOCA 409 on re-run desyncs disk cert from DB cert | fix (idempotency on disk presence) |
| 7 | SDK ``verify_tls=False`` silently drops client cert at httpx layer | fixed (``verify_tls=True`` + ``ca_chain_path``) |

## Open follow-up
Bug #8 (separate issue) — ``/v1/egress/resolve`` does not yet handle user principal recipients. ADR-020 added user principals as a third type, but the egress resolver only looks them up in ``internal_agents``. Bot's A2U send to ``orga::user::claim-officer`` 404s. Backend change tracked separately.

## Test plan
- ``./demo.sh full && cd scenarios/insurance-demo && ./run.sh prep-ca && ./run.sh seed`` — 7/7 phases green
- ``./run.sh trigger-night-reporter`` — login + MCP query OK; sends fail at resolve (#8 above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)