### PR TITLE
docs: add per-component READMEs and clarify legacy directory naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ enterprise-kit/    BYOCA guide, OPA policy bundles, PDP template
 docs/              cullis.io site source + ops runbook
 ```
 
+> [!NOTE]
+> `app/` and `mcp_proxy/` are legacy directory names that predate the
+> Court / Mastio rebrand. The on-disk paths and the brand names refer to
+> the same components. Python package imports follow the same legacy
+> (`from app import ...` for Court, `from mcp_proxy import ...` for
+> Mastio). Each directory has its own README with a per-component
+> overview.
+
 Runtime: Python 3.11 · FastAPI · PostgreSQL 16 · Redis · HashiCorp Vault · cryptography · PyJWT · OpenTelemetry + Jaeger · OPA · Docker · Helm.
 
 ---

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,69 @@
+# `app` — Cullis Court
+
+**The cross-organization control plane for the Cullis federated agent-trust network.**
+
+This directory implements **Cullis Court**, the network-level component that
+operators run to federate organizations together. The directory is named
+`app/` for historical reasons, the brand name `Court` and the directory name
+`app/` refer to the same thing.
+
+The Court is one of three Cullis components:
+
+| Component       | Directory          | Runs where        | Owned by          |
+|-----------------|--------------------|-------------------|-------------------|
+| Cullis Court    | `app/`             | Cross-org network | Network operator  |
+| Cullis Mastio   | `mcp_proxy/`       | Inside an org     | Org admin         |
+| Cullis Connector| `cullis_connector/`| End-user laptop   | End user          |
+
+## What the Court does
+
+- Maintains the federated **registry** of organizations and their agents.
+- Issues **counter-signatures** on Mastio events so cross-org peers can
+  trust them without trusting each Mastio individually.
+- Enforces **federation policy** (default-deny, dual-allow, attach-CA flow).
+- Anchors a **third-party audit hash chain** in parallel to per-org chains,
+  so cross-org non-repudiation does not depend on either party's records
+  alone.
+- Operates the **A2A relay** for cross-org one-shot messages (encrypted
+  end-to-end, the Court never reads plaintext).
+
+## Code layout
+
+```
+main.py            FastAPI app, lifespan, routers, middleware
+config.py          Settings (env vars)
+auth/              x509 + JWT + DPoP, JTI blacklist, revocation
+broker/            Sessions, messages, WebSocket, persistence
+dashboard/         Operator web UI (Jinja2 + HTMX + Tailwind)
+policy/            Federation policy engine, PDP webhooks
+registry/          Orgs, agents, bindings, capability discovery
+onboarding/        Join request + admin approve/reject
+federation/        Cross-org publishing, registry sync
+audit/             Hash chain, dual-write, TSA anchor
+db/                SQLAlchemy models, migrations entry
+spiffe.py          SPIFFE ID translation
+e2e_crypto.py      AES-256-GCM + RSA-OAEP envelope helpers
+kms/               KMS adapter (filesystem dev, HashiCorp Vault prod)
+redis/             Connection pool, graceful fallback
+rate_limit/        Sliding window (in-memory + Redis sorted set)
+telemetry.py       OpenTelemetry init
+```
+
+Migrations live at the repo root in `alembic/`. The standalone-mode
+counterpart (intra-org Mastio without a Court) is in `mcp_proxy/`, see its
+own README.
+
+## Running
+
+The Court does not boot in isolation, the canonical way to run it is via the
+sandbox stack at the repo root:
+
+```bash
+./sandbox/demo.sh full
+```
+
+That brings up Court + 2 Mastios + 3 agents + 2 MCP servers + SPIRE +
+Keycloak + Vault + Postgres in two organizations.
+
+For self-hosted production deployment, see `deploy/` (Docker Compose +
+Helm chart) and the runbook at [cullis.io/operate/runbook](https://cullis.io/operate/runbook).

--- a/mcp_proxy/README.md
+++ b/mcp_proxy/README.md
@@ -1,0 +1,80 @@
+# `mcp_proxy` — Cullis Mastio
+
+**The org-level trust authority for the Cullis federated agent-trust network.**
+
+This directory implements **Cullis Mastio**, the per-organization component
+that an org admin deploys inside their own infrastructure. The directory is
+named `mcp_proxy/` for historical reasons, the brand name `Mastio` and the
+directory name `mcp_proxy/` refer to the same thing. Same for the Python
+package import path (`from mcp_proxy import ...`) and the published wheel
+name (`cullis-mastio` on PyPI from v0.3.x onwards).
+
+The Mastio is one of three Cullis components:
+
+| Component       | Directory          | Runs where        | Owned by          |
+|-----------------|--------------------|-------------------|-------------------|
+| Cullis Court    | `app/`             | Cross-org network | Network operator  |
+| Cullis Mastio   | `mcp_proxy/`       | Inside an org     | Org admin         |
+| Cullis Connector| `cullis_connector/`| End-user laptop   | End user          |
+
+## What the Mastio does
+
+- Issues **agent identity** (x509 with SPIFFE SAN, optional BYOCA).
+- Enforces **per-org policy** (default-deny session, default-allow message,
+  PDP webhook with fail-safe deny-on-timeout).
+- Records a **local hash-chain audit** that never leaves the org.
+- Acts as the **MCP reverse-proxy** between in-org agents and the MCP
+  servers exposed by the org.
+- Hosts the **embedded AI gateway** (LiteLLM in-process by default,
+  Portkey or BYO upstream optionally), so per-principal egress policy is
+  enforced at the same trust boundary as A2A.
+- Runs in two modes, **standalone** (air-gapped, single-org, no Court) or
+  **federated** (attached to a Court for cross-org reachability). Same
+  binary, admin action toggles.
+
+## Code layout
+
+```
+main.py            FastAPI app, lifespan, routers
+config.py          Settings (env vars, MCP_PROXY_* prefix)
+db.py / db_models.py  SQLAlchemy async models
+alembic/           Per-Mastio migrations (revision id ≤ 32 char)
+admin/             Org admin API + dashboard backend
+agents/            Agent enrollment, cert lifecycle, rotation
+auth/              x509 + JWT + DPoP, federation bridge
+audit/             Local hash chain, dual-write to Court
+dashboard/         Admin web UI (Jinja2 + HTMX + Tailwind)
+egress/            AI gateway dispatcher + LiteLLM embedded backend
+enrollment/        Device-code, invite token, attach-CA flows
+federation/        Court bridge, cross-org publish/subscribe
+guardian/          LLM Guardian fast-path endpoint, ticket signer
+ingress/           Inbound A2A receiver, decrypt + verify
+local/             Standalone-mode shortcuts
+middleware/        Auth + DPoP + rate limit + CORS
+observability/     OpenTelemetry, custom metrics
+pki/               CA chain, cert issuance, OCSP-equivalent revocation
+policy/            PDP webhook, default rules
+rbac.py            Multi-admin RBAC (ADR-018)
+redis/             Connection pool
+registry/          Local agent registry
+reverse_proxy/     MCP reverse-proxy (auto-inject Cullis identity)
+spiffe.py          SPIFFE ID translation
+sync/              Federation sync workers
+tools/             CLI helpers
+```
+
+## Running
+
+For local dev and demos, use the sandbox stack at the repo root:
+
+```bash
+./sandbox/demo.sh full
+```
+
+For self-hosted production deployment (Mastio standalone or attached to a
+Court), see `deploy/` (Docker Compose + Helm chart) and the install guide
+at [cullis.io/install/mastio-self-host](https://cullis.io/install/mastio-self-host).
+
+The Mastio also ships as a standalone container bundle in
+`packaging/mastio-bundle/` and a PyPI wheel `cullis-mastio` for embedded
+deployments.


### PR DESCRIPTION
## Summary

- Add `app/README.md` (Cullis Court) and `mcp_proxy/README.md` (Cullis Mastio) so users landing in those directories from a direct clone or code search find a per-component overview instead of an unannotated source tree.
- Each component README states the brand-to-directory mapping explicitly: `app/` is Cullis Court, `mcp_proxy/` is Cullis Mastio. Both are legacy paths that predate the rebrand and will not be renamed in the short term to avoid churn on imports, env var prefixes (`MCP_PROXY_*`), deploy scripts, Helm chart values, and downstream installations.
- Add a parallel naming note in the top-level `README.md` under "Project layout" for the same reason.
- `cullis_connector/` and `cullis_sdk/` already ship their own READMEs and need no change.

## Test plan

- [ ] CI green (test, security, Signed-off-by, smoke matrix, helm-test)
- [ ] Cloudflare Pages site build green
- [ ] GitHub renders the `[!NOTE]` callout in the top-level README
- [ ] `app/README.md` and `mcp_proxy/README.md` show as the directory landing pages on GitHub