### PR TITLE
chore(frontdesk-bundle): pin Connector to v0.4.0 stable

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - frontdesk_net
 
   connector:
-    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0-rc2}
+    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0}
     # ``dashboard`` mounts the local-auth router (ADR-025) by default; the
     # legacy fake-SSO Ambassador shared-mode is reachable by setting
     # ``AMBASSADOR_MODE=shared`` explicitly in frontdesk.env. ADR-025


### PR DESCRIPTION
## Summary

Bumps the default `CONNECTOR_VERSION` pin in the Frontdesk bundle compose from `0.4.0-rc2` to `0.4.0` so the bundle pulls the stable Connector image released alongside this commit (tag `connector-v0.4.0`, ghcr.io publish in flight at PR time).

Prerequisite for cutting the `frontdesk-bundle-v0.2.0` tag. The 0.4.0 image carries today's four dogfood fixes (Mastio Users CRUD via Ambassador, SPA loopback override, whoami collision, ollama timeout) so bundle + Connector ship in lockstep.

`CHAT_VERSION` left at `0.2.0-rc1` — Chat is out of scope for this stable cut.

## Test plan

- [x] One-line YAML pin change, no logic touched
- [ ] Merge → tag `frontdesk-bundle-v0.2.0` → workflow rolls the bundle tar.gz/zip with the new default pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)