### PR TITLE
feat(spa): stop button + retry on the streaming chat turn

### DIFF
--- a/frontend/cullis-chat/src/components/ChatApp.tsx
+++ b/frontend/cullis-chat/src/components/ChatApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { ChatContext, type ChatContextValue } from '../lib/chat-context';
 import { ApiError, chatCompletionStream } from '../lib/api';
 import { ensureSession } from '../lib/session-singleton';
@@ -31,7 +31,8 @@ type Action =
   | { type: 'error'; message: string }
   | { type: 'select_message'; id: string | null }
   | { type: 'set_draft'; text: string }
-  | { type: 'clear_draft' };
+  | { type: 'clear_draft' }
+  | { type: 'truncate_at'; index: number };
 
 function reducer(state: ChatState, action: Action): ChatState {
   switch (action.type) {
@@ -81,6 +82,8 @@ function reducer(state: ChatState, action: Action): ChatState {
       return { ...state, draft: action.text };
     case 'clear_draft':
       return { ...state, draft: undefined };
+    case 'truncate_at':
+      return { ...state, messages: state.messages.slice(0, Math.max(0, action.index)) };
   }
 }
 
@@ -95,6 +98,13 @@ const FLUSH_MS = 60;
 
 function newId(prefix: string): string {
   return `${prefix}_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+function isAbortError(err: unknown): boolean {
+  // `fetch` rejects an AbortController.abort() with a DOMException whose
+  // name is "AbortError"; the ReadableStream reader can also throw the same
+  // shape when its parent signal aborts.
+  return typeof err === 'object' && err !== null && (err as { name?: unknown }).name === 'AbortError';
 }
 
 function reasonOf(err: unknown): string {
@@ -117,6 +127,8 @@ function reasonOf(err: unknown): string {
 export default function ChatApp() {
   const [state, dispatch] = useReducer(reducer, INITIAL);
   const [sessionReady, setSessionReady] = useState(false);
+  // One in-flight stream per chat instance. Stop button aborts via this.
+  const abortRef = useRef<AbortController | null>(null);
 
   // Session init at mount.
   useEffect(() => {
@@ -139,11 +151,15 @@ export default function ChatApp() {
     return () => window.clearTimeout(t);
   }, [state.selectedMessageId]);
 
-  const send = useCallback(async (text: string) => {
+  const send = useCallback(async (text: string, historyOverride?: ChatMessage[]) => {
     if (!sessionReady) {
-      dispatch({ type: 'error', message: 'Session is not ready yet — try again in a moment.' });
+      dispatch({ type: 'error', message: 'Session is not ready yet, try again in a moment.' });
       return;
     }
+    // If a previous stream is still in flight, abort it before starting a new one.
+    // Prevents two concurrent streams stepping on the same placeholder id space.
+    abortRef.current?.abort();
+
     const userMsg: ChatMessage = {
       id: newId('m'),
       role: 'user',
@@ -162,6 +178,9 @@ export default function ChatApp() {
     dispatch({ type: 'append', message: placeholder });
     dispatch({ type: 'sending' });
 
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+
     const accumulator = { content: '' };
     let lastFlush = 0;
     function flush(force = false) {
@@ -172,8 +191,12 @@ export default function ChatApp() {
     }
 
     try {
-      const history = state.messages.concat(userMsg).map((m) => ({ role: m.role, content: m.content }));
-      const events = chatCompletionStream({ model: readSelectedModel(), messages: history });
+      const baseHistory = historyOverride ?? state.messages;
+      const history = baseHistory.concat(userMsg).map((m) => ({ role: m.role, content: m.content }));
+      const events = chatCompletionStream(
+        { model: readSelectedModel(), messages: history },
+        ctrl.signal,
+      );
 
       let traceId: string | undefined;
       for await (const ev of events) {
@@ -210,14 +233,43 @@ export default function ChatApp() {
       dispatch({ type: 'patch', id: placeholder.id, patch: { pending: false, trace_id: traceId } });
       dispatch({ type: 'idle' });
     } catch (err) {
+      flush(true);
+      if (isAbortError(err)) {
+        // User pressed Stop. Keep partial content, mark cancelled.
+        dispatch({ type: 'patch', id: placeholder.id, patch: { pending: false, cancelled: true } });
+        dispatch({ type: 'idle' });
+        return;
+      }
+      // Genuine failure: keep partial content if any, surface error inline.
       dispatch({
         type: 'patch',
         id: placeholder.id,
-        patch: { content: '(no answer)', pending: false },
+        patch: { pending: false, error: reasonOf(err) },
       });
-      dispatch({ type: 'error', message: reasonOf(err) });
+      dispatch({ type: 'idle' });
+    } finally {
+      if (abortRef.current === ctrl) abortRef.current = null;
     }
   }, [sessionReady, state.messages]);
+
+  const cancel = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  const retry = useCallback((assistantMessageId: string) => {
+    // Find the assistant message we want to re-roll and the user turn that
+    // immediately preceded it. Drop both, then re-send the same user text;
+    // ChatApp's send() will append a fresh user + placeholder and stream.
+    const msgs = state.messages;
+    const idx = msgs.findIndex((m) => m.id === assistantMessageId);
+    if (idx < 0) return;
+    const userIdx = idx - 1;
+    if (userIdx < 0 || msgs[userIdx].role !== 'user') return;
+    const userText = msgs[userIdx].content;
+    const historyBefore = msgs.slice(0, userIdx);
+    dispatch({ type: 'truncate_at', index: userIdx });
+    void send(userText, historyBefore);
+  }, [state.messages, send]);
 
   const value = useMemo<ChatContextValue>(
     () => ({
@@ -227,12 +279,14 @@ export default function ChatApp() {
       selectedMessageId: state.selectedMessageId,
       selectMessage: (id) => dispatch({ type: 'select_message', id }),
       send,
+      cancel,
+      retry,
       draft: state.draft,
       setDraft: (text) => dispatch({ type: 'set_draft', text }),
       consumeDraft: () => dispatch({ type: 'clear_draft' }),
       sessionReady,
     }),
-    [state, send, sessionReady],
+    [state, send, cancel, retry, sessionReady],
   );
 
   // Initial collapse state from localStorage. The TopBar toggle script

--- a/frontend/cullis-chat/src/components/ChatWindow.tsx
+++ b/frontend/cullis-chat/src/components/ChatWindow.tsx
@@ -7,7 +7,7 @@ import { MessageInput } from './MessageInput';
  * shared via context, so AuditPanel can mirror selection / scroll-to.
  */
 export function ChatWindow() {
-  const { messages, status, error, send, draft, setDraft, consumeDraft, sessionReady } = useChat();
+  const { messages, status, error, send, cancel, draft, setDraft, consumeDraft, sessionReady } = useChat();
 
   return (
     <div className="chat-shell">
@@ -26,6 +26,7 @@ export function ChatWindow() {
 
       <MessageInput
         onSend={send}
+        onCancel={cancel}
         disabled={!sessionReady}
         isSending={status === 'sending'}
         draft={draft}

--- a/frontend/cullis-chat/src/components/Message.tsx
+++ b/frontend/cullis-chat/src/components/Message.tsx
@@ -1,5 +1,6 @@
 import { MarkdownView } from './MarkdownView';
 import { ToolCallIndicator } from './ToolCallIndicator';
+import { useChat } from '../lib/chat-context';
 import type { ChatMessage } from '../lib/types';
 
 interface Props {
@@ -18,6 +19,7 @@ interface Props {
  * marginalia chips above the body.
  */
 export function Message({ message, selected, onClick }: Props) {
+  const { retry } = useChat();
   const isUser = message.role === 'user';
   const ts = new Date(message.createdAt);
   const tsLabel = ts.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
@@ -57,13 +59,47 @@ export function Message({ message, selected, onClick }: Props) {
         <div className={`msg-body msg-body-assistant${message.pending ? ' msg-pending' : ''}`}>
           {message.content.length > 0 ? (
             <MarkdownView text={message.content} pending={message.pending} />
-          ) : (
+          ) : !message.cancelled && !message.error ? (
             <span className="msg-empty-pending" aria-label="awaiting first chunk">
               <em>thinking</em>
             </span>
-          )}
+          ) : null}
         </div>
       )}
+
+      {!isUser && message.cancelled ? (
+        <footer className="msg-footer msg-cancelled" role="status">
+          <span className="msg-footer-label">stopped</span>
+          <button
+            type="button"
+            className="msg-retry"
+            onClick={(e) => {
+              e.stopPropagation();
+              retry(message.id);
+            }}
+          >
+            retry
+          </button>
+        </footer>
+      ) : null}
+
+      {!isUser && message.error ? (
+        <footer className="msg-footer msg-error" role="alert">
+          <span className="msg-footer-label">
+            <strong>stream interrupted</strong> {message.error}
+          </span>
+          <button
+            type="button"
+            className="msg-retry"
+            onClick={(e) => {
+              e.stopPropagation();
+              retry(message.id);
+            }}
+          >
+            retry
+          </button>
+        </footer>
+      ) : null}
     </article>
   );
 }

--- a/frontend/cullis-chat/src/components/MessageInput.tsx
+++ b/frontend/cullis-chat/src/components/MessageInput.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState, type FormEvent, type KeyboardEvent } from 
 
 interface Props {
   onSend: (text: string) => void;
+  /** Called when the user clicks the Stop button while a turn is streaming. */
+  onCancel?: () => void;
   disabled?: boolean;
   isSending?: boolean;
   /** When set, replaces the textarea content (used by hint buttons). */
@@ -9,7 +11,7 @@ interface Props {
   onDraftConsumed?: () => void;
 }
 
-export function MessageInput({ onSend, disabled, isSending, draft, onDraftConsumed }: Props) {
+export function MessageInput({ onSend, onCancel, disabled, isSending, draft, onDraftConsumed }: Props) {
   const [value, setValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -62,9 +64,20 @@ export function MessageInput({ onSend, disabled, isSending, draft, onDraftConsum
         disabled={disabled}
         aria-label="Message"
       />
-      <button type="submit" className="send" disabled={submitDisabled}>
-        <span className="send-label">{isSending ? 'sending' : 'send'}</span>
-      </button>
+      {isSending ? (
+        <button
+          type="button"
+          className="stop"
+          onClick={() => onCancel?.()}
+          aria-label="Stop streaming"
+        >
+          <span className="stop-label">stop</span>
+        </button>
+      ) : (
+        <button type="submit" className="send" disabled={submitDisabled}>
+          <span className="send-label">send</span>
+        </button>
+      )}
     </form>
   );
 }

--- a/frontend/cullis-chat/src/lib/chat-context.ts
+++ b/frontend/cullis-chat/src/lib/chat-context.ts
@@ -17,6 +17,13 @@ export interface ChatContextValue {
   selectedMessageId: string | null;
   selectMessage: (id: string | null) => void;
   send: (text: string) => void;
+  /** Abort the in-flight streaming turn (if any). Partial content stays.
+   *  Idempotent: a no-op when status is 'idle'. */
+  cancel: () => void;
+  /** Re-issue the last user turn. Drops any inline error / cancelled flag
+   *  from the prior assistant message and starts a fresh streaming turn
+   *  with the same conversation history up to that point. */
+  retry: (assistantMessageId: string) => void;
   /** Bumps a draft into the input box (hint clicks). */
   draft?: string;
   consumeDraft: () => void;

--- a/frontend/cullis-chat/src/lib/types.ts
+++ b/frontend/cullis-chat/src/lib/types.ts
@@ -34,6 +34,11 @@ export interface ChatMessage {
   pending?: boolean;
   /** Tool calls observed during this turn, in arrival order. */
   toolCalls?: ToolCallEvent[];
+  /** User clicked Stop while this assistant turn was streaming. */
+  cancelled?: boolean;
+  /** Non-fatal failure during streaming. Surfaced inline next to the partial
+   *  content with a Retry button. Clears on retry. */
+  error?: string;
 }
 
 export interface ToolCall {

--- a/frontend/cullis-chat/src/styles/chat-window.css
+++ b/frontend/cullis-chat/src/styles/chat-window.css
@@ -177,6 +177,77 @@
   padding-bottom: 0.1rem;
 }
 
+/* Footer slot under an assistant message body. Hosts inline state
+ * surfaces (stopped, stream interrupted) plus the retry affordance. */
+.msg-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+  padding: 0.45rem 0.65rem;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+}
+
+.msg-footer-label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.msg-footer-label strong {
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-right: 0.35rem;
+}
+
+.msg-cancelled {
+  background: rgba(110, 113, 128, 0.10);
+  border: 1px solid var(--border-medium);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.66rem;
+}
+
+.msg-error {
+  background: rgba(240, 165, 0, 0.06);
+  border: 1px solid rgba(240, 165, 0, 0.35);
+  color: var(--accent-amber);
+}
+
+.msg-retry {
+  flex-shrink: 0;
+  font-family: var(--font-brand);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 0.35rem 0.8rem;
+  background: transparent;
+  color: var(--accent-cyan);
+  border: 1px solid var(--accent-cyan-dim);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--t-fast) var(--ease-soft),
+              color var(--t-fast) var(--ease-soft),
+              border-color var(--t-fast) var(--ease-soft);
+}
+
+.msg-retry:hover {
+  background: var(--accent-cyan);
+  color: var(--bg-void);
+  border-color: var(--accent-cyan);
+}
+
+.msg-retry:active {
+  transform: translateY(1px);
+}
+
 .tool-chip {
   display: inline-flex;
   align-items: center;
@@ -782,6 +853,46 @@
   color: var(--text-tertiary);
   border-color: var(--border-medium);
   box-shadow: none;
+}
+
+/* STOP: shown in place of send while a turn is streaming. Same footprint
+ * as .send so the input row layout does not shift on transition. Amber tone
+ * to read as 'interrupt', not 'destructive'. */
+.stop {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 96px;
+  padding: 0.6rem 1.25rem;
+  font-family: var(--font-brand);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  background: var(--bg-elevated);
+  color: var(--accent-amber);
+  border: 1px solid rgba(240, 165, 0, 0.45);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-button);
+  cursor: pointer;
+  transition: transform var(--t-fast) var(--ease-soft),
+              box-shadow var(--t-fast) var(--ease-soft),
+              background var(--t-fast) var(--ease-soft),
+              border-color var(--t-fast) var(--ease-soft),
+              color var(--t-fast) var(--ease-soft);
+}
+
+.stop:hover {
+  background: var(--accent-amber);
+  color: var(--bg-void);
+  border-color: var(--accent-amber);
+  box-shadow: var(--shadow-button-primary);
+  transform: translateY(-1px);
+}
+
+.stop:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-button-pressed);
 }
 
 

--- a/frontend/cullis-chat/tests/e2e/cancel-retry.spec.ts
+++ b/frontend/cullis-chat/tests/e2e/cancel-retry.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+test('stop button aborts the in-flight stream, retry re-issues the turn', async ({ page }) => {
+  await page.goto('/');
+
+  const input = page.locator('.chat-input textarea');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+
+  // gdpr fixture exercises the tool-call loop in the mock Ambassador, so the
+  // first chunk lands quickly but the full answer takes several seconds,
+  // giving us a stable window to press Stop without racing the [DONE] event.
+  await input.fill('what is the gdpr training status of mario rossi?');
+  await page.locator('.send').click();
+
+  // Wait for the stop button to appear, i.e. the stream is in flight.
+  const stop = page.locator('.stop');
+  await expect(stop).toBeVisible({ timeout: 5_000 });
+
+  // Press Stop and check the inline cancelled footer + retry affordance.
+  await stop.click();
+
+  const cancelled = page.locator('.msg-cancelled').first();
+  await expect(cancelled).toBeVisible({ timeout: 5_000 });
+  await expect(cancelled).toContainText(/stopped/i);
+
+  const retryBtn = cancelled.locator('.msg-retry');
+  await expect(retryBtn).toBeVisible();
+
+  // Send button comes back, stop button is gone.
+  await expect(page.locator('.send')).toBeVisible();
+  await expect(stop).toHaveCount(0);
+
+  // Retry: a new streaming turn starts. The cancelled footer should disappear
+  // (the old assistant message + its user pair are dropped, both re-issued).
+  await retryBtn.click();
+  await expect(page.locator('.stop')).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('.msg-cancelled')).toHaveCount(0);
+});
+
+test('cancel preserves any partial content already streamed', async ({ page }) => {
+  await page.goto('/');
+
+  const input = page.locator('.chat-input textarea');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+
+  await input.fill('what is the gdpr training status of mario rossi?');
+  await page.locator('.send').click();
+
+  // Wait until at least one chunk has been rendered into the assistant body.
+  // The tool chip is the most reliable early signal; once it's visible, we
+  // know streaming has started but the answer is not yet complete.
+  await expect(page.locator('.tool-chip').first()).toBeVisible({ timeout: 5_000 });
+
+  await page.locator('.stop').click();
+
+  // The cancelled footer hangs off the same assistant article, so its DOM
+  // sibling msg-body should still exist (content may be empty if cancel
+  // landed before the first text chunk, that is an acceptable race).
+  const cancelledArticle = page.locator('.msg').filter({ has: page.locator('.msg-cancelled') });
+  await expect(cancelledArticle).toHaveCount(1);
+});


### PR DESCRIPTION
## Summary

- Adds a **Stop** button that swaps in for **Send** while a chat turn is streaming. Aborts the in-flight stream via an `AbortController` wired through `chatCompletionStream`.
- Cancelling preserves whatever content was already accumulated and tags the assistant turn with `cancelled: true`. An inline amber footer surfaces the state and offers a **Retry** button.
- Stream failures (network drop, parser error) take the same shape: assistant turn gets `error: <reason>`, same inline footer + Retry.
- **Retry** drops both the failed assistant message and the user prompt that triggered it, then re-issues the same user text against the history that existed before the failed turn, so the LLM gets a clean re-roll with no duplicate user message.
- Adds Playwright spec `cancel-retry.spec.ts` covering both the cancel and the retry path against the `gdpr` mock fixture (tool-call loop gives a stable streaming window).

## Why

Streaming today has no out, the user can press Send and then watch a long answer crawl with no way to interrupt. This is Step 4 of the Cullis Chat Sprint 1 pickup (`project_pickup_cullis_chat_sprint`). Scope was rightsized during audit: the streaming caret blink was already in place (`.markdown-body.is-pending::after` + `--caret-blink` token), so this PR is the state-model + UI layer around it.

No automatic retry. LLM responses are not idempotent so a silent second roll would surprise the user; the explicit Retry button is cheap and unambiguous.

## Test plan

- [x] `npm run build` clean (Astro static + React).
- [x] `npx tsc --noEmit` reports only the pre-existing `vitest` types miss in `tests/unit/auth.test.ts`, no new errors.
- [x] Manual: Send a gdpr query against the dev mock, press Stop mid-stream, see the cancelled footer + partial content. Click Retry, watch a new stream start with the same prompt.
- [ ] CI Playwright: `cancel-retry.spec.ts` (NixOS Chromium remains broken locally per memo, CI Ubuntu will run it).
- [ ] Manual mobile viewport check deferred to Sprint 1 Step 8 polish PR.

## Out of scope

- Tool-call card `args` / `result` rendering: the backend does not emit those fields yet (audit found `mcp_proxy/egress/llm_chat_router.py:222-231` and `connector/ambassador/streaming.py` never produce `tool_call_*` SSE events; only the mock does). Tracked as Sprint 1 Step 7, blocked on backend instrumentation decisions.
- Conversation persistence: tracked as Sprint 1 Step 6.

🔒 No new auth / network / data path. Pure SPA UX. /security-review skippable per `feedback_security_review_per_pr` (docs/UI-only carveout extends here).