### PR TITLE
fix(mastio-bundle): add mastio-nginx + mcp-proxy to default NGINX_SAN + docs

### DIFF
--- a/docs/integrations/librechat.md
+++ b/docs/integrations/librechat.md
@@ -63,7 +63,10 @@ If you prefer the dashboard, see the
 ### 2. Add the Cullis endpoint to `librechat.yaml`
 
 In your LibreChat config (`librechat.yaml`), add a custom OpenAI
-endpoint pointing at the Mastio:
+endpoint pointing at the Mastio. The right `baseURL` depends on your
+topology:
+
+**A. Production / VPS** — Mastio behind a real CA at a public hostname:
 
 ```yaml
 version: 1.2.1
@@ -85,11 +88,59 @@ endpoints:
         fetch: true
       titleConvo: true
       titleModel: "claude-haiku-4-5"
-      # The Mastio's TLS leaf is signed by the org's Org CA. In dev
-      # / self-signed deploys, either mount the Org CA bundle into
-      # the LibreChat container, or set the following for the
-      # development bundle:
-      # tls: { rejectUnauthorized: false }   # NEVER in production
+```
+
+**B. Dev / same docker host** — LibreChat joins
+``cullis-mastio_proxy_net`` so it can resolve the Mastio via docker
+DNS:
+
+```yaml
+version: 1.2.1
+cache: true
+
+endpoints:
+  custom:
+    - name: "Cullis"
+      apiKey: "${OPENAI_API_KEY}"
+      # Same-host docker compose: speak HTTPS to the nginx sidecar by
+      # its container name. Requires the cert to have ``mastio-nginx``
+      # in its SAN list — the bundle ships this by default (proxy.env
+      # ``MCP_PROXY_NGINX_SAN``). If you're on an older bundle that
+      # doesn't include it, either regenerate proxy.env with the new
+      # default or fall back to plain HTTP on the in-network mcp-proxy
+      # port: ``baseURL: "http://mcp-proxy:9100/v1"``. HTTP plain is
+      # acceptable here because the bridge network is the trust
+      # boundary; never expose port 9100 outside the host.
+      baseURL: "https://mastio-nginx:9443/v1"
+      models:
+        default: ["claude-haiku-4-5"]
+        fetch: true
+      titleConvo: false
+      # Mount the org CA into the LibreChat container so Node trusts
+      # the self-signed leaf:
+      #   volumes:
+      #     - ./cullis-mastio-bundle/certs/org-ca.pem:/app/certs/org-ca.pem:ro
+      #   environment:
+      #     - NODE_EXTRA_CA_CERTS=/app/certs/org-ca.pem
+```
+
+To put LibreChat on the same network as the Mastio bundle, in your
+LibreChat `docker-compose.yml`:
+
+```yaml
+services:
+  api:
+    # ... existing config ...
+    networks:
+      - librechat
+      - mastio
+
+networks:
+  librechat:
+    driver: bridge
+  mastio:
+    external: true
+    name: cullis-mastio_proxy_net
 ```
 
 Restart LibreChat. If you use the docker-compose bundle, that is
@@ -138,9 +189,32 @@ The token is wrong, revoked, or expired. Check:
 
 Mastio is reachable on the address but TLS verification fails. In
 production, mount your org's CA bundle into the LibreChat container
-and set `NODE_EXTRA_CA_CERTS` to it. In dev, the bundle's self-signed
-cert needs explicit trust — see the commented `tls.rejectUnauthorized`
-line above. Do not ship `rejectUnauthorized: false` to production.
+and set `NODE_EXTRA_CA_CERTS=/path/to/org-ca.pem`. In dev, the
+bundle's self-signed cert needs explicit trust — see the
+``volumes`` + ``NODE_EXTRA_CA_CERTS`` snippet in section 2B.
+
+### `Host: mastio-nginx is not in the cert's altnames`
+
+You're hitting `https://mastio-nginx:9443/v1` from a LibreChat
+container on the bundle's docker network, but the Mastio's TLS leaf
+was minted before ``mastio-nginx`` was added to ``MCP_PROXY_NGINX_SAN``
+(default added in the 2026-05-11 bundle update).
+
+Two fixes:
+
+1. **Regenerate the cert with the updated SAN**:
+   ```bash
+   cd cullis-mastio-bundle/
+   # Edit proxy.env to add mastio-nginx,mcp-proxy to MCP_PROXY_NGINX_SAN
+   # then restart — the Mastio regenerates the cert on next boot.
+   ./deploy.sh --down && ./deploy.sh
+   ```
+
+2. **Switch the LibreChat baseURL to plain HTTP on the in-network
+   mcp-proxy port**: ``baseURL: "http://mcp-proxy:9100/v1"``. This
+   bypasses TLS entirely, which is acceptable because the docker
+   bridge network is itself the trust boundary. Never expose port
+   9100 outside the host.
 
 ### Wrong model list
 

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -67,12 +67,16 @@ services:
       MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-https://host.docker.internal:9443}
       MCP_PROXY_ALLOWED_ORIGINS:   ${MCP_PROXY_ALLOWED_ORIGINS:-}
       MCP_PROXY_NGINX_CERT_DIR:    ${MCP_PROXY_NGINX_CERT_DIR:-/var/lib/mastio/nginx-certs}
-      # SAN covers the three host-side names the cert can validate at:
+      # SAN covers the names the cert can validate at:
       # ``localhost`` (host browser default), ``mastio.local`` (legacy
-      # alias), ``host.docker.internal`` (sibling container scenario,
-      # PR #520+ default). Any custom public URL is added in front of
-      # this list by ./deploy.sh during proxy.env generation.
-      MCP_PROXY_NGINX_SAN:         ${MCP_PROXY_NGINX_SAN:-mastio.local,localhost,host.docker.internal}
+      # alias), ``host.docker.internal`` (sibling bundle scenario via
+      # host-gateway), ``mastio-nginx`` + ``mcp-proxy`` (third-party
+      # container in shared docker network — LibreChat / Cherry / n8n
+      # / AnythingLLM joining ``cullis-mastio_proxy_net`` and speaking
+      # HTTPS to those container names). Any custom public URL is
+      # added in front of this list by ./deploy.sh during proxy.env
+      # generation.
+      MCP_PROXY_NGINX_SAN:         ${MCP_PROXY_NGINX_SAN:-mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy}
       SSL_CERT_FILE:               ${MCP_PROXY_BROKER_CA_BUNDLE:-}
       REQUESTS_CA_BUNDLE:          ${MCP_PROXY_BROKER_CA_BUNDLE:-}
       MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -89,8 +89,7 @@ MCP_PROXY_PORT=9443
 MCP_PROXY_NGINX_CERT_DIR=/var/lib/mastio/nginx-certs
 
 # SAN(s) baked into the nginx server cert. Comma-separated for multi-
-# host. Default covers the three host-side names a sibling bundle (or
-# host-side curl) may reach this Mastio at:
+# host. Default covers five names a client may reach this Mastio at:
 #
 #   * ``mastio.local``           — legacy alias retained for back-compat
 #   * ``localhost``              — host browser default
@@ -105,10 +104,24 @@ MCP_PROXY_NGINX_CERT_DIR=/var/lib/mastio/nginx-certs
 #                                  handshake (``Hostname mismatch,
 #                                  certificate is not valid for
 #                                  'host.docker.internal'``).
+#   * ``mastio-nginx``           — name of the nginx sidecar container
+#                                  on the bundle's docker network. A
+#                                  third-party container (LibreChat,
+#                                  Cherry Studio in docker, n8n,
+#                                  AnythingLLM, ...) that joins
+#                                  ``cullis-mastio_proxy_net`` and
+#                                  speaks HTTPS to ``mastio-nginx:9443``
+#                                  needs this SAN to validate the cert.
+#                                  Without it the client falls back to
+#                                  HTTP plain ``mcp-proxy:9100`` or
+#                                  fails handshake.
+#   * ``mcp-proxy``              — name of the Mastio mcp-proxy
+#                                  container. Same reason, included for
+#                                  symmetry with the above.
 #
 # Override with the operator's actual hostnames in production (the cert
 # is regenerated on the next Mastio boot if SAN changes).
-MCP_PROXY_NGINX_SAN=mastio.local,localhost,host.docker.internal
+MCP_PROXY_NGINX_SAN=mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy
 
 # ADR-006 standalone mode (default after ADR-014 PR-D). True = the
 # Mastio runs as a self-contained mini-broker, derives its own Org CA,


### PR DESCRIPTION
## Summary

Customer-path fix discovered by LibreChat → Mastio docker smoke today. The bundle's nginx cert SAN didn't include the bundle's own container names, so any third-party container joining `cullis-mastio_proxy_net` and speaking HTTPS to `mastio-nginx:9443` failed TLS verification.

## Bug

```
Hostname/IP does not match certificate's altnames: Host: mastio-nginx.
is not in the cert's altnames: DNS:mastio.local, DNS:localhost,
DNS:host.docker.internal
```

LibreChat (and any other OpenAI-compat client running on the same docker host) cannot validate the cert. Workaround was plain HTTP on `mcp-proxy:9100`, but the strategic recommendation in `docs/integrations/librechat.md` is HTTPS within the docker network too. Cert needs to validate.

## Fix

Add `mastio-nginx` + `mcp-proxy` to the default SAN list in both `proxy.env.example` (operator-edited template) and `docker-compose.yml` (compose fallback when env-file is missing). Comments expanded inline.

## Docs

`docs/integrations/librechat.md` reorganised:
- Section 2 split into **2A Production/VPS** (public hostname behind real CA) and **2B Dev/same docker host** (joins `cullis-mastio_proxy_net`, HTTPS to `mastio-nginx`, mounts org CA inline)
- New troubleshooting entry for the `not in altnames` failure with two fix paths (regenerate cert / fall back to HTTP plain)

## Backward compat

- Customers with an old `proxy.env` keep their old SAN list (env-file wins). To get the new entries: regenerate via `./generate-proxy-env.sh --force` or hand-edit, then `./deploy.sh --down && ./deploy.sh` to force a fresh nginx cert.
- New customers automatically get the 5-element default.

## Test plan

- [x] `docker compose --env-file proxy.env.example config` parses, the SAN var resolves to the new 5-element list
- [ ] Re-run LibreChat docker smoke against a freshly-regenerated cert — will exercise the HTTPS path inside the docker network (TODO before next customer demo, not blocker for VPS test where public CA terminates anyway)

## Refs

- Memo `feedback_mastio_nginx_san_container_name` (root cause analysis)
- Memo `project_smoke_librechat_mastio_e2e` (smoke that surfaced it)
- Builds on ADR-027 PR #594 (LibreChat integration docs)