### PR TITLE
feat(federation): per-org require_mastio_mtls enforce flag (Wave 3 U4 Phase 2)

### DIFF
--- a/alembic/versions/p6k7l8m9n0o1_org_require_mtls.py
+++ b/alembic/versions/p6k7l8m9n0o1_org_require_mtls.py
@@ -1,0 +1,37 @@
+"""Wave 3 U4 Phase 2 — organizations.require_mastio_mtls
+
+Revision ID: p6k7l8m9n0o1
+Revises: o5j6k7l8m9n0
+Create Date: 2026-05-08 20:30:00.000000
+
+Per-org boolean: when true, federation endpoints reject Mastio calls that
+do NOT present a TLS client cert binding to the pinned ``mastio_pubkey``.
+Default false preserves the Phase 1 verify-if-present behavior so the flip
+is opt-in. Operators turn it on once their nginx (or terminating layer)
+is wired to forward the cert via ``X-Cullis-Mastio-Cert`` or once the
+Court terminates TLS directly with ``ssl_cert_reqs=optional``.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "p6k7l8m9n0o1"
+down_revision = "o5j6k7l8m9n0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "require_mastio_mtls",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "require_mastio_mtls")

--- a/app/auth/mastio_mtls.py
+++ b/app/auth/mastio_mtls.py
@@ -145,3 +145,37 @@ def enforce_if_present(request: Request, mastio_pubkey_pem: str) -> bool:
         return False
     verify_mastio_cert_pubkey(cert, mastio_pubkey_pem)
     return True
+
+
+def enforce_if_required(
+    request: Request,
+    mastio_pubkey_pem: str,
+    *,
+    require: bool,
+) -> bool:
+    """Phase 2 helper: like :func:`enforce_if_present` but escalates a
+    missing peer cert to 403 when ``require`` is True.
+
+    Returns True if a cert was presented and verified. Raises 403 on
+    mismatch (always) or on absence when ``require`` is True.
+
+    Operators flip ``require`` (per-org column ``require_mastio_mtls``)
+    once the Court's terminating layer (uvicorn ssl_cert_reqs=optional
+    or nginx with ssl_verify_client + header pass-through) is wired to
+    actually surface the peer cert. Until then ``require=False`` keeps
+    the verify-if-present semantic so a half-deployed setup doesn't
+    self-DoS.
+    """
+    cert = extract_mastio_cert(request)
+    if cert is None:
+        if require:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=(
+                    "organization requires Mastio mTLS but no peer "
+                    "certificate was presented to the Court"
+                ),
+            )
+        return False
+    verify_mastio_cert_pubkey(cert, mastio_pubkey_pem)
+    return True

--- a/app/auth/router.py
+++ b/app/auth/router.py
@@ -10,7 +10,7 @@ from app.auth.models import TokenRequest, TokenResponse, TokenPayload
 from app.auth.jwt import create_access_token, get_current_agent
 from app.auth import mastio_countersig
 from app.auth.mastio_countersig import COUNTERSIG_HEADER
-from app.auth.mastio_mtls import enforce_if_present as enforce_mastio_mtls
+from app.auth.mastio_mtls import enforce_if_required as enforce_mastio_mtls
 from app.auth.x509_verifier import verify_client_assertion
 from app.auth.dpop import verify_dpop_proof, build_htu
 from app.config import get_settings
@@ -153,13 +153,16 @@ async def issue_token(
             org_record = await _get_org_for_mtls(db, org_id)
             if org_record is not None and org_record.mastio_pubkey:
                 try:
-                    enforce_mastio_mtls(request, org_record.mastio_pubkey)
+                    enforce_mastio_mtls(
+                        request, org_record.mastio_pubkey,
+                        require=bool(org_record.require_mastio_mtls),
+                    )
                 except HTTPException:
                     AUTH_DENY_COUNTER.add(1, {"reason": "mastio_mtls"})
                     await log_event(
                         db, "auth.token_request", "denied",
                         agent_id=agent_id, org_id=org_id,
-                        details={"reason": "mastio_mtls_pubkey_mismatch"},
+                        details={"reason": "mastio_mtls_failed"},
                     )
                     raise
 

--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_countersig
-from app.auth.mastio_mtls import enforce_if_present as enforce_mastio_mtls
+from app.auth.mastio_mtls import enforce_if_required as enforce_mastio_mtls
 from app.db.database import get_db
 from app.db.audit import log_event
 from app.registry.org_store import get_org_by_id
@@ -179,19 +179,21 @@ async def publish_agent(
         )
         raise
 
-    # 2b. Wave 3 U4 — bidirectional mTLS verify-if-present. A peer cert
-    #     bound to the same key as ``mastio_pubkey`` is a stronger proof
-    #     than the JWT countersig alone (binds the live TLS session to
-    #     the org's signing key). Phase 1: log + 403 on mismatch, no-op
-    #     when no peer cert is presented. Phase 2 will add per-org
-    #     ``require_mtls`` to flip "missing" → 403.
+    # 2b. Wave 3 U4 — bidirectional mTLS. A peer cert bound to the same
+    #     key as ``mastio_pubkey`` binds the live TLS session to the org's
+    #     signing key (stronger than JWT countersig alone). Phase 2: when
+    #     ``organizations.require_mastio_mtls`` is true, missing cert →
+    #     403; otherwise verify-if-present (Phase 1 backward compat).
     try:
-        verified = enforce_mastio_mtls(request, org.mastio_pubkey)
+        verified = enforce_mastio_mtls(
+            request, org.mastio_pubkey,
+            require=bool(org.require_mastio_mtls),
+        )
     except HTTPException:
         await log_event(
             db, "federation.publish_rejected", "denied",
             org_id=org_id,
-            details={"reason": "mastio_mtls_pubkey_mismatch",
+            details={"reason": "mastio_mtls_failed",
                      "agent_id": body.agent_id},
         )
         raise
@@ -355,15 +357,19 @@ async def publish_stats(
         )
         raise
 
-    # Wave 3 U4 — bidirectional mTLS verify-if-present (mirrors
-    # publish-agent). 403 on key mismatch, no-op when absent.
+    # Wave 3 U4 — bidirectional mTLS (mirrors publish-agent). 403 on
+    # mismatch always; missing cert → 403 only when the org has
+    # ``require_mastio_mtls`` set.
     try:
-        enforce_mastio_mtls(request, org.mastio_pubkey)
+        enforce_mastio_mtls(
+            request, org.mastio_pubkey,
+            require=bool(org.require_mastio_mtls),
+        )
     except HTTPException:
         await log_event(
             db, "federation.stats_rejected", "denied",
             org_id=body.org_id,
-            details={"reason": "mastio_mtls_pubkey_mismatch"},
+            details={"reason": "mastio_mtls_failed"},
         )
         raise
 

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -539,6 +539,48 @@ async def patch_org_mastio_pubkey(
     }
 
 
+class RequireMastioMtlsPatch(BaseModel):
+    """Body for ``PATCH /v1/admin/orgs/{org_id}/require-mtls`` —
+    Wave 3 U4 Phase 2 toggle.
+    """
+    require_mastio_mtls: bool
+
+
+@admin_router.patch("/orgs/{org_id}/require-mtls",
+                    dependencies=[Depends(_require_admin)])
+async def patch_org_require_mastio_mtls(
+    org_id: str,
+    body: RequireMastioMtlsPatch,
+    db: AsyncSession = Depends(get_db),
+):
+    """Wave 3 U4 Phase 2 — flip per-org Mastio mTLS enforcement.
+
+    When true, federation endpoints (``/v1/auth/token``,
+    ``/v1/federation/publish-agent``, ``/v1/federation/publish-stats``)
+    reject Mastio calls that don't present a TLS client cert binding
+    to the pinned ``mastio_pubkey``. Default false preserves the Phase 1
+    verify-if-present behavior, so the flip is opt-in once the
+    deployment's terminating layer is wired to surface the peer cert
+    (uvicorn ``ssl_cert_reqs=optional`` or nginx ``ssl_verify_client``
+    + ``X-Cullis-Mastio-Cert`` header pass-through).
+    """
+    org = await get_org_by_id(db, org_id)
+    if org is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, detail="Organization not found")
+
+    org.require_mastio_mtls = body.require_mastio_mtls
+    await db.commit()
+    await log_event(
+        db, "admin.require_mastio_mtls_patched", "ok",
+        org_id=org_id,
+        details={"require_mastio_mtls": body.require_mastio_mtls},
+    )
+    return {
+        "org_id": org_id,
+        "require_mastio_mtls": body.require_mastio_mtls,
+    }
+
+
 class MastioPubkeyRotateRequest(BaseModel):
     """Body for ``POST /onboarding/orgs/{org_id}/mastio-pubkey/rotate``.
 

--- a/app/registry/org_store.py
+++ b/app/registry/org_store.py
@@ -56,6 +56,12 @@ class OrganizationRecord(Base):
     # session allows every mutation). See app/dashboard/router.py for
     # the enforcement and unseal flow.
     sealed = Column(Boolean, nullable=False, default=False, server_default="0")
+    # Wave 3 U4 Phase 2 — when true, federation endpoints reject Mastio
+    # calls that don't present a TLS client cert binding to ``mastio_pubkey``.
+    # Default false preserves Phase 1 verify-if-present (cert optional).
+    require_mastio_mtls = Column(
+        Boolean, nullable=False, default=False, server_default="0",
+    )
 
     def verify_secret(self, plain: str) -> bool:
         return bcrypt.checkpw(plain.encode(), self.secret_hash.encode())

--- a/tests/test_mastio_mtls.py
+++ b/tests/test_mastio_mtls.py
@@ -23,6 +23,7 @@ from app.auth.mastio_mtls import (
     extract_mastio_cert,
     verify_mastio_cert_pubkey,
     enforce_if_present,
+    enforce_if_required,
 )
 
 
@@ -192,3 +193,38 @@ def test_enforce_cert_mismatch_raises_403():
     with pytest.raises(HTTPException) as exc:
         enforce_if_present(req, other_pubkey_pem)
     assert exc.value.status_code == 403
+
+
+# ─── enforce_if_required (Phase 2) ───────────────────────────────────
+
+def test_enforce_required_no_cert_raises_403():
+    _, _, pubkey_pem, _ = _mint_pair()
+    req = _request_with_header(None)
+    with pytest.raises(HTTPException) as exc:
+        enforce_if_required(req, pubkey_pem, require=True)
+    assert exc.value.status_code == 403
+    assert "no peer certificate" in exc.value.detail
+
+
+def test_enforce_required_no_cert_no_require_returns_false():
+    """require=False keeps the verify-if-present behavior."""
+    _, _, pubkey_pem, _ = _mint_pair()
+    req = _request_with_header(None)
+    assert enforce_if_required(req, pubkey_pem, require=False) is False
+
+
+def test_enforce_required_cert_match_returns_true():
+    _, _, pubkey_pem, cert_pem = _mint_pair()
+    req = _request_with_header(quote(cert_pem))
+    assert enforce_if_required(req, pubkey_pem, require=True) is True
+
+
+def test_enforce_required_cert_mismatch_raises_403_regardless_of_require():
+    """Mismatch is fatal whether require is True or False."""
+    _, _, _, cert_pem = _mint_pair()
+    _, _, other_pubkey_pem, _ = _mint_pair()
+    req = _request_with_header(quote(cert_pem))
+    for require in (True, False):
+        with pytest.raises(HTTPException) as exc:
+            enforce_if_required(req, other_pubkey_pem, require=require)
+        assert exc.value.status_code == 403

--- a/tests/test_require_mastio_mtls_admin.py
+++ b/tests/test_require_mastio_mtls_admin.py
@@ -1,0 +1,99 @@
+"""Wave 3 U4 Phase 2 — admin endpoint for the per-org mTLS enforce flag.
+
+Covers:
+  - PATCH /v1/admin/orgs/{id}/require-mtls flips the flag (true/false)
+  - Persisted on the OrganizationRecord
+  - Missing admin secret → 403
+  - Unknown org → 404
+  - Audit event emitted
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.config import get_settings
+from tests.cert_factory import get_org_ca_pem
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN_SECRET = get_settings().admin_secret
+
+
+async def _create_org(client: AsyncClient, org_id: str) -> None:
+    invite = await client.post(
+        "/v1/admin/invites",
+        json={"label": org_id, "ttl_hours": 1},
+        headers={"x-admin-secret": ADMIN_SECRET},
+    )
+    token = invite.json()["token"]
+    await client.post("/v1/onboarding/join", json={
+        "org_id": org_id,
+        "display_name": org_id,
+        "secret": f"{org_id}-secret",
+        "ca_certificate": get_org_ca_pem(org_id),
+        "invite_token": token,
+    })
+
+
+async def _fetch_flag(org_id: str) -> bool | None:
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import get_org_by_id
+    async with AsyncSessionLocal() as db:
+        org = await get_org_by_id(db, org_id)
+        return org.require_mastio_mtls if org else None
+
+
+async def test_default_is_false(client: AsyncClient):
+    await _create_org(client, "mtls-default")
+    assert await _fetch_flag("mtls-default") is False
+
+
+async def test_patch_flips_to_true(client: AsyncClient):
+    await _create_org(client, "mtls-true")
+    r = await client.patch(
+        "/v1/admin/orgs/mtls-true/require-mtls",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"require_mastio_mtls": True},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["org_id"] == "mtls-true"
+    assert body["require_mastio_mtls"] is True
+    assert await _fetch_flag("mtls-true") is True
+
+
+async def test_patch_flips_back_to_false(client: AsyncClient):
+    await _create_org(client, "mtls-flip")
+    await client.patch(
+        "/v1/admin/orgs/mtls-flip/require-mtls",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"require_mastio_mtls": True},
+    )
+    r = await client.patch(
+        "/v1/admin/orgs/mtls-flip/require-mtls",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"require_mastio_mtls": False},
+    )
+    assert r.status_code == 200
+    assert r.json()["require_mastio_mtls"] is False
+    assert await _fetch_flag("mtls-flip") is False
+
+
+async def test_wrong_admin_secret_rejected(client: AsyncClient):
+    await _create_org(client, "mtls-noauth")
+    r = await client.patch(
+        "/v1/admin/orgs/mtls-noauth/require-mtls",
+        headers={"x-admin-secret": "wrong-secret"},
+        json={"require_mastio_mtls": True},
+    )
+    assert r.status_code == 403
+
+
+async def test_unknown_org_404(client: AsyncClient):
+    r = await client.patch(
+        "/v1/admin/orgs/does-not-exist/require-mtls",
+        headers={"x-admin-secret": ADMIN_SECRET},
+        json={"require_mastio_mtls": True},
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary

- Builds on PR #518 (Phase 1 verify-if-present): Phase 2 adds a per-org `organizations.require_mastio_mtls` boolean that escalates a missing peer cert to 403
- Default `false` preserves Phase 1 behavior so the flip is opt-in once the deployment's terminating layer (nginx with `ssl_verify_client` + `X-Cullis-Mastio-Cert` pass-through, or uvicorn `ssl_cert_reqs=optional`) is wired
- New `enforce_if_required(req, pem, require=)` helper used by `/v1/auth/token`, `/v1/federation/publish-agent`, `/v1/federation/publish-stats`
- New admin endpoint `PATCH /v1/admin/orgs/{org_id}/require-mtls` mirrors the existing mastio-pubkey patch route
- Audit reason unified: `mastio_mtls_failed` (was `mastio_mtls_pubkey_mismatch`) so dashboards don't have to parse two strings

## Why

Phase 1 alone is "polite mTLS" — the cert is verified when surfaced, ignored when missing. Phase 2 lets ops actually enforce the binding once their TLS layer is wired, while keeping zero-disruption rollout for orgs that haven't upgraded yet.

Refs: audit-2026-05-08 Ultra Plan U4.

## Phase 3 deferred

- Sandbox `nginx-court` sidecar that terminates TLS and pass-throughs the cert (today the sandbox Court runs HTTP plain by design — it's a routing/dashboard demo, not an enforcement bench)
- Helm/Compose deploy templates documenting the nginx snippet

## Test plan

- [x] 4 new unit tests on `enforce_if_required` (require=true blocks missing; require=false preserves Phase 1; mismatch fatal regardless)
- [x] 5 new admin endpoint tests (default false, flip true, flip back, wrong secret 403, unknown org 404)
- [x] Full suite: 2799 pass, 8 pre-existing fail on origin/main (postgres bindings + connector pystray headless)
- [x] Smoke gate: `./sandbox/demo.sh full` + `oneshot-a-to-b` (cross-org A2A) + `mcp-catalog` (intra-org MCP) green with default `require_mastio_mtls=false`
- [ ] CI green
- [ ] Phase 3 sandbox nginx-court (separate PR)