### PR TITLE
docs: bump frontdesk-bundle to v0.1.0-rc4 (threat-model bind fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
 cd ..
-curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc3/cullis-frontdesk-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc4/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle && ./deploy.sh
 ```
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -198,14 +198,14 @@ cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
         <li>
           <div class="bundle-head">
             <strong>Frontdesk bundle</strong>
-            <span class="bundle-tag">frontdesk-bundle-v0.1.0-rc3</span>
+            <span class="bundle-tag">frontdesk-bundle-v0.1.0-rc4</span>
           </div>
           <p class="bundle-blurb">
             Multi-user Cullis Chat (SPA on <code>:8080</code>) co-located
             with a Mastio on the same host. Adds a shared-mode Connector
             so multiple human users issue ADR-020 user principals.
           </p>
-          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc3/cullis-frontdesk-bundle.tar.gz | tar xz
+          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc4/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle &amp;&amp; ./deploy.sh</code></pre>
         </li>
 


### PR DESCRIPTION
## Summary

``frontdesk-bundle-v0.1.0-rc4`` cuts include the 127.0.0.1 default bind (#546) that closes the LAN-plain-HTTP threat-model flank. Bump pinned URLs in README + site so a fresh customer copy-paste lands on the bundle that matches the documented zero-trust posture.

Mastio rc3 unchanged.

## Files

- ``README.md`` (1 URL)
- ``site/src/pages/download.astro`` (2 occurrences: bundle-tag span + bundle-cmd curl).

## Test plan

- [ ] CI green.
- [ ] rc4 bundle tarball returns HTTP 200 (release CI in flight).