### PR TITLE
fix(spa): graceful 404 handling on inbox passthrough gap (Phase 5)

### DIFF
--- a/frontend/cullis-chat/src/components/core/Inbox.tsx
+++ b/frontend/cullis-chat/src/components/core/Inbox.tsx
@@ -86,8 +86,17 @@ export default function Inbox() {
       const rows = await listInbox({ limit: 50 });
       setMessages(rows);
     } catch (err) {
-      const msg =
-        err instanceof ApiError ? `api error ${err.status}` : 'failed to load';
+      // 404 surfaces when the Connector Ambassador hasn't wired the
+      // /v1/inbox passthrough yet (tracked separately as a backend
+      // issue). Show a calm "endpoint pending" copy instead of a raw
+      // API error so the demo screenshot is honest about the state.
+      let msg = 'failed to load';
+      if (err instanceof ApiError) {
+        msg =
+          err.status === 404
+            ? 'inbox endpoint pending — backend wiring in flight'
+            : `api error ${err.status}`;
+      }
       setError(msg);
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary

Phase 5 of the SPA rework. Tactical fix for the 2026-05-07 dogfood: the Frontdesk Connector Ambassador does not yet expose \`/v1/inbox\` (tracked as #488), so the SPA Inbox surface received a raw \"api error 404\" in the error state, which read as a hard breakage.

This PR distinguishes 404 from other failures and surfaces a calm \`inbox endpoint pending — backend wiring in flight\` message instead, keeping the demo screenshot honest about the temporary state without making the surface look broken.

## Companion issues opened during dogfood

- #488 Connector Ambassador missing \`/v1/inbox\` passthrough (blocks live inbox surface)
- #489 Frontdesk Connector inbox poller fails SSL hostname check on \`host.docker.internal\` (warning spam, no crash)

The mitigation in this PR drops back to the regular API error path once #488 ships; no schema or behaviour change.

## Test plan

- [x] \`astro build\` passes (\`/index.html\` + \`/inbox/index.html\` generated, no TS errors)
- [ ] CI \`cullis-chat / build-and-e2e\` green
- [ ] Reviewer pulls + visual on \`http://localhost:8080/?user=mario\` against the running insurance-demo bundle: Inbox surface shows the new copy instead of skeleton or raw \"api error 404\"