### PR TITLE
chore(frontdesk-bundle): bump default image versions to ADR-025 release pair

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - frontdesk_net
 
   connector:
-    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0-rc1}
+    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0-rc2}
     # ``dashboard`` mounts the Ambassador router via web.py lifespan when
     # AMBASSADOR_MODE=shared (cullis_connector/web.py:152). Bind to all
     # interfaces inside the container so nginx can reach it.
@@ -135,7 +135,7 @@ services:
     # + bundled JS/CSS. /api/session/* and /v1/* proxying to the
     # Connector happens in the outer nginx layer below; this inner
     # container only serves static assets.
-    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.1.0-rc1}
+    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.2.0-rc1}
     expose:
       - "8080"
     depends_on:

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -29,12 +29,12 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the cullis-connector image to pull. Pin a release tag
 # in production rather than ``latest``. The default tracks the latest
 # release validated against this bundle.
-# CONNECTOR_VERSION=0.4.0-rc1
+# CONNECTOR_VERSION=0.4.0-rc2
 
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on
 # every ``chat-vX.Y.Z`` tag (matrix build with CULLIS_BRAND=frontdesk).
-# CHAT_VERSION=0.1.0-rc1
+# CHAT_VERSION=0.2.0-rc1
 
 # -- Optional: bundle behaviour --------------------------------------------
 


### PR DESCRIPTION
Bumps default image refs in `packaging/frontdesk-bundle/docker-compose.yml` + `frontdesk.env.example`:

- `cullis-connector`: `0.4.0-rc1` → `0.4.0-rc2` (ADR-025 backend)
- `cullis-chat-frontdesk`: `0.1.0-rc1` → `0.2.0-rc1` (ADR-025 SPA)

Pairs with `frontdesk-bundle-v0.2.0-rc1` cut next.

## Test plan
- [x] sed-only diff, no logic change
- [ ] CI green