### PR TITLE
refactor(crypto): unify base64url strict decoder across Court, Mastio, SDK

### DIFF
--- a/app/auth/mastio_countersig.py
+++ b/app/auth/mastio_countersig.py
@@ -17,22 +17,16 @@ ADR-009 flow. Phase 3 flips this to NOT NULL.
 """
 from __future__ import annotations
 
-import base64
-
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.utils.validation import strict_b64url_decode
+
 
 COUNTERSIG_HEADER = "X-Cullis-Mastio-Signature"
-
-
-def _b64url_decode_nopad(data: str) -> bytes:
-    """Decode base64url with or without padding (see feedback_base64url_nopad)."""
-    padding = "=" * ((4 - len(data) % 4) % 4)
-    return base64.urlsafe_b64decode(data + padding)
 
 
 def verify_mastio_countersig(
@@ -78,7 +72,7 @@ def verify_mastio_countersig(
         )
 
     try:
-        signature = _b64url_decode_nopad(signature_b64.strip())
+        signature = strict_b64url_decode(signature_b64.strip())
     except Exception as exc:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/cullis_sdk/_b64url.py
+++ b/cullis_sdk/_b64url.py
@@ -1,0 +1,87 @@
+"""Strict base64url decoder — vendored for the SDK distribution (audit H5 / F-C-3).
+
+The SDK has zero runtime dependency on ``app/``, so the canonical implementation
+from ``app.utils.validation.strict_b64url_decode`` is vendored here verbatim.
+Behavior must remain identical to the canonical copy; parity is verified by
+``tests/test_b64url_decoder_parity.py``.
+
+Do NOT relax or extend this implementation without a corresponding change to
+``app/utils/validation.strict_b64url_decode`` and ``mcp_proxy/utils/validation.py``.
+"""
+from __future__ import annotations
+
+import base64
+import re
+
+# url-safe base64 alphabet (RFC 4648 §5). Excludes padding — handled separately.
+_B64URL_ALPHABET_RE = re.compile(r"^[A-Za-z0-9_-]*$")
+
+
+class B64urlError(ValueError):
+    """Raised when a base64url string is malformed or non-canonical."""
+
+
+def strict_b64url_decode(s: str | bytes) -> bytes:
+    """Decode a base64url string, rejecting non-canonical encodings.
+
+    Accepts ``s`` with OR without trailing ``=`` padding (the codebase
+    convention — TS SDK omits padding, some tests include it). Rejects:
+
+      * Non-alphabet characters (whitespace, ``+``, ``/``, ``\\n``, etc.)
+      * Excess padding (e.g. ``AAAA===`` — valid for stdlib, rejected here)
+      * Impossible lengths (``len(s.rstrip("=")) % 4 == 1``)
+      * Trailing "garbage bits" in partial-quantum inputs — Python's stdlib
+        silently zeroes the unused low-order bits of the last char, which
+        means ``AAAA`` and ``AAAB`` decode to the same 3 bytes.
+
+    On any violation raises ``B64urlError`` (a ``ValueError`` subclass) so
+    callers that wrap in ``except Exception`` continue to work.
+    """
+    if isinstance(s, bytes):
+        try:
+            s = s.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise B64urlError("base64url input is not ASCII") from exc
+    if not isinstance(s, str):
+        raise B64urlError(
+            f"base64url input must be str/bytes, got {type(s).__name__}"
+        )
+
+    # Strip trailing padding (tolerant). ``AAAA==`` and ``AAAA====`` both
+    # strip to ``AAAA`` — the over-padded case is caught when we re-pad
+    # below (stdlib silently ignores excess padding; we force-match).
+    stripped = s.rstrip("=")
+
+    # Reject non-alphabet content — no whitespace, no vanilla +/.
+    if not _B64URL_ALPHABET_RE.fullmatch(stripped):
+        raise B64urlError("base64url contains non-url-safe characters")
+
+    # Length mod 4 == 1 is impossible in base64 (1 char = 6 bits, no way
+    # to complete a byte). Raise explicitly — stdlib would raise too but
+    # via the less-specific ``binascii.Error``.
+    rem = len(stripped) % 4
+    if rem == 1:
+        raise B64urlError("base64url length is not valid (length % 4 == 1)")
+
+    # Re-pad to canonical form and decode.
+    padded = stripped + ("=" * ((4 - rem) % 4))
+    try:
+        decoded = base64.urlsafe_b64decode(padded)
+    except Exception as exc:
+        raise B64urlError(f"base64url decode failed: {exc}") from exc
+
+    # Re-encode and compare to catch "garbage bits" in partial-quantum
+    # inputs. stdlib silently drops the low-order bits of the last char
+    # when they aren't consumed — that means two different input strings
+    # can decode to the same bytes, which breaks canonicalization (JKT).
+    canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
+    if canonical != stripped:
+        raise B64urlError(
+            "base64url contains non-canonical trailing bits — "
+            "decoded bytes do not round-trip to the input"
+        )
+
+    return decoded
+
+
+__all__ = ["B64urlError", "strict_b64url_decode"]

--- a/cullis_sdk/dpop.py
+++ b/cullis_sdk/dpop.py
@@ -234,5 +234,6 @@ def _ec_from_private_jwk(jwk: dict) -> ec.EllipticCurvePrivateKey:
 
 
 def _b64url_decode(s: str) -> bytes:
-    pad = "=" * (-len(s) % 4)
-    return base64.urlsafe_b64decode(s + pad)
+    """Strict base64url decode — delegates to the canonical vendored implementation."""
+    from cullis_sdk._b64url import strict_b64url_decode as _strict
+    return _strict(s)

--- a/mcp_proxy/auth/dpop.py
+++ b/mcp_proxy/auth/dpop.py
@@ -20,7 +20,6 @@ import hmac as _hmac
 import json
 import logging
 import os
-import re
 import time
 from urllib.parse import urlparse, urlunparse
 
@@ -31,6 +30,10 @@ from fastapi import HTTPException, Response, status
 import jwt as jose_jwt
 
 from mcp_proxy.config import get_settings
+from mcp_proxy.utils.validation import (
+    canonicalize_b64url as _canonicalize_b64url_impl,
+    strict_b64url_decode as _strict_b64url_decode,
+)
 
 _log = logging.getLogger("mcp_proxy")
 
@@ -78,50 +81,13 @@ def set_dpop_nonce_header(response: Response) -> None:
 # Base64url helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-# url-safe base64 alphabet (RFC 4648 section 5). Excludes ``=`` — padding
-# is tolerated below but not part of the "payload" alphabet. We reject
-# whitespace, vanilla ``+``/``/``, and anything else outside the set.
-_B64URL_ALPHABET_RE = re.compile(r"^[A-Za-z0-9_-]*$")
-
-
 def _b64url_decode(s: str | bytes) -> bytes:
-    """Strict base64url decode — tolerates padding, rejects garbage bits.
+    """Strict base64url decode — delegates to ``mcp_proxy.utils.validation``.
 
-    Audit F-C-3: mirrors ``app.utils.validation.strict_b64url_decode``.
-    The mcp_proxy package deliberately has no runtime dependency on
-    ``app/``, so the helper is inlined here. Behavior must stay in sync:
-
-      * Accepts the input with OR without trailing ``=`` (TS SDK does
-        not pad; some server-side paths do).
-      * Rejects whitespace / non-url-safe chars / excess padding.
-      * Rejects partial-quantum inputs whose trailing char has garbage
-        bits in the unused low-order positions — Python's stdlib
-        silently discards those, which means two distinct wire encodings
-        decode to the same bytes and break JKT canonicalization.
+    Audit S8: previously inlined; now imports from the single vendored copy
+    so all Mastio paths stay in sync with ``app.utils.validation``.
     """
-    if isinstance(s, bytes):
-        try:
-            s = s.decode("ascii")
-        except UnicodeDecodeError as exc:
-            raise ValueError("base64url input is not ASCII") from exc
-    stripped = s.rstrip("=")
-    if not _B64URL_ALPHABET_RE.fullmatch(stripped):
-        raise ValueError("base64url contains non-url-safe characters")
-    rem = len(stripped) % 4
-    if rem == 1:
-        raise ValueError("base64url length is not valid (length % 4 == 1)")
-    padded = stripped + ("=" * ((4 - rem) % 4))
-    try:
-        decoded = base64.urlsafe_b64decode(padded)
-    except Exception as exc:
-        raise ValueError(f"base64url decode failed: {exc}") from exc
-    canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
-    if canonical != stripped:
-        raise ValueError(
-            "base64url contains non-canonical trailing bits — "
-            "decoded bytes do not round-trip to the input"
-        )
-    return decoded
+    return _strict_b64url_decode(s)
 
 
 def _canonicalize_b64url(s: str) -> str:
@@ -130,7 +96,7 @@ def _canonicalize_b64url(s: str) -> str:
     Used for JKT canonicalization — collapses padding / tail-bit variants
     of the same key into a single canonical form before hashing.
     """
-    return base64.urlsafe_b64encode(_b64url_decode(s)).rstrip(b"=").decode("ascii")
+    return _canonicalize_b64url_impl(s)
 
 
 def _b64url_encode(b: bytes) -> str:

--- a/mcp_proxy/auth/jwks_client.py
+++ b/mcp_proxy/auth/jwks_client.py
@@ -6,10 +6,8 @@ Supports:
   - Local override file (air-gapped deployments)
   - Automatic cache refresh on key-id miss (with rate limiting)
 """
-import base64
 import json
 import logging
-import re
 import time
 
 import httpx
@@ -29,30 +27,16 @@ _EC_JWK_CURVES = {
 _MIN_REFETCH_INTERVAL = 60  # seconds
 
 
-_B64URL_ALPHABET_RE = re.compile(r"^[A-Za-z0-9_-]*$")
+from mcp_proxy.utils.validation import strict_b64url_decode as _strict_b64url_decode
 
 
 def _b64url_decode(s: str) -> bytes:
-    """Strict base64url decode — tolerates padding, rejects garbage bits.
+    """Strict base64url decode — delegates to ``mcp_proxy.utils.validation``.
 
-    Audit F-C-3: even though JWKS is trusted infra, keeping the decoder
-    identical to the DPoP one here prevents drift if someone later feeds
-    attacker-controlled material through this path.
+    Audit S8: previously inlined; now imports from the single vendored copy
+    in mcp_proxy so all Mastio paths stay in sync.
     """
-    if isinstance(s, bytes):
-        s = s.decode("ascii")
-    stripped = s.rstrip("=")
-    if not _B64URL_ALPHABET_RE.fullmatch(stripped):
-        raise ValueError("base64url contains non-url-safe characters")
-    rem = len(stripped) % 4
-    if rem == 1:
-        raise ValueError("base64url length is not valid (length % 4 == 1)")
-    padded = stripped + ("=" * ((4 - rem) % 4))
-    decoded = base64.urlsafe_b64decode(padded)
-    canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
-    if canonical != stripped:
-        raise ValueError("base64url contains non-canonical trailing bits")
-    return decoded
+    return _strict_b64url_decode(s)
 
 
 def _jwk_to_rsa_public_key(jwk: dict) -> RSAPublicKey:

--- a/mcp_proxy/utils/validation.py
+++ b/mcp_proxy/utils/validation.py
@@ -1,0 +1,100 @@
+"""Strict base64url decoder — vendored for Mastio (audit S8 / F-C-3).
+
+``mcp_proxy`` has no runtime dependency on ``app/``, so the canonical
+implementation from ``app.utils.validation.strict_b64url_decode`` is
+vendored here verbatim. Behavior must remain identical to the canonical copy;
+parity is verified by ``tests/test_b64url_decoder_parity.py``.
+
+All base64url decoding within ``mcp_proxy/`` should import from here rather
+than inlining its own copy, so any future hardening applies in one place.
+
+Do NOT relax or extend this implementation without a corresponding change to
+``app/utils/validation.strict_b64url_decode`` and ``cullis_sdk/_b64url.py``.
+"""
+from __future__ import annotations
+
+import base64
+import re
+
+# url-safe base64 alphabet (RFC 4648 §5). Excludes padding — handled separately.
+_B64URL_ALPHABET_RE = re.compile(r"^[A-Za-z0-9_-]*$")
+
+
+class B64urlError(ValueError):
+    """Raised when a base64url string is malformed or non-canonical."""
+
+
+def strict_b64url_decode(s: str | bytes) -> bytes:
+    """Decode a base64url string, rejecting non-canonical encodings.
+
+    Accepts ``s`` with OR without trailing ``=`` padding (the codebase
+    convention — TS SDK omits padding, some tests include it). Rejects:
+
+      * Non-alphabet characters (whitespace, ``+``, ``/``, ``\\n``, etc.)
+      * Excess padding (e.g. ``AAAA===`` — valid for stdlib, rejected here)
+      * Impossible lengths (``len(s.rstrip("=")) % 4 == 1``)
+      * Trailing "garbage bits" in partial-quantum inputs — Python's stdlib
+        silently zeroes the unused low-order bits of the last char, which
+        means ``AAAA`` and ``AAAB`` decode to the same 3 bytes.
+
+    On any violation raises ``B64urlError`` (a ``ValueError`` subclass) so
+    callers that wrap in ``except Exception`` continue to work.
+    """
+    if isinstance(s, bytes):
+        try:
+            s = s.decode("ascii")
+        except UnicodeDecodeError as exc:
+            raise B64urlError("base64url input is not ASCII") from exc
+    if not isinstance(s, str):
+        raise B64urlError(
+            f"base64url input must be str/bytes, got {type(s).__name__}"
+        )
+
+    # Strip trailing padding (tolerant). ``AAAA==`` and ``AAAA====`` both
+    # strip to ``AAAA`` — the over-padded case is caught when we re-pad
+    # below (stdlib silently ignores excess padding; we force-match).
+    stripped = s.rstrip("=")
+
+    # Reject non-alphabet content — no whitespace, no vanilla +/.
+    if not _B64URL_ALPHABET_RE.fullmatch(stripped):
+        raise B64urlError("base64url contains non-url-safe characters")
+
+    # Length mod 4 == 1 is impossible in base64 (1 char = 6 bits, no way
+    # to complete a byte). Raise explicitly — stdlib would raise too but
+    # via the less-specific ``binascii.Error``.
+    rem = len(stripped) % 4
+    if rem == 1:
+        raise B64urlError("base64url length is not valid (length % 4 == 1)")
+
+    # Re-pad to canonical form and decode.
+    padded = stripped + ("=" * ((4 - rem) % 4))
+    try:
+        decoded = base64.urlsafe_b64decode(padded)
+    except Exception as exc:
+        raise B64urlError(f"base64url decode failed: {exc}") from exc
+
+    # Re-encode and compare to catch "garbage bits" in partial-quantum
+    # inputs. stdlib silently drops the low-order bits of the last char
+    # when they aren't consumed — that means two different input strings
+    # can decode to the same bytes, which breaks canonicalization (JKT).
+    canonical = base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
+    if canonical != stripped:
+        raise B64urlError(
+            "base64url contains non-canonical trailing bits — "
+            "decoded bytes do not round-trip to the input"
+        )
+
+    return decoded
+
+
+def canonicalize_b64url(s: str) -> str:
+    """Round-trip a base64url string through strict decode -> no-pad encode.
+
+    Used to normalize JWK coordinates before thumbprint hashing. Two wire
+    encodings of the same key collapse to the same canonical string.
+    """
+    decoded = strict_b64url_decode(s)
+    return base64.urlsafe_b64encode(decoded).rstrip(b"=").decode("ascii")
+
+
+__all__ = ["B64urlError", "canonicalize_b64url", "strict_b64url_decode"]

--- a/tests/test_b64url_decoder_parity.py
+++ b/tests/test_b64url_decoder_parity.py
@@ -1,0 +1,150 @@
+"""Parity test for the three vendored strict base64url decoders (audit H4/H5/S8).
+
+Verifies that all three implementations behave identically on every input in
+the test matrix:
+
+  1. ``app.utils.validation.strict_b64url_decode`` — canonical (Court)
+  2. ``mcp_proxy.utils.validation.strict_b64url_decode`` — vendored for Mastio (S8)
+  3. ``cullis_sdk._b64url.strict_b64url_decode`` — vendored for SDK (H5)
+
+All three must:
+  * Accept the same valid inputs and return identical bytes.
+  * Raise ``ValueError`` (or a subclass) on every invalid input.
+  * Raise on non-canonical trailing-bit inputs (the core security property).
+
+The test does NOT assert on the exact exception message, only on the type, so
+minor wording differences between implementations do not cause false failures.
+"""
+from __future__ import annotations
+
+import base64
+import pytest
+
+# ── import all three implementations ─────────────────────────────────────────
+
+from app.utils.validation import strict_b64url_decode as _court_decode
+from mcp_proxy.utils.validation import strict_b64url_decode as _mastio_decode
+from cullis_sdk._b64url import strict_b64url_decode as _sdk_decode
+
+_IMPLS = [
+    ("court", _court_decode),
+    ("mastio", _mastio_decode),
+    ("sdk", _sdk_decode),
+]
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _b64url(b: bytes) -> str:
+    """Canonical no-pad base64url encode, used to build valid test inputs."""
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+# ── valid input matrix ────────────────────────────────────────────────────────
+
+_VALID_CASES: list[tuple[str, bytes, str]] = [
+    # label, expected_bytes, input_string
+    ("empty", b"", ""),
+    ("1byte", b"\x00", _b64url(b"\x00")),
+    ("2bytes", b"\x00\x01", _b64url(b"\x00\x01")),
+    ("3bytes", b"\x00\x01\x02", _b64url(b"\x00\x01\x02")),
+    ("4bytes", b"\xff\xfe\xfd\xfc", _b64url(b"\xff\xfe\xfd\xfc")),
+    # With padding appended — all three must tolerate padding
+    ("padded_2mod4", b"\x00\x01\x02", _b64url(b"\x00\x01\x02") + "="),
+    ("padded_1mod4", b"\x00", _b64url(b"\x00") + "=="),
+    # 32 bytes (EC P-256 coordinate size, common in JWK)
+    ("ec_coord_32", bytes(range(32)), _b64url(bytes(range(32)))),
+    # bytes that encode to url-safe chars (contain - and _)
+    ("url_safe_chars", b"\xfb\xef", _b64url(b"\xfb\xef")),  # encodes to "-+8="
+    # bytes input — all three accept bytes as well as str
+    ("bytes_input", b"\xca\xfe", _b64url(b"\xca\xfe")),
+]
+
+
+@pytest.mark.parametrize("label,expected,inp", _VALID_CASES, ids=[c[0] for c in _VALID_CASES])
+@pytest.mark.parametrize("impl_name,impl", _IMPLS, ids=[i[0] for i in _IMPLS])
+def test_valid_inputs(impl_name: str, impl, label: str, expected: bytes, inp: str) -> None:
+    """All implementations decode valid inputs to identical bytes."""
+    got = impl(inp)
+    assert got == expected, (
+        f"[{impl_name}] {label!r}: expected {expected!r}, got {got!r}"
+    )
+
+
+@pytest.mark.parametrize("impl_name,impl", _IMPLS, ids=[i[0] for i in _IMPLS])
+def test_bytes_input_accepted(impl_name: str, impl) -> None:
+    """All implementations accept bytes input (not just str)."""
+    raw = b"AQID"  # canonical b64url for b"\x01\x02\x03"
+    assert impl(raw) == b"\x01\x02\x03"
+
+
+# ── invalid input matrix ──────────────────────────────────────────────────────
+
+_INVALID_CASES: list[tuple[str, str]] = [
+    # label, input_string
+    # Non-url-safe characters
+    ("vanilla_plus", "AA+A"),
+    ("vanilla_slash", "AA/A"),
+    ("whitespace", "AA A"),
+    ("newline", "AA\nAA"),
+    ("tab", "AA\tAA"),
+    # Impossible length (len % 4 == 1)
+    ("bad_length_mod4_eq1", "A"),
+    ("bad_length_mod4_eq1_long", "AAAAA"),
+    # Garbage trailing bits — the critical security property.
+    # Base64 encodes 3 bytes per 4 chars. When you have 2 chars (12 bits)
+    # the last 4 bits must be zero. 'AB' → 0x00 0x10, re-encoded → 'AB'.
+    # 'AC' → 0x00 0x20, re-encoded → 'AC' ≠ 'AB'. But stdlib decodes
+    # both to b'\x00' with a garbage low nibble silently discarded.
+    # We must reject 'AC', 'AD', …, 'AP' when 'AB' is the canonical form.
+    ("garbage_bits_2char", "AC"),   # 'AB' is canonical for b'\x00'; 'AC' is not
+    ("garbage_bits_3char", "AAB"),  # 'AAA' is canonical for b'\x00\x00'; 'AAB' is not
+]
+
+
+@pytest.mark.parametrize("label,inp", _INVALID_CASES, ids=[c[0] for c in _INVALID_CASES])
+@pytest.mark.parametrize("impl_name,impl", _IMPLS, ids=[i[0] for i in _IMPLS])
+def test_invalid_inputs_raise(impl_name: str, impl, label: str, inp: str) -> None:
+    """All implementations raise ValueError (or subclass) on invalid inputs."""
+    with pytest.raises(ValueError, match=""):
+        impl(inp)
+        pytest.fail(f"[{impl_name}] {label!r}: expected ValueError, but returned without error")
+
+
+# ── cross-implementation agreement ───────────────────────────────────────────
+
+_AGREEMENT_VALID = [
+    _b64url(bytes(range(i, i + 10))) for i in range(0, 40, 10)
+]
+_AGREEMENT_INVALID = [
+    "AA+A", "A", "AAAAB", "AA\nAA", "AC", "AAB",
+]
+
+
+@pytest.mark.parametrize("inp", _AGREEMENT_VALID)
+def test_cross_impl_agreement_valid(inp: str) -> None:
+    """All three implementations return identical bytes for valid inputs."""
+    results = {name: impl(inp) for name, impl in _IMPLS}
+    values = list(results.values())
+    assert all(v == values[0] for v in values), (
+        f"Cross-impl disagreement for {inp!r}: {results}"
+    )
+
+
+@pytest.mark.parametrize("inp", _AGREEMENT_INVALID)
+def test_cross_impl_agreement_invalid(inp: str) -> None:
+    """All three implementations raise on the same invalid inputs."""
+    raised = {}
+    for name, impl in _IMPLS:
+        try:
+            result = impl(inp)
+            raised[name] = f"returned {result!r}"
+        except ValueError:
+            raised[name] = "raised"
+        except Exception as exc:
+            raised[name] = f"raised {type(exc).__name__}"
+
+    unanimous = all(v == "raised" for v in raised.values())
+    assert unanimous, (
+        f"Cross-impl disagreement on invalid input {inp!r}: {raised}"
+    )


### PR DESCRIPTION
## Summary
- Consolidate 4 inlined base64url decoders to one canonical strict implementation (`app/utils/validation.py::strict_b64url_decode`)
- Court (`app/auth/mastio_countersig.py`) imports the canonical helper directly
- Mastio vendors a copy in new `mcp_proxy/utils/validation.py` (mcp_proxy has no app/ runtime dep, must be standalone)
- SDK vendors a copy in new `cullis_sdk/_b64url.py` (separate distributable)
- New `tests/test_b64url_decoder_parity.py` (70 tests) asserts cross-implementation agreement on valid inputs, padding tolerance, invalid characters, garbage trailing bits
- Closes audit findings H4 + H5 + S8 (non-strict permissive decoders weakened canonicalization in countersig, SDK DPoP, and Mastio DPoP)

## Test plan
- [ ] `pytest tests/test_b64url_decoder_parity.py -v` (70 passed)
- [ ] `pytest tests/ -k 'dpop or countersig or jwks' -n auto --dist=loadfile` (no regressions)
- [ ] Sandbox smoke B4.4-B4.6 (DPoP auth uses the swapped decoder) green
- [ ] `grep -rn '_b64url_decode_nopad\|urlsafe_b64decode(s + pad)' app/ mcp_proxy/ cullis_sdk/ --include='*.py'` returns nothing