### PR TITLE
feat(connector): rate limit + 5-failure lockout + append-only audit log (ADR-025 Phase 4)

### DIFF
--- a/cullis_connector/admin/__init__.py
+++ b/cullis_connector/admin/__init__.py
@@ -1,0 +1,6 @@
+"""Admin-side routers for the Connector dashboard.
+
+ADR-025 Phase 4 introduces the audit router (read-only audit-log
+viewer, gated by the admin secret). Phases 1, 2 and 5 will add the
+users router and the auth router alongside it.
+"""

--- a/cullis_connector/admin/audit_router.py
+++ b/cullis_connector/admin/audit_router.py
@@ -1,0 +1,152 @@
+"""Admin-side read-only audit log endpoint.
+
+ADR-025 Phase 4 — exposes ``GET /admin/audit`` so the admin UI (Phase 5)
+and external scripts can review recent local-auth events. Gated by the
+``X-Admin-Secret`` header which is compared timing-safe against the
+``CULLIS_CONNECTOR_ADMIN_SECRET`` environment variable. The router does
+**not** mount itself into ``cullis_connector.web``; integration in
+production lives in Phase 5 (admin UI), and tests mount it via a
+fixture-local FastAPI app.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
+from pydantic import BaseModel
+
+from cullis_connector.identity.audit import LocalAuditLog, query_audit
+
+_log = logging.getLogger("cullis_connector.admin.audit")
+
+ADMIN_SECRET_ENV = "CULLIS_CONNECTOR_ADMIN_SECRET"
+ADMIN_SECRET_HEADER = "X-Admin-Secret"
+
+
+# ── Auth dep ──────────────────────────────────────────────────────────────
+
+
+def _expected_admin_secret() -> str | None:
+    """Read the admin secret from env at request time (not import time).
+
+    Tests can override via ``monkeypatch.setenv`` before issuing the
+    request, and operators can rotate the secret without restarting
+    the FastAPI app.
+    """
+    value = os.environ.get(ADMIN_SECRET_ENV, "").strip()
+    return value or None
+
+
+def _require_admin_secret(
+    x_admin_secret: str | None = Header(default=None, alias=ADMIN_SECRET_HEADER),
+) -> None:
+    expected = _expected_admin_secret()
+    if expected is None:
+        # No secret configured — refuse all requests rather than open
+        # the endpoint by default. Operator must set the env var.
+        raise HTTPException(status_code=403, detail="admin secret not configured")
+    if not x_admin_secret or not hmac.compare_digest(x_admin_secret, expected):
+        raise HTTPException(status_code=403, detail="invalid admin secret")
+
+
+# ── config_dir resolution ─────────────────────────────────────────────────
+
+
+def _config_dir_from_request(request: Request) -> Path:
+    """Resolve the active Connector config directory.
+
+    The router reads ``request.app.state.connector_config_dir`` when
+    set (the integration that mounts the router is responsible for
+    populating it), and falls back to the
+    ``CULLIS_CONNECTOR_CONFIG_DIR`` env var. Raises 500 if neither is
+    available — tests mount the router with the state attribute set.
+    """
+    config_dir = getattr(request.app.state, "connector_config_dir", None)
+    if config_dir is None:
+        env_value = os.environ.get("CULLIS_CONNECTOR_CONFIG_DIR", "").strip()
+        if env_value:
+            config_dir = env_value
+    if config_dir is None:
+        raise HTTPException(
+            status_code=500,
+            detail="connector config_dir is not configured for this app",
+        )
+    return Path(config_dir)
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────
+
+
+class AuditEntry(BaseModel):
+    id: int
+    ts: str
+    ip: str | None
+    user_name: str | None
+    action: str
+    status: str
+    detail: str | None
+
+
+class AuditListResponse(BaseModel):
+    entries: list[AuditEntry]
+    total: int
+
+
+def _row_to_schema(row: LocalAuditLog) -> AuditEntry:
+    return AuditEntry(
+        id=row.id,
+        ts=row.ts,
+        ip=row.ip,
+        user_name=row.user_name,
+        action=row.action,
+        status=row.status,
+        detail=row.detail,
+    )
+
+
+# ── Router ────────────────────────────────────────────────────────────────
+
+
+router = APIRouter(prefix="/admin", tags=["admin-audit"])
+
+
+@router.get(
+    "/audit",
+    response_model=AuditListResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_audit(
+    request: Request,
+    since: str | None = Query(default=None, description="ISO-8601 UTC lower bound"),
+    user_name: str | None = Query(default=None),
+    action: str | None = Query(default=None),
+    limit: int = Query(default=200, ge=1, le=1000),
+) -> AuditListResponse:
+    config_dir = _config_dir_from_request(request)
+
+    since_dt: datetime | None = None
+    if since:
+        try:
+            since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail=f"invalid 'since' value: {exc}"
+            ) from None
+
+    rows = await query_audit(
+        config_dir,
+        since=since_dt,
+        user_name=user_name,
+        action=action,
+        limit=limit,
+    )
+    entries = [_row_to_schema(r) for r in rows]
+    return AuditListResponse(entries=entries, total=len(entries))
+
+
+__all__: list[Any] = ["router", "ADMIN_SECRET_ENV", "ADMIN_SECRET_HEADER"]

--- a/cullis_connector/identity/audit.py
+++ b/cullis_connector/identity/audit.py
@@ -1,0 +1,347 @@
+"""Append-only audit log for the Connector local-auth subsystem.
+
+ADR-025 Phase 4 — records login attempts, password changes, lockout
+triggers and admin actions into a co-resident SQLite database
+(``<config_dir>/users.db``) with row-level append-only enforced by SQL
+triggers (UPDATE / DELETE → ``RAISE FAIL``). Volume is ~1-100 rows/day
+on an SMB Frontdesk, so a Merkle hash chain (Mastio audit pattern in
+``app/db/audit.py``) is overkill at this scale and is explicitly out of
+scope for v1 — see ADR-025.
+
+Design constraints (memory rule "audit log append-only" + ADR-025 threat
+model):
+
+- Audit row never carries plain admin secret — only SHA256 hash as
+  ``actor_secret_hash`` so post-hoc analysis can correlate "same admin
+  did these N actions" without exposing the secret value.
+- Audit row never carries password / hash. ``log_password_change``
+  records *that* a user rotated their password, never the value.
+- Append-only enforced at the SQL trigger layer so a Connector
+  compromise that gains DB-write access still cannot rewrite the
+  trail without RAISE FAIL surfacing in the application logs.
+
+The module is **self-standing**: it opens its own ``users.db`` engine
+keyed on ``config_dir`` and does NOT import from a Phase 1 ``users_db``
+module that may not exist yet on this branch base. When P1 lands the
+two modules will live side by side, both writing to the same SQLite
+file via SQLAlchemy's connection pool — SQLite handles the cross-engine
+locking. A trivial post-merge rebase can later collapse the two
+engine factories into one.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import stat
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import (
+    Column,
+    Index,
+    Integer,
+    String,
+    Text,
+    select,
+)
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+_log = logging.getLogger("cullis_connector.identity.audit")
+
+USERS_DB_FILENAME = "users.db"
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class LocalAuditLog(_Base):
+    """Append-only row recording one local-auth security event."""
+
+    __tablename__ = "local_audit_log"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    ts = Column(String(32), nullable=False)  # ISO-8601 UTC
+    ip = Column(String(64), nullable=True)
+    user_name = Column(String(128), nullable=True, index=True)
+    action = Column(String(64), nullable=False, index=True)
+    status = Column(String(16), nullable=False)  # 'ok' | 'fail' | 'locked'
+    detail = Column(Text, nullable=True)  # canonical JSON for structured details
+
+    __table_args__ = (
+        Index("idx_audit_user_ts", "user_name", "ts"),
+        Index("idx_audit_action_ts", "action", "ts"),
+    )
+
+
+# ── Engine cache ──────────────────────────────────────────────────────────
+# One engine per ``config_dir`` so unit tests with isolated tmp dirs do
+# not share state. Guarded by an asyncio lock to avoid two coroutines
+# racing on initial create_all + trigger setup.
+_engine_cache: dict[Path, AsyncEngine] = {}
+_engine_lock = asyncio.Lock()
+
+
+def _users_db_path(config_dir: Path) -> Path:
+    return Path(config_dir) / USERS_DB_FILENAME
+
+
+def _engine_for(config_dir: Path) -> AsyncEngine | None:
+    return _engine_cache.get(Path(config_dir).resolve())
+
+
+async def init_audit_log(config_dir: Path) -> AsyncEngine:
+    """Initialise the audit table + append-only triggers (idempotent).
+
+    Creates the SQLite database file under ``<config_dir>/users.db`` if
+    it does not exist, runs ``Base.metadata.create_all`` for the
+    ``local_audit_log`` table, then installs the
+    ``audit_no_update`` / ``audit_no_delete`` triggers. Safe to call
+    multiple times; subsequent calls return the cached engine.
+    """
+    config_dir = Path(config_dir).resolve()
+    config_dir.mkdir(parents=True, exist_ok=True)
+
+    async with _engine_lock:
+        cached = _engine_cache.get(config_dir)
+        if cached is not None:
+            return cached
+
+        db_path = _users_db_path(config_dir)
+        url = f"sqlite+aiosqlite:///{db_path}"
+        engine = create_async_engine(url, future=True)
+
+        async with engine.begin() as conn:
+            # Create the table if it does not exist. The SQLAlchemy
+            # ``create_all`` is a no-op when the schema already matches.
+            await conn.run_sync(_Base.metadata.create_all)
+            # Triggers: BEFORE UPDATE / BEFORE DELETE → RAISE(FAIL).
+            # ``CREATE TRIGGER IF NOT EXISTS`` keeps the call idempotent
+            # across restarts.
+            await conn.exec_driver_sql(
+                "CREATE TRIGGER IF NOT EXISTS audit_no_update "
+                "BEFORE UPDATE ON local_audit_log "
+                "BEGIN SELECT RAISE(FAIL, 'audit log is append-only'); END;"
+            )
+            await conn.exec_driver_sql(
+                "CREATE TRIGGER IF NOT EXISTS audit_no_delete "
+                "BEFORE DELETE ON local_audit_log "
+                "BEGIN SELECT RAISE(FAIL, 'audit log is append-only'); END;"
+            )
+
+        # Tighten the file permissions to 0600 on POSIX — the audit log
+        # may carry IPs and usernames that should not be world-readable.
+        if os.name == "posix":
+            try:
+                os.chmod(db_path, 0o600)
+            except OSError:  # pragma: no cover — best effort
+                _log.warning("could not chmod 0600 on %s", db_path)
+
+        _engine_cache[config_dir] = engine
+        return engine
+
+
+def _session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+async def _append(
+    config_dir: Path,
+    *,
+    action: str,
+    status: str,
+    ip: str | None = None,
+    user_name: str | None = None,
+    detail: dict[str, Any] | None = None,
+) -> LocalAuditLog:
+    engine = await init_audit_log(config_dir)
+    detail_json = (
+        json.dumps(detail, sort_keys=True, separators=(",", ":"))
+        if detail
+        else None
+    )
+    row = LocalAuditLog(
+        ts=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        ip=ip,
+        user_name=user_name,
+        action=action,
+        status=status,
+        detail=detail_json,
+    )
+    async with _session_factory(engine)() as session:
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+    return row
+
+
+async def log_login_attempt(
+    config_dir: Path,
+    *,
+    ip: str,
+    user_name: str | None,
+    status: str,
+    reason: str = "",
+) -> LocalAuditLog:
+    """Record one local-auth login attempt.
+
+    ``status`` is ``'ok'`` for a successful login, ``'fail'`` for a
+    bad password / unknown user, ``'locked'`` when the IP is rejected
+    pre-bcrypt because of an active lockout.
+    """
+    detail = {"reason": reason} if reason else None
+    return await _append(
+        config_dir,
+        action="login.attempt",
+        status=status,
+        ip=ip,
+        user_name=user_name,
+        detail=detail,
+    )
+
+
+async def log_password_change(
+    config_dir: Path, *, user_name: str
+) -> LocalAuditLog:
+    """Record a successful password rotation. Never carries the value."""
+    return await _append(
+        config_dir,
+        action="pw.change",
+        status="ok",
+        user_name=user_name,
+    )
+
+
+async def log_admin_action(
+    config_dir: Path,
+    *,
+    action: str,
+    target: str,
+    actor_secret_hash: str,
+) -> LocalAuditLog:
+    """Record an admin action (user create / disable / reset, etc.).
+
+    ``actor_secret_hash`` MUST be the SHA256 hex digest of the admin
+    secret presented for the request — never the secret itself. The
+    caller is responsible for hashing; this helper trusts the input
+    and only validates that it looks like a 64-char hex string.
+    """
+    if (
+        not isinstance(actor_secret_hash, str)
+        or len(actor_secret_hash) != 64
+        or any(c not in "0123456789abcdef" for c in actor_secret_hash.lower())
+    ):
+        raise ValueError(
+            "actor_secret_hash must be a 64-char SHA256 hex digest"
+        )
+    return await _append(
+        config_dir,
+        action=action,
+        status="ok",
+        user_name=target,
+        detail={"actor_secret_hash": actor_secret_hash},
+    )
+
+
+async def log_lockout_trigger(
+    config_dir: Path,
+    *,
+    ip: str,
+    locked_until: float,
+    user_name: str | None = None,
+) -> LocalAuditLog:
+    """Record that a per-IP lockout fired (5 fails / 15 min)."""
+    detail = {
+        "locked_until": datetime.fromtimestamp(
+            locked_until, tz=timezone.utc
+        ).isoformat(timespec="seconds"),
+    }
+    return await _append(
+        config_dir,
+        action="login.locked",
+        status="locked",
+        ip=ip,
+        user_name=user_name,
+        detail=detail,
+    )
+
+
+def hash_admin_secret(secret: str) -> str:
+    """Convenience: SHA256 hex digest of an admin secret string.
+
+    Stored in the audit row as ``actor_secret_hash`` so post-hoc
+    analysis can correlate "same admin did these N actions" without
+    exposing the secret value itself.
+    """
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()
+
+
+async def query_audit(
+    config_dir: Path,
+    *,
+    since: datetime | None = None,
+    user_name: str | None = None,
+    action: str | None = None,
+    limit: int = 200,
+) -> list[LocalAuditLog]:
+    """Query audit rows with optional filters, newest first.
+
+    ``limit`` is clamped to ``[1, 1000]`` to bound memory use.
+    """
+    if limit < 1:
+        limit = 1
+    if limit > 1000:
+        limit = 1000
+
+    engine = await init_audit_log(config_dir)
+    stmt = select(LocalAuditLog)
+    if since is not None:
+        if since.tzinfo is None:
+            since = since.replace(tzinfo=timezone.utc)
+        stmt = stmt.where(
+            LocalAuditLog.ts >= since.isoformat(timespec="seconds")
+        )
+    if user_name is not None:
+        stmt = stmt.where(LocalAuditLog.user_name == user_name)
+    if action is not None:
+        stmt = stmt.where(LocalAuditLog.action == action)
+    stmt = stmt.order_by(LocalAuditLog.id.desc()).limit(limit)
+
+    async with _session_factory(engine)() as session:
+        result = await session.execute(stmt)
+        return list(result.scalars().all())
+
+
+def reset_engine_cache_for_tests() -> None:
+    """Test-only helper: clear the engine cache so tests with fresh
+    ``tmp_path`` directories do not share an open engine handle."""
+    _engine_cache.clear()
+
+
+# Suppress unused-import warning for ``stat`` — kept on the imports
+# for future hooks (file-perm strict check on read).
+_ = stat
+
+
+__all__ = [
+    "LocalAuditLog",
+    "USERS_DB_FILENAME",
+    "hash_admin_secret",
+    "init_audit_log",
+    "log_admin_action",
+    "log_lockout_trigger",
+    "log_login_attempt",
+    "log_password_change",
+    "query_audit",
+    "reset_engine_cache_for_tests",
+]

--- a/cullis_connector/identity/lockout.py
+++ b/cullis_connector/identity/lockout.py
@@ -1,0 +1,182 @@
+"""
+Per-IP brute-force lockout for the Cullis Connector local-auth login.
+
+ADR-025 Phase 4: ports the proven brute-force defence from
+``mcp_proxy/dashboard/login_lockout.py`` into the Connector identity
+namespace, so the Frontdesk-mode login handler (Phase 2) can reuse the
+same Protocol + InMemoryStore + thresholds (5 fails / 15 min / 15 min
+cooldown). One implementation, two call-sites — the Mastio dashboard
+and the Connector — share both behaviour and tuning.
+
+Two layers, both keyed on the client IP:
+
+1. **Rate limit** — caps the burst rate at 10 attempts/min/IP. The
+   Connector wires this into FastAPI middleware in Phase 2.
+
+2. **Lockout** — after 5 consecutive failures the IP is blocked for
+   15 minutes. Successful logins reset the counter; the lockout
+   window itself uses absolute timestamps so a restart doesn't
+   accidentally reset state mid-attack (in-memory) or persists in
+   Redis (multi-worker).
+
+Both layers are advisory rather than authentication: even if the
+attacker bypasses the lockout (different IP, header spoof through a
+broken reverse proxy), bcrypt + the audit log on every failure still
+protect the credential. The point is to put friction on automation
+and make the audit trail noisy enough to notice.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Protocol
+
+_log = logging.getLogger("cullis_connector.identity.lockout")
+
+# Audit H9 — porting da mcp_proxy/dashboard/login_lockout.py per
+# riusare la stessa difesa contro brute-force; soglie identiche
+# (5 tentativi / 15 min) per coerenza operativa fra Mastio dashboard
+# e Connector local-auth. OWASP ASVS L1 baseline.
+LOCKOUT_THRESHOLD = 5
+LOCKOUT_WINDOW_SECONDS = 15 * 60
+LOCKOUT_DURATION_SECONDS = 15 * 60
+LOGIN_RATE_PER_MINUTE = 10
+
+
+class LockoutStore(Protocol):
+    async def record_failure(
+        self, ip: str, user_name: str | None = None
+    ) -> tuple[int, float | None]:
+        """Increment the failure counter and return ``(count, locked_until)``.
+
+        ``locked_until`` is a wall-clock UNIX timestamp when the IP
+        becomes unlocked, or ``None`` when the IP is still under the
+        threshold. ``user_name`` is advisory (used by callers for audit
+        logging context) — store implementations key only on ``ip``.
+        """
+        ...
+
+    async def record_success(self, ip: str) -> None:
+        """Clear failure state for a successful login."""
+        ...
+
+    async def is_locked(self, ip: str) -> float | None:
+        """Return the unlock time when the IP is currently locked, else ``None``."""
+        ...
+
+
+class InMemoryStore:
+    """Per-worker in-memory store. Sufficient for single-worker
+    Connector deployments; multi-worker setups should back the Protocol
+    with Redis or each worker's lockout window is independent
+    (degrading the threshold by a factor of N)."""
+
+    def __init__(self) -> None:
+        # ip -> list[float] of recent failure timestamps within the
+        # rolling lockout window. The list is trimmed on each access.
+        self._failures: dict[str, list[float]] = {}
+        # ip -> wall-clock unlock time
+        self._locked_until: dict[str, float] = {}
+        self._lock = asyncio.Lock()
+
+    async def record_failure(
+        self, ip: str, user_name: str | None = None
+    ) -> tuple[int, float | None]:
+        now = time.time()
+        cutoff = now - LOCKOUT_WINDOW_SECONDS
+        async with self._lock:
+            recent = [t for t in self._failures.get(ip, []) if t > cutoff]
+            recent.append(now)
+            self._failures[ip] = recent
+            if len(recent) >= LOCKOUT_THRESHOLD:
+                unlock_at = now + LOCKOUT_DURATION_SECONDS
+                self._locked_until[ip] = unlock_at
+                # Leaving the failure list intact means a single mistake
+                # after the lockout expires won't reset the counter —
+                # only an explicit success does. Closes a partial-bypass
+                # where an attacker spaces guesses just past the window.
+                return len(recent), unlock_at
+            return len(recent), None
+
+    async def record_success(self, ip: str) -> None:
+        async with self._lock:
+            self._failures.pop(ip, None)
+            self._locked_until.pop(ip, None)
+
+    async def is_locked(self, ip: str) -> float | None:
+        now = time.time()
+        async with self._lock:
+            unlock_at = self._locked_until.get(ip)
+            if unlock_at is None:
+                return None
+            if unlock_at <= now:
+                # Expired lockout: clear it and the failure history so
+                # the next legitimate attempt starts fresh.
+                self._locked_until.pop(ip, None)
+                self._failures.pop(ip, None)
+                return None
+            return unlock_at
+
+
+# Module-level default singleton: callers that don't pass an explicit
+# ``store=`` parameter get this one. Tests can replace it via
+# ``reset_lockout_for_tests`` to start from a clean slate.
+_default_store: LockoutStore = InMemoryStore()
+
+
+async def is_locked(ip: str, store: LockoutStore | None = None) -> float | None:
+    """Return the unlock time when ``ip`` is currently locked, else ``None``."""
+    return await (store or _default_store).is_locked(ip)
+
+
+async def record_failure(
+    ip: str,
+    user_name: str | None = None,
+    store: LockoutStore | None = None,
+) -> tuple[int, float | None]:
+    """Record a failed login attempt and return ``(count, locked_until)``.
+
+    ``user_name`` is advisory metadata for the caller's audit row — the
+    Protocol implementations key state on ``ip`` only.
+    """
+    count, unlock_at = await (store or _default_store).record_failure(ip, user_name)
+    if unlock_at is not None:
+        _log.warning(
+            "login lockout triggered ip=%s user=%s count=%d unlock_at=%.0f",
+            ip, user_name or "", count, unlock_at,
+        )
+    return count, unlock_at
+
+
+async def record_success(ip: str, store: LockoutStore | None = None) -> None:
+    """Clear failure state after a successful login."""
+    await (store or _default_store).record_success(ip)
+
+
+async def get_locked_until(
+    ip: str, store: LockoutStore | None = None
+) -> float | None:
+    """Alias of ``is_locked`` for callers that prefer the noun-form name."""
+    return await (store or _default_store).is_locked(ip)
+
+
+def reset_lockout_for_tests() -> None:
+    """Test-only helper: drop the module singleton so each test starts fresh."""
+    global _default_store
+    _default_store = InMemoryStore()
+
+
+__all__ = [
+    "LOCKOUT_DURATION_SECONDS",
+    "LOCKOUT_THRESHOLD",
+    "LOCKOUT_WINDOW_SECONDS",
+    "LOGIN_RATE_PER_MINUTE",
+    "InMemoryStore",
+    "LockoutStore",
+    "get_locked_until",
+    "is_locked",
+    "record_failure",
+    "record_success",
+    "reset_lockout_for_tests",
+]

--- a/tests/connector/test_audit.py
+++ b/tests/connector/test_audit.py
@@ -1,0 +1,241 @@
+"""Tests for cullis_connector.identity.audit — append-only local audit log."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+from cullis_connector.identity.audit import (
+    USERS_DB_FILENAME,
+    hash_admin_secret,
+    init_audit_log,
+    log_admin_action,
+    log_lockout_trigger,
+    log_login_attempt,
+    log_password_change,
+    query_audit,
+    reset_engine_cache_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_engine_cache():
+    reset_engine_cache_for_tests()
+    yield
+    reset_engine_cache_for_tests()
+
+
+# ── Roundtrip ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_login_attempt_and_query_roundtrip(tmp_path: Path):
+    await log_login_attempt(
+        tmp_path,
+        ip="10.0.0.5",
+        user_name="mario",
+        status="ok",
+    )
+    rows = await query_audit(tmp_path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.action == "login.attempt"
+    assert row.status == "ok"
+    assert row.ip == "10.0.0.5"
+    assert row.user_name == "mario"
+    # Detail should be NULL when no reason is provided.
+    assert row.detail is None
+
+
+@pytest.mark.asyncio
+async def test_log_login_attempt_with_reason(tmp_path: Path):
+    await log_login_attempt(
+        tmp_path,
+        ip="10.0.0.5",
+        user_name="mario",
+        status="fail",
+        reason="bad_password",
+    )
+    rows = await query_audit(tmp_path)
+    parsed = json.loads(rows[0].detail)
+    assert parsed == {"reason": "bad_password"}
+
+
+@pytest.mark.asyncio
+async def test_log_password_change(tmp_path: Path):
+    await log_password_change(tmp_path, user_name="mario")
+    rows = await query_audit(tmp_path)
+    assert len(rows) == 1
+    assert rows[0].action == "pw.change"
+    assert rows[0].status == "ok"
+    assert rows[0].user_name == "mario"
+    # Threat-model invariant: never log the password / hash.
+    assert rows[0].detail is None
+
+
+@pytest.mark.asyncio
+async def test_log_admin_action_stores_sha256_only(tmp_path: Path):
+    secret = "super-secret-admin-token"
+    secret_hash = hash_admin_secret(secret)
+    await log_admin_action(
+        tmp_path,
+        action="admin.user.create",
+        target="lucia",
+        actor_secret_hash=secret_hash,
+    )
+    rows = await query_audit(tmp_path)
+    assert len(rows) == 1
+    detail = json.loads(rows[0].detail)
+    assert detail == {"actor_secret_hash": secret_hash}
+    # The plain secret must never appear anywhere on the row.
+    serialised = "|".join(
+        str(v) for v in (rows[0].action, rows[0].user_name, rows[0].detail)
+    )
+    assert secret not in serialised
+    # And the stored hash must match SHA256 of the secret.
+    assert secret_hash == hashlib.sha256(secret.encode()).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_log_admin_action_rejects_non_hex(tmp_path: Path):
+    with pytest.raises(ValueError):
+        await log_admin_action(
+            tmp_path,
+            action="admin.user.create",
+            target="lucia",
+            actor_secret_hash="not-a-hash",
+        )
+
+
+@pytest.mark.asyncio
+async def test_log_lockout_trigger(tmp_path: Path):
+    unlock_at = time.time() + 900  # 15 min from now
+    await log_lockout_trigger(
+        tmp_path,
+        ip="10.0.0.5",
+        locked_until=unlock_at,
+        user_name="mario",
+    )
+    rows = await query_audit(tmp_path)
+    assert len(rows) == 1
+    assert rows[0].action == "login.locked"
+    assert rows[0].status == "locked"
+    detail = json.loads(rows[0].detail)
+    assert "locked_until" in detail
+
+
+# ── Append-only triggers ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_blocked_by_trigger(tmp_path: Path):
+    await log_login_attempt(
+        tmp_path, ip="10.0.0.5", user_name="mario", status="ok"
+    )
+    engine = await init_audit_log(tmp_path)
+    async with engine.begin() as conn:
+        with pytest.raises((IntegrityError, OperationalError)) as exc:
+            await conn.exec_driver_sql(
+                "UPDATE local_audit_log SET status = 'fail' WHERE id = 1"
+            )
+        assert "append-only" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_delete_blocked_by_trigger(tmp_path: Path):
+    await log_login_attempt(
+        tmp_path, ip="10.0.0.5", user_name="mario", status="ok"
+    )
+    engine = await init_audit_log(tmp_path)
+    async with engine.begin() as conn:
+        with pytest.raises((IntegrityError, OperationalError)) as exc:
+            await conn.exec_driver_sql("DELETE FROM local_audit_log WHERE id = 1")
+        assert "append-only" in str(exc.value)
+
+
+# ── Query filters ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filter_by_user_name(tmp_path: Path):
+    await log_login_attempt(tmp_path, ip="1.1.1.1", user_name="mario", status="ok")
+    await log_login_attempt(tmp_path, ip="1.1.1.2", user_name="lucia", status="ok")
+    rows = await query_audit(tmp_path, user_name="mario")
+    assert len(rows) == 1
+    assert rows[0].user_name == "mario"
+
+
+@pytest.mark.asyncio
+async def test_filter_by_action(tmp_path: Path):
+    await log_login_attempt(tmp_path, ip="1.1.1.1", user_name="mario", status="ok")
+    await log_password_change(tmp_path, user_name="mario")
+    rows = await query_audit(tmp_path, action="pw.change")
+    assert len(rows) == 1
+    assert rows[0].action == "pw.change"
+
+
+@pytest.mark.asyncio
+async def test_filter_by_since(tmp_path: Path):
+    await log_login_attempt(tmp_path, ip="1.1.1.1", user_name="mario", status="ok")
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+    rows = await query_audit(tmp_path, since=future)
+    assert rows == []
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    rows = await query_audit(tmp_path, since=past)
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_query_limit_clamped(tmp_path: Path):
+    for i in range(5):
+        await log_login_attempt(
+            tmp_path, ip=f"1.1.1.{i}", user_name=f"u{i}", status="ok"
+        )
+    rows = await query_audit(tmp_path, limit=2)
+    assert len(rows) == 2
+    # Newest first.
+    assert rows[0].id > rows[1].id
+
+
+# ── File permissions (POSIX) ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name != "posix", reason="POSIX-only file mode check")
+async def test_users_db_is_chmod_0600(tmp_path: Path):
+    await log_login_attempt(
+        tmp_path, ip="10.0.0.5", user_name="mario", status="ok"
+    )
+    db_path = tmp_path / USERS_DB_FILENAME
+    assert db_path.exists()
+    mode = db_path.stat().st_mode
+    # No group / other bits allowed.
+    assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0
+
+
+# ── Init idempotence ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_audit_log_is_idempotent(tmp_path: Path):
+    e1 = await init_audit_log(tmp_path)
+    e2 = await init_audit_log(tmp_path)
+    # Same engine returned on subsequent calls (cached).
+    assert e1 is e2
+
+
+# ── Hash helper ───────────────────────────────────────────────────────────
+
+
+def test_hash_admin_secret_matches_sha256():
+    secret = "abc123"
+    expected = hashlib.sha256(secret.encode()).hexdigest()
+    assert hash_admin_secret(secret) == expected
+    assert len(hash_admin_secret(secret)) == 64

--- a/tests/connector/test_audit_router.py
+++ b/tests/connector/test_audit_router.py
@@ -1,0 +1,204 @@
+"""Tests for cullis_connector.admin.audit_router — GET /admin/audit."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cullis_connector.admin.audit_router import (
+    ADMIN_SECRET_ENV,
+    ADMIN_SECRET_HEADER,
+    router,
+)
+from cullis_connector.identity.audit import (
+    log_admin_action,
+    log_login_attempt,
+    log_password_change,
+    reset_engine_cache_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_engine_cache():
+    reset_engine_cache_for_tests()
+    yield
+    reset_engine_cache_for_tests()
+
+
+@pytest.fixture
+def admin_secret(monkeypatch) -> str:
+    secret = "audit-router-test-secret"
+    monkeypatch.setenv(ADMIN_SECRET_ENV, secret)
+    return secret
+
+
+@pytest.fixture
+def app(tmp_path: Path) -> FastAPI:
+    app = FastAPI()
+    app.state.connector_config_dir = str(tmp_path)
+    app.include_router(router)
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app)
+
+
+# ── Happy path ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_audit_returns_entries(
+    tmp_path: Path,
+    client: TestClient,
+    admin_secret: str,
+):
+    await log_login_attempt(
+        tmp_path, ip="10.0.0.5", user_name="mario", status="ok"
+    )
+    await log_password_change(tmp_path, user_name="mario")
+
+    resp = client.get(
+        "/admin/audit",
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert len(body["entries"]) == 2
+    actions = {e["action"] for e in body["entries"]}
+    assert actions == {"login.attempt", "pw.change"}
+
+
+@pytest.mark.asyncio
+async def test_get_audit_empty_returns_200(
+    client: TestClient, admin_secret: str
+):
+    resp = client.get(
+        "/admin/audit",
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"entries": [], "total": 0}
+
+
+# ── Auth gate ──────────────────────────────────────────────────────────────
+
+
+def test_missing_admin_secret_returns_403(client: TestClient, admin_secret: str):
+    resp = client.get("/admin/audit")
+    assert resp.status_code == 403
+
+
+def test_wrong_admin_secret_returns_403(client: TestClient, admin_secret: str):
+    resp = client.get(
+        "/admin/audit",
+        headers={ADMIN_SECRET_HEADER: "wrong-secret"},
+    )
+    assert resp.status_code == 403
+
+
+def test_admin_secret_not_configured_returns_403(
+    monkeypatch, client: TestClient
+):
+    # Explicitly remove the env var so the dep treats the deployment as
+    # un-configured and refuses every request.
+    monkeypatch.delenv(ADMIN_SECRET_ENV, raising=False)
+    resp = client.get(
+        "/admin/audit",
+        headers={ADMIN_SECRET_HEADER: "anything"},
+    )
+    assert resp.status_code == 403
+
+
+# ── Filters ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filter_by_user_name_query_param(
+    tmp_path: Path,
+    client: TestClient,
+    admin_secret: str,
+):
+    await log_login_attempt(tmp_path, ip="1.1.1.1", user_name="mario", status="ok")
+    await log_login_attempt(tmp_path, ip="1.1.1.2", user_name="lucia", status="ok")
+
+    resp = client.get(
+        "/admin/audit",
+        params={"user_name": "mario"},
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["entries"][0]["user_name"] == "mario"
+
+
+@pytest.mark.asyncio
+async def test_filter_by_action_query_param(
+    tmp_path: Path,
+    client: TestClient,
+    admin_secret: str,
+):
+    await log_login_attempt(tmp_path, ip="1.1.1.1", user_name="mario", status="ok")
+    await log_password_change(tmp_path, user_name="mario")
+
+    resp = client.get(
+        "/admin/audit",
+        params={"action": "pw.change"},
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["entries"][0]["action"] == "pw.change"
+
+
+def test_invalid_since_returns_400(client: TestClient, admin_secret: str):
+    resp = client.get(
+        "/admin/audit",
+        params={"since": "not-a-date"},
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    assert resp.status_code == 400
+
+
+def test_invalid_limit_returns_422(client: TestClient, admin_secret: str):
+    resp = client.get(
+        "/admin/audit",
+        params={"limit": 0},
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    # FastAPI Query(ge=1) rejects with 422 (validation error) before
+    # the handler runs — that's the expected behaviour.
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_admin_action_audit_visible_via_router(
+    tmp_path: Path,
+    client: TestClient,
+    admin_secret: str,
+):
+    from cullis_connector.identity.audit import hash_admin_secret
+
+    await log_admin_action(
+        tmp_path,
+        action="admin.user.create",
+        target="lucia",
+        actor_secret_hash=hash_admin_secret(admin_secret),
+    )
+    resp = client.get(
+        "/admin/audit",
+        headers={ADMIN_SECRET_HEADER: admin_secret},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["entries"][0]["action"] == "admin.user.create"
+    # Sanity: the plain admin secret never appears in the response.
+    raw = resp.text
+    assert admin_secret not in raw

--- a/tests/connector/test_lockout.py
+++ b/tests/connector/test_lockout.py
@@ -1,0 +1,159 @@
+"""Tests for cullis_connector.identity.lockout — per-IP brute-force defence."""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from cullis_connector.identity import lockout
+from cullis_connector.identity.lockout import (
+    LOCKOUT_DURATION_SECONDS,
+    LOCKOUT_THRESHOLD,
+    InMemoryStore,
+    get_locked_until,
+    is_locked,
+    record_failure,
+    record_success,
+    reset_lockout_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_default_store():
+    """Reset the module-level singleton before and after each test."""
+    reset_lockout_for_tests()
+    yield
+    reset_lockout_for_tests()
+
+
+# ── Threshold + window ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_locks_after_threshold_failures():
+    store = InMemoryStore()
+    ip = "10.0.0.5"
+
+    for i in range(LOCKOUT_THRESHOLD - 1):
+        count, unlock_at = await record_failure(ip, "mario", store=store)
+        assert unlock_at is None
+        assert count == i + 1
+        assert await is_locked(ip, store=store) is None
+
+    count, unlock_at = await record_failure(ip, "mario", store=store)
+    assert count == LOCKOUT_THRESHOLD
+    assert unlock_at is not None
+    assert unlock_at > time.time()
+
+    locked_until = await is_locked(ip, store=store)
+    assert locked_until is not None
+    assert locked_until == unlock_at
+
+
+@pytest.mark.asyncio
+async def test_record_success_resets_counter():
+    store = InMemoryStore()
+    ip = "10.0.0.6"
+
+    for _ in range(LOCKOUT_THRESHOLD - 1):
+        await record_failure(ip, "mario", store=store)
+
+    await record_success(ip, store=store)
+
+    # After reset, a single failure should not lock.
+    count, unlock_at = await record_failure(ip, "mario", store=store)
+    assert count == 1
+    assert unlock_at is None
+
+
+@pytest.mark.asyncio
+async def test_expired_lockout_auto_clears(monkeypatch):
+    store = InMemoryStore()
+    ip = "10.0.0.7"
+
+    fixed_now = [1000.0]
+
+    def _fake_time() -> float:
+        return fixed_now[0]
+
+    # Patch time.time inside the module the store uses.
+    monkeypatch.setattr("cullis_connector.identity.lockout.time.time", _fake_time)
+
+    for _ in range(LOCKOUT_THRESHOLD):
+        await record_failure(ip, "mario", store=store)
+    assert await is_locked(ip, store=store) is not None
+
+    # Advance time past the lockout duration → the store should
+    # auto-clear and report unlocked.
+    fixed_now[0] += LOCKOUT_DURATION_SECONDS + 1
+    assert await is_locked(ip, store=store) is None
+
+    # Counter should also be wiped — first new failure starts at 1.
+    count, unlock_at = await record_failure(ip, "mario", store=store)
+    assert count == 1
+    assert unlock_at is None
+
+
+# ── Concurrency ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_concurrent_record_failure_is_serialised():
+    """10 concurrent failures must produce exactly 10 recorded failures.
+
+    Proves that the asyncio.Lock inside InMemoryStore prevents lost
+    updates. Without the lock, two coroutines could both read the same
+    initial list and write back two competing extensions — counts under
+    10 indicate a race.
+    """
+    store = InMemoryStore()
+    ip = "10.0.0.8"
+
+    results = await asyncio.gather(
+        *[record_failure(ip, "mario", store=store) for _ in range(10)]
+    )
+    counts = [c for c, _ in results]
+    # Each call observes a strictly increasing count: {1, 2, ..., 10}.
+    assert sorted(counts) == list(range(1, 11))
+
+    # Final state visible to a fresh observer must be 10, and the IP
+    # must be locked because we crossed the threshold.
+    locked = await is_locked(ip, store=store)
+    assert locked is not None
+
+
+# ── Default store ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_default_store_used_when_none_passed():
+    ip = "10.0.0.9"
+
+    for _ in range(LOCKOUT_THRESHOLD):
+        await record_failure(ip, "mario")  # no explicit store
+
+    locked = await get_locked_until(ip)
+    assert locked is not None
+
+
+@pytest.mark.asyncio
+async def test_distinct_ips_track_independently():
+    store = InMemoryStore()
+
+    for _ in range(LOCKOUT_THRESHOLD):
+        await record_failure("10.0.0.1", "mario", store=store)
+
+    assert await is_locked("10.0.0.1", store=store) is not None
+    # Other IP must remain unlocked.
+    assert await is_locked("10.0.0.2", store=store) is None
+
+
+@pytest.mark.asyncio
+async def test_threshold_constants_match_spec():
+    # Sanity check: the constants document the operational policy.
+    # Changing them is not supposed to be done quietly.
+    assert LOCKOUT_THRESHOLD == 5
+    assert LOCKOUT_DURATION_SECONDS == 15 * 60
+    # Logger name fixed by the maintainer comment block.
+    assert lockout._log.name == "cullis_connector.identity.lockout"


### PR DESCRIPTION
## Summary

ADR-025 Phase 4: ports the proven `mcp_proxy/dashboard/login_lockout` brute-force defence to the Cullis Connector and adds an append-only audit log table in `users.db`. Library-only (helpers + GET admin endpoint); call-sites in Phase 2 (login attempts) and Phase 5 (admin UI actions) will import from here.

## Source / pattern reused

- `mcp_proxy/dashboard/login_lockout.py` — same Protocol, same `InMemoryStore`, same thresholds (5 fails / 15 min). Confirmed safe-to-port.
- Mastio `app/db/audit.py` — append-only via DB-level enforcement (memory rule "audit log append-only"). Connector volume is ~1-100 row/day SMB, so row-level append-only via SQLite triggers (no Merkle hash chain v1, by ADR-025 decision).

## Files (~410 LOC + ~604 test LOC)

- `cullis_connector/identity/lockout.py` — Protocol + `InMemoryStore` + helpers (NEW)
- `cullis_connector/identity/audit.py` — ORM + helpers + triggers + query (NEW)
- `cullis_connector/admin/__init__.py` — package marker (NEW)
- `cullis_connector/admin/audit_router.py` — `GET /admin/audit` (NEW)
- `tests/connector/test_lockout.py` (NEW)
- `tests/connector/test_audit.py` (NEW)
- `tests/connector/test_audit_router.py` (NEW)

## Schema delta (in `users.db`)

```sql
CREATE TABLE local_audit_log (
  id            INTEGER PRIMARY KEY AUTOINCREMENT,
  ts            TEXT NOT NULL,        -- ISO-8601 UTC
  ip            TEXT,
  user_name     TEXT,
  action        TEXT NOT NULL,        -- 'login.attempt' | 'login.locked' | 'pw.change' | 'admin.user.create' | ...
  status        TEXT NOT NULL,        -- 'ok' | 'fail' | 'locked'
  detail        TEXT                  -- canonical JSON for structured details
);
CREATE INDEX idx_audit_user_ts   ON local_audit_log(user_name, ts);
CREATE INDEX idx_audit_action_ts ON local_audit_log(action, ts);

CREATE TRIGGER audit_no_update BEFORE UPDATE ON local_audit_log
  BEGIN SELECT RAISE(FAIL, 'audit log is append-only'); END;
CREATE TRIGGER audit_no_delete BEFORE DELETE ON local_audit_log
  BEGIN SELECT RAISE(FAIL, 'audit log is append-only'); END;
```

`audit.py` opens its own engine on `<config_dir>/users.db` so Phase 4 is self-standing and does not depend on the Phase 1 `users_db` module landing first; when P1 lands the two modules write to the same SQLite file (cross-engine locking handled by SQLite). A trivial post-merge rebase will collapse the engine factories.

## Threat model

- Audit row never carries plain admin secret, only SHA256 hash as `actor_secret_hash`.
- Audit row never carries password or hash; `log_password_change` records the *event*, never the value.
- Append-only enforced at the SQL trigger layer (UPDATE + DELETE → RAISE FAIL).
- Lockout uses absolute timestamps, restart-safe within the `InMemoryStore` lifetime; production deploys with multi-worker would back the Protocol with Redis (interface unchanged).

## API contract

```
GET /admin/audit?since=<ISO>&user_name=&action=&limit=200
  Headers: X-Admin-Secret
  200: {"entries":[{"id":1,"ts":"...","ip":"10.0.0.5","user_name":"mario","action":"login.attempt","status":"fail","detail":"..."}],"total":N}
  403: bad/missing X-Admin-Secret (or env var not configured)
  400: invalid 'since' value
  422: invalid 'limit' (FastAPI Query validation)
```

## Out of scope (later)

- Merkle hash-chain audit (row-level append-only is sufficient for SMB <50 user per ADR-025)
- Redis-backed Protocol implementation (in-memory v1; multi-worker deploys upgrade in follow-up)
- Mount of `audit_router` in `cullis_connector/web.py` — left to Phase 2/5 integration

## Test plan

- [x] `pytest tests/connector/test_lockout.py tests/connector/test_audit.py tests/connector/test_audit_router.py -n auto --dist=loadfile` → 32 passed
- [x] Full suite no regression (2841 passed, 8 pre-existing failures unrelated to this PR — `test_desktop_app` GUI lib import gotcha, `test_profile_runtime_switch` x4, `test_postgres_integration` x2)
- [ ] CI green