### PR TITLE
feat(mastio): culk_ API token auth resolver wired into egress dep (ADR-027 Phase 1, PR 2/5)

### DIFF
--- a/mcp_proxy/auth/api_token.py
+++ b/mcp_proxy/auth/api_token.py
@@ -1,0 +1,178 @@
+"""``culk_*`` user API token resolver (ADR-027 Phase 1, PR 2).
+
+Short-circuit auth path for ``/v1/*`` egress endpoints. When the request
+carries ``Authorization: Bearer culk_<...>`` and the token is active in
+``user_api_tokens``, this module resolves it to an ``InternalAgent``
+envelope and the downstream handlers attribute the request to the
+underlying ``user`` principal — same as the LOCAL_TOKEN typed-principal
+path in :mod:`mcp_proxy.auth.local_agent_dep`.
+
+The resolver is intentionally side-by-side with (not instead of) the
+DPoP-bound client-cert path. ADR-027 documents that an API token IS the
+proof of identity for the OpenAI-compat protocol — there is no second
+proof-of-possession layer the way DPoP gives one for cert-based auth.
+The caller wrote ``Authorization: Bearer culk_X``, and we trust that
+header because (a) the token cannot be guessed (256-bit entropy) and
+(b) the token is hashed at rest so a DB leak does not recover it. TLS
+is the transport security boundary.
+
+The integration in ``mcp_proxy.auth.dpop_client_cert.get_agent_from_dpop_client_cert``
+runs this resolver FIRST: if it returns an ``InternalAgent``, we return
+it directly and skip the cert + DPoP chain entirely. The downstream
+handler does not need to know which auth class minted the agent — the
+``InternalAgent.principal_type=="user"`` is the signal that downstream
+audit code uses to attribute correctly.
+
+Touch tracking:
+    Every successful auth updates ``last_used_at`` + ``last_used_ip`` on
+    the token row via ``touch_user_api_token``. Best-effort: failures in
+    the touch are logged but do not break the auth path (the row is
+    valid even if we cannot stat-track).
+
+Audit:
+    Successful auth is recorded by the downstream handler's audit row
+    (``agent_id=<user_principal>``). The resolver itself does not emit
+    an audit entry per request — that would double-log every successful
+    call. A failed auth attempt that supplied a malformed or unknown
+    ``culk_*`` token is silent at this layer; the caller receives 401
+    only when the rest of the auth chain also fails to identify them.
+    Audit of failed tokens is left to the operator: ``last_used_at``
+    stays NULL for unknown tokens, distinguishing them from "minted but
+    never used".
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import Request
+
+from mcp_proxy.db import (
+    touch_user_api_token,
+    verify_user_api_token,
+)
+from mcp_proxy.models import InternalAgent
+
+_log = logging.getLogger("mcp_proxy.auth.api_token")
+
+# Header name + scheme — case-insensitive parse below. ``culk_`` is the
+# stable prefix documented in ADR-027 §wire format.
+_AUTH_HEADER = "authorization"
+_BEARER_PREFIX = "bearer "
+_TOKEN_PREFIX = "culk_"
+
+
+def _extract_bearer_token(request: Request) -> str | None:
+    """Return the cleartext Bearer value if it looks like a culk_ token.
+
+    Returns ``None`` for any of:
+      * Missing ``Authorization`` header
+      * Wrong scheme (not ``Bearer``)
+      * Empty token after the scheme
+      * Value that does not start with ``culk_`` (lets the LOCAL_TOKEN
+        and other Bearer flavours pass through to their own resolvers
+        untouched)
+    """
+    raw = request.headers.get(_AUTH_HEADER, "")
+    if not raw:
+        return None
+    # Case-insensitive scheme match. ``startswith`` on lower-case avoids
+    # allocating a full ``.lower()`` of the whole header for the path
+    # where the header is also not a culk_ token (most requests today).
+    if not raw[: len(_BEARER_PREFIX)].lower() == _BEARER_PREFIX:
+        return None
+    token = raw[len(_BEARER_PREFIX):].strip()
+    if not token or not token.startswith(_TOKEN_PREFIX):
+        return None
+    return token
+
+
+def _principal_type_for(principal_id: str) -> str:
+    """Derive the principal_type from the principal_id shape.
+
+    ADR-020 SPIFFE-style id format ``<org>::user::<name>`` or
+    ``<org>::workload::<name>`` lets us infer the type without a second
+    DB query. Default ``user`` if the id does not contain a typed
+    segment — the token table is currently only minted for user
+    principals (ADR-027 Phase 1 scope), but the resolver is robust to
+    future expansion.
+    """
+    if "::workload::" in principal_id:
+        return "workload"
+    if "::agent::" in principal_id:
+        return "agent"
+    return "user"
+
+
+def _display_name_for(principal_id: str) -> str:
+    """Strip the org + type prefix to yield a human-readable display name.
+
+    Mirrors :mod:`mcp_proxy.auth.local_agent_dep` so the audit / log /
+    UI surface sees the same shape for the same identity regardless of
+    whether the user authed via cookie sessione, LOCAL_TOKEN, or API
+    token. Falls back to the full id if the split fails.
+    """
+    if "::" in principal_id:
+        return principal_id.split("::", 2)[-1]
+    return principal_id
+
+
+def _client_ip(request: Request) -> str | None:
+    """Best-effort client IP for the touch row.
+
+    Mastio sits behind nginx in every realistic deployment, so the
+    request's TCP peer is the proxy. The forwarded chain is in
+    ``X-Forwarded-For`` — take the leftmost entry, that is the
+    closest-to-original client IP added by the trusted reverse proxy.
+    Reverse-proxy spoof scenarios are out of scope for this audit field
+    (it is informational, not load-bearing). Falls back to the TCP peer.
+    """
+    xff = request.headers.get("x-forwarded-for", "")
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    return request.client.host if request.client else None
+
+
+async def _maybe_api_token_principal(request: Request) -> InternalAgent | None:
+    """Resolve a ``culk_*`` API token to its user principal envelope.
+
+    Returns ``None`` if the request does not carry a culk_ token, the
+    token is malformed, or the token is unknown / revoked / expired.
+    Returns the populated ``InternalAgent`` on success. Never raises:
+    a missing or wrong token simply means "I don't handle this auth",
+    not "auth failed" — that decision belongs to the resolver chain
+    further down the pipeline.
+    """
+    token = _extract_bearer_token(request)
+    if token is None:
+        return None
+
+    row = await verify_user_api_token(token)
+    if row is None:
+        # Bounded-time miss (see ``verify_user_api_token`` docstring).
+        # We silently decline so the next resolver gets a shot, instead
+        # of 401-ing here on what might be a perfectly valid LOCAL_TOKEN
+        # that happens to share the Bearer scheme.
+        return None
+
+    # Best-effort last_used touch. Never raises (see helper docstring).
+    await touch_user_api_token(row["id"], client_ip=_client_ip(request))
+
+    principal_id = row["principal_id"]
+    return InternalAgent(
+        agent_id=principal_id,
+        display_name=_display_name_for(principal_id),
+        capabilities=[],
+        created_at=row.get("created_at") or datetime.now(timezone.utc).isoformat(),
+        is_active=True,
+        cert_pem=None,
+        dpop_jkt=None,
+        # ADR-027 tokens are minted for user principals using OpenAI-compat
+        # clients to call ``/v1/chat/completions`` and friends — that is
+        # local egress, not A2A. ``reach="both"`` keeps the door open
+        # without forcing scope here; egress paths don't enforce reach.
+        reach="both",
+        principal_type=_principal_type_for(principal_id),
+    )

--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -72,6 +72,11 @@ async def get_agent_from_dpop_client_cert(request: Request) -> InternalAgent:
     """Egress agent auth: client cert + optional DPoP proof.
 
     Order:
+      0. ADR-027 ``culk_*`` user API token short-circuit. Token is
+         hash-verified against ``user_api_tokens``; if present, the
+         resolved user principal is returned without going through
+         cert + DPoP. The Bearer token IS the proof of identity for
+         OpenAI-compat clients (LibreChat, Cursor, Cherry Studio, ...).
       1. ADR-012 LOCAL_TOKEN short-circuit (cross-org Bearer JWT).
       2. ``get_agent_from_client_cert`` — identity from TLS-layer cert,
          pinned against ``internal_agents.cert_pem``, rate-limited.
@@ -83,6 +88,12 @@ async def get_agent_from_dpop_client_cert(request: Request) -> InternalAgent:
     ``off`` mode is a thin pass-through that returns the cert-auth'd
     agent — useful during the PR-B → PR-C → flip window.
     """
+    # Step 0 — ADR-027 culk_ token. Returns None on miss so step 1+ run.
+    from mcp_proxy.auth.api_token import _maybe_api_token_principal
+    api_token_principal = await _maybe_api_token_principal(request)
+    if api_token_principal is not None:
+        return api_token_principal
+
     from mcp_proxy.auth.local_agent_dep import _maybe_local_internal_agent
     local_agent = await _maybe_local_internal_agent(request)
     if local_agent is not None:

--- a/tests/test_api_token_resolver.py
+++ b/tests/test_api_token_resolver.py
@@ -1,0 +1,223 @@
+"""Integration: ``culk_*`` API token resolver wired into the egress
+``get_agent_from_dpop_client_cert`` dep (ADR-027 Phase 1, PR 2).
+
+Mounts the real llm_chat router with the real dep — no override — and
+hits ``GET /v1/models`` with various ``Authorization`` headers to prove
+the resolver short-circuits the cert + DPoP chain when (and only when)
+a valid ``culk_*`` token is presented.
+
+The ``list_available_models`` helper is patched per-test so the suite
+never reaches an upstream provider. The DB is a tmp sqlite migrated
+through the full Alembic chain (including 0029) so token rows are
+real, not faked.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.db import (
+    dispose_db,
+    init_db,
+    mint_user_api_token,
+    revoke_user_api_token,
+)
+from mcp_proxy.egress import llm_chat_router as router_module
+from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def app_with_real_dep(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_BACKEND", "litellm_embedded")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_PROVIDER", "anthropic")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "orga")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+
+    # Avoid touching upstream catalogue endpoints — return a static list
+    # the assertions can verify.
+    async def fake_list_available_models(enabled):
+        return [
+            {"id": "claude-haiku-4-5", "object": "model", "owned_by": "anthropic"},
+        ]
+    monkeypatch.setattr(
+        router_module, "list_available_models", fake_list_available_models,
+    )
+
+    test_app = FastAPI()
+    test_app.include_router(llm_chat_router)
+    # IMPORTANT — no dependency override on get_agent_from_dpop_client_cert
+    # here; that's the whole point of this test file.
+
+    yield test_app
+
+    get_settings.cache_clear()
+    await dispose_db()
+
+
+async def _mint_token(principal_id: str, label: str = "test") -> str:
+    minted = await mint_user_api_token(
+        principal_id=principal_id,
+        label=label,
+        created_by="orga::admin",
+    )
+    return minted["token"]
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+async def test_valid_api_token_grants_access(app_with_real_dep):
+    token = await _mint_token("orga::user::alice@orga.test")
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["object"] == "list"
+    assert body["data"][0]["id"] == "claude-haiku-4-5"
+
+
+async def test_token_auth_case_insensitive_bearer_scheme(app_with_real_dep):
+    token = await _mint_token("orga::user::bob@orga.test")
+    # Some clients emit "bearer" lowercase or "BEARER" upper — RFC 6750
+    # §2.1 says the scheme is case-insensitive. The resolver must
+    # accept both.
+    for prefix in ("Bearer", "bearer", "BEARER"):
+        async with AsyncClient(
+            transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+        ) as c:
+            r = await c.get(
+                "/v1/models",
+                headers={"Authorization": f"{prefix} {token}"},
+            )
+        assert r.status_code == 200, f"prefix={prefix}: {r.text}"
+
+
+# ── rejection paths ──────────────────────────────────────────────────
+
+
+async def test_no_authorization_header_falls_through_to_cert_layer(app_with_real_dep):
+    # With no Bearer culk_ token and no client cert (test transport has
+    # no TLS), the cert-layer dep raises 403. The resolver MUST decline
+    # silently here, not 401 itself, so this is the chained outcome.
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get("/v1/models")
+    assert r.status_code in (401, 403), r.text
+
+
+async def test_unknown_culk_token_is_rejected(app_with_real_dep):
+    # Well-formed culk_ token, but never minted. Resolver returns None
+    # so the cert layer kicks in and 401/403 because no cert either.
+    fake = "culk_" + "a" * 52
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {fake}"},
+        )
+    assert r.status_code in (401, 403), r.text
+
+
+async def test_revoked_token_is_rejected(app_with_real_dep):
+    token = await _mint_token("orga::user::carol@orga.test", label="will-revoke")
+    # Sanity check: still works before revoke.
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r1 = await c.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r1.status_code == 200
+
+    # Find the token id and revoke it.
+    from mcp_proxy.db import list_user_api_tokens
+    rows = await list_user_api_tokens("orga::user::carol@orga.test")
+    assert len(rows) == 1
+    await revoke_user_api_token(rows[0]["id"], revoked_by="orga::admin")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r2 = await c.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r2.status_code in (401, 403), r2.text
+
+
+async def test_malformed_token_falls_through(app_with_real_dep):
+    # Wrong prefix → resolver declines, cert layer kicks in → 401/403.
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get(
+            "/v1/models",
+            headers={"Authorization": "Bearer sk-ant-not-a-cullis-token"},
+        )
+    assert r.status_code in (401, 403), r.text
+
+
+# ── touch tracking ────────────────────────────────────────────────────
+
+
+async def test_successful_auth_updates_last_used(app_with_real_dep):
+    token = await _mint_token("orga::user::dave@orga.test", label="touch-me")
+
+    from mcp_proxy.db import list_user_api_tokens
+    pre = await list_user_api_tokens("orga::user::dave@orga.test")
+    assert pre[0]["last_used_at"] is None
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200
+
+    post = await list_user_api_tokens("orga::user::dave@orga.test")
+    assert post[0]["last_used_at"] is not None
+
+
+# ── principal type inference ─────────────────────────────────────────
+
+
+async def test_user_principal_type_inferred_from_id_shape(app_with_real_dep):
+    """The downstream handler sees principal_type=user when the token's
+    principal_id contains ``::user::``. The simplest observable proof
+    is that the request succeeds — the resolver returned an
+    ``InternalAgent`` and didn't fall through. The audit row would
+    carry ``principal_type=user`` but ``/v1/models`` doesn't write one,
+    so we rely on the 200 here and on ``test_user_api_tokens_db.py``
+    for direct shape checks.
+    """
+    token = await _mint_token("orga::user::erin@orga.test")
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get(
+            "/v1/models",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary

Second slice of ADR-027. The schema + helpers from PR #590 are now reachable on the wire: a request to `/v1/*` carrying `Authorization: Bearer culk_<...>` is resolved to the underlying user principal and skips the cert + DPoP chain entirely.

Pattern A (LibreChat / Cursor / Cherry Studio → Cullis Mastio) is **functional end-to-end from the auth side** after this PR. The operator still needs the admin mint endpoint (PR 3) to actually issue tokens via API instead of direct DB helper calls.

## What this adds

- `mcp_proxy/auth/api_token.py` — new module, `_maybe_api_token_principal(request)` returns `InternalAgent | None`. Pure additive: never 401s on its own.
- `mcp_proxy/auth/dpop_client_cert.py` — adds the culk_ short-circuit as Step 0 of `get_agent_from_dpop_client_cert`, before LOCAL_TOKEN + client_cert + DPoP chain.
- `tests/test_api_token_resolver.py` — 8 integration tests through the real FastAPI app + real dep + real DB (no `dependency_overrides`). Mocks only `list_available_models` to avoid upstream provider catalogue hits.

## Test coverage

| # | Test | What it asserts |
|---|---|---|
| 1 | `test_valid_api_token_grants_access` | Happy path: minted token → `GET /v1/models` → 200 + model list |
| 2 | `test_token_auth_case_insensitive_bearer_scheme` | RFC 6750 §2.1 — accepts `Bearer`, `bearer`, `BEARER` |
| 3 | `test_no_authorization_header_falls_through_to_cert_layer` | No Bearer → cert layer rejects → 401/403 |
| 4 | `test_unknown_culk_token_is_rejected` | Well-formed but never minted token → fall-through → 401/403 |
| 5 | `test_revoked_token_is_rejected` | Worked, revoked, then rejected |
| 6 | `test_malformed_token_falls_through` | Wrong prefix (`sk-ant-...`) → fall-through (not 401 directly) |
| 7 | `test_successful_auth_updates_last_used` | `last_used_at` populated post-request |
| 8 | `test_user_principal_type_inferred_from_id_shape` | `::user::` → `principal_type="user"` |

## Why short-circuit before DPoP

ADR-027 §threat model documents this: a 256-bit culk_ token IS the proof of identity for OpenAI-compat clients. There is no second proof-of-possession layer the way DPoP gives one for cert-based auth, because:

(a) the token entropy makes guessing infeasible,
(b) DB at-rest is hash-only,
(c) TLS is the transport security boundary.

Forcing DPoP on top would defeat the value prop — LibreChat, Cursor, Cherry Studio don't speak DPoP and never will. Bearer-only is the contract for OpenAI-compat surface.

## How the chain interacts

The resolver returns `None` for any non-culk_ Bearer (LOCAL_TOKEN JWTs, legacy raw API keys, etc) so those flows reach their own dedicated resolvers unchanged. The DPoP path is unchanged for cert-auth agents. No deprecation, no migration.

## Smoke evidence

```
pytest tests/test_api_token_resolver.py
======================= 8 passed, 17 warnings in 19s =======================

./sandbox/smoke.sh
[smoke] PASS=25  FAIL=0  SKIP=1
```

## Not in this PR

- PR 3: admin endpoint `POST /v1/admin/users/{principal_id}/api-tokens` (X-Admin-Secret auth, unblocks scripted demos via curl / Terraform)
- PR 4: dashboard `/proxy/users/{id}/api-tokens` HTMX page (mint modal, list, revoke)
- PR 5: `docs/integrations/librechat.md` + `cherry-studio.md` + `cursor.md` (customer-facing how-to)

## Refs

Builds on PR #590 (ADR-027 PR 1/5 schema + helpers). ADR-027 draft local in `imp/adrs/adr-027-unified-user-credentials.md` (gitignored). Respects the Mastio-is-not-password-store invariant (memo `feedback_mastio_not_password_store`): tokens are bcrypt-hashed Bearer credentials, not passwords.