### PR TITLE
docs: bump README + site /download to mastio-v0.3.2-rc3 + frontdesk-v0.1.0-rc3

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,12 @@ from `ghcr.io` and configure themselves with sensible defaults.
 
 ```bash
 # 1. Mastio (org gateway + first-boot Org CA + dashboard on :9443)
-curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.2-rc2/cullis-mastio-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.2-rc3/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
 cd ..
-curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc2/cullis-frontdesk-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc3/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle && ./deploy.sh
 ```
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -184,28 +184,28 @@ const platforms = [
         <li>
           <div class="bundle-head">
             <strong>Mastio bundle</strong>
-            <span class="bundle-tag">mastio-v0.3.2-rc2</span>
+            <span class="bundle-tag">mastio-v0.3.2-rc3</span>
           </div>
           <p class="bundle-blurb">
             Org gateway. First-boot Org CA, dashboard on <code>:9443</code>,
             agent enrollment + audit chain. The runtime that backs every
             Connector inside one organization.
           </p>
-          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.2-rc2/cullis-mastio-bundle.tar.gz | tar xz
+          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.2-rc3/cullis-mastio-bundle.tar.gz | tar xz
 cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
         </li>
 
         <li>
           <div class="bundle-head">
             <strong>Frontdesk bundle</strong>
-            <span class="bundle-tag">frontdesk-bundle-v0.1.0-rc2</span>
+            <span class="bundle-tag">frontdesk-bundle-v0.1.0-rc3</span>
           </div>
           <p class="bundle-blurb">
             Multi-user Cullis Chat (SPA on <code>:8080</code>) co-located
             with a Mastio on the same host. Adds a shared-mode Connector
             so multiple human users issue ADR-020 user principals.
           </p>
-          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc2/cullis-frontdesk-bundle.tar.gz | tar xz
+          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc3/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle &amp;&amp; ./deploy.sh</code></pre>
         </li>
 


### PR DESCRIPTION
## Summary

Round-2 polish rc3 cuts include the cert-export ordering fix (#542) and the TTY-detect fix (#543). Bump pinned URLs in the public-facing surfaces so a fresh customer copy-paste lands on the working bundles.

## Files

- ``README.md``: 2 quickstart ``curl`` URLs.
- ``site/src/pages/download.astro``: 4 occurrences (2 ``bundle-tag`` labels + 2 ``bundle-cmd`` curl one-liners). Court card stays at ``v0.1.0-rc1`` — no Court rc3 cut.

## Roll-out

Mergeable as soon as the rc3 release pipelines complete and the GH-release tarballs are HTTP 200. Until then the URLs in this PR 404.

## Test plan

- [ ] CI green.
- [ ] Verify both rc3 tarballs HTTP 200 before merge.