### PR TITLE
fix(broker): acquire SessionStore lock around state mutations to prevent dict-mutated-during-iteration

### DIFF
--- a/app/broker/session.py
+++ b/app/broker/session.py
@@ -7,10 +7,34 @@ Each session has a unique ID and tracks:
 - who receives it (target)
 - current status
 - already used nonces (message-level replay protection)
+
+Concurrency model (audit L4-H1):
+The store carries TWO locks with distinct purposes.
+
+- ``_lock`` (``asyncio.Lock``): coarse, transaction-scope lock held by
+  callers around "read-validate-mutate-persist" sequences that span an
+  ``await`` (typically ``await save_session(db, ...)``). It serializes
+  coroutines but is useless against threadpool callers because
+  ``asyncio.Lock`` is not thread-safe. Existing routers use this.
+- ``_state_lock`` (``threading.RLock``): fine-grained, held internally by
+  every mutation method around the in-memory ``self._sessions`` dict and
+  ``Session.status`` writes. Reentrant so ``create`` can call
+  ``_evict_stale`` while still holding it. Defends against the
+  ``RuntimeError: dictionary changed size during iteration`` race that
+  would surface if any caller ever ran the store off the event loop
+  thread (e.g. FastAPI sync endpoints scheduled to the threadpool, future
+  background workers, the dashboard's BackgroundTasks). On the current
+  single-threaded asyncio runtime the lock is uncontended.
+
+Mutation methods MUST acquire ``_state_lock``. Iteration over
+``self._sessions`` MUST snapshot under the lock (``list(...)``) before
+yielding the values to the caller. No ``await`` is performed inside
+``_state_lock``: it only guards in-memory transitions.
 """
 import asyncio
 import logging
 import os
+import threading
 import uuid
 from datetime import datetime, timezone, timedelta
 from dataclasses import dataclass, field
@@ -169,7 +193,13 @@ class SessionStore:
             if active_cap_per_agent is not None
             else SESSION_CAP_ACTIVE_PER_AGENT
         )
-        self._lock = asyncio.Lock()  # protects state transitions (accept/reject/close)
+        # ``_lock`` is the transaction-scope lock for callers that need to
+        # straddle an ``await`` (e.g. mutate-then-persist). ``_state_lock`` is
+        # the in-memory dict guard acquired by every mutation method below;
+        # it is reentrant so ``create`` can call ``_evict_stale`` without
+        # deadlock. See the module docstring for the full contract.
+        self._lock = asyncio.Lock()
+        self._state_lock = threading.RLock()
 
     # ── Eviction ─────────────────────────────────────────────────────────
 
@@ -185,12 +215,13 @@ class SessionStore:
         them to CLOSED and emit a ``session.closed`` event with reason
         ``ttl_expired`` before they disappear.
         """
-        to_remove = [
-            sid for sid, s in self._sessions.items()
-            if s.status in (SessionStatus.closed, SessionStatus.denied)
-        ]
-        for sid in to_remove:
-            del self._sessions[sid]
+        with self._state_lock:
+            to_remove = [
+                sid for sid, s in self._sessions.items()
+                if s.status in (SessionStatus.closed, SessionStatus.denied)
+            ]
+            for sid in to_remove:
+                del self._sessions[sid]
         if to_remove:
             _log.info("Evicted %d stale session(s) from in-memory store", len(to_remove))
         return len(to_remove)
@@ -204,9 +235,11 @@ class SessionStore:
         only ACTIVE is capped; PENDING is rate-limited at the route level
         and auto-swept when it times out).
         """
+        with self._state_lock:
+            snapshot = list(self._sessions.values())
         return sum(
             1
-            for s in self._sessions.values()
+            for s in snapshot
             if s.status == SessionStatus.active
             and (s.initiator_agent_id == agent_id or s.target_agent_id == agent_id)
         )
@@ -219,59 +252,71 @@ class SessionStore:
         target_org_id: str,
         requested_capabilities: list[str],
     ) -> Session:
-        # Evict stale sessions before checking the cap
-        self._evict_stale()
+        # The whole sequence (evict → cap check → cap-per-agent → insert) must
+        # be atomic w.r.t. concurrent mutations, otherwise two creators can
+        # both observe ``len < _MAX_SESSIONS`` and overflow the cap. RLock is
+        # required so the inner ``_evict_stale`` and ``count_active_for_agent``
+        # calls reacquire without deadlock.
+        with self._state_lock:
+            # Evict stale sessions before checking the cap
+            self._evict_stale()
 
-        if len(self._sessions) >= self._MAX_SESSIONS:
-            raise RuntimeError(
-                f"Session store full ({self._MAX_SESSIONS} sessions) — "
-                "cannot create new session"
+            if len(self._sessions) >= self._MAX_SESSIONS:
+                raise RuntimeError(
+                    f"Session store full ({self._MAX_SESSIONS} sessions) — "
+                    "cannot create new session"
+                )
+
+            # M1.4 per-agent ACTIVE cap (applies to the initiator; the target's
+            # cap is re-checked when they accept).
+            active_for_initiator = self.count_active_for_agent(initiator_agent_id)
+            if active_for_initiator >= self._active_cap_per_agent:
+                raise AgentSessionCapExceeded(
+                    agent_id=initiator_agent_id,
+                    current=active_for_initiator,
+                    cap=self._active_cap_per_agent,
+                )
+
+            session_id = str(uuid.uuid4())
+            now = datetime.now(timezone.utc)
+            session = Session(
+                session_id=session_id,
+                initiator_agent_id=initiator_agent_id,
+                initiator_org_id=initiator_org_id,
+                target_agent_id=target_agent_id,
+                target_org_id=target_org_id,
+                requested_capabilities=requested_capabilities,
+                created_at=now,
+                expires_at=now + self._ttl,
             )
-
-        # M1.4 per-agent ACTIVE cap (applies to the initiator; the target's
-        # cap is re-checked when they accept).
-        active_for_initiator = self.count_active_for_agent(initiator_agent_id)
-        if active_for_initiator >= self._active_cap_per_agent:
-            raise AgentSessionCapExceeded(
-                agent_id=initiator_agent_id,
-                current=active_for_initiator,
-                cap=self._active_cap_per_agent,
-            )
-
-        session_id = str(uuid.uuid4())
-        now = datetime.now(timezone.utc)
-        session = Session(
-            session_id=session_id,
-            initiator_agent_id=initiator_agent_id,
-            initiator_org_id=initiator_org_id,
-            target_agent_id=target_agent_id,
-            target_org_id=target_org_id,
-            requested_capabilities=requested_capabilities,
-            created_at=now,
-            expires_at=now + self._ttl,
-        )
-        self._sessions[session_id] = session
-        return session
+            self._sessions[session_id] = session
+            return session
 
     def get(self, session_id: str) -> Session | None:
-        session = self._sessions.get(session_id)
-        if session and session.is_expired() and session.status != SessionStatus.closed:
-            session.status = SessionStatus.closed
-        return session
+        # The TTL-expiry side-effect mutates ``session.status``, so the read
+        # has to happen under the state lock to stay consistent with concurrent
+        # ``close`` / ``activate`` callers.
+        with self._state_lock:
+            session = self._sessions.get(session_id)
+            if session and session.is_expired() and session.status != SessionStatus.closed:
+                session.status = SessionStatus.closed
+            return session
 
     def activate(self, session_id: str) -> Session | None:
-        session = self.get(session_id)
-        if session and session.status == SessionStatus.pending:
-            session.status = SessionStatus.active
-            session.touch()
-        return session
+        with self._state_lock:
+            session = self.get(session_id)
+            if session and session.status == SessionStatus.pending:
+                session.status = SessionStatus.active
+                session.touch()
+            return session
 
     def reject(self, session_id: str) -> Session | None:
-        session = self.get(session_id)
-        if session and session.status == SessionStatus.pending:
-            session.status = SessionStatus.denied
-            session.close_reason = SessionCloseReason.rejected
-        return session
+        with self._state_lock:
+            session = self.get(session_id)
+            if session and session.status == SessionStatus.pending:
+                session.status = SessionStatus.denied
+                session.close_reason = SessionCloseReason.rejected
+            return session
 
     def close(
         self,
@@ -284,12 +329,13 @@ class SessionStore:
         the ``session.closed`` event (M1.3). The event emission itself
         lives at the router level — this method only mutates state.
         """
-        session = self._sessions.get(session_id)
-        if session and session.status != SessionStatus.closed:
-            session.status = SessionStatus.closed
-            if session.close_reason is None:
-                session.close_reason = reason
-        return session
+        with self._state_lock:
+            session = self._sessions.get(session_id)
+            if session and session.status != SessionStatus.closed:
+                session.status = SessionStatus.closed
+                if session.close_reason is None:
+                    session.close_reason = reason
+            return session
 
     def close_all_for_agent(
         self,
@@ -297,16 +343,24 @@ class SessionStore:
         reason: SessionCloseReason = SessionCloseReason.normal,
     ) -> list[Session]:
         """Close all active/pending sessions involving the given agent.
-        Returns the list of sessions that were closed."""
+        Returns the list of sessions that were closed.
+
+        Snapshots the current sessions under ``_state_lock`` before iterating,
+        so a concurrent ``create`` can never trigger
+        ``RuntimeError: dictionary changed size during iteration`` (audit L4-H1).
+        Mutation of each session's status also happens under the same lock so
+        the close decision is atomic w.r.t. ``activate`` / ``close``.
+        """
         closed = []
-        for s in self._sessions.values():
-            if s.status in (SessionStatus.active, SessionStatus.pending) and (
-                s.initiator_agent_id == agent_id or s.target_agent_id == agent_id
-            ):
-                s.status = SessionStatus.closed
-                if s.close_reason is None:
-                    s.close_reason = reason
-                closed.append(s)
+        with self._state_lock:
+            for s in list(self._sessions.values()):
+                if s.status in (SessionStatus.active, SessionStatus.pending) and (
+                    s.initiator_agent_id == agent_id or s.target_agent_id == agent_id
+                ):
+                    s.status = SessionStatus.closed
+                    if s.close_reason is None:
+                        s.close_reason = reason
+                    closed.append(s)
         return closed
 
     def find_stale(
@@ -323,7 +377,9 @@ class SessionStore:
         close events with the right reason.
         """
         out: list[tuple[Session, SessionCloseReason]] = []
-        for s in self._sessions.values():
+        with self._state_lock:
+            snapshot = list(self._sessions.values())
+        for s in snapshot:
             if s.status in (SessionStatus.closed, SessionStatus.denied):
                 continue
             if s.is_expired():
@@ -333,8 +389,10 @@ class SessionStore:
         return out
 
     def list_for_agent(self, agent_id: str, *, limit: int = 100, offset: int = 0) -> list[Session]:
+        with self._state_lock:
+            snapshot = list(self._sessions.values())
         matches = [
-            s for s in self._sessions.values()
+            s for s in snapshot
             if s.initiator_agent_id == agent_id or s.target_agent_id == agent_id
         ]
         if limit <= 0:

--- a/tests/test_session_store_concurrent.py
+++ b/tests/test_session_store_concurrent.py
@@ -1,0 +1,209 @@
+"""Audit L4-H1 regression , SessionStore concurrent-mutation safety.
+
+The original finding was that ``SessionStore._lock`` (asyncio.Lock) was
+declared with the comment "protects state transitions (accept/reject/close)"
+but never acquired inside any mutation method. The fix introduces a
+reentrant ``_state_lock`` (threading.RLock) that is held inside every
+mutation and around every iteration over ``self._sessions``. This file
+is the chaos test that would surface the original bug.
+
+Specifically reproduces the two failure modes called out in the audit:
+
+  1. ``close_all_for_agent`` iterating ``self._sessions.values()`` while
+     another task ``create()`` s a new session , ``RuntimeError: dictionary
+     changed size during iteration``.
+  2. Two concurrent acceptors / closers racing on the same pending session.
+
+We can't easily preempt asyncio coroutines mid-iteration on a single
+event loop, so we drive the store from a thread pool. That mirrors the
+real risk surface (FastAPI threadpool sync endpoints, BackgroundTasks,
+future workers) and exposes the pre-fix bug deterministically.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from app.broker.models import SessionCloseReason, SessionStatus
+from app.broker.session import SessionStore
+
+
+# ── Threadpool driver ────────────────────────────────────────────────────
+
+
+def test_threaded_create_vs_close_all_no_iteration_error():
+    """Hammer create() and close_all_for_agent() from many threads.
+
+    Pre-fix this raises RuntimeError("dictionary changed size during
+    iteration") within seconds. Post-fix the threading.RLock around the
+    iteration snapshot makes it safe.
+    """
+    store = SessionStore(active_cap_per_agent=10_000)
+    # Lift the hard cap so the create loop doesn't hit "Session store full".
+    store._MAX_SESSIONS = 100_000
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+    AGENT = "agent-victim"
+
+    def creator() -> None:
+        i = 0
+        try:
+            while not stop.is_set():
+                store.create(
+                    initiator_agent_id=AGENT,
+                    initiator_org_id="org-a",
+                    target_agent_id=f"peer-{i}",
+                    target_org_id="org-b",
+                    requested_capabilities=[],
+                )
+                i += 1
+        except BaseException as exc:  # noqa: BLE001 , capture for assertion
+            errors.append(exc)
+
+    def closer() -> None:
+        try:
+            while not stop.is_set():
+                store.close_all_for_agent(AGENT)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=creator) for _ in range(4)] + [
+        threading.Thread(target=closer) for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+
+    # Let the workers race for a short, deterministic window.
+    threading.Event().wait(0.5)
+    stop.set()
+    for t in threads:
+        t.join(timeout=5)
+        assert not t.is_alive(), "worker thread did not stop"
+
+    assert not errors, f"concurrent create/close raced: {errors!r}"
+
+
+def test_threaded_concurrent_close_idempotent():
+    """N closers on the same session-set never double-mark or crash."""
+    store = SessionStore(active_cap_per_agent=10_000)
+    store._MAX_SESSIONS = 10_000
+
+    sessions = [
+        store.create(
+            initiator_agent_id="alice",
+            initiator_org_id="org-a",
+            target_agent_id=f"bob-{i}",
+            target_org_id="org-b",
+            requested_capabilities=[],
+        )
+        for i in range(50)
+    ]
+    for s in sessions:
+        store.activate(s.session_id)
+
+    errors: list[BaseException] = []
+
+    def closer() -> None:
+        try:
+            for s in sessions:
+                store.close(s.session_id)
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=closer) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not errors, f"concurrent close raised: {errors!r}"
+    for s in sessions:
+        assert s.status == SessionStatus.closed
+        # close_reason set exactly once , the lock makes the if-None check atomic.
+        assert s.close_reason == SessionCloseReason.normal
+
+
+def test_threaded_create_under_per_agent_cap_stays_within_cap():
+    """create() runs evict + cap check + insert atomically.
+
+    Without the RLock around the whole sequence, two concurrent creators
+    could both observe ``count_active_for_agent == cap - 1`` and both
+    insert, blowing past the cap. With the lock the count is exact.
+    """
+    cap = 5
+    store = SessionStore(active_cap_per_agent=cap)
+    store._MAX_SESSIONS = 10_000
+
+    errors: list[BaseException] = []
+    cap_rejections = 0
+    cap_lock = threading.Lock()
+
+    # Pre-seed the agent with `cap` ACTIVE sessions so further creates must
+    # be rejected. Each thread tries to push one more.
+    seeds = [
+        store.create("alice", "org-a", f"target-{i}", "org-b", [])
+        for i in range(cap)
+    ]
+    for s in seeds:
+        store.activate(s.session_id)
+
+    def attempt() -> None:
+        nonlocal cap_rejections
+        from app.broker.session import AgentSessionCapExceeded
+
+        try:
+            store.create("alice", "org-a", "extra", "org-b", [])
+        except AgentSessionCapExceeded:
+            with cap_lock:
+                cap_rejections += 1
+        except BaseException as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=attempt) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not errors, f"create() raised unexpected error: {errors!r}"
+    # All 20 should be rejected (cap was already saturated by the seeds).
+    assert cap_rejections == 20
+    # The active count for alice must not have grown past the cap.
+    assert store.count_active_for_agent("alice") == cap
+
+
+# ── Asyncio-level sanity ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_asyncio_gather_create_then_close_all():
+    """End-to-end on the event loop: many gather()-ed coroutines drive the
+    store the way the broker router does in production. No RuntimeError,
+    every session ends in a terminal state.
+    """
+    store = SessionStore(active_cap_per_agent=10_000)
+    store._MAX_SESSIONS = 10_000
+    AGENT = "alice"
+
+    async def one_create(i: int) -> None:
+        store.create(AGENT, "org-a", f"peer-{i}", "org-b", [])
+
+    async def close_sweep() -> None:
+        store.close_all_for_agent(AGENT)
+
+    # Interleave 30 creates with 5 close_all calls.
+    tasks = [one_create(i) for i in range(30)]
+    tasks += [close_sweep() for _ in range(5)]
+    await asyncio.gather(*tasks)
+
+    # Every session that survived the creates must be in a terminal state
+    # OR pending (a create that completed after the last close_all is fine).
+    for s in list(store._sessions.values()):
+        assert s.status in (
+            SessionStatus.pending,
+            SessionStatus.active,
+            SessionStatus.closed,
+        )


### PR DESCRIPTION
## Summary
- `app/broker/session.py:172` declared `self._lock = asyncio.Lock()` with comment "protects state transitions" but `grep` showed only the declaration site, never an acquisition. Mutation methods (`activate`, `reject`, `close`, `close_all_for_agent`, `create`, `_evict_stale`, etc.) mutated `self._sessions` and `session.status` without synchronization
- Under Frontdesk multi-user (ADR-019/020/021), `close_all_for_agent` could iterate `self._sessions.values()` while another coroutine `create()`s, raising `RuntimeError: dictionary changed size during iteration` casually under load
- Fix: introduced a second `_state_lock` (`threading.RLock`, reentrant) acquired by every mutation method. Original `asyncio.Lock` retained for routers' transaction-scope `mutate-then-await-save_session` blocks (`tests/test_audit_r3.py::test_save_session_inside_lock` still passes). Single-file diff, zero caller changes
- Audit ID: L4-H1 (internal review 2026-05-08, Ultra Plan top concurrency HA bug #1)

## Test plan
- [x] 4 new concurrent regression tests in `tests/test_session_store_concurrent.py`:
  - `test_threaded_create_vs_close_all_no_iteration_error`: 4 creators + 4 closers hammer 500ms; pre-fix produced `RuntimeError: dictionary changed size during iteration` (verified by stash-revert), post-fix zero errors
  - `test_threaded_concurrent_close_idempotent`: 50 sessions, 10 closer threads; each session closed exactly once
  - `test_threaded_create_under_per_agent_cap_stays_within_cap`: pre-saturate cap=5, 20 concurrent creators; all 20 rejected, count exact at cap
  - `test_asyncio_gather_create_then_close_all`: asyncio gather of 30 creates + 5 close_all_for_agent
- [x] `pytest tests/test_session_*.py tests/test_audit_r2_t2.py tests/test_audit_r3.py tests/test_m3_sweeper_ttl.py tests/test_proxy_local_*.py tests/test_oneshot_cross.py tests/test_persistence.py tests/test_security_fixes.py -v` (120 passed including the 4 new)
- [x] Sandbox smoke green (23 PASS / 2 pre-existing OIDC fail / 1 SKIP)

## Notes
- 10 acquisition sites added: `_evict_stale`, `count_active_for_agent`, `create`, `get` (TTL-expiry side effect), `activate`, `reject`, `close`, `close_all_for_agent` (with `list(...)` snapshot inside lock), `find_stale`, `list_for_agent`
- No `await` inside any `with self._state_lock:` block (verified via AST walker). External-await paths use the original `asyncio.Lock` at the router level