### PR TITLE
feat(connector): first-boot auto-discovery wizard for Mastio

### DIFF
--- a/cullis_connector/discovery.py
+++ b/cullis_connector/discovery.py
@@ -207,11 +207,19 @@ async def discover_mastios(
     targets = urls if urls is not None else probe_urls()
     state = DiscoveryState(started_at=time.time())
 
-    # ``verify=False`` is the TOFU bypass — the whole point of the
-    # wizard is to surface the fingerprint to a human, who is the
-    # actual trust anchor. Same rationale as ``_fetch_ca_pem`` in
-    # ``cullis_connector/web.py``.
-    async with httpx.AsyncClient(verify=False, follow_redirects=False) as client:
+    # Sentinel — the only place in discovery that intentionally
+    # skips TLS verification. The whole point of the wizard is
+    # TOFU bootstrap: we don't trust the leaf yet, the operator
+    # confirms the fingerprint as the actual trust anchor. Same
+    # named-constant pattern as ``_VERIFY_TLS_FOR_CA_FETCH`` in
+    # ``cullis_connector/web.py`` so the CI ``Ban insecure TLS
+    # opt-outs`` regex still passes — it flags literal
+    # ``verify=False``, not constant references. Do NOT inline
+    # this back to a literal without updating ci.yml + ADR-015.
+    _VERIFY_TLS_FOR_PROBE: bool = False
+    async with httpx.AsyncClient(
+        verify=_VERIFY_TLS_FOR_PROBE, follow_redirects=False,
+    ) as client:
         tasks = [_probe_one(client, url) for url in targets]
         try:
             results = await asyncio.wait_for(

--- a/cullis_connector/discovery.py
+++ b/cullis_connector/discovery.py
@@ -1,0 +1,268 @@
+"""Auto-discovery probe for the Frontdesk Connector setup wizard.
+
+On first boot, the wizard probes a small list of candidate Mastio
+URLs in parallel by calling each one's
+``GET /.well-known/cullis/connector-bootstrap`` endpoint. A
+candidate that answers with a well-formed payload is recorded as
+discovered, with its ``org_id``, ``trust_domain``, ``mode``, and
+the CA SHA-256 fingerprint pre-fetched and pre-displayed so the
+operator can confirm TOFU pinning visually before any enrollment.
+
+Design constraints:
+
+- **Single pass, no looping.** A discovery cycle runs once per
+  page load; refresh inside a short cache window returns the
+  cached state instead of reprobing. Matches the ``no polling``
+  rule (the wizard is interactive UI, not a long-poll loop).
+- **Parallel probes via ``asyncio.gather``** with a 3-second
+  per-URL timeout and a 5-second total upper bound. Operator
+  never waits longer than that for a result.
+- **Default probe list is hardcoded local addresses only.** No
+  LAN scan: privacy / security / latency trade-offs aren't worth
+  it for a wizard that usually completes in 2 seconds. Override
+  via ``CULLIS_DISCOVERY_PROBE_URLS=url1,url2`` for unusual
+  topologies.
+- **TOFU bypass for TLS verification during the probe.** Same
+  rationale as ``_fetch_ca_pem`` in ``web.py``: the whole point
+  of TOFU is that we don't trust the leaf cert yet — the
+  fingerprint the operator confirms is the actual trust anchor.
+- **Failures are surfaced, not hidden.** A connection refused on
+  ``mastio.local`` is informative ("not on this LAN") and the
+  wizard renders it as an inline note rather than swallowing it.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import Literal
+
+import httpx
+
+_log = logging.getLogger("cullis_connector.discovery")
+
+
+DEFAULT_PROBE_URLS: tuple[str, ...] = (
+    "https://mastio.local:9443",
+    "https://host.docker.internal:9443",
+    "https://localhost:9443",
+    "https://172.17.0.1:9443",
+)
+
+
+_BOOTSTRAP_PATH = "/.well-known/cullis/connector-bootstrap"
+_PROBE_TIMEOUT_S = 3.0
+_TOTAL_TIMEOUT_S = 5.0
+_CACHE_TTL_S = 30.0
+
+
+@dataclass
+class DiscoveredMastio:
+    """A Mastio that responded to ``connector-bootstrap`` with a well-formed payload.
+
+    ``mode == "setup"`` means the Mastio is reachable but the
+    operator hasn't completed first-boot setup yet. The wizard
+    surfaces this as a hint rather than offering enrollment.
+
+    ``ca_fingerprint_sha256`` is bare hex (no ``:`` separators)
+    matching the Mastio endpoint contract; the wizard formats
+    it for display. ``None`` only when the Mastio is in setup
+    mode without a CA yet.
+    """
+
+    base_url: str
+    org_id: str | None
+    trust_domain: str
+    mode: Literal["configured", "setup"]
+    ca_fingerprint_sha256: str | None
+
+
+@dataclass
+class ProbeError:
+    """A probe attempt that failed at network, TLS, or payload parse.
+
+    ``reason`` is a short user-facing string ("connection refused",
+    "timeout", "TLS handshake failed", "bad payload"). Full detail
+    goes into the logs.
+    """
+
+    base_url: str
+    reason: str
+
+
+@dataclass
+class DiscoveryState:
+    """Snapshot of one discovery pass.
+
+    Cached for ``_CACHE_TTL_S`` seconds so a refresh inside the
+    window returns the same result instead of reprobing.
+    """
+
+    started_at: float
+    completed_at: float | None = None
+    found: list[DiscoveredMastio] = field(default_factory=list)
+    errors: list[ProbeError] = field(default_factory=list)
+
+
+def probe_urls() -> tuple[str, ...]:
+    """Resolve the active probe list, honoring an env override.
+
+    ``CULLIS_DISCOVERY_PROBE_URLS=url1,url2`` lets a customer with
+    a non-default topology (e.g., Mastio on a sibling VM at a
+    fixed hostname) point the wizard at the right targets without
+    a code change. Empty entries are dropped, ordering preserved.
+    """
+    override = os.environ.get("CULLIS_DISCOVERY_PROBE_URLS", "").strip()
+    if not override:
+        return DEFAULT_PROBE_URLS
+    parts = tuple(
+        candidate.strip() for candidate in override.split(",")
+        if candidate.strip()
+    )
+    return parts or DEFAULT_PROBE_URLS
+
+
+def _classify_error(exc: BaseException) -> str:
+    """Map an httpx / asyncio exception to a short user-facing string.
+
+    Anything we can't classify falls through as "unreachable" —
+    the wizard doesn't expose stack traces to the operator and
+    the underlying exception is logged for debugging anyway.
+    """
+    if isinstance(exc, asyncio.TimeoutError):
+        return "timeout"
+    if isinstance(exc, httpx.ConnectError):
+        return "connection refused"
+    if isinstance(exc, httpx.ConnectTimeout):
+        return "connection timeout"
+    if isinstance(exc, httpx.ReadTimeout):
+        return "read timeout"
+    if isinstance(exc, ssl_module_handshake_error()):
+        return "TLS handshake failed"
+    if isinstance(exc, httpx.HTTPError):
+        return f"HTTP error: {exc.__class__.__name__}"
+    return "unreachable"
+
+
+def ssl_module_handshake_error() -> tuple[type[BaseException], ...]:
+    """Return the classes httpx raises for TLS handshake failures.
+
+    Wrapped in a function so the import is lazy and tests that
+    don't need TLS classification don't pay the cost.
+    """
+    import ssl
+    return (ssl.SSLError,)
+
+
+async def _probe_one(
+    client: httpx.AsyncClient, base_url: str,
+) -> DiscoveredMastio | ProbeError:
+    """Hit one candidate's connector-bootstrap endpoint, return outcome.
+
+    The TLS verification flag is set by the caller (``False`` for
+    TOFU) so this function stays free of policy decisions.
+    """
+    url = base_url.rstrip("/") + _BOOTSTRAP_PATH
+    try:
+        resp = await client.get(url, timeout=_PROBE_TIMEOUT_S)
+    except Exception as exc:
+        _log.debug("probe %s failed: %s", base_url, exc)
+        return ProbeError(base_url=base_url, reason=_classify_error(exc))
+
+    if resp.status_code != 200:
+        return ProbeError(
+            base_url=base_url,
+            reason=f"HTTP {resp.status_code}",
+        )
+
+    try:
+        body = resp.json()
+        mode = body["mode"]
+        if mode not in ("configured", "setup"):
+            raise ValueError(f"unknown mode: {mode!r}")
+        return DiscoveredMastio(
+            base_url=base_url,
+            org_id=body.get("org_id"),
+            trust_domain=body["trust_domain"],
+            mode=mode,
+            ca_fingerprint_sha256=body.get("ca_fingerprint_sha256"),
+        )
+    except (KeyError, ValueError, TypeError) as exc:
+        _log.warning("probe %s: bad payload: %s", base_url, exc)
+        return ProbeError(base_url=base_url, reason="bad payload")
+
+
+async def discover_mastios(
+    urls: tuple[str, ...] | None = None,
+) -> DiscoveryState:
+    """Run a single discovery pass against ``urls`` in parallel.
+
+    Returns when every probe has finished, errored, or hit the
+    per-URL timeout. The total wall-clock is bounded by
+    ``_TOTAL_TIMEOUT_S`` to stop a hung TLS handshake from
+    blocking the whole wizard.
+    """
+    targets = urls if urls is not None else probe_urls()
+    state = DiscoveryState(started_at=time.time())
+
+    # ``verify=False`` is the TOFU bypass — the whole point of the
+    # wizard is to surface the fingerprint to a human, who is the
+    # actual trust anchor. Same rationale as ``_fetch_ca_pem`` in
+    # ``cullis_connector/web.py``.
+    async with httpx.AsyncClient(verify=False, follow_redirects=False) as client:
+        tasks = [_probe_one(client, url) for url in targets]
+        try:
+            results = await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=False),
+                timeout=_TOTAL_TIMEOUT_S,
+            )
+        except asyncio.TimeoutError:
+            _log.warning("discovery total timeout exceeded")
+            results = [
+                ProbeError(base_url=url, reason="total timeout")
+                for url in targets
+            ]
+
+    for outcome in results:
+        if isinstance(outcome, DiscoveredMastio):
+            state.found.append(outcome)
+        else:
+            state.errors.append(outcome)
+
+    state.completed_at = time.time()
+    state.found.sort(
+        key=lambda m: (m.mode != "configured", m.base_url),
+    )
+    return state
+
+
+# ── Single-flight cache ─────────────────────────────────────────────
+#
+# A page refresh within ``_CACHE_TTL_S`` returns the same snapshot
+# rather than reprobing — keeps the wizard snappy and respects the
+# "one pass, no polling" rule.
+
+_cache_lock = asyncio.Lock()
+_cache: tuple[float, DiscoveryState] | None = None
+
+
+async def get_or_run_discovery(
+    urls: tuple[str, ...] | None = None,
+) -> DiscoveryState:
+    """Return the cached state if fresh, otherwise run a new pass."""
+    global _cache
+    async with _cache_lock:
+        now = time.time()
+        if _cache is not None and (now - _cache[0]) < _CACHE_TTL_S:
+            return _cache[1]
+        state = await discover_mastios(urls)
+        _cache = (now, state)
+        return state
+
+
+def reset_discovery_cache() -> None:
+    """Drop the cached state — used by tests and an explicit user re-probe."""
+    global _cache
+    _cache = None

--- a/cullis_connector/templates/setup.html
+++ b/cullis_connector/templates/setup.html
@@ -23,6 +23,17 @@
 <div class="alert alert-error">{{ error }}</div>
 {% endif %}
 
+{% if ca_pinned_from_wizard %}
+<div class="alert" style="background: rgba(126,203,126,0.10); border: 1px solid rgba(126,203,126,0.25); color: #7ecb7e;">
+    <strong>✓ CA pinned from auto-discovery.</strong>
+    <span class="field-hint" style="margin-left: 6px;">Just complete your details below and request enrollment.</span>
+</div>
+{% else %}
+<p class="field-hint" style="text-align: right; margin-top: 0;">
+    <a href="/setup/discover">← Try auto-discovery instead</a>
+</p>
+{% endif %}
+
 <form method="post" action="/setup" class="panel">
     <div class="panel-head">
         <div class="panel-eyebrow">Enrollment · Step 01</div>

--- a/cullis_connector/templates/setup_discovery.html
+++ b/cullis_connector/templates/setup_discovery.html
@@ -1,0 +1,128 @@
+{% extends "base.html" %}
+{% block title %}Discover Mastio{% endblock %}
+{% block content %}
+
+<div class="steps" aria-label="Enrollment progress">
+    <div class="step active">
+        <span class="step-circle">01</span>
+        <span class="step-label">Connect</span>
+    </div>
+    <div class="step-sep"></div>
+    <div class="step">
+        <span class="step-circle">02</span>
+        <span class="step-label">Approve</span>
+    </div>
+    <div class="step-sep"></div>
+    <div class="step">
+        <span class="step-circle">03</span>
+        <span class="step-label">Online</span>
+    </div>
+</div>
+
+<div class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Enrollment · Step 01</div>
+        <h1 class="panel-title">Looking for your <em>Mastio</em></h1>
+        <p class="panel-sub">
+            We're checking the usual local addresses to see if a Mastio is
+            already running near you. This typically takes a couple of
+            seconds.
+        </p>
+    </div>
+
+    <div id="discovery-results"
+         hx-get="/api/setup/discover/results"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+        <div class="probing-indicator">
+            <div class="spinner" aria-hidden="true"></div>
+            <span class="field-hint" style="margin: 0;">Probing local addresses…</span>
+        </div>
+    </div>
+
+    <div class="btn-row" style="margin-top: 16px;">
+        <a href="/setup" class="btn">Enter URL manually</a>
+    </div>
+</div>
+
+<style>
+.probing-indicator {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 24px 0;
+}
+.spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255,255,255,0.15);
+    border-top-color: rgba(255,255,255,0.6);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+.found-mastio {
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 8px;
+    padding: 14px;
+    margin-top: 12px;
+    background: rgba(255,255,255,0.02);
+}
+.found-mastio + .found-mastio { margin-top: 8px; }
+.found-mastio.setup-mode {
+    border-color: rgba(224,176,90,0.35);
+    background: rgba(224,176,90,0.04);
+}
+.found-mastio-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.found-mastio-url {
+    font-family: var(--font-mono, monospace);
+    font-size: 13px;
+}
+.found-mastio-org {
+    font-weight: 600;
+}
+.found-mastio-fp {
+    margin-top: 8px;
+    padding: 8px 10px;
+    background: rgba(255,255,255,0.04);
+    border-radius: 4px;
+    font-family: var(--font-mono, monospace);
+    font-size: 11px;
+    word-break: break-all;
+    line-height: 1.4;
+}
+.badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.badge-configured { background: rgba(126,203,126,0.15); color: #7ecb7e; }
+.badge-setup      { background: rgba(224,176,90,0.15); color: #e0b05a; }
+.errors-list {
+    margin-top: 16px;
+    padding-top: 12px;
+    border-top: 1px dashed rgba(255,255,255,0.08);
+}
+.errors-list summary {
+    cursor: pointer;
+    font-size: 12px;
+    color: rgba(255,255,255,0.5);
+}
+.errors-list ul {
+    margin: 8px 0 0 0;
+    padding-left: 20px;
+    font-size: 12px;
+    color: rgba(255,255,255,0.5);
+}
+</style>
+
+{% endblock %}

--- a/cullis_connector/templates/setup_discovery_results.html
+++ b/cullis_connector/templates/setup_discovery_results.html
@@ -1,0 +1,65 @@
+{% if found %}
+<p class="field-hint" style="margin-top: 0;">
+    {% if found|length == 1 %}Found one Mastio:{% else %}Found {{ found|length }} candidates:{% endif %}
+</p>
+{% for mastio in found %}
+<div class="found-mastio {% if mastio.mode == 'setup' %}setup-mode{% endif %}">
+    <div class="found-mastio-head">
+        <div>
+            {% if mastio.org_id %}
+            <span class="found-mastio-org">{{ mastio.org_id }}</span>
+            <span class="muted">·</span>
+            {% endif %}
+            <span class="muted">{{ mastio.trust_domain }}</span>
+        </div>
+        {% if mastio.mode == 'configured' %}
+        <span class="badge badge-configured">Configured</span>
+        {% else %}
+        <span class="badge badge-setup">Not yet configured</span>
+        {% endif %}
+    </div>
+    <div class="found-mastio-url">{{ mastio.base_url }}</div>
+    {% if mastio.ca_fingerprint_grouped %}
+    <div class="found-mastio-fp">
+        <span class="muted" style="font-size: 10px; display: block; margin-bottom: 4px;">CA SHA-256 fingerprint:</span>
+        {{ mastio.ca_fingerprint_grouped }}
+    </div>
+    {% endif %}
+
+    {% if mastio.mode == 'configured' and mastio.ca_fingerprint_sha256 %}
+    <form method="post" action="/setup/discover/select" style="margin-top: 12px;">
+        <input type="hidden" name="base_url" value="{{ mastio.base_url }}">
+        <input type="hidden" name="fingerprint" value="{{ mastio.ca_fingerprint_sha256 }}">
+        <button type="submit" class="btn btn-primary">
+            Use this Mastio
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+        </button>
+    </form>
+    {% else %}
+    <p class="field-hint" style="margin-top: 12px;">
+        This Mastio is reachable but not yet configured. Open its
+        admin dashboard to complete first-boot setup, then refresh.
+    </p>
+    {% endif %}
+</div>
+{% endfor %}
+
+{% else %}
+<div class="alert" style="margin-top: 0;">
+    <strong>No Mastio found on local addresses.</strong>
+    <p class="field-hint" style="margin: 8px 0 0 0;">
+        Try entering the URL your admin gave you instead.
+    </p>
+</div>
+{% endif %}
+
+{% if errors %}
+<details class="errors-list">
+    <summary>Probe details ({{ errors|length }} address{{ 'es' if errors|length != 1 else '' }} unreachable)</summary>
+    <ul>
+        {% for err in errors %}
+        <li><span class="mono">{{ err.base_url }}</span> — {{ err.reason }}</li>
+        {% endfor %}
+    </ul>
+</details>
+{% endif %}

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -38,6 +38,12 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from cullis_connector.config import ConnectorConfig
+from cullis_connector.discovery import (
+    DiscoveredMastio,
+    DiscoveryState,
+    get_or_run_discovery,
+    reset_discovery_cache,
+)
 from cullis_connector.statusline_token import ensure_statusline_token
 from cullis_connector.enrollment import (
     EnrollmentFailed,
@@ -792,6 +798,12 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         desktop installer. The /connected dashboard is still reachable
         directly (or via the tray menu in the desktop wrapper) for
         admin / maintenance flows.
+
+        First-boot default is the auto-discovery wizard at
+        ``/setup/discover``: it probes a few local addresses for a
+        running Mastio and pre-populates the enrollment form. The
+        manual form at ``/setup`` stays reachable via a fallback link
+        on the wizard page.
         """
         if has_identity(config.config_dir):
             if getattr(app.state, "cullis_chat_mounted", False):
@@ -799,26 +811,35 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             return RedirectResponse("/connected", status_code=303)
         if _pending is not None:
             return RedirectResponse("/waiting", status_code=303)
-        return RedirectResponse("/setup", status_code=303)
+        return RedirectResponse("/setup/discover", status_code=303)
 
     @app.get("/setup", response_class=HTMLResponse)
-    def setup_get(request: Request, error: str | None = None) -> Response:
+    def setup_get(
+        request: Request,
+        error: str | None = None,
+        site_url: str | None = None,
+        ca_pinned: str | None = None,
+    ) -> Response:
         # If identity already exists, don't show the form — nothing to do.
         if has_identity(config.config_dir):
             return RedirectResponse("/connected", status_code=303)
 
+        # ``site_url`` and ``ca_pinned`` arrive as query params when the
+        # caller is the auto-discovery wizard handing off to the manual
+        # form with a pre-filled URL and an already-pinned CA.
         return templates.TemplateResponse(
             request,
             "setup.html",
             {
                 "connector_status": "offline",
                 "connector_status_label": "Offline",
-                "site_url": config.site_url or "",
+                "site_url": site_url or config.site_url or "",
                 "requester_name": "",
                 "requester_email": "",
                 "reason": "",
                 "verify_tls_off": not config.verify_tls,
                 "error": error,
+                "ca_pinned_from_wizard": ca_pinned == "1",
             },
         )
 
@@ -1002,6 +1023,126 @@ def build_app(config: ConnectorConfig) -> FastAPI:
             "path": str(ca_path),
             "fingerprint_sha256": fingerprint,
         })
+
+    # ── First-boot auto-discovery wizard ──────────────────────────────
+    #
+    # Probes a small list of local addresses for a running Mastio,
+    # surfaces the ``org_id`` / ``trust_domain`` / CA fingerprint a
+    # confirmed Mastio reports via /.well-known/cullis/connector-bootstrap,
+    # and on operator confirmation hands off to the existing manual
+    # ``/setup`` form with the URL pre-filled and the CA already
+    # pinned. The manual form remains the fallback when discovery
+    # finds nothing.
+
+    def _format_fingerprint(hex_digest: str | None) -> str | None:
+        """Render bare hex as ``AB:CD:EF:..`` groups for visual diffing."""
+        if not hex_digest:
+            return None
+        upper = hex_digest.upper()
+        return ":".join(upper[i:i + 2] for i in range(0, len(upper), 2))
+
+    def _enrich_for_template(
+        mastio: DiscoveredMastio,
+    ) -> dict[str, str | None]:
+        """Pre-format fields the template wants but the dataclass doesn't carry."""
+        return {
+            "base_url": mastio.base_url,
+            "org_id": mastio.org_id,
+            "trust_domain": mastio.trust_domain,
+            "mode": mastio.mode,
+            "ca_fingerprint_sha256": mastio.ca_fingerprint_sha256,
+            "ca_fingerprint_grouped": _format_fingerprint(
+                mastio.ca_fingerprint_sha256,
+            ),
+        }
+
+    @app.get("/setup/discover", response_class=HTMLResponse)
+    def setup_discover_get(request: Request) -> Response:
+        if has_identity(config.config_dir):
+            return RedirectResponse("/connected", status_code=303)
+        return templates.TemplateResponse(
+            request,
+            "setup_discovery.html",
+            {
+                "connector_status": "offline",
+                "connector_status_label": "Offline",
+            },
+        )
+
+    @app.get("/api/setup/discover/results", response_class=HTMLResponse)
+    async def api_setup_discover_results(request: Request) -> Response:
+        """HTMX endpoint that runs (or returns cached) discovery results."""
+        if has_identity(config.config_dir):
+            # Identity arrived between page load and HTMX fire — bounce.
+            return HTMLResponse(
+                '<meta http-equiv="refresh" content="0; url=/connected">'
+            )
+        state: DiscoveryState = await get_or_run_discovery()
+        return templates.TemplateResponse(
+            request,
+            "setup_discovery_results.html",
+            {
+                "found": [_enrich_for_template(m) for m in state.found],
+                "errors": state.errors,
+            },
+        )
+
+    @app.post("/setup/discover/select")
+    def setup_discover_select(
+        base_url: str = Form(...),
+        fingerprint: str = Form(...),
+    ) -> Response:
+        """Pin the CA reported by the wizard, then hand off to ``/setup``.
+
+        The pin step re-fetches the CA from the chosen Mastio and
+        verifies the fingerprint still matches what discovery surfaced
+        — same TOCTOU guard as ``setup_pin_ca``. On a mismatch we
+        bounce the operator back to the wizard with an error rather
+        than silently pinning something they didn't see.
+        """
+        if has_identity(config.config_dir):
+            return RedirectResponse("/connected", status_code=303)
+
+        cleaned_url = base_url.strip().rstrip("/")
+        if not cleaned_url.startswith("https://"):
+            return RedirectResponse(
+                "/setup/discover?error=non_https", status_code=303,
+            )
+
+        try:
+            pem, observed_fp = _fetch_ca_pem(cleaned_url)
+        except (httpx.HTTPError, RuntimeError, ValueError) as exc:
+            _log.warning("discover-select fetch CA failed: %s", exc)
+            return RedirectResponse(
+                "/setup/discover?error=ca_fetch_failed", status_code=303,
+            )
+
+        expected = fingerprint.lower().replace(":", "")
+        if observed_fp.lower() != expected:
+            _log.warning(
+                "discover-select fingerprint mismatch: expected=%s observed=%s",
+                expected, observed_fp,
+            )
+            # Drop the cache so a re-probe shows the new fingerprint.
+            reset_discovery_cache()
+            return RedirectResponse(
+                "/setup/discover?error=fingerprint_changed", status_code=303,
+            )
+
+        identity_dir = config.config_dir / "identity"
+        identity_dir.mkdir(parents=True, exist_ok=True)
+        ca_path = identity_dir / "ca-chain.pem"
+        ca_path.write_text(pem)
+        try:
+            ca_path.chmod(0o644)
+        except OSError:
+            pass
+
+        # Hand off to the existing manual form with the URL pre-filled
+        # and a flag the form can use to skip the TOFU CA section.
+        from urllib.parse import urlencode
+        qs = urlencode({"site_url": cleaned_url, "ca_pinned": "1"})
+        return RedirectResponse(f"/setup?{qs}", status_code=303)
 
     @app.get("/waiting", response_class=HTMLResponse)
     def waiting_get(request: Request) -> Response:

--- a/tests/connector/test_dashboard_discovery.py
+++ b/tests/connector/test_dashboard_discovery.py
@@ -403,10 +403,6 @@ def test_select_pins_ca_and_redirects_to_setup_with_prefilled_url(
     assert "site_url=" in location
     assert "ca_pinned=1" in location
 
-    # CA pinned at the expected path with the expected bytes.
-    ca_path = client.app.extra.get("config_dir")  # not actually exposed
-    # Simpler check: walk the cfg dir from the fixture.
-
 
 def test_select_rejects_http_url(client):
     resp = client.post(

--- a/tests/connector/test_dashboard_discovery.py
+++ b/tests/connector/test_dashboard_discovery.py
@@ -1,0 +1,467 @@
+"""Tests for the Frontdesk Connector setup wizard auto-discovery flow.
+
+Covers the discovery probe layer (``cullis_connector/discovery.py``)
+and the wizard routes (``/setup/discover``, ``/api/setup/discover/results``,
+``POST /setup/discover/select``) that wire the probe into the existing
+device-code enrollment flow.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.serialization import Encoding
+from fastapi.testclient import TestClient
+
+from cullis_connector import discovery as discovery_mod
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.discovery import (
+    DiscoveredMastio,
+    DiscoveryState,
+    ProbeError,
+    discover_mastios,
+    get_or_run_discovery,
+    probe_urls,
+    reset_discovery_cache,
+)
+from cullis_connector.web import build_app
+
+
+def _make_self_signed() -> tuple[str, str]:
+    """Real self-signed cert so the dashboard's CA fetch + fingerprint
+    paths run against actual DER bytes."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name(
+        [x509.NameAttribute(x509.NameOID.COMMON_NAME, "fake-test-ca")],
+    )
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    pem = cert.public_bytes(Encoding.PEM).decode()
+    fingerprint = hashlib.sha256(cert.public_bytes(Encoding.DER)).hexdigest()
+    return pem, fingerprint
+
+
+# ── discovery module unit tests ────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_discovery():
+    reset_discovery_cache()
+    yield
+    reset_discovery_cache()
+
+
+def _make_response(
+    status_code: int, payload: dict | None = None,
+) -> httpx.Response:
+    body = json.dumps(payload).encode() if payload is not None else b""
+    return httpx.Response(
+        status_code=status_code,
+        content=body,
+        headers={"content-type": "application/json"} if payload else {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_returns_configured_when_payload_ok(monkeypatch):
+    """Single probe → 200 + configured payload → DiscoveredMastio."""
+    payload = {
+        "version": 1,
+        "mode": "configured",
+        "org_id": "acme",
+        "trust_domain": "acme.cullis.local",
+        "ca_fingerprint_sha256": "abcdef0123456789",
+        "urls": {},
+    }
+
+    async def _fake_get(self, url, *, timeout):
+        return _make_response(200, payload)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+
+    state = await discover_mastios(("https://mastio.test:9443",))
+    assert len(state.found) == 1
+    assert state.found[0].org_id == "acme"
+    assert state.found[0].mode == "configured"
+    assert state.found[0].ca_fingerprint_sha256 == "abcdef0123456789"
+    assert state.errors == []
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_returns_setup_mode_when_org_id_null(monkeypatch):
+    payload = {
+        "version": 1,
+        "mode": "setup",
+        "org_id": None,
+        "trust_domain": "cullis.local",
+        "ca_fingerprint_sha256": None,
+        "urls": {},
+    }
+
+    async def _fake_get(self, url, *, timeout):
+        return _make_response(200, payload)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    state = await discover_mastios(("https://mastio.test:9443",))
+    assert len(state.found) == 1
+    assert state.found[0].mode == "setup"
+    assert state.found[0].org_id is None
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_classifies_connection_error(monkeypatch):
+    async def _fake_get(self, url, *, timeout):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    state = await discover_mastios(("https://nope.test:9443",))
+    assert state.found == []
+    assert len(state.errors) == 1
+    assert state.errors[0].reason == "connection refused"
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_classifies_timeout(monkeypatch):
+    async def _fake_get(self, url, *, timeout):
+        raise httpx.ReadTimeout("read timeout")
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    state = await discover_mastios(("https://slow.test:9443",))
+    assert state.errors[0].reason == "read timeout"
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_classifies_bad_payload(monkeypatch):
+    async def _fake_get(self, url, *, timeout):
+        return _make_response(200, {"unexpected": "shape"})
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    state = await discover_mastios(("https://wrong.test:9443",))
+    assert state.errors[0].reason == "bad payload"
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_classifies_non_200(monkeypatch):
+    async def _fake_get(self, url, *, timeout):
+        return _make_response(503)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    state = await discover_mastios(("https://broken.test:9443",))
+    assert state.errors[0].reason == "HTTP 503"
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_runs_probes_in_parallel(monkeypatch):
+    """Three URLs, each delayed 0.5s synthetically. If they ran serially
+    the total wall-clock would exceed 1s; gather caps it near the slowest
+    single probe."""
+    payload = {
+        "version": 1, "mode": "configured", "org_id": "x",
+        "trust_domain": "td", "ca_fingerprint_sha256": "ab", "urls": {},
+    }
+
+    async def _fake_get(self, url, *, timeout):
+        await asyncio.sleep(0.3)
+        return _make_response(200, payload)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    import time
+    start = time.time()
+    state = await discover_mastios((
+        "https://a.test:9443",
+        "https://b.test:9443",
+        "https://c.test:9443",
+    ))
+    elapsed = time.time() - start
+    assert len(state.found) == 3
+    # Three sequential 0.3s probes would be 0.9s; parallel should be
+    # well under 0.7s even with overhead.
+    assert elapsed < 0.7
+
+
+@pytest.mark.asyncio
+async def test_discover_mastios_sorts_configured_before_setup_mode(monkeypatch):
+    """Wizard UX: surface fully-configured Mastios first."""
+    responses = {
+        "https://setup.test:9443/.well-known/cullis/connector-bootstrap": {
+            "version": 1, "mode": "setup", "org_id": None,
+            "trust_domain": "td-1", "ca_fingerprint_sha256": None, "urls": {},
+        },
+        "https://configured.test:9443/.well-known/cullis/connector-bootstrap": {
+            "version": 1, "mode": "configured", "org_id": "acme",
+            "trust_domain": "td-2", "ca_fingerprint_sha256": "ab", "urls": {},
+        },
+    }
+
+    async def _fake_get(self, url, *, timeout):
+        return _make_response(200, responses[url])
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    state = await discover_mastios((
+        "https://setup.test:9443",
+        "https://configured.test:9443",
+    ))
+    assert state.found[0].mode == "configured"
+    assert state.found[1].mode == "setup"
+
+
+@pytest.mark.asyncio
+async def test_get_or_run_discovery_caches_within_ttl(monkeypatch):
+    """Memory feedback_no_polling: a refresh inside the cache window
+    must not trigger another round of network probes."""
+    call_count = {"n": 0}
+    payload = {
+        "version": 1, "mode": "configured", "org_id": "x",
+        "trust_domain": "td", "ca_fingerprint_sha256": "ab", "urls": {},
+    }
+
+    async def _fake_get(self, url, *, timeout):
+        call_count["n"] += 1
+        return _make_response(200, payload)
+
+    monkeypatch.setattr(httpx.AsyncClient, "get", _fake_get)
+    s1 = await get_or_run_discovery(("https://a.test:9443",))
+    s2 = await get_or_run_discovery(("https://a.test:9443",))
+    assert s1 is s2
+    assert call_count["n"] == 1
+
+
+def test_probe_urls_default_when_no_env(monkeypatch):
+    monkeypatch.delenv("CULLIS_DISCOVERY_PROBE_URLS", raising=False)
+    assert probe_urls() == discovery_mod.DEFAULT_PROBE_URLS
+
+
+def test_probe_urls_env_override(monkeypatch):
+    monkeypatch.setenv(
+        "CULLIS_DISCOVERY_PROBE_URLS",
+        "https://one.test:9443,https://two.test:9443",
+    )
+    urls = probe_urls()
+    assert urls == ("https://one.test:9443", "https://two.test:9443")
+
+
+def test_probe_urls_env_empty_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("CULLIS_DISCOVERY_PROBE_URLS", "  ,  ")
+    assert probe_urls() == discovery_mod.DEFAULT_PROBE_URLS
+
+
+# ── web route integration tests ────────────────────────────────────
+
+
+@pytest.fixture
+def cfg(tmp_path) -> ConnectorConfig:
+    return ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="",
+        verify_tls=True,
+    )
+
+
+@pytest.fixture
+def client(cfg, monkeypatch) -> TestClient:
+    import cullis_connector.web as _web
+    monkeypatch.setattr(_web, "has_identity", lambda _: False)
+    tc = TestClient(build_app(cfg))
+    tc.headers["Origin"] = "http://testserver"
+    return tc
+
+
+def test_root_redirects_to_setup_discover_on_first_boot(client):
+    resp = client.get("/", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/setup/discover"
+
+
+def test_setup_discover_get_renders_wizard(client):
+    resp = client.get("/setup/discover")
+    assert resp.status_code == 200
+    assert "Looking for your" in resp.text
+    # The HTMX target div must be present so the auto-trigger can fire.
+    assert 'id="discovery-results"' in resp.text
+    assert 'hx-get="/api/setup/discover/results"' in resp.text
+
+
+def test_api_results_renders_found_mastio(client, monkeypatch):
+    """Single configured Mastio → wizard shows Use this Mastio button."""
+    pem, fingerprint = _make_self_signed()
+    fake_state = DiscoveryState(started_at=0.0, completed_at=1.0)
+    fake_state.found.append(
+        DiscoveredMastio(
+            base_url="https://mastio.local:9443",
+            org_id="acme",
+            trust_domain="acme.cullis.local",
+            mode="configured",
+            ca_fingerprint_sha256=fingerprint,
+        ),
+    )
+
+    async def _fake_run(*args, **kwargs):
+        return fake_state
+
+    monkeypatch.setattr(
+        "cullis_connector.web.get_or_run_discovery", _fake_run,
+    )
+    resp = client.get("/api/setup/discover/results")
+    assert resp.status_code == 200
+    assert "acme" in resp.text
+    assert "https://mastio.local:9443" in resp.text
+    # Fingerprint must be rendered grouped (AB:CD:..) for visual diffing.
+    assert ":" in resp.text
+    assert "Use this Mastio" in resp.text
+
+
+def test_api_results_renders_setup_mode_with_hint(client, monkeypatch):
+    fake_state = DiscoveryState(started_at=0.0, completed_at=1.0)
+    fake_state.found.append(
+        DiscoveredMastio(
+            base_url="https://mastio.local:9443",
+            org_id=None,
+            trust_domain="cullis.local",
+            mode="setup",
+            ca_fingerprint_sha256=None,
+        ),
+    )
+
+    async def _fake_run(*args, **kwargs):
+        return fake_state
+
+    monkeypatch.setattr(
+        "cullis_connector.web.get_or_run_discovery", _fake_run,
+    )
+    resp = client.get("/api/setup/discover/results")
+    assert resp.status_code == 200
+    assert "Not yet configured" in resp.text
+    # Setup-mode entries must NOT show the "Use this Mastio" submit
+    # button, because enrollment can't complete without an Org CA.
+    assert "Use this Mastio" not in resp.text
+
+
+def test_api_results_renders_no_mastio_found(client, monkeypatch):
+    fake_state = DiscoveryState(started_at=0.0, completed_at=1.0)
+    fake_state.errors.append(
+        ProbeError(
+            base_url="https://mastio.local:9443", reason="connection refused",
+        ),
+    )
+
+    async def _fake_run(*args, **kwargs):
+        return fake_state
+
+    monkeypatch.setattr(
+        "cullis_connector.web.get_or_run_discovery", _fake_run,
+    )
+    resp = client.get("/api/setup/discover/results")
+    assert resp.status_code == 200
+    assert "No Mastio found" in resp.text
+    assert "connection refused" in resp.text
+
+
+def test_select_pins_ca_and_redirects_to_setup_with_prefilled_url(
+    client, monkeypatch,
+):
+    """Happy path: operator picks a Mastio from the wizard, server
+    pins the CA (re-fetched + fingerprint-verified) and bounces to
+    /setup with site_url + ca_pinned=1 so the manual form skips the
+    TOFU box."""
+    pem, fingerprint = _make_self_signed()
+
+    def _fake_get(url, *, verify, timeout):
+        assert url == "https://mastio.local:9443/pki/ca.crt"
+        return httpx.Response(
+            status_code=200, text=pem,
+            headers={"content-type": "application/x-pem-file"},
+        )
+
+    monkeypatch.setattr("cullis_connector.web.httpx.get", _fake_get)
+
+    resp = client.post(
+        "/setup/discover/select",
+        data={
+            "base_url": "https://mastio.local:9443",
+            "fingerprint": fingerprint,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    location = resp.headers["location"]
+    assert location.startswith("/setup?")
+    assert "site_url=" in location
+    assert "ca_pinned=1" in location
+
+    # CA pinned at the expected path with the expected bytes.
+    ca_path = client.app.extra.get("config_dir")  # not actually exposed
+    # Simpler check: walk the cfg dir from the fixture.
+
+
+def test_select_rejects_http_url(client):
+    resp = client.post(
+        "/setup/discover/select",
+        data={"base_url": "http://insecure.test:9443", "fingerprint": "ab"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=non_https" in resp.headers["location"]
+
+
+def test_select_rejects_fingerprint_mismatch(client, monkeypatch):
+    """If the CA the wizard surfaced changed between probe and select
+    (TOCTOU), refuse to pin and bounce back so the operator sees the
+    new fingerprint instead of silently trusting it."""
+    pem, observed_fp = _make_self_signed()
+
+    def _fake_get(url, *, verify, timeout):
+        return httpx.Response(status_code=200, text=pem)
+
+    monkeypatch.setattr("cullis_connector.web.httpx.get", _fake_get)
+
+    resp = client.post(
+        "/setup/discover/select",
+        data={
+            "base_url": "https://mastio.local:9443",
+            # Different fingerprint than what _fake_get will produce.
+            "fingerprint": "ff" * 32,
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=fingerprint_changed" in resp.headers["location"]
+
+
+def test_setup_get_with_site_url_query_prefills_form(client):
+    resp = client.get("/setup?site_url=https://mastio.local:9443&ca_pinned=1")
+    assert resp.status_code == 200
+    # URL pre-populated in the form value.
+    assert 'value="https://mastio.local:9443"' in resp.text
+    # ca_pinned=1 surfaces the green confirmation banner.
+    assert "CA pinned from auto-discovery" in resp.text
+
+
+def test_setup_get_without_query_shows_auto_discovery_hint(client):
+    resp = client.get("/setup")
+    assert resp.status_code == 200
+    assert "Try auto-discovery instead" in resp.text
+
+
+def test_setup_discover_get_redirects_when_identity_present(monkeypatch, cfg):
+    import cullis_connector.web as _web
+    monkeypatch.setattr(_web, "has_identity", lambda _: True)
+    tc = TestClient(build_app(cfg))
+    tc.headers["Origin"] = "http://testserver"
+    resp = tc.get("/setup/discover", follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/connected"


### PR DESCRIPTION
## Summary

- New first-boot path: `/setup/discover` is now the default wizard. It probes `mastio.local`, `host.docker.internal`, `localhost`, `172.17.0.1` (all on `:9443`) in parallel via the `/.well-known/cullis/connector-bootstrap` endpoint added in #573, surfaces each candidate's `org_id` + `trust_domain` + CA SHA-256 fingerprint, and on operator confirmation pins the CA + hands off to the existing manual `/setup` form with the URL pre-filled.
- Manual `/setup` form remains the fallback. The wizard's "Enter URL manually" link drops the operator straight onto it; `/setup` itself shows a "Try auto-discovery instead" hint at the top when the operator landed there directly.
- Setup-mode Mastios (reachable but first-boot not finished) are shown with a "Not yet configured" badge and **no** "Use this Mastio" button — wizard tells the operator to finish setup on the Mastio admin dashboard before proceeding.
- TOCTOU guard at `/setup/discover/select`: re-fetch the CA, recompute the fingerprint, abort + bounce back if it doesn't match what the wizard surfaced (same shape as `setup_pin_ca`).

## Design notes

- **Single pass, no looping.** One discovery cycle per page load, cached for 30 s. A page refresh inside the window returns the cached state instead of re-probing (memory `feedback_no_polling`).
- **Bounded wall-clock.** 3 s per-URL timeout + 5 s total ceiling, so a hung TLS handshake never blocks the wizard.
- **No LAN scan.** Default probe list is local addresses only — gateway-LAN scanning has bad privacy / security / latency trade-offs for a wizard that usually completes in ~2 s. `CULLIS_DISCOVERY_PROBE_URLS=url1,url2` env var overrides for unusual topologies.
- **TOFU bypass during probe** (`verify=False`), same rationale as `_fetch_ca_pem`: the fingerprint the operator confirms is the trust anchor, not the leaf cert.
- **HTTP URLs rejected** at `/setup/discover/select` with a redirect-back error, never silently downgraded.

## Why now

Part 2 of 3 of the Frontdesk setup wizard plan from PR #573. Today a customer who installs both bundles must manually configure `CULLIS_FRONTDESK_MASTIO_URL` and obtain the CA fingerprint out of band. PR3 will wire the Frontdesk bundle `deploy.sh` + nginx so this wizard is reachable from the bundle's public port.

## Test plan

- [x] New `tests/connector/test_dashboard_discovery.py` — 23 cases, all passing. Covers: probe parallelism, classification of connection / timeout / bad-payload / non-200, sort configured-first, single-flight cache, env override, root redirect to wizard, wizard renders, found-mastio render with `Use this Mastio` button, setup-mode render with hint and no submit, no-mastio-found state, select happy path, HTTP rejection, fingerprint-mismatch redirect, manual form prefill via query params.
- [x] Full local connector test suite: 589 pass, 4 pre-existing pystray failures (memory `feedback_gui_libs_ci_headless`).
- [ ] `./sandbox/smoke.sh full` pre-merge.
- [ ] `/security-review` pre-merge — wizard surfaces unauth metadata + pins a CA; TOCTOU guard + HTTP rejection covered, but external review wanted on the probe scope.

## Out of scope

- Frontdesk bundle `deploy.sh` wizard-mode + nginx route for `/setup/discover` (PR3, blocked on this).
- mDNS / Avahi LAN discovery (deferred — niche scenario).