### PR TITLE
feat(frontdesk-bundle): add init-permissions service + mastio.local extra_host

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -48,6 +48,25 @@
 
 services:
 
+  # ── Init: ensure connector_data ownership matches the cullis user ──
+  # The cullis-connector image runs as user ``cullis`` (uid 10001).
+  # Docker's bind mount preserves the host directory's owner, which on
+  # Linux is typically the operator's uid (1000). Without this init
+  # step the connector container fails the first write to
+  # /home/cullis/.cullis with ``Permission denied``. Run a tiny busybox
+  # as root to chown the bind target before the connector starts. The
+  # service exits 0 on success and the connector's depends_on gates on
+  # service_completed_successfully.
+  init-permissions:
+    image: busybox:stable
+    user: "0:0"
+    command: ["sh", "-c", "chown -R 10001:10001 /data && echo ok"]
+    volumes:
+      - ${CONNECTOR_DATA_DIR:-./connector_data}:/data
+    restart: "no"
+    networks:
+      - frontdesk_net
+
   connector:
     image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0-rc1}
     # ``dashboard`` mounts the Ambassador router via web.py lifespan when
@@ -97,11 +116,17 @@ services:
       # corporate root if Mastio TLS is rooted there).
       - ${CULLIS_FRONTDESK_CA_BUNDLE_HOST:?must point to your Mastio CA chain PEM}:/etc/cullis/ca-bundle.pem:ro
     # In dev with the Mastio published on the docker host (rather than a
-    # routable hostname), the Connector reaches it via host.docker.internal.
-    # Production deployments route over a real DNS name; this entry is a
-    # no-op there.
+    # routable hostname), the Connector reaches it via either alias.
+    # ``host.docker.internal`` matches the Mastio bundle's default Public
+    # URL (PR #521); ``mastio.local`` is the legacy alias still recorded
+    # in the Mastio's NGINX SAN. Production deployments route over a real
+    # DNS name; both entries are no-ops there.
     extra_hosts:
       - "host.docker.internal:host-gateway"
+      - "mastio.local:host-gateway"
+    depends_on:
+      init-permissions:
+        condition: service_completed_successfully
     networks:
       - frontdesk_net
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- New `init-permissions` busybox service runs as root, `chown -R 10001:10001 /data` on the `connector_data` bind mount, exits 0. Connector `depends_on` it with `service_completed_successfully` so the cullis user (uid 10001) inside the container can always write its identity material.
- `mastio.local:host-gateway` joins `host.docker.internal:host-gateway` in the connector's `extra_hosts`. Both names appear in the Mastio bundle's default nginx SAN (after PR #521), so an operator who picked either as the Mastio public URL gets correct resolution.

## Why

Two manual workarounds that customers had to apply via SSH during the 2026-05-08 customer-VM dogfood:

1. `sudo chown -R 10001:10001 connector_data` (workaround C in `project_session_2026_05_08_dogfood_vm_install_path_broken.md`) — without it, on Linux where the host uid is typically 1000, the first write to `/home/cullis/.cullis` from inside the container fails with `Permission denied`. The Connector comes up with a broken Ambassador, no clear error chain.
2. `docker-compose.override.yml` adding `mastio.local:host-gateway` (workaround E) — without it, `mastio.local` does not resolve from the connector's bridge network, breaking deployments where the Mastio operator picked that hostname.

Both are now invisible to the customer.

## Test plan

- [ ] `docker compose -f packaging/frontdesk-bundle/docker-compose.yml config` validates (no schema errors)
- [ ] On a fresh Linux host with `mkdir connector_data` (host uid != 10001):
  - [ ] `docker compose --env-file frontdesk.env up -d` starts cleanly
  - [ ] `docker compose logs init-permissions` shows `ok`
  - [ ] `docker compose exec connector ls -la /home/cullis/.cullis` shows uid 10001 ownership
- [ ] Connector resolves `mastio.local` to the host gateway: `docker compose exec connector getent hosts mastio.local` returns the host gateway IP
- [ ] Re-run `docker compose up -d` is idempotent (init-permissions runs again, chown is a no-op)

## Companion

The `deploy.sh` enrollment one-shot in PR #523 also writes to `connector_data/` and needs the same chown protection at enroll time (before this init container can run). Will be addressed by a follow-up commit on that PR's branch — keeping this one focused on compose-side ergonomics.

Refs: project_session_2026_05_08_dogfood_vm_install_path_broken.md, project_gap_frontdesk_bundle_no_deploy_script.md