### PR TITLE
feat(mcp_proxy): add connector-bootstrap discovery endpoint

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1037,6 +1037,13 @@ app.include_router(jwks_local_router)
 from mcp_proxy.pki.public import router as pki_public_router
 app.include_router(pki_public_router)
 
+# Frontdesk Connector setup wizard — anonymous metadata at
+# /.well-known/cullis/connector-bootstrap so the wizard can probe
+# multiple candidate URLs in parallel and surface ``org_id`` +
+# ``trust_domain`` + CA fingerprint without a side-channel.
+from mcp_proxy.pki.bootstrap import router as pki_bootstrap_router
+app.include_router(pki_bootstrap_router)
+
 # ADR-012 Phase 2 — proxy-native /v1/auth/token. Gated behind
 # ``settings.local_auth_enabled`` so the reverse-proxy path remains the
 # default. MUST be registered before ``build_reverse_proxy_router()`` so

--- a/mcp_proxy/pki/bootstrap.py
+++ b/mcp_proxy/pki/bootstrap.py
@@ -1,0 +1,200 @@
+"""Public connector-bootstrap endpoint — first-contact discovery.
+
+Exposes the metadata a Frontdesk Connector needs to start its setup
+wizard against this Mastio: the org identity (``org_id``,
+``trust_domain``), the CA fingerprint anchor for TOFU pinning, and
+the relative URLs of the endpoints the wizard will follow up with
+(CA download, enrollment start/poll, JWKS).
+
+Anonymous, like ``/pki/ca.crt`` and ``/.well-known/jwks-local.json``
+— it publishes only what an unauthenticated client could already
+reconstruct from a TLS handshake plus that anonymous CA fetch. What
+it adds is a single structured payload the wizard can probe in
+parallel against a small list of candidate URLs (``mastio.local``,
+``host.docker.internal``, ``localhost``, ``172.17.0.1``) so the
+operator never has to copy-paste an URL or a fingerprint by hand.
+
+The response always returns 200, even when the Mastio has just been
+installed and the operator hasn't completed the first-boot setup
+yet. In that case ``mode`` is ``"setup"`` and ``org_id`` /
+``ca_fingerprint_sha256`` are ``null`` — the wizard distinguishes
+"this Mastio exists but isn't configured" from "no Mastio at this
+URL" (which manifests as connection refused / timeout, never as a
+malformed payload).
+
+URLs in the response are **relative paths**, never absolute. The
+client concatenates them with the base URL it probed. Returning
+absolute URLs here would force us to know what hostname the
+operator pointed at us, which conflicts with the dual semantics of
+``MCP_PROXY_PROXY_PUBLIC_URL`` (DPoP htu vs OIDC redirect — see the
+``proxy_env_public_url_vm`` failure mode).
+
+Rate-limit budget mirrors ``/pki/ca.crt`` and the JWKS endpoint:
+30 hits/minute per IP, enough for any honest first-contact poll
+and tight enough to throttle a scraper hammering one host.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from fastapi import APIRouter, HTTPException, Request, Response, status
+from pydantic import BaseModel, Field
+
+from mcp_proxy.auth.rate_limit import get_agent_rate_limiter
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import get_config
+
+router = APIRouter(tags=["pki"])
+
+_BOOTSTRAP_RATE_LIMIT_PER_MINUTE = 30
+
+
+def _client_ip(request: Request) -> str:
+    """Return the rate-limit subject for this request.
+
+    Uses ``request.client.host`` populated by uvicorn's
+    ``ProxyHeadersMiddleware`` (the deployed shape runs uvicorn
+    behind nginx with ``--proxy-headers --forwarded-allow-ips=<nginx>``)
+    so the value reflects the last trusted XFF hop, not an
+    attacker-controlled raw header. Same pattern as
+    ``mcp_proxy/pki/public.py`` and ``mcp_proxy/auth/jwks_local.py``.
+    """
+    client = request.client
+    return client.host if client is not None else "unknown"
+
+
+class BootstrapUrls(BaseModel):
+    ca: str = Field(default="/pki/ca.crt")
+    enrollment_start: str = Field(default="/v1/enrollment/start")
+    enrollment_status_template: str = Field(
+        default="/v1/enrollment/{session_id}/status"
+    )
+    jwks: str = Field(default="/.well-known/jwks-local.json")
+
+
+class BootstrapResponse(BaseModel):
+    """Metadata payload for first-contact connector discovery.
+
+    ``version`` is the schema version. Bump it on breaking shape
+    changes — adding a new optional field is not breaking.
+
+    ``mode`` is ``"configured"`` when the operator has finished
+    first-boot setup (``org_id`` and Org CA both present), else
+    ``"setup"``. The wizard surfaces this as a "configure your
+    Mastio first" hint instead of attempting enrollment.
+    """
+
+    version: int = 1
+    mode: Literal["configured", "setup"]
+    org_id: str | None
+    trust_domain: str
+    ca_fingerprint_sha256: str | None
+    urls: BootstrapUrls = Field(default_factory=BootstrapUrls)
+
+
+def _compute_fingerprint(pem: str) -> str:
+    """Hex SHA-256 over the DER body of the PEM cert.
+
+    Same anchor the Connector ``_fetch_ca_pem`` computes when it
+    pins the CA — see ``cullis_connector/web.py``. Returning the
+    bare hex (no ``:`` separators) lets the wizard render whichever
+    grouped form it prefers; the client compares case-insensitively
+    after stripping ``:``.
+    """
+    cert = x509.load_pem_x509_certificate(pem.encode())
+    return cert.fingerprint(hashes.SHA256()).hex()
+
+
+def _compute_etag(payload: BootstrapResponse) -> str:
+    """Strong ETag over the JSON body.
+
+    Lets a wizard that probes the same Mastio twice in a row skip
+    the second body. The fingerprint changes only on CA rotation
+    and the org_id is set once at first boot, so the ETag is
+    effectively stable per-Mastio between rotations.
+    """
+    digest = hashlib.sha256(
+        payload.model_dump_json().encode()
+    ).hexdigest()
+    return f'"{digest[:32]}"'
+
+
+def _etag_matches(header: str, etag: str) -> bool:
+    value = header.strip()
+    if value == "*":
+        return True
+    for candidate in value.split(","):
+        token = candidate.strip()
+        if token.startswith("W/"):
+            token = token[2:]
+        if token == etag:
+            return True
+    return False
+
+
+@router.get(
+    "/.well-known/cullis/connector-bootstrap",
+    summary="First-contact metadata for the Connector setup wizard",
+    response_model=BootstrapResponse,
+)
+async def connector_bootstrap(request: Request) -> Response:
+    client_ip = _client_ip(request)
+    if not await get_agent_rate_limiter().check(
+        f"ip:{client_ip}", _BOOTSTRAP_RATE_LIMIT_PER_MINUTE,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="connector bootstrap rate limit exceeded",
+        )
+
+    settings = get_settings()
+
+    # ``app.state.org_id`` is wired in lifespan (mcp_proxy/main.py:313)
+    # to the resolved org_id (env override, DB config, or derived from
+    # the Org CA in standalone mode). Falling back to
+    # ``get_config("org_id")`` covers the rare case where bootstrap
+    # is hit before lifespan finishes — we still answer 200 with
+    # mode="setup" rather than 503.
+    org_id = getattr(request.app.state, "org_id", None)
+    if not org_id:
+        org_id = await get_config("org_id") or ""
+
+    pem = await get_config("org_ca_cert")
+    if pem:
+        ca_fingerprint: str | None = _compute_fingerprint(pem)
+    else:
+        ca_fingerprint = None
+
+    mode: Literal["configured", "setup"]
+    if org_id and ca_fingerprint:
+        mode = "configured"
+    else:
+        mode = "setup"
+
+    payload = BootstrapResponse(
+        mode=mode,
+        org_id=org_id or None,
+        trust_domain=settings.trust_domain,
+        ca_fingerprint_sha256=ca_fingerprint,
+    )
+
+    etag = _compute_etag(payload)
+    headers = {
+        "Cache-Control": "public, max-age=60",
+        "ETag": etag,
+    }
+
+    if_none_match = request.headers.get("if-none-match")
+    if if_none_match and _etag_matches(if_none_match, etag):
+        return Response(
+            status_code=status.HTTP_304_NOT_MODIFIED, headers=headers,
+        )
+
+    return Response(
+        content=payload.model_dump_json(),
+        media_type="application/json",
+        headers=headers,
+    )

--- a/tests/test_pki_bootstrap.py
+++ b/tests/test_pki_bootstrap.py
@@ -1,0 +1,198 @@
+"""Tests for ``GET /.well-known/cullis/connector-bootstrap`` — the
+anonymous metadata endpoint a Frontdesk Connector probes against
+candidate Mastio URLs during its first-boot setup wizard.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from mcp_proxy.auth.rate_limit import reset_agent_rate_limiter
+from mcp_proxy.pki.bootstrap import router as bootstrap_router
+
+
+def _self_signed_pem() -> tuple[str, str]:
+    """Build a throwaway self-signed cert and return ``(pem, fingerprint_hex)``.
+
+    A real cert is required because the endpoint computes the
+    SHA-256 fingerprint by parsing the DER body — a fake "PEM"
+    string would fail at ``x509.load_pem_x509_certificate``.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name(
+        [x509.NameAttribute(NameOID.COMMON_NAME, "test-ca-bootstrap")],
+    )
+    now = datetime.now(timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(days=30))
+        .sign(key, hashes.SHA256())
+    )
+    pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    fingerprint = cert.fingerprint(hashes.SHA256()).hex()
+    return pem, fingerprint
+
+
+@pytest.fixture(autouse=True)
+def _reset_limiter():
+    reset_agent_rate_limiter()
+    yield
+    reset_agent_rate_limiter()
+
+
+def _client(
+    *,
+    org_id: str | None = "acme",
+    ca_pem: str | None = None,
+    trust_domain: str = "acme.cullis.local",
+) -> TestClient:
+    """Build a FastAPI test app with bootstrap router mounted and the
+    config layer + settings + app.state stubbed.
+
+    ``org_id`` and ``ca_pem`` together drive the ``mode`` field:
+    both present → ``configured``; either missing → ``setup``.
+    """
+    app = FastAPI()
+    app.include_router(bootstrap_router)
+    app.state.org_id = org_id or ""
+
+    async def _fake_get_config(key: str) -> str | None:
+        if key == "org_id":
+            return org_id
+        if key == "org_ca_cert":
+            return ca_pem
+        return None
+
+    fake_settings = SimpleNamespace(trust_domain=trust_domain)
+
+    cfg_patch = patch("mcp_proxy.pki.bootstrap.get_config", _fake_get_config)
+    settings_patch = patch(
+        "mcp_proxy.pki.bootstrap.get_settings", lambda: fake_settings,
+    )
+    cfg_patch.start()
+    settings_patch.start()
+    app.state._patches = (cfg_patch, settings_patch)
+    return TestClient(app)
+
+
+def test_configured_mode_returns_full_payload():
+    pem, fingerprint = _self_signed_pem()
+    with _client(org_id="acme", ca_pem=pem) as client:
+        resp = client.get("/.well-known/cullis/connector-bootstrap")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["version"] == 1
+        assert body["mode"] == "configured"
+        assert body["org_id"] == "acme"
+        assert body["trust_domain"] == "acme.cullis.local"
+        assert body["ca_fingerprint_sha256"] == fingerprint
+        urls = body["urls"]
+        assert urls["ca"] == "/pki/ca.crt"
+        assert urls["enrollment_start"] == "/v1/enrollment/start"
+        assert urls["enrollment_status_template"].endswith(
+            "/{session_id}/status",
+        )
+        assert urls["jwks"] == "/.well-known/jwks-local.json"
+
+
+def test_setup_mode_when_no_org_id_and_no_ca():
+    """Fresh Mastio that hasn't completed first-boot — wizard must be
+    able to tell this apart from "no Mastio at all" (which surfaces
+    as a connection error, never as a malformed payload)."""
+    with _client(org_id=None, ca_pem=None) as client:
+        resp = client.get("/.well-known/cullis/connector-bootstrap")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mode"] == "setup"
+        assert body["org_id"] is None
+        assert body["ca_fingerprint_sha256"] is None
+
+
+def test_setup_mode_when_org_id_present_but_ca_missing():
+    """Half-configured Mastio: ``org_id`` set via env, CA not yet
+    generated. Still ``setup`` because the wizard can't pin a
+    fingerprint without a CA to anchor on."""
+    with _client(org_id="acme", ca_pem=None) as client:
+        resp = client.get("/.well-known/cullis/connector-bootstrap")
+        body = resp.json()
+        assert body["mode"] == "setup"
+        assert body["org_id"] == "acme"
+        assert body["ca_fingerprint_sha256"] is None
+
+
+def test_setup_mode_when_ca_present_but_org_id_missing():
+    pem, _ = _self_signed_pem()
+    with _client(org_id=None, ca_pem=pem) as client:
+        resp = client.get("/.well-known/cullis/connector-bootstrap")
+        body = resp.json()
+        assert body["mode"] == "setup"
+        assert body["org_id"] is None
+        # We still expose the fingerprint so a wizard could pin
+        # what's there for a future re-check, even if it can't
+        # complete enrollment yet.
+        assert body["ca_fingerprint_sha256"] is not None
+
+
+def test_urls_are_relative_paths():
+    """Gotcha: returning absolute URLs would force us to know the
+    operator-facing hostname, which conflicts with the dual
+    semantics of ``MCP_PROXY_PROXY_PUBLIC_URL`` (htu vs OIDC
+    redirect). Wizard concatenates with the base URL it probed."""
+    pem, _ = _self_signed_pem()
+    with _client(org_id="acme", ca_pem=pem) as client:
+        body = client.get("/.well-known/cullis/connector-bootstrap").json()
+        for value in body["urls"].values():
+            assert value.startswith("/"), (
+                f"expected relative path, got absolute URL: {value}"
+            )
+
+
+def test_etag_strong_match_returns_304():
+    pem, _ = _self_signed_pem()
+    with _client(org_id="acme", ca_pem=pem) as client:
+        first = client.get("/.well-known/cullis/connector-bootstrap")
+        etag = first.headers["ETag"]
+        second = client.get(
+            "/.well-known/cullis/connector-bootstrap",
+            headers={"If-None-Match": etag},
+        )
+        assert second.status_code == 304
+        assert second.content == b""
+
+
+def test_endpoint_is_anonymous():
+    pem, _ = _self_signed_pem()
+    with _client(org_id="acme", ca_pem=pem) as client:
+        # No auth header, cookie, or client cert — same shape as
+        # /pki/ca.crt and /.well-known/jwks-local.json.
+        resp = client.get("/.well-known/cullis/connector-bootstrap")
+        assert resp.status_code == 200
+
+
+def test_payload_is_valid_json_with_known_keys():
+    """Minimal contract test: third-party setup wizards (or our own
+    Connector after a refactor) rely on the keys being stable."""
+    pem, _ = _self_signed_pem()
+    with _client(org_id="acme", ca_pem=pem) as client:
+        resp = client.get("/.well-known/cullis/connector-bootstrap")
+        body = json.loads(resp.text)
+        assert set(body.keys()) == {
+            "version", "mode", "org_id", "trust_domain",
+            "ca_fingerprint_sha256", "urls",
+        }
+        assert resp.headers["content-type"].startswith("application/json")


### PR DESCRIPTION
## Summary

- Adds `GET /.well-known/cullis/connector-bootstrap`: anonymous, rate-limited metadata endpoint that the upcoming Frontdesk Connector setup wizard probes against candidate Mastio URLs (`mastio.local`, `host.docker.internal`, `localhost`, `172.17.0.1`) on first boot.
- Returns `org_id`, `trust_domain`, CA SHA-256 fingerprint, and the relative URLs for the follow-up enrollment flow.
- Always 200, even on a fresh Mastio with no `org_id` and no CA: payload sets `mode="setup"` with the missing fields nullable so the wizard distinguishes "Mastio not configured" from "no Mastio at this URL" (connection refused / timeout).
- Rate-limited 30/min per IP and ETag-cached, mirroring `/pki/ca.crt` and `/.well-known/jwks-local.json`. URLs in the payload are relative paths so the wizard concatenates with whichever base URL it probed (avoids the `MCP_PROXY_PROXY_PUBLIC_URL` htu/OIDC dual-use trap that broke #335).

## Why now

First step of the Frontdesk setup wizard plan. Today a customer who installs both the Mastio and Frontdesk bundles must manually configure `CULLIS_FRONTDESK_MASTIO_URL` and obtain the CA fingerprint out of band; the first design partner will hit this gap. PR2 will add the wizard on the Connector side; PR3 will wire the Frontdesk bundle `deploy.sh` + nginx routing.

## Test plan

- [x] New `tests/test_pki_bootstrap.py` (8 cases, all passing): configured mode, three setup-mode permutations (no org_id, no CA, only one of the two), relative-URL contract, ETag round-trip 304, anonymous access, payload schema stability.
- [x] Full local pytest: 2997 pass, 8 pre-existing failures all in known buckets (pystray/pywebview headless + postgres binding flake).
- [ ] `./sandbox/smoke.sh full` pre-merge.
- [ ] `/security-review` pre-merge — endpoint is public + unauth so DoS / info-leak surface needs explicit pass.

## Out of scope (follow-up PRs)

- Connector-side wizard UI + auto-discovery probe logic (PR2).
- Frontdesk `deploy.sh` wizard-mode + nginx route for `/setup` (PR3).