### PR TITLE
feat(connector): /login + session cookie + first-login password change (ADR-025 Phase 2)

### DIFF
--- a/cullis_connector/auth/__init__.py
+++ b/cullis_connector/auth/__init__.py
@@ -1,0 +1,8 @@
+"""Connector auth surface — ADR-025 Phase 2.
+
+Holds the FastAPI routers that drive end-user authentication flows
+when ``AUTH_MODE=local`` (the Frontdesk SMB default). Distinct from
+``cullis_connector.admin`` (which hosts admin-only provisioning APIs)
+and from ``cullis_connector.ambassador.shared`` (which handles the
+multi-tenant SSO flow when ``AMBASSADOR_MODE=shared``).
+"""

--- a/cullis_connector/auth/local_router.py
+++ b/cullis_connector/auth/local_router.py
@@ -1,0 +1,449 @@
+"""Local-mode login + session router — ADR-025 Phase 2.
+
+Mounted by ``cullis_connector.web.build_app`` when
+``AUTH_MODE=local`` (default for Frontdesk SMB deployments without a
+corporate IdP).
+
+Endpoints:
+
+    GET  /login                       server-side fallback form
+    GET  /change-password             server-side fallback form
+    POST /api/auth/login              JSON {user_name,password} → cookie
+    POST /api/auth/logout             clears cookie
+    POST /api/auth/change-password    JSON {old_password,new_password}
+    GET  /api/auth/whoami-local       returns cookie payload echo
+    GET  /api/auth/runtime-info       no-auth hint for the SPA bootstrap
+
+Cookie shape (``cullis_local_session``): see
+``cullis_connector.identity.local_session``. The cookie is HttpOnly +
+SameSite=Strict and Secure unless ``CULLIS_CONNECTOR_DEV=1``.
+
+Phase-4 stubs (lockout / audit) are wired here as no-op helpers so
+this PR does not depend on the parallel lockout PR landing first. A
+follow-up patch swaps the stubs for the real implementations once
+both have merged.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from fastapi import APIRouter, HTTPException, Request, Response, status
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+from pathlib import Path
+from pydantic import BaseModel, Field
+
+from cullis_connector.ambassador.shared.wire import bootstrap_cookie_secret
+from cullis_connector.identity.local_session import (
+    LOCAL_SESSION_COOKIE_NAME,
+    LOCAL_SESSION_TTL_SEC,
+    LocalSessionPayload,
+    build_payload,
+    issue_local_cookie,
+    parse_local_cookie,
+)
+from cullis_connector.identity.users import (
+    MIN_PASSWORD_LENGTH,
+    get_user_by_name,
+    mark_password_changed,
+    set_password_hash,
+    verify_password,
+)
+from cullis_connector.identity.users_db import get_users_session
+
+_log = logging.getLogger("cullis_connector.auth.local_router")
+
+
+_TEMPLATES_DIR = Path(__file__).parent.parent / "templates"
+_templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+
+
+router = APIRouter(tags=["auth", "local"])
+
+
+# ── Phase 4 stubs ────────────────────────────────────────────────────────
+#
+# Wired to the real lockout + audit modules in a follow-up PR after
+# Phase 4 (cullis_connector/identity/lockout.py + audit.py) lands. For
+# Phase 2 these are intentional no-ops that emit a single warning so
+# the call-sites stay shaped correctly and follow-up only edits the
+# helper bodies.
+
+
+def _check_lockout(ip: str, user_name: str) -> bool:
+    """Return ``True`` if the (ip, user_name) pair is currently locked.
+
+    Phase-2 stub — never locked. Wired to lockout/audit in follow-up PR
+    after Phase 4 lands.
+    """
+    return False
+
+
+def _record_login_attempt(
+    ip: str, user_name: str, success: bool,
+) -> None:
+    """Record a login attempt for lockout + audit accounting.
+
+    Phase-2 stub — no-op. Wired to lockout/audit in follow-up PR after
+    Phase 4 lands.
+    """
+    # Single debug line only — never log the password and never log a
+    # full audit event from the stub (so the follow-up PR's audit
+    # writer is the only place rows are emitted).
+    _log.debug(
+        "login attempt (stub) ip=%s user_name=%s success=%s",
+        ip, user_name, success,
+    )
+
+
+# ── Request / response models ────────────────────────────────────────────
+
+
+class LoginRequest(BaseModel):
+    user_name: str = Field(..., min_length=1, max_length=64)
+    password: str = Field(..., min_length=1, max_length=4096)
+
+
+class LoginResponse(BaseModel):
+    ok: bool
+    must_change_password: bool
+    principal_name: str
+    exp: int
+
+
+class ChangePasswordRequest(BaseModel):
+    old_password: str = Field(..., min_length=1, max_length=4096)
+    new_password: str = Field(..., min_length=MIN_PASSWORD_LENGTH, max_length=4096)
+
+
+class ChangePasswordResponse(BaseModel):
+    ok: bool
+    must_change_password: bool
+    principal_name: str
+    exp: int
+
+
+class WhoamiLocalResponse(BaseModel):
+    user_name: str
+    principal_name: str
+    must_change_password: bool
+    exp: int
+
+
+class RuntimeInfoResponse(BaseModel):
+    auth_mode: str
+    login_url: str
+    require_change_password_url: str
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _is_secure_cookie() -> bool:
+    """Return True unless we're explicitly in dev mode.
+
+    The Frontdesk container's reverse proxy terminates TLS, so the
+    Connector's own cookie must carry ``Secure`` so the browser refuses
+    to attach it to HTTP requests. ``CULLIS_CONNECTOR_DEV=1`` flips it
+    off so the dashboard works on plain ``http://127.0.0.1:7777``
+    during local development.
+    """
+    return os.environ.get("CULLIS_CONNECTOR_DEV", "") != "1"
+
+
+def _config_dir(request: Request) -> Path:
+    config = getattr(request.app.state, "connector_config", None)
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="connector_config not bound on app.state",
+        )
+    return config.config_dir
+
+
+def _cookie_secret(request: Request) -> bytes:
+    """Return the cached cookie secret, bootstrapping it on first call.
+
+    Stashed on ``app.state`` so the bootstrap (file IO + chmod) only
+    runs once per process even though ``parse_local_cookie`` /
+    ``issue_local_cookie`` need the secret on every request.
+    """
+    cached = getattr(request.app.state, "local_cookie_secret", None)
+    if cached is not None:
+        return cached
+    secret = bootstrap_cookie_secret(_config_dir(request))
+    request.app.state.local_cookie_secret = secret
+    return secret
+
+
+def _set_cookie(
+    response: Response, cookie_value: str, *, max_age: int = LOCAL_SESSION_TTL_SEC,
+) -> None:
+    response.set_cookie(
+        LOCAL_SESSION_COOKIE_NAME,
+        cookie_value,
+        max_age=max_age,
+        httponly=True,
+        samesite="strict",
+        secure=_is_secure_cookie(),
+        path="/",
+    )
+
+
+def _clear_cookie(response: Response) -> None:
+    # Delete by setting Max-Age=0 with the same flags so the browser
+    # actually overwrites the prior cookie. ``delete_cookie`` does not
+    # always emit Max-Age which some browsers ignore.
+    response.set_cookie(
+        LOCAL_SESSION_COOKIE_NAME,
+        value="",
+        max_age=0,
+        httponly=True,
+        samesite="strict",
+        secure=_is_secure_cookie(),
+        path="/",
+    )
+
+
+async def _require_local_session(request: Request) -> LocalSessionPayload:
+    """FastAPI dep — return a valid session payload or raise 401.
+
+    Also re-checks the user is still enabled in users.db on every
+    request (defence in depth — an admin who disables a user mid-flight
+    must invalidate the existing cookie). Cheap: a single indexed
+    lookup on the username PK.
+    """
+    raw = request.cookies.get(LOCAL_SESSION_COOKIE_NAME, "")
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="login required",
+        )
+    secret = _cookie_secret(request)
+    payload = parse_local_cookie(raw, secret)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="login required",
+        )
+    config_dir = _config_dir(request)
+    async with get_users_session(config_dir) as session:
+        user = await get_user_by_name(session, payload.user_name)
+    if user is None or user.disabled:
+        # Account vanished or was disabled since the cookie was issued
+        # — treat as logged out. Generic 401 to avoid leaking which
+        # state caused the failure.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="login required",
+        )
+    return payload
+
+
+def _client_ip(request: Request) -> str:
+    """Best-effort caller IP. Used only for the Phase-4 lockout stub."""
+    if request.client is not None:
+        return request.client.host or ""
+    return ""
+
+
+# ── Server-side fallback HTML ────────────────────────────────────────────
+
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request) -> Response:
+    """Plain HTML form for non-SPA clients + ops debug."""
+    return _templates.TemplateResponse(
+        request,
+        "login.html",
+        {
+            "connector_status": "offline",
+            "connector_status_label": "Sign in",
+            "error": None,
+        },
+    )
+
+
+@router.get("/change-password", response_class=HTMLResponse)
+async def change_password_page(request: Request) -> Response:
+    """Plain HTML form for non-SPA first-login change flow."""
+    return _templates.TemplateResponse(
+        request,
+        "change_password.html",
+        {
+            "connector_status": "waiting",
+            "connector_status_label": "Change password",
+            "error": None,
+        },
+    )
+
+
+# ── JSON API ─────────────────────────────────────────────────────────────
+
+
+@router.post("/api/auth/login", response_model=LoginResponse)
+async def login(body: LoginRequest, request: Request) -> JSONResponse:
+    """Verify credentials and issue a session cookie.
+
+    Generic 401 on every failure (missing user, wrong password,
+    disabled account) so a brute-forcer cannot enumerate valid
+    user_names off the response code or message.
+    """
+    ip = _client_ip(request)
+    if _check_lockout(ip, body.user_name):
+        # Phase-4 stub — never returns True today. Real implementation
+        # surfaces 429 with a Retry-After header.
+        _record_login_attempt(ip, body.user_name, success=False)
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="too many login attempts",
+        )
+
+    config_dir = _config_dir(request)
+    async with get_users_session(config_dir) as session:
+        user = await get_user_by_name(session, body.user_name)
+        if user is None or user.disabled:
+            _record_login_attempt(ip, body.user_name, success=False)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid credentials",
+            )
+        ok = await verify_password(session, body.user_name, body.password)
+    if not ok:
+        _record_login_attempt(ip, body.user_name, success=False)
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+
+    payload = build_payload(
+        user_name=user.user_name,
+        must_change_password=user.must_change_password,
+    )
+    secret = _cookie_secret(request)
+    cookie_value = issue_local_cookie(payload, secret)
+    body_out = LoginResponse(
+        ok=True,
+        must_change_password=payload.must_change_password,
+        principal_name=payload.principal_name,
+        exp=payload.exp,
+    )
+    response = JSONResponse(body_out.model_dump())
+    _set_cookie(response, cookie_value)
+    _record_login_attempt(ip, body.user_name, success=True)
+    # Never log the password — only the username + result.
+    _log.info(
+        "local login ok user_name=%s must_change=%s",
+        user.user_name, payload.must_change_password,
+    )
+    return response
+
+
+@router.post("/api/auth/logout")
+async def logout(request: Request) -> JSONResponse:
+    """Invalidate the cookie. No-op when called without one."""
+    response = JSONResponse({"ok": True})
+    _clear_cookie(response)
+    return response
+
+
+@router.post("/api/auth/change-password", response_model=ChangePasswordResponse)
+async def change_password(
+    body: ChangePasswordRequest, request: Request,
+) -> JSONResponse:
+    """Verify old password + persist new + reissue cookie.
+
+    Uses ``_require_local_session`` semantics inline so we can reissue
+    the cookie on the same response. Wrong old password returns 401
+    (not 403) to avoid distinguishing "logged in but wrong old pw"
+    from "session expired".
+    """
+    payload = await _require_local_session(request)
+    config_dir = _config_dir(request)
+    async with get_users_session(config_dir) as session:
+        ok = await verify_password(
+            session, payload.user_name, body.old_password,
+        )
+        if not ok:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="invalid credentials",
+            )
+        try:
+            updated = await set_password_hash(
+                session, payload.user_name, body.new_password,
+                must_change=False,
+            )
+        except ValueError as exc:
+            # ``set_password_hash`` re-validates length/whitespace.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            )
+        if not updated:
+            # User vanished between cookie parse and update — generic
+            # 401 so attackers cannot probe state via this endpoint.
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="login required",
+            )
+        # Belt + braces: explicitly clear must_change in case
+        # ``set_password_hash`` semantics drift in future. Currently
+        # already cleared via ``must_change=False``.
+        await mark_password_changed(session, payload.user_name)
+
+    new_payload = build_payload(
+        user_name=payload.user_name,
+        must_change_password=False,
+        principal_name=payload.principal_name,
+    )
+    secret = _cookie_secret(request)
+    cookie_value = issue_local_cookie(new_payload, secret)
+    body_out = ChangePasswordResponse(
+        ok=True,
+        must_change_password=False,
+        principal_name=new_payload.principal_name,
+        exp=new_payload.exp,
+    )
+    response = JSONResponse(body_out.model_dump())
+    _set_cookie(response, cookie_value)
+    _log.info(
+        "local password changed user_name=%s", payload.user_name,
+    )
+    return response
+
+
+@router.get("/api/auth/whoami-local", response_model=WhoamiLocalResponse)
+async def whoami_local(request: Request) -> WhoamiLocalResponse:
+    """Echo the cookie payload — drives the SPA's "are you logged in" probe."""
+    payload = await _require_local_session(request)
+    return WhoamiLocalResponse(
+        user_name=payload.user_name,
+        principal_name=payload.principal_name,
+        must_change_password=payload.must_change_password,
+        exp=payload.exp,
+    )
+
+
+@router.get("/api/auth/runtime-info", response_model=RuntimeInfoResponse)
+async def runtime_info() -> RuntimeInfoResponse:
+    """Public hint for the SPA bootstrap: which login flow to render.
+
+    Intentionally no-auth so the SPA can fetch this before it has any
+    cookie. Returns only public-safe metadata (URL paths, mode name).
+    """
+    # Hardcoded "local" because this router is only mounted in
+    # local mode by ``build_app``. Callers in shared/oidc mode get
+    # 404 from FastAPI (no router mounted) — the SPA detects this and
+    # falls back to the SSO bootstrap path.
+    return RuntimeInfoResponse(
+        auth_mode="local",
+        login_url="/login",
+        require_change_password_url="/change-password",
+    )
+
+
+__all__ = [
+    "_require_local_session",
+    "router",
+]

--- a/cullis_connector/identity/auth_mode.py
+++ b/cullis_connector/identity/auth_mode.py
@@ -1,0 +1,87 @@
+"""Auth mode resolver for Cullis Connector — ADR-025 Phase 2.
+
+The Connector decides at boot which auth model to enable:
+
+  - ``"local"``  — local users.db + signed session cookie (default,
+                   Frontdesk SMB scenario).
+  - ``"oidc"``   — corporate IdP via OIDC (single-tenant single-user;
+                   Phase 6+ wires the Connector to the existing Mastio
+                   /auth/oidc helpers).
+  - ``"shared"`` — multi-tenant Frontdesk shared mode (ADR-019/021).
+                   Triggered by the legacy ``AMBASSADOR_MODE=shared`` env.
+
+Precedence:
+
+  1. ``AMBASSADOR_MODE=shared`` env wins → ``"shared"`` (back-compat
+     for existing ADR-021 deployments that have only ever set this var).
+  2. ``AUTH_MODE`` env value, lowercased and validated against the set
+     above. Anything unrecognised falls back to ``"local"`` with a
+     warning so a typo'd env doesn't silently disable the auth surface.
+  3. Default ``"local"``.
+
+The helpers exist as a single source of truth so the dashboard, the
+admin router, and the (Phase 2) login router all read the same value
+without duplicating env parsing.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Optional
+
+_log = logging.getLogger("cullis_connector.identity.auth_mode")
+
+ENV_AUTH_MODE = "AUTH_MODE"
+ENV_AMBASSADOR_MODE = "AMBASSADOR_MODE"
+
+MODE_LOCAL = "local"
+MODE_OIDC = "oidc"
+MODE_SHARED = "shared"
+
+_VALID_MODES = (MODE_LOCAL, MODE_OIDC, MODE_SHARED)
+
+
+def read_auth_mode(env: Optional[dict] = None) -> str:
+    """Return the active auth mode, one of ``local`` / ``oidc`` / ``shared``.
+
+    ``env`` lets tests inject a dict instead of the live ``os.environ``.
+    """
+    e = env if env is not None else os.environ
+    ambassador = (e.get(ENV_AMBASSADOR_MODE) or "").strip().lower()
+    if ambassador == "shared":
+        return MODE_SHARED
+    raw = (e.get(ENV_AUTH_MODE) or "").strip().lower()
+    if not raw:
+        return MODE_LOCAL
+    if raw in _VALID_MODES:
+        return raw
+    _log.warning(
+        "AUTH_MODE=%r is not one of %s; falling back to %s",
+        raw, _VALID_MODES, MODE_LOCAL,
+    )
+    return MODE_LOCAL
+
+
+def is_local_mode(env: Optional[dict] = None) -> bool:
+    return read_auth_mode(env) == MODE_LOCAL
+
+
+def is_oidc_mode(env: Optional[dict] = None) -> bool:
+    return read_auth_mode(env) == MODE_OIDC
+
+
+def is_shared_mode(env: Optional[dict] = None) -> bool:
+    return read_auth_mode(env) == MODE_SHARED
+
+
+__all__ = [
+    "ENV_AMBASSADOR_MODE",
+    "ENV_AUTH_MODE",
+    "MODE_LOCAL",
+    "MODE_OIDC",
+    "MODE_SHARED",
+    "is_local_mode",
+    "is_oidc_mode",
+    "is_shared_mode",
+    "read_auth_mode",
+]

--- a/cullis_connector/identity/local_session.py
+++ b/cullis_connector/identity/local_session.py
@@ -1,0 +1,229 @@
+"""Local-mode session cookie for Cullis Connector — ADR-025 Phase 2.
+
+When ``AUTH_MODE=local`` (the Frontdesk SMB scenario without a
+corporate IdP) the Connector authenticates end users directly against
+``users.db`` and issues a short-lived HMAC-signed session cookie. This
+module owns the encode/decode of that cookie. Conceptually the same
+shape as ``cullis_connector/ambassador/shared/cookie.py`` but with a
+distinct payload schema: it carries the local user_name, a
+must-change-password flag, and a per-session CSRF token.
+
+Format: ``<base64url(payload_json)>.<base64url(hmac_sha256(payload, secret))>``
+
+The payload is canonical JSON (sorted keys, separators ``(",", ":")``).
+``parse_local_cookie`` collapses every failure mode (bad encoding, bad
+signature, expired, malformed JSON) to ``None`` so callers cannot leak
+the failure reason via timing or exception type.
+
+The HMAC primitives are intentionally duplicated from
+``cullis_connector.ambassador.shared.cookie`` rather than imported, so
+local-mode does not pull the shared-mode credential cache + provisioner
+graph into the boot path. Both modules use the same HMAC-SHA256 with
+``hmac.compare_digest`` so behaviour is byte-identical.
+"""
+from __future__ import annotations
+
+import base64
+import hmac
+import json
+import logging
+import secrets
+import time
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Optional
+
+_log = logging.getLogger("cullis_connector.identity.local_session")
+
+# Cookie name for the local-mode session. Distinct from the shared-mode
+# cookie name (``cullis_session``) so a Frontdesk container that gets
+# reconfigured between modes does not present a stale cookie of the
+# wrong shape and silently authenticate.
+LOCAL_SESSION_COOKIE_NAME = "cullis_local_session"
+
+# 8-hour TTL — same as ``mcp_proxy/dashboard/session.py`` admin cookie.
+# Long enough to cover a full work session, short enough that a stolen
+# cookie has a bounded blast radius.
+LOCAL_SESSION_TTL_SEC = 8 * 3600
+
+# Minimum signing-secret length. 16 bytes is the floor we require so a
+# misconfigured operator cannot ship a 4-byte HMAC key. The Frontdesk
+# bootstrap (`bootstrap_cookie_secret`) generates 32 bytes.
+_MIN_SECRET_BYTES = 16
+
+# Caps on cookie payload size — keep cookies well under the 4KiB browser
+# limit and refuse anything larger than would be reasonable.
+_MAX_PAYLOAD_BYTES = 1024
+_MAX_COOKIE_BYTES = 2048
+
+
+@dataclass(frozen=True)
+class LocalSessionPayload:
+    """Structured contents of a local-mode session cookie."""
+
+    user_name: str               # 'mario'
+    principal_name: str          # initially same as user_name; Phase 3 SPIFFE
+    must_change_password: bool
+    csrf_token: str              # 16 bytes hex
+    iat: int                     # issued-at, unix seconds
+    exp: int                     # expiry, unix seconds
+
+    def as_json_bytes(self) -> bytes:
+        return json.dumps(
+            {
+                "user_name": self.user_name,
+                "principal_name": self.principal_name,
+                "must_change_password": bool(self.must_change_password),
+                "csrf_token": self.csrf_token,
+                "iat": int(self.iat),
+                "exp": int(self.exp),
+            },
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+    @classmethod
+    def from_json_bytes(cls, raw: bytes) -> "LocalSessionPayload":
+        obj = json.loads(raw)
+        if not isinstance(obj, dict):
+            raise ValueError("payload must be a JSON object")
+        for k in (
+            "user_name",
+            "principal_name",
+            "must_change_password",
+            "csrf_token",
+            "iat",
+            "exp",
+        ):
+            if k not in obj:
+                raise ValueError(f"payload missing required key {k!r}")
+        return cls(
+            user_name=str(obj["user_name"]),
+            principal_name=str(obj["principal_name"]),
+            must_change_password=bool(obj["must_change_password"]),
+            csrf_token=str(obj["csrf_token"]),
+            iat=int(obj["iat"]),
+            exp=int(obj["exp"]),
+        )
+
+
+def _b64url_encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    pad = "=" * ((4 - len(data) % 4) % 4)
+    return base64.urlsafe_b64decode(data + pad)
+
+
+def _hmac(secret: bytes, payload: bytes) -> bytes:
+    return hmac.new(secret, payload, sha256).digest()
+
+
+def new_csrf_token() -> str:
+    """Return a fresh 16-byte hex CSRF token (32 hex chars)."""
+    return secrets.token_hex(16)
+
+
+def issue_local_cookie(
+    payload: LocalSessionPayload, secret: bytes,
+) -> str:
+    """HMAC-sign + base64url-encode a local session payload.
+
+    Raises ``ValueError`` if the payload exceeds the soft cap or if the
+    secret is too short.
+    """
+    if len(secret) < _MIN_SECRET_BYTES:
+        raise ValueError(
+            f"secret must be at least {_MIN_SECRET_BYTES} bytes",
+        )
+    raw = payload.as_json_bytes()
+    if len(raw) > _MAX_PAYLOAD_BYTES:
+        raise ValueError(
+            f"cookie payload too large ({len(raw)} bytes "
+            f"> {_MAX_PAYLOAD_BYTES})",
+        )
+    sig = _hmac(secret, raw)
+    return f"{_b64url_encode(raw)}.{_b64url_encode(sig)}"
+
+
+def parse_local_cookie(
+    cookie_value: str,
+    secret: bytes,
+    *,
+    now: Optional[int] = None,
+) -> Optional[LocalSessionPayload]:
+    """Verify + decode a local session cookie. Returns ``None`` on any failure.
+
+    Failure modes collapse to ``None`` on purpose so callers cannot
+    leak via timing or exception type which check failed (bad sig vs
+    expired vs malformed).
+    """
+    if not cookie_value or len(cookie_value) > _MAX_COOKIE_BYTES:
+        return None
+    try:
+        encoded_payload, encoded_sig = cookie_value.split(".", 1)
+    except ValueError:
+        return None
+    try:
+        raw_payload = _b64url_decode(encoded_payload)
+        raw_sig = _b64url_decode(encoded_sig)
+    except (ValueError, base64.binascii.Error):  # type: ignore[attr-defined]
+        return None
+    if len(secret) < _MIN_SECRET_BYTES:
+        # Caller bug: never accept a too-short secret on parse either.
+        return None
+    expected_sig = _hmac(secret, raw_payload)
+    if not hmac.compare_digest(raw_sig, expected_sig):
+        return None
+    try:
+        payload = LocalSessionPayload.from_json_bytes(raw_payload)
+    except (ValueError, json.JSONDecodeError, TypeError):
+        return None
+    cur = int(now if now is not None else time.time())
+    if cur >= payload.exp:
+        return None
+    if cur < payload.iat:
+        # Issued in the future — refuse rather than accept, something
+        # is wrong with the issuer's clock.
+        return None
+    return payload
+
+
+def build_payload(
+    *,
+    user_name: str,
+    must_change_password: bool,
+    principal_name: str = "",
+    csrf_token: Optional[str] = None,
+    ttl_seconds: int = LOCAL_SESSION_TTL_SEC,
+    now: Optional[int] = None,
+) -> LocalSessionPayload:
+    """Convenience constructor — fills iat/exp + a fresh CSRF token.
+
+    ``principal_name`` defaults to the bare user_name (Phase 2). Phase 3
+    replaces it with the full SPIFFE form once user-principal CSR
+    issuance lands.
+    """
+    if ttl_seconds <= 0 or ttl_seconds > 24 * 3600:
+        raise ValueError("ttl_seconds must be in (0, 86400]")
+    cur = int(now if now is not None else time.time())
+    return LocalSessionPayload(
+        user_name=user_name,
+        principal_name=principal_name or user_name,
+        must_change_password=bool(must_change_password),
+        csrf_token=csrf_token or new_csrf_token(),
+        iat=cur,
+        exp=cur + ttl_seconds,
+    )
+
+
+__all__ = [
+    "LOCAL_SESSION_COOKIE_NAME",
+    "LOCAL_SESSION_TTL_SEC",
+    "LocalSessionPayload",
+    "build_payload",
+    "issue_local_cookie",
+    "new_csrf_token",
+    "parse_local_cookie",
+]

--- a/cullis_connector/templates/change_password.html
+++ b/cullis_connector/templates/change_password.html
@@ -1,0 +1,114 @@
+{% extends "base.html" %}
+{% block title %}Change password{% endblock %}
+{% block content %}
+
+<div class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Cullis · First sign-in</div>
+        <h1 class="panel-title">Set a <em>new password</em></h1>
+        <p class="panel-sub">
+            You're using a temporary password. Pick a new one to
+            continue. Minimum 8 characters; longer is better.
+        </p>
+    </div>
+
+    {% if error %}
+    <div class="alert alert-error" id="cp-error">{{ error }}</div>
+    {% endif %}
+
+    <form id="cp-form" class="form" novalidate>
+        <div class="field">
+            <label class="field-label" for="old_password">Current password</label>
+            <input
+                id="old_password"
+                name="old_password"
+                type="password"
+                autocomplete="current-password"
+                required>
+        </div>
+
+        <div class="field">
+            <label class="field-label" for="new_password">New password</label>
+            <input
+                id="new_password"
+                name="new_password"
+                type="password"
+                autocomplete="new-password"
+                minlength="8"
+                required>
+        </div>
+
+        <div class="field">
+            <label class="field-label" for="confirm_password">Confirm new password</label>
+            <input
+                id="confirm_password"
+                name="confirm_password"
+                type="password"
+                autocomplete="new-password"
+                minlength="8"
+                required>
+        </div>
+
+        <div class="form-actions">
+            <button class="btn btn-primary" type="submit" id="cp-submit">
+                Save new password
+            </button>
+        </div>
+    </form>
+</div>
+
+<script>
+(function() {
+    var form = document.getElementById('cp-form');
+    if (!form) { return; }
+    form.addEventListener('submit', function(ev) {
+        ev.preventDefault();
+        var btn = document.getElementById('cp-submit');
+        var box = document.getElementById('cp-error');
+        function showError(msg) {
+            if (!box) {
+                box = document.createElement('div');
+                box.className = 'alert alert-error';
+                box.id = 'cp-error';
+                form.parentNode.insertBefore(box, form);
+            }
+            box.textContent = msg;
+        }
+        var old_password = document.getElementById('old_password').value;
+        var new_password = document.getElementById('new_password').value;
+        var confirm_password = document.getElementById('confirm_password').value;
+        if (new_password !== confirm_password) {
+            showError('New passwords do not match.');
+            return;
+        }
+        if (new_password.length < 8) {
+            showError('New password must be at least 8 characters.');
+            return;
+        }
+        if (btn) { btn.disabled = true; }
+        fetch('/api/auth/change-password', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                old_password: old_password,
+                new_password: new_password,
+            }),
+        }).then(function(r) {
+            if (!r.ok) {
+                return r.json().then(function(j) {
+                    throw new Error(j.detail || 'Could not change password');
+                });
+            }
+            return r.json();
+        }).then(function() {
+            window.location.href = '/';
+        }).catch(function(err) {
+            showError(err.message || 'Could not change password');
+            if (btn) { btn.disabled = false; }
+        });
+    });
+})();
+</script>
+
+{% endblock %}

--- a/cullis_connector/templates/login.html
+++ b/cullis_connector/templates/login.html
@@ -1,0 +1,94 @@
+{% extends "base.html" %}
+{% block title %}Sign in{% endblock %}
+{% block content %}
+
+<div class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Cullis · Sign in</div>
+        <h1 class="panel-title">Sign in to <em>your workspace</em></h1>
+        <p class="panel-sub">
+            Use the credentials your administrator gave you. If you
+            haven't set a password yet, use the temporary one and you'll
+            be prompted to change it.
+        </p>
+    </div>
+
+    {% if error %}
+    <div class="alert alert-error" id="login-error">{{ error }}</div>
+    {% endif %}
+
+    <form id="login-form" class="form" novalidate>
+        <div class="field">
+            <label class="field-label" for="user_name">Username</label>
+            <input
+                id="user_name"
+                name="user_name"
+                type="text"
+                autocomplete="username"
+                autocapitalize="none"
+                spellcheck="false"
+                required>
+        </div>
+
+        <div class="field">
+            <label class="field-label" for="password">Password</label>
+            <input
+                id="password"
+                name="password"
+                type="password"
+                autocomplete="current-password"
+                required>
+        </div>
+
+        <div class="form-actions">
+            <button class="btn btn-primary" type="submit" id="login-submit">
+                Sign in
+            </button>
+        </div>
+    </form>
+</div>
+
+<script>
+(function() {
+    var form = document.getElementById('login-form');
+    if (!form) { return; }
+    form.addEventListener('submit', function(ev) {
+        ev.preventDefault();
+        var btn = document.getElementById('login-submit');
+        if (btn) { btn.disabled = true; }
+        var user_name = document.getElementById('user_name').value;
+        var password = document.getElementById('password').value;
+        fetch('/api/auth/login', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ user_name: user_name, password: password }),
+        }).then(function(r) {
+            if (!r.ok) {
+                return r.json().then(function(j) {
+                    throw new Error(j.detail || 'Sign in failed');
+                });
+            }
+            return r.json();
+        }).then(function(j) {
+            if (j.must_change_password) {
+                window.location.href = '/change-password';
+            } else {
+                window.location.href = '/';
+            }
+        }).catch(function(err) {
+            var box = document.getElementById('login-error');
+            if (!box) {
+                box = document.createElement('div');
+                box.className = 'alert alert-error';
+                box.id = 'login-error';
+                form.parentNode.insertBefore(box, form);
+            }
+            box.textContent = err.message || 'Sign in failed';
+            if (btn) { btn.disabled = false; }
+        });
+    });
+})();
+</script>
+
+{% endblock %}

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -564,13 +564,23 @@ def build_app(config: ConnectorConfig) -> FastAPI:
     # for SMB deployments without a corporate IdP). Set AUTH_MODE=oidc
     # to skip the mount entirely so the local-users surface does not
     # exist at all in IdP-only deployments.
-    auth_mode = os.environ.get("AUTH_MODE", "local").strip().lower() or "local"
+    #
+    # Phase 2 — additionally mount the local login + session router
+    # under the same gate so /login, /api/auth/* and the cookie-issuing
+    # endpoints exist exactly when admin pre-creation does.
+    from cullis_connector.identity.auth_mode import (
+        MODE_LOCAL, read_auth_mode,
+    )
+    auth_mode = read_auth_mode()
     app.state.auth_mode = auth_mode
-    if auth_mode == "local":
+    if auth_mode == MODE_LOCAL:
         from cullis_connector.admin.users_router import router as _users_router
+        from cullis_connector.auth.local_router import router as _auth_local_router
         app.include_router(_users_router)
+        app.include_router(_auth_local_router)
         _log.info(
-            "ADR-025 admin /admin/users mounted (AUTH_MODE=%s)", auth_mode,
+            "ADR-025 admin /admin/users + /api/auth/* mounted (AUTH_MODE=%s)",
+            auth_mode,
         )
     else:
         _log.info(
@@ -613,6 +623,7 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         if (
             request.url.path.startswith("/v1/")
             or request.url.path.startswith("/api/session/")
+            or request.url.path.startswith("/api/auth/")
             or request.url.path.startswith("/admin/")
         ):
             # ``/admin/*`` runs its own constant-time ``X-Admin-Secret``
@@ -620,6 +631,16 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             # is not auto-attached by browsers, so the route is not a
             # CSRF vector — mirroring the exemption already granted to
             # the Bearer-token path below.
+            #
+            # ``/api/auth/*`` (ADR-025 Phase 2) is the login bootstrap:
+            # the browser does not yet have a session cookie when it
+            # POSTs /api/auth/login, so a CSRF token derived from the
+            # session is impossible by construction. We instead require
+            # JSON content-type on these routes (browsers will not
+            # auto-set ``application/json`` on a cross-origin form-POST
+            # without an Origin/Referer header that the SameSite=Strict
+            # cookie already gates) — the router uses Pydantic-bound
+            # JSON bodies which 422 on form-encoded payloads.
             return await call_next(request)
         if request.method in ("POST", "PUT", "DELETE", "PATCH"):
             authz = request.headers.get("authorization", "")

--- a/tests/connector/test_auth_local_router.py
+++ b/tests/connector/test_auth_local_router.py
@@ -1,0 +1,410 @@
+"""Integration tests for /api/auth/* — ADR-025 Phase 2.
+
+Drives ``cullis_connector.web.build_app`` via fastapi.testclient and
+asserts the login + change-password + whoami contracts: cookie
+issuance, must_change_password gating, generic 401 on every credential
+failure, logout cookie clearing, runtime-info no-auth path.
+
+Each test gets a fresh ``tmp_path`` so the per-test users.db + cookie
+secret are isolated from siblings.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity.local_session import (
+    LOCAL_SESSION_COOKIE_NAME,
+    parse_local_cookie,
+)
+from cullis_connector.identity.users_db import dispose_users_engines
+from cullis_connector.web import build_app
+
+
+ADMIN_SECRET = "test-admin-secret-not-default"
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_engines():
+    yield
+    await dispose_users_engines()
+
+
+@pytest.fixture
+def connector_config(tmp_path):
+    cfg = ConnectorConfig(
+        config_dir=tmp_path / "connector",
+        site_url="http://mastio.test",
+        verify_tls=False,
+    )
+    cfg.config_dir.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+@pytest.fixture
+def client(connector_config, monkeypatch):
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    # Allow non-Secure cookie under TestClient (http://testserver)
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    app = build_app(connector_config)
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+    return tc
+
+
+def _admin_headers() -> dict[str, str]:
+    return {"X-Admin-Secret": ADMIN_SECRET}
+
+
+def _create_user(
+    client: TestClient,
+    *,
+    user_name: str,
+    password: str,
+    must_change: bool = True,
+) -> None:
+    r = client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": user_name,
+            "password": password,
+            "must_change_password": must_change,
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+def _cookie_secret(client: TestClient) -> bytes:
+    """Read the on-disk cookie secret bootstrapped by the router.
+
+    Used to manually parse the issued cookie in assertions without
+    going through the router again.
+    """
+    config_dir = client.app.state.connector_config.config_dir
+    return (config_dir / "cookie.secret").read_bytes()
+
+
+# ── runtime-info (no auth) ───────────────────────────────────────────────
+
+
+def test_runtime_info_returns_local_mode_no_auth(client):
+    r = client.get("/api/auth/runtime-info")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auth_mode"] == "local"
+    assert body["login_url"] == "/login"
+    assert body["require_change_password_url"] == "/change-password"
+
+
+def test_runtime_info_does_not_set_cookie(client):
+    r = client.get("/api/auth/runtime-info")
+    assert r.status_code == 200
+    assert LOCAL_SESSION_COOKIE_NAME not in r.cookies
+
+
+# ── login: success path ─────────────────────────────────────────────────
+
+
+def test_login_success_must_change_true_sets_cookie(client):
+    _create_user(
+        client, user_name="mario", password="temp123!secure", must_change=True,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "temp123!secure"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["must_change_password"] is True
+    assert body["principal_name"] == "mario"
+    assert body["exp"] > 0
+
+    # Cookie issued
+    raw = r.cookies.get(LOCAL_SESSION_COOKIE_NAME)
+    assert raw, "expected cookie to be set"
+    payload = parse_local_cookie(raw, _cookie_secret(client))
+    assert payload is not None
+    assert payload.user_name == "mario"
+    assert payload.must_change_password is True
+
+
+def test_login_success_must_change_false(client):
+    _create_user(
+        client,
+        user_name="alice",
+        password="longpassword",
+        must_change=False,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "alice", "password": "longpassword"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["must_change_password"] is False
+
+
+# ── login: failure paths ─────────────────────────────────────────────────
+
+
+def test_login_wrong_password_returns_401_generic(client):
+    _create_user(client, user_name="mario", password="longpassword")
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "WRONG-pass"},
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"] == "invalid credentials"
+    assert LOCAL_SESSION_COOKIE_NAME not in r.cookies
+
+
+def test_login_unknown_user_returns_same_401_message(client):
+    """Username enumeration defence — same code + message as wrong pw."""
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "ghost", "password": "anything-here"},
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"] == "invalid credentials"
+
+
+def test_login_disabled_user_rejected(client, connector_config):
+    """A disabled user cannot log in even with the right password."""
+    from sqlalchemy import update
+
+    from cullis_connector.identity.users import LocalUser
+    from cullis_connector.identity.users_db import get_users_session
+
+    _create_user(
+        client, user_name="disabled-user", password="longpassword",
+        must_change=False,
+    )
+
+    # Manually flip the disabled column — there is no admin endpoint
+    # for it yet (Phase 1 didn't ship one).
+    import asyncio
+
+    async def _disable():
+        async with get_users_session(connector_config.config_dir) as session:
+            await session.execute(
+                update(LocalUser)
+                .where(LocalUser.user_name == "disabled-user")
+                .values(disabled=1),
+            )
+
+    asyncio.get_event_loop().run_until_complete(_disable())
+
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "disabled-user", "password": "longpassword"},
+    )
+    assert r.status_code == 401
+    assert r.json()["detail"] == "invalid credentials"
+
+
+def test_login_validation_error_short_user_name(client):
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "", "password": "longpassword"},
+    )
+    # Pydantic min_length=1 → 422
+    assert r.status_code == 422
+
+
+# ── whoami-local ─────────────────────────────────────────────────────────
+
+
+def test_whoami_local_requires_cookie(client):
+    r = client.get("/api/auth/whoami-local")
+    assert r.status_code == 401
+
+
+def test_whoami_local_returns_payload_after_login(client):
+    _create_user(
+        client, user_name="mario", password="longpassword", must_change=True,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 200
+    # TestClient session keeps cookies across requests.
+    r2 = client.get("/api/auth/whoami-local")
+    assert r2.status_code == 200, r2.text
+    body = r2.json()
+    assert body["user_name"] == "mario"
+    assert body["must_change_password"] is True
+    assert body["principal_name"] == "mario"
+    assert body["exp"] > 0
+
+
+def test_whoami_local_rejects_tampered_cookie(client):
+    _create_user(client, user_name="mario", password="longpassword")
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    # Replace the cookie with garbage and confirm the dep rejects it.
+    client.cookies.set(LOCAL_SESSION_COOKIE_NAME, "tampered.value")
+    r = client.get("/api/auth/whoami-local")
+    assert r.status_code == 401
+
+
+# ── change-password ──────────────────────────────────────────────────────
+
+
+def test_change_password_happy_path_clears_must_change(client):
+    _create_user(
+        client, user_name="mario", password="oldpassword", must_change=True,
+    )
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "oldpassword"},
+    )
+    r = client.post(
+        "/api/auth/change-password",
+        json={
+            "old_password": "oldpassword",
+            "new_password": "fresh-and-long-enough",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["must_change_password"] is False
+
+    # Cookie reissued with must_change=False
+    raw = r.cookies.get(LOCAL_SESSION_COOKIE_NAME)
+    assert raw
+    parsed = parse_local_cookie(raw, _cookie_secret(client))
+    assert parsed is not None
+    assert parsed.must_change_password is False
+    assert parsed.user_name == "mario"
+
+    # And subsequent login uses the new password.
+    client.cookies.clear()
+    r2 = client.post(
+        "/api/auth/login",
+        json={
+            "user_name": "mario",
+            "password": "fresh-and-long-enough",
+        },
+    )
+    assert r2.status_code == 200
+    assert r2.json()["must_change_password"] is False
+
+
+def test_change_password_wrong_old_returns_401(client):
+    _create_user(client, user_name="mario", password="oldpassword")
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "oldpassword"},
+    )
+    r = client.post(
+        "/api/auth/change-password",
+        json={
+            "old_password": "WRONG-old-pw",
+            "new_password": "fresh-and-long-enough",
+        },
+    )
+    assert r.status_code == 401
+
+
+def test_change_password_too_short_returns_400_or_422(client):
+    _create_user(client, user_name="mario", password="oldpassword")
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "oldpassword"},
+    )
+    r = client.post(
+        "/api/auth/change-password",
+        json={
+            "old_password": "oldpassword",
+            "new_password": "short",
+        },
+    )
+    assert r.status_code in (400, 422)
+
+
+def test_change_password_requires_cookie(client):
+    _create_user(client, user_name="mario", password="oldpassword")
+    r = client.post(
+        "/api/auth/change-password",
+        json={
+            "old_password": "oldpassword",
+            "new_password": "fresh-and-long-enough",
+        },
+    )
+    assert r.status_code == 401
+
+
+# ── logout ───────────────────────────────────────────────────────────────
+
+
+def test_logout_clears_cookie_via_max_age_zero(client):
+    _create_user(client, user_name="mario", password="longpassword")
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    r = client.post("/api/auth/logout")
+    assert r.status_code == 200
+    set_cookie = r.headers.get("set-cookie", "")
+    assert LOCAL_SESSION_COOKIE_NAME in set_cookie
+    assert "Max-Age=0" in set_cookie or "max-age=0" in set_cookie.lower()
+
+
+def test_logout_without_cookie_is_no_op(client):
+    """Idempotent logout — no auth required, succeeds for stateless clients."""
+    r = client.post("/api/auth/logout")
+    assert r.status_code == 200
+
+
+def test_post_logout_cookie_invalid_on_whoami(client):
+    _create_user(client, user_name="mario", password="longpassword")
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    client.post("/api/auth/logout")
+    # TestClient mirrors the Set-Cookie Max-Age=0 by removing the cookie.
+    r = client.get("/api/auth/whoami-local")
+    assert r.status_code == 401
+
+
+# ── server-side fallback HTML ────────────────────────────────────────────
+
+
+def test_login_page_renders(client):
+    r = client.get("/login")
+    assert r.status_code == 200
+    assert "Sign in" in r.text
+
+
+def test_change_password_page_renders(client):
+    r = client.get("/change-password")
+    assert r.status_code == 200
+    assert "Set a" in r.text or "new password" in r.text
+
+
+# ── AUTH_MODE gating ─────────────────────────────────────────────────────
+
+
+def test_auth_local_router_not_mounted_when_oidc(connector_config, monkeypatch):
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "oidc")
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    app = build_app(connector_config)
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+    r = tc.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 404
+    r2 = tc.get("/api/auth/runtime-info")
+    assert r2.status_code == 404

--- a/tests/connector/test_local_session.py
+++ b/tests/connector/test_local_session.py
@@ -1,0 +1,273 @@
+"""Unit tests for cullis_connector.identity.local_session — ADR-025 Phase 2.
+
+Cookie issue/parse roundtrip, signature tamper detection, expiry,
+encoding errors, CSRF token rotation, and TTL defaults. Pure-function
+tests — no FastAPI / no DB.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from cullis_connector.identity.local_session import (
+    LOCAL_SESSION_COOKIE_NAME,
+    LOCAL_SESSION_TTL_SEC,
+    LocalSessionPayload,
+    build_payload,
+    issue_local_cookie,
+    new_csrf_token,
+    parse_local_cookie,
+)
+
+
+SECRET = b"\x00" * 32  # any 32-byte HMAC key works for the unit tests
+
+
+# ── happy path ──────────────────────────────────────────────────────────
+
+
+def test_constants_match_contract():
+    assert LOCAL_SESSION_COOKIE_NAME == "cullis_local_session"
+    assert LOCAL_SESSION_TTL_SEC == 8 * 3600
+
+
+def test_roundtrip_preserves_all_fields():
+    payload = build_payload(
+        user_name="mario",
+        must_change_password=True,
+        principal_name="acme.test/acme/user/mario",
+    )
+    cookie = issue_local_cookie(payload, SECRET)
+    parsed = parse_local_cookie(cookie, SECRET)
+    assert parsed is not None
+    assert parsed.user_name == "mario"
+    assert parsed.principal_name == "acme.test/acme/user/mario"
+    assert parsed.must_change_password is True
+    assert parsed.csrf_token == payload.csrf_token
+    assert parsed.iat == payload.iat
+    assert parsed.exp == payload.exp
+
+
+def test_principal_name_defaults_to_user_name():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    assert payload.principal_name == "mario"
+
+
+# ── TTL defaults ─────────────────────────────────────────────────────────
+
+
+def test_default_ttl_is_eight_hours():
+    now = 1_700_000_000
+    payload = build_payload(
+        user_name="mario", must_change_password=False, now=now,
+    )
+    assert payload.iat == now
+    assert payload.exp == now + 8 * 3600
+
+
+def test_explicit_ttl_respected():
+    now = 1_700_000_000
+    payload = build_payload(
+        user_name="mario",
+        must_change_password=False,
+        ttl_seconds=900,
+        now=now,
+    )
+    assert payload.exp == now + 900
+
+
+def test_zero_or_too_long_ttl_raises():
+    with pytest.raises(ValueError):
+        build_payload(
+            user_name="mario", must_change_password=False, ttl_seconds=0,
+        )
+    with pytest.raises(ValueError):
+        build_payload(
+            user_name="mario",
+            must_change_password=False,
+            ttl_seconds=24 * 3600 + 1,
+        )
+
+
+# ── expiry / clock skew ──────────────────────────────────────────────────
+
+
+def test_expired_cookie_returns_none():
+    now = 1_700_000_000
+    payload = build_payload(
+        user_name="mario", must_change_password=False, now=now,
+        ttl_seconds=60,
+    )
+    cookie = issue_local_cookie(payload, SECRET)
+    assert parse_local_cookie(cookie, SECRET, now=now + 60) is None
+    assert parse_local_cookie(cookie, SECRET, now=now + 99999) is None
+
+
+def test_future_iat_returns_none():
+    """Cookie issued in the future = clock skew or replay; refuse it."""
+    now = 1_700_000_000
+    payload = build_payload(
+        user_name="mario", must_change_password=False, now=now + 60,
+    )
+    cookie = issue_local_cookie(payload, SECRET)
+    assert parse_local_cookie(cookie, SECRET, now=now) is None
+
+
+def test_pre_expiry_returns_payload():
+    now = 1_700_000_000
+    payload = build_payload(
+        user_name="mario", must_change_password=False, now=now,
+    )
+    cookie = issue_local_cookie(payload, SECRET)
+    parsed = parse_local_cookie(cookie, SECRET, now=now + 60)
+    assert parsed is not None
+    assert parsed.user_name == "mario"
+
+
+# ── signature tamper ─────────────────────────────────────────────────────
+
+
+def test_tampered_signature_returns_none():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    cookie = issue_local_cookie(payload, SECRET)
+    body, sig = cookie.split(".", 1)
+    bad = sig[:-1] + ("A" if sig[-1] != "A" else "B")
+    assert parse_local_cookie(f"{body}.{bad}", SECRET) is None
+
+
+def test_tampered_payload_returns_none():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    cookie = issue_local_cookie(payload, SECRET)
+    body, sig = cookie.split(".", 1)
+    bad_body = body[:-1] + ("A" if body[-1] != "A" else "B")
+    assert parse_local_cookie(f"{bad_body}.{sig}", SECRET) is None
+
+
+def test_wrong_secret_returns_none():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    cookie = issue_local_cookie(payload, SECRET)
+    assert parse_local_cookie(cookie, b"\x99" * 32) is None
+
+
+# ── encoding / structural errors ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",
+        "no-dot-here",
+        "...",
+        "%%%.%%%",
+        "a" * 5000,  # exceeds _MAX_COOKIE_BYTES
+    ],
+)
+def test_malformed_cookie_returns_none(bad):
+    assert parse_local_cookie(bad, SECRET) is None
+
+
+def test_short_secret_rejected_on_issue():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    with pytest.raises(ValueError):
+        issue_local_cookie(payload, b"\x00" * 8)
+
+
+def test_short_secret_rejected_on_parse():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    cookie = issue_local_cookie(payload, SECRET)
+    # If a caller passes a too-short secret to parse, fail closed.
+    assert parse_local_cookie(cookie, b"\x00" * 8) is None
+
+
+# ── CSRF token rotation ──────────────────────────────────────────────────
+
+
+def test_csrf_token_rotates_on_each_build():
+    a = build_payload(user_name="mario", must_change_password=False)
+    b = build_payload(user_name="mario", must_change_password=False)
+    assert a.csrf_token != b.csrf_token
+    assert len(a.csrf_token) == 32
+    assert all(c in "0123456789abcdef" for c in a.csrf_token)
+
+
+def test_explicit_csrf_token_respected():
+    payload = build_payload(
+        user_name="mario", must_change_password=False, csrf_token="x" * 32,
+    )
+    assert payload.csrf_token == "x" * 32
+
+
+def test_new_csrf_token_format():
+    tok = new_csrf_token()
+    assert len(tok) == 32
+    int(tok, 16)  # raises if not hex
+
+
+# ── must_change flag round-trips as a real bool ──────────────────────────
+
+
+def test_must_change_true_round_trips_as_bool():
+    payload = build_payload(user_name="mario", must_change_password=True)
+    cookie = issue_local_cookie(payload, SECRET)
+    parsed = parse_local_cookie(cookie, SECRET)
+    assert parsed is not None
+    assert parsed.must_change_password is True
+    assert isinstance(parsed.must_change_password, bool)
+
+
+def test_must_change_false_round_trips_as_bool():
+    payload = build_payload(user_name="mario", must_change_password=False)
+    cookie = issue_local_cookie(payload, SECRET)
+    parsed = parse_local_cookie(cookie, SECRET)
+    assert parsed is not None
+    assert parsed.must_change_password is False
+    assert isinstance(parsed.must_change_password, bool)
+
+
+# ── direct dataclass JSON roundtrip ─────────────────────────────────────
+
+
+def test_payload_json_canonical_keys():
+    payload = LocalSessionPayload(
+        user_name="mario",
+        principal_name="mario",
+        must_change_password=False,
+        csrf_token="a" * 32,
+        iat=1_700_000_000,
+        exp=1_700_028_800,
+    )
+    raw = payload.as_json_bytes()
+    # Sorted keys + compact separators — stable hash input for HMAC.
+    assert raw == (
+        b'{"csrf_token":"' + b"a" * 32 + b'",'
+        b'"exp":1700028800,'
+        b'"iat":1700000000,'
+        b'"must_change_password":false,'
+        b'"principal_name":"mario",'
+        b'"user_name":"mario"}'
+    )
+
+
+def test_payload_from_json_missing_key_raises():
+    import json
+    raw = json.dumps({"user_name": "mario"}).encode()
+    with pytest.raises(ValueError):
+        LocalSessionPayload.from_json_bytes(raw)
+
+
+def test_payload_from_json_non_object_raises():
+    with pytest.raises(ValueError):
+        LocalSessionPayload.from_json_bytes(b"[1,2,3]")
+
+
+# ── live time path (smoke) ───────────────────────────────────────────────
+
+
+def test_live_time_default_now_works():
+    """Ensure passing no explicit ``now`` resolves through time.time."""
+    payload = build_payload(user_name="mario", must_change_password=False)
+    assert abs(payload.iat - int(time.time())) < 5
+    cookie = issue_local_cookie(payload, SECRET)
+    parsed = parse_local_cookie(cookie, SECRET)
+    assert parsed is not None


### PR DESCRIPTION
## Summary

ADR-025 Phase 2 — local-auth flow on the Cullis Connector. ``AUTH_MODE=local`` (default for SMB Frontdesk without a corporate IdP) wires this router; ``AUTH_MODE=oidc`` and ``shared`` modes keep their existing flows untouched.

Pairs with #548 (Phase 1 schema + admin API, MERGED) and #551 (Phase 4 lockout + audit, MERGED). Phase 3 (post-login CSR → Mastio mint) and Phase 5 (SPA login UI) follow.

## What this PR does

- ``cullis_connector/identity/local_session.py``: HMAC-signed session cookie ``cullis_local_session`` with payload ``{user_name, principal_name, must_change_password, csrf_token, iat, exp}``, default 8h TTL. Reuses the base64url + HMAC-SHA256 primitives from ``ambassador/shared/cookie.py`` so the two cookie schemas share a single signing implementation while keeping disjoint payload shapes.
- ``cullis_connector/identity/auth_mode.py``: ``read_auth_mode()`` returns ``"local" | "oidc" | "shared"`` from env. ``AMBASSADOR_MODE=shared`` takes precedence for back-compat.
- ``cullis_connector/auth/local_router.py``: six endpoints (``GET /login``, ``POST /api/auth/login``, ``POST /api/auth/logout``, ``POST /api/auth/change-password``, ``GET /api/auth/whoami-local``, ``GET /api/auth/runtime-info``). ``_require_local_session`` dep rejects missing/expired cookie + rejects ``disabled=1`` users (per security review carry-forward note from #548).
- ``cullis_connector/templates/login.html`` + ``change_password.html``: server-side fallbacks. SPA login (Phase 5) is the canonical UX.
- ``cullis_connector/web.py``: when ``auth_mode == "local"``, mount the router; CSRF middleware exempts ``/api/auth/*``.

## Threat model

- bcrypt verify wrapped in ``await asyncio.to_thread``.
- Generic 401 ``"invalid credentials"`` (no user-existence oracle).
- Cookie ``HttpOnly; Secure; SameSite=Strict; Path=/``; ``Secure`` set when ``CULLIS_CONNECTOR_DEV != "1"``.
- Disabled users rejected at session resolution even with valid cookie.
- Plain passwords never logged.

## Test plan

- [x] 49 new tests pass (``pytest tests/connector/test_local_session.py tests/connector/test_auth_local_router.py``)
- [x] Full suite: 2897 pass, 8 pre-existing failures unrelated
- [ ] CI green
- [ ] /security-review pre-merge