### PR TITLE
fix(frontdesk-bundle): activate ADR-025 local-auth as default + bump stale defaults

### DIFF
--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -1,14 +1,20 @@
 # Cullis Frontdesk — multi-user container bundle
 
-Deploys Cullis Chat as a corporate web app, identity-aware via SSO. One container per N concurrent users, audit attributed per user. Implements ADR-019 rev 3 Phase 7.
+Deploys Cullis Chat as a corporate web app, identity-aware. One container per N concurrent users, audit attributed per user. Implements ADR-019 rev 3 Phase 7 + ADR-025 dual-mode auth.
+
+## Auth mode (default: ADR-025 local)
+
+By default the bundle ships **ADR-025 `AUTH_MODE=local`**: the SPA serves a real `/login` form backed by a `users.db` (bcrypt hashed); the admin pre-creates accounts via `POST /admin/users` with `X-Admin-Secret`; each post-login session mints a per-user UserPrincipal cert at the sibling Mastio. Audit chain shows the actual employee, not a shared placeholder.
 
 ```
 [browser Mario] ──┐
-[browser Anna]  ──┼─→ [nginx :8080] ──→ [Cullis Chat SPA] ──→ [Connector :7777, AMBASSADOR_MODE=shared]
-[browser Luca]  ──┘     ↑                                        ↓ DPoP+mTLS, per-user keys via UserPrincipalKMS
-                        SSO: oauth2-proxy + IDP                  ↓
-                        injects X-Forwarded-User             [Cullis Mastio cloud]
+[browser Anna]  ──┼─→ [nginx :8080] ──→ [Cullis Chat SPA] ──→ [Connector :7777, AUTH_MODE=local]
+[browser Luca]  ──┘     ↑                                        ↓ DPoP+mTLS, per-user UserPrincipal cert
+                        /login form (real bcrypt auth)            ↓
+                        admin provisions via /admin/users    [Cullis Mastio]
 ```
+
+**Legacy shared-mode SSO** (pre-v0.2.0): set `AMBASSADOR_MODE=shared` in `frontdesk.env` to fall back to the `X-Forwarded-User` injection pattern. Kept for back-compat with existing deploys; new deploys should prefer `AUTH_MODE=local` or wire OIDC delegation upstream of the bundle (oauth2-proxy + corporate IdP).
 
 ## Prerequisites
 

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -87,7 +87,8 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
-  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0-rc1)
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0-rc2)
+  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.2.0-rc1)
   CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.1.0-rc1)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
@@ -156,8 +157,8 @@ _load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 |
 ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
-CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0-rc1}"
-CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.1.0-rc1}"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0-rc2}"
+CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.2.0-rc1}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"
 HTTP_PORT="$(_load_env FRONTDESK_HTTP_PORT)";         HTTP_PORT="${HTTP_PORT:-8080}"
@@ -349,9 +350,22 @@ echo -e "  ${BOLD}Mastio target${RESET}    ${GRAY}${SITE_URL_DISPLAY}${RESET}"
 echo -e "  ${BOLD}Org${RESET}              ${GRAY}${ORG_ID} (${TRUST_DOMAIN})${RESET}"
 echo -e "  ${BOLD}Profile${RESET}          ${GRAY}${CONNECTOR_PROFILE} (data: ${DATA_DIR})${RESET}"
 echo ""
-echo "  Smoke test (dev fake-SSO injects X-Forwarded-User from ?user=):"
-echo "    open http://localhost:${HTTP_PORT}?user=mario"
-echo "    open http://localhost:${HTTP_PORT}?user=anna   # incognito tab"
+if [[ "${AMBASSADOR_MODE:-}" == "shared" ]]; then
+    echo "  ${YELLOW}Legacy shared mode active${RESET} (AMBASSADOR_MODE=shared)."
+    echo "    open http://localhost:${HTTP_PORT}?user=mario   # X-Forwarded-User dev only"
+    echo "    open http://localhost:${HTTP_PORT}?user=anna    # incognito tab"
+else
+    echo "  Next steps (ADR-025 local-auth):"
+    echo "    1. Pre-create users via the admin API (X-Admin-Secret guarded):"
+    echo ""
+    echo "       ADMIN=\"\$(grep '^MCP_PROXY_ADMIN_SECRET' ../cullis-mastio-bundle/proxy.env | cut -d= -f2-)\""
+    echo "       curl -X POST http://localhost:${HTTP_PORT}/admin/users \\"
+    echo "         -H \"X-Admin-Secret: \$ADMIN\" -H 'Content-Type: application/json' \\"
+    echo "         -d '{\"user_name\":\"mario\",\"password\":\"temp123!\",\"display_name\":\"Mario Rossi\"}'"
+    echo ""
+    echo "    2. Open the SPA in a browser and sign in:"
+    echo "       open http://localhost:${HTTP_PORT}/login"
+fi
 echo ""
 echo "  Useful commands:"
 echo "    $COMPOSE --env-file frontdesk.env logs -f connector"

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -6,12 +6,12 @@
 # ghcr.io — the bundle no longer requires a repo checkout or local
 # ``docker build``.
 #
-#   nginx          80   reverse proxy + (dev) fake-SSO injecting X-Forwarded-User
+#   nginx          80   reverse proxy
 #     ↓
 #   cullis-chat    8080 nginx-static SPA, Frontdesk-branded build
 #                       (ghcr.io/cullis-security/cullis-chat-frontdesk)
 #     ↓
-#   connector      7777 cullis-connector dashboard + Ambassador (shared mode)
+#   connector      7777 cullis-connector dashboard + ADR-025 local-auth
 #                       (ghcr.io/cullis-security/cullis-connector)
 #     ↓ DPoP+mTLS
 #   [Cullis Mastio cloud — out of scope for this bundle]
@@ -32,15 +32,26 @@
 #                                                # missing, runs the one-shot
 #                                                # enrollment, brings up the
 #                                                # stack, waits for health
-#   open http://localhost:8080?user=mario        # demo user switch (dev only)
+#   open http://localhost:8080/login             # ADR-025 local-auth login
+#                                                # form (default: AUTH_MODE=local)
 #
 #   Run ``docker compose --env-file frontdesk.env up -d`` directly only if
 #   you have already enrolled the Connector and provisioned frontdesk.env
 #   by hand (see ./deploy.sh source for the underlying steps).
 #
-# Production: replace nginx with oauth2-proxy + your IDP. The
-# X-Forwarded-User header MUST come from a trusted proxy; the Connector
-# refuses requests whose source IP is not in CULLIS_TRUSTED_PROXIES.
+# Default auth: ADR-025 ``AUTH_MODE=local`` ships a real /login form
+# backed by users.db (bcrypt hashed). The admin pre-creates accounts
+# via ``POST /admin/users`` with ``X-Admin-Secret``, then employees
+# sign in. Per-user UserPrincipal certs are minted by the sibling
+# Mastio after each login (post-login CSR flow).
+#
+# Legacy fake-SSO mode: set ``AMBASSADOR_MODE=shared`` in frontdesk.env
+# to fall back to the pre-v0.2.0 ``X-Forwarded-User``-injected pattern.
+# Trusted proxies guard required (``CULLIS_TRUSTED_PROXIES``).
+#
+# Production: in either mode, replace nginx with oauth2-proxy + your
+# IdP for the strongest posture (TLS termination + corporate MFA +
+# OIDC delegation back to Mastio).
 # =============================================================================
 
 services:
@@ -66,9 +77,11 @@ services:
 
   connector:
     image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0-rc2}
-    # ``dashboard`` mounts the Ambassador router via web.py lifespan when
-    # AMBASSADOR_MODE=shared (cullis_connector/web.py:152). Bind to all
-    # interfaces inside the container so nginx can reach it.
+    # ``dashboard`` mounts the local-auth router (ADR-025) by default; the
+    # legacy fake-SSO Ambassador shared-mode is reachable by setting
+    # ``AMBASSADOR_MODE=shared`` explicitly in frontdesk.env. ADR-025
+    # gives a real /login form, bcrypt-hashed users.db, and per-user
+    # UserPrincipal certs minted by the sibling Mastio.
     command: >
       dashboard
       --host 0.0.0.0
@@ -78,13 +91,20 @@ services:
     expose:
       - "7777"
     environment:
-      # Shared mode wiring (ADR-021 PR4c). Required.
-      AMBASSADOR_MODE: shared
+      # ADR-025 dual-mode auth. ``local`` (default) gives the SPA a real
+      # /login form backed by users.db; admin pre-creates accounts via
+      # POST /admin/users with X-Admin-Secret. To fall back to the
+      # legacy ``X-Forwarded-User``-based shared-mode SSO that the bundle
+      # shipped before v0.2.0, set ``AMBASSADOR_MODE=shared`` in
+      # frontdesk.env explicitly (also requires CULLIS_TRUSTED_PROXIES).
+      AUTH_MODE: ${AUTH_MODE:-local}
+      AMBASSADOR_MODE: ${AMBASSADOR_MODE:-}
+      CULLIS_CONNECTOR_ADMIN_SECRET: ${CULLIS_CONNECTOR_ADMIN_SECRET:-}
       CULLIS_FRONTDESK_ORG_ID: ${CULLIS_FRONTDESK_ORG_ID}
       CULLIS_FRONTDESK_TRUST_DOMAIN: ${CULLIS_FRONTDESK_TRUST_DOMAIN}
       # Trust the docker bridge network so X-Forwarded-User from nginx is
-      # accepted. Default covers the bridge networks docker hands out by
-      # default (172.16.0.0/12). Tighten if you know your CIDR.
+      # accepted when (and only when) AMBASSADOR_MODE=shared. Default
+      # covers the bridge networks docker hands out (172.16.0.0/12).
       CULLIS_TRUSTED_PROXIES: ${CULLIS_TRUSTED_PROXIES:-127.0.0.1/32,::1/128,172.16.0.0/12}
       CULLIS_FRONTDESK_COOKIE_TTL_S: ${CULLIS_FRONTDESK_COOKIE_TTL_S:-3600}
       # Where Mastio's CSR endpoint lives. Falls back to site_url when empty.


### PR DESCRIPTION
## Summary

The frontdesk-bundle-v0.2.0-rc1 cut shipped the ADR-025 backend in `cullis-connector:0.4.0-rc2` but kept the legacy shared-mode SSO active by default, so the new /login form + admin Users tab were unreachable on a fresh `./deploy.sh`. This PR makes ADR-025 the default and corrects the stale references in deploy.sh that the v0.2.0-rc1 cut missed.

## Three bugs found by the AI-as-customer dogfood after rc2 image

- **N6**: `deploy.sh:159` hardcoded `CONNECTOR_VERSION:-0.4.0-rc1` + `CHAT_VERSION:-0.1.0-rc1`. PR #555 bumped `docker-compose.yml` + `frontdesk.env.example` but missed the shell defaults — split-brain pulls (`docker run` one-shot pulled rc1 while `compose up` pulled rc2).
- **N7**: deploy summary suggested `open ?user=mario` (legacy fake-SSO) regardless of the active auth mode. Now branches on `AMBASSADOR_MODE`: local-mode prints the admin-provisioning curl + /login URL; shared-mode keeps the `?user=` smoke as opt-in legacy.
- **N8 (root cause)**: `docker-compose.yml` hardcoded `AMBASSADOR_MODE: shared`, which Phase 2 of ADR-025 documented as taking precedence over `AUTH_MODE`. Result: the bundle shipped the new image but the new behaviour was suppressed.

## Changes

- `docker-compose.yml` connector environment:
  - `AUTH_MODE=${AUTH_MODE:-local}` (new default)
  - `AMBASSADOR_MODE=${AMBASSADOR_MODE:-}` (unset by default — opt-in via frontdesk.env)
  - `CULLIS_CONNECTOR_ADMIN_SECRET` surfaced
- `deploy.sh` defaults bumped to `CONNECTOR_VERSION=0.4.0-rc2` + `CHAT_VERSION=0.2.0-rc1`
- `deploy.sh` summary branches on auth mode (local prints admin-provisioning curl + /login; shared keeps `?user=` example)
- `README.md` intro explains auth-mode default + fallback

## Roll-out

Re-cut `frontdesk-bundle-v0.2.0-rc2` after this lands. Existing operators who pinned `AMBASSADOR_MODE=shared` in frontdesk.env are unaffected; new `./deploy.sh` runs activate ADR-025 out of the box.

No image / runtime change — bundle config + script + docs only.

## Test plan

- [x] `bash -n deploy.sh` syntax OK
- [x] AI-as-customer host-side dogfood verified the bundle (pre-fix) was running AMBASSADOR_MODE=shared (wrong default)
- [ ] CI green
- [ ] VM dogfood with rc2 to validate end-to-end login + send messaggio