### PR TITLE
ci: gate latest tag in release-connector to non-RC builds

### DIFF
--- a/.github/workflows/release-connector.yml
+++ b/.github/workflows/release-connector.yml
@@ -178,9 +178,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository_owner }}/cullis-connector
+          # latest=auto would override the explicit enable= guard below.
+          flavor: |
+            latest=false
           tags: |
             type=match,pattern=connector-v(.*),group=1
-            type=raw,value=latest
+            type=match,pattern=connector-v(\d+\.\d+)\..*,group=1,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-rc') && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') }}
 
       - name: Build & push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- Add `flavor: latest=false` to `docker/metadata-action@v5` step in release-connector workflow
- Mirror `release-mastio.yml` pattern with `enable=` guard excluding `-rc/-alpha/-beta` tags
- Prevent RC tags (e.g. `connector-v0.4.0-rc1`) from silently overwriting `latest` on GHCR

## Test plan
- [ ] YAML still parses (`python -c "import yaml; yaml.safe_load(open('.github/workflows/release-connector.yml'))"`)
- [ ] Workflow dispatch dry-run on a `-rc` tag confirms `latest` is NOT pushed
- [ ] Stable tag (e.g. `connector-v0.4.0`) still pushes `latest`