### PR TITLE
chore(connector): bump to v0.4.0-rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,74 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.4.0-rc1] — 2026-05-08
+
+First connector minor since `connector-v0.3.6` (1 May). Folds ~17
+PRs of work driven by ADR-019 (Cullis Frontdesk) and ADR-021
+(shared-mode + multi-user KMS). Pre-release tag (`-rc1`) so the
+image lands on `ghcr.io` for end-to-end validation before the
+final v0.4.0 cut.
+
+### Highlights
+
+- **Ambassador, single-mode and shared-mode** ([#406], [#417],
+  [#418], [#428], [#430]): the Connector now exposes an
+  OpenAI-compatible Ambassador surface. `AMBASSADOR_MODE=single`
+  serves the desktop user (one local identity); `=shared` serves
+  N users behind an SSO-terminating reverse proxy via per-user
+  cookie + UserPrincipalKMS-signed requests.
+- **Cullis Chat SPA at `/chat`** ([#429], [#432]–[#434]): the
+  static SPA mounts directly under the Connector dashboard,
+  authenticated by the same cookie minted at `/api/session/init`.
+  PyInstaller binaries embed the bundle so single-user installs
+  work with no extra server.
+- **Shared-mode → Mastio CSR + MCP roundtrip** ([#437], [#442],
+  [#445]): per-user CSR endpoint is owned by the Mastio (moved
+  off Court), the Connector mints a per-user agent cert on
+  cookie issuance, and shared-mode requests reach MCP servers
+  with the right user identity attached to the audit chain.
+- **`/v1/inbox` passthrough on shared ambassador** ([#488]): the
+  inbox endpoints (list/ack/archive) bypass the Mastio hop and
+  call the broker directly with the user's own cert+key.
+- **Dashboard restyle to the cullis.io design system** ([#425],
+  [#426]): tokens, palette, typography aligned to the public
+  site.
+
+### Fixed
+
+- **`cullis-connector` Docker image now installs the
+  `[dashboard]` extra** ([#436]): previously `cullis-connector
+  dashboard` ImportError'd on `fastapi`. The Frontdesk container
+  bundle no longer needs its `Dockerfile.connector` wrapper as a
+  workaround.
+- **`/chat` gated behind enrollment** ([#433]): pre-enrollment
+  visits redirect to `/setup` instead of rendering the SPA with
+  a missing identity.
+
+### Notes
+
+- `cullis-sdk>=0.1.3` is now required at runtime for the
+  user-principal factory + `chat_completion`. The wheel install
+  pins this transitively.
+- Ambassador cookie TTL defaults to 1h (`CULLIS_FRONTDESK_COOKIE_TTL_S`).
+
+[#406]: https://github.com/cullis-security/cullis/pull/406
+[#417]: https://github.com/cullis-security/cullis/pull/417
+[#418]: https://github.com/cullis-security/cullis/pull/418
+[#425]: https://github.com/cullis-security/cullis/pull/425
+[#426]: https://github.com/cullis-security/cullis/pull/426
+[#428]: https://github.com/cullis-security/cullis/pull/428
+[#429]: https://github.com/cullis-security/cullis/pull/429
+[#430]: https://github.com/cullis-security/cullis/pull/430
+[#432]: https://github.com/cullis-security/cullis/pull/432
+[#433]: https://github.com/cullis-security/cullis/pull/433
+[#434]: https://github.com/cullis-security/cullis/pull/434
+[#436]: https://github.com/cullis-security/cullis/pull/436
+[#437]: https://github.com/cullis-security/cullis/pull/437
+[#442]: https://github.com/cullis-security/cullis/pull/442
+[#445]: https://github.com/cullis-security/cullis/pull/445
+[#488]: https://github.com/cullis-security/cullis/pull/488
+
 ## [v0.3.1] — 2026-05-07 (cullis-mastio)
 
 First minor since `mastio-v0.3.0-rc3` (29 April). Folds 116 commits

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.3.6"
+__version__ = "0.4.0-rc1"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.3.6"
+version = "0.4.0-rc1"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Version bump only, no code changes. Sets up the first pre-release tag for connector v0.4.0.

- \`cullis_connector/__init__.py\`: \`__version__ = "0.4.0-rc1"\`
- \`packaging/pypi/pyproject.toml\`: \`version = "0.4.0-rc1"\`
- \`CHANGELOG.md\`: new \`[v0.4.0-rc1]\` section above the mastio v0.3.1 block

## Why

Connector code on \`main\` has accumulated ~17 PRs since \`connector-v0.3.6\` (1 May), most of them ADR-019 (Cullis Frontdesk) and ADR-021 (shared-mode + multi-user KMS). The published \`ghcr.io/cullis-security/cullis-connector:0.3.6\` image predates all of this, including the \`[dashboard]\` extras fix in #436. Cutting a pre-release tag now lets the bulldozer (validation across the four components on a fresh VM) pull a real image with the current shared-mode + Frontdesk code.

\`-rc1\` rather than final \`v0.4.0\`: this is the first end-to-end customer-shaped install of the new ambassador, so we want one pass through the validation VMs (Mastio, Connector, Court, Frontdesk) before promoting to a stable tag.

## What's in v0.4.0

CHANGELOG covers the highlights:

- Ambassador single-mode + shared-mode (cookie + UserPrincipalKMS)
- Cullis Chat SPA mounted at \`/chat\`, embedded in PyInstaller binary
- Shared-mode → Mastio CSR + per-user MCP roundtrip
- \`/v1/inbox\` passthrough on shared ambassador
- Dashboard restyle to cullis.io design system
- Docker image now installs \`[dashboard]\` extras (Frontdesk bundle's \`Dockerfile.connector\` wrapper becomes obsolete after this lands)

## Test plan

- [ ] CI green on this PR
- [ ] After merge, push \`connector-v0.4.0-rc1\`
- [ ] Verify release-connector.yml succeeds end to end:
  - PyPI publish via OIDC trusted publishing
  - \`ghcr.io/cullis-security/cullis-connector:0.4.0-rc1\` multi-arch
  - PyInstaller binaries (linux/macos/windows)
  - GitHub Release marked as prerelease (because \`-rc1\`)
- [ ] Smoke test: \`docker run --rm ghcr.io/cullis-security/cullis-connector:0.4.0-rc1 --version\` returns \`0.4.0-rc1\`
- [ ] Smoke test: \`docker run ... dashboard --port 7777\` boots without ImportError on \`fastapi\` (validates the \`[dashboard]\` extras fix from #436 actually shipped in this image)