### PR TITLE
fix(pyinstaller): bundle SQLAlchemy + aiosqlite + bcrypt for ADR-021 users.db

### DIFF
--- a/packaging/pyinstaller/build.sh
+++ b/packaging/pyinstaller/build.sh
@@ -65,7 +65,7 @@ echo "==> Building ${BIN_NAME} on ${PLATFORM}/${ARCH}"
 python -m pip install --upgrade pip pyinstaller >&2
 python -m pip install --upgrade \
     "mcp[cli]>=1.0" "httpx>=0.24.0" "cryptography>=41.0.0" "PyYAML>=6.0" \
-    "bcrypt>=4.0" \
+    "bcrypt>=4.0" "sqlalchemy[asyncio]>=2.0" "aiosqlite>=0.19" \
     "fastapi>=0.110" "uvicorn[standard]>=0.27" "jinja2>=3.1" "python-multipart>=0.0.9" >&2
 # mcp[cli] pulls in typer — required by `--collect-submodules mcp` below
 # because mcp.cli raises ImportError at module-load time when typer is
@@ -120,6 +120,13 @@ pyinstaller \
   --hidden-import "uvicorn.protocols.http.h11_impl" \
   --hidden-import "uvicorn.protocols.websockets.auto" \
   --hidden-import "uvicorn.logging" \
+  --hidden-import "sqlalchemy" \
+  --hidden-import "sqlalchemy.dialects.sqlite" \
+  --hidden-import "sqlalchemy.dialects.sqlite.aiosqlite" \
+  --hidden-import "sqlalchemy.ext.asyncio" \
+  --hidden-import "sqlalchemy.orm" \
+  --hidden-import "aiosqlite" \
+  --hidden-import "bcrypt" \
   cullis_connector/__main__.py
 
 FINAL_NAME="${BIN_NAME}-${PLATFORM}-${ARCH}"


### PR DESCRIPTION
## Summary

Two changes to `packaging/pyinstaller/build.sh`:

1. Install `sqlalchemy[asyncio]>=2.0` + `aiosqlite>=0.19` in the build venv (matches `packaging/pypi/pyproject.toml`).
2. Add `sqlalchemy`, its dynamic submodules (`dialects.sqlite`, `dialects.sqlite.aiosqlite`, `ext.asyncio`, `orm`), `aiosqlite` and `bcrypt` to `--hidden-import`.

## Why

The `connector-v0.4.0` release binary on windows-latest (and presumably linux + macos, the matrix just stopped at the first failure) crashed at startup with:

```
File "cullis_connector\identity\users.py", line 37, in <module>
    from sqlalchemy import Index, Integer, String, select
ModuleNotFoundError: No module named 'sqlalchemy'
```

CI run: https://github.com/cullis-security/cullis/actions/runs/25642379187

ADR-021 (multi-user KMS) introduced `cullis_connector.identity.{users, users_db, audit, cert_session_map}`, all `from sqlalchemy import …` at module load. PyInstaller's static analyser walks the import graph but only follows imports of packages **installed in the build venv** — and `build.sh` was still installing the pre-ADR-021 dependency set. SQLAlchemy + aiosqlite were absent, so the resulting binary had nothing to bundle.

Even with the deps installed, SQLAlchemy loads its dialects **by name** at first `create_async_engine` call (not via `import`), so PyInstaller can't see them through static analysis. Hence the explicit `--hidden-import` list.

## Note on duplication

`packaging/connector/cullis-connector.spec` already has the same hidden-imports — it's the local-build spec, not the one CI invokes. A follow-up could collapse the two by making `build.sh` `--spec` into the existing file, but that requires parameterising `name` + `strip` first. Out of scope here.

## Test plan

- [x] `grep -c 'sqlalchemy' packaging/pyinstaller/build.sh` returns 5 (1 pip-install line + 4 hidden-import lines)
- [ ] Re-run `release-connector` workflow on a `connector-v0.4.1` tag, expect all three matrix platforms green
- [ ] Smoke binary post-install: `./cullis-connector --version` exits 0 on linux + macos + windows
- [ ] Smoke `./cullis-connector dashboard --profile smoke` boots without `ModuleNotFoundError`