### PR TITLE
ci: release pipeline for cullis-court Docker image and Helm chart

### DIFF
--- a/.github/workflows/release-court.yml
+++ b/.github/workflows/release-court.yml
@@ -1,0 +1,237 @@
+# Release pipeline for the Cullis Court.
+#
+# Triggered by pushing a tag of the form `court-vX.Y.Z`. On tag push:
+#
+#   1. Run the Court test subset to gate the release.
+#   2. Build and push the multi-arch Docker image to ghcr.io.
+#   3. Package + push the `cullis` Helm chart to ghcr.io.
+#   4. Create a GitHub Release with image + chart references.
+#
+# The Court is a network-level control plane and is normally deployed
+# via Helm in a Kubernetes cluster, so this pipeline does not produce a
+# standalone tar.gz bundle (the Mastio bundle exists because it is the
+# air-gapped single-host deploy target; the Court is not).
+
+name: release-court
+
+on:
+  push:
+    tags:
+      - "court-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  # ── 1. Tests ─────────────────────────────────────────────────────────
+  test:
+    name: Test Court
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: requirements.txt
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Court test subset
+        env:
+          OTEL_ENABLED: "false"
+          DATABASE_URL: "sqlite+aiosqlite://"
+        run: |
+          pytest \
+            tests/test_broker.py \
+            tests/test_onboarding.py \
+            tests/test_audit_chain.py \
+            tests/test_audit_export.py \
+            tests/test_federation_publish.py \
+            tests/test_federation_read.py \
+            tests/test_federation_publisher.py \
+            tests/test_federation_events.py \
+            tests/test_court_plugin_system.py \
+            tests/test_user_principals_registry.py \
+            tests/test_updates_registry.py \
+            tests/test_broker_mastio_pubkey_rotate.py \
+            --tb=short
+
+  # ── 2. Extract version ───────────────────────────────────────────────
+  version:
+    name: Extract version
+    needs: test
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+    steps:
+      - name: Extract version from tag
+        id: extract
+        run: |
+          # court-v1.2.3 → 1.2.3
+          version="${GITHUB_REF_NAME#court-v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Releasing cullis-court: ${version}"
+
+  # ── 3. Docker image → ghcr.io ───────────────────────────────────────
+  build-docker:
+    name: Build & push Docker image
+    needs: [test, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/cullis-court
+          # latest=auto would override the explicit enable= guard below.
+          flavor: |
+            latest=false
+          tags: |
+            type=match,pattern=court-v(.*),group=1
+            type=match,pattern=court-v(\d+\.\d+)\..*,group=1,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
+          labels: |
+            org.opencontainers.image.title=Cullis Court
+            org.opencontainers.image.description=Cross-organization control plane for the Cullis federated agent-trust network
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ needs.version.outputs.version }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── 4. Helm chart → ghcr.io/<owner>/charts/cullis ────────────────────
+  publish-helm:
+    name: Package & push Helm chart
+    needs: [build-docker, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pinned to SHA (was @v4 floating major) — audit 2026-04-30 lane 8 M5.
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4  # v4.3.1
+        with:
+          version: "v3.14.4"
+
+      - name: Login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io \
+              --username "${{ github.actor }}" \
+              --password-stdin
+
+      - name: Override chart + app version from tag
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          # The tag is the source of truth; Chart.yaml's baked-in version
+          # is the floor for local development. Bump both in lockstep here
+          # so `helm install ... --version X.Y.Z` always matches the image.
+          sed -i "s/^version: .*/version: ${VERSION}/" deploy/helm/cullis/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${VERSION}\"/" deploy/helm/cullis/Chart.yaml
+          head -15 deploy/helm/cullis/Chart.yaml
+
+      - name: Package chart
+        run: |
+          mkdir -p dist/charts
+          helm package deploy/helm/cullis --destination dist/charts
+          ls -lah dist/charts
+
+      - name: Push chart to OCI registry
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          helm push \
+            "dist/charts/cullis-${VERSION}.tgz" \
+            "oci://ghcr.io/${OWNER}/charts"
+
+  # ── 5. GitHub Release ────────────────────────────────────────────────
+  release:
+    name: Create GitHub Release
+    needs: [build-docker, publish-helm, version]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog section
+        id: changelog
+        env:
+          VERSION: ${{ needs.version.outputs.version }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          version="${VERSION}"
+          if [[ -f CHANGELOG.md ]]; then
+            awk "/^## \\[?v?${version}\\]?/{flag=1; next} /^## /{flag=0} flag" CHANGELOG.md \
+              > release-notes.md || true
+          fi
+          if [[ ! -s release-notes.md ]]; then
+            cat > release-notes.md <<NOTES
+          Release ${GITHUB_REF_NAME}
+
+          ## Artifacts
+
+          - **Docker image**: \`ghcr.io/${OWNER}/cullis-court:${version}\`
+          - **Helm chart**: \`oci://ghcr.io/${OWNER}/charts/cullis:${version}\`
+
+          ## Kubernetes quickstart
+
+          \`\`\`bash
+          helm install cullis-court \\
+            oci://ghcr.io/${OWNER}/charts/cullis \\
+            --version ${version} \\
+            --set broker.publicUrl=https://court.example.com \\
+            --set trustDomain=court.example.com
+          \`\`\`
+
+          The chart deploys the Court as a network-level control plane
+          with HPA, PodDisruptionBudget, NetworkPolicy, and cert-manager
+          TLS termination. See \`deploy/helm/cullis/values.yaml\` for
+          the full surface and \`docs/k8s-quickstart.md\` for the
+          end-to-end walkthrough.
+          NOTES
+          fi
+          cat release-notes.md
+
+      - name: Create release
+        # Pinned to SHA (was @v2 floating major) — audit 2026-04-30 lane 8 M5.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Cullis Court ${{ github.ref_name }}"
+          body_path: release-notes.md
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}


### PR DESCRIPTION
## Summary

The Mastio (`mcp_proxy/`) and the Connector (`cullis_connector/`) ship through dedicated `release-*` workflows that publish multi-arch images to ghcr.io on tag push. The Court (`app/`) has a Dockerfile (root) but no matching pipeline, so consumers cannot pull a pre-built image; the only path is clone + local build. This PR closes that gap.

## What it does

`release-court.yml` mirrors `release-mastio.yml` with Court-specific adjustments:

| | Mastio | Court |
|---|---|---|
| Tag pattern | `mastio-v*` | `court-v*` |
| Build context | `.` + `mcp_proxy/Dockerfile` | `.` + root `Dockerfile` |
| Image | `ghcr.io/<owner>/cullis-mastio` | `ghcr.io/<owner>/cullis-court` |
| Helm chart | `deploy/helm/cullis-mastio/` | `deploy/helm/cullis/` (slug `cullis`, pre-rebrand naming retained) |
| Standalone bundle | `cullis-mastio-bundle.tar.gz` + `.zip` | None (Court is network-level, deployed via Helm in k8s) |

Test subset (12 files): `test_broker`, `test_onboarding`, `test_audit_chain`, `test_audit_export`, `test_federation_publish`, `test_federation_read`, `test_federation_publisher`, `test_federation_events`, `test_court_plugin_system`, `test_user_principals_registry`, `test_updates_registry`, `test_broker_mastio_pubkey_rotate`. Mirrors the Mastio scope: enough to fail fast on regressions in the Court's defining surface.

## Idle workflow

Nothing happens until an operator pushes a `court-v*` tag. No PR / push triggers, no impact on existing CI gates.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` passes (workflow file is valid YAML)
- [x] All 12 referenced test files exist in `tests/`
- [x] `deploy/helm/cullis/Chart.yaml` and root `Dockerfile` exist
- [ ] CI green on this PR (workflow file additions, no semantic test changes expected)
- [ ] First production validation: tag push `court-v0.1.0-rc1` after merge produces an image at `ghcr.io/<owner>/cullis-court:0.1.0-rc1`

## Follow-ups

- `release-chat.yml` (Cullis Chat SPA) is the next gap to close. Tracked separately.
- Connector-as-Docker-image (currently a wheel + PyInstaller binary) is a larger design decision and is not in scope here.