### PR TITLE
feat(spa+connector): SPA login form + admin Users tab + IdentityBadge dynamic (ADR-025 Phase 5)

### DIFF
--- a/frontend/cullis-chat/package-lock.json
+++ b/frontend/cullis-chat/package-lock.json
@@ -21,7 +21,8 @@
         "@playwright/test": "^1.49.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^2.1.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2032,6 +2033,92 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2166,6 +2253,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/astro": {
@@ -2470,6 +2567,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/camelcase": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-8.0.0.tgz",
@@ -2512,6 +2619,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2552,6 +2676,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2784,6 +2918,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/defu": {
@@ -3060,6 +3204,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3519,6 +3673,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -4572,6 +4733,23 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -5107,6 +5285,13 @@
         "@types/hast": "^3.0.4"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5143,6 +5328,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
@@ -5221,6 +5420,13 @@
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -5244,6 +5450,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -5740,6 +5976,534 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
@@ -6230,6 +6994,611 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -6247,6 +7616,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/frontend/cullis-chat/package.json
+++ b/frontend/cullis-chat/package.json
@@ -12,6 +12,8 @@
     "preview": "astro preview",
     "start": "node ./dist/server/entry.mjs",
     "astro": "astro",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install --with-deps chromium"
   },
@@ -28,7 +30,8 @@
     "@playwright/test": "^1.49.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^2.1.0"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/frontend/cullis-chat/src/components/IdentityBadge.tsx
+++ b/frontend/cullis-chat/src/components/IdentityBadge.tsx
@@ -1,17 +1,23 @@
 import { useEffect, useState } from 'react';
-import { whoami } from '../lib/api';
-import { ensureSession } from '../lib/session-singleton';
+import { ApiError } from '../lib/api';
+import { whoamiAuto } from '../lib/auth';
+import { ensureSession, redirectToLogin } from '../lib/session-singleton';
 import type { Principal } from '../lib/types';
 
 /**
- * Live identity badge in the TopBar. Reads the principal from
- * the local Astro `/api/session/whoami` route, which forwards to
- * the Ambassador's shared-mode `/api/session/whoami` endpoint and
- * translates the cookie-payload shape into the ADR-020 principal
- * shape we render here. Single mode falls through to a "local"
- * placeholder so the badge still shows something useful.
+ * Live identity badge in the TopBar. Reads the principal via
+ * ``whoamiAuto`` (ADR-025 Phase 5):
  *
- * v0.1 shape (ADR-020): principal_type display em + name.
+ *   1. Try the Ambassador's ``/api/session/whoami`` (ADR-020 shape).
+ *   2. On 401/404, fall back to ``/api/auth/whoami-local`` so local-
+ *      mode Frontdesk users see their username before Mastio CSR
+ *      enrollment completes (Phase 3 deferred-provisioning case).
+ *   3. On any other error, render the offline placeholder.
+ *
+ * If both probes fail with 401 we redirect to ``/login`` rather than
+ * leaving the badge stuck on "offline" — the user is just not signed
+ * in, and the SPA's ``ensureSession`` already redirected anyway, so
+ * we mirror that behaviour from this island for safety.
  */
 export default function IdentityBadge() {
   const [principal, setPrincipal] = useState<Principal | null>(null);
@@ -22,15 +28,16 @@ export default function IdentityBadge() {
     (async () => {
       try {
         await ensureSession();
-        const raw = await whoami();
+        const result = await whoamiAuto();
         if (cancelled) return;
-        const p =
-          raw && typeof raw === 'object' && 'principal' in raw
-            ? (raw as { principal: Principal }).principal
-            : (raw as Principal);
-        setPrincipal(p);
-      } catch {
-        if (!cancelled) setError(true);
+        setPrincipal(result.principal);
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 401) {
+          redirectToLogin();
+          return;
+        }
+        setError(true);
       }
     })();
     return () => {

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -10,6 +10,7 @@
 
 import IdentityBadge from './IdentityBadge.tsx';
 import ModelPicker from './ModelPicker.tsx';
+import TopBarSessionMenu from './auth/TopBarSessionMenu.tsx';
 import brand from '@brand/config';
 
 const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
@@ -33,6 +34,7 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
       <span class="status-label">connected</span>
     </span>
     <IdentityBadge client:load />
+    <TopBarSessionMenu client:load />
     {auditToggleEnabled && (
       <button
         type="button"
@@ -278,6 +280,75 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     color: var(--accent-cyan);
     font-size: 1rem;
     line-height: 1;
+  }
+
+  /* Session menu — Logout + Admin link (ADR-025 Phase 5).
+     React island, so styles need :global. */
+  :global(.topbar-session-menu) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  :global(.topbar-link) {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.7rem;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-medium);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-button);
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-family: var(--font-mono);
+    transition: border-color var(--t-fast) var(--ease-soft),
+                color var(--t-fast) var(--ease-soft);
+  }
+
+  :global(.topbar-link:hover) {
+    border-color: var(--accent-cyan);
+    color: var(--accent-cyan);
+  }
+
+  :global(.topbar-link .folio) {
+    border-right: 1px solid var(--border-subtle);
+    padding-right: 0.5rem;
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+  }
+
+  :global(.topbar-link-label) {
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+  }
+
+  :global(.topbar-logout) {
+    appearance: none;
+    background: transparent;
+    border: 1px solid var(--border-medium);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    padding: 0.4rem 0.75rem;
+    cursor: pointer;
+    transition: border-color var(--t-fast) var(--ease-soft),
+                color var(--t-fast) var(--ease-soft);
+  }
+
+  :global(.topbar-logout:hover:not(:disabled)) {
+    border-color: var(--accent-amber);
+    color: var(--accent-amber);
+  }
+
+  :global(.topbar-logout:disabled) {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 
   @media (max-width: 1100px) {

--- a/frontend/cullis-chat/src/components/admin/AdminUsers.tsx
+++ b/frontend/cullis-chat/src/components/admin/AdminUsers.tsx
@@ -1,0 +1,623 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ApiError } from '../../lib/api';
+import {
+  type AdminUser,
+  adminCreateUser,
+  adminDeleteUser,
+  adminListUsers,
+  adminResetPassword,
+  clearAdminSecret,
+  readAdminSecret,
+  writeAdminSecret,
+} from '../../lib/auth';
+
+/**
+ * Admin Users tab — ADR-025 Phase 5.
+ *
+ * Surfaces ``/admin/users`` (Phase 1) so a Frontdesk operator can
+ * provision local users without curl. Admin auth is the
+ * ``X-Admin-Secret`` header; the SPA prompts for it on first load
+ * and caches it in sessionStorage so it does not survive a tab
+ * close (defence in depth — the secret never lives in localStorage).
+ */
+export default function AdminUsers() {
+  const [secret, setSecret] = useState<string | null>(() => readAdminSecret());
+  const [users, setUsers] = useState<AdminUser[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [filter, setFilter] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [resetState, setResetState] = useState<{
+    user_name: string;
+    temp_password: string | null;
+  } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<AdminUser | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!secret) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await adminListUsers(secret);
+      setUsers(list);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setError('Admin secret rejected. Re-enter the X-Admin-Secret to continue.');
+        clearAdminSecret();
+        setSecret(null);
+        setUsers(null);
+      } else {
+        setError(`Could not load users (${err instanceof ApiError ? err.status : 'network'}).`);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [secret]);
+
+  useEffect(() => {
+    if (secret) refresh();
+  }, [secret, refresh]);
+
+  const filtered = useMemo(() => {
+    if (!users) return [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return users;
+    return users.filter(
+      (u) =>
+        u.user_name.toLowerCase().includes(q) ||
+        u.display_name.toLowerCase().includes(q),
+    );
+  }, [users, filter]);
+
+  if (!secret) {
+    return <AdminSecretPrompt onSubmit={(s) => { writeAdminSecret(s); setSecret(s); }} />;
+  }
+
+  return (
+    <main className="auth-shell" style={{ alignItems: 'flex-start', paddingTop: '3rem' }}>
+      <div className="auth-card auth-card-wide admin-page">
+        <header className="admin-header">
+          <div>
+            <span className="folio">Local users · ADR-025</span>
+            <h1>Users</h1>
+          </div>
+          <div className="admin-toolbar">
+            <input
+              type="search"
+              className="admin-search"
+              placeholder="Filter by username..."
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+            <button
+              type="button"
+              className="auth-button"
+              style={{ marginTop: 0, padding: '0.55rem 1rem' }}
+              onClick={() => setCreating(true)}
+            >
+              + New user
+            </button>
+            <button
+              type="button"
+              className="auth-button auth-button-ghost"
+              style={{ marginTop: 0, padding: '0.55rem 1rem' }}
+              onClick={() => { clearAdminSecret(); setSecret(null); setUsers(null); }}
+              title="Clear admin secret"
+            >
+              Sign out admin
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="auth-error" role="alert">{error}</div>
+        )}
+
+        <div className="admin-table-wrap">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Username</th>
+                <th>Display name</th>
+                <th>Status</th>
+                <th>Created</th>
+                <th>Password changed</th>
+                <th aria-label="actions" />
+              </tr>
+            </thead>
+            <tbody>
+              {loading && (
+                <tr>
+                  <td colSpan={6} className="admin-table-empty">Loading…</td>
+                </tr>
+              )}
+              {!loading && filtered.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="admin-table-empty">
+                    {users === null ? 'No data.' : 'No users match the filter.'}
+                  </td>
+                </tr>
+              )}
+              {!loading &&
+                filtered.map((u) => (
+                  <tr key={u.user_name}>
+                    <td className="admin-mono">{u.user_name}</td>
+                    <td>{u.display_name || <span style={{ color: 'var(--text-tertiary)' }}>—</span>}</td>
+                    <td>
+                      <UserStatusPill user={u} />
+                    </td>
+                    <td className="admin-mono" title={u.created_at}>
+                      {formatDate(u.created_at)}
+                    </td>
+                    <td className="admin-mono" title={u.password_changed_at ?? ''}>
+                      {u.password_changed_at ? formatDate(u.password_changed_at) : '—'}
+                    </td>
+                    <td>
+                      <div className="admin-actions">
+                        <button
+                          type="button"
+                          className="admin-action"
+                          onClick={() =>
+                            setResetState({ user_name: u.user_name, temp_password: null })
+                          }
+                        >
+                          Reset pw
+                        </button>
+                        <button
+                          type="button"
+                          className="admin-action admin-action-danger"
+                          onClick={() => setConfirmDelete(u)}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {creating && (
+        <CreateUserModal
+          secret={secret}
+          onClose={() => setCreating(false)}
+          onCreated={() => { setCreating(false); refresh(); }}
+        />
+      )}
+
+      {resetState && (
+        <ResetPasswordModal
+          secret={secret}
+          state={resetState}
+          setState={setResetState}
+          onDone={() => { setResetState(null); refresh(); }}
+        />
+      )}
+
+      {confirmDelete && (
+        <DeleteUserModal
+          secret={secret}
+          user={confirmDelete}
+          onClose={() => setConfirmDelete(null)}
+          onDeleted={() => { setConfirmDelete(null); refresh(); }}
+        />
+      )}
+    </main>
+  );
+}
+
+// ── secret prompt ─────────────────────────────────────────────────────
+
+function AdminSecretPrompt({ onSubmit }: { onSubmit: (s: string) => void }) {
+  const [value, setValue] = useState('');
+  return (
+    <main className="auth-shell">
+      <div className="auth-card">
+        <h1 className="auth-title">Admin access</h1>
+        <p className="auth-subtitle">Enter the Connector admin secret</p>
+        <form
+          className="auth-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            if (!value) return;
+            onSubmit(value);
+          }}
+          noValidate
+        >
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="admin_secret">X-Admin-Secret</label>
+            <input
+              id="admin_secret"
+              name="admin_secret"
+              type="password"
+              className="auth-input"
+              autoComplete="off"
+              required
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+            />
+            <span className="auth-help">
+              Set on the Connector via <code>CULLIS_CONNECTOR_ADMIN_SECRET</code>.
+              Stored only in this tab&apos;s sessionStorage.
+            </span>
+          </div>
+          <button type="submit" className="auth-button" disabled={!value}>
+            Continue
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}
+
+// ── status pill ───────────────────────────────────────────────────────
+
+function UserStatusPill({ user }: { user: AdminUser }) {
+  if (user.disabled) {
+    return <span className="admin-pill admin-pill-disabled">Disabled</span>;
+  }
+  if (user.must_change_password) {
+    return <span className="admin-pill admin-pill-pending">Pending</span>;
+  }
+  return <span className="admin-pill admin-pill-active">Active</span>;
+}
+
+// ── create user modal ─────────────────────────────────────────────────
+
+function CreateUserModal({
+  secret,
+  onClose,
+  onCreated,
+}: {
+  secret: string;
+  onClose: () => void;
+  onCreated: () => void;
+}) {
+  const [userName, setUserName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [pw, setPw] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await adminCreateUser(secret, {
+        user_name: userName.trim(),
+        password: pw,
+        display_name: displayName.trim(),
+        must_change_password: true,
+      });
+      onCreated();
+    } catch (e2) {
+      if (e2 instanceof ApiError) {
+        if (e2.status === 409) {
+          setErr('A user with that name already exists.');
+        } else if (e2.status === 400) {
+          const detail =
+            e2.payload && typeof e2.payload === 'object' && 'detail' in e2.payload
+              ? String((e2.payload as { detail?: unknown }).detail ?? '')
+              : '';
+          setErr(detail || 'Invalid username or password.');
+        } else if (e2.status === 403) {
+          setErr('Admin secret rejected.');
+        } else {
+          setErr(`Could not create user (${e2.status}).`);
+        }
+      } else {
+        setErr('Could not create user. Check your connection.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="admin-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="new-user-title"
+      onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
+    >
+      <div className="admin-modal">
+        <h2 id="new-user-title">New user</h2>
+        <p>The user will be required to change their password on first sign-in.</p>
+        <form className="auth-form" onSubmit={onSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="cu_user_name">Username</label>
+            <input
+              id="cu_user_name"
+              type="text"
+              className="auth-input"
+              required
+              autoFocus
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              pattern="[A-Za-z0-9._\-]{1,64}"
+              title="Letters, digits, dot, underscore, hyphen. Up to 64 characters."
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+            />
+          </div>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="cu_display_name">Display name (optional)</label>
+            <input
+              id="cu_display_name"
+              type="text"
+              className="auth-input"
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              maxLength={256}
+            />
+          </div>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="cu_password">Temporary password</label>
+            <input
+              id="cu_password"
+              type="text"
+              className="auth-input"
+              required
+              minLength={8}
+              value={pw}
+              onChange={(e) => setPw(e.target.value)}
+              autoComplete="off"
+            />
+            <span className="auth-help">
+              Minimum 8 characters. The user must change this on first sign-in.
+            </span>
+          </div>
+
+          {err && <div className="auth-error" role="alert">{err}</div>}
+
+          <div className="admin-modal-actions">
+            <button
+              type="button"
+              className="auth-button auth-button-ghost"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="auth-button"
+              style={{ marginTop: 0 }}
+              disabled={submitting || !userName || pw.length < 8}
+            >
+              {submitting ? 'Creating...' : 'Create user'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ── reset password modal ──────────────────────────────────────────────
+
+function ResetPasswordModal({
+  secret,
+  state,
+  setState,
+  onDone,
+}: {
+  secret: string;
+  state: { user_name: string; temp_password: string | null };
+  setState: (s: { user_name: string; temp_password: string | null } | null) => void;
+  onDone: () => void;
+}) {
+  const [pw, setPw] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await adminResetPassword(secret, state.user_name, pw);
+      setState({ user_name: state.user_name, temp_password: pw });
+    } catch (e2) {
+      if (e2 instanceof ApiError) {
+        if (e2.status === 404) {
+          setErr('User no longer exists.');
+        } else if (e2.status === 400) {
+          const detail =
+            e2.payload && typeof e2.payload === 'object' && 'detail' in e2.payload
+              ? String((e2.payload as { detail?: unknown }).detail ?? '')
+              : '';
+          setErr(detail || 'Password did not meet requirements.');
+        } else {
+          setErr(`Could not reset password (${e2.status}).`);
+        }
+      } else {
+        setErr('Could not reset password. Check your connection.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const showResult = state.temp_password !== null;
+
+  return (
+    <div
+      className="admin-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="reset-pw-title"
+      onClick={(e) => { if (e.target === e.currentTarget && !submitting) setState(null); }}
+    >
+      <div className="admin-modal">
+        <h2 id="reset-pw-title">Reset password</h2>
+        <p>
+          Setting a new temporary password for <code>{state.user_name}</code>. They will be
+          required to change it on next sign-in.
+        </p>
+
+        {!showResult && (
+          <form className="auth-form" onSubmit={onSubmit} noValidate>
+            <div className="auth-field">
+              <label className="auth-label" htmlFor="rp_password">New temporary password</label>
+              <input
+                id="rp_password"
+                type="text"
+                className="auth-input"
+                required
+                minLength={8}
+                value={pw}
+                onChange={(e) => setPw(e.target.value)}
+                autoFocus
+                autoComplete="off"
+              />
+            </div>
+
+            {err && <div className="auth-error" role="alert">{err}</div>}
+
+            <div className="admin-modal-actions">
+              <button
+                type="button"
+                className="auth-button auth-button-ghost"
+                onClick={() => setState(null)}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="auth-button"
+                style={{ marginTop: 0 }}
+                disabled={submitting || pw.length < 8}
+              >
+                {submitting ? 'Resetting...' : 'Reset password'}
+              </button>
+            </div>
+          </form>
+        )}
+
+        {showResult && (
+          <div>
+            <p style={{ color: 'var(--accent-cyan)', marginBottom: '0.4rem' }}>
+              Password reset. Share this temporary password securely — it will not be shown again.
+            </p>
+            <code className="admin-temp-pw">{state.temp_password}</code>
+            <div className="admin-modal-actions">
+              <button
+                type="button"
+                className="auth-button"
+                style={{ marginTop: 0 }}
+                onClick={onDone}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── delete user modal ─────────────────────────────────────────────────
+
+function DeleteUserModal({
+  secret,
+  user,
+  onClose,
+  onDeleted,
+}: {
+  secret: string;
+  user: AdminUser;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function onConfirm() {
+    if (submitting) return;
+    setSubmitting(true);
+    setErr(null);
+    try {
+      await adminDeleteUser(secret, user.user_name);
+      onDeleted();
+    } catch (e2) {
+      if (e2 instanceof ApiError) {
+        if (e2.status === 404) {
+          // Already gone — treat as success.
+          onDeleted();
+          return;
+        }
+        setErr(`Could not delete user (${e2.status}).`);
+      } else {
+        setErr('Could not delete user. Check your connection.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      className="admin-modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="del-user-title"
+      onClick={(e) => { if (e.target === e.currentTarget && !submitting) onClose(); }}
+    >
+      <div className="admin-modal">
+        <h2 id="del-user-title">Delete user</h2>
+        <p>
+          Permanently remove <code>{user.user_name}</code>? The user&apos;s sessions and audit
+          history will remain in the audit log.
+        </p>
+
+        {err && <div className="auth-error" role="alert">{err}</div>}
+
+        <div className="admin-modal-actions">
+          <button
+            type="button"
+            className="auth-button auth-button-ghost"
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="auth-button auth-button-danger"
+            style={{ marginTop: 0 }}
+            onClick={onConfirm}
+            disabled={submitting}
+          >
+            {submitting ? 'Deleting...' : 'Delete user'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  // Servers emit ISO-8601 strings. Render in the user's locale, falling
+  // back to the raw string if Date.parse fails (e.g. server emits a
+  // shape we have not seen).
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  });
+}

--- a/frontend/cullis-chat/src/components/auth/ChangePasswordForm.tsx
+++ b/frontend/cullis-chat/src/components/auth/ChangePasswordForm.tsx
@@ -1,0 +1,184 @@
+import { useMemo, useState } from 'react';
+import { ApiError } from '../../lib/api';
+import { changePassword } from '../../lib/auth';
+
+const MIN_LEN = 8;
+
+/**
+ * Heuristic 0-4 password strength score. Not a substitute for the
+ * server-side length check (the API enforces ``MIN_PASSWORD_LENGTH``),
+ * but a useful nudge: encourages mixed character classes and
+ * discourages obvious weak passwords.
+ *
+ *   0 — empty / shorter than MIN_LEN
+ *   1 — meets minimum length
+ *   2 — adds one extra character class
+ *   3 — adds two extra classes OR length >= 12
+ *   4 — three+ classes AND length >= 12
+ */
+function scoreStrength(pw: string): number {
+  if (pw.length < MIN_LEN) return 0;
+  let classes = 0;
+  if (/[a-z]/.test(pw)) classes++;
+  if (/[A-Z]/.test(pw)) classes++;
+  if (/[0-9]/.test(pw)) classes++;
+  if (/[^A-Za-z0-9]/.test(pw)) classes++;
+  let score = 1;
+  if (classes >= 2) score = 2;
+  if (classes >= 3 || pw.length >= 12) score = 3;
+  if (classes >= 3 && pw.length >= 12) score = 4;
+  return score;
+}
+
+const STRENGTH_LABELS = ['too short', 'weak', 'fair', 'good', 'strong'];
+
+/**
+ * Change password — the post-login first-login flow plus the
+ * "I want to rotate my password" use case (same endpoint).
+ *
+ * On success the cookie is reissued by the server with
+ * ``must_change_password=false`` and we redirect to /.
+ */
+export default function ChangePasswordForm() {
+  const [oldPw, setOldPw] = useState('');
+  const [newPw, setNewPw] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const score = useMemo(() => scoreStrength(newPw), [newPw]);
+  const mismatch = confirm.length > 0 && confirm !== newPw;
+  const tooShort = newPw.length > 0 && newPw.length < MIN_LEN;
+
+  const canSubmit =
+    !submitting &&
+    oldPw.length > 0 &&
+    newPw.length >= MIN_LEN &&
+    confirm === newPw;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setError(null);
+    setSubmitting(true);
+    try {
+      await changePassword(oldPw, newPw);
+      window.location.assign('/');
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 401) {
+          setError('Old password is incorrect.');
+        } else if (err.status === 400) {
+          const detail =
+            err.payload && typeof err.payload === 'object' && 'detail' in err.payload
+              ? String((err.payload as { detail?: unknown }).detail ?? '')
+              : '';
+          setError(detail || 'Password did not meet requirements.');
+        } else {
+          setError(`Could not change password (${err.status}). Try again.`);
+        }
+      } else {
+        setError('Could not change password. Check your connection and try again.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className="auth-shell">
+      <div className="auth-card">
+        <a className="auth-brand" href="/" aria-label="Cullis Frontdesk home">
+          <img src="/cullis-mark.svg" alt="" width="22" height="22" />
+          <span className="auth-wordmark">
+            Cullis <span className="tail">Frontdesk</span>
+          </span>
+        </a>
+
+        <h1 className="auth-title">Set a new password</h1>
+        <p className="auth-subtitle">
+          Required on first sign-in. Minimum {MIN_LEN} characters.
+        </p>
+
+        <form className="auth-form" onSubmit={onSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="old_password">Current password</label>
+            <input
+              id="old_password"
+              name="old_password"
+              type="password"
+              className="auth-input"
+              autoComplete="current-password"
+              required
+              value={oldPw}
+              onChange={(e) => setOldPw(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="new_password">New password</label>
+            <input
+              id="new_password"
+              name="new_password"
+              type="password"
+              className="auth-input"
+              autoComplete="new-password"
+              required
+              minLength={MIN_LEN}
+              value={newPw}
+              onChange={(e) => setNewPw(e.target.value)}
+              disabled={submitting}
+              aria-invalid={tooShort}
+            />
+            <div className="pw-strength" aria-live="polite">
+              <div className="pw-strength-bar">
+                <div
+                  className="pw-strength-fill"
+                  data-level={score}
+                  aria-hidden="true"
+                />
+              </div>
+              <span className="pw-strength-label">{STRENGTH_LABELS[score]}</span>
+            </div>
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="confirm_password">Confirm new password</label>
+            <input
+              id="confirm_password"
+              name="confirm_password"
+              type="password"
+              className="auth-input"
+              autoComplete="new-password"
+              required
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              disabled={submitting}
+              aria-invalid={mismatch}
+            />
+            {mismatch && (
+              <span className="auth-help" style={{ color: 'var(--accent-amber)' }}>
+                Passwords do not match.
+              </span>
+            )}
+          </div>
+
+          {error && (
+            <div className="auth-error" role="alert">
+              {error}
+            </div>
+          )}
+
+          <button type="submit" className="auth-button" disabled={!canSubmit}>
+            {submitting ? 'Updating...' : 'Confirm'}
+          </button>
+        </form>
+
+        <p className="auth-footer">
+          Choose a unique password. Mix letters, numbers, and symbols for the strongest result.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/cullis-chat/src/components/auth/LoginForm.tsx
+++ b/frontend/cullis-chat/src/components/auth/LoginForm.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useState } from 'react';
+import { LoginError, loginLocal } from '../../lib/auth';
+
+/**
+ * Local-mode sign-in form — ADR-025 Phase 5.
+ *
+ * On success:
+ *   - if ``must_change_password`` is true, redirect to /change-password
+ *   - otherwise redirect to /
+ *
+ * On 401: render a generic "invalid credentials" error (the server
+ * deliberately collapses missing-user, wrong-password, and disabled-
+ * account into the same response so we cannot enumerate users).
+ *
+ * On 429: render a Retry-After countdown so the user can see how long
+ * the lockout lasts. The ticker decrements once per second and the
+ * submit button stays disabled until the lockout clears.
+ *
+ * If the login response carries ``provisioning: "deferred"`` (Phase 3
+ * — Mastio CSR enrollment failed but the cookie was issued anyway),
+ * we surface a one-line non-blocking warning before redirecting.
+ */
+export default function LoginForm() {
+  const [userName, setUserName] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [retryAfter, setRetryAfter] = useState(0);
+  const [provisioningWarn, setProvisioningWarn] = useState<string | null>(null);
+
+  // Tick down the retry-after countdown.
+  useEffect(() => {
+    if (retryAfter <= 0) return;
+    const t = setTimeout(() => setRetryAfter((s) => Math.max(0, s - 1)), 1000);
+    return () => clearTimeout(t);
+  }, [retryAfter]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (submitting || retryAfter > 0) return;
+    setError(null);
+    setProvisioningWarn(null);
+    setSubmitting(true);
+    try {
+      const res = await loginLocal(userName.trim(), password);
+      if (res.provisioning === 'deferred') {
+        setProvisioningWarn(
+          'Sign-in succeeded, but agent enrollment with Mastio is pending. Some features may be unavailable until enrollment completes.',
+        );
+        // Brief pause so the user can read the banner before redirect.
+        await new Promise((r) => setTimeout(r, 1500));
+      }
+      const next = res.must_change_password ? '/change-password' : '/';
+      window.location.assign(next);
+    } catch (err) {
+      if (err instanceof LoginError) {
+        if (err.details.status === 429) {
+          setError(
+            err.details.retryAfter
+              ? `Too many sign-in attempts. Try again in ${err.details.retryAfter} seconds.`
+              : 'Too many sign-in attempts. Try again later.',
+          );
+          if (err.details.retryAfter) setRetryAfter(err.details.retryAfter);
+        } else if (err.details.status === 401) {
+          setError('Invalid username or password.');
+        } else {
+          setError(`Sign-in failed (${err.details.status}). Try again.`);
+        }
+      } else {
+        setError('Sign-in failed. Check your connection and try again.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const disabled = submitting || retryAfter > 0;
+
+  return (
+    <main className="auth-shell">
+      <div className="auth-card">
+        <a className="auth-brand" href="/" aria-label="Cullis Frontdesk home">
+          <img src="/cullis-mark.svg" alt="" width="22" height="22" />
+          <span className="auth-wordmark">
+            Cullis <span className="tail">Frontdesk</span>
+          </span>
+        </a>
+
+        <h1 className="auth-title">Sign in</h1>
+        <p className="auth-subtitle">Local account · per-user identity</p>
+
+        {provisioningWarn && (
+          <div className="auth-banner auth-banner-warn" role="status">
+            {provisioningWarn}
+          </div>
+        )}
+
+        <form className="auth-form" onSubmit={onSubmit} noValidate>
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="user_name">Username</label>
+            <input
+              id="user_name"
+              name="user_name"
+              type="text"
+              className="auth-input"
+              autoComplete="username"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              required
+              value={userName}
+              onChange={(e) => setUserName(e.target.value)}
+              disabled={disabled}
+              placeholder="mario"
+              aria-invalid={!!error}
+            />
+          </div>
+
+          <div className="auth-field">
+            <label className="auth-label" htmlFor="password">Password</label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              className="auth-input"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              disabled={disabled}
+              aria-invalid={!!error}
+            />
+          </div>
+
+          {error && (
+            <div className="auth-error" role="alert">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className="auth-button"
+            disabled={disabled || !userName || !password}
+          >
+            {retryAfter > 0
+              ? `Locked · ${retryAfter}s`
+              : submitting ? 'Signing in...' : 'Sign in'}
+          </button>
+        </form>
+
+        <p className="auth-footer">
+          Forgot your password? Contact your administrator.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/frontend/cullis-chat/src/components/auth/TopBarSessionMenu.tsx
+++ b/frontend/cullis-chat/src/components/auth/TopBarSessionMenu.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from 'react';
+import {
+  ADMIN_SECRET_STORAGE_KEY,
+  fetchRuntimeInfo,
+  logoutLocal,
+} from '../../lib/auth';
+import { redirectToLogin } from '../../lib/session-singleton';
+
+/**
+ * Right-side TopBar overflow — ADR-025 Phase 5.
+ *
+ * Two affordances:
+ *
+ *   - Logout button (visible only when the Connector is in local
+ *     mode; in OIDC mode the IdP owns sign-out).
+ *   - Admin link (visible only when the SPA has the admin secret
+ *     in sessionStorage — i.e. the user already authenticated to
+ *     /admin/users in this tab).
+ *
+ * Both surfaces are progressive enhancement; the badge already shows
+ * the principal so this component stays small and non-blocking.
+ */
+export default function TopBarSessionMenu() {
+  const [authMode, setAuthMode] = useState<string | null>(null);
+  const [hasAdminSecret, setHasAdminSecret] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const info = await fetchRuntimeInfo();
+      if (!cancelled) setAuthMode(info?.auth_mode ?? null);
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    function check() {
+      try {
+        setHasAdminSecret(!!sessionStorage.getItem(ADMIN_SECRET_STORAGE_KEY));
+      } catch {
+        setHasAdminSecret(false);
+      }
+    }
+    check();
+    // Cross-tab updates fire `storage` for localStorage only, but a
+    // hand-edit in DevTools is detectable on focus.
+    window.addEventListener('focus', check);
+    return () => window.removeEventListener('focus', check);
+  }, []);
+
+  if (authMode !== 'local') return null;
+
+  async function onLogout() {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await logoutLocal();
+    } catch {
+      /* ignore — clearing the cookie always succeeds client-side. */
+    }
+    redirectToLogin();
+  }
+
+  return (
+    <div className="topbar-session-menu">
+      {hasAdminSecret && (
+        <a className="topbar-link" href="/admin/users" title="Manage local users">
+          <span className="folio">admin</span>
+          <span className="topbar-link-label">Users</span>
+        </a>
+      )}
+      <button
+        type="button"
+        className="topbar-logout"
+        onClick={onLogout}
+        disabled={busy}
+        title="Sign out of this session"
+      >
+        {busy ? '...' : 'Logout'}
+      </button>
+    </div>
+  );
+}

--- a/frontend/cullis-chat/src/lib/auth.ts
+++ b/frontend/cullis-chat/src/lib/auth.ts
@@ -1,0 +1,348 @@
+/**
+ * Local-mode auth client — ADR-025 Phase 5.
+ *
+ * Wraps the Connector's ``/api/auth/*`` and ``/admin/users`` endpoints
+ * with typed request/response shapes. The SPA uses these from three
+ * surfaces:
+ *
+ *   - LoginForm           POST /api/auth/login
+ *   - ChangePasswordForm  POST /api/auth/change-password
+ *   - AdminUsers          GET/POST/DELETE /admin/users
+ *
+ * Endpoints live on the Connector (same-origin, cookie auth). The
+ * admin surface is gated by the ``X-Admin-Secret`` header which the
+ * SPA reads from sessionStorage — see AdminUsers.tsx.
+ *
+ * ``whoamiAuto`` papers over the two whoami shapes (Ambassador's
+ * ADR-020 wrapped principal vs the local-mode echo of the cookie
+ * payload) so the IdentityBadge call site can stay simple.
+ */
+import { ApiError } from './api';
+import type { Principal } from './types';
+
+export const ADMIN_SECRET_STORAGE_KEY = 'cullis-chat:admin-secret';
+
+// ── shared low-level fetch ────────────────────────────────────────────
+
+interface FetchOpts extends RequestInit {
+  /** Throw on non-2xx (default). Set false to inspect status manually. */
+  throwOnError?: boolean;
+}
+
+async function jsonRequest<T>(
+  url: string,
+  opts: FetchOpts = {},
+): Promise<{ status: number; headers: Headers; data: T | null; error: ApiError | null }> {
+  const { throwOnError = true, headers: hdr, ...rest } = opts;
+  const res = await fetch(url, {
+    credentials: 'same-origin',
+    ...rest,
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...(hdr ?? {}),
+    },
+  });
+  let data: T | null = null;
+  if (res.status !== 204) {
+    const text = await res.text();
+    if (text) {
+      try {
+        data = JSON.parse(text) as T;
+      } catch {
+        data = (text as unknown) as T;
+      }
+    }
+  }
+  if (!res.ok) {
+    const err = new ApiError(res.status, data);
+    if (throwOnError) throw err;
+    return { status: res.status, headers: res.headers, data, error: err };
+  }
+  return { status: res.status, headers: res.headers, data, error: null };
+}
+
+// ── runtime info / mode detection ──────────────────────────────────────
+
+export interface RuntimeInfo {
+  auth_mode: 'local' | 'oidc' | string;
+  login_url: string;
+  require_change_password_url: string;
+}
+
+/**
+ * Probe ``/api/auth/runtime-info``. Returns ``null`` when the route
+ * is unmounted (404) — that means the Connector is not in local mode
+ * and the SPA should fall back to the Ambassador session bootstrap.
+ */
+export async function fetchRuntimeInfo(): Promise<RuntimeInfo | null> {
+  const res = await fetch('/api/auth/runtime-info', {
+    credentials: 'same-origin',
+    headers: { Accept: 'application/json' },
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) return null;
+  try {
+    return (await res.json()) as RuntimeInfo;
+  } catch {
+    return null;
+  }
+}
+
+// ── login / logout / change-password ──────────────────────────────────
+
+export interface LoginResponse {
+  ok: boolean;
+  must_change_password: boolean;
+  principal_name: string;
+  exp: number;
+  /** Phase 3 — present when Mastio CSR enrollment is deferred. */
+  provisioning?: 'ok' | 'deferred';
+}
+
+export interface LoginErrorDetails {
+  status: number;
+  /** Seconds the caller must wait before retrying (429 only). */
+  retryAfter?: number;
+  detail?: string;
+}
+
+export class LoginError extends Error {
+  constructor(public details: LoginErrorDetails) {
+    super(`login error: ${details.status}`);
+  }
+}
+
+export async function loginLocal(
+  user_name: string,
+  password: string,
+): Promise<LoginResponse> {
+  const res = await jsonRequest<LoginResponse | { detail?: string }>(
+    '/api/auth/login',
+    {
+      method: 'POST',
+      body: JSON.stringify({ user_name, password }),
+      throwOnError: false,
+    },
+  );
+  if (res.error) {
+    let retryAfter: number | undefined;
+    const ra = res.headers.get('Retry-After');
+    if (ra) {
+      const n = Number.parseInt(ra, 10);
+      if (Number.isFinite(n) && n > 0) retryAfter = n;
+    }
+    const detail =
+      res.data && typeof res.data === 'object' && 'detail' in res.data
+        ? String((res.data as { detail?: unknown }).detail ?? '')
+        : undefined;
+    throw new LoginError({ status: res.status, retryAfter, detail });
+  }
+  // Phase 3 may surface provisioning state via a response header so
+  // the SPA can render a non-blocking banner. Read both shapes.
+  const data = res.data as LoginResponse;
+  if (!data.provisioning) {
+    const flag = res.headers.get('X-Cullis-Provisioning-Failed');
+    if (flag && flag.toLowerCase() === 'true') {
+      data.provisioning = 'deferred';
+    }
+  }
+  return data;
+}
+
+export async function logoutLocal(): Promise<void> {
+  await jsonRequest('/api/auth/logout', { method: 'POST', body: '{}' });
+}
+
+export interface ChangePasswordResponse {
+  ok: boolean;
+  must_change_password: boolean;
+  principal_name: string;
+  exp: number;
+}
+
+export async function changePassword(
+  oldPassword: string,
+  newPassword: string,
+): Promise<ChangePasswordResponse> {
+  const res = await jsonRequest<ChangePasswordResponse>(
+    '/api/auth/change-password',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        old_password: oldPassword,
+        new_password: newPassword,
+      }),
+    },
+  );
+  return res.data as ChangePasswordResponse;
+}
+
+export interface WhoamiLocal {
+  user_name: string;
+  principal_name: string;
+  must_change_password: boolean;
+  exp: number;
+}
+
+export async function whoamiLocal(): Promise<WhoamiLocal> {
+  const res = await jsonRequest<WhoamiLocal>('/api/auth/whoami-local');
+  return res.data as WhoamiLocal;
+}
+
+/**
+ * Best-effort principal probe with a graceful fallback.
+ *
+ * - Try the Ambassador's ``/api/session/whoami`` (ADR-020 shape).
+ * - On 401/404, fall back to ``/api/auth/whoami-local`` and synthesise
+ *   an ADR-020 principal so the IdentityBadge can render uniformly.
+ * - Re-throw on anything that is not a 401/404 so the caller can
+ *   distinguish "user is not signed in" from "transport broke".
+ */
+export async function whoamiAuto(): Promise<{
+  source: 'session' | 'local';
+  principal: Principal;
+}> {
+  try {
+    const res = await jsonRequest<{ ok: boolean; principal: Principal } | Principal>(
+      '/api/session/whoami',
+    );
+    const data = res.data;
+    if (data && typeof data === 'object' && 'principal' in data) {
+      return { source: 'session', principal: (data as { principal: Principal }).principal };
+    }
+    return { source: 'session', principal: data as Principal };
+  } catch (err) {
+    if (!(err instanceof ApiError) || (err.status !== 401 && err.status !== 404)) {
+      throw err;
+    }
+    const local = await whoamiLocal();
+    return {
+      source: 'local',
+      principal: {
+        spiffe_id: null,
+        principal_type: 'user',
+        name: local.user_name,
+        org: '',
+        trust_domain: null,
+      },
+    };
+  }
+}
+
+// ── admin: users ──────────────────────────────────────────────────────
+
+export interface AdminUser {
+  user_name: string;
+  display_name: string;
+  must_change_password: boolean;
+  created_at: string;
+  password_changed_at?: string | null;
+  disabled?: boolean;
+}
+
+export interface AdminUserList {
+  users: AdminUser[];
+  total: number;
+}
+
+export interface CreateUserPayload {
+  user_name: string;
+  password: string;
+  must_change_password?: boolean;
+  display_name?: string;
+}
+
+function adminHeaders(secret: string): Record<string, string> {
+  return { 'X-Admin-Secret': secret };
+}
+
+export async function adminCreateUser(
+  secret: string,
+  payload: CreateUserPayload,
+): Promise<AdminUser> {
+  const res = await jsonRequest<AdminUser>('/admin/users', {
+    method: 'POST',
+    headers: adminHeaders(secret),
+    body: JSON.stringify({
+      must_change_password: true,
+      display_name: '',
+      ...payload,
+    }),
+  });
+  return res.data as AdminUser;
+}
+
+export async function adminListUsers(
+  secret: string,
+  q?: string,
+): Promise<AdminUser[]> {
+  const qs = new URLSearchParams();
+  if (q) qs.set('q', q);
+  const url = qs.toString() ? `/admin/users?${qs}` : '/admin/users';
+  const res = await jsonRequest<AdminUserList>(url, {
+    method: 'GET',
+    headers: adminHeaders(secret),
+  });
+  return (res.data as AdminUserList).users;
+}
+
+export async function adminDeleteUser(
+  secret: string,
+  user_name: string,
+): Promise<void> {
+  await jsonRequest(`/admin/users/${encodeURIComponent(user_name)}`, {
+    method: 'DELETE',
+    headers: adminHeaders(secret),
+  });
+}
+
+export interface ResetPasswordResponse {
+  user_name: string;
+  must_change_password: boolean;
+}
+
+export async function adminResetPassword(
+  secret: string,
+  user_name: string,
+  newPassword: string,
+): Promise<ResetPasswordResponse> {
+  const res = await jsonRequest<ResetPasswordResponse>(
+    `/admin/users/${encodeURIComponent(user_name)}/reset-password`,
+    {
+      method: 'POST',
+      headers: adminHeaders(secret),
+      body: JSON.stringify({ new_password: newPassword }),
+    },
+  );
+  return res.data as ResetPasswordResponse;
+}
+
+// ── sessionStorage helpers (admin secret) ──────────────────────────────
+
+export function readAdminSecret(): string | null {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    return sessionStorage.getItem(ADMIN_SECRET_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeAdminSecret(secret: string): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    sessionStorage.setItem(ADMIN_SECRET_STORAGE_KEY, secret);
+  } catch {
+    /* ignore — Safari private mode etc. */
+  }
+}
+
+export function clearAdminSecret(): void {
+  if (typeof sessionStorage === 'undefined') return;
+  try {
+    sessionStorage.removeItem(ADMIN_SECRET_STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/cullis-chat/src/lib/session-singleton.ts
+++ b/frontend/cullis-chat/src/lib/session-singleton.ts
@@ -1,4 +1,5 @@
-import { initSession } from './api';
+import { ApiError, initSession } from './api';
+import { fetchRuntimeInfo } from './auth';
 
 /**
  * Idempotent session bootstrap. Three islands need the cookie before
@@ -6,19 +7,61 @@ import { initSession } from './api';
  * completions), IdentityBadge (whoami), ModelPicker (list models).
  * Every island calls `ensureSession()`; only the first call hits
  * `/api/session/init`, the rest piggyback on the cached promise.
+ *
+ * ADR-025 Phase 5 — when the Connector is in local mode and
+ * ``/api/session/init`` reports the caller is not signed in (401), we
+ * redirect to ``/login`` so the user can authenticate. The redirect is
+ * a one-shot side effect: the promise rejects so callers fail fast,
+ * but the user does not see a transient error UI.
  */
 let pending: Promise<void> | null = null;
 
+const LOGIN_PATH = '/login';
+const CHANGE_PASSWORD_PATH = '/change-password';
+
+function pathIsAuthFlow(): boolean {
+  if (typeof window === 'undefined') return false;
+  const p = window.location.pathname;
+  return p === LOGIN_PATH || p === CHANGE_PASSWORD_PATH;
+}
+
+/**
+ * Best-effort redirect to ``/login``. Silently swallows redirect when
+ * we are already on an auth-flow page, so the bootstrap on
+ * ``/login`` itself does not loop.
+ */
+export function redirectToLogin(): void {
+  if (typeof window === 'undefined') return;
+  if (pathIsAuthFlow()) return;
+  window.location.assign(LOGIN_PATH);
+}
+
+async function bootstrap(): Promise<void> {
+  try {
+    await initSession();
+    return;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) {
+      // Only chase the local-mode redirect when the Connector says
+      // it is in local mode. In OIDC mode we let the caller surface
+      // the error so the UI can render an SSO bootstrap link.
+      const info = await fetchRuntimeInfo();
+      if (info && info.auth_mode === 'local') {
+        redirectToLogin();
+      }
+    }
+    throw err;
+  }
+}
+
 export function ensureSession(): Promise<void> {
   if (!pending) {
-    pending = initSession()
-      .then(() => undefined)
-      .catch((err) => {
-        // Reset the cache on failure so a retry can happen, but propagate
-        // the rejection to the caller so it can surface the error.
-        pending = null;
-        throw err;
-      });
+    pending = bootstrap().catch((err) => {
+      // Reset the cache on failure so a retry can happen, but propagate
+      // the rejection to the caller so it can surface the error.
+      pending = null;
+      throw err;
+    });
   }
   return pending;
 }

--- a/frontend/cullis-chat/src/pages/admin/users.astro
+++ b/frontend/cullis-chat/src/pages/admin/users.astro
@@ -1,0 +1,40 @@
+---
+// Admin Users tab — ADR-025 Phase 5.
+//
+// Server-side gate: the /admin/users endpoints require the
+// X-Admin-Secret header (cullis_connector/admin/users_router.py). The
+// SPA prompts for the secret on first load and stores it only in
+// sessionStorage so it does not survive a tab close. This page does
+// not enforce auth — it is the React island that fails closed if
+// the secret is missing or rejected.
+import '../../styles/tokens.css';
+import '../../styles/globals.css';
+import '../../styles/auth.css';
+import AdminUsers from '../../components/admin/AdminUsers.tsx';
+import brand from '@brand/config';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#0a0f1a" />
+    <meta name="description" content={`Admin · users · ${brand.displayName}`} />
+    <meta name="referrer" content="same-origin" />
+    <meta name="robots" content="noindex" />
+    <title>{`Admin users · ${brand.displayName}`}</title>
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}${brand.logoMark}`} />
+  </head>
+  <body class="auth-body">
+    <AdminUsers client:load />
+  </body>
+</html>
+
+<style is:global>
+  body.auth-body {
+    overflow-y: auto;
+    height: auto;
+    min-height: 100vh;
+  }
+</style>

--- a/frontend/cullis-chat/src/pages/change-password.astro
+++ b/frontend/cullis-chat/src/pages/change-password.astro
@@ -1,0 +1,41 @@
+---
+// Change-password page — ADR-025 Phase 5.
+//
+// Reached via two paths:
+//   - LoginForm redirect when the server returns must_change_password=true
+//   - User-initiated password rotation (linked from /admin/users by admins
+//     and from a future settings panel for end users).
+//
+// Requires a valid local session cookie; server-side enforcement
+// happens in cullis_connector/auth/local_router.py — the SPA simply
+// surfaces the 401.
+import '../styles/tokens.css';
+import '../styles/globals.css';
+import '../styles/auth.css';
+import ChangePasswordForm from '../components/auth/ChangePasswordForm.tsx';
+import brand from '@brand/config';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#0a0f1a" />
+    <meta name="description" content={`Change password · ${brand.displayName}`} />
+    <meta name="referrer" content="same-origin" />
+    <title>{`Change password · ${brand.displayName}`}</title>
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}${brand.logoMark}`} />
+  </head>
+  <body class="auth-body">
+    <ChangePasswordForm client:load />
+  </body>
+</html>
+
+<style is:global>
+  body.auth-body {
+    overflow-y: auto;
+    height: auto;
+    min-height: 100vh;
+  }
+</style>

--- a/frontend/cullis-chat/src/pages/login.astro
+++ b/frontend/cullis-chat/src/pages/login.astro
@@ -1,0 +1,37 @@
+---
+// Sign-in page — ADR-025 Phase 5.
+//
+// Mounts the React <LoginForm> island. No TopBar / Sidebar: the auth
+// flow is intentionally chrome-free so the user knows they are not
+// signed in yet. Cookie-issuing happens server-side via
+// /api/auth/login (POST), which the form calls directly.
+import '../styles/tokens.css';
+import '../styles/globals.css';
+import '../styles/auth.css';
+import LoginForm from '../components/auth/LoginForm.tsx';
+import brand from '@brand/config';
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="generator" content={Astro.generator} />
+    <meta name="theme-color" content="#0a0f1a" />
+    <meta name="description" content={`Sign in · ${brand.displayName}`} />
+    <meta name="referrer" content="same-origin" />
+    <title>{`Sign in · ${brand.displayName}`}</title>
+    <link rel="icon" type="image/svg+xml" href={`${import.meta.env.BASE_URL}${brand.logoMark}`} />
+  </head>
+  <body class="auth-body">
+    <LoginForm client:load />
+  </body>
+</html>
+
+<style is:global>
+  body.auth-body {
+    overflow-y: auto;
+    height: auto;
+    min-height: 100vh;
+  }
+</style>

--- a/frontend/cullis-chat/src/styles/auth.css
+++ b/frontend/cullis-chat/src/styles/auth.css
@@ -1,0 +1,525 @@
+/* Cullis Chat — auth surface (login, change-password, admin/users).
+ *
+ * Shares tokens with the chat shell (tokens.css). The auth shell is
+ * not a fixed-viewport app: it scrolls naturally on small screens.
+ *
+ * Design language:
+ *   - Centered card on a dark void background, no chrome above.
+ *   - Instrument Serif italic for the "set a new password" headline.
+ *   - DM Mono small caps for field labels.
+ *   - Cyan focus ring + cyan submit button (the only colour CTA).
+ *   - Zero radius card; subtle hairline border + soft drop.
+ */
+
+.auth-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem 1.5rem;
+  background:
+    radial-gradient(circle at 50% -10%, rgba(0, 229, 199, 0.06), transparent 60%),
+    var(--bg-void);
+  overflow-y: auto;
+}
+
+.auth-card {
+  width: 100%;
+  max-width: 420px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  border-radius: 0;
+  padding: 2.4rem 2rem 2rem;
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.03) inset,
+    0 24px 60px -28px rgba(0, 0, 0, 0.7),
+    0 0 0 1px rgba(0, 229, 199, 0.04) inset;
+}
+
+.auth-card-wide {
+  max-width: 1080px;
+}
+
+.auth-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1.6rem;
+  text-decoration: none;
+  color: var(--text-primary);
+}
+
+.auth-brand img {
+  filter: drop-shadow(0 0 10px rgba(0, 229, 199, 0.35));
+}
+
+.auth-wordmark {
+  font-family: var(--font-brand);
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.auth-wordmark .tail {
+  color: var(--accent-cyan);
+  font-weight: 500;
+}
+
+.auth-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 2rem;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  margin-bottom: 0.4rem;
+  line-height: 1.1;
+}
+
+.auth-subtitle {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  margin-bottom: 1.6rem;
+}
+
+.auth-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.auth-field {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.auth-label {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.auth-input {
+  appearance: none;
+  background: var(--bg-void);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  padding: 0.7rem 0.9rem;
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  letter-spacing: 0;
+  transition: border-color var(--t-fast) var(--ease-soft),
+              background var(--t-fast) var(--ease-soft);
+}
+
+.auth-input::placeholder {
+  color: var(--text-tertiary);
+}
+
+.auth-input:hover {
+  border-color: var(--border-strong);
+}
+
+.auth-input:focus,
+.auth-input:focus-visible {
+  outline: none;
+  border-color: var(--accent-cyan);
+  box-shadow: 0 0 0 1px var(--accent-cyan);
+  background: var(--bg-surface);
+}
+
+.auth-input[aria-invalid='true'] {
+  border-color: var(--accent-amber);
+}
+
+.auth-help {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+}
+
+.auth-button {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.2rem;
+  background: var(--accent-cyan);
+  color: var(--bg-void);
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: var(--shadow-button-primary);
+  transition: transform var(--t-fast) var(--ease-soft),
+              background var(--t-fast) var(--ease-soft),
+              box-shadow var(--t-fast) var(--ease-soft);
+  margin-top: 0.4rem;
+}
+
+.auth-button:hover:not(:disabled) {
+  background: #1ff0d4;
+  transform: translateY(-1px);
+}
+
+.auth-button:active:not(:disabled) {
+  transform: translateY(0);
+  box-shadow: var(--shadow-button-pressed);
+}
+
+.auth-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.auth-button-ghost {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-button);
+  border: 1px solid var(--border-medium);
+}
+
+.auth-button-ghost:hover:not(:disabled) {
+  background: var(--bg-card-hover);
+  border-color: var(--border-strong);
+}
+
+.auth-button-danger {
+  background: transparent;
+  color: var(--accent-amber);
+  border: 1px solid var(--accent-amber);
+  box-shadow: none;
+}
+
+.auth-button-danger:hover:not(:disabled) {
+  background: rgba(240, 165, 0, 0.08);
+  transform: translateY(-1px);
+}
+
+.auth-error {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--accent-amber);
+  background: rgba(240, 165, 0, 0.08);
+  border-left: 2px solid var(--accent-amber);
+  padding: 0.55rem 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.auth-banner {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--accent-cyan);
+  background: rgba(0, 229, 199, 0.06);
+  border-left: 2px solid var(--accent-cyan);
+  padding: 0.55rem 0.75rem;
+  letter-spacing: 0.02em;
+  margin-bottom: 1rem;
+}
+
+.auth-banner-warn {
+  color: var(--accent-amber);
+  background: rgba(240, 165, 0, 0.06);
+  border-left-color: var(--accent-amber);
+}
+
+.auth-footer {
+  margin-top: 1.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+  text-align: center;
+  line-height: 1.5;
+}
+
+/* ── password strength bar ────────────────────────────────────────── */
+
+.pw-strength {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: 0.4rem;
+}
+
+.pw-strength-bar {
+  height: 4px;
+  background: var(--bg-void);
+  border: 1px solid var(--border-subtle);
+  position: relative;
+  overflow: hidden;
+}
+
+.pw-strength-fill {
+  height: 100%;
+  width: 0%;
+  background: var(--accent-amber);
+  transition: width var(--t-base) var(--ease-soft),
+              background var(--t-base) var(--ease-soft);
+}
+
+.pw-strength-fill[data-level='1'] { width: 25%; background: #f0a500; }
+.pw-strength-fill[data-level='2'] { width: 50%; background: #f0a500; }
+.pw-strength-fill[data-level='3'] { width: 75%; background: var(--accent-teal); }
+.pw-strength-fill[data-level='4'] { width: 100%; background: var(--accent-cyan); }
+
+.pw-strength-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  min-width: 5.2em;
+  text-align: right;
+}
+
+/* ── admin users table ────────────────────────────────────────────── */
+
+.admin-page {
+  width: 100%;
+  display: grid;
+  gap: 1.6rem;
+}
+
+.admin-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.admin-header h1 {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 2rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.admin-header .folio {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  display: block;
+  margin-bottom: 0.3rem;
+}
+
+.admin-toolbar {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.admin-search {
+  appearance: none;
+  background: var(--bg-void);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.8rem;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  min-width: 220px;
+}
+
+.admin-search:focus,
+.admin-search:focus-visible {
+  outline: none;
+  border-color: var(--accent-cyan);
+  box-shadow: 0 0 0 1px var(--accent-cyan);
+}
+
+.admin-table-wrap {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-body);
+  font-size: 0.88rem;
+  text-align: left;
+}
+
+.admin-table thead th {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+  padding: 0.85rem 1rem;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border-medium);
+  font-weight: 500;
+}
+
+.admin-table tbody td {
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  vertical-align: middle;
+}
+
+.admin-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.admin-table tbody tr:hover {
+  background: var(--bg-card-hover);
+}
+
+.admin-table-empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+}
+
+.admin-mono {
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  letter-spacing: 0.02em;
+}
+
+.admin-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.18rem 0.55rem;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  border: 1px solid var(--border-medium);
+}
+
+.admin-pill-active {
+  color: var(--accent-cyan);
+  border-color: rgba(0, 229, 199, 0.4);
+  background: rgba(0, 229, 199, 0.06);
+}
+
+.admin-pill-pending {
+  color: var(--accent-amber);
+  border-color: rgba(240, 165, 0, 0.4);
+  background: rgba(240, 165, 0, 0.06);
+}
+
+.admin-pill-disabled {
+  color: var(--text-tertiary);
+  border-color: var(--border-medium);
+}
+
+.admin-actions {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.admin-action {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.6rem;
+  cursor: pointer;
+  transition: border-color var(--t-fast) var(--ease-soft),
+              color var(--t-fast) var(--ease-soft);
+}
+
+.admin-action:hover:not(:disabled) {
+  border-color: var(--accent-cyan);
+  color: var(--accent-cyan);
+}
+
+.admin-action-danger:hover:not(:disabled) {
+  border-color: var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* ── modal ────────────────────────────────────────────────────────── */
+
+.admin-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 8, 16, 0.78);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  display: grid;
+  place-items: center;
+  z-index: 100;
+  padding: 1.5rem;
+}
+
+.admin-modal {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-medium);
+  width: 100%;
+  max-width: 460px;
+  padding: 1.8rem;
+  box-shadow: 0 24px 60px -20px rgba(0, 0, 0, 0.7);
+}
+
+.admin-modal h2 {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.4rem;
+  margin-bottom: 0.3rem;
+}
+
+.admin-modal p {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: var(--text-tertiary);
+  margin-bottom: 1.2rem;
+}
+
+.admin-modal-actions {
+  display: flex;
+  gap: 0.7rem;
+  justify-content: flex-end;
+  margin-top: 1.4rem;
+}
+
+.admin-temp-pw {
+  display: block;
+  margin-top: 0.6rem;
+  padding: 0.6rem 0.8rem;
+  background: var(--bg-void);
+  border: 1px solid var(--accent-cyan);
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  color: var(--accent-cyan);
+  letter-spacing: 0.04em;
+  user-select: all;
+  word-break: break-all;
+}

--- a/frontend/cullis-chat/tests/unit/auth.test.ts
+++ b/frontend/cullis-chat/tests/unit/auth.test.ts
@@ -1,0 +1,385 @@
+/**
+ * Vitest — auth client (ADR-025 Phase 5).
+ *
+ * Mocks global ``fetch`` to assert the request shape and the way the
+ * client surfaces server responses (status, headers, error class).
+ *
+ * No DOM, no React. The auth React components are exercised by
+ * Playwright e2e specs; this suite focuses on the wrapper contract
+ * so a typo in a URL or a missing ``X-Admin-Secret`` header is
+ * caught at the lib boundary.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ADMIN_SECRET_STORAGE_KEY,
+  LoginError,
+  adminCreateUser,
+  adminDeleteUser,
+  adminListUsers,
+  adminResetPassword,
+  changePassword,
+  clearAdminSecret,
+  fetchRuntimeInfo,
+  loginLocal,
+  logoutLocal,
+  readAdminSecret,
+  whoamiAuto,
+  whoamiLocal,
+  writeAdminSecret,
+} from '../../src/lib/auth';
+
+interface FakeFetchInit extends RequestInit {}
+
+interface MockResponseInit {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+function mockResponse({ status = 200, body, headers = {} }: MockResponseInit = {}) {
+  const text = body === undefined ? '' : JSON.stringify(body);
+  const h = new Headers({ 'content-type': 'application/json', ...headers });
+  return new Response(text, { status, headers: h });
+}
+
+const calls: { url: string; init: FakeFetchInit }[] = [];
+
+beforeEach(() => {
+  calls.length = 0;
+  // Default — every test installs its own mock with .mockImplementation.
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    return mockResponse();
+  }) as unknown as typeof fetch;
+
+  // sessionStorage shim for node-environment runs.
+  const store = new Map<string, string>();
+  // vitest node env has no sessionStorage by default; install a minimal
+  // Storage-shaped object on the global so the `auth.ts` helpers work.
+  (globalThis as unknown as { sessionStorage: Storage }).sessionStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => { store.set(k, v); },
+    removeItem: (k: string) => { store.delete(k); },
+    clear: () => { store.clear(); },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() { return store.size; },
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── loginLocal ────────────────────────────────────────────────────────
+
+describe('loginLocal', () => {
+  it('posts JSON body and returns the parsed payload on success', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return mockResponse({
+          status: 200,
+          body: {
+            ok: true,
+            must_change_password: false,
+            principal_name: 'mario',
+            exp: 1234567890,
+          },
+        });
+      },
+    );
+    const res = await loginLocal('mario', 'hunter2hunter2');
+    expect(res.ok).toBe(true);
+    expect(res.principal_name).toBe('mario');
+    expect(calls[0].url).toBe('/api/auth/login');
+    expect(calls[0].init.method).toBe('POST');
+    const body = JSON.parse(String(calls[0].init.body ?? ''));
+    expect(body).toEqual({ user_name: 'mario', password: 'hunter2hunter2' });
+  });
+
+  it('throws LoginError with status=401 on invalid credentials', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({ status: 401, body: { detail: 'invalid credentials' } }),
+    );
+    await expect(loginLocal('mario', 'wrong')).rejects.toMatchObject({
+      details: { status: 401, detail: 'invalid credentials' },
+    });
+  });
+
+  it('reads Retry-After on 429 and surfaces it in LoginError', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({
+        status: 429,
+        body: { detail: 'too many login attempts' },
+        headers: { 'retry-after': '42' },
+      }),
+    );
+    let caught: unknown = null;
+    try {
+      await loginLocal('mario', 'wrong');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LoginError);
+    const e = caught as LoginError;
+    expect(e.details.status).toBe(429);
+    expect(e.details.retryAfter).toBe(42);
+    expect(e.details.detail).toBe('too many login attempts');
+  });
+
+  it('marks provisioning=deferred when the X-Cullis-Provisioning-Failed header is present', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({
+        status: 200,
+        body: {
+          ok: true,
+          must_change_password: false,
+          principal_name: 'mario',
+          exp: 1234567890,
+        },
+        headers: { 'x-cullis-provisioning-failed': 'true' },
+      }),
+    );
+    const res = await loginLocal('mario', 'pw');
+    expect(res.provisioning).toBe('deferred');
+  });
+});
+
+// ── logoutLocal / changePassword / whoamiLocal ────────────────────────
+
+describe('logoutLocal', () => {
+  it('POSTs /api/auth/logout', async () => {
+    await logoutLocal();
+    expect(calls[0].url).toBe('/api/auth/logout');
+    expect(calls[0].init.method).toBe('POST');
+  });
+});
+
+describe('changePassword', () => {
+  it('posts old/new password and parses the response', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return mockResponse({
+          status: 200,
+          body: {
+            ok: true,
+            must_change_password: false,
+            principal_name: 'mario',
+            exp: 1234567890,
+          },
+        });
+      },
+    );
+    const res = await changePassword('old', 'newpassword1');
+    expect(res.ok).toBe(true);
+    expect(calls[0].url).toBe('/api/auth/change-password');
+    const body = JSON.parse(String(calls[0].init.body ?? ''));
+    expect(body).toEqual({ old_password: 'old', new_password: 'newpassword1' });
+  });
+});
+
+describe('whoamiLocal', () => {
+  it('returns the parsed cookie echo', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({
+        status: 200,
+        body: { user_name: 'mario', principal_name: 'mario', must_change_password: false, exp: 1 },
+      }),
+    );
+    const res = await whoamiLocal();
+    expect(res.user_name).toBe('mario');
+  });
+});
+
+// ── whoamiAuto fallback ───────────────────────────────────────────────
+
+describe('whoamiAuto', () => {
+  it('returns ADR-020 principal when /api/session/whoami succeeds', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === '/api/session/whoami') {
+          return mockResponse({
+            status: 200,
+            body: {
+              ok: true,
+              principal: {
+                spiffe_id: 'spiffe://demo/agent/x',
+                principal_type: 'agent',
+                name: 'agent-x',
+                org: 'demo',
+                trust_domain: 'demo',
+              },
+            },
+          });
+        }
+        throw new Error(`unexpected url ${url}`);
+      },
+    );
+    const res = await whoamiAuto();
+    expect(res.source).toBe('session');
+    expect(res.principal.principal_type).toBe('agent');
+    expect(res.principal.name).toBe('agent-x');
+  });
+
+  it('falls back to /api/auth/whoami-local on 401 and synthesises a user principal', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url === '/api/session/whoami') {
+          return mockResponse({ status: 401, body: { detail: 'unauthenticated' } });
+        }
+        if (url === '/api/auth/whoami-local') {
+          return mockResponse({
+            status: 200,
+            body: {
+              user_name: 'mario',
+              principal_name: 'mario',
+              must_change_password: false,
+              exp: 1,
+            },
+          });
+        }
+        throw new Error(`unexpected url ${url}`);
+      },
+    );
+    const res = await whoamiAuto();
+    expect(res.source).toBe('local');
+    expect(res.principal.principal_type).toBe('user');
+    expect(res.principal.name).toBe('mario');
+    expect(res.principal.spiffe_id).toBeNull();
+  });
+
+  it('re-throws on 5xx from /api/session/whoami', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({ status: 500, body: { detail: 'boom' } }),
+    );
+    await expect(whoamiAuto()).rejects.toMatchObject({ status: 500 });
+  });
+});
+
+// ── runtime-info ──────────────────────────────────────────────────────
+
+describe('fetchRuntimeInfo', () => {
+  it('returns null on 404 (route unmounted = OIDC mode)', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => new Response('', { status: 404 }),
+    );
+    const info = await fetchRuntimeInfo();
+    expect(info).toBeNull();
+  });
+
+  it('returns the parsed payload when local mode is active', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => mockResponse({
+        status: 200,
+        body: {
+          auth_mode: 'local',
+          login_url: '/login',
+          require_change_password_url: '/change-password',
+        },
+      }),
+    );
+    const info = await fetchRuntimeInfo();
+    expect(info?.auth_mode).toBe('local');
+  });
+});
+
+// ── admin endpoints ───────────────────────────────────────────────────
+
+describe('admin: create / list / delete / reset', () => {
+  const SECRET = 'admin-secret-test';
+
+  it('adminCreateUser sends X-Admin-Secret and JSON body', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return mockResponse({
+          status: 201,
+          body: {
+            user_name: 'mario',
+            display_name: '',
+            must_change_password: true,
+            created_at: '2026-05-08T00:00:00Z',
+          },
+        });
+      },
+    );
+    const res = await adminCreateUser(SECRET, {
+      user_name: 'mario',
+      password: 'temp1234',
+    });
+    expect(res.user_name).toBe('mario');
+    expect(calls[0].url).toBe('/admin/users');
+    expect(calls[0].init.method).toBe('POST');
+    const headers = new Headers(calls[0].init.headers as HeadersInit);
+    expect(headers.get('X-Admin-Secret')).toBe(SECRET);
+    const body = JSON.parse(String(calls[0].init.body ?? ''));
+    expect(body.user_name).toBe('mario');
+    expect(body.password).toBe('temp1234');
+    // Defaults applied.
+    expect(body.must_change_password).toBe(true);
+    expect(body.display_name).toBe('');
+  });
+
+  it('adminListUsers builds the q= query string and unwraps the list', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return mockResponse({
+          status: 200,
+          body: { users: [{ user_name: 'mario', display_name: '', must_change_password: false, created_at: 'x' }], total: 1 },
+        });
+      },
+    );
+    const res = await adminListUsers(SECRET, 'mar');
+    expect(res).toHaveLength(1);
+    expect(res[0].user_name).toBe('mario');
+    expect(calls[0].url).toBe('/admin/users?q=mar');
+    const headers = new Headers(calls[0].init.headers as HeadersInit);
+    expect(headers.get('X-Admin-Secret')).toBe(SECRET);
+  });
+
+  it('adminDeleteUser DELETEs the username-encoded path', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return new Response(null, { status: 204 });
+      },
+    );
+    await adminDeleteUser(SECRET, 'mario.rossi');
+    expect(calls[0].url).toBe('/admin/users/mario.rossi');
+    expect(calls[0].init.method).toBe('DELETE');
+  });
+
+  it('adminResetPassword POSTs to /reset-password and returns the response', async () => {
+    (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async (input: RequestInfo | URL, init?: FakeFetchInit) => {
+        calls.push({ url: String(input), init: init ?? {} });
+        return mockResponse({
+          status: 200,
+          body: { user_name: 'mario', must_change_password: true },
+        });
+      },
+    );
+    const res = await adminResetPassword(SECRET, 'mario', 'new12345');
+    expect(res.must_change_password).toBe(true);
+    expect(calls[0].url).toBe('/admin/users/mario/reset-password');
+    const body = JSON.parse(String(calls[0].init.body ?? ''));
+    expect(body).toEqual({ new_password: 'new12345' });
+  });
+});
+
+// ── sessionStorage helpers ────────────────────────────────────────────
+
+describe('admin secret session storage', () => {
+  it('round-trips via writeAdminSecret/readAdminSecret/clearAdminSecret', () => {
+    expect(readAdminSecret()).toBeNull();
+    writeAdminSecret('abc123');
+    expect(readAdminSecret()).toBe('abc123');
+    expect(sessionStorage.getItem(ADMIN_SECRET_STORAGE_KEY)).toBe('abc123');
+    clearAdminSecret();
+    expect(readAdminSecret()).toBeNull();
+  });
+});

--- a/frontend/cullis-chat/vitest.config.ts
+++ b/frontend/cullis-chat/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest config — ADR-025 Phase 5.
+ *
+ * Pure unit tests for ``src/lib`` (auth client, fetch wrappers).
+ * React component tests live separately under tests/e2e via
+ * Playwright; Vitest stays node-environment to keep the bar low
+ * (no jsdom, no testing-library) and the test runtime fast.
+ */
+export default defineConfig({
+  test: {
+    include: ['tests/unit/**/*.test.ts'],
+    environment: 'node',
+    globals: false,
+    reporters: 'default',
+    pool: 'forks',
+    isolate: true,
+  },
+});


### PR DESCRIPTION
## Summary

ADR-025 Phase 5 — wire the Cullis Chat SPA into the local-mode auth
endpoints landed in Phase 1 (#548), Phase 2 (#552), and Phase 4 (#551).
The browser surface now covers the full lifecycle without curl: sign
in, first-login password change, admin user provisioning, and
session-aware identity badge.

Phase 3 (deferred-CSR provisioning) lands in a parallel PR; the SPA
already reads its non-blocking warning header so those two flows
stack cleanly without a follow-up.

## Patterns reused

- ``jsonFetch`` + ``ApiError`` from ``src/lib/api.ts`` (extended via
  the new ``src/lib/auth.ts`` so existing ChatApp / Inbox callers
  stay untouched).
- ``parseSpiffe`` untouched — ``whoamiAuto`` synthesises a clean
  ADR-020 user principal on the local-mode fallback so the
  ``IdentityBadge`` rendering path stays uniform.
- ``ensureSession()`` now redirects to ``/login`` on 401 in local
  mode (probed via ``/api/auth/runtime-info``), so every island
  that calls it (ChatApp, ModelPicker, IdentityBadge) fails closed
  into the auth flow rather than rendering a stale offline shell.
- Tailwind tokens in ``src/styles/tokens.css`` (mirrored from
  ``site/global.css`` per ``feedback_design_tokens_unified``) drive
  the new ``auth.css`` — Instrument Serif italic headlines, DM
  Mono small-caps labels, zero-radius card, void+cyan palette.

## Files

New:
- ``frontend/cullis-chat/src/lib/auth.ts``
- ``frontend/cullis-chat/src/components/auth/LoginForm.tsx``
- ``frontend/cullis-chat/src/components/auth/ChangePasswordForm.tsx``
- ``frontend/cullis-chat/src/components/auth/TopBarSessionMenu.tsx``
- ``frontend/cullis-chat/src/components/admin/AdminUsers.tsx``
- ``frontend/cullis-chat/src/pages/login.astro``
- ``frontend/cullis-chat/src/pages/change-password.astro``
- ``frontend/cullis-chat/src/pages/admin/users.astro``
- ``frontend/cullis-chat/src/styles/auth.css``
- ``frontend/cullis-chat/vitest.config.ts``
- ``frontend/cullis-chat/tests/unit/auth.test.ts``

Modified:
- ``frontend/cullis-chat/src/lib/session-singleton.ts`` — local-mode
  redirect on 401.
- ``frontend/cullis-chat/src/components/IdentityBadge.tsx`` — redirect
  on 401, fall back via ``whoamiAuto``.
- ``frontend/cullis-chat/src/components/TopBar.astro`` — mount the
  ``TopBarSessionMenu`` island + scoped styles.
- ``frontend/cullis-chat/package.json`` — Vitest devDep + ``test``
  script.

## Threat model

- **Admin secret never in localStorage.** ``AdminUsers`` caches the
  ``X-Admin-Secret`` in ``sessionStorage`` so it does not survive a
  tab close, and exposes a ``Sign out admin`` button that clears it
  on demand. The SPA never embeds the secret in URLs, postMessage
  payloads, or service-worker caches.
- **Cookie auth, not bearer.** All login responses reuse the same
  ``cullis_local_session`` cookie minted by Phase 2; the SPA never
  reads or stores it (HttpOnly + SameSite=Strict + Secure unless
  ``CULLIS_CONNECTOR_DEV=1``).
- **Generic 401 on login failure.** The SPA surface mirrors the
  server's wording so missing-user, wrong-password, and disabled-
  account stay indistinguishable.
- **Provisioning deferred banner is informational only.** It does
  not block sign-in, gate the cookie, or change navigation — only
  surfaces the Phase 3 ``X-Cullis-Provisioning-Failed`` header so
  the user knows agent enrollment with Mastio is pending.
- **No new state-changing routes on the Connector.** Only existing
  endpoints from Phase 1/2/4 are exercised; CSRF guard and rate
  limits already in place upstream.

## Test plan

- [x] ``cd frontend/cullis-chat && npm install`` — installs Vitest 2.1.
- [x] ``cd frontend/cullis-chat && npm test`` — 17 unit tests pass
      (auth.ts wrappers: login happy/401/429, Retry-After parsing,
      provisioning header, change-password, whoamiAuto fallback,
      admin CRUD, sessionStorage round-trip).
- [x] ``cd frontend/cullis-chat && npx tsc --noEmit`` — clean.
- [x] ``cd frontend/cullis-chat && npm run build`` — 5 pages built
      (``/``, ``/login``, ``/change-password``, ``/admin/users``,
      ``/inbox``), no warnings beyond Shiki grammar chunks.
- [x] ``pytest tests/connector/test_users_db.py
      tests/connector/test_admin_users_endpoint.py
      tests/connector/test_auth_local_router.py
      -n auto --dist=loadfile`` — 60 passed, no regression.
- [ ] Manual dogfood: bring up Frontdesk bundle, sign in via
      ``/login``, change password, provision a second user from
      ``/admin/users``, sign out, sign back in as the new user.