### PR TITLE
docs: bump Frontdesk bundle quickstart to v0.2.0-rc3 (ADR-025 fully wired)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd cullis-mastio-bundle && ./deploy.sh
 
 # 2. Frontdesk (multi-user chat on :8080, enrolls against the Mastio above)
 cd ..
-curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.2.0-rc1/cullis-frontdesk-bundle.tar.gz | tar xz
+curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.2.0-rc3/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle && ./deploy.sh
 ```
 

--- a/site/src/pages/download.astro
+++ b/site/src/pages/download.astro
@@ -198,14 +198,14 @@ cd cullis-mastio-bundle &amp;&amp; ./deploy.sh</code></pre>
         <li>
           <div class="bundle-head">
             <strong>Frontdesk bundle</strong>
-            <span class="bundle-tag">frontdesk-bundle-v0.2.0-rc1</span>
+            <span class="bundle-tag">frontdesk-bundle-v0.2.0-rc3</span>
           </div>
           <p class="bundle-blurb">
             Multi-user Cullis Chat (SPA on <code>:8080</code>) co-located
             with a Mastio on the same host. Adds a shared-mode Connector
             so multiple human users issue ADR-020 user principals.
           </p>
-          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.2.0-rc1/cullis-frontdesk-bundle.tar.gz | tar xz
+          <pre class="bundle-cmd"><code>curl -L https://github.com/cullis-security/cullis/releases/download/frontdesk-bundle-v0.2.0-rc3/cullis-frontdesk-bundle.tar.gz | tar xz
 cd cullis-frontdesk-bundle &amp;&amp; ./deploy.sh</code></pre>
         </li>
 


### PR DESCRIPTION
AI-as-customer dogfood T+47s confirmed rc3 sblocca il flusso ADR-025 (admin/users + login + change-password + whoami-local). README + site /download a rc3.