### PR TITLE
fix(mastio-bundle): include host.docker.internal in default NGINX_SAN

### DIFF
--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -89,11 +89,26 @@ MCP_PROXY_PORT=9443
 MCP_PROXY_NGINX_CERT_DIR=/var/lib/mastio/nginx-certs
 
 # SAN(s) baked into the nginx server cert. Comma-separated for multi-
-# host. Default targets the docker-compose dev hostname plus localhost
-# for host-side curl. Override with the operator's actual hostnames in
-# production (the cert is regenerated on the next Mastio boot if SAN
-# changes).
-MCP_PROXY_NGINX_SAN=mastio.local,localhost
+# host. Default covers the three host-side names a sibling bundle (or
+# host-side curl) may reach this Mastio at:
+#
+#   * ``mastio.local``           — legacy alias retained for back-compat
+#   * ``localhost``              — host browser default
+#   * ``host.docker.internal``   — sibling bundle (Frontdesk Connector)
+#                                  reaches across docker networks via
+#                                  the host-gateway alias. The Mastio
+#                                  bundle's docker-compose default
+#                                  ``MCP_PROXY_PROXY_PUBLIC_URL`` is
+#                                  ``https://host.docker.internal:9443``,
+#                                  so dropping this SAN breaks the
+#                                  Connector at the very first TLS
+#                                  handshake (``Hostname mismatch,
+#                                  certificate is not valid for
+#                                  'host.docker.internal'``).
+#
+# Override with the operator's actual hostnames in production (the cert
+# is regenerated on the next Mastio boot if SAN changes).
+MCP_PROXY_NGINX_SAN=mastio.local,localhost,host.docker.internal
 
 # ADR-006 standalone mode (default after ADR-014 PR-D). True = the
 # Mastio runs as a self-contained mini-broker, derives its own Org CA,


### PR DESCRIPTION
## Summary
- `proxy.env.example` was minting `MCP_PROXY_NGINX_SAN=mastio.local,localhost` while the compose default URL points at `https://host.docker.internal:9443`
- The first TLS handshake from a sibling-bundle Frontdesk Connector hits `Hostname mismatch, certificate is not valid for 'host.docker.internal'` and every downstream call (CSR mint, inbox, chat) inherits the SSL-verify error
- Aligned the example with the compose default (`docker-compose.yml:68` already has the right SAN list as fallback)

## Test plan
- [x] Wipe nginx_certs volume + restart Mastio → cert regenerated with the 3-entry SAN
- [x] Sibling Frontdesk Connector enroll + chat completion no longer SSL-fails

## Notes
- Discovered during 2026-05-10 dogfood from clean tarball — quickstart hit this in <2 minutes
- Sibling PRs: #567 (`MCP_PROXY_ANTHROPIC_API_KEY` mapping), #568 (dashboard users), #569 (U2U dataplane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)