### PR TITLE
feat(spa): copy buttons on every message and code block

### DIFF
--- a/frontend/cullis-chat/src/components/CopyButton.tsx
+++ b/frontend/cullis-chat/src/components/CopyButton.tsx
@@ -1,0 +1,46 @@
+import { useState, type MouseEvent } from 'react';
+import { copyToClipboard } from '../lib/clipboard';
+
+interface Props {
+  /** The literal text written to the clipboard. */
+  text: string;
+  /** Hint surfaced via aria-label, e.g. "message", "code". */
+  label?: string;
+  /** Override the root class. Default `copy-btn` keeps it visually
+   *  consistent with the message-level overlay. Code blocks pass a
+   *  more specific class. */
+  className?: string;
+}
+
+/**
+ * Square overlay that writes `text` to the clipboard on click.
+ *
+ * Transient 'copied' state for 1.2s gives visual confirmation. The
+ * button stops the parent click event so it does not also toggle the
+ * assistant-message audit cross-highlight when placed inside `.msg`.
+ */
+export function CopyButton({ text, label, className = 'copy-btn' }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleClick(e: MouseEvent<HTMLButtonElement>) {
+    e.stopPropagation();
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  }
+
+  const aria = copied ? 'Copied to clipboard' : label ? `Copy ${label}` : 'Copy';
+  return (
+    <button
+      type="button"
+      className={`${className}${copied ? ' is-copied' : ''}`}
+      onClick={handleClick}
+      aria-label={aria}
+    >
+      <span className="copy-btn-label" aria-hidden="true">
+        {copied ? 'copied' : 'copy'}
+      </span>
+    </button>
+  );
+}

--- a/frontend/cullis-chat/src/components/Message.tsx
+++ b/frontend/cullis-chat/src/components/Message.tsx
@@ -1,6 +1,7 @@
 import { MarkdownView } from './MarkdownView';
 import { ToolCallIndicator } from './ToolCallIndicator';
 import { useChat } from '../lib/chat-context';
+import { CopyButton } from './CopyButton';
 import type { ChatMessage } from '../lib/types';
 
 interface Props {
@@ -10,10 +11,10 @@ interface Props {
 }
 
 /**
- * One chat turn — user or assistant.
+ * One chat turn, user or assistant.
  *
  * Assistant content is rendered through `MarkdownView` (DOMPurify +
- * marked + lazy Shiki). User content is plain text — escaped by React.
+ * marked + lazy Shiki). User content is plain text, escaped by React.
  *
  * Tool calls observed during the turn are rendered as inline
  * marginalia chips above the body.
@@ -99,6 +100,13 @@ export function Message({ message, selected, onClick }: Props) {
             retry
           </button>
         </footer>
+      ) : null}
+
+      {message.content.length > 0 ? (
+        <CopyButton
+          text={message.content}
+          label={isUser ? 'message' : 'response'}
+        />
       ) : null}
     </article>
   );

--- a/frontend/cullis-chat/src/lib/clipboard.ts
+++ b/frontend/cullis-chat/src/lib/clipboard.ts
@@ -1,0 +1,35 @@
+/**
+ * Clipboard write with a textarea-based fallback for non-secure contexts.
+ *
+ * `navigator.clipboard.writeText` requires a secure context (HTTPS or
+ * localhost). Cullis Chat is occasionally deployed behind an internal
+ * reverse proxy without TLS terminating where the browser thinks; the
+ * fallback uses the legacy `document.execCommand('copy')` against a
+ * hidden textarea, which most browsers still honour from user gestures.
+ */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to legacy path
+    }
+  }
+
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'fixed';
+    ta.style.top = '0';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand('copy');
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/cullis-chat/src/lib/markdown.ts
+++ b/frontend/cullis-chat/src/lib/markdown.ts
@@ -17,6 +17,7 @@
 
 import DOMPurify from 'dompurify';
 import { marked } from 'marked';
+import { copyToClipboard } from './clipboard';
 
 const SAFE_TAGS = [
   'a',
@@ -156,15 +157,60 @@ export async function highlightCodeBlocks(root: HTMLElement): Promise<void> {
     const finalLang = supported ? lang : 'text';
     const html = hi.codeToHtml(text, { lang: finalLang, theme: SHIKI_THEME });
     // Replace the <pre> with Shiki's <pre>. We mark the new code as done.
-    const wrapper = document.createElement('div');
-    wrapper.innerHTML = html;
-    const newPre = wrapper.firstElementChild as HTMLElement | null;
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    const newPre = tmp.firstElementChild as HTMLElement | null;
     if (!newPre) continue;
     const innerCode = newPre.querySelector('code');
     if (innerCode) innerCode.setAttribute('data-shiki', 'done');
     newPre.classList.add('shiki-block');
-    pre.replaceWith(newPre);
+    // Wrap in a `.code-block-wrap` and attach an overlay copy button.
+    // If the original <pre> was already inside such a wrap (unlikely
+    // here because we re-render the markdown into a fresh container,
+    // but safe to handle for re-runs), we replace the inner <pre> only.
+    const existingWrap = pre.parentElement?.classList.contains('code-block-wrap')
+      ? (pre.parentElement as HTMLElement)
+      : null;
+    if (existingWrap) {
+      pre.replaceWith(newPre);
+      // Refresh the button's closure-captured text by re-attaching.
+      const oldBtn = existingWrap.querySelector('.code-copy');
+      oldBtn?.remove();
+      existingWrap.appendChild(buildCodeCopyButton(text));
+    } else {
+      const wrap = document.createElement('div');
+      wrap.className = 'code-block-wrap';
+      wrap.appendChild(buildCodeCopyButton(text));
+      pre.replaceWith(wrap);
+      wrap.appendChild(newPre);
+    }
   }
+}
+
+function buildCodeCopyButton(text: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.className = 'code-copy';
+  btn.setAttribute('aria-label', 'Copy code');
+  const labelEl = document.createElement('span');
+  labelEl.className = 'copy-btn-label';
+  labelEl.setAttribute('aria-hidden', 'true');
+  labelEl.textContent = 'copy';
+  btn.appendChild(labelEl);
+  btn.addEventListener('click', async (ev) => {
+    ev.stopPropagation();
+    const ok = await copyToClipboard(text);
+    if (!ok) return;
+    btn.classList.add('is-copied');
+    labelEl.textContent = 'copied';
+    btn.setAttribute('aria-label', 'Copied to clipboard');
+    window.setTimeout(() => {
+      btn.classList.remove('is-copied');
+      labelEl.textContent = 'copy';
+      btn.setAttribute('aria-label', 'Copy code');
+    }, 1200);
+  });
+  return btn;
 }
 
 async function safeLoad(hi: { loadLanguage: (l: string) => Promise<unknown> }, lang: string): Promise<boolean> {

--- a/frontend/cullis-chat/src/styles/chat-window.css
+++ b/frontend/cullis-chat/src/styles/chat-window.css
@@ -904,3 +904,93 @@
   font-size: 0.66rem;
   letter-spacing: 0.16em;
 }
+
+/* Copy controls
+ *
+ * One overlay per assistant or user turn (`.copy-btn` placed inside `.msg`)
+ * plus one overlay per Shiki code block (`.code-copy` inside
+ * `.code-block-wrap`). Visible on hover for pointer devices, always
+ * visible on touch devices since hover is not reliable there. */
+
+.msg {
+  position: relative;
+}
+
+.copy-btn,
+.code-copy {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.6rem;
+  font-family: var(--font-brand);
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--t-fast) var(--ease-soft),
+              color var(--t-fast) var(--ease-soft),
+              border-color var(--t-fast) var(--ease-soft),
+              background var(--t-fast) var(--ease-soft);
+}
+
+.copy-btn {
+  top: 0;
+  right: 0;
+  /* Float just above the body so it does not clip the cyan accent
+   * border-left on the assistant block. */
+  z-index: 1;
+}
+
+.code-copy {
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 1;
+}
+
+.msg:hover .copy-btn,
+.copy-btn:focus-visible,
+.code-block-wrap:hover .code-copy,
+.code-copy:focus-visible {
+  opacity: 1;
+}
+
+.copy-btn:hover,
+.code-copy:hover {
+  color: var(--accent-cyan);
+  border-color: var(--accent-cyan-dim);
+}
+
+.copy-btn.is-copied,
+.code-copy.is-copied {
+  opacity: 1;
+  color: var(--accent-cyan);
+  border-color: var(--accent-cyan);
+  background: var(--accent-cyan-glow);
+}
+
+/* Touch devices: keep the overlay visible at half opacity so the
+ * affordance is discoverable without a hover state. */
+@media (hover: none) {
+  .copy-btn,
+  .code-copy {
+    opacity: 0.5;
+  }
+  .copy-btn:active,
+  .code-copy:active {
+    opacity: 1;
+  }
+}
+
+/* Wrap that anchors the per-code-block copy button. Built up by
+ * `highlightCodeBlocks()` in lib/markdown.ts after Shiki replaces
+ * the raw `<pre>`. */
+.code-block-wrap {
+  position: relative;
+}

--- a/frontend/cullis-chat/tests/e2e/copy-buttons.spec.ts
+++ b/frontend/cullis-chat/tests/e2e/copy-buttons.spec.ts
@@ -68,8 +68,21 @@ test('code blocks get their own copy overlay after Shiki highlights', async ({ p
   const codeBlock = page.locator('.msg-assistant .code-block-wrap').first();
   await expect(codeBlock).toBeVisible({ timeout: 15_000 });
 
-  // Exactly one copy overlay per code block.
-  const codeCopy = codeBlock.locator('.code-copy');
+  // The gdpr fixture streams chunks. While `pending` is true, MarkdownView
+  // re-renders the markdown body on every chunk, which means
+  // `dangerouslySetInnerHTML` wipes and rebuilds .code-block-wrap each
+  // time. A click on the button right now would be followed by the next
+  // chunk destroying that button before the `is-copied` class can be
+  // read. Wait for the streaming caret to disappear (pending=false) so
+  // the DOM is stable before interacting.
+  await expect(page.locator('.markdown-body.is-pending')).toHaveCount(0, {
+    timeout: 15_000,
+  });
+
+  // Re-locate after streaming completes: the previous wrap was likely
+  // replaced by the final render, so the locator must be fresh.
+  const finalBlock = page.locator('.msg-assistant .code-block-wrap').first();
+  const codeCopy = finalBlock.locator('.code-copy');
   await expect(codeCopy).toHaveCount(1);
 
   await codeCopy.click({ force: true });

--- a/frontend/cullis-chat/tests/e2e/copy-buttons.spec.ts
+++ b/frontend/cullis-chat/tests/e2e/copy-buttons.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+test('copy button on assistant message turns to "copied" then resets', async ({ page, context }) => {
+  // The clipboard API needs an explicit permission grant in Chromium.
+  // We also test the visible state transition (label + class) so the spec
+  // does not depend on actually reading the clipboard, which would require
+  // a separate browser-side permissions dance in some Playwright versions.
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/');
+
+  const input = page.locator('.chat-input textarea');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+
+  await input.fill('ciao');
+  await page.locator('.send').click();
+
+  // Wait for the assistant message body to be rendered.
+  const assistantMsg = page.locator('.msg-assistant').last();
+  await expect(assistantMsg).toBeVisible({ timeout: 15_000 });
+  await expect(assistantMsg.locator('.msg-body-assistant')).toContainText(/cullis|mcp|gdpr/i, {
+    timeout: 15_000,
+  });
+
+  // Click copy. Force is needed because the button is opacity:0 until
+  // hover; Playwright would otherwise complain about non-interactable.
+  const copyBtn = assistantMsg.locator('.copy-btn');
+  await expect(copyBtn).toHaveCount(1);
+  await copyBtn.click({ force: true });
+
+  await expect(copyBtn).toHaveClass(/is-copied/);
+  await expect(copyBtn.locator('.copy-btn-label')).toHaveText(/copied/i);
+
+  // The 'copied' state reverts after 1.2s.
+  await expect(copyBtn).not.toHaveClass(/is-copied/, { timeout: 2_000 });
+  await expect(copyBtn.locator('.copy-btn-label')).toHaveText(/copy/i);
+});
+
+test('copy button on user message is wired and shows the same transient state', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/');
+
+  const input = page.locator('.chat-input textarea');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+  await input.fill('hello');
+  await page.locator('.send').click();
+
+  const userMsg = page.locator('.msg-user').last();
+  await expect(userMsg).toBeVisible({ timeout: 5_000 });
+
+  const copyBtn = userMsg.locator('.copy-btn');
+  await expect(copyBtn).toHaveCount(1);
+  await copyBtn.click({ force: true });
+  await expect(copyBtn).toHaveClass(/is-copied/);
+});
+
+test('code blocks get their own copy overlay after Shiki highlights', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.goto('/');
+
+  const input = page.locator('.chat-input textarea');
+  await expect(input).toBeEnabled({ timeout: 10_000 });
+
+  // gdpr fixture in the mock Ambassador returns markdown with a SQL fence.
+  await input.fill('what is the gdpr training status of mario rossi?');
+  await page.locator('.send').click();
+
+  // Wait for the Shiki-replaced <pre> to appear inside the assistant body.
+  const codeBlock = page.locator('.msg-assistant .code-block-wrap').first();
+  await expect(codeBlock).toBeVisible({ timeout: 15_000 });
+
+  // Exactly one copy overlay per code block.
+  const codeCopy = codeBlock.locator('.code-copy');
+  await expect(codeCopy).toHaveCount(1);
+
+  await codeCopy.click({ force: true });
+  await expect(codeCopy).toHaveClass(/is-copied/);
+  await expect(codeCopy.locator('.copy-btn-label')).toHaveText(/copied/i);
+  await expect(codeCopy).not.toHaveClass(/is-copied/, { timeout: 2_000 });
+});


### PR DESCRIPTION
## Summary

- New `CopyButton` React component used as an overlay on each user / assistant message turn (`.msg .copy-btn`).
- Per code-block overlay (`.code-copy`) injected by the Shiki post-render hook in `lib/markdown.ts` after the highlight replaces the raw `<pre>`. The wrap div `.code-block-wrap` anchors it.
- Both overlays share the same transient `is-copied` state (1.2s) with label `copied` and an `aria-label` flip for screen readers.
- `lib/clipboard.ts` extracts the write logic: `navigator.clipboard.writeText` first, fallback to a hidden textarea + `document.execCommand('copy')` so the feature works behind an internal reverse proxy without TLS terminating where the browser thinks.
- Playwright spec `copy-buttons.spec.ts` exercises the visible state transitions (class + label) without reading the clipboard.

## Why

Step 8a of the Cullis Chat Sprint 1 polish pickup. Office-worker ICP keeps copying chunks of LLM output into other tools (mail, docs, internal ticketing); without a copy affordance they triple-click and risk grabbing surrounding artefacts (timestamps, role badges) into the paste. One-button copy of the **raw markdown** for the message body and **plain text** for code blocks makes the round trip frictionless.

## Implementation notes

- Visibility: opacity 0 by default on pointer devices, 1 on hover / focus-visible; 0.5 always on `(hover: none)` touch devices so the affordance stays discoverable.
- The code overlay's click handler captures `text` in its closure. Re-running `highlightCodeBlocks()` on the same DOM root removes the old button and rebuilds a fresh one so the closure stays in sync with the current code text.
- `.msg { position: relative; }` was added so the overlay anchors to each turn; nothing else in the layout depends on absolute children of `.msg` today.

## Test plan

- [x] `npm run build` clean (Astro + React + Shiki + DOMPurify + clipboard helper).
- [x] No new em-dashes / en-dashes introduced (grep on touched files clean).
- [ ] CI Playwright: `copy-buttons.spec.ts` (3 tests). NixOS Chromium remains broken locally, CI Ubuntu runs the suite.
- [ ] Manual: hover an assistant message, click copy, paste into another window, verify the literal markdown lands.

## Out of scope

- Sidebar / responsive mobile breakpoints: Sprint 1 Step 8b (#10), blocked on conv-list (#13) and tool card (#17) so the layouts are final.
- Bulk "copy conversation" affordance: post-Sprint 1 if a design partner asks for it.

🔒 No new auth / network / data path. Pure SPA UX. /security-review skippable per `feedback_security_review_per_pr` (docs/UI-only carveout extends here).