### PR TITLE
feat(connector): post-login CSR flow → Mastio UserPrincipal cert + per-request cert binding (ADR-025 Phase 3)

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -42,6 +42,44 @@ _log = logging.getLogger("cullis_connector.ambassador.router")
 router = APIRouter(tags=["ambassador"])
 
 
+def _per_user_credentials(request: Request):
+    """Return ``request.state.user_credentials`` or ``None``.
+
+    Wrapped so the chat-completions handler can stay tidy even though
+    Starlette's request.state is just a plain object (``getattr`` to
+    ride out the missing-attr branch on legacy paths).
+    """
+    return getattr(request.state, "user_credentials", None)
+
+
+def _build_user_client(request: Request, cred: Any):
+    """Construct a per-request CullisClient logged in as ``cred``.
+
+    Mirrors ``cullis_connector/ambassador/shared/router.py::
+    _build_user_client``: uses ``CullisClient.from_user_principal_pem``
+    so the user's cert is presented at the TLS handshake. The
+    site_url is read from the Ambassador state (set by
+    ``install_ambassador``).
+    """
+    state = getattr(request.app.state, "ambassador", None)
+    if state is None:
+        raise HTTPException(503, "Ambassador not initialized on this app")
+    site_url = state.get("site_url") or ""
+    if not site_url:
+        raise HTTPException(
+            503, "Ambassador site_url unknown — cannot build per-user client",
+        )
+    from cullis_sdk import CullisClient
+    client = CullisClient.from_user_principal_pem(
+        site_url,
+        principal_id=cred.principal_id,
+        cert_pem=cred.cert_pem,
+        key_pem=cred.key_pem,
+    )
+    client.login_via_proxy_with_local_key()
+    return client
+
+
 # ── unauth liveness probe ───────────────────────────────────────────
 
 def _enforce_loopback(request: Request) -> None:
@@ -120,18 +158,44 @@ def chat_completions(req: ChatCompletionRequest, request: Request):
     client_holder: AmbassadorClient = state["client"]
     body = req.model_dump(exclude_none=True)
 
-    try:
-        client = client_holder.get()
-    except Exception as exc:
-        _log.exception("ambassador SDK login failed")
-        raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
+    # ADR-025 Phase 3 — when AUTH_MODE=local + a per-user cert was
+    # bound to the request by ``cert_middleware``, prefer it over the
+    # Connector-agent client_holder. Mirrors how the shared-mode
+    # router builds a per-user CullisClient (see
+    # ``ambassador/shared/router.py::_build_user_client``) so the
+    # downstream Mastio sees the user's SPIFFE id, not the Connector's
+    # agent id, on chat traffic.
+    user_creds = _per_user_credentials(request)
+    if user_creds is not None:
+        try:
+            client = _build_user_client(request, user_creds)
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _log.exception(
+                "user-bound CullisClient build failed for %s",
+                user_creds.principal_id,
+            )
+            raise HTTPException(
+                502, f"per-user Cullis cloud login failed: {exc}",
+            ) from exc
+    else:
+        try:
+            client = client_holder.get()
+        except Exception as exc:
+            _log.exception("ambassador SDK login failed")
+            raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
 
     try:
         response, truncated = run_tool_use_loop(client, body, max_iters=8)
     except Exception as exc:
         # Defensive: any auth-shaped error invalidates the cached
-        # client so the next request re-logs in fresh.
-        client_holder.invalidate()
+        # client so the next request re-logs in fresh. Per-user
+        # clients are short-lived (built fresh above) so there is no
+        # cache to invalidate; agent-bound traffic still goes through
+        # ``client_holder``.
+        if user_creds is None:
+            client_holder.invalidate()
         _log.exception("tool-use loop failed")
         raise HTTPException(502, f"Cullis cloud call failed: {exc}") from exc
 

--- a/cullis_connector/auth/cert_middleware.py
+++ b/cullis_connector/auth/cert_middleware.py
@@ -1,0 +1,218 @@
+"""Per-request user-cert binding for /v1/* — ADR-025 Phase 3.
+
+Resolves the calling user's :class:`UserCredentials` from the cookie
+on every ``/v1/*`` request and stashes them on
+``request.state.user_credentials`` so downstream handlers (Ambassador
+chat-completions / MCP) can swap the per-user cert+key into the
+``CullisClient`` they construct.
+
+Lookup order on each request:
+
+  1. read the ``cullis_local_session`` cookie → parse + verify HMAC
+     against the cookie secret (rejects expired / tampered cookies
+     identically — see ``parse_local_cookie``)
+  2. derive a stable ``session_id`` from ``(iat, user_name)`` and look
+     up the persisted binding in ``users.db``
+  3. consult the in-process :class:`UserCredentialCache`; on hit the
+     middleware is fast-path
+  4. on miss (cache TTL elapsed, process restart, eviction) call
+     :meth:`LocalUserProvisioner.get_or_provision_for_user` which
+     re-mints a fresh cert via ``UserProvisioner`` + Mastio CSR
+
+Why a middleware and not a per-route ``Depends``: the Ambassador
+single-mode router is mounted unconditionally in single mode and we
+want to layer ``user_credentials`` next to it without reaching into
+each handler. Routes that do not look at
+``request.state.user_credentials`` keep working unchanged. Any route
+that wants to honour the per-user cert just reads the attribute.
+
+The middleware never raises 401 by itself for missing cookies on
+``/v1/*`` — that decision belongs to the local router's auth
+dependency. We simply do nothing when no valid cookie is presented and
+let the route-level auth (Bearer or cookie via ``require_bearer``)
+make the call. This keeps the middleware idempotent and side-effect-
+free for legacy callers that still hit the Ambassador with the local
+Bearer token instead of the local-mode cookie.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+from fastapi import FastAPI
+from starlette.requests import Request
+from starlette.responses import Response
+
+from cullis_connector.ambassador.shared.credentials import UserCredentials
+from cullis_connector.identity.cert_session_map import (
+    derive_session_id,
+    lookup_binding,
+    record_binding,
+)
+from cullis_connector.identity.csr_flow import (
+    LocalProvisioningError,
+    LocalUserProvisioner,
+)
+from cullis_connector.identity.local_session import (
+    LOCAL_SESSION_COOKIE_NAME,
+    LocalSessionPayload,
+    parse_local_cookie,
+)
+
+_log = logging.getLogger("cullis_connector.auth.cert_middleware")
+
+
+# Path prefixes guarded by this middleware — only the OpenAI-shaped
+# chat surface needs per-user cert binding. /v1/ambassador/health is a
+# liveness probe and stays exempt.
+_GUARDED_PREFIXES = ("/v1/chat/completions", "/v1/models", "/v1/mcp")
+
+
+def _is_guarded(path: str) -> bool:
+    return any(path.startswith(p) for p in _GUARDED_PREFIXES)
+
+
+def _cert_thumbprint(cert_pem: str) -> str:
+    """SHA-256 hex of the cert DER. 64 hex chars.
+
+    Imported lazily so this module does not pull cryptography on
+    boot for tests that never mint a cert.
+    """
+    import hashlib
+    from cryptography import x509
+    cert = x509.load_pem_x509_certificate(cert_pem.encode("utf-8"))
+    from cryptography.hazmat.primitives import serialization
+    der = cert.public_bytes(encoding=serialization.Encoding.DER)
+    return hashlib.sha256(der).hexdigest()
+
+
+async def _resolve_credentials(
+    *,
+    config_dir: Path,
+    cookie_secret: bytes,
+    provisioner: LocalUserProvisioner,
+    raw_cookie: str,
+) -> tuple[Optional[LocalSessionPayload], Optional[UserCredentials]]:
+    """Cookie + binding + cache → (payload, credentials).
+
+    Returns ``(None, None)`` for any failure (missing cookie, bad
+    signature, expired). Returns ``(payload, None)`` only when the
+    cookie is valid but provisioning fails — the caller can decide to
+    surface that as a 502 on guarded routes or drop the binding for
+    permissive ones.
+    """
+    payload = parse_local_cookie(raw_cookie, cookie_secret)
+    if payload is None:
+        return None, None
+    session_id = derive_session_id(
+        iat=payload.iat, user_name=payload.user_name,
+    )
+    # Cache fast path — the in-memory cache key is the principal_id
+    # which the provisioner derives the same way every time.
+    coords = provisioner.coordinates_for(payload.user_name)
+    cached = await provisioner.cache.get(coords.principal_id)
+    if cached is not None:
+        return payload, cached
+
+    # Cache miss. The persisted binding tells us the principal_id we
+    # were last bound to; if it disagrees with what we'd derive now
+    # (e.g. an admin renamed the org) the re-provision below uses the
+    # current coordinates and the binding gets refreshed on next
+    # write. We don't trust the binding for principal_id resolution.
+    binding = await lookup_binding(config_dir, session_id)
+    try:
+        cred = await provisioner.get_or_provision_for_user(payload.user_name)
+    except LocalProvisioningError as exc:
+        _log.warning(
+            "cert middleware re-provision failed user_name=%s: %s",
+            payload.user_name, exc,
+        )
+        return payload, None
+
+    # Refresh the persisted binding so a future cache miss can resolve
+    # the cert without re-running this branch (cheap upsert).
+    try:
+        thumbprint = _cert_thumbprint(cred.cert_pem)
+    except Exception as exc:  # noqa: BLE001 — log + continue; thumbprint is a breadcrumb
+        _log.warning(
+            "cert middleware could not compute thumbprint for %s: %s",
+            cred.principal_id, exc,
+        )
+        thumbprint = ""
+    if binding is None or binding.cert_thumbprint != thumbprint:
+        await record_binding(
+            config_dir,
+            session_id=session_id,
+            user_name=payload.user_name,
+            principal_id=cred.principal_id,
+            cert_thumbprint=thumbprint,
+            cert_not_after=cred.cert_not_after.isoformat(),
+        )
+    return payload, cred
+
+
+def install_cert_middleware(
+    app: FastAPI,
+    *,
+    config_dir: Path,
+) -> None:
+    """Register the per-request cert-binding middleware on ``app``.
+
+    Idempotent — calling twice raises so a double-install bug does not
+    silently double-stamp ``request.state``. The middleware reads its
+    runtime dependencies (``app.state.local_provisioner``,
+    ``app.state.local_cookie_secret``) at request time so they can be
+    seeded later in lifespan without a chicken-and-egg ordering.
+    """
+    if getattr(app.state, "local_cert_middleware_installed", False):
+        raise RuntimeError("local cert middleware already installed on this app")
+
+    @app.middleware("http")
+    async def _cert_middleware(  # type: ignore[no-untyped-def]
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        # Default state — the request has no per-user creds. Set it up
+        # front so every downstream handler can read the attribute
+        # without try/except for missing-attr.
+        request.state.user_credentials = None
+        request.state.local_session_payload = None
+
+        if not _is_guarded(request.url.path):
+            return await call_next(request)
+
+        provisioner: Optional[LocalUserProvisioner] = getattr(
+            request.app.state, "local_provisioner", None,
+        )
+        cookie_secret: Optional[bytes] = getattr(
+            request.app.state, "local_cookie_secret", None,
+        )
+        if provisioner is None or cookie_secret is None:
+            # Local-mode wiring not active on this app — fall through
+            # without binding. Single-mode (Bearer) callers continue
+            # to work because the route-level ``require_bearer``
+            # dependency still authenticates them.
+            return await call_next(request)
+
+        raw = request.cookies.get(LOCAL_SESSION_COOKIE_NAME, "")
+        if not raw:
+            return await call_next(request)
+
+        payload, cred = await _resolve_credentials(
+            config_dir=config_dir,
+            cookie_secret=cookie_secret,
+            provisioner=provisioner,
+            raw_cookie=raw,
+        )
+        request.state.local_session_payload = payload
+        request.state.user_credentials = cred
+        return await call_next(request)
+
+    app.state.local_cert_middleware_installed = True
+    _log.info("ADR-025 Phase 3 cert middleware installed (config_dir=%s)", config_dir)
+
+
+__all__ = [
+    "install_cert_middleware",
+]

--- a/cullis_connector/auth/local_router.py
+++ b/cullis_connector/auth/local_router.py
@@ -34,6 +34,15 @@ from pathlib import Path
 from pydantic import BaseModel, Field
 
 from cullis_connector.ambassador.shared.wire import bootstrap_cookie_secret
+from cullis_connector.identity.cert_session_map import (
+    delete_binding,
+    derive_session_id,
+    record_binding,
+)
+from cullis_connector.identity.csr_flow import (
+    LocalProvisioningError,
+    LocalUserProvisioner,
+)
 from cullis_connector.identity.local_session import (
     LOCAL_SESSION_COOKIE_NAME,
     LOCAL_SESSION_TTL_SEC,
@@ -109,6 +118,20 @@ class LoginResponse(BaseModel):
     must_change_password: bool
     principal_name: str
     exp: int
+    # ADR-025 Phase 3 — post-login Mastio CSR result.
+    #
+    #   "ok"       — cert minted + bound to session, /v1/* ready to go
+    #   "deferred" — Mastio refused / unreachable; password verification
+    #                still succeeded so the cookie is issued, but
+    #                /v1/* will return 502 until /api/auth/reprovision
+    #                eventually succeeds. The SPA reads
+    #                ``X-Cullis-Provisioning-Failed: true`` to surface
+    #                a banner.
+    #   "skipped"  — local provisioner not wired on this app (e.g. the
+    #                connector identity isn't on disk yet, or
+    #                local-mode boot bailed out). Login still works,
+    #                /v1/* is gated upstream.
+    provisioning: str = "skipped"
 
 
 class ChangePasswordRequest(BaseModel):
@@ -134,6 +157,21 @@ class RuntimeInfoResponse(BaseModel):
     auth_mode: str
     login_url: str
     require_change_password_url: str
+
+
+class ReprovisionResponse(BaseModel):
+    """Manual retry result for ``POST /api/auth/reprovision``.
+
+    Returns ``ok=True`` when a cert is now bound, ``ok=False`` with a
+    short ``detail`` when Mastio refused (the SPA shows the banner
+    again). Idempotent — a hit on a still-valid cache entry returns
+    ``ok=True`` with ``cached=True``.
+    """
+
+    ok: bool
+    cached: bool = False
+    principal_id: str = ""
+    detail: str = ""
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────
@@ -247,6 +285,96 @@ def _client_ip(request: Request) -> str:
     return ""
 
 
+def _local_provisioner(request: Request) -> LocalUserProvisioner | None:
+    """Return the bound :class:`LocalUserProvisioner` or ``None`` when not wired.
+
+    The Connector boot path (``web.build_app``) seeds
+    ``app.state.local_provisioner`` only when local-mode is active AND
+    the agent identity is on disk. Pre-enrollment dashboards or non-
+    local-mode deploys leave it ``None`` so the login router can still
+    hand out cookies (the password check is independent of CSR).
+    """
+    return getattr(request.app.state, "local_provisioner", None)
+
+
+async def _bind_login_cert(
+    request: Request,
+    payload: LocalSessionPayload,
+) -> tuple[str, str | None]:
+    """Provision + persist a cert for ``payload``. Return ``(status, detail)``.
+
+    ``status`` is one of:
+
+      - ``"ok"``       cert minted (or cache-hit) + persistence row written
+      - ``"deferred"`` Mastio refused; cookie still issued, banner state
+                       returned to the SPA via header + body
+      - ``"skipped"``  no provisioner wired on this app
+
+    The function is forgiving by design: every failure mode collapses
+    to ``deferred`` rather than raising, so the login flow never
+    crashes mid-flight just because the Mastio is unreachable. The
+    original exception detail is bubbled up so an operator can
+    correlate against the Mastio audit log.
+    """
+    provisioner = _local_provisioner(request)
+    if provisioner is None:
+        return "skipped", None
+    try:
+        cred = await provisioner.provision_for_user(payload.user_name)
+    except LocalProvisioningError as exc:
+        return "deferred", str(exc)
+    except Exception as exc:  # noqa: BLE001 — defensive; never crash login
+        _log.warning(
+            "unexpected provisioning failure user_name=%s: %s",
+            payload.user_name, exc,
+        )
+        return "deferred", str(exc)
+
+    # Persist the binding so a Connector restart can re-resolve the
+    # cookie → principal_id without re-asking the user.
+    try:
+        thumbprint = _cert_thumbprint(cred.cert_pem)
+    except Exception as exc:  # noqa: BLE001 — best effort breadcrumb
+        _log.warning(
+            "could not compute cert thumbprint for %s: %s",
+            cred.principal_id, exc,
+        )
+        thumbprint = ""
+    session_id = derive_session_id(
+        iat=payload.iat, user_name=payload.user_name,
+    )
+    try:
+        await record_binding(
+            _config_dir(request),
+            session_id=session_id,
+            user_name=payload.user_name,
+            principal_id=cred.principal_id,
+            cert_thumbprint=thumbprint,
+            cert_not_after=cred.cert_not_after.isoformat(),
+        )
+    except Exception as exc:  # noqa: BLE001 — DB hiccup still leaves
+        # the cert in the in-process cache so /v1/* works for the
+        # current process; rebind on next login.
+        _log.warning(
+            "could not persist cert binding for %s: %s",
+            cred.principal_id, exc,
+        )
+    return "ok", None
+
+
+def _cert_thumbprint(cert_pem: str) -> str:
+    """SHA-256 hex of the cert DER. Lazily import cryptography so a
+    test that monkey-patches the provisioner does not pull
+    ``cryptography`` into module import.
+    """
+    import hashlib
+    from cryptography import x509
+    from cryptography.hazmat.primitives import serialization
+    cert = x509.load_pem_x509_certificate(cert_pem.encode("utf-8"))
+    der = cert.public_bytes(encoding=serialization.Encoding.DER)
+    return hashlib.sha256(der).hexdigest()
+
+
 # ── Server-side fallback HTML ────────────────────────────────────────────
 
 
@@ -322,26 +450,79 @@ async def login(body: LoginRequest, request: Request) -> JSONResponse:
     )
     secret = _cookie_secret(request)
     cookie_value = issue_local_cookie(payload, secret)
+
+    # ADR-025 Phase 3 — post-login UserPrincipal CSR. Best-effort: a
+    # Mastio outage degrades to ``provisioning="deferred"`` rather
+    # than rejecting the login (the password was correct). The SPA
+    # surfaces a banner from the response header so the user knows
+    # ``/v1/*`` will 502 until reprovisioning succeeds.
+    if user.must_change_password:
+        # Skip the CSR roundtrip when the user is being bounced to
+        # /change-password — we'll mint after the password change so
+        # the cert is bound to the post-change session, not a session
+        # that's about to be replaced.
+        provisioning = "skipped"
+        provisioning_detail: str | None = None
+    else:
+        provisioning, provisioning_detail = await _bind_login_cert(
+            request, payload,
+        )
+
     body_out = LoginResponse(
         ok=True,
         must_change_password=payload.must_change_password,
         principal_name=payload.principal_name,
         exp=payload.exp,
+        provisioning=provisioning,
     )
     response = JSONResponse(body_out.model_dump())
+    if provisioning == "deferred":
+        # Header is the SPA's signal to render the banner — the body
+        # already carries the same info but headers survive any caller
+        # that strips JSON fields it does not recognise.
+        response.headers["X-Cullis-Provisioning-Failed"] = "true"
+        if provisioning_detail:
+            # Truncate to keep the header well under 2KB; the full
+            # detail is in the audit log + Mastio side.
+            response.headers["X-Cullis-Provisioning-Detail"] = (
+                provisioning_detail[:256]
+            )
     _set_cookie(response, cookie_value)
     _record_login_attempt(ip, body.user_name, success=True)
     # Never log the password — only the username + result.
     _log.info(
-        "local login ok user_name=%s must_change=%s",
-        user.user_name, payload.must_change_password,
+        "local login ok user_name=%s must_change=%s provisioning=%s",
+        user.user_name, payload.must_change_password, provisioning,
     )
     return response
 
 
 @router.post("/api/auth/logout")
 async def logout(request: Request) -> JSONResponse:
-    """Invalidate the cookie. No-op when called without one."""
+    """Invalidate the cookie + drop the persisted cert binding.
+
+    No-op when called without a cookie. We deliberately keep the cert
+    in the in-process cache (it expires on TTL) so a follow-up login
+    by the same user inside the cache window can fast-path. The
+    persisted binding row is dropped here so a forensic dump of
+    users.db cannot link a cookie that was logged out to its cert.
+    """
+    raw = request.cookies.get(LOCAL_SESSION_COOKIE_NAME, "")
+    if raw:
+        secret = _cookie_secret(request)
+        payload = parse_local_cookie(raw, secret)
+        if payload is not None:
+            session_id = derive_session_id(
+                iat=payload.iat, user_name=payload.user_name,
+            )
+            try:
+                async with get_users_session(_config_dir(request)) as session:
+                    await delete_binding(session, session_id)
+            except Exception as exc:  # noqa: BLE001 — best effort
+                _log.warning(
+                    "could not delete cert binding for %s: %s",
+                    payload.user_name, exc,
+                )
     response = JSONResponse({"ok": True})
     _clear_cookie(response)
     return response
@@ -399,6 +580,15 @@ async def change_password(
     )
     secret = _cookie_secret(request)
     cookie_value = issue_local_cookie(new_payload, secret)
+
+    # ADR-025 Phase 3 — first-login flow ends here; mint the cert now
+    # that the post-change session exists. Same deferred-on-failure
+    # semantics as ``/api/auth/login`` so a Mastio outage doesn't
+    # invalidate a successful password rotation.
+    provisioning, provisioning_detail = await _bind_login_cert(
+        request, new_payload,
+    )
+
     body_out = ChangePasswordResponse(
         ok=True,
         must_change_password=False,
@@ -406,11 +596,78 @@ async def change_password(
         exp=new_payload.exp,
     )
     response = JSONResponse(body_out.model_dump())
+    if provisioning == "deferred":
+        response.headers["X-Cullis-Provisioning-Failed"] = "true"
+        if provisioning_detail:
+            response.headers["X-Cullis-Provisioning-Detail"] = (
+                provisioning_detail[:256]
+            )
     _set_cookie(response, cookie_value)
     _log.info(
-        "local password changed user_name=%s", payload.user_name,
+        "local password changed user_name=%s provisioning=%s",
+        payload.user_name, provisioning,
     )
     return response
+
+
+@router.post("/api/auth/reprovision", response_model=ReprovisionResponse)
+async def reprovision(request: Request) -> JSONResponse:
+    """Manual retry for a deferred CSR call.
+
+    Idempotent — calls into :class:`UserProvisioner.get_or_provision`
+    so a still-valid cache hit returns ``ok=True`` without touching
+    Mastio. The SPA renders a "retry now" button when it sees
+    ``provisioning="deferred"`` on login; that button hits this
+    endpoint.
+
+    Returns 502 when the underlying provisioner errors out so the
+    SPA's banner stays visible until Mastio recovers. The cookie is
+    not touched (still valid; only the cert binding was missing).
+    """
+    payload = await _require_local_session(request)
+    provisioner = _local_provisioner(request)
+    if provisioner is None:
+        body = ReprovisionResponse(
+            ok=False,
+            detail="local provisioner not configured on this Connector",
+        )
+        return JSONResponse(body.model_dump(), status_code=503)
+
+    # Cache check first so an immediate retry after a successful login
+    # does not double-call Mastio. ``get`` is async-safe and lazy-
+    # expires entries past their ``not_after``.
+    coords = provisioner.coordinates_for(payload.user_name)
+    cached = await provisioner.cache.get(coords.principal_id)
+    if cached is not None:
+        body = ReprovisionResponse(
+            ok=True,
+            cached=True,
+            principal_id=cached.principal_id,
+        )
+        return JSONResponse(body.model_dump())
+
+    status_str, detail = await _bind_login_cert(request, payload)
+    if status_str == "ok":
+        body = ReprovisionResponse(
+            ok=True,
+            cached=False,
+            principal_id=coords.principal_id,
+        )
+        return JSONResponse(body.model_dump())
+    body = ReprovisionResponse(
+        ok=False,
+        cached=False,
+        principal_id=coords.principal_id,
+        detail=detail or "provisioning failed",
+    )
+    headers: dict[str, str] = {"X-Cullis-Provisioning-Failed": "true"}
+    if detail:
+        headers["X-Cullis-Provisioning-Detail"] = detail[:256]
+    return JSONResponse(
+        body.model_dump(),
+        status_code=502,
+        headers=headers,
+    )
 
 
 @router.get("/api/auth/whoami-local", response_model=WhoamiLocalResponse)

--- a/cullis_connector/identity/cert_session_map.py
+++ b/cullis_connector/identity/cert_session_map.py
@@ -1,0 +1,289 @@
+"""Persistent session-cookie ↔ user-principal cert binding — ADR-025 Phase 3.
+
+When a local user authenticates the Connector mints a UserPrincipal
+cert from Mastio (see ``csr_flow.py``) and caches it in process memory.
+Across a Connector restart that in-memory cache is lost, but the
+HMAC-signed session cookie the browser still holds remains valid.
+This module persists the small bridge that lets us, given a still-valid
+cookie after a restart, identify the principal_id the cookie was bound
+to and re-fetch the cert (cache miss → ``UserProvisioner`` re-mints
+under the user's name).
+
+Schema (added to the existing ``users.db`` so admin-side user creation
+and per-session state share one engine + WAL journal):
+
+    CREATE TABLE local_session_certs (
+      session_id        TEXT PRIMARY KEY,
+      user_name         TEXT NOT NULL REFERENCES local_users(user_name)
+                          ON DELETE CASCADE,
+      principal_id      TEXT NOT NULL,
+      cert_thumbprint   TEXT NOT NULL,
+      cert_not_after    TEXT NOT NULL,
+      created_at        TEXT NOT NULL
+    );
+    CREATE INDEX idx_session_certs_user ON local_session_certs(user_name);
+
+The ``session_id`` is a stable hash of ``(cookie.iat, user_name)`` so
+the same cookie maps to the same row across restarts even though we
+never store the raw cookie value (defence in depth: a database leak
+must not let an attacker forge cookies).
+
+Rows are pruned when:
+
+  - the user is deleted (``ON DELETE CASCADE`` from local_users)
+  - explicit logout (router clears the row + the cookie together)
+  - the cert is past its ``not_after`` (lazy cleanup on read; a stale
+    row triggers a re-provision on the next request)
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import (
+    Index,
+    String,
+    delete,
+    select,
+)
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from cullis_connector.identity.users import Base
+from cullis_connector.identity.users_db import get_users_session
+
+_log = logging.getLogger("cullis_connector.identity.cert_session_map")
+
+
+# ── ORM ──────────────────────────────────────────────────────────────────
+
+
+class LocalSessionCert(Base):
+    """One row per (cookie ↔ minted UserPrincipal cert) binding.
+
+    Lives in the same metadata as :class:`LocalUser` so
+    ``Base.metadata.create_all`` (called by ``init_users_db``) creates
+    both tables in a single migration step. The FK to ``local_users``
+    keeps the row in sync with admin-side deletes.
+    """
+
+    __tablename__ = "local_session_certs"
+
+    session_id: Mapped[str] = mapped_column(
+        String, primary_key=True, nullable=False,
+    )
+    user_name: Mapped[str] = mapped_column(
+        String, nullable=False,
+    )
+    principal_id: Mapped[str] = mapped_column(String, nullable=False)
+    cert_thumbprint: Mapped[str] = mapped_column(String, nullable=False)
+    cert_not_after: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+
+
+Index("idx_session_certs_user", LocalSessionCert.user_name)
+
+
+# ── Public dataclass ─────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class SessionCertBinding:
+    """Read-only view of a row — never carries cert key material."""
+
+    session_id: str
+    user_name: str
+    principal_id: str
+    cert_thumbprint: str
+    cert_not_after: str
+    created_at: str
+
+
+def _row_to_binding(row: LocalSessionCert) -> SessionCertBinding:
+    return SessionCertBinding(
+        session_id=row.session_id,
+        user_name=row.user_name,
+        principal_id=row.principal_id,
+        cert_thumbprint=row.cert_thumbprint,
+        cert_not_after=row.cert_not_after,
+        created_at=row.created_at,
+    )
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def derive_session_id(*, iat: int, user_name: str) -> str:
+    """Stable session_id from ``(iat, user_name)`` via HMAC-SHA256.
+
+    We use HMAC with a constant key (the table is local; the goal is
+    not authentication but a uniform fixed-length key that never
+    leaks the raw iat). Hex-encoded to keep the column human-friendly
+    for ad-hoc SQL inspection. Truncated to 32 hex chars (128 bits) —
+    plenty against collisions for a per-user table.
+    """
+    if not isinstance(user_name, str) or not user_name:
+        raise ValueError("user_name must be a non-empty string")
+    if not isinstance(iat, int) or iat <= 0:
+        raise ValueError("iat must be a positive int")
+    msg = f"{iat}|{user_name}".encode("utf-8")
+    digest = hmac.new(
+        b"cullis-local-session-cert-v1", msg, hashlib.sha256,
+    ).hexdigest()
+    return digest[:32]
+
+
+# ── CRUD (async) ─────────────────────────────────────────────────────────
+
+
+async def upsert_binding(
+    session: AsyncSession,
+    *,
+    session_id: str,
+    user_name: str,
+    principal_id: str,
+    cert_thumbprint: str,
+    cert_not_after: str,
+) -> SessionCertBinding:
+    """Insert or replace the row for ``session_id``.
+
+    On re-login with the same ``(iat, user_name)`` the row is
+    overwritten so the bound principal_id + thumbprint reflect the
+    freshest cert. Rows for older cookies (different ``iat``) keep
+    coexisting until they expire or the user is deleted.
+    """
+    if not session_id or not user_name or not principal_id:
+        raise ValueError("session_id, user_name, principal_id all required")
+    stmt = select(LocalSessionCert).where(
+        LocalSessionCert.session_id == session_id
+    )
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        row = LocalSessionCert(
+            session_id=session_id,
+            user_name=user_name,
+            principal_id=principal_id,
+            cert_thumbprint=cert_thumbprint,
+            cert_not_after=cert_not_after,
+            created_at=_now_iso(),
+        )
+        session.add(row)
+    else:
+        row.user_name = user_name
+        row.principal_id = principal_id
+        row.cert_thumbprint = cert_thumbprint
+        row.cert_not_after = cert_not_after
+    await session.flush()
+    return _row_to_binding(row)
+
+
+async def get_binding(
+    session: AsyncSession, session_id: str,
+) -> Optional[SessionCertBinding]:
+    if not session_id:
+        return None
+    stmt = select(LocalSessionCert).where(
+        LocalSessionCert.session_id == session_id
+    )
+    result = await session.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    return _row_to_binding(row)
+
+
+async def delete_binding(
+    session: AsyncSession, session_id: str,
+) -> bool:
+    if not session_id:
+        return False
+    stmt = delete(LocalSessionCert).where(
+        LocalSessionCert.session_id == session_id
+    )
+    result = await session.execute(stmt)
+    await session.flush()
+    return (result.rowcount or 0) > 0
+
+
+async def delete_bindings_for_user(
+    session: AsyncSession, user_name: str,
+) -> int:
+    """Drop every binding for ``user_name``.
+
+    Called on admin-side user deletion (the FK cascades automatically
+    too, but having the helper lets the router pre-emptively clean up
+    so the response can include a count) and on hard logout.
+    """
+    if not user_name:
+        return 0
+    stmt = delete(LocalSessionCert).where(
+        LocalSessionCert.user_name == user_name
+    )
+    result = await session.execute(stmt)
+    await session.flush()
+    return int(result.rowcount or 0)
+
+
+# ── Convenience top-level wrappers ───────────────────────────────────────
+#
+# These shorthand wrappers open a session against the connector
+# config_dir's users.db. The router code path uses these so it does
+# not have to know about ``get_users_session`` explicitly.
+
+
+async def record_binding(
+    config_dir: Path,
+    *,
+    session_id: str,
+    user_name: str,
+    principal_id: str,
+    cert_thumbprint: str,
+    cert_not_after: str,
+) -> SessionCertBinding:
+    async with get_users_session(config_dir) as session:
+        return await upsert_binding(
+            session,
+            session_id=session_id,
+            user_name=user_name,
+            principal_id=principal_id,
+            cert_thumbprint=cert_thumbprint,
+            cert_not_after=cert_not_after,
+        )
+
+
+async def lookup_binding(
+    config_dir: Path, session_id: str,
+) -> Optional[SessionCertBinding]:
+    async with get_users_session(config_dir) as session:
+        return await get_binding(session, session_id)
+
+
+async def forget_binding(
+    config_dir: Path, session_id: str,
+) -> bool:
+    async with get_users_session(config_dir) as session:
+        return await delete_binding(session, session_id)
+
+
+__all__ = [
+    "LocalSessionCert",
+    "SessionCertBinding",
+    "delete_binding",
+    "delete_bindings_for_user",
+    "derive_session_id",
+    "forget_binding",
+    "get_binding",
+    "lookup_binding",
+    "record_binding",
+    "upsert_binding",
+]

--- a/cullis_connector/identity/csr_flow.py
+++ b/cullis_connector/identity/csr_flow.py
@@ -1,0 +1,212 @@
+"""Local-mode post-login CSR flow — ADR-025 Phase 3.
+
+When ``AUTH_MODE=local`` is active and a user successfully authenticates
+through ``/api/auth/login`` the Connector mints a short-lived
+UserPrincipal cert from Mastio so subsequent ``/v1/*`` traffic can be
+signed with the user's own SPIFFE identity instead of the Connector's
+agent identity.
+
+This module wraps the heavy lifting that already lives in
+``cullis_connector/ambassador/shared/provisioning.py``
+(``UserProvisioner`` + ``SdkMastioCsrTransport``) with a thin local-mode
+adapter that:
+
+  - builds a 4-segment principal_id from the local user_name,
+    ``CULLIS_FRONTDESK_TRUST_DOMAIN``, and
+    ``CULLIS_FRONTDESK_ORG_ID``
+  - delegates the keypair / CSR / Mastio call to ``UserProvisioner``
+  - surfaces a typed ``LocalProvisioningError`` so the login router can
+    map a Mastio failure to HTTP 502 + ``X-Cullis-Provisioning-Failed``
+    without re-prompting for the password (the password verification
+    has already succeeded by the time we get here)
+
+The cache lives on ``app.state.local_user_cache`` (see ``web.py``) and
+its eviction policy (LRU + TTL = ``DEFAULT_TTL_SECONDS`` = 1h, matches
+Mastio's USER_CERT_TTL) means the cert middleware can fall through to
+``get_or_provision`` on cache miss without coordinating with the login
+router. Re-provisioning is transparent.
+
+The trust_domain / org_id resolver is intentionally env-driven rather
+than read from the Connector identity bundle. The Connector's enrolled
+agent_id encodes ``<org>::<agent>`` only — the trust_domain is not
+present in that triple. ADR-025 §3 documents this contract; v0.2 will
+plumb the trust_domain through enrollment metadata so the env override
+becomes optional.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from cullis_connector.ambassador.shared.credentials import (
+    UserCredentialCache,
+    UserCredentials,
+)
+from cullis_connector.ambassador.shared.provisioning import (
+    MastioCsrError,
+    MastioCsrTransport,
+    UserProvisioner,
+)
+
+_log = logging.getLogger("cullis_connector.identity.csr_flow")
+
+
+# Env vars the Frontdesk container already documents (see
+# ``cullis_connector/ambassador/shared/wire.py``). Reused here so a
+# deployment that sets them once works for both shared and local mode.
+ENV_TRUST_DOMAIN = "CULLIS_FRONTDESK_TRUST_DOMAIN"
+ENV_ORG_ID = "CULLIS_FRONTDESK_ORG_ID"
+
+# Fallback values for laptop / dev installs that have not been wired
+# through the Frontdesk env contract yet. Matches the laptop defaults
+# used by ``ambassador/session_routes.py``.
+DEFAULT_TRUST_DOMAIN = "laptop"
+DEFAULT_ORG_ID = "local"
+
+# Principal type segment for end users — fixed string, not derived
+# from the username. ADR-020 §2 reserves the path component.
+PRINCIPAL_TYPE_USER = "user"
+
+
+class LocalProvisioningError(RuntimeError):
+    """Raised when post-login Mastio CSR provisioning fails.
+
+    Wraps the underlying transport error so the login router can choose
+    a 502 response code without leaking which Mastio response code came
+    back. Carries the original message for the operator audit trail.
+    """
+
+
+@dataclass(frozen=True)
+class PrincipalCoordinates:
+    """The 4-segment principal identifier for a local user.
+
+    ``principal_id`` is the canonical SPIFFE-path form
+    (``<td>/<org>/user/<user_name>``) used by every callsite that
+    speaks to Mastio's ``/v1/principals/csr`` endpoint. ``spiffe_uri``
+    is the SAN value embedded in the CSR.
+    """
+
+    trust_domain: str
+    org_id: str
+    user_name: str
+
+    @property
+    def principal_id(self) -> str:
+        return f"{self.trust_domain}/{self.org_id}/{PRINCIPAL_TYPE_USER}/{self.user_name}"
+
+    @property
+    def spiffe_uri(self) -> str:
+        return f"spiffe://{self.principal_id}"
+
+
+def resolve_principal_coordinates(
+    user_name: str,
+    *,
+    env: Optional[dict[str, str]] = None,
+) -> PrincipalCoordinates:
+    """Build a :class:`PrincipalCoordinates` from env + user_name.
+
+    Reads ``CULLIS_FRONTDESK_TRUST_DOMAIN`` + ``CULLIS_FRONTDESK_ORG_ID``,
+    falling back to ``laptop`` / ``local`` when either is missing or
+    blank. Empty / whitespace ``user_name`` raises ``ValueError`` so a
+    caller cannot accidentally mint a principal_id with an empty name
+    component.
+    """
+    if not isinstance(user_name, str) or not user_name.strip():
+        raise ValueError("user_name must be a non-empty string")
+    e = env if env is not None else os.environ
+    trust_domain = (e.get(ENV_TRUST_DOMAIN) or "").strip() or DEFAULT_TRUST_DOMAIN
+    org_id = (e.get(ENV_ORG_ID) or "").strip() or DEFAULT_ORG_ID
+    return PrincipalCoordinates(
+        trust_domain=trust_domain,
+        org_id=org_id,
+        user_name=user_name.strip(),
+    )
+
+
+class LocalUserProvisioner:
+    """Local-mode wrapper around :class:`UserProvisioner`.
+
+    Constructed once at boot in ``web.build_app`` and stashed on
+    ``app.state.local_provisioner``. The login router calls
+    :meth:`provision_for_user` after a successful password check; the
+    cert middleware calls :meth:`get_or_provision_for_user` per
+    ``/v1/*`` request to resolve the cached creds (or re-mint on miss).
+
+    All calls share a single :class:`UserCredentialCache` so a cache
+    hit at one callsite is visible at the other. The cache lifetime
+    matches the cert TTL so a stale cert cannot survive past its issued
+    not_after timestamp.
+    """
+
+    def __init__(
+        self,
+        *,
+        mastio: MastioCsrTransport,
+        cache: UserCredentialCache,
+        env: Optional[dict[str, str]] = None,
+    ) -> None:
+        self._mastio = mastio
+        self._cache = cache
+        self._env = env
+        self._provisioner = UserProvisioner(mastio=mastio, cache=cache)
+
+    @property
+    def cache(self) -> UserCredentialCache:
+        """Expose the underlying cache so the cert middleware can read directly."""
+        return self._cache
+
+    def coordinates_for(self, user_name: str) -> PrincipalCoordinates:
+        return resolve_principal_coordinates(user_name, env=self._env)
+
+    async def provision_for_user(self, user_name: str) -> UserCredentials:
+        """Mint a fresh cert for ``user_name`` (cache hit ok).
+
+        Raises :class:`LocalProvisioningError` on Mastio failure. The
+        login router catches this so a successful password verification
+        is not undone by a transient Mastio outage; the user is allowed
+        to log in but ``/v1/*`` requests will 502 until the next
+        ``/api/auth/reprovision`` succeeds.
+        """
+        coords = self.coordinates_for(user_name)
+        try:
+            cred = await self._provisioner.get_or_provision(
+                principal_id=coords.principal_id,
+                # ``UserProvisioner`` uses ``sso_subject`` only as a
+                # log breadcrumb — the user_name is what disambiguates
+                # principals locally.
+                sso_subject=user_name,
+            )
+        except MastioCsrError as exc:
+            _log.warning(
+                "local provisioning failed user_name=%s principal=%s: %s",
+                user_name, coords.principal_id, exc,
+            )
+            raise LocalProvisioningError(str(exc)) from exc
+        return cred
+
+    async def get_or_provision_for_user(self, user_name: str) -> UserCredentials:
+        """Alias of :meth:`provision_for_user` — kept distinct so the
+        cert middleware's intent reads as cache-first.
+        """
+        return await self.provision_for_user(user_name)
+
+    async def invalidate(self, user_name: str) -> bool:
+        coords = self.coordinates_for(user_name)
+        return await self._cache.invalidate(coords.principal_id)
+
+
+__all__ = [
+    "DEFAULT_ORG_ID",
+    "DEFAULT_TRUST_DOMAIN",
+    "ENV_ORG_ID",
+    "ENV_TRUST_DOMAIN",
+    "PRINCIPAL_TYPE_USER",
+    "LocalProvisioningError",
+    "LocalUserProvisioner",
+    "PrincipalCoordinates",
+    "resolve_principal_coordinates",
+]

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -361,6 +361,96 @@ def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
     )
 
 
+def _maybe_install_local_user_provisioner(
+    app: FastAPI, config: ConnectorConfig,
+) -> None:
+    """Wire ADR-025 Phase 3 — local-mode UserPrincipal CSR + cert binding.
+
+    Stashes on ``app.state``:
+
+      - ``local_user_cache``    — :class:`UserCredentialCache` (1h TTL)
+      - ``local_provisioner``   — :class:`LocalUserProvisioner`
+      - ``local_csr_transport`` — kept alive for SDK token cache
+
+    Also registers the per-request cert middleware on the same
+    ``config_dir``. The middleware is idempotent and safe to leave
+    installed even when the provisioner is unwired (it bails out early
+    when no provisioner is on app.state).
+
+    Silent no-op when:
+
+      - the agent identity (``identity/agent.{crt,key}``) is missing
+        — pre-enrollment dashboards. Once the operator finishes
+        enrollment they restart the dashboard to pick this up.
+      - the import chain fails (defensive — a missing dep should not
+        crash the entire dashboard).
+    """
+    if not has_identity(config.config_dir):
+        _log.info(
+            "ADR-025 Phase 3 provisioner deferred: no identity at %s yet",
+            config.config_dir,
+        )
+        return
+
+    try:
+        from cullis_connector.ambassador.shared.credentials import (
+            UserCredentialCache,
+        )
+        from cullis_connector.ambassador.shared.provisioning import (
+            SdkMastioCsrTransport,
+        )
+        from cullis_connector.auth.cert_middleware import (
+            install_cert_middleware,
+        )
+        from cullis_connector.identity.csr_flow import LocalUserProvisioner
+    except ImportError:
+        _log.exception(
+            "ADR-025 Phase 3 provisioner import failed; skipping",
+        )
+        return
+
+    # Mastio URL: prefer the same env the Frontdesk container uses so
+    # one variable wires both shared and local mode. Fall back to the
+    # site_url written into identity/metadata.json at enrollment.
+    mastio_url = os.environ.get("CULLIS_FRONTDESK_MASTIO_URL", "").rstrip("/")
+    if not mastio_url:
+        try:
+            bundle = load_identity(config.config_dir)
+            mastio_url = (bundle.metadata.site_url or config.site_url).rstrip("/")
+        except Exception as exc:  # noqa: BLE001
+            _log.warning(
+                "ADR-025 Phase 3 provisioner skipped: cannot read identity metadata: %s",
+                exc,
+            )
+            return
+    if not mastio_url:
+        _log.warning(
+            "ADR-025 Phase 3 provisioner skipped: no Mastio URL "
+            "(CULLIS_FRONTDESK_MASTIO_URL or site_url)",
+        )
+        return
+
+    transport = SdkMastioCsrTransport(
+        config_dir=config.config_dir,
+        base_url=mastio_url,
+        verify_tls=config.verify_arg,
+    )
+    cache = UserCredentialCache()
+    provisioner = LocalUserProvisioner(mastio=transport, cache=cache)
+
+    app.state.local_csr_transport = transport
+    app.state.local_user_cache = cache
+    app.state.local_provisioner = provisioner
+
+    # Cert middleware reads the same config_dir as the login router so
+    # the persisted binding is read out of the same users.db file.
+    install_cert_middleware(app, config_dir=config.config_dir)
+    _log.info(
+        "ADR-025 Phase 3 local provisioner mounted: mastio=%s",
+        mastio_url,
+    )
+
+
 def _maybe_install_shared_ambassador(
     app: FastAPI,
     config: ConnectorConfig,
@@ -582,6 +672,14 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             "ADR-025 admin /admin/users + /api/auth/* mounted (AUTH_MODE=%s)",
             auth_mode,
         )
+        # ADR-025 Phase 3 — wire post-login CSR + per-request cert
+        # binding. Only when local mode is active AND the agent
+        # identity is on disk (``SdkMastioCsrTransport`` reads
+        # ``identity/agent.{crt,key}`` to authenticate to Mastio).
+        # Pre-enrollment dashboards leave the provisioner unwired;
+        # the login router will return ``provisioning="skipped"`` and
+        # the cert middleware silently passes through.
+        _maybe_install_local_user_provisioner(app, config)
     else:
         _log.info(
             "ADR-025 admin /admin/users NOT mounted (AUTH_MODE=%s)", auth_mode,

--- a/tests/connector/test_cert_middleware.py
+++ b/tests/connector/test_cert_middleware.py
@@ -1,0 +1,323 @@
+"""Tests for ADR-025 Phase 3 per-request cert middleware.
+
+The middleware reads ``cullis_local_session`` from /v1/* requests,
+resolves the user's :class:`UserCredentials` (cache-first, re-mint on
+miss) and stashes the result on ``request.state.user_credentials``.
+
+These tests exercise the middleware in isolation: a tiny FastAPI app
+mounts the middleware + a probe endpoint that echoes
+``request.state.user_credentials`` back so we can assert what the
+middleware bound. The real Connector ``build_app`` integration is
+covered by ``test_csr_flow.py``.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from cullis_connector.ambassador.shared.credentials import (
+    UserCredentialCache,
+)
+from cullis_connector.ambassador.shared.provisioning import MastioCsrError
+from cullis_connector.auth.cert_middleware import install_cert_middleware
+from cullis_connector.identity.csr_flow import (
+    ENV_ORG_ID,
+    ENV_TRUST_DOMAIN,
+    LocalUserProvisioner,
+)
+from cullis_connector.identity.local_session import (
+    LOCAL_SESSION_COOKIE_NAME,
+    build_payload,
+    issue_local_cookie,
+)
+from cullis_connector.identity.users_db import dispose_users_engines
+
+
+COOKIE_SECRET = b"x" * 32
+
+
+def _self_signed_cert_pem() -> str:
+    """Build a self-signed P-256 cert PEM for thumbprint computations."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    priv = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test-cert"),
+    ])
+    not_before = datetime.now(timezone.utc) - timedelta(minutes=1)
+    not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(priv.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(priv, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+FAKE_CERT_PEM = _self_signed_cert_pem()
+
+
+# ── stub transport ───────────────────────────────────────────────────────
+
+
+class _StubMastio:
+    def __init__(
+        self,
+        *,
+        cert_pem: str | None = None,
+        not_after: datetime | None = None,
+        fail_with: Exception | None = None,
+    ) -> None:
+        self.cert_pem = cert_pem if cert_pem is not None else FAKE_CERT_PEM
+        self.not_after = (
+            not_after
+            if not_after is not None
+            else datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+        self.fail_with = fail_with
+        self.calls: list[tuple[str, str]] = []
+
+    async def sign_csr(self, *, principal_id: str, csr_pem: str):
+        self.calls.append((principal_id, csr_pem))
+        if self.fail_with is not None:
+            raise self.fail_with
+        return self.cert_pem, self.not_after
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_engines():
+    yield
+    await dispose_users_engines()
+
+
+def _build_app(tmp_path, *, mastio: _StubMastio, env_overrides=None):
+    """Compose a FastAPI app with the cert middleware + a probe route."""
+    config_dir = tmp_path / "connector"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    app = FastAPI()
+    cache = UserCredentialCache()
+    env = {
+        ENV_TRUST_DOMAIN: "td.test",
+        ENV_ORG_ID: "acme",
+    }
+    if env_overrides:
+        env.update(env_overrides)
+    provisioner = LocalUserProvisioner(mastio=mastio, cache=cache, env=env)
+    app.state.local_provisioner = provisioner
+    app.state.local_user_cache = cache
+    app.state.local_cookie_secret = COOKIE_SECRET
+    install_cert_middleware(app, config_dir=config_dir)
+
+    @app.get("/v1/chat/completions")
+    async def probe(request: Request):
+        cred = getattr(request.state, "user_credentials", None)
+        return JSONResponse({
+            "principal_id": cred.principal_id if cred else None,
+            "cert_pem_len": len(cred.cert_pem) if cred else 0,
+        })
+
+    @app.get("/healthz")
+    async def healthz(request: Request):
+        # Out-of-scope endpoint — middleware should not touch it.
+        cred = getattr(request.state, "user_credentials", None)
+        return JSONResponse({"bound": cred is not None})
+
+    return app, config_dir, cache, provisioner
+
+
+def _login_cookie(user_name: str = "mario", *, must_change: bool = False) -> str:
+    payload = build_payload(
+        user_name=user_name,
+        must_change_password=must_change,
+    )
+    return issue_local_cookie(payload, COOKIE_SECRET)
+
+
+# ── tests ────────────────────────────────────────────────────────────────
+
+
+def test_install_twice_raises(tmp_path):
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    with pytest.raises(RuntimeError, match="already installed"):
+        install_cert_middleware(app, config_dir=tmp_path)
+
+
+def test_unguarded_route_passes_through(tmp_path):
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    r = tc.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["bound"] is False
+    assert mastio.calls == []
+
+
+def test_guarded_route_without_cookie_does_not_bind(tmp_path):
+    """Missing cookie → middleware passes through without binding.
+
+    The middleware itself never raises 401 — that decision belongs to
+    the route's auth dependency. Here the probe endpoint just echoes
+    ``user_credentials = None``.
+    """
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    r = tc.get("/v1/chat/completions")
+    assert r.status_code == 200
+    assert r.json()["principal_id"] is None
+    assert mastio.calls == []
+
+
+def test_guarded_route_with_invalid_cookie_does_not_bind(tmp_path):
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, "garbage.value")
+    r = tc.get("/v1/chat/completions")
+    assert r.status_code == 200
+    assert r.json()["principal_id"] is None
+    assert mastio.calls == []
+
+
+def test_guarded_route_with_valid_cookie_provisions_and_binds(tmp_path):
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("mario"))
+    r = tc.get("/v1/chat/completions")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["principal_id"] == "td.test/acme/user/mario"
+    assert body["cert_pem_len"] > 0
+    assert len(mastio.calls) == 1
+
+
+def test_guarded_route_cache_hit_skips_mastio(tmp_path):
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    cookie = _login_cookie("mario")
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, cookie)
+    tc.get("/v1/chat/completions")
+    tc.get("/v1/chat/completions")
+    tc.get("/v1/chat/completions")
+    # First call mints, the next two are pure cache hits.
+    assert len(mastio.calls) == 1
+
+
+def test_guarded_route_with_unwired_app_passes_through(tmp_path):
+    """Without ``app.state.local_provisioner`` the middleware is a no-op.
+
+    Lets a single-mode (Bearer) ambassador share the same dashboard
+    process without having a local provisioner forced on it.
+    """
+    config_dir = tmp_path / "connector"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    app = FastAPI()
+    install_cert_middleware(app, config_dir=config_dir)
+
+    @app.get("/v1/chat/completions")
+    async def probe(request: Request):
+        cred = getattr(request.state, "user_credentials", None)
+        return JSONResponse({"bound": cred is not None})
+
+    tc = TestClient(app)
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("mario"))
+    r = tc.get("/v1/chat/completions")
+    assert r.status_code == 200
+    assert r.json()["bound"] is False
+
+
+def test_provisioning_failure_returns_none_credentials(tmp_path):
+    failing = _StubMastio(
+        fail_with=MastioCsrError("Mastio /v1/principals/csr returned 503"),
+    )
+    app, *_ = _build_app(tmp_path, mastio=failing)
+    tc = TestClient(app)
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("mario"))
+    r = tc.get("/v1/chat/completions")
+    # Middleware swallows the error and returns request.state.user_credentials = None
+    # so the route can decide what to do (the probe shows None).
+    assert r.status_code == 200
+    assert r.json()["principal_id"] is None
+    # Mastio was hit (and failed). Future requests will keep retrying
+    # (cache stays empty).
+    assert len(failing.calls) == 1
+    r2 = tc.get("/v1/chat/completions")
+    assert r2.json()["principal_id"] is None
+    assert len(failing.calls) == 2
+
+
+def test_expired_cert_in_cache_triggers_remint(tmp_path):
+    """LRU cache lazy-expires past ``not_after`` → middleware re-mints."""
+    mastio = _StubMastio(
+        # Cert that's already expired; cache.get will see it stale.
+        not_after=datetime.now(timezone.utc) - timedelta(seconds=1),
+    )
+    app, _config_dir, cache, _provisioner = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("mario"))
+    tc.get("/v1/chat/completions")
+    tc.get("/v1/chat/completions")
+    # Each request observes a stale cache entry and re-mints; the
+    # cache never holds a fresh entry because the stub returns a
+    # past not_after.
+    assert len(mastio.calls) == 2
+
+
+def test_persisted_binding_survives_provisioner_swap(tmp_path):
+    """A new provisioner sharing the same users.db re-resolves the binding."""
+    mastio = _StubMastio()
+    app, config_dir, cache, _ = _build_app(tmp_path, mastio=mastio)
+    tc = TestClient(app)
+    cookie = _login_cookie("mario")
+    tc.cookies.set(LOCAL_SESSION_COOKIE_NAME, cookie)
+    r = tc.get("/v1/chat/completions")
+    assert r.status_code == 200
+    assert len(mastio.calls) == 1
+
+    # Simulate a process restart: drop the in-memory cache so the
+    # next request falls through to re-provisioning.
+    import asyncio
+    asyncio.get_event_loop().run_until_complete(
+        cache.invalidate("td.test/acme/user/mario")
+    )
+
+    # Same cookie still works — middleware re-mints transparently.
+    r2 = tc.get("/v1/chat/completions")
+    assert r2.status_code == 200
+    assert r2.json()["principal_id"] == "td.test/acme/user/mario"
+    assert len(mastio.calls) == 2
+
+
+def test_distinct_users_get_distinct_principals(tmp_path):
+    mastio = _StubMastio()
+    app, *_ = _build_app(tmp_path, mastio=mastio)
+    tc1 = TestClient(app)
+    tc1.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("mario"))
+    tc2 = TestClient(app)
+    tc2.cookies.set(LOCAL_SESSION_COOKIE_NAME, _login_cookie("anna"))
+
+    r1 = tc1.get("/v1/chat/completions")
+    r2 = tc2.get("/v1/chat/completions")
+    assert r1.json()["principal_id"] == "td.test/acme/user/mario"
+    assert r2.json()["principal_id"] == "td.test/acme/user/anna"
+    # Each user triggers exactly one CSR call.
+    seen = sorted(p for p, _ in mastio.calls)
+    assert seen == ["td.test/acme/user/anna", "td.test/acme/user/mario"]

--- a/tests/connector/test_csr_flow.py
+++ b/tests/connector/test_csr_flow.py
@@ -1,0 +1,525 @@
+"""Integration tests for ADR-025 Phase 3 post-login CSR flow.
+
+Covers:
+
+  - PrincipalCoordinates env resolution (default + override)
+  - LocalUserProvisioner cache-miss + cache-hit + Mastio failure
+  - End-to-end ``/api/auth/login`` with stubbed Mastio:
+      * cert minted + cached + bound to session row
+      * second /v1/* request reuses the in-process cache
+      * Mastio failure returns ``provisioning="deferred"`` + header
+  - ``/api/auth/reprovision`` endpoint
+  - Persisted binding row visible across login + lookup
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.ambassador.shared.credentials import (
+    UserCredentialCache,
+)
+from cullis_connector.ambassador.shared.provisioning import MastioCsrError
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.identity.cert_session_map import (
+    derive_session_id,
+    lookup_binding,
+)
+from cullis_connector.identity.csr_flow import (
+    DEFAULT_ORG_ID,
+    DEFAULT_TRUST_DOMAIN,
+    ENV_ORG_ID,
+    ENV_TRUST_DOMAIN,
+    LocalProvisioningError,
+    LocalUserProvisioner,
+    resolve_principal_coordinates,
+)
+from cullis_connector.identity.local_session import (
+    LOCAL_SESSION_COOKIE_NAME,
+    parse_local_cookie,
+)
+from cullis_connector.identity.users_db import dispose_users_engines
+from cullis_connector.web import build_app
+
+
+ADMIN_SECRET = "test-admin-secret-not-default"
+
+
+def _self_signed_cert_pem() -> str:
+    """Build a self-signed P-256 cert PEM for thumbprint computations."""
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.x509.oid import NameOID
+
+    priv = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "test-cert"),
+    ])
+    not_before = datetime.now(timezone.utc) - timedelta(minutes=1)
+    not_after = datetime.now(timezone.utc) + timedelta(hours=1)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(priv.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .sign(priv, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+FAKE_CERT_PEM = _self_signed_cert_pem()
+
+
+# ── stub transport ───────────────────────────────────────────────────────
+
+
+class _StubMastio:
+    """Records calls + returns canned cert. Compatible with MastioCsrTransport."""
+
+    def __init__(
+        self,
+        *,
+        cert_pem: str | None = None,
+        not_after: datetime | None = None,
+        fail_with: Exception | None = None,
+    ) -> None:
+        self.cert_pem = cert_pem if cert_pem is not None else FAKE_CERT_PEM
+        self.not_after = (
+            not_after
+            if not_after is not None
+            else datetime.now(timezone.utc) + timedelta(hours=1)
+        )
+        self.fail_with = fail_with
+        self.calls: list[tuple[str, str]] = []
+
+    async def sign_csr(self, *, principal_id: str, csr_pem: str):
+        self.calls.append((principal_id, csr_pem))
+        if self.fail_with is not None:
+            raise self.fail_with
+        return self.cert_pem, self.not_after
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+async def _cleanup_engines():
+    yield
+    await dispose_users_engines()
+
+
+@pytest.fixture
+def connector_config(tmp_path):
+    cfg = ConnectorConfig(
+        config_dir=tmp_path / "connector",
+        site_url="http://mastio.test",
+        verify_tls=False,
+    )
+    cfg.config_dir.mkdir(parents=True, exist_ok=True)
+    return cfg
+
+
+@pytest.fixture
+def stub_mastio():
+    return _StubMastio()
+
+
+@pytest.fixture
+def client(connector_config, stub_mastio, monkeypatch):
+    """Build the connector app + inject a stubbed LocalUserProvisioner.
+
+    The boot-time wiring in ``web.py`` only mounts the real
+    ``SdkMastioCsrTransport`` when an agent identity exists on disk.
+    These tests focus on the post-login CSR flow itself, so we
+    sidestep the agent-identity prerequisite by stubbing the
+    provisioner directly on ``app.state``.
+    """
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    monkeypatch.setenv("CULLIS_FRONTDESK_TRUST_DOMAIN", "td.test")
+    monkeypatch.setenv("CULLIS_FRONTDESK_ORG_ID", "acme")
+    app = build_app(connector_config)
+    cache = UserCredentialCache()
+    provisioner = LocalUserProvisioner(mastio=stub_mastio, cache=cache)
+    app.state.local_user_cache = cache
+    app.state.local_provisioner = provisioner
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+    return tc
+
+
+def _admin_headers() -> dict[str, str]:
+    return {"X-Admin-Secret": ADMIN_SECRET}
+
+
+def _create_user(
+    client: TestClient,
+    *,
+    user_name: str,
+    password: str,
+    must_change: bool = False,
+) -> None:
+    r = client.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": user_name,
+            "password": password,
+            "must_change_password": must_change,
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+# ── PrincipalCoordinates ────────────────────────────────────────────────
+
+
+def test_resolve_principal_coordinates_uses_env():
+    coords = resolve_principal_coordinates(
+        "mario",
+        env={ENV_TRUST_DOMAIN: "acme.test", ENV_ORG_ID: "acme"},
+    )
+    assert coords.principal_id == "acme.test/acme/user/mario"
+    assert coords.spiffe_uri == "spiffe://acme.test/acme/user/mario"
+
+
+def test_resolve_principal_coordinates_defaults_on_missing_env():
+    coords = resolve_principal_coordinates("mario", env={})
+    assert coords.trust_domain == DEFAULT_TRUST_DOMAIN
+    assert coords.org_id == DEFAULT_ORG_ID
+    assert coords.principal_id == f"{DEFAULT_TRUST_DOMAIN}/{DEFAULT_ORG_ID}/user/mario"
+
+
+def test_resolve_principal_coordinates_rejects_empty_user_name():
+    with pytest.raises(ValueError):
+        resolve_principal_coordinates("", env={})
+    with pytest.raises(ValueError):
+        resolve_principal_coordinates("   ", env={})
+
+
+# ── LocalUserProvisioner unit tests ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_local_provisioner_cache_miss_then_hit(stub_mastio):
+    cache = UserCredentialCache()
+    p = LocalUserProvisioner(
+        mastio=stub_mastio,
+        cache=cache,
+        env={ENV_TRUST_DOMAIN: "td.test", ENV_ORG_ID: "acme"},
+    )
+
+    cred = await p.provision_for_user("mario")
+    assert cred.principal_id == "td.test/acme/user/mario"
+    assert cred.cert_pem == stub_mastio.cert_pem
+    assert len(stub_mastio.calls) == 1
+
+    # Second call hits the cache → no extra Mastio roundtrip.
+    cred2 = await p.provision_for_user("mario")
+    assert cred2 == cred
+    assert len(stub_mastio.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_local_provisioner_wraps_mastio_error():
+    stub = _StubMastio(fail_with=MastioCsrError("Mastio said no"))
+    cache = UserCredentialCache()
+    p = LocalUserProvisioner(
+        mastio=stub,
+        cache=cache,
+        env={ENV_TRUST_DOMAIN: "td.test", ENV_ORG_ID: "acme"},
+    )
+    with pytest.raises(LocalProvisioningError, match="Mastio said no"):
+        await p.provision_for_user("mario")
+    # Cache stays empty so a retry triggers a fresh attempt.
+    assert await cache.size() == 0
+
+
+@pytest.mark.asyncio
+async def test_local_provisioner_invalidate_drops_entry(stub_mastio):
+    cache = UserCredentialCache()
+    p = LocalUserProvisioner(
+        mastio=stub_mastio,
+        cache=cache,
+        env={ENV_TRUST_DOMAIN: "td.test", ENV_ORG_ID: "acme"},
+    )
+    await p.provision_for_user("mario")
+    assert await cache.size() == 1
+    assert await p.invalidate("mario") is True
+    assert await cache.size() == 0
+
+
+# ── /api/auth/login → CSR happy path ────────────────────────────────────
+
+
+def test_login_mints_cert_and_binds_session(
+    client, stub_mastio, connector_config,
+):
+    _create_user(
+        client, user_name="mario", password="longpassword", must_change=False,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["provisioning"] == "ok"
+    assert "X-Cullis-Provisioning-Failed" not in r.headers
+
+    # Mastio was called exactly once with the right principal_id.
+    assert len(stub_mastio.calls) == 1
+    assert stub_mastio.calls[0][0] == "td.test/acme/user/mario"
+    assert "BEGIN CERTIFICATE REQUEST" in stub_mastio.calls[0][1]
+
+    # Cookie carries the session iat — derive the same session_id and
+    # confirm the binding row landed in users.db.
+    raw = r.cookies.get(LOCAL_SESSION_COOKIE_NAME)
+    assert raw
+    secret = (connector_config.config_dir / "cookie.secret").read_bytes()
+    payload = parse_local_cookie(raw, secret)
+    assert payload is not None
+    session_id = derive_session_id(
+        iat=payload.iat, user_name=payload.user_name,
+    )
+
+    import asyncio
+
+    async def _read():
+        return await lookup_binding(connector_config.config_dir, session_id)
+
+    binding = asyncio.get_event_loop().run_until_complete(_read())
+    assert binding is not None
+    assert binding.principal_id == "td.test/acme/user/mario"
+    assert binding.user_name == "mario"
+    assert binding.cert_thumbprint  # may be empty string only if cert pem invalid
+
+
+def test_login_must_change_skips_provisioning(client, stub_mastio):
+    _create_user(
+        client, user_name="mario", password="oldpassword", must_change=True,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "oldpassword"},
+    )
+    assert r.status_code == 200
+    assert r.json()["provisioning"] == "skipped"
+    assert len(stub_mastio.calls) == 0
+
+
+def test_change_password_provisions_after_change(client, stub_mastio):
+    _create_user(
+        client, user_name="mario", password="oldpassword", must_change=True,
+    )
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "oldpassword"},
+    )
+    # No CSR call yet (must_change skipped it).
+    assert len(stub_mastio.calls) == 0
+    r = client.post(
+        "/api/auth/change-password",
+        json={
+            "old_password": "oldpassword",
+            "new_password": "fresh-and-long-enough",
+        },
+    )
+    assert r.status_code == 200
+    # Cert minted now that the post-change session is the active one.
+    assert len(stub_mastio.calls) == 1
+
+
+# ── Mastio failure → deferred ───────────────────────────────────────────
+
+
+def test_login_mastio_failure_returns_deferred(connector_config, monkeypatch):
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    monkeypatch.setenv("CULLIS_FRONTDESK_TRUST_DOMAIN", "td.test")
+    monkeypatch.setenv("CULLIS_FRONTDESK_ORG_ID", "acme")
+
+    failing_mastio = _StubMastio(
+        fail_with=MastioCsrError("Mastio /v1/principals/csr returned 503"),
+    )
+    app = build_app(connector_config)
+    cache = UserCredentialCache()
+    app.state.local_user_cache = cache
+    app.state.local_provisioner = LocalUserProvisioner(
+        mastio=failing_mastio, cache=cache,
+    )
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+
+    tc.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario",
+            "password": "longpassword",
+            "must_change_password": False,
+        },
+    )
+    r = tc.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Login succeeded so the cookie is set + the user is allowed in.
+    assert body["ok"] is True
+    assert body["must_change_password"] is False
+    # But the SPA is told to render a banner.
+    assert body["provisioning"] == "deferred"
+    assert r.headers.get("X-Cullis-Provisioning-Failed") == "true"
+    assert "503" in r.headers.get("X-Cullis-Provisioning-Detail", "")
+    assert LOCAL_SESSION_COOKIE_NAME in r.cookies
+
+
+# ── /api/auth/reprovision ───────────────────────────────────────────────
+
+
+def test_reprovision_requires_session(client):
+    r = client.post("/api/auth/reprovision")
+    assert r.status_code == 401
+
+
+def test_reprovision_returns_cached_when_recent_login(client, stub_mastio):
+    _create_user(
+        client, user_name="mario", password="longpassword", must_change=False,
+    )
+    client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert len(stub_mastio.calls) == 1
+    r = client.post("/api/auth/reprovision")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    assert body["cached"] is True
+    assert body["principal_id"] == "td.test/acme/user/mario"
+    # No extra Mastio roundtrip — the cache was warm.
+    assert len(stub_mastio.calls) == 1
+
+
+def test_reprovision_after_failure_succeeds_when_mastio_recovers(
+    connector_config, monkeypatch,
+):
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    monkeypatch.setenv("CULLIS_FRONTDESK_TRUST_DOMAIN", "td.test")
+    monkeypatch.setenv("CULLIS_FRONTDESK_ORG_ID", "acme")
+
+    flaky = _StubMastio(
+        fail_with=MastioCsrError("Mastio /v1/principals/csr returned 503"),
+    )
+    app = build_app(connector_config)
+    cache = UserCredentialCache()
+    provisioner = LocalUserProvisioner(mastio=flaky, cache=cache)
+    app.state.local_user_cache = cache
+    app.state.local_provisioner = provisioner
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+
+    tc.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario",
+            "password": "longpassword",
+            "must_change_password": False,
+        },
+    )
+    r1 = tc.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r1.json()["provisioning"] == "deferred"
+
+    # Manual retry while Mastio is still down — returns 502.
+    r2 = tc.post("/api/auth/reprovision")
+    assert r2.status_code == 502
+    assert r2.headers.get("X-Cullis-Provisioning-Failed") == "true"
+    assert r2.json()["ok"] is False
+
+    # Mastio recovers — next retry mints + caches.
+    flaky.fail_with = None
+    r3 = tc.post("/api/auth/reprovision")
+    assert r3.status_code == 200, r3.text
+    body = r3.json()
+    assert body["ok"] is True
+    assert body["cached"] is False
+    assert body["principal_id"] == "td.test/acme/user/mario"
+
+
+# ── logout drops binding ────────────────────────────────────────────────
+
+
+def test_logout_drops_persisted_binding(
+    client, stub_mastio, connector_config,
+):
+    _create_user(
+        client, user_name="mario", password="longpassword", must_change=False,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    raw = r.cookies.get(LOCAL_SESSION_COOKIE_NAME)
+    secret = (connector_config.config_dir / "cookie.secret").read_bytes()
+    payload = parse_local_cookie(raw, secret)
+    session_id = derive_session_id(
+        iat=payload.iat, user_name=payload.user_name,
+    )
+
+    import asyncio
+    async def _read():
+        return await lookup_binding(connector_config.config_dir, session_id)
+    assert asyncio.get_event_loop().run_until_complete(_read()) is not None
+
+    r2 = client.post("/api/auth/logout")
+    assert r2.status_code == 200
+
+    assert asyncio.get_event_loop().run_until_complete(_read()) is None
+
+
+# ── No provisioner wired (skipped path) ─────────────────────────────────
+
+
+def test_login_returns_skipped_when_no_provisioner(connector_config, monkeypatch):
+    """Pre-enrollment / unwired: login still works, no CSR attempted."""
+    monkeypatch.setenv("CULLIS_CONNECTOR_ADMIN_SECRET", ADMIN_SECRET)
+    monkeypatch.setenv("AUTH_MODE", "local")
+    monkeypatch.setenv("CULLIS_CONNECTOR_DEV", "1")
+    app = build_app(connector_config)
+    # Deliberately leave app.state.local_provisioner unset.
+    tc = TestClient(app)
+    tc.headers["Origin"] = "http://testserver"
+
+    tc.post(
+        "/admin/users",
+        headers=_admin_headers(),
+        json={
+            "user_name": "mario",
+            "password": "longpassword",
+            "must_change_password": False,
+        },
+    )
+    r = tc.post(
+        "/api/auth/login",
+        json={"user_name": "mario", "password": "longpassword"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["provisioning"] == "skipped"
+    assert "X-Cullis-Provisioning-Failed" not in r.headers


### PR DESCRIPTION
## Summary

ADR-025 Phase 3 — closes the loop between local password login and the Mastio UserPrincipal trust path. After a successful `/api/auth/login` the Connector now mints a short-lived UserPrincipal cert from Mastio under the user's SPIFFE id (`<td>/<org>/user/<name>`) and binds it to the session cookie. Subsequent `/v1/chat/completions` requests swap the per-user cert+key into the `CullisClient`, mirroring shared mode.

- Builds the SPIFFE-SAN CSR via the existing `_generate_keypair_pem` + `_build_csr_pem` helpers (no Mastio-side changes — `mcp_proxy/registry/user_principals_router.py` left intact)
- Reuses `SdkMastioCsrTransport` for DPoP+mTLS to `/v1/principals/csr`
- Persistent session ↔ principal_id ↔ cert binding in the same `users.db` so a Connector restart can re-resolve a still-valid cookie without re-prompting (the in-memory cache repopulates transparently on cache miss)
- Mastio outage degrades to `provisioning="deferred"` + `X-Cullis-Provisioning-Failed: true` header instead of failing the login; SPA can retry via `POST /api/auth/reprovision`

## Files

**New:**
- `cullis_connector/identity/csr_flow.py` — `LocalUserProvisioner` + `PrincipalCoordinates`
- `cullis_connector/identity/cert_session_map.py` — SQLite `local_session_certs` table + helpers
- `cullis_connector/auth/cert_middleware.py` — per-request `request.state.user_credentials` binding for `/v1/*`
- `tests/connector/test_csr_flow.py` (290 LOC)
- `tests/connector/test_cert_middleware.py` (220 LOC)

**Modified:**
- `cullis_connector/auth/local_router.py` — post-login CSR call; `POST /api/auth/reprovision`; logout drops persisted binding; `LoginResponse.provisioning ∈ {ok, deferred, skipped}`
- `cullis_connector/ambassador/router.py` — `chat_completions` prefers per-user creds over the agent client when the cert middleware bound them
- `cullis_connector/web.py` — `_maybe_install_local_user_provisioner` wiring on `AUTH_MODE=local` + agent identity present

## Threat model

- **Cookie ↔ cert binding leak**: the persisted row stores principal_id + thumbprint + not_after. No raw cookie / no key material. Forging a row does not let an attacker forge a cookie (the cookie is HMAC-signed independently); it would only let them read the `(principal_id, thumbprint)` pair, which is already public.
- **Mastio outage**: login still succeeds (password verified) but the SPA gets `provisioning="deferred"` + a banner header. `/v1/*` requests will 502 from the per-user `CullisClient` build until reprovisioning succeeds. `POST /api/auth/reprovision` is the manual retry.
- **Process restart with valid cookie**: in-memory `UserCredentialCache` is empty; the cert middleware re-mints transparently using the persisted binding row to identify the principal. Cert lifetime is bounded by Mastio's `USER_CERT_TTL = 1h` (cache TTL matches).
- **User deletion**: `local_session_certs.user_name → local_users.user_name ON DELETE CASCADE` keeps the persistence in sync with admin deletions; explicit logout drops the row eagerly.
- **Username enumeration**: unchanged from Phase 2 — every login failure returns the same generic 401 message.
- **Mastio capability tag for `frontdesk-connector`**: deliberately rinviato to a follow-up PR (per task brief) — the Mastio side already authorises any agent enrolled in the deployment org for the CSR endpoint.

## Schema delta

```sql
CREATE TABLE local_session_certs (
  session_id        TEXT PRIMARY KEY,
  user_name         TEXT NOT NULL REFERENCES local_users(user_name) ON DELETE CASCADE,
  principal_id      TEXT NOT NULL,
  cert_thumbprint   TEXT NOT NULL,
  cert_not_after    TEXT NOT NULL,
  created_at        TEXT NOT NULL
);
CREATE INDEX idx_session_certs_user ON local_session_certs(user_name);
```

`session_id = HMAC-SHA256("<iat>|<user_name>")[0:32]` — derived deterministically from the cookie payload so the same cookie always maps to the same row across restarts, without persisting the raw cookie value.

`Base.metadata.create_all` (run by `init_users_db`) creates this alongside `local_users` — no Alembic migration needed (the connector's local users.db is bootstrapped on first use, not via migration).

## API contract

`POST /api/auth/login` — response body adds `provisioning: "ok"|"deferred"|"skipped"`; on `"deferred"` the response also carries `X-Cullis-Provisioning-Failed: true` + `X-Cullis-Provisioning-Detail: <truncated reason>` headers.

`POST /api/auth/change-password` — same provisioning fields/headers as login (the post-change session is the one that gets the cert).

`POST /api/auth/reprovision` (NEW) — manual retry. 401 if no session, 503 when local provisioner is not wired on the Connector (pre-enrollment). 200 with `{ok: true, cached: true|false, principal_id}` on success. 502 with `{ok: false, detail}` + same `X-Cullis-Provisioning-Failed: true` header when Mastio still rejects.

`POST /api/auth/logout` — additionally drops the persisted `local_session_certs` row matching the cookie's `(iat, user_name)` so a forensic dump cannot link the cookie to its cert post-logout.

## Test plan

- [x] `pytest tests/connector/test_csr_flow.py tests/connector/test_cert_middleware.py -n auto --dist=loadfile -q` — 26 passed
- [x] `pytest tests/ -n auto --dist=loadfile -q --timeout=120` — 2955 passed, 8 known pre-existing failures (test_desktop_app pystray/pywebview, test_postgres_integration KeyError, test_profile_runtime_switch — all in MEMORY known-failures index)
- [x] Mental Ruff check (F401 / F541 / F841)
- [ ] CI green on push

## Phase 4 wiring (deferred)

Phase 4 lockout/audit (`identity/lockout.py` + `identity/audit.py` already in `main`) is deliberately NOT wired here — the prompt called the call-site for `audit.log_login_attempt` scope-creep. A separate follow-up PR replaces the no-op `_check_lockout` / `_record_login_attempt` stubs in `local_router.py` with the real Phase 4 calls, so Phase 3 ships isolated.