### PR TITLE
feat(spa): restore chat-window style alignment with Mastio dashboard

### DIFF
--- a/frontend/cullis-chat/src/components/MessageInput.tsx
+++ b/frontend/cullis-chat/src/components/MessageInput.tsx
@@ -64,7 +64,6 @@ export function MessageInput({ onSend, disabled, isSending, draft, onDraftConsum
       />
       <button type="submit" className="send" disabled={submitDisabled}>
         <span className="send-label">{isSending ? 'sending' : 'send'}</span>
-        <span className="send-arrow" aria-hidden="true">→</span>
       </button>
     </form>
   );

--- a/frontend/cullis-chat/src/components/SidebarLeft.astro
+++ b/frontend/cullis-chat/src/components/SidebarLeft.astro
@@ -21,13 +21,13 @@ const chatHref = base;
 const inboxHref = `${base}inbox`;
 ---
 
-<aside class="sidebar-left" aria-label="Conversation history">
-  <header class="sl-head">
-    <span class="eyebrow">conversations</span>
-    <a class="sl-new" href={chatHref} aria-label="Start a new chat" title="New chat">
-      <span aria-hidden="true">+</span> new
+<aside class="sidebar-left" aria-label="Sidebar">
+  <nav class="sl-nav">
+    <a class="sl-item" href={chatHref} aria-label="Start a new chat" title="New chat">
+      <svg class="sl-item-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+      <span class="sl-item-label">New chat</span>
     </a>
-  </header>
+  </nav>
 
   <nav class="sl-surfaces" aria-label="Surfaces">
     <a
@@ -49,15 +49,10 @@ const inboxHref = `${base}inbox`;
   </nav>
 
   <div class="sl-empty">
-    <p class="sl-empty-title">
-      <em>Nothing</em><br />
-      here yet.
-    </p>
     <p class="sl-empty-body">
       Conversation history lands in <span class="ver">v0.5</span>.
       Until then every reload starts a fresh thread.
     </p>
-    <div class="sl-rule" aria-hidden="true"></div>
     <p class="folio">CLLS-CHAT · <em>v0.1</em></p>
   </div>
 </aside>
@@ -70,34 +65,46 @@ const inboxHref = `${base}inbox`;
     flex-direction: column;
   }
 
-  .sl-head {
-    padding: 1.25rem 1.25rem 0.9rem;
-    border-bottom: 1px solid var(--border-subtle);
+  /* Nav list — Mastio dashboard pattern (.nav-item / .nav-active). */
+  .sl-nav {
+    padding: 0.75rem 0.5rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  .sl-item {
     display: flex;
     align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-  }
-
-  /* "+ new" — full-page navigation to / so React island state resets
-     cleanly. v0.1 has no server-side history; v0.5 will swap this for
-     a real "spawn new conversation" action that also persists. */
-  .sl-new {
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--text-secondary);
+    gap: 0.625rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-sm);
+    border-left: 2px solid transparent;
+    font-family: var(--font-body);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: #6b7280; /* text-gray-500, identical to Mastio inactive */
     text-decoration: none;
-    padding: 0.25rem 0.55rem;
-    border: 1px solid var(--border-medium);
-    border-left: 2px solid var(--accent-cyan);
-    transition: color var(--t-base) ease, border-color var(--t-base) ease;
+    transition: all 0.15s ease;
   }
 
-  .sl-new:hover, .sl-new:focus-visible {
+  .sl-item:hover:not(.sl-item-active) {
+    background: rgba(255, 255, 255, 0.03);
+    color: #d1d5db; /* text-gray-300 */
+  }
+
+  .sl-item-active {
+    background: rgba(0, 229, 199, 0.08);
     color: var(--accent-cyan);
-    border-color: var(--accent-cyan);
+    border-left-color: var(--accent-cyan);
+  }
+
+  .sl-item-icon {
+    flex-shrink: 0;
+  }
+
+  .sl-item-label {
+    line-height: 1.2;
   }
 
   .sl-surfaces {
@@ -155,16 +162,18 @@ const inboxHref = `${base}inbox`;
   }
 
   .sl-empty-title {
-    font-family: var(--font-display);
-    font-size: 1.6rem;
-    line-height: 1.05;
+    font-family: var(--font-brand);
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    line-height: 1.4;
     color: var(--text-primary);
     margin: 0;
-    letter-spacing: -0.01em;
   }
 
   .sl-empty-title em {
-    font-style: italic;
+    font-style: normal;
     color: var(--accent-cyan);
   }
 
@@ -174,7 +183,7 @@ const inboxHref = `${base}inbox`;
     line-height: 1.55;
     color: var(--text-secondary);
     margin: 0;
-    max-width: 22ch;
+    max-width: 24ch;
   }
 
   .sl-empty-body .ver {
@@ -182,15 +191,9 @@ const inboxHref = `${base}inbox`;
     font-size: 0.78em;
     letter-spacing: 0.08em;
     color: var(--accent-cyan);
-    padding: 0.05em 0.35em;
+    padding: 0.05em 0.4em;
     background: var(--accent-cyan-glow);
     border: 1px solid var(--accent-cyan-dim);
-  }
-
-  .sl-rule {
-    width: 32px;
-    height: 1px;
-    background: var(--accent-cyan);
-    margin-top: 0.4rem;
+    border-radius: var(--radius-sm);
   }
 </style>

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -63,7 +63,7 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     align-items: center;
     height: var(--topbar-h);
     padding: 0 1.4rem;
-    background: rgba(5, 5, 8, 0.85);
+    background: rgba(10, 15, 26, 0.85);
     backdrop-filter: blur(18px);
     -webkit-backdrop-filter: blur(18px);
     border-bottom: 1px solid var(--border-subtle);
@@ -113,24 +113,32 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
 
   /* ModelPicker — global rules so they apply to the React island
      (Astro scoped styles don't reach into mounted React subtrees). */
+  /* Model picker — raised ghost control. Subtle border + relief shadow,
+     no cyan focus ring (the SEND button is the only cyan-emphasis surface). */
   :global(.model-picker) {
     display: inline-flex;
     align-items: center;
-    gap: 0.55rem;
-    padding: 0.4rem 0.75rem;
+    gap: 0.6rem;
+    padding: 0.45rem 0.85rem;
     background: var(--bg-elevated);
     border: 1px solid var(--border-medium);
-    transition: border-color var(--t-base) ease;
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-button);
+    transition: border-color var(--t-fast) var(--ease-soft),
+                background var(--t-fast) var(--ease-soft);
   }
 
   :global(.model-picker:hover),
   :global(.model-picker:focus-within) {
-    border-color: var(--accent-cyan);
+    border-color: var(--border-strong);
+    background: var(--bg-card);
   }
 
   :global(.model-picker .folio) {
-    border-right: 1px solid var(--border-subtle);
-    padding-right: 0.55rem;
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    color: var(--text-tertiary);
+    padding-right: 0.4rem;
   }
 
   :global(.model-picker select) {
@@ -138,20 +146,21 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     background: transparent;
     border: none;
     color: var(--text-primary);
-    font-family: var(--font-mono);
-    font-size: 0.78rem;
-    letter-spacing: 0.04em;
+    font-family: var(--font-body);
+    font-size: 0.85rem;
+    font-weight: 500;
+    letter-spacing: 0;
     cursor: pointer;
-    padding: 0.1rem 1.5rem 0.1rem 0;
-    background-image: linear-gradient(45deg, transparent 50%, var(--accent-cyan) 50%),
-                      linear-gradient(135deg, var(--accent-cyan) 50%, transparent 50%);
-    background-position: calc(100% - 12px) 50%, calc(100% - 6px) 50%;
-    background-size: 6px 6px;
+    padding: 0.1rem 1.4rem 0.1rem 0;
+    /* Single chevron — clean dropdown indicator. */
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%238a8d9b' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='6 9 12 15 18 9'/></svg>");
+    background-position: right 0 center;
+    background-size: 12px 12px;
     background-repeat: no-repeat;
   }
 
   :global(.model-picker[data-loaded='false']) {
-    opacity: 0.7;
+    opacity: 0.65;
   }
 
   /* Native <option> rendering ignores the parent <select> background
@@ -190,17 +199,20 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     display: inline-flex;
     align-items: center;
     gap: 0.55rem;
-    padding: 0.35rem 0.75rem;
+    padding: 0.4rem 0.8rem;
+    background: var(--bg-elevated);
     border: 1px solid var(--border-medium);
-    border-left: 2px solid var(--accent-cyan);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-button);
   }
 
   :global(.identity-badge-loading) {
-    border-left-color: var(--text-tertiary);
+    opacity: 0.7;
   }
 
   :global(.identity-badge-error) {
-    border-left-color: var(--accent-amber);
+    border-color: var(--accent-amber);
+    color: var(--accent-amber);
   }
 
   :global(.identity-badge .folio) {
@@ -231,23 +243,34 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     color: var(--text-tertiary);
   }
 
-  /* Audit toggle — slim icon button matching `.comp-download` family */
+  /* Audit toggle — raised ghost button. */
   .audit-toggle {
     display: inline-flex;
     align-items: center;
     gap: 0.45rem;
-    padding: 0.35rem 0.65rem;
-    background: transparent;
+    padding: 0.4rem 0.7rem;
+    background: var(--bg-elevated);
     border: 1px solid var(--border-medium);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-button);
     color: var(--text-secondary);
     cursor: pointer;
-    transition: all var(--t-base) ease;
+    transition: transform var(--t-fast) var(--ease-soft),
+                box-shadow var(--t-fast) var(--ease-soft),
+                color var(--t-fast) var(--ease-soft),
+                border-color var(--t-fast) var(--ease-soft);
     font-family: var(--font-mono);
   }
 
   .audit-toggle:hover {
     border-color: var(--accent-cyan);
     color: var(--accent-cyan);
+    transform: translateY(-1px);
+  }
+
+  .audit-toggle:active {
+    transform: translateY(0);
+    box-shadow: var(--shadow-button-pressed);
   }
 
   .audit-toggle-icon {

--- a/frontend/cullis-chat/src/styles/chat-window.css
+++ b/frontend/cullis-chat/src/styles/chat-window.css
@@ -44,44 +44,43 @@
 }
 
 .chat-empty-title {
-  font-family: var(--font-display);
-  font-weight: 400;
-  font-size: clamp(2rem, 4.5vw, 3.2rem);
-  line-height: 1.05;
-  letter-spacing: -0.02em;
+  font-family: var(--font-brand);
+  font-weight: 600;
+  font-size: clamp(1.4rem, 2.6vw, 1.8rem);
+  line-height: 1.2;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
   color: var(--text-primary);
   margin: 0.4rem 0 0.2rem;
 }
 
 .chat-empty-title em {
-  font-style: italic;
+  font-style: normal;
   color: var(--accent-cyan);
 }
 
 .chat-empty-sub {
   font-family: var(--font-body);
-  font-size: 1rem;
-  line-height: 1.65;
+  font-size: 0.95rem;
+  line-height: 1.6;
   color: var(--text-secondary);
-  max-width: 48ch;
+  max-width: 56ch;
   margin: 0;
 }
 
 .chat-empty-hints {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 1.25rem;
-  padding-top: 1.25rem;
-  border-top: 1px solid var(--border-subtle);
+  gap: 0.55rem;
+  margin-top: 1.5rem;
 }
 
 .hint {
   font-family: var(--font-mono);
-  font-size: 0.82rem;
+  font-size: 0.86rem;
   line-height: 1.5;
-  color: var(--text-tertiary);
-  letter-spacing: 0.01em;
+  color: var(--text-secondary);
+  letter-spacing: 0;
   background: none;
   border: none;
   cursor: pointer;
@@ -184,7 +183,8 @@
   gap: 0.6rem;
   padding: 0.4rem 0.75rem;
   background: var(--tool-bg);
-  border-left: 2px solid var(--tool-border);
+  border: 1px solid var(--tool-border);
+  border-radius: var(--radius-sm);
   font-family: var(--font-mono);
   font-size: 0.78rem;
   color: var(--text-secondary);
@@ -347,6 +347,7 @@
   background: var(--bg-card);
   border: 1px solid var(--border-subtle);
   border-left: 3px solid var(--accent-cyan-dim);
+  border-radius: var(--radius-sm);
   padding: 0.85rem 1rem;
   cursor: pointer;
   font-family: var(--font-body);
@@ -595,7 +596,9 @@
   padding: 1rem 1.1rem;
   overflow-x: auto;
   background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
   border-left: 3px solid var(--accent-cyan);
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
 }
 
@@ -612,7 +615,9 @@
 .markdown-body pre.shiki,
 .markdown-body pre.shiki-block {
   background: var(--bg-card) !important;
+  border: 1px solid var(--border-subtle);
   border-left: 3px solid var(--accent-cyan);
+  border-radius: var(--radius-sm);
   padding: 1rem 1.1rem;
   margin: 0.85em 0;
   font-size: 0.85rem;
@@ -662,6 +667,7 @@
   background: rgba(240, 165, 0, 0.06);
   border: 1px solid rgba(240, 165, 0, 0.3);
   border-left: 3px solid var(--accent-amber);
+  border-radius: var(--radius-sm);
   color: var(--text-primary);
   padding: 0.85rem 1rem;
   font-family: var(--font-body);
@@ -686,6 +692,7 @@
   padding: 0.75rem 0.9rem;
   background: var(--input-bg);
   border: 1px solid var(--input-border);
+  border-radius: var(--radius-md);
   transition: border-color var(--t-base) ease;
 }
 
@@ -702,10 +709,11 @@
 .prompt {
   font-family: var(--font-mono);
   color: var(--accent-cyan);
-  font-size: 1rem;
-  line-height: 1.6;
-  padding-bottom: 0.05rem;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  padding: 0.1rem 0;
   user-select: none;
+  align-self: end;
 }
 
 .chat-input textarea {
@@ -728,40 +736,54 @@
   color: var(--text-tertiary);
 }
 
+/* SEND — dim at rest (cyan inviting but spento), bright cyan on hover. */
 .send {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
-  padding: 0.55rem 0.9rem;
-  font-family: var(--font-mono);
-  font-size: 0.74rem;
-  font-weight: 400;
-  letter-spacing: 0.16em;
+  justify-content: center;
+  min-width: 96px;
+  padding: 0.6rem 1.25rem;
+  font-family: var(--font-brand);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
-  background: transparent;
+  background: var(--bg-elevated);
   color: var(--accent-cyan);
-  border: 1px solid var(--accent-cyan);
+  border: 1px solid var(--accent-cyan-dim);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-button);
   cursor: pointer;
-  transition: all var(--t-base) ease;
+  transition: transform var(--t-fast) var(--ease-soft),
+              box-shadow var(--t-fast) var(--ease-soft),
+              background var(--t-fast) var(--ease-soft),
+              border-color var(--t-fast) var(--ease-soft),
+              color var(--t-fast) var(--ease-soft);
 }
 
 .send:not([disabled]):hover {
-  background: var(--accent-cyan);
+  background: linear-gradient(180deg, #1cf2d4 0%, var(--accent-cyan) 100%);
   color: var(--bg-void);
+  border-color: var(--accent-cyan);
+  box-shadow: var(--shadow-button-primary);
+  transform: translateY(-1px);
+}
+
+.send:not([disabled]):active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-button-pressed);
+  background: var(--accent-cyan);
 }
 
 .send[disabled] {
   cursor: not-allowed;
   opacity: 0.45;
+  background: var(--bg-elevated);
+  color: var(--text-tertiary);
+  border-color: var(--border-medium);
+  box-shadow: none;
 }
 
-.send-arrow {
-  transition: transform var(--t-base) ease;
-}
-
-.send:not([disabled]):hover .send-arrow {
-  transform: translateX(3px);
-}
 
 .chat-foot {
   text-align: center;

--- a/frontend/cullis-chat/src/styles/globals.css
+++ b/frontend/cullis-chat/src/styles/globals.css
@@ -19,9 +19,9 @@ html, body {
 body {
   color: var(--text-primary);
   font-family: var(--font-body);
-  font-size: 0.95rem;
-  font-weight: 400;
-  line-height: 1.55;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  line-height: 1.6;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
   overflow: hidden;
@@ -92,51 +92,23 @@ body {
   grid-template-columns: minmax(0, 1fr);
 }
 
-/* Subtle grid background CONFINED to the main pane (sidebar + audit
- * stay flat surface for legibility — different from the site, where
- * the grid is global). */
+/* Mastio-style flat surface — no grid pattern, no overlay. */
 .chat-main {
   position: relative;
   background: var(--bg-void);
 }
 
-.chat-main::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background-image:
-    linear-gradient(var(--border-subtle) 1px, transparent 1px),
-    linear-gradient(90deg, var(--border-subtle) 1px, transparent 1px);
-  background-size: 80px 80px;
-  pointer-events: none;
-  mask-image: radial-gradient(ellipse 80% 100% at 50% 30%, black 30%, transparent 80%);
-  -webkit-mask-image: radial-gradient(ellipse 80% 100% at 50% 30%, black 30%, transparent 80%);
-  z-index: 0;
-}
-
-.chat-main > * {
-  position: relative;
-  z-index: 1;
-}
-
-/* Eyebrow — borrowed from site, used for pane headers */
+/* Eyebrow — Mastio-style section heading: Chakra Petch uppercase, no rule. */
 .eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  font-weight: 400;
+  font-family: var(--font-brand);
+  font-size: 0.75rem;
+  font-weight: 600;
   letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: var(--accent-cyan);
+  color: var(--text-secondary);
   display: inline-flex;
   align-items: center;
-  gap: 0.7rem;
-}
-
-.eyebrow::before {
-  content: '';
-  width: 24px;
-  height: 1px;
-  background: var(--accent-cyan);
+  gap: 0.5rem;
 }
 
 /* Folio — borrowed from site, used as small breadcrumbs in messages */

--- a/frontend/cullis-chat/src/styles/tokens.css
+++ b/frontend/cullis-chat/src/styles/tokens.css
@@ -6,18 +6,17 @@
  * candidates for back-port to the site once stable.
  */
 
-@import url('https://fonts.googleapis.com/css2?family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&family=Chakra+Petch:wght@400;500;600;700&display=swap');
-@import url('https://api.fontshare.com/v2/css?f[]=satoshi@300,400,500,700,900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Chakra+Petch:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=DM+Mono:wght@300;400;500&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 :root {
   /* ---- Mirrored from cullis.io ---- */
 
-  /* Palette */
-  --bg-void: #050508;
-  --bg-surface: #0a0b10;
-  --bg-elevated: #10121a;
-  --bg-card: #13151f;
-  --bg-card-hover: #161923;
+  /* Palette — bluish charcoal, matched to Mastio dashboard (surface-950..700). */
+  --bg-void: #0a0f1a;
+  --bg-surface: #111827;
+  --bg-elevated: #1a1f2e;
+  --bg-card: #1a1f2e;
+  --bg-card-hover: #252b3d;
   --border-subtle: rgba(255, 255, 255, 0.06);
   --border-medium: rgba(255, 255, 255, 0.10);
   --border-strong: rgba(255, 255, 255, 0.18);
@@ -37,11 +36,29 @@
   --cullis-badge-agent: #8b5cf6;
   --cullis-badge-workload: #10b981;
 
-  /* Fonts */
+  /* Fonts — Mastio dashboard family (DM Sans / JetBrains Mono / Chakra Petch). */
   --font-display: 'Instrument Serif', Georgia, serif;
-  --font-body: 'Satoshi', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-mono: 'DM Mono', 'SF Mono', Menlo, monospace;
+  --font-body: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', Menlo, monospace;
   --font-brand: 'Chakra Petch', sans-serif;
+
+  /* Radius — match Mastio: small on controls, medium on cards, pill on status. */
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-pill: 9999px;
+
+  /* Relief — subtle depth shadows for solid + ghost buttons.
+   * `--shadow-button` adds a tiny dark drop + light top-edge inset, so
+   * a flat button reads as raised. `--shadow-button-pressed` flips the
+   * inset to a darker top, simulating press.
+   * `--shadow-button-primary` is a stronger drop for filled accents. */
+  --shadow-button: 0 1px 0 rgba(255, 255, 255, 0.05) inset,
+                   0 1px 2px rgba(0, 0, 0, 0.35),
+                   0 2px 6px rgba(0, 0, 0, 0.18);
+  --shadow-button-primary: 0 1px 0 rgba(255, 255, 255, 0.30) inset,
+                           0 1px 2px rgba(0, 0, 0, 0.45),
+                           0 2px 8px rgba(0, 229, 199, 0.18);
+  --shadow-button-pressed: 0 1px 2px rgba(0, 0, 0, 0.45) inset;
 
   /* Motion (mirrored from site Nav/buttons) */
   --ease-soft: cubic-bezier(0.16, 1, 0.3, 1);
@@ -60,7 +77,7 @@
   --msg-pad-x: 1.4rem;
   --msg-pad-y: 1.1rem;
   --msg-gap: 1.4rem;
-  --msg-radius: 0;          /* Cullis is zero-radius — sharp edges, like the site buttons */
+  --msg-radius: var(--radius-sm);  /* aligned with Mastio cards/controls */
 
   /* Roles. Assistant uses card surface with cyan border-left like site .comp-aside.
      User reads as a "sent" line — no card, just a folio + text. */


### PR DESCRIPTION
## Summary

Restores six SPA chat surface style changes that were stashed locally on 2026-05-06 and never landed. Recovered via reflog (\`stash@{2}\`) and applied on top of \`main\` post-PR #482 with a manual merge on the SidebarLeft.

- **SidebarLeft**: nav rebuilt with the Mastio dashboard \`.nav-item / .nav-active\` pattern (icon + "New chat" label + accent-cyan left border, neutral hover state). The Phase 2 surface switcher (Chat / Inbox) lives beneath as a separate \`<nav class="sl-surfaces">\` so both affordances coexist.
- **TopBar**: typography + spacing realigned with the Mastio header.
- **chat-window.css / globals.css**: spacing pass, trims of unused selectors.
- **tokens.css**: adopts the Mastio palette family (\`--bg-void: #0a0f1a\`, \`--font-body: DM Sans\`, \`--font-mono: JetBrains Mono\`), adds \`--radius-sm/md/pill\` and \`--shadow-button*\` tokens. \`--cullis-badge-user/agent/workload\` from PR #479 are preserved so \`<PrincipalBadge>\` keeps its color tokens.
- **MessageInput**: drops the trailing arrow on the send button.

The two conflict files (SidebarLeft.astro, tokens.css) were merged by hand: kept stash content as base, layered the PR #482 surface switcher and the PR #479 badge tokens on top.

## Test plan

- [x] \`astro build\` passes — both \`/index.html\` and \`/inbox/index.html\` are generated, no TS errors
- [x] Visual smoke on \`http://127.0.0.1:4321/\` (chat) + \`/inbox\` during the restore: SidebarLeft nav matches Mastio style, surface switcher visible, badges render
- [ ] Reviewer pull + screenshot pass on /chat and /inbox
- [ ] CI \`cullis-chat / build-and-e2e\` green

## Origin

Recovered from \`stash@{2}\` (\`WIP on feat/nixos-a2a-sdk-derivation: b12507c ...\`, 2026-05-06 23:33). The stash will be dropped after merge.