### PR TITLE
fix(mastio-bundle): map MCP_PROXY_ANTHROPIC_API_KEY into the container

### DIFF
--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -78,6 +78,12 @@ services:
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
       MCP_PROXY_VAULT_ADDR:        ${MCP_PROXY_VAULT_ADDR:-}
       MCP_PROXY_VAULT_TOKEN:       ${MCP_PROXY_VAULT_TOKEN:-}
+      # Anthropic upstream key for the embedded AI gateway (ADR-017).
+      # Empty default disables /v1/chat/completions cleanly (the rest of
+      # the Mastio still works — registry, MCP, audit). Without this
+      # mapping the value reaches proxy.env and never the lifespan, so
+      # chat returns 503 ``provider_key_missing``.
+      MCP_PROXY_ANTHROPIC_API_KEY: ${MCP_PROXY_ANTHROPIC_API_KEY:-}
       PROXY_TRUST_DOMAIN:          ${PROXY_TRUST_DOMAIN:-}
       PROXY_INTRA_ORG:             ${PROXY_INTRA_ORG:-}
       PROXY_TRANSPORT_INTRA_ORG:   ${PROXY_TRANSPORT_INTRA_ORG:-}


### PR DESCRIPTION
## Summary
- Add `MCP_PROXY_ANTHROPIC_API_KEY: ${MCP_PROXY_ANTHROPIC_API_KEY:-}` to `packaging/mastio-bundle/docker-compose.yml`
- Without this mapping, `--env-file proxy.env` only feeds compose substitutions; the var never reaches the container, and chat returns 503 silently
- Same pattern as PR #566's `MCP_PROXY_INITIAL_ADMIN_PASSWORD` mapping

## Test plan
- [x] `docker compose --env-file proxy.env config | grep ANTHROPIC` shows value
- [x] End-to-end Frontdesk SPA → Connector → Mastio → Haiku chat returns reply (validated 2026-05-10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)