### PR TITLE
feat(dashboard): users tab create + invite via /proxy/users/create (ADR-020)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3054,13 +3054,17 @@ async def badge_users(request: Request):
 
 
 @router.get("/users", response_class=HTMLResponse)
-async def users_page(request: Request):
-    """Read-only listing of user principals registered on this Mastio.
+async def users_page(
+    request: Request,
+    new_user_name: str | None = None,
+    error: str | None = None,
+):
+    """Listing of user principals registered on this Mastio.
 
-    Backed by ``local_user_principals``, the same table the admin API
-    at ``/v1/admin/users`` writes into. Rows appear here whenever a
-    Frontdesk SSO user touches the CSR endpoint (``upsert_from_csr``)
-    or an admin pre-creates them via ``POST /v1/admin/users``.
+    Backed by ``local_user_principals``. Rows land here either via the
+    Frontdesk SSO CSR signing path (``upsert_from_csr``), via the
+    ``POST /v1/admin/users`` X-Admin-Secret API, or via the
+    ``POST /proxy/users/create`` form on this dashboard.
     """
     session = require_login(request)
     if isinstance(session, RedirectResponse):
@@ -3077,7 +3081,115 @@ async def users_page(request: Request):
         request, session,
         active="users",
         users=users,
+        new_user_name=new_user_name,
+        error=error,
     ))
+
+
+@router.post("/users/create")
+async def users_create(request: Request):
+    """Form-driven counterpart of ``POST /v1/admin/users``.
+
+    Same idempotent insert into ``local_user_principals``: re-posting an
+    existing ``user_name`` returns the existing row without overwriting
+    metadata so a real SSO touch can't be clobbered by a careless
+    re-create. The cert itself is minted on first
+    ``/v1/principals/csr`` — this row is the directory entry, not the
+    credential.
+    """
+    import re
+
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from datetime import datetime, timezone
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db, get_config
+    from mcp_proxy.config import get_settings
+
+    form = await request.form()
+    user_name = str(form.get("user_name", "")).strip()
+    display_name = str(form.get("display_name", "")).strip()
+    reach = str(form.get("reach", "intra")).strip() or "intra"
+    surface = str(form.get("surface", "")).strip() or None
+
+    if not user_name:
+        return RedirectResponse(
+            url="/proxy/users?error=user_name+is+required",
+            status_code=303,
+        )
+    if not re.fullmatch(r"[a-zA-Z0-9._\-]{1,64}", user_name):
+        return RedirectResponse(
+            url=(
+                "/proxy/users?error=user_name+must+match+[a-zA-Z0-9._-]"
+                "+and+be+at+most+64+chars"
+            ),
+            status_code=303,
+        )
+    if reach not in ("intra", "cross", "both"):
+        return RedirectResponse(
+            url="/proxy/users?error=reach+must+be+intra%2C+cross+or+both",
+            status_code=303,
+        )
+
+    org_id = await get_config("org_id") or get_settings().org_id
+    if not org_id:
+        return RedirectResponse(
+            url=(
+                "/proxy/users?error=org_id+not+set"
+                "+%E2%80%94+complete+broker+setup+first"
+            ),
+            status_code=303,
+        )
+
+    principal_id = f"{org_id}::user::{user_name}"
+    now = datetime.now(timezone.utc).isoformat()
+
+    try:
+        async with get_db() as conn:
+            existing = (await conn.execute(
+                _sql_text(
+                    "SELECT principal_id FROM local_user_principals "
+                    "WHERE principal_id = :pid"
+                ),
+                {"pid": principal_id},
+            )).first()
+            if existing is None:
+                await conn.execute(
+                    _sql_text(
+                        """
+                        INSERT INTO local_user_principals (
+                            principal_id, user_name, display_name,
+                            reach, surface, created_at
+                        ) VALUES (
+                            :pid, :uname, :disp, :reach, :surface, :now
+                        )
+                        """
+                    ),
+                    {
+                        "pid": principal_id,
+                        "uname": user_name,
+                        "disp": display_name or None,
+                        "reach": reach,
+                        "surface": surface,
+                        "now": now,
+                    },
+                )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("users_create failed user_name=%s: %s", user_name, exc)
+        from urllib.parse import quote
+        return RedirectResponse(
+            url=f"/proxy/users?error={quote(f'create failed: {exc}')}",
+            status_code=303,
+        )
+
+    return RedirectResponse(
+        url=f"/proxy/users?new_user_name={user_name}",
+        status_code=303,
+    )
 
 
 @router.get("/badge/audit")

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -1,8 +1,31 @@
 {% extends "base.html" %}
 {% block title %}Users{% endblock %}
-{% block header_title %}Users{% endblock %}
+{% block header_title %}User Principals{% endblock %}
 {% block content %}
 <div class="max-w-6xl">
+
+    <!-- New user created — confirm + remind operator they still need to
+         provision the password lato Connector for SSO to land. -->
+    {% if new_user_name %}
+    <div class="mb-6 p-5 bg-emerald-900/10 border border-emerald-600/30 rounded-lg">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 text-emerald-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <div class="flex-1">
+                <p class="text-sm font-semibold text-emerald-400 mb-1">User principal created</p>
+                <p class="text-xs text-emerald-500/70 mb-3">
+                    The Mastio reserved the principal id and seeded the
+                    directory row. The cert lands on the first SSO touch
+                    via <code class="text-accent-400/80">/v1/principals/csr</code>.
+                </p>
+                <p class="text-xs text-gray-500 mb-1">User: <span class="font-mono text-gray-400">{{ new_user_name }}</span></p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if error %}
+    <div class="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
+    {% endif %}
 
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
@@ -14,20 +37,90 @@
                 Per-user identity for Frontdesk shared mode (ADR-020 / ADR-021)
             </p>
         </div>
+        <button onclick="document.getElementById('create-panel').classList.toggle('hidden')"
+                class="px-4 py-2 text-xs font-semibold rounded transition-all"
+                style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
+                onmouseover="this.style.background='#fff'; this.style.boxShadow='0 0 20px rgba(0,229,199,0.15)'"
+                onmouseout="this.style.background='#00e5c7'; this.style.boxShadow='none'">
+            + Create User
+        </button>
     </div>
 
-    <!-- Context banner — explain how rows land here, since the page
-         is read-only and operators arriving from the install path
-         expect a "Create user" button that does not exist by design. -->
+    <!-- Context banner — explain that the Mastio row is the directory
+         entry, not the credential. The actual login password lives in
+         the Connector's users.db (ADR-025) and is provisioned via the
+         Connector admin API or the Frontdesk dashboard. -->
     <div class="mb-6 p-4 bg-surface-900/60 border border-gray-800/50 rounded-lg text-xs text-gray-500 leading-relaxed">
-        Rows appear here automatically the first time a user authenticates
-        through a Frontdesk container — the SSO header reaches the
-        Connector Ambassador, the Ambassador asks Mastio to mint a
-        per-user cert via <code class="text-accent-400/80">/v1/principals/csr</code>,
-        and the CSR signing path upserts the principal into this table.
-        Pre-create rows out-of-band via
-        <code class="text-accent-400/80">POST /v1/admin/users</code>
-        (X-Admin-Secret) when you need a row before the first SSO touch.
+        Creating a user here reserves the principal id and seeds the
+        directory row so downstream policies + audit show the user even
+        before first login. The login password is set on the
+        <strong class="text-gray-300">Connector</strong> (ADR-025 local-auth)
+        via <code class="text-accent-400/80">POST /admin/users</code>
+        with <code class="text-accent-400/80">X-Admin-Secret</code>, or
+        through the Frontdesk admin tab. Rows also land here automatically
+        the first time a user authenticates through a Frontdesk container.
+    </div>
+
+    <!-- Create User panel (hidden by default) -->
+    <div id="create-panel" class="hidden mb-6 bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">New User</h3>
+        <form method="post" action="/proxy/users/create" class="space-y-4">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">User Name</label>
+                    <input type="text" name="user_name" required
+                           placeholder="mario"
+                           pattern="[a-zA-Z0-9._\-]{1,64}"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
+                    <p class="text-[10px] text-gray-600 mt-1">Letters, digits, dot, underscore, dash. Becomes the SPIFFE id suffix.</p>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Display Name</label>
+                    <input type="text" name="display_name"
+                           placeholder="Mario Rossi"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 transition-all">
+                    <p class="text-[10px] text-gray-600 mt-1">Optional label for the dashboard. Falls back to user name.</p>
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Reach</label>
+                    <select name="reach"
+                            class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white font-mono transition-all">
+                        <option value="intra" selected>intra-org (same org only)</option>
+                        <option value="cross">cross-org (other orgs only)</option>
+                        <option value="both">both (intra + cross)</option>
+                    </select>
+                    <p class="text-[10px] text-gray-600 mt-1">ADR-020 — controls which networks the user principal can sign into.</p>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Surface</label>
+                    <input type="text" name="surface"
+                           placeholder="frontdesk"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
+                    <p class="text-[10px] text-gray-600 mt-1">Optional hint: which Connector surface this user logs in from (frontdesk, cullis-chat, cli).</p>
+                </div>
+            </div>
+            <p class="text-[10px] text-gray-500 flex items-center gap-1.5">
+                <svg class="w-3 h-3 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                Cert is minted on the first SSO touch (CSR signing path upserts this row).
+            </p>
+            <div class="flex items-center gap-3 pt-1">
+                <button type="submit"
+                        class="px-5 py-2 text-xs font-semibold rounded transition-all"
+                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
+                        onmouseover="this.style.background='#fff'"
+                        onmouseout="this.style.background='#00e5c7'">
+                    Create
+                </button>
+                <button type="button"
+                        onclick="document.getElementById('create-panel').classList.add('hidden')"
+                        class="px-4 py-2 text-xs text-gray-500 border border-gray-700 rounded hover:bg-gray-800 transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
     </div>
 
     <!-- Table -->
@@ -107,9 +200,8 @@
                         </svg>
                         <p class="text-sm text-gray-600">No user principals yet</p>
                         <p class="text-xs text-gray-700 mt-1">
-                            The first Frontdesk SSO sign-in (or
-                            <code>POST /v1/admin/users</code>) will register
-                            a row here.
+                            Click <span class="text-accent-400">+ Create User</span> to seed one,
+                            or wait for the first Frontdesk SSO sign-in.
                         </p>
                     </td>
                 </tr>


### PR DESCRIPTION
## Summary
- New `POST /proxy/users/create` form endpoint, idempotent insert into `local_user_principals` (mirrors `POST /v1/admin/users` X-Admin-Secret API)
- `users.html` rewritten with `+ Create User` button + create panel matching `agents.html` pattern (user_name, display_name, reach, surface)
- Banner explains that the Mastio row is the directory entry; login password is set on the Connector (ADR-025) — no overlap with `users.db`

## Test plan
- [x] Created `alice` via dashboard form → row appears in `local_user_principals`
- [x] Re-posting same user_name redirects without overwriting (idempotent)
- [x] Invalid user_name pattern → redirect with error
- [x] Used the row as recipient in U2U intra-org dataplane test (sibling PR)

## Notes
- Closes the gap noted in memory `project_gap_mastio_dashboard_no_users_section`
- Sibling PRs ship the actual U2U dataplane wiring + the bring-up `MCP_PROXY_ANTHROPIC_API_KEY` mapping fix (#567)

🤖 Generated with [Claude Code](https://claude.com/claude-code)