### PR TITLE
fix(mcp_proxy): decouple OIDC redirect_uri from proxy_public_url (sandbox B3.7+B3.8)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -26,6 +26,14 @@ class ProxySettings(BaseSettings):
 
     proxy_public_url: str = ""  # for DPoP htu validation
 
+    # OIDC callback base URL — must be browser-reachable AND registered
+    # as a redirect_uri on the IdP. Distinct from proxy_public_url
+    # because that one pins the DPoP htu to the internal TLS sidecar
+    # (e.g. mastio-nginx:9443) which the host browser cannot resolve
+    # and which Keycloak does not have registered as a redirect_uri.
+    # Falls back to proxy_public_url, then request.base_url.
+    oidc_redirect_uri_base: str = ""
+
     # KMS backend for the Org CA (and, in follow-up, Mastio leaf keys).
     # ``local`` keeps the keys in proxy_config DB (current default,
     # works for community + small deploys). Other values dispatch to

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3511,14 +3511,19 @@ async def settings_local_password(request: Request):
 def _oidc_redirect_uri(request: Request) -> str:
     """Build the OIDC callback URL.
 
-    Prefers the configured proxy_public_url (so the IdP sees a stable
-    externally-reachable URL), falls back to the request base URL for
-    dev/test environments.
+    Prefers oidc_redirect_uri_base (browser-reachable URL the IdP has
+    registered), then proxy_public_url (legacy single-knob deploys),
+    then the request base URL for dev/test. The first two are distinct
+    because proxy_public_url pins DPoP htu to the internal TLS sidecar
+    (e.g. mastio-nginx:9443), which is not browser-reachable nor
+    registered on the IdP — using it as redirect_uri yields a 400
+    ``Invalid parameter: redirect_uri`` from Keycloak.
     """
     from mcp_proxy.config import get_settings as _s
-    pub = _s().proxy_public_url
-    if pub:
-        return pub.rstrip("/") + "/proxy/oidc/callback"
+    settings = _s()
+    base = settings.oidc_redirect_uri_base or settings.proxy_public_url
+    if base:
+        return base.rstrip("/") + "/proxy/oidc/callback"
     return str(request.base_url).rstrip("/") + "/proxy/oidc/callback"
 
 

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -267,6 +267,11 @@ services:
       # match. Pin it here so ``_build_htu`` returns the URL the agent
       # actually signed.
       MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-a:9443"
+      # OIDC redirect_uri must be browser-reachable AND registered on
+      # Keycloak. Realm seed registers ``http://localhost:9100/...``
+      # (host-side) and ``http://proxy-a:9100/...`` (in-network).
+      # Distinct from PROXY_PUBLIC_URL above which is the TLS sidecar.
+      MCP_PROXY_OIDC_REDIRECT_URI_BASE: "http://localhost:9100"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-a"
       # ADR-017 native AI gateway on Mastio (post-2026-05-06 architectural
       # fix): the Mastio dispatches LLM calls itself via litellm_embedded.
@@ -601,6 +606,9 @@ services:
       MCP_PROXY_BROKER_JWKS_URL:   "http://broker:8000/.well-known/jwks.json"
       # ADR-014 — see proxy-a rationale; pin htu to the orgb sidecar.
       MCP_PROXY_PROXY_PUBLIC_URL:  "https://mastio-nginx-b:9443"
+      # OIDC redirect_uri — see proxy-a comment. Realm seed registers
+      # ``http://localhost:9200/...`` + ``http://proxy-b:9100/...``.
+      MCP_PROXY_OIDC_REDIRECT_URI_BASE: "http://localhost:9200"
       MCP_PROXY_ADMIN_SECRET:      "sandbox-proxy-admin-b"
       MCP_PROXY_DATABASE_URL:      "sqlite+aiosqlite:////data/mcp_proxy.db"
       MCP_PROXY_ORG_ID:            "orgb"

--- a/tests/test_proxy_dashboard_oidc.py
+++ b/tests/test_proxy_dashboard_oidc.py
@@ -338,3 +338,51 @@ async def test_login_page_hides_sso_button_when_unconfigured(proxy_app):
 # the partial endpoint were removed in this PR — peer-org discovery
 # now lives exclusively on ``/proxy/network``. See
 # ``project_reach_enforcement`` + the PR description for the migration.
+
+
+# ── _oidc_redirect_uri fallback chain ────────────────────────────────
+
+
+def _fake_request(base_url: str = "http://localhost:9100/"):
+    """Minimal Request stub exposing ``base_url`` for ``_oidc_redirect_uri``."""
+    class _R:
+        pass
+    r = _R()
+    r.base_url = base_url
+    return r
+
+
+def test_oidc_redirect_uri_prefers_dedicated_setting(monkeypatch):
+    from mcp_proxy import config as _config
+    from mcp_proxy.dashboard.router import _oidc_redirect_uri
+
+    s = _config.get_settings()
+    monkeypatch.setattr(s, "oidc_redirect_uri_base", "http://localhost:9100")
+    monkeypatch.setattr(s, "proxy_public_url", "https://mastio-nginx-a:9443")
+
+    uri = _oidc_redirect_uri(_fake_request("http://internal/"))
+    assert uri == "http://localhost:9100/proxy/oidc/callback"
+
+
+def test_oidc_redirect_uri_falls_back_to_proxy_public_url(monkeypatch):
+    from mcp_proxy import config as _config
+    from mcp_proxy.dashboard.router import _oidc_redirect_uri
+
+    s = _config.get_settings()
+    monkeypatch.setattr(s, "oidc_redirect_uri_base", "")
+    monkeypatch.setattr(s, "proxy_public_url", "https://example.com")
+
+    uri = _oidc_redirect_uri(_fake_request())
+    assert uri == "https://example.com/proxy/oidc/callback"
+
+
+def test_oidc_redirect_uri_falls_back_to_request_base_url(monkeypatch):
+    from mcp_proxy import config as _config
+    from mcp_proxy.dashboard.router import _oidc_redirect_uri
+
+    s = _config.get_settings()
+    monkeypatch.setattr(s, "oidc_redirect_uri_base", "")
+    monkeypatch.setattr(s, "proxy_public_url", "")
+
+    uri = _oidc_redirect_uri(_fake_request("http://localhost:9100/"))
+    assert uri == "http://localhost:9100/proxy/oidc/callback"


### PR DESCRIPTION
## Summary

PR #335 (ADR-014 mTLS htu pinning, 2026-04-28) overloaded ``MCP_PROXY_PROXY_PUBLIC_URL`` for two uses with **opposite** requirements:

- **DPoP htu pinning**: wants the internal TLS sidecar URL (e.g. ``https://mastio-nginx-a:9443``).
- **OIDC redirect_uri**: wants a browser-reachable URL that the IdP has registered (e.g. ``http://localhost:9100``).

``_oidc_redirect_uri`` in ``dashboard/router.py`` reads ``proxy_public_url`` directly, so since #335 it serves Keycloak a redirect_uri the realm has not registered. Keycloak rejects with ``400 Invalid parameter: redirect_uri`` and the sandbox login flow breaks. Sandbox smokes **B3.7** (``alice@orga``) and **B3.8** (``bob@orgb``) have been red on every run since #335 merged.

**This is not a smoke-only failure.** The same regression hits any real-user browser login that goes through the host port (9100/9200) instead of the internal nginx sidecar, since the sidecar hostname is not host-resolvable nor TLS-trusted by the host browser. Quietly shipped for ~11 days.

## Pattern

Introduce a dedicated ``oidc_redirect_uri_base`` setting and a fallback chain in ``_oidc_redirect_uri``:

1. ``oidc_redirect_uri_base`` (new, browser-reachable + IdP-registered).
2. ``proxy_public_url`` (legacy single-knob deploys, kept for back-compat).
3. ``request.base_url`` (dev/test last-resort).

Sandbox ``proxy-a`` + ``proxy-b`` ship with the new env set to ``http://localhost:9100`` / ``http://localhost:9200`` to match the realm seeds (``realm-orga.json`` + ``realm-orgb.json``). **No realm seed change required.**

## Files

- ``mcp_proxy/config.py`` — new ``oidc_redirect_uri_base`` setting (env: ``MCP_PROXY_OIDC_REDIRECT_URI_BASE``).
- ``mcp_proxy/dashboard/router.py`` — ``_oidc_redirect_uri`` uses the 3-step fallback chain. Inline comment explains why decoupling is necessary.
- ``sandbox/docker-compose.yml`` — env set on ``proxy-a`` + ``proxy-b``.
- ``tests/test_proxy_dashboard_oidc.py`` — 3 new unit tests on the fallback chain.

## Test plan

- [x] 3 new unit tests on ``_oidc_redirect_uri``: dedicated setting wins, proxy_public_url fallback, request.base_url last-resort. All pass.
- [x] Targeted suite ``test_proxy_dashboard_oidc.py``: 17 pass.
- [x] Full suite: 2807 pass, 8 pre-existing fail (connector pystray + postgres bindings, ``feedback_ci_known_failures``), 0 regressions.
- [ ] Sandbox smoke deferred — host's qemu customer-vm autostarts and binds 9443 (same blocker as #533 + #536). The change will be exercised end-to-end by the CI ``demo_network smoke`` job which runs in a clean container, and B3.7/B3.8 should flip green.
- [ ] CI green.

## Why this is investigation-grade rather than guess

Root cause was identified in a separate read-only investigation worktree by tracing ``MCP_PROXY_PROXY_PUBLIC_URL`` across both consumers (DPoP htu pinning in ``_build_htu`` and OIDC redirect_uri construction in ``_oidc_redirect_uri``), reproducing the failure end-to-end with the sandbox stack up (303 to Keycloak with the wrong redirect_uri → 400), and matching the realm seeds against the wire URL.