### PR TITLE
fix(frontdesk-bundle): detect TTY before docker run -it (CI / piped stdin)

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -271,9 +271,20 @@ else
     # uses to reach Mastio at enroll-time matches what it will use at
     # runtime (compose attaches the same host-gateway extra_hosts to the
     # connector service). The container exits 0 once Mastio approves;
-    # the script unblocks and continues to ``compose up``. ``-it`` so the
-    # operator sees the polling status messages while waiting.
-    docker run --rm -it \
+    # the script unblocks and continues to ``compose up``.
+    #
+    # ``-it`` was unconditional in rc1/rc2 — that fails outright in any
+    # non-TTY context (CI runner, ssh pipe, ``echo "" | ./deploy.sh``,
+    # IDE-integrated terminals without tty allocation) with
+    # ``the input device is not a TTY``. Detect ``[ -t 0 ]`` and only
+    # request ``-t`` when stdin is actually a tty. The polling output
+    # streams either way; in non-TTY mode it just lacks the carriage
+    # returns that re-paint the spinner line.
+    DOCKER_TTY_FLAGS=""
+    if [[ -t 0 && -t 1 ]]; then
+        DOCKER_TTY_FLAGS="-it"
+    fi
+    docker run --rm $DOCKER_TTY_FLAGS \
         --add-host "host.docker.internal:host-gateway" \
         -v "${DATA_DIR_ABS}:/home/cullis/.cullis" \
         -v "${CA_BUNDLE_ABS}:/etc/cullis/ca-bundle.pem:ro" \


### PR DESCRIPTION
## Summary

AI-as-customer re-dogfood 2026-05-09 with ``frontdesk-bundle-v0.1.0-rc2`` surfaced a NEW high-severity bug (N1): ``./deploy.sh`` unconditionally invokes ``docker run --rm -it ... enroll ...``. ``-it`` requires a TTY on stdin; any non-TTY caller — CI runner, ``echo "" | ./deploy.sh``, ssh pipe, IDE terminal without tty allocation, agent-driven dogfood — gets ``the input device is not a TTY`` and the install aborts at the enroll step.

Customer running the bundle from a Jenkins job, from a remote provisioning script, or from an automation harness cannot proceed past enrollment.

## Fix

Detect ``[ -t 0 && -t 1 ]`` (both stdin and stdout are real ttys) and only pass ``-it`` in that case. Otherwise pass nothing. The container's polling output streams in either mode — the only loss in non-TTY mode is the carriage-return spinner repaint, replaced by plain log lines.

## Files

- ``packaging/frontdesk-bundle/deploy.sh`` — bash-only, no compose / image change.

## Test plan

- [x] ``bash -n`` syntax check.
- [x] Interactive terminal: ``./deploy.sh`` still uses ``-it``, output still pretty.
- [x] Piped stdin: ``echo "" | ./deploy.sh`` no longer fails on docker run.
- [x] Detached: ``./deploy.sh </dev/null`` reaches Mastio approval block.
- [ ] CI green.

## Roll-out

Takes effect on the next frontdesk-bundle rc/stable cut. Fix unblocks the AI-customer dogfood path and any CI consumer.