### PR TITLE
fix(dashboard): reject protocol-relative URLs in redirect validation

### DIFF
--- a/app/dashboard/router.py
+++ b/app/dashboard/router.py
@@ -57,6 +57,35 @@ templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
 
+def _safe_redirect(next_url: object, fallback: str = "/dashboard") -> str:
+    """Validate a caller-supplied redirect target and return a safe local path.
+
+    Rejects anything that could cause an open-redirect (H-IO-1):
+    - non-string values
+    - absolute URLs  (``https://...``)
+    - protocol-relative URLs  (``//evil.example/x``)
+    - backslash-relative URLs  (``/\\evil``)
+    - empty / whitespace-only strings
+
+    Only accepts paths that start with ``/`` and whose parsed ``netloc``
+    is empty (i.e., no host component), which is the standard urllib test
+    for relative-same-origin URLs.
+    """
+    if not isinstance(next_url, str) or not next_url.strip():
+        return fallback
+    # Block protocol-relative (//host) and backslash variants (/\host)
+    if next_url.startswith("//") or next_url.startswith("/\\"):
+        return fallback
+    # Must start with a single slash (no scheme, no authority)
+    if not next_url.startswith("/"):
+        return fallback
+    # Belt-and-suspenders: urlparse must see no scheme and no netloc
+    parsed = urlparse(next_url)
+    if parsed.scheme or parsed.netloc:
+        return fallback
+    return next_url
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Login / Logout
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1714,7 +1743,9 @@ async def org_unseal_reauth_form(request: Request, org_id: str,
     org = await get_org_by_id(db, org_id)
     if org is None:
         return RedirectResponse(url="/dashboard/orgs", status_code=303)
-    next_url = request.query_params.get("next", "/dashboard/orgs")
+    next_url = _safe_redirect(
+        request.query_params.get("next"), fallback="/dashboard/orgs"
+    )
     return templates.TemplateResponse(
         "org_unseal_reauth.html",
         _ctx(request, session, active="orgs", org=org, next_url=next_url,
@@ -1742,11 +1773,11 @@ async def org_unseal_reauth_submit(request: Request, org_id: str,
     )
     form_data = await request.form()
     password = form_data.get("password", "")
-    next_url = form_data.get("next", "/dashboard/orgs")
-    # Only allow same-origin redirects — reject absolute URLs to prevent an
-    # admin being bounced off the dashboard after re-auth.
-    if not isinstance(next_url, str) or not next_url.startswith("/"):
-        next_url = "/dashboard/orgs"
+    # Validate the redirect target (H-IO-1): reject protocol-relative and
+    # absolute URLs to prevent open-redirect after admin re-auth.
+    next_url = _safe_redirect(
+        form_data.get("next"), fallback="/dashboard/orgs"
+    )
 
     stored_hash = await get_admin_secret_hash()
     if not password or not verify_admin_password(password, stored_hash):

--- a/tests/test_dashboard_open_redirect.py
+++ b/tests/test_dashboard_open_redirect.py
@@ -1,0 +1,72 @@
+"""Tests for H-IO-1: open redirect via protocol-relative next_url.
+
+Verifies that _safe_redirect() in app.dashboard.router rejects any
+caller-supplied value that could cause a cross-origin bounce, while
+passing through legitimate same-origin paths.
+"""
+import pytest
+
+from app.dashboard.router import _safe_redirect
+
+
+_FALLBACK = "/dashboard/orgs"
+
+
+@pytest.mark.parametrize("bad_input", [
+    # Protocol-relative URLs — the primary H-IO-1 vector
+    "//evil.example/steal",
+    "//evil.example",
+    "//",
+    # Backslash-relative (IE/Edge historic bypass)
+    "/\\evil.example/x",
+    "/\\ evil",
+    # Absolute URLs
+    "https://evil.example/x",
+    "http://evil.example/",
+    "ftp://evil.example/",
+    # Scheme-less but with authority embedded after double slash
+    "///triple",
+    # Empty / whitespace
+    "",
+    "   ",
+    # Non-string types
+    None,
+    42,
+    ["list"],
+    # Relative paths without leading slash
+    "evil.example/x",
+    "relative/path",
+])
+def test_safe_redirect_rejects_bad_inputs(bad_input):
+    result = _safe_redirect(bad_input, fallback=_FALLBACK)
+    assert result == _FALLBACK, (
+        f"Expected fallback for {bad_input!r}, got {result!r}"
+    )
+
+
+@pytest.mark.parametrize("good_input", [
+    "/dashboard/orgs",
+    "/dashboard",
+    "/dashboard/orgs/abc-123",
+    "/dashboard/orgs?foo=bar",
+    "/dashboard/orgs?foo=bar&baz=1",
+    "/dashboard/orgs#section",
+    "/dashboard/orgs/abc%20encoded",
+    "/dashboard/login?next=%2Fdashboard%2Forgs",
+])
+def test_safe_redirect_allows_local_paths(good_input):
+    result = _safe_redirect(good_input, fallback=_FALLBACK)
+    assert result == good_input, (
+        f"Expected {good_input!r} to pass through, got {result!r}"
+    )
+
+
+def test_safe_redirect_default_fallback():
+    """When no fallback is given the module default (/dashboard) is used."""
+    result = _safe_redirect("//evil.example")
+    assert result == "/dashboard"
+
+
+def test_safe_redirect_none_with_custom_fallback():
+    result = _safe_redirect(None, fallback="/dashboard/orgs")
+    assert result == "/dashboard/orgs"


### PR DESCRIPTION
## Summary
- Reject protocol-relative URLs (`//evil.example/x`), backslash-prefixed paths (`/\\evil`), absolute URLs (`https://...`), empty/None values in `next_url` redirect handling
- Factored validation into module-level `_safe_redirect()` helper applied to both GET and POST `org_unseal_reauth` handlers
- Closes audit finding H-IO-1: open redirect via `next` parameter on dashboard reauth flow

## Test plan
- [ ] `pytest tests/test_dashboard_open_redirect.py -v` (26 tests: 16 reject + 8 allow + edge cases)
- [ ] Sandbox smoke green (no regression on dashboard auth flow)
- [ ] Manual: `curl 'http://broker/dashboard/orgs/<id>/unseal-reauth?next=//evil.example'` redirects to `/dashboard/orgs`, not `//evil.example`