### PR TITLE
fix(mastio-bundle): scriptable first-boot + org-id export to unblock chained deploys

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -97,6 +97,18 @@ class ProxySettings(BaseSettings):
     # same filesystem. Ignored when ``dashboard_signing_key`` is set.
     dashboard_signing_key_path: str = "certs/.mcp_proxy_dashboard_signing_key"
 
+    # Optional bcrypt seed for the very first boot. When set AND no
+    # ``proxy_config.admin_password_hash`` row exists yet, the lifespan
+    # hashes this value and persists it so the operator can reach
+    # /proxy/login without first opening /proxy/register in a browser.
+    # Subsequent boots ignore this var (the existing hash wins) so a
+    # rotation happens via the dashboard, not by editing the env file.
+    # Empty (default) preserves the historical "browser wizard" UX.
+    # Used by packaging/mastio-bundle/deploy.sh so a release tarball can
+    # come up fully self-serve in CI / scripted demos / Frontdesk
+    # bring-up where blocking on a browser is not acceptable.
+    initial_admin_password: str = ""
+
     # Break-glass re-enable for the local admin password sign-in path.
     # Normal state: operators flip the toggle in Settings → Sign-in methods,
     # which writes ``proxy_config.local_password_enabled`` in the DB. Setting

--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -334,6 +334,30 @@ async def is_admin_password_set() -> bool:
     return bool(await get_config(ADMIN_PASSWORD_KEY))
 
 
+async def seed_initial_admin_password(plaintext: str) -> bool:
+    """First-boot only: hash + persist ``plaintext`` if no hash exists yet.
+
+    Returns True if a fresh hash was written, False if a password was
+    already set (so the seed is ignored, the dashboard remains the
+    rotation surface) or if the value is empty (no-op).
+
+    This is the scripted-bring-up counterpart to /proxy/register: the
+    Mastio bundle (``packaging/mastio-bundle/deploy.sh``) mints a random
+    password on first run, exports it via ``MCP_PROXY_INITIAL_ADMIN_PASSWORD``,
+    and the operator reads it back from a file on disk; subsequent
+    boots are no-ops because the persisted hash wins. Without this, a
+    fresh Mastio cannot come up self-serve (Frontdesk bundle, CI,
+    customer quickstart), every flow blocks on a browser hop into the
+    register form.
+    """
+    if not plaintext:
+        return False
+    if await is_admin_password_set():
+        return False
+    await set_admin_password(plaintext)
+    return True
+
+
 async def set_admin_password(plaintext: str) -> None:
     """Hash the password with bcrypt and persist it.
 

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -137,6 +137,29 @@ async def lifespan(app: FastAPI):
     # 2. Initialize database
     await init_db(settings.database_url)
 
+    # 2a. First-boot scripted admin password seed. No-op when the var is
+    # unset OR when proxy_config.admin_password_hash already exists.
+    # Used by packaging/mastio-bundle/deploy.sh so a fresh tarball can
+    # come up fully self-serve (Frontdesk bring-up, CI, customer
+    # quickstart) without blocking on the /proxy/register browser hop.
+    # Rotation goes through the dashboard, not by editing this env.
+    if settings.initial_admin_password:
+        try:
+            from mcp_proxy.dashboard.session import seed_initial_admin_password
+            seeded = await seed_initial_admin_password(
+                settings.initial_admin_password,
+            )
+            if seeded:
+                _log.info(
+                    "First-boot admin password seeded from "
+                    "MCP_PROXY_INITIAL_ADMIN_PASSWORD; rotate via /proxy/login",
+                )
+        except Exception as exc:  # never block lifespan on the seed
+            _log.warning(
+                "First-boot admin password seed failed (operator can still "
+                "register via /proxy/register): %s", exc,
+            )
+
     # 2b. Initialize the shared Redis client (audit F-B-12).
     # Empty REDIS_URL is a supported single-instance configuration —
     # ``init_redis`` is a no-op, and callers (JTI store, rate limiter)

--- a/packaging/frontdesk-bundle/generate-frontdesk-env.sh
+++ b/packaging/frontdesk-bundle/generate-frontdesk-env.sh
@@ -89,6 +89,26 @@ default_ca_bundle() {
     echo ""
 }
 
+# Sibling Mastio bundle exports the auto-derived org_id to
+# ./certs/org-id alongside the CA. Without picking it up, the
+# Frontdesk default ``acme`` is wrong against a standalone Mastio's
+# 16-char hex id, the SPIFFE attribution silently mismatches, and the
+# operator only finds out when audit rows show the wrong principal.
+default_org_id() {
+    local candidates=(
+        "$SCRIPT_DIR/../cullis-mastio-bundle/certs/org-id"
+        "$SCRIPT_DIR/../mastio-bundle/certs/org-id"
+    )
+    local sibling
+    for sibling in "${candidates[@]}"; do
+        if [[ -f "$sibling" ]]; then
+            tr -d '[:space:]' < "$sibling"
+            return
+        fi
+    done
+    echo ""
+}
+
 case "$MODE" in
     prod)
         [[ -n "${CULLIS_FRONTDESK_ORG_ID:-}" ]]         || die "--prod requires CULLIS_FRONTDESK_ORG_ID env var"
@@ -100,7 +120,14 @@ case "$MODE" in
         CA_BUNDLE="${CULLIS_FRONTDESK_CA_BUNDLE_HOST}"
         ;;
     defaults)
-        ORG_ID="${CULLIS_FRONTDESK_ORG_ID:-acme}"
+        # ORG_ID precedence: explicit env > sibling Mastio export
+        # (./certs/org-id, written by mastio-bundle deploy.sh) > legacy
+        # ``acme`` placeholder. The sibling lookup matches the same
+        # tarball-vs-repo dance default_ca_bundle does, so the two
+        # auto-detects move together: if the operator ran the Mastio
+        # bundle, both org_id and the CA come from there.
+        ORG_ID="${CULLIS_FRONTDESK_ORG_ID:-$(default_org_id)}"
+        ORG_ID="${ORG_ID:-acme}"
         TRUST_DOMAIN="${CULLIS_FRONTDESK_TRUST_DOMAIN:-${ORG_ID}.test}"
         CA_BUNDLE="${CULLIS_FRONTDESK_CA_BUNDLE_HOST:-$(default_ca_bundle)}"
         if [[ -z "$CA_BUNDLE" ]]; then
@@ -118,9 +145,14 @@ case "$MODE" in
         echo ""
         _default_ca="$(default_ca_bundle)"
         ca_prompt_default="${_default_ca:-./mastio-org-ca.pem}"
+        # Sibling Mastio bundle (if present) wins the org_id default
+        # over the legacy ``acme``. Operator can still override at the
+        # prompt, but the offered default is the right one.
+        _default_org_id="$(default_org_id)"
+        org_prompt_default="${_default_org_id:-acme}"
 
-        read -rp "  Org ID [acme]: " ORG_ID
-        ORG_ID="${ORG_ID:-acme}"
+        read -rp "  Org ID [${org_prompt_default}]: " ORG_ID
+        ORG_ID="${ORG_ID:-${org_prompt_default}}"
 
         read -rp "  SPIFFE trust domain [${ORG_ID}.test]: " TRUST_DOMAIN
         TRUST_DOMAIN="${TRUST_DOMAIN:-${ORG_ID}.test}"

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -343,6 +343,39 @@ else
     rm -f "$ORG_CA_HOST" 2>/dev/null
 fi
 
+# Export Org ID alongside the Org CA. Standalone Mastios derive a
+# 16-char hex id from the Org CA at first boot (proxy_config.org_id);
+# downstream bundles (Frontdesk in particular) need it to set
+# CULLIS_FRONTDESK_ORG_ID. Without this, generate-frontdesk-env.sh
+# defaults to ``acme`` / ``acme.test`` which doesn't match the Mastio,
+# and a SPIFFE id mismatch surfaces only at runtime when the audit
+# chain attribution starts looking wrong. Read the value out of the
+# health endpoint via curl + jq is fragile (jq may be missing, the
+# endpoint shape evolves); read it directly from the sqlite DB the
+# Mastio writes at first boot.
+ORG_ID_HOST="$CERT_DIR/org-id"
+if [[ -n "$PROXY_CID" ]]; then
+    ORG_ID_VAL="$(docker exec "$PROXY_CID" python3 -c "
+import sqlite3
+try:
+    c = sqlite3.connect('/data/mcp_proxy.db')
+    row = c.execute(\"SELECT value FROM proxy_config WHERE key='org_id'\").fetchone()
+    print(row[0] if row else '')
+except Exception:
+    print('')
+" 2>/dev/null)"
+    ORG_ID_VAL="${ORG_ID_VAL//[$'\t\r\n ']}"
+    if [[ -n "$ORG_ID_VAL" ]]; then
+        echo "$ORG_ID_VAL" > "$ORG_ID_HOST"
+        chmod 644 "$ORG_ID_HOST"
+        ok "Org ID exported to ./certs/org-id (${ORG_ID_VAL})"
+    else
+        warn "Could not read org_id from proxy_config — Frontdesk bundle"
+        warn "will fall back to its default org slug. Set"
+        warn "CULLIS_FRONTDESK_ORG_ID manually in frontdesk.env."
+    fi
+fi
+
 PUBLIC_URL="$(grep -E '^MCP_PROXY_PROXY_PUBLIC_URL=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
 PUBLIC_URL="${PUBLIC_URL:-https://localhost:${PROXY_PORT}}"
 
@@ -356,13 +389,23 @@ if [[ -f "$ORG_CA_HOST" ]]; then
     echo -e "                   ${GRAY}use as CULLIS_FRONTDESK_CA_BUNDLE_HOST when bringing up the Frontdesk bundle${RESET}"
 fi
 echo ""
+SEED_PWD="$(grep -E '^MCP_PROXY_INITIAL_ADMIN_PASSWORD=' "$SCRIPT_DIR/proxy.env" 2>/dev/null | cut -d= -f2-)"
+
 if [[ "$MODE" == "development" ]]; then
     echo "  Next steps (development):"
     echo "    1. Open ${PUBLIC_URL}/proxy/login"
     echo "       (browser will warn — TLS is signed by your local Org CA,"
     echo "        not a public CA. Accept the self-signed warning.)"
-    echo "    2. Complete the first-boot setup wizard"
-    echo "    3. Enroll agents via the Connector or paste an invite token"
+    if [[ -n "$SEED_PWD" ]]; then
+        echo "    2. Sign in as ``admin`` with this password:"
+        echo "         ${SEED_PWD}"
+        echo "       (rotate via /proxy/settings on first sign-in. The seed"
+        echo "        env is ignored on subsequent boots; the persisted hash wins.)"
+        echo "    3. Enroll agents via the Connector or paste an invite token"
+    else
+        echo "    2. Complete the first-boot setup wizard"
+        echo "    3. Enroll agents via the Connector or paste an invite token"
+    fi
 else
     echo "  Next steps (production):"
     echo "    1. Front-door TLS at your edge LB → mastio-nginx :${PROXY_PORT}"

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -39,6 +39,13 @@ services:
       MCP_PROXY_STANDALONE:        ${MCP_PROXY_STANDALONE:-true}
       MCP_PROXY_ADMIN_SECRET:      ${MCP_PROXY_ADMIN_SECRET:-change-me-in-production}
       MCP_PROXY_DASHBOARD_SIGNING_KEY: ${MCP_PROXY_DASHBOARD_SIGNING_KEY:-}
+      # First-boot scriptable admin password seed (PR #566). Empty
+      # default preserves the historical /proxy/register browser
+      # wizard. When generate-proxy-env.sh mints a value, the lifespan
+      # hashes + persists it on the very first boot only; subsequent
+      # boots ignore the env (the persisted hash wins, rotation goes
+      # through the dashboard).
+      MCP_PROXY_INITIAL_ADMIN_PASSWORD: ${MCP_PROXY_INITIAL_ADMIN_PASSWORD:-}
       MCP_PROXY_DATABASE_URL:      sqlite+aiosqlite:////data/mcp_proxy.db
       MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
       MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -68,8 +68,15 @@ gen_secret() { openssl rand -base64 32 | tr -d '/+=' | head -c 32; }
 
 ADMIN_SECRET="$(gen_secret)"
 SIGNING_KEY="$(gen_secret)"
+# Bcrypt seed for the very first lifespan: paired with the
+# MCP_PROXY_INITIAL_ADMIN_PASSWORD env that ``mcp_proxy/main.py`` reads
+# right after init_db. No-op on subsequent boots (the persisted hash
+# wins). Without this, a fresh tarball cannot come up self-serve;
+# Frontdesk + CI + customer quickstart all block on a /proxy/register
+# browser hop.
+INITIAL_ADMIN_PASSWORD="$(gen_secret)"
 
-ok "Generated random admin secret + signing key"
+ok "Generated random admin secret + signing key + first-boot password"
 
 case "$MODE" in
     prod)
@@ -108,11 +115,17 @@ sed -i "s|^MCP_PROXY_DASHBOARD_SIGNING_KEY=.*|MCP_PROXY_DASHBOARD_SIGNING_KEY=${
 sed -i "s|^MCP_PROXY_BROKER_URL=.*|MCP_PROXY_BROKER_URL=${BROKER}|"                  "$OUT"
 sed -i "s|^MCP_PROXY_BROKER_JWKS_URL=.*|MCP_PROXY_BROKER_JWKS_URL=${JWKS}|"          "$OUT"
 sed -i "s|^MCP_PROXY_PROXY_PUBLIC_URL=.*|MCP_PROXY_PROXY_PUBLIC_URL=${PUBLIC}|"      "$OUT"
+# proxy.env.example does not ship the seed line (we mint per-deploy);
+# append unconditionally. The Mastio lifespan ignores it once a hash
+# exists, so re-running --force does not surprise-reset the password.
+echo "MCP_PROXY_INITIAL_ADMIN_PASSWORD=${INITIAL_ADMIN_PASSWORD}" >> "$OUT"
 
 ok "Wrote ${OUT}"
 echo ""
-echo -e "  ${BOLD}MCP_PROXY_ADMIN_SECRET${RESET}      ${GRAY}${ADMIN_SECRET:0:8}...${RESET}"
-echo -e "  ${BOLD}MCP_PROXY_BROKER_URL${RESET}        ${GRAY}${BROKER}${RESET}"
-echo -e "  ${BOLD}MCP_PROXY_PROXY_PUBLIC_URL${RESET}  ${GRAY}${PUBLIC}${RESET}"
-echo -e "  ${BOLD}MCP_PROXY_ENVIRONMENT${RESET}       ${GRAY}${ENVIRONMENT}${RESET}"
+echo -e "  ${BOLD}MCP_PROXY_ADMIN_SECRET${RESET}            ${GRAY}${ADMIN_SECRET:0:8}…${RESET}"
+echo -e "  ${BOLD}MCP_PROXY_INITIAL_ADMIN_PASSWORD${RESET}  ${GRAY}${INITIAL_ADMIN_PASSWORD}${RESET}"
+echo -e "                                  ${GRAY}(login at /proxy/login as ``admin`` with this password, then rotate)${RESET}"
+echo -e "  ${BOLD}MCP_PROXY_BROKER_URL${RESET}              ${GRAY}${BROKER}${RESET}"
+echo -e "  ${BOLD}MCP_PROXY_PROXY_PUBLIC_URL${RESET}        ${GRAY}${PUBLIC}${RESET}"
+echo -e "  ${BOLD}MCP_PROXY_ENVIRONMENT${RESET}             ${GRAY}${ENVIRONMENT}${RESET}"
 echo ""

--- a/tests/test_proxy_initial_admin_password_seed.py
+++ b/tests/test_proxy_initial_admin_password_seed.py
@@ -1,0 +1,91 @@
+"""First-boot scriptable admin-password seed (PR #566).
+
+Covers ``mcp_proxy.dashboard.session.seed_initial_admin_password``: a
+no-op when the env value is empty OR when a hash already exists in
+``proxy_config.admin_password_hash``, otherwise hashes and persists so
+the operator can sign in at /proxy/login without first opening
+/proxy/register in a browser. The Mastio bundle reads
+``MCP_PROXY_INITIAL_ADMIN_PASSWORD`` from proxy.env, this seed is what
+turns it into a usable login.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def init_db_isolated(tmp_path, monkeypatch):
+    """Tear up a clean SQLite db on a path the lifespan ignores; we
+    drive ``init_db`` ourselves so the test owns the schema lifecycle
+    (no FastAPI lifespan dance, no shared in-memory state across
+    tests)."""
+    db_file = tmp_path / "proxy_seed_test.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.db import init_db
+    settings = get_settings()
+    await init_db(settings.database_url)
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_seed_writes_hash_when_none_exists(init_db_isolated):
+    """Happy path: pristine DB + non-empty plaintext → hash persisted,
+    helper returns True so the lifespan can log the seed event."""
+    from mcp_proxy.dashboard.session import (
+        is_admin_password_set,
+        seed_initial_admin_password,
+        verify_admin_password,
+    )
+
+    assert await is_admin_password_set() is False
+    seeded = await seed_initial_admin_password("dogfood-pass-12345")
+    assert seeded is True
+    assert await is_admin_password_set() is True
+    # The hash actually verifies the original plaintext (bcrypt round-trip).
+    assert await verify_admin_password("dogfood-pass-12345") is True
+    assert await verify_admin_password("wrong-password-xx") is False
+
+
+@pytest.mark.asyncio
+async def test_seed_is_noop_when_password_already_set(init_db_isolated):
+    """Subsequent boots must not surprise-rotate the password. The
+    persisted hash always wins; rotation goes through the dashboard."""
+    from mcp_proxy.dashboard.session import (
+        seed_initial_admin_password,
+        set_admin_password,
+        verify_admin_password,
+    )
+
+    # Operator-rotated password from a previous boot.
+    await set_admin_password("operator-rotated-pw-99")
+
+    # Bundle re-runs deploy.sh, which still carries the original env
+    # value (the seed is mint-once but the env line is sticky).
+    seeded = await seed_initial_admin_password("dogfood-pass-12345")
+    assert seeded is False
+
+    # The rotated password is still the live one.
+    assert await verify_admin_password("operator-rotated-pw-99") is True
+    assert await verify_admin_password("dogfood-pass-12345") is False
+
+
+@pytest.mark.asyncio
+async def test_seed_is_noop_for_empty_value(init_db_isolated):
+    """``MCP_PROXY_INITIAL_ADMIN_PASSWORD`` defaults to ``""`` so any
+    deploy that doesn't set it preserves the historical browser-wizard
+    UX. Empty string must short-circuit before bcrypt complains about
+    minimum length."""
+    from mcp_proxy.dashboard.session import (
+        is_admin_password_set,
+        seed_initial_admin_password,
+    )
+
+    seeded = await seed_initial_admin_password("")
+    assert seeded is False
+    assert await is_admin_password_set() is False


### PR DESCRIPTION
## Summary

Sister PR to #565. Same dogfood found two more gaps when chaining the Mastio + Frontdesk bundles end-to-end on a clean machine. Both are about the bring-up not being self-serve: a fresh Mastio still wants a browser hop into ``/proxy/register``, and the Frontdesk's ``CULLIS_FRONTDESK_ORG_ID`` quietly diverges from the Mastio's auto-derived id because there's no pickup path between the two tarballs.

### Bug 3: Mastio first-boot needs a browser

``mastio-bundle/deploy.sh`` finishes with ``Open https://localhost:9443/proxy/login`` then ``Complete the first-boot setup wizard``. There's no env var to pre-seed the admin password, so any chained flow (Frontdesk's ``deploy.sh`` invoking enroll on a freshly-booted Mastio, CI runs, customer quickstart scripts) has to interleave a human browser step. The same issue blocks deterministic dogfood in this repo.

Fix: ``MCP_PROXY_INITIAL_ADMIN_PASSWORD`` is honoured by the lifespan iff no ``proxy_config.admin_password_hash`` row exists yet (mint-once, persist, rotation through the dashboard). Empty default preserves the existing browser-wizard UX. Bundle wires it:

- ``generate-proxy-env.sh`` mints a random 32-byte password alongside ``MCP_PROXY_ADMIN_SECRET`` + ``DASHBOARD_SIGNING_KEY`` (same shape — mint once, append to ``proxy.env``).
- ``deploy.sh`` summary prints the value once with a ``rotate via /proxy/settings`` reminder when the seed is set.
- The lifespan logs the seed event so an operator inspecting Mastio logs can confirm it took.

### Bug 4: Frontdesk org_id silently mismatches

The Mastio standalone derives a 16-char hex ``org_id`` (e.g. ``3807b7496b22230c``) at first boot. The Frontdesk's ``generate-frontdesk-env.sh --defaults`` writes ``CULLIS_FRONTDESK_ORG_ID=acme``. The two never reconcile, the SPIFFE attribution downstream is wrong, and the operator only finds out at runtime when audit rows show the wrong principal.

Fix:

- ``mastio-bundle/deploy.sh`` exports ``proxy_config.org_id`` to ``./certs/org-id`` alongside the existing ``./certs/org-ca.pem`` (same sibling layout the Frontdesk already understands).
- ``frontdesk-bundle/generate-frontdesk-env.sh`` adds ``default_org_id`` mirroring ``default_ca_bundle`` (same tarball-vs-repo sibling dance) and threads it as the default for both ``--defaults`` and the interactive prompt.
- The two auto-detects move together: if the operator ran the Mastio bundle, both ``org_id`` and the CA come from there. If they didn't, the legacy ``acme`` default still works for an operator standing up Frontdesk against a non-bundle Mastio.

## Test plan

- [x] ``pytest tests/test_proxy_initial_admin_password_seed.py -n auto`` — 3 pass (happy path, idempotent on existing hash, no-op on empty env).
- [x] ``pytest tests/ -n auto --dist=loadfile`` — 2981 pass; 2 pre-existing failures in ``test_postgres_integration.py`` (postgres KeyError known issue) plus the 4 pre-existing tray-menu failures, all unrelated to this diff.
- [x] ``./demo_network/smoke.sh full`` — green (broker round-trip + dashboard session persistence + audit chain + MCP echo).
- [x] Manual bundle bring-up: ``./generate-proxy-env.sh --defaults`` mints a password, ``proxy.env`` carries the line, ``./deploy.sh`` prints it; ``./certs/org-id`` lands; ``./generate-frontdesk-env.sh --defaults`` picks up both.
- [ ] /security-review on the diff (run after CI green).

## Notes

- The seed env is sticky in ``proxy.env`` after first boot. That's by design: a re-run of ``./deploy.sh`` should not surprise-rotate the password, and the lifespan ignores it once the hash exists. Operators who want to truly reset go through ``cullis-proxy reset-password`` (the existing CLI break-glass).
- ``./certs/org-id`` is a single-line text file, no newline in the value (``tr`` strips whitespace on read). Same shape as the existing ``./certs/org-ca.pem`` from a Frontdesk consumer's perspective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)