### PR TITLE
chore(frontdesk-bundle): expose SPA env passthrough + drop fragile extra_hosts

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -100,6 +100,36 @@ services:
       AUTH_MODE: ${AUTH_MODE:-local}
       AMBASSADOR_MODE: ${AMBASSADOR_MODE:-}
       CULLIS_CONNECTOR_ADMIN_SECRET: ${CULLIS_CONNECTOR_ADMIN_SECRET:-}
+      # Loopback enforcement is the right default on a laptop where the
+      # Ambassador binds to 127.0.0.1, but on the Frontdesk bundle the
+      # Ambassador sits behind nginx on a private docker bridge, so the
+      # TCP peer is the nginx sidecar IP (172.x.x.x), not loopback —
+      # leaving the guard on returns 403 ``Ambassador only accepts
+      # loopback connections`` on every /api/session/init from the SPA.
+      CULLIS_AMBASSADOR_LOOPBACK_ONLY: ${CULLIS_AMBASSADOR_LOOPBACK_ONLY:-false}
+      # Comma-separated list of models the SPA's model picker offers
+      # when the Connector cannot fetch a live list from the Mastio.
+      # Mirror this with /proxy/ai-providers on the Mastio so SSO chat
+      # actually routes — listing a model here without a configured
+      # provider returns 502.
+      CULLIS_ADVERTISED_MODELS: ${CULLIS_ADVERTISED_MODELS:-}
+      # SDK / Connector → Mastio request timeout. 10 s default is fine
+      # for cloud Claude (~3 s) but Ollama chain-of-thought models on
+      # the host can take 30-60 s. Pair with the Mastio's
+      # MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S so the deadline ladder
+      # is consistent end-to-end.
+      CULLIS_REQUEST_TIMEOUT_S: ${CULLIS_REQUEST_TIMEOUT_S:-180}
+      # ADR-025 session cookie gets a ``Secure`` flag by default so
+      # production deployments (TLS-terminated at the nginx edge) refuse
+      # to leak it on HTTP. Browsers treat ``localhost`` as a "secure
+      # context" anyway, so the dogfood-on-laptop case keeps working
+      # with the flag on. But on a LAN IP (192.168.x.x) accessed from a
+      # phone over plain HTTP, the browser will drop the cookie on every
+      # request after login — flipping this to ``1`` removes the Secure
+      # flag and lets the LAN demo flow through. **Cookie travels in
+      # clear over the LAN** when this is on, so do not enable it in
+      # production.
+      CULLIS_CONNECTOR_DEV: ${CULLIS_CONNECTOR_DEV:-}
       CULLIS_FRONTDESK_ORG_ID: ${CULLIS_FRONTDESK_ORG_ID}
       CULLIS_FRONTDESK_TRUST_DOMAIN: ${CULLIS_FRONTDESK_TRUST_DOMAIN}
       # Trust the docker bridge network so X-Forwarded-User from nginx is
@@ -132,15 +162,15 @@ services:
       # frontdesk.env to point at your Mastio's CA chain (or the org's
       # corporate root if Mastio TLS is rooted there).
       - ${CULLIS_FRONTDESK_CA_BUNDLE_HOST:?must point to your Mastio CA chain PEM}:/etc/cullis/ca-bundle.pem:ro
-    # In dev with the Mastio published on the docker host (rather than a
-    # routable hostname), the Connector reaches it via either alias.
-    # ``host.docker.internal`` matches the Mastio bundle's default Public
-    # URL (PR #521); ``mastio.local`` is the legacy alias still recorded
-    # in the Mastio's NGINX SAN. Production deployments route over a real
-    # DNS name; both entries are no-ops there.
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-      - "mastio.local:host-gateway"
+    # On Linux ``host.docker.internal:host-gateway`` resolves to the
+    # docker0 bridge IP (172.17.0.1) — which is unreachable across
+    # custom docker bridges because of iptables FORWARD policy. The
+    # Mastio bundle is on a different bridge, so the Connector
+    # times out on every CSR / chat round trip.
+    # Fix: attach the Mastio nginx sidecar to this network at boot
+    # (see deploy.sh) and let docker DNS resolve ``host.docker.internal``
+    # to the Mastio's address inside this bridge. ``extra_hosts`` is
+    # omitted so /etc/hosts does not pre-empt the docker DNS alias.
     depends_on:
       init-permissions:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary

Four Connector env knobs were already wired in code but not exposed through the Frontdesk bundle's `docker-compose.yml`. This adds the passthrough block so operators can configure them via `frontdesk.env` like everything else, plus drops the `extra_hosts: host-gateway` block which never worked across custom docker bridges on Linux.

Depends on **PR-B** (#582). Merge order: PR-B first, then PR-C.

Split from DRAFT #580. Config only — no security review needed.

## Added env passthrough

| Env | Default | Why |
|---|---|---|
| `CULLIS_AMBASSADOR_LOOPBACK_ONLY` | `false` | Bundle topology never has 127.0.0.1 peers (nginx sidecar IP). Leaving the guard on returns 403 on every `/api/session/init`. |
| `CULLIS_ADVERTISED_MODELS` | empty | SPA model picker fallback list. Pair with `/proxy/ai-providers` on the Mastio. |
| `CULLIS_REQUEST_TIMEOUT_S` | `180` | Ollama chain-of-thought routinely takes 30-60s; SDK default 10s 502'd. Mirrors `MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S` on the Mastio. |
| `CULLIS_CONNECTOR_DEV` | empty | When `1`, ADR-025 cookie drops the `Secure` flag for LAN demos over plain HTTP (phone-from-LAN). Production deployments leave it empty. |

## Dropped extra_hosts block

```yaml
extra_hosts:
  - "host.docker.internal:host-gateway"
  - "mastio.local:host-gateway"
```

On Linux `host-gateway` resolves to the docker0 bridge IP (172.17.0.1), which is unreachable across custom docker bridges because of the iptables FORWARD policy — see memory `feedback_connector_port_collision_loop.md`. The replacement: `deploy.sh` attaches the Mastio nginx sidecar to the Frontdesk docker network at boot, and docker DNS resolves `host.docker.internal` from inside the bridge. The `extra_hosts` mapping would otherwise pre-empt the docker DNS alias (separate packaging follow-up — manual step at deploy time today).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — compose YAML parses
- [ ] `pytest tests/ -n auto --dist=loadfile` — full suite pre-merge (paired with PR-A + PR-B; this PR adds no Python code)
- [ ] Bring up the Frontdesk bundle end-to-end with PR-A + PR-B merged, verify the SPA `/api/session/init` flow lands without 403 (post-merge smoke, not blocking this PR)

## Out of scope

- `deploy.sh` Mastio-network-attach step (separate PR).