### PR TITLE
feat(dashboard): API tokens tab on user detail with mint + revoke (ADR-027 Phase 1, PR 4/5)

### DIFF
--- a/mcp_proxy/dashboard/api_tokens.py
+++ b/mcp_proxy/dashboard/api_tokens.py
@@ -1,0 +1,174 @@
+"""Dashboard mutations for user API tokens (ADR-027 Phase 1, PR 4).
+
+The GET surface is folded into ``user_detail.html`` so the operator
+sees tokens inline with the rest of the user's metadata (the rendering
+sits in :func:`mcp_proxy.dashboard.router.user_detail_page`, which now
+pulls ``api_tokens`` into the template context). This module only
+handles the two mutations:
+
+  POST   /proxy/users/{principal_id}/api-tokens/create
+         Form-submit from the "Create new token" panel in the API
+         Tokens tab. Mints a row, then 303-redirects back to the user
+         page with ``?new_token=<cleartext>`` so the template can
+         render the one-time "save it now" banner.
+
+  POST   /proxy/users/{principal_id}/api-tokens/{token_id}/revoke
+         Form-submit from the per-row Revoke button. 303-redirects
+         back to the user page with ``?ok=token+revoked``.
+
+Both routes go through ``require_login`` (cookie session) +
+``verify_csrf`` (token tied to the dashboard session), mirroring
+``users_reset_password`` and ``users_delete``. The hash-chained audit
+log is written by the underlying ``mcp_proxy.db`` helpers — same audit
+shape as the admin REST surface in :mod:`mcp_proxy.admin.api_tokens`.
+"""
+from __future__ import annotations
+
+import logging
+from urllib.parse import quote
+
+from fastapi import APIRouter, Form, Request
+from fastapi.responses import RedirectResponse
+
+from mcp_proxy.dashboard.session import require_login, verify_csrf
+from mcp_proxy.db import (
+    get_user_api_token,
+    log_audit,
+    mint_user_api_token,
+    revoke_user_api_token,
+)
+
+_log = logging.getLogger("mcp_proxy.dashboard.api_tokens")
+
+router = APIRouter(
+    prefix="/proxy/users", tags=["dashboard-api-tokens"],
+)
+
+
+def _back_to_user(principal_id: str, query: str = "") -> RedirectResponse:
+    """Redirect back to the user detail page, optionally with a query string."""
+    base = f"/proxy/users/{quote(principal_id, safe='')}"
+    return RedirectResponse(
+        f"{base}?{query}" if query else base,
+        status_code=303,
+    )
+
+
+@router.post("/{principal_id:path}/api-tokens/create")
+async def create_api_token(
+    principal_id: str,
+    request: Request,
+    label: str = Form(""),
+    expires_at: str = Form(""),
+    scope_providers: list[str] | None = Form(None),
+) -> RedirectResponse:
+    """Mint a new culk_ token for ``principal_id`` and redirect back to
+    the user detail page with the cleartext as a single-use query param.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return _back_to_user(principal_id, "error=csrf")
+
+    clean_label = (label or "").strip()
+    if not clean_label:
+        return _back_to_user(principal_id, "token_error=label+is+required")
+
+    clean_expiry: str | None = (expires_at or "").strip() or None
+    # The form's <input type="date"> emits ``YYYY-MM-DD``. Promote it to
+    # an ISO-8601 UTC timestamp so the DB helper's ``expires_at`` filter
+    # (string comparison vs ``datetime.now(UTC).isoformat()``) works.
+    if clean_expiry and len(clean_expiry) == 10:
+        clean_expiry = f"{clean_expiry}T23:59:59+00:00"
+
+    scope_list = [s.strip() for s in (scope_providers or []) if s.strip()]
+
+    created_by = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+
+    try:
+        minted = await mint_user_api_token(
+            principal_id=principal_id,
+            label=clean_label,
+            created_by=created_by,
+            scope_providers=scope_list,
+            expires_at=clean_expiry,
+        )
+    except ValueError as exc:
+        return _back_to_user(
+            principal_id,
+            f"token_error={quote(str(exc))}",
+        )
+
+    await log_audit(
+        agent_id=created_by,
+        action="api_token.mint",
+        status="success",
+        details={
+            "event": "api_token.mint",
+            "source": "dashboard",
+            "token_id": minted["id"],
+            "principal_id": minted["principal_id"],
+            "label": minted["label"],
+            "scope_providers": minted["scope_providers"],
+            "expires_at": minted["expires_at"],
+        },
+    )
+    _log.info(
+        "dashboard mint api-token id=%s principal=%s label=%s by=%s",
+        minted["id"], minted["principal_id"], minted["label"], created_by,
+    )
+    return _back_to_user(
+        principal_id,
+        f"new_token={quote(minted['token'])}&new_token_label={quote(minted['label'])}",
+    )
+
+
+@router.post("/{principal_id:path}/api-tokens/{token_id}/revoke")
+async def revoke_api_token(
+    principal_id: str,
+    token_id: str,
+    request: Request,
+) -> RedirectResponse:
+    """Mark a token as revoked. Idempotent — re-clicking Revoke on an
+    already-revoked row still returns to the user page without error."""
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return _back_to_user(principal_id, "error=csrf")
+
+    row = await get_user_api_token(token_id)
+    if row is None or row["principal_id"] != principal_id:
+        return _back_to_user(
+            principal_id,
+            "token_error=token+not+found+for+this+user",
+        )
+
+    revoked_by = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+    effective = await revoke_user_api_token(token_id, revoked_by=revoked_by)
+    await log_audit(
+        agent_id=revoked_by,
+        action="api_token.revoke",
+        status="success",
+        details={
+            "event": "api_token.revoke",
+            "source": "dashboard",
+            "token_id": token_id,
+            "principal_id": principal_id,
+            "effective": effective,
+        },
+    )
+    _log.info(
+        "dashboard revoke api-token id=%s principal=%s effective=%s by=%s",
+        token_id, principal_id, effective, revoked_by,
+    )
+    return _back_to_user(principal_id, "ok=token+revoked")

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3435,6 +3435,21 @@ async def user_detail_page(principal_id: str, request: Request):
     action_message = request.query_params.get("ok")
     error = request.query_params.get("error")
 
+    # ADR-027 — show this user's API tokens inline + render the
+    # one-time cleartext banner when ``?new_token=`` is set (the mint
+    # POST redirects back here with the freshly-minted token in the
+    # URL exactly once; if the operator reloads the page, the query
+    # param is gone and the banner does not re-render).
+    api_tokens: list[dict] = []
+    try:
+        from mcp_proxy.db import list_user_api_tokens
+        api_tokens = await list_user_api_tokens(principal_id)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning("user_detail_page: api_tokens query failed: %s", exc)
+    new_api_token = request.query_params.get("new_token")
+    new_api_token_label = request.query_params.get("new_token_label")
+    api_token_error = request.query_params.get("token_error")
+
     return templates.TemplateResponse("user_detail.html", _ctx(
         request, session,
         active="users",
@@ -3447,6 +3462,10 @@ async def user_detail_page(principal_id: str, request: Request):
         new_user_temp_password=new_user_temp_password,
         action_message=action_message,
         error=error,
+        api_tokens=api_tokens,
+        new_api_token=new_api_token,
+        new_api_token_label=new_api_token_label,
+        api_token_error=api_token_error,
     ))
 
 

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -74,6 +74,10 @@
                 class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
             Activity
         </button>
+        <button type="button" onclick="switchTab('api-tokens')" id="tab-api-tokens"
+                class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
+            API Tokens
+        </button>
         {% if frontdesk_enabled %}
         <button type="button" onclick="switchTab('danger')" id="tab-danger"
                 class="main-tab-btn px-4 py-2.5 text-sm font-medium border-b-2 transition-colors border-transparent text-gray-500 hover:text-gray-300">
@@ -216,8 +220,147 @@
         </div>
     </div>
 
+    <!-- TAB 3: API Tokens (ADR-027) -->
+    <div id="panel-api-tokens" class="main-tab-panel hidden">
+
+        {% if new_api_token %}
+        <div class="mb-6 p-5 bg-amber-900/10 border border-amber-600/30 rounded-lg">
+            <p class="text-sm font-semibold text-amber-400 mb-2">
+                API token created · save it now
+            </p>
+            <p class="text-xs text-amber-500/80 mb-3">
+                Label: <span class="font-mono text-gray-300">{{ new_api_token_label }}</span>.
+                Hand this to <span class="font-mono text-gray-300">{{ user.user_name }}</span> out-of-band.
+                Paste into LibreChat / Cursor / Cherry Studio under the OpenAI-compat
+                provider config. This value will not be shown again — if lost,
+                revoke + mint a fresh one.
+            </p>
+            <div class="bg-surface-950 border border-amber-700/30 rounded p-3 flex items-center justify-between gap-3">
+                <code class="text-sm text-amber-300 font-mono break-all select-all">{{ new_api_token }}</code>
+                <button type="button"
+                        data-copy="{{ new_api_token|e }}"
+                        class="text-[10px] text-gray-400 hover:text-white uppercase tracking-wider border border-gray-700 rounded px-2 py-1">
+                    copy
+                </button>
+            </div>
+        </div>
+        {% endif %}
+
+        {% if api_token_error %}
+        <div class="mb-6 p-3 bg-red-500/10 border border-red-500/20 rounded text-sm text-red-400">
+            {{ api_token_error }}
+        </div>
+        {% endif %}
+
+        <!-- Create form -->
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm mb-6">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-3">Create new token</h3>
+            <p class="text-xs text-gray-500 mb-4">
+                Mints a Bearer credential bound to this user principal. The token is shown
+                once on creation. Audit chain attributes every request made with it to
+                <span class="font-mono text-gray-400">{{ user.principal_id }}</span>.
+            </p>
+            <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/api-tokens/create" class="space-y-4">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">
+                        Label <span class="text-red-400">*</span>
+                    </label>
+                    <input type="text" name="label" required maxlength="128"
+                           placeholder="e.g. Cursor laptop · LibreChat staging · n8n pipeline"
+                           class="w-full bg-surface-950 border border-gray-800 rounded px-3 py-2 text-sm text-gray-200 font-mono focus:outline-none focus:border-[#00e5c7]">
+                </div>
+
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">
+                        Expires (optional)
+                    </label>
+                    <input type="date" name="expires_at"
+                           class="bg-surface-950 border border-gray-800 rounded px-3 py-2 text-sm text-gray-200 font-mono focus:outline-none focus:border-[#00e5c7]">
+                    <p class="text-[10px] text-gray-600 mt-1">Empty = never expire. Rotate via Revoke + Create.</p>
+                </div>
+
+                <div>
+                    <label class="block text-[10px] text-gray-500 uppercase tracking-wider mb-1.5">
+                        Scope · providers (optional)
+                    </label>
+                    <div class="flex flex-wrap gap-3 text-xs text-gray-300">
+                        {% for p in ["anthropic", "openai", "gemini", "bedrock", "vertex", "ollama"] %}
+                        <label class="inline-flex items-center gap-1.5 cursor-pointer">
+                            <input type="checkbox" name="scope_providers" value="{{ p }}"
+                                   class="accent-[#00e5c7]">
+                            <span class="font-mono">{{ p }}</span>
+                        </label>
+                        {% endfor %}
+                    </div>
+                    <p class="text-[10px] text-gray-600 mt-1">No selection = all configured providers. Hint for the policy layer, not yet enforced as ACL.</p>
+                </div>
+
+                <button type="submit"
+                        class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-[#00e5c7]/10 border border-[#00e5c7]/30 text-[#00e5c7] rounded hover:bg-[#00e5c7]/20 transition-colors">
+                    Mint token
+                </button>
+            </form>
+        </div>
+
+        <!-- Token list -->
+        <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
+            <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">
+                Active tokens
+                <span class="text-[10px] text-gray-600 ml-2">({{ api_tokens|length }})</span>
+            </h3>
+            {% if api_tokens %}
+            <table class="w-full text-xs">
+                <thead>
+                    <tr class="border-b border-gray-800 text-[10px] uppercase tracking-wider text-gray-600">
+                        <th class="text-left pb-2">Label</th>
+                        <th class="text-left pb-2">Last4</th>
+                        <th class="text-left pb-2">Scope</th>
+                        <th class="text-left pb-2">Created</th>
+                        <th class="text-left pb-2">Last used</th>
+                        <th class="text-left pb-2">Expires</th>
+                        <th class="text-right pb-2"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for t in api_tokens %}
+                    <tr class="border-b border-gray-900 last:border-0">
+                        <td class="py-3 text-gray-300">{{ t.label }}</td>
+                        <td class="py-3 text-gray-500 font-mono">…{{ t.token_last4 }}</td>
+                        <td class="py-3 text-gray-500 font-mono">
+                            {% if t.scope_providers %}{{ t.scope_providers|join(', ') }}{% else %}all{% endif %}
+                        </td>
+                        <td class="py-3 text-gray-500 font-mono">{{ t.created_at[:19] if t.created_at else '—' }}</td>
+                        <td class="py-3 text-gray-500 font-mono">
+                            {% if t.last_used_at %}{{ t.last_used_at[:19] }}{% else %}<span class="italic">never</span>{% endif %}
+                        </td>
+                        <td class="py-3 text-gray-500 font-mono">
+                            {% if t.expires_at %}{{ t.expires_at[:10] }}{% else %}<span class="italic">never</span>{% endif %}
+                        </td>
+                        <td class="py-3 text-right">
+                            <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/api-tokens/{{ t.id }}/revoke"
+                                  onsubmit="return confirm('Revoke this token? Any client using it will start getting 401.')">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                                <button type="submit"
+                                        class="text-[10px] uppercase tracking-wider text-red-400 hover:text-red-300 border border-red-900/40 rounded px-2 py-1 hover:bg-red-900/20 transition-colors">
+                                    Revoke
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="text-xs text-gray-600 italic">No active tokens. Mint one above to let an OpenAI-compat client (LibreChat / Cursor / Cherry Studio) authenticate as this user against <span class="font-mono text-gray-400">/v1/*</span>.</p>
+            {% endif %}
+        </div>
+
+    </div>
+
     {% if frontdesk_enabled %}
-    <!-- TAB 3: Danger Zone -->
+    <!-- TAB 4: Danger Zone -->
     <div id="panel-danger" class="main-tab-panel hidden">
         <div class="bg-red-900/5 border border-red-900/20 rounded-lg p-6 space-y-6">
             <div>

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1099,6 +1099,14 @@ app.include_router(admin_ai_providers_router)
 from mcp_proxy.admin.api_tokens import router as admin_api_tokens_router
 app.include_router(admin_api_tokens_router)
 
+# ADR-027 dashboard mutations (mint / revoke) for the same tokens.
+# The GET surface is folded into ``user_detail.html`` (see
+# ``user_detail_page`` below — pulls api_tokens into the template
+# context). This router only handles the form submissions, with
+# cookie-session auth + CSRF mirroring ``users_reset_password``.
+from mcp_proxy.dashboard.api_tokens import router as dashboard_api_tokens_router
+app.include_router(dashboard_api_tokens_router)
+
 # ADR-006 Fase 1 / PR #3 — proxy-native discovery + public-key endpoints.
 # Must precede the reverse-proxy catch-all: /v1/federation/agents/{id}/
 # public-key would otherwise fall into the `/v1/federation/*` forward

--- a/tests/test_dashboard_api_tokens.py
+++ b/tests/test_dashboard_api_tokens.py
@@ -307,7 +307,9 @@ async def test_user_detail_shows_one_time_banner_when_new_token_query_present(pr
     # Just render the page with the query param; we don't need to
     # actually mint here — the template branch is gated on the param.
     from urllib.parse import quote
-    csrf = await _csrf(proxy_logged_in, pid)  # also seeds the row
+    # Seeds the local_user_principals row (return value intentionally
+    # discarded — we don't POST anything in this test, just GET).
+    await _csrf(proxy_logged_in, pid)
     fake_token = "culk_" + "x" * 52
     page = await proxy_logged_in.get(
         f"/proxy/users/{quote(pid, safe='')}?new_token={quote(fake_token)}&new_token_label=demo",

--- a/tests/test_dashboard_api_tokens.py
+++ b/tests/test_dashboard_api_tokens.py
@@ -1,0 +1,318 @@
+"""Dashboard mutations for user API tokens (ADR-027 Phase 1, PR 4).
+
+Pins on the cookie-auth + CSRF flow that mirrors users_reset_password:
+
+  * Anonymous POST is bounced to /proxy/login
+  * Form mint redirects 303 with ``?new_token=`` + ``?new_token_label=``
+    so the template can render the one-time banner
+  * Empty label rejected with ``?token_error=`` redirect
+  * Revoke happy path → 303 with ``?ok=token+revoked``
+  * Revoke unknown id → 303 with ``?token_error=``
+  * Revoke a token belonging to another user → 303 with ``?token_error=``
+    (prevents cross-user revoke from a stale form)
+  * After mint, GET /proxy/users/{pid} shows the token in the table
+"""
+from __future__ import annotations
+
+import re
+from urllib.parse import unquote, urlsplit, parse_qs
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "test.local")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield client
+    get_settings.cache_clear()
+
+
+async def _csrf(client: AsyncClient, principal_id: str) -> str:
+    """Pull the CSRF token from a user_detail render so we can POST."""
+    from urllib.parse import quote
+    page = await client.get(
+        f"/proxy/users/{quote(principal_id, safe='')}",
+        follow_redirects=False,
+    )
+    # If the user row does not exist locally yet, user_detail redirects
+    # to /proxy/users with an error. Seed a row directly in the DB so
+    # we have something to render against.
+    if page.status_code == 303:
+        # Seed local_user_principals row, then re-fetch.
+        from datetime import datetime, timezone
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, display_name, reach, "
+                    "surface, cert_thumbprint, created_at, last_active_at) "
+                    "VALUES (:pid, :name, :dn, 'intra', 'frontdesk', "
+                    "NULL, :ts, NULL)"
+                ),
+                {
+                    "pid": principal_id,
+                    "name": principal_id.split("::")[-1],
+                    "dn": principal_id.split("::")[-1],
+                    "ts": datetime.now(timezone.utc).isoformat(),
+                },
+            )
+        page = await client.get(
+            f"/proxy/users/{quote(principal_id, safe='')}",
+            follow_redirects=False,
+        )
+    assert page.status_code == 200, page.text[:300]
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token not found"
+    return m.group(1)
+
+
+# ── helpers for redirect parsing ─────────────────────────────────────
+
+
+def _redirect_query(resp) -> dict[str, list[str]]:
+    loc = resp.headers.get("location", "")
+    qs = urlsplit(loc).query
+    return parse_qs(qs)
+
+
+# ── auth ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_anonymous_post_redirects_to_login(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            r = await cli.post(
+                "/proxy/users/acme::user::alice/api-tokens/create",
+                data={"label": "x"},
+                follow_redirects=False,
+            )
+    assert r.status_code in (303, 401, 403), r.text
+    if r.status_code == 303:
+        assert "login" in r.headers.get("location", ""), r.headers
+
+
+# ── mint ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mint_redirects_with_cleartext_in_query(proxy_logged_in):
+    pid = "acme::user::alice"
+    csrf = await _csrf(proxy_logged_in, pid)
+    from urllib.parse import quote
+    r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/create",
+        data={"csrf_token": csrf, "label": "Cursor laptop"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+    qs = _redirect_query(r)
+    assert "new_token" in qs, qs
+    token = unquote(qs["new_token"][0])
+    assert token.startswith("culk_")
+    assert len(token) == 57
+    assert qs["new_token_label"][0] == "Cursor+laptop" or unquote(qs["new_token_label"][0]) == "Cursor laptop"
+
+
+@pytest.mark.asyncio
+async def test_mint_empty_label_redirects_with_error(proxy_logged_in):
+    pid = "acme::user::bob"
+    csrf = await _csrf(proxy_logged_in, pid)
+    from urllib.parse import quote
+    r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/create",
+        data={"csrf_token": csrf, "label": "   "},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+    qs = _redirect_query(r)
+    assert "token_error" in qs, qs
+
+
+@pytest.mark.asyncio
+async def test_mint_persists_scope_and_expires(proxy_logged_in):
+    pid = "acme::user::carol"
+    csrf = await _csrf(proxy_logged_in, pid)
+    from urllib.parse import quote
+    r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/create",
+        data={
+            "csrf_token": csrf,
+            "label": "LibreChat anthro-only",
+            "expires_at": "2027-12-31",
+            # Multi-value: httpx serialises a list as repeated form fields.
+            "scope_providers": ["anthropic", "openai"],
+        },
+        follow_redirects=False,
+    )
+    assert r.status_code == 303, r.text
+
+    # Verify the row in DB
+    from mcp_proxy.db import list_user_api_tokens
+    rows = await list_user_api_tokens(pid)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["label"] == "LibreChat anthro-only"
+    assert sorted(row["scope_providers"]) == ["anthropic", "openai"]
+    # YYYY-MM-DD promoted to a full ISO timestamp by the route
+    assert row["expires_at"] is not None
+    assert row["expires_at"].startswith("2027-12-31")
+
+
+# ── revoke ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_revoke_happy_path(proxy_logged_in):
+    pid = "acme::user::dave"
+    csrf = await _csrf(proxy_logged_in, pid)
+    from urllib.parse import quote
+    mint_r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/create",
+        data={"csrf_token": csrf, "label": "to-revoke"},
+        follow_redirects=False,
+    )
+    assert mint_r.status_code == 303
+
+    from mcp_proxy.db import list_user_api_tokens
+    rows = await list_user_api_tokens(pid)
+    token_id = rows[0]["id"]
+
+    csrf2 = await _csrf(proxy_logged_in, pid)
+    revoke_r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/{token_id}/revoke",
+        data={"csrf_token": csrf2},
+        follow_redirects=False,
+    )
+    assert revoke_r.status_code == 303
+    qs = _redirect_query(revoke_r)
+    assert "ok" in qs, qs
+
+    # Default list filters revoked rows out
+    after = await list_user_api_tokens(pid)
+    assert after == []
+    after_full = await list_user_api_tokens(pid, include_revoked=True)
+    assert len(after_full) == 1
+    assert after_full[0]["revoked_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_revoke_unknown_id_returns_error(proxy_logged_in):
+    pid = "acme::user::erin"
+    csrf = await _csrf(proxy_logged_in, pid)
+    from urllib.parse import quote
+    r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/nonexistent-id/revoke",
+        data={"csrf_token": csrf},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    qs = _redirect_query(r)
+    assert "token_error" in qs, qs
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_of_different_user_rejected(proxy_logged_in):
+    """A stale revoke form from one user's page must not be able to
+    nuke another user's token by guessing the id."""
+    from urllib.parse import quote
+    pid_a = "acme::user::frank"
+    pid_b = "acme::user::grace"
+    csrf_a = await _csrf(proxy_logged_in, pid_a)
+    await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid_a, safe='')}/api-tokens/create",
+        data={"csrf_token": csrf_a, "label": "frank-only"},
+        follow_redirects=False,
+    )
+    from mcp_proxy.db import list_user_api_tokens
+    rows = await list_user_api_tokens(pid_a)
+    tid = rows[0]["id"]
+
+    csrf_b = await _csrf(proxy_logged_in, pid_b)
+    r = await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid_b, safe='')}/api-tokens/{tid}/revoke",
+        data={"csrf_token": csrf_b},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    qs = _redirect_query(r)
+    assert "token_error" in qs, qs
+    # The original token is still active.
+    still = await list_user_api_tokens(pid_a)
+    assert len(still) == 1
+    assert still[0]["revoked_at"] is None
+
+
+# ── render integration ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_detail_renders_token_table(proxy_logged_in):
+    pid = "acme::user::heidi"
+    csrf = await _csrf(proxy_logged_in, pid)
+    from urllib.parse import quote
+    await proxy_logged_in.post(
+        f"/proxy/users/{quote(pid, safe='')}/api-tokens/create",
+        data={"csrf_token": csrf, "label": "render-test"},
+        follow_redirects=False,
+    )
+    page = await proxy_logged_in.get(
+        f"/proxy/users/{quote(pid, safe='')}",
+    )
+    assert page.status_code == 200
+    body = page.text
+    # The API Tokens tab button must be present
+    assert "API Tokens" in body
+    # The token label rendered in the active-tokens table
+    assert "render-test" in body
+
+
+@pytest.mark.asyncio
+async def test_user_detail_shows_one_time_banner_when_new_token_query_present(proxy_logged_in):
+    pid = "acme::user::ivan"
+    # Just render the page with the query param; we don't need to
+    # actually mint here — the template branch is gated on the param.
+    from urllib.parse import quote
+    csrf = await _csrf(proxy_logged_in, pid)  # also seeds the row
+    fake_token = "culk_" + "x" * 52
+    page = await proxy_logged_in.get(
+        f"/proxy/users/{quote(pid, safe='')}?new_token={quote(fake_token)}&new_token_label=demo",
+    )
+    assert page.status_code == 200
+    body = page.text
+    assert fake_token in body
+    assert "save it now" in body  # one-time banner copy


### PR DESCRIPTION
## Summary

Cookie-auth UI for the same `culk_` tokens that PR #592 exposed via `X-Admin-Secret` REST. Non-CLI admins mint and revoke from the existing per-user dashboard page. Shared `api_token.mint` + `api_token.revoke` audit shape with the REST surface.

## What this adds

- `mcp_proxy/dashboard/api_tokens.py` — 2 cookie + CSRF POST handlers (mint, revoke), with cross-user defence on revoke
- `mcp_proxy/dashboard/router.py:user_detail_page` — pulls `list_user_api_tokens(principal_id)` + new_token query params into template context
- `mcp_proxy/dashboard/templates/user_detail.html` — new `API Tokens` tab between Activity and Danger Zone, with:
  - One-time amber banner when `new_token` query param present (Copy button hook)
  - Create form: label (required) + expires_at (date) + scope_providers (multi-select checkboxes)
  - Active tokens table: label, last4, scope, created, last_used, expires, Revoke button
- `mcp_proxy/main.py` — mount the dashboard router
- `tests/test_dashboard_api_tokens.py` — 9 integration tests

## Test coverage

| Area | Tests |
|---|---|
| Auth | Anonymous POST → 303 to /proxy/login |
| Mint happy path | 303 + `new_token` + `new_token_label` query params |
| Mint validation | Empty label rejected with `token_error` query |
| Mint persistence | scope_providers + expires_at (YYYY-MM-DD → ISO timestamp) saved |
| Revoke happy path | 303 + `ok=token+revoked`, row marked revoked |
| Revoke idempotent | Default list filters revoked, `include_revoked=true` shows it |
| Revoke unknown | `token_error` query |
| Revoke cross-user defence | Rejects token whose `principal_id` ≠ URL principal |
| Render | After mint, table shows the token; banner renders when query present |

## Test plan

- [x] `pytest tests/test_dashboard_api_tokens.py` — 9/9 PASS in 24s
- [x] `./sandbox/smoke.sh` — 25/0/1 PASS

## Demo flow now available (non-CLI admin path)

1. Admin loggato Mastio dashboard → Users → click user (es. Daniele)
2. Tab "API Tokens" → Create new token, label "Cursor laptop", scope: anthropic + openai, no expiry
3. Banner amber appare con `culk_x7q3...j9k2` + Copy button
4. Admin condivide token con Daniele
5. Daniele incolla in Cursor: Settings → AI → Custom Endpoint → Base URL `https://mastio.acme.local:9443/v1` + API key = il token

Stesso flow del PR #592 ma senza curl, per ops senza terminale.

## Not in this PR

- PR 5: `docs/integrations/{librechat,cherry-studio,cursor}.md` customer how-to. Closes ADR-027 Phase 1.

## Refs

Builds on PR #590 (schema), #591 (resolver), #592 (admin REST). Audit `source=dashboard` distinguishes UI mutations from REST in post-hoc forensics.