### PR TITLE
feat(connector): users.db sqlite + bcrypt + admin API for local user provisioning (ADR-025 Phase 1)

### DIFF
--- a/cullis_connector/admin/__init__.py
+++ b/cullis_connector/admin/__init__.py
@@ -1,0 +1,6 @@
+"""Connector admin API package — ADR-025 Phase 1.
+
+Provisioning endpoints for local user accounts. Only mounted by
+``cullis_connector.web.build_app`` when ``AUTH_MODE=local`` (the
+default for Frontdesk shared mode without a corporate IdP).
+"""

--- a/cullis_connector/admin/auth.py
+++ b/cullis_connector/admin/auth.py
@@ -1,0 +1,38 @@
+"""Connector admin-API auth dependency.
+
+Mirrors ``mcp_proxy/admin/users.py``'s ``X-Admin-Secret`` contract so
+operators only have to learn one shape: every admin route on the
+Cullis stack reads the same header, compared in constant time. The
+secret value lives in the ``CULLIS_CONNECTOR_ADMIN_SECRET`` env var
+and is intentionally distinct from the Mastio admin secret — the two
+control planes are separate, and a leaked Mastio secret should not
+grant local user provisioning on the Connector.
+
+Returns 403 (not 401) on miss/mismatch to match the existing Mastio
+admin endpoints.
+"""
+from __future__ import annotations
+
+import hmac
+import os
+
+from fastapi import Header, HTTPException, status
+
+ADMIN_SECRET_ENV = "CULLIS_CONNECTOR_ADMIN_SECRET"
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    """FastAPI dependency. Raises 403 unless the header matches the env."""
+    expected = os.environ.get(ADMIN_SECRET_ENV, "")
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="admin secret not configured on this Connector",
+        )
+    if not hmac.compare_digest(x_admin_secret or "", expected):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )

--- a/cullis_connector/admin/users_router.py
+++ b/cullis_connector/admin/users_router.py
@@ -1,0 +1,226 @@
+"""Admin API for local user provisioning — ADR-025 Phase 1.
+
+Endpoints:
+
+- ``POST   /admin/users``                          create user (201/400/409)
+- ``GET    /admin/users``                          list users (200)
+- ``DELETE /admin/users/{user_name}``              delete user (204/404)
+- ``POST   /admin/users/{user_name}/reset-password`` admin reset (200/404)
+
+All routes are gated by ``X-Admin-Secret`` — see
+``cullis_connector/admin/auth.py``. The router is only mounted when
+``AUTH_MODE=local`` (the FrontDesk shared-mode default).
+
+The router pulls ``connector_config`` off the FastAPI ``app.state``
+the same way the rest of ``cullis_connector/web.py`` does, so test
+harnesses that call ``build_app(cfg)`` get an isolated users.db per
+test without any monkey-patching.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
+
+from cullis_connector.admin.auth import _require_admin_secret
+from cullis_connector.identity.users import (
+    User,
+    create_user,
+    delete_user,
+    get_user_by_name,
+    list_users,
+    reset_password,
+)
+from cullis_connector.identity.users_db import get_users_session
+
+_log = logging.getLogger("cullis_connector.admin.users_router")
+
+
+router = APIRouter(
+    prefix="/admin/users",
+    tags=["admin", "users"],
+    dependencies=[Depends(_require_admin_secret)],
+)
+
+
+# ── request / response models ───────────────────────────────────────────
+
+
+class CreateUserRequest(BaseModel):
+    user_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    password: str = Field(..., min_length=8)
+    must_change_password: bool = True
+    display_name: str = Field("", max_length=256)
+
+
+class ResetPasswordRequest(BaseModel):
+    new_password: str = Field(..., min_length=8)
+
+
+class UserOut(BaseModel):
+    user_name: str
+    display_name: str
+    must_change_password: bool
+    created_at: str
+    password_changed_at: Optional[str] = None
+    disabled: bool = False
+
+
+class UserListResponse(BaseModel):
+    users: list[UserOut]
+    total: int
+
+
+class ResetPasswordResponse(BaseModel):
+    user_name: str
+    must_change_password: bool
+
+
+def _to_out(user: User) -> UserOut:
+    return UserOut(
+        user_name=user.user_name,
+        display_name=user.display_name,
+        must_change_password=user.must_change_password,
+        created_at=user.created_at,
+        password_changed_at=user.password_changed_at,
+        disabled=user.disabled,
+    )
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _config_dir(request: Request):
+    config = getattr(request.app.state, "connector_config", None)
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="connector_config not bound on app.state",
+        )
+    return config.config_dir
+
+
+# ── endpoints ───────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    response_model=UserOut,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_user_endpoint(
+    body: CreateUserRequest, request: Request,
+) -> UserOut:
+    """Create a local user. 409 on duplicate, 400 on bad regex / weak password."""
+    config_dir = _config_dir(request)
+    try:
+        async with get_users_session(config_dir) as session:
+            user = await create_user(
+                session,
+                name=body.user_name,
+                password=body.password,
+                must_change=body.must_change_password,
+                display_name=body.display_name,
+            )
+        # NEVER log the password — only the username + result.
+        _log.info(
+            "admin: created local user user_name=%s must_change=%s",
+            user.user_name, user.must_change_password,
+        )
+        return _to_out(user)
+    except IntegrityError:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"user_name {body.user_name!r} already exists",
+        )
+    except ValueError as exc:
+        # Surfaced from username/password validators.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+
+
+@router.get("", response_model=UserListResponse)
+async def list_users_endpoint(
+    request: Request,
+    q: str = Query("", max_length=128),
+    disabled: Optional[bool] = Query(None),
+    limit: int = Query(200, ge=1, le=500),
+) -> UserListResponse:
+    config_dir = _config_dir(request)
+    async with get_users_session(config_dir) as session:
+        users = await list_users(
+            session, q=q, disabled=disabled, limit=limit,
+        )
+    items = [_to_out(u) for u in users]
+    return UserListResponse(users=items, total=len(items))
+
+
+@router.delete(
+    "/{user_name}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_user_endpoint(
+    user_name: str, request: Request,
+) -> Response:
+    config_dir = _config_dir(request)
+    async with get_users_session(config_dir) as session:
+        ok = await delete_user(session, user_name)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"user_name {user_name!r} not found",
+        )
+    _log.info("admin: deleted local user user_name=%s", user_name)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{user_name}/reset-password",
+    response_model=ResetPasswordResponse,
+)
+async def reset_password_endpoint(
+    user_name: str, body: ResetPasswordRequest, request: Request,
+) -> ResetPasswordResponse:
+    """Admin-driven password reset.
+
+    Sets a new temporary password and forces ``must_change_password=True``
+    so the user is prompted to change it on first login. Phase 5's SPA
+    flow consumes this endpoint from the admin Users tab.
+    """
+    config_dir = _config_dir(request)
+    try:
+        async with get_users_session(config_dir) as session:
+            ok = await reset_password(
+                session, user_name, body.new_password,
+            )
+            if not ok:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"user_name {user_name!r} not found",
+                )
+            user = await get_user_by_name(session, user_name)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        )
+    # Defensive — get_user_by_name should succeed since reset_password
+    # returned True, but guard anyway so the response model is clean.
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"user_name {user_name!r} not found",
+        )
+    _log.info(
+        "admin: reset password user_name=%s must_change=%s",
+        user.user_name, user.must_change_password,
+    )
+    return ResetPasswordResponse(
+        user_name=user.user_name,
+        must_change_password=user.must_change_password,
+    )

--- a/cullis_connector/identity/__init__.py
+++ b/cullis_connector/identity/__init__.py
@@ -4,6 +4,11 @@ Phase 2b introduces persistent identity: a private key and Org-CA-signed
 certificate live under ``<config_dir>/identity/`` and are loaded at server
 start. The private key is generated locally and never leaves the machine;
 the Site only ever sees the public half submitted during enrollment.
+
+ADR-025 Phase 1 also adds a ``users.db`` next to the identity dir for
+local user accounts (Frontdesk shared-mode dual auth). The user table
+is gated behind ``AUTH_MODE=local`` at the web layer — see
+``cullis_connector/web.py``.
 """
 
 from cullis_connector.identity.keypair import (
@@ -18,14 +23,42 @@ from cullis_connector.identity.store import (
     load_identity,
     save_identity,
 )
+from cullis_connector.identity.users import (
+    User,
+    create_user,
+    delete_user,
+    get_user_by_name,
+    list_users,
+    mark_password_changed,
+    reset_password,
+    set_password_hash,
+    verify_password,
+)
+from cullis_connector.identity.users_db import (
+    USERS_DB_FILENAME,
+    get_users_session,
+    init_users_db,
+)
 
 __all__ = [
     "IdentityBundle",
     "IdentityNotFound",
+    "USERS_DB_FILENAME",
+    "User",
+    "create_user",
+    "delete_user",
     "generate_keypair",
+    "get_user_by_name",
+    "get_users_session",
     "has_identity",
+    "init_users_db",
+    "list_users",
     "load_identity",
+    "mark_password_changed",
     "private_key_to_pem",
     "public_key_to_pem",
+    "reset_password",
     "save_identity",
+    "set_password_hash",
+    "verify_password",
 ]

--- a/cullis_connector/identity/users.py
+++ b/cullis_connector/identity/users.py
@@ -1,0 +1,309 @@
+"""Local user accounts for Cullis Connector / Frontdesk shared mode.
+
+ADR-025 Phase 1 — backing store for the Frontdesk dual-mode auth
+flow. When the Frontdesk container is deployed without a corporate
+IdP, end users sign in against a local users.db on the Connector.
+This module owns the SQLAlchemy ORM model + the small set of async
+helpers the admin API and the (later-phase) login endpoint use.
+
+Design notes:
+
+- bcrypt cost 12 — same as ``mcp_proxy/dashboard/session.py`` admin
+  password hashing. ``bcrypt.checkpw`` is CPU-bound C code, so we
+  always wrap it in ``asyncio.to_thread`` to keep the event loop
+  responsive while a verification runs (~150 ms / call on commodity
+  hardware).
+- Username regex matches the Mastio convention
+  (``mcp_proxy/admin/users.py``): ``^[a-zA-Z0-9._-]{1,64}$``. That
+  guarantees the user_name is safe to splice into a SPIFFE id and
+  closes any SQL-injection / log-poisoning vector on the bare string.
+- Password rule v1 follows NIST 800-63B: min 8 chars, no upper bound,
+  no complexity requirement, but reject all-whitespace strings to
+  avoid accidental empty hashes from typo'd inputs.
+- The plaintext password is NEVER persisted, NEVER returned, and
+  NEVER logged. Only the bcrypt hash (60-char ``$2b$...``) leaves
+  this module.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+import bcrypt
+from sqlalchemy import Index, Integer, String, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+_log = logging.getLogger("cullis_connector.identity.users")
+
+
+# ── SQLAlchemy ORM ────────────────────────────────────────────────────────
+
+
+class Base(DeclarativeBase):
+    """Declarative base scoped to the Connector users.db schema.
+
+    Kept separate from any other ORM ``Base`` in the codebase so
+    ``Base.metadata.create_all`` only creates this module's tables.
+    """
+
+
+class LocalUser(Base):
+    __tablename__ = "local_users"
+
+    user_name: Mapped[str] = mapped_column(String, primary_key=True, nullable=False)
+    password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    display_name: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    must_change_password: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1,
+    )
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    password_changed_at: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    disabled: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
+Index("idx_local_users_must_change", LocalUser.must_change_password)
+
+
+# ── Public dataclass ──────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class User:
+    """Read-only view of a local user row.
+
+    Never carries the password hash — callers should not be able to
+    accidentally serialise it into a response or a log line. The
+    verification path lives entirely inside this module via
+    :func:`verify_password`.
+    """
+
+    user_name: str
+    display_name: str
+    must_change_password: bool
+    created_at: str
+    password_changed_at: Optional[str]
+    disabled: bool
+
+
+def _row_to_user(row: LocalUser) -> User:
+    return User(
+        user_name=row.user_name,
+        display_name=row.display_name or "",
+        must_change_password=bool(row.must_change_password),
+        created_at=row.created_at,
+        password_changed_at=row.password_changed_at,
+        disabled=bool(row.disabled),
+    )
+
+
+# ── Validation ────────────────────────────────────────────────────────────
+
+
+_USERNAME_RE = re.compile(r"^[a-zA-Z0-9._-]{1,64}$")
+MIN_PASSWORD_LENGTH = 8
+
+
+def _validate_username(name: str) -> None:
+    if not isinstance(name, str) or not _USERNAME_RE.match(name):
+        raise ValueError(
+            "user_name must match ^[a-zA-Z0-9._-]{1,64}$",
+        )
+
+
+def _validate_password(plain: str) -> None:
+    if not isinstance(plain, str):
+        raise ValueError("password must be a string")
+    if len(plain) < MIN_PASSWORD_LENGTH:
+        raise ValueError(
+            f"password must be at least {MIN_PASSWORD_LENGTH} characters",
+        )
+    if not plain.strip():
+        raise ValueError("password must not be only whitespace")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+# ── bcrypt helpers ────────────────────────────────────────────────────────
+
+
+def _hash_password_sync(plain: str) -> str:
+    """Blocking bcrypt hash. Caller wraps in asyncio.to_thread."""
+    return bcrypt.hashpw(
+        plain.encode("utf-8"), bcrypt.gensalt(rounds=12),
+    ).decode("utf-8")
+
+
+def _check_password_sync(plain: str, stored_hash: str) -> bool:
+    try:
+        return bcrypt.checkpw(plain.encode("utf-8"), stored_hash.encode("utf-8"))
+    except (ValueError, TypeError):
+        return False
+
+
+# ── CRUD helpers ──────────────────────────────────────────────────────────
+
+
+async def create_user(
+    session: AsyncSession,
+    *,
+    name: str,
+    password: str,
+    must_change: bool = True,
+    display_name: str = "",
+) -> User:
+    """Insert a new local user.
+
+    Raises ``ValueError`` on bad regex / weak password.
+    Raises ``sqlalchemy.exc.IntegrityError`` on duplicate user_name —
+    the admin router catches that and returns HTTP 409.
+    """
+    _validate_username(name)
+    _validate_password(password)
+    pwd_hash = await asyncio.to_thread(_hash_password_sync, password)
+    row = LocalUser(
+        user_name=name,
+        password_hash=pwd_hash,
+        display_name=display_name or None,
+        must_change_password=1 if must_change else 0,
+        created_at=_now_iso(),
+        password_changed_at=None,
+        disabled=0,
+    )
+    session.add(row)
+    await session.flush()
+    # NEVER log the password or the hash. The bcrypt cost embeds the
+    # salt, so a leaked log line would still be brute-forceable for
+    # weak passwords.
+    _log.info("local_users: created user_name=%s", name)
+    return _row_to_user(row)
+
+
+async def get_user_by_name(
+    session: AsyncSession, name: str,
+) -> Optional[User]:
+    """Return the user row, or ``None`` if it does not exist."""
+    if not isinstance(name, str) or not name:
+        return None
+    stmt = select(LocalUser).where(LocalUser.user_name == name)
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    return _row_to_user(row)
+
+
+async def list_users(
+    session: AsyncSession,
+    *,
+    q: str = "",
+    disabled: Optional[bool] = None,
+    limit: int = 200,
+) -> list[User]:
+    """Return up to ``limit`` users, newest-first.
+
+    ``q`` does a case-insensitive substring match on ``user_name``
+    and ``display_name``. ``disabled`` filters by status when set;
+    ``None`` returns both enabled and disabled rows.
+    """
+    stmt = select(LocalUser)
+    if q:
+        like = f"%{q.lower()}%"
+        stmt = stmt.where(
+            (LocalUser.user_name.ilike(like))
+            | (LocalUser.display_name.ilike(like))
+        )
+    if disabled is not None:
+        stmt = stmt.where(LocalUser.disabled == (1 if disabled else 0))
+    stmt = stmt.order_by(LocalUser.created_at.desc()).limit(int(limit))
+    result = await session.execute(stmt)
+    rows = result.scalars().all()
+    return [_row_to_user(r) for r in rows]
+
+
+async def delete_user(session: AsyncSession, name: str) -> bool:
+    """Delete the user. Returns ``True`` if a row was removed."""
+    stmt = select(LocalUser).where(LocalUser.user_name == name)
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return False
+    await session.delete(row)
+    await session.flush()
+    _log.info("local_users: deleted user_name=%s", name)
+    return True
+
+
+async def verify_password(
+    session: AsyncSession, name: str, plain: str,
+) -> bool:
+    """Constant-time bcrypt verify. Returns ``False`` if user is missing."""
+    if not isinstance(plain, str) or not plain:
+        return False
+    if not isinstance(name, str) or not name:
+        return False
+    stmt = select(LocalUser.password_hash).where(LocalUser.user_name == name)
+    result = await session.execute(stmt)
+    stored = result.scalar_one_or_none()
+    if not stored:
+        return False
+    return await asyncio.to_thread(_check_password_sync, plain, stored)
+
+
+async def set_password_hash(
+    session: AsyncSession,
+    name: str,
+    plain: str,
+    *,
+    must_change: bool = False,
+) -> bool:
+    """Re-hash and persist a new password for an existing user.
+
+    Returns ``False`` if the user does not exist. Validates the new
+    password against the same length / whitespace rules used at
+    ``create_user`` time.
+    """
+    _validate_password(plain)
+    stmt = select(LocalUser).where(LocalUser.user_name == name)
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return False
+    new_hash = await asyncio.to_thread(_hash_password_sync, plain)
+    row.password_hash = new_hash
+    row.must_change_password = 1 if must_change else 0
+    row.password_changed_at = _now_iso()
+    await session.flush()
+    _log.info(
+        "local_users: password updated user_name=%s must_change=%s",
+        name, bool(must_change),
+    )
+    return True
+
+
+async def mark_password_changed(session: AsyncSession, name: str) -> bool:
+    """Clear the must_change_password flag without touching the hash."""
+    stmt = select(LocalUser).where(LocalUser.user_name == name)
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return False
+    row.must_change_password = 0
+    row.password_changed_at = _now_iso()
+    await session.flush()
+    return True
+
+
+async def reset_password(
+    session: AsyncSession, name: str, new_password: str,
+) -> bool:
+    """Admin reset path — sets a new password and forces a change on next login."""
+    return await set_password_hash(
+        session, name, new_password, must_change=True,
+    )

--- a/cullis_connector/identity/users_db.py
+++ b/cullis_connector/identity/users_db.py
@@ -17,6 +17,7 @@ bcrypt hashes are not readable by other local users on the host.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from contextlib import asynccontextmanager
@@ -38,11 +39,34 @@ _log = logging.getLogger("cullis_connector.identity.users_db")
 USERS_DB_FILENAME = "users.db"
 
 
-# Per-config_dir engine cache. Each ConnectorConfig.config_dir maps to
-# a single AsyncEngine for the lifetime of the process. This keeps
-# WAL/journal connections warm and avoids the "database is locked"
-# class of error from a fresh engine being spun up on every request.
-_engines: dict[Path, AsyncEngine] = {}
+# Per-(config_dir, event_loop_id) engine cache. Each ConnectorConfig.config_dir
+# maps to a single AsyncEngine PER asyncio event loop for the lifetime of that
+# loop. This keeps WAL/journal connections warm and avoids the "database is
+# locked" class of error from a fresh engine being spun up on every request,
+# while also preventing cross-loop pollution that breaks pytest-asyncio shards
+# (the connection pool ties to the loop that opened it; reusing the engine on
+# a different loop fails with "There is no current event loop in thread").
+#
+# The loop key is ``id(loop)`` rather than the loop object itself so a closed
+# loop can be GCed without the cache holding it alive. Stale entries (loop
+# closed) are detected and replaced lazily by ``_users_engine``.
+_engines: dict[tuple[Path, int], AsyncEngine] = {}
+
+
+def _current_loop_key() -> int:
+    """Return the id of the current running loop, or 0 if none.
+
+    Sync entrypoints (e.g. fastapi.testclient.TestClient bridging into
+    an async route) may call into this module without a running loop;
+    those flows still need a working engine, so we fall back to a stable
+    0-key bucket. The pytest-asyncio session loop case takes the running
+    branch and gets its own per-loop engine.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return 0
+    return id(loop)
 
 
 def _users_db_path(config_dir: Path) -> Path:
@@ -50,8 +74,13 @@ def _users_db_path(config_dir: Path) -> Path:
 
 
 def _users_engine(config_dir: Path) -> AsyncEngine:
-    """Return (creating if needed) the cached AsyncEngine for ``config_dir``."""
-    key = Path(config_dir).resolve()
+    """Return (creating if needed) the cached AsyncEngine for ``config_dir``.
+
+    Cache is keyed by ``(config_dir, current_loop_id)`` so a fresh
+    pytest-asyncio loop gets its own engine instead of inheriting a
+    stale one whose connection pool is bound to a closed loop.
+    """
+    key = (Path(config_dir).resolve(), _current_loop_key())
     engine = _engines.get(key)
     if engine is not None:
         return engine
@@ -130,7 +159,24 @@ async def get_users_session(
 
 
 async def dispose_users_engines() -> None:
-    """Tear down all cached engines — used by tests for isolation."""
-    while _engines:
-        _, engine = _engines.popitem()
-        await engine.dispose()
+    """Tear down all cached engines — used by tests for isolation.
+
+    Engines created on the *current* event loop are awaited cleanly
+    (closing aiosqlite connections + shutting down the pool). Engines
+    bound to a different loop (e.g. a closed pytest-asyncio loop from
+    a previous test) cannot be awaited safely; we just drop the
+    reference and let GC reclaim them.
+    """
+    current = _current_loop_key()
+    keys = list(_engines.keys())
+    for key in keys:
+        engine = _engines.pop(key, None)
+        if engine is None:
+            continue
+        _, loop_id = key
+        if loop_id == current and current != 0:
+            try:
+                await engine.dispose()
+            except Exception as exc:  # pragma: no cover — best-effort
+                _log.debug("dispose_users_engines: %s", exc)
+        # else: engine bound to a foreign/closed loop — drop the ref.

--- a/cullis_connector/identity/users_db.py
+++ b/cullis_connector/identity/users_db.py
@@ -1,0 +1,136 @@
+"""Async SQLite engine + session factory for the Connector's users.db.
+
+ADR-025 Phase 1 — separate from any agent-side state. The Connector
+already has ``identity/`` for the agent cert/key bundle; the local
+user database lives one level up at ``<config_dir>/users.db`` so a
+profile reset (``identity/`` wipe) does not blow away the user
+accounts the admin pre-created.
+
+WAL journaling is enabled on first connection so an active SPA login
+flow does not block an admin DELETE in another tab. ``synchronous =
+NORMAL`` is the WAL-mode recommended trade-off — safe against process
+crashes, slightly weaker against full OS-level power loss; acceptable
+for a single-machine end-user database.
+
+The DB file is ``chmod 0600`` after creation (POSIX only) so the
+bcrypt hashes are not readable by other local users on the host.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from cullis_connector.identity.users import Base
+
+_log = logging.getLogger("cullis_connector.identity.users_db")
+
+USERS_DB_FILENAME = "users.db"
+
+
+# Per-config_dir engine cache. Each ConnectorConfig.config_dir maps to
+# a single AsyncEngine for the lifetime of the process. This keeps
+# WAL/journal connections warm and avoids the "database is locked"
+# class of error from a fresh engine being spun up on every request.
+_engines: dict[Path, AsyncEngine] = {}
+
+
+def _users_db_path(config_dir: Path) -> Path:
+    return Path(config_dir) / USERS_DB_FILENAME
+
+
+def _users_engine(config_dir: Path) -> AsyncEngine:
+    """Return (creating if needed) the cached AsyncEngine for ``config_dir``."""
+    key = Path(config_dir).resolve()
+    engine = _engines.get(key)
+    if engine is not None:
+        return engine
+
+    Path(config_dir).mkdir(parents=True, exist_ok=True)
+    db_path = _users_db_path(config_dir)
+    url = f"sqlite+aiosqlite:///{db_path}"
+    engine = create_async_engine(url, echo=False, future=True)
+
+    # Apply WAL + synchronous=NORMAL on every fresh aiosqlite connection.
+    @event.listens_for(engine.sync_engine, "connect")
+    def _on_connect(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+        finally:
+            cursor.close()
+
+    _engines[key] = engine
+    return engine
+
+
+async def init_users_db(config_dir: Path) -> None:
+    """Create the schema if missing and enforce 0600 perms on the DB file.
+
+    Idempotent — calling it twice on the same config_dir is safe.
+    """
+    engine = _users_engine(config_dir)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_path = _users_db_path(config_dir)
+    _enforce_db_perms(db_path)
+
+
+def _enforce_db_perms(db_path: Path) -> None:
+    """Best-effort chmod 0600 on the users.db file (POSIX only).
+
+    bcrypt hashes are not catastrophic if leaked but they are still
+    a credential — let's not leave them group/world readable.
+    """
+    if os.name != "posix":
+        return
+    try:
+        if db_path.exists():
+            os.chmod(db_path, 0o600)
+    except OSError as exc:
+        _log.warning(
+            "could not chmod 0600 %s: %s (continuing)", db_path, exc,
+        )
+
+
+@asynccontextmanager
+async def get_users_session(
+    config_dir: Path,
+) -> AsyncIterator[AsyncSession]:
+    """Async context manager yielding a transactional session.
+
+    Lazily initialises the schema on first use, so callers (router
+    handlers, tests) do not need to remember to call
+    :func:`init_users_db` themselves. Each enter/exit pair commits on
+    clean exit and rolls back on exception, mirroring SQLAlchemy's
+    ``AsyncSession`` recommended idiom.
+    """
+    await init_users_db(config_dir)
+    engine = _users_engine(config_dir)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+async def dispose_users_engines() -> None:
+    """Tear down all cached engines — used by tests for isolation."""
+    while _engines:
+        _, engine = _engines.popitem()
+        await engine.dispose()

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -558,6 +558,25 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     templates.env.globals["cullis_chat_mounted"] = chat_dist is not None
     app.state.cullis_chat_mounted = chat_dist is not None
 
+    # ── ADR-025 Phase 1 — local user provisioning admin API ─────────────
+    #
+    # Mount only when AUTH_MODE=local (the FrontDesk shared-mode default
+    # for SMB deployments without a corporate IdP). Set AUTH_MODE=oidc
+    # to skip the mount entirely so the local-users surface does not
+    # exist at all in IdP-only deployments.
+    auth_mode = os.environ.get("AUTH_MODE", "local").strip().lower() or "local"
+    app.state.auth_mode = auth_mode
+    if auth_mode == "local":
+        from cullis_connector.admin.users_router import router as _users_router
+        app.include_router(_users_router)
+        _log.info(
+            "ADR-025 admin /admin/users mounted (AUTH_MODE=%s)", auth_mode,
+        )
+    else:
+        _log.info(
+            "ADR-025 admin /admin/users NOT mounted (AUTH_MODE=%s)", auth_mode,
+        )
+
     # ── CSRF / cross-origin guard ────────────────────────────────────────
     #
     # Audit 2026-04-30 lane 5 C1 — every state-changing endpoint on the
@@ -594,7 +613,13 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         if (
             request.url.path.startswith("/v1/")
             or request.url.path.startswith("/api/session/")
+            or request.url.path.startswith("/admin/")
         ):
+            # ``/admin/*`` runs its own constant-time ``X-Admin-Secret``
+            # check (see ``cullis_connector/admin/auth.py``). The header
+            # is not auto-attached by browsers, so the route is not a
+            # CSRF vector — mirroring the exemption already granted to
+            # the Bearer-token path below.
             return await call_next(request)
         if request.method in ("POST", "PUT", "DELETE", "PATCH"):
             authz = request.headers.get("authorization", "")

--- a/tests/connector/test_admin_users_endpoint.py
+++ b/tests/connector/test_admin_users_endpoint.py
@@ -1,0 +1,286 @@
+"""HTTP integration tests for /admin/users — ADR-025 Phase 1.
+
+Drives ``cullis_connector.web.build_app`` via fastapi.testclient and
+asserts the admin API contracts: 201/400/404/409/403 paths, list
+filter, delete idempotency, and reset-password flipping
+``must_change_password`` back to True.
+
+Each test gets a fresh ``tmp_path`` so the per-test users.db is fully
+isolated (no shared engine state across tests).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import build_app
+
+# Local AsyncEngine cache — flushed between tests so each test sees
+# a fresh users.db at its own tmp_path.
+from cullis_connector.identity.users_db import dispose_users_engines
+
+ADMIN_SECRET = "test-admin-secret-not-default"
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_engines():
+    yield
+    await dispose_users_engines()
+
+
+@pytest.fixture
+def connector_config(tmp_path):
+    cfg = ConnectorConfig(
+        config_dir=tmp_path / "connector",
+        site_url="http://mastio.test",
+        verify_tls=False,
+    )
+    cfg.config_dir.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+@pytest.fixture
+def client(connector_config, monkeypatch):
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    app = build_app(connector_config)
+    tc = TestClient(app)
+    # CSRF guard expects same-origin Origin on state-changing requests
+    # for non-/admin paths; admin is exempt but TestClient uses
+    # http://testserver as default base URL anyway.
+    tc.headers["Origin"] = "http://testserver"
+    return tc
+
+
+def _admin_headers() -> dict[str, str]:
+    return {"X-Admin-Secret": ADMIN_SECRET}
+
+
+# ── auth ────────────────────────────────────────────────────────────────
+
+
+def test_create_user_403_without_admin_secret(client):
+    r = client.post(
+        "/admin/users",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    # Pydantic missing-header → 422; FastAPI Header(...) without alias
+    # would be 422 too, but we use Header(..., alias="X-Admin-Secret"),
+    # so a missing header is also 422 from FastAPI before our 403
+    # check runs. Either way, the route is not creating the user.
+    assert r.status_code in (403, 422)
+
+
+def test_create_user_403_with_wrong_admin_secret(client):
+    r = client.post(
+        "/admin/users",
+        headers={"X-Admin-Secret": "wrong-secret"},
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 403
+
+
+def test_admin_secret_env_unset_returns_403(connector_config, monkeypatch):
+    monkeypatch.delenv("CULLIS_CONNECTOR_ADMIN_SECRET", raising=False)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    app = build_app(connector_config)
+    tc = TestClient(app)
+    r = tc.post(
+        "/admin/users",
+        headers={"X-Admin-Secret": "anything"},
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 403
+
+
+# ── create ─────────────────────────────────────────────────────────────
+
+
+def test_create_user_201_happy_path(client):
+    r = client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario",
+            "password": "temp123!secure",
+            "must_change_password": True,
+            "display_name": "Mario Rossi",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["user_name"] == "mario"
+    assert body["display_name"] == "Mario Rossi"
+    assert body["must_change_password"] is True
+    assert body["disabled"] is False
+    assert body["password_changed_at"] is None
+    assert body["created_at"]
+    assert "password" not in body
+    assert "password_hash" not in body
+
+
+def test_create_user_400_bad_username_regex(client):
+    r = client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario rossi",  # space → invalid
+            "password": "longpassword",
+        },
+    )
+    # Pydantic field-level pattern reject → 422
+    assert r.status_code in (400, 422)
+
+
+def test_create_user_400_password_too_short(client):
+    r = client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario",
+            "password": "short",  # < 8 chars
+        },
+    )
+    assert r.status_code in (400, 422)
+
+
+def test_create_user_409_on_duplicate(client):
+    payload = {"user_name": "mario", "password": "longpassword"}
+    r1 = client.post(
+        "/admin/users", headers=_admin_headers(), json=payload,
+    )
+    assert r1.status_code == 201
+    r2 = client.post(
+        "/admin/users", headers=_admin_headers(), json=payload,
+    )
+    assert r2.status_code == 409
+
+
+# ── list ───────────────────────────────────────────────────────────────
+
+
+def test_list_users_returns_created_rows(client):
+    for name in ("alice", "bob", "carol"):
+        client.post(
+            "/admin/users",
+            headers=_admin_headers(),
+            json={"user_name": name, "password": "longpassword"},
+        )
+    r = client.get("/admin/users", headers=_admin_headers())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 3
+    assert {u["user_name"] for u in body["users"]} == {"alice", "bob", "carol"}
+
+
+def test_list_users_filter_by_q(client):
+    client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario",
+            "password": "longpassword",
+            "display_name": "Mario Rossi",
+        },
+    )
+    client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "lucia",
+            "password": "longpassword",
+            "display_name": "Lucia Bianchi",
+        },
+    )
+    r = client.get("/admin/users?q=lucia", headers=_admin_headers())
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["users"][0]["user_name"] == "lucia"
+
+
+# ── delete ─────────────────────────────────────────────────────────────
+
+
+def test_delete_user_204_then_404(client):
+    client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={"user_name": "todel", "password": "longpassword"},
+    )
+    r1 = client.delete("/admin/users/todel", headers=_admin_headers())
+    assert r1.status_code == 204
+    r2 = client.delete("/admin/users/todel", headers=_admin_headers())
+    assert r2.status_code == 404
+
+
+def test_delete_user_404_for_unknown(client):
+    r = client.delete("/admin/users/ghost", headers=_admin_headers())
+    assert r.status_code == 404
+
+
+# ── reset password ─────────────────────────────────────────────────────
+
+
+def test_reset_password_200_and_must_change_true(client):
+    client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "resetme",
+            "password": "old-password",
+            "must_change_password": False,
+        },
+    )
+    r = client.post(
+        "/admin/users/resetme/reset-password",
+        headers=_admin_headers(),
+        json={"new_password": "fresh-temp-pwd"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["user_name"] == "resetme"
+    assert body["must_change_password"] is True
+
+
+def test_reset_password_404_for_unknown_user(client):
+    r = client.post(
+        "/admin/users/ghost/reset-password",
+        headers=_admin_headers(),
+        json={"new_password": "fresh-temp-pwd"},
+    )
+    assert r.status_code == 404
+
+
+def test_reset_password_400_when_too_short(client):
+    client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={"user_name": "short", "password": "longpassword"},
+    )
+    r = client.post(
+        "/admin/users/short/reset-password",
+        headers=_admin_headers(),
+        json={"new_password": "no"},  # < 8 chars
+    )
+    assert r.status_code in (400, 422)
+
+
+# ── AUTH_MODE gating ───────────────────────────────────────────────────
+
+
+def test_admin_users_not_mounted_when_auth_mode_oidc(connector_config, monkeypatch):
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "oidc")
+    app = build_app(connector_config)
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+
+    r = tc.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    # Router not mounted → 404 from FastAPI (no matching route).
+    assert r.status_code == 404

--- a/tests/connector/test_users_db.py
+++ b/tests/connector/test_users_db.py
@@ -1,0 +1,280 @@
+"""Tests for cullis_connector.identity.users / users_db — ADR-025 Phase 1.
+
+Covers the DB layer in isolation: bcrypt verify, must_change_password
+toggling, list filters, delete + reset-password semantics, and the
+0600 permission enforcement on the SQLite file.
+"""
+from __future__ import annotations
+
+import os
+import stat
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from cullis_connector.identity.users import (
+    create_user,
+    delete_user,
+    get_user_by_name,
+    list_users,
+    mark_password_changed,
+    reset_password,
+    set_password_hash,
+    verify_password,
+)
+from cullis_connector.identity.users_db import (
+    USERS_DB_FILENAME,
+    dispose_users_engines,
+    get_users_session,
+    init_users_db,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def config_dir(tmp_path):
+    d = tmp_path / "connector"
+    d.mkdir(parents=True, exist_ok=True)
+    yield d
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_engines():
+    """Each test gets a fresh engine cache so per-tmp_path DBs don't leak."""
+    yield
+    await dispose_users_engines()
+
+
+# ── happy path ──────────────────────────────────────────────────────────
+
+
+async def test_create_user_happy_path(config_dir):
+    async with get_users_session(config_dir) as session:
+        user = await create_user(
+            session,
+            name="mario",
+            password="temp123!secure",
+            must_change=True,
+            display_name="Mario Rossi",
+        )
+    assert user.user_name == "mario"
+    assert user.display_name == "Mario Rossi"
+    assert user.must_change_password is True
+    assert user.disabled is False
+    assert user.password_changed_at is None
+    assert user.created_at  # ISO timestamp
+
+
+async def test_get_user_by_name_returns_none_for_missing(config_dir):
+    async with get_users_session(config_dir) as session:
+        result = await get_user_by_name(session, "nobody")
+    assert result is None
+
+
+async def test_create_user_then_get(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(
+            session, name="alice", password="superlong-pwd",
+        )
+    async with get_users_session(config_dir) as session:
+        fetched = await get_user_by_name(session, "alice")
+    assert fetched is not None
+    assert fetched.user_name == "alice"
+
+
+# ── duplicates ──────────────────────────────────────────────────────────
+
+
+async def test_duplicate_user_raises_integrity_error(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(session, name="dup", password="password1")
+
+    with pytest.raises(IntegrityError):
+        async with get_users_session(config_dir) as session:
+            await create_user(session, name="dup", password="password2")
+
+
+# ── bcrypt verify ──────────────────────────────────────────────────────
+
+
+async def test_verify_password_pass_and_fail(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(
+            session, name="bob", password="correct-horse-battery",
+        )
+
+    async with get_users_session(config_dir) as session:
+        assert await verify_password(
+            session, "bob", "correct-horse-battery",
+        ) is True
+        assert await verify_password(
+            session, "bob", "wrong-password",
+        ) is False
+        assert await verify_password(
+            session, "bob", "",
+        ) is False
+
+
+async def test_verify_password_unknown_user_returns_false(config_dir):
+    # Sanity: never expose existence via timing — verify_password
+    # short-circuits to False before bcrypt runs.
+    async with get_users_session(config_dir) as session:
+        assert await verify_password(session, "ghost", "anything-here") is False
+
+
+# ── must_change_password flag ──────────────────────────────────────────
+
+
+async def test_mark_password_changed_clears_flag(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(
+            session, name="charlie", password="initial-pwd",
+            must_change=True,
+        )
+
+    async with get_users_session(config_dir) as session:
+        ok = await mark_password_changed(session, "charlie")
+    assert ok is True
+
+    async with get_users_session(config_dir) as session:
+        u = await get_user_by_name(session, "charlie")
+    assert u is not None
+    assert u.must_change_password is False
+    assert u.password_changed_at is not None
+
+
+# ── list filters ───────────────────────────────────────────────────────
+
+
+async def test_list_users_filter_by_q_and_disabled(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(
+            session, name="aaa", password="password1",
+            display_name="Mario Rossi",
+        )
+        await create_user(
+            session, name="bbb", password="password2",
+            display_name="Lucia Bianchi",
+        )
+        await create_user(
+            session, name="ccc", password="password3",
+        )
+
+    # Substring match on display_name (case-insensitive).
+    async with get_users_session(config_dir) as session:
+        rows = await list_users(session, q="mario")
+    assert {u.user_name for u in rows} == {"aaa"}
+
+    async with get_users_session(config_dir) as session:
+        rows = await list_users(session, q="MARIO")
+    assert {u.user_name for u in rows} == {"aaa"}
+
+    async with get_users_session(config_dir) as session:
+        rows = await list_users(session, q="bb")  # matches user_name
+    assert {u.user_name for u in rows} == {"bbb"}
+
+    # disabled filter — none disabled in fixture, both filters work.
+    async with get_users_session(config_dir) as session:
+        rows = await list_users(session, disabled=False)
+    assert len(rows) == 3
+    async with get_users_session(config_dir) as session:
+        rows = await list_users(session, disabled=True)
+    assert rows == []
+
+
+# ── delete ─────────────────────────────────────────────────────────────
+
+
+async def test_delete_user_removes_row(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(session, name="todel", password="goodpassword")
+
+    async with get_users_session(config_dir) as session:
+        ok = await delete_user(session, "todel")
+    assert ok is True
+
+    async with get_users_session(config_dir) as session:
+        assert await get_user_by_name(session, "todel") is None
+
+
+async def test_delete_user_returns_false_if_missing(config_dir):
+    async with get_users_session(config_dir) as session:
+        ok = await delete_user(session, "ghost")
+    assert ok is False
+
+
+# ── reset password ─────────────────────────────────────────────────────
+
+
+async def test_reset_password_sets_must_change_true(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(
+            session, name="resetme", password="old-password",
+            must_change=False,  # already changed once
+        )
+
+    async with get_users_session(config_dir) as session:
+        ok = await reset_password(session, "resetme", "new-temp-pwd")
+    assert ok is True
+
+    async with get_users_session(config_dir) as session:
+        u = await get_user_by_name(session, "resetme")
+        # New password verifies; old does not.
+        assert await verify_password(session, "resetme", "new-temp-pwd") is True
+        assert await verify_password(session, "resetme", "old-password") is False
+    assert u is not None
+    assert u.must_change_password is True
+
+
+async def test_set_password_hash_keeps_or_clears_must_change(config_dir):
+    async with get_users_session(config_dir) as session:
+        await create_user(session, name="user1", password="initial1234")
+
+    async with get_users_session(config_dir) as session:
+        ok = await set_password_hash(
+            session, "user1", "user-chosen-pw", must_change=False,
+        )
+    assert ok is True
+
+    async with get_users_session(config_dir) as session:
+        u = await get_user_by_name(session, "user1")
+    assert u is not None
+    assert u.must_change_password is False
+
+
+# ── validation ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["", " ", "with space", "exclam!", "a" * 65, "slash/in/name", "qu'ote"],
+)
+async def test_create_user_rejects_bad_username(config_dir, bad_name):
+    async with get_users_session(config_dir) as session:
+        with pytest.raises(ValueError):
+            await create_user(session, name=bad_name, password="password1")
+
+
+@pytest.mark.parametrize("bad_pw", ["", "short", "       ", "  \t\n  "])
+async def test_create_user_rejects_bad_password(config_dir, bad_pw):
+    async with get_users_session(config_dir) as session:
+        with pytest.raises(ValueError):
+            await create_user(session, name="okuser", password=bad_pw)
+
+
+# ── perms ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only chmod check")
+async def test_users_db_file_is_chmod_0600(config_dir):
+    await init_users_db(config_dir)
+    db_path = config_dir / USERS_DB_FILENAME
+    assert db_path.exists()
+    mode = stat.S_IMODE(db_path.stat().st_mode)
+    # Owner-only read/write — no group, no world bits.
+    assert mode == 0o600, (
+        f"users.db permissions are {oct(mode)} — expected 0o600. "
+        "bcrypt hashes must not be group/world readable."
+    )


### PR DESCRIPTION
## Summary

ADR-025 Phase 1: introduces local users.db on the Cullis Connector for SMB scenarios where customers do not have a corporate IdP. Schema + admin API for create/list/delete/reset-password. Pairs with Phase 2 (login endpoint), Phase 3 (CSR flow to Mastio UserPrincipal cert), Phase 4 (lockout + audit), Phase 5 (SPA login + admin Users tab).

## Pattern reused

- ``mcp_proxy/dashboard/session.py`` bcrypt cost-12 verify pattern.
- ``mcp_proxy/admin/users.py`` admin endpoint shape + ``X-Admin-Secret`` dep + idempotent-on-conflict semantics.
- ``cullis_connector/identity/store.py`` file-mode 0600 enforcement on credential blobs.

## Files (~470 LOC code + ~410 LOC tests)

- ``cullis_connector/identity/users.py``           ORM + helpers (NEW)
- ``cullis_connector/identity/users_db.py``        engine factory + WAL (NEW)
- ``cullis_connector/identity/__init__.py``        re-export (MODIFY)
- ``cullis_connector/admin/__init__.py``           package shell (NEW)
- ``cullis_connector/admin/auth.py``               admin secret dep (NEW)
- ``cullis_connector/admin/users_router.py``       POST/GET/DELETE/reset (NEW)
- ``cullis_connector/web.py``                      mount router on ``AUTH_MODE=local`` (MODIFY)
- ``tests/connector/test_users_db.py``             DB layer tests (NEW)
- ``tests/connector/test_admin_users_endpoint.py`` HTTP integration tests (NEW)

## Schema

```sql
CREATE TABLE local_users (
  user_name             TEXT PRIMARY KEY,
  password_hash         TEXT NOT NULL,
  display_name          TEXT,
  must_change_password  INTEGER NOT NULL DEFAULT 1,
  created_at            TEXT NOT NULL,
  password_changed_at   TEXT,
  disabled              INTEGER NOT NULL DEFAULT 0
);
CREATE INDEX idx_local_users_must_change ON local_users(must_change_password);
```

WAL journal mode + ``synchronous=NORMAL``, file mode 0600 enforced. DB lives at ``<config_dir>/users.db`` (one level up from ``identity/`` so a profile reset does not blow away accounts).

## API contracts

```
POST   /admin/users                          201 / 400 / 409 / 403
GET    /admin/users?q=&disabled=&limit=      200
DELETE /admin/users/{user_name}              204 / 404
POST   /admin/users/{user_name}/reset-password 200 / 404
```

All gated by ``X-Admin-Secret`` (env: ``CULLIS_CONNECTOR_ADMIN_SECRET``). Router only mounts when ``AUTH_MODE=local`` (default); ``AUTH_MODE=oidc`` skips the mount entirely.

## Threat model deltas

- Plain user passwords NEVER logged; only the bcrypt hash leaves the users module.
- bcrypt cost 12, ``await asyncio.to_thread(bcrypt.checkpw, ...)`` so the event loop is not blocked under concurrent verifies.
- ``X-Admin-Secret`` constant-time compare via ``hmac.compare_digest``; missing env returns 403, never silently allows.
- Username regex ``^[a-zA-Z0-9._-]{1,64}$`` mirrors ``mcp_proxy/admin/users.py`` (no SQL injection vector + no SPIFFE id breakage).
- Min password length 8; no upper bound, no complexity rule v1 (NIST 800-63B-aligned). All-whitespace rejected to avoid typo'd empty hashes.
- CSRF guard exempts ``/admin/*`` (own auth, ``X-Admin-Secret`` is not auto-attached by browsers), mirroring the existing ``/v1/*`` and Bearer exemptions.

## Out of scope (later phases)

- Login endpoint + cookie session (Phase 2)
- Post-login CSR flow to Mastio UserPrincipal cert (Phase 3)
- Rate limit + lockout + audit log (Phase 4)
- SPA login UI + admin Users tab (Phase 5)

## Test plan

- [x] ``pytest tests/connector/test_users_db.py tests/connector/test_admin_users_endpoint.py -n auto --dist=loadfile`` passes (39/39 green)
- [x] Connector suite no regression — 451/451 pass on this branch (one unrelated pre-existing failure in ``test_profile_runtime_switch.py`` reproduces on origin/main)
- [x] ``ruff check`` clean on all new files
- [ ] CI green