### PR TITLE
docs: bump quickstart to mastio-v0.3.2-rc2 + frontdesk-v0.1.0-rc2 + version-neutral bundle README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ from `ghcr.io` and configure themselves with sensible defaults.
 
 ```bash
 # 1. Mastio (org gateway + first-boot Org CA + dashboard on :9443)
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.1/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.2-rc2/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
 cd ..
-curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc1/cullis-frontdesk-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc2/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle && ./deploy.sh
 ```
 

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -3,20 +3,26 @@
 Self-contained Mastio deploy. Pulls the published image from GHCR, no
 source tree required.
 
-## Quickstart (3 commands)
+## Quickstart (2 commands, you already have this tarball)
 
 ```bash
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.1/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle/
 ./deploy.sh
 ```
 
-Newer Mastio releases are listed at
-<https://github.com/cullis-security/cullis/releases?q=mastio-v>; the
-URL above is pinned because GitHub's `releases/latest/` marker is
-shared across all bundles in this repo (Mastio + Frontdesk + Court +
-Chat + Connector) and would 404 the moment a non-Mastio release takes
-the Latest slot.
+This README ships **inside** the bundle tarball, so by the time you
+are reading it you have already extracted the code. To grab a fresh
+download from scratch, see <https://cullis.io/download/> for the
+current recommended URL — that page tracks the latest rc / stable
+release. The full Mastio version list is at
+<https://github.com/cullis-security/cullis/releases?q=mastio-v>.
+
+> Why no pinned ``curl ...`` URL here? The download URL must point at a
+> specific release tag, but the README ships *inside* the tarball; a
+> hard-coded version drifts the moment a newer rc/stable cuts and
+> readers paste a stale URL even though they are already running a
+> newer bundle. The cullis.io/download page above is updated atomically
+> with each release.
 
 Open `https://localhost:9443/proxy/login` (the browser will warn — the
 TLS cert is signed by your auto-generated Org CA, not a public CA).


### PR DESCRIPTION
## Summary

AI-as-customer re-dogfood 2026-05-09 surfaced two README issues post-rc2 cut:

1. **Root README pinned URLs are stale**. PR #540 pinned them to ``mastio-v0.3.1`` + ``frontdesk-bundle-v0.1.0-rc1`` because those were the newest at the time. After cutting -rc2 of both, customers copy-paste a stale download path, get the bundle that the dogfood found broken, and the polish-sprint feedback loop re-fires.
2. **NEW bug N2**: ``packaging/mastio-bundle/README.md`` ships *inside* the bundle tarball but hardcodes ``releases/download/mastio-v0.3.1/cullis-mastio-bundle.tar.gz``. A user who already extracted rc2 reads the bundle README, sees v0.3.1 in the curl example, and either re-downloads the wrong version (cognitive whiplash) or assumes the running bundle is v0.3.1.

## Fix

- ``README.md``: bump pinned URLs to the current rc2 of both bundles.
- ``packaging/mastio-bundle/README.md``: drop the hardcoded curl URL entirely. Pivot Quickstart to "you already have this tarball, just ``cd && ./deploy.sh``" and link to ``cullis.io/download/`` for the case where the reader hits the README via GitHub source view. Site /download is updated atomically with each release (per #541), so it never drifts.

## Files

- ``README.md``
- ``packaging/mastio-bundle/README.md``

## Test plan

- [x] Both updated URLs return 200 (verified earlier with ``curl -sIL``).
- [x] Markdown renders correctly on GitHub preview.
- [x] No code change.
- [ ] CI green.

## Roll-out

The root README change is live as soon as merged. The bundle README change ships in the next ``mastio-bundle-v*`` tag — current ``rc2`` already-cut bundles will keep showing the old hardcoded URL, but the next rc/stable will be self-consistent.