### PR TITLE
feat(mcp_proxy): AD-style password layer for user principals

### DIFF
--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -8,18 +8,33 @@ table on every signature, so a user that *does* go through SSO first
 shows up automatically.
 
 Endpoints:
-- POST ``/v1/admin/users``   create a principal row (idempotent on conflict)
-- GET  ``/v1/admin/users``   list, optionally filtered by reach / surface / q
+- POST   ``/v1/admin/users``                              create / upsert
+- GET    ``/v1/admin/users``                              list
+- POST   ``/v1/admin/users/{principal_id}/reset-password``  rotate password
+- POST   ``/v1/admin/users/{principal_id}/deactivate``    block sign-in
+- POST   ``/v1/admin/users/{principal_id}/reactivate``    re-allow sign-in
+- DELETE ``/v1/admin/users/{principal_id}``               purge row
 
 Auth: ``X-Admin-Secret`` (same contract as ``/v1/admin/agents``).
+
+AD-style password layer (migration 0026): when ``password`` is supplied
+on create or via reset-password the row gets a bcrypt hash + the
+``must_change_password`` flag, mirroring how a domain admin hands an
+employee a one-time credential. The ``/v1/principals/password-login``
+endpoint validates the hash and mints a DPoP-bound JWT the client then
+spends on ``/v1/principals/csr`` to obtain its cert. Rows that never
+receive a password (today's SSO-upsert path) keep ``password_hash``
+NULL and are unaffected.
 """
 from __future__ import annotations
 
+import asyncio
 import hmac
 import logging
 from datetime import datetime, timezone
 from typing import Optional
 
+import bcrypt
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy import text
@@ -51,6 +66,8 @@ def _require_admin_secret(
 
 
 _VALID_REACH = ("intra", "cross", "both")
+MIN_PASSWORD_LENGTH = 8
+MAX_PASSWORD_LENGTH = 128
 
 
 class UserCreateRequest(BaseModel):
@@ -58,6 +75,19 @@ class UserCreateRequest(BaseModel):
     display_name: str = Field("", max_length=256)
     reach: str = Field("intra")
     surface: Optional[str] = Field(None, max_length=64)
+    # AD-style: admin types the initial password. NULL leaves the row in
+    # SSO-only mode (today's behaviour). When supplied, the row is forced
+    # into "must change password at first login" so the admin's choice is
+    # never the long-lived secret.
+    password: Optional[str] = Field(
+        None, min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH,
+    )
+
+
+class PasswordResetRequest(BaseModel):
+    new_password: str = Field(
+        ..., min_length=MIN_PASSWORD_LENGTH, max_length=MAX_PASSWORD_LENGTH,
+    )
 
 
 class UserOut(BaseModel):
@@ -68,6 +98,9 @@ class UserOut(BaseModel):
     surface: Optional[str]
     last_active: Optional[str]
     created_at: str
+    has_password: bool = False
+    must_change_password: bool = False
+    disabled: bool = False
 
 
 class UserListResponse(BaseModel):
@@ -89,6 +122,57 @@ def _principal_id(org_id: str, user_name: str) -> str:
     return f"{org_id}::user::{user_name}"
 
 
+def _hash_password_sync(plain: str) -> str:
+    return bcrypt.hashpw(
+        plain.encode("utf-8"), bcrypt.gensalt(rounds=12),
+    ).decode("utf-8")
+
+
+def _check_password_sync(plain: str, stored_hash: str) -> bool:
+    try:
+        return bcrypt.checkpw(
+            plain.encode("utf-8"), stored_hash.encode("utf-8"),
+        )
+    except (ValueError, TypeError):
+        return False
+
+
+async def hash_password(plain: str) -> str:
+    return await asyncio.to_thread(_hash_password_sync, plain)
+
+
+async def verify_password(plain: str, stored_hash: str) -> bool:
+    if not isinstance(plain, str) or not plain:
+        return False
+    if not isinstance(stored_hash, str) or not stored_hash:
+        return False
+    return await asyncio.to_thread(_check_password_sync, plain, stored_hash)
+
+
+def _row_to_userout(row) -> "UserOut":
+    return UserOut(
+        principal_id=row["principal_id"],
+        user_name=row["user_name"],
+        display_name=row["display_name"],
+        reach=row["reach"],
+        surface=row["surface"],
+        last_active=row["last_active_at"],
+        created_at=row["created_at"],
+        has_password=bool(row["password_hash"]),
+        must_change_password=bool(row["must_change_password"]),
+        disabled=bool(row["disabled"]),
+    )
+
+
+# Centralised SELECT list — keeps every read path returning the same
+# shape, which the dashboard + endpoints below all depend on.
+_SELECT_COLS = (
+    "principal_id, user_name, display_name, reach, surface, "
+    "created_at, last_active_at, password_hash, "
+    "must_change_password, disabled"
+)
+
+
 # ── endpoints ───────────────────────────────────────────────────────────
 
 
@@ -103,10 +187,14 @@ async def create_user(
 ) -> UserOut:
     """Insert (or no-op on duplicate) a user-principal row.
 
-    Idempotent: re-posting the same ``user_name`` returns 201 with the
-    existing row; ``display_name`` / ``reach`` / ``surface`` are *not*
-    overwritten on conflict so admin pre-population can't blow away
-    a row a real Frontdesk SSO touch already filled in.
+    Idempotent on user_name: re-posting the same name returns 201 with
+    the existing row; ``display_name`` / ``reach`` / ``surface`` are
+    *not* overwritten so a real Frontdesk SSO touch can't be blown away
+    by admin pre-population. If ``password`` is supplied AND the row had
+    no password yet, it is set + ``must_change_password`` flipped to
+    True. Re-issuing a password through this endpoint on a row that
+    already has one is rejected — admins must use the explicit
+    ``/reset-password`` action so password rotation is auditable.
     """
     if body.reach not in _VALID_REACH:
         raise HTTPException(
@@ -121,13 +209,11 @@ async def create_user(
         )
     pid = _principal_id(mgr.org_id, body.user_name)
     now = _now_iso()
+    pw_hash = await hash_password(body.password) if body.password else None
     async with get_db() as conn:
         existing = (await conn.execute(
-            text(
-                "SELECT principal_id, user_name, display_name, reach, "
-                "       surface, created_at, last_active_at "
-                "  FROM local_user_principals WHERE principal_id = :pid"
-            ),
+            text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                 "WHERE principal_id = :pid"),
             {"pid": pid},
         )).mappings().first()
         if existing is None:
@@ -136,9 +222,12 @@ async def create_user(
                     """
                     INSERT INTO local_user_principals (
                         principal_id, user_name, display_name,
-                        reach, surface, created_at
+                        reach, surface, created_at,
+                        password_hash, must_change_password, disabled,
+                        password_updated_at
                     ) VALUES (
-                        :pid, :uname, :disp, :reach, :surface, :now
+                        :pid, :uname, :disp, :reach, :surface, :now,
+                        :pw, :mcp, :dis, :pwnow
                     )
                     """
                 ),
@@ -149,26 +238,55 @@ async def create_user(
                     "reach": body.reach,
                     "surface": body.surface,
                     "now": now,
+                    "pw": pw_hash,
+                    "mcp": bool(pw_hash),
+                    "dis": bool(False),
+                    "pwnow": now if pw_hash else None,
                 },
             )
-            return UserOut(
-                principal_id=pid,
-                user_name=body.user_name,
-                display_name=body.display_name or None,
-                reach=body.reach,
-                surface=body.surface,
-                last_active=None,
-                created_at=now,
+            row = (await conn.execute(
+                text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                     "WHERE principal_id = :pid"),
+                {"pid": pid},
+            )).mappings().first()
+            return _row_to_userout(row)
+
+        # Row exists — handle password top-up only if the row has no
+        # hash yet (admin filling in credentials post-SSO bootstrap).
+        if pw_hash and not existing["password_hash"]:
+            await conn.execute(
+                text(
+                    """
+                    UPDATE local_user_principals
+                       SET password_hash         = :pw,
+                           must_change_password  = :mcp,
+                           password_updated_at   = :pwnow
+                     WHERE principal_id = :pid
+                    """
+                ),
+                {
+                    "pid": pid,
+                    "pw": pw_hash,
+                    "mcp": bool(True),
+                    "pwnow": now,
+                },
             )
-        return UserOut(
-            principal_id=existing["principal_id"],
-            user_name=existing["user_name"],
-            display_name=existing["display_name"],
-            reach=existing["reach"],
-            surface=existing["surface"],
-            last_active=existing["last_active_at"],
-            created_at=existing["created_at"],
-        )
+            row = (await conn.execute(
+                text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                     "WHERE principal_id = :pid"),
+                {"pid": pid},
+            )).mappings().first()
+            return _row_to_userout(row)
+
+        if pw_hash and existing["password_hash"]:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "user already has a password — use "
+                    "/v1/admin/users/{principal_id}/reset-password"
+                ),
+            )
+        return _row_to_userout(existing)
 
 
 @router.get(
@@ -187,11 +305,7 @@ async def list_users(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"reach must be one of {_VALID_REACH}",
         )
-    sql = (
-        "SELECT principal_id, user_name, display_name, reach, surface, "
-        "       created_at, last_active_at "
-        "  FROM local_user_principals "
-    )
+    sql = f"SELECT {_SELECT_COLS} FROM local_user_principals "
     where: list[str] = []
     params: dict[str, object] = {"limit": limit}
     if reach is not None:
@@ -211,19 +325,142 @@ async def list_users(
     sql += " ORDER BY created_at DESC LIMIT :limit"
     async with get_db() as conn:
         rows = (await conn.execute(text(sql), params)).mappings().all()
-    items = [
-        UserOut(
-            principal_id=r["principal_id"],
-            user_name=r["user_name"],
-            display_name=r["display_name"],
-            reach=r["reach"],
-            surface=r["surface"],
-            last_active=r["last_active_at"],
-            created_at=r["created_at"],
-        )
-        for r in rows
-    ]
+    items = [_row_to_userout(r) for r in rows]
     return UserListResponse(users=items, total=len(items))
+
+
+@router.post(
+    "/{principal_id}/reset-password",
+    response_model=UserOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def reset_password(
+    principal_id: str, body: PasswordResetRequest,
+) -> UserOut:
+    """Force-set a new password and re-arm ``must_change_password``.
+
+    Used when the employee forgot the password or the admin wants to
+    rotate the credential. Always re-arms the change-on-first-login
+    flag so the admin's typed value is never long-lived.
+    """
+    pw_hash = await hash_password(body.new_password)
+    now = _now_iso()
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                UPDATE local_user_principals
+                   SET password_hash         = :pw,
+                       must_change_password  = :mcp,
+                       password_updated_at   = :now
+                 WHERE principal_id = :pid
+                """
+            ),
+            {
+                "pid": principal_id,
+                "pw": pw_hash,
+                "mcp": bool(True),
+                "now": now,
+            },
+        )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="user principal not found",
+            )
+        row = (await conn.execute(
+            text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                 "WHERE principal_id = :pid"),
+            {"pid": principal_id},
+        )).mappings().first()
+    _log.info("admin reset password for principal_id=%s", principal_id)
+    return _row_to_userout(row)
+
+
+@router.post(
+    "/{principal_id}/deactivate",
+    response_model=UserOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def deactivate_user(principal_id: str) -> UserOut:
+    """Block sign-in without deleting the audit history.
+
+    Sets ``disabled=True``. The login endpoint refuses disabled rows;
+    existing certs remain on disk but cannot be re-issued nor re-bound
+    to a fresh DPoP key (the JWT mint path checks the same flag).
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE local_user_principals SET disabled = :dis "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id, "dis": bool(True)},
+        )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="user principal not found",
+            )
+        row = (await conn.execute(
+            text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                 "WHERE principal_id = :pid"),
+            {"pid": principal_id},
+        )).mappings().first()
+    _log.info("admin deactivated principal_id=%s", principal_id)
+    return _row_to_userout(row)
+
+
+@router.post(
+    "/{principal_id}/reactivate",
+    response_model=UserOut,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def reactivate_user(principal_id: str) -> UserOut:
+    """Inverse of ``deactivate_user``."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE local_user_principals SET disabled = :dis "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id, "dis": bool(False)},
+        )
+        if result.rowcount == 0:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="user principal not found",
+            )
+        row = (await conn.execute(
+            text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                 "WHERE principal_id = :pid"),
+            {"pid": principal_id},
+        )).mappings().first()
+    _log.info("admin reactivated principal_id=%s", principal_id)
+    return _row_to_userout(row)
+
+
+@router.delete(
+    "/{principal_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def delete_user(principal_id: str) -> None:
+    """Purge the directory row.
+
+    Intentionally narrow: this only drops the Mastio-side display row.
+    Issued certs continue to live in the audit chain; the admin can
+    still reconcile against past activity by principal_id. If the row
+    doesn't exist we return 204 anyway — DELETE is idempotent.
+    """
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "DELETE FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )
+    _log.info("admin deleted principal_id=%s", principal_id)
 
 
 # ── populator helper ────────────────────────────────────────────────────
@@ -268,11 +505,13 @@ async def upsert_from_csr(
                         INSERT INTO local_user_principals (
                             principal_id, user_name, display_name,
                             reach, surface, cert_thumbprint,
-                            created_at, last_active_at
+                            created_at, last_active_at,
+                            must_change_password, disabled
                         ) VALUES (
                             :pid, :uname, NULL,
                             'intra', :surface, :thumb,
-                            :now, :now
+                            :now, :now,
+                            :mcp, :dis
                         )
                         """
                     ),
@@ -280,6 +519,7 @@ async def upsert_from_csr(
                         "pid": pid, "uname": user_name,
                         "surface": surface_hint, "thumb": cert_thumbprint,
                         "now": now,
+                        "mcp": bool(False), "dis": bool(False),
                     },
                 )
             else:

--- a/mcp_proxy/alembic/versions/0026_user_password.py
+++ b/mcp_proxy/alembic/versions/0026_user_password.py
@@ -1,0 +1,96 @@
+"""AD-style local password credentials for user principals.
+
+Revision ID: 0026_user_password
+Revises: 0025_local_principals
+Create Date: 2026-05-10 22:00:00.000000
+
+Adds a local password layer on top of ``local_user_principals`` so an org
+admin can pre-provision an employee account from the dashboard and hand
+the credential out-of-band, mirroring the Active Directory flow:
+
+  admin creates row with bcrypt(password) + must_change_password=True
+  employee logs into Cullis Chat / dashboard with user_name + password
+  /v1/principals/password-login mints a short-lived DPoP-bound JWT
+  the JWT is presented to the existing /v1/principals/csr endpoint
+  the user's cert is minted, must_change_password forces a change first
+
+Backward compatible: the SSO upsert path (``upsert_from_csr``) leaves
+``password_hash`` NULL, so SSO-only users keep working unchanged. The
+login endpoint refuses NULL hashes with a clear "this is an SSO-only
+account" message rather than treating it as a wrong-password attempt.
+
+Boolean columns use ``server_default`` literals; the application always
+binds ``bool(x)`` to dodge the Postgres BOOLEAN binding gotcha that
+SQLite silently masks (memory: feedback_postgres_type_binding).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0026_user_password"
+down_revision: Union[str, Sequence[str], None] = "0025_local_principals"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_USERS = "local_user_principals"
+
+
+def _has_column(inspector: sa.engine.reflection.Inspector, table: str, col: str) -> bool:
+    return any(c["name"] == col for c in inspector.get_columns(table))
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _USERS not in set(inspector.get_table_names()):
+        # Migration 0025 not applied (fresh test stamp). The column adds
+        # below would error; bail silently to keep the chain idempotent
+        # alongside the 0025 ``if _USERS not in existing`` guard.
+        return
+
+    if not _has_column(inspector, _USERS, "password_hash"):
+        op.add_column(
+            _USERS,
+            sa.Column("password_hash", sa.Text(), nullable=True),
+        )
+    if not _has_column(inspector, _USERS, "must_change_password"):
+        op.add_column(
+            _USERS,
+            sa.Column(
+                "must_change_password", sa.Boolean(),
+                nullable=False, server_default=sa.false(),
+            ),
+        )
+    if not _has_column(inspector, _USERS, "disabled"):
+        op.add_column(
+            _USERS,
+            sa.Column(
+                "disabled", sa.Boolean(),
+                nullable=False, server_default=sa.false(),
+            ),
+        )
+    if not _has_column(inspector, _USERS, "password_updated_at"):
+        op.add_column(
+            _USERS,
+            sa.Column("password_updated_at", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _USERS not in set(inspector.get_table_names()):
+        return
+
+    for col in (
+        "password_updated_at",
+        "disabled",
+        "must_change_password",
+        "password_hash",
+    ):
+        if _has_column(inspector, _USERS, col):
+            op.drop_column(_USERS, col)

--- a/mcp_proxy/registry/user_principals_router.py
+++ b/mcp_proxy/registry/user_principals_router.py
@@ -1,25 +1,44 @@
-"""ADR-021 PR4a (proxy-side) — POST /v1/principals/csr.
+"""ADR-021 PR4a (proxy-side) — POST /v1/principals/csr + AD-style password login.
 
-The Frontdesk Connector calls this endpoint at every SSO touch to mint
-a fresh user-principal cert. Originally lived on the broker; moved to
+The Frontdesk Connector calls ``/csr`` at every SSO touch to mint a
+fresh user-principal cert. Originally lived on the broker; moved to
 the proxy because the org-CA private key (the right signer for these
 certs) only exists on the proxy. See ``principals_csr.py`` header for
 the full rationale.
 
-Auth: the same DPoP-bound JWT the proxy already issues for the rest of
-``/v1/*`` (``get_authenticated_agent``). RBAC: caller may only sign
-CSRs for principals in its own org — enforced inside ``sign_user_csr``
-against ``AgentManager.org_id``.
+The ``/password-login`` and ``/change-password`` endpoints layer an
+Active-Directory style local credential on top of the same principal
+table. Admin pre-creates a row with bcrypt(password) +
+must_change_password via ``POST /v1/admin/users``; the user logs in
+with user_name + password + their DPoP public key, gets a short-lived
+DPoP-bound JWT, and spends it on ``/csr`` to materialise the cert.
+
+Auth contract:
+- ``/csr`` and ``/change-password`` use ``get_authenticated_agent``
+  (DPoP-bound JWT). RBAC inside ``sign_user_csr`` enforces same-org.
+- ``/password-login`` is intentionally unauthenticated — it IS the
+  authentication endpoint. Brute-force is bounded by bcrypt cost
+  (rounds=12) and the rate limiter the dashboard wraps it in.
 """
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field
+from sqlalchemy import text
 
+from mcp_proxy.admin.users import (
+    _SELECT_COLS,
+    _principal_id as _short_principal_id,
+    hash_password,
+    verify_password,
+)
 from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.auth.dpop import compute_jkt
+from mcp_proxy.db import get_db
 from mcp_proxy.models import TokenPayload
 from mcp_proxy.registry.principals_csr import (
     CsrValidationError,
@@ -95,6 +114,33 @@ async def sign_csr(
             detail="cannot sign a CSR for a principal in a different org",
         )
 
+    # AD-style password gate: if the principal has a local password and
+    # the change-password flag is still set, refuse to mint a long-lived
+    # cert until the user rotates the admin-supplied initial credential.
+    # Only applies to user principals — agents/workloads have no
+    # password leg. Best-effort lookup; absence of the row leaves the
+    # legacy SSO flow untouched.
+    if token.principal_type == "user":
+        try:
+            short_pid = f"{token.org}::user::{body.principal_id.split('/')[-1]}"
+            user_row = await _load_user_row(short_pid)
+            if user_row and user_row["password_hash"] and bool(
+                user_row["must_change_password"],
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=(
+                        "must change password before minting cert — call "
+                        "/v1/principals/change-password first"
+                    ),
+                )
+        except HTTPException:
+            raise
+        except Exception as exc:  # noqa: BLE001 — best-effort gate
+            _log.warning(
+                "principals.csr: must_change_password gate skipped: %s", exc,
+            )
+
     agent_manager = getattr(request.app.state, "agent_manager", None)
     if agent_manager is None:
         raise HTTPException(
@@ -146,4 +192,226 @@ async def sign_csr(
         cert_pem=cert_pem,
         cert_thumbprint=thumbprint,
         cert_not_after=not_after,
+    )
+
+
+# ── AD-style password layer ─────────────────────────────────────────────
+
+
+# Short TTL so the login token can only be used for the immediate CSR /
+# change-password follow-up; the resulting cert is the long-lived
+# credential, not this JWT.
+_LOGIN_TOKEN_TTL_SECONDS = 5 * 60
+_MIN_PASSWORD_LENGTH = 8
+_MAX_PASSWORD_LENGTH = 128
+
+
+class PasswordLoginRequest(BaseModel):
+    user_name: str = Field(..., pattern=r"^[a-zA-Z0-9._-]{1,64}$")
+    password: str = Field(
+        ..., min_length=_MIN_PASSWORD_LENGTH, max_length=_MAX_PASSWORD_LENGTH,
+    )
+    # The DPoP public key the client just generated. The server hashes
+    # it (RFC 7638) and pins ``cnf.jkt`` so the issued JWT can only be
+    # spent with proofs from this same key.
+    dpop_jwk: dict = Field(...)
+
+
+class PasswordLoginResponse(BaseModel):
+    access_token: str
+    token_type: str = "DPoP"
+    expires_in: int
+    principal_id: str
+    must_change_password: bool
+
+
+class ChangePasswordRequest(BaseModel):
+    old_password: str = Field(
+        ..., min_length=_MIN_PASSWORD_LENGTH, max_length=_MAX_PASSWORD_LENGTH,
+    )
+    new_password: str = Field(
+        ..., min_length=_MIN_PASSWORD_LENGTH, max_length=_MAX_PASSWORD_LENGTH,
+    )
+
+
+class ChangePasswordResponse(BaseModel):
+    principal_id: str
+    must_change_password: bool
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _load_user_row(principal_id: str) -> Optional[dict]:
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(f"SELECT {_SELECT_COLS} FROM local_user_principals "
+                 "WHERE principal_id = :pid"),
+            {"pid": principal_id},
+        )).mappings().first()
+    return dict(row) if row else None
+
+
+@router.post(
+    "/password-login",
+    response_model=PasswordLoginResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def password_login(
+    body: PasswordLoginRequest, request: Request,
+) -> PasswordLoginResponse:
+    """Verify ``user_name + password`` and mint a DPoP-bound JWT.
+
+    Failure modes return generic 401 (no oracle on which leg failed):
+    - row missing
+    - password mismatch
+    - SSO-only row (``password_hash`` NULL)
+    - row disabled
+
+    On success the response includes ``must_change_password``; the SPA
+    must show a change-password screen before letting the user touch
+    anything sensitive. The CSR endpoint also refuses cert minting
+    while the flag is set, so even a misbehaving client cannot bypass.
+    """
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None or not getattr(mgr, "ca_loaded", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized — Org CA not loaded",
+        )
+    issuer = getattr(request.app.state, "local_issuer", None)
+    if issuer is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="local JWT issuer not initialized",
+        )
+    try:
+        dpop_jkt = compute_jkt(body.dpop_jwk)
+    except (ValueError, KeyError, TypeError) as exc:
+        _log.warning("password-login: invalid DPoP JWK: %s", exc)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid DPoP JWK",
+        ) from exc
+
+    pid = _short_principal_id(mgr.org_id, body.user_name)
+    row = await _load_user_row(pid)
+    if row is None:
+        # Constant-ish time: still hash a throwaway to dodge user-enum.
+        await verify_password(body.password, "$2b$12$invalidsaltinvalidsalt..")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+    if bool(row["disabled"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="account disabled",
+        )
+    if not row["password_hash"]:
+        # SSO-only row — no local credential to verify against.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "account has no local password — sign in via Frontdesk SSO"
+            ),
+        )
+    if not await verify_password(body.password, row["password_hash"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid credentials",
+        )
+
+    must_change = bool(row["must_change_password"])
+    token = issuer.issue(
+        agent_id=pid,
+        ttl_seconds=_LOGIN_TOKEN_TTL_SECONDS,
+        extra_claims={
+            "cnf": {"jkt": dpop_jkt},
+            "principal_type": "user",
+            "org": mgr.org_id,
+            "must_change_password": must_change,
+        },
+    )
+    _log.info(
+        "password-login OK principal_id=%s must_change=%s",
+        pid, must_change,
+    )
+    return PasswordLoginResponse(
+        access_token=token.token,
+        expires_in=token.expires_at - token.issued_at,
+        principal_id=pid,
+        must_change_password=must_change,
+    )
+
+
+@router.post(
+    "/change-password",
+    response_model=ChangePasswordResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def change_password(
+    body: ChangePasswordRequest,
+    request: Request,
+    token: TokenPayload = Depends(get_authenticated_agent),
+) -> ChangePasswordResponse:
+    """Self-service password change — auth via the login JWT.
+
+    Verifies the old password, hashes the new one, clears the
+    ``must_change_password`` flag. Refuses if the principal is not a
+    user (workloads + agents have no password leg) or the row was
+    disabled between login and change.
+    """
+    if token.principal_type != "user":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="only user principals may change a password",
+        )
+    pid = token.agent_id  # `<org>::user::<name>` shape (ADR-020)
+    row = await _load_user_row(pid)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="user principal not found",
+        )
+    if bool(row["disabled"]):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="account disabled",
+        )
+    if not row["password_hash"] or not await verify_password(
+        body.old_password, row["password_hash"],
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="invalid current password",
+        )
+    if body.old_password == body.new_password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="new password must differ from current",
+        )
+    new_hash = await hash_password(body.new_password)
+    now = _now_iso()
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                UPDATE local_user_principals
+                   SET password_hash         = :pw,
+                       must_change_password  = :mcp,
+                       password_updated_at   = :now
+                 WHERE principal_id = :pid
+                """
+            ),
+            {
+                "pid": pid, "pw": new_hash,
+                "mcp": bool(False), "now": now,
+            },
+        )
+    _log.info("change-password OK principal_id=%s", pid)
+    return ChangePasswordResponse(
+        principal_id=pid,
+        must_change_password=False,
     )

--- a/tests/test_admin_users_password.py
+++ b/tests/test_admin_users_password.py
@@ -1,0 +1,295 @@
+"""AD-style password layer for user principals — admin endpoints.
+
+Covers the password fields added in migration 0026:
+  - create_user: with password sets bcrypt hash + must_change_password
+  - create_user: idempotent top-up when existing row has no password
+  - create_user: 409 when caller tries to re-set an already-set password
+  - reset_password: rotates hash + re-arms must_change_password
+  - deactivate / reactivate: flip the disabled flag
+  - delete_user: 204 (idempotent on missing row)
+
+The password verification + JWT minting paths live in
+``test_password_login.py``. This file pins the admin-facing surface
+the dashboard wires its forms to.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── create with password ───────────────────────────────────────────────
+
+
+async def test_create_with_password_sets_hash_and_flag(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-create")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users",
+                headers=h,
+                json={
+                    "user_name": "alice",
+                    "display_name": "Alice Rossi",
+                    "reach": "intra",
+                    "password": "InitialPwd!2026",
+                },
+            )
+            assert r.status_code == 201, r.text
+            data = r.json()
+            assert data["has_password"] is True
+            assert data["must_change_password"] is True
+            assert data["disabled"] is False
+            assert "password" not in data  # never echo plaintext
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_without_password_leaves_sso_only(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-noopt")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users",
+                headers=h,
+                json={"user_name": "bob"},
+            )
+            assert r.status_code == 201
+            data = r.json()
+            assert data["has_password"] is False
+            assert data["must_change_password"] is False
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_top_up_password_on_existing_sso_row(
+    tmp_path, monkeypatch,
+):
+    """Admin pre-created the row via SSO upsert (no password); now wants
+    to attach a local credential. Endpoint must accept it and flip the
+    flag without overwriting other metadata."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-topup")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "carol", "display_name": "Carol"},
+            )
+            r = await cli.post(
+                "/v1/admin/users", headers=h,
+                json={
+                    "user_name": "carol",
+                    "display_name": "ignored",  # idempotency: kept old
+                    "password": "SecondShot!2026",
+                },
+            )
+            assert r.status_code == 201
+            data = r.json()
+            assert data["display_name"] == "Carol"  # original preserved
+            assert data["has_password"] is True
+            assert data["must_change_password"] is True
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_rejects_password_replacement(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-noreuse")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "dave", "password": "FirstPwd!2026"},
+            )
+            r = await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "dave", "password": "SecondPwd!2026"},
+            )
+            assert r.status_code == 409
+            assert "reset-password" in r.json()["detail"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_rejects_too_short_password(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-short")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "eve", "password": "short"},
+            )
+            assert r.status_code == 422
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── reset password ─────────────────────────────────────────────────────
+
+
+async def test_reset_password_rotates_hash_and_rearms_flag(
+    tmp_path, monkeypatch,
+):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-reset")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "frank", "password": "InitialPwd!2026"},
+            )
+            # Verify the change-flag clears via change-password (simulated
+            # by direct DB poke) so reset truly re-arms.
+            from mcp_proxy.db import get_db
+            async with get_db() as conn:
+                await conn.execute(
+                    text(
+                        "UPDATE local_user_principals "
+                        "   SET must_change_password = :mcp "
+                        " WHERE user_name = 'frank'"
+                    ),
+                    {"mcp": False},
+                )
+
+            r = await cli.post(
+                "/v1/admin/users/pw-reset::user::frank/reset-password",
+                headers=h,
+                json={"new_password": "RotatedPwd!2026"},
+            )
+            assert r.status_code == 200, r.text
+            data = r.json()
+            assert data["has_password"] is True
+            assert data["must_change_password"] is True
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reset_password_404_for_missing_principal(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-reset-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users/pw-reset-404::user::ghost/reset-password",
+                headers=h,
+                json={"new_password": "AnyPwd!2026"},
+            )
+            assert r.status_code == 404
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── deactivate / reactivate ────────────────────────────────────────────
+
+
+async def test_deactivate_then_reactivate_flips_flag(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-flip")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "gail"},
+            )
+            pid = "pw-flip::user::gail"
+
+            r = await cli.post(
+                f"/v1/admin/users/{pid}/deactivate", headers=h,
+            )
+            assert r.status_code == 200
+            assert r.json()["disabled"] is True
+
+            r = await cli.post(
+                f"/v1/admin/users/{pid}/reactivate", headers=h,
+            )
+            assert r.status_code == 200
+            assert r.json()["disabled"] is False
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_deactivate_404_for_missing(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-deact-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users/pw-deact-404::user::ghost/deactivate",
+                headers=h,
+            )
+            assert r.status_code == 404
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── delete ─────────────────────────────────────────────────────────────
+
+
+async def test_delete_user_purges_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-del")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "harry"},
+            )
+            r = await cli.delete(
+                "/v1/admin/users/pw-del::user::harry", headers=h,
+            )
+            assert r.status_code == 204
+
+            r = await cli.get("/v1/admin/users", headers=h)
+            assert r.json()["total"] == 0
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_delete_user_idempotent_on_missing(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "pw-del-noop")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.delete(
+                "/v1/admin/users/pw-del-noop::user::ghost", headers=h,
+            )
+            assert r.status_code == 204
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_password_login.py
+++ b/tests/test_password_login.py
@@ -1,0 +1,390 @@
+"""Password-login + change-password endpoints — happy path + rejections.
+
+The login endpoint mints a DPoP-bound JWT via the in-process
+``LocalIssuer``. We decode the resulting JWT (re-using the keystore
+the issuer signed it with) so each test pins both the HTTP contract
+AND the cnf.jkt binding the SPA needs to spend the token on /csr.
+
+Change-password is exercised with a ``dependency_overrides`` swap to
+sidestep DPoP-proof construction in unit tests — the e2e DPoP path is
+already covered by ``test_principals_csr.py`` and the smoke suite.
+"""
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+def _b64url_uint(n: int, length: int) -> str:
+    return base64.urlsafe_b64encode(
+        n.to_bytes(length, "big"),
+    ).decode().rstrip("=")
+
+
+def _make_dpop_jwk() -> dict:
+    """Generate a P-256 keypair and serialise its public part as a JWK.
+
+    Mirrors what the SPA will do client-side via Web Crypto. We only
+    need the public JWK for ``cnf.jkt`` derivation server-side.
+    """
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_numbers = priv.public_key().public_numbers()
+    return {
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _b64url_uint(pub_numbers.x, 32),
+        "y": _b64url_uint(pub_numbers.y, 32),
+    }
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _create_user(cli, *, user_name: str, password: str | None):
+    from mcp_proxy.config import get_settings
+    h = {"X-Admin-Secret": get_settings().admin_secret}
+    payload = {"user_name": user_name}
+    if password is not None:
+        payload["password"] = password
+    r = await cli.post("/v1/admin/users", headers=h, json=payload)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+# ── login: 401 paths ───────────────────────────────────────────────────
+
+
+async def test_login_401_when_user_missing(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-miss")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "nobody",
+                    "password": "GoodEnoughPwd!",
+                    "dpop_jwk": _make_dpop_jwk(),
+                },
+            )
+            assert r.status_code == 401
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_login_401_when_sso_only(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-sso")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="ivy", password=None)
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "ivy",
+                    "password": "WhateverPwd!",
+                    "dpop_jwk": _make_dpop_jwk(),
+                },
+            )
+            assert r.status_code == 401
+            assert "SSO" in r.json()["detail"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_login_401_on_wrong_password(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-wrong")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="jane", password="RealPwd!2026")
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "jane",
+                    "password": "WrongPwd!2026",
+                    "dpop_jwk": _make_dpop_jwk(),
+                },
+            )
+            assert r.status_code == 401
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_login_401_when_disabled(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-disabled")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.config import get_settings
+            h = {"X-Admin-Secret": get_settings().admin_secret}
+            await _create_user(cli, user_name="ken", password="RealPwd!2026")
+            await cli.post(
+                "/v1/admin/users/lg-disabled::user::ken/deactivate",
+                headers=h,
+            )
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "ken",
+                    "password": "RealPwd!2026",
+                    "dpop_jwk": _make_dpop_jwk(),
+                },
+            )
+            assert r.status_code == 401
+            assert "disabled" in r.json()["detail"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_login_400_on_bad_jwk(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-badjwk")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="leo", password="RealPwd!2026")
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "leo",
+                    "password": "RealPwd!2026",
+                    "dpop_jwk": {"kty": "RSA"},  # missing required members
+                },
+            )
+            assert r.status_code == 400
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── login: happy path ─────────────────────────────────────────────────
+
+
+async def test_login_ok_returns_dpop_bound_jwt(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-ok")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="mia", password="RealPwd!2026")
+            jwk = _make_dpop_jwk()
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "mia",
+                    "password": "RealPwd!2026",
+                    "dpop_jwk": jwk,
+                },
+            )
+            assert r.status_code == 200, r.text
+            data = r.json()
+            assert data["token_type"] == "DPoP"
+            assert data["principal_id"] == "lg-ok::user::mia"
+            assert data["must_change_password"] is True
+            assert data["expires_in"] > 0
+
+            # Decode the JWT payload (no signature check — the keystore
+            # rotation API isn't needed for this assertion).
+            payload_b64 = data["access_token"].split(".")[1]
+            payload_b64 += "=" * (-len(payload_b64) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload_b64))
+            from mcp_proxy.auth.dpop import compute_jkt
+            expected_jkt = compute_jkt(jwk)
+            assert claims["cnf"]["jkt"] == expected_jkt
+            assert claims["principal_type"] == "user"
+            assert claims["sub"] == "lg-ok::user::mia"
+            assert claims["must_change_password"] is True
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_login_must_change_false_after_admin_clears_flag(
+    tmp_path, monkeypatch,
+):
+    """Admin-cleared flag (or post change-password) flows through to
+    the login response so the SPA stops showing the change screen."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "lg-flag")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="nina", password="RealPwd!2026")
+            from mcp_proxy.db import get_db
+            from sqlalchemy import text
+            async with get_db() as conn:
+                await conn.execute(
+                    text(
+                        "UPDATE local_user_principals "
+                        "   SET must_change_password = :mcp "
+                        " WHERE user_name = 'nina'"
+                    ),
+                    {"mcp": False},
+                )
+            r = await cli.post(
+                "/v1/principals/password-login",
+                json={
+                    "user_name": "nina",
+                    "password": "RealPwd!2026",
+                    "dpop_jwk": _make_dpop_jwk(),
+                },
+            )
+            assert r.status_code == 200
+            assert r.json()["must_change_password"] is False
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── change-password: dependency-override path ─────────────────────────
+
+
+def _override_user_token(app, principal_id: str, org: str):
+    from mcp_proxy.auth.dependencies import get_authenticated_agent
+    from mcp_proxy.models import TokenPayload
+
+    async def _stub() -> TokenPayload:
+        return TokenPayload(
+            sub=f"spiffe://cullis.test/{org}/user/{principal_id.split('::')[-1]}",
+            agent_id=principal_id,
+            org=org,
+            exp=2_000_000_000,
+            iat=1_000_000_000,
+            jti="test-jti",
+            scope=["local"],
+            cnf={"jkt": "test-jkt"},
+            principal_type="user",
+        )
+
+    app.dependency_overrides[get_authenticated_agent] = _stub
+
+
+async def test_change_password_happy_path(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "cp-ok")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="omar", password="OldPwd!2026")
+            pid = "cp-ok::user::omar"
+            _override_user_token(app, pid, "cp-ok")
+            try:
+                r = await cli.post(
+                    "/v1/principals/change-password",
+                    json={
+                        "old_password": "OldPwd!2026",
+                        "new_password": "NewPwd!2026",
+                    },
+                )
+                assert r.status_code == 200, r.text
+                assert r.json()["must_change_password"] is False
+
+                # And the new password actually works on a re-login.
+                r2 = await cli.post(
+                    "/v1/principals/password-login",
+                    json={
+                        "user_name": "omar",
+                        "password": "NewPwd!2026",
+                        "dpop_jwk": _make_dpop_jwk(),
+                    },
+                )
+                assert r2.status_code == 200
+                assert r2.json()["must_change_password"] is False
+            finally:
+                app.dependency_overrides.clear()
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_change_password_rejects_wrong_old(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "cp-wrong")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="paul", password="OldPwd!2026")
+            pid = "cp-wrong::user::paul"
+            _override_user_token(app, pid, "cp-wrong")
+            try:
+                r = await cli.post(
+                    "/v1/principals/change-password",
+                    json={
+                        "old_password": "WrongPwd!2026",
+                        "new_password": "NewPwd!2026",
+                    },
+                )
+                assert r.status_code == 401
+            finally:
+                app.dependency_overrides.clear()
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_change_password_rejects_same_password(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "cp-same")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            await _create_user(cli, user_name="quinn", password="SamePwd!2026")
+            pid = "cp-same::user::quinn"
+            _override_user_token(app, pid, "cp-same")
+            try:
+                r = await cli.post(
+                    "/v1/principals/change-password",
+                    json={
+                        "old_password": "SamePwd!2026",
+                        "new_password": "SamePwd!2026",
+                    },
+                )
+                assert r.status_code == 400
+            finally:
+                app.dependency_overrides.clear()
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_change_password_403_for_non_user_principal(
+    tmp_path, monkeypatch,
+):
+    """An agent / workload JWT must NOT be accepted here even if its
+    cnf and DPoP all check out — the password leg is user-only."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "cp-agent")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.auth.dependencies import get_authenticated_agent
+            from mcp_proxy.models import TokenPayload
+
+            async def _agent_stub():
+                return TokenPayload(
+                    sub="spiffe://cullis.test/cp-agent/agent/bot",
+                    agent_id="cp-agent::bot",
+                    org="cp-agent",
+                    exp=2_000_000_000, iat=1_000_000_000,
+                    jti="t", scope=["local"], cnf={"jkt": "x"},
+                    principal_type="agent",
+                )
+            app.dependency_overrides[get_authenticated_agent] = _agent_stub
+            try:
+                r = await cli.post(
+                    "/v1/principals/change-password",
+                    json={
+                        "old_password": "AnyPwd!2026",
+                        "new_password": "NextPwd!2026",
+                    },
+                )
+                assert r.status_code == 403
+            finally:
+                app.dependency_overrides.clear()
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0025_local_principals",)]
+    assert rows == [("0026_user_password",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0025_local_principals",)]
+    assert version == [("0026_user_password",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0025_local_principals"
+HEAD_REVISION = "0026_user_password"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0025_local_principals"
+HEAD_REVISION = "0026_user_password"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0025_local_principals"
+HEAD_REVISION = "0026_user_password"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

PR1 of the AD-style users sprint. Lets an org admin pre-provision an employee account with an initial password the user is forced to rotate at first sign-in. Backward compatible with the SSO upsert path: rows without a password keep their cert-only flow.

- **Migration 0026** adds `password_hash`, `must_change_password`, `disabled`, `password_updated_at` to `local_user_principals` (idempotent, NULL-safe for SSO-only rows).
- **`POST /v1/principals/password-login`** verifies bcrypt and mints a 5-minute DPoP-bound JWT (`cnf.jkt` + `principal_type=user` + `must_change_password`) via the existing `LocalIssuer`. The SPA spends it on the existing `/v1/principals/csr` to materialise its cert.
- **`POST /v1/principals/change-password`** self-service rotation, refuses when `principal_type != "user"`, blocks reusing the current password.
- **Cert-mint gate**: `/csr` refuses to sign while `must_change_password=true` so a misbehaving client cannot bypass the rotation step.
- **Admin lifecycle** on `/v1/admin/users/{principal_id}/*`: `reset-password`, `deactivate`, `reactivate`, `delete`. Idempotent delete.
- **21 new tests** (`test_admin_users_password.py` + `test_password_login.py`); 5 migration tests bumped to `HEAD_REVISION="0026_user_password"`.

Bcrypt rounds=12, async via `asyncio.to_thread`. Login endpoint never echoes the plaintext, error messages are uniform 401 to dodge user enumeration (a throwaway hash is verified even on missing rows).

PR2 (forthcoming) will rewrite the dashboard `users.html` + add `user_detail.html` to expose all this through the admin UI.

## Test plan

- [x] `pytest tests/test_admin_users_password.py tests/test_password_login.py tests/test_admin_users.py -p no:cacheprovider` — 28 passed
- [x] `pytest tests/ -n auto --dist=loadfile --ignore=tests/connector --ignore=tests/test_postgres_integration.py` — 2456 passed, 9 skipped, 0 failed
- [ ] `./sandbox/smoke.sh full` — pre-merge gate (run by reviewer or in follow-up before merge)
- [ ] `/security-review` — pre-merge gate