### PR TITLE
fix(dashboard): session cookie samesite=strict (audit M-IO-1)

### DIFF
--- a/app/dashboard/session.py
+++ b/app/dashboard/session.py
@@ -241,7 +241,13 @@ def set_session(response: Response, role: str = "admin", org_id: str | None = No
         _COOKIE_NAME, signed,
         max_age=_COOKIE_MAX_AGE,
         httponly=True,
-        samesite="lax",
+        # Audit M-IO-1 — strict denies the cookie on cross-site requests
+        # entirely, blocking CSRF + login-flow leaks via top-level
+        # navigations from third-party sites. Safe for the dashboard
+        # session cookie because the dashboard never receives links from
+        # external origins (the OIDC redirect flow uses a separate
+        # _OIDC_STATE_COOKIE that must stay ``lax`` for the IdP round-trip).
+        samesite="strict",
         secure=is_https,
     )
     return csrf_token
@@ -285,7 +291,7 @@ def add_reauth_scope(
         _COOKIE_NAME, signed,
         max_age=_COOKIE_MAX_AGE,
         httponly=True,
-        samesite="lax",
+        samesite="strict",  # see audit M-IO-1 note above
         secure=is_https,
     )
 
@@ -294,7 +300,7 @@ def clear_session(response: Response) -> None:
     """Delete the session cookie."""
     from app.config import get_settings
     is_https = "https" in get_settings().broker_public_url.lower() if get_settings().broker_public_url else False
-    response.delete_cookie(_COOKIE_NAME, samesite="lax", secure=is_https)
+    response.delete_cookie(_COOKIE_NAME, samesite="strict", secure=is_https)
 
 
 def require_login(request: Request) -> DashboardSession | RedirectResponse:

--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -228,7 +228,13 @@ def set_session(
         _COOKIE_NAME, signed,
         max_age=_COOKIE_MAX_AGE,
         httponly=True,
-        samesite="lax",
+        # Audit M-IO-1 — strict denies the cookie on cross-site requests
+        # entirely, blocking CSRF + login-flow leaks via top-level
+        # navigations from third-party sites. Safe for the proxy
+        # session cookie because the proxy never receives links from
+        # external origins (the OIDC redirect flow uses a separate
+        # _OIDC_STATE_COOKIE that must stay ``lax`` for the IdP round-trip).
+        samesite="strict",
         secure=_use_secure,
     )
     return csrf_token
@@ -237,7 +243,7 @@ def set_session(
 def clear_session(response: Response) -> None:
     """Delete the session cookie."""
     response.delete_cookie(
-        _COOKIE_NAME, samesite="lax", secure=_should_set_secure_cookie(),
+        _COOKIE_NAME, samesite="strict", secure=_should_set_secure_cookie(),
     )
 
 


### PR DESCRIPTION
## Summary

- Dashboard session cookies (``cullis_session``) flipped from ``samesite="lax"`` to ``"strict"``. Strict denies the cookie on cross-site requests entirely, blocking CSRF + login-flow leaks via top-level navigations from third-party sites.
- Safe because the dashboards never receive links from external origins. The OIDC redirect flow uses a *separate* ``_OIDC_STATE_COOKIE`` that **must** stay ``lax`` (the IdP callback is by definition cross-site), and that one is left untouched.

## Files

- ``app/dashboard/session.py`` — Court dashboard cookies (3 sites: issue, refresh, clear)
- ``mcp_proxy/dashboard/session.py`` — Mastio proxy dashboard cookies (2 sites: issue, clear)

OIDC state cookies stay ``lax`` in both files (5 unchanged sites with that value).

## Test plan

- [x] Connector + dashboard + OIDC + cookie + csrf test suites: 423 pass, 3 pre-existing fail unrelated (test_e2e + postgres flake)
- [x] Full suite: 2794 pass; failures are all pre-existing (postgres bindings + pystray headless + an xdist scheduling flake on test_require_mastio_mtls_admin that passes when isolated)
- [ ] Sandbox smoke deferred — host's qemu customer-vm autostarts and binds 9443, can't free it for a clean ``./sandbox/demo.sh full`` run on this machine. Manual dashboard login + redirect verification recommended after merge.
- [ ] CI green