### PR TITLE
fix(dashboard): copy buttons leak HTML when org_id is rendered

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -177,6 +177,29 @@ function copyToClipboard(text) {
         showToast('Copied to clipboard', 'success');
     });
 }
+
+// Delegated handler for inline copy buttons. Buttons opt in via
+// ``data-copy="<value>"``; the original button text is restored after
+// 1500ms. This replaces the per-button inline ``onclick="navigator.
+// clipboard.writeText({{ x|tojson }}); …"`` pattern, which was unsafe
+// inside double-quoted HTML attributes — Jinja's ``|tojson`` emits
+// quoted JSON, the inner ``"`` terminated the attribute and the rest
+// of the JS leaked into the DOM as visible text.
+document.addEventListener('click', function(ev) {
+    var btn = ev.target.closest('[data-copy]');
+    if (!btn) return;
+    var text = btn.getAttribute('data-copy');
+    if (text === null) return;
+    navigator.clipboard.writeText(text).then(function() {
+        if (!btn.dataset.copyOriginal) {
+            btn.dataset.copyOriginal = btn.textContent.trim();
+        }
+        btn.textContent = btn.dataset.copyDone || 'Copied ✓';
+        setTimeout(function() {
+            btn.textContent = btn.dataset.copyOriginal;
+        }, 1500);
+    });
+});
 </script>
 </body>
 </html>

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -178,6 +178,7 @@ function copyToClipboard(text) {
     });
 }
 
+{% raw %}
 // Delegated handler for inline copy buttons. Buttons opt in via
 // ``data-copy="<value>"``; the original button text is restored after
 // 1500ms. This replaces the per-button inline ``onclick="navigator.
@@ -185,6 +186,7 @@ function copyToClipboard(text) {
 // inside double-quoted HTML attributes — Jinja's ``|tojson`` emits
 // quoted JSON, the inner ``"`` terminated the attribute and the rest
 // of the JS leaked into the DOM as visible text.
+{% endraw %}
 document.addEventListener('click', function(ev) {
     var btn = ev.target.closest('[data-copy]');
     if (!btn) return;

--- a/mcp_proxy/dashboard/templates/downloads.html
+++ b/mcp_proxy/dashboard/templates/downloads.html
@@ -56,7 +56,8 @@
                         <code class="text-sm text-accent-400" style="font-family: 'JetBrains Mono', monospace;">{{ proxy_url }}</code>
                     </div>
                     <button type="button"
-                            onclick="navigator.clipboard.writeText({{ proxy_url|tojson }}).then(function(){var b=event.target;var o=b.textContent;b.textContent='Copied';setTimeout(function(){b.textContent=o;},1600);})"
+                            data-copy="{{ proxy_url|e }}"
+                            data-copy-done="Copied"
                             class="px-3 py-1.5 text-[11px] uppercase tracking-wider font-semibold border border-gray-700 text-gray-300 rounded hover:bg-gray-800/60 hover:border-accent-400 hover:text-accent-400 transition"
                             style="font-family: 'Chakra Petch', sans-serif;">
                         Copy

--- a/mcp_proxy/dashboard/templates/link_broker.html
+++ b/mcp_proxy/dashboard/templates/link_broker.html
@@ -16,7 +16,7 @@
         <div class="flex items-center gap-3">
             <code class="text-sm text-white break-all flex-1" style="font-family: 'JetBrains Mono', monospace;">{{ org_id }}</code>
             <button type="button"
-                    onclick="navigator.clipboard.writeText({{ org_id|tojson }}); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
+                    data-copy="{{ org_id|e }}"
                     class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
                 Copy
             </button>

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -98,7 +98,7 @@
             <div class="flex items-center justify-between gap-3 mb-2">
                 <p class="text-[10px] text-gray-500 uppercase tracking-[0.2em]">Org ID (share with Court admin)</p>
                 <button type="button"
-                        onclick="navigator.clipboard.writeText({{ org_id|tojson }}); this.innerText='Copied ✓'; setTimeout(()=>this.innerText='Copy', 1500);"
+                        data-copy="{{ org_id|e }}"
                         class="px-2 py-1 text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30 rounded hover:bg-accent-500/20">
                     Copy
                 </button>


### PR DESCRIPTION
## Summary

- Replace 3 inline `onclick="navigator.clipboard.writeText({{ x|tojson }}); …"` handlers (overview.html, downloads.html, link_broker.html) with a single delegated `click` listener in `base.html` that targets `[data-copy]` buttons.
- Each template now uses `data-copy="{{ x|e }}"` (HTML-escape, attribute-safe) and optional `data-copy-done` for the post-copy label.

## Why

Jinja's `|tojson` filter emits JSON-encoded values *including their wrapping double quotes*, e.g. `"75d6ee859acb814b"`. Embedded in a double-quoted HTML attribute that's `onclick="navigator.clipboard.writeText("75d6ee859acb814b"); …"` — the second `"` terminates the attribute, the rest of the JS leaks into the DOM as visible text. Confirmed visually during the 2026-05-08 customer-VM dogfood: the Overview card showed the JS fragment + Tailwind class string rendered next to the org_id field instead of a clean Copy button.

Documented as `project_bug_mastio_dashboard_overview_html_leak.md`. Wave 2 PR #1.

## Test plan

- [ ] CI green
- [ ] Manual: standalone Mastio (auto-derived hex org_id) → `/proxy/overview` shows clean Copy button, no leaked text
- [ ] Click Copy → button flashes "Copied ✓" → reverts to "Copy" after 1500ms; clipboard contains the org_id
- [ ] Same on `/proxy/setup` link-broker card and `/proxy/downloads` proxy URL card
- [ ] Long values with HTML-meta chars (e.g. a proxy_url like `https://mastio.acme.com/path?q=1&x=2`) round-trip correctly via the `|e` filter

## Knock-on benefit

Future Wave 2 dashboard work (Users section, Enrollments invite modal) can reuse `[data-copy]` for any new Copy affordance with one HTML attribute, no per-button JS.

Refs: project_bug_mastio_dashboard_overview_html_leak.md, project_wave2_gaps_2026_05_08.md