### PR TITLE
feat(federation): bidirectional mTLS verify-if-present on Mastio→Court (Wave 3 U4 Phase 1)

### DIFF
--- a/app/auth/mastio_mtls.py
+++ b/app/auth/mastio_mtls.py
@@ -1,0 +1,147 @@
+"""Wave 3 U4 — bidirectional mTLS verification on Mastio→Court calls.
+
+Layer on top of the existing JWT counter-signature (ADR-009): when the
+calling Mastio also presents a TLS client certificate during the handshake,
+verify that the certificate's public key matches the org's pinned
+``mastio_pubkey``. Today the JWT counter-sig alone proves possession of
+the org's signing key, but a leaked countersig (replayed from an audit
+log, for instance) would still authorize the request. With mTLS bound to
+the same key, an attacker would need both the leaked sig AND a TLS
+session terminated with that key — a strict superset of the assumption.
+
+Phase 1 (this PR) — verify-if-present:
+  * If the connection terminates at Court with a peer cert, extract it.
+  * If a peer cert is present, its SubjectPublicKeyInfo MUST match the
+    pinned ``mastio_pubkey``; mismatch raises 403.
+  * If no peer cert is present, this is a no-op (legacy path) — the
+    JWT countersig remains the sole proof.
+  * Future Phase 2 will add a per-org ``require_mtls`` flag that flips
+    "missing cert" from "no-op" to "403". Deploy/nginx config for cert
+    pass-through is also Phase 2.
+
+Cert extraction sources (tried in order):
+  1. ``request.scope["transport"]`` — uvicorn termination with
+     ``ssl_cert_reqs=ssl.CERT_OPTIONAL``. Returns the peercert dict via
+     the asyncio transport. Used by the sandbox/demo Court.
+  2. Header ``X-Cullis-Mastio-Cert`` — nginx pass-through (Phase 2).
+     Format: URL-encoded PEM (``$ssl_client_escaped_cert``). Trusted only
+     because the front layer is the deployment boundary.
+
+The two paths converge on a parsed ``x509.Certificate`` so the verify
+function doesn't care which path produced it.
+"""
+from __future__ import annotations
+
+import logging
+from urllib.parse import unquote
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from fastapi import HTTPException, Request, status
+
+_log = logging.getLogger("app.auth.mastio_mtls")
+
+PASS_THROUGH_HEADER = "X-Cullis-Mastio-Cert"
+
+
+def extract_mastio_cert(request: Request) -> x509.Certificate | None:
+    """Return the peer cert from the TLS handshake if available, else None.
+
+    Tries the uvicorn ASGI transport first, then the nginx pass-through
+    header. Logs at debug if neither path produced a cert; logs at warning
+    if a path produced bytes that didn't parse as a certificate (operator
+    misconfiguration is more likely than active attack at this layer, but
+    we still refuse the cert rather than ignoring silently).
+    """
+    # Path 1: uvicorn ssl_cert_reqs=optional → peercert in transport.
+    transport = request.scope.get("transport")
+    if transport is not None:
+        peercert_der = None
+        try:
+            ssl_obj = transport.get_extra_info("ssl_object")
+            if ssl_obj is not None:
+                peercert_der = ssl_obj.getpeercert(binary_form=True)
+        except Exception as exc:  # pragma: no cover — defensive
+            _log.debug("mastio mTLS: transport.get_extra_info failed: %s", exc)
+        if peercert_der:
+            try:
+                return x509.load_der_x509_certificate(peercert_der)
+            except ValueError as exc:
+                _log.warning(
+                    "mastio mTLS: peer cert from transport is not parseable: %s",
+                    exc,
+                )
+                return None
+
+    # Path 2: nginx pass-through header (Phase 2 wiring).
+    header_val = request.headers.get(PASS_THROUGH_HEADER)
+    if header_val:
+        # nginx ssl_client_escaped_cert → URL-encoded PEM with newlines as %0A
+        pem = unquote(header_val).strip()
+        if pem.startswith("-----BEGIN CERTIFICATE-----"):
+            try:
+                return x509.load_pem_x509_certificate(pem.encode())
+            except ValueError as exc:
+                _log.warning(
+                    "mastio mTLS: header cert is not parseable: %s", exc,
+                )
+                return None
+        else:
+            _log.warning(
+                "mastio mTLS: %s present but not PEM (got %d chars)",
+                PASS_THROUGH_HEADER, len(pem),
+            )
+            return None
+
+    return None
+
+
+def verify_mastio_cert_pubkey(
+    cert: x509.Certificate,
+    mastio_pubkey_pem: str,
+) -> None:
+    """Raise 403 unless ``cert``'s SubjectPublicKeyInfo matches the pinned PEM.
+
+    The comparison is byte-equality on the SubjectPublicKeyInfo DER form,
+    which is what ``mastio_pubkey`` already stores (loaded as PEM, but the
+    underlying key bytes are stable across PEM/DER round-trips).
+    """
+    try:
+        pinned = serialization.load_pem_public_key(mastio_pubkey_pem.encode())
+    except Exception as exc:
+        # Onboarding validates the PEM before pinning, so a malformed
+        # column at this point means operator tampering. Fail closed.
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="pinned mastio_pubkey is unreadable",
+        ) from exc
+
+    pinned_der = pinned.public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    cert_der = cert.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    if pinned_der != cert_der:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "mastio mTLS: peer cert public key does not match the "
+                "pinned organizations.mastio_pubkey"
+            ),
+        )
+
+
+def enforce_if_present(request: Request, mastio_pubkey_pem: str) -> bool:
+    """Phase 1 helper: verify cert if present, no-op if absent.
+
+    Returns True if a cert was presented and verified, False if no cert
+    was presented (legacy path). Raises 403 on mismatch.
+    """
+    cert = extract_mastio_cert(request)
+    if cert is None:
+        return False
+    verify_mastio_cert_pubkey(cert, mastio_pubkey_pem)
+    return True

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -10,6 +10,7 @@ from app.auth.models import TokenRequest, TokenResponse, TokenPayload
 from app.auth.jwt import create_access_token, get_current_agent
 from app.auth import mastio_countersig
 from app.auth.mastio_countersig import COUNTERSIG_HEADER
+from app.auth.mastio_mtls import enforce_if_present as enforce_mastio_mtls
 from app.auth.x509_verifier import verify_client_assertion
 from app.auth.dpop import verify_dpop_proof, build_htu
 from app.config import get_settings
@@ -142,6 +143,25 @@ async def issue_token(
                 details={"reason": "mastio_countersig_missing_or_invalid"},
             )
             raise
+
+        # ── Wave 3 U4 — bidirectional mTLS verify-if-present ─────────────────
+        # User principals already covered by enforce_on_token_request short-
+        # circuit (no countersig check, no mTLS check) since the user's KMS-
+        # held key isn't on the Mastio. Agents/workloads check both layers.
+        if principal_type != "user":
+            from app.registry.org_store import get_org_by_id as _get_org_for_mtls
+            org_record = await _get_org_for_mtls(db, org_id)
+            if org_record is not None and org_record.mastio_pubkey:
+                try:
+                    enforce_mastio_mtls(request, org_record.mastio_pubkey)
+                except HTTPException:
+                    AUTH_DENY_COUNTER.add(1, {"reason": "mastio_mtls"})
+                    await log_event(
+                        db, "auth.token_request", "denied",
+                        agent_id=agent_id, org_id=org_id,
+                        details={"reason": "mastio_mtls_pubkey_mismatch"},
+                    )
+                    raise
 
         # ── Registry lookup ──────────────────────────────────────────────────
         if principal_type == "user":

--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_countersig
+from app.auth.mastio_mtls import enforce_if_present as enforce_mastio_mtls
 from app.db.database import get_db
 from app.db.audit import log_event
 from app.registry.org_store import get_org_by_id
@@ -177,6 +178,25 @@ async def publish_agent(
                      "agent_id": body.agent_id},
         )
         raise
+
+    # 2b. Wave 3 U4 — bidirectional mTLS verify-if-present. A peer cert
+    #     bound to the same key as ``mastio_pubkey`` is a stronger proof
+    #     than the JWT countersig alone (binds the live TLS session to
+    #     the org's signing key). Phase 1: log + 403 on mismatch, no-op
+    #     when no peer cert is presented. Phase 2 will add per-org
+    #     ``require_mtls`` to flip "missing" → 403.
+    try:
+        verified = enforce_mastio_mtls(request, org.mastio_pubkey)
+    except HTTPException:
+        await log_event(
+            db, "federation.publish_rejected", "denied",
+            org_id=org_id,
+            details={"reason": "mastio_mtls_pubkey_mismatch",
+                     "agent_id": body.agent_id},
+        )
+        raise
+    if verified:
+        _log.debug("federation.publish_agent: mastio mTLS verified for %s", org_id)
 
     # 3. Validate the agent cert chains to the org CA (unless we're only
     #    recording a revocation — a revoked agent's cert chain doesn't
@@ -332,6 +352,18 @@ async def publish_stats(
             db, "federation.stats_rejected", "denied",
             org_id=body.org_id,
             details={"reason": "countersig_invalid"},
+        )
+        raise
+
+    # Wave 3 U4 — bidirectional mTLS verify-if-present (mirrors
+    # publish-agent). 403 on key mismatch, no-op when absent.
+    try:
+        enforce_mastio_mtls(request, org.mastio_pubkey)
+    except HTTPException:
+        await log_event(
+            db, "federation.stats_rejected", "denied",
+            org_id=body.org_id,
+            details={"reason": "mastio_mtls_pubkey_mismatch"},
         )
         raise
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -44,6 +44,77 @@ def get_jwks_client():
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Wave 3 U4 — federation httpx client mTLS upgrade
+# ─────────────────────────────────────────────────────────────────────────────
+
+async def _upgrade_federation_client_to_mtls(app, agent_mgr, settings) -> None:
+    """Rebuild ``app.state.reverse_proxy_client`` with the Mastio leaf cert
+    as the TLS client certificate, so the Court can verify the live TLS
+    session was terminated by a holder of the same key as the pinned
+    ``organizations.mastio_pubkey``.
+
+    The previous (no-cert) client created earlier in the lifespan is
+    closed before the rebuild so its connection pool isn't leaked. The
+    SSLContext is built explicitly because httpx 0.28 silently drops the
+    ``cert=`` argument when ``verify=`` is also a non-bool — the SDK
+    already hit this and works around it the same way (cullis_sdk/
+    client.py).
+    """
+    import ssl
+    import tempfile
+    import httpx as _httpx
+
+    leaf_cert_pem, leaf_key_pem = agent_mgr.get_mastio_credentials()
+
+    ssl_ctx = ssl.create_default_context()
+    if not settings.broker_verify_tls:
+        # Match the legacy unverified semantic when the operator opts
+        # out via ``broker_verify_tls=false`` (sandbox / tests where the
+        # broker uses an untrusted self-signed cert).
+        ssl_ctx.check_hostname = False
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+
+    # ``load_cert_chain`` only accepts file paths, not in-memory PEM.
+    # Write to NamedTemporaryFile, load, then unlink — the SSLContext
+    # holds the parsed material in memory after load, so removing the
+    # file is safe and avoids leaving the leaf private key on disk.
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".pem", delete=False,
+    ) as cert_f:
+        cert_f.write(leaf_cert_pem)
+        cert_path = cert_f.name
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".pem", delete=False,
+    ) as key_f:
+        key_f.write(leaf_key_pem)
+        key_path = key_f.name
+
+    try:
+        ssl_ctx.load_cert_chain(certfile=cert_path, keyfile=key_path)
+    finally:
+        os.unlink(cert_path)
+        os.unlink(key_path)
+
+    # Close the no-cert client created earlier so its pool isn't leaked.
+    old_client = getattr(app.state, "reverse_proxy_client", None)
+    if old_client is not None:
+        try:
+            await old_client.aclose()
+        except Exception as exc:  # pragma: no cover — defensive close
+            _log.debug("reverse_proxy_client old close: %s", exc)
+
+    app.state.reverse_proxy_client = _httpx.AsyncClient(
+        timeout=30.0,
+        verify=ssl_ctx,
+        follow_redirects=False,
+    )
+    _log.info(
+        "Wave 3 U4 — federation httpx client upgraded with Mastio leaf "
+        "client cert (mTLS toward broker)",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Lifespan
 # ─────────────────────────────────────────────────────────────────────────────
 
@@ -116,6 +187,13 @@ async def lifespan(app: FastAPI):
 
         # ADR-004 PR A — reverse-proxy httpx client. One shared AsyncClient
         # so the forwarder re-uses HTTP/2 connections across requests.
+        # Wave 3 U4 — the client cert is added in a second pass below,
+        # after ``ensure_mastio_identity`` has minted/loaded the leaf.
+        # We initialize the client here without a cert so any code path
+        # that runs between this point and the upgrade still has a usable
+        # client. The upgrade is a close+rebuild; in practice nothing
+        # uses the client during that window because the bridge isn't
+        # wired yet.
         import httpx as _httpx
         app.state.reverse_proxy_broker_url = broker_url
         app.state.reverse_proxy_client = _httpx.AsyncClient(
@@ -159,6 +237,21 @@ async def lifespan(app: FastAPI):
             await agent_mgr.ensure_mastio_identity()
         except Exception as exc:  # defensive — never block lifespan on this
             _log.warning("Mastio identity bootstrap failed: %s", exc)
+
+        # Wave 3 U4 — bidirectional mTLS toward the broker. Once the
+        # Mastio leaf is loaded, rebuild the federation httpx client with
+        # the leaf cert as the TLS client cert. The Court verifies the
+        # cert's pubkey against the pinned ``organizations.mastio_pubkey``
+        # — same key as the JWT countersig, no new schema. Federation
+        # mode only; standalone keeps reverse_proxy_client=None.
+        if not settings.standalone and getattr(agent_mgr, "mastio_loaded", False):
+            try:
+                await _upgrade_federation_client_to_mtls(app, agent_mgr, settings)
+            except Exception as exc:
+                _log.warning(
+                    "Wave 3 U4 mTLS upgrade failed (broker uplink will "
+                    "still work via JWT countersig only): %s", exc,
+                )
 
         # ADR-014 — emit the TLS server cert that the nginx sidecar
         # serves on 9443. The CA bundle (public Org CA cert) goes

--- a/tests/test_mastio_mtls.py
+++ b/tests/test_mastio_mtls.py
@@ -1,0 +1,194 @@
+"""Tests for Wave 3 U4 — bidirectional mTLS verify-if-present.
+
+Covers ``app.auth.mastio_mtls`` extract + verify functions. Real TLS
+handshake validation is out of scope for unit tests (requires uvicorn
+with ssl_cert_reqs=optional and a live socket); those land in the
+sandbox smoke pre-merge gate.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+from urllib.parse import quote
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from fastapi import HTTPException, Request
+
+from app.auth.mastio_mtls import (
+    PASS_THROUGH_HEADER,
+    extract_mastio_cert,
+    verify_mastio_cert_pubkey,
+    enforce_if_present,
+)
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────
+
+def _mint_pair(now: datetime | None = None):
+    """Mint an EC P-256 keypair + self-signed cert for the test."""
+    now = now or datetime.now(timezone.utc)
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test-mastio"),
+    ])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=30))
+        .sign(key, hashes.SHA256())
+    )
+    pubkey_pem = key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    return key, cert, pubkey_pem, cert_pem
+
+
+def _request_with_header(value: str | None) -> Request:
+    """Build a minimal Request whose only relevant input is one header."""
+    headers = []
+    if value is not None:
+        headers.append((PASS_THROUGH_HEADER.lower().encode(), value.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/federation/publish-agent",
+        "headers": headers,
+        "query_string": b"",
+        # No "transport" key — extract should fall through to the header.
+    }
+    return Request(scope=scope)
+
+
+def _request_with_transport_cert(cert_der: bytes | None) -> Request:
+    """Build a Request whose ``scope['transport']`` returns ``cert_der``."""
+    transport = MagicMock()
+    ssl_obj = MagicMock()
+    ssl_obj.getpeercert = MagicMock(return_value=cert_der)
+    transport.get_extra_info = MagicMock(
+        side_effect=lambda key: ssl_obj if key == "ssl_object" else None,
+    )
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/federation/publish-agent",
+        "headers": [],
+        "query_string": b"",
+        "transport": transport,
+    }
+    return Request(scope=scope)
+
+
+# ─── extract_mastio_cert ─────────────────────────────────────────────
+
+def test_extract_returns_none_when_no_cert():
+    req = _request_with_header(None)
+    assert extract_mastio_cert(req) is None
+
+
+def test_extract_via_header_pass_through():
+    _, cert, _, cert_pem = _mint_pair()
+    encoded = quote(cert_pem)
+    req = _request_with_header(encoded)
+    parsed = extract_mastio_cert(req)
+    assert parsed is not None
+    assert parsed.subject == cert.subject
+
+
+def test_extract_via_header_malformed_returns_none():
+    req = _request_with_header(quote("not a certificate"))
+    assert extract_mastio_cert(req) is None
+
+
+def test_extract_via_header_garbled_pem_returns_none():
+    pem_garbled = "-----BEGIN CERTIFICATE-----\nbm90LWFjdHVhbA==\n-----END CERTIFICATE-----"
+    req = _request_with_header(quote(pem_garbled))
+    assert extract_mastio_cert(req) is None
+
+
+def test_extract_via_transport():
+    _, cert, _, _ = _mint_pair()
+    cert_der = cert.public_bytes(serialization.Encoding.DER)
+    req = _request_with_transport_cert(cert_der)
+    parsed = extract_mastio_cert(req)
+    assert parsed is not None
+    assert parsed.subject == cert.subject
+
+
+def test_extract_transport_no_peer_cert_falls_through_to_header():
+    """If the transport reports no peer cert, the header path still runs."""
+    _, cert, _, cert_pem = _mint_pair()
+    transport = MagicMock()
+    ssl_obj = MagicMock()
+    ssl_obj.getpeercert = MagicMock(return_value=b"")  # no peer cert
+    transport.get_extra_info = MagicMock(
+        side_effect=lambda key: ssl_obj if key == "ssl_object" else None,
+    )
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/x",
+        "headers": [
+            (PASS_THROUGH_HEADER.lower().encode(), quote(cert_pem).encode()),
+        ],
+        "query_string": b"",
+        "transport": transport,
+    }
+    req = Request(scope=scope)
+    parsed = extract_mastio_cert(req)
+    assert parsed is not None
+    assert parsed.subject == cert.subject
+
+
+# ─── verify_mastio_cert_pubkey ───────────────────────────────────────
+
+def test_verify_match_no_raise():
+    _, cert, pubkey_pem, _ = _mint_pair()
+    verify_mastio_cert_pubkey(cert, pubkey_pem)  # no raise
+
+
+def test_verify_mismatch_raises_403():
+    _, cert, _, _ = _mint_pair()
+    _, _, other_pubkey_pem, _ = _mint_pair()  # different key
+    with pytest.raises(HTTPException) as exc:
+        verify_mastio_cert_pubkey(cert, other_pubkey_pem)
+    assert exc.value.status_code == 403
+
+
+def test_verify_unreadable_pinned_pem_raises_500():
+    _, cert, _, _ = _mint_pair()
+    with pytest.raises(HTTPException) as exc:
+        verify_mastio_cert_pubkey(cert, "-----BEGIN GARBAGE-----\nx\n-----END GARBAGE-----")
+    assert exc.value.status_code == 500
+
+
+# ─── enforce_if_present ──────────────────────────────────────────────
+
+def test_enforce_no_cert_returns_false():
+    _, _, pubkey_pem, _ = _mint_pair()
+    req = _request_with_header(None)
+    assert enforce_if_present(req, pubkey_pem) is False
+
+
+def test_enforce_cert_match_returns_true():
+    _, _, pubkey_pem, cert_pem = _mint_pair()
+    req = _request_with_header(quote(cert_pem))
+    assert enforce_if_present(req, pubkey_pem) is True
+
+
+def test_enforce_cert_mismatch_raises_403():
+    _, _, _, cert_pem = _mint_pair()
+    _, _, other_pubkey_pem, _ = _mint_pair()
+    req = _request_with_header(quote(cert_pem))
+    with pytest.raises(HTTPException) as exc:
+        enforce_if_present(req, other_pubkey_pem)
+    assert exc.value.status_code == 403


### PR DESCRIPTION
## Summary

- Bind the federation auth proof to the live TLS session: when the Mastio's leaf cert is presented as a TLS client cert, the Court verifies its `SubjectPublicKeyInfo` against the same pinned `organizations.mastio_pubkey` already used for the JWT counter-signature
- Mastio side: `_upgrade_federation_client_to_mtls` rebuilds `reverse_proxy_client` with leaf cert+key in `ssl.SSLContext` after `ensure_mastio_identity` runs
- Court side: new `app/auth/mastio_mtls.py` extracts peer cert from uvicorn ASGI transport (direct TLS) or `X-Cullis-Mastio-Cert` header (nginx pass-through, Phase 2). Hooked into `/v1/auth/token`, `/v1/federation/publish-agent`, `/v1/federation/publish-stats`
- Phase 1 = verify-if-present: 403 on pubkey mismatch, no-op when no cert is presented (legacy / pre-deploy clients keep working). Zero schema change, reuses existing pin
- Audit events: `mastio_mtls_pubkey_mismatch` alongside existing `mastio_countersig` denial reasons

## Why

Today a leaked countersig (replayed from an audit log, recorded in transit before HTTPS, etc.) is sufficient to authorize a federation request. With this PR, an attacker would also need a TLS session terminated with the org's private key — a strict superset of the prior assumption.

Refs: audit-2026-05-08 Ultra Plan U4.

## Phase 2 (deferred to separate PR after this lands)

- Per-org `require_mtls` boolean to flip "missing cert" → 403 (today still 200 for backward compat)
- Nginx config in sandbox + deploy templates for the pass-through path
- E2E sandbox smoke validating the full handshake

## Test plan

- [x] 12 new unit tests in `tests/test_mastio_mtls.py` (extraction paths, key match/mismatch, enforce-if-present)
- [x] 296/296 pre-existing tests in impacted area pass (federation, mastio, auth_token, auth_router, main_lifespan, countersig, rate_limit)
- [x] Full suite: 2789 pass, 6 pre-existing fail on origin/main (postgres bindings KeyError + connector pystray headless — unrelated to this PR)
- [ ] CI green
- [ ] Phase 2 sandbox E2E smoke (separate PR)