### PR TITLE
feat(dashboard): Mastio Users page mints registry-only rows when Frontdesk is absent

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3285,23 +3285,28 @@ async def users_page(request: Request):
 
 @router.post("/users/create")
 async def users_create(request: Request):
-    """Create a user on the Frontdesk Ambassador.
+    """Create a user. Two paths depending on the deployment topology:
 
-    The Mastio mints a one-time temp password, forwards it to the
-    Frontdesk together with the user metadata, surfaces it to the admin
-    on the redirect, and forgets it. We do not log the value anywhere.
+    1. **Frontdesk Ambassador configured** (``MCP_PROXY_FRONTDESK_AMBASSADOR_URL``
+       set): the Mastio mints a one-time temp password, forwards it to the
+       Frontdesk together with the user metadata, surfaces it to the admin
+       on the redirect, and forgets it. The Frontdesk's ``users.db`` holds
+       the bcrypt hash; the Mastio never logs the value anywhere.
+
+    2. **Registry-only fallback** (no Frontdesk, no SSO): writes a row in
+       ``local_user_principals`` without any credential. Used when the
+       deployment authenticates clients via ADR-027 ``culk_*`` API tokens
+       — the admin pre-creates the user principal here, then mints a
+       Bearer token from the user detail page's API Tokens tab. No
+       password, no IdP, no temp credential to distribute. Workable for
+       VPS demos where the customer points LibreChat / Cursor / Cherry
+       Studio at the Mastio with token auth.
     """
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return session
     if not await verify_csrf(request, session):
         return RedirectResponse("/proxy/users?error=csrf", status_code=303)
-
-    if _frontdesk_admin_target() is None:
-        return RedirectResponse(
-            "/proxy/users?error=Frontdesk+not+configured",
-            status_code=303,
-        )
 
     form = await request.form()
     user_name = (form.get("user_name") or "").strip()
@@ -3311,6 +3316,83 @@ async def users_create(request: Request):
             "/proxy/users?error=user_name+is+required",
             status_code=303,
         )
+
+    # Registry-only fallback path — no Frontdesk to delegate to.
+    if _frontdesk_admin_target() is None:
+        from urllib.parse import quote
+        from mcp_proxy.db import get_config, get_db, log_audit
+        from sqlalchemy import text
+        try:
+            # Prefer app.state.agent_manager.org_id (set at lifespan
+            # start, source of truth), fall back to proxy_config table
+            # for legacy deployments that pre-date the agent_manager
+            # singleton.
+            mgr = getattr(request.app.state, "agent_manager", None)
+            org_id = getattr(mgr, "org_id", None) if mgr is not None else None
+            if not org_id:
+                org_id = await get_config("org_id") or ""
+            if not org_id:
+                return RedirectResponse(
+                    "/proxy/users?error=Mastio+org_id+not+initialised",
+                    status_code=303,
+                )
+            principal_id = f"{org_id}::user::{user_name}"
+            async with get_db() as conn:
+                result = await conn.execute(
+                    text(
+                        "SELECT 1 FROM local_user_principals "
+                        "WHERE principal_id = :pid"
+                    ),
+                    {"pid": principal_id},
+                )
+                if result.first() is not None:
+                    return RedirectResponse(
+                        f"/proxy/users?error=User+{user_name}+already+exists",
+                        status_code=303,
+                    )
+                await conn.execute(
+                    text(
+                        """
+                        INSERT INTO local_user_principals
+                        (principal_id, user_name, display_name, reach,
+                         surface, created_at)
+                        VALUES (:pid, :uname, :dname, 'intra', 'registry',
+                                datetime('now'))
+                        """
+                    ),
+                    {
+                        "pid": principal_id,
+                        "uname": user_name,
+                        "dname": display_name,
+                    },
+                )
+            await log_audit(
+                agent_id=(
+                    getattr(session, "principal_id", None)
+                    or getattr(session, "username", None)
+                    or "dashboard-admin"
+                ),
+                action="user.create",
+                status="success",
+                details={
+                    "event": "user.create",
+                    "source": "registry-only",
+                    "principal_id": principal_id,
+                    "user_name": user_name,
+                    "display_name": display_name,
+                },
+            )
+            return RedirectResponse(
+                f"/proxy/users/{quote(principal_id, safe='')}"
+                "?ok=Registry+row+created+-+mint+an+API+token+to+grant+access",
+                status_code=303,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log.exception("users_create registry-only failed: %s", exc)
+            return RedirectResponse(
+                "/proxy/users?error=Failed+to+create+registry+row",
+                status_code=303,
+            )
 
     temp_password = _generate_temp_password()
     status_code, body, transport_err = await _frontdesk_admin_call(

--- a/mcp_proxy/dashboard/templates/users.html
+++ b/mcp_proxy/dashboard/templates/users.html
@@ -51,7 +51,6 @@
                 Identity registry · credentials live at the Source
             </p>
         </div>
-        {% if frontdesk_enabled %}
         <button onclick="document.getElementById('create-panel').classList.toggle('hidden')"
                 class="px-4 py-2 text-xs font-semibold rounded transition-all"
                 style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
@@ -59,7 +58,6 @@
                 onmouseout="this.style.background='#00e5c7'; this.style.boxShadow='none'">
             + Create User
         </button>
-        {% endif %}
     </div>
 
     {# Context banner — Mastio is the control plane (lifecycle + audit),
@@ -74,12 +72,15 @@
         holds multi-user passwords, the
         <strong class="text-gray-300">Connector desktop</strong> holds
         laptop keypairs, <strong class="text-gray-300">SSO</strong>
-        rows are governed at the IdP. Create / reset / delete from this
-        page forwards the call to the right canale — the Mastio never
-        sees the plaintext password.
+        rows are governed at the IdP, and
+        <strong class="text-gray-300">ADR-027 API tokens</strong>
+        (<code class="text-accent-400">culk_*</code>) authenticate
+        OpenAI-compat clients (LibreChat / Cursor / Cherry Studio)
+        without a Source at all — mint them from the user detail page.
+        Create / reset / delete from this page forwards the call to the
+        right canale — the Mastio never sees the plaintext password.
     </div>
 
-    {% if frontdesk_enabled %}
     <!-- Create User panel (hidden by default) -->
     <div id="create-panel" class="hidden mb-6 bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
         <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">New User</h3>
@@ -102,10 +103,19 @@
                     <p class="text-[10px] text-gray-600 mt-1">Optional label. Falls back to user name.</p>
                 </div>
             </div>
+            {% if frontdesk_enabled %}
             <p class="text-[10px] text-gray-500 flex items-start gap-1.5">
                 <svg class="w-3 h-3 text-emerald-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
-                The Mastio generates a 20-char temp password, forwards it to the Frontdesk Ambassador, and shows it to you here once. The user is forced to rotate it at first sign-in.
+                Frontdesk Ambassador is configured. The Mastio generates a 20-char temp password, forwards it to the Frontdesk, and shows it to you here once. The user is forced to rotate it at first sign-in.
             </p>
+            {% else %}
+            <p class="text-[10px] text-gray-500 flex items-start gap-1.5">
+                <svg class="w-3 h-3 text-accent-400 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                <span>
+                    <strong class="text-gray-300">Registry-only mode</strong> — Frontdesk Ambassador is not configured, no password will be generated. The row appears in the registry only. To grant access, open the user's detail page and mint a <code class="text-accent-400">culk_*</code> API token (ADR-027). The user pastes that token into LibreChat / Cursor / Cherry Studio as the OpenAI-compatible API key.
+                </span>
+            </p>
+            {% endif %}
             <div class="flex items-center gap-3 pt-1">
                 <button type="submit"
                         class="px-5 py-2 text-xs font-semibold rounded transition-all"
@@ -122,7 +132,6 @@
             </div>
         </form>
     </div>
-    {% endif %}
 
     <!-- Table -->
     <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg overflow-hidden backdrop-blur-sm">
@@ -232,11 +241,8 @@
                         </svg>
                         <p class="text-sm text-gray-600">No user principals yet</p>
                         <p class="text-xs text-gray-700 mt-1">
-                            {% if frontdesk_enabled %}
-                            Click <span class="text-accent-400">+ Create User</span> to seed one.
-                            {% else %}
-                            Configure <code>MCP_PROXY_FRONTDESK_AMBASSADOR_URL</code> to enable lifecycle actions, or wait for the first SSO sign-in.
-                            {% endif %}
+                            Click <span class="text-accent-400">+ Create User</span> to seed one
+                            {% if not frontdesk_enabled %}(registry-only, then mint a <code>culk_*</code> token from the user detail page){% endif %}, or wait for the first SSO / Frontdesk sign-in.
                         </p>
                     </td>
                 </tr>

--- a/tests/test_dashboard_users_via_ambassador.py
+++ b/tests/test_dashboard_users_via_ambassador.py
@@ -118,9 +118,13 @@ def test_temp_password_distinct_across_calls():
 
 
 @pytest.mark.asyncio
-async def test_users_create_returns_not_configured_when_frontdesk_missing(
+async def test_users_create_registry_only_when_frontdesk_missing(
     tmp_path, monkeypatch,
 ):
+    """No Frontdesk Ambassador configured = create the registry row
+    directly in ``local_user_principals`` without minting a temp password
+    (ADR-027 path — the admin will mint a ``culk_*`` token from the
+    detail page to grant access)."""
     app = await _spin(tmp_path, monkeypatch, frontdesk=False)
     transport = ASGITransport(app=app)
     async with app.router.lifespan_context(app):
@@ -129,11 +133,51 @@ async def test_users_create_returns_not_configured_when_frontdesk_missing(
             csrf = await _csrf(cli)
             r = await cli.post(
                 "/proxy/users/create",
-                data={"csrf_token": csrf, "user_name": "alice"},
+                data={
+                    "csrf_token": csrf,
+                    "user_name": "alice",
+                    "display_name": "Alice Demo",
+                },
                 follow_redirects=False,
             )
-            assert r.status_code == 303
-            assert "Frontdesk+not+configured" in r.headers["location"]
+            assert r.status_code == 303, r.text
+            loc = r.headers["location"]
+            # Redirect to per-user detail page with a success banner.
+            assert "/proxy/users/td-org%3A%3Auser%3A%3Aalice" in loc, loc
+            assert "Registry+row+created" in loc, loc
+            # Crucially no temp password in the URL — registry-only mode
+            # doesn't mint one.
+            assert "new_pw" not in loc, loc
+
+            # Verify the row landed in local_user_principals.
+            from mcp_proxy.db import get_db
+            from sqlalchemy import text
+            async with get_db() as conn:
+                result = await conn.execute(
+                    text(
+                        "SELECT user_name, display_name, surface "
+                        "FROM local_user_principals "
+                        "WHERE principal_id = 'td-org::user::alice'"
+                    ),
+                )
+                row = result.mappings().first()
+            assert row is not None
+            assert row["user_name"] == "alice"
+            assert row["display_name"] == "Alice Demo"
+            assert row["surface"] == "registry"
+
+            # Second submit with the same name → 303 to ?error=...exists.
+            r2 = await cli.post(
+                "/proxy/users/create",
+                data={
+                    "csrf_token": csrf,
+                    "user_name": "alice",
+                    "display_name": "Alice Two",
+                },
+                follow_redirects=False,
+            )
+            assert r2.status_code == 303
+            assert "already+exists" in r2.headers["location"]
     from mcp_proxy.config import get_settings
     get_settings.cache_clear()
 


### PR DESCRIPTION
## Summary

Closes the UX gap surfaced during the LibreChat demo today. An admin on a Mastio **without** Frontdesk Ambassador and **without** SSO can now register users from the dashboard with a single click — instead of being forced to `curl POST /v1/admin/users`.

## Why

For the ADR-027 deployment pattern (LibreChat / Cursor / Cherry Studio authenticating against the Mastio via `culk_*` Bearer tokens), the user principal needs to exist in the registry before minting a token from the per-user API Tokens tab. Without this PR, the demo flow in `docs/integrations/README.md` had a "now switch to curl" step that broke the "everything from the dashboard" narrative.

Memo: `project_gap_mastio_dashboard_create_user_registry_only` (opened earlier today).

## What changes

| File | Change |
|---|---|
| `mcp_proxy/dashboard/router.py` | `users_create` adds a registry-only fallback when `_frontdesk_admin_target()` is None. Inserts in `local_user_principals` directly, logs `user.create` with `source=registry-only`, redirects to user detail page with banner pointing to ADR-027 token mint |
| `mcp_proxy/dashboard/templates/users.html` | `+ Create User` button + form rendered unconditionally. Inline copy switches based on `frontdesk_enabled`. Page banner enumerates all 4 credential source classes (Frontdesk / Connector / SSO / ADR-027 token) |
| `tests/test_dashboard_users_via_ambassador.py` | Replaces the legacy "not configured" assertion with `test_users_create_registry_only_when_frontdesk_missing` — verifies the row lands in DB with `surface=registry`, banner is `Registry+row+created`, duplicate user_name still 303s |

## Test plan

- [x] `pytest tests/test_dashboard_users_via_ambassador.py` — 10/10 PASS in 22s
- [x] `./sandbox/smoke.sh` — 25/0/1 PASS
- [x] Live: rebuild Mastio docker + redeploy LibreChat smoke stack, click `+ Create User` from dashboard, row appears, user detail page suggests minting `culk_*` token

## Architecture invariant respected

Mastio still doesn't store passwords. Registry-only mode is exactly that — only the principal metadata (user_name, display_name, reach, surface) lands in `local_user_principals`. Credentials still live at the Source (Frontdesk / Connector / SSO / ADR-027 token storage). Memo `feedback_mastio_not_password_store` invariant holds.

## Refs

Builds on ADR-027 PRs #590-#594 + #595. Closes the gap captured in `project_gap_mastio_dashboard_create_user_registry_only`.