### PR TITLE
fix(connector+spa): bundle dogfood polish (N17 + N20 + N21)

### DIFF
--- a/cullis_connector/identity/csr_flow.py
+++ b/cullis_connector/identity/csr_flow.py
@@ -35,6 +35,7 @@ becomes optional.
 """
 from __future__ import annotations
 
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -102,6 +103,43 @@ class PrincipalCoordinates:
         return f"spiffe://{self.principal_id}"
 
 
+def _org_id_from_enrolled_agent(env: dict[str, str]) -> Optional[str]:
+    """Try to extract the org_id from the Connector's enrolled agent_id.
+
+    The Connector's ``cullis-connector enroll`` writes its agent_id in the
+    canonical ``<org_id>::<agent_name>`` form into the profile metadata
+    (``<config_dir>/profiles/<profile>/identity/metadata.json``). When
+    Mastio derives its org_id randomly at first-boot (no env override),
+    the Frontdesk bundle has no way to know that random hex via env, and
+    a CSR with the bundle's default ``acme`` org gets refused with a
+    "principal in a different org" 403. Reading the org_id back from
+    the enrolled agent_id keeps both sides aligned without forcing the
+    operator to copy a random hex into frontdesk.env.
+    """
+    config_dir = (env.get("CULLIS_CONNECTOR_CONFIG_DIR") or "").strip()
+    if not config_dir:
+        # The Connector image runs as ``cullis`` with home
+        # ``/home/cullis`` and the bundle bind-mounts ``connector_data``
+        # there. Default to that path so the resolver works in the
+        # shipped container without extra wiring.
+        config_dir = "/home/cullis/.cullis"
+    profile = (env.get("CONNECTOR_PROFILE") or "frontdesk").strip() or "frontdesk"
+    metadata_path = os.path.join(
+        config_dir, "profiles", profile, "identity", "metadata.json"
+    )
+    try:
+        with open(metadata_path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    agent_id = payload.get("agent_id")
+    if not isinstance(agent_id, str) or "::" not in agent_id:
+        return None
+    org, _, _ = agent_id.partition("::")
+    org = org.strip()
+    return org or None
+
+
 def resolve_principal_coordinates(
     user_name: str,
     *,
@@ -109,17 +147,34 @@ def resolve_principal_coordinates(
 ) -> PrincipalCoordinates:
     """Build a :class:`PrincipalCoordinates` from env + user_name.
 
-    Reads ``CULLIS_FRONTDESK_TRUST_DOMAIN`` + ``CULLIS_FRONTDESK_ORG_ID``,
-    falling back to ``laptop`` / ``local`` when either is missing or
-    blank. Empty / whitespace ``user_name`` raises ``ValueError`` so a
-    caller cannot accidentally mint a principal_id with an empty name
+    Resolution order for ``org_id``:
+
+    1. ``CULLIS_FRONTDESK_ORG_ID`` env override (operator decided
+       explicitly).
+    2. The org component of the Connector's *enrolled* ``agent_id``
+       (read from ``profiles/<profile>/identity/metadata.json``). This
+       is the right value 99% of the time: it is the org the sibling
+       Mastio actually uses, so the CSR's principal_id lives in the
+       same org as the Connector cert that signs it.
+    3. ``DEFAULT_ORG_ID`` fallback for fresh installs that have not
+       enrolled yet.
+
+    ``trust_domain`` resolves from env override + fallback. The
+    enrollment payload does not currently carry trust_domain
+    explicitly; until ``cullis-connector enroll`` plumbs it through,
+    operators that override env stay supported and dev/laptop installs
+    land on ``laptop``.
+
+    Empty / whitespace ``user_name`` raises ``ValueError`` so a caller
+    cannot accidentally mint a principal_id with an empty name
     component.
     """
     if not isinstance(user_name, str) or not user_name.strip():
         raise ValueError("user_name must be a non-empty string")
     e = env if env is not None else os.environ
     trust_domain = (e.get(ENV_TRUST_DOMAIN) or "").strip() or DEFAULT_TRUST_DOMAIN
-    org_id = (e.get(ENV_ORG_ID) or "").strip() or DEFAULT_ORG_ID
+    org_env = (e.get(ENV_ORG_ID) or "").strip()
+    org_id = org_env or _org_id_from_enrolled_agent(e) or DEFAULT_ORG_ID
     return PrincipalCoordinates(
         trust_domain=trust_domain,
         org_id=org_id,

--- a/frontend/cullis-chat/src/components/auth/LoginForm.tsx
+++ b/frontend/cullis-chat/src/components/auth/LoginForm.tsx
@@ -28,6 +28,29 @@ export default function LoginForm() {
   const [retryAfter, setRetryAfter] = useState(0);
   const [provisioningWarn, setProvisioningWarn] = useState<string | null>(null);
 
+  // ADR-025 Phase 5 follow-up (bug N17, 2026-05-09 VM dogfood): if the
+  // browser's password manager auto-fills both fields before React
+  // hydrates, the controlled inputs end up displaying the auto-filled
+  // values but our React state stays at the empty initial value. The
+  // submit button (disabled on ``!userName || !password``) never
+  // re-enables and clicks do nothing. Reading the DOM values once the
+  // hydration is mounted backfills the state so the form behaves the
+  // way the user expects.
+  useEffect(() => {
+    const u = document.getElementById('user_name') as HTMLInputElement | null;
+    const p = document.getElementById('password') as HTMLInputElement | null;
+    if (u && u.value && !userName) setUserName(u.value);
+    if (p && p.value && !password) setPassword(p.value);
+    // Defer one tick so Brave / Chrome autofill (which fires AFTER the
+    // mount event in some flows) has had a chance to populate.
+    const t = setTimeout(() => {
+      if (u && u.value && !userName) setUserName(u.value);
+      if (p && p.value && !password) setPassword(p.value);
+    }, 200);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Tick down the retry-after countdown.
   useEffect(() => {
     if (retryAfter <= 0) return;

--- a/frontend/cullis-chat/src/lib/session-singleton.ts
+++ b/frontend/cullis-chat/src/lib/session-singleton.ts
@@ -37,16 +37,31 @@ export function redirectToLogin(): void {
 }
 
 async function bootstrap(): Promise<void> {
+  // ADR-025 Phase 5 follow-up (bug N20, 2026-05-09 VM dogfood):
+  // ``/api/session/init`` is only mounted when the Connector runs in
+  // shared mode (AMBASSADOR_MODE=shared). In local mode the SPA
+  // already has its session cookie minted by /api/auth/login, so
+  // calling /api/session/init returns 403 and clutters the UI with a
+  // misleading error banner. Probe runtime-info first and skip the
+  // legacy bootstrap when ``auth_mode === 'local'``.
+  const info = await fetchRuntimeInfo();
+  if (info && info.auth_mode === 'local') {
+    // The local-mode session cookie was issued by /api/auth/login.
+    // If the user is on a chat page without a valid cookie (cookie
+    // expired, never logged in), the IdentityBadge whoami probe will
+    // catch the 401 and redirect to /login — that's the right entry
+    // point in local mode, NOT /api/session/init.
+    return;
+  }
   try {
     await initSession();
     return;
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) {
-      // Only chase the local-mode redirect when the Connector says
-      // it is in local mode. In OIDC mode we let the caller surface
-      // the error so the UI can render an SSO bootstrap link.
-      const info = await fetchRuntimeInfo();
-      if (info && info.auth_mode === 'local') {
+      // Defensive: runtime-info absent (older Connector image) but
+      // session/init says we are not signed in — assume local-mode
+      // semantics and redirect to /login.
+      if (!info) {
         redirectToLogin();
       }
     }


### PR DESCRIPTION
fix(connector+spa): bundle dogfood polish (N17 + N20 + N21)

Three bugs from the 2026-05-09 dogfood of frontdesk-bundle-v0.2.0-rc3.

N17 LoginForm autofill: Brave/Chrome populate the input DOM values
before React hydrates, so the controlled-input state stays empty and
the submit button stuck disabled. Fix: useEffect backfills state from
the DOM values once at mount and again 200ms later.

N20 SPA hit legacy /api/session/init in local mode: that route is
mounted only with AMBASSADOR_MODE=shared, so AUTH_MODE=local installs
saw a 403 banner cover the chat. Fix: session-singleton probes
/api/auth/runtime-info first and short-circuits the legacy bootstrap
when auth_mode is local.

N21 CSR refused with cross-org error: csr_flow built principal_id
from CULLIS_FRONTDESK_ORG_ID env (default acme) while Mastio standalone
auto-derives a random hex org. Fix: when the env override is unset,
read the org_id back from the Connector's enrolled agent_id (canonical
org::agent format persisted in profiles/<p>/identity/metadata.json).
Env override stays honoured.

Tests: 15/15 connector csr_flow + 17/17 SPA auth.test.ts.

Roll-out cuts: connector-v0.4.0-rc3, chat-v0.2.0-rc2,
frontdesk-bundle-v0.2.0-rc4.
