### PR TITLE
feat(spa): Inbox surface — Phase 2 SPA rework

### DIFF
--- a/app/dashboard/_demo_cast.py
+++ b/app/dashboard/_demo_cast.py
@@ -1,0 +1,134 @@
+"""
+Hardcoded demo cast for Phase 1 of the SPA rework (insurance demo).
+
+The Mastio admin dashboard renders four principal-type sections (Users,
+Agents, Workloads, Resources). The corresponding admin REST routes
+(/v1/admin/users, /v1/admin/workloads) are still being designed by the
+backend session — see ``imp/insurance-demo-spec.md``. Until those land,
+this module returns the principal cast hardcoded from the spec so the
+dashboard can be screenshot-recorded for the demo.
+
+Swap path: when the admin endpoints ship, replace each ``*_cast`` call
+in ``app/dashboard/router.py`` with an httpx call to the real route.
+This module then deletes cleanly.
+"""
+from __future__ import annotations
+
+
+def users_cast() -> list[dict]:
+    """Return the user principals from the insurance demo spec."""
+    return [
+        {
+            "principal_id": "mediterranean::user::claim-officer",
+            "display_name": "Claim Officer",
+            "reach": "cross",
+            "surface": "Cullis Chat (desktop)",
+            "last_active": "active",
+            "last_active_iso": None,
+        },
+        {
+            "principal_id": "mediterranean::user::claim-manager",
+            "display_name": "Claim Manager",
+            "reach": "cross",
+            "surface": "Cullis Chat /chat (web)",
+            "last_active": "active",
+            "last_active_iso": None,
+        },
+        {
+            "principal_id": "asia-pacific::user::counterparty-liaison",
+            "display_name": "Counterparty Liaison",
+            "reach": "both",
+            "surface": "Frontdesk (web)",
+            "last_active": "active",
+            "last_active_iso": None,
+        },
+    ]
+
+
+def workloads_cast() -> list[dict]:
+    """Return the workload principals from the insurance demo spec."""
+    return [
+        {
+            "principal_id": "asia-pacific::workload::frontdesk-container",
+            "display_name": "Asia-Pacific Frontdesk",
+            "reach": "both",
+            "hosted_principals_count": 1,
+            "image_digest": "sha256:c1ed4e8f7a02b9d4f6e3c2a1b8d7e6f5",
+            "runtime_status": "running",
+        },
+    ]
+
+
+def resources_cast() -> list[dict]:
+    """Return MCP/HTTP/DB resources from the insurance demo spec."""
+    return [
+        {
+            "resource_id": "mediterranean::resource::mcp::claims-db",
+            "display_name": "Claims Database",
+            "type": "mcp",
+            "endpoint": "mcp://claims-db.mediterranean.local",
+            "bindings_count": 2,
+            "last_accessed": "active",
+            "last_accessed_iso": None,
+        },
+    ]
+
+
+def peers_cast() -> list[dict]:
+    """Return federated peer organizations for the demo (two orgs)."""
+    return [
+        {
+            "org_id": "mediterranean",
+            "trust_domain": "mediterranean.cullis.test",
+            "status": "active",
+            "ca_fingerprint": "sha256:a1b2c3d4e5f6a7b8c9d0e1f2",
+            "joined_at": "active",
+            "joined_at_iso": None,
+        },
+        {
+            "org_id": "asia-pacific",
+            "trust_domain": "asia-pacific.cullis.test",
+            "status": "active",
+            "ca_fingerprint": "sha256:9f8e7d6c5b4a3928170615f4",
+            "joined_at": "active",
+            "joined_at_iso": None,
+        },
+    ]
+
+
+def agent_extras(agent_id: str) -> dict:
+    """Return enrollment_method + automation_type for known cast agents.
+
+    Returns empty dict for agents that are not in the demo cast — the
+    template renders an em-dash for missing fields. This is intentional:
+    real agents from the registry may not yet have these fields tagged.
+    """
+    table = {
+        "mediterranean::agent::night-reporter": {
+            "enrollment_method": "Connector",
+            "automation_type": "cron",
+        },
+        "mediterranean::agent::ticket-bot": {
+            "enrollment_method": "BYOCA",
+            "automation_type": "request-response",
+        },
+    }
+    return table.get(agent_id, {})
+
+
+def cast_counts() -> dict:
+    """Counts for the left-nav badges (HTMX-polled)."""
+    return {
+        "users": len(users_cast()),
+        "agents": len([a for a in agent_extras_keys()]),
+        "workloads": len(workloads_cast()),
+        "resources": len(resources_cast()),
+    }
+
+
+def agent_extras_keys() -> list[str]:
+    """Return the agent_ids known to the demo cast."""
+    return [
+        "mediterranean::agent::night-reporter",
+        "mediterranean::agent::ticket-bot",
+    ]

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -659,8 +659,13 @@ async def overview(request: Request, db: AsyncSession = Depends(get_db)):
         select(func.count(AuditLog.id)).where(AuditLog.timestamp >= _one_hour_ago)
     )).scalar() or 0
 
+    # Users count is hardcoded from the insurance demo cast until
+    # /v1/admin/users lands (backend session). See _demo_cast.py.
+    users_total = len(_demo_cast.users_cast())
+
     stats = {
         "orgs": orgs_total, "orgs_active": orgs_active, "orgs_pending": orgs_pending,
+        "users": users_total,
         "agents": agents_total, "agents_active": agents_active,
         "sessions_active": sessions_active,
         "audit_events": audit_events,

--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -46,6 +46,7 @@ from app.policy.store import PolicyRecord, create_policy, get_policy, deactivate
 from app.broker.db_models import SessionRecord, SessionMessageRecord, RfqRecord, RfqResponseRecord
 from app.broker.ws_manager import ws_manager
 from app.auth.transaction_token import create_transaction_token, compute_payload_hash
+from app.dashboard import _demo_cast
 
 import logging
 _log = logging.getLogger("agent_trust")
@@ -875,6 +876,7 @@ async def agents_list(request: Request, db: AsyncSession = Depends(get_db)):
 
     agent_list = []
     for agent in agents:
+        extras = _demo_cast.agent_extras(agent.agent_id)
         agent_list.append({
             "agent_id": agent.agent_id,
             "org_id": agent.org_id,
@@ -884,11 +886,75 @@ async def agents_list(request: Request, db: AsyncSession = Depends(get_db)):
             "binding_status": binding_statuses.get(agent.agent_id),
             "ws_connected": ws_manager.is_connected(agent.agent_id),
             "cert_thumbprint": agent.cert_thumbprint,
+            "enrollment_method": extras.get("enrollment_method"),
+            "automation_type": extras.get("automation_type"),
         })
 
     return templates.TemplateResponse("agents.html",
         _ctx(request, session, active="agents", agents=agent_list)
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Users / Workloads / Resources / Federation (ADR-020 principal-type sections)
+#
+# Phase 1 of the SPA rework ships these views with hardcoded demo data
+# from imp/insurance-demo-spec.md. The matching admin REST endpoints
+# (/v1/admin/users, /v1/admin/workloads) are owned by the backend
+# session and land separately. Once they are live, swap the
+# ``_demo_cast.*`` calls below for httpx calls to those routes and
+# delete app/dashboard/_demo_cast.py.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@router.get("/users", response_class=HTMLResponse)
+async def users_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("users.html", _ctx(
+        request, session, active="users",
+        users=_demo_cast.users_cast(),
+        endpoint_ready=False,
+    ))
+
+
+@router.get("/workloads", response_class=HTMLResponse)
+async def workloads_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("workloads.html", _ctx(
+        request, session, active="workloads",
+        workloads=_demo_cast.workloads_cast(),
+        endpoint_ready=False,
+    ))
+
+
+@router.get("/resources", response_class=HTMLResponse)
+async def resources_list(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("resources.html", _ctx(
+        request, session, active="resources",
+        resources=_demo_cast.resources_cast(),
+    ))
+
+
+@router.get("/federation", response_class=HTMLResponse)
+async def federation_view(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    return templates.TemplateResponse("federation.html", _ctx(
+        request, session, active="federation",
+        peers=_demo_cast.peers_cast(),
+        court_status="Online",
+        court_endpoint="https://court.cullis.test",
+        court_audit_status="Healthy",
+        court_last_anchor="active",
+        court_last_anchor_iso=None,
+    ))
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1199,6 +1265,53 @@ async def badge_pending_sessions(request: Request, db: AsyncSession = Depends(ge
     if count > 0:
         return f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-yellow-500/20 text-yellow-400">{count}</span>'
     return ""
+
+
+def _count_chip(count: int) -> str:
+    """Neutral count chip used in the principal-type nav badges."""
+    if count <= 0:
+        return ""
+    return (
+        '<span class="px-1.5 py-0.5 rounded-full text-[10px] font-mono '
+        f'bg-gray-700/40 text-gray-400">{count}</span>'
+    )
+
+
+@router.get("/badge/users-count", response_class=HTMLResponse)
+async def badge_users_count(request: Request):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    return _count_chip(len(_demo_cast.users_cast()))
+
+
+@router.get("/badge/agents-count", response_class=HTMLResponse)
+async def badge_agents_count(request: Request, db: AsyncSession = Depends(get_db)):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    count = (await db.execute(select(func.count(AgentRecord.agent_id)))).scalar() or 0
+    if count == 0:
+        # During demo recording the registry may not yet be populated.
+        # Fall back to the cast count so the badge is screenshot-ready.
+        count = len(_demo_cast.agent_extras_keys())
+    return _count_chip(int(count))
+
+
+@router.get("/badge/workloads-count", response_class=HTMLResponse)
+async def badge_workloads_count(request: Request):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    return _count_chip(len(_demo_cast.workloads_cast()))
+
+
+@router.get("/badge/resources-count", response_class=HTMLResponse)
+async def badge_resources_count(request: Request):
+    session = get_session(request)
+    if not session.logged_in:
+        return ""
+    return _count_chip(len(_demo_cast.resources_cast()))
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/app/dashboard/static_src/input.css
+++ b/app/dashboard/static_src/input.css
@@ -7,6 +7,14 @@
  * Keep in sync with mcp_proxy/dashboard/static_src/input.css.
  */
 
+:root {
+  /* Principal type badge — ADR-020 user/agent/workload, mirrored
+     from site/global.css and cullis-chat/tokens.css. */
+  --cullis-badge-user: #3b7af5;
+  --cullis-badge-agent: #8b5cf6;
+  --cullis-badge-workload: #10b981;
+}
+
 @layer base {
   body {
     font-family: 'DM Sans', sans-serif;

--- a/app/dashboard/templates/_principal_badge.html
+++ b/app/dashboard/templates/_principal_badge.html
@@ -1,0 +1,37 @@
+{# Principal type badge — ADR-020.
+   Usage:
+     {% from "_principal_badge.html" import principal_badge %}
+     {{ principal_badge("user") }}
+
+   `kind` is one of: user | agent | workload. Falls back to a neutral
+   chip for unknown values so a typo does not break the page. #}
+{% macro principal_badge(kind) -%}
+  {%- set k = (kind or "")|lower -%}
+  {%- if k == "user" -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style="background: rgba(59,122,245,0.10); color: var(--cullis-badge-user, #3b7af5); border-color: rgba(59,122,245,0.25);">User</span>
+  {%- elif k == "agent" -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style="background: rgba(139,92,246,0.10); color: var(--cullis-badge-agent, #8b5cf6); border-color: rgba(139,92,246,0.25);">Agent</span>
+  {%- elif k == "workload" -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em]"
+          style="background: rgba(16,185,129,0.10); color: var(--cullis-badge-workload, #10b981); border-color: rgba(16,185,129,0.25);">Workload</span>
+  {%- else -%}
+    <span class="inline-flex items-center px-1.5 py-[1px] rounded-sm border text-[10px] font-semibold uppercase tracking-[0.18em] bg-gray-700/30 text-gray-400 border-gray-700/40">{{ kind|default("?", true) }}</span>
+  {%- endif -%}
+{%- endmacro %}
+
+{# Reach chip — intra | cross | both. Visually distinct from principal
+   type badge. #}
+{% macro reach_chip(reach) -%}
+  {%- set r = (reach or "")|lower -%}
+  {%- if r == "intra" -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-gray-500/10 text-gray-400">Intra</span>
+  {%- elif r == "cross" -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-amber-500/10 text-amber-400">Cross</span>
+  {%- elif r == "both" -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-accent-400/10 text-accent-400">Both</span>
+  {%- else -%}
+    <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium uppercase tracking-wider bg-gray-700/20 text-gray-500">{{ reach|default("none", true) }}</span>
+  {%- endif -%}
+{%- endmacro %}

--- a/app/dashboard/templates/agents.html
+++ b/app/dashboard/templates/agents.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "_principal_badge.html" import principal_badge %}
 {% block title %}Agents{% endblock %}
 {% block header_title %}Agents{% endblock %}
 {% block content %}
@@ -8,7 +9,7 @@
     <div class="flex items-center justify-between mb-6">
         <div>
             <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Federated Agents</h2>
-            <p class="text-xs text-gray-600 mt-0.5">{{ agents | length }} registered</p>
+            <p class="text-xs text-gray-600 mt-0.5">{{ agents | length }} registered &middot; non-human autonomous principals</p>
         </div>
         <a href="/dashboard/agents/register"
            class="px-4 py-2 text-xs font-semibold rounded transition-all"
@@ -27,6 +28,8 @@
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Agent</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Organization</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Enrollment</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Automation</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Capabilities</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Binding</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">WebSocket</th>
@@ -38,7 +41,10 @@
                 {% for agent in agents %}
                 <tr class="table-row-hover transition-colors">
                     <td class="px-5 py-4">
-                        <a href="/dashboard/agents/{{ agent.agent_id }}" class="text-sm text-white hover:text-accent-400 transition-colors">{{ agent.display_name }}</a>
+                        <div class="flex items-center gap-2">
+                            {{ principal_badge("agent") }}
+                            <a href="/dashboard/agents/{{ agent.agent_id }}" class="text-sm text-white hover:text-accent-400 transition-colors">{{ agent.display_name }}</a>
+                        </div>
                         <p class="text-[10px] text-gray-600 font-mono mt-0.5">{{ agent.agent_id }}</p>
                     </td>
                     <td class="px-5 py-4 text-xs text-gray-400 font-mono">{{ agent.org_id }}</td>
@@ -51,6 +57,20 @@
                         <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-wider">
                             <span class="w-1.5 h-1.5 rounded-full bg-gray-600"></span>Inactive
                         </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if agent.enrollment_method %}
+                        <span class="text-[10px] text-gray-400 font-mono uppercase tracking-wider">{{ agent.enrollment_method }}</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if agent.automation_type %}
+                        <span class="text-[10px] text-gray-400 uppercase tracking-wider">{{ agent.automation_type }}</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
                         {% endif %}
                     </td>
                     <td class="px-5 py-4">
@@ -100,7 +120,7 @@
                 {% endfor %}
                 {% if not agents %}
                 <tr>
-                    <td colspan="8" class="px-5 py-16 text-center">
+                    <td colspan="10" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                         <p class="text-sm text-gray-600">No agents registered</p>
                     </td>

--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -48,12 +48,6 @@
                 Agents
                 <span hx-get="/dashboard/badge/agents-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/workloads"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'workloads' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
-                Workloads
-                <span hx-get="/dashboard/badge/workloads-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
-            </a>
             <a href="/dashboard/resources"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'resources' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2 2 3 4 3h8c2 0 4-1 4-3V7c0-2-2-3-4-3H8C6 4 4 5 4 7zm4 0h8M8 12h8M8 17h5"/></svg>

--- a/app/dashboard/templates/base.html
+++ b/app/dashboard/templates/base.html
@@ -27,53 +27,65 @@
         </div>
 
         <!-- Navigation -->
-        <div class="flex-1 px-2 py-3 space-y-0.5">
+        <div class="flex-1 px-2 py-3 space-y-0.5 overflow-y-auto">
             <a href="/dashboard"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'overview' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zm10 0a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/></svg>
                 Overview
             </a>
-            <a href="/dashboard/orgs"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'orgs' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/></svg>
-                Organizations
-                <span hx-get="/dashboard/badge/pending-orgs" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+
+            <!-- Principals group -->
+            <div class="mt-3 mb-1 px-3 text-[9px] font-semibold uppercase tracking-[0.22em] text-gray-700">Principals</div>
+            <a href="/dashboard/users"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'users' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
+                Users
+                <span hx-get="/dashboard/badge/users-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
             <a href="/dashboard/agents"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'agents' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
                 Agents
+                <span hx-get="/dashboard/badge/agents-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/sessions"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'sessions' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"/></svg>
-                Sessions
-                <span hx-get="/dashboard/badge/pending-sessions" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+            <a href="/dashboard/workloads"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'workloads' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+                Workloads
+                <span hx-get="/dashboard/badge/workloads-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/rfqs"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'rfq' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01"/></svg>
-                RFQs
+            <a href="/dashboard/resources"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'resources' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2 2 3 4 3h8c2 0 4-1 4-3V7c0-2-2-3-4-3H8C6 4 4 5 4 7zm4 0h8M8 12h8M8 17h5"/></svg>
+                Resources
+                <span hx-get="/dashboard/badge/resources-count" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
-            <a href="/dashboard/policies"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'policies' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
-                Policies
-            </a>
+
+            <!-- Federation group -->
+            <div class="mt-3 mb-1 px-3 text-[9px] font-semibold uppercase tracking-[0.22em] text-gray-700">Federation</div>
             <a href="/dashboard/bindings"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'bindings' %}nav-active{% else %}text-gray-500{% endif %}">
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'bindings' or active == 'policies' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"/></svg>
                 Bindings
             </a>
-            <a href="/dashboard/admin/settings"
-               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'admin_settings' %}nav-active{% else %}text-gray-500{% endif %}">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
-                Settings
+            <a href="/dashboard/federation"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'federation' or active == 'orgs' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0zM3 12h18M12 3a15 15 0 010 18M12 3a15 15 0 000 18"/></svg>
+                Federation
+                <span hx-get="/dashboard/badge/pending-orgs" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
             <a href="/dashboard/audit"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'audit' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
                 Audit Log
+            </a>
+
+            <!-- System group -->
+            <div class="mt-3 mb-1 px-3 text-[9px] font-semibold uppercase tracking-[0.22em] text-gray-700">System</div>
+            <a href="/dashboard/admin/settings"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'admin_settings' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                Settings
             </a>
             <a href="{{ jaeger_url or 'http://localhost:16686' }}" target="_blank" rel="noopener"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item text-gray-500">

--- a/app/dashboard/templates/federation.html
+++ b/app/dashboard/templates/federation.html
@@ -1,0 +1,100 @@
+{% extends "base.html" %}
+{% block title %}Federation{% endblock %}
+{% block header_title %}Federation{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="federation" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Federation</h2>
+            <p class="text-xs text-gray-600 mt-0.5">Peer organizations &amp; Court health</p>
+        </div>
+    </div>
+
+    <!-- Court status -->
+    <div class="mb-6 bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <div class="px-5 py-4 border-b border-gray-800/60">
+            <div class="flex items-center justify-between">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Court</h3>
+                <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-[10px] font-medium bg-accent-400/10 text-accent-400 uppercase tracking-wider">
+                    <span class="w-1.5 h-1.5 rounded-full bg-accent-400 pulse-dot"></span>
+                    {{ court_status or "Online" }}
+                </span>
+            </div>
+        </div>
+        <div class="px-5 py-3 grid grid-cols-3 gap-4 text-xs">
+            <div>
+                <div class="text-gray-600 uppercase tracking-wider text-[10px] mb-1">Endpoint</div>
+                <div class="text-gray-300 font-mono text-[11px]">{{ court_endpoint or "https://court.cullis.test" }}</div>
+            </div>
+            <div>
+                <div class="text-gray-600 uppercase tracking-wider text-[10px] mb-1">Audit dual-write</div>
+                <div class="text-emerald-400 text-[11px]">{{ court_audit_status or "Healthy" }}</div>
+            </div>
+            <div>
+                <div class="text-gray-600 uppercase tracking-wider text-[10px] mb-1">Last anchor</div>
+                <div class="text-gray-300 text-[11px]" title="{{ court_last_anchor_iso or '' }}">{{ court_last_anchor or "—" }}</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Peer orgs -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <div class="px-5 py-3 border-b border-gray-800/60 flex items-center justify-between">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Peer organizations</h3>
+            <span class="text-[10px] text-gray-600 uppercase tracking-wider">{{ peers | length }} federated</span>
+        </div>
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Org ID</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Trust domain</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">CA fingerprint</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Joined</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for p in peers %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4 text-sm text-white font-mono">{{ p.org_id }}</td>
+                    <td class="px-5 py-4 text-xs text-gray-400 font-mono">{{ p.trust_domain }}</td>
+                    <td class="px-5 py-4">
+                        {% if p.status == "active" %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
+                        </span>
+                        {% elif p.status == "pending" %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-yellow-500/10 text-yellow-400 uppercase tracking-wider">Pending</span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-wider">{{ p.status }}</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if p.ca_fingerprint %}
+                        <span class="text-[10px] text-gray-400 font-mono" title="{{ p.ca_fingerprint }}">{{ p.ca_fingerprint[:14] }}…</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-500" title="{{ p.joined_at_iso or '' }}">{{ p.joined_at or "—" }}</td>
+                </tr>
+                {% endfor %}
+                {% if not peers %}
+                <tr>
+                    <td colspan="5" class="px-5 py-12 text-center text-sm text-gray-600">No peer organizations federated</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+
+    <!-- Legacy /orgs link -->
+    <div class="mt-4 text-[11px] text-gray-700">
+        Legacy organization CRUD lives at
+        <a href="/dashboard/orgs" class="text-gray-500 hover:text-accent-400 transition-colors underline decoration-dotted">/dashboard/orgs</a>
+        (own-org operations not yet exposed in Federation tab).
+    </div>
+</div>
+{% endblock %}

--- a/app/dashboard/templates/overview.html
+++ b/app/dashboard/templates/overview.html
@@ -75,13 +75,22 @@
             <div class="px-5 py-5 cell">
                 <div class="flex items-center justify-between">
                     <p class="mono text-[10px] uppercase tracking-[0.22em] text-white/45">organizations</p>
-                    <a href="/dashboard/orgs" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">ls →</a>
+                    <a href="/dashboard/federation" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">ls →</a>
                 </div>
                 <p class="heading text-[40px] leading-none font-semibold text-white mt-3 tnum mono">{{ stats.orgs }}</p>
                 <div class="mt-2 flex items-center gap-3 mono text-[10px] uppercase tracking-wider">
                     <span class="text-[#00e5c7]">● {{ stats.orgs_active }} active</span>
                     {% if stats.orgs_pending %}<span class="text-amber-300">◐ {{ stats.orgs_pending }} pending</span>{% endif %}
                 </div>
+            </div>
+            <!-- Users -->
+            <div class="px-5 py-5 cell">
+                <div class="flex items-center justify-between">
+                    <p class="mono text-[10px] uppercase tracking-[0.22em] text-white/45">users</p>
+                    <a href="/dashboard/users" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">ls →</a>
+                </div>
+                <p class="heading text-[40px] leading-none font-semibold text-white mt-3 tnum mono">{{ stats.users }}</p>
+                <div class="mt-2 mono text-[10px] uppercase tracking-wider text-white/40">human principals</div>
             </div>
             <!-- Agents -->
             <div class="px-5 py-5 cell">
@@ -91,15 +100,6 @@
                 </div>
                 <p class="heading text-[40px] leading-none font-semibold text-white mt-3 tnum mono">{{ stats.agents }}</p>
                 <div class="mt-2 mono text-[10px] uppercase tracking-wider text-[#00e5c7]">● {{ stats.agents_active }} active</div>
-            </div>
-            <!-- Sessions -->
-            <div class="px-5 py-5 cell">
-                <div class="flex items-center justify-between">
-                    <p class="mono text-[10px] uppercase tracking-[0.22em] text-white/45">sessions · live</p>
-                    <a href="/dashboard/sessions" class="mono text-[10px] uppercase tracking-wider text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">tail →</a>
-                </div>
-                <p class="heading text-[40px] leading-none font-semibold {% if stats.sessions_active > 0 %}text-[#00e5c7]{% else %}text-white{% endif %} mt-3 tnum mono">{{ stats.sessions_active }}</p>
-                <div class="mt-2 mono text-[10px] uppercase tracking-wider text-white/40">active sockets</div>
             </div>
             <!-- Audit -->
             <div class="px-5 py-5">
@@ -199,12 +199,12 @@
                         <span class="text-white tnum">{{ stats.orgs_active }}</span>
                     </div>
                     <div class="flex items-center justify-between mono text-[11px]">
-                        <span class="text-white/55 uppercase tracking-wider">live sessions</span>
-                        <span class="text-[#00e5c7] tnum">{{ stats.sessions_active }}</span>
+                        <span class="text-white/55 uppercase tracking-wider">active agents</span>
+                        <span class="text-[#00e5c7] tnum">{{ stats.agents_active }}</span>
                     </div>
                 </div>
                 <div class="mt-4 pt-4 border-t hairline">
-                    <a href="/dashboard/orgs" class="mono text-[10px] uppercase tracking-[0.22em] text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">Inspect organizations →</a>
+                    <a href="/dashboard/federation" class="mono text-[10px] uppercase tracking-[0.22em] text-[#00e5c7]/80 hover:text-[#00e5c7] transition-colors">Inspect federation →</a>
                 </div>
             </div>
         </aside>

--- a/app/dashboard/templates/resources.html
+++ b/app/dashboard/templates/resources.html
@@ -1,0 +1,84 @@
+{% extends "base.html" %}
+{% block title %}Resources{% endblock %}
+{% block header_title %}MCP Resources{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="resources" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Resources</h2>
+            <p class="text-xs text-gray-600 mt-0.5">{{ resources | length }} registered &middot; MCP tools, HTTP services, databases</p>
+        </div>
+    </div>
+
+    <!-- Resources table -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Resource</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Type</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Endpoint</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Bindings</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last accessed</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for r in resources %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                            <span class="text-[10px] text-gray-500 font-mono"
+                                  title="{{ r.resource_id }}">{{ r.resource_id }}</span>
+                            <button type="button" class="text-gray-700 hover:text-accent-400 transition-colors"
+                                    onclick="copyToClipboard('{{ r.resource_id }}')" title="Copy ID">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            </button>
+                        </div>
+                    </td>
+                    <td class="px-5 py-4 text-sm text-white">{{ r.display_name }}</td>
+                    <td class="px-5 py-4">
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-info-400/10 text-info-400 uppercase tracking-wider">
+                            {% if r.type == "mcp" %}
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"/></svg>
+                                MCP
+                            {% elif r.type == "http" %}
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+                                HTTP
+                            {% elif r.type in ("database", "postgres", "db") %}
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7c0-1.5 3.5-3 8-3s8 1.5 8 3v10c0 1.5-3.5 3-8 3s-8-1.5-8-3V7zm0 0c0 1.5 3.5 3 8 3s8-1.5 8-3M4 12c0 1.5 3.5 3 8 3s8-1.5 8-3"/></svg>
+                                Database
+                            {% else %}
+                                {{ r.type }}
+                            {% endif %}
+                        </span>
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-400 font-mono truncate max-w-xs" title="{{ r.endpoint }}">{{ r.endpoint }}</td>
+                    <td class="px-5 py-4">
+                        <a href="/dashboard/bindings?resource={{ r.resource_id }}"
+                           class="text-xs text-accent-400 hover:text-accent-500 transition-colors font-mono">{{ r.bindings_count }} →</a>
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-500" title="{{ r.last_accessed_iso or '' }}">{{ r.last_accessed or "never" }}</td>
+                    <td class="px-5 py-4 space-x-1.5">
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Detail page lands in Phase 2">Details</button>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not resources %}
+                <tr>
+                    <td colspan="7" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 7v10c0 2 2 3 4 3h8c2 0 4-1 4-3V7c0-2-2-3-4-3H8C6 4 4 5 4 7zm4 0h8M8 12h8M8 17h5"/></svg>
+                        <p class="text-sm text-gray-600">No resources registered</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/dashboard/templates/users.html
+++ b/app/dashboard/templates/users.html
@@ -1,0 +1,79 @@
+{% extends "base.html" %}
+{% from "_principal_badge.html" import principal_badge, reach_chip %}
+{% block title %}Users{% endblock %}
+{% block header_title %}User Principals{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="users" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Users</h2>
+            <p class="text-xs text-gray-600 mt-0.5">{{ users | length }} registered &middot; human principals (SSO + per-user KMS)</p>
+        </div>
+    </div>
+
+    {% if not endpoint_ready %}
+    <div class="mb-4 px-4 py-3 rounded border border-yellow-700/40 bg-yellow-500/5 text-yellow-300 text-xs">
+        <strong class="font-semibold">Endpoint pending.</strong>
+        Showing demo cast hardcoded from <code class="font-mono">imp/insurance-demo-spec.md</code>.
+        Backend route <code class="font-mono">/v1/admin/users</code> lands in a follow-up PR.
+    </div>
+    {% endif %}
+
+    <!-- Users table -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Surface</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last active</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for u in users %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                            {{ principal_badge("user") }}
+                            <span class="text-[10px] text-gray-500 font-mono"
+                                  title="{{ u.principal_id }}">{{ u.principal_id }}</span>
+                            <button type="button" class="text-gray-700 hover:text-accent-400 transition-colors"
+                                    onclick="copyToClipboard('{{ u.principal_id }}')" title="Copy ID">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            </button>
+                        </div>
+                    </td>
+                    <td class="px-5 py-4 text-sm text-white">{{ u.display_name }}</td>
+                    <td class="px-5 py-4">{{ reach_chip(u.reach) }}</td>
+                    <td class="px-5 py-4">
+                        <span class="text-[10px] text-gray-400 uppercase tracking-wider">{{ u.surface or "—" }}</span>
+                    </td>
+                    <td class="px-5 py-4 text-[11px] text-gray-500" title="{{ u.last_active_iso or '' }}">{{ u.last_active or "never" }}</td>
+                    <td class="px-5 py-4 space-x-1.5">
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Edit reach lands with /v1/admin/users (pending)">Edit reach</button>
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Revoke lands with /v1/admin/users (pending)">Revoke</button>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not users %}
+                <tr>
+                    <td colspan="6" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/></svg>
+                        <p class="text-sm text-gray-600">No users registered</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/app/dashboard/templates/workloads.html
+++ b/app/dashboard/templates/workloads.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% from "_principal_badge.html" import principal_badge, reach_chip %}
+{% block title %}Workloads{% endblock %}
+{% block header_title %}Workload Principals{% endblock %}
+{% block content %}
+<div id="page-content" data-sse-page="workloads" class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">Workloads</h2>
+            <p class="text-xs text-gray-600 mt-0.5">{{ workloads | length }} registered &middot; container/VM hosts of user principals (SPIFFE-attested)</p>
+        </div>
+    </div>
+
+    {% if not endpoint_ready %}
+    <div class="mb-4 px-4 py-3 rounded border border-yellow-700/40 bg-yellow-500/5 text-yellow-300 text-xs">
+        <strong class="font-semibold">Endpoint pending.</strong>
+        Showing demo cast hardcoded from <code class="font-mono">imp/insurance-demo-spec.md</code>.
+        Backend route <code class="font-mono">/v1/admin/workloads</code> lands in a follow-up PR.
+    </div>
+    {% endif %}
+
+    <!-- Workloads table -->
+    <div class="bg-surface-900/80 border border-gray-800/60 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Display name</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Hosted</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Image digest</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Runtime</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for w in workloads %}
+                <tr class="table-row-hover transition-colors">
+                    <td class="px-5 py-4">
+                        <div class="flex items-center gap-2">
+                            {{ principal_badge("workload") }}
+                            <span class="text-[10px] text-gray-500 font-mono"
+                                  title="{{ w.principal_id }}">{{ w.principal_id }}</span>
+                            <button type="button" class="text-gray-700 hover:text-accent-400 transition-colors"
+                                    onclick="copyToClipboard('{{ w.principal_id }}')" title="Copy ID">
+                                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/></svg>
+                            </button>
+                        </div>
+                    </td>
+                    <td class="px-5 py-4 text-sm text-white">{{ w.display_name }}</td>
+                    <td class="px-5 py-4">{{ reach_chip(w.reach) }}</td>
+                    <td class="px-5 py-4 text-xs text-gray-400 font-mono">{{ w.hosted_principals_count }}</td>
+                    <td class="px-5 py-4">
+                        {% if w.image_digest %}
+                        <span class="text-[10px] text-gray-400 font-mono" title="{{ w.image_digest }}">{{ w.image_digest[:14] }}…</span>
+                        {% else %}
+                        <span class="text-[10px] text-gray-700">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if w.runtime_status == "running" %}
+                        <span class="inline-flex items-center gap-1.5 text-[10px] text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Running
+                        </span>
+                        {% elif w.runtime_status == "unhealthy" %}
+                        <span class="inline-flex items-center gap-1.5 text-[10px] text-yellow-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-yellow-500"></span>Unhealthy
+                        </span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 text-[10px] text-gray-500 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-gray-700"></span>{{ w.runtime_status or "stopped" }}
+                        </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 space-x-1.5">
+                        <button type="button" disabled
+                                class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-800/60 text-gray-700 rounded cursor-not-allowed"
+                                title="Manage lands with /v1/admin/workloads (pending)">Manage</button>
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not workloads %}
+                <tr>
+                    <td colspan="7" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+                        <p class="text-sm text-gray-600">No workloads registered</p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/frontend/cullis-chat/mock/ambassador.mjs
+++ b/frontend/cullis-chat/mock/ambassador.mjs
@@ -128,6 +128,71 @@ function unauthorized(res) {
   jsonResponse(res, 401, { error: { code: 'no_bearer', message: 'Bearer required' } });
 }
 
+// ─── Inbox in-memory store ──────────────────────────────────────────
+// Seeded with one demo row so /inbox renders a real message in
+// Playwright. send() appends, ack() flips delivery_state, archive()
+// removes from the visible list. Mirrors the broker `InboxItem`
+// shape (`app/inbox/router.py`).
+const INBOX_MOCK = (() => {
+  const nowIso = () => new Date().toISOString();
+  const ttlIso = (h = 24) =>
+    new Date(Date.now() + h * 3600 * 1000).toISOString();
+  const seed = {
+    msg_id: 'msg_seed_001',
+    sender_org_id: 'mediterranean',
+    sender_principal_type: 'agent',
+    sender_name: 'night-reporter',
+    subject: 'Cross-company-flagged claims · nightly summary',
+    body:
+      'Two claims flagged for cross-company review overnight:\n\n' +
+      '  · CLM-2026-0412 (vehicle, asia-pacific)\n' +
+      '  · CLM-2026-0419 (property, asia-pacific)\n\n' +
+      'See the audit chain for full provenance.',
+    delivery_state: 'pending',
+    consent_id: null,
+    enqueued_at: nowIso(),
+    delivered_at: null,
+    ttl_expires_at: ttlIso(72),
+  };
+  const rows = [seed];
+  return {
+    list() { return rows.filter((r) => r.delivery_state !== 'archived'); },
+    send(body) {
+      const msg_id = 'msg_' + Math.random().toString(36).slice(2, 10);
+      rows.unshift({
+        msg_id,
+        sender_org_id: 'demo',
+        sender_principal_type: 'user',
+        sender_name: 'mario',
+        subject: body?.subject ?? null,
+        body: body?.body ?? '',
+        delivery_state: 'pending',
+        consent_id: null,
+        enqueued_at: nowIso(),
+        delivered_at: null,
+        ttl_expires_at: ttlIso(24),
+      });
+      return { msg_id, inserted: true, quadrant: 'u2u' };
+    },
+    ack(msgId) {
+      const row = rows.find((r) => r.msg_id === msgId);
+      if (!row) return false;
+      if (row.delivery_state === 'pending') {
+        row.delivery_state = 'delivered';
+        row.delivered_at = nowIso();
+        return true;
+      }
+      return false;
+    },
+    archive(msgId) {
+      const row = rows.find((r) => r.msg_id === msgId);
+      if (!row) return false;
+      row.delivery_state = 'archived';
+      return true;
+    },
+  };
+})();
+
 const server = createServer(async (req, res) => {
   // Loopback-only — same posture as the real Ambassador.
   if (!['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.socket.remoteAddress ?? '')) {
@@ -226,6 +291,40 @@ const server = createServer(async (req, res) => {
       ],
     });
     return;
+  }
+
+  // ─── Inbox surface (ADR-020 Phase 4) ────────────────────────────
+  // The mock keeps an in-memory list seeded with one demo message so
+  // /inbox renders a real row in Playwright. POST /send appends a
+  // synthetic msg_id and refreshes the list. Ack/archive are wired
+  // for end-to-end coverage of the read/dismiss UI flows.
+  if (req.method === 'GET' && pathname === '/v1/inbox') {
+    jsonResponse(res, 200, INBOX_MOCK.list());
+    return;
+  }
+  if (req.method === 'POST' && pathname === '/v1/inbox/send') {
+    let body;
+    try { body = await readJson(req); } catch {
+      jsonResponse(res, 400, { error: { code: 'bad_json' } });
+      return;
+    }
+    const result = INBOX_MOCK.send(body);
+    jsonResponse(res, 201, result);
+    return;
+  }
+  {
+    const m = pathname.match(/^\/v1\/inbox\/([^/]+)\/(ack|archive)$/);
+    if (m && req.method === 'POST') {
+      const [, msgId, action] = m;
+      if (action === 'ack') {
+        const flipped = INBOX_MOCK.ack(msgId);
+        jsonResponse(res, 200, { acked: flipped, msg_id: msgId });
+      } else {
+        const archived = INBOX_MOCK.archive(msgId);
+        jsonResponse(res, 200, { archived, msg_id: msgId });
+      }
+      return;
+    }
   }
 
   if (req.method === 'POST' && pathname === '/v1/chat/completions') {

--- a/frontend/cullis-chat/src/components/Inbox.tsx
+++ b/frontend/cullis-chat/src/components/Inbox.tsx
@@ -1,0 +1,671 @@
+/**
+ * Inbox — shared component for Cullis Chat (consumer) and Frontdesk
+ * (enterprise). Lists pending messages, opens a detail panel with
+ * audit-chain provenance, and offers a compose form for the four
+ * ADR-020 quadrants (U2A, U2U, A2U, A2A).
+ *
+ * Backend contract: `app/inbox/router.py` (REST surface) +
+ * `lib/api.ts::INBOX_BASE`. Audit-chain detail (`/v1/audit/messages/
+ * {msg_id}`) is BLOCKED in the spec until the broker ships it; the
+ * detail panel renders a placeholder so the demo screenshot is honest.
+ *
+ * The component is intentionally one file: split lands in Phase 3
+ * when the SPA core is extracted into `components/core/`.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  ackInboxMessage,
+  archiveInboxMessage,
+  ApiError,
+  listInbox,
+  sendInboxMessage,
+} from '../lib/api';
+import { ensureSession } from '../lib/session-singleton';
+import type {
+  InboxMessage,
+  InboxSendRequest,
+  InboxTab,
+  PrincipalType,
+} from '../lib/types';
+import PrincipalBadge from './core/PrincipalBadge';
+
+const TABS: { id: InboxTab; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'unread', label: 'Unread' },
+  { id: 'sent', label: 'Sent' },
+  { id: 'drafts', label: 'Drafts' },
+];
+
+const PRINCIPAL_TYPES: PrincipalType[] = ['user', 'agent', 'workload'];
+
+function formatRelative(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return iso;
+  const delta = Math.max(0, Date.now() - t);
+  if (delta < 60_000) return 'just now';
+  if (delta < 3_600_000) return `${Math.floor(delta / 60_000)}m`;
+  if (delta < 86_400_000) return `${Math.floor(delta / 3_600_000)}h`;
+  return `${Math.floor(delta / 86_400_000)}d`;
+}
+
+function deriveSubject(msg: InboxMessage): string {
+  if (msg.subject && msg.subject.trim()) return msg.subject;
+  // Prefer the first line of the body, capped — same shape as Mail.app.
+  const firstLine = msg.body.split('\n')[0]?.trim() ?? '';
+  if (firstLine.length > 80) return `${firstLine.slice(0, 77)}…`;
+  return firstLine || '(no subject)';
+}
+
+function snippet(body: string): string {
+  const flat = body.replace(/\s+/g, ' ').trim();
+  return flat.length > 120 ? `${flat.slice(0, 117)}…` : flat;
+}
+
+interface ToastState {
+  kind: 'success' | 'error';
+  message: string;
+}
+
+export default function Inbox() {
+  const [messages, setMessages] = useState<InboxMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<InboxTab>('all');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [composing, setComposing] = useState(false);
+  const [toast, setToast] = useState<ToastState | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await ensureSession();
+      const rows = await listInbox({ limit: 50 });
+      setMessages(rows);
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? `api error ${err.status}` : 'failed to load';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Auto-dismiss toasts after 3.5s — never block the surface.
+  useEffect(() => {
+    if (!toast) return;
+    const t = window.setTimeout(() => setToast(null), 3500);
+    return () => window.clearTimeout(t);
+  }, [toast]);
+
+  const filtered = useMemo(() => {
+    switch (tab) {
+      case 'unread':
+        return messages.filter((m) => m.delivery_state === 'pending');
+      case 'sent':
+      case 'drafts':
+        // Sent + Drafts require server-side support that lands with
+        // the four-quadrant outbox — for Phase 2 they render an empty
+        // state so the tab affordance is real.
+        return [];
+      case 'all':
+      default:
+        return messages;
+    }
+  }, [messages, tab]);
+
+  const selected = useMemo(
+    () => (selectedId ? messages.find((m) => m.msg_id === selectedId) ?? null : null),
+    [messages, selectedId],
+  );
+
+  const handleAck = useCallback(
+    async (msgId: string) => {
+      try {
+        await ackInboxMessage(msgId);
+        setMessages((rows) =>
+          rows.map((r) =>
+            r.msg_id === msgId ? { ...r, delivery_state: 'delivered' } : r,
+          ),
+        );
+      } catch (err) {
+        setToast({ kind: 'error', message: 'ack failed' });
+      }
+    },
+    [],
+  );
+
+  const handleArchive = useCallback(
+    async (msgId: string) => {
+      try {
+        await archiveInboxMessage(msgId);
+        setMessages((rows) => rows.filter((r) => r.msg_id !== msgId));
+        setSelectedId((cur) => (cur === msgId ? null : cur));
+        setToast({ kind: 'success', message: 'archived' });
+      } catch (err) {
+        setToast({ kind: 'error', message: 'archive failed' });
+      }
+    },
+    [],
+  );
+
+  const handleSent = useCallback(() => {
+    setComposing(false);
+    setToast({ kind: 'success', message: 'message sent' });
+    void refresh();
+  }, [refresh]);
+
+  const handleSendError = useCallback((message: string) => {
+    setToast({ kind: 'error', message });
+  }, []);
+
+  return (
+    <main className="inbox-main" aria-label="Inbox">
+      <header className="inbox-header">
+        <div className="inbox-header-titles">
+          <p className="folio">cullis · inbox</p>
+          <h1 className="inbox-title">
+            <em>Messages</em>
+          </h1>
+        </div>
+        <button
+          type="button"
+          className="inbox-compose-btn"
+          onClick={() => {
+            setComposing(true);
+            setSelectedId(null);
+          }}
+        >
+          + Compose
+        </button>
+      </header>
+
+      <nav className="inbox-tabs" aria-label="Inbox filter">
+        {TABS.map((t) => {
+          const count =
+            t.id === 'unread'
+              ? messages.filter((m) => m.delivery_state === 'pending').length
+              : t.id === 'all'
+                ? messages.length
+                : 0;
+          const active = tab === t.id;
+          return (
+            <button
+              key={t.id}
+              type="button"
+              className={`inbox-tab${active ? ' inbox-tab-active' : ''}`}
+              aria-pressed={active}
+              onClick={() => setTab(t.id)}
+            >
+              <span>{t.label}</span>
+              {count > 0 ? <span className="inbox-tab-count">{count}</span> : null}
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="inbox-body">
+        <section className="inbox-list" aria-label="Message list">
+          {loading ? (
+            <InboxSkeleton />
+          ) : error ? (
+            <InboxError message={error} onRetry={refresh} />
+          ) : filtered.length === 0 ? (
+            <InboxEmpty tab={tab} />
+          ) : (
+            <ol className="inbox-rows">
+              {filtered.map((m) => (
+                <InboxRow
+                  key={m.msg_id}
+                  message={m}
+                  selected={m.msg_id === selectedId}
+                  onSelect={() => {
+                    setSelectedId(m.msg_id);
+                    setComposing(false);
+                  }}
+                />
+              ))}
+            </ol>
+          )}
+        </section>
+
+        <aside className="inbox-detail" aria-label="Message detail">
+          {composing ? (
+            <ComposeForm
+              onSent={handleSent}
+              onError={handleSendError}
+              onCancel={() => setComposing(false)}
+            />
+          ) : selected ? (
+            <MessageDetail
+              message={selected}
+              onAck={() => handleAck(selected.msg_id)}
+              onArchive={() => handleArchive(selected.msg_id)}
+            />
+          ) : (
+            <DetailPlaceholder />
+          )}
+        </aside>
+      </div>
+
+      {toast ? (
+        <div
+          role="status"
+          className={`inbox-toast inbox-toast-${toast.kind}`}
+        >
+          {toast.message}
+        </div>
+      ) : null}
+    </main>
+  );
+}
+
+// ─── Sub-components ──────────────────────────────────────────────────
+
+interface InboxRowProps {
+  message: InboxMessage;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+function InboxRow({ message, selected, onSelect }: InboxRowProps) {
+  const unread = message.delivery_state === 'pending';
+  const cls = [
+    'inbox-row',
+    unread ? 'inbox-row-unread' : '',
+    selected ? 'inbox-row-selected' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return (
+    <li>
+      <button type="button" className={cls} onClick={onSelect}>
+        <div className="inbox-row-head">
+          <PrincipalBadge type={message.sender_principal_type} size="sm" />
+          <span className="inbox-row-sender">{message.sender_name}</span>
+          <span className="inbox-row-org" title={message.sender_org_id}>
+            {message.sender_org_id}
+          </span>
+          <time className="inbox-row-time" dateTime={message.enqueued_at}>
+            {formatRelative(message.enqueued_at)}
+          </time>
+        </div>
+        <div className="inbox-row-subject">{deriveSubject(message)}</div>
+        <div className="inbox-row-snippet">{snippet(message.body)}</div>
+        <div className="inbox-row-meta">
+          <VerificationChip state={message.delivery_state} />
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function VerificationChip({ state }: { state: string }) {
+  // The backend hash chain runs server-side and is verified at every
+  // append. The SPA can only surface the delivery state that the
+  // recipient sees: pending = arrived but not yet acked, delivered =
+  // hash-chain row landed and acked, archived = soft-hidden.
+  const map: Record<string, { label: string; tone: 'ok' | 'warn' | 'mute' }> = {
+    pending: { label: 'verified ✓', tone: 'ok' },
+    delivered: { label: 'verified ✓', tone: 'ok' },
+    archived: { label: 'archived', tone: 'mute' },
+  };
+  const meta = map[state] ?? { label: state, tone: 'mute' as const };
+  return (
+    <span className={`verify-chip verify-chip-${meta.tone}`}>{meta.label}</span>
+  );
+}
+
+function MessageDetail({
+  message,
+  onAck,
+  onArchive,
+}: {
+  message: InboxMessage;
+  onAck: () => void;
+  onArchive: () => void;
+}) {
+  return (
+    <article className="msg-detail">
+      <header className="msg-detail-head">
+        <div className="msg-detail-titles">
+          <p className="folio">message</p>
+          <h2 className="msg-detail-subject">{deriveSubject(message)}</h2>
+        </div>
+        <div className="msg-detail-actions">
+          {message.delivery_state === 'pending' ? (
+            <button type="button" onClick={onAck} className="msg-action">
+              Mark read
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={onArchive}
+            className="msg-action msg-action-danger"
+          >
+            Archive
+          </button>
+        </div>
+      </header>
+
+      <dl className="msg-detail-fields">
+        <div>
+          <dt>From</dt>
+          <dd className="msg-detail-from">
+            <PrincipalBadge
+              type={message.sender_principal_type}
+              size="sm"
+            />
+            <span>{message.sender_name}</span>
+            <span className="msg-detail-org">@ {message.sender_org_id}</span>
+          </dd>
+        </div>
+        <div>
+          <dt>Received</dt>
+          <dd>
+            <time dateTime={message.enqueued_at}>{message.enqueued_at}</time>
+          </dd>
+        </div>
+        <div>
+          <dt>Expires</dt>
+          <dd>
+            <time dateTime={message.ttl_expires_at}>
+              {message.ttl_expires_at}
+            </time>
+          </dd>
+        </div>
+        {message.consent_id ? (
+          <div>
+            <dt>Consent</dt>
+            <dd className="msg-detail-mono">{message.consent_id}</dd>
+          </div>
+        ) : null}
+      </dl>
+
+      <section className="msg-detail-body">
+        <h3 className="msg-detail-section-title">
+          <em>Body</em>
+        </h3>
+        <pre className="msg-detail-pre">{message.body}</pre>
+      </section>
+
+      <section className="msg-detail-audit">
+        <h3 className="msg-detail-section-title">
+          <em>Audit chain</em>
+        </h3>
+        <p className="msg-detail-audit-pending">
+          Per-message audit chain detail
+          (<code>GET /v1/audit/messages/{message.msg_id}</code>) lands when
+          the broker exposes the route. Server-side, every row is appended
+          to the per-org hash chain and dual-written through Court for
+          cross-org messages.
+        </p>
+        <dl className="msg-detail-fields">
+          <div>
+            <dt>msg_id</dt>
+            <dd className="msg-detail-mono">{message.msg_id}</dd>
+          </div>
+          <div>
+            <dt>state</dt>
+            <dd>
+              <VerificationChip state={message.delivery_state} />
+            </dd>
+          </div>
+        </dl>
+      </section>
+    </article>
+  );
+}
+
+function ComposeForm({
+  onSent,
+  onError,
+  onCancel,
+}: {
+  onSent: () => void;
+  onError: (message: string) => void;
+  onCancel: () => void;
+}) {
+  const [recipientOrg, setRecipientOrg] = useState('');
+  const [recipientType, setRecipientType] = useState<PrincipalType>('user');
+  const [recipientName, setRecipientName] = useState('');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const reachLabel = useMemo(() => {
+    const trimmed = recipientOrg.trim().toLowerCase();
+    if (!trimmed) return null;
+    // Heuristic: same-org if recipientOrg matches the caller's org —
+    // for Phase 2 we don't have caller principal yet, so we just
+    // show the recipient quadrant target so the user sees what kind
+    // of capability scope is being exercised.
+    return `target: ${recipientType}@${trimmed}`;
+  }, [recipientOrg, recipientType]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!recipientOrg || !recipientName || !body) return;
+    setSending(true);
+    try {
+      const req: InboxSendRequest = {
+        recipient_org_id: recipientOrg.trim(),
+        recipient_principal_type: recipientType,
+        recipient_name: recipientName.trim(),
+        body,
+        subject: subject.trim() || undefined,
+      };
+      await sendInboxMessage(req);
+      onSent();
+      // Clear after a successful send so the form is ready for the
+      // next compose without manual reset.
+      setRecipientOrg('');
+      setRecipientName('');
+      setSubject('');
+      setBody('');
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? `send failed (${err.status})`
+          : 'send failed';
+      onError(msg);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const canSend = !!(
+    recipientOrg.trim() &&
+    recipientName.trim() &&
+    body.trim() &&
+    !sending
+  );
+
+  return (
+    <form className="msg-compose" onSubmit={submit}>
+      <header className="msg-detail-head">
+        <div className="msg-detail-titles">
+          <p className="folio">new message</p>
+          <h2 className="msg-detail-subject">
+            <em>Compose</em>
+          </h2>
+        </div>
+        <div className="msg-detail-actions">
+          <button
+            type="button"
+            className="msg-action"
+            onClick={onCancel}
+            disabled={sending}
+          >
+            Cancel
+          </button>
+        </div>
+      </header>
+
+      <fieldset className="msg-compose-fieldset" disabled={sending}>
+        <label className="msg-compose-row">
+          <span className="msg-compose-label">recipient org</span>
+          <input
+            type="text"
+            value={recipientOrg}
+            onChange={(e) => setRecipientOrg(e.target.value)}
+            placeholder="mediterranean"
+            spellCheck={false}
+            autoComplete="off"
+            required
+          />
+        </label>
+
+        <label className="msg-compose-row">
+          <span className="msg-compose-label">recipient type</span>
+          <select
+            value={recipientType}
+            onChange={(e) => setRecipientType(e.target.value as PrincipalType)}
+          >
+            {PRINCIPAL_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="msg-compose-row">
+          <span className="msg-compose-label">recipient name</span>
+          <input
+            type="text"
+            value={recipientName}
+            onChange={(e) => setRecipientName(e.target.value)}
+            placeholder="claim-officer"
+            spellCheck={false}
+            autoComplete="off"
+            required
+          />
+        </label>
+
+        <label className="msg-compose-row">
+          <span className="msg-compose-label">subject</span>
+          <input
+            type="text"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="optional"
+            autoComplete="off"
+          />
+        </label>
+
+        <label className="msg-compose-row msg-compose-row-stack">
+          <span className="msg-compose-label">body</span>
+          <textarea
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            rows={10}
+            placeholder="Body (Markdown allowed)"
+            required
+          />
+        </label>
+      </fieldset>
+
+      <footer className="msg-compose-footer">
+        {reachLabel ? (
+          <span className="msg-compose-scope" title="Capability scope">
+            {reachLabel}
+          </span>
+        ) : (
+          <span />
+        )}
+        <button
+          type="submit"
+          className="msg-compose-send"
+          disabled={!canSend}
+        >
+          {sending ? 'Sending…' : 'Send'}
+        </button>
+      </footer>
+    </form>
+  );
+}
+
+function InboxSkeleton() {
+  return (
+    <ol className="inbox-rows" aria-busy="true">
+      {[0, 1, 2, 3, 4].map((i) => (
+        <li key={i}>
+          <div className="inbox-row inbox-row-skeleton">
+            <div className="skel-line skel-line-head" />
+            <div className="skel-line skel-line-subject" />
+            <div className="skel-line skel-line-snippet" />
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function InboxEmpty({ tab }: { tab: InboxTab }) {
+  const copy: Record<InboxTab, { title: string; body: string }> = {
+    all: {
+      title: 'Empty.',
+      body: 'No messages have been delivered to this principal yet.',
+    },
+    unread: {
+      title: 'All caught up.',
+      body: 'Nothing pending. Acked messages move to All.',
+    },
+    sent: {
+      title: 'Sent items',
+      body: 'The four-quadrant outbox lands in a follow-up. Sent appears here.',
+    },
+    drafts: {
+      title: 'No drafts',
+      body: 'Local drafts arrive with the offline composer in Phase 5.',
+    },
+  };
+  const c = copy[tab];
+  return (
+    <div className="inbox-empty">
+      <p className="inbox-empty-title">
+        <em>{c.title}</em>
+      </p>
+      <p className="inbox-empty-body">{c.body}</p>
+    </div>
+  );
+}
+
+function InboxError({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="inbox-error">
+      <p className="inbox-error-title">
+        <em>Could not load.</em>
+      </p>
+      <p className="inbox-error-body">{message}</p>
+      <button type="button" className="msg-action" onClick={onRetry}>
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function DetailPlaceholder() {
+  return (
+    <div className="inbox-detail-empty">
+      <p className="inbox-empty-title">
+        <em>No message selected.</em>
+      </p>
+      <p className="inbox-empty-body">
+        Pick a row to read it, or compose a new one.
+      </p>
+    </div>
+  );
+}

--- a/frontend/cullis-chat/src/components/SidebarLeft.astro
+++ b/frontend/cullis-chat/src/components/SidebarLeft.astro
@@ -7,15 +7,46 @@
 // voice: a short headline in italic serif and a folio note.
 //
 // Becomes a real list in v0.5 (ADR-019 Step 6 — server-side history).
+//
+// `active` is the surface name passed from the page Astro file
+// (`chat` for index.astro, `inbox` for inbox.astro). Used to mark
+// the matching surface link in the in-rail navigation.
+
+interface Props {
+  active?: 'chat' | 'inbox';
+}
+const { active = 'chat' } = Astro.props as Props;
+const base = import.meta.env.BASE_URL;
+const chatHref = base;
+const inboxHref = `${base}inbox`;
 ---
 
 <aside class="sidebar-left" aria-label="Conversation history">
   <header class="sl-head">
     <span class="eyebrow">conversations</span>
-    <a class="sl-new" href={import.meta.env.BASE_URL} aria-label="Start a new chat" title="New chat">
+    <a class="sl-new" href={chatHref} aria-label="Start a new chat" title="New chat">
       <span aria-hidden="true">+</span> new
     </a>
   </header>
+
+  <nav class="sl-surfaces" aria-label="Surfaces">
+    <a
+      href={chatHref}
+      class:list={['sl-surface', { 'sl-surface-active': active === 'chat' }]}
+      aria-current={active === 'chat' ? 'page' : undefined}
+    >
+      <span class="sl-surface-label">Chat</span>
+      <span class="sl-surface-hint">conversation</span>
+    </a>
+    <a
+      href={inboxHref}
+      class:list={['sl-surface', { 'sl-surface-active': active === 'inbox' }]}
+      aria-current={active === 'inbox' ? 'page' : undefined}
+    >
+      <span class="sl-surface-label">Inbox</span>
+      <span class="sl-surface-hint">messages</span>
+    </a>
+  </nav>
 
   <div class="sl-empty">
     <p class="sl-empty-title">
@@ -67,6 +98,53 @@
   .sl-new:hover, .sl-new:focus-visible {
     color: var(--accent-cyan);
     border-color: var(--accent-cyan);
+  }
+
+  .sl-surfaces {
+    display: flex;
+    flex-direction: column;
+    padding: 0.4rem 0.6rem 0.6rem;
+    gap: 0.1rem;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+
+  .sl-surface {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.6rem;
+    padding: 0.55rem 0.7rem;
+    text-decoration: none;
+    color: var(--text-secondary);
+    border-left: 2px solid transparent;
+    transition: color var(--t-base) ease, background var(--t-base) ease,
+      border-color var(--t-base) ease;
+  }
+
+  .sl-surface:hover {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--accent-cyan) 3%, transparent);
+  }
+
+  .sl-surface-active {
+    color: var(--accent-cyan);
+    border-left-color: var(--accent-cyan);
+    background: color-mix(in srgb, var(--accent-cyan) 5%, transparent);
+  }
+
+  .sl-surface-label {
+    font-family: var(--font-display);
+    font-size: 1rem;
+    font-style: italic;
+    letter-spacing: -0.005em;
+  }
+
+  .sl-surface-hint {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: var(--text-tertiary);
   }
 
   .sl-empty {

--- a/frontend/cullis-chat/src/components/core/PrincipalBadge.tsx
+++ b/frontend/cullis-chat/src/components/core/PrincipalBadge.tsx
@@ -1,0 +1,35 @@
+/**
+ * PrincipalBadge — shared chip for the three ADR-020 principal types.
+ *
+ * Single component used wherever a principal is rendered: inbox sender,
+ * dashboard tables, audit log rows, identity panel. Color comes from
+ * design tokens declared in `styles/tokens.css` (mirror of
+ * `site/global.css`):
+ *
+ *   --cullis-badge-user      #3b7af5
+ *   --cullis-badge-agent     #8b5cf6
+ *   --cullis-badge-workload  #10b981
+ *
+ * Pure presentational, no state, no fetches.
+ */
+import type { PrincipalType } from '../../lib/types';
+
+interface Props {
+  type: PrincipalType;
+  /** Compact: 9px font for tight rows. Default 10px. */
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+const LABELS: Record<PrincipalType, string> = {
+  user: 'User',
+  agent: 'Agent',
+  workload: 'Workload',
+};
+
+export default function PrincipalBadge({ type, size = 'md', className }: Props) {
+  const cls = ['principal-badge', `principal-badge-${type}`];
+  if (size === 'sm') cls.push('principal-badge-sm');
+  if (className) cls.push(className);
+  return <span className={cls.join(' ')}>{LABELS[type]}</span>;
+}

--- a/frontend/cullis-chat/src/lib/api.ts
+++ b/frontend/cullis-chat/src/lib/api.ts
@@ -23,9 +23,21 @@ import { parseSSE, type SSEEvent } from './sse';
 import type {
   ChatCompletionRequest,
   ChatCompletionResponse,
+  InboxMessage,
+  InboxSendRequest,
+  InboxSendResponse,
   Model,
   Principal,
 } from './types';
+
+/**
+ * Inbox base path. The spec at `imp/insurance-demo-spec.md` originally
+ * named this `/v1/egress/message/*`; the broker today exposes
+ * `/v1/inbox/*` (see `app/inbox/router.py`). Tracked as a BLOCKED:
+ * note in the spec — flip this constant when the rename lands and
+ * everything else just works.
+ */
+const INBOX_BASE = '/v1/inbox';
 
 class ApiError extends Error {
   constructor(public status: number, public payload: unknown) {
@@ -116,5 +128,51 @@ export async function* chatCompletionStream(
   yield* parseSSE(res.body, signal);
 }
 
-export { ApiError };
+// ─── Inbox surface (ADR-020 Phase 4) ──────────────────────────────────
+
+/** GET /v1/inbox — list messages addressed to the caller. */
+export async function listInbox(opts?: {
+  since?: string;
+  limit?: number;
+  includeArchived?: boolean;
+}): Promise<InboxMessage[]> {
+  const qs = new URLSearchParams();
+  if (opts?.since) qs.set('since', opts.since);
+  if (opts?.limit !== undefined) qs.set('limit', String(opts.limit));
+  if (opts?.includeArchived) qs.set('include_archived', 'true');
+  const suffix = qs.toString();
+  const url = suffix ? `${INBOX_BASE}?${suffix}` : INBOX_BASE;
+  return jsonFetch<InboxMessage[]>(url);
+}
+
+/** POST /v1/inbox/send — enqueue a message to a Cullis principal. */
+export async function sendInboxMessage(
+  req: InboxSendRequest,
+): Promise<InboxSendResponse> {
+  return jsonFetch<InboxSendResponse>(`${INBOX_BASE}/send`, {
+    method: 'POST',
+    body: JSON.stringify(req),
+  });
+}
+
+/** POST /v1/inbox/{msg_id}/ack — mark delivered. */
+export async function ackInboxMessage(
+  msgId: string,
+  online: boolean = false,
+): Promise<{ acked: boolean; msg_id: string }> {
+  const url = `${INBOX_BASE}/${encodeURIComponent(msgId)}/ack${online ? '?online=true' : ''}`;
+  return jsonFetch<{ acked: boolean; msg_id: string }>(url, { method: 'POST' });
+}
+
+/** POST /v1/inbox/{msg_id}/archive — soft hide. */
+export async function archiveInboxMessage(
+  msgId: string,
+): Promise<{ archived: boolean; msg_id: string }> {
+  return jsonFetch<{ archived: boolean; msg_id: string }>(
+    `${INBOX_BASE}/${encodeURIComponent(msgId)}/archive`,
+    { method: 'POST' },
+  );
+}
+
+export { ApiError, INBOX_BASE };
 export type { SSEEvent };

--- a/frontend/cullis-chat/src/lib/types.ts
+++ b/frontend/cullis-chat/src/lib/types.ts
@@ -69,3 +69,42 @@ export interface ChatCompletionResponse {
   choices: { index: number; message: { role: ChatRole; content: string }; finish_reason: string }[];
   cullis_audit?: AuditTrace;
 }
+
+/**
+ * ADR-020 Phase 4 — REST inbox surface.
+ *
+ * Mirrors `app.inbox.router.InboxItem` (broker side). Field shape is
+ * stable across single and shared mode: only `sender_principal_type`
+ * may differ between flows (user/agent/workload).
+ */
+export interface InboxMessage {
+  msg_id: string;
+  sender_org_id: string;
+  sender_principal_type: PrincipalType;
+  sender_name: string;
+  subject: string | null;
+  body: string;
+  delivery_state: 'pending' | 'delivered' | 'archived' | string;
+  consent_id: string | null;
+  enqueued_at: string;
+  delivered_at: string | null;
+  ttl_expires_at: string;
+}
+
+export interface InboxSendRequest {
+  recipient_org_id: string;
+  recipient_principal_type: PrincipalType;
+  recipient_name: string;
+  body: string;
+  subject?: string;
+  idempotency_key?: string;
+}
+
+export interface InboxSendResponse {
+  msg_id: string;
+  inserted: boolean;
+  quadrant: string;
+}
+
+/** Inbox UI tabs — drives client-side filtering, not a server param. */
+export type InboxTab = 'all' | 'unread' | 'sent' | 'drafts';

--- a/frontend/cullis-chat/src/pages/inbox.astro
+++ b/frontend/cullis-chat/src/pages/inbox.astro
@@ -1,0 +1,33 @@
+---
+// Inbox page — companion surface to /chat. Same shell (TopBar +
+// SidebarLeft) but renders the React island <Inbox /> in the main
+// area instead of <ChatApp />. Phase 3 of the SPA rework refactors
+// the shared shell into a single layout with a slot; until then the
+// duplication is intentional and small.
+import '../styles/tokens.css';
+import '../styles/globals.css';
+import '../styles/inbox.css';
+import TopBar from '../components/TopBar.astro';
+import SidebarLeft from '../components/SidebarLeft.astro';
+import Inbox from '../components/Inbox.tsx';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#050508" />
+    <meta name="description" content="Cullis Chat inbox — identity-aware messages for users and agents." />
+    <meta name="referrer" content="same-origin" />
+    <title>Inbox · Cullis Chat</title>
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}cullis-mark.svg`} />
+  </head>
+  <body class="app-shell">
+    <TopBar />
+    <div class="app-body">
+      <SidebarLeft active="inbox" />
+      <Inbox client:load />
+    </div>
+  </body>
+</html>

--- a/frontend/cullis-chat/src/styles/inbox.css
+++ b/frontend/cullis-chat/src/styles/inbox.css
@@ -1,0 +1,671 @@
+/* Inbox — Cullis Chat / Frontdesk shared surface.
+ *
+ * Same editorial industrial voice as the chat shell: serif italic
+ * display, mono caps eyebrow, accent-cyan, zero radius. CSS-only,
+ * no JS hover states. Lives in a separate file so consumers that
+ * never load /inbox don't pay the bytes.
+ */
+
+.inbox-main {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: var(--bg-void);
+  overflow: hidden;
+}
+
+/* ─── Header ──────────────────────────────────────────────── */
+
+.inbox-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.4rem 1.6rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.inbox-header-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.inbox-title {
+  font-family: var(--font-display);
+  font-size: 1.65rem;
+  line-height: 1;
+  color: var(--text-primary);
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.inbox-title em {
+  font-style: italic;
+  color: var(--accent-cyan);
+}
+
+.inbox-compose-btn {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bg-void);
+  background: var(--accent-cyan);
+  border: 1px solid var(--accent-cyan);
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+  transition: background var(--t-base) ease, color var(--t-base) ease;
+}
+
+.inbox-compose-btn:hover,
+.inbox-compose-btn:focus-visible {
+  background: var(--text-primary);
+  color: var(--bg-void);
+}
+
+/* ─── Tabs ───────────────────────────────────────────────── */
+
+.inbox-tabs {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.6rem 1.6rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+}
+
+.inbox-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--text-tertiary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: 2px solid transparent;
+  padding: 0.4rem 0.8rem 0.45rem;
+  cursor: pointer;
+  transition: color var(--t-base) ease, border-color var(--t-base) ease;
+}
+
+.inbox-tab:hover {
+  color: var(--text-secondary);
+}
+
+.inbox-tab-active {
+  color: var(--accent-cyan);
+  border-bottom-color: var(--accent-cyan);
+}
+
+.inbox-tab-count {
+  font-size: 0.65rem;
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--text-primary) 8%, transparent);
+  padding: 0.05rem 0.4rem;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+.inbox-tab-active .inbox-tab-count {
+  background: var(--accent-cyan-glow);
+  color: var(--accent-cyan);
+}
+
+/* ─── Body — list + detail two-pane ──────────────────────── */
+
+.inbox-body {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(320px, 420px) 1fr;
+  min-height: 0;
+}
+
+@media (max-width: 880px) {
+  .inbox-body {
+    grid-template-columns: 1fr;
+  }
+  .inbox-detail {
+    display: none;
+  }
+}
+
+.inbox-list {
+  border-right: 1px solid var(--border-subtle);
+  overflow-y: auto;
+  background: var(--bg-surface);
+}
+
+.inbox-rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.inbox-rows li + li .inbox-row {
+  border-top: 1px solid var(--border-subtle);
+}
+
+.inbox-row {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  padding: 0.85rem 1.2rem;
+  cursor: pointer;
+  position: relative;
+  border-left: 2px solid transparent;
+  transition: background var(--t-base) ease, border-color var(--t-base) ease;
+  color: inherit;
+  font: inherit;
+}
+
+.inbox-row:hover {
+  background: color-mix(in srgb, var(--accent-cyan) 3%, transparent);
+}
+
+.inbox-row-selected {
+  background: color-mix(in srgb, var(--accent-cyan) 6%, transparent);
+  border-left-color: var(--accent-cyan);
+}
+
+.inbox-row-unread::before {
+  content: '';
+  position: absolute;
+  left: 0.5rem;
+  top: 50%;
+  width: 4px;
+  height: 4px;
+  background: var(--accent-cyan);
+  transform: translateY(-50%);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--accent-cyan) 60%, transparent);
+}
+
+.inbox-row-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.inbox-row-sender {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.83rem;
+}
+
+.inbox-row-org {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.05em;
+  margin-left: 0.1rem;
+}
+
+.inbox-row-time {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.inbox-row-subject {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  font-weight: 500;
+  margin-bottom: 0.18rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.inbox-row-unread .inbox-row-subject {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.inbox-row-snippet {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  line-height: 1.45;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.inbox-row-meta {
+  margin-top: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.verify-chip {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.05rem 0.4rem;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+}
+
+.verify-chip-ok {
+  color: var(--accent-cyan);
+  border-color: var(--accent-cyan-dim);
+  background: var(--accent-cyan-glow);
+}
+
+.verify-chip-warn {
+  color: var(--accent-amber);
+  border-color: color-mix(in srgb, var(--accent-amber) 30%, transparent);
+  background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
+}
+
+.verify-chip-mute {
+  color: var(--text-tertiary);
+}
+
+/* ─── Detail panel ───────────────────────────────────────── */
+
+.inbox-detail {
+  overflow-y: auto;
+  background: var(--bg-void);
+  padding: 1.4rem 1.6rem 2rem;
+}
+
+.msg-detail-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.msg-detail-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+}
+
+.msg-detail-subject {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  line-height: 1.15;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.01em;
+  word-break: break-word;
+}
+
+.msg-detail-subject em {
+  font-style: italic;
+  color: var(--accent-cyan);
+}
+
+.msg-detail-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.msg-action {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: color var(--t-base) ease, border-color var(--t-base) ease;
+}
+
+.msg-action:hover:not(:disabled),
+.msg-action:focus-visible:not(:disabled) {
+  color: var(--accent-cyan);
+  border-color: var(--accent-cyan);
+}
+
+.msg-action:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.msg-action-danger:hover:not(:disabled),
+.msg-action-danger:focus-visible:not(:disabled) {
+  color: #ff5b6b;
+  border-color: color-mix(in srgb, #ff5b6b 60%, transparent);
+}
+
+.msg-detail-fields {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem 1.2rem;
+  margin: 1rem 0;
+}
+
+.msg-detail-fields div {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 0.8rem;
+  align-items: baseline;
+}
+
+.msg-detail-fields dt {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.msg-detail-fields dd {
+  font-size: 0.83rem;
+  color: var(--text-primary);
+  margin: 0;
+  word-break: break-word;
+}
+
+.msg-detail-from {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.msg-detail-org {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+}
+
+.msg-detail-mono {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+}
+
+.msg-detail-section-title {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin: 1.2rem 0 0.6rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.msg-detail-section-title em {
+  font-style: italic;
+  color: var(--accent-cyan);
+  text-transform: none;
+  letter-spacing: 0.02em;
+  font-family: var(--font-display);
+  font-size: 1rem;
+}
+
+.msg-detail-body {
+  margin-top: 1rem;
+}
+
+.msg-detail-pre {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text-primary);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  padding: 1rem;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  max-height: 50vh;
+}
+
+.msg-detail-audit {
+  margin-top: 1rem;
+}
+
+.msg-detail-audit-pending {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  background: color-mix(in srgb, var(--accent-amber) 5%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-amber) 25%, transparent);
+  border-left-width: 2px;
+  padding: 0.7rem 0.9rem;
+  line-height: 1.5;
+}
+
+.msg-detail-audit-pending code {
+  font-family: var(--font-mono);
+  font-size: 0.74em;
+  background: var(--bg-card);
+  padding: 0 0.3em;
+}
+
+/* ─── Compose form ───────────────────────────────────────── */
+
+.msg-compose {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.msg-compose-fieldset {
+  border: 0;
+  padding: 1rem 0 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  flex: 1;
+}
+
+.msg-compose-row {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  align-items: baseline;
+  gap: 0.8rem;
+}
+
+.msg-compose-row-stack {
+  align-items: start;
+}
+
+.msg-compose-label {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.msg-compose-row input,
+.msg-compose-row select,
+.msg-compose-row textarea {
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  color: var(--text-primary);
+  padding: 0.45rem 0.65rem;
+  width: 100%;
+  outline: none;
+  transition: border-color var(--t-base) ease, box-shadow var(--t-base) ease;
+}
+
+.msg-compose-row textarea {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  resize: vertical;
+  min-height: 8rem;
+  line-height: 1.5;
+}
+
+.msg-compose-row input:focus,
+.msg-compose-row select:focus,
+.msg-compose-row textarea:focus {
+  border-color: var(--input-border-focus);
+  box-shadow: 0 0 0 1px var(--input-border-focus);
+}
+
+.msg-compose-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-subtle);
+  margin-top: 0.8rem;
+}
+
+.msg-compose-scope {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  padding: 0.3rem 0.6rem;
+}
+
+.msg-compose-send {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--bg-void);
+  background: var(--accent-cyan);
+  border: 1px solid var(--accent-cyan);
+  padding: 0.55rem 1.2rem;
+  cursor: pointer;
+  transition: background var(--t-base) ease, color var(--t-base) ease;
+}
+
+.msg-compose-send:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.msg-compose-send:hover:not(:disabled),
+.msg-compose-send:focus-visible:not(:disabled) {
+  background: var(--text-primary);
+  color: var(--bg-void);
+}
+
+/* ─── Empty / error / placeholder states ─────────────────── */
+
+.inbox-empty,
+.inbox-error,
+.inbox-detail-empty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding: 3rem 1.6rem;
+  align-items: flex-start;
+}
+
+.inbox-empty-title,
+.inbox-error-title {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  line-height: 1.1;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.inbox-empty-title em,
+.inbox-error-title em {
+  font-style: italic;
+  color: var(--accent-cyan);
+}
+
+.inbox-empty-body,
+.inbox-error-body {
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+  max-width: 32ch;
+  margin: 0;
+  line-height: 1.55;
+}
+
+.inbox-error-body {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--accent-amber);
+  background: color-mix(in srgb, var(--accent-amber) 6%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent-amber) 25%, transparent);
+  padding: 0.5rem 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+/* ─── Skeleton ───────────────────────────────────────────── */
+
+.inbox-row-skeleton {
+  cursor: default;
+}
+
+.skel-line {
+  height: 0.55rem;
+  background: linear-gradient(90deg,
+    var(--border-subtle) 0%,
+    color-mix(in srgb, var(--text-primary) 8%, transparent) 50%,
+    var(--border-subtle) 100%);
+  background-size: 200% 100%;
+  animation: skel-shimmer 1.6s ease-in-out infinite;
+  margin-bottom: 0.4rem;
+}
+
+.skel-line-head { width: 65%; height: 0.65rem; }
+.skel-line-subject { width: 80%; height: 0.7rem; }
+.skel-line-snippet { width: 100%; height: 0.55rem; margin-bottom: 0; }
+
+@keyframes skel-shimmer {
+  0% { background-position: 100% 0; }
+  100% { background-position: -100% 0; }
+}
+
+/* ─── Toast ──────────────────────────────────────────────── */
+
+.inbox-toast {
+  position: fixed;
+  bottom: 1.4rem;
+  right: 1.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  padding: 0.7rem 1rem;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  border-left-width: 2px;
+  z-index: 50;
+  animation: toast-in 0.25s var(--ease-soft) both;
+}
+
+.inbox-toast-success {
+  color: var(--accent-cyan);
+  border-left-color: var(--accent-cyan);
+}
+
+.inbox-toast-error {
+  color: var(--accent-amber);
+  border-left-color: var(--accent-amber);
+}
+
+@keyframes toast-in {
+  from { transform: translateY(8px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}

--- a/frontend/cullis-chat/src/styles/tokens.css
+++ b/frontend/cullis-chat/src/styles/tokens.css
@@ -88,3 +88,41 @@
   /* Pulse-dot reused from site */
   --pulse-color: var(--accent-cyan);
 }
+
+/* Principal type badges — shared <PrincipalBadge> chip.
+   Same visual treatment as the dashboard `_principal_badge.html`
+   macro: tiny pill, uppercase, foreground = the badge color, soft
+   tinted background. The values come from the design tokens above
+   so a future theme tweak only updates one place. */
+.principal-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border: 1px solid transparent;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  user-select: none;
+}
+.principal-badge-sm {
+  font-size: 9px;
+  padding: 0 5px;
+  letter-spacing: 0.16em;
+}
+.principal-badge-user {
+  color: var(--cullis-badge-user);
+  background: color-mix(in srgb, var(--cullis-badge-user) 10%, transparent);
+  border-color: color-mix(in srgb, var(--cullis-badge-user) 25%, transparent);
+}
+.principal-badge-agent {
+  color: var(--cullis-badge-agent);
+  background: color-mix(in srgb, var(--cullis-badge-agent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--cullis-badge-agent) 25%, transparent);
+}
+.principal-badge-workload {
+  color: var(--cullis-badge-workload);
+  background: color-mix(in srgb, var(--cullis-badge-workload) 10%, transparent);
+  border-color: color-mix(in srgb, var(--cullis-badge-workload) 25%, transparent);
+}

--- a/frontend/cullis-chat/src/styles/tokens.css
+++ b/frontend/cullis-chat/src/styles/tokens.css
@@ -31,6 +31,12 @@
   --accent-blue: #3d7aed;
   --accent-teal: #00b8a9;
 
+  /* Principal type badges — ADR-020 user/agent/workload, source of
+     truth in site/global.css. Used by <PrincipalBadge> in core. */
+  --cullis-badge-user: #3b7af5;
+  --cullis-badge-agent: #8b5cf6;
+  --cullis-badge-workload: #10b981;
+
   /* Fonts */
   --font-display: 'Instrument Serif', Georgia, serif;
   --font-body: 'Satoshi', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/frontend/cullis-chat/tests/e2e/inbox.spec.ts
+++ b/frontend/cullis-chat/tests/e2e/inbox.spec.ts
@@ -74,14 +74,32 @@ test('inbox: compose form submits and toast confirms', async ({ page }) => {
 });
 
 test('inbox: empty unread tab once seed is acked', async ({ page }) => {
+  // Note: the mock ambassador is a single process shared across the
+  // whole spec file, so by the time this test runs other tests may
+  // have already mutated the seed (acked, sent extras). We don't
+  // assume initial state — instead we ack any remaining unread and
+  // assert the resulting Unread tab is empty.
   await page.goto('/inbox');
 
-  // Seed is initially unread; ack via detail panel.
-  await page.locator('.inbox-row').first().click();
-  await page.getByRole('button', { name: 'Mark read' }).click();
-  await expect(page.getByRole('button', { name: 'Mark read' })).toHaveCount(0);
+  // Ack every row that's still pending. We loop because there can be
+  // a fresh user-sent message from the compose test.
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const firstRow = page.locator('.inbox-row').first();
+    if ((await firstRow.count()) === 0) break;
+    await firstRow.click();
+    const markBtn = page.getByRole('button', { name: 'Mark read' });
+    if ((await markBtn.count()) === 0) break;
+    await markBtn.click();
+    await expect(markBtn).toHaveCount(0, { timeout: 5_000 });
+    // Switch to Unread to see if any are left — drives the loop.
+    await page.getByRole('button', { name: 'Unread' }).click();
+    if ((await page.locator('.inbox-row').count()) === 0) break;
+    // Otherwise switch back to All and continue.
+    await page.getByRole('button', { name: 'All' }).click();
+  }
 
-  // Switch to Unread tab — empty state should render
+  // Final assertion: Unread tab is empty.
   await page.getByRole('button', { name: 'Unread' }).click();
   await expect(page.locator('.inbox-empty-title')).toContainText(/caught up/i);
 });

--- a/frontend/cullis-chat/tests/e2e/inbox.spec.ts
+++ b/frontend/cullis-chat/tests/e2e/inbox.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Inbox surface end-to-end.
+ *
+ * Talks to the mock Ambassador at :7777 (mock/ambassador.mjs) which
+ * seeds one row from the night-reporter agent. The dev server boots
+ * the SPA so /inbox is a real Astro static page that mounts the
+ * <Inbox /> React island.
+ */
+
+test('inbox: seeded message renders with principal badge + verify chip', async ({ page }) => {
+  await page.goto('/inbox');
+
+  // Page header
+  await expect(page.locator('.inbox-title')).toContainText(/Messages/i);
+
+  // Sidebar surface link is marked active for /inbox
+  await expect(page.locator('.sl-surface-active')).toContainText(/Inbox/i);
+
+  // The seed row from the mock is visible: agent sender, subject, badge
+  const row = page.locator('.inbox-row').first();
+  await expect(row).toBeVisible({ timeout: 10_000 });
+  await expect(row.locator('.principal-badge-agent')).toContainText(/Agent/i);
+  await expect(row).toContainText('night-reporter');
+  await expect(row).toContainText(/Cross-company-flagged/i);
+  await expect(row.locator('.verify-chip-ok')).toContainText(/verified/i);
+});
+
+test('inbox: open detail panel and ack flips chip', async ({ page }) => {
+  await page.goto('/inbox');
+  await page.locator('.inbox-row').first().click();
+
+  // Detail panel populates
+  await expect(page.locator('.msg-detail-subject')).toContainText(/Cross-company/i);
+  await expect(page.locator('.msg-detail-pre')).toContainText('CLM-2026-0412');
+
+  // Audit chain placeholder is honest about the missing endpoint
+  await expect(page.locator('.msg-detail-audit-pending')).toContainText(
+    /audit chain detail/i,
+  );
+
+  // Mark read flips the verification chip from pending to delivered
+  await page.getByRole('button', { name: 'Mark read' }).click();
+  // The "Mark read" button hides once the row is no longer pending
+  await expect(page.getByRole('button', { name: 'Mark read' })).toHaveCount(0, {
+    timeout: 5_000,
+  });
+});
+
+test('inbox: compose form submits and toast confirms', async ({ page }) => {
+  await page.goto('/inbox');
+  await page.getByRole('button', { name: '+ Compose' }).click();
+
+  // Compose form is visible
+  await expect(page.locator('.msg-compose')).toBeVisible();
+
+  // Send button disabled until required fields filled
+  const sendBtn = page.getByRole('button', { name: 'Send' });
+  await expect(sendBtn).toBeDisabled();
+
+  await page.getByLabel('recipient org').fill('asia-pacific');
+  await page.getByLabel('recipient name').fill('counterparty-liaison');
+  await page.getByLabel('body').fill('Cross-company verification request.');
+
+  // Once required fields are filled the button enables and submits
+  await expect(sendBtn).toBeEnabled();
+  await sendBtn.click();
+
+  // Success toast appears
+  await expect(page.locator('.inbox-toast-success')).toContainText(/sent/i, {
+    timeout: 5_000,
+  });
+});
+
+test('inbox: empty unread tab once seed is acked', async ({ page }) => {
+  await page.goto('/inbox');
+
+  // Seed is initially unread; ack via detail panel.
+  await page.locator('.inbox-row').first().click();
+  await page.getByRole('button', { name: 'Mark read' }).click();
+  await expect(page.getByRole('button', { name: 'Mark read' })).toHaveCount(0);
+
+  // Switch to Unread tab — empty state should render
+  await page.getByRole('button', { name: 'Unread' }).click();
+  await expect(page.locator('.inbox-empty-title')).toContainText(/caught up/i);
+});

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -26,6 +26,11 @@
   --accent-blue: #3d7aed;
   --accent-teal: #00b8a9;
 
+  /* Principal type badges — ADR-020 user/agent/workload */
+  --cullis-badge-user: #3b7af5;
+  --cullis-badge-agent: #8b5cf6;
+  --cullis-badge-workload: #10b981;
+
   /* Fonts */
   --font-display: 'Instrument Serif', Georgia, serif;
   --font-body: 'Satoshi', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,12 @@ module.exports = {
           400: '#0ea5e9',
           500: '#0284c7',
         },
+        // Principal type badges — ADR-020 user/agent/workload
+        badge: {
+          user: '#3b7af5',
+          agent: '#8b5cf6',
+          workload: '#10b981',
+        },
       },
       fontFamily: {
         heading: ['Chakra Petch', 'sans-serif'],
@@ -35,6 +41,10 @@ module.exports = {
     'bg-emerald-900/90', 'border-emerald-700/50', 'text-emerald-300',
     'bg-red-900/90', 'border-red-700/50', 'text-red-300',
     'bg-accent-400', 'pulse-dot', 'bg-gray-700',
+    // Principal badge variants — referenced via macro
+    'bg-badge-user/10', 'text-badge-user', 'border-badge-user/20',
+    'bg-badge-agent/10', 'text-badge-agent', 'border-badge-agent/20',
+    'bg-badge-workload/10', 'text-badge-workload', 'border-badge-workload/20',
   ],
   plugins: [],
 };

--- a/tests/integration/cullis_network/lib/cullis-mastio.nix
+++ b/tests/integration/cullis_network/lib/cullis-mastio.nix
@@ -162,6 +162,11 @@
             "state"
             "dist"
             "result"
+            # Dev-box .env can carry host-specific values (BROKER_PUBLIC_URL
+            # pointing at the dev IP) that pydantic-settings picks up over
+            # the explicit env we set per VM, breaking DPoP htu validation.
+            ".env"
+            ".env.local"
           ]);
       };
       # Custom derivations for PyPI packages not yet in nixpkgs.
@@ -359,8 +364,28 @@
           # ``app/kms/admin_secret.py`` defaults to ``certs/`` relative
           # to the broker's CWD, which here is the read-only Nix store.
           # Redirect to the writable state dir so first-boot mkdir of
-          # ``.admin_bootstrap_token`` succeeds.
+          # ``.admin_bootstrap_token`` succeeds. Lands via #468.
           CULLIS_LOCAL_KMS_DIR = certsDir;
+          # Court advertises itself as ``http://court:8000`` so cities
+          # signing DPoP proofs with that exact URL pass htu validation.
+          # When the broker is loopback-only (cities) the override stops
+          # any inherited dev-box ``BROKER_PUBLIC_URL`` from the source
+          # tree's ``.env`` (already filtered, but env override is the
+          # authoritative source). pydantic-settings: env > .env > defaults.
+          # Issue #462 tracks turning this into an allowlist for multi-
+          # ingress Court setups.
+          BROKER_PUBLIC_URL =
+            if cfg.nginxAllowExternal
+            then "http://court:${toString cfg.brokerPort}"
+            else "http://127.0.0.1:${toString cfg.brokerPort}";
+          # Sandbox/demo PDP fall-through (issue #461 / PR #463). Cities
+          # are registered without a webhook_url; the dispatcher would
+          # otherwise default-deny every cross-org call. ``allow`` lets
+          # the test fixture exercise the path with audit rows tagged
+          # ``policy_default_allow`` so reviewers can grep for the
+          # bypass after the fact. Production refuses this value (see
+          # ``app/config.py::validate_config``).
+          POLICY_DEFAULT_DECISION = "allow";
         };
         serviceConfig = {
           Type = "simple";
@@ -413,6 +438,25 @@
           # hub), inferred from ``cfg.brokerUrl == ""``.
           MCP_PROXY_STANDALONE =
             if cfg.brokerUrl != "" then "false" else "true";
+          # DPoP htu validation needs the public URL the SDK speaks to
+          # (nginx mTLS endpoint), not the loopback uvicorn binds. Without
+          # this set, ``_build_htu`` falls back to ``request.url`` which
+          # in our setup is ``http://127.0.0.1:9100`` and never matches
+          # the SDK's ``https://mastio.<td>:9443/...`` signed proof.
+          # See feedback_proxy_env_public_url_vm.md +
+          # feedback_proxy_headers_insufficient.md — auto-detect via
+          # ``--proxy-headers`` alone is not enough.
+          MCP_PROXY_PROXY_PUBLIC_URL =
+            "https://mastio.${cfg.trustDomain}:${toString cfg.nginxPort}";
+        } // lib.optionalAttrs (cfg.brokerUrl != "") {
+          # ADR-012 — non-standalone proxies default to forwarding
+          # ``/v1/auth/token`` to the broker, which fails htu validation
+          # in our cross-org topology (Court only sees the forwarded URL,
+          # not the SDK's signed mastio.<td>:9443 URL). Cities should
+          # issue tokens locally exactly like the standalone case;
+          # Court keeps standalone=true and turns this on via the
+          # auto-default in ``config.py``.
+          MCP_PROXY_LOCAL_AUTH_ENABLED = "true";
         } // lib.optionalAttrs cfg.enableMockServices {
           # Point the AI gateway at the mock LLM. We use the
           # ``portkey`` backend wrapper because it honours

--- a/tests/integration/cullis_network/tier2-cross-org.nix
+++ b/tests/integration/cullis_network/tier2-cross-org.nix
@@ -213,6 +213,450 @@ let
     print(f"BOOTSTRAPPED org_id={org_id} on Court")
   '';
 
+  # Provisions a single agent on the local Mastio via the BYOCA
+  # enrollment endpoint. Mints an Org-CA-signed cert, generates a DPoP
+  # keypair, POSTs to ``/v1/admin/agents/enroll/byoca``, and persists
+  # the runtime credentials under
+  # ``<identity_root>/<org_id>/agents/<agent_name>/`` so the SDK's
+  # ``CullisClient.from_identity_dir`` can pick them up later. Mirrors
+  # ``reference/bootstrap/bootstrap_mastio.py::_enroll_one_byoca`` but
+  # written for the test driver (no /state shared mount, no docker).
+  provisionAgentScript = pkgs.writeText "provision-agent.py" ''
+    """Provision a single agent on the local Mastio via BYOCA enroll.
+
+    Args (positional):
+      org_id          short org id
+      agent_name      short agent name (no ``::``)
+      capabilities    comma-separated list (use empty string for none)
+      proxy_url       local proxy admin (e.g. ``http://127.0.0.1:9100``)
+      admin_secret    proxy admin secret
+      identity_root   filesystem root for runtime creds
+      org_ca_cert     filesystem path to ``org-ca.pem``
+      org_ca_key      filesystem path to ``org-ca.key``
+      trust_domain    SPIFFE trust domain (e.g. ``roma.cullis.test``)
+    """
+    import base64
+    import json
+    import os
+    import pathlib
+    import subprocess
+    import sys
+    import urllib.error
+    import urllib.request
+
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    if len(sys.argv) != 10:
+        print(
+            f"USAGE: {sys.argv[0]} org_id agent_name capabilities proxy_url "
+            f"admin_secret identity_root org_ca_cert org_ca_key trust_domain",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    (_, org_id, agent_name, caps_csv, proxy_url, admin_secret,
+     identity_root, org_ca_cert, org_ca_key, trust_domain) = sys.argv
+
+    capabilities = [c for c in caps_csv.split(",") if c]
+    agent_id = f"{org_id}::{agent_name}"
+    # Cullis SPIFFE SAN convention (mcp_proxy/auth/client_cert.py
+    # ``_parse_spiffe_uri``): 3-component path = ``{td}/{org}/{name}``.
+    # The 4-component typed variant (``{td}/{org}/agent/{name}``) is
+    # also valid; this 3-comp form mirrors what
+    # ``agent_manager._generate_agent_cert`` emits in production.
+    spiffe_uri = f"spiffe://{trust_domain}/{org_id}/{agent_name}"
+
+    identity_dir = pathlib.Path(identity_root) / org_id / "agents" / agent_name
+    identity_dir.mkdir(parents=True, exist_ok=True)
+    cert_path = identity_dir / "agent.pem"
+    key_path = identity_dir / "agent-key.pem"
+    dpop_path = identity_dir / "dpop.jwk"
+    ca_chain_path = pathlib.Path(identity_root) / org_id / "ca.pem"
+    ca_chain_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Mint EC P-256 cert signed by Org CA. Using openssl rather than
+    # cryptography directly keeps the cert structure byte-identical to
+    # the existing ``fedtest`` cert generation in this file (same
+    # subject/SAN convention).
+    csr_path = identity_dir / "agent.csr"
+    extfile = identity_dir / "agent.ext"
+    extfile.write_text(
+        f"subjectAltName=URI:{spiffe_uri}\nextendedKeyUsage=clientAuth\n"
+    )
+    subprocess.check_call([
+        "openssl", "ecparam", "-name", "prime256v1", "-genkey", "-noout",
+        "-out", str(key_path),
+    ])
+    subprocess.check_call([
+        "openssl", "req", "-new", "-key", str(key_path),
+        "-out", str(csr_path),
+        "-subj", f"/CN={agent_id}/O={org_id}",
+    ])
+    subprocess.check_call([
+        "openssl", "x509", "-req", "-in", str(csr_path),
+        "-CA", org_ca_cert, "-CAkey", org_ca_key, "-CAcreateserial",
+        "-out", str(cert_path), "-days", "1",
+        "-extfile", str(extfile),
+    ])
+    cert_path.chmod(0o644)
+    key_path.chmod(0o600)
+    print(f"  minted cert + key for {agent_id} (SAN={spiffe_uri})")
+
+    # Generate DPoP keypair (EC P-256). Public JWK goes into the enroll
+    # body so the Mastio pins ``dpop_jkt`` from the first request;
+    # private JWK lands on disk next to the cert for the runtime SDK.
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_nums = priv.public_key().public_numbers()
+    priv_nums = priv.private_numbers()
+
+    def _b64url(n: int) -> str:
+        return base64.urlsafe_b64encode(n.to_bytes(32, "big")).rstrip(b"=").decode()
+
+    public_jwk = {
+        "kty": "EC", "crv": "P-256",
+        "x": _b64url(pub_nums.x), "y": _b64url(pub_nums.y),
+    }
+    private_jwk = {**public_jwk, "d": _b64url(priv_nums.private_value)}
+
+    # POST /v1/admin/agents/enroll/byoca
+    body = json.dumps({
+        "agent_name": agent_name,
+        "display_name": agent_name,
+        "capabilities": capabilities,
+        "federated": True,
+        "cert_pem": cert_path.read_text(),
+        "private_key_pem": key_path.read_text(),
+        "dpop_jwk": public_jwk,
+    }).encode()
+    req = urllib.request.Request(
+        f"{proxy_url}/v1/admin/agents/enroll/byoca",
+        data=body, method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Admin-Secret": admin_secret,
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+            code = resp.getcode()
+    except urllib.error.HTTPError as exc:
+        print(f"FAILED enroll/byoca → HTTP {exc.code}: {exc.read().decode()[:300]}",
+              file=sys.stderr)
+        sys.exit(1)
+
+    if code != 201:
+        print(f"FAILED enroll/byoca → HTTP {code}", file=sys.stderr)
+        sys.exit(1)
+
+    # Persist runtime DPoP private JWK + Org CA chain alongside the cert
+    # — these four files are exactly what ``CullisClient.from_identity_dir``
+    # opens on send.
+    dpop_path.write_text(
+        json.dumps({"private_jwk": private_jwk}, separators=(",", ":"))
+    )
+    dpop_path.chmod(0o600)
+    ca_chain_path.write_text(open(org_ca_cert).read())
+    ca_chain_path.chmod(0o644)
+
+    jkt = (data.get("dpop_jkt") or "")[:12]
+    thumb = (data.get("cert_thumbprint") or "")[:12]
+    print(f"PROVISIONED {agent_id} jkt={jkt}… thumb={thumb}…")
+  '';
+
+  # Drives the binding flow on Court for an agent that the federation
+  # publisher has already pushed. ``POST /v1/registry/bindings`` takes
+  # ``X-Org-Id`` + ``X-Org-Secret`` headers; the body's ``org_id`` must
+  # match the auth org (intra-org binding only — cross-org A2A is
+  # gated by federation registry visibility + cert chain, not by a
+  # cross-org binding row). Retries POST while the publisher catches
+  # up — 404 means the agent isn't visible on Court yet.
+  bindAgentScript = pkgs.writeText "bind-agent.py" ''
+    """Create + approve a binding for a federated agent on Court.
+
+    Args (positional):
+      court_url       e.g. ``http://court:8000``
+      org_id          short org id
+      org_secret      same secret submitted at /onboarding/join
+      agent_id        full ``org::name``
+      scope_csv       comma-separated capabilities (subset of agent's caps)
+    """
+    import json
+    import sys
+    import time
+    import urllib.error
+    import urllib.request
+
+    if len(sys.argv) != 6:
+        print(
+            f"USAGE: {sys.argv[0]} court_url org_id org_secret agent_id scope_csv",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    _, court_url, org_id, org_secret, agent_id, scope_csv = sys.argv
+    scope = [c for c in scope_csv.split(",") if c]
+    headers = {"X-Org-Id": org_id, "X-Org-Secret": org_secret,
+               "Content-Type": "application/json"}
+
+
+    def _req(method, url, body=None, allow_status=()):
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.getcode(), resp.read().decode()
+        except urllib.error.HTTPError as exc:
+            payload = exc.read().decode()
+            if exc.code in allow_status:
+                return exc.code, payload
+            raise
+
+
+    # Retry create until publisher has pushed the agent to Court
+    # (404 → agent_id not visible yet, retry; 409 → already there).
+    binding_id = None
+    deadline = time.monotonic() + 30.0
+    last_err = "(no attempt)"
+    while time.monotonic() < deadline:
+        try:
+            code, payload = _req(
+                "POST", f"{court_url}/v1/registry/bindings",
+                body={"org_id": org_id, "agent_id": agent_id, "scope": scope},
+                allow_status=(404, 409),
+            )
+        except urllib.error.URLError as exc:
+            last_err = f"connection: {exc}"
+            time.sleep(1.0)
+            continue
+        if code == 201:
+            binding_id = json.loads(payload)["id"]
+            print(f"  created binding {binding_id} for {agent_id}")
+            break
+        if code == 409:
+            # Already there — list and find it.
+            lc, lp = _req(
+                "GET", f"{court_url}/v1/registry/bindings?org_id={org_id}",
+            )
+            for b in json.loads(lp):
+                if b.get("agent_id") == agent_id:
+                    binding_id = b["id"]
+                    break
+            print(f"  binding already existed → id={binding_id}")
+            break
+        last_err = f"HTTP {code}: {payload[:200]}"
+        time.sleep(1.0)
+
+    if binding_id is None:
+        print(
+            f"FAILED binding create did not succeed in 30s "
+            f"(last={last_err})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Approve. 200 / 204 both ok; 409 if already approved.
+    code, payload = _req(
+        "POST", f"{court_url}/v1/registry/bindings/{binding_id}/approve",
+        allow_status=(409,),
+    )
+    print(f"  approve → HTTP {code}")
+    print(f"BOUND {agent_id} scope={scope} binding_id={binding_id}")
+  '';
+
+  # Creates an allow-all session policy for the given org on Court.
+  # Mirrors ``reference/bootstrap/bootstrap.py::phase_5_session_policies``.
+  # Without this, ``evaluate_session_policy`` defaults to deny on the
+  # ``/v1/broker/oneshot/forward`` path → 403 even with a valid binding.
+  policyAllowScript = pkgs.writeText "policy-allow.py" ''
+    """Create a default-allow session policy on Court for one org.
+
+    Args (positional):
+      court_url       e.g. ``http://court:8000``
+      org_id          short org id
+      org_secret      same secret submitted at /onboarding/join
+    """
+    import json
+    import sys
+    import urllib.error
+    import urllib.request
+
+    if len(sys.argv) != 4:
+        print(f"USAGE: {sys.argv[0]} court_url org_id org_secret",
+              file=sys.stderr)
+        sys.exit(2)
+
+    _, court_url, org_id, org_secret = sys.argv
+
+    body = {
+        "policy_id": f"{org_id}::session-allow-all",
+        "org_id": org_id,
+        "policy_type": "session",
+        "rules": {
+            "effect": "allow",
+            "conditions": {"target_org_id": [], "capabilities": []},
+        },
+    }
+    req = urllib.request.Request(
+        f"{court_url}/v1/policy/rules",
+        data=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Org-Id": org_id,
+            "X-Org-Secret": org_secret,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            code = resp.getcode()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 409:
+            code = 409  # already there — idempotent
+        else:
+            print(f"FAILED policy create → HTTP {exc.code}: "
+                  f"{exc.read().decode()[:300]}",
+                  file=sys.stderr)
+            sys.exit(1)
+    print(f"POLICY {body['policy_id']} → HTTP {code}")
+  '';
+
+  # Loads a CullisClient from disk-pinned identity files and fires
+  # ``send_oneshot`` against a cross-org recipient. The local proxy's
+  # ``/v1/egress/resolve`` returns the recipient's cert from Court's
+  # federation registry, the SDK encrypts + signs, and the broker
+  # bridge forwards via ``POST /v1/broker/oneshot/forward`` on Court.
+  oneshotSendScript = pkgs.writeText "oneshot-send.py" ''
+    """SDK-driven cross-org one-shot send.
+
+    Args (positional):
+      mastio_url      e.g. ``https://mastio.roma.cullis.test:9443``
+      org_id          sender's org
+      agent_name      sender's agent name
+      target_id       recipient ``org::name``
+      identity_root   filesystem root with provisioned creds
+      nonce           opaque marker, echoed inside payload for receiver match
+    """
+    import json
+    import pathlib
+    import sys
+
+    from cullis_sdk import CullisClient
+
+    if len(sys.argv) != 7:
+        print(
+            f"USAGE: {sys.argv[0]} mastio_url org_id agent_name target_id "
+            f"identity_root nonce",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    _, mastio_url, org_id, agent_name, target_id, identity_root, nonce = sys.argv
+    identity_dir = pathlib.Path(identity_root) / org_id / "agents" / agent_name
+    cert_path = identity_dir / "agent.pem"
+    key_path = identity_dir / "agent-key.pem"
+    dpop_path = identity_dir / "dpop.jwk"
+    ca_chain = pathlib.Path(identity_root) / org_id / "ca.pem"
+
+    client = CullisClient.from_identity_dir(
+        mastio_url,
+        cert_path=cert_path,
+        key_path=key_path,
+        dpop_key_path=dpop_path,
+        agent_id=f"{org_id}::{agent_name}",
+        org_id=org_id,
+        ca_chain_path=ca_chain,
+    )
+    client.login_via_proxy()
+    client._signing_key_pem = key_path.read_text()
+
+    payload = {"nonce": nonce, "hello": "cross-org A2A from nixosTest",
+               "sender": f"{org_id}::{agent_name}"}
+    resp = client.send_oneshot(target_id, payload)
+    print(json.dumps({"sent_to": target_id, "nonce": nonce, **resp}))
+    print("ONESHOT_SENT")
+  '';
+
+  # Polls the recipient's inbox until the expected nonce arrives, then
+  # decrypts the envelope and verifies the inner signature. ``nonce``
+  # is the marker to match (passed in plaintext payload by the sender);
+  # the deadline keeps the test bounded if the message never lands.
+  oneshotPollScript = pkgs.writeText "oneshot-poll.py" ''
+    """SDK-driven inbox poll + decrypt for the receiver side.
+
+    Args (positional):
+      mastio_url      e.g. ``https://mastio.tokyo.cullis.test:9443``
+      org_id          recipient's org
+      agent_name      recipient's agent name
+      identity_root   filesystem root with provisioned creds
+      expected_nonce  the nonce the sender embedded in payload
+      timeout_s       wait deadline (seconds)
+    """
+    import pathlib
+    import sys
+    import time
+
+    from cullis_sdk import CullisClient
+
+    if len(sys.argv) != 7:
+        print(
+            f"USAGE: {sys.argv[0]} mastio_url org_id agent_name "
+            f"identity_root expected_nonce timeout_s",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    (_, mastio_url, org_id, agent_name, identity_root, expected_nonce,
+     timeout_s) = sys.argv
+    deadline = time.monotonic() + float(timeout_s)
+    identity_dir = pathlib.Path(identity_root) / org_id / "agents" / agent_name
+    ca_chain = pathlib.Path(identity_root) / org_id / "ca.pem"
+
+    client = CullisClient.from_identity_dir(
+        mastio_url,
+        cert_path=identity_dir / "agent.pem",
+        key_path=identity_dir / "agent-key.pem",
+        dpop_key_path=identity_dir / "dpop.jwk",
+        agent_id=f"{org_id}::{agent_name}",
+        org_id=org_id,
+        ca_chain_path=ca_chain,
+    )
+    client.login_via_proxy()
+    # Envelope-mode decrypt unwraps the AES key with the recipient's
+    # private key. ``from_identity_dir`` skips ``__init__`` so we
+    # populate ``_signing_key_pem`` explicitly, mirroring what the
+    # send side does.
+    client._signing_key_pem = (identity_dir / "agent-key.pem").read_text()
+
+    last_err = "(no rows yet)"
+    while time.monotonic() < deadline:
+        rows = client.receive_oneshot()
+        for row in rows:
+            try:
+                decrypted = client.decrypt_oneshot(row)
+            except Exception as exc:  # noqa: BLE001 — surface decrypt failure
+                last_err = f"decrypt: {exc}"
+                continue
+            payload = decrypted.get("payload") or {}
+            if payload.get("nonce") == expected_nonce:
+                print(
+                    f"RECEIVED nonce={expected_nonce} "
+                    f"sender={payload.get('sender')} "
+                    f"sender_verified={decrypted.get('sender_verified')} "
+                    f"mode={decrypted.get('mode')}"
+                )
+                sys.exit(0)
+            last_err = (
+                f"nonce mismatch: got {payload.get('nonce')!r}, "
+                f"want {expected_nonce!r}"
+            )
+        time.sleep(1.0)
+
+    print(f"FAILED no message with nonce={expected_nonce} within "
+          f"{timeout_s}s (last={last_err})", file=sys.stderr)
+    sys.exit(1)
+  '';
+
   # Per-city Mastio config. Each entry produces a NixOS node that
   # drops the ``cullis.mastio`` module on top of a base
   # ``virtualisation`` block; the module handles broker + proxy +
@@ -497,6 +941,140 @@ pkgs.testers.nixosTest {
             f"{court.succeed('journalctl -u cullis-broker --no-pager -n 50')}"
         )
         print(f"  publish accepted by Court:\n    {publish_log}")
+
+    with subtest("Cross-org A2A oneshot: roma::sender → tokyo::receiver"):
+        # Six-phase round-trip — Roma SDK encrypt+sign, broker bridge
+        # forwards, Court counter-signs, Tokyo SDK decrypts+verifies.
+        # Each phase reuses one of the helper scripts defined in the
+        # ``let`` block above; the test driver wires them together
+        # with the right env per VM.
+        identity_root = "/var/lib/cullis/test-identities"
+
+        # Phase 1: provision both agents on their respective Mastios
+        # via the BYOCA enroll endpoint. The script mints a cert
+        # against the local Org CA, generates a DPoP keypair, posts
+        # the public material to /v1/admin/agents/enroll/byoca, and
+        # drops cert+key+dpop+CA chain on disk in the layout the
+        # SDK's ``from_identity_dir`` expects.
+        for city, cfg in (
+            (roma,  {"orgId": "roma",  "agentName": "sender",
+                     "trustDomain": "roma.cullis.test"}),
+            (tokyo, {"orgId": "tokyo", "agentName": "receiver",
+                     "trustDomain": "tokyo.cullis.test"}),
+        ):
+            out = city.succeed(
+                "python3 ${provisionAgentScript} "
+                f"{cfg['orgId']} {cfg['agentName']} oneshot.message "
+                "http://127.0.0.1:9100 test-admin-secret "
+                f"{identity_root} "
+                "/var/lib/cullis/certs/org-ca.pem "
+                "/var/lib/cullis/certs/org-ca.key "
+                f"{cfg['trustDomain']}"
+            )
+            assert "PROVISIONED" in out, (
+                f"provisioning of {cfg['orgId']}::{cfg['agentName']} failed:\n{out}"
+            )
+            print(f"  {cfg['orgId']}::{cfg['agentName']} provisioned")
+
+        # No trust-bundle plumbing needed: PR #467 (issue #459) delegates
+        # cross-org chain checks to Court, which already verified the
+        # leaf at federation publish time. Each agent's ``ca.pem`` holds
+        # only the local Org CA and the SDK's ``decrypt_oneshot`` skips
+        # the chain step for cross-org senders.
+
+        # Phase 2: wait for the federation publisher to push both
+        # rows to Court. The ``federated=true`` flag came in via
+        # provisioning; poll interval is forced to 2s by the module
+        # env. Look for the success log line on each side.
+        for city, agent_id in (
+            (roma, "roma::sender"),
+            (tokyo, "tokyo::receiver"),
+        ):
+            city.wait_until_succeeds(
+                "journalctl -u cullis-proxy --no-pager | "
+                f"grep -q 'federation publish OK: {agent_id}'",
+                timeout=20,
+            )
+            print(f"  {agent_id} published to Court")
+
+        # Phase 3: bind both agents on Court so authentication +
+        # capability gates allow the oneshot. Each binding is
+        # intra-org (the auth org_id must match the body org_id);
+        # cross-org A2A is gated by federation registry visibility
+        # plus the recipient's intra-org binding having scope.
+        for city, cfg in (
+            (roma,  {"orgId": "roma",  "agentId": "roma::sender"}),
+            (tokyo, {"orgId": "tokyo", "agentId": "tokyo::receiver"}),
+        ):
+            out = city.succeed(
+                "python3 ${bindAgentScript} "
+                "http://court:8000 "
+                f"{cfg['orgId']} {cfg['orgId']}-secret-test "
+                f"{cfg['agentId']} oneshot.message"
+            )
+            assert "BOUND" in out, (
+                f"binding for {cfg['agentId']} failed:\n{out}"
+            )
+            print(f"  {cfg['agentId']} bound + approved on Court")
+
+        # Phase 3b: install an allow-all session policy on Court for
+        # both orgs. Without this, ``evaluate_session_policy`` on the
+        # ``/v1/broker/oneshot/forward`` path defaults to deny → 403
+        # even with valid bindings.
+        for city, org_id in ((roma, "roma"), (tokyo, "tokyo")):
+            out = city.succeed(
+                "python3 ${policyAllowScript} "
+                f"http://court:8000 {org_id} {org_id}-secret-test"
+            )
+            assert "POLICY" in out, f"policy create for {org_id} failed:\n{out}"
+            print(f"  {org_id} session-allow-all policy installed")
+
+        # Phase 4: send. Roma SDK loads the cert/key/dpop from disk,
+        # logs in via the local proxy, encrypts the payload for the
+        # Tokyo recipient (cert pulled from Court via /resolve), and
+        # POSTs to ``/v1/egress/message/send``.
+        nonce = "tier2-a2a-cross-org-roundtrip"
+        out = roma.succeed(
+            "python3 ${oneshotSendScript} "
+            "https://mastio.roma.cullis.test:9443 "
+            "roma sender tokyo::receiver "
+            f"{identity_root} {nonce}"
+        )
+        assert "ONESHOT_SENT" in out, f"send_oneshot failed:\n{out}"
+        print(f"  Roma SDK fired one-shot:\n    {out.strip()}")
+
+        # Phase 5: receive. Tokyo SDK polls inbox, decrypts the
+        # envelope, verifies the inner signature, and confirms the
+        # nonce matches what Roma sent. Times out at 20s — the
+        # broker queue + bridge poll cadence is in the 2-5s range.
+        out = tokyo.succeed(
+            "python3 ${oneshotPollScript} "
+            "https://mastio.tokyo.cullis.test:9443 "
+            "tokyo receiver "
+            f"{identity_root} {nonce} 20"
+        )
+        assert "RECEIVED" in out, f"inbox poll did not match nonce:\n{out}"
+        assert "sender_verified=True" in out, (
+            f"recipient could not verify sender signature:\n{out}"
+        )
+        print(f"  Tokyo SDK received + verified:\n    {out.strip()}")
+
+        # Phase 6: dump the local oneshot audit rows (informative). The
+        # broker-side ``log_event_cross_org`` writes the canonical
+        # cross-org pair on Court; each Mastio mirrors a local row via
+        # the egress pipeline (``mcp_proxy/egress/oneshot.py`` →
+        # ``oneshot_sent`` / ``oneshot_delivered``). Surface the rows
+        # for visual inspection without asserting an exact event_type
+        # name (varies by code path); the previous assertions on send
+        # + receive already proved the round-trip cryptographically.
+        for city in (roma, tokyo):
+            rc, dump = city.execute(
+                "sqlite3 /var/lib/cullis/proxy.sqlite "
+                "\"SELECT event_type, result FROM audit_log "
+                "WHERE event_type LIKE '%oneshot%' "
+                "ORDER BY id DESC LIMIT 5\" 2>&1 || true"
+            )
+            print(f"  {city.name} oneshot audit (last 5):\n{dump.rstrip()}")
 
     # Cross-org cert chain refusal (default-deny) — the third
     # invariant the demo sells — needs a Roma-minted cert

--- a/tests/test_dashboard_principals.py
+++ b/tests/test_dashboard_principals.py
@@ -152,12 +152,32 @@ async def test_nav_includes_principal_sections(client: AsyncClient):
     # Every section link present in the new nav structure
     assert 'href="/dashboard/users"' in body
     assert 'href="/dashboard/agents"' in body
-    assert 'href="/dashboard/workloads"' in body
     assert 'href="/dashboard/resources"' in body
     assert 'href="/dashboard/federation"' in body
+    # Workloads are LOCAL-only runtime infrastructure: they don't
+    # federate, so the Court network-admin nav must not surface them.
+    # The /dashboard/workloads route stays alive (URL-accessible) for
+    # future per-org Mastio admin reuse.
+    assert 'href="/dashboard/workloads"' not in body
     # Group labels
     assert "Principals" in body
     assert "Federation" in body
+
+
+async def test_overview_stats_strip(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Stats strip cells
+    assert "organizations" in body
+    assert "users" in body
+    assert "agents" in body
+    assert "audit chain" in body
+    # Sessions cell must not be on overview anymore
+    assert "sessions · live" not in body
+    # Users cell links to the Users page
+    assert 'href="/dashboard/users"' in body
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_dashboard_principals.py
+++ b/tests/test_dashboard_principals.py
@@ -11,7 +11,6 @@ When the backend session lands /v1/admin/users + /v1/admin/workloads,
 these tests should be widened to assert against real data and the
 ``endpoint_ready=False`` banner should disappear from the templates.
 """
-import json
 import pytest
 from httpx import AsyncClient
 

--- a/tests/test_dashboard_principals.py
+++ b/tests/test_dashboard_principals.py
@@ -1,0 +1,175 @@
+"""
+Test dashboard principal-type sections (Phase 1 of SPA rework).
+
+Verifies the new /dashboard/users, /dashboard/workloads,
+/dashboard/resources, /dashboard/federation pages render and that the
+hardcoded demo cast from imp/insurance-demo-spec.md is visible. Also
+verifies the new badge-count endpoints respond with neutral chips so
+the left-nav is screenshot-ready for the demo recording.
+
+When the backend session lands /v1/admin/users + /v1/admin/workloads,
+these tests should be widened to assert against real data and the
+``endpoint_ready=False`` banner should disappear from the templates.
+"""
+import json
+import pytest
+from httpx import AsyncClient
+
+from app.config import get_settings
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _admin_cookies(client: AsyncClient) -> dict:
+    resp = await client.post("/dashboard/login", data={
+        "user_id": "admin", "password": get_settings().admin_secret,
+    }, follow_redirects=False)
+    assert resp.status_code == 303, f"login failed: {resp.text[:200]}"
+    return dict(resp.cookies)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Section pages render with cast names visible
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_users_page_renders_with_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/users", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Cast principals from the spec
+    assert "Claim Officer" in body
+    assert "Claim Manager" in body
+    assert "Counterparty Liaison" in body
+    # Principal type badge for users
+    assert ">User<" in body
+    # Pending-endpoint banner is still showing (will go away when
+    # /v1/admin/users lands)
+    assert "Endpoint pending" in body
+
+
+async def test_workloads_page_renders_with_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/workloads", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Asia-Pacific Frontdesk" in body
+    assert "frontdesk-container" in body
+    assert ">Workload<" in body
+    assert "Endpoint pending" in body
+
+
+async def test_resources_page_renders_with_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/resources", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Claims Database" in body
+    assert "claims-db" in body
+    # MCP type icon path
+    assert ">MCP<" in body or "mcp" in body.lower()
+
+
+async def test_federation_page_renders_peers(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/federation", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "mediterranean" in body
+    assert "asia-pacific" in body
+    assert "Court" in body
+    # Legacy /orgs link is preserved per the legacy-consolidation plan
+    assert "/dashboard/orgs" in body
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Auth required
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path", [
+    "/dashboard/users",
+    "/dashboard/workloads",
+    "/dashboard/resources",
+    "/dashboard/federation",
+])
+async def test_principal_pages_require_login(client: AsyncClient, path: str):
+    resp = await client.get(path, follow_redirects=False)
+    assert resp.status_code == 303
+    assert "/login" in resp.headers.get("location", "")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Badge-count endpoints
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("path,expected_count", [
+    ("/dashboard/badge/users-count", 3),
+    ("/dashboard/badge/workloads-count", 1),
+    ("/dashboard/badge/resources-count", 1),
+])
+async def test_badge_count_chips_render(client: AsyncClient, path: str, expected_count: int):
+    cookies = await _admin_cookies(client)
+    resp = await client.get(path, cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Either the chip with the count is present or the count-0 short-circuit
+    # (empty body) — the cast spec guarantees non-zero.
+    assert str(expected_count) in body, f"expected count {expected_count} in {body!r}"
+
+
+async def test_badge_agents_count_falls_back_to_cast(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/badge/agents-count", cookies=cookies)
+    assert resp.status_code == 200
+    # Empty registry falls back to the cast count (2: night-reporter +
+    # ticket-bot) so the demo screenshot is non-zero.
+    body = resp.text
+    assert body == "" or "2" in body or any(c.isdigit() for c in body)
+
+
+@pytest.mark.parametrize("path", [
+    "/dashboard/badge/users-count",
+    "/dashboard/badge/workloads-count",
+    "/dashboard/badge/resources-count",
+    "/dashboard/badge/agents-count",
+])
+async def test_badge_count_unauth_returns_empty(client: AsyncClient, path: str):
+    """Unauthenticated badge call returns empty string, not redirect."""
+    resp = await client.get(path)
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Nav: principal-type sections appear on every page
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_nav_includes_principal_sections(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    # Every section link present in the new nav structure
+    assert 'href="/dashboard/users"' in body
+    assert 'href="/dashboard/agents"' in body
+    assert 'href="/dashboard/workloads"' in body
+    assert 'href="/dashboard/resources"' in body
+    assert 'href="/dashboard/federation"' in body
+    # Group labels
+    assert "Principals" in body
+    assert "Federation" in body
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Agents page extras: enrollment_method + automation_type columns exist
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def test_agents_page_renders_new_columns(client: AsyncClient):
+    cookies = await _admin_cookies(client)
+    resp = await client.get("/dashboard/agents", cookies=cookies)
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Enrollment" in body
+    assert "Automation" in body
+    # Agent badge appears in the principal column
+    assert ">Agent<" in body


### PR DESCRIPTION
## Summary

Phase 2 of the SPA rework. Adds the shared `<Inbox />` surface that drops into both Cullis Chat (consumer) and Frontdesk (enterprise), per the contract in `imp/insurance-demo-spec.md`.

- New `/inbox` route in the Astro SPA. Reuses the existing TopBar + SidebarLeft shell; the React island lives in `components/Inbox.tsx`.
- List view with sender + `<PrincipalBadge />` + subject + verify chip. Tabs: All / Unread / Sent / Drafts.
- Detail panel with full body + audit-chain placeholder (see BLOCKED note below).
- Compose form with target picker (org + principal type + name) and a capability-scope hint before send.
- Skeleton, empty, error and toast states are all real (not placeholders).
- New shared `<PrincipalBadge type="user|agent|workload">` in `components/core/PrincipalBadge.tsx`. Single source of truth used by Inbox today and by Frontdesk surface in Phase 4. Styles live in `styles/tokens.css`.
- API client: `lib/api.ts` gains `INBOX_BASE` plus `listInbox / sendInboxMessage / ackInboxMessage / archiveInboxMessage`, hitting the broker `app/inbox/router.py` REST surface.
- Mock Ambassador (`mock/ambassador.mjs`) now serves `/v1/inbox` so the dev server and Playwright e2e drive a real flow seeded with one `night-reporter` message.
- 4 new e2e specs in `tests/e2e/inbox.spec.ts` covering row render + ack + compose + empty states.

## BLOCKED notes (for the backend session)

- **API path**. Spec says `/v1/egress/message/*`, broker exposes `/v1/inbox/*`. The SPA codes against `/v1/inbox/*` via a single `INBOX_BASE` constant — flipping is one line.
- **`GET /v1/audit/messages/{msg_id}`** is not implemented yet. Detail panel renders an honest "Audit chain pending" placeholder until the broker ships the route.

## Stacking

This PR is stacked on top of #479 (Phase 1 dashboard sections). Branch base intentionally targets `main`, not the parent branch (memory `feedback_stacked_pr_base_branch`); rebase happens automatically once #479 lands.

## Test plan

- [x] `astro build` succeeds locally — both `/index.html` and `/inbox/index.html` are generated, no TS errors
- [ ] Playwright e2e (`tests/e2e/inbox.spec.ts`) — local run on NixOS fails with libglib-2.0.so.0 missing (memory `feedback_playwright_nixos`); the CI `cullis-chat / build-and-e2e` job is the real gate
- [ ] Visual smoke pass on `/inbox` after a reviewer pulls the branch
- [ ] Phase 1 PR (#479) merge → rebase this branch + retest