### PR TITLE
docs(mastio-bundle): document Anthropic API key for chat

### DIFF
--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -28,6 +28,32 @@ Open `https://localhost:9443/proxy/login` (the browser will warn — the
 TLS cert is signed by your auto-generated Org CA, not a public CA).
 Complete the first-boot wizard and enroll your first agent.
 
+## Enable chat (Anthropic API key)
+
+The Mastio includes an embedded AI gateway (ADR-017) that powers the
+chat completion endpoint used by Cullis Chat and Frontdesk. Without a
+provider key, chat returns HTTP 503 `provider_key_missing` and the UI
+shows an error — registry / MCP / audit keep working regardless.
+
+To enable chat, copy `proxy.env.example` to `proxy.env` (the deploy
+script does this on first run if missing), open it, and set:
+
+```bash
+MCP_PROXY_ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Then restart the bundle:
+
+```bash
+./deploy.sh --pull
+```
+
+Today only Anthropic is wired as upstream provider. OpenAI / Gemini
+are on the roadmap; setting `MCP_PROXY_AI_GATEWAY_PROVIDER` to anything
+other than `anthropic` returns HTTP 501 until the corresponding wiring
+lands. See the AI gateway block in `proxy.env.example` for the full
+list of tunables (backend, provider, sidecar URL, timeout).
+
 ## Pin a release
 
 ```bash

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -109,3 +109,39 @@ MCP_PROXY_STANDALONE=true
 # MCP_PROXY_SECRET_BACKEND=vault
 # MCP_PROXY_VAULT_ADDR=https://vault.myorg.example.com:8200
 # MCP_PROXY_VAULT_TOKEN=   # scoped token, NOT the root token
+
+# ─── AI gateway (ADR-017, embedded LiteLLM) ──────────────────────────────────
+
+# The Mastio embeds LiteLLM in-process to dispatch /v1/chat/completions
+# directly to the upstream LLM provider, with Cullis identity + audit on
+# every call. Required for Cullis Chat (canale 1) and Frontdesk (canale
+# 2) end-user chat flows. Without a provider key, those endpoints return
+# HTTP 503 ``provider_key_missing`` and the chat UI shows an error.
+#
+# Today only ``anthropic`` is wired as provider (other providers return
+# 501 ``provider_not_implemented`` — OpenAI / Gemini are roadmap). The
+# default backend is the embedded LiteLLM library; switch to a Portkey
+# sidecar by setting ``MCP_PROXY_AI_GATEWAY_BACKEND=portkey`` and
+# pointing ``MCP_PROXY_AI_GATEWAY_URL`` at it.
+
+# [REQUIRED for chat UI] Anthropic API key — the upstream LLM credential
+# used by every chat completion. Mint a scoped key at
+# https://console.anthropic.com/settings/keys and rotate per the org's
+# secret-rotation policy. Leaving this empty disables chat (the rest of
+# the Mastio still works — registry, MCP, audit).
+MCP_PROXY_ANTHROPIC_API_KEY=
+
+# Backend dispatcher. ``litellm_embedded`` (default) calls LiteLLM in
+# the same process; ``portkey`` proxies through a Portkey sidecar at
+# ``MCP_PROXY_AI_GATEWAY_URL``.
+#MCP_PROXY_AI_GATEWAY_BACKEND=litellm_embedded
+
+# Active upstream provider. Anthropic only at v0.3.x; other values are
+# rejected with HTTP 501 until the corresponding wiring lands.
+#MCP_PROXY_AI_GATEWAY_PROVIDER=anthropic
+
+# Portkey sidecar URL — only consulted when backend=portkey.
+#MCP_PROXY_AI_GATEWAY_URL=http://localhost:8787
+
+# Per-request timeout to the upstream provider, seconds.
+#MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S=30


### PR DESCRIPTION
## Summary

The embedded AI gateway (ADR-017) requires `MCP_PROXY_ANTHROPIC_API_KEY` to be set, otherwise `/v1/chat/completions` returns `503 provider_key_missing` and Cullis Chat / Frontdesk show an error. Until now the env var existed in `mcp_proxy/config.py:320` but had no presence in `proxy.env.example` or the bundle `README.md`, so a small-business operator following the quickstart had no path from "Mastio is up" to "chat works" without reading the Python source.

This PR adds:
- A self-contained `AI gateway (ADR-017, embedded LiteLLM)` section in `packaging/mastio-bundle/proxy.env.example` covering the Anthropic key plus the related `ai_gateway_backend` / `_provider` / `_url` / `_request_timeout_s` tunables, with explanatory comments (defaults annotated, multi-provider state explicitly flagged as Anthropic-only today).
- An `Enable chat (Anthropic API key)` subsection in `packaging/mastio-bundle/README.md` immediately after the quickstart, so the next step from "Mastio is up" is obvious without source diving.

Documents only what is wired today: `provider=anthropic`. Other providers still return `501 provider_not_implemented` (`mcp_proxy/egress/ai_gateway.py:322-328`) and the comments say so explicitly to avoid raising expectations.

## Test plan

- [ ] `cat proxy.env.example` shows the new AI gateway section
- [ ] `cat README.md` shows the new "Enable chat (Anthropic API key)" section between quickstart and "Pin a release"
- [ ] No code changes in `mcp_proxy/`, no schema changes, no breaking effect on existing deployments (default key is empty as before).
- [ ] CI green (DCO + signed-off-by + Cloudflare Pages preview)