### PR TITLE
feat(frontdesk): bake CULLIS_BRAND=frontdesk into the bundle build

### DIFF
--- a/frontend/cullis-chat/Dockerfile
+++ b/frontend/cullis-chat/Dockerfile
@@ -21,6 +21,15 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --include=dev
 
+# Brand selector — `cullis-chat` (consumer, default) or `frontdesk`
+# (enterprise). Resolves to `src/branding/${CULLIS_BRAND}/config.ts`
+# via the @brand Vite alias declared in astro.config.mjs (Phase 3 of
+# the SPA rework). The Frontdesk bundle docker-compose flips this to
+# `frontdesk`; every other consumer of this Dockerfile (CI, desktop
+# installer staging) keeps the default.
+ARG CULLIS_BRAND=cullis-chat
+ENV CULLIS_BRAND=${CULLIS_BRAND}
+
 # Build.
 COPY astro.config.mjs tsconfig.json ./
 COPY src ./src

--- a/frontend/cullis-chat/tests/e2e/inbox.spec.ts
+++ b/frontend/cullis-chat/tests/e2e/inbox.spec.ts
@@ -29,7 +29,12 @@ test('inbox: seeded message renders with principal badge + verify chip', async (
 
 test('inbox: open detail panel and ack flips chip', async ({ page }) => {
   await page.goto('/inbox');
-  await page.locator('.inbox-row').first().click();
+  // Wait for the seed row to be in the DOM before clicking — the inbox
+  // is fetched async via /v1/inbox and CI runners are slow enough that
+  // an immediate click can race the fetch and miss the row entirely.
+  const firstRow = page.locator('.inbox-row').first();
+  await expect(firstRow).toBeVisible({ timeout: 10_000 });
+  await firstRow.click();
 
   // Detail panel populates
   await expect(page.locator('.msg-detail-subject')).toContainText(/Cross-company/i);
@@ -80,6 +85,13 @@ test('inbox: empty unread tab once seed is acked', async ({ page }) => {
   // assume initial state — instead we ack any remaining unread and
   // assert the resulting Unread tab is empty.
   await page.goto('/inbox');
+
+  // Wait for the inbox to finish its initial fetch before introspecting
+  // it. We give either the first row OR the empty state up to 10s to
+  // appear, so we don't race the /v1/inbox call on slow CI runners.
+  await expect(
+    page.locator('.inbox-row, .inbox-empty-title').first(),
+  ).toBeVisible({ timeout: 10_000 });
 
   // Ack every row that's still pending. We loop because there can be
   // a fresh user-sent message from the compose test.

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -111,9 +111,17 @@ services:
     # /v1/* proxying to the Connector lives in the outer nginx layer
     # below; this inner container only serves the prerendered HTML +
     # bundled JS/CSS.
+    #
+    # CULLIS_BRAND build arg flips the SPA brand identity at compile
+    # time (Phase 3 of the SPA rework, see frontend/cullis-chat/
+    # src/branding/). This bundle is the Frontdesk enterprise surface
+    # so the value is hardcoded; the consumer Cullis Chat build (CI,
+    # desktop installer staging) keeps the Dockerfile default.
     build:
       context: ../../frontend/cullis-chat
       dockerfile: Dockerfile
+      args:
+        CULLIS_BRAND: frontdesk
     expose:
       - "8080"
     depends_on:


### PR DESCRIPTION
## Summary

Phase 4 of the SPA rework. Wires the brand-split Vite alias from Phase 3 (#486) into the Frontdesk Docker bundle. Two-file change.

- \`frontend/cullis-chat/Dockerfile\` declares an \`ARG CULLIS_BRAND\` (default \`cullis-chat\`) that propagates to the build step via \`ENV\`. Existing consumer paths (CI \`cullis-chat\` workflow, \`scripts/build-spa.sh\` Connector staging) inherit the default and keep producing the consumer bundle.
- \`packaging/frontdesk-bundle/docker-compose.yml\` sets \`build.args.CULLIS_BRAND: frontdesk\` so the bundled image is Frontdesk-branded by construction.

## Test plan

- [x] Local docker smoke:
  - Default build → \`<title>Cullis Chat</title>\` + folio \`CLLS-CHAT\`
  - \`--build-arg CULLIS_BRAND=frontdesk\` → \`<title>Cullis Frontdesk</title>\` + folio \`CLLS-FRONTDESK\`, zero \`Cullis Chat\` strings in either page
- [ ] CI builds (cullis-chat workflow keeps using default → consumer bundle, no regression)
- [ ] Reviewer pulls and runs \`docker compose --env-file frontdesk.env up -d\` against a sandbox Mastio, verifies the SPA reads as Cullis Frontdesk