### PR TITLE
feat(demo): Frontdesk identity bootstrap + A2U live end-to-end

### DIFF
--- a/app/auth/mastio_countersig.py
+++ b/app/auth/mastio_countersig.py
@@ -101,6 +101,7 @@ async def enforce_on_token_request(
     org_id: str,
     client_assertion: str,
     signature_header: str | None,
+    principal_type: str | None = None,
 ) -> None:
     """ADR-009 — the single gate on /v1/auth/token.
 
@@ -108,10 +109,20 @@ async def enforce_on_token_request(
     incomplete) or if the counter-signature is missing/invalid. Verified
     via :func:`verify_mastio_countersig` against the pinned PEM.
 
+    User principals (ADR-021) skip this gate: their certs are issued by
+    the org's Mastio via ``/v1/principals/csr``, so the cert itself IS
+    the Mastio's vouch — a per-login counter-signature is redundant
+    (and unworkable without the user's private key resident at the
+    Mastio, which the ADR-021 KMS model forbids). Agents and workloads
+    keep the per-login gate because their certs may have been issued
+    out-of-band (BYOCA / SPIFFE).
+
     Hook point exposed as a module-level function so ``tests/conftest.py``
     can monkey-patch it to a no-op for the bulk of the suite, while the
     ADR-009 test files re-enable the real implementation in their scope.
     """
+    if principal_type == "user":
+        return
     from app.registry.org_store import get_org_by_id
     org_record = await get_org_by_id(db, org_id)
     if org_record is None or not org_record.mastio_pubkey:

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -132,6 +132,7 @@ async def issue_token(
                 org_id=org_id,
                 client_assertion=body.client_assertion,
                 signature_header=mastio_signature,
+                principal_type=principal_type,
             )
         except HTTPException:
             AUTH_DENY_COUNTER.add(1, {"reason": "mastio_countersig"})

--- a/reference/scenarios/insurance-demo/compose.frontdesk.yml
+++ b/reference/scenarios/insurance-demo/compose.frontdesk.yml
@@ -49,7 +49,11 @@ services:
     expose: ["7777"]
     environment:
       AMBASSADOR_MODE: shared
-      CULLIS_FRONTDESK_ORG_ID:        ${FRONTDESK_AP_ORG_ID:-asia-pacific}
+      # Backend org_id MUST match the reference compose (orgb), NOT the
+      # display name. JWT sub + SPIFFE SAN are validated against the
+      # Mastio's MCP_PROXY_ORG_ID; mismatch → 401 ``sub mismatch`` on
+      # /v1/auth/token.
+      CULLIS_FRONTDESK_ORG_ID:        ${FRONTDESK_AP_ORG_ID:-orgb}
       CULLIS_FRONTDESK_TRUST_DOMAIN:  ${FRONTDESK_AP_TRUST_DOMAIN:-orgb.test}
       CULLIS_TRUSTED_PROXIES:         ${FRONTDESK_AP_TRUSTED_PROXIES:-127.0.0.1/32,::1/128,172.16.0.0/12}
       CULLIS_FRONTDESK_COOKIE_TTL_S:  3600

--- a/reference/scenarios/insurance-demo/nginx/frontdesk-asia-pacific.conf
+++ b/reference/scenarios/insurance-demo/nginx/frontdesk-asia-pacific.conf
@@ -22,8 +22,14 @@
 # for the canonical persona ↔ principal mapping.
 map $arg_user $forwarded_user {
     default      "unknown@frontdesk.dev";
-    "kenji"      "kenji.watanabe@orgb.test";
-    "watanabe"   "kenji.watanabe@orgb.test";
+    # The SDK provisioner derives the principal name from
+    # ``sub.split("@")[0]`` — so the local part of the SSO subject IS
+    # the user principal name. Use the role (counterparty-liaison) so
+    # the principal_id matches the cast in seed.py + reach_consents
+    # rather than the persona surface name.
+    "kenji"      "counterparty-liaison@orgb.test";
+    "watanabe"   "counterparty-liaison@orgb.test";
+    "liaison"    "counterparty-liaison@orgb.test";
 }
 
 server {

--- a/reference/scenarios/insurance-demo/run.sh
+++ b/reference/scenarios/insurance-demo/run.sh
@@ -69,10 +69,14 @@ cmd_prep_ca() {
     docker cp "$container:/state/orga/ca.pem"     "$STATE_DIR/orga-ca.pem"
     docker cp "$container:/state/orga/ca-key.pem" "$STATE_DIR/orga-ca.key"
     docker cp "$container:/state/orga/org_secret" "$STATE_DIR/orga-org-secret"
+    docker cp "$container:/state/orgb/ca.pem"     "$STATE_DIR/orgb-ca.pem" 2>/dev/null || true
+    docker cp "$container:/state/orgb/ca-key.pem" "$STATE_DIR/orgb-ca.key" 2>/dev/null || true
     docker cp "$container:/state/orgb/org_secret" "$STATE_DIR/orgb-org-secret" 2>/dev/null || true
     chmod 600 "$STATE_DIR/orga-ca.key" "$STATE_DIR/orga-org-secret"
+    [ -f "$STATE_DIR/orgb-ca.key" ] && chmod 600 "$STATE_DIR/orgb-ca.key"
     [ -f "$STATE_DIR/orgb-org-secret" ] && chmod 600 "$STATE_DIR/orgb-org-secret"
     _ok "orga Org CA at $STATE_DIR/orga-ca.{pem,key}"
+    _ok "orgb Org CA at $STATE_DIR/orgb-ca.{pem,key}"
     _ok "org secrets at $STATE_DIR/{orga,orgb}-org-secret (needed for /v1/registry/bindings)"
 }
 

--- a/reference/scenarios/insurance-demo/seed/seed.py
+++ b/reference/scenarios/insurance-demo/seed/seed.py
@@ -532,6 +532,157 @@ def phase_provision_workload(client: httpx.Client) -> None:
             _ok(f"workload orgb::workload::{spec['workload_name']} ready")
 
 
+def phase_provision_frontdesk_connector_identity(client: httpx.Client) -> None:
+    """Phase 4.5 — bootstrap the Frontdesk Connector's own agent identity.
+
+    The shared Ambassador on the Asia-Pacific Frontdesk container needs an
+    enrolled connector identity at ``/root/.cullis/profiles/
+    frontdesk-asia-pacific/identity/`` before it will install (the
+    identity backs the per-request UserProvisioner that mints user
+    certs via /v1/principals/csr). Without it, ``GET /v1/inbox``
+    returns 404 because the ambassador router was never mounted.
+
+    Steps:
+      1. Mint a fresh connector cert/key with the orgb Org CA.
+      2. POST /v1/admin/agents/enroll/byoca on Mastio B (proxy-b)
+         to register the cert; Mastio stores it as the connector's
+         agent_id ``orgb::frontdesk-asia-pacific-connector``.
+      3. Drop ``agent.crt`` + ``agent.key`` + ``ca-chain.pem`` into the
+         Connector volume so the dashboard sees the identity on next
+         boot.
+
+    Idempotent: skips mint+enroll if the identity files already exist
+    in the volume.
+    """
+    _h("Phase 4.5 — bootstrap Frontdesk Connector identity (orgb)")
+    org_ca = STATE_DIR / "orgb-ca.pem"
+    org_ca_key = STATE_DIR / "orgb-ca.key"
+    if not (org_ca.exists() and org_ca_key.exists()):
+        _fail(
+            "missing orgb Org CA — run ./run.sh prep-ca to copy it from "
+            "the bootstrap-state volume",
+        )
+        raise SystemExit(1)
+
+    # Volume is named by docker compose: <project>_<volume_name>.
+    # We address it through a helper container that mounts the volume
+    # read-write.
+    volume_name = "cullis-reference_frontdesk-asia-pacific-connector-data"
+    profile = "frontdesk-asia-pacific"
+    # Volume mounts at /data inside the helper container; the connector
+    # mounts the same volume at /root/.cullis. Same files, different
+    # mount points — write under /data, read in the dashboard at /root.
+    target_dir = f"/data/profiles/{profile}/identity"
+
+    # Probe whether the identity is already present.
+    probe = subprocess.run(
+        ["docker", "run", "--rm",
+         "-v", f"{volume_name}:/data",
+         "alpine", "sh", "-c",
+         f"test -f /data/profiles/{profile}/identity/agent.crt && echo PRESENT || echo MISSING"],
+        capture_output=True, text=True,
+    )
+    if "PRESENT" in probe.stdout:
+        _ok(f"connector identity already in volume {volume_name} — skipping")
+        return
+
+    agent_name = "frontdesk-asia-pacific-connector"
+    cert_pem, key_pem = _gen_agent_cert(
+        "orgb", agent_name, "orgb.test", org_ca, org_ca_key,
+    )
+
+    # Enroll on Mastio B as a regular BYOCA agent. The connector's
+    # /v1/principals/csr calls are JWT-authed, so the agent must be
+    # registered.
+    body = {
+        "agent_name":      agent_name,
+        "display_name":    "Asia-Pacific Frontdesk Connector",
+        "capabilities":    ["principals.csr.sign"],
+        "federated":       False,
+        "cert_pem":        cert_pem,
+        "private_key_pem": key_pem,
+    }
+    r = client.post(
+        f"{PROXY_B_URL}/v1/admin/agents/enroll/byoca",
+        json=body, headers=_admin_headers(PROXY_B_URL), timeout=15.0,
+    )
+    if r.status_code == 409:
+        # Disk had no identity (probe said MISSING) but Mastio kept the
+        # row from a prior run with a different cert — same drift bug
+        # we hit on the orga bots. Hard-delete + retry so cert on disk
+        # matches DB.
+        _warn(f"{agent_name} already on Mastio B with stale cert — re-enrolling")
+        agent_id = f"orgb::{agent_name}"
+        client.delete(
+            f"{PROXY_B_URL}/v1/admin/agents/{agent_id}",
+            headers=_admin_headers(PROXY_B_URL), timeout=10.0,
+        )
+        # The DELETE soft-deletes; another POST returns 409 on the
+        # zombie row. Direct DB scrub: drop the row entirely on the
+        # Mastio's sqlite so BYOCA INSERT can land. Reuses the
+        # ``proxy-b`` container we already have a shell into.
+        subprocess.run(
+            ["docker", "compose", "-f",
+             str(REPO_ROOT / "reference" / "docker-compose.yml"),
+             "exec", "-T", "proxy-b",
+             "python3", "-c",
+             "import sqlite3; c=sqlite3.connect('/data/mcp_proxy.db'); "
+             f"c.execute(\"DELETE FROM internal_agents WHERE agent_id='{agent_id}'\"); "
+             "c.commit()"],
+            check=True, capture_output=True,
+        )
+        r = client.post(
+            f"{PROXY_B_URL}/v1/admin/agents/enroll/byoca",
+            json=body, headers=_admin_headers(PROXY_B_URL), timeout=15.0,
+        )
+        if r.status_code != 201:
+            _fail(f"BYOCA re-enroll {agent_name}: HTTP {r.status_code} {r.text[:200]}")
+            raise SystemExit(1)
+        _ok(f"connector {agent_name} re-enrolled on Mastio B (fresh cert)")
+    elif r.status_code != 201:
+        _fail(f"BYOCA enroll {agent_name}: HTTP {r.status_code} {r.text[:200]}")
+        raise SystemExit(1)
+    else:
+        _ok(f"connector {agent_name} enrolled on Mastio B")
+
+    # Drop cert + key + ca-chain into the volume. The Connector reads
+    # ``identity/agent.crt`` + ``identity/agent.key`` + ``identity/
+    # ca-chain.pem`` per cullis_connector/config.py. Each file goes
+    # in its own ``docker run`` so stdin isn't multiplexed (a NUL-split
+    # heredoc was tempting but ``cat > file`` consumes all stdin).
+    ca_chain = org_ca.read_text()
+    # ``metadata.json`` is what ``CullisClient.from_connector`` keys off
+    # — the SDK's ``UserProvisioner`` calls it on every CSR sign and
+    # raises ``FileNotFoundError`` without it. Minimal viable shape.
+    metadata = json.dumps({
+        "agent_id":     f"orgb::{agent_name}",
+        "site_url":     "https://mastio-nginx-b:9443",
+        "capabilities": ["principals.csr.sign"],
+        "issued_at":    time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }, indent=2)
+    for fname, content, mode in (
+        ("agent.crt", cert_pem, "644"),
+        ("agent.key", key_pem,  "600"),
+        ("ca-chain.pem", ca_chain, "644"),
+        ("metadata.json", metadata, "644"),
+    ):
+        sub = subprocess.run(
+            ["docker", "run", "--rm", "-i",
+             "-v", f"{volume_name}:/data",
+             "alpine", "sh", "-c",
+             f"mkdir -p {target_dir} && cat > {target_dir}/{fname} && "
+             f"chmod {mode} {target_dir}/{fname}"],
+            input=content, capture_output=True, text=True,
+        )
+        if sub.returncode != 0:
+            _fail(f"writing {fname} failed: {sub.stderr[:200]}")
+            raise SystemExit(1)
+    _ok(
+        f"connector identity dropped at /root/.cullis/profiles/{profile}/identity "
+        f"in {volume_name}",
+    )
+
+
 def phase_provision_resources(client: httpx.Client) -> None:
     _h("Phase 5 — provision MCP resource (claims-db)")
     for spec in MEDITERRANEAN_RESOURCES:
@@ -676,6 +827,7 @@ def main() -> int:
         phase_bind_orga_agents_on_court(client)
         phase_provision_user_principals(client)
         phase_provision_workload(client)
+        phase_provision_frontdesk_connector_identity(client)
         phase_provision_resources(client)
     phase_seed_claims_db()
     phase_grant_reach_consents()


### PR DESCRIPTION
## Summary

Closes the loop for the insurance demo: open Cullis Chat as a Frontdesk user → see real broker-side inbox messages. End-to-end now reproducible from \`./run.sh seed && ./run.sh frontdesk\`.

## Backend
- **\`app/auth/mastio_countersig.py\`** — exempt user principals from the per-login counter-signature gate. The user cert is issued by the org's Mastio via \`/v1/principals/csr\` so the cert itself IS the Mastio's vouch; per-login counter-sig is redundant for users (and unworkable: the user's private key is KMS-released, never resident at the Mastio). Agents + workloads keep the gate.

## Demo wiring
- **\`seed.py\` Phase 4.5** — mints a BYOCA cert for the Frontdesk container with the orgb Org CA, enrolls on Mastio B, drops cert + key + ca-chain + metadata.json into the Connector volume at the path \`cullis_connector/identity/store.py\` expects. Idempotent + recovers from cert-drift via direct sqlite DELETE on stale rows.
- **\`compose.frontdesk.yml\`** — joins \`public-wan\`, sets \`CULLIS_BROKER_URL=http://broker:8000\`, runs as root for chown/mkdir on the volume, mounts the volume at \`/root/.cullis\`, points SSL bundles at the read-only mounted CA.
- **\`nginx/frontdesk-asia-pacific.conf\`** — persona map: \`?user=kenji\` → \`counterparty-liaison@orgb.test\` (role-based principal, matches the seed cast + \`reach_consents\`).
- **\`run.sh prep-ca\`** also extracts orgb CA + key for cert minting; \`frontdesk-prep\` uses the local connector image.

## Verified live

\`\`\`
$ curl http://localhost:8090/api/session/init?user=kenji
{"principal_id":"orgb.test/orgb/user/counterparty-liaison",...}  # HTTP 200

$ curl http://localhost:8090/v1/inbox -b /tmp/kenji.cookie
[{"msg_id":"628519c5-3c28-4fee-b7d6-ce3f939d7711",
  "sender_principal_type":"agent","sender_name":"night-reporter",
  "subject":"cross-org probe","delivery_state":"queued",...}]  # HTTP 200
\`\`\`

This row is the cross-org A2U smoke that the earlier session left in \`user_inbox_messages\`. The full Cullis Chat → broker → user_inbox flow now works through the production-shaped path (Frontdesk SSO → cookie → ambassador → user CSR → broker login → /v1/inbox).

## What's now possible
- Open Cullis Chat as claim-officer / claim-manager / counterparty-liaison
- See real messages
- Trigger night-reporter / ticket-bot from \`./run.sh\` and watch them land

🤖 Generated with [Claude Code](https://claude.com/claude-code)