### PR TITLE
release(connector): v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.4.1] — 2026-05-11
+
+Patch release. Restores the PyInstaller binary distribution path that was
+broken in v0.4.0: ADR-021's ``cullis_connector.identity`` modules import
+SQLAlchemy at module load, but ``packaging/pyinstaller/build.sh`` did not
+install SQLAlchemy in the build venv nor declare it as a hidden import, so
+the resulting executable crashed at first launch with
+``ModuleNotFoundError: No module named 'sqlalchemy'``. PyPI wheel and Docker
+image of v0.4.0 were unaffected (they install from
+``packaging/pypi/pyproject.toml``, which lists sqlalchemy) — only the
+single-binary download path was broken.
+
+### Fixed
+
+- **PyInstaller binary now bundles SQLAlchemy + aiosqlite + bcrypt**
+  ([#588]): install ``sqlalchemy[asyncio]>=2.0`` and ``aiosqlite>=0.19`` in
+  the build venv, and add them — plus ``sqlalchemy.dialects.sqlite``,
+  ``sqlalchemy.dialects.sqlite.aiosqlite``, ``sqlalchemy.ext.asyncio``,
+  ``sqlalchemy.orm`` — to ``--hidden-import``. SQLAlchemy resolves
+  dialects by name at first ``create_async_engine`` call, so static
+  analysis cannot see them even when the package is installed.
+
+### Not in this release
+
+- The two fixes for the Frontdesk bundle dev shell (PR #586
+  ``deploy.sh`` default version and PR #587 nginx ``Host`` header
+  preserving the client port) ship as
+  ``frontdesk-bundle-v0.2.1`` rather than a Connector point release —
+  they live in ``packaging/frontdesk-bundle/`` and do not touch the
+  Connector binary.
+
+[#588]: https://github.com/cullis-security/cullis/pull/588
+
 ## [v0.4.0] — 2026-05-11
 
 Stable cut of the v0.4.0 line. Folds five Connector + Ambassador bug

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.0"
+version = "0.4.1"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Patch release of `cullis-connector` — bumps `cullis_connector.__version__` and `packaging/pypi/pyproject.toml` to `0.4.1`, plus a CHANGELOG entry.

## Why

The PyInstaller binary built for v0.4.0 was broken: ADR-021's `cullis_connector.identity.{users,users_db,audit,cert_session_map}` import `sqlalchemy` at module load, but `packaging/pyinstaller/build.sh` did not install SQLAlchemy in the build venv nor declare it as a hidden import. The binary crashed at first launch with `ModuleNotFoundError: No module named 'sqlalchemy'`.

PR #588 fixed the build script. This PR cuts the actual release that ships the working binary.

The PyPI wheel and Docker image of v0.4.0 were **unaffected** (they install from `packaging/pypi/pyproject.toml`, which lists `sqlalchemy[asyncio]`). Only the single-binary GitHub Release asset was broken; this v0.4.1 replaces it.

## Test plan

- [x] Version strings consistent: `__init__.py` `0.4.1`, `pyproject.toml` `0.4.1`, CHANGELOG entry `v0.4.1`
- [x] CI on `release/connector-v0.4.1` green before merge
- [ ] Tag `connector-v0.4.1` after merge — workflow re-runs the build matrix on linux/macos/windows, this time bundling SQLAlchemy
- [ ] Smoke: download each platform binary from the v0.4.1 Release, run `./cullis-connector --version`, expect `0.4.1` exit 0