### PR TITLE
feat(frontdesk-bundle): add deploy.sh + generate-frontdesk-env.sh

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -12,40 +12,46 @@ Deploys Cullis Chat as a corporate web app, identity-aware via SSO. One containe
 
 ## Prerequisites
 
-1. **A reachable Mastio.** The Connector enrolls against it and forwards requests to its proxy + audit chain. Stand one up with `packaging/mastio-bundle/` if you do not already have one.
-2. **An invite code** issued by your Mastio admin (`/v1/admin/invites` on the Mastio dashboard).
-3. **A Mastio CA bundle PEM** on the host machine, exported as `CULLIS_FRONTDESK_CA_BUNDLE_HOST` in `frontdesk.env`. Without it the Connector can boot but every Mastio call fails the TLS handshake.
+1. **A reachable Mastio.** The Connector enrolls against it and forwards requests to its proxy + audit chain. Stand one up with `packaging/mastio-bundle/` if you do not already have one (the sibling bundle exports its CA to `../mastio-bundle/certs/org-ca.pem`, which `./deploy.sh` here picks up automatically).
+2. **An invite code** issued by your Mastio admin (Mastio dashboard → Enrollments → Create invite, target name = `frontdesk`).
+3. **A Mastio CA bundle PEM** on the host machine. Auto-detected when the sibling Mastio bundle is at `../mastio-bundle/`; otherwise set `CULLIS_FRONTDESK_CA_BUNDLE_HOST` in `frontdesk.env`.
 4. **Docker Compose v2.20+**. The bundle pulls all three images from `ghcr.io`; no repo checkout or `docker build` required.
 
-## One-shot enrollment
-
-The bundle does not enroll the Connector for you. Run this once before `docker compose up`:
+## Quickstart (deploy.sh)
 
 ```bash
-docker run --rm -it \
-  -v $(pwd)/connector_data:/home/cullis/.cullis \
-  ghcr.io/cullis-security/cullis-connector:0.4.0-rc1 \
-  enroll \
-    --site https://mastio.acme.local:9443 \
-    --code <INVITE_CODE_FROM_MASTIO_ADMIN> \
-    --profile frontdesk
+./deploy.sh
 ```
 
-This writes the cert + key + config to the local `connector_data/` directory. The bundle mounts that directory into the Connector container; subsequent `docker compose up` calls reuse the same identity.
+That single command:
 
-If you wipe `connector_data/`, you must re-enroll.
+1. Generates `frontdesk.env` with sensible same-host defaults if it doesn't exist (auto-detecting the Mastio CA path).
+2. Prompts for the invite code (or accepts `--code <invite>`) and the Mastio site URL (defaults to `https://host.docker.internal:9443` for the same-host topology).
+3. Runs the one-shot enrollment via a throwaway `cullis-connector` container, writing the identity material to `./connector_data/`.
+4. `docker compose up -d` and waits until `http://localhost:8080` answers.
+5. Prints the SPA URL and a fake-SSO smoke test command.
 
-## Bring the bundle up
+Re-runs are idempotent: if `connector_data/profiles/<profile>/identity/metadata.json` exists, the enrollment step is skipped.
+
+### Non-interactive
 
 ```bash
-cp frontdesk.env.example frontdesk.env
-# Edit frontdesk.env:
-#   - CULLIS_FRONTDESK_ORG_ID, CULLIS_FRONTDESK_TRUST_DOMAIN: match what
-#     you registered on the Mastio.
-#   - CULLIS_FRONTDESK_CA_BUNDLE_HOST: path on this host to the Mastio
-#     CA chain PEM. Required, no default.
+# Pre-supply the invite code, skip prompts:
+./deploy.sh --code my-invite-code-from-mastio --site https://mastio.acme.local:9443
 
-docker compose --env-file frontdesk.env up -d
+# Already enrolled out-of-band, just bring the stack up:
+./deploy.sh --skip-enroll
+
+# Production: requires a pre-provisioned frontdesk.env with real values
+./deploy.sh --prod
+```
+
+### Manual generate (no deploy)
+
+```bash
+./generate-frontdesk-env.sh --interactive   # prompts for ORG_ID, trust domain, CA path
+./generate-frontdesk-env.sh --defaults      # same-host defaults, no prompts
+./generate-frontdesk-env.sh --prod          # validates env vars, fails fast
 ```
 
 The bundle exposes nginx on the host port from `FRONTDESK_HTTP_PORT` (default `8080`).
@@ -105,8 +111,8 @@ For oauth2-proxy specifically, the upstream config `--pass-user-headers=true` is
 ## Tear down
 
 ```bash
-docker compose down            # stop containers, keep connector_data volume
-docker compose down -v         # also wipe connector_data (forces re-enrollment)
+./deploy.sh --down             # stop containers, keep connector_data
+docker compose --env-file frontdesk.env down -v   # also wipe connector_data (forces re-enrollment)
 ```
 
 ## Known limitations

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Frontdesk — image-based deploy (no source tree required)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Pulls the published Connector + Frontdesk Chat images from GHCR and
+# brings up nginx + chat + connector via docker-compose. The Connector
+# is enrolled against an existing Mastio (separate bundle, see
+# packaging/mastio-bundle/) using an invite code minted on the Mastio
+# dashboard. ADR-019 Phase 7.
+#
+# Modes (combinable):
+#   (default)         dev: generate frontdesk.env from --defaults if missing
+#   --prod            fail-fast on insecure defaults, requires frontdesk.env
+#   --down            stop + remove containers
+#   --pull            re-pull images (otherwise pulled on first up)
+#
+# Enrollment:
+#   --code <invite>   skip the invite-code prompt
+#   --site <url>      override CULLIS_SITE_URL for the enroll step
+#   --skip-enroll     bring the bundle up assuming connector_data is already
+#                     enrolled out-of-band
+#
+# Examples:
+#   ./deploy.sh                                      # interactive
+#   ./deploy.sh --code abc123 --site https://mastio.acme.local:9443
+#   ./deploy.sh --skip-enroll                        # second run, identity exists
+#   ./deploy.sh --down                               # stop + remove
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+export COMPOSE_PROJECT_NAME="cullis-frontdesk"
+
+GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'
+BOLD=$'\033[1m'; GRAY=$'\033[90m'; RESET=$'\033[0m'
+ok()   { echo -e "  ${GREEN}✓${RESET}  $1"; }
+warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
+err()  { echo -e "  ${RED}✗${RESET}  $1"; }
+die()  { err "$1"; exit 1; }
+step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
+
+if docker compose version &>/dev/null 2>&1; then
+    COMPOSE="docker compose"
+elif command -v docker-compose &>/dev/null; then
+    COMPOSE="docker-compose"
+else
+    die "docker compose is not installed"
+fi
+
+print_help() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+
+Deploys the Cullis Frontdesk bundle from the published images (no source
+tree required). Default = dev mode, prompts for missing values.
+
+Options:
+  (no flags)                  Dev mode: generate frontdesk.env if missing,
+                              prompt for invite code at enrollment time
+  --prod                      Production: fail-fast on insecure defaults,
+                              frontdesk.env must exist with real values
+  --down                      Stop and remove containers
+  --pull                      Force-pull the images before starting
+  --code <invite>             Pre-supply the invite code (skip prompt)
+  --site <url>                Mastio URL the Connector enrolls against,
+                              defaults to https://host.docker.internal:9443
+                              for the same-host topology
+  --skip-enroll               Skip the enrollment one-shot (use when the
+                              connector_data volume is already populated)
+  --help, -h                  Show this help and exit
+
+Environment variables (loaded from frontdesk.env, set by
+generate-frontdesk-env.sh):
+  CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
+  CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
+  CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0-rc1)
+  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.1.0-rc1)
+  CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
+  CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
+  FRONTDESK_HTTP_PORT                Host port to bind nginx (default: 8080)
+EOF
+}
+
+ACTION="up"
+MODE="development"
+FORCE_PULL=0
+INVITE_CODE=""
+CLI_SITE_URL=""
+SKIP_ENROLL=0
+
+while [[ $# -gt 0 ]]; do
+    arg="$1"
+    case "$arg" in
+        --down)         ACTION="down"; shift ;;
+        --pull)         FORCE_PULL=1; shift ;;
+        --prod)         MODE="production"; shift ;;
+        --skip-enroll)  SKIP_ENROLL=1; shift ;;
+        --code)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--code requires an invite code"
+            INVITE_CODE="$1"; shift ;;
+        --code=*)       INVITE_CODE="${arg#--code=}"; shift ;;
+        --site)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--site requires a URL"
+            CLI_SITE_URL="$1"; shift ;;
+        --site=*)       CLI_SITE_URL="${arg#--site=}"; shift ;;
+        --help|-h)      print_help; exit 0 ;;
+        *) die "Unknown argument: $arg (use --help)" ;;
+    esac
+done
+
+if [[ "$ACTION" == "down" ]]; then
+    step "Stopping Cullis Frontdesk"
+    $COMPOSE --env-file frontdesk.env down 2>/dev/null \
+        || $COMPOSE down
+    ok "Frontdesk stopped"
+    exit 0
+fi
+
+# ── frontdesk.env — create if missing, validate in prod ─────────────────────
+step "Environment configuration (frontdesk.env)"
+
+if [[ ! -f "$SCRIPT_DIR/frontdesk.env" ]]; then
+    warn "frontdesk.env not found — generating one"
+    if [[ "$MODE" == "production" ]]; then
+        die "--prod requires frontdesk.env to exist. Run: CULLIS_FRONTDESK_ORG_ID=acme CULLIS_FRONTDESK_TRUST_DOMAIN=acme.prod CULLIS_FRONTDESK_CA_BUNDLE_HOST=/path/to/ca.pem ./generate-frontdesk-env.sh --prod"
+    fi
+    bash "$SCRIPT_DIR/generate-frontdesk-env.sh" --defaults
+fi
+
+# Load env with grep (sourcing is fragile because the file is also a
+# docker-compose env file with shell-incompatible substitutions).
+_load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 | cut -d= -f2- || true; }
+
+ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
+TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
+CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0-rc1}"
+CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.1.0-rc1}"
+CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
+DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"
+HTTP_PORT="$(_load_env FRONTDESK_HTTP_PORT)";         HTTP_PORT="${HTTP_PORT:-8080}"
+ENV_SITE_URL="$(_load_env CULLIS_SITE_URL)"
+
+if [[ "$MODE" == "production" ]]; then
+    _errors=()
+    [[ -n "$ORG_ID" ]]       || _errors+=("CULLIS_FRONTDESK_ORG_ID is empty")
+    [[ -n "$TRUST_DOMAIN" ]] || _errors+=("CULLIS_FRONTDESK_TRUST_DOMAIN is empty")
+    [[ -n "$CA_BUNDLE" ]]    || _errors+=("CULLIS_FRONTDESK_CA_BUNDLE_HOST is empty")
+    [[ -z "$CA_BUNDLE" || -f "$CA_BUNDLE" ]] || _errors+=("CA bundle not found at: $CA_BUNDLE")
+    if [[ ${#_errors[@]} -gt 0 ]]; then
+        echo ""
+        err "Production frontdesk.env is not safe to deploy:"
+        for e in "${_errors[@]}"; do echo -e "    ${RED}✗${RESET} $e"; done
+        echo ""
+        die "Fix the issues above and rerun. Aborting before compose up."
+    fi
+    ok "frontdesk.env validated for production"
+fi
+
+# ── Pre-flight: CA bundle readable ──────────────────────────────────────────
+if [[ -z "$CA_BUNDLE" || ! -f "$CA_BUNDLE" ]]; then
+    err "Mastio CA bundle not found at: ${CA_BUNDLE:-<unset>}"
+    err "Edit frontdesk.env: set CULLIS_FRONTDESK_CA_BUNDLE_HOST to the path"
+    err "of your Mastio's Org CA. The sibling Mastio bundle exports it to"
+    err "../mastio-bundle/certs/org-ca.pem when ./deploy.sh runs there."
+    exit 1
+fi
+ok "CA bundle: $CA_BUNDLE"
+
+# ── Pre-flight: host port not already in use ────────────────────────────────
+if command -v ss >/dev/null 2>&1 && ss -tlnH "sport = :${HTTP_PORT}" 2>/dev/null | grep -q .; then
+    err "Host port ${HTTP_PORT} is already in use — another service is bound there."
+    err "Override FRONTDESK_HTTP_PORT in frontdesk.env to a free port."
+    die "Refusing to start — fix the port conflict first."
+fi
+
+# ── Enrollment one-shot ─────────────────────────────────────────────────────
+mkdir -p "$DATA_DIR"
+ENROLLMENT_METADATA="$DATA_DIR/profiles/${CONNECTOR_PROFILE}/identity/metadata.json"
+
+if [[ -f "$ENROLLMENT_METADATA" ]]; then
+    ok "Connector profile '${CONNECTOR_PROFILE}' already enrolled"
+elif [[ $SKIP_ENROLL -eq 1 ]]; then
+    warn "--skip-enroll: assuming Connector profile is enrolled out-of-band"
+else
+    step "Enrolling Connector profile '${CONNECTOR_PROFILE}'"
+
+    # Site URL precedence: CLI flag > frontdesk.env CULLIS_SITE_URL > prompt.
+    SITE_URL="${CLI_SITE_URL:-${ENV_SITE_URL}}"
+    if [[ -z "$SITE_URL" ]]; then
+        echo ""
+        echo "  ${BOLD}Where does the Connector reach the Mastio?${RESET}"
+        echo "    ${GRAY}- Same host (laptop / single VM): just press Enter${RESET}"
+        echo "    ${GRAY}- Different host: enter the public URL Mastio is bound at${RESET}"
+        echo ""
+        read -rp "  Site URL [https://host.docker.internal:9443]: " SITE_URL
+        SITE_URL="${SITE_URL:-https://host.docker.internal:9443}"
+    fi
+    ok "Site URL: $SITE_URL"
+
+    if [[ -z "$INVITE_CODE" ]]; then
+        echo ""
+        echo "  ${BOLD}Get an invite code from the Mastio dashboard:${RESET}"
+        # Translate host.docker.internal back to localhost for the browser
+        # hint, since the operator opens the dashboard from the host.
+        _dashboard_url="${SITE_URL/host.docker.internal/localhost}"
+        echo "    1. Open ${_dashboard_url}/proxy/login"
+        echo "    2. Go to Enrollments → Create invite (target name: ${CONNECTOR_PROFILE})"
+        echo "    3. Paste the generated code below"
+        echo ""
+        read -rp "  Invite code: " INVITE_CODE
+        [[ -n "$INVITE_CODE" ]] || die "Invite code is required to enroll"
+    fi
+
+    # Resolve to absolute paths so docker volume mounts work regardless of
+    # where the operator invokes the script from.
+    CA_BUNDLE_ABS="$(cd "$(dirname "$CA_BUNDLE")" && pwd)/$(basename "$CA_BUNDLE")"
+    DATA_DIR_ABS="$(cd "$DATA_DIR" && pwd)"
+
+    # Use a bridge network with host-gateway so the URL the Connector
+    # uses to reach Mastio at enroll-time matches what it will use at
+    # runtime (compose attaches the same host-gateway extra_hosts to the
+    # connector service). Without this, ``--network host`` would let the
+    # enroll succeed via localhost but the saved site_url in
+    # metadata.json would not resolve from the bridge network at runtime.
+    echo ""
+    docker run --rm \
+        --add-host "host.docker.internal:host-gateway" \
+        -v "${DATA_DIR_ABS}:/home/cullis/.cullis" \
+        -v "${CA_BUNDLE_ABS}:/etc/cullis/ca-bundle.pem:ro" \
+        -e SSL_CERT_FILE=/etc/cullis/ca-bundle.pem \
+        -e REQUESTS_CA_BUNDLE=/etc/cullis/ca-bundle.pem \
+        "ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION}" \
+        enroll \
+            --site "$SITE_URL" \
+            --code "$INVITE_CODE" \
+            --profile "$CONNECTOR_PROFILE" \
+        || die "Enrollment failed — verify the Mastio is reachable at $SITE_URL and the invite code is valid"
+
+    if [[ ! -f "$ENROLLMENT_METADATA" ]]; then
+        die "Enrollment finished without writing metadata to $ENROLLMENT_METADATA — check container logs above"
+    fi
+    ok "Connector enrolled: ${CONNECTOR_PROFILE}"
+fi
+
+# ── Pull + Start ────────────────────────────────────────────────────────────
+step "Deploying Cullis Frontdesk (${MODE})"
+echo -e "  Connector image: ${GRAY}ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION}${RESET}"
+echo -e "  Chat image:      ${GRAY}ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION}${RESET}"
+
+if [[ $FORCE_PULL -eq 1 ]]; then
+    echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env pull${RESET}"
+    $COMPOSE --env-file frontdesk.env pull
+    ok "Images pulled"
+fi
+
+echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env up -d${RESET}"
+$COMPOSE --env-file frontdesk.env up -d
+ok "Containers started"
+
+# ── Wait for health ─────────────────────────────────────────────────────────
+step "Waiting for services"
+
+echo -n "  nginx + chat + connector "
+for i in $(seq 1 60); do
+    if curl -sf "http://localhost:${HTTP_PORT}/" >/dev/null 2>&1; then
+        echo -e " ${GREEN}ready${RESET}"
+        break
+    fi
+    echo -n "."
+    sleep 1
+    if [[ $i -eq 60 ]]; then
+        echo -e " ${RED}timeout${RESET}"
+        warn "Frontdesk did not become healthy — check logs:"
+        warn "  $COMPOSE --env-file frontdesk.env logs"
+    fi
+done
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+SITE_URL_DISPLAY="${CLI_SITE_URL:-${ENV_SITE_URL:-(see frontdesk.env CULLIS_SITE_URL)}}"
+
+echo ""
+echo -e "${GREEN}${BOLD}Cullis Frontdesk deployed (${MODE}).${RESET}"
+echo ""
+echo -e "  ${BOLD}SPA URL${RESET}          ${GRAY}http://localhost:${HTTP_PORT}${RESET}"
+echo -e "  ${BOLD}Mastio target${RESET}    ${GRAY}${SITE_URL_DISPLAY}${RESET}"
+echo -e "  ${BOLD}Org${RESET}              ${GRAY}${ORG_ID} (${TRUST_DOMAIN})${RESET}"
+echo -e "  ${BOLD}Profile${RESET}          ${GRAY}${CONNECTOR_PROFILE} (data: ${DATA_DIR})${RESET}"
+echo ""
+echo "  Smoke test (dev fake-SSO injects X-Forwarded-User from ?user=):"
+echo "    open http://localhost:${HTTP_PORT}?user=mario"
+echo "    open http://localhost:${HTTP_PORT}?user=anna   # incognito tab"
+echo ""
+echo "  Useful commands:"
+echo "    $COMPOSE --env-file frontdesk.env logs -f connector"
+echo "    $COMPOSE --env-file frontdesk.env ps"
+echo "    $0 --down"
+echo ""

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -182,7 +182,26 @@ fi
 
 # ── Enrollment one-shot ─────────────────────────────────────────────────────
 mkdir -p "$DATA_DIR"
-ENROLLMENT_METADATA="$DATA_DIR/profiles/${CONNECTOR_PROFILE}/identity/metadata.json"
+DATA_DIR_ABS="$(cd "$DATA_DIR" && pwd)"
+ENROLLMENT_METADATA="$DATA_DIR_ABS/profiles/${CONNECTOR_PROFILE}/identity/metadata.json"
+
+# Ensure the bind target is owned by uid 10001 (the cullis user inside
+# the connector image), otherwise the enrollment one-shot below + the
+# connector container at runtime fail to write identity material with
+# ``Permission denied`` on Linux where the host uid is typically 1000.
+# The compose-up path has the same fix via an ``init-permissions``
+# service (PR #524); this handles the enroll-time path that runs first.
+_data_uid="$(stat -c '%u' "$DATA_DIR_ABS" 2>/dev/null || echo 0)"
+if [[ "$_data_uid" != "10001" ]]; then
+    if docker run --rm --user 0:0 \
+            -v "${DATA_DIR_ABS}:/data" \
+            busybox:stable chown -R 10001:10001 /data >/dev/null 2>&1; then
+        ok "connector_data ownership normalized to uid 10001"
+    else
+        warn "Could not chown ${DATA_DIR_ABS} via docker"
+        warn "Run manually if enrollment fails: sudo chown -R 10001:10001 ${DATA_DIR_ABS}"
+    fi
+fi
 
 if [[ -f "$ENROLLMENT_METADATA" ]]; then
     ok "Connector profile '${CONNECTOR_PROFILE}' already enrolled"
@@ -218,10 +237,10 @@ else
         [[ -n "$INVITE_CODE" ]] || die "Invite code is required to enroll"
     fi
 
-    # Resolve to absolute paths so docker volume mounts work regardless of
-    # where the operator invokes the script from.
+    # Resolve to absolute path so docker volume mount works regardless of
+    # where the operator invokes the script from. ``DATA_DIR_ABS`` was
+    # already resolved above for the chown step.
     CA_BUNDLE_ABS="$(cd "$(dirname "$CA_BUNDLE")" && pwd)/$(basename "$CA_BUNDLE")"
-    DATA_DIR_ABS="$(cd "$DATA_DIR" && pwd)"
 
     # Use a bridge network with host-gateway so the URL the Connector
     # uses to reach Mastio at enroll-time matches what it will use at

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -26,20 +26,17 @@
 #      writes identity material to ``./connector_data``; without it the
 #      Ambassador comes up but cannot reach Mastio.
 #
-#      One-shot enrollment (run once before ``docker compose up``):
-#
-#        docker run --rm -it \
-#          -v $(pwd)/connector_data:/home/cullis/.cullis \
-#          ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0-rc1} \
-#          enroll --site https://mastio.acme.local:9443 \
-#                 --code <INVITE_CODE_FROM_MASTIO_ADMIN> \
-#                 --profile frontdesk
-#
 # Usage:
 #
-#   cp frontdesk.env.example frontdesk.env       # then edit required values
-#   docker compose --env-file frontdesk.env up -d
+#   ./deploy.sh                                  # generates frontdesk.env if
+#                                                # missing, runs the one-shot
+#                                                # enrollment, brings up the
+#                                                # stack, waits for health
 #   open http://localhost:8080?user=mario        # demo user switch (dev only)
+#
+#   Run ``docker compose --env-file frontdesk.env up -d`` directly only if
+#   you have already enrolled the Connector and provisioned frontdesk.env
+#   by hand (see ./deploy.sh source for the underlying steps).
 #
 # Production: replace nginx with oauth2-proxy + your IDP. The
 # X-Forwarded-User header MUST come from a trusted proxy; the Connector

--- a/packaging/frontdesk-bundle/generate-frontdesk-env.sh
+++ b/packaging/frontdesk-bundle/generate-frontdesk-env.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Frontdesk — Generate frontdesk.env (no secrets, just wiring)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Frontdesk inherits identity from the Connector profile (cert + key minted
+# by Mastio during enrollment). There are no secrets to generate here —
+# this script only fills in the wiring vars: org slug, trust domain, CA
+# bundle path, image versions.
+#
+# Usage:
+#   ./generate-frontdesk-env.sh              # Interactive
+#   ./generate-frontdesk-env.sh --defaults   # Sensible same-host defaults
+#   ./generate-frontdesk-env.sh --prod       # Needs ORG_ID + TRUST_DOMAIN +
+#                                            # CA_BUNDLE_HOST env vars
+#   ./generate-frontdesk-env.sh --force      # Overwrite existing frontdesk.env
+#
+# Environment variables (used by --prod, optional elsewhere):
+#   CULLIS_FRONTDESK_ORG_ID           — org slug, e.g. ``acme``
+#   CULLIS_FRONTDESK_TRUST_DOMAIN     — SPIFFE TD, e.g. ``acme.prod``
+#   CULLIS_FRONTDESK_CA_BUNDLE_HOST   — host path to Mastio CA chain PEM
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'
+BOLD=$'\033[1m'; GRAY=$'\033[90m'; RESET=$'\033[0m'
+ok()   { echo -e "  ${GREEN}✓${RESET}  $1"; }
+warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
+err()  { echo -e "  ${RED}✗${RESET}  $1"; }
+die()  { err "$1"; exit 1; }
+
+MODE="interactive"
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --defaults) MODE="defaults" ;;
+        --prod)     MODE="prod" ;;
+        --force)    FORCE=1 ;;
+        --help|-h)
+            echo "Usage: $0 [--defaults|--prod] [--force]"
+            exit 0
+            ;;
+        *) die "Unknown argument: $arg (use --help)" ;;
+    esac
+done
+
+OUT="$SCRIPT_DIR/frontdesk.env"
+if [[ -f "$OUT" && "$FORCE" -eq 0 ]]; then
+    if [[ "$MODE" != "interactive" ]]; then
+        ok "Keeping existing frontdesk.env (use --force to overwrite)"
+        exit 0
+    fi
+    warn "frontdesk.env already exists"
+    read -rp "  Overwrite with fresh values? [y/N]: " reply
+    [[ "$reply" =~ ^[Yy] ]] || { ok "Keeping existing frontdesk.env"; exit 0; }
+fi
+
+[[ -f "$SCRIPT_DIR/frontdesk.env.example" ]] || die "frontdesk.env.example not found"
+
+# Default Mastio CA path: the sibling Mastio bundle exports its Org CA to
+# ./certs/org-ca.pem when ./deploy.sh runs (PR #520). If that file is on
+# disk next to us we wire it as the trust anchor automatically; otherwise
+# the operator has to provide a path.
+default_ca_bundle() {
+    local sibling="$SCRIPT_DIR/../mastio-bundle/certs/org-ca.pem"
+    if [[ -f "$sibling" ]]; then
+        # Use absolute path so docker compose substitution works regardless
+        # of where the operator invokes ./deploy.sh from.
+        local abs_dir
+        abs_dir="$(cd "$(dirname "$sibling")" && pwd)"
+        echo "${abs_dir}/$(basename "$sibling")"
+    else
+        echo ""
+    fi
+}
+
+case "$MODE" in
+    prod)
+        [[ -n "${CULLIS_FRONTDESK_ORG_ID:-}" ]]         || die "--prod requires CULLIS_FRONTDESK_ORG_ID env var"
+        [[ -n "${CULLIS_FRONTDESK_TRUST_DOMAIN:-}" ]]   || die "--prod requires CULLIS_FRONTDESK_TRUST_DOMAIN env var"
+        [[ -n "${CULLIS_FRONTDESK_CA_BUNDLE_HOST:-}" ]] || die "--prod requires CULLIS_FRONTDESK_CA_BUNDLE_HOST env var (path to Mastio CA chain PEM)"
+        [[ -f "${CULLIS_FRONTDESK_CA_BUNDLE_HOST}" ]]   || die "CA bundle not found at: ${CULLIS_FRONTDESK_CA_BUNDLE_HOST}"
+        ORG_ID="${CULLIS_FRONTDESK_ORG_ID}"
+        TRUST_DOMAIN="${CULLIS_FRONTDESK_TRUST_DOMAIN}"
+        CA_BUNDLE="${CULLIS_FRONTDESK_CA_BUNDLE_HOST}"
+        ;;
+    defaults)
+        ORG_ID="${CULLIS_FRONTDESK_ORG_ID:-acme}"
+        TRUST_DOMAIN="${CULLIS_FRONTDESK_TRUST_DOMAIN:-${ORG_ID}.test}"
+        CA_BUNDLE="${CULLIS_FRONTDESK_CA_BUNDLE_HOST:-$(default_ca_bundle)}"
+        if [[ -z "$CA_BUNDLE" ]]; then
+            warn "No Mastio CA bundle found at ../mastio-bundle/certs/org-ca.pem"
+            warn "Set CULLIS_FRONTDESK_CA_BUNDLE_HOST in frontdesk.env to a"
+            warn "valid path before running ./deploy.sh, otherwise compose"
+            warn "will fail at ``up`` time with a clear error."
+            CA_BUNDLE="./MUST_SET_TO_MASTIO_CA_BUNDLE_PATH"
+        fi
+        ;;
+    interactive)
+        echo ""
+        _default_ca="$(default_ca_bundle)"
+        ca_prompt_default="${_default_ca:-./mastio-org-ca.pem}"
+
+        read -rp "  Org ID [acme]: " ORG_ID
+        ORG_ID="${ORG_ID:-acme}"
+
+        read -rp "  SPIFFE trust domain [${ORG_ID}.test]: " TRUST_DOMAIN
+        TRUST_DOMAIN="${TRUST_DOMAIN:-${ORG_ID}.test}"
+
+        read -rp "  Mastio CA bundle path [${ca_prompt_default}]: " CA_BUNDLE
+        CA_BUNDLE="${CA_BUNDLE:-${ca_prompt_default}}"
+        if [[ ! -f "$CA_BUNDLE" ]]; then
+            warn "CA bundle path '$CA_BUNDLE' does not exist on disk."
+            warn "Run ../mastio-bundle/deploy.sh first to generate it, or"
+            warn "edit frontdesk.env later before ./deploy.sh."
+        fi
+        ;;
+esac
+
+cp "$SCRIPT_DIR/frontdesk.env.example" "$OUT"
+sed -i "s|^CULLIS_FRONTDESK_ORG_ID=.*|CULLIS_FRONTDESK_ORG_ID=${ORG_ID}|"               "$OUT"
+sed -i "s|^CULLIS_FRONTDESK_TRUST_DOMAIN=.*|CULLIS_FRONTDESK_TRUST_DOMAIN=${TRUST_DOMAIN}|" "$OUT"
+sed -i "s|^CULLIS_FRONTDESK_CA_BUNDLE_HOST=.*|CULLIS_FRONTDESK_CA_BUNDLE_HOST=${CA_BUNDLE}|" "$OUT"
+
+ok "Wrote ${OUT}"
+echo ""
+echo -e "  ${BOLD}CULLIS_FRONTDESK_ORG_ID${RESET}          ${GRAY}${ORG_ID}${RESET}"
+echo -e "  ${BOLD}CULLIS_FRONTDESK_TRUST_DOMAIN${RESET}    ${GRAY}${TRUST_DOMAIN}${RESET}"
+echo -e "  ${BOLD}CULLIS_FRONTDESK_CA_BUNDLE_HOST${RESET}  ${GRAY}${CA_BUNDLE}${RESET}"
+echo ""


### PR DESCRIPTION
## Summary

- New `packaging/frontdesk-bundle/deploy.sh` (304 lines): generates `frontdesk.env`, runs the one-shot Connector enrollment, brings the stack up, waits for health, prints summary.
- New `packaging/frontdesk-bundle/generate-frontdesk-env.sh` (133 lines): mirrors the Mastio bundle's `generate-proxy-env.sh` pattern with `--defaults / --interactive / --prod` modes. Auto-detects `CULLIS_FRONTDESK_CA_BUNDLE_HOST` from `../mastio-bundle/certs/org-ca.pem` if the sibling Mastio bundle is on disk.
- README rewritten so `./deploy.sh` is the documented front door; manual `docker run` + `docker compose` steps are referenced but no longer the primary path.
- `docker-compose.yml` header comment updated to point at `./deploy.sh`.

## Why

The Frontdesk bundle was a "raw materials" drop until now — the customer-VM dogfood on 2026-05-08 (gaps C, E, G in `project_session_2026_05_08_dogfood_vm_install_path_broken.md`) required 7 manual SSH workarounds to reach a working SPA, every single one of which corresponds to "the bundle should do this for me".

This PR makes the Frontdesk bundle's UX feature-parity with the Mastio bundle: a single `./deploy.sh` reaches a working SPA on a fresh host with no manual file editing.

## Dependencies

- Soft-depends on PR #520 (Mastio exports Org CA to `./certs/org-ca.pem`): without it, `generate-frontdesk-env.sh --defaults` falls back to a placeholder path and the operator gets a clear "CA bundle not found" error explaining what to do.
- Soft-depends on PR #521 (Mastio default URL `host.docker.internal:9443`): the Frontdesk default URL matches; if PR #521 lands first the same-host topology works without proxy.env edits.

Neither is a hard dependency — this PR works standalone with placeholder fallbacks.

## Test plan

- [ ] `./generate-frontdesk-env.sh --help` prints usage
- [ ] `./generate-frontdesk-env.sh --defaults` in a clean dir writes a frontdesk.env with `acme` org and `acme.test` trust domain
- [ ] `./generate-frontdesk-env.sh --prod` without env vars dies with a clear error
- [ ] `./deploy.sh --help` prints usage
- [ ] `./deploy.sh` end-to-end (with a Mastio running and an invite code from the dashboard) reaches `http://localhost:8080` with the SPA loaded
- [ ] Re-running `./deploy.sh` after success is idempotent (skips enrollment, recreates containers if needed)
- [ ] `./deploy.sh --skip-enroll` works when `connector_data` is pre-populated
- [ ] `./deploy.sh --down` stops the bundle cleanly

## Acceptance criterion (sprint goal)

> `rm cullis-customer.qcow2 && ./run.sh`, in VM: `curl mastio-bundle.tar.gz | tar xz && ./deploy.sh --defaults`, then `curl frontdesk-bundle.tar.gz | tar xz && ./deploy.sh`. SPA loads with PRINCIPAL resolved + SEND active in <10 min wall-clock, zero SSH from the host.

This PR is the third leg of three needed to satisfy that criterion.

Refs: project_gap_frontdesk_bundle_no_deploy_script.md, project_session_2026_05_08_dogfood_vm_install_path_broken.md