### PR TITLE
fix(frontdesk-bundle): accept --interactive flag + auto-detect cullis-mastio-bundle path

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -12,9 +12,9 @@ Deploys Cullis Chat as a corporate web app, identity-aware via SSO. One containe
 
 ## Prerequisites
 
-1. **A reachable Mastio.** The Connector enrolls against it and forwards requests to its proxy + audit chain. Stand one up with `packaging/mastio-bundle/` if you do not already have one (the sibling bundle exports its CA to `../mastio-bundle/certs/org-ca.pem`, which `./deploy.sh` here picks up automatically).
+1. **A reachable Mastio.** The Connector enrolls against it and forwards requests to its proxy + audit chain. Stand one up with `packaging/mastio-bundle/` if you do not already have one. The sibling bundle exports its CA to `../cullis-mastio-bundle/certs/org-ca.pem` when extracted from the release tarball, or `../mastio-bundle/certs/org-ca.pem` when running out of a repo checkout — `./deploy.sh` here picks up either automatically.
 2. **An invite code** issued by your Mastio admin (Mastio dashboard → Enrollments → Create invite, target name = `frontdesk`).
-3. **A Mastio CA bundle PEM** on the host machine. Auto-detected when the sibling Mastio bundle is at `../mastio-bundle/`; otherwise set `CULLIS_FRONTDESK_CA_BUNDLE_HOST` in `frontdesk.env`.
+3. **A Mastio CA bundle PEM** on the host machine. Auto-detected at `../cullis-mastio-bundle/certs/` (release tarball) or `../mastio-bundle/certs/` (repo); otherwise set `CULLIS_FRONTDESK_CA_BUNDLE_HOST` in `frontdesk.env`.
 4. **Docker Compose v2.20+**. The bundle pulls all three images from `ghcr.io`; no repo checkout or `docker build` required.
 
 ## Quickstart (deploy.sh)

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -168,7 +168,9 @@ if [[ -z "$CA_BUNDLE" || ! -f "$CA_BUNDLE" ]]; then
     err "Mastio CA bundle not found at: ${CA_BUNDLE:-<unset>}"
     err "Edit frontdesk.env: set CULLIS_FRONTDESK_CA_BUNDLE_HOST to the path"
     err "of your Mastio's Org CA. The sibling Mastio bundle exports it to"
-    err "../mastio-bundle/certs/org-ca.pem when ./deploy.sh runs there."
+    err "../cullis-mastio-bundle/certs/org-ca.pem (release tarball) or"
+    err "../mastio-bundle/certs/org-ca.pem (repo layout) when its"
+    err "./deploy.sh runs."
     exit 1
 fi
 ok "CA bundle: $CA_BUNDLE"

--- a/packaging/frontdesk-bundle/generate-frontdesk-env.sh
+++ b/packaging/frontdesk-bundle/generate-frontdesk-env.sh
@@ -36,11 +36,15 @@ MODE="interactive"
 FORCE=0
 for arg in "$@"; do
     case "$arg" in
-        --defaults) MODE="defaults" ;;
-        --prod)     MODE="prod" ;;
-        --force)    FORCE=1 ;;
+        --defaults)    MODE="defaults" ;;
+        --prod)        MODE="prod" ;;
+        # ``--interactive`` is the implicit default — accept it as an
+        # explicit alias so operators who type it (or scripts that
+        # always pass an explicit mode) don't get a die.
+        --interactive) MODE="interactive" ;;
+        --force)       FORCE=1 ;;
         --help|-h)
-            echo "Usage: $0 [--defaults|--prod] [--force]"
+            echo "Usage: $0 [--defaults|--interactive|--prod] [--force]"
             exit 0
             ;;
         *) die "Unknown argument: $arg (use --help)" ;;
@@ -61,20 +65,28 @@ fi
 [[ -f "$SCRIPT_DIR/frontdesk.env.example" ]] || die "frontdesk.env.example not found"
 
 # Default Mastio CA path: the sibling Mastio bundle exports its Org CA to
-# ./certs/org-ca.pem when ./deploy.sh runs (PR #520). If that file is on
-# disk next to us we wire it as the trust anchor automatically; otherwise
-# the operator has to provide a path.
+# ./certs/org-ca.pem when ./deploy.sh runs (PR #520). The release tarball
+# extracts as ``cullis-mastio-bundle/`` (release-mastio.yml) but the repo
+# layout is ``packaging/mastio-bundle/``; check both so this works whether
+# the operator extracted the tarball next to ours or is running out of a
+# repo checkout.
 default_ca_bundle() {
-    local sibling="$SCRIPT_DIR/../mastio-bundle/certs/org-ca.pem"
-    if [[ -f "$sibling" ]]; then
-        # Use absolute path so docker compose substitution works regardless
-        # of where the operator invokes ./deploy.sh from.
-        local abs_dir
-        abs_dir="$(cd "$(dirname "$sibling")" && pwd)"
-        echo "${abs_dir}/$(basename "$sibling")"
-    else
-        echo ""
-    fi
+    local candidates=(
+        "$SCRIPT_DIR/../cullis-mastio-bundle/certs/org-ca.pem"
+        "$SCRIPT_DIR/../mastio-bundle/certs/org-ca.pem"
+    )
+    local sibling
+    for sibling in "${candidates[@]}"; do
+        if [[ -f "$sibling" ]]; then
+            # Use absolute path so docker compose substitution works
+            # regardless of where the operator invokes ./deploy.sh from.
+            local abs_dir
+            abs_dir="$(cd "$(dirname "$sibling")" && pwd)"
+            echo "${abs_dir}/$(basename "$sibling")"
+            return
+        fi
+    done
+    echo ""
 }
 
 case "$MODE" in
@@ -92,7 +104,10 @@ case "$MODE" in
         TRUST_DOMAIN="${CULLIS_FRONTDESK_TRUST_DOMAIN:-${ORG_ID}.test}"
         CA_BUNDLE="${CULLIS_FRONTDESK_CA_BUNDLE_HOST:-$(default_ca_bundle)}"
         if [[ -z "$CA_BUNDLE" ]]; then
-            warn "No Mastio CA bundle found at ../mastio-bundle/certs/org-ca.pem"
+            warn "No Mastio CA bundle found next to this bundle."
+            warn "Looked at ../cullis-mastio-bundle/certs/org-ca.pem and"
+            warn "../mastio-bundle/certs/org-ca.pem (depending on whether"
+            warn "you extracted the release tarball or run from a repo)."
             warn "Set CULLIS_FRONTDESK_CA_BUNDLE_HOST in frontdesk.env to a"
             warn "valid path before running ./deploy.sh, otherwise compose"
             warn "will fail at ``up`` time with a clear error."
@@ -114,7 +129,8 @@ case "$MODE" in
         CA_BUNDLE="${CA_BUNDLE:-${ca_prompt_default}}"
         if [[ ! -f "$CA_BUNDLE" ]]; then
             warn "CA bundle path '$CA_BUNDLE' does not exist on disk."
-            warn "Run ../mastio-bundle/deploy.sh first to generate it, or"
+            warn "Run the sibling Mastio bundle's deploy.sh first to"
+            warn "generate it, or"
             warn "edit frontdesk.env later before ./deploy.sh."
         fi
         ;;


### PR DESCRIPTION
## Summary

- `generate-frontdesk-env.sh` now accepts `--interactive` as an explicit alias for the implicit-default interactive mode (instead of dying with "Unknown argument").
- `default_ca_bundle()` now checks both `../cullis-mastio-bundle/certs/org-ca.pem` (release tarball name) AND `../mastio-bundle/certs/org-ca.pem` (repo layout), in order, returning the first hit.
- Warning + error text in `generate-frontdesk-env.sh`, `deploy.sh`, and `README.md` updated to document both paths.

## Why

Two friction points reproduced during the customer-VM dogfood retry on 2026-05-08 (`project_wave2_gaps_2026_05_08.md` gaps #2 + #3):

1. The user typed `./generate-frontdesk-env.sh --interactive` and got an `Unknown argument` error. The flag was implicit-default-only; explicit invocation died. Confusing because `--help` lists `--defaults` and `--prod` as the alternatives, implying interactive is a third state but with no flag name.
2. After running the Mastio bundle from the release tarball (`tar xz` produced `cullis-mastio-bundle/`), the Frontdesk script's auto-detect looked for `../mastio-bundle/` and missed the sibling. Real customers fall back to the placeholder `./mastio-org-ca.pem`, then either edit `frontdesk.env` manually or hit a TLS handshake failure later.

## Test plan

- [ ] `./generate-frontdesk-env.sh --interactive` enters interactive mode (no error)
- [ ] `./generate-frontdesk-env.sh --help` lists `--interactive` alongside `--defaults` and `--prod`
- [ ] In a fresh dir with `../cullis-mastio-bundle/certs/org-ca.pem` present, `--defaults` mode auto-fills `CULLIS_FRONTDESK_CA_BUNDLE_HOST` to that absolute path
- [ ] In a repo checkout where only `../mastio-bundle/certs/org-ca.pem` exists, the same `--defaults` mode picks that one up
- [ ] When neither sibling path exists, the warning text mentions both candidates

Refs: project_wave2_gaps_2026_05_08.md, project_session_2026_05_08_dogfood_vm_install_path_broken.md