### PR TITLE
feat(dashboard): add Users section for ADR-020 / ADR-021 user principals

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3018,6 +3018,56 @@ async def badge_enrollments(request: Request):
     return HTMLResponse("")
 
 
+@router.get("/badge/users")
+async def badge_users(request: Request):
+    """Return user-principal count badge fragment for the sidebar."""
+    session = get_session(request)
+    if not session.logged_in:
+        return HTMLResponse("")
+    try:
+        from mcp_proxy.db import count_user_principals
+        n = await count_user_principals()
+    except Exception:  # table may not exist in pre-migrated setups
+        return HTMLResponse("")
+    if n:
+        return HTMLResponse(
+            f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-accent-500/15 text-accent-400">{n}</span>'
+        )
+    return HTMLResponse("")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Users — local user principals (ADR-020 / ADR-021)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.get("/users", response_class=HTMLResponse)
+async def users_page(request: Request):
+    """Read-only listing of user principals registered on this Mastio.
+
+    Backed by ``local_user_principals``, the same table the admin API
+    at ``/v1/admin/users`` writes into. Rows appear here whenever a
+    Frontdesk SSO user touches the CSR endpoint (``upsert_from_csr``)
+    or an admin pre-creates them via ``POST /v1/admin/users``.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    try:
+        from mcp_proxy.db import list_user_principals
+        users = await list_user_principals()
+    except Exception as exc:  # noqa: BLE001 — table may not exist on legacy DBs
+        _log.warning("users_page: list_user_principals failed: %s", exc)
+        users = []
+
+    return templates.TemplateResponse("users.html", _ctx(
+        request, session,
+        active="users",
+        users=users,
+    ))
+
+
 @router.get("/badge/audit")
 async def badge_audit(request: Request):
     """Return recent audit count badge fragment."""

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -44,6 +44,15 @@
                 Agents
                 <span hx-get="/proxy/badge/agents" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
+            <a href="/proxy/users"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'users' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+                </svg>
+                Users
+                <span hx-get="/proxy/badge/users" hx-trigger="load, every 30s" hx-swap="innerHTML" class="ml-auto"></span>
+            </a>
             <a href="/proxy/enrollments"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'enrollments' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"/></svg>

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -1,0 +1,121 @@
+{% extends "base.html" %}
+{% block title %}Users{% endblock %}
+{% block header_title %}Users{% endblock %}
+{% block content %}
+<div class="max-w-6xl">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-semibold text-white uppercase tracking-wider">User Principals</h2>
+            <p class="text-xs text-gray-600 mt-0.5">
+                {{ users | length }} registered
+                <span class="text-gray-700 mx-1">&middot;</span>
+                Per-user identity for Frontdesk shared mode (ADR-020 / ADR-021)
+            </p>
+        </div>
+    </div>
+
+    <!-- Context banner — explain how rows land here, since the page
+         is read-only and operators arriving from the install path
+         expect a "Create user" button that does not exist by design. -->
+    <div class="mb-6 p-4 bg-surface-900/60 border border-gray-800/50 rounded-lg text-xs text-gray-500 leading-relaxed">
+        Rows appear here automatically the first time a user authenticates
+        through a Frontdesk container — the SSO header reaches the
+        Connector Ambassador, the Ambassador asks Mastio to mint a
+        per-user cert via <code class="text-accent-400/80">/v1/principals/csr</code>,
+        and the CSR signing path upserts the principal into this table.
+        Pre-create rows out-of-band via
+        <code class="text-accent-400/80">POST /v1/admin/users</code>
+        (X-Admin-Secret) when you need a row before the first SSO touch.
+    </div>
+
+    <!-- Table -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
+        <table class="w-full">
+            <thead>
+                <tr class="border-b border-gray-800/60">
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">User</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal ID</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Surface</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last active</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Created</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-800/40">
+                {% for u in users %}
+                <tr class="table-row-hover transition-colors align-top">
+                    <td class="px-5 py-4">
+                        <div class="text-sm text-white">
+                            {{ u.display_name or u.user_name }}
+                        </div>
+                        {% if u.display_name %}
+                        <div class="text-[11px] text-gray-500 font-mono">{{ u.user_name }}</div>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4">
+                        <code class="text-[11px] font-mono text-accent-400/80 break-all" title="{{ u.principal_id }}">
+                            {{ u.principal_id }}
+                        </code>
+                        <button type="button"
+                                data-copy="{{ u.principal_id|e }}"
+                                class="ml-1 text-[10px] text-gray-600 hover:text-gray-300 uppercase tracking-wider">
+                            copy
+                        </button>
+                    </td>
+                    <td class="px-5 py-4">
+                        {% if u.reach == 'cross' %}
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30">
+                            cross-org
+                        </span>
+                        {% elif u.reach == 'both' %}
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30">
+                            both
+                        </span>
+                        {% else %}
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-gray-500/10 text-gray-400 border border-gray-500/30">
+                            intra-org
+                        </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 text-xs text-gray-400 font-mono">
+                        {% if u.surface %}
+                        {{ u.surface }}
+                        {% else %}
+                        <span class="text-gray-700 italic">—</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">
+                        {% if u.last_active_at %}
+                        {{ u.last_active_at[:19] }}
+                        {% else %}
+                        <span class="text-gray-700 italic">never</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">
+                        {{ u.created_at[:19] if u.created_at else '—' }}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not users %}
+                <tr>
+                    <td colspan="6" class="px-5 py-16 text-center">
+                        <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+                        </svg>
+                        <p class="text-sm text-gray-600">No user principals yet</p>
+                        <p class="text-xs text-gray-700 mt-1">
+                            The first Frontdesk SSO sign-in (or
+                            <code>POST /v1/admin/users</code>) will register
+                            a row here.
+                        </p>
+                    </td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -570,6 +570,39 @@ async def list_agents() -> list[dict]:
         return [_agent_row_to_dict(row) for row in result.mappings().all()]
 
 
+async def list_user_principals() -> list[dict]:
+    """List user principals registered on this Mastio.
+
+    Pairs with the dashboard ``/proxy/users`` page. Reads the same
+    ``local_user_principals`` table the admin API at
+    ``/v1/admin/users`` exposes — one row per Frontdesk SSO user that
+    has either touched the CSR endpoint at least once
+    (``upsert_from_csr`` populator) or been pre-created via
+    ``POST /v1/admin/users``. Ordered most-recently-created first so
+    the dashboard top row is the latest signup.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT principal_id, user_name, display_name, reach, "
+                "       surface, cert_thumbprint, created_at, last_active_at "
+                "  FROM local_user_principals "
+                " ORDER BY created_at DESC"
+            )
+        )
+        return [dict(row) for row in result.mappings().all()]
+
+
+async def count_user_principals() -> int:
+    """Cheap count for the sidebar badge on /proxy/users."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("SELECT COUNT(*) AS n FROM local_user_principals")
+        )
+        row = result.mappings().first()
+        return int(row["n"]) if row else 0
+
+
 async def deactivate_agent(agent_id: str) -> bool:
     """Soft-delete an agent by setting ``is_active=0``.
 


### PR DESCRIPTION
## Summary

- New `/proxy/users` page (read-only) listing `local_user_principals`: User · Principal ID · Reach · Surface · Last active · Created.
- New sidebar entry "Users" between Agents and Enrollments with htmx badge (`/proxy/badge/users`, refresh every 30s).
- New `list_user_principals()` and `count_user_principals()` helpers in `mcp_proxy/db.py`.
- Reuses the `[data-copy]` pattern from PR #530 for principal_id copy buttons.

## Why

The admin API (`/v1/admin/users` over X-Admin-Secret) and the populator (`upsert_from_csr` on the CSR signing path) already wrote rows into `local_user_principals` end-to-end. The `mcp_proxy/admin/users.py` docstring even mentions "the dashboard's Users tab" — but that tab was never built. Customers running the Frontdesk shared-mode flow couldn't see *any* of the user principals being minted, which made the ADR-019 / ADR-020 / ADR-021 positioning invisible from the dashboard.

Documented as `project_gap_mastio_dashboard_no_users_section.md` after the 2026-05-08 customer-VM dogfood. Wave 2 PR (last of the install-path polish).

## Read-only for v1

No revoke / rotate / capability-edit / inbox-preview affordances yet — that's the agent_detail-equivalent follow-up. The minimum viable surface is *visibility*: an admin who can see N user principals on this page validates the ADR-021 shared-mode flow worked end-to-end. Add affordances on demand when the first design partner asks.

## Empty state

The empty-state copy explains *how* rows land here — first SSO touch via Frontdesk OR `POST /v1/admin/users` — so admins arriving from the install path don't go hunting for a non-existent "Create user" button. The population path is intentionally SSO-driven, not a dashboard form.

## Frontend tokens

Per `feedback_design_tokens_unified.md`: Chakra Petch tracking on the section title, JetBrains Mono on principal_id and timestamps, accent-cyan pill for `reach=cross`/`both`, gray pill for `intra`. No hardcoded `#hex` colors — Tailwind class palette only.

## Test plan

- [ ] `pytest tests/` — no regressions (no new schema, only SELECT queries on existing table)
- [ ] Manual: standalone Mastio with no SSO touches → `/proxy/users` shows empty state
- [ ] `POST /v1/admin/users` (X-Admin-Secret) creates a row → it appears in `/proxy/users` immediately
- [ ] Frontdesk shared-mode SSO touch → `upsert_from_csr` runs → row appears with `last_active_at` populated
- [ ] Sidebar badge shows the count (or stays hidden when 0)
- [ ] `[data-copy]` button copies the principal_id correctly (PR #530 pattern)

Refs: project_gap_mastio_dashboard_no_users_section.md, project_wave2_gaps_2026_05_08.md, ADR-020 user principal first-class, ADR-021 Frontdesk shared mode + UserPrincipalKMS