### PR TITLE
fix(mastio): refuse in-memory DPoP JTI + challenge store in production

### DIFF
--- a/mcp_proxy/auth/challenge_store.py
+++ b/mcp_proxy/auth/challenge_store.py
@@ -126,8 +126,15 @@ _store: ChallengeStore | None = None
 
 
 def _init_store() -> ChallengeStore:
-    """Select the best available backend. Warns in production when only
-    the in-memory store is available (multi-worker can race).
+    """Select the best available backend.
+
+    Production posture: refuse the in-memory fallback unless the operator
+    has explicitly opted in via
+    ``MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true``. Without the opt-in,
+    a multi-worker HA deploy that lost Redis would silently allow a
+    captured login nonce to be consumed on one worker and replayed on
+    another. Mirrors :mod:`mcp_proxy.auth.dpop_jti_store` (audit L1-M4 /
+    Ultra U-DD-1).
     """
     from mcp_proxy.config import get_settings
     from mcp_proxy.redis.pool import get_redis
@@ -137,13 +144,27 @@ def _init_store() -> ChallengeStore:
         _log.info("login challenge store: Redis")
         return RedisChallengeStore(redis)
 
-    if get_settings().environment == "production":
+    settings = get_settings()
+    if settings.environment == "production":
+        if not settings.allow_inmemory_security_stores:
+            _log.critical(
+                "login challenge store: Redis unavailable in production "
+                "and MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES is not set. "
+                "Refusing the in-memory fallback to avoid cross-worker "
+                "replay of login nonces. Set MCP_PROXY_REDIS_URL for HA, "
+                "or set MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true to "
+                "acknowledge a single-instance/single-worker deployment.",
+            )
+            raise RuntimeError(
+                "login challenge store requires Redis in production "
+                "unless MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true is "
+                "set (audit L1-M4 / Ultra U-DD-1)."
+            )
         _log.warning(
             "login challenge store: Redis unavailable in production — "
-            "falling back to in-memory. Safe only for single-instance/"
-            "single-worker deployments. Multi-worker/HA deploys MUST set "
-            "MCP_PROXY_REDIS_URL; otherwise a captured login nonce can be "
-            "consumed on one worker and replayed on another."
+            "using in-memory because MCP_PROXY_ALLOW_INMEMORY_SECURITY_"
+            "STORES is set. Safe only for single-instance/single-worker "
+            "deployments."
         )
 
     _log.info("login challenge store: in-memory")

--- a/mcp_proxy/auth/dpop_jti_store.py
+++ b/mcp_proxy/auth/dpop_jti_store.py
@@ -89,17 +89,17 @@ _store: DpopJtiStore | None = None
 def _init_store() -> DpopJtiStore:
     """Select the best available backend.
 
-    Mastio has a legitimate single-instance production mode (single-tenant
-    intra-org, SQLite + in-memory) where Redis is unnecessary. That differs
-    from the multi-tenant broker (``app/``), which *always* requires Redis
-    in production. So the factory does not refuse in-memory in production —
-    it only logs a warning. ``validate_config`` surfaces the same warning
-    at startup.
+    Production posture: refuse the in-memory fallback unless the operator
+    has explicitly opted in via
+    ``MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true``. The Court raises
+    unconditionally (multi-tenant); the Mastio supports a legitimate
+    single-instance production mode but makes that choice explicit
+    rather than silent (audit L1-H1 / Ultra U-DD-1). Without the opt-in,
+    a multi-worker HA deploy that lost Redis would silently allow DPoP
+    replay across workers within the ``iat`` window (RFC 9449 violation).
 
-    Operators running Mastio multi-worker (HA) MUST set
-    ``MCP_PROXY_REDIS_URL``; otherwise each worker holds an independent
-    JTI dict and a captured DPoP proof can be replayed N× across workers
-    within the ``iat`` window (RFC 9449).
+    Dev/test (``environment != "production"``) keeps the warning-only
+    path for ergonomics.
     """
     from mcp_proxy.redis.pool import get_redis
     from mcp_proxy.config import get_settings
@@ -109,12 +109,28 @@ def _init_store() -> DpopJtiStore:
         _log.info("DPoP JTI store: Redis")
         return RedisDpopJtiStore(redis)
 
-    if get_settings().environment == "production":
+    settings = get_settings()
+    if settings.environment == "production":
+        if not settings.allow_inmemory_security_stores:
+            _log.critical(
+                "DPoP JTI store: Redis unavailable in production and "
+                "MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES is not set. "
+                "Refusing the in-memory fallback to avoid cross-worker "
+                "replay of DPoP proofs (RFC 9449). Set MCP_PROXY_REDIS_URL "
+                "for HA, or set MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true "
+                "to acknowledge a single-instance/single-worker deployment.",
+            )
+            raise RuntimeError(
+                "DPoP JTI store requires Redis in production unless "
+                "MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true is set "
+                "(audit L1-H1 / Ultra U-DD-1)."
+            )
         _log.warning(
             "DPoP JTI store: Redis unavailable in production — using "
-            "in-memory. This is safe only for single-instance/single-worker "
-            "deployments. Multi-worker/HA deploys MUST set "
-            "MCP_PROXY_REDIS_URL (see audit F-B-12)."
+            "in-memory because MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES "
+            "is set. Safe only for single-instance/single-worker "
+            "deployments; multi-worker/HA deploys MUST set "
+            "MCP_PROXY_REDIS_URL."
         )
 
     _log.info("DPoP JTI store: in-memory")

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -240,6 +240,17 @@ class ProxySettings(BaseSettings):
     # Accepts redis:// or rediss:// URLs.
     redis_url: str = ""
 
+    # Audit L1-H1 / Ultra U-DD-1: in production the DPoP JTI store and the
+    # login-challenge nonce store both refuse to fall back to in-memory
+    # when Redis is unavailable, because a multi-worker deploy without a
+    # shared store silently allows replay across workers (RFC 9449
+    # violation). Single-instance / single-worker production deployments
+    # that genuinely don't need Redis can opt out by setting this flag to
+    # true; the existing warning is then preserved. Default: secure
+    # (refuse). Mirrors the Court's hard-raise but keeps the legitimate
+    # single-instance Mastio path explicit rather than implicit.
+    allow_inmemory_security_stores: bool = False
+
     # Egress DPoP mode — audit F-B-11 Phase 1 (#181).
     # Controls whether ``/v1/egress/*`` handlers accept a DPoP proof
     # (RFC 9449) in addition to the legacy ``X-API-Key`` bearer:

--- a/tests/test_mcp_proxy_jti_store.py
+++ b/tests/test_mcp_proxy_jti_store.py
@@ -108,22 +108,44 @@ async def test_factory_returns_redis_when_available(monkeypatch):
         jti_mod.reset_dpop_jti_store()
 
 
-async def test_factory_allows_in_memory_in_production_single_instance(monkeypatch):
-    """Audit F-B-12 — unlike the broker, Mastio supports a legitimate
-    single-instance production mode. The factory must NOT raise when
-    prod + no Redis; it logs a warning and returns in-memory so
-    single-worker deploys keep working.
-
-    Intercept ``_log.warning`` directly on the module under test —
-    pytest's caplog misses records on CI because the ``mcp_proxy``
-    logger is configured with ``propagate=False`` (see
-    ``mcp_proxy/logging_setup.py``). A module-level monkeypatch has no
-    dependency on logging framework behaviour.
+async def test_factory_refuses_in_memory_in_production_by_default(monkeypatch):
+    """Audit L1-H1 / Ultra U-DD-1 — production + no Redis without explicit
+    opt-in must RAISE rather than silently fall back to in-memory. Multi-
+    worker HA deploys would otherwise allow cross-worker DPoP replay
+    (RFC 9449 violation).
     """
     from mcp_proxy.config import get_settings
 
     monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
     monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.delenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", raising=False)
+    get_settings.cache_clear()
+
+    jti_mod.reset_dpop_jti_store()
+    try:
+        with pytest.raises(RuntimeError, match="DPoP JTI store requires Redis"):
+            jti_mod._init_store()
+    finally:
+        get_settings.cache_clear()
+        jti_mod.reset_dpop_jti_store()
+
+
+async def test_factory_allows_in_memory_in_production_with_explicit_optin(monkeypatch):
+    """Single-instance / single-worker production deployments that don't
+    need Redis can opt out via ``MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES
+    =true``. The factory then keeps the legacy in-memory + warning
+    behaviour. The broker (Court) raises unconditionally; this opt-in
+    preserves the legitimate Mastio single-instance path.
+
+    Intercept ``_log.warning`` directly on the module — pytest's caplog
+    misses records because the ``mcp_proxy`` logger is configured with
+    ``propagate=False``.
+    """
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "true")
     get_settings.cache_clear()
 
     warnings: list[str] = []
@@ -137,7 +159,6 @@ async def test_factory_allows_in_memory_in_production_single_instance(monkeypatc
     try:
         store = jti_mod._init_store()
         assert isinstance(store, jti_mod.InMemoryDpopJtiStore)
-        # Warning must be emitted so operators see the single-instance constraint.
         assert any("single-instance" in msg for msg in warnings), (
             f"expected single-instance warning, got: {warnings}"
         )

--- a/tests/test_proxy_challenge_response.py
+++ b/tests/test_proxy_challenge_response.py
@@ -399,3 +399,65 @@ async def test_in_memory_store_cross_agent_isolation():
     assert await store.consume("bob", "n") is False
     # Alice can still consume.
     assert await store.consume("alice", "n") is True
+
+
+# ── factory: production fail-closed (audit L1-M4 / Ultra U-DD-1) ─────
+
+
+@pytest.mark.asyncio
+async def test_factory_refuses_in_memory_in_production_by_default(monkeypatch):
+    """Production + no Redis without explicit opt-in must RAISE rather
+    than silently fall back to in-memory; multi-worker HA deploys would
+    otherwise let a captured login nonce be replayed across workers.
+    """
+    from mcp_proxy.auth import challenge_store as cs_mod
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.redis import pool as redis_pool
+
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.delenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", raising=False)
+    get_settings.cache_clear()
+
+    cs_mod.reset_challenge_store()
+    try:
+        with pytest.raises(RuntimeError, match="login challenge store requires Redis"):
+            cs_mod._init_store()
+    finally:
+        get_settings.cache_clear()
+        cs_mod.reset_challenge_store()
+
+
+@pytest.mark.asyncio
+async def test_factory_allows_in_memory_in_production_with_explicit_optin(monkeypatch):
+    """Single-instance / single-worker production deployments that don't
+    need Redis can opt out via ``MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES
+    =true``. The factory then keeps the legacy in-memory + warning
+    behaviour.
+    """
+    from mcp_proxy.auth import challenge_store as cs_mod
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.redis import pool as redis_pool
+
+    monkeypatch.setattr(redis_pool, "get_redis", lambda: None)
+    monkeypatch.setenv("MCP_PROXY_ENVIRONMENT", "production")
+    monkeypatch.setenv("MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES", "true")
+    get_settings.cache_clear()
+
+    warnings: list[str] = []
+
+    def _record(msg, *args, **kwargs):
+        warnings.append(str(msg) % args if args else str(msg))
+
+    monkeypatch.setattr(cs_mod._log, "warning", _record)
+
+    cs_mod.reset_challenge_store()
+    try:
+        store = cs_mod._init_store()
+        assert isinstance(store, cs_mod.InMemoryChallengeStore)
+        assert any("single-instance" in msg for msg in warnings), (
+            f"expected single-instance warning, got: {warnings}"
+        )
+    finally:
+        get_settings.cache_clear()
+        cs_mod.reset_challenge_store()


### PR DESCRIPTION
## Summary
- Mastio (`mcp_proxy/`) DPoP JTI store and login-challenge nonce store previously fell back to in-memory in production with only a warning when Redis was unavailable. Court (`app/`) correctly raises in the same situation. The asymmetry meant a multi-worker Mastio HA deploy losing Redis would silently allow DPoP proofs (and login nonces) to be replayed across workers within the iat window (RFC 9449 violation)
- Default is now fail-closed: production + no Redis → `RuntimeError` at factory init
- Legitimate single-instance / single-worker production deployments (the case the original docstring documented) preserved via explicit opt-in: `MCP_PROXY_ALLOW_INMEMORY_SECURITY_STORES=true`
- Audit IDs: L1-H1 (DPoP JTI), L1-M4 (challenge store), Ultra Plan U-DD-1 (top DD red flag)

## Test plan
- [ ] `pytest tests/test_mcp_proxy_jti_store.py tests/test_proxy_challenge_response.py -v` (29 tests pass; new `test_factory_refuses_in_memory_in_production_by_default` + renamed `test_factory_allows_in_memory_in_production_with_explicit_optin` for both stores)
- [ ] Broader sweep `pytest tests/ -k "proxy and (auth or dpop or jti or challenge)"` (40 passed, 2 skipped, no regressions)
- [ ] Sandbox smoke green on B4.4/B4.5/B4.6 (DPoP auth path uses Redis-backed store, fix path-isolated)
- [ ] Manual: production env (`MCP_PROXY_ENVIRONMENT=production`) without `MCP_PROXY_REDIS_URL` and without the new opt-in fails fast at startup; setting opt-in flag preserves the in-memory + warning behaviour

## Notes
- Settings field `allow_inmemory_security_stores` documented in config.py near `redis_url`. Empty / not-set → secure default
- `validate_config` not modified: the factory is the right place to raise (it has the live Redis state); validate_config runs before Redis client init