### PR TITLE
fix(observability): atomic bucket counter in traffic_recorder (closes recurring CI flake)

### DIFF
--- a/mcp_proxy/observability/traffic_recorder.py
+++ b/mcp_proxy/observability/traffic_recorder.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -93,7 +94,15 @@ class TrafficRecorder:
         self._engine = engine
         self._flush_interval_s = float(flush_interval_s)
         # agent_id → bucket_ts → count
+        # Protected by _lock: record() may be called from multiple threads
+        # (or asyncio tasks running on different thread-pool workers) concurrently.
+        # The read-modify-write `agent_buckets[bucket] = get(..., 0) + 1` is NOT
+        # atomic under CPython even though individual dict ops are — the GIL can
+        # be released between the LOAD and the STORE bytecodes. A threading.Lock
+        # costs microseconds and is safe to acquire from both sync and async
+        # contexts because we never hold it across an await.
         self._buckets: dict[str, dict[str, int]] = {}
+        self._lock = threading.Lock()
         self._flush_task: asyncio.Task | None = None
         self._stopped = False
         # Counters exposed via the admin observability endpoint.
@@ -108,15 +117,21 @@ class TrafficRecorder:
         bucket. Cheap: one dict lookup + one increment. Runs in the
         request's own task so a slow auth dep doesn't block other
         agents' records.
+
+        Thread-safe: the read-modify-write on the bucket counter is
+        protected by ``self._lock``. The lock is held for nanoseconds
+        (two dict ops) so contention is negligible even under high
+        concurrency.
         """
         if not agent_id:
             return
         bucket = _bucket_ts_iso()
-        agent_buckets = self._buckets.get(agent_id)
-        if agent_buckets is None:
-            self._buckets[agent_id] = {bucket: 1}
-            return
-        agent_buckets[bucket] = agent_buckets.get(bucket, 0) + 1
+        with self._lock:
+            agent_buckets = self._buckets.get(agent_id)
+            if agent_buckets is None:
+                self._buckets[agent_id] = {bucket: 1}
+                return
+            agent_buckets[bucket] = agent_buckets.get(bucket, 0) + 1
 
     async def start(self) -> None:
         if self._flush_task is not None:
@@ -175,10 +190,12 @@ class TrafficRecorder:
     async def _flush_once(self) -> None:
         if not self._buckets:
             return
-        # Atomic swap: Python ref assignment is a single bytecode, and
-        # all record() calls happen in the same asyncio event loop, so
-        # between the two lines below no other record() can run.
-        pending, self._buckets = self._buckets, {}
+        # Swap under the lock so no in-flight record() writes get lost
+        # between the emptiness check and the reference swap.
+        with self._lock:
+            if not self._buckets:
+                return
+            pending, self._buckets = self._buckets, {}
         try:
             await self._write_pending(pending)
             self.flush_count += 1

--- a/tests/test_mcp_proxy_traffic_recorder.py
+++ b/tests/test_mcp_proxy_traffic_recorder.py
@@ -7,6 +7,7 @@ the shadow-mode test (commit 8).
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 
 import pytest
@@ -250,3 +251,39 @@ def test_record_agent_request_ignores_exceptions():
 
     # Exception is swallowed — helper never propagates.
     record_agent_request(_Request(), "agent-a")
+
+
+# ── regression test: L4-H7 atomic bucket counter ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_record_concurrent_threads_no_lost_increments(engine):
+    """Regression for L4-H7: concurrent record() calls must not lose counts.
+
+    Spawns N=100 threads, each calling record() once for the same agent+bucket.
+    Under the old code the non-atomic read-modify-write could lose increments
+    intermittently (the documented 'traffic_recorder timing flake' CI gotcha).
+    Under the fixed code the final count must be exactly N, deterministically.
+
+    Uses ThreadPoolExecutor so the threads are truly concurrent (not asyncio
+    tasks, which are cooperative and would not expose the race). Asyncio tasks
+    would not exercise the race because they yield only at await points and
+    record() has none.
+    """
+    r = TrafficRecorder(engine)
+    N = 100
+
+    with ThreadPoolExecutor(max_workers=N) as pool:
+        futures = [pool.submit(r.record, "agent-concurrent") for _ in range(N)]
+        for f in futures:
+            f.result()  # re-raise any exception from worker threads
+
+    # All N increments must be accounted for in a single bucket.
+    total = sum(
+        count
+        for buckets in r._buckets.values()
+        for count in buckets.values()
+    )
+    assert total == N, (
+        f"expected {N} increments, got {total}: lost {N - total} under concurrency"
+    )


### PR DESCRIPTION
## Summary
- `mcp_proxy/observability/traffic_recorder.py` `record()` did `agent_buckets[bucket] = agent_buckets.get(bucket, 0) + 1` (sync). Under CPython GIL each individual op is atomic but the read-modify-write pair is not — concurrent records for the same agent+bucket race, counts under-report
- This is the documented root cause of the recurring "traffic_recorder timing flake" CI gotcha (project memory `feedback_ci_known_failures.md`). Fix CLOSES the flake deterministically
- Strategy: `threading.Lock` around the R-M-W (nanosecond hold, no contention concern). Same lock around the `_flush_once()` swap to eliminate the window where a concurrent `record()` could write into the dict already handed to the writer
- Audit ID: L4-H7 (internal review 2026-05-08)

## Test plan
- [x] New regression: N=100 OS threads via `ThreadPoolExecutor(max_workers=100)`, all calling `record("agent-concurrent")`. Asserts total count == 100. Pre-fix this assertion failed intermittently; post-fix deterministically green
- [x] `pytest tests/test_mcp_proxy_traffic_recorder.py -v` (13/13 passed)
- [x] Sandbox smoke green

## Notes
- `anomaly_evaluator.py:388` has visually identical pattern (`get(..., 0) + 1` on `_hot_counter`) but the R-M-W lives entirely inside `async def run_cycle` which never yields between read and store, so asyncio's cooperative scheduler guarantees serial access. NOT the same class of bug; left untouched
- Memory delta after merge: `feedback_ci_known_failures.md` no longer needs to mention `traffic_recorder timing` (postgres binding KeyError remains)