### PR TITLE
fix(frontdesk-bundle): collapse CSP add_header to single line — nginx does not honour line-continuation

### DIFF
--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -55,17 +55,19 @@ server {
     # nonce path requires an Astro middleware (gone) or a server-side
     # injector. Auto-hash via Astro's experimental CSP is the right
     # follow-up; tracked separately.
-    add_header Content-Security-Policy
-        "default-src 'self'; \
-         script-src 'self' 'unsafe-inline'; \
-         style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; \
-         font-src 'self' https://fonts.gstatic.com https://api.fontshare.com https://cdn.fontshare.com data:; \
-         img-src 'self' data:; \
-         connect-src 'self'; \
-         object-src 'none'; \
-         base-uri 'self'; \
-         frame-ancestors 'none'; \
-         form-action 'self'" always;
+    # IMPORTANT: keep this on a single physical line.
+    #
+    # Nginx does NOT interpret a trailing backslash inside a string
+    # argument as line-continuation — it copies the literal "\" + the
+    # following whitespace into the response header. Browsers then stop
+    # parsing the CSP at the first stray "\" and only apply
+    # ``default-src 'self'``. ``script-src 'unsafe-inline'`` is silently
+    # dropped, Astro's hydration scripts are blocked, the SPA never
+    # mounts, the LoginForm submit button stays disabled (its enabled
+    # state is set by React state that never initialises). The visible
+    # symptom is "click does nothing" with a wall of CSP errors in
+    # DevTools.
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.fontshare.com; font-src 'self' https://fonts.gstatic.com https://api.fontshare.com https://cdn.fontshare.com data:; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "same-origin" always;


### PR DESCRIPTION
Bug N18 from the 2026-05-09 VM dogfood with rc3.

The multi-line CSP policy used trailing backslashes for readability. Nginx does NOT honour line-continuation inside add_header string arguments — the literal `\` + newline land in the response header, browsers stop parsing the CSP at the first stray backslash, and only `default-src 'self'` applies. SPA hydration scripts get CSP-blocked, React islands never mount, LoginForm submit button stays `cursor: not-allowed`, clicks do nothing.

Fix: single physical line. Same policy, no embedded backslashes.

## Test plan

- [x] Verified the broken header on rc3 deploy: `Content-Security-Policy: default-src 'self'; \\ script-src ...` (literal backslash in the wire)
- [ ] CI green
- [ ] Re-dogfood VM with rc4 — login form actually clicks.