### PR TITLE
fix(sdk-ts): verify inner signature on decryptPayload (non-repudiation)

### DIFF
--- a/sdk-ts/package.json
+++ b/sdk-ts/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node tests/canonical_json.test.mjs"
+    "test": "npm run build && node tests/canonical_json.test.mjs && node tests/decrypt_payload.test.mjs"
   },
   "dependencies": {
     "jose": "^5.0.0"

--- a/sdk-ts/src/client.ts
+++ b/sdk-ts/src/client.ts
@@ -19,7 +19,12 @@ import {
   createDPoPProof,
   generateDPoPKeyPair,
 } from "./auth.js";
-import { signMessage, encryptForAgent, decryptFromAgent } from "./crypto.js";
+import {
+  signMessage,
+  verifyMessageSignature,
+  encryptForAgent,
+  decryptFromAgent,
+} from "./crypto.js";
 import type {
   BrokerClientOptions,
   SessionResponse,
@@ -388,12 +393,22 @@ export class BrokerClient {
     });
     const messages = JSON.parse(resp.text) as InboxMessage[];
 
-    // Decrypt each message
-    return messages.map((msg) => this.decryptPayload(msg, sessionId));
+    // Decrypt each message in parallel (each may fetch the sender cert
+    // from the registry; the pubkey cache de-duplicates per-agent
+    // round trips within the TTL window).
+    return Promise.all(messages.map((msg) => this.decryptPayload(msg, sessionId)));
   }
 
   /**
    * Get an agent's public key PEM from the registry (TTL-cached).
+   *
+   * Prefers ``cert_pem`` (full X.509) over ``public_key_pem`` (bare SPKI)
+   * to match the Python SDK's behaviour. The H7 audit fix on
+   * ``verifyMessageSignature`` rejects bare SPKI — callers that need to
+   * verify inner signatures (e.g. ``decryptPayload``) require the full
+   * cert. Older brokers that don't populate ``cert_pem`` still work for
+   * encryption (``createPublicKey`` accepts both forms) but inner-sig
+   * verification will fail loudly with a clear error.
    */
   async getAgentPublicKey(
     agentId: string,
@@ -408,12 +423,22 @@ export class BrokerClient {
     // ADR-010 Phase 6a — public-key lookup served under /v1/federation/.
     const path = `/v1/federation/agents/${agentId}/public-key`;
     const resp = await this.authedRequest("GET", path);
-    const data = JSON.parse(resp.text) as { public_key_pem: string };
+    const data = JSON.parse(resp.text) as {
+      cert_pem?: string | null;
+      public_key_pem?: string | null;
+    };
+    const pem = data.cert_pem || data.public_key_pem;
+    if (!pem) {
+      throw new Error(
+        `Registry returned no key material for ${agentId} ` +
+          "(neither cert_pem nor public_key_pem)",
+      );
+    }
     this.pubkeyCache.set(agentId, {
-      pem: data.public_key_pem,
+      pem,
       fetchedAt: Date.now(),
     });
-    return data.public_key_pem;
+    return pem;
   }
 
   // ── RFQ (Request for Quote) ──────────────────────────────────
@@ -577,12 +602,27 @@ export class BrokerClient {
   }
 
   /**
-   * Decrypt the payload of a received message if it is E2E encrypted.
+   * Decrypt the payload of a received message if it is E2E encrypted,
+   * AND verify the inner (plaintext) signature for non-repudiation.
+   *
+   * The inner signature is the only proof that the sender's *private*
+   * key produced the plaintext: a compromised broker can substitute
+   * the ciphertext after the AES-GCM key has been unwrapped, and AES-GCM
+   * alone (which only authenticates against the broker-controllable
+   * AAD) would not catch this. Skipping the inner-sig check would let
+   * the broker forge messages silently, breaking the entire
+   * non-repudiation property the protocol promises to recipients.
+   *
+   * Audit reference: L9-C1 (sdk-ts, 2026-05-08). Mirrors the Python
+   * ``cullis_sdk.client._fetch_pubkey_proxy_then_broker`` +
+   * ``verify_inner_signature`` pattern (cullis_sdk/client.py:2689).
+   *
+   * Throws on any cryptographic failure (decrypt or verify).
    */
-  private decryptPayload(
+  private async decryptPayload(
     msg: InboxMessage,
     sessionId: string,
-  ): InboxMessage {
+  ): Promise<InboxMessage> {
     if (!this.signingKeyPem) {
       return msg;
     }
@@ -604,7 +644,9 @@ export class BrokerClient {
     const senderAgentId = msg.sender_agent_id;
     const clientSeq = msg.client_seq;
 
-    const [plaintextPayload] = decryptFromAgent(
+    // 1. Decrypt — recovers both the plaintext payload AND the inner
+    //    signature the sender produced over that plaintext.
+    const [plaintextPayload, innerSignature] = decryptFromAgent(
       cipherBlob,
       this.signingKeyPem,
       sessionId,
@@ -612,6 +654,66 @@ export class BrokerClient {
       clientSeq,
     );
 
+    // 2. Fetch the sender's certificate (TTL-cached). H7 audit fix:
+    //    ``verifyMessageSignature`` rejects bare SPKI — registry
+    //    response must carry the full cert under ``cert_pem``.
+    const senderCertPem = await this.getAgentPublicKey(senderAgentId);
+
+    // 3. Convert the wire-side timestamp back into the seconds-since-epoch
+    //    integer the sender signed against. The broker serialises its
+    //    stored ``datetime`` as ISO-8601, but ``signMessage`` consumed an
+    //    epoch int; we accept either shape so this stays robust to the
+    //    broker normalising the field.
+    const ts = parseTimestamp(msg.timestamp);
+
+    // 4. Verify. Throws on cert/binding/signature failure — propagate
+    //    rather than masking, since a verify failure means a forged
+    //    plaintext (broker compromise) or a misconfigured peer.
+    try {
+      verifyMessageSignature(
+        senderCertPem,
+        innerSignature,
+        sessionId,
+        senderAgentId,
+        msg.nonce,
+        ts,
+        plaintextPayload,
+        clientSeq,
+      );
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `inner signature verification failed for message from ` +
+          `${senderAgentId} (seq=${msg.seq}): ${reason}`,
+      );
+    }
+
     return { ...msg, payload: plaintextPayload };
   }
+}
+
+/**
+ * Best-effort coercion of the wire ``timestamp`` field to seconds since
+ * the Unix epoch (the integer form ``signMessage`` consumed at send).
+ *
+ * The broker's ``InboxMessage`` Pydantic model serialises a stored
+ * ``datetime`` as ISO-8601, but the sender's inner-signature canonical
+ * was built with ``Math.floor(Date.now()/1000)`` (an int). Accept both
+ * shapes:
+ *   - number → trusted as-is
+ *   - numeric string → parsed as int
+ *   - ISO-8601 string → parsed via ``Date.parse`` and floored to seconds
+ */
+function parseTimestamp(value: string | number): number {
+  if (typeof value === "number") {
+    return Math.floor(value);
+  }
+  if (/^-?\d+$/.test(value)) {
+    return parseInt(value, 10);
+  }
+  const ms = Date.parse(value);
+  if (Number.isNaN(ms)) {
+    throw new Error(`Cannot parse message timestamp: ${value}`);
+  }
+  return Math.floor(ms / 1000);
 }

--- a/sdk-ts/tests/decrypt_payload.test.mjs
+++ b/sdk-ts/tests/decrypt_payload.test.mjs
@@ -1,0 +1,314 @@
+// Inner signature verification on receive — L9-C1 regression test.
+//
+// Verifies that ``BrokerClient.decryptPayload()`` (the receive-side hook
+// invoked by ``poll()``) refuses to surface a plaintext that fails the
+// non-repudiation check. A compromised broker that swaps the ciphertext
+// after key-unwrap MUST be rejected loudly; previously the inner signature
+// returned by ``decryptFromAgent`` was discarded and forged plaintext
+// would have been silently delivered to the application.
+//
+// Run via `npm test` (exits non-zero on any failure).
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateKeyPairSync } from "node:crypto";
+
+import { BrokerClient } from "../dist/client.js";
+import { signMessage, encryptForAgent } from "../dist/crypto.js";
+
+// ── Fixture helpers ────────────────────────────────────────────────
+
+/**
+ * Build a sender keypair + self-signed X.509 cert whose CN matches
+ * ``agentId``. ``verifyMessageSignature`` rejects bare SPKI keys and
+ * binds the cert subject to ``sender_agent_id``, so we need a real
+ * cert with the correct CN.
+ */
+function makeSenderIdentity(agentId) {
+  const tmp = mkdtempSync(join(tmpdir(), "cullis-sdk-test-"));
+  const keyPath = join(tmp, "key.pem");
+  const certPath = join(tmp, "cert.pem");
+
+  // RSA key + self-signed cert via openssl. RSA chosen to exercise
+  // the RSA-PSS-SHA256 signing path (the dominant production deployment
+  // — ECDSA path is tested implicitly by the existing crypto helpers).
+  execSync(
+    `openssl req -x509 -newkey rsa:2048 -nodes ` +
+      `-keyout ${keyPath} -out ${certPath} -days 1 ` +
+      `-subj "/CN=${agentId}" 2>/dev/null`,
+    { stdio: "pipe" },
+  );
+  return {
+    keyPem: readFileSync(keyPath, "utf-8"),
+    certPem: readFileSync(certPath, "utf-8"),
+  };
+}
+
+/** Build a recipient RSA keypair as PEM. Recipients only need a key. */
+function makeRecipientKeypair() {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  });
+  return {
+    privatePem: privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+    publicPem: publicKey.export({ type: "spki", format: "pem" }).toString(),
+  };
+}
+
+/**
+ * Construct a fully-formed encrypted ``InboxMessage`` as the broker
+ * would deliver it on the wire — payload is a ``CipherBlob``, nonce
+ * and timestamp on the envelope match what the sender signed.
+ */
+function buildEncryptedInbox({
+  senderKeyPem,
+  recipientPubPem,
+  sessionId,
+  senderAgentId,
+  payload,
+  clientSeq,
+  // Defaults below let individual tests override (e.g. to fabricate a
+  // signature mismatch by changing the nonce post-encrypt).
+  nonce = "test-nonce-" + Math.random().toString(36).slice(2),
+  timestamp = Math.floor(Date.now() / 1000),
+}) {
+  // Inner signature: signed over the plaintext payload.
+  const innerSig = signMessage(
+    senderKeyPem,
+    sessionId,
+    senderAgentId,
+    nonce,
+    timestamp,
+    payload,
+    clientSeq,
+  );
+  const cipherBlob = encryptForAgent(
+    payload,
+    recipientPubPem,
+    sessionId,
+    senderAgentId,
+    innerSig,
+    clientSeq,
+  );
+  return {
+    seq: 0,
+    sender_agent_id: senderAgentId,
+    payload: cipherBlob,
+    nonce,
+    timestamp,
+    signature: null,
+    client_seq: clientSeq,
+  };
+}
+
+/**
+ * Build a ``BrokerClient`` instance plumbed for offline ``decryptPayload``
+ * testing: signing key is set so decryption proceeds, and the pubkey
+ * cache is pre-seeded with the sender's cert so no HTTP fetch happens.
+ *
+ * We bypass the constructor's TLS guard via the supported path
+ * (verifyTls defaults to true) and reach into private state through
+ * the ``any`` escape hatch — this is a unit-test helper, not a real
+ * consumer pattern.
+ */
+function makeClientWithCachedSenderCert(recipientKeyPem, senderAgentId, senderCertPem) {
+  const client = new BrokerClient({ baseUrl: "https://broker.test" });
+  // Inject the recipient's signing key — required for ``decryptPayload``
+  // to attempt decryption rather than no-op.
+  client.signingKeyPem = recipientKeyPem;
+  // Pre-seed the pubkey cache so ``getAgentPublicKey`` resolves without
+  // hitting the (un-authenticated) HTTP path.
+  client.pubkeyCache.set(senderAgentId, {
+    pem: senderCertPem,
+    fetchedAt: Date.now(),
+  });
+  return client;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+
+const sessionId = "test-session-" + Math.random().toString(36).slice(2);
+const senderAgentId = "acme::alice";
+const otherAgentId = "acme::eve";
+const sender = makeSenderIdentity(senderAgentId);
+const otherSender = makeSenderIdentity(otherAgentId);
+const recipient = makeRecipientKeypair();
+
+let failed = 0;
+
+async function runCase(name, fn) {
+  try {
+    await fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  FAIL  ${name}: ${err.message}`);
+  }
+}
+
+// Case 1 — happy path: a correctly-signed and -encrypted message
+// round-trips and the plaintext is exposed to the caller.
+await runCase("positive: valid inner sig — decryptPayload returns plaintext", async () => {
+  const client = makeClientWithCachedSenderCert(
+    recipient.privatePem, senderAgentId, sender.certPem,
+  );
+  const payload = { hello: "world", n: 42 };
+  const inbox = buildEncryptedInbox({
+    senderKeyPem: sender.keyPem,
+    recipientPubPem: recipient.publicPem,
+    sessionId,
+    senderAgentId,
+    payload,
+    clientSeq: 0,
+  });
+  const out = await client.decryptPayload(inbox, sessionId);
+  assert.deepEqual(out.payload, payload, "decrypted payload must match");
+  assert.equal(out.sender_agent_id, senderAgentId);
+});
+
+// Case 2 — the broker (or anyone in the middle) re-encrypts a
+// fabricated plaintext using the recipient's public key. AES-GCM
+// alone would accept this; the inner signature must catch it.
+await runCase("negative: fabricated plaintext (re-encrypted) — throws", async () => {
+  const client = makeClientWithCachedSenderCert(
+    recipient.privatePem, senderAgentId, sender.certPem,
+  );
+  const realPayload = { msg: "send $1 to charity" };
+  const inbox = buildEncryptedInbox({
+    senderKeyPem: sender.keyPem,
+    recipientPubPem: recipient.publicPem,
+    sessionId,
+    senderAgentId,
+    payload: realPayload,
+    clientSeq: 1,
+  });
+
+  // Attacker re-encrypts a forged payload using the SAME inner signature
+  // (which was computed over the legit payload, so it won't match the
+  // forgery). If our verify step is missing, AES-GCM authenticates
+  // happily because the AAD only binds session+sender+client_seq.
+  const innerSigOverReal = signMessage(
+    sender.keyPem, sessionId, senderAgentId, inbox.nonce, inbox.timestamp,
+    realPayload, 1,
+  );
+  const forgedPayload = { msg: "send $1000000 to attacker" };
+  inbox.payload = encryptForAgent(
+    forgedPayload, recipient.publicPem, sessionId, senderAgentId,
+    innerSigOverReal, 1,
+  );
+
+  await assert.rejects(
+    () => client.decryptPayload(inbox, sessionId),
+    /inner signature verification failed/i,
+    "must reject forged plaintext re-encrypted by the broker",
+  );
+});
+
+// Case 3 — wrong sender cert (e.g. registry returns Eve's cert when
+// the message claims to be from Alice). The sig was produced with
+// Alice's key but verify is attempted with Eve's key.
+await runCase("negative: wrong sender cert — throws", async () => {
+  const client = new BrokerClient({ baseUrl: "https://broker.test" });
+  client.signingKeyPem = recipient.privatePem;
+  // Cache returns OTHER agent's cert under Alice's id — the cert subject
+  // doesn't bind ``acme::alice``, so ``verifyMessageSignature`` rejects.
+  client.pubkeyCache.set(senderAgentId, {
+    pem: otherSender.certPem,
+    fetchedAt: Date.now(),
+  });
+  const inbox = buildEncryptedInbox({
+    senderKeyPem: sender.keyPem,
+    recipientPubPem: recipient.publicPem,
+    sessionId,
+    senderAgentId,
+    payload: { ok: true },
+    clientSeq: 2,
+  });
+
+  await assert.rejects(
+    () => client.decryptPayload(inbox, sessionId),
+    /inner signature verification failed/i,
+    "must reject when registry returns the wrong cert for the sender",
+  );
+});
+
+// Case 4 — the ciphertext envelope itself is replayed with a tampered
+// nonce field (broker tries to make the recipient verify a different
+// canonical). Inner sig was computed with the original nonce and won't
+// validate against the tampered envelope.
+await runCase("negative: tampered envelope nonce — throws", async () => {
+  const client = makeClientWithCachedSenderCert(
+    recipient.privatePem, senderAgentId, sender.certPem,
+  );
+  const inbox = buildEncryptedInbox({
+    senderKeyPem: sender.keyPem,
+    recipientPubPem: recipient.publicPem,
+    sessionId,
+    senderAgentId,
+    payload: { v: 1 },
+    clientSeq: 3,
+  });
+  // Broker rewrites the visible nonce. AAD does NOT include the nonce
+  // (AAD = session|sender|client_seq), so AES-GCM still decrypts — only
+  // the inner-signature check catches this.
+  inbox.nonce = "broker-rewrote-this-nonce";
+
+  await assert.rejects(
+    () => client.decryptPayload(inbox, sessionId),
+    /inner signature verification failed/i,
+    "must reject envelope-level nonce tampering",
+  );
+});
+
+// Case 5 — a single byte flip in the inner-signature blob makes
+// verification fail even when everything else is consistent. Guards
+// against the "AES-GCM said OK so I trust it" anti-pattern.
+await runCase("negative: inner signature byte-flip — throws", async () => {
+  const client = makeClientWithCachedSenderCert(
+    recipient.privatePem, senderAgentId, sender.certPem,
+  );
+  const realPayload = { v: 2 };
+  const inbox = buildEncryptedInbox({
+    senderKeyPem: sender.keyPem,
+    recipientPubPem: recipient.publicPem,
+    sessionId,
+    senderAgentId,
+    payload: realPayload,
+    clientSeq: 4,
+  });
+
+  // Re-encrypt with a corrupted inner signature. We flip a byte in
+  // the middle of the original signature — RSA-PSS-SHA256 must reject.
+  const goodSig = signMessage(
+    sender.keyPem, sessionId, senderAgentId, inbox.nonce, inbox.timestamp,
+    realPayload, 4,
+  );
+  // ``goodSig`` is base64url; decode, flip, re-encode — easier:
+  // just overwrite a base64url char. Replace mid-string char with one
+  // that's still in the base64url alphabet so decode itself succeeds.
+  const mid = Math.floor(goodSig.length / 2);
+  const orig = goodSig[mid];
+  const flipped = orig === "A" ? "B" : "A";
+  const corruptedSig = goodSig.slice(0, mid) + flipped + goodSig.slice(mid + 1);
+
+  inbox.payload = encryptForAgent(
+    realPayload, recipient.publicPem, sessionId, senderAgentId,
+    corruptedSig, 4,
+  );
+
+  await assert.rejects(
+    () => client.decryptPayload(inbox, sessionId),
+    /inner signature verification failed/i,
+    "must reject a single-byte flip in the inner signature",
+  );
+});
+
+// ── Done ───────────────────────────────────────────────────────────
+
+if (failed > 0) {
+  console.error(`\n${failed} test(s) failed`);
+  process.exit(1);
+}
+console.log(`\nall 5 inner-signature tests passed`);


### PR DESCRIPTION
## Summary
- TypeScript SDK `decryptPayload()` now verifies the inner signature returned by `decryptFromAgent()`, throwing on any verification failure
- Reuses existing `getAgentPublicKey()` + 5-minute `pubkeyCache` for sender cert lookup (Python SDK parity, no extra broker round-trip on cache hit)
- 5 new tests in `sdk-ts/tests/decrypt_payload.test.mjs`: 1 positive + 4 negative (broker-fabricated re-encrypted plaintext, wrong sender cert, tampered envelope nonce, signature byte-flip)
- Closes audit finding L9-C1 (CRITICAL): a compromised broker could replace plaintext after key-unwrap and the TS recipient accepted the fabricated payload silently

## Test plan
- [ ] `cd sdk-ts && npm test` (10 tests pass: 5 existing canonical_json + 5 new inner-sig)
- [ ] `cd sdk-ts && npx tsc --noEmit` clean
- [ ] Negative paths actually throw (not just no-op)

## Known follow-up
The broker session-inbox path (`app/broker/session.py:store_message`) overwrites the signer's wire timestamp with `datetime.now()` at storage time. This means TS SDK session-poll traffic will fail verify until the broker preserves the signed timestamp end-to-end. The Python SDK doesn't hit this today because it uses the one-shot envelope path. Tracking as a separate follow-up; this PR ships the SDK fix independently.