### PR TITLE
fix(mcp_proxy): surface real Mastio release version on /health (tag drift)

### DIFF
--- a/.github/workflows/release-mastio.yml
+++ b/.github/workflows/release-mastio.yml
@@ -124,6 +124,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ needs.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -57,6 +57,14 @@ RUN mkdir -p /data /var/lib/mastio/nginx-certs && \
 
 ENV PYTHONPATH=/app
 ENV MCP_PROXY_DATABASE_URL=sqlite+aiosqlite:////data/mcp_proxy.db
+
+# Surface the Mastio release version on /health. release-mastio.yml passes
+# ``--build-arg VERSION=<tag>``; un-passed builds fall back to ``dev`` so a
+# developer-laptop curl yields ``"version":"dev"`` rather than a stale literal
+# that drifts from the running tag.
+ARG VERSION=dev
+ENV CULLIS_MASTIO_VERSION=${VERSION}
+
 # cullis-enterprise#11 — Python defaults stderr to block-buffering when
 # connected to a pipe (container stdio goes through a pipe to the runtime).
 # Under burst load, logging.StreamHandler(sys.stderr) records accumulate

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -31,6 +31,14 @@ from mcp_proxy.logging_setup import configure_json_logging
 configure_json_logging()
 _log = logging.getLogger("mcp_proxy")
 
+
+# Mastio version surfaced on /health. Injected at image build time via
+# ``--build-arg VERSION=...`` (release-mastio.yml passes the tag-derived
+# version, e.g. ``0.3.2``). Falls back to ``dev`` for source-checkout runs
+# so curl on a developer laptop yields ``"version":"dev"`` rather than a
+# stale literal that drifts from the running tag.
+_MASTIO_VERSION = os.environ.get("CULLIS_MASTIO_VERSION", "dev")
+
 # ─────────────────────────────────────────────────────────────────────────────
 # JWKS client reference (set during lifespan)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1198,7 +1206,7 @@ async def health(request: Request):
         underneath. Stdlib-verifier cross-org federation silently
         401s; remediation is ``POST /pki/rotate-ca``.
     """
-    body: dict = {"status": "ok", "version": "0.1.0"}
+    body: dict = {"status": "ok", "version": _MASTIO_VERSION}
     warnings: list[str] = []
     agent_mgr = getattr(request.app.state, "agent_manager", None)
     if agent_mgr is not None and getattr(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -51,3 +51,10 @@ async def test_health_legacy_still_works(client):
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
     assert "version" in resp.json()
+
+
+# NB: Mastio /health (mcp_proxy.main) is tested separately —
+# tests/test_proxy_health_version.py covers the version surface there.
+# The ``client`` fixture above wires the Court app (app.main), which has
+# its own /health endpoint backed by ``settings.app_version`` and is the
+# subject of the assertions in this file.

--- a/tests/test_proxy_health_version.py
+++ b/tests/test_proxy_health_version.py
@@ -1,0 +1,41 @@
+"""Tests for the Mastio (mcp_proxy) ``/health`` version surface.
+
+Bug #8 from the 2026-05-09 AI-as-customer dogfood: a customer that
+runs ``cullis-mastio:0.3.1`` and curls ``/health`` sees
+``{"status":"ok","version":"0.1.0"}``. ``0.1.0`` was a literal in
+``mcp_proxy/main.py`` that nobody bumped after mastio-v0.3.0 cut.
+The fix swaps the literal for ``_MASTIO_VERSION``, which is read
+from ``CULLIS_MASTIO_VERSION`` and falls back to ``dev``.
+``release-mastio.yml`` passes ``--build-arg VERSION=<tag>`` so the
+running image labels and ``/health`` agree.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_mastio_version_defaults_to_dev_in_source_checkout():
+    """Without CULLIS_MASTIO_VERSION env (the default for a source
+    checkout / pytest run), ``_MASTIO_VERSION`` is ``dev`` so ops cannot
+    confuse a dev process with a tagged release."""
+    import mcp_proxy.main as _m
+    assert _m._MASTIO_VERSION == "dev"
+
+
+@pytest.mark.asyncio
+async def test_mastio_health_surfaces_module_version(monkeypatch):
+    """The ``/health`` handler reads ``_MASTIO_VERSION`` at call time
+    (not a baked literal), so a release image with VERSION=1.2.3 baked
+    in surfaces that exact value."""
+    import mcp_proxy.main as _m
+    monkeypatch.setattr(_m, "_MASTIO_VERSION", "1.2.3")
+
+    class _Req:
+        class _App:
+            class _State:
+                pass
+            state = _State()
+        app = _App()
+
+    body = await _m.health(_Req())
+    assert body == {"status": "ok", "version": "1.2.3"}


### PR DESCRIPTION
## Summary

AI-as-customer dogfood 2026-05-09 (bug #8): pulled ``ghcr.io/cullis-security/cullis-mastio:0.3.1``, ``curl /health``, got ``{"status":"ok","version":"0.1.0"}``. The OCI image label says 0.3.1 but ``/health`` says 0.1.0. ``0.1.0`` was a literal in ``mcp_proxy/main.py`` that never tracked tag bumps.

Bad signal for a security-positioned product — an evaluator who diffs ``image tag`` vs ``/health version`` reads "stale build, untrusted release pipeline".

## Fix

- ``mcp_proxy/main.py`` reads the version from ``CULLIS_MASTIO_VERSION`` at module import; defaults to ``dev``.
- ``mcp_proxy/Dockerfile`` declares ``ARG VERSION=dev`` and exposes ``ENV CULLIS_MASTIO_VERSION=${VERSION}``.
- ``.github/workflows/release-mastio.yml`` passes ``--build-arg VERSION=${{ needs.version.outputs.version }}`` to the docker buildx step, so a ``mastio-v0.3.2`` tag yields ``"version":"0.3.2"`` on ``/health``, matching the OCI label.

Source checkouts / pytest runs (no env var) land on the ``dev`` fallback so a laptop curl never claims a fake release version.

## Tests

- [x] 2 new in ``tests/test_proxy_health_version.py``: default is ``dev``, monkeypatched override surfaces verbatim.
- [x] Existing ``tests/test_health.py`` (Court app /health) untouched, still green.
- [x] Targeted: ``pytest tests/test_proxy_health_version.py tests/test_health.py``: 7 pass.
- [ ] CI green.

## Roll-out note

The fix only takes effect for new image builds. The already-cut tag ``mastio-v0.3.1`` keeps reporting ``0.1.0``; the next mastio-v0.3.2 release picks up the corrected behavior automatically.