### PR TITLE
fix(sdk): default verify_tls=True in mcp_server CullisClient construction

### DIFF
--- a/cullis_sdk/mcp_server.py
+++ b/cullis_sdk/mcp_server.py
@@ -7,13 +7,16 @@ Run standalone:
 Or configure in Claude Desktop / Claude Code as an MCP server.
 
 Environment variables:
-    BROKER_URL       — Broker address (required)
-    AGENT_ID         — Agent identifier (required)
-    ORG_ID           — Organization identifier (required)
-    AGENT_CERT_PATH  — Path to PEM certificate (required unless using Vault)
-    AGENT_KEY_PATH   — Path to PEM private key (required unless using Vault)
-    VAULT_ADDR       — Vault address (optional, for credential loading)
-    VAULT_TOKEN      — Vault token (optional)
+    BROKER_URL              — Broker address (required)
+    AGENT_ID                — Agent identifier (required)
+    ORG_ID                  — Organization identifier (required)
+    AGENT_CERT_PATH         — Path to PEM certificate (required unless using Vault)
+    AGENT_KEY_PATH          — Path to PEM private key (required unless using Vault)
+    VAULT_ADDR              — Vault address (optional, for credential loading)
+    VAULT_TOKEN             — Vault token (optional)
+    CULLIS_MCP_VERIFY_TLS   — Set to "false"/"0"/"no" to disable TLS verification
+                              of the broker (dev only, against self-signed certs).
+                              Default: verify.
 """
 from __future__ import annotations
 
@@ -74,7 +77,22 @@ def cullis_connect(
         return "Error: org_id is required (or set ORG_ID env var)"
 
     try:
-        client = CullisClient(broker, verify_tls=False)
+        # TLS verification: default ON (matches CullisClient default). Operators
+        # working against a self-signed broker in dev can opt out with
+        # CULLIS_MCP_VERIFY_TLS=false; CullisClient still refuses verify_tls=False
+        # when CULLIS_ENV=production unless CULLIS_SDK_ALLOW_INSECURE_TLS=1.
+        _verify_env = os.environ.get("CULLIS_MCP_VERIFY_TLS", "").strip().lower()
+        verify_tls = _verify_env not in {"0", "false", "no"}
+        if not verify_tls:
+            print(
+                "WARNING: CULLIS_MCP_VERIFY_TLS is disabled — broker TLS "
+                "verification OFF. Use only for local dev against a self-"
+                "signed broker.",
+                file=sys.stderr,
+                flush=True,
+            )
+
+        client = CullisClient(broker, verify_tls=verify_tls)
 
         # Try Vault first if configured
         vault_addr = os.environ.get("VAULT_ADDR", "")

--- a/tests/test_sdk_mcp_server_verify_tls.py
+++ b/tests/test_sdk_mcp_server_verify_tls.py
@@ -1,0 +1,112 @@
+"""Regression tests for the SDK MCP server TLS verification default.
+
+Closes audit finding U1 (Ultra Plan 2026-05-08): the MCP server wrapper used
+to construct CullisClient with ``verify_tls=False`` hardcoded, exposing the
+LLM-driven agent-host integration to MITM on the broker connection. The fix
+defaults to ``verify_tls=True`` and only opts out when CULLIS_MCP_VERIFY_TLS
+is explicitly set to a falsy string.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_mcp_server():
+    """Re-import the module so it picks up env at decision time."""
+    import cullis_sdk.mcp_server as mod
+
+    return importlib.reload(mod)
+
+
+@pytest.fixture
+def fake_client_class(monkeypatch):
+    """Patch CullisClient inside the mcp_server module and capture call kwargs."""
+    captured: dict = {}
+
+    class _FakeClient:
+        def __init__(self, broker, *, verify_tls=True, timeout=10.0):
+            captured["broker"] = broker
+            captured["verify_tls"] = verify_tls
+            captured["timeout"] = timeout
+            self.token = None  # avoids _get_client tripping later
+
+        def login(self, *_a, **_kw):
+            self.token = "stub"
+
+        def login_from_pem(self, *_a, **_kw):
+            self.token = "stub"
+
+    mod = _reload_mcp_server()
+    monkeypatch.setattr(mod, "CullisClient", _FakeClient)
+    monkeypatch.setattr(mod, "_client", None, raising=False)
+    return mod, captured
+
+
+def test_default_verify_tls_is_true(fake_client_class, monkeypatch, tmp_path):
+    """No env var set → CullisClient must be constructed with verify_tls=True."""
+    monkeypatch.delenv("CULLIS_MCP_VERIFY_TLS", raising=False)
+
+    cert = tmp_path / "agent.crt"
+    cert.write_text("PEM")
+    key = tmp_path / "agent.key"
+    key.write_text("PEM")
+
+    mod, captured = fake_client_class
+    result = mod.cullis_connect(
+        broker_url="https://broker.test",
+        agent_id="orga::agent-a",
+        org_id="orga",
+        cert_path=str(cert),
+        key_path=str(key),
+    )
+
+    assert "Connected" in result, result
+    assert captured["verify_tls"] is True
+
+
+@pytest.mark.parametrize("disable_value", ["false", "FALSE", "0", "no", "No"])
+def test_env_disables_verify_tls(fake_client_class, monkeypatch, tmp_path, disable_value, capsys):
+    """CULLIS_MCP_VERIFY_TLS in {false,0,no} (case-insensitive) opts out."""
+    monkeypatch.setenv("CULLIS_MCP_VERIFY_TLS", disable_value)
+
+    cert = tmp_path / "agent.crt"
+    cert.write_text("PEM")
+    key = tmp_path / "agent.key"
+    key.write_text("PEM")
+
+    mod, captured = fake_client_class
+    mod.cullis_connect(
+        broker_url="https://broker.test",
+        agent_id="orga::agent-a",
+        org_id="orga",
+        cert_path=str(cert),
+        key_path=str(key),
+    )
+
+    assert captured["verify_tls"] is False
+    captured_streams = capsys.readouterr()
+    assert "CULLIS_MCP_VERIFY_TLS is disabled" in captured_streams.err
+
+
+@pytest.mark.parametrize("truthy_value", ["true", "1", "yes", "", "  ", "garbage"])
+def test_non_falsy_env_keeps_verify_tls_on(fake_client_class, monkeypatch, tmp_path, truthy_value):
+    """Anything not in {false,0,no} (case-insensitive) → verify_tls stays True."""
+    monkeypatch.setenv("CULLIS_MCP_VERIFY_TLS", truthy_value)
+
+    cert = tmp_path / "agent.crt"
+    cert.write_text("PEM")
+    key = tmp_path / "agent.key"
+    key.write_text("PEM")
+
+    mod, captured = fake_client_class
+    mod.cullis_connect(
+        broker_url="https://broker.test",
+        agent_id="orga::agent-a",
+        org_id="orga",
+        cert_path=str(cert),
+        key_path=str(key),
+    )
+
+    assert captured["verify_tls"] is True


### PR DESCRIPTION
## Summary
- The MCP server wrapper (`cullis_sdk/mcp_server.py`) hardcoded `CullisClient(broker, verify_tls=False)` on line 77, exposing LLM-driven agent hosts (Claude Desktop, Claude Code, Cursor MCP) to MITM on the broker connection
- `CullisClient._check_insecure_tls` already refuses `verify_tls=False` in production when `CULLIS_ENV=production` AND `CULLIS_SDK_ALLOW_INSECURE_TLS` ≠ 1, but a sandbox/dev MCP host with `CULLIS_ENV` unset got a silent warning and no protection
- Default `verify_tls` to True; opt-out via `CULLIS_MCP_VERIFY_TLS=false` (or `0`/`no`) with stderr warning visible to the MCP host
- Closes audit finding U1 (Ultra Plan 2026-05-08, missed by our L9 lane which audited sdk-ts only)

## Test plan
- [ ] `pytest tests/test_sdk_mcp_server_verify_tls.py -v` (12 tests pass: default true, env disables in {false,FALSE,0,no,No}, env truthy/garbage keeps true)
- [ ] Sandbox smoke green (no regression on existing SDK paths; the MCP server wrapper isn't exercised by smoke directly)
- [ ] Manual: `python -m cullis_sdk.mcp_server` against self-signed broker fails as expected; setting `CULLIS_MCP_VERIFY_TLS=false` proceeds with warning