### PR TITLE
docs: bump Frontdesk bundle quickstart to v0.2.0-rc1 (ADR-025 dual-mode auth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
 cd ..
-curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc4/cullis-frontdesk-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.2.0-rc1/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle && ./deploy.sh
 ```
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -198,14 +198,14 @@ cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
         <li>
           <div class="bundle-head">
             <strong>Frontdesk bundle</strong>
-            <span class="bundle-tag">frontdesk-bundle-v0.1.0-rc4</span>
+            <span class="bundle-tag">frontdesk-bundle-v0.2.0-rc1</span>
           </div>
           <p class="bundle-blurb">
             Multi-user Cullis Chat (SPA on <code>:8080</code>) co-located
             with a Mastio on the same host. Adds a shared-mode Connector
             so multiple human users issue ADR-020 user principals.
           </p>
-          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.1.0-rc4/cullis-frontdesk-bundle.tar.gz | tar xz
+          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.2.0-rc1/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle &amp;&amp; ./deploy.sh</code></pre>
         </li>
 


### PR DESCRIPTION
Bumps quickstart pinned URLs in README + site /download to point at the ADR-025 dual-mode auth release.

- `frontdesk-bundle`: `v0.1.0-rc4` → `v0.2.0-rc1` (login + admin Users pages active)
- Mastio bundle unchanged (`mastio-v0.3.2-rc3`)

## Test plan
- [x] Pinned tarball returns HTTP 200
- [ ] CI green
- [ ] CF Pages production deploy after merge