### PR TITLE
feat(dashboard): surface org display_name in sidebar + Overview CTA

### DIFF
--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -20,6 +20,18 @@
                 <img src="/static/cullis-mark.svg" alt="Cullis" style="height: 26px; width: auto; filter: drop-shadow(0 0 10px rgba(0,229,199,0.25));">
                 <span class="font-heading font-semibold text-sm text-white uppercase tracking-[0.18em]">Cullis</span>
             </div>
+            {% if display_name %}
+            <div class="mt-2.5 mb-1.5">
+                <p class="text-[11px] text-gray-200 truncate" title="{{ display_name }}" style="font-family: 'Chakra Petch', sans-serif; letter-spacing: 0.05em;">
+                    {{ display_name }}
+                </p>
+                {% if org_id %}
+                <p class="text-[9px] text-gray-600 truncate mt-0.5" title="{{ org_id }}" style="font-family: 'JetBrains Mono', monospace;">
+                    {{ org_id }}
+                </p>
+                {% endif %}
+            </div>
+            {% endif %}
             <div class="flex items-center gap-2 mt-1.5">
                 <span class="inline-block font-heading text-[9px] font-semibold uppercase tracking-[0.22em] px-1.5 py-0.5 rounded-sm bg-accent-400/10 text-accent-400 border border-accent-400/20">Mastio</span>
                 <span class="text-[10px] text-gray-600 uppercase tracking-wider">Org Trust Authority</span>

--- a/mcp_proxy/dashboard/templates/overview.html
+++ b/mcp_proxy/dashboard/templates/overview.html
@@ -69,9 +69,18 @@
                 <h2 class="text-xl font-semibold text-white" style="font-family: 'Chakra Petch', sans-serif;">
                     {{ display_name or org_id or "Unconfigured" }}
                 </h2>
-                {% if org_id %}
+                {% if org_id and display_name %}
+                {# Title is the friendly name; hex stays as a small reference subtitle. #}
                 <p class="text-xs text-gray-500 mt-1" style="font-family: 'JetBrains Mono', monospace;">
                     {{ org_id }}
+                </p>
+                {% elif org_id and not display_name %}
+                {# Title fell back to the deterministic hex; nudge the operator
+                   to set a friendly display name so audit logs and SSO surfaces
+                   show "Acme Corporation" instead of the 16-char hash. #}
+                <p class="text-[11px] text-amber-400/80 mt-1.5">
+                    Hex above is the deterministic Org ID (ADR-006 §2.2).
+                    <a href="/proxy/setup" class="underline hover:text-amber-300">Set a friendly display name →</a>
                 </p>
                 {% endif %}
             </div>


### PR DESCRIPTION
## Summary

- **Sidebar**: when `display_name` is set, render it as a small `Chakra Petch` line under the Cullis logo, with the deterministic 16-char `org_id` as a `JetBrains Mono` sub-line. The "Mastio · Org Trust Authority" pill stays as a stable brand anchor.
- **Overview "Organization" card**: when `display_name` is empty and `org_id` is present, the title falls back to the hex (current behaviour) but an amber inline CTA now appears: "Hex above is the deterministic Org ID (ADR-006 §2.2). Set a friendly display name →" linking to `/proxy/setup`.

No backend changes — `display_name` was already plumbed end-to-end (`set_config('display_name')` + dashboard context loader + Setup form input). This PR makes it visible everywhere a dashboard user looks.

## Why

The standalone Mastio's `org_id` is deterministic from the Org CA pubkey: a 16-char hex like `75d6ee859acb814b`. Real customers expect to see "Acme Corporation" on their dashboard, not a hash. The 2026-05-08 customer dogfood (gap #1 in `project_wave2_gaps_2026_05_08.md`) surfaced this loud and clear: founder asked "ma invece di 75d6... potevo mettere il nome dell'azienda?" while sitting in front of a hex-only Overview screen.

## Visual change

Two screenshots' worth (no real screenshots in PR yet, will attach during review):

- **Before** — sidebar: Cullis logo + "MASTIO · Org Trust Authority". Nothing identifies *which* org this is.
- **After** (with display_name set) — sidebar: Cullis logo, then "Acme Corporation" line, then "75d6ee859acb814b" hex sub-line, then "MASTIO · Org Trust Authority" pill.

- **Before** — Overview Organization card title: `75d6ee859acb814b`. No nudge to fix it.
- **After** (display_name empty) — Overview Organization card title: `75d6ee859acb814b`, with amber inline link "Set a friendly display name →" pointing at /proxy/setup.

## Test plan

- [ ] Manual: standalone Mastio fresh boot → Overview shows hex title + amber CTA
- [ ] Click CTA → arrives at /proxy/setup with the Display Name field focusable
- [ ] Submit display_name "Acme Corporation" → /proxy/overview now shows "Acme Corporation" as title with hex as subtitle, amber CTA gone
- [ ] Sidebar reflects the new display_name across all routes
- [ ] When display_name is empty the sidebar section stays hidden (no "Unconfigured" placeholder cluttering the brand)

## Frontend tokens used

Per `feedback_design_tokens_unified` memory: Chakra Petch for the brand line, JetBrains Mono for the hex, accent-cyan for the brand pill, amber-400 for the nudge. No hardcoded `#hex` colors — Tailwind class palette only.

Refs: project_wave2_gaps_2026_05_08.md, project_gap_mastio_dashboard_no_users_section.md