### PR TITLE
fix(frontdesk-bundle): bind to 127.0.0.1 by default + document TLS terminator pattern

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -115,9 +115,76 @@ For oauth2-proxy specifically, the upstream config `--pass-user-headers=true` is
 docker compose --env-file frontdesk.env down -v   # also wipe connector_data (forces re-enrollment)
 ```
 
+## Threat model & exposure
+
+The Frontdesk bundle serves **plain HTTP** on `:80` inside the
+container. By default the host port (`8080`) is bound to **`127.0.0.1`
+only**, not `0.0.0.0`. Three exposure modes:
+
+| Mode | Bind | Where Frontdesk is reachable | Coherent with Cullis threat model? |
+|------|------|------------------------------|------------------------------------|
+| Default (dogfood, single-user) | `127.0.0.1:8080` | The host's own browser only | Yes. Localhost is a W3C "secure context" — SPA crypto, Secure cookies, Service Workers all behave as on HTTPS. |
+| LAN multi-user, no TLS | `0.0.0.0:8080` | Any host on the LAN, plain HTTP | **No.** Session cookie + DPoP proofs travel cleartext. A coworker on the same office network can intercept and replay. Not "zero-trust fabric for AI agents" if the SPA-to-Connector hop isn't authenticated. |
+| LAN / internet, with TLS terminator | `0.0.0.0:8080` (or `127.0.0.1` if terminator is on the same host) | The terminator's HTTPS port | Yes. Pattern: `Browser → HTTPS → terminator → :8080 (loopback or LAN) → cullis-chat`. Recommended for any deploy with more than one user. |
+
+To expose Frontdesk over the LAN or the internet, override the bind:
+
+```bash
+# In frontdesk.env
+FRONTDESK_HTTP_BIND=0.0.0.0
+FRONTDESK_HTTP_PORT=8080
+```
+
+…AND put a TLS terminator in front. Below are three minimal recipes.
+
+### oauth2-proxy + corporate IdP
+
+```bash
+# Terminator on the same host as the bundle. oauth2-proxy authenticates
+# the user against your IdP, terminates TLS, and forwards to the bundle.
+docker run -d --name oauth2-proxy \
+  -p 443:4180 \
+  -v $PWD/oauth2-proxy.cfg:/etc/oauth2-proxy.cfg:ro \
+  -v $PWD/tls.crt:/etc/tls.crt:ro -v $PWD/tls.key:/etc/tls.key:ro \
+  quay.io/oauth2-proxy/oauth2-proxy:latest \
+    --config=/etc/oauth2-proxy.cfg \
+    --upstream=http://127.0.0.1:8080 \
+    --tls-cert-file=/etc/tls.crt --tls-key-file=/etc/tls.key
+```
+
+### Caddy with auto-Let's Encrypt
+
+```caddyfile
+frontdesk.acme.example.com {
+    reverse_proxy 127.0.0.1:8080
+}
+```
+
+### Traefik label on the bundle's docker-compose
+
+Add a labels block under the `nginx` service in
+`docker-compose.override.yml`:
+
+```yaml
+services:
+  nginx:
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.frontdesk.rule: "Host(`frontdesk.acme.example.com`)"
+      traefik.http.routers.frontdesk.tls.certresolver: "acme"
+```
+
+If you bind `0.0.0.0:8080` without one of the above, you have just put
+plain-HTTP user-principal authentication on a multi-user network. The
+``zero-trust fabric`` tagline does not survive that. Pick a path.
+
+A ``--with-tls-sidecar`` option that bakes a self-signed cert + nginx
+TLS terminator into the bundle (the same pattern Mastio's
+``mastio-nginx`` uses) is on the roadmap as ADR-024 — track that ADR
+draft for the design discussion.
+
 ## Known limitations
 
-- **No HTTPS in the bundle.** Production deployments terminate TLS at the corporate ingress (or at oauth2-proxy with a cert), upstream of nginx. The bundle binds `:80` on purpose.
 - **No autoscale.** Single Connector replica per bundle; the cookie secret lives on local disk so horizontal scale needs a shared secret store. Roadmap.
 - **Cookie secret rotation** is manual for now: stop the bundle, delete `connector_data/cookie.secret`, restart. Forces every browser to re-init the session, no security incident.
 - **The bundle does not bundle the Mastio.** Cleanly separates concerns; deploy Mastio with `packaging/mastio-bundle/` and point this bundle at it.

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -147,7 +147,16 @@ services:
   nginx:
     image: nginx:1.27-alpine
     ports:
-      - "${FRONTDESK_HTTP_PORT:-8080}:80"
+      # Bind to 127.0.0.1 by default — Frontdesk serves plain HTTP and
+      # leaks the SPA session cookie on any non-loopback path. Localhost
+      # is a W3C "secure context" (SPA crypto + Secure cookies + Service
+      # Workers all work as if on HTTPS), so dogfood and single-user
+      # evaluations on the same host are safe. To expose on the LAN or
+      # the public internet, override FRONTDESK_HTTP_BIND to ``0.0.0.0``
+      # AND put a TLS terminator (oauth2-proxy / Caddy / Traefik / nginx)
+      # in front. Doing one without the other is incoherent with the
+      # zero-trust threat model — see README "Threat model & exposure".
+      - "${FRONTDESK_HTTP_BIND:-127.0.0.1}:${FRONTDESK_HTTP_PORT:-8080}:80"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     depends_on:


### PR DESCRIPTION
## Summary

The Frontdesk bundle's nginx front served plain HTTP on ``0.0.0.0:8080``, so any host on the same LAN could read the SPA session cookie + DPoP proofs in cleartext. That is incoherent with the **"zero-trust fabric for AI agents"** tagline — an attacker on the same office network can intercept and replay a user-principal session without breaking any Cullis crypto.

Localhost is a W3C ["secure context"](https://w3c.github.io/webappsec-secure-contexts/): SPA crypto, Secure cookies, Service Workers all behave on ``http://127.0.0.1`` exactly as on HTTPS. So binding to loopback by default keeps dogfood + single-user evaluation safe with zero friction.

## Changes

### (a) ``docker-compose.yml`` — bind to 127.0.0.1

```yaml
ports:
  - "${FRONTDESK_HTTP_BIND:-127.0.0.1}:${FRONTDESK_HTTP_PORT:-8080}:80"
```

To expose on the LAN or the internet, override ``FRONTDESK_HTTP_BIND=0.0.0.0`` AND put a TLS terminator in front. Doing one without the other leaves the threat model broken.

### (c) ``README.md`` — explicit threat model + 3 recipes

New "Threat model & exposure" section before "Known limitations":

- 3-mode table (localhost / LAN-no-TLS / TLS-terminator) marking which is coherent with the Cullis threat model.
- Minimal copy-paste recipes for oauth2-proxy, Caddy auto-Let's-Encrypt, Traefik labels.
- Pointer to ADR-024 draft (built-in ``--with-tls-sidecar`` option, longer-term).

## Out of scope (tracked separately)

- **(b) Built-in TLS sidecar** (same pattern ``mastio-nginx`` uses) — drafted as ADR-024 in ``imp/adrs/0024-frontdesk-tls-sidecar.md``. Bigger change (~200 lines), default-OFF, opt-in via ``--with-tls`` flag. Revisit after the rc3 VM dogfood lands and a design partner explicitly asks for single-server HTTPS one-command install.

## Why now

AI-as-customer re-dogfood 2026-05-09 surfaced this as a threat-model gap. The Mastio bundle has a TLS sidecar (``mastio-nginx`` on 9443) so Mastio is fine. Frontdesk was the only Cullis surface still on plain HTTP without a default loopback bind. The fix is one line in compose + one section in README; no code, no test impact.

## Test plan

- [x] ``docker compose --env-file frontdesk.env up -d`` continues to work, ``http://127.0.0.1:8080`` reachable from host browser, NOT reachable from other LAN hosts (verified via ``curl http://<host-lan-ip>:8080`` from another machine).
- [x] Setting ``FRONTDESK_HTTP_BIND=0.0.0.0`` in ``frontdesk.env`` restores LAN reachability for operators who run a TLS terminator in front.
- [x] Markdown renders correctly on GitHub preview.
- [ ] CI green.

## Roll-out

Bundle-only PR; no image / Connector / SDK change. Takes effect on the next ``frontdesk-bundle-v*`` rc/stable cut.