### PR TITLE
fix(frontdesk-bundle): preserve client port in nginx Host header forwarded to Connector

### DIFF
--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -87,7 +87,7 @@ server {
     location /api/session/ {
         proxy_pass http://connector:7777$request_uri;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -105,7 +105,7 @@ server {
     location /api/auth/ {
         proxy_pass http://connector:7777$request_uri;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -121,7 +121,7 @@ server {
     location /admin/ {
         proxy_pass http://connector:7777$request_uri;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -136,7 +136,7 @@ server {
     location /v1/ {
         proxy_pass http://connector:7777$request_uri;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -168,7 +168,7 @@ server {
     location ~ ^/(setup|api/setup|waiting|api/status)(/.*)?$ {
         proxy_pass http://connector:7777$request_uri;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -183,7 +183,7 @@ server {
     location / {
         proxy_pass http://cullis-chat:8080;
         proxy_http_version 1.1;
-        proxy_set_header Host $host;
+        proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
## Summary

Replace `proxy_set_header Host $host;` with `proxy_set_header Host $http_host;` in every `location` of `packaging/frontdesk-bundle/nginx/default.conf`. Six locations affected, all in the dev nginx of the Frontdesk bundle.

## Why

`$host` is nginx's normalised server-name (or `Host` header with port stripped). When a browser hits `http://localhost:8080/setup/`, the upstream Connector receives `Host: localhost` — port lost.

Starlette's automatic trailing-slash redirect builds its `Location` header from the upstream-visible `Host`, so it emits `Location: http://localhost/setup` and the browser lands on port 80 (connection refused).

`$http_host` is the raw client-supplied `Host` header verbatim — including the port — which is what an upstream needs to build correct absolute URLs (Location headers, canonical links, OIDC redirect URIs, etc.).

## Smoke evidence

Before:
```
$ curl -I http://localhost:8080/setup/
HTTP/1.1 307 Temporary Redirect
Location: http://localhost/setup
```

After (verified locally with the patched config):
```
$ curl -I http://localhost:8080/setup/
HTTP/1.1 307 Temporary Redirect
Location: http://localhost:8080/setup
```

## Scope

Dev-nginx-only. The bundle README explicitly tells operators to swap this file for an oauth2-proxy in production; that path uses the same `$http_host` idiom by convention, so the contract surfaced to the Connector is unchanged.

## Test plan

- [x] `grep -c 'proxy_set_header Host' packaging/frontdesk-bundle/nginx/default.conf` returns 6
- [x] `grep -c '\\$host' packaging/frontdesk-bundle/nginx/default.conf` returns 0
- [x] Re-run smoke from `/tmp/cullis-smoke-2026-05-11/` shows correct port preserved on `/setup/` redirect
- [ ] No regression on the `/v1/`, `/admin/`, `/api/session/`, `/api/auth/` paths (covered by Phase-3 chat smoke)