### PR TITLE
docs: pin quickstart URLs to specific tags (releases/latest is unreliable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,14 +77,21 @@ from `ghcr.io` and configure themselves with sensible defaults.
 
 ```bash
 # 1. Mastio (org gateway + first-boot Org CA + dashboard on :9443)
-curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
 cd ..
-curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-frontdesk-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc1/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle && ./deploy.sh
 ```
+
+> **Why pinned tags, not `releases/latest/`?** GitHub's `Latest` marker
+> points to a single release across the whole repo. Cullis ships two
+> independent bundles (Mastio + Frontdesk) with separate version
+> trains; a `releases/latest/download/cullis-frontdesk-bundle.tar.gz`
+> URL 404s the moment a Mastio release becomes Latest. Newer versions
+> are at <https://github.com/cullis-security/cullis/releases>.
 
 The Mastio dashboard is at `https://localhost:9443/proxy/login` (self-signed
 TLS, accept the warning); the Frontdesk SPA is at `http://localhost:8080`.

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -6,10 +6,17 @@ source tree required.
 ## Quickstart (3 commands)
 
 ```bash
-curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle/
 ./deploy.sh
 ```
+
+Newer Mastio releases are listed at
+<https://github.com/cullis-security/cullis/releases?q=mastio-v>; the
+URL above is pinned because GitHub's `releases/latest/` marker is
+shared across all bundles in this repo (Mastio + Frontdesk + Court +
+Chat + Connector) and would 404 the moment a non-Mastio release takes
+the Latest slot.
 
 Open `https://localhost:9443/proxy/login` (the browser will warn — the
 TLS cert is signed by your auto-generated Org CA, not a public CA).


### PR DESCRIPTION
## Summary

AI-as-customer dogfood 2026-05-09 (bug #1): the README quickstart copy-paste runs

```bash
curl -L https://github.com/cullis-security/cullis/releases/latest/download/cullis-frontdesk-bundle.tar.gz | tar xz
```

…which 404s. GitHub's ``Latest`` marker is repo-wide and currently points at ``mastio-v0.3.1``; that tag has no Frontdesk asset, so the lookup returns 404. The same failure mode hits any future ordering — Mastio + Frontdesk + Court + Chat + Connector all share one Latest slot, so two of them are always broken at copy-paste time.

## Fix

- Pin Mastio quickstart URL to ``mastio-v0.3.1`` (latest stable tag).
- Pin Frontdesk quickstart URL to ``frontdesk-bundle-v0.1.0-rc1`` (only existing tag).
- Add a callout explaining the design choice and linking to the filtered releases page for newer versions.

## Files

- ``README.md`` Quickstart — single host (bundles).
- ``packaging/mastio-bundle/README.md`` Quickstart.

## Roll-out note

The pin keeps the copy-paste evergreen for as long as the named tags exist. Once ``mastio-v0.3.2`` ships (with the Users dashboard + Org CA host export + HTML leak fixes already merged in main), the URL bumps in a 1-line follow-up PR. Same pattern for any future Frontdesk stable.

## Test plan

- [x] Both pinned URLs return 200 + the expected ``Content-Type: application/gzip``.
- [x] No code changes, docs-only, no test impact.
- [ ] CI green.