### PR TITLE
docs: surface the bundle one-liner install path on README + cullis.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,32 @@ them, no agent re-enrollment.
 
 ---
 
-## Quickstart
+## Quickstart — single host (bundles)
+
+For a single-host evaluation: a Mastio + multi-user Frontdesk chat in two
+commands, no repo clone needed. Both bundles pull the published images
+from `ghcr.io` and configure themselves with sensible defaults.
+
+**Requirements**: Docker Engine with Compose v2, ~2 GB RAM.
+
+```bash
+# 1. Mastio (org gateway + first-boot Org CA + dashboard on :9443)
+curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-mastio-bundle.tar.gz | tar xz
+cd cullis-mastio-bundle && ./deploy.sh
+
+# 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
+cd ..
+curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-frontdesk-bundle.tar.gz | tar xz
+cd cullis-frontdesk-bundle && ./deploy.sh
+```
+
+The Mastio dashboard is at `https://localhost:9443/proxy/login` (self-signed
+TLS, accept the warning); the Frontdesk SPA is at `http://localhost:8080`.
+See [`packaging/mastio-bundle/README.md`](packaging/mastio-bundle/README.md)
+and [`packaging/frontdesk-bundle/README.md`](packaging/frontdesk-bundle/README.md)
+for production overrides (custom hostname, oauth2-proxy + IDP, image pinning).
+
+## Quickstart — full enterprise stack (sandbox)
 
 Boot the full enterprise stack — Court + 2 Mastios + 3 agents + 2 MCP servers
 in 2 organizations, wired with SPIRE, Keycloak, Vault and Postgres — then

--- a/site/src/pages/deployment.astro
+++ b/site/src/pages/deployment.astro
@@ -287,6 +287,30 @@ import Layout from '../layouts/Layout.astro';
       <div class="install-grid">
         <article class="install-card reveal" data-delay="1">
           <div class="install-head">
+            <div class="install-label">For one host, one curl</div>
+            <h3>Bundle install</h3>
+          </div>
+          <pre><code>curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-mastio-bundle.tar.gz | tar xz
+cd cullis-mastio-bundle &amp;&amp; ./deploy.sh
+# then, in a sibling dir:
+curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-frontdesk-bundle.tar.gz | tar xz
+cd cullis-frontdesk-bundle &amp;&amp; ./deploy.sh</code></pre>
+          <p>
+            Two prebuilt bundles, no repo clone. The Mastio bundle brings up
+            the org gateway with a self-signed Org CA and the admin
+            dashboard; the Frontdesk bundle brings up the multi-user chat
+            container and enrolls itself against the Mastio. Pulls images
+            from ghcr.io, sensible defaults, opt-in production overrides.
+          </p>
+          <ul class="install-specs">
+            <li><span class="k">Time</span><span>~2 minutes first boot</span></li>
+            <li><span class="k">Requires</span><span>Docker + Compose v2 · ~2 GB RAM</span></li>
+            <li><span class="k">Best for</span><span>single-host evaluation or pilot</span></li>
+          </ul>
+        </article>
+
+        <article class="install-card reveal" data-delay="2">
+          <div class="install-head">
             <div class="install-label">For evaluation</div>
             <h3>Sandbox demo</h3>
           </div>
@@ -306,9 +330,9 @@ cd cullis
           </ul>
         </article>
 
-        <article class="install-card featured reveal" data-delay="2">
+        <article class="install-card featured reveal" data-delay="3">
           <div class="install-head">
-            <div class="install-label">For a single host</div>
+            <div class="install-label">For a single host with TLS</div>
             <h3>Self-host · Compose</h3>
           </div>
           <pre><code>git clone https://github.com/cullis-security/cullis
@@ -329,7 +353,7 @@ cd cullis
           </ul>
         </article>
 
-        <article class="install-card reveal" data-delay="3">
+        <article class="install-card reveal" data-delay="4">
           <div class="install-head">
             <div class="install-label">For Kubernetes</div>
             <h3>Helm chart</h3>


### PR DESCRIPTION
## Summary

- `README.md`: new "Quickstart — single host (bundles)" section above the existing sandbox quickstart. Two curl one-liners pointing at the stable-name release URLs (`cullis-{mastio,frontdesk}-bundle.tar.gz`), each followed by `cd ... && ./deploy.sh`.
- `site/src/pages/deployment.astro`: new install card "Bundle install — for one host, one curl" added as the first option in the install grid (before Sandbox demo, Self-host Compose, Helm).
- Existing "Self-host · Compose" card label tightened to "For a single host with TLS" to disambiguate from the bundle path that targets the same audience but with a different TLS story.

## Why

A founder doing a fresh customer-style install on 2026-05-08 could not find the Mastio bundle tarball at all without us pointing them at the ghcr.io URL — even though `mastio-v0.3.1` had been live for days. The site lead with `git clone https://github.com/...`, the README led with `./sandbox/demo.sh full`, neither mentioned that a 2 MB tarball with a single `./deploy.sh` was the easier path. (Documented as `project_gap_bundle_discoverability.md`.)

## Stable-name URLs

The release workflows publish two filenames per release: a versioned one (`cullis-mastio-bundle-X.Y.Z.tar.gz`) and a stable-name alias (`cullis-mastio-bundle.tar.gz`). The docs link the stable-name path via `/releases/latest/download/...` so the same one-liner keeps working across releases without a version bump in copy.

## Dependencies

Soft-depends on PR #525 (`release-frontdesk-bundle.yml`) so the Frontdesk URL eventually points at a real artifact. Until that workflow runs once, the Frontdesk one-liner 404s — but the Mastio one (already published since v0.3.1) works today.

## Test plan

- [ ] CI: site build still passes (Astro + Tailwind, the site is published from the repo)
- [ ] Visual regression on `/deployment`: 4 cards render in the install grid, first is "Bundle install"
- [ ] After PR #525 lands and a `frontdesk-bundle-v0.1.0` tag fires the workflow: `curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-frontdesk-bundle.tar.gz` returns the tarball

Refs: project_gap_bundle_discoverability.md, project_session_2026_05_08_dogfood_vm_install_path_broken.md