### PR TITLE
feat(spa): brand split — Phase 3 SPA rework

### DIFF
--- a/frontend/cullis-chat/astro.config.mjs
+++ b/frontend/cullis-chat/astro.config.mjs
@@ -1,5 +1,15 @@
 import { defineConfig } from 'astro/config';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import react from '@astrojs/react';
+
+// Brand split — see src/branding/{cullis-chat,frontdesk}. The alias
+// `@brand` resolves to whichever brand bundle this build produces.
+// Default consumer build is `cullis-chat`; the Frontdesk Dockerfile
+// (Phase 4) sets `CULLIS_BRAND=frontdesk` before invoking npm run build.
+const CULLIS_BRAND = process.env.CULLIS_BRAND === 'frontdesk' ? 'frontdesk' : 'cullis-chat';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const brandDir = path.resolve(__dirname, 'src', 'branding', CULLIS_BRAND);
 
 // Cullis Chat SPA — ADR-019 Phase 8b-2b: pure static.
 //
@@ -41,6 +51,11 @@ export default defineConfig({
     host: '127.0.0.1',
   },
   vite: {
+    resolve: {
+      alias: {
+        '@brand': brandDir,
+      },
+    },
     server: {
       // Dev: forward both /v1/* and /api/* to the mock Ambassador.
       // The SPA's session bootstrap (POST /api/session/init), the

--- a/frontend/cullis-chat/src/branding/cullis-chat/config.ts
+++ b/frontend/cullis-chat/src/branding/cullis-chat/config.ts
@@ -1,0 +1,27 @@
+/**
+ * Cullis Chat brand — consumer single-user surface.
+ *
+ * Imported via the `@brand` alias declared in astro.config.mjs.
+ * Build-time selection: `CULLIS_BRAND=cullis-chat` (default) sets the
+ * alias to this file; `CULLIS_BRAND=frontdesk` swaps to the
+ * `frontdesk/config.ts` sibling. Same SPA, different identity.
+ */
+import type { BrandConfig } from '../types';
+
+const config: BrandConfig = {
+  id: 'cullis-chat',
+  displayName: 'Cullis Chat',
+  brandHead: 'Cullis',
+  brandTail: 'Chat',
+  ariaHome: 'Cullis Chat home',
+  layoutTitle: 'Cullis Chat',
+  layoutDescription:
+    'Identity-aware chat. Every message is signed, audited, and traceable.',
+  inboxTitle: 'Inbox · Cullis Chat',
+  inboxDescription:
+    'Cullis Chat inbox — identity-aware messages for users and agents.',
+  logoMark: 'cullis-mark.svg',
+  sidebarFolio: 'CLLS-CHAT',
+};
+
+export default config;

--- a/frontend/cullis-chat/src/branding/frontdesk/config.ts
+++ b/frontend/cullis-chat/src/branding/frontdesk/config.ts
@@ -1,0 +1,29 @@
+/**
+ * Cullis Frontdesk brand — enterprise multi-user surface.
+ *
+ * Built from the same SPA source via `CULLIS_BRAND=frontdesk astro build`.
+ * Layout, palette, animations are identical to the consumer build —
+ * only the lockup, copy, and folio change. Per-user KMS + SSO + the
+ * X-Forwarded-User topbar are the runtime-shape differences and live
+ * outside the brand config (they switch on at the Connector level
+ * once shared mode is detected).
+ */
+import type { BrandConfig } from '../types';
+
+const config: BrandConfig = {
+  id: 'frontdesk',
+  displayName: 'Cullis Frontdesk',
+  brandHead: 'Cullis',
+  brandTail: 'Frontdesk',
+  ariaHome: 'Cullis Frontdesk home',
+  layoutTitle: 'Cullis Frontdesk',
+  layoutDescription:
+    'Identity-aware chat for enterprise teams. SSO + per-user KMS, signed and audited end-to-end.',
+  inboxTitle: 'Inbox · Cullis Frontdesk',
+  inboxDescription:
+    'Cullis Frontdesk inbox — cross-org messages for enterprise teams.',
+  logoMark: 'cullis-mark.svg',
+  sidebarFolio: 'CLLS-FRONTDESK',
+};
+
+export default config;

--- a/frontend/cullis-chat/src/branding/types.ts
+++ b/frontend/cullis-chat/src/branding/types.ts
@@ -1,0 +1,36 @@
+/**
+ * BrandConfig — shape of a SPA brand identity.
+ *
+ * The two implementations live in `cullis-chat/config.ts` (consumer)
+ * and `frontdesk/config.ts` (enterprise). Build-time aliasing in
+ * `astro.config.mjs` resolves `@brand/config` to one or the other
+ * based on the `CULLIS_BRAND` env var.
+ *
+ * Keep this lean: every field added here must be defined in both
+ * sibling configs. Brand split intentionally covers identity only,
+ * not layout, palette, or capabilities.
+ */
+export interface BrandConfig {
+  /** Stable identifier, equal to the folder name. */
+  id: 'cullis-chat' | 'frontdesk';
+  /** "Cullis Chat" or "Cullis Frontdesk" — the human label. */
+  displayName: string;
+  /** First half of the wordmark lockup ("Cullis"). */
+  brandHead: string;
+  /** Second half of the wordmark lockup ("Chat" / "Frontdesk"). */
+  brandTail: string;
+  /** aria-label on the brand link. */
+  ariaHome: string;
+  /** <title> on the chat layout. */
+  layoutTitle: string;
+  /** <meta name="description"> on the chat layout. */
+  layoutDescription: string;
+  /** <title> on the inbox page. */
+  inboxTitle: string;
+  /** <meta name="description"> on the inbox page. */
+  inboxDescription: string;
+  /** Filename under /public for the brand mark SVG. */
+  logoMark: string;
+  /** Folio code shown in SidebarLeft and other footer-style spots. */
+  sidebarFolio: string;
+}

--- a/frontend/cullis-chat/src/components/SidebarLeft.astro
+++ b/frontend/cullis-chat/src/components/SidebarLeft.astro
@@ -12,6 +12,8 @@
 // (`chat` for index.astro, `inbox` for inbox.astro). Used to mark
 // the matching surface link in the in-rail navigation.
 
+import brand from '@brand/config';
+
 interface Props {
   active?: 'chat' | 'inbox';
 }
@@ -53,7 +55,7 @@ const inboxHref = `${base}inbox`;
       Conversation history lands in <span class="ver">v0.5</span>.
       Until then every reload starts a fresh thread.
     </p>
-    <p class="folio">CLLS-CHAT · <em>v0.1</em></p>
+    <p class="folio">{brand.sidebarFolio} · <em>v0.1</em></p>
   </div>
 </aside>
 

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -10,15 +10,16 @@
 
 import IdentityBadge from './IdentityBadge.tsx';
 import ModelPicker from './ModelPicker.tsx';
+import brand from '@brand/config';
 
 const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
 ---
 
 <header class="topbar">
-  <a class="brand" href={import.meta.env.BASE_URL} aria-label="Cullis Chat home">
-    <img src={`${import.meta.env.BASE_URL}cullis-mark.svg`} alt="" width="26" height="26" />
+  <a class="brand" href={import.meta.env.BASE_URL} aria-label={brand.ariaHome}>
+    <img src={`${import.meta.env.BASE_URL}${brand.logoMark}`} alt="" width="26" height="26" />
     <span class="wordmark">
-      Cullis <span class="brand-tail">Chat</span>
+      {brand.brandHead} <span class="brand-tail">{brand.brandTail}</span>
     </span>
   </a>
 

--- a/frontend/cullis-chat/src/components/core/Inbox.tsx
+++ b/frontend/cullis-chat/src/components/core/Inbox.tsx
@@ -9,8 +9,10 @@
  * {msg_id}`) is BLOCKED in the spec until the broker ships it; the
  * detail panel renders a placeholder so the demo screenshot is honest.
  *
- * The component is intentionally one file: split lands in Phase 3
- * when the SPA core is extracted into `components/core/`.
+ * Lives in `components/core/` as a shared SPA primitive; Cullis Chat
+ * (consumer) and Frontdesk (enterprise) both mount the same instance.
+ * Sub-views (list, detail, compose) are intentionally inline in this
+ * file: split if the file exceeds ~600 lines.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -20,15 +22,15 @@ import {
   ApiError,
   listInbox,
   sendInboxMessage,
-} from '../lib/api';
-import { ensureSession } from '../lib/session-singleton';
+} from '../../lib/api';
+import { ensureSession } from '../../lib/session-singleton';
 import type {
   InboxMessage,
   InboxSendRequest,
   InboxTab,
   PrincipalType,
-} from '../lib/types';
-import PrincipalBadge from './core/PrincipalBadge';
+} from '../../lib/types';
+import PrincipalBadge from './PrincipalBadge';
 
 const TABS: { id: InboxTab; label: string }[] = [
   { id: 'all', label: 'All' },

--- a/frontend/cullis-chat/src/layouts/ChatLayout.astro
+++ b/frontend/cullis-chat/src/layouts/ChatLayout.astro
@@ -11,6 +11,7 @@ import '../styles/globals.css';
 import TopBar from '../components/TopBar.astro';
 import SidebarLeft from '../components/SidebarLeft.astro';
 import ChatApp from '../components/ChatApp.tsx';
+import brand from '@brand/config';
 
 interface Props {
   title?: string;
@@ -18,8 +19,8 @@ interface Props {
 }
 
 const {
-  title = 'Cullis Chat',
-  description = 'Identity-aware chat for Cullis Frontdesk. Every message is signed, audited, and traceable.',
+  title = brand.layoutTitle,
+  description = brand.layoutDescription,
 } = Astro.props;
 ---
 
@@ -33,7 +34,7 @@ const {
     <meta name="description" content={description} />
     <meta name="referrer" content="same-origin" />
     <title>{title}</title>
-    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}cullis-mark.svg`} />
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}${brand.logoMark}`} />
   </head>
   <body class="app-shell">
     <TopBar />

--- a/frontend/cullis-chat/src/pages/inbox.astro
+++ b/frontend/cullis-chat/src/pages/inbox.astro
@@ -9,7 +9,8 @@ import '../styles/globals.css';
 import '../styles/inbox.css';
 import TopBar from '../components/TopBar.astro';
 import SidebarLeft from '../components/SidebarLeft.astro';
-import Inbox from '../components/Inbox.tsx';
+import Inbox from '../components/core/Inbox.tsx';
+import brand from '@brand/config';
 ---
 <!doctype html>
 <html lang="en">
@@ -18,10 +19,10 @@ import Inbox from '../components/Inbox.tsx';
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <meta name="theme-color" content="#050508" />
-    <meta name="description" content="Cullis Chat inbox — identity-aware messages for users and agents." />
+    <meta name="description" content={brand.inboxDescription} />
     <meta name="referrer" content="same-origin" />
-    <title>Inbox · Cullis Chat</title>
-    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}cullis-mark.svg`} />
+    <title>{brand.inboxTitle}</title>
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}${brand.logoMark}`} />
   </head>
   <body class="app-shell">
     <TopBar />

--- a/frontend/cullis-chat/src/pages/index.astro
+++ b/frontend/cullis-chat/src/pages/index.astro
@@ -2,7 +2,4 @@
 import ChatLayout from '../layouts/ChatLayout.astro';
 ---
 
-<ChatLayout
-  title="Cullis Chat"
-  description="Identity-aware chat for Cullis Frontdesk. Every message is signed, audited, and traceable."
-/>
+<ChatLayout />


### PR DESCRIPTION
## Summary

Phase 3 of the SPA rework. Splits the SPA brand identity into two build targets sharing a single source tree, so Phase 4 can bake a Frontdesk-flavored Docker image without forking the source.

\`\`\`
CULLIS_BRAND=cullis-chat   (default, consumer)
CULLIS_BRAND=frontdesk     (enterprise, Phase 4 Docker bundle)
\`\`\`

- New \`src/branding/types.ts\` declares \`BrandConfig\` (shared shape).
- \`src/branding/cullis-chat/config.ts\` and \`src/branding/frontdesk/config.ts\` provide brand identity (display name, lockup head/tail, layout title + description, inbox title + description, sidebar folio code, logo path).
- \`astro.config.mjs\` registers a Vite alias \`@brand\` that resolves to \`src/branding/{CULLIS_BRAND}/\` based on the env var.
- Layout / page / component imports of brand strings replaced with \`import brand from '@brand/config'\`. Affected: \`ChatLayout.astro\`, \`inbox.astro\`, \`index.astro\` (drops hardcoded props so brand defaults apply), \`TopBar.astro\` (wordmark + aria + logo), \`SidebarLeft.astro\` (folio).
- \`components/Inbox.tsx\` moves to \`components/core/Inbox.tsx\` alongside \`PrincipalBadge.tsx\`. Both are surface-agnostic primitives used by both build targets.

Per the spec, brand differences are intentionally limited to logo + copy strings (no color shift, no density change, no layout fork). The same dark void+cyan palette and editorial industrial voice ship in both bundles.

## Test plan

- [x] Default \`astro build\`: \`<title>Cullis Chat</title>\` + \`Inbox · Cullis Chat\`, folio \`CLLS-CHAT\`, no stray \`Frontdesk\` in /inbox
- [x] \`CULLIS_BRAND=frontdesk astro build\`: \`<title>Cullis Frontdesk</title>\` + \`Inbox · Cullis Frontdesk\`, folio \`CLLS-FRONTDESK\`, zero \`Cullis Chat\` strings in either page
- [ ] CI \`cullis-chat / build-and-e2e\` green (existing Playwright specs run against the default consumer build)
- [ ] Reviewer screenshot pass on both builds