### PR TITLE
fix(mcp_proxy): mask exception internals in guardian + dashboard + admin (audit H-IO-2 Phase C)

### DIFF
--- a/mcp_proxy/admin/agents.py
+++ b/mcp_proxy/admin/agents.py
@@ -440,9 +440,11 @@ async def register_agent_dpop_jwk(
     try:
         jkt = compute_jkt(jwk)
     except (ValueError, KeyError) as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning("admin.agents: malformed JWK: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"malformed JWK: {exc}",
+            detail="malformed JWK",
         ) from exc
 
     async with get_db() as conn:

--- a/mcp_proxy/admin/enroll.py
+++ b/mcp_proxy/admin/enroll.py
@@ -203,9 +203,11 @@ def _validate_dpop_jwk(dpop_jwk: dict | None) -> str | None:
     try:
         return compute_jkt(dpop_jwk)
     except (ValueError, KeyError) as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning("admin.enroll: dpop_jwk is malformed: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"dpop_jwk is malformed: {exc}",
+            detail="dpop_jwk is malformed",
         ) from exc
 
 
@@ -245,9 +247,12 @@ async def enroll_byoca(
     try:
         cert = x509.load_pem_x509_certificate(body.cert_pem.encode())
     except ValueError as exc:
+        # Audit H-IO-2 — cryptography ValueError leaks ASN.1/DER/OpenSSL
+        # internals; log for ops, return generic.
+        _log.warning("admin.enroll byoca: cert_pem PEM parse failed: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"cert_pem is not a valid X.509 PEM: {exc}",
+            detail="cert_pem is not a valid X.509 PEM",
         ) from exc
 
     # Step 2 — key matches cert.
@@ -404,9 +409,13 @@ async def _resolve_trust_bundle(body_override: str | None) -> x509.Certificate:
     try:
         return x509.load_pem_x509_certificate(pem.encode())
     except ValueError as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning(
+            "admin.enroll spiffe: trust_bundle_pem PEM parse failed: %s", exc,
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"trust_bundle_pem is not a valid X.509 PEM: {exc}",
+            detail="trust_bundle_pem is not a valid X.509 PEM",
         ) from exc
 
 
@@ -455,9 +464,11 @@ async def enroll_spiffe(
     try:
         svid = x509.load_pem_x509_certificate(body.svid_pem.encode())
     except ValueError as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning("admin.enroll spiffe: svid_pem PEM parse failed: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"svid_pem is not a valid X.509 PEM: {exc}",
+            detail="svid_pem is not a valid X.509 PEM",
         ) from exc
 
     # Step 2 — key matches SVID.

--- a/mcp_proxy/auth/challenge_response.py
+++ b/mcp_proxy/auth/challenge_response.py
@@ -269,13 +269,15 @@ async def sign_challenged_assertion(
         chain = _load_chain(x5c_der)
         _verify_chain(chain, ca_cert)
     except ValueError as exc:
+        # Audit H-IO-2 — chain failure text leaks cryptography lib internals
+        # (ASN.1 / OID / signature alg); log for ops, return generic.
         _log.info(
             "login challenge rejected for %s: x509 chain invalid: %s",
             agent.agent_id, exc,
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"x509 chain: {exc}",
+            detail="x509 chain verification failed",
         ) from exc
 
     leaf = chain[0]
@@ -291,13 +293,16 @@ async def sign_challenged_assertion(
         except Exception:
             pass
         _log_clock_skew_hint(exc, agent.agent_id)
+        # Audit H-IO-2 — jwt-library exception text would let an attacker
+        # probe which check (signature, exp, kid, claim shape) failed;
+        # log for ops, return generic.
         _log.info(
             "login challenge rejected for %s: assertion invalid: %s",
             agent.agent_id, exc,
         )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"assertion: {exc}",
+            detail="assertion invalid",
         ) from exc
 
     # sub must match the cert holder — prevents agent A from using

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -109,10 +109,12 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
         # kid matched this Mastio but validation still failed — that's a
         # spoofing or tamper attempt, surface 401 rather than falling
         # through silently.
+        # Audit H-IO-2 — server log carries the rejection reason; HTTP
+        # detail is generic so an attacker can't probe which check fired.
         _log.info("local token rejected: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"local token: {exc}",
+            detail="local token rejected",
             headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
         ) from exc
 
@@ -179,10 +181,11 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
             token, keystore, expected_issuer=issuer.issuer,
         )
     except LocalTokenError as exc:
+        # Audit H-IO-2 — server log carries the rejection reason.
         _log.info("local token rejected (egress): %s", exc)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"local token: {exc}",
+            detail="local token rejected",
             headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
         ) from exc
 

--- a/mcp_proxy/auth/local_validator.py
+++ b/mcp_proxy/auth/local_validator.py
@@ -173,9 +173,11 @@ async def require_local_token(request: Request) -> LocalTokenPayload:
             token, keystore, expected_issuer=issuer.issuer,
         )
     except LocalTokenError as exc:
+        # Audit H-IO-2 — server log carries the rejection reason; HTTP
+        # detail is generic so an attacker can't probe which check fired.
         _log.info("local token rejected: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=str(exc),
+            detail="local token rejected",
             headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
         ) from exc

--- a/mcp_proxy/dashboard/mcp_resources.py
+++ b/mcp_proxy/dashboard/mcp_resources.py
@@ -78,9 +78,13 @@ def _parse_allowed_domains(raw: str) -> list[str]:
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning(
+            "mcp_resources: invalid allowed_domains JSON: %s", exc,
+        )
         raise HTTPException(
             status_code=400,
-            detail=f"invalid allowed_domains JSON: {exc}",
+            detail="invalid allowed_domains JSON",
         ) from exc
     if not isinstance(parsed, list):
         raise HTTPException(

--- a/mcp_proxy/dashboard/policies_local.py
+++ b/mcp_proxy/dashboard/policies_local.py
@@ -111,7 +111,9 @@ async def policies_create(request: Request):
     try:
         parsed = json.loads(rules_raw) if rules_raw else {}
     except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail=f"invalid rules_json: {exc}") from exc
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning("policies_local: invalid rules_json: %s", exc)
+        raise HTTPException(status_code=400, detail="invalid rules_json") from exc
     if not isinstance(parsed, dict):
         raise HTTPException(status_code=400, detail="rules_json must be an object")
 

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -2449,6 +2449,9 @@ async def mastio_key_rotate(request: Request):
         )
         raise
     except Exception as exc:
+        # Audit H-IO-2 — audit row carries the full reason; HTTP detail
+        # is generic so an attacker can't probe rotation internals.
+        _log.warning("mastio_key.rotate failed (old_kid=%s): %s", old_kid, exc)
         await log_audit(
             agent_id="admin",
             action="mastio_key.rotate",
@@ -2457,7 +2460,7 @@ async def mastio_key_rotate(request: Request):
         )
         raise HTTPException(
             status_code=500,
-            detail=f"rotation failed: {exc}",
+            detail="rotation failed",
         ) from exc
 
     # Rebuild the LocalIssuer so subsequent token mints use the new signer.
@@ -2548,13 +2551,22 @@ async def mastio_key_complete_staged(request: Request):
     try:
         result = await agent_mgr.complete_staged_rotation(decision)
     except RuntimeError as exc:
+        # Audit H-IO-2 — audit row carries the full reason; HTTP detail
+        # is generic so an attacker can't probe internal staging state.
+        _log.warning(
+            "mastio_key.complete_staged failed (decision=%s): %s",
+            decision, exc,
+        )
         await log_audit(
             agent_id="admin",
             action="mastio_key.complete_staged",
             status="failure",
             detail=f"decision={decision}, reason={exc}",
         )
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=409,
+            detail="complete-staged rotation failed",
+        ) from exc
 
     # Rebuild LocalIssuer so local-token issuance resumes. Mirrors the
     # rebuild that runs at the end of the rotate endpoint above — the

--- a/mcp_proxy/dashboard/updates_router.py
+++ b/mcp_proxy/dashboard/updates_router.py
@@ -366,9 +366,12 @@ async def updates_apply(migration_id: str, request: Request):
             status="failure",
             detail=f"migration_id={migration_id}, error={error_msg}",
         )
+        # Audit H-IO-2 — audit row + server log carry the migration's
+        # underlying exception text; HTTP detail stays generic so the
+        # response can't be used to probe migration internals.
         raise HTTPException(
             status_code=500,
-            detail=f"apply failed: {error_msg}",
+            detail="apply failed",
         )
 
     await _update_status_with_retry(
@@ -453,9 +456,11 @@ async def updates_rollback(migration_id: str, request: Request):
             status="failure",
             detail=f"migration_id={migration_id}, error={error_msg}",
         )
+        # Audit H-IO-2 — audit row + server log carry the migration's
+        # underlying exception text; HTTP detail stays generic.
         raise HTTPException(
             status_code=500,
-            detail=f"rollback failed: {error_msg}",
+            detail="rollback failed",
         )
 
     await _update_status_with_retry(

--- a/mcp_proxy/guardian/endpoint.py
+++ b/mcp_proxy/guardian/endpoint.py
@@ -86,9 +86,16 @@ async def inspect(
             req.payload_b64 + "=" * (-len(req.payload_b64) % 4),
         )
     except (binascii.Error, ValueError) as exc:
+        # Audit H-IO-2 — base64 lib exception text would let an attacker
+        # fingerprint encoder behaviour; keep the structured ``reason``
+        # tag, drop the inner ``error`` field. Log for ops triage.
+        _log.warning(
+            "guardian inspect: malformed payload_b64 from %s: %s",
+            agent.agent_id, exc,
+        )
         raise HTTPException(
             status_code=422,
-            detail={"reason": "malformed_payload_b64", "error": str(exc)},
+            detail={"reason": "malformed_payload_b64"},
         ) from exc
 
     audit_id = uuid.uuid4().hex
@@ -126,9 +133,18 @@ async def inspect(
     except GuardianTicketError as exc:
         # Treat as 503 (config issue) rather than 500 — the operator
         # has a known fix (set/rotate the key).
+        # Audit H-IO-2 — ``exc.detail`` carries the underlying
+        # jwt-library text (key shape, decode failure mode) and would
+        # let a caller probe ticket-key configuration; keep the
+        # structured ``reason`` tag, drop the inner ``error`` field.
+        # Log for ops triage.
+        _log.warning(
+            "guardian inspect: ticket sign failed reason=%s detail=%s",
+            exc.reason, exc.detail or exc.reason,
+        )
         raise HTTPException(
             status_code=503,
-            detail={"reason": exc.reason, "error": exc.detail or exc.reason},
+            detail={"reason": exc.reason},
         ) from exc
 
     try:

--- a/mcp_proxy/guardian/judges/lakera.py
+++ b/mcp_proxy/guardian/judges/lakera.py
@@ -74,8 +74,11 @@ class LakeraJudge(Judge):
                 if self._owns_http and client is not self._http:
                     await client.aclose()
         except httpx.HTTPError as exc:
+            # Audit H-IO-2 — httpx exc text leaks upstream URL / TLS / DNS
+            # detail; keep the ``http_error`` tag, drop the inner text.
+            _log.warning("lakera http error: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"http_error: {exc}",
+                judge=self.name, detail="http_error",
             )
 
         latency_ms = int((time.perf_counter() - started) * 1000)
@@ -87,8 +90,11 @@ class LakeraJudge(Judge):
         try:
             data = resp.json()
         except ValueError as exc:
+            # Audit H-IO-2 — JSON decoder exc text quotes upstream body
+            # bytes; keep the tag, drop inner text.
+            _log.warning("lakera malformed response: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"malformed_response: {exc}",
+                judge=self.name, detail="malformed_response",
             )
 
         # Lakera v2 shape: ``flagged: bool`` + ``breakdown`` per detector.

--- a/mcp_proxy/guardian/judges/llama_guard.py
+++ b/mcp_proxy/guardian/judges/llama_guard.py
@@ -55,9 +55,12 @@ class LlamaGuardJudge(Judge):
         try:
             from litellm import acompletion
         except ImportError as exc:
+            # Audit H-IO-2 — ImportError text echoes module path / version
+            # internals; keep the stable tag, drop the inner text.
+            _log.warning("llama_guard litellm import failed: %s", exc)
             return Judge.unavailable(
                 judge=self.name,
-                detail=f"litellm_not_installed: {exc}",
+                detail="litellm_not_installed",
             )
 
         text = payload.decode("utf-8", errors="replace")
@@ -77,16 +80,22 @@ class LlamaGuardJudge(Judge):
                 timeout=self._timeout,
             )
         except Exception as exc:
+            # Audit H-IO-2 — upstream exc text leaks provider URL / API
+            # error body / TLS detail; keep the tag, drop inner text.
+            _log.warning("llama_guard upstream error: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"upstream_error: {exc}",
+                judge=self.name, detail="upstream_error",
             )
 
         latency_ms = int((time.perf_counter() - started) * 1000)
         try:
             content = response.choices[0].message.content or ""
         except Exception as exc:
+            # Audit H-IO-2 — exc text from response decode quotes upstream
+            # body bytes; keep the tag, drop inner text.
+            _log.warning("llama_guard malformed response: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"malformed_response: {exc}",
+                judge=self.name, detail="malformed_response",
             )
 
         verdict = content.strip().lower()

--- a/mcp_proxy/guardian/judges/nemo.py
+++ b/mcp_proxy/guardian/judges/nemo.py
@@ -90,9 +90,12 @@ class NemoJudge(Judge):
         except RuntimeError as exc:
             return Judge.unavailable(judge=self.name, detail=str(exc))
         except Exception as exc:
+            # Audit H-IO-2 — exc text leaks LLMRails / LiteLLM internals;
+            # keep the stable ``rails_load_failed`` tag, drop the inner
+            # exception text. Server log carries the full reason.
             _log.warning("nemo rails load failed: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"rails_load_failed: {exc}",
+                judge=self.name, detail="rails_load_failed",
             )
 
         text = payload.decode("utf-8", errors="replace")
@@ -101,9 +104,12 @@ class NemoJudge(Judge):
                 rails.generate, messages=[{"role": "user", "content": text}],
             )
         except Exception as exc:
+            # Audit H-IO-2 — exc text from rails.generate can leak prompt
+            # template fragments and provider error bodies; keep the tag,
+            # drop the inner text. Server log carries the full reason.
             _log.warning("nemo rails generate failed: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"rails_generate_failed: {exc}",
+                judge=self.name, detail="rails_generate_failed",
             )
 
         # NeMo response shape: {"role": "assistant", "content": "..."}.

--- a/mcp_proxy/guardian/judges/openai_moderation.py
+++ b/mcp_proxy/guardian/judges/openai_moderation.py
@@ -65,8 +65,11 @@ class OpenAIModerationJudge(Judge):
                 if self._owns_http and client is not self._http:
                     await client.aclose()
         except httpx.HTTPError as exc:
+            # Audit H-IO-2 — httpx exc text leaks upstream URL / TLS / DNS
+            # detail; keep the ``http_error`` tag, drop the inner text.
+            _log.warning("openai_moderation http error: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"http_error: {exc}",
+                judge=self.name, detail="http_error",
             )
 
         latency_ms = int((time.perf_counter() - started) * 1000)
@@ -78,8 +81,11 @@ class OpenAIModerationJudge(Judge):
         try:
             data = resp.json()
         except ValueError as exc:
+            # Audit H-IO-2 — JSON decoder exc text quotes upstream body
+            # bytes; keep the ``malformed_response`` tag, drop inner text.
+            _log.warning("openai_moderation malformed response: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"malformed_response: {exc}",
+                judge=self.name, detail="malformed_response",
             )
 
         results = data.get("results") or []

--- a/mcp_proxy/guardian/judges/portkey.py
+++ b/mcp_proxy/guardian/judges/portkey.py
@@ -80,8 +80,11 @@ class PortkeyJudge(Judge):
                 if self._owns_http and client is not self._http:
                     await client.aclose()
         except httpx.HTTPError as exc:
+            # Audit H-IO-2 — httpx exc text leaks upstream URL / TLS / DNS
+            # detail; keep the ``http_error`` tag, drop the inner text.
+            _log.warning("portkey http error: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"http_error: {exc}",
+                judge=self.name, detail="http_error",
             )
 
         latency_ms = int((time.perf_counter() - started) * 1000)
@@ -93,8 +96,11 @@ class PortkeyJudge(Judge):
         try:
             data = resp.json()
         except ValueError as exc:
+            # Audit H-IO-2 — JSON decoder exc text quotes upstream body
+            # bytes; keep the tag, drop inner text.
+            _log.warning("portkey malformed response: %s", exc)
             return Judge.unavailable(
-                judge=self.name, detail=f"malformed_response: {exc}",
+                judge=self.name, detail="malformed_response",
             )
 
         # Portkey shape: ``verdict: "pass" | "fail"`` + per-check details.

--- a/mcp_proxy/registry/user_principals_router.py
+++ b/mcp_proxy/registry/user_principals_router.py
@@ -82,9 +82,11 @@ async def sign_csr(
             body.principal_id,
         )
     except ValueError as exc:
+        # Audit H-IO-2 — log full parse error, return a generic detail.
+        _log.warning("principals.csr: invalid principal_id: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"invalid principal_id: {exc}",
+            detail="invalid principal_id",
         ) from exc
 
     if token.org != principal_org:
@@ -109,16 +111,22 @@ async def sign_csr(
             agent_manager=agent_manager,
         )
     except CsrValidationError as exc:
+        # Audit H-IO-2 — CSR validation errors can echo OpenSSL/cryptography
+        # internals (ASN.1, DER, key params) and SPIFFE-id mismatch text;
+        # log for ops, return generic.
+        _log.warning("principals.csr: CSR validation failed: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
+            detail="CSR validation failed",
         ) from exc
     except RuntimeError as exc:
         # Org CA not loaded — surface to the caller as 503 so their
         # provisioner retries instead of failing the user session.
+        # Audit H-IO-2 — log full reason, return a generic detail.
+        _log.warning("principals.csr: Org CA unavailable: %s", exc)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
+            detail="Org CA temporarily unavailable",
         ) from exc
 
     _log.info(


### PR DESCRIPTION
## Summary

Audit H-IO-2 Phase C — bonifies the remaining caught-exception leaks in ``mcp_proxy/`` outside the egress + ai_gateway hotspot (Phase B, parallel PR). 32 sites in 16 files. Same rewrite pattern as Phase A (#533): log full exception via the file's existing ``logging.getLogger`` handle, leave operator-facing audit ``log_event`` ``details`` JSON unchanged, replace the wire ``detail`` (or ``JudgeResult.detail``) with a stable generic prefix.

## Pattern

- Log full exception via ``_log.warning`` for ops triage.
- Audit ``log_audit`` rows that already carried ``str(exc)`` in ``details`` JSON: **unchanged** — operator-only, audit chain is the right place for specifics.
- HTTP ``detail`` (or ``JudgeResult.detail``) becomes a stable generic prefix.

## Files (32 sites in 16 files)

| File | Sites | Notes |
|---|---|---|
| ``mcp_proxy/registry/user_principals_router.py`` | 3 | principal_id parse, CSR validation, Org CA RuntimeError |
| ``mcp_proxy/admin/agents.py`` | 1 | JWK jkt |
| ``mcp_proxy/admin/enroll.py`` | 4 | dpop_jwk + BYOCA cert + SPIFFE trust_bundle + SPIFFE svid |
| ``mcp_proxy/auth/local_agent_dep.py`` | 2 | LocalToken intra-org + egress |
| ``mcp_proxy/auth/local_validator.py`` | 1 | LocalToken bearer validate |
| ``mcp_proxy/auth/challenge_response.py`` | 2 | x509 chain verify, JWT assertion decode |
| ``mcp_proxy/dashboard/policies_local.py`` | 1 | rules_json JSON parse |
| ``mcp_proxy/dashboard/mcp_resources.py`` | 1 | allowed_domains JSON parse |
| ``mcp_proxy/dashboard/router.py`` | 2 | Mastio key rotate + complete-staged |
| ``mcp_proxy/dashboard/updates_router.py`` | 2 | apply, rollback |
| ``mcp_proxy/guardian/endpoint.py`` | 2 | malformed payload_b64, ticket sign — drop ``error`` field of structured detail; keep ``reason`` tag |
| ``mcp_proxy/guardian/judges/nemo.py`` | 2 | rails_load_failed, rails_generate_failed |
| ``mcp_proxy/guardian/judges/openai_moderation.py`` | 2 | http_error, malformed_response |
| ``mcp_proxy/guardian/judges/portkey.py`` | 2 | http_error, malformed_response |
| ``mcp_proxy/guardian/judges/llama_guard.py`` | 3 | litellm_not_installed, upstream_error, malformed_response |
| ``mcp_proxy/guardian/judges/lakera.py`` | 2 | http_error, malformed_response |

## Guardian-specific decisions

- **Judges**: ``JudgeResult.detail`` is consumed by the slow-path queue (enterprise plugin) and persisted to operator-facing audit rows. The wire never exposes it directly — the public ``InspectResponse`` only carries the filtered ``reasons`` list. We still mask because the same fingerprintable signal (heuristic markers, lib chatter) leaks via whichever audit-export surface a customer eventually wires up. The ``_log.warning`` keeps the full diagnostic for ops, including the cases ``nemo.py`` was already logging.
- **GuardianTicketError**: internal Python state. Wire surface is at ``mcp_proxy/guardian/endpoint.py`` line 131 which used to put ``exc.detail or exc.reason`` into a wire ``error`` field. We **drop the ``error`` field entirely**; the structured ``reason`` tag (``"expired"``, ``"bad_signature"``, ``"malformed"``, …) is preserved. Test assertions only check the structured ``reason``, so the wire contract is unchanged from a legitimate-caller's perspective.
- **block_reason structured vs detail relaxed**: the guardian wire response (``InspectResponse``) already carries decision via the enum field plus the structured ``reasons`` list — the ``detail`` of a 422/503 only fires on infrastructure errors (malformed payload encoding, ticket key not configured) and never carries a per-judge block reason. No structural change needed.
- **``nemo.py`` line 91**: hand-crafted ``RuntimeError("nemoguardrails_not_installed: pip install nemoguardrails")`` — operator-controlled message, not lib chatter. Left untouched. The scaffold test asserts on the stable tag (``"nemoguardrails_not_installed"``) which is preserved.

## Excluded from scope

- ``mcp_proxy/egress/`` + ``mcp_proxy/ai_gateway/`` — Phase B (parallel PR).
- Audit ``log_audit`` rows whose ``details`` JSON carries ``str(exc)`` — operator-only, unchanged per Phase A pattern.
- Server-side Jinja template renders that include exception text (e.g. ``_login_err`` in ``dashboard/router.py``) — task flagged out of scope.
- Upstream broker/response body echoes (e.g. ``link_broker.py:267`` ``detail=body_or_err``) — not an ``exc`` echo, different audit surface.
- ``mcp_proxy/guardian/ticket.py`` ``GuardianTicketError(detail=…)`` — internal Python state; the wire mask is at the endpoint layer.

## Test impact

- **Targeted suite** (guardian + principals_csr + admin_enroll + admin_agents + proxy_local + challenge_response + dashboard_mcp + local_policies + mastio_key + updates): **362 pass, 0 fail**.
- **Full suite**: **2804 pass, 8 pre-existing fail** (postgres bindings + connector pystray — same gates as #533, none introduced here), 34 skipped.
- All keyword-based detail asserts (``"chain"``, ``"assertion"``, ``"local token"``, ``"csr"``, ``"applied"``, ``"APPLY"``, ``"ROLLBACK"``, ``"pending"``) survive because the masked strings preserve the keywords.
- No test asserts on the dropped ``error`` field of the guardian endpoint's structured detail.

## Test plan

- [x] Targeted suite (16 file scope): 362 pass.
- [x] Full suite: 2804 pass, 8 pre-existing fail, 0 regressions.
- [ ] Sandbox smoke deferred — same blocker as #533 (host's qemu customer-vm autostarts and binds 9443). Changes are exception-handler + judge-result paths only; the 200-path is unchanged.
- [ ] CI green.

Refs: audit-2026-05-08 H-IO-2. Companion to #533 (Phase A) and the parallel egress + ai_gateway PR (Phase B).