### PR TITLE
feat(mastio): admin REST endpoints to mint/list/revoke culk_ tokens (ADR-027 Phase 1, PR 3/5)

### DIFF
--- a/mcp_proxy/admin/api_tokens.py
+++ b/mcp_proxy/admin/api_tokens.py
@@ -1,0 +1,275 @@
+"""Admin API for user API tokens (ADR-027 Phase 1, PR 3).
+
+Mint, list, and revoke ``culk_*`` tokens via Bearer ``X-Admin-Secret``.
+This is the scripted path (curl / Terraform / CI) that unblocks the
+"point LibreChat at Cullis Mastio" pattern without forcing the admin
+through the browser dashboard. The dashboard UI (PR 4) wraps the same
+audit + DB writes.
+
+Endpoints:
+
+  POST   /v1/admin/api-tokens
+         Mint a token for ``principal_id`` with ``label`` + optional
+         ``scope_providers``, ``scope_paths``, ``expires_at``. Response
+         shows the cleartext token ONE TIME. Subsequent reads see only
+         ``token_last4``.
+
+  GET    /v1/admin/api-tokens?principal_id=<pid>&include_revoked=<bool>
+         List token metadata. ``principal_id`` filter is optional;
+         omitting it returns all tokens across all users (admin-wide
+         dashboard view). ``include_revoked`` defaults to false.
+
+  GET    /v1/admin/api-tokens/{token_id}
+         Single-row fetch. Returns 404 if unknown.
+
+  DELETE /v1/admin/api-tokens/{token_id}
+         Mark revoked. Idempotent — returns 204 even when the token
+         was already revoked, so retried Terraform / CI jobs don't
+         flap. The audit row distinguishes "new revoke" from "no-op".
+
+Auth: ``X-Admin-Secret`` header. Same contract as
+``mcp_proxy/admin/ai_providers.py`` and ``mcp_proxy/admin/users.py``.
+
+Audit: every mutation writes a row to the hash-chained ``audit_log``
+table. Mint logs ``api_token.mint`` with the new ``token_id`` and
+``principal_id`` (never the cleartext). Revoke logs ``api_token.revoke``
+with the token_id + an ``effective`` flag distinguishing the
+first-time revoke from the idempotent retry.
+"""
+from __future__ import annotations
+
+import hmac
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from mcp_proxy.config import get_settings
+from mcp_proxy.db import (
+    get_user_api_token,
+    list_user_api_tokens,
+    log_audit,
+    mint_user_api_token,
+    revoke_user_api_token,
+)
+
+_log = logging.getLogger("mcp_proxy.admin.api_tokens")
+
+router = APIRouter(prefix="/v1/admin/api-tokens", tags=["admin"])
+
+
+# ── auth ────────────────────────────────────────────────────────────────
+
+
+def _require_admin_secret(
+    x_admin_secret: str = Header(..., alias="X-Admin-Secret"),
+) -> None:
+    settings = get_settings()
+    if not hmac.compare_digest(x_admin_secret, settings.admin_secret):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="invalid admin secret",
+        )
+
+
+# ── models ──────────────────────────────────────────────────────────────
+
+
+class MintRequest(BaseModel):
+    principal_id: str = Field(..., min_length=1, max_length=256)
+    label: str = Field(..., min_length=1, max_length=128)
+    # Empty list = no restriction. Validation of provider names against
+    # the catalog is intentionally not enforced here — the token may
+    # outlive any specific provider configuration, and ``scope_providers``
+    # is a hint for the policy layer, not a hard ACL today.
+    scope_providers: list[str] = Field(default_factory=list)
+    # Default applied by the DB helper when omitted (``["/v1/*"]``).
+    scope_paths: Optional[list[str]] = None
+    # ISO-8601 UTC, e.g. ``2026-08-11T00:00:00Z``. Null means never expire.
+    expires_at: Optional[str] = Field(None, max_length=64)
+    # The admin can pass an explicit ``created_by`` (e.g. an audit
+    # identifier for a Terraform run); when omitted we record the
+    # static string ``"admin-secret"`` since the X-Admin-Secret auth
+    # does not carry a principal identity.
+    created_by: Optional[str] = Field(None, max_length=256)
+
+
+class MintResponse(BaseModel):
+    """Mint response surface. ``token`` field present ONLY here."""
+    id: str
+    principal_id: str
+    label: str
+    token: str
+    token_last4: str
+    scope_providers: list[str]
+    scope_paths: list[str]
+    created_at: str
+    created_by: str
+    expires_at: Optional[str]
+
+
+class TokenMeta(BaseModel):
+    """Public token row shape — no ``token`` cleartext, no ``token_hash``."""
+    id: str
+    principal_id: str
+    label: str
+    token_last4: str
+    scope_providers: list[str]
+    scope_paths: list[str]
+    created_at: str
+    created_by: str
+    last_used_at: Optional[str]
+    last_used_ip: Optional[str]
+    expires_at: Optional[str]
+    revoked_at: Optional[str]
+    revoked_by: Optional[str]
+
+
+class ListResponse(BaseModel):
+    tokens: list[TokenMeta]
+    total: int
+
+
+# ── endpoints ───────────────────────────────────────────────────────────
+
+
+@router.post(
+    "",
+    response_model=MintResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def mint_token(body: MintRequest) -> MintResponse:
+    """Issue a new ``culk_*`` token for the given user principal.
+
+    The cleartext ``token`` field in the response is the ONLY time it
+    will be returned. The caller must capture it now; subsequent reads
+    expose only ``token_last4``.
+    """
+    created_by = body.created_by or "admin-secret"
+    try:
+        minted = await mint_user_api_token(
+            principal_id=body.principal_id,
+            label=body.label,
+            created_by=created_by,
+            scope_providers=body.scope_providers,
+            scope_paths=body.scope_paths,
+            expires_at=body.expires_at,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    await log_audit(
+        agent_id=created_by,
+        action="api_token.mint",
+        status="success",
+        details={
+            "event": "api_token.mint",
+            "token_id": minted["id"],
+            "principal_id": minted["principal_id"],
+            "label": minted["label"],
+            "scope_providers": minted["scope_providers"],
+            "scope_paths": minted["scope_paths"],
+            "expires_at": minted["expires_at"],
+        },
+    )
+    _log.info(
+        "api-token mint id=%s principal=%s label=%s scope_providers=%s expires=%s by=%s",
+        minted["id"], minted["principal_id"], minted["label"],
+        minted["scope_providers"], minted["expires_at"], created_by,
+    )
+    return MintResponse(**{k: minted[k] for k in MintResponse.model_fields})
+
+
+@router.get(
+    "",
+    response_model=ListResponse,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def list_tokens(
+    principal_id: Optional[str] = Query(
+        None,
+        description=(
+            "Filter by user principal_id (e.g. ``orga::user::alice``). "
+            "Omit to list across all users (admin-wide view)."
+        ),
+    ),
+    include_revoked: bool = Query(
+        False,
+        description="When true, includes revoked tokens for audit purposes.",
+    ),
+) -> ListResponse:
+    rows = await list_user_api_tokens(
+        principal_id, include_revoked=include_revoked,
+    )
+    return ListResponse(
+        tokens=[TokenMeta(**{k: r.get(k) for k in TokenMeta.model_fields}) for r in rows],
+        total=len(rows),
+    )
+
+
+@router.get(
+    "/{token_id}",
+    response_model=TokenMeta,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def get_token(token_id: str) -> TokenMeta:
+    row = await get_user_api_token(token_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="token not found",
+        )
+    return TokenMeta(**{k: row.get(k) for k in TokenMeta.model_fields})
+
+
+@router.delete(
+    "/{token_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def delete_token(
+    token_id: str,
+    revoked_by: Optional[str] = Header(
+        None,
+        alias="X-Revoked-By",
+        description=(
+            "Audit attribution for the revoke. Defaults to "
+            "``admin-secret`` when omitted."
+        ),
+    ),
+) -> None:
+    """Revoke a token. Idempotent — returns 204 on already-revoked rows.
+
+    A revoke that hits an unknown ``token_id`` returns 404, distinguishing
+    "no-op idempotent" (token already revoked, 204) from "wrong id"
+    (404). The caller's retry logic should treat 204 + 404 differently:
+    204 = success, 404 = re-check the id.
+    """
+    row = await get_user_api_token(token_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="token not found",
+        )
+    by = revoked_by or "admin-secret"
+    effective = await revoke_user_api_token(token_id, revoked_by=by)
+    await log_audit(
+        agent_id=by,
+        action="api_token.revoke",
+        status="success",
+        details={
+            "event": "api_token.revoke",
+            "token_id": token_id,
+            "principal_id": row["principal_id"],
+            "effective": effective,
+        },
+    )
+    _log.info(
+        "api-token revoke id=%s principal=%s effective=%s by=%s",
+        token_id, row["principal_id"], effective, by,
+    )

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1092,6 +1092,13 @@ app.include_router(admin_enroll_router)
 from mcp_proxy.admin.ai_providers import router as admin_ai_providers_router
 app.include_router(admin_ai_providers_router)
 
+# ADR-027 Phase 1 — culk_ user API tokens for OpenAI-compat Bearer
+# auth (LibreChat / Cursor / Cherry Studio / curl). Admin mints
+# tokens via X-Admin-Secret; the auth resolver in
+# ``mcp_proxy/auth/api_token.py`` validates them on every /v1/* call.
+from mcp_proxy.admin.api_tokens import router as admin_api_tokens_router
+app.include_router(admin_api_tokens_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/federation/agents/{id}/
 # public-key would otherwise fall into the `/v1/federation/*` forward

--- a/tests/test_admin_api_tokens.py
+++ b/tests/test_admin_api_tokens.py
@@ -1,0 +1,321 @@
+"""Admin REST API for user API tokens (ADR-027 Phase 1, PR 3).
+
+Pins on the wire-level behaviour:
+
+  * POST mint returns cleartext token in the 201 body
+  * Subsequent GETs never expose ``token`` or ``token_hash``
+  * GET list filters by ``principal_id`` and respects ``include_revoked``
+  * GET single returns 404 on unknown id
+  * DELETE 204 + audit row, idempotent on already-revoked
+  * 403 on missing / wrong ``X-Admin-Secret``
+  * End-to-end: mint via REST + use the token to auth a ``/v1/models``
+    call (closes the loop with PR 2's resolver)
+
+Uses the full app with both PR 2 (auth resolver) and PR 3 (admin
+endpoints) mounted. DB is a tmp sqlite migrated through 0029.
+"""
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.test")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", org_id)
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _headers():
+    from mcp_proxy.config import get_settings
+    return {"X-Admin-Secret": get_settings().admin_secret}
+
+
+# ── auth ─────────────────────────────────────────────────────────────
+
+
+async def test_missing_admin_secret_rejected(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-auth-1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get("/v1/admin/api-tokens")
+            # FastAPI returns 422 for missing required Header param.
+            assert r.status_code in (403, 422), r.text
+
+
+async def test_wrong_admin_secret_rejected(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-auth-2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.get(
+                "/v1/admin/api-tokens",
+                headers={"X-Admin-Secret": "wrong-secret"},
+            )
+            assert r.status_code == 403, r.text
+
+
+# ── mint ─────────────────────────────────────────────────────────────
+
+
+async def test_mint_returns_cleartext_token_once(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-mint-1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={
+                    "principal_id": "tok-mint-1::user::alice",
+                    "label": "Cursor laptop",
+                },
+            )
+            assert r.status_code == 201, r.text
+            body = r.json()
+            assert body["token"].startswith("culk_")
+            assert len(body["token"]) == 57
+            assert body["token_last4"] == body["token"][-4:]
+            assert body["principal_id"] == "tok-mint-1::user::alice"
+            assert body["label"] == "Cursor laptop"
+            token_id = body["id"]
+
+            # GET single never shows cleartext
+            r2 = await cli.get(f"/v1/admin/api-tokens/{token_id}", headers=h)
+            assert r2.status_code == 200
+            body2 = r2.json()
+            assert "token" not in body2
+            assert "token_hash" not in body2
+            assert body2["token_last4"] == body["token_last4"]
+
+
+async def test_mint_with_scope_and_expiry(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-mint-2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={
+                    "principal_id": "tok-mint-2::user::bob",
+                    "label": "LibreChat anthropic-only",
+                    "scope_providers": ["anthropic"],
+                    "expires_at": "2027-01-01T00:00:00+00:00",
+                },
+            )
+            assert r.status_code == 201, r.text
+            body = r.json()
+            assert body["scope_providers"] == ["anthropic"]
+            assert body["expires_at"] == "2027-01-01T00:00:00+00:00"
+
+
+async def test_mint_rejects_empty_label(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-mint-3")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={
+                    "principal_id": "tok-mint-3::user::eve",
+                    "label": "",
+                },
+            )
+            # Pydantic Field min_length=1 -> 422
+            assert r.status_code == 422, r.text
+
+
+# ── list ─────────────────────────────────────────────────────────────
+
+
+async def test_list_filters_by_principal(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-list-1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-list-1::user::alice", "label": "a1"},
+            )
+            await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-list-1::user::bob", "label": "b1"},
+            )
+
+            r = await cli.get(
+                "/v1/admin/api-tokens?principal_id=tok-list-1::user::alice",
+                headers=h,
+            )
+            assert r.status_code == 200
+            body = r.json()
+            assert body["total"] == 1
+            assert body["tokens"][0]["principal_id"] == "tok-list-1::user::alice"
+
+            r_all = await cli.get("/v1/admin/api-tokens", headers=h)
+            assert r_all.json()["total"] == 2
+
+
+async def test_list_excludes_revoked_by_default(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-list-2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r1 = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-list-2::user::carol", "label": "active"},
+            )
+            r2 = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-list-2::user::carol", "label": "to-revoke"},
+            )
+            await cli.delete(
+                f"/v1/admin/api-tokens/{r2.json()['id']}",
+                headers=h,
+            )
+            r_default = await cli.get(
+                "/v1/admin/api-tokens?principal_id=tok-list-2::user::carol",
+                headers=h,
+            )
+            assert r_default.json()["total"] == 1
+            assert r_default.json()["tokens"][0]["id"] == r1.json()["id"]
+
+            r_all = await cli.get(
+                "/v1/admin/api-tokens?principal_id=tok-list-2::user::carol&include_revoked=true",
+                headers=h,
+            )
+            assert r_all.json()["total"] == 2
+
+
+# ── revoke ───────────────────────────────────────────────────────────
+
+
+async def test_revoke_204_and_idempotent(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-revoke-1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-revoke-1::user::dave", "label": "x"},
+            )
+            tid = r.json()["id"]
+
+            d1 = await cli.delete(f"/v1/admin/api-tokens/{tid}", headers=h)
+            assert d1.status_code == 204
+
+            d2 = await cli.delete(f"/v1/admin/api-tokens/{tid}", headers=h)
+            # idempotent: still 204, audit row tags effective=False
+            assert d2.status_code == 204
+
+
+async def test_revoke_unknown_returns_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-revoke-2")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            d = await cli.delete("/v1/admin/api-tokens/nonexistent-id", headers=h)
+            assert d.status_code == 404
+
+
+# ── audit ────────────────────────────────────────────────────────────
+
+
+async def test_mint_writes_audit_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-audit-1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-audit-1::user::erin", "label": "audited"},
+            )
+
+        # Read audit log directly (lifespan exit dispose_db'd; reopen)
+        from mcp_proxy.db import get_db, init_db, dispose_db
+        from sqlalchemy import text
+        await init_db(
+            f"sqlite+aiosqlite:///{tmp_path / 'proxy.sqlite'}",
+        )
+        try:
+            async with get_db() as conn:
+                result = await conn.execute(
+                    text(
+                        "SELECT action, status, agent_id "
+                        "FROM audit_log WHERE action = 'api_token.mint'"
+                    ),
+                )
+                rows = result.mappings().all()
+        finally:
+            await dispose_db()
+        assert len(rows) == 1
+        assert rows[0]["action"] == "api_token.mint"
+        assert rows[0]["status"] == "success"
+
+
+# ── end-to-end with PR 2 resolver ────────────────────────────────────
+
+
+async def test_mint_via_rest_then_auth_v1_models(tmp_path, monkeypatch):
+    """Closes the loop: a token minted via the admin REST API is
+    immediately usable as Bearer for ``/v1/models`` (the PR 2 resolver
+    finds it). This is the demo flow customers will run."""
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_BACKEND", "litellm_embedded")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_PROVIDER", "anthropic")
+
+    app = await _spin_proxy(tmp_path, monkeypatch, "tok-e2e-1")
+
+    # Patch list_available_models inside the live module to avoid
+    # upstream catalogue traffic.
+    from mcp_proxy.egress import llm_chat_router as router_module
+    async def fake_list_available_models(enabled):
+        return [{"id": "claude-haiku-4-5", "object": "model", "owned_by": "anthropic"}]
+    monkeypatch.setattr(
+        router_module, "list_available_models", fake_list_available_models,
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/api-tokens",
+                headers=h,
+                json={"principal_id": "tok-e2e-1::user::ferris", "label": "e2e"},
+            )
+            assert r.status_code == 201
+            token = r.json()["token"]
+
+            r2 = await cli.get(
+                "/v1/models",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert r2.status_code == 200, r2.text
+            assert r2.json()["data"][0]["id"] == "claude-haiku-4-5"


### PR DESCRIPTION
## Summary

Third slice of ADR-027. The schema + helpers from PR #590 and the auth resolver from PR #591 are now drivable by curl / Terraform / CI via an `X-Admin-Secret`-authenticated REST API. Together with PR #591 this closes the "mint token + use it" loop entirely on the wire.

## Endpoints

- `POST /v1/admin/api-tokens` — mint, returns cleartext `token` ONCE
- `GET /v1/admin/api-tokens?principal_id=<pid>&include_revoked=<bool>` — list with optional filter
- `GET /v1/admin/api-tokens/{token_id}` — single fetch, 404 unknown
- `DELETE /v1/admin/api-tokens/{token_id}` — revoke, 204 idempotent, 404 unknown id

Auth: `X-Admin-Secret` header. Audit: hash-chained row per mutation (`api_token.mint` / `api_token.revoke`).

## Demo flow now available end-to-end

```bash
curl -X POST https://mastio.acme.local:9443/v1/admin/api-tokens \
  -H "X-Admin-Secret: ${ADMIN_SECRET}" \
  -H "Content-Type: application/json" \
  -d '{"principal_id":"acme::user::daniele","label":"Cursor laptop"}'
# {"id":"...","token":"culk_x7q3...j9k2","token_last4":"j9k2",...}
```

Quel `token` incollato in Cursor / LibreChat / Cherry Studio `Authorization: Bearer ...` funziona contro `/v1/*` del Mastio. Audit chain logga il **user principal** non il client app. Pattern A live.

## Test coverage (11 tests)

| Area | Tests |
|---|---|
| Auth | missing secret → 422/403, wrong secret → 403 |
| Mint | cleartext-once, scope+expiry, validation 422 on empty label |
| List | filter by principal_id, include_revoked toggle |
| Revoke | 204 idempotent, 404 on unknown id |
| Audit | hash-chained row written with correct action/status |
| E2E | mint via REST → Bearer su `/v1/models` → 200 (closes PR 2 loop) |

## Test plan

- [x] `pytest tests/test_admin_api_tokens.py` — 11/11 PASS in 24s
- [x] `./sandbox/smoke.sh` — 25/0/1 PASS (pre-existing skip on B4.9)

## Files

- `mcp_proxy/admin/api_tokens.py` — 4 endpoints + Pydantic models
- `mcp_proxy/main.py` — mount router next to admin AI providers and Users
- `tests/test_admin_api_tokens.py` — 11 integration tests

## Not in this PR

- PR 4: dashboard `/proxy/users/{id}/api-tokens` HTMX UI (mint modal, list, revoke)
- PR 5: customer-facing docs `docs/integrations/{librechat,cherry-studio,cursor}.md`

## Refs

Builds on PR #590 + PR #591. ADR-027 draft local in `imp/adrs/`. Respects `feedback_mastio_not_password_store`: tokens are bcrypt-hashed Bearer credentials, the Mastio cannot recover cleartext.