### PR TITLE
feat(adr-020): wire U2U intra-org dataplane end-to-end

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -307,6 +307,139 @@ async def mcp_passthrough(request: Request) -> JSONResponse:
     })
 
 
+# ── /v1/inbox — intra-org user-to-user messaging ────────────────────
+#
+# ADR-008 / ADR-020: passes through to the Mastio's
+# ``/v1/egress/message/{send,inbox}`` using the calling user's
+# UserPrincipal cert (set by ``cert_middleware``). Auth gate mirrors
+# /v1/chat/completions: when ``user_credentials`` is bound, bypass
+# loopback + bearer; otherwise the route 401s. The Cullis SDK's
+# ``send_oneshot`` does the resolve + sign + envelope dance, so the
+# Connector just plumbs request → SDK call → response.
+#
+# Cross-org via broker is intentionally NOT wired here yet — the
+# shared-mode router (``ambassador/shared/router.py``) carries that
+# code path. Standalone Mastio + ADR-025 local-auth covers intra-org
+# only, which is the v0.2 dogfood scope.
+
+def _coerce_payload(value: Any) -> dict:
+    """SPA may send the message body as a string ("ciao alice") or as a
+    structured dict ({"text": "ciao alice"}). Mastio's
+    ``SendOneShotRequest.payload`` is typed as ``dict``, so coerce a
+    bare string to ``{"text": <str>}`` for the operator-friendly UX."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        return {"text": value}
+    raise HTTPException(400, "payload must be a JSON object or string")
+
+
+@router.post("/v1/inbox/send")
+def inbox_send(request: Request, body: dict):
+    """Send a one-shot message via the Mastio's intra-org egress.
+
+    Requires the cert middleware to have resolved a user principal
+    (``request.state.user_credentials``); shared bearer + loopback
+    enforcement still apply when no per-user cert is bound, so a CLI
+    caller using the local Bearer can also send if it carries the
+    Connector-agent identity.
+    """
+    user_creds = _per_user_credentials(request)
+    if user_creds is None:
+        _enforce_loopback(request)
+        state = _get_state(request)
+        _enforce_bearer(request, state)
+        client_holder: AmbassadorClient = state["client"]
+        try:
+            client = client_holder.get()
+        except Exception as exc:
+            _log.exception("ambassador SDK login failed (inbox send)")
+            raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
+    else:
+        try:
+            client = _build_user_client(request, user_creds)
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _log.exception(
+                "user-bound CullisClient build failed (inbox send) for %s",
+                user_creds.principal_id,
+            )
+            raise HTTPException(
+                502, f"per-user Cullis cloud login failed: {exc}",
+            ) from exc
+
+    recipient_id = body.get("recipient_id")
+    if not isinstance(recipient_id, str) or not recipient_id:
+        raise HTTPException(400, "recipient_id is required (str)")
+    payload = _coerce_payload(body.get("payload", ""))
+    correlation_id = body.get("correlation_id")
+    reply_to = body.get("reply_to")
+    ttl_seconds = int(body.get("ttl_seconds", 300) or 300)
+    capabilities = body.get("capabilities") or []
+    if not isinstance(capabilities, list):
+        raise HTTPException(400, "capabilities must be a list of strings")
+
+    try:
+        result = client.send_oneshot(
+            recipient_id,
+            payload,
+            correlation_id=correlation_id,
+            reply_to=reply_to,
+            ttl_seconds=ttl_seconds,
+            capabilities=capabilities,
+        )
+    except Exception as exc:
+        _log.exception("inbox send failed for recipient=%s", recipient_id)
+        raise HTTPException(502, f"inbox send failed: {exc}") from exc
+    return result
+
+
+@router.get("/v1/inbox")
+def inbox_list(
+    request: Request,
+    since: str | None = None,
+    limit: int = 50,
+):
+    """Poll the calling principal's intra-org one-shot inbox."""
+    user_creds = _per_user_credentials(request)
+    if user_creds is None:
+        _enforce_loopback(request)
+        state = _get_state(request)
+        _enforce_bearer(request, state)
+        client_holder: AmbassadorClient = state["client"]
+        try:
+            client = client_holder.get()
+        except Exception as exc:
+            _log.exception("ambassador SDK login failed (inbox list)")
+            raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
+    else:
+        try:
+            client = _build_user_client(request, user_creds)
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            _log.exception(
+                "user-bound CullisClient build failed (inbox list) for %s",
+                user_creds.principal_id,
+            )
+            raise HTTPException(
+                502, f"per-user Cullis cloud login failed: {exc}",
+            ) from exc
+
+    params: dict[str, Any] = {"limit": int(limit)}
+    if since is not None:
+        params["since"] = since
+    try:
+        resp = client._authed_request("GET", "/v1/egress/message/inbox", params=params)
+    except Exception as exc:
+        _log.exception("inbox list HTTP failed")
+        raise HTTPException(502, f"inbox list failed: {exc}") from exc
+    if resp.status_code >= 400:
+        raise HTTPException(resp.status_code, detail=resp.text[:400])
+    return resp.json()
+
+
 # ── Wiring helper ───────────────────────────────────────────────────
 
 def install_ambassador(

--- a/cullis_connector/auth/cert_middleware.py
+++ b/cullis_connector/auth/cert_middleware.py
@@ -66,7 +66,15 @@ _log = logging.getLogger("cullis_connector.auth.cert_middleware")
 # Path prefixes guarded by this middleware — only the OpenAI-shaped
 # chat surface needs per-user cert binding. /v1/ambassador/health is a
 # liveness probe and stays exempt.
-_GUARDED_PREFIXES = ("/v1/chat/completions", "/v1/models", "/v1/mcp")
+_GUARDED_PREFIXES = (
+    "/v1/chat/completions",
+    "/v1/models",
+    "/v1/mcp",
+    # ADR-008 / ADR-020 — inbox send + list need the per-user cert so
+    # the SDK call to Mastio's ``/v1/egress/message/{send,inbox}`` is
+    # authenticated as the user principal, not the Connector-agent.
+    "/v1/inbox",
+)
 
 
 def _is_guarded(path: str) -> bool:

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -2220,11 +2220,17 @@ class CullisClient:
         # ``decide_route`` classifies the recipient intra vs cross
         # correctly — otherwise intra-org sends are mis-routed to the
         # broker bridge and 404 on the Court side.
+        # ADR-020 — typed principals (``user::alice`` / ``workload::x``)
+        # already carry ``::`` from the principal-type prefix; the old
+        # heuristic (``"::" not in _raw_target``) wrongly skipped the
+        # org prefix for them and made ``decide_route`` parse ``user``
+        # as the org, denying every U2U send at the reach gate. Pin to
+        # ``startswith("<org>::")`` instead.
         _resolved_org = decision.get("target_org_id")
         _raw_target = decision["target_agent_id"]
         target_agent_id = (
             f"{_resolved_org}::{_raw_target}"
-            if _resolved_org and "::" not in _raw_target
+            if _resolved_org and not _raw_target.startswith(f"{_resolved_org}::")
             else _raw_target
         )
 
@@ -2391,11 +2397,17 @@ class CullisClient:
         # ``decide_route`` classifies the recipient intra vs cross
         # correctly — otherwise intra-org sends are mis-routed to the
         # broker bridge and 404 on the Court side.
+        # ADR-020 — typed principals (``user::alice`` / ``workload::x``)
+        # already carry ``::`` from the principal-type prefix; the old
+        # heuristic (``"::" not in _raw_target``) wrongly skipped the
+        # org prefix for them and made ``decide_route`` parse ``user``
+        # as the org, denying every U2U send at the reach gate. Pin to
+        # ``startswith("<org>::")`` instead.
         _resolved_org = decision.get("target_org_id")
         _raw_target = decision["target_agent_id"]
         target_agent_id = (
             f"{_resolved_org}::{_raw_target}"
-            if _resolved_org and "::" not in _raw_target
+            if _resolved_org and not _raw_target.startswith(f"{_resolved_org}::")
             else _raw_target
         )
 

--- a/mcp_proxy/egress/router.py
+++ b/mcp_proxy/egress/router.py
@@ -941,30 +941,83 @@ async def resolve_recipient(
 
         target_cert_pem: str | None = None
         if transport == "mtls-only":
-            # ``internal_agents.agent_id`` is ``<org>::<name>`` in
-            # production (ADR-010 invariant) but legacy rows + some
-            # test fixtures still use the bare ``<name>`` form. Try
-            # full first, then bare — picking the first row via
-            # ``ORDER BY`` so the full-form match wins when both
-            # exist. 404 only if neither is found.
-            full_agent_id = f"{target_org}::{target_agent}"
-            async with get_db() as conn:
-                result = await conn.execute(
-                    text(
-                        "SELECT cert_pem, is_active FROM internal_agents "
-                        "WHERE agent_id IN (:full_id, :bare_id) "
-                        "ORDER BY CASE WHEN agent_id = :full_id "
-                        "THEN 0 ELSE 1 END LIMIT 1"
-                    ),
-                    {"full_id": full_agent_id, "bare_id": target_agent},
-                )
-                row = result.mappings().first()
-                if row is None or not row["is_active"]:
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"intra-org target not found: {full_agent_id}",
+            # ADR-020 — typed-principal recipients (user::, workload::)
+            # live in ``local_user_principals`` / ``local_workload_principals``,
+            # NOT in ``internal_agents``. Detect the prefix and fork the
+            # lookup. The user's leaf cert may not have been minted yet
+            # (alice has a directory row but no cert until her first
+            # SSO touch via ``/v1/principals/csr``), so missing
+            # ``cert_thumbprint`` is fine — Mastio-mediated intra-org
+            # delivery does not handshake the sender against the
+            # recipient's cert; the message lands in ``local_messages``
+            # and the recipient picks it up at their next inbox poll.
+            if target_agent.startswith("user::"):
+                user_name = target_agent[len("user::"):]
+                full_principal_id = f"{target_org}::user::{user_name}"
+                async with get_db() as conn:
+                    result = await conn.execute(
+                        text(
+                            "SELECT cert_thumbprint FROM local_user_principals "
+                            "WHERE principal_id = :pid"
+                        ),
+                        {"pid": full_principal_id},
                     )
-                target_cert_pem = row["cert_pem"]
+                    row = result.mappings().first()
+                    if row is None:
+                        raise HTTPException(
+                            status_code=404,
+                            detail=f"intra-org user principal not found: {full_principal_id}",
+                        )
+                # cert_pem is intentionally None for user principals:
+                # the sender encrypts under the message envelope path
+                # only when transport=='envelope' (cross-org). Intra-org
+                # mtls-only relies on Mastio as the broker; no peer TLS
+                # handshake from sender to recipient is performed.
+                target_cert_pem = None
+            elif target_agent.startswith("workload::"):
+                workload_name = target_agent[len("workload::"):]
+                full_principal_id = f"{target_org}::workload::{workload_name}"
+                async with get_db() as conn:
+                    result = await conn.execute(
+                        text(
+                            "SELECT principal_id FROM local_workload_principals "
+                            "WHERE principal_id = :pid"
+                        ),
+                        {"pid": full_principal_id},
+                    )
+                    row = result.mappings().first()
+                    if row is None:
+                        raise HTTPException(
+                            status_code=404,
+                            detail=f"intra-org workload principal not found: {full_principal_id}",
+                        )
+                target_cert_pem = None
+            else:
+                # Untyped recipient — agent. Same query as before:
+                # ``internal_agents.agent_id`` is ``<org>::<name>`` in
+                # production (ADR-010 invariant) but legacy rows + some
+                # test fixtures still use the bare ``<name>`` form. Try
+                # full first, then bare — picking the first row via
+                # ``ORDER BY`` so the full-form match wins when both
+                # exist. 404 only if neither is found.
+                full_agent_id = f"{target_org}::{target_agent}"
+                async with get_db() as conn:
+                    result = await conn.execute(
+                        text(
+                            "SELECT cert_pem, is_active FROM internal_agents "
+                            "WHERE agent_id IN (:full_id, :bare_id) "
+                            "ORDER BY CASE WHEN agent_id = :full_id "
+                            "THEN 0 ELSE 1 END LIMIT 1"
+                        ),
+                        {"full_id": full_agent_id, "bare_id": target_agent},
+                    )
+                    row = result.mappings().first()
+                    if row is None or not row["is_active"]:
+                        raise HTTPException(
+                            status_code=404,
+                            detail=f"intra-org target not found: {full_agent_id}",
+                        )
+                    target_cert_pem = row["cert_pem"]
 
         return ResolveResponse(
             path="intra-org",


### PR DESCRIPTION
## Summary
Closes the U2U intra-org quadrant of ADR-020 by fixing **four distinct gaps** along the SPA → Connector → Mastio chain, all surfaced by today's dogfood (mario user → alice user, same org, no Court).

| # | Layer | Bug | Fix |
|---|---|---|---|
| 1 | Connector ambassador (single-mode) | No `POST /v1/inbox/send` / `GET /v1/inbox` passthrough | Added both, with the same loopback+bearer bypass pattern as `chat_completions` |
| 2 | cert_middleware | `_GUARDED_PREFIXES` missing `/v1/inbox` → cookie never resolved into `user_credentials` for inbox paths | Added `/v1/inbox` to the tuple |
| 3 | Mastio `resolve_recipient` | Lookup hit only `internal_agents`, returned 404 for `user::alice`/`workload::x` | Forked on `user::`/`workload::` prefix, lookup `local_user_principals`/`local_workload_principals` |
| 4 | SDK `target_agent_id` reconstruction | `"::" not in raw` skipped org prefix for typed principals → 403 reach denied (`target_org` parsed as `user`) | Switched to `startswith(f"{org}::")` |

## Test plan
- [x] `mario` POSTs `/v1/inbox/send` recipient=`bc061673f91585aa::user::alice` → 200 enqueued
- [x] `alice` GETs `/v1/inbox` → returns 1 message, sender=`bc061673f91585aa::user::mario`, payload signed mtls-only ECDSA
- [x] Mastio audit log shows `oneshot_sent` + `oneshot_delivered` events
- [x] Existing chat-completions path still works (regression check on `_enforce_loopback` / `_enforce_bearer` short-circuits)
- [ ] Browser SPA `Inbox.tsx` page renders empty at hydration — known separate bug, not blocking

## Notes
- Cross-org via broker intentionally NOT wired here; that's the shared-mode router's job
- Sibling PRs: #567 (`MCP_PROXY_ANTHROPIC_API_KEY` compose mapping), #568 (dashboard `/proxy/users/create`)
- Memory: `project_session_2026_05_10_u2u_intra_org` + `feedback_typed_principal_resolve_gotcha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)