### PR TITLE
fix(frontdesk-bundle): pin enroll docker run to the compose-managed bridge

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -311,7 +311,25 @@ else
     if [[ -t 0 && -t 1 ]]; then
         DOCKER_TTY_FLAGS="-it"
     fi
+
+    # Pin the enroll docker run to the frontdesk_net bridge that the
+    # compose stack will use. Without this, the container lands on the
+    # default bridge, where ``host.docker.internal:host-gateway``
+    # resolves to a gateway IP that on Linux-native Docker is NOT
+    # forwarded to the host's published ports (Docker Desktop on
+    # macOS/Windows fakes the resolution via NAT magic, masking the
+    # bug). Symptom on Linux: ``Could not reach Site at
+    # https://host.docker.internal:9443: timed out`` after 10s. Pre-
+    # creating the user-defined bridge gives the same gateway routing
+    # behaviour the compose-managed Connector container will see.
+    ENROLL_NET="${COMPOSE_PROJECT_NAME}_frontdesk_net"
+    if ! docker network inspect "$ENROLL_NET" >/dev/null 2>&1; then
+        docker network create "$ENROLL_NET" >/dev/null \
+            || die "Could not create docker network ${ENROLL_NET} for the enroll one-shot"
+    fi
+
     docker run --rm $DOCKER_TTY_FLAGS \
+        --network "$ENROLL_NET" \
         --add-host "host.docker.internal:host-gateway" \
         -v "${DATA_DIR_ABS}:/home/cullis/.cullis" \
         -v "${CA_BUNDLE_ABS}:/etc/cullis/ca-bundle.pem:ro" \


### PR DESCRIPTION
## Summary
- Enroll one-shot now creates (idempotent) and joins `${COMPOSE_PROJECT_NAME}_frontdesk_net` before running, instead of landing on the default bridge
- Default bridge on Linux-native Docker does NOT forward `host.docker.internal:host-gateway` to the host's published ports → 10s timeout on enroll
- Docker Desktop on macOS/Windows masks this via its own NAT shim — that's why the bug never surfaced in upstream dev

## Test plan
- [x] Linux-native Docker 28.x: enroll completes (was timing out)
- [x] Compose `up` after enroll reuses the same network without conflict (idempotent network create)

## Notes
- Discovered during 2026-05-10 vanilla dogfood from clean tarball
- Sibling release-blocker PRs: #567 (`MCP_PROXY_ANTHROPIC_API_KEY` mapping), #568 (dashboard users), #569 (U2U dataplane), #570 (NGINX_SAN host.docker.internal)
- Together these 4 PRs unblock the customer quickstart from clean tarball on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)