### PR TITLE
chore(connector): bump to 0.4.0-rc2 + PyInstaller hiddenimports for ADR-025 deps

### DIFF
--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.0-rc1"
+__version__ = "0.4.0-rc2"
 __all__ = ["__version__"]

--- a/packaging/connector/cullis-connector.spec
+++ b/packaging/connector/cullis-connector.spec
@@ -36,6 +36,19 @@ hiddenimports = [
     "uvicorn.protocols.websockets.auto",
     "uvicorn.protocols.websockets.wsproto_impl",
     "uvicorn.logging",
+    # ADR-025 Phase 1/3/4 — local-auth users.db, audit log, cert
+    # session map. SQLAlchemy + aiosqlite are imported by
+    # cullis_connector.identity.{users_db,audit,cert_session_map};
+    # bcrypt by cullis_connector.identity.users. PyInstaller's static
+    # analysis misses the aiosqlite dialect pulled at runtime by
+    # SQLAlchemy + the bcrypt _bcrypt extension module.
+    "sqlalchemy",
+    "sqlalchemy.dialects.sqlite",
+    "sqlalchemy.dialects.sqlite.aiosqlite",
+    "sqlalchemy.ext.asyncio",
+    "sqlalchemy.orm",
+    "aiosqlite",
+    "bcrypt",
 ]
 
 # Desktop shell deps are imported lazily inside function bodies in

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.0-rc1"
+version = "0.4.0-rc2"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Fixes the connector-v0.4.0-rc2 release pipeline failure: PyInstaller binary builds missed sqlalchemy + aiosqlite + bcrypt that ADR-025 Phase 1/3/4 added; version files still pointed at 0.4.0-rc1 so the version-match gate also failed. Cuts re-cut after merge.