### PR TITLE
fix(frontdesk-bundle): proxy /api/auth/* + /admin/* to the Connector (ADR-025)

### DIFF
--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -77,6 +77,11 @@ server {
     # local Bearer (single mode); whoami reads it back; logout clears
     # it. All three live on the Connector after ADR-019 Phase 8a + 8b-2a;
     # the SPA's old Astro server-side equivalents are gone (Phase 8b-2b).
+    #
+    # NOTE: only mounted on the Connector when AMBASSADOR_MODE=shared.
+    # In ADR-025 local-auth mode (default since v0.2.0-rc2) the SPA hits
+    # /api/auth/* below instead; the 404 surfaced here in local mode is
+    # by design.
     location /api/session/ {
         proxy_pass http://connector:7777$request_uri;
         proxy_http_version 1.1;
@@ -85,6 +90,39 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-User $forwarded_user;
+    }
+
+    # ----- /api/auth/*: ADR-025 local-auth login flow ---------------------
+    #
+    # Mounted on the Connector when AUTH_MODE=local (the v0.2.0-rc2
+    # default). Surfaces /login + /change-password + /whoami-local +
+    # /logout + /runtime-info + /reprovision. The SPA LoginForm and
+    # ChangePasswordForm components POST here directly. ``X-Forwarded-User``
+    # is intentionally NOT injected — local-auth verifies the password
+    # against bcrypt in users.db, no upstream identity claim required.
+    location /api/auth/ {
+        proxy_pass http://connector:7777$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # ----- /admin/*: ADR-025 admin Users / audit endpoints -----------------
+    #
+    # ``X-Admin-Secret`` gated on the Connector. The AdminUsers SPA tab
+    # pulls these to provision/list/delete/reset users; ops also calls
+    # them with curl. The secret never reaches nginx (it's only on the
+    # caller's request header), so no special handling here besides the
+    # passthrough.
+    location /admin/ {
+        proxy_pass http://connector:7777$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     # ----- /v1/*: bypass the SPA, direct to the Ambassador -----


### PR DESCRIPTION
## Summary

frontdesk-bundle-v0.2.0-rc2 flipped the auth default to local-mode (#559) but the bundle nginx config still proxied only the legacy `/api/session/*` + `/v1/*` + `/` routes. Every ADR-025 endpoint (`/api/auth/*`, `/admin/*`) hit the catch-all `/` and was passed to the static `cullis-chat` SPA server, which 404'd or redirected back to the SPA index.

Net effect: bundle defaults to local-auth, SPA renders the LoginForm, but `POST /api/auth/login` 404s — user cannot sign in.

Verified by AI-as-customer dogfood with rc2: `AUTH_MODE=local` confirmed in container env, `/api/auth/runtime-info` returned SPA HTML instead of JSON.

## Fix

Two new location blocks in `packaging/frontdesk-bundle/nginx/default.conf`:
- `/api/auth/` → `connector:7777` (login, change-password, whoami-local, logout, runtime-info, reprovision). No `X-Forwarded-User` injection (local-auth uses bcrypt).
- `/admin/` → `connector:7777` (Users + audit). `X-Admin-Secret` flows through verbatim.

`/api/session/*` block kept for `AMBASSADOR_MODE=shared` back-compat.

## Test plan

- [x] Pre-fix: `curl /api/auth/runtime-info` returns SPA HTML
- [ ] Post-fix: `curl /api/auth/runtime-info` returns JSON `{auth_mode:"local",...}`
- [ ] Post-fix: AI-as-customer dogfood end-to-end on rc3

## Roll-out

Re-cut `frontdesk-bundle-v0.2.0-rc3` after merge. Bump README + site /download.