### PR TITLE
docs(integrations): LibreChat + Cherry Studio + Cursor how-to (ADR-027 Phase 1, PR 5/5)

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,122 @@
+# Integrations — point your OpenAI-compat client at Cullis Mastio
+
+Cullis Mastio exposes an OpenAI-compatible API surface at
+`https://<mastio-host>:9443/v1/*`. Any client that speaks the
+OpenAI HTTP protocol can talk to Cullis as if it were
+`api.openai.com` or `api.anthropic.com`, and get back:
+
+- per-user identity attribution in the Mastio audit chain
+- centralised provider credentials (no API key stored on the client)
+- policy enforcement at the PDP layer
+- cross-org federation when paired with a Court deployment
+
+The contract: every request carries `Authorization: Bearer culk_<…>`
+where `culk_<…>` is a Cullis user API token (ADR-027). The token
+identifies which **user principal** is making the call; the underlying
+provider call (Anthropic / OpenAI / Gemini / Bedrock / Vertex / Ollama)
+is made by the Mastio with the org-wide credentials managed in the
+dashboard.
+
+## Integration guides
+
+| Client | Type | Guide |
+|---|---|---|
+| LibreChat | self-hosted web, multi-user | [librechat.md](librechat.md) |
+| Cherry Studio | desktop, MCP-native | [cherry-studio.md](cherry-studio.md) |
+| Cursor | IDE, agentic | [cursor.md](cursor.md) |
+
+All three guides assume:
+
+1. A Mastio is reachable at a known URL (e.g.
+   `https://mastio.acme.local:9443` for dev, or your VPS hostname for
+   production).
+2. The admin has configured at least one AI provider in the dashboard
+   at `/proxy/ai-providers` (or via
+   `PUT /v1/admin/ai-providers/{provider}` REST).
+3. A user principal exists in the Mastio (created via Frontdesk SSO
+   first login, or pre-provisioned via `POST /v1/admin/users`).
+
+## Minting a token
+
+### Via dashboard (browser)
+
+1. Sign in to the Mastio dashboard at `https://<mastio-host>:9443/proxy/login`.
+2. Navigate to **Users** → click the target user.
+3. Switch to the **API Tokens** tab.
+4. Fill in **Label** (e.g. `Cursor laptop daniele`, `LibreChat staging`),
+   optionally pick scope providers and expiry, click **Mint token**.
+5. The cleartext token appears in an amber banner once. Copy it now —
+   it is never shown again.
+
+### Via curl (CI / Terraform)
+
+```bash
+ADMIN_SECRET="<from MCP_PROXY_ADMIN_SECRET in proxy.env>"
+MASTIO_URL="https://mastio.acme.local:9443"
+
+curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
+  -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal_id": "acme::user::daniele@acme.local",
+    "label": "Cursor laptop daniele"
+  }'
+# Response: {"id":"...","token":"culk_x7q3...j9k2","token_last4":"j9k2",...}
+```
+
+The `token` field is the cleartext credential. Stash it in your password
+manager or pipe it straight to the client config. Subsequent GETs on
+the same row return only `token_last4`.
+
+## Revocation
+
+Both surfaces revoke the same way:
+
+- Dashboard: per-row **Revoke** button in the API Tokens tab.
+- REST: `DELETE /v1/admin/api-tokens/{token_id}` with `X-Admin-Secret`.
+
+Revoke is immediate. Clients holding the revoked token start getting
+`401 Unauthorized` on the next request. Recovery: mint a fresh token,
+distribute it, the client picks up the new credential on its next
+config load.
+
+## What ends up in the audit log
+
+Every `/v1/*` request authenticated with a `culk_*` token writes a
+hash-chained row with:
+
+- `agent_id` = the user principal id (e.g.
+  `acme::user::daniele@acme.local`)
+- `action` = e.g. `egress_llm_chat`
+- `details.principal_type` = `user`
+- `details.model`, `details.provider`, `details.upstream_request_id`
+
+The provider's own API key never appears in the chain. The Cullis
+token id does not appear in egress audit rows (it appears only in
+`api_token.mint` / `api_token.revoke` audit rows, with `details.source`
+distinguishing dashboard from REST provenance).
+
+## Security model recap
+
+- `culk_*` tokens are 256-bit Bearer credentials. Treat them like an
+  Anthropic / OpenAI API key: store in a password manager, never paste
+  into shared chats, rotate periodically.
+- The Mastio stores only a bcrypt hash. A DB leak does not recover
+  the token; revoke + re-mint is the recovery path either way.
+- Tokens are bound to a single user principal. Per-client labels make
+  forensics easy when a client is compromised (revoke that token,
+  others keep working).
+- For higher-assurance clients (workload agents, server-to-server),
+  the cert-based mTLS + DPoP path is still the right choice. API
+  tokens are the OpenAI-compat convenience layer, not a replacement
+  for cert auth.
+
+## See also
+
+- ADR-027 (local: `imp/adrs/adr-027-unified-user-credentials.md`) —
+  formal model and rationale.
+- ADR-025 (`imp/adrs/0025-frontdesk-dual-mode-auth.md`) — dual-mode
+  Frontdesk auth (password local + OIDC). Tokens here are the third
+  credential form alongside those two.
+- ADR-020 (`imp/adrs/adr-020-user-principal-and-quadrants.md`) — user
+  principal first-class.

--- a/docs/integrations/cherry-studio.md
+++ b/docs/integrations/cherry-studio.md
@@ -1,0 +1,169 @@
+# Cherry Studio → Cullis Mastio
+
+[Cherry Studio](https://github.com/CherryHQ/cherry-studio) is a
+desktop chat client for macOS / Windows / Linux. It speaks both the
+OpenAI HTTP protocol and the Anthropic Messages protocol, and has
+first-class MCP server integration. Pointing it at Cullis Mastio
+gives a single Mac user a Cullis-attributed agentic surface without
+spinning up a self-hosted web app.
+
+Topology (desktop single-user):
+
+```
+┌─────────────────┐   /v1/chat/completions    ┌──────────────────┐
+│  Cherry Studio  │ ───────────────────────►  │   Cullis Mastio  │
+│  (Mac desktop)  │   Authorization:          │  (yours, VPS or │
+│                 │   Bearer culk_<...>       │   localhost)     │
+└─────────────────┘                            └──────────────────┘
+```
+
+## 1. Mint a token
+
+Either via the dashboard (Users → your user → API Tokens tab →
+**Mint token**, label e.g. `Cherry Studio laptop`), or via curl:
+
+```bash
+ADMIN_SECRET="<MCP_PROXY_ADMIN_SECRET from proxy.env>"
+MASTIO_URL="https://mastio.acme.local:9443"
+
+curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
+  -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal_id": "acme::user::daniele@acme.local",
+    "label": "Cherry Studio laptop"
+  }'
+# {"token":"culk_x7q3...j9k2", ...}
+```
+
+Copy the `token` value. Subsequent reads only show the last 4 chars.
+
+## 2. Add Cullis as a custom provider
+
+Cherry Studio supports both OpenAI-style and Anthropic-style custom
+endpoints. The Mastio exposes both — pick whichever your usual model
+prefers.
+
+### Option A — OpenAI-compatible (works for all providers)
+
+1. Cherry Studio → **Settings** (gear icon, bottom-left).
+2. **Model Providers** → **Add Custom Provider**.
+3. Fill in:
+   - **Provider Type**: `OpenAI-compatible`
+   - **Name**: `Cullis`
+   - **API Base URL**: `https://mastio.acme.local:9443/v1`
+   - **API Key**: paste your `culk_*` token
+4. Click **Fetch Models** — Cherry Studio queries
+   `GET /v1/models` on the Mastio and populates the dropdown with
+   everything the org has enabled.
+5. **Save**.
+
+### Option B — Anthropic-style (only when you want native Claude tool calls)
+
+The Mastio's embedded LiteLLM serves `/v1/messages` (Anthropic
+protocol) alongside `/v1/chat/completions` (OpenAI protocol). If
+you prefer the native Anthropic surface (e.g. for richer tool-call
+behaviour with Claude models):
+
+1. Settings → Model Providers → **Add Custom Provider**.
+2. Fill in:
+   - **Provider Type**: `Anthropic`
+   - **Name**: `Cullis (Anthropic)`
+   - **API Base URL**: `https://mastio.acme.local:9443`
+     (no `/v1` suffix — Cherry adds `/v1/messages` itself)
+   - **API Key**: same `culk_*` token
+3. Save.
+
+Both options can coexist. You will see them as two separate
+providers in the model picker.
+
+## 3. TLS for the self-signed dev cert
+
+If you are pointing Cherry Studio at a development Mastio bundle
+(self-signed Org CA), the desktop app refuses the connection. Two
+ways out:
+
+- **Trust the Org CA on your laptop** (preferred). Copy
+  `cullis-mastio-bundle/certs/org-ca.pem` from the deployment host to
+  your Mac, then:
+  - macOS: `sudo security add-trusted-cert -d -r trustRoot -k
+    /Library/Keychains/System.keychain org-ca.pem`
+  - Linux: copy to `/usr/local/share/ca-certificates/` and run
+    `sudo update-ca-certificates`.
+  - Windows: import into **Trusted Root Certification Authorities**
+    via `certmgr.msc`.
+- **Use the Mastio behind a real CA** (production). Front the Mastio
+  with Caddy / nginx terminating Let's Encrypt and point Cherry at
+  the public hostname.
+
+## 4. MCP servers (the agentic part)
+
+Cherry Studio's headline feature is MCP integration. The Cullis
+Connector itself ships an MCP server you can expose to Cherry. This
+gives the chat model tools like `cullis.send_oneshot`,
+`cullis.list_agents`, `cullis.inbox` — turning Cherry into a
+fully-fledged Cullis agentic frontend.
+
+Setup is independent from the API token above. See the Connector
+desktop docs (`docs/connector/quickstart.md`) for the MCP install
+flow (`cullis-connector install-mcp --client cherry-studio`). The
+MCP path runs over local stdio; the API token + Mastio path runs
+over HTTPS. The two can coexist.
+
+## 5. Verify
+
+In Cherry Studio:
+
+1. Start a new conversation.
+2. Pick a model from the **Cullis** provider you just added.
+3. Send `hello`.
+
+Cross-check on the Mastio:
+
+```bash
+# from any shell that can reach the Mastio
+curl -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+  "${MASTIO_URL}/v1/admin/api-tokens?principal_id=acme::user::daniele@acme.local" \
+  | jq '.tokens[0] | {last_used_at, last_used_ip}'
+```
+
+You should see `last_used_at` updated to within the last few
+seconds, and `last_used_ip` set to your laptop's address (or the
+trusted-proxy IP if you're behind one).
+
+## Troubleshooting
+
+### "Connection refused" / network error
+
+- Confirm the URL: include `https://` and the port (`:9443` for the
+  bundle default).
+- Test from the same machine: `curl -v
+  "https://mastio.acme.local:9443/healthz"`. If that fails, the
+  problem is networking (firewall, DNS), not Cherry.
+
+### "Unauthorized" / 401
+
+- The token is wrong, revoked, or expired. Re-mint and re-paste.
+
+### Model dropdown is empty after "Fetch Models"
+
+- The Mastio has no enabled AI provider yet. Sign in to the Mastio
+  dashboard at `/proxy/ai-providers` and configure at least one
+  (Anthropic with a valid `sk-ant-*` key is the easiest).
+
+### Tools / function calls don't work
+
+The Mastio normalises tool-call schemas between OpenAI and Anthropic
+formats. Some edge cases (parallel tool calls, ultra-recent model
+features) lag behind the upstream provider. If you hit one, try the
+Anthropic-style provider (option B above) for Claude models —
+native pass-through has fewer translation pitfalls.
+
+## Single-user vs multi-user trade-off
+
+Cherry Studio is desktop single-user by design. If you want the same
+Cullis-attributed chat experience for multiple people in your team,
+[LibreChat](librechat.md) is the better fit — same Mastio backend,
+multi-user web UI. Both deployments can talk to the same Mastio at
+the same time; they show up as different `last_used_ip` values in
+the token's audit metadata.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,181 @@
+# Cursor → Cullis Mastio
+
+[Cursor](https://cursor.com) is an AI-first IDE based on VSCode. It
+supports OpenAI-compatible custom endpoints, so you can route Cursor's
+chat, edit, and agent operations through Cullis Mastio. Every model
+call is attributed to your Cullis user principal in the audit chain.
+
+Topology:
+
+```
+┌──────────────────┐   /v1/chat/completions    ┌──────────────────┐
+│      Cursor      │ ───────────────────────►  │   Cullis Mastio  │
+│  (Mac/Win IDE)   │   Authorization:          │  (yours)         │
+│                  │   Bearer culk_<...>       │                  │
+└──────────────────┘                            └──────────────────┘
+```
+
+## Important caveat up front
+
+Cursor's **agentic** features (Composer, Agents, multi-step edits)
+make heavy use of provider-specific extensions to the chat completion
+API — tool-call streaming patterns, system prompt injection,
+context-window stuffing. The Mastio's embedded LiteLLM normalises
+the common subset, but some agentic operations may degrade or fail
+when routed through a custom endpoint.
+
+What works reliably today:
+
+- Chat panel (`Cmd+L` / `Ctrl+L`) — standard chat with any model
+  the Mastio has configured.
+- Inline edit (`Cmd+K` / `Ctrl+K`) — works with OpenAI-format models
+  and with Claude via the Anthropic-compatible normaliser.
+
+What may misbehave:
+
+- Composer multi-step agents on Claude 4.x with tool calls — known
+  edge cases around parallel tool calls. Fall back to OpenAI models
+  for now, or use the native Anthropic provider in Cursor (bypassing
+  Cullis) for those flows.
+- Cursor Tab and code autocompletion — these use Cursor's own models
+  on Cursor's infrastructure regardless of your custom endpoint
+  setting. Cullis cannot intercept them.
+
+## 1. Mint a token
+
+Either via the dashboard or via curl. See the
+[README mint section](README.md#minting-a-token) for both.
+
+Example via curl:
+
+```bash
+ADMIN_SECRET="<MCP_PROXY_ADMIN_SECRET>"
+MASTIO_URL="https://mastio.acme.local:9443"
+
+curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
+  -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal_id": "acme::user::daniele@acme.local",
+    "label": "Cursor laptop daniele"
+  }'
+```
+
+## 2. Configure Cursor
+
+1. Open Cursor → **Cursor Settings** (`Cmd+,` on Mac).
+2. Navigate to **Models**.
+3. Toggle off all built-in providers if you want all traffic through
+   Cullis. (You can also keep them on and add Cullis as one provider
+   among many.)
+4. Scroll down to **OpenAI API Key** section → click **Override OpenAI
+   Base URL**.
+5. Fill in:
+   - **API Base URL**: `https://mastio.acme.local:9443/v1`
+   - **API Key**: paste your `culk_*` token
+6. In **Models**, type the model name you want to use (e.g.
+   `claude-sonnet-4-6`) and click **Add Model**. Cursor doesn't auto-
+   discover from `/v1/models`; you have to type each model id
+   explicitly. This is a Cursor limitation, not a Cullis one.
+7. **Verify** — Cursor pings the endpoint with the listed models;
+   green checkmark on success.
+
+If you want to use Anthropic-style models with Cursor's Claude path
+(more reliable for tool-heavy agentic flows), the Mastio also serves
+`/v1/messages` natively. Cursor doesn't expose an Anthropic-style
+custom endpoint in the OSS-builds UI, but if you have an
+Anthropic-flavoured Pro plan integration, point its base URL at the
+same Mastio host (no `/v1` suffix).
+
+## 3. TLS for self-signed dev cert
+
+In production, front the Mastio with a real CA (Let's Encrypt via
+Caddy or nginx). In dev with the bundle's self-signed cert, install
+the bundle's Org CA into the Mac keychain:
+
+```bash
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain \
+  /path/to/cullis-mastio-bundle/certs/org-ca.pem
+```
+
+Then restart Cursor. The connection should succeed.
+
+## 4. Verify
+
+In Cursor:
+
+1. Open the chat panel (`Cmd+L`).
+2. Pick a Cullis-routed model from the model dropdown.
+3. Ask `say hi`.
+
+Cross-check on the Mastio dashboard at `/proxy/users` → your user →
+**API Tokens** tab. The `last_used_at` column for the Cursor token
+should show the timestamp of your chat. If it doesn't update, the
+request either never left Cursor (check Network in Cursor's developer
+tools) or the Mastio rejected it before the resolver touched the row
+(check the Mastio logs).
+
+## 5. Audit chain
+
+Every Cursor chat lands a hash-chained audit row with:
+
+- `agent_id`: your user principal id
+- `action`: `egress_llm_chat`
+- `details.model`: the model you picked
+- `details.provider`: which upstream the Mastio routed to
+  (Anthropic / OpenAI / etc — managed in `/proxy/ai-providers`)
+- `details.cost_usd`: when the upstream returns it (usage tokens × pricing)
+
+Browse the chain at `/proxy/audit` in the Mastio dashboard, or query
+via SQL on the proxy DB. The hash chain means an admin trying to
+selectively delete a row breaks the chain — full integrity guarantee
+out of the box.
+
+## Troubleshooting
+
+### "Verify" button red, no error message
+
+Cursor verifies models one-by-one by sending a minimal request. The
+failure could be:
+
+- TLS: see section 3.
+- Model not configured in the Mastio: the model id you typed
+  (`claude-sonnet-4-6`) must match exactly what an enabled provider
+  in `/proxy/ai-providers` exposes. Inspect: `curl -H "Authorization:
+  Bearer ${TOKEN}" "${MASTIO_URL}/v1/models" | jq '.data[].id'`.
+
+### Chat works but Composer / Agents fails
+
+Known limitation. The agentic surface uses provider-specific extensions
+that don't always round-trip through normalisation. Workarounds:
+
+- Use simpler models (Haiku-4.5 instead of Opus-4.7) for Composer
+  flows. Less tool-call complexity tends to survive.
+- Fall back to Cursor's native Anthropic / OpenAI providers for
+  agentic flows (loses audit attribution for those calls, but the
+  feature works).
+- File an issue on the Cullis repo with the failing payload — we
+  can extend the LiteLLM normaliser for common Cursor patterns.
+
+### Cursor Tab (inline autocomplete) doesn't use Cullis
+
+By design. Cursor Tab is a separate service on Cursor's own
+infrastructure. It is not exposed via the custom endpoint mechanism.
+Only chat + inline edit + Composer use the custom endpoint setting.
+
+## Multi-machine setup
+
+If you use Cursor on multiple machines (laptop + desktop), mint
+**two** tokens with distinct labels:
+
+```bash
+# Laptop
+curl ... -d '{"principal_id":"...","label":"Cursor — laptop"}'
+# Desktop
+curl ... -d '{"principal_id":"...","label":"Cursor — desktop"}'
+```
+
+This way `last_used_ip` audit metadata tells you which machine made
+each call, and you can revoke one without disrupting the other (e.g.
+laptop stolen → revoke the laptop token, desktop keeps working).

--- a/docs/integrations/librechat.md
+++ b/docs/integrations/librechat.md
@@ -1,0 +1,184 @@
+# LibreChat → Cullis Mastio
+
+[LibreChat](https://github.com/danny-avila/LibreChat) is a self-hosted
+multi-user web app that speaks the OpenAI HTTP protocol. Pointing it at
+Cullis Mastio gives every LibreChat conversation a verifiable user
+principal in the Mastio audit chain, with zero changes to the LibreChat
+UX your users already know.
+
+Topology:
+
+```
+┌──────────────────┐   /v1/chat/completions    ┌──────────────────┐
+│   LibreChat      │ ───────────────────────►  │   Cullis Mastio  │
+│ (web, multi-user)│   Authorization:          │  (yours)          │
+│                  │   Bearer culk_<...>       │                   │
+└──────────────────┘                            └────────┬─────────┘
+                                                         │
+                                                         │ org-wide provider creds
+                                                         ▼
+                                              ┌──────────────────┐
+                                              │  Anthropic / ... │
+                                              └──────────────────┘
+```
+
+Two integration modes, pick one:
+
+- **Per-user API key** (no LibreChat modifications): each LibreChat
+  user pastes their own Cullis token in their profile. Recommended
+  for the first deployment — keeps the LibreChat user list and the
+  Cullis user list independent.
+- **Single shared key + X-Forwarded-User** (advanced): one Cullis
+  token for the whole LibreChat instance, with per-request user
+  attribution via the proxy header. Requires a Cullis-side flag not
+  yet shipped (planned). Skip for now.
+
+## Per-user API key (recommended)
+
+### 1. Mint a token per LibreChat user
+
+For each LibreChat user that should be a Cullis principal, mint a
+token associated with the corresponding user principal:
+
+```bash
+ADMIN_SECRET="<MCP_PROXY_ADMIN_SECRET from proxy.env>"
+MASTIO_URL="https://mastio.acme.local:9443"
+
+curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
+  -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "principal_id": "acme::user::alice@acme.local",
+    "label": "LibreChat — alice"
+  }'
+# {"token":"culk_x7q3...j9k2", ...}
+```
+
+Save the cleartext `token` value. You will paste it into LibreChat
+under Alice's profile.
+
+If you prefer the dashboard, see the
+[README mint section](README.md#minting-a-token).
+
+### 2. Add the Cullis endpoint to `librechat.yaml`
+
+In your LibreChat config (`librechat.yaml`), add a custom OpenAI
+endpoint pointing at the Mastio:
+
+```yaml
+version: 1.2.1
+cache: true
+
+endpoints:
+  custom:
+    - name: "Cullis"
+      apiKey: "${OPENAI_API_KEY}"
+      # User-supplied key: each LibreChat user pastes their own
+      # culk_ token in their profile. The literal "${OPENAI_API_KEY}"
+      # tells LibreChat to use the request-time per-user key instead
+      # of a server-wide env var.
+      baseURL: "https://mastio.acme.local:9443/v1"
+      models:
+        default: ["claude-haiku-4-5"]
+        # Live discovery: LibreChat hits /v1/models on the Mastio
+        # and shows whatever the org has configured + enabled.
+        fetch: true
+      titleConvo: true
+      titleModel: "claude-haiku-4-5"
+      # The Mastio's TLS leaf is signed by the org's Org CA. In dev
+      # / self-signed deploys, either mount the Org CA bundle into
+      # the LibreChat container, or set the following for the
+      # development bundle:
+      # tls: { rejectUnauthorized: false }   # NEVER in production
+```
+
+Restart LibreChat. If you use the docker-compose bundle, that is
+`docker compose restart api`.
+
+### 3. Each user pastes their token
+
+Each LibreChat user logs in to LibreChat and:
+
+1. Click their avatar → **Settings**.
+2. Open the **Models** or **Account** tab (location varies by
+   LibreChat version).
+3. Find the **Cullis** custom endpoint they just configured.
+4. Paste their `culk_*` token under **API Key**.
+5. Save and refresh the chat page.
+
+The model dropdown now shows whatever the Mastio admin has
+configured + enabled in `/proxy/ai-providers` — Claude, GPT-4,
+Gemini, Bedrock, Vertex, Ollama. Pick one, chat, audit chain attributes
+the request to that user.
+
+## Verify
+
+A successful first chat should produce:
+
+- LibreChat: regular conversation response.
+- Mastio audit log (browser at `/proxy/audit` or `tail` the container
+  stderr): one row per request with `agent_id=acme::user::alice@acme.local`,
+  `action=egress_llm_chat`, `details.model=<the model you picked>`.
+- Mastio dashboard → Users → Alice → API Tokens tab: the
+  `last_used_at` column shows the timestamp of the call.
+
+## Troubleshooting
+
+### 401 on every chat
+
+The token is wrong, revoked, or expired. Check:
+
+- `curl -i -H "Authorization: Bearer ${TOKEN}" "${MASTIO_URL}/v1/models"`.
+  - If `401`, the token is not valid. Re-mint from the dashboard.
+  - If `200` but LibreChat still 401, LibreChat is sending the wrong
+    `Authorization` header. Inspect LibreChat logs: `docker compose
+    logs api | grep -i auth`.
+
+### `connect ECONNREFUSED` or `unable to verify the first certificate`
+
+Mastio is reachable on the address but TLS verification fails. In
+production, mount your org's CA bundle into the LibreChat container
+and set `NODE_EXTRA_CA_CERTS` to it. In dev, the bundle's self-signed
+cert needs explicit trust — see the commented `tls.rejectUnauthorized`
+line above. Do not ship `rejectUnauthorized: false` to production.
+
+### Wrong model list
+
+LibreChat shows fewer/different models than expected:
+
+- Confirm the Mastio's `/v1/models` returns what you expect:
+  `curl -H "Authorization: Bearer ${TOKEN}" "${MASTIO_URL}/v1/models"`.
+- The list comes from `ai_provider_credentials` rows with `enabled=true`.
+  Toggle providers in `/proxy/ai-providers` if needed.
+
+### Tool calls behave inconsistently
+
+LibreChat agents v2 emit OpenAI-flavoured tool calls. The Mastio's
+embedded LiteLLM normalises them to the upstream provider's format
+(Anthropic / Bedrock / etc). Some edge cases (parallel tool calls
+against Claude) may not round-trip cleanly today. Workaround: pick a
+provider whose native tool-call format matches what LibreChat emits
+(OpenAI native is the safest), or disable agents v2 and use single-shot
+chat for that conversation.
+
+## Rotation
+
+To rotate Alice's token without disrupting other users:
+
+1. Mastio dashboard → Users → Alice → API Tokens → **Revoke** the
+   active row.
+2. **Mint token** new row with the same label.
+3. Send Alice the new value out-of-band.
+4. Alice pastes it in LibreChat **API Key** field. Old chats are
+   preserved, new requests use the new token.
+
+Or via REST:
+
+```bash
+curl -X DELETE "${MASTIO_URL}/v1/admin/api-tokens/${OLD_TOKEN_ID}" \
+  -H "X-Admin-Secret: ${ADMIN_SECRET}"
+curl -X POST "${MASTIO_URL}/v1/admin/api-tokens" \
+  -H "X-Admin-Secret: ${ADMIN_SECRET}" \
+  -H "Content-Type: application/json" \
+  -d '{"principal_id":"acme::user::alice@acme.local","label":"LibreChat — alice (rotated)"}'
+```


### PR DESCRIPTION
## Summary

Final slice of ADR-027 Phase 1. Customer-facing how-to docs for the three reference OpenAI-compat clients, with concrete copy-paste configs against a stock Mastio deployment.

## Files

| Path | Audience |
|---|---|
| `docs/integrations/README.md` | Overview: topology, mint, revoke, audit, security model |
| `docs/integrations/librechat.md` | Self-hosted multi-user web — per-user API key path with `librechat.yaml` snippet |
| `docs/integrations/cherry-studio.md` | Desktop single-user — OpenAI + Anthropic options, MCP cross-ref, TLS install |
| `docs/integrations/cursor.md` | IDE, agentic — caveat upfront, step-by-step, Composer limitations, multi-machine strategy |

## What this unlocks

A customer follows a single page end-to-end from "I have a Cullis Mastio at <url>" to "Cherry Studio on my Mac chats through it with audit + identity attribution". The three reference clients cover ~80% of the OpenAI-compat ecosystem patterns; AnythingLLM / OpenWebUI / n8n / Zapier all fit the same templates.

## Closes ADR-027 Phase 1

After this PR the five-slice Phase 1 is complete:

| PR | Cosa |
|---|---|
| #590 | schema + DB helpers |
| #591 | auth resolver |
| #592 | admin REST endpoints |
| #593 | dashboard HTMX UI |
| **#594** | **docs (this one)** |

Phase 2-4 (Connector locale accepts culk_ tokens, user self-service mint, local.token deprecation) remain ADR-deferred — pending VPS customer test feedback to see which actually moves the pitch.

## Test plan

- [x] Markdown renders cleanly (no broken anchors)
- [ ] First customer (VPS test) follows the README + chosen integration page end-to-end with zero out-of-band help
- [ ] Feedback collected on which sections are ambiguous

## Out of scope

- Docs site rendering (these are markdown in `docs/`, picked up by the static site build automatically)
- Translation IT/EN (English baseline; IT translation if/when needed for community)
- Per-feature deep dive (this is how-to, not reference)

## Refs

ADR-027 (local in `imp/adrs/`). Builds on ADR-020 (user principal), ADR-021 (multi-user KMS), ADR-025 (Frontdesk dual-mode auth).