### PR TITLE
feat(egress): proxy-mediated user inbox send (#481)

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -2704,6 +2704,71 @@ class CullisClient:
             "mode": mode,
         }
 
+    # ── ADR-020 Phase 4 — user inbox send ────────────────────────────
+
+    def send_to_inbox(
+        self,
+        *,
+        recipient_org_id: str,
+        recipient_principal_type: str,
+        recipient_name: str,
+        body: dict | str,
+        subject: str | None = None,
+        idempotency_key: str | None = None,
+    ) -> dict:
+        """Send a message to a user / agent / workload principal's inbox.
+
+        This is the ADR-020 / Phase 4 delivery path — distinct from
+        :meth:`send_oneshot` which encrypts an envelope for agent ↔
+        agent E2E. The inbox path is plaintext-at-rest within the
+        broker (the broker is the trust boundary the user signed up
+        for) and reach-policy gated.
+
+        Default route is the Mastio-mediated path
+        (``POST /v1/egress/inbox/send`` → ``BrokerBridge`` →
+        ``POST /v1/inbox/send`` on the broker). When ``self.base`` is a
+        broker URL — i.e. the SDK is run from inside the proxy via
+        ``BrokerBridge.get_client()`` — set ``via_broker=True`` on the
+        instance to skip the egress prefix.
+
+        ``body`` is JSON-serialised when it arrives as a dict; pass a
+        plain string to send pre-serialised content.
+
+        Returns ``{"msg_id", "inserted", "quadrant"}`` on success.
+        Raises :class:`PermissionError` on a 403 from reach-policy.
+        """
+        import json as _json
+        if isinstance(body, dict):
+            body_str = _json.dumps(body)
+        else:
+            body_str = body
+        payload: dict[str, Any] = {
+            "recipient_org_id":          recipient_org_id,
+            "recipient_principal_type":  recipient_principal_type,
+            "recipient_name":            recipient_name,
+            "body":                      body_str,
+        }
+        if subject is not None:
+            payload["subject"] = subject
+        if idempotency_key is not None:
+            payload["idempotency_key"] = idempotency_key
+        # Hop selector: BrokerBridge sets ``_inbox_path_via_broker=True``
+        # on the per-agent broker client so the same SDK method works on
+        # both sides of the Mastio. Default is the mastio-mediated path
+        # (egress prefix), which is what every external SDK caller uses.
+        path = (
+            "/v1/inbox/send"
+            if getattr(self, "_inbox_path_via_broker", False)
+            else "/v1/egress/inbox/send"
+        )
+        resp = self._authed_request("POST", path, json=payload)
+        if resp.status_code == 403:
+            raise PermissionError(
+                f"inbox send denied (reach policy): {resp.text}",
+            )
+        resp.raise_for_status()
+        return resp.json()
+
     def send_oneshot_and_wait(
         self,
         recipient_id: str,

--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -69,6 +69,10 @@ class BrokerBridge:
                 countersign_fn=countersign_fn,
             ),
         )
+        # ADR-020 Phase 4 — when the SDK's send_to_inbox is called from
+        # this client (we are inside the proxy talking *to* the broker),
+        # skip the egress prefix and call /v1/inbox/send directly.
+        client._inbox_path_via_broker = True
         logger.info("Authenticated CullisClient for agent: %s", agent_id)
         return client
 

--- a/mcp_proxy/egress/inbox.py
+++ b/mcp_proxy/egress/inbox.py
@@ -1,0 +1,149 @@
+"""ADR-020 Phase 4 — proxy-mediated user inbox send.
+
+``POST /v1/egress/inbox/send`` lets an agent (or any cert-authenticated
+SDK caller) deliver to a Cullis user / agent / workload principal's
+inbox without holding a broker-aud JWT directly. The proxy authenticates
+the caller via mTLS+DPoP (same as every ``/v1/egress/*`` route), then
+hands off to ``BrokerBridge`` which uses the per-agent broker
+``CullisClient`` to call the broker's ``/v1/inbox/send`` on the agent's
+behalf.
+
+Why a dedicated endpoint instead of forwarding ``/v1/inbox/*`` straight
+to the broker:
+
+  * Tokens issued by the proxy's local ``/v1/auth/token`` have
+    ``aud=cullis-local`` (ADR-012), so the broker would reject them at
+    ``app.auth.jwt.get_current_agent``. ``BrokerBridge.get_client()``
+    holds an agent-scoped client that authenticates with a *broker*-aud
+    token, transparently to the SDK caller.
+  * Egress audit (``mcp_proxy.local.audit.append_local_audit``) gets the
+    same ``oneshot_*`` event-type contract every other egress call
+    uses, so the audit chain has a single source of truth for outbound
+    messages.
+
+Inbound rate-limit + reach + policy checks live on the broker side
+(``app/inbox/store.py::enqueue``); we surface its 403 (reach denied) /
+422 (validation) verbatim.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
+from mcp_proxy.config import get_settings
+from mcp_proxy.local.audit import append_local_audit
+from mcp_proxy.models import InternalAgent
+
+_log = logging.getLogger("mcp_proxy.egress.inbox")
+
+router = APIRouter(prefix="/v1/egress", tags=["egress-inbox"])
+
+
+class InboxSendRequest(BaseModel):
+    recipient_org_id: str = Field(..., min_length=1, max_length=128)
+    recipient_principal_type: str = Field(..., min_length=1, max_length=16)
+    recipient_name: str = Field(..., min_length=1, max_length=128)
+    body: str = Field(..., max_length=64 * 1024)
+    subject: str | None = Field(None, max_length=256)
+    idempotency_key: str | None = Field(None, max_length=256)
+
+
+class InboxSendResponse(BaseModel):
+    msg_id: str
+    inserted: bool
+    quadrant: str
+
+
+@router.post("/inbox/send", response_model=InboxSendResponse)
+async def send_to_inbox(
+    body: InboxSendRequest,
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
+) -> InboxSendResponse:
+    """Forward an inbox-send call to the broker on behalf of ``agent``.
+
+    Returns the broker's ``msg_id`` / ``inserted`` / ``quadrant`` tuple
+    on success. 503 when the broker bridge is missing (standalone proxy
+    boot before federation is wired). 403 when reach policy denies the
+    quadrant.
+    """
+    settings = get_settings()
+    local_org = settings.org_id or ""
+
+    bridge = getattr(request.app.state, "broker_bridge", None)
+    if bridge is None:
+        await append_local_audit(
+            event_type="inbox_send_denied",
+            result="error",
+            agent_id=agent.agent_id,
+            org_id=local_org,
+            details={
+                "recipient_org_id": body.recipient_org_id,
+                "recipient_principal_type": body.recipient_principal_type,
+                "recipient_name": body.recipient_name,
+                "reason": "broker_bridge_unavailable",
+            },
+        )
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Broker uplink not configured — inbox send unavailable on "
+                "a standalone proxy."
+            ),
+        )
+
+    audit_details = {
+        "recipient_org_id": body.recipient_org_id,
+        "recipient_principal_type": body.recipient_principal_type,
+        "recipient_name": body.recipient_name,
+        "subject": body.subject,
+    }
+
+    try:
+        broker_client = await bridge.get_client(agent.agent_id)
+        # ``CullisClient.send_to_inbox`` calls the broker's
+        # ``POST /v1/inbox/send`` over the broker-aud session that
+        # BrokerBridge maintains for this agent.
+        result = broker_client.send_to_inbox(
+            recipient_org_id=body.recipient_org_id,
+            recipient_principal_type=body.recipient_principal_type,
+            recipient_name=body.recipient_name,
+            body=body.body,
+            subject=body.subject,
+            idempotency_key=body.idempotency_key,
+        )
+    except PermissionError as exc:
+        await append_local_audit(
+            event_type="inbox_send_denied",
+            result="denied",
+            agent_id=agent.agent_id,
+            org_id=local_org,
+            details={**audit_details, "reason": str(exc)},
+        )
+        raise HTTPException(status_code=403, detail=str(exc)) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001 — surface broker errors as 502
+        await append_local_audit(
+            event_type="inbox_send_denied",
+            result="error",
+            agent_id=agent.agent_id,
+            org_id=local_org,
+            details={**audit_details, "reason": f"broker_forward_failed: {exc}"},
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"Broker forward failed: {exc}",
+        ) from exc
+
+    await append_local_audit(
+        event_type="inbox_send_ok",
+        result="ok",
+        agent_id=agent.agent_id,
+        org_id=local_org,
+        details={**audit_details, "msg_id": result.get("msg_id", "")},
+    )
+    return InboxSendResponse(**result)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1015,6 +1015,13 @@ app.include_router(guardian_router)
 from mcp_proxy.egress.oneshot import router as oneshot_router
 app.include_router(oneshot_router)
 
+# ADR-020 Phase 4 — proxy-mediated user inbox send. Lets agents deliver
+# to user / agent / workload principal inboxes through their Mastio
+# without holding a broker-aud JWT directly. See egress/inbox.py for
+# the reasoning behind a dedicated endpoint vs. forwarding /v1/inbox.
+from mcp_proxy.egress.inbox import router as egress_inbox_router
+app.include_router(egress_inbox_router)
+
 # ADR-014 PR-C: the legacy /v1/local/ws endpoint relied on api_key
 # query-param auth, which is gone. The local_ws_manager itself stays
 # (push fan-out by agent_id) — it's used by the egress router to deliver

--- a/tests/test_sdk_send_to_inbox.py
+++ b/tests/test_sdk_send_to_inbox.py
@@ -1,0 +1,162 @@
+"""SDK ``send_to_inbox`` helper — request shape + auth integration.
+
+The helper wraps the broker's ``POST /v1/inbox/send`` endpoint (ADR-020
+Phase 4) and is the canonical SDK path for agent → user / user → user
+delivery, distinct from ``send_oneshot`` which encrypts an envelope for
+agent ↔ agent E2E.
+
+These tests cover only the SDK layer: the body shape produced by the
+helper and its handling of common server responses. End-to-end coverage
+of the broker side lives in ``test_user_inbox.py``; the proxy reverse-
+proxy forwarding for ``/v1/inbox/*`` is exercised by the live smoke
+that drove issue #481.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from cullis_sdk.client import CullisClient
+
+
+def _client() -> CullisClient:
+    """Build a minimally-initialised CullisClient bypassing __init__.
+
+    Mirrors the cls.__new__(cls) factory pattern used by
+    ``from_identity_dir`` / ``from_enrollment``. DPoP keys are real
+    because ``_authed_request`` builds a DPoP proof on every call.
+    """
+    from cullis_sdk.auth import generate_dpop_keypair
+    inst = CullisClient.__new__(CullisClient)
+    inst.base = "http://mastio.test"
+    inst.token = "fake-access-token"
+    inst._label = "agent::night-reporter"
+    inst._http = MagicMock()
+    inst._dpop_privkey, inst._dpop_pubkey_jwk = generate_dpop_keypair()
+    inst._dpop_nonce = None
+    inst.server_role = None
+    return inst
+
+
+def _mock_response(client: CullisClient, *, status_code: int, body: dict | str):
+    """Stub ``client._http.request`` to return a fixed response.
+
+    ``raise_for_status`` mirrors httpx's real behaviour so the SDK's
+    own raise path is exercised end-to-end.
+    """
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.text = body if isinstance(body, str) else str(body)
+    resp.json.return_value = body if isinstance(body, dict) else {}
+    resp.headers = {}
+
+    def _raise():
+        if status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {status_code}", request=MagicMock(), response=resp,
+            )
+
+    resp.raise_for_status = _raise
+    client._http.request.return_value = resp
+    return resp
+
+
+def test_send_to_inbox_serialises_dict_body():
+    c = _client()
+    _mock_response(c, status_code=201, body={
+        "msg_id": "m1", "inserted": True, "quadrant": "A2U-intra",
+    })
+    out = c.send_to_inbox(
+        recipient_org_id="orga",
+        recipient_principal_type="user",
+        recipient_name="claim-officer",
+        body={"hello": "world"},
+        subject="night report",
+    )
+    assert out["msg_id"] == "m1"
+    assert out["quadrant"] == "A2U-intra"
+
+    # Verify the wire-level request was built correctly.
+    call = c._http.request.call_args
+    assert call.args[0] == "POST"
+    # Default route is mastio-mediated egress prefix.
+    assert call.args[1].endswith("/v1/egress/inbox/send")
+    payload = call.kwargs["json"]
+    assert payload["recipient_org_id"] == "orga"
+    assert payload["recipient_principal_type"] == "user"
+    assert payload["recipient_name"] == "claim-officer"
+    # Dict body becomes JSON string.
+    assert payload["body"] == '{"hello": "world"}'
+    assert payload["subject"] == "night report"
+    # Optional fields omitted when not supplied.
+    assert "idempotency_key" not in payload
+
+
+def test_send_to_inbox_passes_string_body_through():
+    c = _client()
+    _mock_response(c, status_code=201, body={
+        "msg_id": "m2", "inserted": True, "quadrant": "U2U-intra",
+    })
+    c.send_to_inbox(
+        recipient_org_id="orga",
+        recipient_principal_type="user",
+        recipient_name="claim-manager",
+        body="raw text already serialised",
+        idempotency_key="claim-2026-0501",
+    )
+    payload = c._http.request.call_args.kwargs["json"]
+    assert payload["body"] == "raw text already serialised"
+    assert payload["idempotency_key"] == "claim-2026-0501"
+
+
+def test_send_to_inbox_403_raises_permission_error():
+    c = _client()
+    _mock_response(c, status_code=403, body={
+        "detail": {"reason": "reach denied", "quadrant": "A2U-cross"},
+    })
+    with pytest.raises(PermissionError, match="reach"):
+        c.send_to_inbox(
+            recipient_org_id="orgb",
+            recipient_principal_type="user",
+            recipient_name="counterparty-liaison",
+            body={"x": 1},
+        )
+
+
+def test_send_to_inbox_500_raises_http_status_error():
+    c = _client()
+    _mock_response(c, status_code=500, body={"detail": "boom"})
+    with pytest.raises(httpx.HTTPStatusError):
+        c.send_to_inbox(
+            recipient_org_id="orga",
+            recipient_principal_type="user",
+            recipient_name="claim-officer",
+            body={"x": 1},
+        )
+
+
+def test_via_broker_flag_uses_direct_path():
+    """When the SDK is run inside the proxy (BrokerBridge sets the flag),
+    send_to_inbox calls /v1/inbox/send directly on the broker — no
+    /v1/egress/ prefix."""
+    c = _client()
+    c._inbox_path_via_broker = True
+    _mock_response(c, status_code=201, body={
+        "msg_id": "m3", "inserted": True, "quadrant": "A2U-intra",
+    })
+    c.send_to_inbox(
+        recipient_org_id="orga",
+        recipient_principal_type="user",
+        recipient_name="claim-officer",
+        body={"x": 1},
+    )
+    assert c._http.request.call_args.args[1].endswith("/v1/inbox/send")
+
+
+def test_egress_inbox_router_is_registered():
+    """The proxy must mount the new egress/inbox router. Sanity check."""
+    from mcp_proxy.egress.inbox import router
+    routes = {r.path for r in router.routes}
+    assert "/v1/egress/inbox/send" in routes


### PR DESCRIPTION
## Summary

ADR-020 Phase 4 introduced ``user_inbox_messages`` on the broker as the durable delivery primitive for A2U / U2A / U2U messages. Agents authenticate against their Mastio with proxy-local tokens (``aud=cullis-local``, ADR-012); the broker rejects those at ``app.auth.jwt.get_current_agent``. Result: an SDK ``send_to_user`` call had no path to the broker.

This PR adds the missing hop via a dedicated proxy endpoint that uses ``BrokerBridge`` to forward on the agent's behalf, mirroring how ``/v1/egress/oneshot`` translates SDK calls to broker calls.

### Changes
- ``mcp_proxy/egress/inbox.py`` — new ``POST /v1/egress/inbox/send``. mTLS+DPoP auth, then ``BrokerBridge.get_client(agent_id).send_to_inbox(...)``.
- ``cullis_sdk/client.send_to_inbox`` — SDK helper. Routes to ``/v1/egress/inbox/send`` by default; when the SDK is run *inside* the proxy via ``BrokerBridge.get_client()`` (the broker-side client), the ``_inbox_path_via_broker`` flag flips to ``/v1/inbox/send`` direct.
- ``mcp_proxy/egress/broker_bridge.py`` — sets the via-broker flag on every cached client.
- Audit events: ``inbox_send_ok`` / ``inbox_send_denied`` in the local audit chain.

## Closes
Half of #481 (SDK + proxy hop). The demo-side wiring (seed.py federated=True + approved binding for the bots) lands as a follow-up on PR #480.

## Test plan
- ``pytest tests/test_sdk_send_to_inbox.py`` — 6 tests, green locally
- ``pytest tests/test_proxy_reverse_forwarding.py tests/test_user_inbox.py tests/test_oneshot_cross_envelope.py`` — 37/37 green (regression)
- Live smoke against ``reference/demo.sh full``: the bot reaches BrokerBridge cleanly. Beyond that the broker enforces \"approved binding\" — that's reference-bootstrap setup work, not a code gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)