### PR TITLE
fix(mastio-bundle): pre-create certs/ host dir so docker cp can write

### DIFF
--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -285,6 +285,16 @@ if [[ $SHARED_BROKER -eq 1 ]]; then
     fi
 fi
 
+# Pre-create the bind-mount target for the optional corporate CA bundle.
+# docker-compose.yml mounts ``${CULLIS_CERTS_DIR:-./certs}:/certs:ro``;
+# if the directory does not exist when ``compose up`` runs, Docker
+# auto-creates it as ``root:root`` and the post-up ``docker cp org-ca``
+# step further down (run as the host user) cannot write into it. Creating
+# it here as the invoking user keeps ownership host-side and the export
+# works without sudo.
+CERT_DIR="${CULLIS_CERTS_DIR:-$SCRIPT_DIR/certs}"
+mkdir -p "$CERT_DIR"
+
 echo -e "  ${GRAY}$COMPOSE $COMPOSE_FILES --env-file proxy.env up -d${RESET}"
 $COMPOSE $COMPOSE_FILES --env-file proxy.env up -d
 ok "Containers started"
@@ -314,10 +324,16 @@ done
 # named volume. Downstream consumers (Frontdesk Connector enroll, mTLS
 # verify, manual curl smoke) need it as a trust anchor on the host. Copy
 # it out so operators don't have to docker cp by hand.
-CERT_DIR="$SCRIPT_DIR/certs"
-mkdir -p "$CERT_DIR"
 PROXY_CID="$($COMPOSE $COMPOSE_FILES ps -q mcp-proxy 2>/dev/null || true)"
 ORG_CA_HOST="$CERT_DIR/org-ca.pem"
+# If a previous ``compose up`` (e.g. before the pre-mkdir fix landed)
+# created ``./certs`` as root, reclaim ownership before docker cp so the
+# host user can write into it without sudo. Cheap no-op when ownership is
+# already correct.
+if [[ ! -w "$CERT_DIR" ]]; then
+    docker run --rm -v "$CERT_DIR:/target" --entrypoint /bin/sh \
+        alpine -c "chown -R $(id -u):$(id -g) /target" >/dev/null 2>&1 || true
+fi
 if [[ -n "$PROXY_CID" ]] && docker cp "$PROXY_CID:/var/lib/mastio/nginx-certs/org-ca.crt" "$ORG_CA_HOST" 2>/dev/null; then
     chmod 644 "$ORG_CA_HOST"
     ok "Org CA exported to ./certs/org-ca.pem"


### PR DESCRIPTION
## Summary

AI-as-customer re-dogfood 2026-05-09 with ``mastio-v0.3.2-rc2`` flipped bug #4 from CLOSED back to **NOT-CLOSED**. ``./deploy.sh`` runs ``\$COMPOSE up -d`` *before* creating ``./certs/``. Docker auto-creates the bind-mount target (``\${CULLIS_CERTS_DIR:-./certs}:/certs:ro`` in docker-compose.yml:85) as ``root:root``, then the ``mkdir -p "\$CERT_DIR"`` further down is a no-op, and the subsequent ``docker cp`` (run as host user) cannot write into ``./certs/`` because the parent is root-owned. The export silently warns and falls back to manual instructions; Frontdesk sibling auto-detect still finds nothing.

## Fix

1. Pre-create ``\$CERT_DIR`` (resolving ``CULLIS_CERTS_DIR`` early) **before** ``compose up`` so Docker mounts an existing user-owned directory and never needs to create it as root.
2. Add a defensive chown reclaim for hosts that already have a stale root-owned ``./certs/`` from a pre-fix deploy. Uses ``docker run alpine chown`` so it works without local sudo.

## Files

- ``packaging/mastio-bundle/deploy.sh`` — bash-only, no compose / image change.

## Test plan

- [x] Bash syntax check (``bash -n``).
- [x] Re-tested locally: deploy.sh with pre-mkdir works on a clean host (``./certs/org-ca.pem`` written, ownership = host user).
- [x] Reclaim path tested by manually root-owning ``./certs/`` then re-running deploy.sh.
- [ ] CI green.

## Roll-out

The fix only takes effect on a fresh ``./deploy.sh`` after the next mastio bundle rc/stable cut. Bundle-only PR; image identical.