### PR TITLE
fix(broker): preserve signer's wire timestamp on store_message (audit W1.6)

### DIFF
--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -624,8 +624,17 @@ async def send_message(
         # (false-positive is safe — it just blocks a replayed nonce).
         session.cache_nonce(envelope.nonce)
 
-        seq = session.store_message(current_agent.agent_id, envelope.payload, envelope.nonce,
-                                    envelope.signature, client_seq=envelope.client_seq)
+        # Audit W1.6 — preserve the signer's wire timestamp instead of
+        # overwriting with broker-side now(). MessageEnvelope.timestamp
+        # is unix seconds UTC; convert to a tz-aware datetime for the
+        # StoredMessage row (consumers like the SDK session-poller infer
+        # ordering and skew from this value).
+        signer_ts = datetime.fromtimestamp(envelope.timestamp, tz=timezone.utc)
+        seq = session.store_message(
+            current_agent.agent_id, envelope.payload, envelope.nonce,
+            envelope.signature, client_seq=envelope.client_seq,
+            timestamp=signer_ts,
+        )
         # M1.2 — record activity to defer idle timeout
         session.touch()
 

--- a/app/broker/session.py
+++ b/app/broker/session.py
@@ -136,17 +136,31 @@ class Session:
         self.used_nonces.add(nonce)
 
     def store_message(self, sender_agent_id: str, payload: dict, nonce: str,
-                      signature: str | None = None, client_seq: int | None = None) -> int:
-        """Store the message in the session inbox and return the assigned seq."""
+                      signature: str | None = None, client_seq: int | None = None,
+                      timestamp: datetime | None = None) -> int:
+        """Store the message in the session inbox and return the assigned seq.
+
+        ``timestamp`` is the *signer's* wire timestamp (seconds since epoch
+        is converted to UTC datetime by the caller). When omitted, the
+        StoredMessage default_factory falls back to ``datetime.now(utc)``,
+        which is broker-side and discards the signer's claim — that mode
+        exists only for legacy callers that don't carry a signed timestamp
+        (transaction tokens, internal injections). Audit W1.6: the broker
+        used to silently overwrite the signed timestamp with its local
+        now() for every send, breaking SDK session-poll consumers that
+        rely on the signer's clock for ordering inferences."""
         seq = self._next_seq
-        self._messages.append(StoredMessage(
+        msg_kwargs = dict(
             seq=seq,
             sender_agent_id=sender_agent_id,
             payload=payload,
             nonce=nonce,
             signature=signature,
             client_seq=client_seq,
-        ))
+        )
+        if timestamp is not None:
+            msg_kwargs["timestamp"] = timestamp
+        self._messages.append(StoredMessage(**msg_kwargs))
         self._next_seq += 1
         return seq
 

--- a/tests/test_broker_signer_timestamp_preservation.py
+++ b/tests/test_broker_signer_timestamp_preservation.py
@@ -1,0 +1,76 @@
+"""Audit W1.6 — broker preserves the signer's wire timestamp on
+``store_message`` instead of silently overwriting with broker-side now().
+
+The pre-fix behaviour discarded ``MessageEnvelope.timestamp`` and stamped
+the StoredMessage with whatever the broker clock said at insert time.
+SDK consumers (session-poll, ordering-by-timestamp) need the signer's
+claim, not the broker's local clock.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+
+from app.broker.session import Session, SessionStatus
+
+
+def _make_session() -> Session:
+    return Session(
+        session_id="sess-w16",
+        initiator_agent_id="orga::a",
+        initiator_org_id="orga",
+        target_agent_id="orgb::b",
+        target_org_id="orgb",
+        requested_capabilities=[],
+        status=SessionStatus.active,
+    )
+
+
+def test_store_message_preserves_caller_timestamp():
+    sess = _make_session()
+    signed_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    seq = sess.store_message(
+        sender_agent_id="orga::a",
+        payload={"hello": "world"},
+        nonce="nonce-1",
+        signature="sig-1",
+        timestamp=signed_at,
+    )
+    stored = sess._messages[seq]
+    assert stored.timestamp == signed_at, (
+        "broker must store the signer's wire timestamp verbatim"
+    )
+
+
+def test_store_message_falls_back_to_now_when_timestamp_omitted():
+    """Legacy callers (transaction tokens, internal injections) that
+    don't carry a signed timestamp keep the broker-now behaviour."""
+    sess = _make_session()
+    before = datetime.now(timezone.utc)
+    seq = sess.store_message(
+        sender_agent_id="orga::a",
+        payload={"x": 1},
+        nonce="nonce-fallback",
+        signature="sig-fallback",
+    )
+    after = datetime.now(timezone.utc)
+    stored = sess._messages[seq]
+    # Bracketed by the call window — proves default_factory ran.
+    assert before - timedelta(seconds=1) <= stored.timestamp <= after + timedelta(seconds=1)
+
+
+def test_store_message_timestamp_independent_per_message():
+    """Two consecutive sends with different signer clocks must not
+    collide on the broker's now()."""
+    sess = _make_session()
+    ts1 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    ts2 = datetime(2026, 1, 1, 12, 0, 5, tzinfo=timezone.utc)
+    seq1 = sess.store_message(
+        sender_agent_id="orga::a", payload={}, nonce="n1",
+        signature="s1", timestamp=ts1,
+    )
+    seq2 = sess.store_message(
+        sender_agent_id="orga::a", payload={}, nonce="n2",
+        signature="s2", timestamp=ts2,
+    )
+    assert sess._messages[seq1].timestamp == ts1
+    assert sess._messages[seq2].timestamp == ts2


### PR DESCRIPTION
## Summary

- The broker overwrote ``MessageEnvelope.timestamp`` (the signer's unix-seconds claim) with ``datetime.now()`` at insert time. SDK consumers that infer ordering or skew from the stored ``timestamp`` (notably session-poll in ``cullis_sdk``) saw the broker's local clock instead of the signer's
- Pass the signer's wire timestamp through ``store_message``; fall back to ``now()`` only when no signed timestamp is supplied (transaction tokens, internal injections)
- ``StoredMessage.timestamp`` default_factory remains the safe fallback for those legacy paths — zero behavior change for non-signed inserts

## Why

Audit W1.6 — without this fix the SDK session-poll path can't reason about cross-org clock skew or end-to-end latency, because every stored message is restamped with the broker's view at insert time. The broker shouldn't be erasing claims it has already verified upstream.

## Test plan

- [x] 3 new unit tests on `Session.store_message` — preservation path, fallback path, per-message independence
- [x] Broker + session + audit + timestamp selection: 263 pass
- [x] Pre-existing fails unchanged: `test_e2e::test_step5/6` (e2e flake on main) + `test_postgres_integration` (postgres bindings KeyError known on main)
- [ ] CI green