### PR TITLE
fix(frontdesk-bundle): align deploy.sh + env.example defaults to Connector 0.4.0 stable

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -103,9 +103,8 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
-  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0-rc2)
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0)
   CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.2.0-rc1)
-  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.1.0-rc1)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
   FRONTDESK_HTTP_PORT                Host port to bind nginx (default: 8080)
@@ -201,7 +200,7 @@ _load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 |
 ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
-CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0-rc2}"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0}"
 CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.2.0-rc1}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -42,7 +42,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the cullis-connector image to pull. Pin a release tag
 # in production rather than ``latest``. The default tracks the latest
 # release validated against this bundle.
-# CONNECTOR_VERSION=0.4.0-rc2
+# CONNECTOR_VERSION=0.4.0
 
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on


### PR DESCRIPTION
## Summary

- Bump `deploy.sh` and `frontdesk.env.example` to `CONNECTOR_VERSION=0.4.0` (was `0.4.0-rc2`)
- Drop a stale duplicate `CHAT_VERSION` line in the help text (claimed `0.1.0-rc1`)

## Why

PR #585 pinned `packaging/frontdesk-bundle/docker-compose.yml` to `cullis-connector:0.4.0` stable, but `deploy.sh` still hardcoded `CONNECTOR_VERSION="0.4.0-rc2"` as its own default. Because `deploy.sh` runs `_load_env` from `frontdesk.env` and then forces its own fallback **before** invoking compose, the `${CONNECTOR_VERSION:-0.4.0}` substitution in the compose file was overridden every time.

Customers who downloaded the `frontdesk-bundle-v0.2.0` stable tarball and ran `./deploy.sh` got `cullis-connector:0.4.0-rc2` pulled from GHCR instead of the stable image advertised on the release page. Found during a scripted smoke of the stable tarballs (`/tmp/cullis-smoke-2026-05-11/`).

## Diff

Three call sites in this bundle now agree on `0.4.0`:
- `deploy.sh:106` (help text)
- `deploy.sh:203` (default value)
- `frontdesk.env.example:45` (commented suggestion)

## Test plan

- [x] `grep -rE '0\.4\.0-rc2' packaging/frontdesk-bundle/` returns no results
- [x] `git diff` shows 3 hunks across 2 files, all `rc2 → stable`
- [ ] Re-cut `frontdesk-bundle-v0.2.1` patch tag once merged
- [ ] Smoke the v0.2.1 tarball end-to-end before announcing