### PR TITLE
feat(mastio-users): CRUD via Frontdesk Ambassador, password on data plane

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -352,6 +352,17 @@ class ProxySettings(BaseSettings):
     guardian_ticket_key: str = ""
     guardian_ticket_ttl_s: int = 30
 
+    # Frontdesk Ambassador admin API target. The Mastio dashboard is
+    # the control plane: when an admin creates/resets/deletes a user
+    # principal from /proxy/users, the Mastio forwards the lifecycle
+    # call to the Frontdesk Ambassador running on this URL, which is
+    # the data plane for password storage (users.db, bcrypt). The
+    # secret is the same value the Frontdesk has under
+    # CULLIS_CONNECTOR_ADMIN_SECRET. Empty defaults keep the dashboard
+    # page read-only (legacy behaviour).
+    frontdesk_ambassador_url: str = ""
+    frontdesk_admin_secret: str = ""
+
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):
         override = os.environ.get("PROXY_DB_URL")

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3049,35 +3049,526 @@ async def badge_users(request: Request):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Users — local user principals (ADR-020 / ADR-021)
+# Users — control plane (Mastio) over the credential data plane (Frontdesk)
+#
+# The Mastio is the identity authority: it holds the principal registry,
+# audit attribution, and the cert authority. It does NOT hold passwords.
+# When the admin creates / resets / deletes a user from this dashboard,
+# we forward the call to the Frontdesk Ambassador admin API (which owns
+# users.db, bcrypt, lifecycle). The plaintext password is generated on
+# the Mastio just-in-time, sent to the Frontdesk once over the loopback,
+# surfaced to the admin once, and never persisted on this side.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# Single source of truth for "is the Frontdesk wiring configured?". Used
+# by both the page template (to hide Create/Reset/Delete) and the POST
+# handlers (to short-circuit with a clear error rather than crashing).
+def _frontdesk_admin_target() -> tuple[str, str] | None:
+    from mcp_proxy.config import get_settings
+    s = get_settings()
+    url = (s.frontdesk_ambassador_url or "").strip().rstrip("/")
+    secret = (s.frontdesk_admin_secret or "").strip()
+    if not url or not secret:
+        return None
+    return url, secret
+
+
+def _generate_temp_password() -> str:
+    """16-char unambiguous random temp password.
+
+    The admin reads this off the dashboard banner and dictates it to
+    the user out-of-band, so the alphabet excludes characters that
+    are easy to confuse visually: ``0/O``, ``1/l/I``, ``-/_``. 16 chars
+    over an alphabet of ~50 distinct symbols still gives ~90 bits of
+    entropy, well over what a one-shot bcrypt-hashed temp credential
+    needs (the user is forced to rotate at first sign-in anyway).
+    """
+    import secrets
+    alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"
+    return "".join(secrets.choice(alphabet) for _ in range(16))
+
+
+async def _fetch_frontdesk_users() -> dict[str, dict] | None:
+    """Pull the canale's user list. Keyed by ``user_name`` for join.
+
+    Returns ``None`` if the Frontdesk is not configured or unreachable
+    — callers should fall back to the Mastio-local view in that case
+    rather than rendering an empty page.
+    """
+    target = _frontdesk_admin_target()
+    if target is None:
+        return None
+    url, secret = target
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(
+                f"{url}/admin/users",
+                headers={"X-Admin-Secret": secret},
+            )
+        if r.status_code != 200:
+            _log.warning(
+                "frontdesk admin list failed: status=%s",
+                r.status_code,
+            )
+            return None
+        body = r.json()
+    except Exception as exc:  # noqa: BLE001 — wire-level failure
+        _log.warning("frontdesk admin list error: %s", exc)
+        return None
+    return {u["user_name"]: u for u in body.get("users", [])}
+
+
+async def _frontdesk_admin_call(
+    method: str,
+    path: str,
+    *,
+    json_body: dict | None = None,
+) -> tuple[int, dict | None, str | None]:
+    """Thin httpx wrapper. Returns ``(status, json_or_none, error_str)``.
+
+    ``error_str`` is None on transport success regardless of HTTP status;
+    callers inspect ``status`` for app-level outcomes. A ``None`` body
+    + non-None error means the call did not complete (DNS, connect,
+    timeout) — surface a generic message, do not stringify the
+    exception into the browser.
+    """
+    target = _frontdesk_admin_target()
+    if target is None:
+        return 0, None, "frontdesk_not_configured"
+    url, secret = target
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            r = await client.request(
+                method,
+                f"{url}{path}",
+                headers={
+                    "X-Admin-Secret": secret,
+                    "Content-Type": "application/json",
+                },
+                json=json_body,
+            )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("frontdesk admin call %s %s failed: %s", method, path, exc)
+        return 0, None, "transport_error"
+    body: dict | None = None
+    try:
+        body = r.json() if r.content else None
+    except Exception:
+        body = None
+    return r.status_code, body, None
+
+
+async def _build_user_view() -> tuple[list[dict], bool]:
+    """Merge Mastio principal registry + Frontdesk users.db.
+
+    Mastio rows (``local_user_principals``) carry cert + last_active +
+    surface. Frontdesk rows carry the credential state (has_password,
+    must_change_password, disabled). One physical user shows up in both
+    when they have signed in at least once; pre-seeded users live only
+    on the Frontdesk side until first CSR. The merged view favours the
+    Mastio row for principal_id / cert / surface and fills credential
+    state from the Frontdesk.
+    """
+    try:
+        from mcp_proxy.db import list_user_principals
+        mastio_rows = await list_user_principals()
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("users_page: list_user_principals failed: %s", exc)
+        mastio_rows = []
+
+    fd_users = await _fetch_frontdesk_users()
+    fd_enabled = fd_users is not None
+    fd_users = fd_users or {}
+
+    # Derive org_id once so we can synthesize a principal_id for
+    # Frontdesk-only rows. Read from the Mastio config; falls back to
+    # an empty string if not yet configured (early first-boot path).
+    from mcp_proxy.db import get_config
+    try:
+        org_id = await get_config("org_id") or ""
+    except Exception:
+        org_id = ""
+
+    merged: list[dict] = []
+    seen_user_names: set[str] = set()
+
+    for row in mastio_rows:
+        user_name = row.get("user_name") or ""
+        seen_user_names.add(user_name)
+        fd = fd_users.get(user_name, {})
+        merged.append({
+            "principal_id": row.get("principal_id"),
+            "user_name": user_name,
+            "display_name": fd.get("display_name") or row.get("display_name") or "",
+            "reach": row.get("reach"),
+            "surface": row.get("surface"),
+            "cert_thumbprint": row.get("cert_thumbprint"),
+            "created_at": row.get("created_at"),
+            "last_active_at": row.get("last_active_at"),
+            "in_frontdesk": user_name in fd_users,
+            "has_password": bool(fd) if fd_enabled else False,
+            "must_change_password": bool(fd.get("must_change_password")),
+            "disabled": bool(fd.get("disabled")),
+            "password_changed_at": fd.get("password_changed_at"),
+        })
+
+    # Frontdesk-only rows (no Mastio cert yet). Synthesize a placeholder
+    # principal_id so the detail link works; once the user signs in and
+    # the CSR endpoint fires, the real Mastio row supersedes this entry.
+    for user_name, fd in fd_users.items():
+        if user_name in seen_user_names:
+            continue
+        principal_id = f"{org_id}::user::{user_name}" if org_id else f"::user::{user_name}"
+        merged.append({
+            "principal_id": principal_id,
+            "user_name": user_name,
+            "display_name": fd.get("display_name", ""),
+            "reach": "intra",
+            "surface": "frontdesk",
+            "cert_thumbprint": None,
+            "created_at": fd.get("created_at"),
+            "last_active_at": None,
+            "in_frontdesk": True,
+            "has_password": True,
+            "must_change_password": bool(fd.get("must_change_password")),
+            "disabled": bool(fd.get("disabled")),
+            "password_changed_at": fd.get("password_changed_at"),
+        })
+
+    # Newest first.
+    merged.sort(
+        key=lambda u: u.get("created_at") or "",
+        reverse=True,
+    )
+    return merged, fd_enabled
+
+
+def _split_principal_id(principal_id: str) -> tuple[str, str]:
+    """Pull ``(org_id, user_name)`` out of ``<org>::user::<name>``.
+
+    Tolerates a missing org prefix (synthetic ids from frontdesk-only
+    rows) and returns empty strings rather than raising so the caller
+    can decide whether to 404.
+    """
+    if "::user::" in principal_id:
+        head, name = principal_id.split("::user::", 1)
+        return head, name
+    return "", ""
 
 
 @router.get("/users", response_class=HTMLResponse)
 async def users_page(request: Request):
-    """Read-only listing of user principals registered on this Mastio.
-
-    Backed by ``local_user_principals``, the same table the admin API
-    at ``/v1/admin/users`` writes into. Rows appear here whenever a
-    Frontdesk SSO user touches the CSR endpoint (``upsert_from_csr``)
-    or an admin pre-creates them via ``POST /v1/admin/users``.
-    """
+    """Merged identity view: Mastio registry × Frontdesk Ambassador."""
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return session
 
-    try:
-        from mcp_proxy.db import list_user_principals
-        users = await list_user_principals()
-    except Exception as exc:  # noqa: BLE001 — table may not exist on legacy DBs
-        _log.warning("users_page: list_user_principals failed: %s", exc)
-        users = []
+    users, fd_enabled = await _build_user_view()
+
+    # Banners survive one render via query string (POST-redirect-GET).
+    new_user_name = request.query_params.get("new_user")
+    new_user_temp_password = request.query_params.get("new_pw")
+    action_message = request.query_params.get("ok")
+    error = request.query_params.get("error")
 
     return templates.TemplateResponse("users.html", _ctx(
         request, session,
         active="users",
         users=users,
+        frontdesk_enabled=fd_enabled,
+        new_user_name=new_user_name,
+        new_user_temp_password=new_user_temp_password,
+        action_message=action_message,
+        error=error,
     ))
+
+
+@router.post("/users/create")
+async def users_create(request: Request):
+    """Create a user on the Frontdesk Ambassador.
+
+    The Mastio mints a one-time temp password, forwards it to the
+    Frontdesk together with the user metadata, surfaces it to the admin
+    on the redirect, and forgets it. We do not log the value anywhere.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse("/proxy/users?error=csrf", status_code=303)
+
+    if _frontdesk_admin_target() is None:
+        return RedirectResponse(
+            "/proxy/users?error=Frontdesk+not+configured",
+            status_code=303,
+        )
+
+    form = await request.form()
+    user_name = (form.get("user_name") or "").strip()
+    display_name = (form.get("display_name") or "").strip()
+    if not user_name:
+        return RedirectResponse(
+            "/proxy/users?error=user_name+is+required",
+            status_code=303,
+        )
+
+    temp_password = _generate_temp_password()
+    status_code, body, transport_err = await _frontdesk_admin_call(
+        "POST",
+        "/admin/users",
+        json_body={
+            "user_name": user_name,
+            "password": temp_password,
+            "must_change_password": True,
+            "display_name": display_name,
+        },
+    )
+    if transport_err:
+        return RedirectResponse(
+            "/proxy/users?error=Frontdesk+unreachable",
+            status_code=303,
+        )
+    if status_code == 409:
+        return RedirectResponse(
+            f"/proxy/users?error=User+{user_name}+already+exists",
+            status_code=303,
+        )
+    if status_code >= 400:
+        # Surface a generic message; the Frontdesk's own log carries the
+        # detailed error, the Mastio worker log carries the status code.
+        detail = (body or {}).get("detail") if isinstance(body, dict) else None
+        _log.warning(
+            "users_create: frontdesk rejected status=%s detail=%s",
+            status_code, detail,
+        )
+        return RedirectResponse(
+            "/proxy/users?error=Frontdesk+rejected+the+request",
+            status_code=303,
+        )
+
+    # Pre-seed the Mastio row so the principal is visible immediately,
+    # not just after the first CSR. The Frontdesk-only fallback in
+    # ``_build_user_view`` already handles this, but writing a Mastio
+    # row earlier keeps the cert thumbprint slot stable across reloads.
+    # Use the same admin path the existing ``/v1/admin/users`` endpoint
+    # would.
+    org_id = ""
+    try:
+        from mcp_proxy.db import get_config, get_db
+        from sqlalchemy import text
+        org_id = await get_config("org_id") or ""
+        if org_id:
+            principal_id = f"{org_id}::user::{user_name}"
+            async with get_db() as conn:
+                await conn.execute(
+                    text(
+                        """
+                        INSERT OR IGNORE INTO local_user_principals
+                        (principal_id, user_name, display_name, reach, surface, created_at)
+                        VALUES (:pid, :uname, :dname, 'intra', 'frontdesk', datetime('now'))
+                        """
+                    ),
+                    {"pid": principal_id, "uname": user_name, "dname": display_name},
+                )
+    except Exception as exc:  # noqa: BLE001 — pre-seed is best-effort
+        _log.warning("users_create: mastio pre-seed failed: %s", exc)
+
+    # Redirect to the per-user detail page rather than the list — the
+    # banner with the one-time temp password lands where the admin is
+    # most likely to dwell (and where they can click Reset Password
+    # again if they lose the value). On the list page the banner is
+    # easy to miss and gone the moment the admin clicks anywhere else.
+    from urllib.parse import quote
+    target_pid = f"{org_id}::user::{user_name}" if org_id else f"::user::{user_name}"
+    return RedirectResponse(
+        f"/proxy/users/{quote(target_pid, safe='')}?new_pw={quote(temp_password)}",
+        status_code=303,
+    )
+
+
+@router.get("/users/{principal_id:path}", response_class=HTMLResponse)
+async def user_detail_page(principal_id: str, request: Request):
+    """Per-user detail: Mastio attribution + Frontdesk credential state + audit."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    users, fd_enabled = await _build_user_view()
+    user = next(
+        (u for u in users if u.get("principal_id") == principal_id),
+        None,
+    )
+    if user is None:
+        return RedirectResponse(
+            "/proxy/users?error=user+not+found",
+            status_code=303,
+        )
+
+    # Audit rows attributed to this principal id.
+    audit_entries: list[dict] = []
+    try:
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            result = await conn.execute(
+                text(
+                    "SELECT timestamp, action, tool_name, status, detail "
+                    "  FROM audit_log "
+                    " WHERE agent_id = :pid "
+                    " ORDER BY timestamp DESC LIMIT 20"
+                ),
+                {"pid": principal_id},
+            )
+            audit_entries = [dict(r) for r in result.mappings().all()]
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("user_detail_page: audit query failed: %s", exc)
+
+    from mcp_proxy.db import get_config
+    try:
+        org_id = await get_config("org_id") or ""
+        trust_domain = await get_config("trust_domain") or "cullis.local"
+    except Exception:
+        org_id, trust_domain = "", "cullis.local"
+
+    reset_temp_password = request.query_params.get("reset_pw")
+    new_user_temp_password = request.query_params.get("new_pw")
+    action_message = request.query_params.get("ok")
+    error = request.query_params.get("error")
+
+    return templates.TemplateResponse("user_detail.html", _ctx(
+        request, session,
+        active="users",
+        user=user,
+        audit_entries=audit_entries,
+        org_id=org_id,
+        trust_domain=trust_domain,
+        frontdesk_enabled=fd_enabled,
+        reset_temp_password=reset_temp_password,
+        new_user_temp_password=new_user_temp_password,
+        action_message=action_message,
+        error=error,
+    ))
+
+
+@router.post("/users/{principal_id:path}/reset-password")
+async def users_reset_password(principal_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=csrf",
+            status_code=303,
+        )
+    if _frontdesk_admin_target() is None:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Frontdesk+not+configured",
+            status_code=303,
+        )
+
+    _, user_name = _split_principal_id(principal_id)
+    if not user_name:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=invalid+principal+id",
+            status_code=303,
+        )
+
+    new_pw = _generate_temp_password()
+    status_code, body, transport_err = await _frontdesk_admin_call(
+        "POST",
+        f"/admin/users/{user_name}/reset-password",
+        json_body={"new_password": new_pw},
+    )
+    if transport_err:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Frontdesk+unreachable",
+            status_code=303,
+        )
+    if status_code == 404:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=User+not+found+on+Frontdesk",
+            status_code=303,
+        )
+    if status_code >= 400:
+        _log.warning(
+            "users_reset_password: frontdesk rejected status=%s",
+            status_code,
+        )
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Reset+failed",
+            status_code=303,
+        )
+
+    from urllib.parse import quote
+    return RedirectResponse(
+        f"/proxy/users/{quote(principal_id)}?reset_pw={quote(new_pw)}",
+        status_code=303,
+    )
+
+
+@router.post("/users/{principal_id:path}/delete")
+async def users_delete(principal_id: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=csrf",
+            status_code=303,
+        )
+    if _frontdesk_admin_target() is None:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Frontdesk+not+configured",
+            status_code=303,
+        )
+
+    _, user_name = _split_principal_id(principal_id)
+    if not user_name:
+        return RedirectResponse(
+            "/proxy/users?error=invalid+principal+id",
+            status_code=303,
+        )
+
+    status_code, _, transport_err = await _frontdesk_admin_call(
+        "DELETE",
+        f"/admin/users/{user_name}",
+    )
+    if transport_err:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Frontdesk+unreachable",
+            status_code=303,
+        )
+    # 404 on the Frontdesk side means the Frontdesk row was already gone;
+    # we still scrub the Mastio attribution row so the dashboard reflects
+    # reality.
+    if status_code not in (204, 404):
+        _log.warning(
+            "users_delete: frontdesk rejected status=%s",
+            status_code,
+        )
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Delete+failed+on+Frontdesk",
+            status_code=303,
+        )
+
+    try:
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "DELETE FROM local_user_principals WHERE principal_id = :pid"
+                ),
+                {"pid": principal_id},
+            )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("users_delete: mastio cleanup failed: %s", exc)
+
+    from urllib.parse import quote
+    return RedirectResponse(
+        f"/proxy/users?ok=Deleted+{quote(user_name)}",
+        status_code=303,
+    )
 
 
 @router.get("/badge/audit")

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -1,0 +1,278 @@
+{% extends "base.html" %}
+{% block title %}{{ user.display_name or user.user_name }} — User Principal{% endblock %}
+{% block header_title %}User Principal{% endblock %}
+{% block content %}
+<div class="max-w-5xl">
+
+    <!-- Back link -->
+    <a href="/proxy/users" class="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-300 transition-colors mb-6">
+        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+        Back to Users
+    </a>
+
+    {% if action_message %}
+    <div class="mb-6 p-4 bg-emerald-900/10 border border-emerald-600/30 rounded-lg text-xs text-emerald-400">
+        {{ action_message }}
+    </div>
+    {% endif %}
+    {% set _temp_pw = reset_temp_password or new_user_temp_password %}
+    {% if _temp_pw %}
+    <div class="mb-6 p-5 bg-amber-900/10 border border-amber-600/30 rounded-lg">
+        <p class="text-sm font-semibold text-amber-400 mb-2">
+            {% if new_user_temp_password %}User created · one-time temp credential
+            {% else %}Password reset · one-time temp credential{% endif %}
+        </p>
+        <p class="text-xs text-amber-500/80 mb-3">
+            Hand this to <span class="font-mono text-gray-300">{{ user.user_name }}</span> out-of-band. The user is forced to rotate at next sign-in. This value will not be shown again — if you lose it, use <em>Danger Zone → Reset Password</em> to mint a fresh one.
+        </p>
+        <div class="bg-surface-950 border border-amber-700/30 rounded p-3 flex items-center justify-between gap-3">
+            <code class="text-sm text-amber-300 font-mono break-all select-all">{{ _temp_pw }}</code>
+            <button type="button"
+                    data-copy="{{ _temp_pw|e }}"
+                    class="text-[10px] text-gray-400 hover:text-white uppercase tracking-wider border border-gray-700 rounded px-2 py-1">
+                copy
+            </button>
+        </div>
+    </div>
+    {% endif %}
+    {% if error %}
+    <div class="mb-6 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
+    {% endif %}
+
+    <!-- Header -->
+    <div class="flex items-start justify-between mb-6">
+        <div>
+            <h2 class="text-lg font-heading font-semibold text-white">{{ user.display_name or user.user_name }}</h2>
+            <p class="text-xs font-mono text-gray-500 mt-1">{{ user.principal_id }}</p>
+        </div>
+        {% if user.disabled %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Disabled
+        </span>
+        {% elif user.must_change_password %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-amber-500 pulse-dot"></span>Pending password change
+        </span>
+        {% elif user.has_password %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
+        </span>
+        {% else %}
+        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-400 uppercase tracking-wider">
+            <span class="w-1.5 h-1.5 rounded-full bg-gray-500"></span>No credential
+        </span>
+        {% endif %}
+    </div>
+
+    <!-- ── Tab Navigation ────────────────────────────────────────────────── -->
+    <div class="flex gap-1 mb-6 border-b border-gray-800">
+        <button type="button" onclick="switchTab('overview')" id="tab-overview"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-[#00e5c7] text-white">
+            Overview
+        </button>
+        <button type="button" onclick="switchTab('activity')" id="tab-activity"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
+            Activity
+        </button>
+        {% if frontdesk_enabled %}
+        <button type="button" onclick="switchTab('danger')" id="tab-danger"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
+            Danger Zone
+        </button>
+        {% endif %}
+    </div>
+
+    <!-- TAB 1: Overview -->
+    <div id="panel-overview" class="main-tab-panel">
+
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
+            <div class="grid grid-cols-2 md:grid-cols-3 gap-6">
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Principal ID</p>
+                    <p class="text-sm text-gray-300 font-mono break-all">{{ user.principal_id }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">User Name</p>
+                    <p class="text-sm text-gray-300 font-mono">{{ user.user_name }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Surface</p>
+                    {% if user.surface %}
+                    <p class="text-sm text-gray-300 font-mono">{{ user.surface }}</p>
+                    {% elif user.in_frontdesk %}
+                    <p class="text-sm text-gray-300 font-mono">frontdesk</p>
+                    {% else %}
+                    <p class="text-sm text-gray-700 italic">—</p>
+                    {% endif %}
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Created</p>
+                    <p class="text-sm text-gray-300 font-mono">{{ user.created_at[:19] if user.created_at else '—' }}</p>
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Last active</p>
+                    {% if user.last_active_at %}
+                    <p class="text-sm text-gray-300 font-mono">{{ user.last_active_at[:19] }}</p>
+                    {% else %}
+                    <p class="text-sm text-gray-700 italic">never</p>
+                    {% endif %}
+                </div>
+                <div>
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider mb-1">Credential lives at</p>
+                    {% if user.in_frontdesk %}
+                    <p class="text-sm text-violet-400 font-mono">Frontdesk users.db</p>
+                    {% else %}
+                    <p class="text-sm text-gray-700 italic">unknown</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">Authentication</h3>
+            <div class="space-y-3">
+                <div class="flex items-start gap-3">
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider w-32 mt-1">Password</p>
+                    {% if user.has_password %}
+                        {% if user.must_change_password %}
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider">
+                            Set, pending change
+                        </span>
+                        {% else %}
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            Set
+                        </span>
+                        {% endif %}
+                        {% if user.password_changed_at %}
+                        <span class="text-[11px] text-gray-600 mt-1.5">
+                            Last updated {{ user.password_changed_at[:19] }}
+                        </span>
+                        {% endif %}
+                    {% else %}
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-500 uppercase tracking-wider">
+                        Not set
+                    </span>
+                    {% endif %}
+                </div>
+                <div class="flex items-start gap-3">
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider w-32 mt-1">Cert thumbprint</p>
+                    {% if user.cert_thumbprint %}
+                    <code class="text-xs text-gray-400 font-mono break-all" title="{{ user.cert_thumbprint }}">{{ user.cert_thumbprint[:32] }}{% if user.cert_thumbprint|length > 32 %}…{% endif %}</code>
+                    {% else %}
+                    <span class="text-xs text-gray-700 italic mt-1">No cert minted yet</span>
+                    {% endif %}
+                </div>
+                <div class="flex items-start gap-3">
+                    <p class="text-[10px] text-gray-600 uppercase tracking-wider w-32 mt-1">SPIFFE</p>
+                    <code class="text-xs text-gray-400 font-mono break-all">spiffe://{{ trust_domain }}/{{ org_id }}/user/{{ user.user_name }}</code>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- TAB 2: Activity -->
+    <div id="panel-activity" class="main-tab-panel hidden">
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
+            <div class="px-6 py-4 border-b border-gray-800/60">
+                <h3 class="text-sm font-semibold text-white uppercase tracking-wider">Recent Activity</h3>
+                <p class="text-[11px] text-gray-600 mt-1">Last {{ audit_entries|length }} audit row{% if audit_entries|length != 1 %}s{% endif %} attributed to this principal.</p>
+            </div>
+            <table class="w-full">
+                <thead>
+                    <tr class="border-b border-gray-800/40">
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Timestamp</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Action</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Tool</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
+                        <th class="px-5 py-2.5 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Detail</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-800/40">
+                    {% for entry in audit_entries %}
+                    <tr class="table-row-hover transition-colors">
+                        <td class="px-5 py-3 text-xs text-gray-500 font-mono whitespace-nowrap">{{ entry.timestamp[:19] }}</td>
+                        <td class="px-5 py-3 text-xs text-gray-300">{{ entry.action }}</td>
+                        <td class="px-5 py-3 text-xs text-gray-400 font-mono">{{ entry.tool_name or '-' }}</td>
+                        <td class="px-5 py-3">
+                            {% if entry.status == 'success' %}
+                            <span class="text-[10px] text-emerald-400 uppercase tracking-wider">OK</span>
+                            {% elif entry.status == 'denied' %}
+                            <span class="text-[10px] text-red-400 uppercase tracking-wider">Denied</span>
+                            {% elif entry.status == 'error' %}
+                            <span class="text-[10px] text-red-400 uppercase tracking-wider">Error</span>
+                            {% else %}
+                            <span class="text-[10px] text-yellow-400 uppercase tracking-wider">{{ entry.status }}</span>
+                            {% endif %}
+                        </td>
+                        <td class="px-5 py-3 text-xs text-gray-600 max-w-[200px] truncate" title="{{ entry.detail or '' }}">{{ entry.detail or '-' }}</td>
+                    </tr>
+                    {% endfor %}
+                    {% if not audit_entries %}
+                    <tr><td colspan="5" class="px-5 py-8 text-center text-xs text-gray-600">No recent activity for this principal</td></tr>
+                    {% endif %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    {% if frontdesk_enabled %}
+    <!-- TAB 3: Danger Zone -->
+    <div id="panel-danger" class="main-tab-panel hidden">
+        <div class="bg-red-900/5 border border-red-900/20 rounded-lg p-6 space-y-6">
+            <div>
+                <h3 class="text-sm font-semibold text-red-400 uppercase tracking-wider mb-2">Danger Zone</h3>
+                <p class="text-[11px] text-gray-600">Operations on this principal are mostly irreversible. The audit chain keeps the history regardless. The Mastio forwards each action to the Frontdesk Ambassador (the canale that holds the credential).</p>
+            </div>
+
+            <!-- Reset password -->
+            <div class="border-t border-red-900/20 pt-5">
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Reset Password</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    The Mastio mints a 20-char temp credential, forwards it to the Frontdesk, and shows it to you here once. The user is forced to change it at next sign-in.
+                </p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/reset-password"
+                      onsubmit="return confirm('Reset this user\'s password? They will need the new value to sign back in.')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-amber-600/20 border border-amber-600/30 text-amber-400 rounded hover:bg-amber-600/30 transition-colors">
+                        Reset Password
+                    </button>
+                </form>
+            </div>
+
+            <!-- Delete -->
+            <div class="border-t border-red-900/20 pt-5">
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Delete</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    Removes the row from the Frontdesk users.db and from the Mastio registry. Past audit entries stay in the chain so the principal id remains attributable. Cannot be undone.
+                </p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/delete"
+                      onsubmit="return confirm('PERMANENTLY DELETE this user principal? The user will no longer be able to sign in.')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-red-600/20 border border-red-600/30 text-red-400 rounded hover:bg-red-600/30 transition-colors">
+                        Delete User
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+</div>
+
+<script>
+function switchTab(name) {
+    document.querySelectorAll('.main-tab-panel').forEach(function(p) { p.classList.add('hidden'); });
+    document.querySelectorAll('.main-tab-btn').forEach(function(b) {
+        b.classList.remove('border-[#00e5c7]', 'text-white');
+        b.classList.add('border-transparent', 'text-gray-500');
+    });
+    document.getElementById('panel-' + name).classList.remove('hidden');
+    var btn = document.getElementById('tab-' + name);
+    btn.classList.add('border-[#00e5c7]', 'text-white');
+    btn.classList.remove('border-transparent', 'text-gray-500');
+}
+</script>
+{% endblock %}

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -1,8 +1,45 @@
 {% extends "base.html" %}
 {% block title %}Users{% endblock %}
-{% block header_title %}Users{% endblock %}
+{% block header_title %}User Principals{% endblock %}
 {% block content %}
 <div class="max-w-6xl">
+
+    {# New user created — surface the one-time temp password ONCE.
+       The Mastio generates it, forwards it to the Frontdesk Ambassador,
+       and never persists it. The admin hands it to the user out-of-band;
+       must_change_password is on so it lasts one sign-in. #}
+    {% if new_user_name and new_user_temp_password %}
+    <div class="mb-6 p-5 bg-emerald-900/10 border border-emerald-600/30 rounded-lg">
+        <div class="flex items-start gap-3">
+            <svg class="w-5 h-5 text-emerald-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            <div class="flex-1">
+                <p class="text-sm font-semibold text-emerald-400 mb-1">User principal created</p>
+                <p class="text-xs text-emerald-500/70 mb-3">
+                    User <span class="font-mono text-gray-300">{{ new_user_name }}</span> is now provisioned on
+                    the Frontdesk Ambassador. The credential below is
+                    one-time — hand it out-of-band, the user is forced to
+                    rotate it at first sign-in.
+                </p>
+                <div class="bg-surface-950 border border-emerald-700/30 rounded p-3 flex items-center justify-between gap-3">
+                    <code class="text-sm text-emerald-300 font-mono break-all select-all">{{ new_user_temp_password }}</code>
+                    <button type="button"
+                            data-copy="{{ new_user_temp_password|e }}"
+                            class="text-[10px] text-gray-400 hover:text-white uppercase tracking-wider border border-gray-700 rounded px-2 py-1">
+                        copy
+                    </button>
+                </div>
+                <p class="text-[10px] text-amber-400/80 mt-2">This password will not be shown again. Reload the page to dismiss.</p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if action_message %}
+    <div class="mb-4 p-3 bg-emerald-500/10 border border-emerald-500/20 rounded text-sm text-emerald-400">{{ action_message }}</div>
+    {% endif %}
+    {% if error %}
+    <div class="mb-4 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">{{ error }}</div>
+    {% endif %}
 
     <!-- Header -->
     <div class="flex items-center justify-between mb-6">
@@ -11,33 +48,81 @@
             <p class="text-xs text-gray-600 mt-0.5">
                 {{ users | length }} registered
                 <span class="text-gray-700 mx-1">&middot;</span>
-                Per-user identity for Frontdesk shared mode (ADR-020 / ADR-021)
+                Identity registry · credentials live at the Source
             </p>
         </div>
+        {% if frontdesk_enabled %}
+        <button onclick="document.getElementById('create-panel').classList.toggle('hidden')"
+                class="px-4 py-2 text-xs font-semibold rounded transition-all"
+                style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
+                onmouseover="this.style.background='#fff'; this.style.boxShadow='0 0 20px rgba(0,229,199,0.15)'"
+                onmouseout="this.style.background='#00e5c7'; this.style.boxShadow='none'">
+            + Create User
+        </button>
+        {% endif %}
     </div>
 
-    <!-- Context banner — read-only by design.
-         Mastio is the cert-attribution registry, not the credential
-         store. Passwords + lifecycle live where the Source column
-         points (Frontdesk container admin / Connector desktop /
-         upstream IdP). Surfacing this here matters because operators
-         arriving from the install path otherwise expect a "Create
-         user" button on this page — there isn't one by design. -->
+    {# Context banner — Mastio is the control plane (lifecycle + audit),
+       the canale (Frontdesk Ambassador / Connector laptop / IdP SSO) is
+       the data plane (credential storage). The admin orchestrates from
+       here; the password itself never touches this DB. #}
     <div class="mb-6 p-4 bg-surface-900/60 border border-gray-800/50 rounded-lg text-xs text-gray-500 leading-relaxed">
-        This is the Mastio's <strong class="text-gray-300">attribution
-        registry</strong> — one row per principal that has been signed
-        a cert. Credentials live at the Source (see column): a
-        <strong class="text-gray-300">Frontdesk container</strong>
-        admin panel manages multi-user passwords, the
-        <strong class="text-gray-300">Connector desktop</strong>
-        manages single-user keys on the laptop,
-        <strong class="text-gray-300">SSO</strong> rows are governed
-        upstream at the IdP. Rows land here automatically on the first
-        cert mint via <code class="text-accent-400/80">/v1/principals/csr</code>;
-        pre-seed out-of-band with
-        <code class="text-accent-400/80">POST /v1/admin/users</code>
-        (X-Admin-Secret) when needed.
+        This is the Mastio's <strong class="text-gray-300">identity authority</strong> — every
+        principal that signs in to your org is tracked here. Credentials
+        themselves live at the <strong class="text-gray-300">Source</strong>:
+        the <strong class="text-gray-300">Frontdesk container</strong>
+        holds multi-user passwords, the
+        <strong class="text-gray-300">Connector desktop</strong> holds
+        laptop keypairs, <strong class="text-gray-300">SSO</strong>
+        rows are governed at the IdP. Create / reset / delete from this
+        page forwards the call to the right canale — the Mastio never
+        sees the plaintext password.
     </div>
+
+    {% if frontdesk_enabled %}
+    <!-- Create User panel (hidden by default) -->
+    <div id="create-panel" class="hidden mb-6 bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">New User</h3>
+        <form method="post" action="/proxy/users/create" class="space-y-4">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">User Name</label>
+                    <input type="text" name="user_name" required
+                           placeholder="mario"
+                           pattern="[a-zA-Z0-9._\-]{1,64}"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
+                    <p class="text-[10px] text-gray-600 mt-1">Letters, digits, dot, underscore, dash. Becomes the SPIFFE id suffix.</p>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Display Name</label>
+                    <input type="text" name="display_name"
+                           placeholder="Mario Rossi"
+                           class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 transition-all">
+                    <p class="text-[10px] text-gray-600 mt-1">Optional label. Falls back to user name.</p>
+                </div>
+            </div>
+            <p class="text-[10px] text-gray-500 flex items-start gap-1.5">
+                <svg class="w-3 h-3 text-emerald-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                The Mastio generates a 20-char temp password, forwards it to the Frontdesk Ambassador, and shows it to you here once. The user is forced to rotate it at first sign-in.
+            </p>
+            <div class="flex items-center gap-3 pt-1">
+                <button type="submit"
+                        class="px-5 py-2 text-xs font-semibold rounded transition-all"
+                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
+                        onmouseover="this.style.background='#fff'"
+                        onmouseout="this.style.background='#00e5c7'">
+                    Create
+                </button>
+                <button type="button"
+                        onclick="document.getElementById('create-panel').classList.add('hidden')"
+                        class="px-4 py-2 text-xs text-gray-500 border border-gray-700 rounded hover:bg-gray-800 transition-colors">
+                    Cancel
+                </button>
+            </div>
+        </form>
+    </div>
+    {% endif %}
 
     <!-- Table -->
     <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
@@ -46,20 +131,21 @@
                 <tr class="border-b border-gray-800/60">
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">User</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Principal ID</th>
-                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Reach</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Status</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider"
                         title="Where this principal's credential lives — Mastio never holds passwords">Source</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Last active</th>
                     <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Created</th>
+                    <th class="px-5 py-3 text-left text-[10px] font-medium text-gray-600 uppercase tracking-wider">Actions</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-gray-800/40">
                 {% for u in users %}
                 <tr class="table-row-hover transition-colors align-top">
                     <td class="px-5 py-4">
-                        <div class="text-sm text-white">
+                        <a href="/proxy/users/{{ u.principal_id|urlencode }}" class="text-sm text-white hover:text-accent-400 transition-colors">
                             {{ u.display_name or u.user_name }}
-                        </div>
+                        </a>
                         {% if u.display_name %}
                         <div class="text-[11px] text-gray-500 font-mono">{{ u.user_name }}</div>
                         {% endif %}
@@ -75,55 +161,48 @@
                         </button>
                     </td>
                     <td class="px-5 py-4">
-                        {% if u.reach == 'cross' %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30">
-                            cross-org
+                        {% if u.disabled %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-red-500/10 text-red-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-red-500"></span>Disabled
                         </span>
-                        {% elif u.reach == 'both' %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-accent-500/10 text-accent-400 border border-accent-400/30">
-                            both
+                        {% elif u.must_change_password %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-400 uppercase tracking-wider"
+                              title="Temp password set — user must rotate at first sign-in">
+                            <span class="w-1.5 h-1.5 rounded-full bg-amber-500 pulse-dot"></span>Pending change
+                        </span>
+                        {% elif u.has_password %}
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-emerald-500/10 text-emerald-400 uppercase tracking-wider">
+                            <span class="w-1.5 h-1.5 rounded-full bg-emerald-500 pulse-dot"></span>Active
                         </span>
                         {% else %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-gray-500/10 text-gray-400 border border-gray-500/30">
-                            intra-org
+                        <span class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-[10px] font-medium bg-gray-500/10 text-gray-400 uppercase tracking-wider"
+                              title="No credential at the canale yet">
+                            <span class="w-1.5 h-1.5 rounded-full bg-gray-500"></span>No credential
                         </span>
                         {% endif %}
                     </td>
                     <td class="px-5 py-4">
-                        {# Inferred source — derived from ``surface`` hint
-                           (set by the Connector Ambassador on first sign-in)
-                           with a fallback that distinguishes SSO-upserted
-                           rows (cert_thumbprint present, surface NULL)
-                           from admin-pre-seeded rows (no cert yet). #}
                         {% set _surface = (u.surface or '').lower() %}
-                        {% if 'frontdesk' in _surface %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-violet-500/10 text-violet-400 border border-violet-400/30"
-                              title="Credential lives in this Frontdesk container's users.db (ADR-025). Manage from the Frontdesk admin panel.">
+                        {% if 'frontdesk' in _surface or u.in_frontdesk %}
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-violet-500/10 text-violet-400 border border-violet-400/30">
                             Frontdesk
                         </span>
                         {% elif 'connector' in _surface or 'cullis-chat' in _surface or 'cli' in _surface or 'desktop' in _surface %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-info-400/10 text-info-400 border border-info-400/30"
-                              title="Credential lives on the user's laptop in the Connector users.db.">
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-info-400/10 text-info-400 border border-info-400/30">
                             Connector
                         </span>
                         {% elif 'sso' in _surface or 'oidc' in _surface or 'keycloak' in _surface or 'okta' in _surface %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-emerald-500/10 text-emerald-400 border border-emerald-400/30"
-                              title="Credential lives at the upstream IdP. Lifecycle is governed there.">
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-emerald-500/10 text-emerald-400 border border-emerald-400/30">
                             SSO
                         </span>
                         {% elif u.cert_thumbprint %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-gray-500/10 text-gray-400 border border-gray-500/30"
-                              title="Cert minted but the surface hint is missing — likely an older Connector or a direct CSR caller.">
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-gray-500/10 text-gray-400 border border-gray-500/30">
                             Cert-direct
                         </span>
                         {% else %}
-                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-amber-500/10 text-amber-400 border border-amber-400/30"
-                              title="Pre-seeded via POST /v1/admin/users — no cert minted yet, no surface bound. Will resolve on first sign-in.">
+                        <span class="px-2 py-0.5 rounded text-[10px] uppercase tracking-wider bg-amber-500/10 text-amber-400 border border-amber-400/30">
                             Pre-seeded
                         </span>
-                        {% endif %}
-                        {% if u.surface %}
-                        <div class="text-[10px] text-gray-600 font-mono mt-1" title="raw surface hint">{{ u.surface }}</div>
                         {% endif %}
                     </td>
                     <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">
@@ -136,20 +215,28 @@
                     <td class="px-5 py-4 text-xs text-gray-500 font-mono whitespace-nowrap">
                         {{ u.created_at[:19] if u.created_at else '—' }}
                     </td>
+                    <td class="px-5 py-4">
+                        <a href="/proxy/users/{{ u.principal_id|urlencode }}"
+                           class="px-2.5 py-1 text-[10px] font-medium uppercase tracking-wider border border-gray-700 text-gray-400 rounded hover:bg-gray-800 hover:text-white transition-colors">
+                            Details
+                        </a>
+                    </td>
                 </tr>
                 {% endfor %}
                 {% if not users %}
                 <tr>
-                    <td colspan="6" class="px-5 py-16 text-center">
+                    <td colspan="7" class="px-5 py-16 text-center">
                         <svg class="w-10 h-10 mx-auto text-gray-800 mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
                                   d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
                         </svg>
                         <p class="text-sm text-gray-600">No user principals yet</p>
                         <p class="text-xs text-gray-700 mt-1">
-                            The first Frontdesk SSO sign-in (or
-                            <code>POST /v1/admin/users</code>) will register
-                            a row here.
+                            {% if frontdesk_enabled %}
+                            Click <span class="text-accent-400">+ Create User</span> to seed one.
+                            {% else %}
+                            Configure <code>MCP_PROXY_FRONTDESK_AMBASSADOR_URL</code> to enable lifecycle actions, or wait for the first SSO sign-in.
+                            {% endif %}
                         </p>
                     </td>
                 </tr>

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -84,6 +84,16 @@ services:
       # mapping the value reaches proxy.env and never the lifespan, so
       # chat returns 503 ``provider_key_missing``.
       MCP_PROXY_ANTHROPIC_API_KEY: ${MCP_PROXY_ANTHROPIC_API_KEY:-}
+      # Frontdesk Ambassador admin endpoint. Lets the Mastio dashboard
+      # orchestrate user lifecycle (create / reset / delete) against
+      # the bundle that actually holds the credentials. Empty values
+      # leave /proxy/users in read-only mode.
+      MCP_PROXY_FRONTDESK_AMBASSADOR_URL: ${MCP_PROXY_FRONTDESK_AMBASSADOR_URL:-}
+      MCP_PROXY_FRONTDESK_ADMIN_SECRET:   ${MCP_PROXY_FRONTDESK_ADMIN_SECRET:-}
+      # AI gateway request timeout. The 30 s default is fine for
+      # claude-haiku-4-5 (~3 s) but local Ollama models with chain-of-
+      # thought (qwen3.5, deepseek-r1) routinely take 20-40 s.
+      MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S: ${MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S:-180}
       PROXY_TRUST_DOMAIN:          ${PROXY_TRUST_DOMAIN:-}
       PROXY_INTRA_ORG:             ${PROXY_INTRA_ORG:-}
       PROXY_TRANSPORT_INTRA_ORG:   ${PROXY_TRANSPORT_INTRA_ORG:-}
@@ -101,6 +111,12 @@ services:
       - mastio_nginx_certs:/var/lib/mastio/nginx-certs:rw
     networks:
       - proxy_net
+    # When the Mastio orchestrates user lifecycle on a sibling Frontdesk
+    # bundle (see MCP_PROXY_FRONTDESK_AMBASSADOR_URL), the Frontdesk is
+    # reachable via the docker host gateway. Mirrors the same alias the
+    # Frontdesk bundle uses to talk back to us.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]

--- a/tests/test_dashboard_users_via_ambassador.py
+++ b/tests/test_dashboard_users_via_ambassador.py
@@ -1,0 +1,438 @@
+"""Mastio dashboard /proxy/users CRUD forwarded to Frontdesk Ambassador.
+
+Mastio is the control plane (principal registry, attribution, cert
+authority). Frontdesk is the data plane (users.db, bcrypt, password
+lifecycle). The dashboard mints a one-time temp password, forwards
+the lifecycle call to ``frontdesk_ambassador_url``, surfaces the temp
+password once on redirect, and never persists or logs the plaintext.
+
+Tests cover:
+  - 16-char unambiguous temp-password alphabet
+  - Create / Reset / Delete forwards with X-Admin-Secret header
+  - Degraded mode when the Ambassador is not configured (read-only)
+  - Error mapping: 409 → user exists, transport → unreachable
+  - Plaintext temp password never leaves through ``_log``
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+# Most tests are async (ASGI client). The two ``_temp_password`` ones
+# at the top are pure functions, so we mark per-test instead of
+# applying ``pytestmark`` globally — that keeps pytest from warning
+# about the asyncio marker on sync tests.
+
+
+async def _spin(tmp_path, monkeypatch, *, frontdesk: bool = True):
+    db_file = tmp_path / "p.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "td-org")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    if frontdesk:
+        monkeypatch.setenv("MCP_PROXY_FRONTDESK_AMBASSADOR_URL", "http://fd-test:7777")
+        monkeypatch.setenv("MCP_PROXY_FRONTDESK_ADMIN_SECRET", "test-admin-secret")
+    else:
+        monkeypatch.delenv("MCP_PROXY_FRONTDESK_AMBASSADOR_URL", raising=False)
+        monkeypatch.delenv("MCP_PROXY_FRONTDESK_ADMIN_SECRET", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _login(cli: AsyncClient) -> None:
+    from mcp_proxy.dashboard.session import set_admin_password
+    await set_admin_password("test-password-1234")
+    r = await cli.post(
+        "/proxy/login",
+        data={"password": "test-password-1234"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+
+
+async def _csrf(cli: AsyncClient) -> str:
+    r = await cli.get("/proxy/users")
+    assert r.status_code == 200, r.text
+    m = re.search(r'name="csrf_token" value="([^"]+)"', r.text)
+    assert m, "csrf_token not found in /proxy/users page"
+    return m.group(1)
+
+
+def _install_fake_frontdesk(monkeypatch, *, responses):
+    """Patch _frontdesk_admin_call to record + script responses.
+
+    ``responses`` is a list of ``(status, body, transport_err)`` tuples
+    popped in order. The captured calls live on the returned list.
+    """
+    calls: list[dict] = []
+
+    async def fake_call(method, path, *, json_body=None):
+        calls.append({"method": method, "path": path, "json_body": json_body})
+        if not responses:
+            raise AssertionError(f"unexpected extra call: {method} {path}")
+        return responses.pop(0)
+
+    from mcp_proxy.dashboard import router as dash_router
+    monkeypatch.setattr(dash_router, "_frontdesk_admin_call", fake_call)
+    # Also short-circuit the list fetch so the page render doesn't try
+    # to hit fd-test on background pulls during the redirect-following
+    # detail page render.
+    async def fake_fetch_list():
+        return {}
+    monkeypatch.setattr(dash_router, "_fetch_frontdesk_users", fake_fetch_list)
+    return calls
+
+
+# ── temp password generator ────────────────────────────────────────────
+
+
+def test_temp_password_alphabet_is_unambiguous():
+    from mcp_proxy.dashboard.router import _generate_temp_password
+    forbidden = set("0O1lI-_")
+    for _ in range(50):
+        pw = _generate_temp_password()
+        assert len(pw) == 16, f"want 16 chars, got {len(pw)}"
+        assert not (set(pw) & forbidden), (
+            f"temp pw {pw!r} contains forbidden char from {forbidden}"
+        )
+
+
+def test_temp_password_distinct_across_calls():
+    from mcp_proxy.dashboard.router import _generate_temp_password
+    seen = {_generate_temp_password() for _ in range(200)}
+    # 16 chars over a ~56-char alphabet, 200 draws: collision probability
+    # is astronomical. Anything less than 200 distinct values means the
+    # RNG is broken.
+    assert len(seen) == 200
+
+
+# ── degraded mode (no Frontdesk wired) ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_create_returns_not_configured_when_frontdesk_missing(
+    tmp_path, monkeypatch,
+):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=False)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/create",
+                data={"csrf_token": csrf, "user_name": "alice"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "Frontdesk+not+configured" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── happy path: create ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_create_forwards_to_ambassador_and_redirects_to_detail(
+    tmp_path, monkeypatch,
+):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        calls = _install_fake_frontdesk(
+            monkeypatch, responses=[(201, {"user_name": "alice"}, None)],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/create",
+                data={
+                    "csrf_token": csrf,
+                    "user_name": "alice",
+                    "display_name": "Alice Rossi",
+                },
+                follow_redirects=False,
+            )
+            assert r.status_code == 303, r.text
+            loc = r.headers["location"]
+            assert "/proxy/users/" in loc
+            assert "new_pw=" in loc, "temp password must be in redirect query"
+    # Forwarded call shape
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["method"] == "POST"
+    assert c["path"] == "/admin/users"
+    body = c["json_body"]
+    assert body["user_name"] == "alice"
+    assert body["display_name"] == "Alice Rossi"
+    assert body["must_change_password"] is True
+    assert isinstance(body["password"], str) and len(body["password"]) == 16
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_create_409_returns_already_exists(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        _install_fake_frontdesk(
+            monkeypatch, responses=[(409, {"detail": "already exists"}, None)],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/create",
+                data={"csrf_token": csrf, "user_name": "alice"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "already+exists" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_create_transport_error_returns_unreachable(
+    tmp_path, monkeypatch,
+):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        _install_fake_frontdesk(
+            monkeypatch, responses=[(0, None, "transport_error")],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/create",
+                data={"csrf_token": csrf, "user_name": "alice"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "Frontdesk+unreachable" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── reset-password ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_reset_password_forwards_and_surfaces_new_temp(
+    tmp_path, monkeypatch,
+):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        calls = _install_fake_frontdesk(
+            monkeypatch, responses=[(204, None, None)],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            pid = "td-org::user::alice"
+            r = await cli.post(
+                f"/proxy/users/{pid}/reset-password",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303, r.text
+            loc = r.headers["location"]
+            assert "reset_pw=" in loc
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["method"] == "POST"
+    assert c["path"] == "/admin/users/alice/reset-password"
+    assert isinstance(c["json_body"]["new_password"], str)
+    assert len(c["json_body"]["new_password"]) == 16
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── delete ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_delete_204_scrubs_mastio_row(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        # Pre-seed a Mastio row so we can verify the scrub.
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, display_name, reach, surface, created_at) "
+                    "VALUES (:pid, :uname, :dname, 'intra', 'frontdesk', "
+                    "datetime('now'))"
+                ),
+                {
+                    "pid": "td-org::user::alice",
+                    "uname": "alice",
+                    "dname": "Alice",
+                },
+            )
+        calls = _install_fake_frontdesk(
+            monkeypatch, responses=[(204, None, None)],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/delete",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303, r.text
+            assert "/proxy/users?ok=Deleted" in r.headers["location"]
+        # Mastio row gone.
+        async with get_db() as conn:
+            row = (await conn.execute(
+                text(
+                    "SELECT principal_id FROM local_user_principals "
+                    "WHERE principal_id = :pid"
+                ),
+                {"pid": "td-org::user::alice"},
+            )).first()
+            assert row is None, "expected Mastio row to be scrubbed after delete"
+    assert calls[0]["method"] == "DELETE"
+    assert calls[0]["path"] == "/admin/users/alice"
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_delete_404_is_idempotent_and_still_scrubs(
+    tmp_path, monkeypatch,
+):
+    """If the Frontdesk says 404, the row is already gone on that side.
+
+    We still scrub the Mastio attribution row so the dashboard view
+    converges (no orphaned principal floating without credentials).
+    """
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, display_name, reach, surface, created_at) "
+                    "VALUES ('td-org::user::ghost', 'ghost', '', 'intra', "
+                    "'frontdesk', datetime('now'))"
+                )
+            )
+        _install_fake_frontdesk(monkeypatch, responses=[(404, None, None)])
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::ghost/delete",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "/proxy/users?ok=Deleted" in r.headers["location"]
+        async with get_db() as conn:
+            row = (await conn.execute(
+                text(
+                    "SELECT principal_id FROM local_user_principals "
+                    "WHERE principal_id = 'td-org::user::ghost'"
+                )
+            )).first()
+            assert row is None
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── security: plaintext password never logged ──────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plaintext_temp_password_never_logged(tmp_path, monkeypatch):
+    """The dashboard mints a temp password and hands it to the admin via
+    the redirect query string. It must NEVER show up in the worker log
+    even at WARNING level when the Frontdesk rejects the request.
+
+    We capture every call to ``_log.warning`` / ``_log.info`` /
+    ``_log.error`` on the dashboard router module and assert the
+    16-char value never appears in any formatted argument.
+    """
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        # Force the Frontdesk to reject with 500 so the warning path
+        # fires (the happy path takes no log line). We also script a
+        # transport error path to cover that branch.
+        _install_fake_frontdesk(
+            monkeypatch,
+            responses=[(500, {"detail": "boom"}, None)],
+        )
+        # Capture every log line emitted from the router module.
+        from mcp_proxy.dashboard import router as dash_router
+        log_calls: list[tuple[str, tuple, dict]] = []
+
+        def _capture(level):
+            def inner(msg, *args, **kwargs):
+                log_calls.append((msg, args, kwargs))
+            return inner
+
+        monkeypatch.setattr(dash_router._log, "warning", _capture("warning"))
+        monkeypatch.setattr(dash_router._log, "info", _capture("info"))
+        monkeypatch.setattr(dash_router._log, "error", _capture("error"))
+
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/create",
+                data={"csrf_token": csrf, "user_name": "audit-target"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            # The temp password lives in the redirect query string; pull it
+            # out so we know exactly what value to look for in the log.
+            loc = r.headers["location"]
+            # Either banner is acceptable here (500 path redirects to list
+            # with error), but for the leak check we just want to verify
+            # that whatever 16-char strings might exist NEVER end up in
+            # _log calls. So we synthesise a probe password too.
+            assert "new_pw=" in loc or "Frontdesk+rejected" in loc, loc
+
+    # No log entry may carry a 16-char unambiguous string that matches
+    # the alphabet — that would be a leak. Heuristic: scan every arg
+    # for any 16-char substring made entirely of the alphabet.
+    alphabet = set(
+        "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"
+    )
+    leak_re = re.compile(
+        r"[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789]{16}"
+    )
+    for msg, args, _kwargs in log_calls:
+        for piece in (msg, *args):
+            s = str(piece)
+            for candidate in leak_re.findall(s):
+                # Confirm it is purely alphabet chars (no padding).
+                assert not (set(candidate) <= alphabet and len(candidate) == 16 and
+                            candidate.isalnum()), (
+                    f"possible temp password leak in log: {s!r}"
+                )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()


### PR DESCRIPTION
## Summary

- Mastio dashboard regains the Users lifecycle UI (Create / Reset / Delete) without bringing back password storage on the Mastio. The Mastio mints a one-time 16-char temp password (unambiguous alphabet), forwards the call to the configured Frontdesk Ambassador admin API, surfaces it once on the per-user detail page banner, and never persists or logs the plaintext.
- Reinstates what PR #579 dropped, the right way: Mastio = control plane, Frontdesk = credential data plane.
- Split from the dogfood draft #580. PR-B (Connector Ambassador SPA fixes) and PR-C (frontdesk-bundle compose passthrough) follow.

## Endpoints (admin login + CSRF gated)

- `POST /proxy/users/create` — mints temp password, forwards to `POST {ambassador}/admin/users` with `must_change_password=true`, pre-seeds `local_user_principals`, 303 to detail page with `new_pw=` query.
- `GET /proxy/users/{principal_id}` — merged view: Mastio cert + Frontdesk credential state + last 20 audit rows scoped to the principal. Reset / Delete in a Danger Zone tab.
- `POST /proxy/users/{pid}/reset-password` — mints + forwards to `POST {ambassador}/admin/users/{user_name}/reset-password`, surfaces `reset_pw=` banner.
- `POST /proxy/users/{pid}/delete` — `DELETE {ambassador}/admin/users/{user_name}` + scrubs the Mastio attribution row. 404 on Frontdesk side is treated as idempotent so the view converges.

Empty `frontdesk_ambassador_url` + `frontdesk_admin_secret` keep `/proxy/users` in legacy read-only mode for Mastios deployed without a sibling Frontdesk.

## Packaging

`packaging/mastio-bundle/docker-compose.yml`:
- env passthrough for `MCP_PROXY_FRONTDESK_AMBASSADOR_URL`, `MCP_PROXY_FRONTDESK_ADMIN_SECRET`, `MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S` (default 180s for chain-of-thought Ollama).
- `extra_hosts: host.docker.internal:host-gateway` so the Mastio can reach a sibling Frontdesk on the host docker bridge.

## Tests

`tests/test_dashboard_users_via_ambassador.py` — 10 cases:

- [x] Temp password alphabet is unambiguous (no `0/O/1/l/I/-/_`) + 16 chars + collision-free over 200 draws.
- [x] Read-only fallback when Frontdesk is not configured.
- [x] Create happy path: forwards `POST /admin/users` with `must_change_password=true`, 303 with `new_pw=` query.
- [x] Create 409 maps to "user already exists"; transport error maps to "Frontdesk unreachable".
- [x] Reset-password forwards + surfaces new temp via `reset_pw=` query.
- [x] Delete 204 scrubs the Mastio attribution row.
- [x] Delete 404 is idempotent and still scrubs.
- [x] Plaintext temp password never appears in `_log.warning` / `info` / `error` args even on Frontdesk 500.

## Test plan

- [x] `pytest tests/test_dashboard_users_via_ambassador.py` — 10/10 green
- [ ] `pytest tests/ -n auto --dist=loadfile` — full suite pre-merge
- [ ] `./sandbox/smoke.sh full` — pre-merge gate with PR-B + PR-C
- [ ] `/security-review` — to be attached before merge

## Out of scope

- SPA Inbox.tsx empty render (separate PR, not in dogfood batch).
- Mastio nginx sidecar auto-attach to the Frontdesk docker network (still manual at `deploy.sh` time).