### PR TITLE
feat(mcp_proxy): multi-provider AI gateway, dashboard-managed

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -140,24 +140,47 @@ def _get_state(request: Request) -> dict:
     return state
 
 
+# In-process cache for the upstream model list. The Mastio answer is
+# stable per-deployment until an admin edits AI Providers, so a 30s
+# TTL keeps the chat sidebar snappy without hammering the egress.
+_MODELS_CACHE_TTL_S = 30.0
+_models_cache: dict[str, tuple[float, list[dict]]] = {}
+
+
+def _fallback_models(state: dict) -> list[dict]:
+    advertised = state["advertised_models"] or ["claude-haiku-4-5"]
+    return [
+        {"id": m, "object": "model", "owned_by": "cullis", "created": 0}
+        for m in advertised
+    ]
+
+
 @router.get("/v1/models")
 def list_models(request: Request) -> dict:
     _enforce_loopback(request)
     state = _get_state(request)
     _enforce_bearer(request, state)
-    advertised = state["advertised_models"] or ["claude-haiku-4-5"]
-    return {
-        "object": "list",
-        "data": [
-            {
-                "id": m,
-                "object": "model",
-                "owned_by": "cullis",
-                "created": 0,
-            }
-            for m in advertised
-        ],
-    }
+
+    cache_key = state.get("agent_id") or "default"
+    cached = _models_cache.get(cache_key)
+    now = time.monotonic()
+    if cached is not None and (now - cached[0]) < _MODELS_CACHE_TTL_S:
+        return {"object": "list", "data": cached[1]}
+
+    holder = state.get("client")
+    data = _fallback_models(state)
+    if holder is not None:
+        try:
+            client = holder.get()
+            data = client.list_models() or data
+        except Exception as exc:
+            _log.debug(
+                "Mastio /v1/models fetch failed, using advertised fallback: %s",
+                exc,
+            )
+
+    _models_cache[cache_key] = (now, data)
+    return {"object": "list", "data": data}
 
 
 # ── /v1/chat/completions ────────────────────────────────────────────

--- a/cullis_connector/ambassador/shared/router.py
+++ b/cullis_connector/ambassador/shared/router.py
@@ -19,6 +19,7 @@ unchanged — both modes can coexist on the same image.
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -261,19 +262,53 @@ async def session_whoami(
 # ── /v1/models ────────────────────────────────────────────────────
 
 
+# Process-local TTL cache keyed on principal_id. The Mastio answer is
+# stable per-org until an admin edits AI Providers, so a 30s TTL keeps
+# the SPA dropdown snappy even with 50 concurrent users.
+_SHARED_MODELS_CACHE_TTL_S = 30.0
+_shared_models_cache: dict[str, tuple[float, list[dict]]] = {}
+
+
+def _shared_fallback_models(state: SharedAmbassadorState) -> list[dict]:
+    advertised = state.advertised_models or ["claude-haiku-4-5"]
+    return [
+        {"id": m, "object": "model", "owned_by": "cullis", "created": 0}
+        for m in advertised
+    ]
+
+
 @router.get("/v1/models")
 async def list_models(
     request: Request,
-    _payload: SessionPayload = Depends(_require_session),
+    cred: UserCredentials = Depends(_require_credentials),
 ) -> dict:
     state = _state(request)
-    return {
-        "object": "list",
-        "data": [
-            {"id": m, "object": "model", "owned_by": "cullis", "created": 0}
-            for m in (state.advertised_models or ["claude-haiku-4-5"])
-        ],
-    }
+
+    cached = _shared_models_cache.get(cred.principal_id)
+    now = time.monotonic()
+    if cached is not None and (now - cached[0]) < _SHARED_MODELS_CACHE_TTL_S:
+        return {"object": "list", "data": cached[1]}
+
+    data = _shared_fallback_models(state)
+    try:
+        client = _build_user_client(state, cred)
+        try:
+            data = client.list_models() or data
+        finally:
+            close = getattr(client, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:
+                    pass
+    except Exception as exc:
+        _log.debug(
+            "shared ambassador /v1/models fetch failed for %s: %s",
+            cred.principal_id, exc,
+        )
+
+    _shared_models_cache[cred.principal_id] = (now, data)
+    return {"object": "list", "data": data}
 
 
 # ── /v1/chat/completions ─────────────────────────────────────────

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -3205,6 +3205,25 @@ class CullisClient:
         resp.raise_for_status()
         return resp.json()
 
+    def list_models(self) -> list[dict]:
+        """Return the OpenAI-compatible model list from Mastio.
+
+        Hits ``GET /v1/egress/models`` (with ``/v1/models`` as a back-
+        compat alias). The Mastio enumerates the providers configured
+        in the ``ai_provider_credentials`` table, surfaces only those
+        whose ``enabled`` is ``True`` and whose required credentials
+        are present, then fans out the static model catalog (Anthropic,
+        OpenAI, Gemini, Bedrock, Vertex) plus a live ``ollama/api/tags``
+        fetch when an Ollama row is configured.
+
+        Returns the ``data`` array verbatim so the Connector Ambassador
+        can pass it straight through to the SPA's ``ModelPicker``.
+        """
+        resp = self._authed_request("GET", "/v1/egress/models")
+        resp.raise_for_status()
+        body = resp.json()
+        return body.get("data", [])
+
     # ── ADR-007 — MCP aggregator (proxy-side only) ─────────────────
     def list_mcp_tools(self) -> list[dict]:
         """List the MCP tools the authenticated agent can call.

--- a/mcp_proxy/admin/ai_providers.py
+++ b/mcp_proxy/admin/ai_providers.py
@@ -1,0 +1,452 @@
+"""Admin API for managing AI provider credentials at runtime.
+
+Lifts the embedded LiteLLM gateway off the single ``ANTHROPIC_API_KEY``
+environment variable. An org admin authenticates with the
+``X-Admin-Secret`` header (same pattern used by ``/v1/admin/agents``)
+and configures Anthropic / OpenAI / Gemini / Bedrock / Vertex / Ollama
+credentials. Every mutation lands in the hash-chained audit log and the
+Mastio process picks up the new value on the next gateway call (no
+restart needed).
+
+Endpoints:
+
+  GET    /v1/admin/ai-providers
+         List all providers with masked credentials. Not-yet-configured
+         providers are returned with ``configured=false`` so the dashboard
+         can render the full catalog in one round-trip.
+
+  GET    /v1/admin/ai-providers/{provider}
+         Single-provider read; same masked shape.
+
+  PUT    /v1/admin/ai-providers/{provider}
+         Upsert credentials. Validates required fields against the
+         catalog and returns 400 with a structured error on miss.
+
+  DELETE /v1/admin/ai-providers/{provider}
+         Remove credentials. The gateway falls back to
+         ``ANTHROPIC_API_KEY`` env for ``anthropic`` to keep legacy
+         deployments alive after the row is dropped.
+
+  POST   /v1/admin/ai-providers/{provider}/enable
+         Toggle the ``enabled`` flag without rotating credentials. The
+         body carries ``{"enabled": true|false}``.
+
+  POST   /v1/admin/ai-providers/{provider}/test
+         Live connectivity probe. Sends a minimal authenticated request
+         to the provider's catalog endpoint (Anthropic models / OpenAI
+         models / Gemini models / Ollama tags). Returns ``ok`` / latency
+         / a sanitised error string. Not all providers support a ping
+         today (Bedrock, Vertex) — those return ``status="unsupported"``
+         and the operator falls back to the first chat completion.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+import time
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, status
+from pydantic import BaseModel, Field
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import (
+    delete_ai_provider_creds,
+    get_ai_provider_creds,
+    list_ai_provider_creds,
+    log_audit,
+    set_ai_provider_enabled,
+    upsert_ai_provider_creds,
+)
+from mcp_proxy.egress.provider_catalog import (
+    PROVIDERS,
+    InvalidCredentialsError,
+    fetch_ollama_models,
+    get_spec,
+    mask_creds,
+    validate_creds,
+)
+
+
+_log = logging.getLogger("mcp_proxy.admin.ai_providers")
+
+router = APIRouter(prefix="/v1/admin/ai-providers", tags=["admin"])
+
+
+# ── auth ────────────────────────────────────────────────────────────────
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+# ── models ──────────────────────────────────────────────────────────────
+
+
+class FieldDef(BaseModel):
+    name: str
+    label: str
+    secret: bool = False
+    required: bool = True
+    placeholder: str = ""
+    help_text: str = ""
+
+
+class ProviderInfo(BaseModel):
+    """Public-facing description of one provider, masked credentials only."""
+
+    provider: str
+    display_name: str
+    docs_url: str
+    fields: list[FieldDef]
+    static_models: list[str] = Field(default_factory=list)
+    dynamic_models: bool = False
+    configured: bool = False
+    enabled: bool = False
+    creds_masked: dict[str, str] = Field(default_factory=dict)
+    updated_at: str | None = None
+    updated_by: str | None = None
+
+
+class ProviderUpsertRequest(BaseModel):
+    """Inbound credentials. Empty/missing optional fields are dropped."""
+
+    creds: dict[str, str]
+    enabled: bool = True
+    updated_by: str | None = None
+
+
+class ProviderEnableRequest(BaseModel):
+    enabled: bool
+
+
+class TestResult(BaseModel):
+    provider: str
+    status: str  # "ok" | "error" | "unsupported"
+    latency_ms: int | None = None
+    detail: str | None = None
+    sample_models: list[str] = Field(default_factory=list)
+
+
+# ── helpers ─────────────────────────────────────────────────────────────
+
+
+def _spec_to_info(provider: str, row: dict | None) -> ProviderInfo:
+    spec = get_spec(provider)
+    if spec is None:  # pragma: no cover — guarded by router validation
+        raise HTTPException(404, f"unknown provider {provider!r}")
+    fields = [
+        FieldDef(
+            name=f.name,
+            label=f.label,
+            secret=f.secret,
+            required=f.required,
+            placeholder=f.placeholder,
+            help_text=f.help_text,
+        )
+        for f in spec.fields
+    ]
+    info = ProviderInfo(
+        provider=spec.provider,
+        display_name=spec.display_name,
+        docs_url=spec.docs_url,
+        fields=fields,
+        static_models=list(spec.static_models),
+        dynamic_models=spec.dynamic_models,
+    )
+    if row is not None:
+        info.configured = True
+        info.enabled = bool(row["enabled"])
+        info.creds_masked = mask_creds(provider, row["creds"] or {})
+        info.updated_at = row.get("updated_at")
+        info.updated_by = row.get("updated_by")
+    return info
+
+
+def _require_known_provider(provider: str) -> str:
+    p = provider.lower()
+    if p not in PROVIDERS:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown provider {provider!r}; "
+                   f"valid: {sorted(PROVIDERS.keys())}",
+        )
+    return p
+
+
+# ── routes ──────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "",
+    response_model=list[ProviderInfo],
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_providers() -> list[ProviderInfo]:
+    rows = await list_ai_provider_creds()
+    by_name = {r["provider"]: r for r in rows}
+    out: list[ProviderInfo] = []
+    for provider in PROVIDERS:
+        out.append(_spec_to_info(provider, by_name.get(provider)))
+    return out
+
+
+@router.get(
+    "/{provider}",
+    response_model=ProviderInfo,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def get_provider(provider: str) -> ProviderInfo:
+    p = _require_known_provider(provider)
+    row = await get_ai_provider_creds(p)
+    return _spec_to_info(p, row)
+
+
+@router.put(
+    "/{provider}",
+    response_model=ProviderInfo,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def upsert_provider(
+    provider: str,
+    body: ProviderUpsertRequest,
+) -> ProviderInfo:
+    p = _require_known_provider(provider)
+    try:
+        cleaned = validate_creds(p, body.creds)
+    except InvalidCredentialsError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    await upsert_ai_provider_creds(
+        p, cleaned,
+        enabled=body.enabled,
+        updated_by=body.updated_by,
+    )
+    await log_audit(
+        agent_id=body.updated_by or "admin",
+        action="ai_provider.upsert",
+        status="success",
+        details={
+            "provider": p,
+            "enabled": body.enabled,
+            "fields": sorted(cleaned.keys()),
+        },
+    )
+    _log.info(
+        "ai-provider upsert provider=%s enabled=%s by=%s fields=%s",
+        p, body.enabled, body.updated_by, sorted(cleaned.keys()),
+    )
+    row = await get_ai_provider_creds(p)
+    return _spec_to_info(p, row)
+
+
+@router.delete(
+    "/{provider}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def delete_provider(provider: str) -> None:
+    p = _require_known_provider(provider)
+    deleted = await delete_ai_provider_creds(p)
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"provider {p!r} has no stored credentials",
+        )
+    await log_audit(
+        agent_id="admin",
+        action="ai_provider.delete",
+        status="success",
+        details={"provider": p},
+    )
+    _log.info("ai-provider deleted provider=%s", p)
+
+
+@router.post(
+    "/{provider}/enable",
+    response_model=ProviderInfo,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def toggle_enabled(
+    provider: str,
+    body: ProviderEnableRequest,
+) -> ProviderInfo:
+    p = _require_known_provider(provider)
+    changed = await set_ai_provider_enabled(p, body.enabled)
+    if not changed:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"provider {p!r} not configured",
+        )
+    await log_audit(
+        agent_id="admin",
+        action=("ai_provider.enable" if body.enabled
+                else "ai_provider.disable"),
+        status="success",
+        details={"provider": p},
+    )
+    row = await get_ai_provider_creds(p)
+    return _spec_to_info(p, row)
+
+
+@router.post(
+    "/{provider}/test",
+    response_model=TestResult,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def test_provider(
+    provider: str,
+    overrides: dict[str, Any] | None = Body(default=None),
+) -> TestResult:
+    """Probe the provider with a lightweight read.
+
+    The optional body lets the dashboard test creds before saving them
+    (``{"creds": {...}}``). When no body is sent we use the stored row.
+    """
+    p = _require_known_provider(provider)
+    creds: dict[str, str] = {}
+
+    if isinstance(overrides, dict) and isinstance(overrides.get("creds"), dict):
+        try:
+            creds = validate_creds(p, overrides["creds"])
+        except InvalidCredentialsError as exc:
+            raise HTTPException(400, str(exc)) from exc
+    else:
+        row = await get_ai_provider_creds(p)
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"provider {p!r} not configured",
+            )
+        creds = dict(row["creds"] or {})
+
+    started = time.perf_counter()
+    try:
+        result = await _live_probe(p, creds)
+    except Exception as exc:  # pragma: no cover — defensive
+        _log.warning("ai-provider test failed provider=%s err=%s", p, exc)
+        result = TestResult(
+            provider=p, status="error",
+            detail=f"{type(exc).__name__}: {exc}"[:512],
+        )
+    result.latency_ms = int((time.perf_counter() - started) * 1000)
+    return result
+
+
+# ── live probes ─────────────────────────────────────────────────────────
+
+
+async def _live_probe(provider: str, creds: dict[str, str]) -> TestResult:
+    if provider == "anthropic":
+        return await _probe_anthropic(creds)
+    if provider == "openai":
+        return await _probe_openai(creds)
+    if provider == "gemini":
+        return await _probe_gemini(creds)
+    if provider == "ollama":
+        return await _probe_ollama(creds)
+    return TestResult(
+        provider=provider,
+        status="unsupported",
+        detail=(
+            f"Live probe not implemented for {provider!r}. "
+            "Issue a chat completion to validate."
+        ),
+    )
+
+
+async def _probe_anthropic(creds: dict[str, str]) -> TestResult:
+    api_key = creds.get("api_key", "")
+    headers = {
+        "x-api-key": api_key,
+        "anthropic-version": "2023-06-01",
+    }
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(
+            "https://api.anthropic.com/v1/models", headers=headers,
+        )
+    if resp.status_code != 200:
+        return TestResult(
+            provider="anthropic", status="error",
+            detail=f"HTTP {resp.status_code}: {resp.text[:256]}",
+        )
+    try:
+        data = resp.json().get("data", [])
+        sample = [d.get("id") for d in data[:5] if d.get("id")]
+    except ValueError:
+        sample = []
+    return TestResult(
+        provider="anthropic", status="ok", sample_models=sample,
+    )
+
+
+async def _probe_openai(creds: dict[str, str]) -> TestResult:
+    api_key = creds.get("api_key", "")
+    base = creds.get("api_base") or "https://api.openai.com/v1"
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(
+            f"{base.rstrip('/')}/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+        )
+    if resp.status_code != 200:
+        return TestResult(
+            provider="openai", status="error",
+            detail=f"HTTP {resp.status_code}: {resp.text[:256]}",
+        )
+    try:
+        data = resp.json().get("data", [])
+        sample = [d.get("id") for d in data[:5] if d.get("id")]
+    except ValueError:
+        sample = []
+    return TestResult(provider="openai", status="ok", sample_models=sample)
+
+
+async def _probe_gemini(creds: dict[str, str]) -> TestResult:
+    api_key = creds.get("api_key", "")
+    url = (
+        "https://generativelanguage.googleapis.com/v1beta/models"
+        f"?key={api_key}"
+    )
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        resp = await client.get(url)
+    if resp.status_code != 200:
+        return TestResult(
+            provider="gemini", status="error",
+            detail=f"HTTP {resp.status_code}: {resp.text[:256]}",
+        )
+    try:
+        data = resp.json().get("models", [])
+        sample = [d.get("name", "").split("/")[-1] for d in data[:5]]
+        sample = [s for s in sample if s]
+    except ValueError:
+        sample = []
+    return TestResult(provider="gemini", status="ok", sample_models=sample)
+
+
+async def _probe_ollama(creds: dict[str, str]) -> TestResult:
+    api_base = creds.get("api_base", "")
+    if not api_base:
+        return TestResult(
+            provider="ollama", status="error", detail="api_base missing",
+        )
+    models = await fetch_ollama_models(api_base, timeout_s=3.0)
+    if not models:
+        return TestResult(
+            provider="ollama", status="error",
+            detail=f"No models reachable at {api_base}/api/tags",
+        )
+    return TestResult(
+        provider="ollama", status="ok",
+        sample_models=models[:5],
+    )

--- a/mcp_proxy/alembic/versions/0027_ai_provider_creds.py
+++ b/mcp_proxy/alembic/versions/0027_ai_provider_creds.py
@@ -1,0 +1,68 @@
+"""Multi-provider AI credentials, dashboard-managed.
+
+Revision ID: 0027_ai_provider_creds
+Revises: 0026_user_password
+Create Date: 2026-05-10 23:30:00.000000
+
+Lifts the embedded AI gateway off the single ``ANTHROPIC_API_KEY``
+environment variable so an org admin can add Gemini, OpenAI, Bedrock,
+Vertex, or a local Ollama base URL from the Mastio dashboard at runtime.
+
+Schema:
+  provider          TEXT PRIMARY KEY  — anthropic, openai, gemini, bedrock,
+                                         vertex, ollama. The catalog in
+                                         ``mcp_proxy.egress.provider_catalog``
+                                         enumerates the supported keys.
+  creds_json        TEXT NOT NULL     — JSON dict of provider-specific fields
+                                         (api_key, aws_access_key_id, ...).
+                                         Stored alongside ``proxy_config``
+                                         entries like ``org_ca_key``; the
+                                         Mastio process is the trust
+                                         boundary, not this column.
+  enabled           BOOLEAN NOT NULL  — operator can pause a provider
+                                         without losing the credentials.
+  updated_at        TEXT NOT NULL     — ISO-8601 UTC.
+  updated_by        TEXT              — principal_id of the admin who set
+                                         the row, NULL when the row was
+                                         seeded from environment for
+                                         backward compat.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0027_ai_provider_creds"
+down_revision: Union[str, Sequence[str], None] = "0026_user_password"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "ai_provider_credentials"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        return
+
+    op.create_table(
+        _TABLE,
+        sa.Column("provider", sa.Text(), primary_key=True),
+        sa.Column("creds_json", sa.Text(), nullable=False),
+        sa.Column(
+            "enabled", sa.Boolean(),
+            nullable=False, server_default=sa.true(),
+        ),
+        sa.Column("updated_at", sa.Text(), nullable=False),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        op.drop_table(_TABLE)

--- a/mcp_proxy/dashboard/ai_providers.py
+++ b/mcp_proxy/dashboard/ai_providers.py
@@ -1,0 +1,343 @@
+"""Dashboard CRUD for AI provider credentials (ADR-017 Phase 4).
+
+Pairs with :mod:`mcp_proxy.admin.ai_providers` (the headless API). The
+admin secret API is what scripts and Terraform talk to; this router is
+what an org admin sees in the browser at ``/proxy/ai-providers``.
+
+Each provider in :data:`mcp_proxy.egress.provider_catalog.PROVIDERS`
+gets a card with the credentials form. Save / Delete / Test / Toggle
+actions live behind CSRF-protected POSTs and write through the same
+``upsert_ai_provider_creds`` / ``delete_ai_provider_creds`` /
+``set_ai_provider_enabled`` helpers used by the API. The audit chain
+sees them with the dashboard session's principal as ``updated_by``,
+keeping API + UI rows traceable in the same way.
+"""
+from __future__ import annotations
+
+import logging
+import pathlib
+import time
+
+from fastapi import APIRouter, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import (
+    delete_ai_provider_creds,
+    get_ai_provider_creds,
+    list_ai_provider_creds,
+    log_audit,
+    set_ai_provider_enabled,
+    upsert_ai_provider_creds,
+)
+from mcp_proxy.egress.provider_catalog import (
+    PROVIDERS,
+    InvalidCredentialsError,
+    fetch_ollama_models,
+    get_spec,
+    mask_creds,
+    validate_creds,
+)
+
+
+_log = logging.getLogger("mcp_proxy.dashboard.ai_providers")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+router = APIRouter(prefix="/proxy/ai-providers", tags=["dashboard-ai-providers"])
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        "active": "ai_providers",
+        **kwargs,
+    }
+
+
+def _provider_view(provider: str, row: dict | None) -> dict:
+    """Render-friendly dict for the ``ai_providers.html`` template."""
+    spec = get_spec(provider)
+    if spec is None:
+        raise HTTPException(404, f"unknown provider {provider!r}")
+    return {
+        "provider": spec.provider,
+        "display_name": spec.display_name,
+        "docs_url": spec.docs_url,
+        "fields": [
+            {
+                "name": f.name,
+                "label": f.label,
+                "secret": f.secret,
+                "required": f.required,
+                "placeholder": f.placeholder,
+                "help_text": f.help_text,
+            }
+            for f in spec.fields
+        ],
+        "static_models": list(spec.static_models),
+        "dynamic_models": spec.dynamic_models,
+        "configured": row is not None,
+        "enabled": bool(row["enabled"]) if row else False,
+        "creds_masked": mask_creds(provider, row["creds"] or {}) if row else {},
+        "updated_at": row.get("updated_at") if row else None,
+        "updated_by": row.get("updated_by") if row else None,
+    }
+
+
+async def _all_providers_view() -> list[dict]:
+    rows = await list_ai_provider_creds()
+    by_name = {r["provider"]: r for r in rows}
+    return [_provider_view(p, by_name.get(p)) for p in PROVIDERS]
+
+
+# ── routes ──────────────────────────────────────────────────────────────
+
+
+@router.get("", response_class=HTMLResponse)
+async def index(request: Request) -> HTMLResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    providers = await _all_providers_view()
+    return templates.TemplateResponse(
+        "ai_providers.html",
+        _ctx(request, session, providers=providers),
+    )
+
+
+@router.post("/{provider}/save")
+async def save(request: Request, provider: str) -> RedirectResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(403, "csrf token mismatch")
+
+    if provider.lower() not in PROVIDERS:
+        raise HTTPException(404, f"unknown provider {provider!r}")
+    p = provider.lower()
+    spec = get_spec(p)
+    assert spec is not None  # known provider per check above
+
+    form = await request.form()
+    inbound: dict[str, str] = {}
+    for fld in spec.fields:
+        raw = form.get(fld.name) or ""
+        raw = str(raw).strip()
+        if fld.secret and raw == "***":
+            # User left the masked placeholder untouched — keep the
+            # existing value rather than wiping it.
+            existing = await get_ai_provider_creds(p)
+            if existing and existing["creds"].get(fld.name):
+                inbound[fld.name] = existing["creds"][fld.name]
+                continue
+            raw = ""
+        if raw:
+            inbound[fld.name] = raw
+
+    enabled = bool(form.get("enabled"))
+
+    try:
+        cleaned = validate_creds(p, inbound)
+    except InvalidCredentialsError as exc:
+        # Re-render the page with the error inline.
+        providers = await _all_providers_view()
+        return templates.TemplateResponse(
+            "ai_providers.html",
+            _ctx(
+                request, session,
+                providers=providers,
+                error_provider=p,
+                error=str(exc),
+            ),
+            status_code=400,
+        )
+
+    updated_by = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+    await upsert_ai_provider_creds(
+        p, cleaned, enabled=enabled, updated_by=updated_by,
+    )
+    await log_audit(
+        agent_id=updated_by,
+        action="ai_provider.upsert",
+        status="success",
+        details={
+            "provider": p,
+            "enabled": enabled,
+            "fields": sorted(cleaned.keys()),
+            "via": "dashboard",
+        },
+    )
+    _log.info(
+        "dashboard ai-provider upsert provider=%s enabled=%s by=%s",
+        p, enabled, updated_by,
+    )
+    return RedirectResponse(
+        url=f"/proxy/ai-providers?saved={p}",
+        status_code=303,
+    )
+
+
+@router.post("/{provider}/delete")
+async def delete(request: Request, provider: str) -> RedirectResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(403, "csrf token mismatch")
+
+    p = provider.lower()
+    if p not in PROVIDERS:
+        raise HTTPException(404, f"unknown provider {provider!r}")
+    deleted = await delete_ai_provider_creds(p)
+    if deleted:
+        updated_by = (
+            getattr(session, "principal_id", None)
+            or getattr(session, "username", None)
+            or "dashboard-admin"
+        )
+        await log_audit(
+            agent_id=updated_by,
+            action="ai_provider.delete",
+            status="success",
+            details={"provider": p, "via": "dashboard"},
+        )
+        _log.info("dashboard ai-provider delete provider=%s by=%s",
+                  p, updated_by)
+    return RedirectResponse(
+        url=f"/proxy/ai-providers?deleted={p}",
+        status_code=303,
+    )
+
+
+@router.post("/{provider}/toggle")
+async def toggle(
+    request: Request,
+    provider: str,
+    enabled: bool = Form(...),
+) -> RedirectResponse:
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(403, "csrf token mismatch")
+
+    p = provider.lower()
+    if p not in PROVIDERS:
+        raise HTTPException(404, f"unknown provider {provider!r}")
+    changed = await set_ai_provider_enabled(p, enabled)
+    if changed:
+        updated_by = (
+            getattr(session, "principal_id", None)
+            or getattr(session, "username", None)
+            or "dashboard-admin"
+        )
+        await log_audit(
+            agent_id=updated_by,
+            action=("ai_provider.enable" if enabled
+                    else "ai_provider.disable"),
+            status="success",
+            details={"provider": p, "via": "dashboard"},
+        )
+    return RedirectResponse(
+        url=f"/proxy/ai-providers?toggled={p}",
+        status_code=303,
+    )
+
+
+@router.post("/{provider}/test", response_class=HTMLResponse)
+async def test(request: Request, provider: str) -> HTMLResponse:
+    """HTMX endpoint — returns a small fragment with the probe result."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(403, "csrf token mismatch")
+
+    p = provider.lower()
+    if p not in PROVIDERS:
+        raise HTTPException(404, f"unknown provider {provider!r}")
+
+    row = await get_ai_provider_creds(p)
+    if row is None:
+        return HTMLResponse(
+            f"<div class='text-red-400 text-xs'>Provider <code>{p}</code> "
+            "is not configured.</div>",
+            status_code=400,
+        )
+    creds = dict(row["creds"] or {})
+
+    started = time.perf_counter()
+    # We deliberately re-import the live probe from the admin module to
+    # share the implementation; the dashboard call sidesteps the
+    # ``X-Admin-Secret`` because the dashboard already authenticated
+    # the operator via ``require_login``.
+    from mcp_proxy.admin.ai_providers import _live_probe
+    try:
+        result = await _live_probe(p, creds)
+    except Exception as exc:  # pragma: no cover — defensive
+        _log.warning("dashboard test failed provider=%s err=%s", p, exc)
+        return HTMLResponse(
+            f"<div class='text-red-400 text-xs'>Probe error: "
+            f"{type(exc).__name__}: {exc}</div>",
+            status_code=200,
+        )
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+
+    if result.status == "ok":
+        sample = ", ".join(result.sample_models[:3]) or "—"
+        return HTMLResponse(
+            f"<div class='text-emerald-400 text-xs'>"
+            f"OK · {elapsed_ms} ms · sample: <span class='font-mono'>"
+            f"{sample}</span></div>",
+        )
+    if result.status == "unsupported":
+        return HTMLResponse(
+            f"<div class='text-amber-400 text-xs'>{result.detail}</div>",
+        )
+    return HTMLResponse(
+        f"<div class='text-red-400 text-xs'>FAIL · {elapsed_ms} ms · "
+        f"{(result.detail or 'unknown error')[:200]}</div>",
+    )
+
+
+@router.get("/{provider}/ollama-models", response_class=HTMLResponse)
+async def ollama_models(request: Request, provider: str) -> HTMLResponse:
+    """Dashboard helper — shows the live model list for an Ollama row."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if provider.lower() != "ollama":
+        raise HTTPException(404, "this endpoint is Ollama-only")
+    row = await get_ai_provider_creds("ollama")
+    if row is None:
+        return HTMLResponse(
+            "<div class='text-gray-500 text-xs'>Save the base URL first.</div>",
+        )
+    api_base = row["creds"].get("api_base", "")
+    models = await fetch_ollama_models(api_base, timeout_s=2.0)
+    if not models:
+        return HTMLResponse(
+            f"<div class='text-amber-400 text-xs'>No models reachable at "
+            f"<code>{api_base}/api/tags</code>.</div>",
+        )
+    items = "".join(
+        f"<li class='font-mono text-xs text-gray-300'>{m}</li>"
+        for m in models
+    )
+    return HTMLResponse(
+        f"<ul class='space-y-1 mt-2'>{items}</ul>",
+    )

--- a/mcp_proxy/dashboard/templates/ai_providers.html
+++ b/mcp_proxy/dashboard/templates/ai_providers.html
@@ -1,0 +1,161 @@
+{% extends "base.html" %}
+{% block title %}AI Providers{% endblock %}
+{% block header_title %}AI Providers{% endblock %}
+{% block content %}
+<div class="max-w-5xl">
+
+    <!-- Header -->
+    <div class="mb-6">
+        <h2 class="text-lg font-semibold text-white uppercase tracking-wider">AI Providers</h2>
+        <p class="text-xs text-gray-600 mt-0.5">
+            Credentials for the embedded LiteLLM gateway.
+            <span class="text-gray-700 mx-1">&middot;</span>
+            Configure a provider to surface its models in Cullis Chat
+            and Frontdesk.
+        </p>
+    </div>
+
+    {% if request.query_params.get('saved') %}
+    <div class="mb-4 p-3 bg-emerald-500/10 border border-emerald-500/20 rounded text-xs text-emerald-300">
+        Saved <span class="font-mono">{{ request.query_params['saved'] }}</span>.
+    </div>
+    {% endif %}
+    {% if request.query_params.get('deleted') %}
+    <div class="mb-4 p-3 bg-amber-500/10 border border-amber-500/20 rounded text-xs text-amber-300">
+        Removed credentials for <span class="font-mono">{{ request.query_params['deleted'] }}</span>.
+    </div>
+    {% endif %}
+    {% if request.query_params.get('toggled') %}
+    <div class="mb-4 p-3 bg-accent-400/10 border border-accent-400/20 rounded text-xs text-accent-400">
+        Toggled <span class="font-mono">{{ request.query_params['toggled'] }}</span>.
+    </div>
+    {% endif %}
+
+    <!-- Cards -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {% for p in providers %}
+        <div class="bg-surface-900/40 border border-gray-800/60 rounded-lg p-5 {% if p.configured and not p.enabled %}opacity-70{% endif %}">
+
+            <!-- Card header -->
+            <div class="flex items-start justify-between mb-3">
+                <div>
+                    <div class="flex items-center gap-2">
+                        <h3 class="text-sm font-semibold text-white">{{ p.display_name }}</h3>
+                        {% if p.configured and p.enabled %}
+                        <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-400 border border-emerald-500/20">configured</span>
+                        {% elif p.configured and not p.enabled %}
+                        <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400 border border-amber-500/20">disabled</span>
+                        {% else %}
+                        <span class="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-gray-800/40 text-gray-500 border border-gray-700/40">not configured</span>
+                        {% endif %}
+                    </div>
+                    <p class="text-[10px] text-gray-600 mt-0.5 font-mono">{{ p.provider }}</p>
+                </div>
+                {% if p.docs_url %}
+                <a href="{{ p.docs_url }}" target="_blank" rel="noopener"
+                   class="text-[10px] uppercase tracking-wider text-gray-500 hover:text-accent-400">docs ↗</a>
+                {% endif %}
+            </div>
+
+            {% if error_provider == p.provider and error %}
+            <div class="mb-3 p-2 bg-red-500/10 border border-red-500/20 rounded text-xs text-red-400">{{ error }}</div>
+            {% endif %}
+
+            <!-- Form -->
+            <form method="post" action="/proxy/ai-providers/{{ p.provider }}/save" class="space-y-3">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+                {% for fld in p.fields %}
+                <div>
+                    <label class="block text-[10px] uppercase tracking-wider text-gray-500 mb-1">
+                        {{ fld.label }}
+                        {% if fld.required %}<span class="text-amber-500">*</span>{% endif %}
+                    </label>
+                    <input
+                        type="{% if fld.secret %}password{% else %}text{% endif %}"
+                        name="{{ fld.name }}"
+                        placeholder="{{ fld.placeholder }}"
+                        value="{% if fld.secret and p.configured and p.creds_masked.get(fld.name) %}***{% else %}{{ p.creds_masked.get(fld.name, '') }}{% endif %}"
+                        autocomplete="off"
+                        spellcheck="false"
+                        class="w-full px-2 py-1.5 bg-surface-950 border border-gray-800 rounded text-xs font-mono text-gray-200 focus:border-accent-400/50 focus:outline-none">
+                    {% if fld.help_text %}
+                    <p class="text-[10px] text-gray-600 mt-1">{{ fld.help_text }}</p>
+                    {% endif %}
+                </div>
+                {% endfor %}
+
+                <label class="flex items-center gap-2 text-xs text-gray-400">
+                    <input type="checkbox" name="enabled" value="true"
+                        {% if not p.configured or p.enabled %}checked{% endif %}>
+                    <span>Enabled</span>
+                </label>
+
+                <div class="flex items-center gap-2 pt-2 border-t border-gray-800/40">
+                    <button type="submit"
+                        class="px-3 py-1.5 rounded bg-accent-400/10 hover:bg-accent-400/20 text-accent-400 text-xs uppercase tracking-wider border border-accent-400/30">
+                        Save
+                    </button>
+
+                    {% if p.configured %}
+                    <button type="button"
+                        hx-post="/proxy/ai-providers/{{ p.provider }}/test"
+                        hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+                        hx-vals='{"csrf_token": "{{ csrf_token }}"}'
+                        hx-target="#test-result-{{ p.provider }}"
+                        hx-swap="innerHTML"
+                        class="px-3 py-1.5 rounded bg-gray-800/40 hover:bg-gray-800/60 text-gray-300 text-xs uppercase tracking-wider border border-gray-700/40">
+                        Test
+                    </button>
+                    {% endif %}
+                </div>
+
+                <div id="test-result-{{ p.provider }}" class="text-xs"></div>
+            </form>
+
+            {% if p.configured %}
+            <div class="mt-3 pt-3 border-t border-gray-800/40 flex items-center justify-between">
+                <p class="text-[10px] text-gray-600">
+                    {% if p.updated_at %}
+                    Updated <span class="font-mono">{{ p.updated_at[:19] }}Z</span>
+                    {% if p.updated_by %} by <span class="font-mono">{{ p.updated_by }}</span>{% endif %}
+                    {% endif %}
+                </p>
+                <form method="post" action="/proxy/ai-providers/{{ p.provider }}/delete"
+                      onsubmit="return confirm('Remove credentials for {{ p.provider }}?');">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                        class="text-[10px] uppercase tracking-wider text-red-500/70 hover:text-red-400">
+                        Remove credentials
+                    </button>
+                </form>
+            </div>
+            {% endif %}
+
+            {% if p.dynamic_models and p.configured and p.enabled %}
+            <div class="mt-3 pt-3 border-t border-gray-800/40">
+                <button type="button"
+                    hx-get="/proxy/ai-providers/{{ p.provider }}/ollama-models"
+                    hx-target="#ollama-models-{{ p.provider }}"
+                    hx-swap="innerHTML"
+                    class="text-[10px] uppercase tracking-wider text-gray-500 hover:text-accent-400">
+                    Refresh model list
+                </button>
+                <div id="ollama-models-{{ p.provider }}"></div>
+            </div>
+            {% elif p.static_models %}
+            <div class="mt-3 pt-3 border-t border-gray-800/40">
+                <p class="text-[10px] uppercase tracking-wider text-gray-600 mb-1">Models</p>
+                <div class="flex flex-wrap gap-1">
+                    {% for m in p.static_models %}
+                    <span class="text-[10px] px-1.5 py-0.5 rounded bg-gray-800/40 text-gray-400 font-mono">{{ m }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
+
+</div>
+{% endblock %}

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -118,6 +118,11 @@
                 Audit Log
                 <span hx-get="/proxy/badge/audit" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
+            <a href="/proxy/ai-providers"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'ai_providers' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>
+                AI Providers
+            </a>
             <a href="/proxy/settings"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'settings' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/></svg>

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1252,3 +1252,131 @@ def _agent_row_to_dict(row: RowMapping) -> dict:
     if "dpop_jkt" in row.keys():
         out["dpop_jkt"] = row["dpop_jkt"]
     return out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AI provider credentials (migration 0027)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def get_ai_provider_creds(provider: str) -> dict | None:
+    """Fetch a single AI provider credential row.
+
+    Returns ``{"provider", "creds", "enabled", "updated_at", "updated_by"}``
+    with ``creds`` already JSON-decoded into a dict, or ``None`` when no
+    row exists. Disabled rows are returned as-is so the admin UI can
+    surface ``enabled: false`` without a separate query.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT provider, creds_json, enabled, updated_at, updated_by "
+                "FROM ai_provider_credentials WHERE provider = :p"
+            ),
+            {"p": provider.lower()},
+        )
+        row = result.mappings().first()
+    if row is None:
+        return None
+    try:
+        creds = json.loads(row["creds_json"]) if row["creds_json"] else {}
+    except (TypeError, ValueError):
+        creds = {}
+    return {
+        "provider": row["provider"],
+        "creds": creds,
+        "enabled": bool(row["enabled"]),
+        "updated_at": row["updated_at"],
+        "updated_by": row["updated_by"],
+    }
+
+
+async def list_ai_provider_creds() -> list[dict]:
+    """Return every configured provider row.
+
+    Order is stable (alphabetical by provider) so the dashboard render
+    never flickers between page loads.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT provider, creds_json, enabled, updated_at, updated_by "
+                "FROM ai_provider_credentials ORDER BY provider ASC"
+            ),
+        )
+        rows = result.mappings().all()
+    out: list[dict] = []
+    for row in rows:
+        try:
+            creds = json.loads(row["creds_json"]) if row["creds_json"] else {}
+        except (TypeError, ValueError):
+            creds = {}
+        out.append({
+            "provider": row["provider"],
+            "creds": creds,
+            "enabled": bool(row["enabled"]),
+            "updated_at": row["updated_at"],
+            "updated_by": row["updated_by"],
+        })
+    return out
+
+
+async def upsert_ai_provider_creds(
+    provider: str,
+    creds: Mapping[str, Any],
+    *,
+    enabled: bool = True,
+    updated_by: str | None = None,
+) -> None:
+    """Insert or replace a provider's credentials.
+
+    The dict is serialised to canonical JSON (sorted keys) so audit
+    diffs stay deterministic.
+    """
+    payload = json.dumps(dict(creds), separators=(",", ":"), sort_keys=True)
+    ts = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO ai_provider_credentials
+                       (provider, creds_json, enabled, updated_at, updated_by)
+                   VALUES (:p, :c, :en, :ts, :ub)
+                   ON CONFLICT(provider) DO UPDATE SET
+                       creds_json = excluded.creds_json,
+                       enabled    = excluded.enabled,
+                       updated_at = excluded.updated_at,
+                       updated_by = excluded.updated_by"""
+            ),
+            {
+                "p": provider.lower(),
+                "c": payload,
+                "en": bool(enabled),
+                "ts": ts,
+                "ub": updated_by,
+            },
+        )
+
+
+async def delete_ai_provider_creds(provider: str) -> bool:
+    """Remove a provider row. Returns True when a row was deleted."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text("DELETE FROM ai_provider_credentials WHERE provider = :p"),
+            {"p": provider.lower()},
+        )
+    return (result.rowcount or 0) > 0
+
+
+async def set_ai_provider_enabled(provider: str, enabled: bool) -> bool:
+    """Toggle the ``enabled`` flag without rotating credentials."""
+    ts = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE ai_provider_credentials "
+                "SET enabled = :en, updated_at = :ts "
+                "WHERE provider = :p"
+            ),
+            {"p": provider.lower(), "en": bool(enabled), "ts": ts},
+        )
+    return (result.rowcount or 0) > 0

--- a/mcp_proxy/db_models.py
+++ b/mcp_proxy/db_models.py
@@ -18,6 +18,7 @@ primary keys use plain Integer + primary_key=True — SQLAlchemy picks SERIAL
 on Postgres and INTEGER on SQLite.
 """
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     Column,
     Float,
@@ -508,3 +509,27 @@ class AgentQuarantineEvent(Base):
         ),
         Index("idx_quarantine_agent", "agent_id", "quarantined_at"),
     )
+
+
+class AIProviderCredentials(Base):
+    """Per-provider credentials for the embedded LiteLLM AI gateway.
+
+    One row per provider key recognised by
+    :mod:`mcp_proxy.egress.provider_catalog`. ``creds_json`` holds a
+    JSON dict whose shape is provider-specific (``api_key`` for
+    Anthropic/OpenAI/Gemini, AWS triplet for Bedrock, project + service
+    account JSON for Vertex, ``api_base`` for Ollama).
+
+    Plaintext at rest, same trust level as ``proxy_config.org_ca_key``:
+    the Mastio process is the boundary, not the column. Cloud KMS
+    backends in cullis-enterprise can wrap this row through the same
+    plugin hook that wraps the Org CA private key.
+    """
+
+    __tablename__ = "ai_provider_credentials"
+
+    provider = Column(Text, primary_key=True)
+    creds_json = Column(Text, nullable=False)
+    enabled = Column(Boolean, nullable=False, server_default="1")
+    updated_at = Column(Text, nullable=False)
+    updated_by = Column(Text, nullable=True)

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -23,6 +23,12 @@ from typing import AsyncIterator
 import httpx
 
 from mcp_proxy.config import ProxySettings as Settings
+from mcp_proxy.db import get_ai_provider_creds
+from mcp_proxy.egress.provider_catalog import (
+    PROVIDERS,
+    litellm_kwargs,
+    parse_provider_from_model,
+)
 from mcp_proxy.egress.schemas import ChatCompletionRequest, ChatCompletionResponse
 
 
@@ -144,7 +150,7 @@ async def dispatch_stream(
     """
     backend = settings.ai_gateway_backend.lower()
     if backend == "litellm_embedded":
-        return _build_litellm_stream(
+        return await _build_litellm_stream(
             req=req,
             agent_id=agent_id,
             org_id=org_id,
@@ -170,22 +176,28 @@ async def _call_portkey(
     settings: Settings,
     http_client: httpx.AsyncClient | None,
 ) -> GatewayResult:
-    provider = settings.ai_gateway_provider.lower()
+    # Portkey path is Phase 1 (legacy). It only validates provider=anthropic
+    # against Portkey's chat-completions shim. The credential is still
+    # sourced through the same DB-first resolver so deployments that
+    # have already migrated to dashboard-managed keys keep working
+    # whichever backend they pin.
+    provider, creds = await _resolve_provider_creds(req.model, settings)
     if provider != "anthropic":
         raise GatewayError(
             501,
             f"provider_not_implemented:{provider}",
-            detail="Phase 1 only validates provider='anthropic' against Portkey.",
+            detail="The Portkey backend only supports Anthropic. "
+                   "Switch ai_gateway_backend to litellm_embedded.",
         )
-
-    if not settings.anthropic_api_key:
+    api_key = creds.get("api_key", "")
+    if not api_key:
         raise GatewayError(503, "provider_key_missing")
 
     upstream_url = f"{settings.ai_gateway_url.rstrip('/')}/v1/chat/completions"
 
     headers = {
         "Content-Type": "application/json",
-        "Authorization": f"Bearer {settings.anthropic_api_key}",
+        "Authorization": f"Bearer {api_key}",
         "x-portkey-provider": provider,
         "x-portkey-trace-id": trace_id,
         "x-portkey-forward-headers": CULLIS_FORWARD_HEADERS,
@@ -301,6 +313,52 @@ def _map_litellm_exception(exc: Exception) -> GatewayError:
     return GatewayError(status, reason, detail=detail)
 
 
+async def _resolve_provider_creds(
+    model: str,
+    settings: Settings,
+) -> tuple[str, dict[str, str]]:
+    """Pick the provider for a model id and return its credentials.
+
+    Resolution:
+      1. ``parse_provider_from_model`` maps the request model to a
+         provider key (``anthropic``, ``openai``, ...).
+      2. ``ai_provider_credentials`` row drives the credential dict.
+      3. Backward compat: when the row is missing for ``anthropic`` we
+         fall back to ``settings.anthropic_api_key`` so existing
+         deployments that have not yet seeded the table keep working.
+      4. ``provider_not_configured`` is raised on miss + no fallback;
+         ``provider_disabled`` is raised on a row with ``enabled=False``.
+    """
+    provider = parse_provider_from_model(model)
+    if provider not in PROVIDERS:
+        raise GatewayError(
+            501,
+            f"provider_not_implemented:{provider}",
+            detail=f"No catalog entry for provider {provider!r}.",
+        )
+
+    row = await get_ai_provider_creds(provider)
+    if row is None:
+        if provider == "anthropic" and settings.anthropic_api_key:
+            return provider, {"api_key": settings.anthropic_api_key}
+        raise GatewayError(
+            503,
+            "provider_not_configured",
+            detail=(
+                f"Provider {provider!r} is not configured. "
+                "Add credentials in the Mastio dashboard "
+                "(Settings → AI Providers)."
+            ),
+        )
+    if not row["enabled"]:
+        raise GatewayError(
+            503,
+            "provider_disabled",
+            detail=f"Provider {provider!r} is configured but disabled.",
+        )
+    return provider, dict(row["creds"] or {})
+
+
 async def _call_litellm_embedded(
     *,
     req: ChatCompletionRequest,
@@ -311,23 +369,17 @@ async def _call_litellm_embedded(
 ) -> GatewayResult:
     """Call the upstream provider via the LiteLLM library, in-process.
 
-    The model id from the request is forwarded as-is. For Anthropic
-    we expect the caller to pass either ``claude-haiku-4-5`` (LiteLLM
-    auto-detects the provider from the catalogue) or
-    ``anthropic/claude-haiku-4-5`` (explicit). The Mastio metadata is
-    attached via the ``metadata`` kwarg so any LiteLLM callback the
-    operator wires up (Datadog, Langfuse, Postgres) sees the agent
-    identity without us doing extra plumbing.
+    The model id from the request drives provider resolution
+    (``parse_provider_from_model``) and the credentials are read from
+    the ``ai_provider_credentials`` table populated by the Mastio
+    admin dashboard. The Mastio metadata is attached via the
+    ``metadata`` kwarg so any LiteLLM callback the operator wires up
+    (Datadog, Langfuse, Postgres) sees the agent identity without us
+    doing extra plumbing.
     """
-    provider = settings.ai_gateway_provider.lower()
-    if provider != "anthropic":
-        raise GatewayError(
-            501,
-            f"provider_not_implemented:{provider}",
-            detail="Phase 3 only validates provider='anthropic' via LiteLLM.",
-        )
-    if not settings.anthropic_api_key:
-        raise GatewayError(503, "provider_key_missing")
+    body = req.model_dump(exclude_none=True)
+    model = body.pop("model")
+    provider, creds = await _resolve_provider_creds(model, settings)
 
     try:
         import litellm
@@ -347,10 +399,7 @@ async def _call_litellm_embedded(
     # fields (e.g. Anthropic does not accept all OpenAI knobs).
     litellm.drop_params = True
 
-    body = req.model_dump(exclude_none=True)
-    # LiteLLM uses provider-prefixed model ids when ambiguous; pass
-    # through whatever the caller sent.
-    model = body.pop("model")
+    provider_kwargs = litellm_kwargs(provider, creds)
 
     metadata = {
         "cullis_agent_id": agent_id,
@@ -362,8 +411,8 @@ async def _call_litellm_embedded(
     try:
         response = await acompletion(
             model=model,
-            api_key=settings.anthropic_api_key,
             metadata=metadata,
+            **provider_kwargs,
             **body,
         )
     except Exception as exc:
@@ -441,7 +490,7 @@ async def _call_litellm_embedded(
     )
 
 
-def _build_litellm_stream(
+async def _build_litellm_stream(
     *,
     req: ChatCompletionRequest,
     agent_id: str,
@@ -451,20 +500,22 @@ def _build_litellm_stream(
 ) -> StreamingDispatch:
     """Build a ``StreamingDispatch`` backed by ``litellm.acompletion(stream=True)``.
 
-    The acompletion call itself happens lazily on first iteration; raise
-    here for the configuration-time errors (missing key, wrong provider,
-    litellm not installed) so the router can audit them as a non-stream
-    error before opening the SSE response.
+    Resolve the provider + credentials before opening the SSE response
+    so configuration errors (provider not configured, disabled, litellm
+    not installed) are surfaced as a regular non-stream error. The
+    underlying ``acompletion`` call still happens lazily on first
+    iteration of ``_aiter`` so the SSE headers can flush immediately.
     """
-    provider = settings.ai_gateway_provider.lower()
-    if provider != "anthropic":
-        raise GatewayError(
-            501,
-            f"provider_not_implemented:{provider}",
-            detail="Streaming only validates provider='anthropic' via LiteLLM.",
-        )
-    if not settings.anthropic_api_key:
-        raise GatewayError(503, "provider_key_missing")
+    body = req.model_dump(exclude_none=True)
+    model = body.pop("model")
+    body.pop("stream", None)
+    # Ask the upstream for a final usage chunk so we can audit accurate
+    # token + cost numbers after the stream drains. Anthropic + OpenAI +
+    # most LiteLLM-routed providers honour this OpenAI-spec field.
+    stream_options = body.pop("stream_options", None) or {}
+    stream_options.setdefault("include_usage", True)
+
+    provider, creds = await _resolve_provider_creds(model, settings)
 
     try:
         import litellm
@@ -478,17 +529,9 @@ def _build_litellm_stream(
                 "package. Install it via requirements.txt."
             ),
         ) from exc
-
     litellm.drop_params = True
 
-    body = req.model_dump(exclude_none=True)
-    model = body.pop("model")
-    body.pop("stream", None)
-    # Ask the upstream for a final usage chunk so we can audit accurate
-    # token + cost numbers after the stream drains. Anthropic + OpenAI +
-    # most LiteLLM-routed providers honour this OpenAI-spec field.
-    stream_options = body.pop("stream_options", None) or {}
-    stream_options.setdefault("include_usage", True)
+    provider_kwargs = litellm_kwargs(provider, creds)
 
     metadata = {
         "cullis_agent_id": agent_id,
@@ -507,10 +550,10 @@ def _build_litellm_stream(
         try:
             stream = await acompletion(
                 model=model,
-                api_key=settings.anthropic_api_key,
                 metadata=metadata,
                 stream=True,
                 stream_options=stream_options,
+                **provider_kwargs,
                 **body,
             )
         except Exception as exc:

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -31,12 +31,16 @@ from fastapi.responses import StreamingResponse
 from mcp_proxy.auth.dpop_client_cert import get_agent_from_dpop_client_cert
 from mcp_proxy.auth.rate_limit import get_token_sum_limiter
 from mcp_proxy.config import get_settings
-from mcp_proxy.db import log_audit
+from mcp_proxy.db import list_ai_provider_creds, log_audit
 from mcp_proxy.egress.ai_gateway import (
     GatewayError,
     StreamingDispatch,
     dispatch,
     dispatch_stream,
+)
+from mcp_proxy.egress.provider_catalog import (
+    PROVIDERS,
+    list_available_models,
 )
 from mcp_proxy.egress.schemas import ChatCompletionRequest
 from mcp_proxy.models import InternalAgent
@@ -314,3 +318,43 @@ async def _handle_stream(
             "X-Cullis-Trace": trace_id,
         },
     )
+
+
+@router.get("/v1/egress/models")
+@router.get("/v1/models")
+async def list_models(
+    agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
+) -> dict:
+    """OpenAI-compatible model list filtered by configured providers.
+
+    Returns the union of model ids surfaced by every enabled row in
+    ``ai_provider_credentials``, plus the static Anthropic catalog when
+    a legacy deployment still relies on ``ANTHROPIC_API_KEY`` and has no
+    DB row yet. Disabled rows are skipped so the SPA dropdown reflects
+    what the gateway will actually accept right now.
+
+    Auth: same mTLS+DPoP cert as the chat-completions endpoint, so the
+    Ambassador can fetch the list with the user's principal cert and
+    surface only models the org has paid keys for.
+    """
+    settings = get_settings()
+    rows = await list_ai_provider_creds()
+    enabled: list[tuple[str, dict[str, str]]] = [
+        (r["provider"], dict(r["creds"] or {}))
+        for r in rows
+        if r["enabled"] and r["provider"] in PROVIDERS
+    ]
+
+    # Backward compat: the env-only deployments that have not yet
+    # written an ``ai_provider_credentials`` row should still see the
+    # Anthropic catalog so existing chat clients keep working.
+    has_anthropic_row = any(p == "anthropic" for p, _ in enabled)
+    if not has_anthropic_row and settings.anthropic_api_key:
+        enabled.append(("anthropic", {"api_key": settings.anthropic_api_key}))
+
+    data = await list_available_models(enabled)
+    logger.debug(
+        "egress.models served agent=%s providers=%s count=%d",
+        agent.agent_id, [p for p, _ in enabled], len(data),
+    )
+    return {"object": "list", "data": data}

--- a/mcp_proxy/egress/provider_catalog.py
+++ b/mcp_proxy/egress/provider_catalog.py
@@ -346,7 +346,11 @@ async def fetch_ollama_models(api_base: str, *, timeout_s: float = 2.0) -> list[
         name = entry.get("name") or entry.get("model")
         if not name:
             continue
-        out.append(f"ollama/{name}")
+        # ``ollama_chat/`` routes through LiteLLM's chat-completion path
+        # (Ollama ``/api/chat``); the legacy ``ollama/`` prefix uses
+        # ``/api/generate`` and silently drops messages payloads on some
+        # builds. ``parse_provider_from_model`` accepts both as input.
+        out.append(f"ollama_chat/{name}")
     return out
 
 

--- a/mcp_proxy/egress/provider_catalog.py
+++ b/mcp_proxy/egress/provider_catalog.py
@@ -1,0 +1,394 @@
+"""Catalog of AI providers supported by the embedded LiteLLM gateway.
+
+Three responsibilities:
+
+1. Declare the credential shape for each provider — which JSON fields
+   the dashboard form must collect, which are secret, which are optional.
+2. Surface the static model list per provider (Anthropic / OpenAI / Gemini
+   / Bedrock / Vertex). Ollama is dynamic and resolved by hitting
+   ``{base_url}/api/tags`` at request time.
+3. Translate a stored credentials row into the kwargs that
+   ``litellm.acompletion(...)`` expects (``api_key``, ``api_base``,
+   ``aws_access_key_id``, ``vertex_project``, ...) and into a model id
+   that LiteLLM disambiguates the right way.
+
+The catalog is intentionally hard-coded rather than mirrored from the
+LiteLLM ``model_cost`` registry so that the dashboard offers a curated
+shortlist (chat models only, no embeddings or moderation, no deprecated
+ids). When a new model lands and the operator wants it before we ship
+the catalog bump, they pick ``custom`` model id and pay the LiteLLM
+auto-detect tax — ``parse_provider_from_model`` falls back to the
+prefix-based router that LiteLLM itself uses internally.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+import httpx
+
+
+_log = logging.getLogger("mcp_proxy.egress.provider_catalog")
+
+
+# ── credential field definitions ─────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CredentialField:
+    """One field on the dashboard form for a provider."""
+
+    name: str
+    label: str
+    secret: bool = False
+    required: bool = True
+    placeholder: str = ""
+    help_text: str = ""
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    provider: str
+    display_name: str
+    fields: tuple[CredentialField, ...]
+    static_models: tuple[str, ...] = field(default_factory=tuple)
+    dynamic_models: bool = False
+    default_model_for_route: str | None = None
+    docs_url: str = ""
+
+
+# Curated chat-completion model lists. Operators can still call any
+# model id LiteLLM recognises by passing ``provider/model`` directly;
+# this is just the shortlist that the SPA shows in the dropdown.
+ANTHROPIC_MODELS: tuple[str, ...] = (
+    "claude-haiku-4-5",
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+)
+OPENAI_MODELS: tuple[str, ...] = (
+    "gpt-4o",
+    "gpt-4o-mini",
+    "o1",
+    "o1-mini",
+)
+GEMINI_MODELS: tuple[str, ...] = (
+    "gemini/gemini-1.5-pro",
+    "gemini/gemini-1.5-flash",
+    "gemini/gemini-2.0-flash",
+)
+BEDROCK_MODELS: tuple[str, ...] = (
+    "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "bedrock/meta.llama3-1-70b-instruct-v1:0",
+)
+VERTEX_MODELS: tuple[str, ...] = (
+    "vertex_ai/gemini-1.5-pro",
+    "vertex_ai/claude-3-5-sonnet@20240620",
+)
+
+
+PROVIDERS: dict[str, ProviderSpec] = {
+    "anthropic": ProviderSpec(
+        provider="anthropic",
+        display_name="Anthropic",
+        fields=(
+            CredentialField("api_key", "API key", secret=True,
+                            placeholder="sk-ant-..."),
+        ),
+        static_models=ANTHROPIC_MODELS,
+        docs_url="https://docs.anthropic.com/en/api/getting-started",
+    ),
+    "openai": ProviderSpec(
+        provider="openai",
+        display_name="OpenAI",
+        fields=(
+            CredentialField("api_key", "API key", secret=True,
+                            placeholder="sk-..."),
+            CredentialField("api_base", "Base URL (optional)",
+                            required=False,
+                            placeholder="https://api.openai.com/v1",
+                            help_text="Override for Azure/compatible "
+                                      "endpoints."),
+        ),
+        static_models=OPENAI_MODELS,
+        docs_url="https://platform.openai.com/docs/api-reference",
+    ),
+    "gemini": ProviderSpec(
+        provider="gemini",
+        display_name="Google Gemini (AI Studio)",
+        fields=(
+            CredentialField("api_key", "API key", secret=True,
+                            placeholder="AIza..."),
+        ),
+        static_models=GEMINI_MODELS,
+        docs_url="https://ai.google.dev/gemini-api/docs/api-key",
+    ),
+    "bedrock": ProviderSpec(
+        provider="bedrock",
+        display_name="AWS Bedrock",
+        fields=(
+            CredentialField("aws_access_key_id", "Access key ID",
+                            secret=True),
+            CredentialField("aws_secret_access_key", "Secret access key",
+                            secret=True),
+            CredentialField("aws_region_name", "Region",
+                            placeholder="us-east-1"),
+        ),
+        static_models=BEDROCK_MODELS,
+        docs_url="https://docs.aws.amazon.com/bedrock/",
+    ),
+    "vertex": ProviderSpec(
+        provider="vertex",
+        display_name="Google Vertex AI",
+        fields=(
+            CredentialField("vertex_project", "GCP project id"),
+            CredentialField("vertex_location", "Location",
+                            placeholder="us-central1"),
+            CredentialField("vertex_credentials_json",
+                            "Service account JSON",
+                            secret=True,
+                            help_text="Paste the full JSON. Stored "
+                                      "verbatim; LiteLLM consumes it via "
+                                      "the ``vertex_credentials`` kwarg."),
+        ),
+        static_models=VERTEX_MODELS,
+        docs_url="https://cloud.google.com/vertex-ai/docs",
+    ),
+    "ollama": ProviderSpec(
+        provider="ollama",
+        display_name="Ollama (local)",
+        fields=(
+            CredentialField("api_base", "Base URL",
+                            placeholder="http://host.docker.internal:11434",
+                            help_text="The Ollama HTTP endpoint reachable "
+                                      "from the Mastio container."),
+        ),
+        dynamic_models=True,
+        docs_url="https://github.com/ollama/ollama/blob/main/docs/api.md",
+    ),
+}
+
+
+def all_provider_names() -> list[str]:
+    return list(PROVIDERS.keys())
+
+
+def get_spec(provider: str) -> ProviderSpec | None:
+    return PROVIDERS.get(provider.lower())
+
+
+# ── credential validation ────────────────────────────────────────────
+
+
+class InvalidCredentialsError(ValueError):
+    """Raised when a credentials dict is missing required fields."""
+
+
+def validate_creds(provider: str, creds: dict[str, Any]) -> dict[str, str]:
+    """Strip unknown keys, enforce required ones, return a clean dict.
+
+    The returned dict is what the admin endpoint stores in the DB.
+    """
+    spec = get_spec(provider)
+    if spec is None:
+        raise InvalidCredentialsError(f"unknown provider {provider!r}")
+    cleaned: dict[str, str] = {}
+    for fld in spec.fields:
+        raw = creds.get(fld.name)
+        if raw is None or raw == "":
+            if fld.required:
+                raise InvalidCredentialsError(
+                    f"missing required field {fld.name!r} for {provider}",
+                )
+            continue
+        if not isinstance(raw, str):
+            raise InvalidCredentialsError(
+                f"{provider}.{fld.name} must be a string, got {type(raw).__name__}",
+            )
+        cleaned[fld.name] = raw.strip()
+    return cleaned
+
+
+def mask_creds(provider: str, creds: dict[str, Any]) -> dict[str, str]:
+    """Return a copy with secret fields replaced by ``"***"``.
+
+    Used by GET endpoints so the dashboard can show "configured" state
+    without ever returning the raw key.
+    """
+    spec = get_spec(provider)
+    if spec is None:
+        return {}
+    out: dict[str, str] = {}
+    for fld in spec.fields:
+        val = creds.get(fld.name)
+        if val is None or val == "":
+            continue
+        if fld.secret:
+            out[fld.name] = "***"
+        else:
+            out[fld.name] = str(val)
+    return out
+
+
+# ── model id parsing ─────────────────────────────────────────────────
+
+
+_PROVIDER_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("anthropic/", "anthropic"),
+    ("openai/", "openai"),
+    ("gemini/", "gemini"),
+    ("vertex_ai/", "vertex"),
+    ("bedrock/", "bedrock"),
+    ("ollama/", "ollama"),
+    ("ollama_chat/", "ollama"),
+)
+
+
+def parse_provider_from_model(model: str) -> str:
+    """Map a model id to a provider key in :data:`PROVIDERS`.
+
+    Resolution order:
+      1. explicit ``provider/...`` prefix
+      2. heuristic on bare ids (``claude-*`` → anthropic, ``gpt-*``/
+         ``o1*`` → openai, ``gemini-*`` → gemini)
+      3. fallback ``"anthropic"`` to keep the legacy single-provider
+         deployments working without code changes.
+    """
+    m = model.strip()
+    lower = m.lower()
+    for prefix, provider in _PROVIDER_PREFIXES:
+        if lower.startswith(prefix):
+            return provider
+    if lower.startswith("claude-") or lower.startswith("anthropic."):
+        return "anthropic"
+    if lower.startswith("gpt-") or lower.startswith("o1"):
+        return "openai"
+    if lower.startswith("gemini-"):
+        return "gemini"
+    return "anthropic"
+
+
+# ── litellm kwargs translation ───────────────────────────────────────
+
+
+def litellm_kwargs(provider: str, creds: dict[str, str]) -> dict[str, Any]:
+    """Translate a stored credentials row into ``litellm.acompletion`` kwargs.
+
+    The caller is responsible for passing them via ``**kwargs``. Empty
+    dicts are returned for unknown providers so the gateway can raise a
+    clean 503 ``provider_not_configured`` upstream.
+    """
+    p = provider.lower()
+    if p == "anthropic":
+        return {"api_key": creds.get("api_key", "")}
+    if p == "openai":
+        kwargs: dict[str, Any] = {"api_key": creds.get("api_key", "")}
+        if creds.get("api_base"):
+            kwargs["api_base"] = creds["api_base"]
+        return kwargs
+    if p == "gemini":
+        return {"api_key": creds.get("api_key", "")}
+    if p == "bedrock":
+        return {
+            "aws_access_key_id": creds.get("aws_access_key_id", ""),
+            "aws_secret_access_key": creds.get("aws_secret_access_key", ""),
+            "aws_region_name": creds.get("aws_region_name", ""),
+        }
+    if p == "vertex":
+        kwargs = {
+            "vertex_project": creds.get("vertex_project", ""),
+            "vertex_location": creds.get("vertex_location", ""),
+        }
+        raw = creds.get("vertex_credentials_json", "")
+        if raw:
+            try:
+                json.loads(raw)
+                kwargs["vertex_credentials"] = raw
+            except json.JSONDecodeError:
+                _log.warning(
+                    "vertex_credentials_json is not valid JSON; "
+                    "passing raw string to LiteLLM",
+                )
+                kwargs["vertex_credentials"] = raw
+        return kwargs
+    if p == "ollama":
+        return {"api_base": creds.get("api_base", "")}
+    return {}
+
+
+# ── ollama dynamic model discovery ───────────────────────────────────
+
+
+async def fetch_ollama_models(api_base: str, *, timeout_s: float = 2.0) -> list[str]:
+    """Return the chat-capable model names that a local Ollama serves.
+
+    Returns ``[]`` (and logs a debug line) on any failure: the dashboard
+    treats Ollama as "not reachable" and the admin can hit the Test
+    button for a verbose error.
+    """
+    if not api_base:
+        return []
+    url = api_base.rstrip("/") + "/api/tags"
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            resp = await client.get(url)
+            resp.raise_for_status()
+            payload = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        _log.debug("ollama tag fetch failed url=%s err=%s", url, exc)
+        return []
+    raw = payload.get("models") or []
+    out: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name") or entry.get("model")
+        if not name:
+            continue
+        out.append(f"ollama/{name}")
+    return out
+
+
+# ── canonical model list (read-side) ─────────────────────────────────
+
+
+async def list_available_models(
+    enabled_providers: Iterable[tuple[str, dict[str, str]]],
+) -> list[dict[str, str]]:
+    """Return the OpenAI-compatible ``/v1/models`` ``data`` array.
+
+    ``enabled_providers`` is an iterable of ``(provider, creds)`` tuples
+    coming from the DB. Disabled rows are filtered by the caller before
+    we get here.
+    """
+    out: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for provider, creds in enabled_providers:
+        spec = get_spec(provider)
+        if spec is None:
+            continue
+        if spec.dynamic_models and provider == "ollama":
+            api_base = creds.get("api_base", "")
+            for mid in await fetch_ollama_models(api_base):
+                if mid in seen:
+                    continue
+                seen.add(mid)
+                out.append({
+                    "id": mid,
+                    "object": "model",
+                    "owned_by": provider,
+                    "provider": provider,
+                })
+            continue
+        for mid in spec.static_models:
+            if mid in seen:
+                continue
+            seen.add(mid)
+            out.append({
+                "id": mid,
+                "object": "model",
+                "owned_by": provider,
+                "provider": provider,
+            })
+    return out

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1086,6 +1086,12 @@ app.include_router(admin_workloads_router)
 from mcp_proxy.admin.enroll import router as admin_enroll_router
 app.include_router(admin_enroll_router)
 
+# ADR-017 Phase 4 — multi-provider AI gateway credentials managed
+# from the dashboard. Anthropic / OpenAI / Gemini / Bedrock / Vertex
+# / Ollama plug into the embedded LiteLLM at runtime.
+from mcp_proxy.admin.ai_providers import router as admin_ai_providers_router
+app.include_router(admin_ai_providers_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/federation/agents/{id}/
 # public-key would otherwise fall into the `/v1/federation/*` forward
@@ -1183,6 +1189,11 @@ app.include_router(link_broker_admin_router)
 # landed in #126; this gives operators a UI instead of raw SQL.
 from mcp_proxy.dashboard.policies_local import router as local_policies_router
 app.include_router(local_policies_router)
+
+# ADR-017 Phase 4 — dashboard CRUD for AI provider credentials (the
+# admin secret API surface lives in mcp_proxy.admin.ai_providers).
+from mcp_proxy.dashboard.ai_providers import router as ai_providers_dashboard_router
+app.include_router(ai_providers_dashboard_router)
 
 # Mounted under /proxy/backends; /proxy/mcp-resources is redirected via a
 # small legacy router in the same module (compat for old bookmarks).

--- a/tests/test_ai_gateway_multi_provider.py
+++ b/tests/test_ai_gateway_multi_provider.py
@@ -1,0 +1,261 @@
+"""Multi-provider routing in ``mcp_proxy.egress.ai_gateway``.
+
+We test the resolver in isolation (no LiteLLM, no HTTP) and validate
+that ``_call_litellm_embedded`` plumbs the right credentials kwargs
+when LiteLLM is mocked.
+
+Background: the gateway used to hard-code ``provider == "anthropic"``
+and read the key from ``settings.anthropic_api_key``. After ADR-017
+Phase 4 it reads from ``ai_provider_credentials`` per provider parsed
+out of the model id.
+"""
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    from mcp_proxy.db import init_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+    return app
+
+
+# ── _resolve_provider_creds ─────────────────────────────────────────
+
+
+async def test_resolver_reads_from_db(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "rsv-db")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import upsert_ai_provider_creds
+    from mcp_proxy.egress.ai_gateway import _resolve_provider_creds
+
+    await upsert_ai_provider_creds(
+        "anthropic", {"api_key": "sk-ant-DB"},
+        enabled=True, updated_by="test",
+    )
+    provider, creds = await _resolve_provider_creds(
+        "claude-haiku-4-5", get_settings(),
+    )
+    assert provider == "anthropic"
+    assert creds["api_key"] == "sk-ant-DB"
+
+
+async def test_resolver_routes_openai_model(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "rsv-oai")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import upsert_ai_provider_creds
+    from mcp_proxy.egress.ai_gateway import _resolve_provider_creds
+
+    await upsert_ai_provider_creds(
+        "openai", {"api_key": "sk-o-1"}, enabled=True,
+    )
+    provider, creds = await _resolve_provider_creds(
+        "gpt-4o-mini", get_settings(),
+    )
+    assert provider == "openai"
+    assert creds["api_key"] == "sk-o-1"
+
+
+async def test_resolver_503_when_provider_missing(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "rsv-miss")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.egress.ai_gateway import GatewayError, _resolve_provider_creds
+
+    # No env fallback, no DB row.
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "")
+    get_settings.cache_clear()
+    with pytest.raises(GatewayError) as ei:
+        await _resolve_provider_creds("gemini-1.5-pro", get_settings())
+    assert ei.value.status_code == 503
+    assert ei.value.reason == "provider_not_configured"
+
+
+async def test_resolver_503_when_disabled(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "rsv-disabled")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import upsert_ai_provider_creds
+    from mcp_proxy.egress.ai_gateway import GatewayError, _resolve_provider_creds
+
+    await upsert_ai_provider_creds(
+        "anthropic", {"api_key": "sk"}, enabled=False,
+    )
+    with pytest.raises(GatewayError) as ei:
+        await _resolve_provider_creds("claude-haiku-4-5", get_settings())
+    assert ei.value.reason == "provider_disabled"
+
+
+async def test_resolver_falls_back_to_env_anthropic(tmp_path, monkeypatch):
+    """Backward compat: deployments that haven't seeded the DB row keep working
+    when ``ANTHROPIC_API_KEY`` is set the legacy way."""
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "sk-env-fallback")
+    await _spin_proxy(tmp_path, monkeypatch, "rsv-env")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.egress.ai_gateway import _resolve_provider_creds
+
+    provider, creds = await _resolve_provider_creds(
+        "claude-haiku-4-5", get_settings(),
+    )
+    assert provider == "anthropic"
+    assert creds == {"api_key": "sk-env-fallback"}
+
+
+async def test_resolver_no_env_fallback_for_other_providers(tmp_path, monkeypatch):
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "sk-env")
+    await _spin_proxy(tmp_path, monkeypatch, "rsv-noenv")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.egress.ai_gateway import GatewayError, _resolve_provider_creds
+
+    # Anthropic env is set but the request asks for OpenAI — must not
+    # silently fall back across providers.
+    with pytest.raises(GatewayError) as ei:
+        await _resolve_provider_creds("gpt-4o", get_settings())
+    assert ei.value.reason == "provider_not_configured"
+
+
+# ── litellm dispatch (mocked) ────────────────────────────────────────
+
+
+def _install_fake_litellm(monkeypatch, response_payload: dict):
+    """Inject a stand-in ``litellm`` module into ``sys.modules``.
+
+    The gateway imports ``litellm`` lazily inside the call functions, so
+    patching ``sys.modules`` before the call is enough.
+    """
+    fake_module = types.ModuleType("litellm")
+    fake_module.drop_params = False
+
+    fake_response = MagicMock()
+    fake_response.model_dump = MagicMock(return_value=response_payload)
+    fake_response.id = response_payload.get("id", "chatcmpl-fake")
+    fake_response.usage = types.SimpleNamespace(
+        prompt_tokens=10, completion_tokens=20,
+    )
+
+    fake_acompletion = AsyncMock(return_value=fake_response)
+    fake_module.acompletion = fake_acompletion
+    fake_module.completion_cost = MagicMock(return_value=0.000123)
+    fake_module.cost_per_token = MagicMock(return_value=(0.0001, 0.0002))
+
+    monkeypatch.setitem(sys.modules, "litellm", fake_module)
+    return fake_acompletion
+
+
+async def test_dispatch_uses_db_credentials_for_anthropic(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "disp-ant")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import upsert_ai_provider_creds
+    from mcp_proxy.egress.ai_gateway import _call_litellm_embedded
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+    await upsert_ai_provider_creds(
+        "anthropic", {"api_key": "sk-ant-from-db"}, enabled=True,
+    )
+    fake = _install_fake_litellm(monkeypatch, {
+        "id": "chatcmpl-x",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "claude-haiku-4-5",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "hi"},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    })
+
+    req = ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    out = await _call_litellm_embedded(
+        req=req, agent_id="agent-x", org_id="org-x",
+        trace_id="t1", settings=get_settings(),
+    )
+    assert out.provider == "anthropic"
+    assert out.backend == "litellm_embedded"
+    fake.assert_called_once()
+    call = fake.call_args
+    assert call.kwargs["api_key"] == "sk-ant-from-db"
+    assert call.kwargs["model"] == "claude-haiku-4-5"
+
+
+async def test_dispatch_routes_openai_with_correct_kwargs(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "disp-oai")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import upsert_ai_provider_creds
+    from mcp_proxy.egress.ai_gateway import _call_litellm_embedded
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+    await upsert_ai_provider_creds(
+        "openai", {"api_key": "sk-o-9", "api_base": "https://acme/v1"},
+        enabled=True,
+    )
+    fake = _install_fake_litellm(monkeypatch, {
+        "id": "chatcmpl-y",
+        "object": "chat.completion",
+        "created": 0,
+        "model": "gpt-4o",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "ok"},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 5, "completion_tokens": 10, "total_tokens": 15},
+    })
+
+    req = ChatCompletionRequest(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hello"}],
+    )
+    out = await _call_litellm_embedded(
+        req=req, agent_id="agent-y", org_id="org-y",
+        trace_id="t2", settings=get_settings(),
+    )
+    assert out.provider == "openai"
+    fake.assert_called_once()
+    call = fake.call_args
+    assert call.kwargs["api_key"] == "sk-o-9"
+    assert call.kwargs["api_base"] == "https://acme/v1"
+    # The gateway must NOT inject anthropic kwargs into the openai call.
+    assert "aws_region_name" not in call.kwargs
+
+
+async def test_dispatch_503_when_provider_disabled(tmp_path, monkeypatch):
+    await _spin_proxy(tmp_path, monkeypatch, "disp-disabled")
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import upsert_ai_provider_creds
+    from mcp_proxy.egress.ai_gateway import (
+        GatewayError,
+        _call_litellm_embedded,
+    )
+    from mcp_proxy.egress.schemas import ChatCompletionRequest
+
+    await upsert_ai_provider_creds(
+        "anthropic", {"api_key": "sk"}, enabled=False,
+    )
+    req = ChatCompletionRequest(
+        model="claude-haiku-4-5",
+        messages=[{"role": "user", "content": "x"}],
+    )
+    with pytest.raises(GatewayError) as ei:
+        await _call_litellm_embedded(
+            req=req, agent_id="a", org_id="o",
+            trace_id="t", settings=get_settings(),
+        )
+    assert ei.value.reason == "provider_disabled"

--- a/tests/test_ai_providers_admin.py
+++ b/tests/test_ai_providers_admin.py
@@ -1,0 +1,267 @@
+"""Admin API for AI provider credentials (ADR-017 Phase 4).
+
+Pins:
+  - GET list returns the full catalog with masked / not-configured rows
+  - PUT validates, writes, returns masked credentials
+  - PUT secret fields never round-trip via GET
+  - DELETE 204 + audit row + 404 on second delete
+  - Enable / disable toggle
+  - Test endpoint surfaces ``unsupported`` for backends with no probe
+  - 403 on missing / wrong admin secret
+  - Audit chain entries are written for every mutation
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── list ─────────────────────────────────────────────────────────────
+
+
+async def test_list_returns_full_catalog_when_empty(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-list-empty")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.get("/v1/admin/ai-providers", headers=h)
+            assert r.status_code == 200
+            data = r.json()
+            providers = {p["provider"]: p for p in data}
+            assert {"anthropic", "openai", "gemini", "bedrock", "vertex", "ollama"} <= providers.keys()
+            for entry in data:
+                assert entry["configured"] is False
+                assert entry["enabled"] is False
+
+
+async def test_get_provider_404_on_unknown(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.get("/v1/admin/ai-providers/foo", headers=h)
+            assert r.status_code == 404
+
+
+# ── auth ─────────────────────────────────────────────────────────────
+
+
+async def test_missing_admin_secret_403(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-noauth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get("/v1/admin/ai-providers")
+            # FastAPI returns 422 when a required Header is missing; the
+            # actual 403 path is hit when a header is supplied but wrong.
+            assert r.status_code in (403, 422)
+
+
+async def test_wrong_admin_secret_403(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-wrongauth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get(
+                "/v1/admin/ai-providers",
+                headers={"X-Admin-Secret": "definitely-wrong"},
+            )
+            assert r.status_code == 403
+
+
+# ── upsert ───────────────────────────────────────────────────────────
+
+
+async def test_upsert_anthropic_validates_and_returns_masked(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-upsert")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.put(
+                "/v1/admin/ai-providers/anthropic",
+                headers=h,
+                json={
+                    "creds": {"api_key": "sk-ant-secret"},
+                    "enabled": True,
+                    "updated_by": "alice",
+                },
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["configured"] is True
+            assert body["enabled"] is True
+            # Secret never round-trips.
+            assert body["creds_masked"]["api_key"] == "***"
+            assert body["updated_by"] == "alice"
+
+
+async def test_upsert_validates_required_fields(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-validate")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.put(
+                "/v1/admin/ai-providers/bedrock",
+                headers=h,
+                json={"creds": {"aws_access_key_id": "AKIA"}, "enabled": True},
+            )
+            assert r.status_code == 400
+
+
+async def test_upsert_unknown_provider_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-unknown")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.put(
+                "/v1/admin/ai-providers/groq-supreme",
+                headers=h,
+                json={"creds": {"api_key": "x"}, "enabled": True},
+            )
+            assert r.status_code == 404
+
+
+# ── delete + idempotency ─────────────────────────────────────────────
+
+
+async def test_delete_then_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-delete")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.put(
+                "/v1/admin/ai-providers/openai",
+                headers=h,
+                json={"creds": {"api_key": "sk-o"}, "enabled": True},
+            )
+            r = await cli.delete("/v1/admin/ai-providers/openai", headers=h)
+            assert r.status_code == 204
+            r = await cli.delete("/v1/admin/ai-providers/openai", headers=h)
+            assert r.status_code == 404
+
+
+# ── enable toggle ────────────────────────────────────────────────────
+
+
+async def test_disable_then_get_shows_disabled(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-toggle")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.put(
+                "/v1/admin/ai-providers/gemini",
+                headers=h,
+                json={"creds": {"api_key": "AIzaXYZ"}, "enabled": True},
+            )
+            r = await cli.post(
+                "/v1/admin/ai-providers/gemini/enable",
+                headers=h, json={"enabled": False},
+            )
+            assert r.status_code == 200
+            assert r.json()["enabled"] is False
+
+
+async def test_enable_404_on_unknown_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-toggle-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/ai-providers/bedrock/enable",
+                headers=h, json={"enabled": True},
+            )
+            assert r.status_code == 404
+
+
+# ── audit chain ──────────────────────────────────────────────────────
+
+
+async def test_upsert_writes_audit_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-audit")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.put(
+                "/v1/admin/ai-providers/anthropic",
+                headers=h,
+                json={
+                    "creds": {"api_key": "sk-ant"},
+                    "enabled": True,
+                    "updated_by": "bob",
+                },
+            )
+            from mcp_proxy.db import get_db
+            from sqlalchemy import text as _t
+            async with get_db() as conn:
+                rows = (await conn.execute(_t(
+                    "SELECT action, agent_id, detail FROM audit_log "
+                    "WHERE action LIKE 'ai_provider.%'"
+                ))).all()
+            actions = [r[0] for r in rows]
+            assert "ai_provider.upsert" in actions
+
+
+# ── test endpoint ────────────────────────────────────────────────────
+
+
+async def test_test_endpoint_unsupported_for_bedrock(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-test-bedrock")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.put(
+                "/v1/admin/ai-providers/bedrock",
+                headers=h,
+                json={
+                    "creds": {
+                        "aws_access_key_id": "AKIA",
+                        "aws_secret_access_key": "s",
+                        "aws_region_name": "us-east-1",
+                    },
+                    "enabled": True,
+                },
+            )
+            r = await cli.post("/v1/admin/ai-providers/bedrock/test", headers=h)
+            assert r.status_code == 200
+            assert r.json()["status"] == "unsupported"
+
+
+async def test_test_endpoint_404_when_no_creds(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "ai-test-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post("/v1/admin/ai-providers/anthropic/test", headers=h)
+            assert r.status_code == 404

--- a/tests/test_provider_catalog.py
+++ b/tests/test_provider_catalog.py
@@ -1,0 +1,222 @@
+"""Unit tests for ``mcp_proxy.egress.provider_catalog``.
+
+Pure logic — no DB, no HTTP. Pins the credential validation,
+masking, and model-id parsing rules so refactors can move things
+around without breaking the dashboard contract.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.egress.provider_catalog import (
+    InvalidCredentialsError,
+    PROVIDERS,
+    fetch_ollama_models,
+    get_spec,
+    list_available_models,
+    litellm_kwargs,
+    mask_creds,
+    parse_provider_from_model,
+    validate_creds,
+)
+
+
+# ── parse_provider_from_model ────────────────────────────────────────
+
+
+@pytest.mark.parametrize("model,expected", [
+    ("claude-haiku-4-5", "anthropic"),
+    ("anthropic/claude-haiku-4-5", "anthropic"),
+    ("gpt-4o", "openai"),
+    ("openai/gpt-4o", "openai"),
+    ("o1-mini", "openai"),
+    ("gemini-1.5-pro", "gemini"),
+    ("gemini/gemini-1.5-pro", "gemini"),
+    ("vertex_ai/gemini-1.5-pro", "vertex"),
+    ("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", "bedrock"),
+    ("ollama/qwen2.5:7b", "ollama"),
+    ("ollama_chat/llama3.1:8b", "ollama"),
+])
+def test_parse_provider_from_model_known(model, expected):
+    assert parse_provider_from_model(model) == expected
+
+
+def test_parse_provider_from_model_falls_back_to_anthropic():
+    # Unknown id without a recognised prefix — keep legacy single-provider
+    # deployments alive instead of raising.
+    assert parse_provider_from_model("nemo-mistral-7b") == "anthropic"
+
+
+# ── validate_creds ───────────────────────────────────────────────────
+
+
+def test_validate_creds_strips_unknown_keys_and_returns_clean_dict():
+    cleaned = validate_creds("anthropic", {
+        "api_key": "sk-ant-test",
+        "junk_field": "should_be_dropped",
+    })
+    assert cleaned == {"api_key": "sk-ant-test"}
+
+
+def test_validate_creds_missing_required_raises():
+    with pytest.raises(InvalidCredentialsError, match="api_key"):
+        validate_creds("anthropic", {})
+
+
+def test_validate_creds_optional_field_skipped_when_empty():
+    cleaned = validate_creds("openai", {
+        "api_key": "sk-test",
+        "api_base": "",  # optional
+    })
+    assert cleaned == {"api_key": "sk-test"}
+
+
+def test_validate_creds_unknown_provider():
+    with pytest.raises(InvalidCredentialsError, match="unknown provider"):
+        validate_creds("does-not-exist", {})
+
+
+def test_validate_creds_rejects_non_string_value():
+    with pytest.raises(InvalidCredentialsError, match="must be a string"):
+        validate_creds("anthropic", {"api_key": 12345})
+
+
+def test_validate_creds_bedrock_full_triplet():
+    cleaned = validate_creds("bedrock", {
+        "aws_access_key_id": "AKIA...",
+        "aws_secret_access_key": "secret",
+        "aws_region_name": "us-east-1",
+    })
+    assert cleaned["aws_region_name"] == "us-east-1"
+
+
+# ── mask_creds ───────────────────────────────────────────────────────
+
+
+def test_mask_creds_replaces_secret_fields():
+    masked = mask_creds("openai", {
+        "api_key": "sk-real",
+        "api_base": "https://example.invalid/v1",
+    })
+    assert masked["api_key"] == "***"
+    assert masked["api_base"] == "https://example.invalid/v1"
+
+
+def test_mask_creds_skips_missing_fields():
+    masked = mask_creds("openai", {"api_key": "sk-real"})
+    assert "api_base" not in masked
+    assert masked == {"api_key": "***"}
+
+
+# ── litellm_kwargs ───────────────────────────────────────────────────
+
+
+def test_litellm_kwargs_anthropic():
+    kwargs = litellm_kwargs("anthropic", {"api_key": "sk-a"})
+    assert kwargs == {"api_key": "sk-a"}
+
+
+def test_litellm_kwargs_openai_with_base():
+    kwargs = litellm_kwargs("openai", {
+        "api_key": "sk-o",
+        "api_base": "https://azure.example/v1",
+    })
+    assert kwargs["api_key"] == "sk-o"
+    assert kwargs["api_base"] == "https://azure.example/v1"
+
+
+def test_litellm_kwargs_openai_without_base_omits_key():
+    kwargs = litellm_kwargs("openai", {"api_key": "sk-o"})
+    assert kwargs == {"api_key": "sk-o"}
+
+
+def test_litellm_kwargs_bedrock():
+    kwargs = litellm_kwargs("bedrock", {
+        "aws_access_key_id": "AKIA",
+        "aws_secret_access_key": "sec",
+        "aws_region_name": "us-west-2",
+    })
+    assert kwargs == {
+        "aws_access_key_id": "AKIA",
+        "aws_secret_access_key": "sec",
+        "aws_region_name": "us-west-2",
+    }
+
+
+def test_litellm_kwargs_ollama():
+    kwargs = litellm_kwargs("ollama", {"api_base": "http://host:11434"})
+    assert kwargs == {"api_base": "http://host:11434"}
+
+
+def test_litellm_kwargs_vertex_passes_credentials_when_present():
+    kwargs = litellm_kwargs("vertex", {
+        "vertex_project": "my-proj",
+        "vertex_location": "us-central1",
+        "vertex_credentials_json": '{"type":"service_account"}',
+    })
+    assert kwargs["vertex_project"] == "my-proj"
+    assert kwargs["vertex_credentials"] == '{"type":"service_account"}'
+
+
+def test_litellm_kwargs_unknown_provider_returns_empty():
+    assert litellm_kwargs("not-a-provider", {}) == {}
+
+
+# ── catalog spec sanity ──────────────────────────────────────────────
+
+
+def test_all_providers_have_at_least_one_field():
+    for name, spec in PROVIDERS.items():
+        assert spec.fields, f"{name} has no credential fields"
+
+
+def test_get_spec_case_insensitive():
+    assert get_spec("Anthropic") is not None
+    assert get_spec("ANTHROPIC") is not None
+    assert get_spec("nope") is None
+
+
+# ── list_available_models ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_available_models_filters_to_configured():
+    enabled = [("anthropic", {"api_key": "sk"})]
+    out = await list_available_models(enabled)
+    assert len(out) > 0
+    assert all(item["provider"] == "anthropic" for item in out)
+
+
+@pytest.mark.asyncio
+async def test_list_available_models_dedup_across_providers():
+    # Anthropic + Bedrock both surface Claude family — test that the
+    # caller picks them in order without duplicates.
+    enabled = [
+        ("anthropic", {"api_key": "sk"}),
+        ("bedrock", {
+            "aws_access_key_id": "k",
+            "aws_secret_access_key": "s",
+            "aws_region_name": "us-east-1",
+        }),
+    ]
+    out = await list_available_models(enabled)
+    ids = [item["id"] for item in out]
+    assert len(ids) == len(set(ids))
+
+
+@pytest.mark.asyncio
+async def test_list_available_models_unknown_provider_skipped():
+    out = await list_available_models([("not-a-thing", {})])
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_ollama_models_unreachable_returns_empty():
+    # Use a port that nothing is listening on; httpx fails fast.
+    out = await fetch_ollama_models("http://127.0.0.1:1", timeout_s=0.5)
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_ollama_models_empty_base_returns_empty():
+    assert await fetch_ollama_models("") == []

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0026_user_password",)]
+    assert rows == [("0027_ai_provider_creds",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0026_user_password",)]
+    assert version == [("0027_ai_provider_creds",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0026_user_password"
+HEAD_REVISION = "0027_ai_provider_creds"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0026_user_password"
+HEAD_REVISION = "0027_ai_provider_creds"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0026_user_password"
+HEAD_REVISION = "0027_ai_provider_creds"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

ADR-017 Phase 4. Lifts the embedded LiteLLM gateway off the single `ANTHROPIC_API_KEY` env var so an org admin can wire **Anthropic / OpenAI / Gemini / Bedrock / Vertex / Ollama** from the Mastio dashboard at runtime, with audit + masked credentials + live probes. The `/v1/models` endpoint reflects only the configured + enabled providers, and the Cullis Chat / Frontdesk SPA dropdown surfaces that list end-to-end via the Connector Ambassador (single + shared mode).

- New table `ai_provider_credentials` (migration `0027_ai_provider_creds`) + `mcp_proxy.egress.provider_catalog` with per-provider credential schema, static model lists, dynamic Ollama `/api/tags` discovery, and `parse_provider_from_model` + `litellm_kwargs` translation.
- `ai_gateway.dispatch` + `dispatch_stream` drop the hard-coded `provider != "anthropic"` guard. `_resolve_provider_creds` reads from DB, falls back to `ANTHROPIC_API_KEY` env so legacy deployments keep working.
- Admin API `/v1/admin/ai-providers` (X-Admin-Secret + audit chain) and dashboard `/proxy/ai-providers` (cookie + CSRF) for Save / Delete / Toggle / Test. Live probes for Anthropic / OpenAI / Gemini / Ollama; Bedrock + Vertex return `unsupported` (no cheap auth-only probe).
- `cullis_sdk.CullisClient.list_models()` + Connector Ambassador (single + shared) fetch the Mastio model list with a 30s in-process TTL cache and fall back to `advertised_models` on error.

## Test plan

- [x] `pytest tests/test_provider_catalog.py tests/test_ai_providers_admin.py tests/test_ai_gateway_multi_provider.py -n auto --dist=loadfile` — 56 tests pass (parsing, masking, validate, kwargs translation, CRUD + audit chain, dispatcher mocked litellm, fallback env)
- [x] `pytest tests/test_proxy_migrations*.py -n auto` — HEAD pinned to `0027_ai_provider_creds`, all green
- [x] `./demo_network/smoke.sh full` — basic + A4 (dashboard signing key) + A7 (audit hash chain) + A8 (mcp echo) all PASS
- [x] **Dogfood live**: lanciato Mastio uvicorn da host, configurato Ollama (`api_base=http://172.17.0.1:11434`) + Anthropic (fake key) via `/v1/admin/ai-providers` API. Test live probe Ollama OK in 27ms con 8 modelli reali. Test Anthropic torna `HTTP 401 invalid x-api-key` come atteso. Filter `/v1/models` con solo Ollama enabled mostra esclusivamente i modelli Ollama (Anthropic/Gemini/Bedrock/Vertex non appaiono). Audit chain ha 3 entry firmate (upsert × 2 + disable).
- [x] **Dispatch end-to-end**: `_call_litellm_embedded` con `model=ollama_chat/qwen3.5:2b` ritorna `reply="Ciao"` (1671 completion tokens, cost_usd=0). Bug scoperto: il prefisso `ollama/` di LiteLLM va su `/api/generate` legacy che droppa silenziosamente il `messages` payload. Fix: catalogo enumera `ollama_chat/<name>` (commit separato).
- [x] Dashboard browser render OK (Tailwind buildato), card per provider con form + Test htmx + sidebar voce **AI Providers** sotto Audit
- [ ] CI verde su PR (in attesa di GitHub Actions)