### PR TITLE
fix(mcp_proxy): mask exception internals in egress + ai_gateway (audit H-IO-2 Phase B)

### DIFF
--- a/mcp_proxy/egress/broker_bridge.py
+++ b/mcp_proxy/egress/broker_bridge.py
@@ -150,9 +150,15 @@ class BrokerBridge:
             async with httpx.AsyncClient(verify=self._verify_tls, timeout=30.0) as http:
                 resp = await http.post(url, json=body)
         except httpx.HTTPError as exc:
+            # Audit H-IO-2 — httpx error text leaks transport/connection
+            # internals. Log full for ops triage, return a stable detail.
+            logger.warning(
+                "court unreachable during mastio pubkey rotation (%s): %s",
+                url, exc,
+            )
             raise HTTPException(
                 status_code=502,
-                detail=f"court unreachable during rotation: {exc}",
+                detail="court unreachable during rotation",
             ) from exc
 
         if resp.status_code >= 500:

--- a/mcp_proxy/egress/inbox.py
+++ b/mcp_proxy/egress/inbox.py
@@ -123,7 +123,15 @@ async def send_to_inbox(
             org_id=local_org,
             details={**audit_details, "reason": str(exc)},
         )
-        raise HTTPException(status_code=403, detail=str(exc)) from exc
+        # Audit H-IO-2 — keep the broker's specific reason in the audit
+        # row but mask it on the wire. PermissionError messages from the
+        # broker leak the policy/reach internals to a caller that already
+        # got told "denied".
+        _log.warning("inbox_send denied for %s: %s", agent.agent_id, exc)
+        raise HTTPException(
+            status_code=403,
+            detail="inbox send denied",
+        ) from exc
     except HTTPException:
         raise
     except Exception as exc:  # noqa: BLE001 — surface broker errors as 502
@@ -134,9 +142,12 @@ async def send_to_inbox(
             org_id=local_org,
             details={**audit_details, "reason": f"broker_forward_failed: {exc}"},
         )
+        # Audit H-IO-2 — log full exception for ops triage, return a
+        # generic 502 so an attacker cannot probe broker internals.
+        _log.warning("inbox_send broker forward failed for %s: %s", agent.agent_id, exc)
         raise HTTPException(
             status_code=502,
-            detail=f"Broker forward failed: {exc}",
+            detail="broker forward failed",
         ) from exc
 
     await append_local_audit(

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -228,10 +228,16 @@ async def _handle_stream(
             yield "data: [DONE]\n\n"
         except GatewayError as exc:
             terminated_with_error = exc
+            # Audit H-IO-2 — ``exc.detail`` comes from str(exc) of the
+            # underlying httpx / LiteLLM / pydantic error and would echo
+            # provider chatter (timeouts, auth-key fragments, schema
+            # mismatch text) back to the SSE consumer. Keep it in the
+            # audit row below for ops triage; on the wire emit only the
+            # stable reason tag + trace id.
             err_frame = {
                 "error": {
                     "type": exc.reason,
-                    "message": exc.detail or exc.reason,
+                    "message": exc.reason,
                     "trace_id": trace_id,
                 },
             }

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -183,7 +183,17 @@ async def send_oneshot(
     try:
         path = decide_route(body.recipient_id, local_org, trust_domain)
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        # Audit H-IO-2 — ``decide_route`` raises ValueError for any
+        # malformed recipient form. The library text leaks parser state;
+        # log it for ops, return a stable 400 to the caller.
+        logger.warning(
+            "oneshot decide_route rejected recipient=%r: %s",
+            body.recipient_id, exc,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="invalid recipient_id",
+        ) from exc
 
     # Reach gate (migration 0017): refuse before we build any envelope
     # or touch the audit chain. A per-agent denied event is still
@@ -286,9 +296,16 @@ async def send_oneshot(
                 org_id=local_org,
                 details={**audit_details, "reason": f"broker_forward_failed: {exc}"},
             )
+            # Audit H-IO-2 — broker exception text can carry httpx/library
+            # internals; the audit row above keeps the specific reason for
+            # ops, the wire stays generic.
+            logger.warning(
+                "oneshot broker forward failed for %s: %s",
+                agent.agent_id, exc,
+            )
             raise HTTPException(
                 status_code=502,
-                detail=f"Broker forward failed: {exc}",
+                detail="broker forward failed",
             ) from exc
 
         broker_msg_id = result.get("msg_id", "")

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -349,8 +349,10 @@ async def open_session(
             request_id=request_id,
             duration_ms=duration_ms,
         )
+        # Audit H-IO-2 — keep the exception in the audit row + module
+        # logger for ops; the wire detail must not echo broker internals.
         logger.error("Failed to open session for %s: %s", agent.agent_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc
 
 
 @router.get("/sessions")
@@ -432,7 +434,7 @@ async def accept_session(
             detail=str(exc)[:500],
         )
         logger.error("Failed to accept session for %s: %s", agent.agent_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc
 
 
 @router.post("/sessions/{session_id}/close")
@@ -488,7 +490,7 @@ async def close_session(
             detail=str(exc)[:500],
         )
         logger.error("Failed to close session %s: %s", session_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc
 
 
 @router.post("/send")
@@ -762,7 +764,7 @@ async def send_message(
                 detail=exc.response.text,
             ) from exc
         logger.error("Failed to send message for %s: %s", agent.agent_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc
 
 
 @router.get("/messages/{session_id}")
@@ -835,7 +837,7 @@ async def poll_messages(
                 detail=exc.response.text,
             ) from exc
         logger.error("Failed to poll messages for %s: %s", agent.agent_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc
 
 
 @router.post("/sessions/{session_id}/messages/{msg_id}/ack")
@@ -909,7 +911,17 @@ async def resolve_recipient(
     try:
         trust_domain, target_org, target_agent = parse_recipient(body.recipient_id)
     except InvalidRecipient as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        # Audit H-IO-2 — InvalidRecipient text leaks parser internals
+        # (which form was tried, what the caller passed). Log for ops,
+        # return a stable 400.
+        logger.warning(
+            "resolve recipient parse failed for %r: %s",
+            body.recipient_id, exc,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="invalid recipient_id",
+        ) from exc
 
     route = decide_route(
         body.recipient_id,
@@ -981,9 +993,15 @@ async def resolve_recipient(
         except HTTPException:
             raise
         except Exception as exc:
+            # Audit H-IO-2 — broker fetch error text reveals court/uplink
+            # internals. Log for ops, generic 502 to caller.
+            logger.warning(
+                "resolve peer public key failed for %s -> %s: %s",
+                agent.agent_id, broker_peer_id, exc,
+            )
             raise HTTPException(
                 status_code=502,
-                detail=f"unable to resolve peer public key: {exc}",
+                detail="unable to resolve peer public key",
             ) from exc
 
     return ResolveResponse(
@@ -1045,7 +1063,15 @@ async def get_agent_public_key(
         # too — ``parse_internal`` rejects them. The caller has to
         # canonicalise to ``org::agent`` since the server cannot
         # safely guess which org the caller meant.
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        # Audit H-IO-2 — log the parse error for ops, mask the wire
+        # detail (parser text leaks which form was tried).
+        logger.warning(
+            "agent public-key parse failed for %r: %s", agent_id, exc,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="invalid agent_id",
+        ) from exc
 
     settings = get_settings()
     route = decide_route(
@@ -1105,9 +1131,14 @@ async def get_agent_public_key(
         except HTTPException:
             raise
         except Exception as exc:
+            # Audit H-IO-2 — same masking as /resolve cross-org branch.
+            logger.warning(
+                "agent public-key broker fetch failed for %s -> %s: %s",
+                agent.agent_id, broker_peer_id, exc,
+            )
             raise HTTPException(
                 status_code=502,
-                detail=f"unable to resolve peer public key: {exc}",
+                detail="unable to resolve peer public key",
             ) from exc
 
     return AgentPublicKeyResponse(
@@ -1305,7 +1336,7 @@ async def discover_agents(
 
     except Exception as exc:
         logger.error("Failed to discover agents for %s: %s", agent.agent_id, exc)
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc
 
 
 @router.post("/tools/invoke")
@@ -1422,4 +1453,4 @@ async def invoke_remote_tool(
         logger.error(
             "Failed to invoke tool %s for %s: %s", body.tool_name, agent.agent_id, exc,
         )
-        raise HTTPException(status_code=502, detail=f"Broker error: {exc}") from exc
+        raise HTTPException(status_code=502, detail="broker error") from exc

--- a/tests/test_proxy_egress_pubkey.py
+++ b/tests/test_proxy_egress_pubkey.py
@@ -196,7 +196,10 @@ async def test_pubkey_cross_org_bridge_error_502(proxy_app):
     finally:
         app.state.broker_bridge = None
     assert resp.status_code == 502
-    assert "broker unreachable" in resp.json()["detail"]
+    # Audit H-IO-2 — wire detail is the stable masked prefix; the
+    # specific exception text ("broker unreachable") stays in the
+    # server-side log for ops triage.
+    assert resp.json()["detail"] == "unable to resolve peer public key"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Phase B of the H-IO-2 sweep started in #533. Same pattern: caught exception text was being echoed straight to the wire via ``HTTPException(detail=f"...{exc}...")`` / ``detail=str(exc)`` — leaks internal type names, library chatter (httpx transport details, ASN.1 / DER parse fragments, pydantic validation paths, LiteLLM provider strings), and occasionally secret-adjacent values.

Phase B scope: ``mcp_proxy/egress/`` + the AI-gateway path that lives under it (``ai_gateway.py`` + ``llm_chat_router.py``). Phase C (remaining ``mcp_proxy/`` subtrees: guardian + dashboard + admin + auth + registry — the audit's ~42 remaining sites) stays separate so the diff is reviewable.

## Pattern (mirrors #533)

- Log the full exception via the file's existing module logger (``logger.warning`` / ``_log.warning``) for ops triage.
- Audit ``append_local_audit`` / ``log_audit`` rows that already carried ``str(exc)`` or ``f"...: {exc}"`` in ``details`` are unchanged — operator-only, audit chain is the right place.
- HTTP detail collapses to a stable masked prefix: ``"broker error"``, ``"broker forward failed"``, ``"inbox send denied"``, ``"invalid recipient_id"``, ``"invalid agent_id"``, ``"unable to resolve peer public key"``, ``"court unreachable during rotation"``.

## Files (17 wire-leak sites)

- ``mcp_proxy/egress/inbox.py`` — 2 sites (``PermissionError`` 403, broker-forward 502).
- ``mcp_proxy/egress/oneshot.py`` — 2 sites (``decide_route`` ``ValueError`` 400, cross-org broker-forward 502).
- ``mcp_proxy/egress/broker_bridge.py`` — 1 site (Court reachability on Mastio pubkey rotate, 502).
- ``mcp_proxy/egress/router.py`` — 11 sites: 7 ``"Broker error"`` paths (open / accept / close session, send, poll, discover, invoke) + 2 ``InvalidRecipient`` parse sites (``/resolve``, ``/agents/{id}/public-key``) + 2 cross-org peer public-key bridge errors.
- ``mcp_proxy/egress/llm_chat_router.py`` — 1 SSE error frame: ``message`` field used to carry ``GatewayError.detail`` (which sources from ``str(exc)`` of upstream httpx / LiteLLM / pydantic errors). Wire frame now carries only the stable ``reason`` tag + ``trace_id``; the audit row keeps the full ``upstream_detail``.

``GatewayError`` instances raised inside ``ai_gateway.py`` (5 sites that put ``str(exc)`` / ``f"...{exc}"`` in ``GatewayError.detail``) are unchanged — that ``detail`` only flows to the audit row (``upstream_detail``) and to the SSE frame this PR fixes. The synchronous-error HTTPException response built in ``llm_chat_router.py`` already carried only ``reason`` + ``trace_id``, which #533's pattern endorses.

Inventory note: #533 estimated Phase B at ~24 sites; the actual wire-leak set is 17 once you separate audit-row writes (which Phase A explicitly preserves) from HTTPException details. The 5 ``ai_gateway.py`` ``GatewayError.detail`` sites and several ``log_audit(detail=str(exc)[:500])`` calls were probably double-counted in the rough estimate.

## Test impact

1 wire-detail assertion was the leak itself:

- ``tests/test_proxy_egress_pubkey.py::test_pubkey_cross_org_bridge_error_502`` asserted ``"broker unreachable" in resp.json()["detail"]`` — that string came from ``str(RuntimeError("broker unreachable"))`` and is exactly what the audit flags. Test now pins the stable masked prefix (``== "unable to resolve peer public key"``) so a future regression that re-introduces the leak flips it red. Same approach as the rotate-test relaxations in #533.

## Test plan

- [x] Targeted: ``pytest -n auto -k "egress or oneshot or inbox or llm_chat or broker_bridge"`` — **202 passed**.
- [x] Full suite: ``pytest tests/ -n auto --dist=loadfile`` — **2804 passed**, 8 pre-existing failures (postgres bindings KeyError + connector GUI-import flakes from pystray/pywebview headless — verified identical set fails on origin/main via stash).
- [ ] Sandbox smoke deferred — host's qemu ``customer-vm`` autostarts and binds 9443, blocking ``./sandbox/demo.sh full`` cleanly (same blocker noted on #533). Changes are exception-handler-only, the runtime path is unchanged for the 200 case.
- [ ] CI green.

## Phase C (deferred)

``mcp_proxy/guardian`` + ``dashboard`` + ``admin`` + ``auth`` + ``registry`` — separate PR.

Refs: audit-2026-05-08 H-IO-2.