### PR TITLE
feat(mastio): user_api_tokens table + DB helpers (ADR-027 Phase 1, PR 1/5)

### DIFF
--- a/mcp_proxy/alembic/versions/0029_user_api_tokens.py
+++ b/mcp_proxy/alembic/versions/0029_user_api_tokens.py
@@ -1,0 +1,102 @@
+"""User API tokens for cross-channel Bearer auth (ADR-027 Phase 1).
+
+Revision ID: 0029_user_api_tokens
+Revises: 0028_revert_user_password
+Create Date: 2026-05-11 12:00:00.000000
+
+Adds the ``user_api_tokens`` table backing ADR-027 ``culk_*`` Bearer
+tokens. Each row maps a long-lived API key to a user principal so any
+OpenAI-compat client (LibreChat, Cursor, Cherry Studio, AnythingLLM,
+curl) can authenticate at ``/v1/*`` without going through DPoP cert
+provisioning.
+
+Schema:
+
+  id                      TEXT PRIMARY KEY      ulid string
+  principal_id            TEXT NOT NULL         FK -> local_user_principals.principal_id
+  label                   TEXT NOT NULL         operator-supplied display name
+  token_hash              TEXT NOT NULL         bcrypt(culk_*) cost 12
+  token_last4             TEXT NOT NULL         last 4 chars of the plaintext, indexed
+  scope_providers_json    TEXT NOT NULL         JSON array, [] = no restriction
+  scope_paths_json        TEXT NOT NULL         JSON array, ["/v1/*"] default
+  created_at              TEXT NOT NULL         ISO-8601 UTC
+  created_by              TEXT NOT NULL         minter principal_id (admin or self)
+  last_used_at            TEXT NULL             ISO-8601 UTC, set on each auth
+  last_used_ip            TEXT NULL             client IP at last successful auth
+  expires_at              TEXT NULL             NULL = never expire
+  revoked_at              TEXT NULL             NULL = active
+  revoked_by              TEXT NULL             principal_id that revoked
+
+Indexes:
+
+  idx_user_api_tokens_principal  ON (principal_id) — list-by-user
+  idx_user_api_tokens_last4      ON (token_last4)  — auth resolver prefix probe
+
+The auth resolver hashes incoming Bearer values and compares against
+``token_hash`` only on rows matching the ``token_last4`` prefix, so the
+bcrypt check cost is amortised: ~65k possible suffix buckets × a
+handful of active tokens per bucket means ≪1 bcrypt op per request on
+the median workload.
+
+No PII outside ``label`` (operator chooses) and ``last_used_ip`` (audit
+need). Tokens themselves are never persisted in plaintext — only the
+mint endpoint returns the cleartext once at creation time.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0029_user_api_tokens"
+down_revision: Union[str, Sequence[str], None] = "0028_revert_user_password"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "user_api_tokens"
+_IDX_PRINCIPAL = "idx_user_api_tokens_principal"
+_IDX_LAST4 = "idx_user_api_tokens_last4"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE in set(inspector.get_table_names()):
+        return
+
+    op.create_table(
+        _TABLE,
+        sa.Column("id",                   sa.Text(), primary_key=True),
+        sa.Column("principal_id",         sa.Text(), nullable=False),
+        sa.Column("label",                sa.Text(), nullable=False),
+        sa.Column("token_hash",           sa.Text(), nullable=False),
+        sa.Column("token_last4",          sa.Text(), nullable=False),
+        sa.Column(
+            "scope_providers_json", sa.Text(),
+            nullable=False, server_default="[]",
+        ),
+        sa.Column(
+            "scope_paths_json", sa.Text(),
+            nullable=False, server_default='["/v1/*"]',
+        ),
+        sa.Column("created_at",   sa.Text(), nullable=False),
+        sa.Column("created_by",   sa.Text(), nullable=False),
+        sa.Column("last_used_at", sa.Text(), nullable=True),
+        sa.Column("last_used_ip", sa.Text(), nullable=True),
+        sa.Column("expires_at",   sa.Text(), nullable=True),
+        sa.Column("revoked_at",   sa.Text(), nullable=True),
+        sa.Column("revoked_by",   sa.Text(), nullable=True),
+    )
+    op.create_index(_IDX_PRINCIPAL, _TABLE, ["principal_id"])
+    op.create_index(_IDX_LAST4,     _TABLE, ["token_last4"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if _TABLE not in set(inspector.get_table_names()):
+        return
+    op.drop_index(_IDX_LAST4, table_name=_TABLE)
+    op.drop_index(_IDX_PRINCIPAL, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -18,13 +18,16 @@ Design choices:
     their existing tables aren't recreated.
 """
 import asyncio
+import base64
 import json
 import logging
+import secrets
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
 
+import bcrypt
 from alembic import command
 from alembic.config import Config as AlembicConfig
 from sqlalchemy import inspect, text
@@ -1378,5 +1381,317 @@ async def set_ai_provider_enabled(provider: str, enabled: bool) -> bool:
                 "WHERE provider = :p"
             ),
             {"p": provider.lower(), "en": bool(enabled), "ts": ts},
+        )
+    return (result.rowcount or 0) > 0
+
+
+# ── User API tokens (ADR-027) ──────────────────────────────────────────────
+
+# Plaintext token wire format: ``culk_`` + 52 chars (256-bit body, base32 lower,
+# strip padding). Total length 57 chars. Stable prefix lets downstream tooling
+# (audit greps, log scrubbers, secret scanners) recognise the token class.
+_API_TOKEN_PREFIX = "culk_"
+_API_TOKEN_BODY_BYTES = 32
+_API_TOKEN_BODY_LEN = 52  # base32(32B) without padding
+_API_TOKEN_FULL_LEN = len(_API_TOKEN_PREFIX) + _API_TOKEN_BODY_LEN
+
+# bcrypt cost. 12 ≈ 200ms on commodity hardware; balances offline-crack
+# resistance and per-request auth latency. Matches dashboard password hash.
+_API_TOKEN_BCRYPT_COST = 12
+
+
+def _new_api_token_plaintext() -> str:
+    """Return a fresh ``culk_<52 base32 chars>`` token string."""
+    raw = secrets.token_bytes(_API_TOKEN_BODY_BYTES)
+    body = base64.b32encode(raw).decode("ascii").rstrip("=").lower()
+    # base32(32 bytes) = 52 chars without padding — never 51 or 53. Assert
+    # tightens any silent change in the stdlib.
+    assert len(body) == _API_TOKEN_BODY_LEN, f"unexpected body length: {len(body)}"
+    return f"{_API_TOKEN_PREFIX}{body}"
+
+
+def _hash_api_token(plaintext: str) -> str:
+    """Return the bcrypt hash of ``plaintext`` as an ASCII string."""
+    return bcrypt.hashpw(
+        plaintext.encode("utf-8"),
+        bcrypt.gensalt(rounds=_API_TOKEN_BCRYPT_COST),
+    ).decode("ascii")
+
+
+def _check_api_token(plaintext: str, hashed: str) -> bool:
+    """Constant-time bcrypt compare."""
+    try:
+        return bcrypt.checkpw(plaintext.encode("utf-8"), hashed.encode("ascii"))
+    except (ValueError, TypeError):
+        # Malformed hash row in DB — refuse, do not raise to caller.
+        return False
+
+
+def _new_token_id() -> str:
+    """Return a 22-char URL-safe unique id for a token row."""
+    return secrets.token_urlsafe(16)
+
+
+async def mint_user_api_token(
+    *,
+    principal_id: str,
+    label: str,
+    created_by: str,
+    scope_providers: list[str] | None = None,
+    scope_paths: list[str] | None = None,
+    expires_at: str | None = None,
+) -> dict:
+    """Mint a new API token for a user principal.
+
+    Returns a dict with the cleartext token in the ``token`` field — this
+    is the ONLY time the cleartext is visible to the caller. Subsequent
+    reads (``get_user_api_token``, ``list_user_api_tokens``) return only
+    metadata + ``token_last4``.
+
+    Arguments:
+        principal_id: ``local_user_principals.principal_id`` (user::name)
+        label: operator-visible name, e.g. ``"Cursor laptop daniele"``
+        created_by: principal_id of the admin or self-mint user
+        scope_providers: empty list = no restriction; ``["anthropic"]`` =
+            only that provider. Stored verbatim, not enforced here.
+        scope_paths: defaults to ``["/v1/*"]``. Stored verbatim.
+        expires_at: ISO-8601 UTC, or ``None`` for no expiry.
+    """
+    if not principal_id:
+        raise ValueError("principal_id is required")
+    if not label or not label.strip():
+        raise ValueError("label is required")
+    if not created_by:
+        raise ValueError("created_by is required")
+
+    plaintext = _new_api_token_plaintext()
+    token_hash = _hash_api_token(plaintext)
+    last4 = plaintext[-4:]
+    token_id = _new_token_id()
+    ts = datetime.now(timezone.utc).isoformat()
+    providers_json = json.dumps(
+        sorted(scope_providers or []), separators=(",", ":"),
+    )
+    paths_json = json.dumps(
+        scope_paths if scope_paths is not None else ["/v1/*"],
+        separators=(",", ":"),
+    )
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """INSERT INTO user_api_tokens (
+                       id, principal_id, label,
+                       token_hash, token_last4,
+                       scope_providers_json, scope_paths_json,
+                       created_at, created_by, expires_at
+                   ) VALUES (
+                       :id, :pid, :label,
+                       :hash, :last4,
+                       :prov, :paths,
+                       :ts, :cb, :exp
+                   )"""
+            ),
+            {
+                "id": token_id,
+                "pid": principal_id,
+                "label": label.strip(),
+                "hash": token_hash,
+                "last4": last4,
+                "prov": providers_json,
+                "paths": paths_json,
+                "ts": ts,
+                "cb": created_by,
+                "exp": expires_at,
+            },
+        )
+    return {
+        "id": token_id,
+        "principal_id": principal_id,
+        "label": label.strip(),
+        "token": plaintext,           # only here, never returned again
+        "token_last4": last4,
+        "scope_providers": sorted(scope_providers or []),
+        "scope_paths": scope_paths if scope_paths is not None else ["/v1/*"],
+        "created_at": ts,
+        "created_by": created_by,
+        "expires_at": expires_at,
+        "last_used_at": None,
+        "last_used_ip": None,
+        "revoked_at": None,
+        "revoked_by": None,
+    }
+
+
+def _row_to_token_dict(row: Mapping[str, Any], include_hash: bool = False) -> dict:
+    """Project a DB row into the public dict shape used by the API."""
+    try:
+        providers = json.loads(row["scope_providers_json"] or "[]")
+    except (TypeError, ValueError):
+        providers = []
+    try:
+        paths = json.loads(row["scope_paths_json"] or '["/v1/*"]')
+    except (TypeError, ValueError):
+        paths = ["/v1/*"]
+    out = {
+        "id":               row["id"],
+        "principal_id":     row["principal_id"],
+        "label":            row["label"],
+        "token_last4":      row["token_last4"],
+        "scope_providers":  providers,
+        "scope_paths":      paths,
+        "created_at":       row["created_at"],
+        "created_by":       row["created_by"],
+        "last_used_at":     row["last_used_at"],
+        "last_used_ip":     row["last_used_ip"],
+        "expires_at":       row["expires_at"],
+        "revoked_at":       row["revoked_at"],
+        "revoked_by":       row["revoked_by"],
+    }
+    if include_hash:
+        out["token_hash"] = row["token_hash"]
+    return out
+
+
+async def get_user_api_token(token_id: str) -> dict | None:
+    """Fetch a token row by id, including revoked/expired rows."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT id, principal_id, label, token_hash, token_last4, "
+                "scope_providers_json, scope_paths_json, created_at, created_by, "
+                "last_used_at, last_used_ip, expires_at, revoked_at, revoked_by "
+                "FROM user_api_tokens WHERE id = :id"
+            ),
+            {"id": token_id},
+        )
+        row = result.mappings().first()
+    if row is None:
+        return None
+    return _row_to_token_dict(row)
+
+
+async def list_user_api_tokens(
+    principal_id: str | None = None,
+    *,
+    include_revoked: bool = False,
+) -> list[dict]:
+    """List token rows ordered by created_at desc.
+
+    With ``principal_id=None`` returns all tokens across all users — used
+    by the admin Cross-org view. With a specific ``principal_id`` returns
+    only that user's tokens.
+
+    By default skips revoked rows; pass ``include_revoked=True`` for audit
+    use cases (dashboard "show history").
+    """
+    clauses: list[str] = []
+    params: dict[str, Any] = {}
+    if principal_id is not None:
+        clauses.append("principal_id = :pid")
+        params["pid"] = principal_id
+    if not include_revoked:
+        clauses.append("revoked_at IS NULL")
+    where = (" WHERE " + " AND ".join(clauses)) if clauses else ""
+    sql = (
+        "SELECT id, principal_id, label, token_hash, token_last4, "
+        "scope_providers_json, scope_paths_json, created_at, created_by, "
+        "last_used_at, last_used_ip, expires_at, revoked_at, revoked_by "
+        "FROM user_api_tokens" + where + " ORDER BY created_at DESC"
+    )
+    async with get_db() as conn:
+        result = await conn.execute(text(sql), params)
+        rows = result.mappings().all()
+    return [_row_to_token_dict(r) for r in rows]
+
+
+async def _find_active_token_candidates_by_last4(last4: str) -> list[dict]:
+    """Return active (not revoked, not expired) tokens whose ``token_last4``
+    matches. Includes ``token_hash`` for bcrypt verification in the resolver.
+
+    The list is typically 0-2 entries on a healthy deployment because
+    last4 has ~65k buckets. The resolver bcrypt-checks each candidate.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT id, principal_id, label, token_hash, token_last4, "
+                "scope_providers_json, scope_paths_json, created_at, created_by, "
+                "last_used_at, last_used_ip, expires_at, revoked_at, revoked_by "
+                "FROM user_api_tokens "
+                "WHERE token_last4 = :last4 "
+                "  AND revoked_at IS NULL "
+                "  AND (expires_at IS NULL OR expires_at > :now)"
+            ),
+            {"last4": last4, "now": now_iso},
+        )
+        rows = result.mappings().all()
+    return [_row_to_token_dict(r, include_hash=True) for r in rows]
+
+
+async def verify_user_api_token(plaintext: str) -> dict | None:
+    """Resolve a plaintext API token to its row.
+
+    Returns the public token dict (no hash) on success, or ``None`` if no
+    active row matches. Constant-ish time even for unknown tokens:
+    bcrypt is run on every candidate; if zero candidates match the last4
+    prefix the function returns quickly, but that timing leak is bounded
+    by the size of the keyspace (~65k buckets) and is acceptable for the
+    threat model (ADR-027 §threat model).
+    """
+    if not plaintext or not plaintext.startswith(_API_TOKEN_PREFIX):
+        return None
+    if len(plaintext) != _API_TOKEN_FULL_LEN:
+        return None
+    last4 = plaintext[-4:]
+    candidates = await _find_active_token_candidates_by_last4(last4)
+    for cand in candidates:
+        if _check_api_token(plaintext, cand["token_hash"]):
+            # Drop the hash before handing back to caller — never let it
+            # leave this function. Defence-in-depth against accidental
+            # logging of the row.
+            cand.pop("token_hash", None)
+            return cand
+    return None
+
+
+async def touch_user_api_token(token_id: str, *, client_ip: str | None) -> None:
+    """Update ``last_used_at`` (and optionally ``last_used_ip``) on auth hit.
+
+    Best-effort: failures are logged but not raised. The auth path must
+    not break because of a stat-tracking UPDATE.
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    try:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE user_api_tokens "
+                    "SET last_used_at = :ts, last_used_ip = :ip "
+                    "WHERE id = :id"
+                ),
+                {"id": token_id, "ts": ts, "ip": client_ip},
+            )
+    except Exception:  # noqa: BLE001
+        _log = logging.getLogger("mcp_proxy.db.api_tokens")
+        _log.warning("failed to touch user_api_token %s", token_id, exc_info=True)
+
+
+async def revoke_user_api_token(token_id: str, *, revoked_by: str) -> bool:
+    """Mark a token as revoked.
+
+    Returns True if the row was updated (was active), False if no-op
+    (already revoked or unknown id). Revocation is final — to "unrevoke"
+    the admin must mint a new token.
+    """
+    ts = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE user_api_tokens "
+                "SET revoked_at = :ts, revoked_by = :by "
+                "WHERE id = :id AND revoked_at IS NULL"
+            ),
+            {"id": token_id, "ts": ts, "by": revoked_by},
         )
     return (result.rowcount or 0) > 0

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0028_revert_user_password",)]
+    assert rows == [("0029_user_api_tokens",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0028_revert_user_password",)]
+    assert version == [("0029_user_api_tokens",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0028_revert_user_password"
+HEAD_REVISION = "0029_user_api_tokens"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0028_revert_user_password"
+HEAD_REVISION = "0029_user_api_tokens"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0028_revert_user_password"
+HEAD_REVISION = "0029_user_api_tokens"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 

--- a/tests/test_user_api_tokens_db.py
+++ b/tests/test_user_api_tokens_db.py
@@ -1,0 +1,317 @@
+"""DB helpers for ``user_api_tokens`` (ADR-027 Phase 1).
+
+Covers the migration (0029_user_api_tokens) end-to-end:
+  - Table + indices created by Alembic
+  - mint returns cleartext token only at creation
+  - verify resolves cleartext to row dict (without hash)
+  - verify rejects unknown / malformed / revoked / expired tokens
+  - revoke is idempotent (second revoke returns False)
+  - list filters revoked rows by default
+  - touch updates last_used_at + last_used_ip best-effort
+
+Uses an isolated SQLite file per test so the Alembic chain runs for
+real, matching the pattern in ``test_pending_updates_db.py``.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import inspect
+
+from mcp_proxy.db import (
+    dispose_db,
+    get_db,
+    get_user_api_token,
+    init_db,
+    list_user_api_tokens,
+    mint_user_api_token,
+    revoke_user_api_token,
+    touch_user_api_token,
+    verify_user_api_token,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+
+
+async def _table_exists(table: str) -> bool:
+    async with get_db() as conn:
+        names = await conn.run_sync(
+            lambda sync_conn: set(inspect(sync_conn).get_table_names())
+        )
+    return table in names
+
+
+async def _index_names(table: str) -> set[str]:
+    async with get_db() as conn:
+        indices = await conn.run_sync(
+            lambda sync_conn: inspect(sync_conn).get_indexes(table)
+        )
+    return {idx["name"] for idx in indices}
+
+
+# ── migration ─────────────────────────────────────────────────────────
+
+
+async def test_migration_creates_table_and_indices(fresh_db):
+    assert await _table_exists("user_api_tokens"), "table missing after init_db"
+    idx_names = await _index_names("user_api_tokens")
+    assert "idx_user_api_tokens_principal" in idx_names
+    assert "idx_user_api_tokens_last4" in idx_names
+
+
+# ── mint ──────────────────────────────────────────────────────────────
+
+
+async def test_mint_returns_cleartext_only_once(fresh_db):
+    minted = await mint_user_api_token(
+        principal_id="acme::user::alice",
+        label="Cursor laptop",
+        created_by="acme::admin",
+    )
+    assert minted["token"].startswith("culk_")
+    assert len(minted["token"]) == 57  # culk_ + 52 base32 chars
+    assert minted["token_last4"] == minted["token"][-4:]
+    assert minted["principal_id"] == "acme::user::alice"
+    assert minted["label"] == "Cursor laptop"
+    assert minted["created_by"] == "acme::admin"
+    assert minted["scope_providers"] == []
+    assert minted["scope_paths"] == ["/v1/*"]
+    assert minted["expires_at"] is None
+    assert minted["revoked_at"] is None
+
+    # get_user_api_token never returns cleartext
+    fetched = await get_user_api_token(minted["id"])
+    assert fetched is not None
+    assert "token" not in fetched
+    assert "token_hash" not in fetched
+    assert fetched["token_last4"] == minted["token_last4"]
+
+
+async def test_mint_requires_principal_label_creator(fresh_db):
+    with pytest.raises(ValueError):
+        await mint_user_api_token(
+            principal_id="",
+            label="x",
+            created_by="admin",
+        )
+    with pytest.raises(ValueError):
+        await mint_user_api_token(
+            principal_id="acme::user::alice",
+            label="   ",
+            created_by="admin",
+        )
+    with pytest.raises(ValueError):
+        await mint_user_api_token(
+            principal_id="acme::user::alice",
+            label="x",
+            created_by="",
+        )
+
+
+async def test_mint_persists_scope_fields(fresh_db):
+    minted = await mint_user_api_token(
+        principal_id="acme::user::bob",
+        label="LibreChat staging",
+        created_by="acme::admin",
+        scope_providers=["anthropic", "openai"],
+        scope_paths=["/v1/chat/completions", "/v1/models"],
+    )
+    fetched = await get_user_api_token(minted["id"])
+    assert fetched["scope_providers"] == ["anthropic", "openai"]
+    assert fetched["scope_paths"] == ["/v1/chat/completions", "/v1/models"]
+
+
+async def test_mint_two_tokens_for_same_user_are_independent(fresh_db):
+    a = await mint_user_api_token(
+        principal_id="acme::user::carol",
+        label="laptop",
+        created_by="acme::admin",
+    )
+    b = await mint_user_api_token(
+        principal_id="acme::user::carol",
+        label="desktop",
+        created_by="acme::admin",
+    )
+    assert a["id"] != b["id"]
+    assert a["token"] != b["token"]
+    assert a["token_last4"] != b["token_last4"] or True  # collision possible
+    rows = await list_user_api_tokens("acme::user::carol")
+    assert {r["id"] for r in rows} == {a["id"], b["id"]}
+
+
+# ── verify ────────────────────────────────────────────────────────────
+
+
+async def test_verify_accepts_valid_token(fresh_db):
+    minted = await mint_user_api_token(
+        principal_id="acme::user::dave",
+        label="test",
+        created_by="acme::admin",
+    )
+    resolved = await verify_user_api_token(minted["token"])
+    assert resolved is not None
+    assert resolved["id"] == minted["id"]
+    assert resolved["principal_id"] == "acme::user::dave"
+    assert "token_hash" not in resolved
+    assert "token" not in resolved
+
+
+async def test_verify_rejects_unknown_token(fresh_db):
+    fake = "culk_" + "a" * 52
+    assert await verify_user_api_token(fake) is None
+
+
+async def test_verify_rejects_malformed_token(fresh_db):
+    assert await verify_user_api_token("") is None
+    assert await verify_user_api_token("nope") is None
+    assert await verify_user_api_token("sk-ant-xxx") is None
+    assert await verify_user_api_token("culk_short") is None
+    assert await verify_user_api_token("culk_" + "a" * 99) is None
+
+
+async def test_verify_rejects_revoked_token(fresh_db):
+    minted = await mint_user_api_token(
+        principal_id="acme::user::erin",
+        label="test",
+        created_by="acme::admin",
+    )
+    assert await verify_user_api_token(minted["token"]) is not None
+    revoked = await revoke_user_api_token(minted["id"], revoked_by="acme::admin")
+    assert revoked is True
+    assert await verify_user_api_token(minted["token"]) is None
+
+
+async def test_verify_rejects_expired_token(fresh_db):
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    minted = await mint_user_api_token(
+        principal_id="acme::user::frank",
+        label="test",
+        created_by="acme::admin",
+        expires_at=past,
+    )
+    assert await verify_user_api_token(minted["token"]) is None
+
+
+async def test_verify_accepts_future_expiry(fresh_db):
+    future = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+    minted = await mint_user_api_token(
+        principal_id="acme::user::grace",
+        label="test",
+        created_by="acme::admin",
+        expires_at=future,
+    )
+    resolved = await verify_user_api_token(minted["token"])
+    assert resolved is not None
+    assert resolved["expires_at"] == future
+
+
+# ── revoke ────────────────────────────────────────────────────────────
+
+
+async def test_revoke_is_idempotent(fresh_db):
+    minted = await mint_user_api_token(
+        principal_id="acme::user::heidi",
+        label="test",
+        created_by="acme::admin",
+    )
+    assert await revoke_user_api_token(minted["id"], revoked_by="acme::admin") is True
+    assert await revoke_user_api_token(minted["id"], revoked_by="acme::admin") is False
+
+
+async def test_revoke_unknown_id_returns_false(fresh_db):
+    assert await revoke_user_api_token("nonexistent-id", revoked_by="acme::admin") is False
+
+
+# ── list ──────────────────────────────────────────────────────────────
+
+
+async def test_list_filters_revoked_by_default(fresh_db):
+    a = await mint_user_api_token(
+        principal_id="acme::user::ivan",
+        label="active",
+        created_by="acme::admin",
+    )
+    b = await mint_user_api_token(
+        principal_id="acme::user::ivan",
+        label="revoked",
+        created_by="acme::admin",
+    )
+    await revoke_user_api_token(b["id"], revoked_by="acme::admin")
+    rows = await list_user_api_tokens("acme::user::ivan")
+    assert [r["id"] for r in rows] == [a["id"]]
+
+
+async def test_list_include_revoked(fresh_db):
+    a = await mint_user_api_token(
+        principal_id="acme::user::jane",
+        label="active",
+        created_by="acme::admin",
+    )
+    b = await mint_user_api_token(
+        principal_id="acme::user::jane",
+        label="revoked",
+        created_by="acme::admin",
+    )
+    await revoke_user_api_token(b["id"], revoked_by="acme::admin")
+    rows = await list_user_api_tokens("acme::user::jane", include_revoked=True)
+    assert {r["id"] for r in rows} == {a["id"], b["id"]}
+
+
+async def test_list_all_users_when_principal_none(fresh_db):
+    await mint_user_api_token(
+        principal_id="acme::user::ken",
+        label="t1",
+        created_by="acme::admin",
+    )
+    await mint_user_api_token(
+        principal_id="acme::user::leo",
+        label="t2",
+        created_by="acme::admin",
+    )
+    rows = await list_user_api_tokens(None)
+    assert len(rows) == 2
+    assert {r["principal_id"] for r in rows} == {"acme::user::ken", "acme::user::leo"}
+
+
+# ── touch ─────────────────────────────────────────────────────────────
+
+
+async def test_touch_updates_last_used(fresh_db):
+    minted = await mint_user_api_token(
+        principal_id="acme::user::mia",
+        label="test",
+        created_by="acme::admin",
+    )
+    pre = await get_user_api_token(minted["id"])
+    assert pre["last_used_at"] is None
+    assert pre["last_used_ip"] is None
+
+    await touch_user_api_token(minted["id"], client_ip="10.0.0.42")
+    post = await get_user_api_token(minted["id"])
+    assert post["last_used_at"] is not None
+    assert post["last_used_ip"] == "10.0.0.42"
+
+
+async def test_touch_unknown_id_does_not_raise(fresh_db):
+    # Best-effort: must not raise even when id doesn't exist
+    await touch_user_api_token("nonexistent-id", client_ip="10.0.0.99")

--- a/tests/test_user_api_tokens_db.py
+++ b/tests/test_user_api_tokens_db.py
@@ -14,7 +14,6 @@ real, matching the pattern in ``test_pending_updates_db.py``.
 """
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 
 import pytest


### PR DESCRIPTION
## Summary

First slice of ADR-027 (unified user credentials). Schema + DB plumbing only. No HTTP surface yet, no resolver mounted, no dashboard. Followups (PR 2 resolver, PR 3 admin endpoint, PR 4 dashboard, PR 5 docs) build on this.

## What this adds

- `mcp_proxy/alembic/versions/0029_user_api_tokens.py` — table + 2 indices (principal_id, last4)
- `mcp_proxy/db.py` — 8 async helpers: `mint_user_api_token`, `verify_user_api_token`, `revoke_user_api_token`, `touch_user_api_token`, `list_user_api_tokens`, `get_user_api_token`, plus private `_new_api_token_plaintext` + `_check_api_token`
- `tests/test_user_api_tokens_db.py` — 18 tests covering migration + all helper paths

## Why ADR-027

Today the only auth at `/v1/*` is DPoP-bound cert (agent) or cookie sessione (Frontdesk browser). Client OpenAI-compat di terze parti (LibreChat, Cursor, Cherry Studio, AnythingLLM, n8n, curl) parlano `Authorization: Bearer <key>` e oggi devono bypassare Cullis o usare il `local.token` filesystem-trust del Connector. ADR-027 introduce `culk_*` long-lived tokens minted dal Mastio, hashed con bcrypt, revocabili, ricondotti al user principal per audit + policy + scope.

Sblocca il pattern "punta LibreChat a Cullis Mastio invece di Anthropic API" (drop-in replacement). Phase 1 (this 5-PR stack) consegna l'auth lato Mastio. Phase 2 (futuro) abilita anche il Connector locale ad accettare gli stessi token.

## Wire format

```
culk_<52 chars base32 lower>      (total 57 chars)
```

32 byte random → base32 lower, padding stripped. Prefisso stabile per log scrubbers e secret scanners (TruffleHog, GitGuardian).

## Schema

```
user_api_tokens (
  id                    TEXT PK,
  principal_id          TEXT NOT NULL,
  label                 TEXT NOT NULL,
  token_hash            TEXT NOT NULL,      -- bcrypt cost 12
  token_last4           TEXT NOT NULL,      -- indexed prefix probe
  scope_providers_json  TEXT NOT NULL DEFAULT '[]',
  scope_paths_json      TEXT NOT NULL DEFAULT '["/v1/*"]',
  created_at            TEXT NOT NULL,
  created_by            TEXT NOT NULL,
  last_used_at          TEXT NULL,
  last_used_ip          TEXT NULL,
  expires_at            TEXT NULL,
  revoked_at            TEXT NULL,
  revoked_by            TEXT NULL
)
```

No FK constraint on `principal_id` perché `local_user_principals` può essere vuota quando un admin mint un token *prima* del primo cert mint del user (caso comune in onboarding pre-distribuzione).

## Threat model

- **Backup / DB leak**: hash-only storage. Token non recuperabile da DB rubato.
- **Brute force**: bcrypt cost 12 (~200ms/op).
- **Timing channel**: la verify costa max N bcrypt op dove N = numero token con stesso last4. Su 10k token attivi, N ≈ 0.15 in media (65k buckets), pari a ~1 bcrypt op nel worst case (l'attaccante non recupera info dal timing).
- **Replay**: nessuna mitigazione cryptografica (i token sono Bearer-style come OpenAI/Anthropic). TLS è il trasporto. Revoca immediata via `revoke_user_api_token` per response a sospetto.

## Test plan

- [x] `pytest tests/test_user_api_tokens_db.py -x` → 18/18 PASS in 34s
- [x] `./sandbox/smoke.sh` → 25/0/1 PASS (skip pre-esistente B4.9)
- [ ] Pytest full suite parallelo (`pytest tests/ -n auto --dist=loadfile`) prima del merge per zero regressioni su `ai_provider_credentials` o `local_user_principals` adiacenti

## Out of scope (followup PRs)

- PR 2: middleware `mcp_proxy.auth.api_token` che monta in pipeline DPoP e bypassa DPoP check quando il Bearer è un `culk_*` valido
- PR 3: admin endpoints `POST/GET/DELETE /v1/admin/users/{principal_id}/api-tokens` autenticati via `X-Admin-Secret`
- PR 4: dashboard pagina `/proxy/users/{principal_id}/api-tokens` con HTMX (modal mint, list, revoke)
- PR 5: doc `docs/integrations/librechat.md` + `cherry-studio.md` + `cursor.md`

## Refs

ADR-027 unified user credentials (draft locale `imp/adrs/`, non in repo per gitignore convention). Build su ADR-020 (user principal), ADR-021 (multi-user KMS), ADR-025 (Frontdesk dual-mode auth), ADR-026 (on-behalf-of cross-org).