### PR TITLE
chore: rename _TOFU_NO_VERIFY constant + drop stale broker AI gateway env

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -768,11 +768,17 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         from cullis_connector.enrollment import cert_fingerprint
         # Sentinel — the only place in the Connector that intentionally
         # skips TLS verification. Rationale captured in the docstring
-        # above. Do NOT inline this back to ``verify=False`` without
+        # above. The constant maps directly to the httpx ``verify=``
+        # parameter: False means "do not verify the TLS chain", which is
+        # what the TOFU bootstrap requires (no anchor pinned yet). Do
+        # NOT inline this back to a literal ``verify=False`` without
         # updating ci.yml + ADR-015.
-        _TOFU_NO_VERIFY: bool = False
+        _VERIFY_TLS_FOR_CA_FETCH: bool = False
         url = site_url.rstrip("/") + "/pki/ca.crt"
-        resp = httpx.get(url, verify=_TOFU_NO_VERIFY, timeout=config.request_timeout_s)
+        resp = httpx.get(
+            url, verify=_VERIFY_TLS_FOR_CA_FETCH,
+            timeout=config.request_timeout_s,
+        )
         if resp.status_code == 404:
             raise RuntimeError(
                 "Site has no Org CA configured yet — ask the admin to "

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -107,15 +107,9 @@ services:
       # demo point look broken: the cookie kept validating across
       # reboots because the signature stayed good.
       KMS_BACKEND: "local"
-      # ADR-017 Phase 1 — AI gateway egress. Court runs litellm_embedded
-      # by default, which routes /v1/llm/chat to Anthropic when the key
-      # is present. Without the key the dispatcher 503s and Cullis Chat /
-      # any agent doing chat_completion fails. Pulled from host env so
-      # the sandbox-mcp .env (existing dogfood key) is reused without
-      # secret duplication.
-      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY:-}"
-      AI_GATEWAY_BACKEND: "litellm_embedded"
-      AI_GATEWAY_PROVIDER: "anthropic"
+      # NB: AI gateway env (ANTHROPIC_API_KEY / AI_GATEWAY_*) lives on the
+      # Mastio service now, not here. PR #517 returned Court /v1/llm/chat
+      # to a 410 Gone per ADR-017 (gateway moved from Court to Mastio).
       BROKER_CA_KEY_PATH: /broker-certs/broker-ca-key.pem
       BROKER_CA_CERT_PATH: /broker-certs/broker-ca.pem
       # ADR-004 PR B — proxy-only topology. Agents now reach the broker


### PR DESCRIPTION
## Summary

Two small audit follow-ups batched because each is a 1-line cleanup with zero behavior change.

1. **Connector TOFU constant rename** (audit Ultra U5) — `_TOFU_NO_VERIFY: bool = False` was a naming bomb (reads as "no verify is off → verify is on", but the value feeds httpx `verify=` and False means skip). Renamed to `_VERIFY_TLS_FOR_CA_FETCH: bool = False` so the value carries the same semantic as the parameter it feeds.

2. **sandbox/docker-compose.yml** — drop stale broker AI gateway env (followup of #517). PR #517 made Court `/v1/llm/chat` return 410 Gone per ADR-017 (gateway moved to Mastio). The broker service no longer reads `ANTHROPIC_API_KEY` / `AI_GATEWAY_*` — they were silent no-ops since #517 landed. Mastio mirrors at lines 281-283 are unchanged.

## Why batched

Both touch ~6 lines each and are zero-risk renames/removals. Splitting them into two PRs would be churn.

## Test plan

- [x] 446/450 connector + TOFU + web + pki_ca tests pass (4 pre-existing pystray headless fails unrelated)
- [x] Sandbox AI gateway path: Mastio still sources `MCP_PROXY_ANTHROPIC_API_KEY` from host env (lines 281-283 unchanged); broker service drop is a no-op per #517
- [ ] CI green