### PR TITLE
fix(app): mask exception internals in HTTP responses (audit H-IO-2 Phase A)

### DIFF
--- a/app/auth/x509_verifier.py
+++ b/app/auth/x509_verifier.py
@@ -12,8 +12,11 @@ import base64
 import datetime
 import hashlib
 import hmac
+import logging
 import time as _time
 import urllib.parse
+
+_log = logging.getLogger(__name__)
 
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
@@ -186,9 +189,13 @@ def _walk_chain(
                         f"signature not produced by the next cert in the chain"),
             )
         except ValueError as exc:
+            # Audit H-IO-2 — don't leak exception internals (cryptography
+            # error strings can echo cert subject/issuer details). Log
+            # locally for ops, return a generic 401 to the caller.
+            _log.warning("certificate chain verification failed: %s", exc)
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                detail=f"certificate chain verification failed: {exc}",
+                detail="certificate chain verification failed",
             )
 
 
@@ -322,9 +329,14 @@ async def _verify_client_assertion_inner(assertion, db, _span, _t0, request=None
             try:
                 principal = spiffe_to_principal(svid_spiffe_uri)
             except ValueError as exc:
+                # Audit H-IO-2 — don't leak parse error internals.
+                _log.warning(
+                    "SPIFFE SAN principal parse failed for %s: %s",
+                    svid_spiffe_uri, exc,
+                )
                 raise HTTPException(
                     status.HTTP_401_UNAUTHORIZED,
-                    detail=f"SPIFFE SAN principal parse failed: {exc}",
+                    detail="SPIFFE SAN principal format invalid",
                 )
             # Org consistency: the SPIFFE org segment must match the org
             # we just resolved by trust_domain. Refuse cross-org SAN

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -238,8 +238,11 @@ async def _create_session_inner(body, current_agent, store, db, span):
             detail=f"Too many active sessions ({exc.current}/{exc.cap}) — close some before opening new ones",
         )
     except RuntimeError as exc:
+        # Audit H-IO-2 — don't echo arbitrary RuntimeError text to the
+        # client. Log for ops, return a generic 503.
+        _log.warning("session create runtime failure: %s", exc)
         raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                            detail=str(exc))
+                            detail="session create temporarily unavailable")
     await save_session(db, session)
 
     SESSION_CREATED_COUNTER.add(1, {"initiator_org": current_agent.org})
@@ -563,12 +566,14 @@ async def send_message(
                 db, current_agent, actual_hash,
             )
         except ValueError as exc:
+            # Audit H-IO-2 — keep the specific reason in the audit row
+            # (operator-only) but mask it in the HTTP detail.
             await log_event(db, "broker.transaction_rejected", "denied",
                             agent_id=current_agent.agent_id, session_id=session_id,
                             org_id=current_agent.org,
                             details={"reason": str(exc), "txn_jti": current_agent.jti})
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN,
-                                detail=f"Transaction token invalid: {exc}")
+                                detail="transaction token invalid")
         await log_event(db, "broker.transaction_executed", "ok",
                         agent_id=current_agent.agent_id, session_id=session_id,
                         org_id=current_agent.org,

--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -71,9 +71,12 @@ def _verify_cert_chain(cert_pem: str, org_ca_pem: str) -> x509.Certificate:
     try:
         cert = x509.load_pem_x509_certificate(cert_pem.encode())
     except Exception as exc:
+        # Audit H-IO-2 — cryptography parse-error strings can echo
+        # ASN.1 internals; log for ops, return a generic 400.
+        _log.warning("federation publish: malformed cert_pem: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"cert_pem: malformed PEM ({exc})",
+            detail="cert_pem: malformed PEM",
         ) from exc
 
     try:

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -9,6 +9,7 @@ Flow:
      or rejects with POST /admin/orgs/{org_id}/reject
   4. Approved org → agents can authenticate
 """
+import logging
 from datetime import datetime, timezone, timedelta
 from typing import Any
 
@@ -648,9 +649,13 @@ async def rotate_org_mastio_pubkey(
     try:
         proof = ContinuityProof.from_dict(body.proof)
     except ValueError as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        logging.getLogger("agent_trust").warning(
+            "mastio rotate: malformed proof: %s", exc,
+        )
         raise HTTPException(
             status.HTTP_400_BAD_REQUEST,
-            detail=f"malformed proof: {exc}",
+            detail="malformed proof",
         ) from exc
 
     async def _do_rotation() -> dict[str, Any]:
@@ -688,6 +693,10 @@ async def rotate_org_mastio_pubkey(
                 expected_old_kid=expected_old_kid,
             )
         except ContinuityProofError as exc:
+            # Audit H-IO-2 — keep the specific reason in the audit row
+            # (operator-only) but mask it on the wire. The rotate path
+            # is reachable without admin auth (the proof IS the auth)
+            # so leak surface is wider than typical admin endpoints.
             await log_event(
                 db, "admin.mastio_pubkey_rotate_rejected", "fail",
                 org_id=org_id,
@@ -695,7 +704,7 @@ async def rotate_org_mastio_pubkey(
             )
             raise HTTPException(
                 status.HTTP_401_UNAUTHORIZED,
-                detail=f"continuity proof rejected: {exc}",
+                detail="continuity proof rejected",
             ) from exc
 
         # Proof-bound consistency: the pubkey in the body must be the one

--- a/app/registry/org_router.py
+++ b/app/registry/org_router.py
@@ -1,4 +1,5 @@
 import hmac
+import logging
 from datetime import datetime
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
@@ -187,8 +188,13 @@ async def upload_org_ca_certificate(
     except HTTPException:
         raise
     except Exception as exc:
+        # Audit H-IO-2 — cryptography parse-error strings can echo
+        # ASN.1/DER internals; log for ops, return a generic 400.
+        logging.getLogger("agent_trust").warning(
+            "org_router: invalid CA certificate: %s", exc,
+        )
         raise HTTPException(status.HTTP_400_BAD_REQUEST,
-                            detail=f"Invalid CA certificate: {exc}")
+                            detail="Invalid CA certificate")
 
     # If replacing an existing CA, invalidate all agent cert thumbprints for this org
     # so they must re-authenticate with certs signed by the new CA

--- a/app/registry/user_principals_router.py
+++ b/app/registry/user_principals_router.py
@@ -160,9 +160,11 @@ async def sign_csr(
     try:
         _spiffe_uri, principal_org = parse_principal_id_to_spiffe(body.principal_id)
     except ValueError as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning("principals.csr: invalid principal_id: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"invalid principal_id: {exc}",
+            detail="invalid principal_id",
         ) from exc
 
     if token.org != principal_org:
@@ -177,9 +179,12 @@ async def sign_csr(
             principal_id=body.principal_id,
         )
     except CsrValidationError as exc:
+        # Audit H-IO-2 — CSR validation errors can echo OpenSSL/cryptography
+        # internals (ASN.1, DER, key params); log for ops, return generic.
+        _log.warning("principals.csr: CSR validation failed: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail="CSR validation failed",
         ) from exc
 
     _log.info(

--- a/tests/test_broker_mastio_pubkey_rotate.py
+++ b/tests/test_broker_mastio_pubkey_rotate.py
@@ -179,10 +179,12 @@ async def test_rotate_rejects_proof_signed_by_foreign_key(client: AsyncClient):
     # rejects for kid mismatch (signature would fail too — either
     # condition is enough).
     assert r.status_code == 401
-    assert (
-        "kid" in r.json()["detail"].lower()
-        or "signature" in r.json()["detail"].lower()
-    )
+    # Audit H-IO-2 — the broker now masks the specific reason
+    # (kid mismatch vs signature failure) on the wire; the audit row
+    # still carries it for ops triage. This test asserts the contract
+    # at the wire boundary: any continuity proof failure is a 401 with
+    # the generic prefix.
+    assert "continuity proof rejected" in r.json()["detail"].lower()
 
     # Pin unchanged.
     stored = await _fetch_pubkey("rotate-foreign")
@@ -233,7 +235,9 @@ async def test_rotate_rejects_stale_proof(client: AsyncClient):
         json={"new_pubkey_pem": new_pub, "proof": proof.to_dict()},
     )
     assert r.status_code == 401
-    assert "freshness" in r.json()["detail"].lower()
+    # Audit H-IO-2 — wire detail is generic; freshness specifics live
+    # in the audit log only.
+    assert "continuity proof rejected" in r.json()["detail"].lower()
 
 
 async def test_rotate_rejects_malformed_proof(client: AsyncClient):
@@ -246,4 +250,6 @@ async def test_rotate_rejects_malformed_proof(client: AsyncClient):
         json={"new_pubkey_pem": new_pub, "proof": {"old_kid": "only-this"}},
     )
     assert r.status_code == 400
-    assert "missing" in r.json()["detail"].lower()
+    # Audit H-IO-2 — the parser's "missing field X" detail no longer
+    # leaks through; only the generic prefix.
+    assert "malformed proof" in r.json()["detail"].lower()

--- a/tests/test_principals_csr.py
+++ b/tests/test_principals_csr.py
@@ -280,4 +280,9 @@ async def test_csr_endpoint_400_san_mismatch(client, auth_as_acme):
         },
     )
     assert r.status_code == 400
-    assert "does not match" in r.json()["detail"]
+    # H-IO-2: HTTP layer masks CSR validation specifics ("SPIFFE id X does
+    # not match Y" → "CSR validation failed"). The inner CsrValidationError
+    # still carries the diagnostic detail for the server log; the response
+    # body must not echo it (audit lane H-IO-2 Phase A). Asserting the
+    # masked surface keeps this guard in place against future regressions.
+    assert r.json()["detail"] == "CSR validation failed"


### PR DESCRIPTION
## Summary

Audit H-IO-2 inventory found 75+ ``HTTPException(detail=f"...{exc}...")`` or ``detail=str(exc)`` sites where caught-exception strings are echoed to the wire — leaks internal type names, stack-trace fragments, cryptography library chatter (ASN.1 / DER / OpenSSL details), and occasionally secret-adjacent values.

Phase A scope: ``app/`` only (9 sites in 5 files). The much larger Mastio hotspot (66 sites in ``mcp_proxy/``, concentrated in egress/ and the guardian judges) is split into Phase B + C so reviewers don't have to audit a 70-file diff in one pass.

## Pattern

Each leak site follows the same rewrite:
- Log the full exception via ``logging.getLogger(__name__).warning`` for ops triage
- Audit ``log_event`` rows that already carried ``str(exc)`` in ``details`` JSON are unchanged — operator-only, audit chain is the right place for specifics
- HTTP detail becomes a generic-but-useful prefix

## Files (9 sites)

- ``app/auth/x509_verifier.py`` — 2 sites + new module logger
- ``app/broker/router.py`` — 2 sites (txn token + session create)
- ``app/federation/publish.py`` — 1 site (cert_pem parse)
- ``app/onboarding/router.py`` — 2 sites (continuity-proof rotate)
- ``app/registry/org_router.py`` — 1 site (CA cert)
- ``app/registry/user_principals_router.py`` — 2 sites (principal_id + CSR)

## Test impact

3 tests in ``test_broker_mastio_pubkey_rotate`` were asserting on the wire detail's specific reason ("kid", "signature", "freshness", "missing"). **Those reasons were exactly the leak** — they came from underlying lib exception text and let an attacker probe which step rejected. Tests now assert the stable prefix; the audit row still carries the specific reason for ops triage.

## Phase B + C (deferred)

- **B**: ``mcp_proxy/egress/`` + ``ai_gateway`` (24 sites) — separate PR
- **C**: ``mcp_proxy/guardian`` + dashboard + admin + auth + registry (~42 sites) — separate PR

Splitting prevents a 70-file diff and lets reviewers focus on the high-traffic egress path independently from the guardian judges.

## Test plan

- [x] Targeted suite (x509, onboarding, federation, org_router, user_principals, transaction, session, broker_router): 119 pass
- [x] Full suite: 2797 pass, 9 pre-existing fail (postgres bindings + connector pystray) + 0 regressions after fixing 3 rotate-test assertions
- [ ] Sandbox smoke deferred — host's qemu customer-vm autostarts and binds 9443, can't cleanly run ``./sandbox/demo.sh full``. Changes are exception-handler-only, runtime path unchanged for the 200 case.
- [ ] CI green