### PR TITLE
feat(mastio-bundle): export Org CA to ./certs/org-ca.pem after deploy

### DIFF
--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -295,6 +295,24 @@ for i in $(seq 1 60); do
     fi
 done
 
+# ── Export Org CA to host filesystem ───────────────────────────────────────
+# The Org CA is generated at first boot inside the mcp-proxy container's
+# named volume. Downstream consumers (Frontdesk Connector enroll, mTLS
+# verify, manual curl smoke) need it as a trust anchor on the host. Copy
+# it out so operators don't have to docker cp by hand.
+CERT_DIR="$SCRIPT_DIR/certs"
+mkdir -p "$CERT_DIR"
+PROXY_CID="$($COMPOSE $COMPOSE_FILES ps -q mcp-proxy 2>/dev/null || true)"
+ORG_CA_HOST="$CERT_DIR/org-ca.pem"
+if [[ -n "$PROXY_CID" ]] && docker cp "$PROXY_CID:/var/lib/mastio/nginx-certs/org-ca.crt" "$ORG_CA_HOST" 2>/dev/null; then
+    chmod 644 "$ORG_CA_HOST"
+    ok "Org CA exported to ./certs/org-ca.pem"
+else
+    warn "Could not export Org CA — retrieve manually:"
+    warn "  docker cp ${COMPOSE_PROJECT_NAME}-mcp-proxy-1:/var/lib/mastio/nginx-certs/org-ca.crt ./certs/org-ca.pem"
+    rm -f "$ORG_CA_HOST" 2>/dev/null
+fi
+
 PUBLIC_URL="$(grep -E '^MCP_PROXY_PROXY_PUBLIC_URL=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
 PUBLIC_URL="${PUBLIC_URL:-https://localhost:${PROXY_PORT}}"
 
@@ -303,6 +321,10 @@ echo -e "${GREEN}${BOLD}Cullis Mastio deployed (${MODE}).${RESET}"
 echo ""
 echo -e "  ${BOLD}Dashboard${RESET}        ${GRAY}${PUBLIC_URL}/proxy/login${RESET}"
 echo -e "  ${BOLD}Health${RESET}           ${GRAY}${PUBLIC_URL}/health${RESET}"
+if [[ -f "$ORG_CA_HOST" ]]; then
+    echo -e "  ${BOLD}Org CA${RESET}           ${GRAY}./certs/org-ca.pem${RESET}"
+    echo -e "                   ${GRAY}use as CULLIS_FRONTDESK_CA_BUNDLE_HOST when bringing up the Frontdesk bundle${RESET}"
+fi
 echo ""
 if [[ "$MODE" == "development" ]]; then
     echo "  Next steps (development):"


### PR DESCRIPTION
## Summary

- `deploy.sh` now `docker cp`s the Org CA out of the mcp-proxy container to `./certs/org-ca.pem` after the health check passes.
- Final summary prints the path with a hint to use it as `CULLIS_FRONTDESK_CA_BUNDLE_HOST` when bringing up the Frontdesk bundle.
- `certs/` is already in root `.gitignore` (line 2), so the exported CA is not accidentally committed.

## Why

During the customer-VM dogfood on 2026-05-08 the install path stalled because the Frontdesk Connector enrollment required the Mastio Org CA as a trust anchor, and the only way to get it on the host was a `docker cp` from a separate SSH session — knowledge of the project name + container layout that a fresh customer does not have. This is gap #6 of that session and a critical-path blocker for any second component on the same machine.

## Test plan

- [ ] Local: `cd packaging/mastio-bundle && ./deploy.sh --defaults` on a clean Docker host
- [ ] Verify `certs/org-ca.pem` exists and is readable: `openssl x509 -in certs/org-ca.pem -text -noout` shows the Org root cert
- [ ] Final summary prints `Org CA  ./certs/org-ca.pem` line
- [ ] If deploy is run a second time, the `chmod 644` + overwrite path works (no permission denied)
- [ ] CI gate: standard mastio bundle smoke (no behavioral change to the running stack)

## Follow-ups

- PR #2 of the install-path polish sprint will consume this default in `frontdesk-bundle/generate-frontdesk-env.sh` (auto-detect path).

Refs: project_gap_mastio_org_ca_not_exposed_on_host.md, project_session_2026_05_08_dogfood_vm_install_path_broken.md