### PR TITLE
feat(dashboard): user detail page + Danger Zone + password in Create form

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3226,9 +3226,19 @@ async def users_create(request: Request):
                     "user already has a password — use Reset Password "
                     "in the user detail Danger Zone to rotate it",
                 )
-    except Exception as exc:  # noqa: BLE001
-        _log.warning("users_create failed user_name=%s: %s", user_name, exc)
-        return _user_form_redirect(f"create failed: {exc}")
+    except Exception:  # noqa: BLE001
+        # Never inline the exception text into the user-facing error.
+        # SQLAlchemy DBAPIError stringifies bound parameters, which would
+        # leak the bcrypt password_hash into both the redirect URL (and
+        # therefore reverse-proxy access logs + browser history) and the
+        # rendered page. Log full traceback locally; surface a generic
+        # message to the operator.
+        _log.warning(
+            "users_create failed user_name=%s", user_name, exc_info=True,
+        )
+        return _user_form_redirect(
+            "create failed — check Mastio logs for details",
+        )
 
     return RedirectResponse(
         url=f"/proxy/users?new_user_name={user_name}",

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3086,16 +3086,41 @@ async def users_page(
     ))
 
 
+def _user_form_redirect(error: str) -> RedirectResponse:
+    from urllib.parse import quote
+    return RedirectResponse(
+        url=f"/proxy/users?error={quote(error)}", status_code=303,
+    )
+
+
+def _user_detail_redirect(principal_id: str, *, message: str | None = None,
+                          error: str | None = None) -> RedirectResponse:
+    from urllib.parse import quote
+    qs = []
+    if message:
+        qs.append(f"message={quote(message)}")
+    if error:
+        qs.append(f"error={quote(error)}")
+    suffix = ("?" + "&".join(qs)) if qs else ""
+    return RedirectResponse(
+        url=f"/proxy/users/{quote(principal_id, safe='')}{suffix}",
+        status_code=303,
+    )
+
+
 @router.post("/users/create")
 async def users_create(request: Request):
     """Form-driven counterpart of ``POST /v1/admin/users``.
 
-    Same idempotent insert into ``local_user_principals``: re-posting an
-    existing ``user_name`` returns the existing row without overwriting
-    metadata so a real SSO touch can't be clobbered by a careless
-    re-create. The cert itself is minted on first
-    ``/v1/principals/csr`` — this row is the directory entry, not the
-    credential.
+    Same idempotent insert into ``local_user_principals`` the X-Admin-Secret
+    API does: re-posting an existing ``user_name`` returns the existing row
+    without overwriting metadata so a real SSO touch can't be clobbered by
+    a careless re-create.
+
+    AD-style password is now optional. When supplied it is bcrypt-hashed
+    (``must_change_password`` flipped to True so the admin's value is
+    never long-lived). When omitted the row stays SSO-only — the cert
+    will land on first ``/v1/principals/csr`` touch as before.
     """
     import re
 
@@ -3115,57 +3140,53 @@ async def users_create(request: Request):
     display_name = str(form.get("display_name", "")).strip()
     reach = str(form.get("reach", "intra")).strip() or "intra"
     surface = str(form.get("surface", "")).strip() or None
+    password = str(form.get("password", "")).strip() or None
 
     if not user_name:
-        return RedirectResponse(
-            url="/proxy/users?error=user_name+is+required",
-            status_code=303,
-        )
+        return _user_form_redirect("user_name is required")
     if not re.fullmatch(r"[a-zA-Z0-9._\-]{1,64}", user_name):
-        return RedirectResponse(
-            url=(
-                "/proxy/users?error=user_name+must+match+[a-zA-Z0-9._-]"
-                "+and+be+at+most+64+chars"
-            ),
-            status_code=303,
+        return _user_form_redirect(
+            "user_name must match [a-zA-Z0-9._-] and be at most 64 chars",
         )
     if reach not in ("intra", "cross", "both"):
-        return RedirectResponse(
-            url="/proxy/users?error=reach+must+be+intra%2C+cross+or+both",
-            status_code=303,
-        )
+        return _user_form_redirect("reach must be intra, cross or both")
+    if password is not None and not (8 <= len(password) <= 128):
+        return _user_form_redirect("password must be 8-128 chars")
 
     org_id = await get_config("org_id") or get_settings().org_id
     if not org_id:
-        return RedirectResponse(
-            url=(
-                "/proxy/users?error=org_id+not+set"
-                "+%E2%80%94+complete+broker+setup+first"
-            ),
-            status_code=303,
+        return _user_form_redirect(
+            "org_id not set — complete broker setup first",
         )
 
     principal_id = f"{org_id}::user::{user_name}"
     now = datetime.now(timezone.utc).isoformat()
+    pw_hash = None
+    if password:
+        from mcp_proxy.admin.users import hash_password
+        pw_hash = await hash_password(password)
 
     try:
         async with get_db() as conn:
             existing = (await conn.execute(
                 _sql_text(
-                    "SELECT principal_id FROM local_user_principals "
+                    "SELECT principal_id, password_hash FROM local_user_principals "
                     "WHERE principal_id = :pid"
                 ),
                 {"pid": principal_id},
-            )).first()
+            )).mappings().first()
             if existing is None:
                 await conn.execute(
                     _sql_text(
                         """
                         INSERT INTO local_user_principals (
                             principal_id, user_name, display_name,
-                            reach, surface, created_at
+                            reach, surface, created_at,
+                            password_hash, must_change_password,
+                            disabled, password_updated_at
                         ) VALUES (
-                            :pid, :uname, :disp, :reach, :surface, :now
+                            :pid, :uname, :disp, :reach, :surface, :now,
+                            :pw, :mcp, :dis, :pwnow
                         )
                         """
                     ),
@@ -3176,19 +3197,231 @@ async def users_create(request: Request):
                         "reach": reach,
                         "surface": surface,
                         "now": now,
+                        "pw": pw_hash,
+                        "mcp": bool(pw_hash),
+                        "dis": bool(False),
+                        "pwnow": now if pw_hash else None,
                     },
+                )
+            elif pw_hash and not existing["password_hash"]:
+                # Top-up: row was pre-created via SSO upsert / metadata-only,
+                # admin is now attaching a local credential to it.
+                await conn.execute(
+                    _sql_text(
+                        """
+                        UPDATE local_user_principals
+                           SET password_hash         = :pw,
+                               must_change_password  = :mcp,
+                               password_updated_at   = :now
+                         WHERE principal_id = :pid
+                        """
+                    ),
+                    {
+                        "pid": principal_id, "pw": pw_hash,
+                        "mcp": bool(True), "now": now,
+                    },
+                )
+            elif pw_hash and existing["password_hash"]:
+                return _user_form_redirect(
+                    "user already has a password — use Reset Password "
+                    "in the user detail Danger Zone to rotate it",
                 )
     except Exception as exc:  # noqa: BLE001
         _log.warning("users_create failed user_name=%s: %s", user_name, exc)
-        from urllib.parse import quote
-        return RedirectResponse(
-            url=f"/proxy/users?error={quote(f'create failed: {exc}')}",
-            status_code=303,
-        )
+        return _user_form_redirect(f"create failed: {exc}")
 
     return RedirectResponse(
         url=f"/proxy/users?new_user_name={user_name}",
         status_code=303,
+    )
+
+
+@router.get("/users/{principal_id:path}", response_class=HTMLResponse)
+async def user_detail_page(
+    request: Request, principal_id: str,
+    message: str | None = None, error: str | None = None,
+):
+    """Detail view for a single user principal — Overview, Activity,
+    Danger Zone tabs. Mirrors ``/proxy/agents/{agent_id}`` but without
+    the Connect tab (user principals don't speak the proxy API
+    directly — they sign in through Cullis Chat / Frontdesk and the
+    cert is minted server-side via ``/v1/principals/csr``).
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from mcp_proxy.db import get_user_principal
+    user = await get_user_principal(principal_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User principal not found")
+
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db, get_config
+    from mcp_proxy.config import get_settings
+    async with get_db() as conn:
+        result = await conn.execute(
+            _sql_text(
+                "SELECT * FROM audit_log WHERE agent_id = :pid "
+                " ORDER BY timestamp DESC LIMIT 20"
+            ),
+            {"pid": principal_id},
+        )
+        audit_entries = [dict(row) for row in result.mappings().all()]
+
+    settings = get_settings()
+    org_id = await get_config("org_id") or settings.org_id or ""
+    trust_domain = (
+        getattr(settings, "trust_domain", None)
+        or getattr(settings, "proxy_trust_domain", None)
+        or "cullis.test"
+    )
+
+    return templates.TemplateResponse("user_detail.html", _ctx(
+        request, session,
+        active="users",
+        user=user,
+        audit_entries=audit_entries,
+        org_id=org_id,
+        trust_domain=trust_domain,
+        action_message=message,
+        error=error,
+    ))
+
+
+async def _require_user_action(request: Request, principal_id: str):
+    """Shared guard for the Danger Zone POST endpoints.
+
+    Returns either a session (good) or a RedirectResponse / HTTPException.
+    Centralised so each lifecycle endpoint stays a 6-line wrapper around
+    one SQL statement.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session, None
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    from mcp_proxy.db import get_user_principal
+    user = await get_user_principal(principal_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User principal not found")
+    return session, user
+
+
+@router.post("/users/{principal_id:path}/deactivate")
+async def user_deactivate(request: Request, principal_id: str):
+    session, _ = await _require_user_action(request, principal_id)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            _sql_text(
+                "UPDATE local_user_principals SET disabled = :dis "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id, "dis": bool(True)},
+        )
+    _log.info("dashboard: deactivated principal_id=%s", principal_id)
+    return _user_detail_redirect(
+        principal_id, message="User deactivated. Sign-in is now blocked.",
+    )
+
+
+@router.post("/users/{principal_id:path}/reactivate")
+async def user_reactivate(request: Request, principal_id: str):
+    session, _ = await _require_user_action(request, principal_id)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            _sql_text(
+                "UPDATE local_user_principals SET disabled = :dis "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id, "dis": bool(False)},
+        )
+    _log.info("dashboard: reactivated principal_id=%s", principal_id)
+    return _user_detail_redirect(
+        principal_id, message="User reactivated. Sign-in is allowed again.",
+    )
+
+
+@router.post("/users/{principal_id:path}/delete")
+async def user_delete(request: Request, principal_id: str):
+    session, _ = await _require_user_action(request, principal_id)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            _sql_text(
+                "DELETE FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )
+    _log.info("dashboard: deleted principal_id=%s", principal_id)
+    from urllib.parse import quote
+    return RedirectResponse(
+        url=(
+            "/proxy/users?error="
+            + quote(f"User {principal_id} deleted.")
+        ),
+        status_code=303,
+    )
+
+
+@router.post("/users/{principal_id:path}/reset-password")
+async def user_reset_password(request: Request, principal_id: str):
+    session, user = await _require_user_action(request, principal_id)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    from datetime import datetime, timezone
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db
+    from mcp_proxy.admin.users import hash_password
+
+    form = await request.form()
+    new_password = str(form.get("new_password", "")).strip()
+    if not (8 <= len(new_password) <= 128):
+        return _user_detail_redirect(
+            principal_id, error="new password must be 8-128 chars",
+        )
+
+    pw_hash = await hash_password(new_password)
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        await conn.execute(
+            _sql_text(
+                """
+                UPDATE local_user_principals
+                   SET password_hash         = :pw,
+                       must_change_password  = :mcp,
+                       password_updated_at   = :now
+                 WHERE principal_id = :pid
+                """
+            ),
+            {
+                "pid": principal_id, "pw": pw_hash,
+                "mcp": bool(True), "now": now,
+            },
+        )
+    _log.info("dashboard: reset password for principal_id=%s", principal_id)
+    return _user_detail_redirect(
+        principal_id,
+        message=(
+            "Password reset. Hand the new value to the user out-of-band; "
+            "they will be forced to change it at next sign-in."
+        ),
     )
 
 

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -1,0 +1,304 @@
+{% extends "base.html" %}
+{% block title %}{{ user.display_name or user.user_name }} — User Principal{% endblock %}
+{% block header_title %}User Principal{% endblock %}
+{% block content %}
+<div class="max-w-5xl">
+
+    <!-- Back link -->
+    <a href="/proxy/users" class="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-300 transition-colors mb-6">
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back to Users
+    </a>
+
+    <!-- Action result banner — confirms Reset Password / Deactivate / Reactivate. -->
+    {% if action_message %}
+    <div class="mb-6 p-4 bg-emerald-900/10 border border-emerald-600/30 rounded-lg text-xs text-emerald-400">
+        {{ action_message }}
+    </div>
+    {% endif %}
+    {% if error %}
+    <div class="mb-6 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
+    {% endif %}
+
+    <!-- Header -->
+    <div class="flex items-start justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-heading font-semibold text-white">{{ user.display_name or user.user_name }}</h2>
+            <p class="text-xs font-mono text-gray-500 mt-1">{{ user.principal_id }}</p>
+        </div>
+        {% if user.disabled %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Disabled
+        </span>
+        {% elif user.must_change_password %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-amber-500 pulse-dot"></span>Pending password change
+        </span>
+        {% elif user.has_password %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
+        </span>
+        {% else %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-gray-500"></span>SSO-only
+        </span>
+        {% endif %}
+    </div>
+
+    <!-- ── Tab Navigation ────────────────────────────────────────────────── -->
+    <div class="flex gap-1 mb-6 border-b border-gray-800">
+        <button type="button" onclick="switchTab('overview')" id="tab-overview"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-[#00e5c7] text-white">
+            Overview
+        </button>
+        <button type="button" onclick="switchTab('activity')" id="tab-activity"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
+            Activity
+        </button>
+        <button type="button" onclick="switchTab('danger')" id="tab-danger"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
+            Danger Zone
+        </button>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- TAB 1: Overview                                                    -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <div id="panel-overview" class="main-tab-panel">
+
+        <!-- Principal info card -->
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
+            <div class="grid grid-cols-2 md:grid-cols-3 gap-6">
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Principal ID</p>
+                    <p class="text-sm text-gray-300 font-mono break-all">{{ user.principal_id }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">User Name</p>
+                    <p class="text-sm text-gray-300 font-mono">{{ user.user_name }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Reach</p>
+                    {% if user.reach == 'cross' %}
+                    <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30">cross-org</span>
+                    {% elif user.reach == 'both' %}
+                    <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30">both</span>
+                    {% else %}
+                    <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-gray-500/10 text-gray-400 border border-gray-500/30">intra-org</span>
+                    {% endif %}
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Surface</p>
+                    {% if user.surface %}
+                    <p class="text-sm text-gray-300 font-mono">{{ user.surface }}</p>
+                    {% else %}
+                    <p class="text-sm text-gray-700 italic">—</p>
+                    {% endif %}
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Created</p>
+                    <p class="text-sm text-gray-300 font-mono">{{ user.created_at[:19] if user.created_at else '—' }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Last active</p>
+                    {% if user.last_active_at %}
+                    <p class="text-sm text-gray-300 font-mono">{{ user.last_active_at[:19] }}</p>
+                    {% else %}
+                    <p class="text-sm text-gray-700 italic">never</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <!-- Authentication card -->
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">Authentication</h3>
+            <div class="space-y-3">
+                <div class="flex items-start gap-3">
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider w-32 mt-1">Local password</p>
+                    {% if user.has_password %}
+                        {% if user.must_change_password %}
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+                            Set, pending change
+                        </span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            Set
+                        </span>
+                        {% endif %}
+                        {% if user.password_updated_at %}
+                        <span class="text-[11px] text-gray-600 mt-1.5">
+                            Last updated {{ user.password_updated_at[:19] }}
+                        </span>
+                        {% endif %}
+                    {% else %}
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-wider">
+                        Not set (SSO only)
+                    </span>
+                    {% endif %}
+                </div>
+                <div class="flex items-start gap-3">
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider w-32 mt-1">Cert thumbprint</p>
+                    {% if user.cert_thumbprint %}
+                    <code class="text-xs text-gray-400 font-mono break-all" title="{{ user.cert_thumbprint }}">{{ user.cert_thumbprint[:32] }}{% if user.cert_thumbprint|length > 32 %}…{% endif %}</code>
+                    {% else %}
+                    <span class="text-xs text-gray-700 italic mt-1">No cert minted yet</span>
+                    {% endif %}
+                </div>
+                <div class="flex items-start gap-3">
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider w-32 mt-1">SPIFFE</p>
+                    <code class="text-xs text-gray-400 font-mono break-all">spiffe://{{ trust_domain }}/{{ org_id }}/user/{{ user.user_name }}</code>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- TAB 2: Activity                                                    -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <div id="panel-activity" class="main-tab-panel hidden">
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
+            <div class="px-6 py-4 border-b border-gray-800/60">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Recent Activity</h3>
+                <p class="text-[11px] text-gray-600 mt-1">Last {{ audit_entries|length }} audit row{% if audit_entries|length != 1 %}s{% endif %} attributed to this principal.</p>
+            </div>
+            <table class="w-full">
+                <thead>
+                    <tr class="border-b border-gray-800/40">
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Timestamp</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Action</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Tool</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Detail</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-800/40">
+                    {% for entry in audit_entries %}
+                    <tr class="table-row-hover transition-colors">
+                        <td class="px-5 py-3 text-xs text-gray-500 font-mono whitespace-nowrap">{{ entry.timestamp[:19] }}</td>
+                        <td class="px-5 py-3 text-xs text-gray-300">{{ entry.action }}</td>
+                        <td class="px-5 py-3 text-xs text-gray-400 font-mono">{{ entry.tool_name or '-' }}</td>
+                        <td class="px-5 py-3">
+                            {% if entry.status == 'success' %}
+                            <span class="text-[10px] text-emerald-400 uppercase tracking-wider">OK</span>
+                            {% elif entry.status == 'denied' %}
+                            <span class="text-[10px] text-red-400 uppercase tracking-wider">Denied</span>
+                            {% elif entry.status == 'error' %}
+                            <span class="text-[10px] text-red-400 uppercase tracking-wider">Error</span>
+                            {% else %}
+                            <span class="text-[10px] text-yellow-400 uppercase tracking-wider">{{ entry.status }}</span>
+                            {% endif %}
+                        </td>
+                        <td class="px-5 py-3 text-xs text-gray-600 max-w-[200px] truncate" title="{{ entry.detail or '' }}">{{ entry.detail or '-' }}</td>
+                    </tr>
+                    {% endfor %}
+                    {% if not audit_entries %}
+                    <tr><td colspan="5" class="px-5 py-8 text-center text-xs text-gray-600">No recent activity for this principal</td></tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <!-- TAB 3: Danger Zone                                                 -->
+    <!-- ═══════════════════════════════════════════════════════════════════ -->
+    <div id="panel-danger" class="main-tab-panel hidden">
+        <div class="bg-red-900/5 border border-red-900/20 rounded-lg p-6 space-y-6">
+            <div>
+                <h3 class="text-sm font-semibold text-red-400 uppercase tracking-wider mb-2">Danger Zone</h3>
+                <p class="text-[11px] text-gray-600">Operations on this principal are mostly irreversible. The audit chain keeps the history regardless.</p>
+            </div>
+
+            <!-- Reset password -->
+            <div class="border-t border-red-900/20 pt-5">
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Reset Password</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    Sets a new initial password. The user is forced to change it
+                    at next sign-in. Hand the new value out-of-band — it will
+                    not be shown again.
+                </p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/reset-password"
+                      onsubmit="return confirm('Reset this user\\'s password? They will need the new value to sign back in.')"
+                      class="flex flex-wrap items-end gap-3">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <div class="flex-1 min-w-[240px]">
+                        <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-wider">New password</label>
+                        <input type="password" name="new_password" required
+                               minlength="8" maxlength="128" autocomplete="new-password"
+                               class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-sm text-white placeholder-gray-600 font-mono transition-all"
+                               placeholder="8-128 chars">
+                    </div>
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-amber-600/20 border border-amber-600/30 text-amber-400 rounded hover:bg-amber-600/30 transition-colors">
+                        Reset Password
+                    </button>
+                </form>
+            </div>
+
+            <!-- Deactivate / Reactivate -->
+            <div class="border-t border-red-900/20 pt-5">
+                {% if user.disabled %}
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Reactivate</p>
+                <p class="text-xs text-gray-500 mb-3">Re-enable sign-in for this principal.</p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/reactivate">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-emerald-600/20 border border-emerald-600/30 text-emerald-400 rounded hover:bg-emerald-600/30 transition-colors">
+                        Reactivate
+                    </button>
+                </form>
+                {% else %}
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Deactivate</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    Block sign-in immediately. The audit row + cert remain on
+                    record; reactivate any time to restore access.
+                </p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/deactivate"
+                      onsubmit="return confirm('Deactivate this user? They will be unable to sign in until reactivated.')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-yellow-600/20 border border-yellow-600/30 text-yellow-400 rounded hover:bg-yellow-600/30 transition-colors">
+                        Deactivate
+                    </button>
+                </form>
+                {% endif %}
+            </div>
+
+            <!-- Delete -->
+            <div class="border-t border-red-900/20 pt-5">
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Delete</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    Purge the directory row. Past audit entries stay in the
+                    chain so the principal id remains attributable. Cannot
+                    be undone.
+                </p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/delete"
+                      onsubmit="return confirm('PERMANENTLY DELETE this user principal? Past audit entries remain attributed to the principal id but the directory row is gone.')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-red-600/20 border border-red-600/30 text-red-400 rounded hover:bg-red-600/30 transition-colors">
+                        Delete User
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+
+</div>
+
+<script>
+function switchTab(name) {
+    document.querySelectorAll('.main-tab-panel').forEach(function(p) { p.classList.add('hidden'); });
+    document.querySelectorAll('.main-tab-btn').forEach(function(b) {
+        b.classList.remove('border-[#00e5c7]', 'text-white');
+        b.classList.add('border-transparent', 'text-gray-500');
+    });
+    document.getElementById('panel-' + name).classList.remove('hidden');
+    var btn = document.getElementById('tab-' + name);
+    btn.classList.add('border-[#00e5c7]', 'text-white');
+    btn.classList.remove('border-transparent', 'text-gray-500');
+}
+</script>
+{% endblock %}

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -46,19 +46,21 @@
         </button>
     </div>
 
-    <!-- Context banner — explain that the Mastio row is the directory
-         entry, not the credential. The actual login password lives in
-         the Connector's users.db (ADR-025) and is provisioned via the
-         Connector admin API or the Frontdesk dashboard. -->
+    <!-- Context banner — two onboarding paths now coexist:
+         (a) admin sets an initial password here (AD-style), user is
+             forced to rotate it at first sign-in;
+         (b) leave the password blank, the row stays SSO-only and the
+             cert lands on the first Frontdesk SSO touch. -->
     <div class="mb-6 p-4 bg-surface-900/60 border border-gray-800/50 rounded-lg text-xs text-gray-500 leading-relaxed">
-        Creating a user here reserves the principal id and seeds the
-        directory row so downstream policies + audit show the user even
-        before first login. The login password is set on the
-        <strong class="text-gray-300">Connector</strong> (ADR-025 local-auth)
-        via <code class="text-accent-400/80">POST /admin/users</code>
-        with <code class="text-accent-400/80">X-Admin-Secret</code>, or
-        through the Frontdesk admin tab. Rows also land here automatically
-        the first time a user authenticates through a Frontdesk container.
+        Two ways to onboard a user:
+        <span class="text-gray-300">set an initial password</span> (admin hands the
+        credential out-of-band, user is forced to change it at first sign-in
+        on Cullis Chat or the dashboard), or
+        <span class="text-gray-300">leave password blank</span> for SSO-only
+        rows (cert lands on first Frontdesk SSO touch via
+        <code class="text-accent-400/80">/v1/principals/csr</code>). Rows
+        also auto-appear when a brand-new SSO user signs in for the first
+        time.
     </div>
 
     <!-- Create User panel (hidden by default) -->
@@ -102,9 +104,21 @@
                     <p class="text-[10px] text-gray-600 mt-1">Optional hint: which Connector surface this user logs in from (frontdesk, cullis-chat, cli).</p>
                 </div>
             </div>
+            <div>
+                <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Initial Password <span class="text-gray-600 normal-case font-normal tracking-normal">(optional)</span></label>
+                <input type="password" name="password" autocomplete="new-password"
+                       minlength="8" maxlength="128"
+                       placeholder="Leave blank for SSO-only"
+                       class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
+                <p class="text-[10px] text-gray-600 mt-1">
+                    8-128 chars. Hand it out-of-band; the user will be forced
+                    to set their own at first sign-in. Leave blank for
+                    Frontdesk-SSO accounts.
+                </p>
+            </div>
             <p class="text-[10px] text-gray-500 flex items-center gap-1.5">
                 <svg class="w-3 h-3 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
-                Cert is minted on the first SSO touch (CSR signing path upserts this row).
+                Cert is minted via password-login or first SSO touch — never stored on this dashboard.
             </p>
             <div class="flex items-center gap-3 pt-1">
                 <button type="submit"
@@ -131,18 +145,20 @@
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">User</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal ID</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Surface</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last active</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Created</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-gray-800/40">
                 {% for u in users %}
                 <tr class="table-row-hover transition-colors align-top">
                     <td class="px-5 py-4">
-                        <div class="text-sm text-white">
+                        <a href="/proxy/users/{{ u.principal_id|urlencode }}" class="text-sm text-white hover:text-accent-400 transition-colors">
                             {{ u.display_name or u.user_name }}
-                        </div>
+                        </a>
                         {% if u.display_name %}
                         <div class="text-[11px] text-gray-500 font-mono">{{ u.user_name }}</div>
                         {% endif %}
@@ -172,6 +188,27 @@
                         </span>
                         {% endif %}
                     </td>
+                    <td class="px-5 py-4">
+                        {% if u.disabled %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Disabled
+                        </span>
+                        {% elif u.must_change_password %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider"
+                              title="Initial password set by admin — user must rotate at first sign-in">
+                            <span class="w-1.5 h-1.5 rounded-full bg-amber-500 pulse-dot"></span>Pending change
+                        </span>
+                        {% elif u.has_password %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
+                        </span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-400 uppercase tracking-wider"
+                              title="No local password — Frontdesk SSO only">
+                            <span class="w-1.5 h-1.5 rounded-full bg-gray-500"></span>SSO-only
+                        </span>
+                        {% endif %}
+                    </td>
                     <td class="px-5 py-4 text-xs text-gray-400 font-mono">
                         {% if u.surface %}
                         {{ u.surface }}
@@ -189,11 +226,17 @@
                     <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">
                         {{ u.created_at[:19] if u.created_at else '—' }}
                     </td>
+                    <td class="px-5 py-4">
+                        <a href="/proxy/users/{{ u.principal_id|urlencode }}"
+                           class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-700 text-gray-400 rounded hover:bg-gray-800 hover:text-white transition-colors">
+                            Details
+                        </a>
+                    </td>
                 </tr>
                 {% endfor %}
                 {% if not users %}
                 <tr>
-                    <td colspan="6" class="px-5 py-16 text-center">
+                    <td colspan="8" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
                                   d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -570,6 +570,28 @@ async def list_agents() -> list[dict]:
         return [_agent_row_to_dict(row) for row in result.mappings().all()]
 
 
+_USER_SELECT_COLS = (
+    "principal_id, user_name, display_name, reach, surface, "
+    "cert_thumbprint, created_at, last_active_at, "
+    "password_hash, must_change_password, disabled, "
+    "password_updated_at"
+)
+
+
+def _user_row_to_dict(row) -> dict:
+    """Materialise a row including the optional AD-style password fields.
+
+    ``has_password`` / ``must_change_password`` / ``disabled`` are
+    surfaced as plain ``bool`` so Jinja templates don't have to coerce
+    Postgres BOOLEAN vs SQLite INTEGER themselves.
+    """
+    out = dict(row)
+    out["has_password"] = bool(out.pop("password_hash", None))
+    out["must_change_password"] = bool(out.get("must_change_password"))
+    out["disabled"] = bool(out.get("disabled"))
+    return out
+
+
 async def list_user_principals() -> list[dict]:
     """List user principals registered on this Mastio.
 
@@ -584,13 +606,30 @@ async def list_user_principals() -> list[dict]:
     async with get_db() as conn:
         result = await conn.execute(
             text(
-                "SELECT principal_id, user_name, display_name, reach, "
-                "       surface, cert_thumbprint, created_at, last_active_at "
+                f"SELECT {_USER_SELECT_COLS} "
                 "  FROM local_user_principals "
                 " ORDER BY created_at DESC"
             )
         )
-        return [dict(row) for row in result.mappings().all()]
+        return [_user_row_to_dict(row) for row in result.mappings().all()]
+
+
+async def get_user_principal(principal_id: str) -> dict | None:
+    """Fetch a single user principal by id, or ``None`` if missing.
+
+    Used by the dashboard detail page (``GET /proxy/users/{id}``).
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                f"SELECT {_USER_SELECT_COLS} "
+                "  FROM local_user_principals "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )
+        row = result.mappings().first()
+    return _user_row_to_dict(row) if row else None
 
 
 async def count_user_principals() -> int:

--- a/tests/test_proxy_dashboard_users_lifecycle.py
+++ b/tests/test_proxy_dashboard_users_lifecycle.py
@@ -1,0 +1,341 @@
+"""Mastio dashboard — Users tab lifecycle (PR2 follow-up to PR #575).
+
+Exercises the new dashboard endpoints layered on top of the AD-style
+password backend already covered by ``test_admin_users_password.py``
+and ``test_password_login.py``:
+
+  POST /proxy/users/create                            (now password-aware)
+  GET  /proxy/users/{principal_id}                    (detail page)
+  POST /proxy/users/{principal_id}/deactivate
+  POST /proxy/users/{principal_id}/reactivate
+  POST /proxy/users/{principal_id}/delete
+  POST /proxy/users/{principal_id}/reset-password
+
+Mirrors the proxy_logged_in pattern from
+``test_proxy_dashboard_mcp_resources.py`` so a future reader sees one
+consistent integration-style fixture across every dashboard tab.
+"""
+from __future__ import annotations
+
+import re
+from urllib.parse import quote
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield client
+    get_settings.cache_clear()
+
+
+async def _csrf(client) -> str:
+    """Pull the CSRF token rendered on the Users page (any
+    authenticated GET works — every dashboard page emits one)."""
+    page = await client.get("/proxy/users")
+    assert page.status_code == 200, page.text[:200]
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token not found in /proxy/users body"
+    return m.group(1)
+
+
+async def _create(
+    client, *, user_name: str, password: str | None = None,
+    display_name: str = "", reach: str = "intra", surface: str = "",
+):
+    csrf = await _csrf(client)
+    data = {
+        "csrf_token": csrf,
+        "user_name": user_name,
+        "display_name": display_name,
+        "reach": reach,
+        "surface": surface,
+    }
+    if password is not None:
+        data["password"] = password
+    return await client.post(
+        "/proxy/users/create", data=data, follow_redirects=False,
+    )
+
+
+async def _row(principal_id: str) -> dict | None:
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT * FROM local_user_principals "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )).mappings().first()
+    return dict(row) if row else None
+
+
+# ── create with password ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_with_password_sets_hash_and_flag(proxy_logged_in):
+    cli = proxy_logged_in
+    resp = await _create(
+        cli, user_name="alice", display_name="Alice Rossi",
+        password="InitialPwd!2026",
+    )
+    assert resp.status_code == 303, resp.text[:200]
+    assert "/proxy/users?new_user_name=alice" in resp.headers["location"]
+
+    row = await _row("acme::user::alice")
+    assert row is not None
+    assert row["password_hash"] is not None
+    assert bool(row["must_change_password"]) is True
+    assert bool(row["disabled"]) is False
+    assert row["password_updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_create_without_password_leaves_sso_only(proxy_logged_in):
+    cli = proxy_logged_in
+    resp = await _create(cli, user_name="bob")
+    assert resp.status_code == 303
+    row = await _row("acme::user::bob")
+    assert row is not None
+    assert row["password_hash"] is None
+    assert bool(row["must_change_password"]) is False
+
+
+@pytest.mark.asyncio
+async def test_create_top_up_password_on_existing_sso_row(proxy_logged_in):
+    cli = proxy_logged_in
+    # First create without password (SSO-only row).
+    await _create(cli, user_name="carol")
+    # Then re-create with a password to attach a credential.
+    await _create(cli, user_name="carol", password="LaterPwd!2026")
+    row = await _row("acme::user::carol")
+    assert row["password_hash"] is not None
+    assert bool(row["must_change_password"]) is True
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_password_replacement(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(cli, user_name="dave", password="FirstPwd!2026")
+    resp = await _create(cli, user_name="dave", password="SecondPwd!2026")
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+    assert "Reset%20Password" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_short_password(proxy_logged_in):
+    cli = proxy_logged_in
+    resp = await _create(cli, user_name="eve", password="short")
+    assert resp.status_code == 303
+    assert "error=password" in resp.headers["location"]
+
+
+# ── detail page ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detail_page_renders_user(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(
+        cli, user_name="frank", display_name="Frank Conti",
+        password="GoodPwd!2026",
+    )
+    resp = await cli.get(
+        f"/proxy/users/{quote('acme::user::frank', safe='')}",
+    )
+    assert resp.status_code == 200, resp.text[:200]
+    body = resp.text
+    assert "Frank Conti" in body
+    assert "acme::user::frank" in body
+    # Status header on the right reflects pending password change.
+    assert "Pending password change" in body
+    # Danger Zone section is present with the three actions.
+    assert "Danger Zone" in body
+    assert "Reset Password" in body
+    assert "Deactivate" in body
+    assert "Delete User" in body
+
+
+@pytest.mark.asyncio
+async def test_detail_page_404_for_missing(proxy_logged_in):
+    cli = proxy_logged_in
+    resp = await cli.get(
+        f"/proxy/users/{quote('acme::user::ghost', safe='')}",
+    )
+    assert resp.status_code == 404
+
+
+# ── deactivate / reactivate ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deactivate_then_reactivate_flips_disabled(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(cli, user_name="gail")
+    pid = "acme::user::gail"
+    csrf = await _csrf(cli)
+
+    resp = await cli.post(
+        f"/proxy/users/{quote(pid, safe='')}/deactivate",
+        data={"csrf_token": csrf}, follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    row = await _row(pid)
+    assert bool(row["disabled"]) is True
+
+    resp = await cli.post(
+        f"/proxy/users/{quote(pid, safe='')}/reactivate",
+        data={"csrf_token": csrf}, follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    row = await _row(pid)
+    assert bool(row["disabled"]) is False
+
+
+@pytest.mark.asyncio
+async def test_deactivate_404_for_missing(proxy_logged_in):
+    cli = proxy_logged_in
+    csrf = await _csrf(cli)
+    resp = await cli.post(
+        f"/proxy/users/{quote('acme::user::ghost', safe='')}/deactivate",
+        data={"csrf_token": csrf}, follow_redirects=False,
+    )
+    assert resp.status_code == 404
+
+
+# ── reset password ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rotates_hash_and_rearms_flag(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(cli, user_name="harry", password="OldPwd!2026")
+    pid = "acme::user::harry"
+    # Manually clear the change-flag so the test proves reset re-arms it.
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "UPDATE local_user_principals SET must_change_password = :mcp "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": pid, "mcp": False},
+        )
+    pre_hash = (await _row(pid))["password_hash"]
+
+    csrf = await _csrf(cli)
+    resp = await cli.post(
+        f"/proxy/users/{quote(pid, safe='')}/reset-password",
+        data={"csrf_token": csrf, "new_password": "BrandNew!2026"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    row = await _row(pid)
+    assert row["password_hash"] != pre_hash  # rotated
+    assert bool(row["must_change_password"]) is True
+
+
+@pytest.mark.asyncio
+async def test_reset_password_rejects_short(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(cli, user_name="ivy", password="OldPwd!2026")
+    pid = "acme::user::ivy"
+    csrf = await _csrf(cli)
+    resp = await cli.post(
+        f"/proxy/users/{quote(pid, safe='')}/reset-password",
+        data={"csrf_token": csrf, "new_password": "tiny"},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "error=" in resp.headers["location"]
+
+
+# ── delete ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_delete_purges_row_and_redirects_to_index(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(cli, user_name="jane")
+    pid = "acme::user::jane"
+    csrf = await _csrf(cli)
+    resp = await cli.post(
+        f"/proxy/users/{quote(pid, safe='')}/delete",
+        data={"csrf_token": csrf}, follow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert "/proxy/users?error=" in resp.headers["location"]
+    assert await _row(pid) is None
+
+
+# ── csrf guard ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_endpoints_reject_missing_csrf(proxy_logged_in):
+    cli = proxy_logged_in
+    await _create(cli, user_name="ken")
+    pid = "acme::user::ken"
+    for action in ("deactivate", "reactivate", "delete", "reset-password"):
+        resp = await cli.post(
+            f"/proxy/users/{quote(pid, safe='')}/{action}",
+            data={"new_password": "AnyPwd!2026"} if action == "reset-password" else {},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 403, f"{action} should reject missing csrf"
+
+
+# ── auth guard ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_detail_page_requires_login(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get(
+                f"/proxy/users/{quote('acme::user::someone', safe='')}",
+                follow_redirects=False,
+            )
+            assert resp.status_code in (303, 307)
+            assert "/proxy/login" in resp.headers.get("location", "") \
+                or "/proxy/register" in resp.headers.get("location", "")
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary

PR2 of the AD-style users sprint, layered on the password backend shipped in #575. Adds the dashboard side: form-level password, per-user detail page with Activity + Danger Zone (Reset Password / Deactivate / Reactivate / Delete).

### Create User form
- New optional **Initial Password** field (8-128 chars) — bcrypt-hashed server-side, ``must_change_password`` flipped to True so the admin's value is never long-lived.
- **Top-up**: re-creating a user that already exists without a password attaches one without overwriting other metadata.
- **Replacement rejected**: re-creating a user that already has a password redirects to the Reset Password Danger Zone action so rotation stays auditable.

### Users list table
- New **Status** pill column (Active / Pending change / SSO-only / Disabled).
- **Display Name + Details button** are clickable into ``/proxy/users/{principal_id}``.
- Existing columns (Reach, Surface, Last active, Created) preserved.

### New per-user detail page (``user_detail.html``)
3 tabs mirroring ``agent_detail.html`` but without Connect (user principals don't speak the proxy API directly):
- **Overview**: principal_id, user_name, reach pill, surface, created, last_active, password state (Set / Set-pending-change / Not-set), cert_thumbprint, SPIFFE id.
- **Activity**: last 20 ``audit_log`` rows attributed to the principal id.
- **Danger Zone**: Reset Password (re-arms ``must_change_password``), Deactivate / Reactivate, Delete (purges directory row).

### Routes added (all CSRF-guarded + require_login)
- ``GET  /proxy/users/{principal_id}``
- ``POST /proxy/users/{principal_id}/deactivate``
- ``POST /proxy/users/{principal_id}/reactivate``
- ``POST /proxy/users/{principal_id}/delete``
- ``POST /proxy/users/{principal_id}/reset-password``
- Extended: ``POST /proxy/users/create`` now accepts ``password``.

### DB layer
- ``mcp_proxy.db.list_user_principals()`` extended to surface ``has_password`` / ``must_change_password`` / ``disabled`` as plain bools (templates don't need to coerce SQLite vs Postgres BOOLEAN themselves).
- New ``mcp_proxy.db.get_user_principal(principal_id)`` for the detail page.

### Tests (14 new in ``test_proxy_dashboard_users_lifecycle.py``)
Create-with-password, top-up, replacement rejection, short-password validation, detail render with Pending pill, 404 for missing, deactivate→reactivate flip, deactivate 404, reset-password rotate + re-arm, reset-password short rejection, delete purge, CSRF guard on every lifecycle endpoint, require-login guard on the detail page.

## Test plan

- [x] ``pytest tests/test_proxy_dashboard_users_lifecycle.py`` — 14 passed
- [x] ``pytest tests/ -n auto --dist=loadfile --ignore=tests/connector --ignore=tests/test_postgres_integration.py`` — 2445 passed, 34 skipped, 0 failed (gotcha noti GUI/postgres ignorati)
- [ ] ``./sandbox/smoke.sh full`` — pre-merge gate
- [ ] ``/security-review`` — pre-merge gate
- [ ] Manual UI dogfood on /proxy/users (create with password, click row, deactivate, reset-password, delete)