### PR TITLE
feat(policy): ADR-029 Phase B+C, PDP payload+response extended and tool-level gate endpoint

### DIFF
--- a/app/broker/oneshot_router.py
+++ b/app/broker/oneshot_router.py
@@ -308,6 +308,17 @@ async def forward_oneshot(
         initiator_agent_id=current_agent.agent_id,
         target_agent_id=recipient.agent_id,
         capabilities=effective_caps,
+        # ADR-029 Phase B: this path is a oneshot dispatch, not a session
+        # open. Surface the distinction so the PDP can write per-kind
+        # policy ("Mario may oneshot acme but not open sessions") even
+        # before tool-level gating lands in Phase C.
+        invocation={
+            "kind": "oneshot",
+            "capabilities_requested": effective_caps,
+        },
+        context={
+            "request_idempotency_key": body.correlation_id,
+        },
     )
     if not pdp_decision.allowed:
         await log_event(

--- a/app/broker/rfq.py
+++ b/app/broker/rfq.py
@@ -78,6 +78,13 @@ async def broadcast_rfq(
             initiator_agent_id=initiator.agent_id,
             target_agent_id=agent.agent_id,
             capabilities=request.capability_filter,
+            # ADR-029 Phase B: RFQ candidate eligibility is still
+            # a session-open style decision (we're filtering who is
+            # reachable, not invoking a tool yet).
+            invocation={
+                "kind": "session_open",
+                "capabilities_requested": request.capability_filter,
+            },
         )
         if decision.allowed:
             approved.append(agent)

--- a/app/broker/router.py
+++ b/app/broker/router.py
@@ -181,6 +181,14 @@ async def _create_session_inner(body, current_agent, store, db, span):
         initiator_agent_id=current_agent.agent_id,
         target_agent_id=body.target_agent_id,
         capabilities=body.requested_capabilities,
+        # ADR-029 Phase B: surface invocation kind so the PDP can write
+        # session-open vs tool-call vs oneshot policy on the same wire.
+        # model is still None here (chosen after session opens); Phase C
+        # will populate it at tool-dispatch time.
+        invocation={
+            "kind": "session_open",
+            "capabilities_requested": body.requested_capabilities,
+        },
     )
     if not pdp_decision.allowed:
         SESSION_DENIED_COUNTER.add(1, {"reason": "pdp_denied"})

--- a/app/policy/backend.py
+++ b/app/policy/backend.py
@@ -24,6 +24,14 @@ async def evaluate_session_policy(
     initiator_agent_id: str,
     target_agent_id: str,
     capabilities: list[str],
+    *,
+    # ADR-029 extended optional context. Callers that have the data
+    # (broker session-open today, tool-dispatch gate in Phase C) pass it
+    # through to the configured backend. Callers without the data omit
+    # the kwargs and the PDP sees the same legacy payload as before.
+    model: dict | None = None,
+    invocation: dict | None = None,
+    context: dict | None = None,
 ) -> WebhookDecision:
     """
     Evaluate a session request using the configured policy backend.
@@ -59,6 +67,9 @@ async def evaluate_session_policy(
             initiator_agent_id=initiator_agent_id,
             target_agent_id=target_agent_id,
             capabilities=capabilities,
+            model=model,
+            invocation=invocation,
+            context=context,
         )
 
     # Default: webhook backend
@@ -74,4 +85,7 @@ async def evaluate_session_policy(
         initiator_agent_id=initiator_agent_id,
         target_agent_id=target_agent_id,
         capabilities=capabilities,
+        model=model,
+        invocation=invocation,
+        context=context,
     )

--- a/app/policy/opa.py
+++ b/app/policy/opa.py
@@ -20,7 +20,12 @@ from urllib.parse import urlparse
 
 import httpx
 
-from app.policy.webhook import WebhookDecision
+from app.policy.webhook import (
+    WebhookDecision,
+    _parse_obligations,
+    _parse_rate_limit,
+    _parse_scope,
+)
 from app.telemetry import tracer
 from app.telemetry_metrics import PDP_WEBHOOK_LATENCY_HISTOGRAM
 
@@ -66,6 +71,13 @@ async def evaluate_session_via_opa(
     initiator_agent_id: str,
     target_agent_id: str,
     capabilities: list[str],
+    *,
+    # ADR-029 extended kwargs. Forwarded into OPA input under the same
+    # keys as the webhook payload, so Rego policies can reference
+    # `input.model.id`, `input.invocation.tool_name`, etc.
+    model: dict | None = None,
+    invocation: dict | None = None,
+    context: dict | None = None,
 ) -> WebhookDecision:
     """
     Evaluate a session request against OPA.
@@ -82,15 +94,23 @@ async def evaluate_session_via_opa(
 
     url = f"{opa_url.rstrip('/')}/v1/data/atn/session/allow"
 
-    input_doc = {
-        "input": {
-            "initiator_agent_id": initiator_agent_id,
-            "initiator_org_id": initiator_org_id,
-            "target_agent_id": target_agent_id,
-            "target_org_id": target_org_id,
-            "capabilities": capabilities,
-        }
+    input_payload: dict = {
+        "initiator_agent_id": initiator_agent_id,
+        "initiator_org_id": initiator_org_id,
+        "target_agent_id": target_agent_id,
+        "target_org_id": target_org_id,
+        "capabilities": capabilities,
     }
+    # ADR-029 extended fields. Only added when provided, so legacy Rego
+    # bundles that ignore these keys keep evaluating as before.
+    if model is not None:
+        input_payload["model"] = model
+    if invocation is not None:
+        input_payload["invocation"] = invocation
+    if context is not None:
+        input_payload["context"] = context
+
+    input_doc = {"input": input_payload}
 
     t0 = time.monotonic()
     try:
@@ -125,25 +145,43 @@ async def evaluate_session_via_opa(
         data = resp.json()
         result = data.get("result", {})
 
+        # ADR-029 extended fields, present only on dict result shape.
+        scope = None
+        rate_limit = None
+        obligations = None
+
         if isinstance(result, bool):
             allowed = result
             reason = ""
         elif isinstance(result, dict):
             allowed = bool(result.get("allow", False))
             reason = str(result.get("reason", ""))[:512]
+            scope = _parse_scope(result.get("scope"))
+            rate_limit = _parse_rate_limit(result.get("rate_limit"))
+            obligations = _parse_obligations(result.get("obligations"))
         else:
             _log.warning("OPA returned unexpected result type: %s — default-deny", type(result))
             return WebhookDecision(allowed=False, reason="OPA returned invalid result", org_id="opa")
 
         if allowed:
             _log.info("OPA allow: %s → %s", initiator_org_id, target_org_id)
-            return WebhookDecision(allowed=True, reason=reason, org_id="opa")
+            return WebhookDecision(
+                allowed=True,
+                reason=reason,
+                org_id="opa",
+                scope=scope,
+                rate_limit=rate_limit,
+                obligations=obligations,
+            )
 
         _log.info("OPA deny: %s → %s reason=%s", initiator_org_id, target_org_id, reason)
         return WebhookDecision(
             allowed=False,
             reason=reason or "Denied by OPA policy",
             org_id="opa",
+            scope=scope,
+            rate_limit=rate_limit,
+            obligations=obligations,
         )
 
     except httpx.TimeoutException:

--- a/app/policy/webhook.py
+++ b/app/policy/webhook.py
@@ -1,5 +1,5 @@
 """
-PDP Webhook caller — federated policy decision for session requests.
+PDP Webhook caller, federated policy decision for session requests.
 
 Each organization registers a webhook URL at onboarding time.
 When Agent A (org A) requests a session with Agent B (org B), the broker
@@ -8,22 +8,50 @@ calls BOTH webhooks and proceeds only if both return {"decision": "allow"}.
 Default-deny: if an org has no webhook configured, the decision is DENY.
 Timeout: 5 seconds per webhook call (synchronous, sequential).
 
-Webhook contract:
+Webhook contract (ADR-029 extended, backward compatible):
   Request:  POST {webhook_url}
             Content-Type: application/json
-            X-ATN-Signature: HMAC-SHA256 of the body (future — not yet enforced)
+            X-ATN-Signature: HMAC-SHA256 of the body
             Body: {
+              # Legacy session-open payload (always present)
               "initiator_agent_id": str,
               "initiator_org_id":   str,
               "target_agent_id":    str,
               "target_org_id":      str,
               "capabilities":       list[str],
-              "session_context":    str   # "initiator" | "target"
+              "session_context":    str,   # "initiator" | "target"
+
+              # ADR-029 extended payload (present when the broker has the data)
+              "model":      dict | None,   # {id, provider, via_gateway}
+              "invocation": dict | None,   # {kind, tool_name?, mcp_server_id?, capabilities_requested}
+              "context":    dict | None    # {trace_id?, parent_session_id?, request_idempotency_key?}
             }
 
   Response: 200 OK  { "decision": "allow" }
             200 OK  { "decision": "deny", "reason": "..." }
-            any non-200 or timeout → treated as DENY
+            200 OK  ADR-029 extended:
+              {
+                "decision": "allow",
+                "reason": "...",
+                "scope": {
+                  "tools_allowed": [...],
+                  "tools_denied":  [...],
+                  "max_session_duration_s": int
+                },
+                "rate_limit": {
+                  "per_minute": int,
+                  "per_day":    int
+                },
+                "obligations": {
+                  "require_user_confirmation": bool,
+                  "trace_visibility":          "full" | "redacted" | "off"
+                }
+              }
+            any non-200 or timeout means DENY.
+
+A PDP that returns the legacy shape continues to work: scope, rate_limit,
+and obligations stay None on the decision and the broker treats that as
+no extra constraints (Phase B backward compatibility).
 """
 import hashlib
 import hmac
@@ -152,10 +180,99 @@ class _PinnedDNSBackend(httpcore.AsyncNetworkBackend):
 
 
 @dataclass
+class DecisionScope:
+    """ADR-029 extended scope returned by a tool-aware PDP.
+
+    A PDP can constrain which tools the session is allowed to invoke and
+    how long the session may stay open. None values mean unset / inherit.
+    """
+    tools_allowed: list[str] | None = None
+    tools_denied: list[str] | None = None
+    max_session_duration_s: int | None = None
+
+
+@dataclass
+class DecisionRateLimit:
+    """ADR-029 extended rate-limit hints returned by the PDP. Enforced at
+    the gate, not by the PDP itself. None values mean no limit."""
+    per_minute: int | None = None
+    per_day: int | None = None
+
+
+@dataclass
+class DecisionObligations:
+    """ADR-029 obligations the PDP attaches to the allow. Defaults are
+    safe-permissive (no confirmation required, redacted trace visibility).
+    """
+    require_user_confirmation: bool = False
+    trace_visibility: str = "redacted"  # full | redacted | off
+
+
+@dataclass
 class WebhookDecision:
     allowed: bool
     reason: str
     org_id: str
+    # ADR-029 extended fields. All optional, all None on legacy responses.
+    # The broker treats None as "no constraint" so existing PDP webhooks
+    # continue to work unchanged.
+    scope: DecisionScope | None = None
+    rate_limit: DecisionRateLimit | None = None
+    obligations: DecisionObligations | None = None
+
+
+def _parse_scope(raw: object) -> DecisionScope | None:
+    """Lift a PDP response 'scope' dict into a DecisionScope dataclass.
+
+    Returns None when the field is absent or malformed; callers treat
+    that as 'no scope restriction'.
+    """
+    if not isinstance(raw, dict):
+        return None
+    return DecisionScope(
+        tools_allowed=_string_list(raw.get("tools_allowed")),
+        tools_denied=_string_list(raw.get("tools_denied")),
+        max_session_duration_s=_int_or_none(raw.get("max_session_duration_s")),
+    )
+
+
+def _parse_rate_limit(raw: object) -> DecisionRateLimit | None:
+    if not isinstance(raw, dict):
+        return None
+    return DecisionRateLimit(
+        per_minute=_int_or_none(raw.get("per_minute")),
+        per_day=_int_or_none(raw.get("per_day")),
+    )
+
+
+def _parse_obligations(raw: object) -> DecisionObligations | None:
+    if not isinstance(raw, dict):
+        return None
+    visibility = raw.get("trace_visibility", "redacted")
+    if visibility not in ("full", "redacted", "off"):
+        visibility = "redacted"
+    return DecisionObligations(
+        require_user_confirmation=bool(raw.get("require_user_confirmation", False)),
+        trace_visibility=visibility,
+    )
+
+
+def _string_list(raw: object) -> list[str] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, list):
+        return None
+    return [str(x) for x in raw if isinstance(x, (str, int))]
+
+
+def _int_or_none(raw: object) -> int | None:
+    if raw is None:
+        return None
+    try:
+        v = int(raw)
+        return v if v > 0 else None
+    except (TypeError, ValueError):
+        return None
 
 
 async def call_pdp_webhook(
@@ -167,6 +284,13 @@ async def call_pdp_webhook(
     target_org_id: str,
     capabilities: list[str],
     session_context: str,  # "initiator" | "target"
+    *,
+    # ADR-029 extended payload. Each kwarg is optional and only added to
+    # the wire payload when non-None, so existing PDP webhooks that
+    # ignore unknown fields keep working.
+    model: dict | None = None,
+    invocation: dict | None = None,
+    context: dict | None = None,
 ) -> WebhookDecision:
     """
     Call the PDP webhook for one organization and return its decision.
@@ -221,7 +345,7 @@ async def call_pdp_webhook(
             org_id=org_id,
         )
 
-    payload = {
+    payload: dict = {
         "initiator_agent_id": initiator_agent_id,
         "initiator_org_id":   initiator_org_id,
         "target_agent_id":    target_agent_id,
@@ -229,6 +353,14 @@ async def call_pdp_webhook(
         "capabilities":       capabilities,
         "session_context":    session_context,
     }
+    # ADR-029 extended fields. Only present when the caller provides them
+    # so legacy PDP webhooks see the exact same payload they always saw.
+    if model is not None:
+        payload["model"] = model
+    if invocation is not None:
+        payload["invocation"] = invocation
+    if context is not None:
+        payload["context"] = context
 
     # Audit 2026-04-30 lane 3 H3 — sign the body with the shared
     # secret so the receiving PDP can verify the call originated
@@ -310,9 +442,23 @@ async def call_pdp_webhook(
             decision = "deny"
         reason = str(data.get("reason", ""))[:512]  # limit reason length
 
+        # ADR-029 extended response: scope / rate_limit / obligations are
+        # all optional. _parse_* returns None on missing or malformed
+        # fields, which the broker treats as "no constraint".
+        scope = _parse_scope(data.get("scope"))
+        rate_limit = _parse_rate_limit(data.get("rate_limit"))
+        obligations = _parse_obligations(data.get("obligations"))
+
         if decision == "allow":
             _log.info("PDP webhook allow: org=%s context=%s", org_id, session_context)
-            return WebhookDecision(allowed=True, reason=reason, org_id=org_id)
+            return WebhookDecision(
+                allowed=True,
+                reason=reason,
+                org_id=org_id,
+                scope=scope,
+                rate_limit=rate_limit,
+                obligations=obligations,
+            )
 
         _log.info(
             "PDP webhook deny: org=%s context=%s reason=%s",
@@ -322,6 +468,9 @@ async def call_pdp_webhook(
             allowed=False,
             reason=reason or f"Denied by org '{org_id}' PDP",
             org_id=org_id,
+            scope=scope,
+            rate_limit=rate_limit,
+            obligations=obligations,
         )
 
     except httpx.TimeoutException:
@@ -340,6 +489,106 @@ async def call_pdp_webhook(
         )
 
 
+def _intersect_scopes(
+    initiator: DecisionScope | None,
+    target: DecisionScope | None,
+) -> DecisionScope | None:
+    """ADR-029 §Decision: source ∩ target. Never union, never expand.
+
+    A None on either side means "no restriction from that side", so the
+    intersection is the other side's restriction. Both None means no
+    scope constraint at all (legacy behaviour).
+    """
+    if initiator is None and target is None:
+        return None
+    if initiator is None:
+        return target
+    if target is None:
+        return initiator
+
+    # Intersection rules:
+    #   tools_allowed: intersection (only what both allow)
+    #   tools_denied:  union        (anyone says deny → deny)
+    #   max_session_duration_s: min (tighter wins)
+    a_allowed = set(initiator.tools_allowed) if initiator.tools_allowed is not None else None
+    b_allowed = set(target.tools_allowed) if target.tools_allowed is not None else None
+    if a_allowed is None and b_allowed is None:
+        allowed: list[str] | None = None
+    elif a_allowed is None:
+        allowed = sorted(b_allowed) if b_allowed is not None else None
+    elif b_allowed is None:
+        allowed = sorted(a_allowed)
+    else:
+        allowed = sorted(a_allowed & b_allowed)
+
+    denied_set: set[str] = set()
+    if initiator.tools_denied:
+        denied_set.update(initiator.tools_denied)
+    if target.tools_denied:
+        denied_set.update(target.tools_denied)
+    denied = sorted(denied_set) if denied_set else None
+
+    durations = [
+        d for d in (initiator.max_session_duration_s, target.max_session_duration_s)
+        if d is not None
+    ]
+    duration = min(durations) if durations else None
+
+    return DecisionScope(
+        tools_allowed=allowed,
+        tools_denied=denied,
+        max_session_duration_s=duration,
+    )
+
+
+def _intersect_rate_limits(
+    initiator: DecisionRateLimit | None,
+    target: DecisionRateLimit | None,
+) -> DecisionRateLimit | None:
+    """Tighter rate limit wins (min of per_minute, min of per_day)."""
+    if initiator is None and target is None:
+        return None
+    if initiator is None:
+        return target
+    if target is None:
+        return initiator
+
+    def _min_or_none(a: int | None, b: int | None) -> int | None:
+        vals = [v for v in (a, b) if v is not None]
+        return min(vals) if vals else None
+
+    return DecisionRateLimit(
+        per_minute=_min_or_none(initiator.per_minute, target.per_minute),
+        per_day=_min_or_none(initiator.per_day, target.per_day),
+    )
+
+
+def _intersect_obligations(
+    initiator: DecisionObligations | None,
+    target: DecisionObligations | None,
+) -> DecisionObligations | None:
+    """Conservative merge: any side that demands user confirmation wins;
+    visibility downgrades to the more restrictive of the two."""
+    if initiator is None and target is None:
+        return None
+    if initiator is None:
+        return target
+    if target is None:
+        return initiator
+    rank = {"full": 2, "redacted": 1, "off": 0}
+    visibility = (
+        initiator.trace_visibility
+        if rank[initiator.trace_visibility] <= rank[target.trace_visibility]
+        else target.trace_visibility
+    )
+    return DecisionObligations(
+        require_user_confirmation=(
+            initiator.require_user_confirmation or target.require_user_confirmation
+        ),
+        trace_visibility=visibility,
+    )
+
+
 async def evaluate_session_via_webhooks(
     initiator_org_id: str,
     initiator_webhook_url: str | None,
@@ -348,10 +597,19 @@ async def evaluate_session_via_webhooks(
     initiator_agent_id: str,
     target_agent_id: str,
     capabilities: list[str],
+    *,
+    # ADR-029 extended kwargs. Passed through to both webhooks so each
+    # side has the same context to decide on.
+    model: dict | None = None,
+    invocation: dict | None = None,
+    context: dict | None = None,
 ) -> WebhookDecision:
     """
     Call both orgs' PDP webhooks. Returns DENY if either denies.
     Both calls are made even if the first denies (for audit completeness).
+
+    On dual allow, the returned WebhookDecision carries the intersection
+    of scope, rate_limit, and obligations (ADR-029 §Decision).
     """
     initiator_decision = await call_pdp_webhook(
         org_id=initiator_org_id,
@@ -362,6 +620,9 @@ async def evaluate_session_via_webhooks(
         target_org_id=target_org_id,
         capabilities=capabilities,
         session_context="initiator",
+        model=model,
+        invocation=invocation,
+        context=context,
     )
 
     target_decision = await call_pdp_webhook(
@@ -373,6 +634,9 @@ async def evaluate_session_via_webhooks(
         target_org_id=target_org_id,
         capabilities=capabilities,
         session_context="target",
+        model=model,
+        invocation=invocation,
+        context=context,
     )
 
     # Track dual-org policy mismatch (one allowed, other denied)
@@ -386,4 +650,17 @@ async def evaluate_session_via_webhooks(
         return initiator_decision
     if not target_decision.allowed:
         return target_decision
-    return WebhookDecision(allowed=True, reason="both PDPs allowed", org_id="broker")
+
+    # Both allow: intersect the constraints (ADR-029).
+    return WebhookDecision(
+        allowed=True,
+        reason="both PDPs allowed",
+        org_id="broker",
+        scope=_intersect_scopes(initiator_decision.scope, target_decision.scope),
+        rate_limit=_intersect_rate_limits(
+            initiator_decision.rate_limit, target_decision.rate_limit,
+        ),
+        obligations=_intersect_obligations(
+            initiator_decision.obligations, target_decision.obligations,
+        ),
+    )

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -182,6 +182,14 @@ class ProxySettings(BaseSettings):
     # the broker via ``POLICY_WEBHOOK_HMAC_SECRET`` to enable.
     pdp_webhook_hmac_secret: str = ""
 
+    # ADR-029 Phase C, tool-level PDP gate. When true, exposes the
+    # POST /v1/policy/tool-call endpoint that the Connector ambassador
+    # calls before executing each MCP tool the model emits in a chat
+    # completion. Default false so existing deployments keep working
+    # untouched until they explicitly enable the gate. Phase D wires
+    # the cross-org federation for tool-call decisions.
+    tool_pdp_enabled: bool = False
+
     # ADR-013 layer 2 — global Mastio rate limit. Token bucket shared
     # across every request (not per-agent), so coordinated compromise
     # across many stolen credentials cannot outrun the aggregate cap.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1008,6 +1008,119 @@ async def pdp_policy(request: Request):
     return JSONResponse(resp)
 
 
+@app.post("/v1/policy/tool-call", tags=["pdp"])
+async def policy_tool_call(request: Request):
+    """ADR-029 Phase C tool-level PDP gate.
+
+    The Connector ambassador calls this endpoint right before executing
+    an MCP tool that the model emitted during a chat completion turn.
+    The endpoint reads the same ``policy_rules`` config that
+    ``/pdp/policy`` uses, looks at the new ``tool_rules`` subtree
+    introduced by ADR-029, and returns allow|deny plus optional
+    scope/rate_limit/obligations.
+
+    Feature flag: ``MCP_PROXY_TOOL_PDP_ENABLED``. Default false; when
+    false the endpoint returns 404 so a misconfigured Connector falls
+    back to its legacy tool-dispatch path with no policy gate. Once
+    operators enable the flag and write ``policy_rules.tool_rules``,
+    the endpoint flips to explicit-allow semantics: a tool that is not
+    listed in tool_rules is denied.
+
+    Every call writes a hash-chained ``policy.tool_call`` audit row,
+    allow and deny alike, so attempts to invoke unauthorised tools
+    stay traceable.
+    """
+    import hashlib
+    import hmac
+    import json as _json
+    from fastapi import HTTPException
+    from mcp_proxy.config import get_settings as _get_settings_runtime
+    from mcp_proxy.db import log_audit
+    from mcp_proxy.policy.tool_call import evaluate_tool_call_policy
+
+    # Read settings at request time, not at module import. The endpoint
+    # is feature-flagged and tests / live reconfig must be able to flip
+    # the flag without restarting the worker.
+    _runtime_settings = _get_settings_runtime()
+    if not _runtime_settings.tool_pdp_enabled:
+        # 404 keeps existing Connector versions on the legacy path
+        # without the noise of a 403 in their logs.
+        raise HTTPException(status_code=404, detail="tool-level PDP disabled")
+
+    raw_body = await request.body()
+    expected_secret = _runtime_settings.pdp_webhook_hmac_secret
+    if expected_secret:
+        provided = request.headers.get("x-atn-signature", "")
+        expected = hmac.new(
+            expected_secret.encode(), raw_body, hashlib.sha256,
+        ).hexdigest()
+        if not provided or not hmac.compare_digest(provided, expected):
+            _log.warning("/v1/policy/tool-call rejected: bad or missing X-ATN-Signature")
+            raise HTTPException(status_code=401, detail="invalid signature")
+
+    try:
+        body = _json.loads(raw_body) if raw_body else {}
+    except _json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="invalid JSON")
+
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="body must be a JSON object")
+
+    principal = body.get("principal") if isinstance(body.get("principal"), dict) else {}
+    invocation = body.get("invocation") if isinstance(body.get("invocation"), dict) else {}
+
+    decision = await evaluate_tool_call_policy(
+        principal_id=str(principal.get("id", "")),
+        principal_type=str(principal.get("type", "agent")),
+        model=body.get("model") if isinstance(body.get("model"), dict) else None,
+        target=body.get("target") if isinstance(body.get("target"), dict) else None,
+        invocation=invocation or None,
+        context=body.get("context") if isinstance(body.get("context"), dict) else None,
+    )
+
+    # Hash-chained audit row, allow and deny alike (forensics needs both).
+    audit_details: dict = {
+        "principal_type": principal.get("type"),
+        "tool_name": invocation.get("tool_name"),
+        "mcp_server_id": invocation.get("mcp_server_id"),
+        "reason": decision.reason,
+    }
+    if isinstance(body.get("model"), dict):
+        audit_details["model"] = body["model"].get("id")
+    if isinstance(body.get("target"), dict):
+        audit_details["target"] = body["target"].get("id")
+    if isinstance(body.get("context"), dict):
+        audit_details["session_id"] = body["context"].get("session_id")
+
+    await log_audit(
+        agent_id=str(principal.get("id", "?")),
+        action="policy.tool_call",
+        status="allow" if decision.allowed else "deny",
+        tool_name=invocation.get("tool_name"),
+        details=audit_details,
+    )
+
+    _log.info(
+        "PDP tool-call %s: principal=%s tool=%s reason=%s",
+        "ALLOW" if decision.allowed else "DENY",
+        principal.get("id"),
+        invocation.get("tool_name"),
+        decision.reason,
+    )
+
+    resp: dict = {
+        "decision": "allow" if decision.allowed else "deny",
+        "reason": decision.reason,
+    }
+    if decision.scope:
+        resp["scope"] = decision.scope
+    if decision.rate_limit:
+        resp["rate_limit"] = decision.rate_limit
+    if decision.obligations:
+        resp["obligations"] = decision.obligations
+    return JSONResponse(resp)
+
+
 @app.get("/pdp/health", tags=["pdp"])
 async def pdp_health():
     """PDP health check."""

--- a/mcp_proxy/policy/tool_call.py
+++ b/mcp_proxy/policy/tool_call.py
@@ -1,0 +1,195 @@
+"""ADR-029 Phase C, tool-level PDP evaluation for the Mastio.
+
+Called from the ``POST /v1/policy/tool-call`` endpoint when the
+Connector ambassador wants to invoke a tool inside a chat completion
+turn. Evaluates against the same ``policy_rules`` config row that
+``/pdp/policy`` reads for session-open decisions, but consults a new
+``tool_rules`` subtree introduced by ADR-029 so admins can write
+per-tool / per-model / per-server policy:
+
+    {
+      "tool_rules": {
+        "acme.catalog.search": {
+          "allowed_principals": ["acme::user::mario@acme.local", ...],
+          "denied_principals":  [...],
+          "allowed_models":     ["claude-haiku-4-5", "qwen-72b-chat"],
+          "allowed_mcp_servers": ["acme-catalog-prod"],
+          "scope":              {...},   // echoed in response
+          "rate_limit":         {...},
+          "obligations":        {...}
+        },
+        "acme.orders.update": {
+          "allowed_principals": []        // explicit "no one"
+        }
+      }
+    }
+
+Default semantics:
+    - tool_rules absent or empty  -> allow (legacy parity).
+    - tool_rules present but tool not listed -> deny (explicit-allow).
+    - tool listed but principal missing from allowed_principals -> deny.
+    - principal in denied_principals -> deny (wins over allowed_principals).
+    - model not in allowed_models -> deny (if allowed_models non-empty).
+    - mcp_server not in allowed_mcp_servers -> deny (if non-empty).
+
+The decision is intentionally kept local to a single Mastio. Cross-org
+federation (the AcmeCorp Mastio policy when Mario invokes a tool that
+targets AcmeCorp's MCP server) lives in Phase D.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from mcp_proxy.db import get_config
+
+_log = logging.getLogger("mcp_proxy.policy.tool_call")
+
+
+@dataclass
+class ToolCallDecision:
+    allowed: bool
+    reason: str
+    # Pass-through of the optional ADR-029 extended fields when the
+    # matching tool_rule has them. None means "no extra constraint".
+    scope: dict[str, Any] | None = None
+    rate_limit: dict[str, Any] | None = None
+    obligations: dict[str, Any] | None = None
+
+
+async def evaluate_tool_call_policy(
+    *,
+    principal_id: str,
+    principal_type: str,
+    model: dict[str, Any] | None,
+    target: dict[str, Any] | None,
+    invocation: dict[str, Any] | None,
+    context: dict[str, Any] | None,
+) -> ToolCallDecision:
+    """Decide whether `principal` may invoke ``invocation.tool_name``
+    via ``model`` against ``target`` right now.
+
+    Returns a ToolCallDecision. The endpoint wrapper writes the audit
+    row regardless of outcome so deny attempts stay traceable.
+    """
+    rules_raw = await get_config("policy_rules")
+    rules: dict[str, Any] = {}
+    if rules_raw:
+        try:
+            rules = json.loads(rules_raw)
+        except json.JSONDecodeError:
+            _log.warning("policy_rules JSON malformed, treating as empty")
+            rules = {}
+
+    tool_rules = rules.get("tool_rules")
+    if not isinstance(tool_rules, dict):
+        tool_rules = {}
+
+    tool_name: str | None = None
+    if isinstance(invocation, dict):
+        tn = invocation.get("tool_name")
+        if isinstance(tn, str) and tn:
+            tool_name = tn
+
+    # Legacy default-allow when no tool_rules configured. Operators who
+    # have never touched ADR-029 settings see no behaviour change.
+    if not tool_rules:
+        return ToolCallDecision(
+            allowed=True,
+            reason="no tool_rules configured (default-allow legacy mode)",
+        )
+
+    if not tool_name:
+        return ToolCallDecision(
+            allowed=False,
+            reason="invocation.tool_name missing",
+        )
+
+    if tool_name not in tool_rules:
+        return ToolCallDecision(
+            allowed=False,
+            reason=f"tool '{tool_name}' not in tool_rules (explicit-allow mode)",
+        )
+
+    rule = tool_rules[tool_name]
+    if not isinstance(rule, dict):
+        return ToolCallDecision(
+            allowed=False,
+            reason=f"tool_rules.{tool_name} entry is not a dict",
+        )
+
+    # Principal denylist beats allowlist (defense in depth).
+    denied_principals = rule.get("denied_principals", [])
+    if isinstance(denied_principals, list) and principal_id in denied_principals:
+        return ToolCallDecision(
+            allowed=False,
+            reason=f"principal '{principal_id}' in tool_rules.{tool_name}.denied_principals",
+        )
+
+    allowed_principals = rule.get("allowed_principals", [])
+    if isinstance(allowed_principals, list) and allowed_principals:
+        if principal_id not in allowed_principals:
+            return ToolCallDecision(
+                allowed=False,
+                reason=(
+                    f"principal '{principal_id}' not in "
+                    f"tool_rules.{tool_name}.allowed_principals"
+                ),
+            )
+
+    # Model check.
+    model_id: str | None = None
+    if isinstance(model, dict):
+        mid = model.get("id")
+        if isinstance(mid, str):
+            model_id = mid
+
+    allowed_models = rule.get("allowed_models", [])
+    if isinstance(allowed_models, list) and allowed_models:
+        if not model_id or model_id not in allowed_models:
+            return ToolCallDecision(
+                allowed=False,
+                reason=(
+                    f"model '{model_id}' not in "
+                    f"tool_rules.{tool_name}.allowed_models"
+                ),
+            )
+
+    # MCP server check.
+    server_id: str | None = None
+    if isinstance(invocation, dict):
+        sid = invocation.get("mcp_server_id")
+        if isinstance(sid, str):
+            server_id = sid
+
+    allowed_servers = rule.get("allowed_mcp_servers", [])
+    if isinstance(allowed_servers, list) and allowed_servers:
+        if not server_id or server_id not in allowed_servers:
+            return ToolCallDecision(
+                allowed=False,
+                reason=(
+                    f"mcp_server '{server_id}' not in "
+                    f"tool_rules.{tool_name}.allowed_mcp_servers"
+                ),
+            )
+
+    # All checks passed. Echo optional scope/rate_limit/obligations
+    # back to the Connector so the caller knows what constraints apply
+    # to the (now-allowed) tool invocation.
+    scope = rule.get("scope") if isinstance(rule.get("scope"), dict) else None
+    rate_limit = (
+        rule.get("rate_limit") if isinstance(rule.get("rate_limit"), dict) else None
+    )
+    obligations = (
+        rule.get("obligations") if isinstance(rule.get("obligations"), dict) else None
+    )
+
+    return ToolCallDecision(
+        allowed=True,
+        reason=f"allowed by tool_rules.{tool_name}",
+        scope=scope,
+        rate_limit=rate_limit,
+        obligations=obligations,
+    )

--- a/tests/test_pdp_webhook_extended_payload.py
+++ b/tests/test_pdp_webhook_extended_payload.py
@@ -1,0 +1,427 @@
+"""ADR-029 Phase B: extended payload + extended response on the PDP
+webhook channel.
+
+The legacy webhook contract (`initiator_agent_id`, `target_agent_id`,
+`capabilities`, `session_context`) keeps working unchanged. The
+extended contract adds:
+
+  Outbound:  model, invocation, context (optional dict fields, only
+             written to the wire when present)
+  Inbound:   scope, rate_limit, obligations (optional dict fields,
+             parsed into typed dataclasses; missing fields become None
+             and the broker treats them as 'no constraint')
+
+When both sides of a dual-allow return scope/rate_limit/obligations,
+the broker intersects them per ADR-029 §Decision (source ∩ target).
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+
+# ── Outbound payload shape ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_payload_legacy_when_no_extended_kwargs(monkeypatch):
+    """call_pdp_webhook without model/invocation/context emits the same
+    payload the legacy contract has always seen, no new keys appear."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"decision": "allow"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+
+    body = captured["body"]
+    assert body["initiator_agent_id"] == "acme::alice"
+    assert body["capabilities"] == ["cap.read"]
+    assert "model" not in body
+    assert "invocation" not in body
+    assert "context" not in body
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_payload_includes_extended_kwargs_when_provided(monkeypatch):
+    """When the caller passes model/invocation/context, the dicts land
+    on the wire under those exact keys."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"decision": "allow"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+        model={"id": "claude-haiku-4-5", "provider": "anthropic"},
+        invocation={
+            "kind": "session_tool_call",
+            "tool_name": "postgres.query",
+            "mcp_server_id": "compliance-postgres",
+        },
+        context={"trace_id": "t_xyz", "parent_session_id": "s_abc"},
+    )
+
+    body = captured["body"]
+    assert body["model"]["id"] == "claude-haiku-4-5"
+    assert body["invocation"]["tool_name"] == "postgres.query"
+    assert body["context"]["trace_id"] == "t_xyz"
+    get_settings.cache_clear()
+
+
+# ── Inbound response shape ──────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_legacy_response_parsed_with_no_extensions(monkeypatch):
+    """A PDP that returns the legacy {decision, reason} shape gets the
+    same decision object as before: extension fields stay None."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"decision": "allow", "reason": "ok"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    d = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+
+    assert d.allowed is True
+    assert d.scope is None
+    assert d.rate_limit is None
+    assert d.obligations is None
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_extended_response_parsed(monkeypatch):
+    """A PDP that returns scope/rate_limit/obligations lands them on
+    the decision as typed dataclasses with the right values."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "decision": "allow",
+            "reason": "ok",
+            "scope": {
+                "tools_allowed": ["acme.catalog.search", "acme.catalog.list"],
+                "tools_denied": ["acme.catalog.update"],
+                "max_session_duration_s": 1800,
+            },
+            "rate_limit": {"per_minute": 60, "per_day": 1000},
+            "obligations": {
+                "require_user_confirmation": True,
+                "trace_visibility": "full",
+            },
+        })
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    d = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+
+    assert d.allowed is True
+    assert d.scope is not None
+    assert d.scope.tools_allowed == ["acme.catalog.search", "acme.catalog.list"]
+    assert d.scope.tools_denied == ["acme.catalog.update"]
+    assert d.scope.max_session_duration_s == 1800
+    assert d.rate_limit is not None
+    assert d.rate_limit.per_minute == 60
+    assert d.rate_limit.per_day == 1000
+    assert d.obligations is not None
+    assert d.obligations.require_user_confirmation is True
+    assert d.obligations.trace_visibility == "full"
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_invalid_trace_visibility_clamps_to_redacted(monkeypatch):
+    """An obligations.trace_visibility value outside the allowed set
+    (full|redacted|off) clamps to 'redacted', not propagated raw."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "decision": "allow",
+            "obligations": {"trace_visibility": "BOGUS_VALUE"},
+        })
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    d = await wh.call_pdp_webhook(
+        org_id="acme",
+        webhook_url="https://example.com/pdp",
+        initiator_agent_id="acme::alice",
+        initiator_org_id="acme",
+        target_agent_id="other-org::bob",
+        target_org_id="other-org",
+        capabilities=["cap.read"],
+        session_context="initiator",
+    )
+
+    assert d.obligations is not None
+    assert d.obligations.trace_visibility == "redacted"
+    get_settings.cache_clear()
+
+
+# ── Cross-org intersection ──────────────────────────────────────────
+
+
+def test_intersect_scopes_tools_allowed_is_intersection():
+    """tools_allowed of (initiator ∩ target). Only what BOTH allow."""
+    from app.policy.webhook import DecisionScope, _intersect_scopes
+    a = DecisionScope(tools_allowed=["x", "y", "z"])
+    b = DecisionScope(tools_allowed=["y", "z", "w"])
+    out = _intersect_scopes(a, b)
+    assert out is not None
+    assert out.tools_allowed == ["y", "z"]
+
+
+def test_intersect_scopes_tools_denied_is_union():
+    """tools_denied of (initiator ∪ target). Anyone says deny → deny."""
+    from app.policy.webhook import DecisionScope, _intersect_scopes
+    a = DecisionScope(tools_denied=["a", "b"])
+    b = DecisionScope(tools_denied=["b", "c"])
+    out = _intersect_scopes(a, b)
+    assert out is not None
+    assert out.tools_denied == ["a", "b", "c"]
+
+
+def test_intersect_scopes_duration_is_min():
+    """Tighter session duration wins."""
+    from app.policy.webhook import DecisionScope, _intersect_scopes
+    a = DecisionScope(max_session_duration_s=3600)
+    b = DecisionScope(max_session_duration_s=900)
+    out = _intersect_scopes(a, b)
+    assert out is not None
+    assert out.max_session_duration_s == 900
+
+
+def test_intersect_scopes_one_side_none_returns_other():
+    """A None scope on one side means 'no restriction from that side'."""
+    from app.policy.webhook import DecisionScope, _intersect_scopes
+    a = DecisionScope(tools_allowed=["x"])
+    assert _intersect_scopes(a, None) == a
+    assert _intersect_scopes(None, a) == a
+    assert _intersect_scopes(None, None) is None
+
+
+def test_intersect_rate_limits_takes_min():
+    from app.policy.webhook import DecisionRateLimit, _intersect_rate_limits
+    a = DecisionRateLimit(per_minute=60, per_day=1000)
+    b = DecisionRateLimit(per_minute=30, per_day=2000)
+    out = _intersect_rate_limits(a, b)
+    assert out is not None
+    assert out.per_minute == 30
+    assert out.per_day == 1000
+
+
+def test_intersect_obligations_user_confirmation_is_or():
+    """If either side requires user confirmation, the final does too."""
+    from app.policy.webhook import DecisionObligations, _intersect_obligations
+    a = DecisionObligations(require_user_confirmation=False, trace_visibility="full")
+    b = DecisionObligations(require_user_confirmation=True, trace_visibility="full")
+    out = _intersect_obligations(a, b)
+    assert out is not None
+    assert out.require_user_confirmation is True
+
+
+def test_intersect_obligations_trace_visibility_picks_more_restrictive():
+    """'off' beats 'redacted' beats 'full'. More restrictive wins."""
+    from app.policy.webhook import DecisionObligations, _intersect_obligations
+    full = DecisionObligations(trace_visibility="full")
+    redacted = DecisionObligations(trace_visibility="redacted")
+    off = DecisionObligations(trace_visibility="off")
+    assert _intersect_obligations(full, redacted).trace_visibility == "redacted"
+    assert _intersect_obligations(redacted, full).trace_visibility == "redacted"
+    assert _intersect_obligations(redacted, off).trace_visibility == "off"
+    assert _intersect_obligations(full, off).trace_visibility == "off"
+
+
+@pytest.mark.asyncio
+async def test_dual_allow_returns_intersected_decision(monkeypatch):
+    """evaluate_session_via_webhooks with two allow sides returning
+    different scopes carries the intersection on the final decision."""
+    from app.config import get_settings
+    monkeypatch.setenv("POLICY_WEBHOOK_ALLOW_PRIVATE_IPS", "true")
+    monkeypatch.setenv("POLICY_WEBHOOK_HMAC_SECRET", "")
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "deny")
+    get_settings.cache_clear()
+
+    from app.policy import webhook as wh
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        # Different scope per host so we can verify intersection.
+        if "initiator" in request.url.host or "initiator" in str(request.url):
+            return httpx.Response(200, json={
+                "decision": "allow",
+                "scope": {
+                    "tools_allowed": ["x", "y"],
+                    "max_session_duration_s": 3600,
+                },
+                "rate_limit": {"per_minute": 60},
+            })
+        return httpx.Response(200, json={
+            "decision": "allow",
+            "scope": {
+                "tools_allowed": ["y", "z"],
+                "max_session_duration_s": 900,
+            },
+            "rate_limit": {"per_minute": 30},
+        })
+
+    transport = httpx.MockTransport(_handler)
+
+    class _ImmediateClient(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "app.policy.webhook._validate_and_resolve_webhook_url",
+        lambda url: "127.0.0.1",
+    )
+    monkeypatch.setattr(wh.httpx, "AsyncClient", _ImmediateClient)
+
+    d = await wh.evaluate_session_via_webhooks(
+        initiator_org_id="acme",
+        initiator_webhook_url="https://initiator.example.com/pdp",
+        target_org_id="other-org",
+        target_webhook_url="https://target.example.com/pdp",
+        initiator_agent_id="acme::alice",
+        target_agent_id="other-org::bob",
+        capabilities=["cap.read"],
+    )
+
+    assert d.allowed is True
+    assert d.scope is not None
+    assert d.scope.tools_allowed == ["y"]
+    assert d.scope.max_session_duration_s == 900
+    assert d.rate_limit is not None
+    assert d.rate_limit.per_minute == 30
+    get_settings.cache_clear()

--- a/tests/test_tool_call_pdp_endpoint.py
+++ b/tests/test_tool_call_pdp_endpoint.py
@@ -1,0 +1,335 @@
+"""ADR-029 Phase C, tool-level PDP gate endpoint tests.
+
+Endpoint: ``POST /v1/policy/tool-call``
+
+Pins the contract:
+
+- The endpoint is gated by ``MCP_PROXY_TOOL_PDP_ENABLED``: 404 when
+  off, 200 with a decision when on.
+- Legacy default-allow mode: no ``policy_rules.tool_rules`` configured
+  means every tool call is allowed (existing Mastios keep working).
+- Explicit-allow mode: as soon as ``tool_rules`` is non-empty, a tool
+  that is not listed in tool_rules is denied.
+- Per-tool principal allowlist / denylist works, denylist wins.
+- Per-tool model allowlist works.
+- Optional scope / rate_limit / obligations on the rule are echoed
+  through the decision response.
+- Every call (allow + deny) writes an ``policy.tool_call`` audit row
+  in the hash-chained audit_log.
+- HMAC signature enforced when ``MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET``
+  is set, same shape as ``/pdp/policy``.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "tool_pdp.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "")  # off by default
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+@pytest_asyncio.fixture
+async def proxy_app_pdp_off(tmp_path, monkeypatch):
+    """Same proxy fixture but with the feature flag OFF, to verify
+    the 404 behaviour."""
+    db_file = tmp_path / "tool_pdp_off.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "false")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _payload(
+    *,
+    principal_id: str = "acme::user::mario@acme.local",
+    tool_name: str = "acme.catalog.search",
+    model_id: str = "claude-haiku-4-5",
+    server_id: str = "acme-catalog-prod",
+):
+    return {
+        "principal": {
+            "id": principal_id,
+            "type": "user",
+            "org": "acme",
+        },
+        "model": {"id": model_id, "provider": "anthropic"},
+        "target": {"id": "acme::workload::catalog-mcp", "type": "workload", "org": "acme"},
+        "invocation": {
+            "kind": "session_tool_call",
+            "tool_name": tool_name,
+            "mcp_server_id": server_id,
+        },
+        "context": {"session_id": "s_test"},
+    }
+
+
+async def _set_tool_rules(rules: dict) -> None:
+    from mcp_proxy.db import set_config
+    await set_config("policy_rules", json.dumps({"tool_rules": rules}))
+
+
+# ── Feature flag gate ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_returns_404_when_feature_flag_off(proxy_app_pdp_off):
+    _, client = proxy_app_pdp_off
+    resp = await client.post("/v1/policy/tool-call", json=_payload())
+    assert resp.status_code == 404
+
+
+# ── Legacy default-allow ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_default_allow_when_tool_rules_empty(proxy_app):
+    _, client = proxy_app
+    # No policy_rules in DB at all.
+    resp = await client.post("/v1/policy/tool-call", json=_payload())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow"
+    assert "legacy" in body["reason"].lower()
+
+
+# ── Explicit-allow mode ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_deny_when_tool_not_in_tool_rules(proxy_app):
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+    p = _payload(tool_name="acme.catalog.update")
+    resp = await client.post("/v1/policy/tool-call", json=p)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "acme.catalog.update" in body["reason"]
+
+
+@pytest.mark.asyncio
+async def test_allow_when_principal_in_allowlist(proxy_app):
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+            "allowed_models": ["claude-haiku-4-5"],
+        }
+    })
+    resp = await client.post("/v1/policy/tool-call", json=_payload())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow"
+
+
+@pytest.mark.asyncio
+async def test_deny_when_principal_in_denylist(proxy_app):
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": [
+                "acme::user::mario@acme.local",
+                "acme::user::anna@acme.local",
+            ],
+            "denied_principals": ["acme::user::anna@acme.local"],
+        }
+    })
+    p = _payload(principal_id="acme::user::anna@acme.local")
+    resp = await client.post("/v1/policy/tool-call", json=p)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "denied_principals" in body["reason"]
+
+
+@pytest.mark.asyncio
+async def test_deny_when_model_not_in_allowed_models(proxy_app):
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+            "allowed_models": ["qwen-72b-chat"],
+        }
+    })
+    resp = await client.post("/v1/policy/tool-call", json=_payload(model_id="claude-haiku-4-5"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "allowed_models" in body["reason"]
+
+
+@pytest.mark.asyncio
+async def test_deny_when_mcp_server_not_in_allowed(proxy_app):
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+            "allowed_mcp_servers": ["other-postgres"],
+        }
+    })
+    resp = await client.post("/v1/policy/tool-call", json=_payload(server_id="acme-catalog-prod"))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "allowed_mcp_servers" in body["reason"]
+
+
+@pytest.mark.asyncio
+async def test_scope_rate_limit_obligations_echoed_on_allow(proxy_app):
+    """When a tool_rule carries scope/rate_limit/obligations the
+    decision response carries them through to the caller."""
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+            "scope": {
+                "tools_allowed": ["acme.catalog.search", "acme.catalog.list"],
+                "max_session_duration_s": 1800,
+            },
+            "rate_limit": {"per_minute": 60},
+            "obligations": {"trace_visibility": "redacted"},
+        }
+    })
+    resp = await client.post("/v1/policy/tool-call", json=_payload())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow"
+    assert body["scope"]["tools_allowed"] == ["acme.catalog.search", "acme.catalog.list"]
+    assert body["scope"]["max_session_duration_s"] == 1800
+    assert body["rate_limit"]["per_minute"] == 60
+    assert body["obligations"]["trace_visibility"] == "redacted"
+
+
+# ── Audit row ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_audit_row_written_on_allow_and_deny(proxy_app):
+    """Every decision lands in audit_log with action=policy.tool_call,
+    status=allow|deny, tool_name set, principal id in agent_id."""
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+            "denied_principals": ["acme::user::anna@acme.local"],
+        }
+    })
+
+    # 1) allow
+    await client.post("/v1/policy/tool-call", json=_payload(
+        principal_id="acme::user::mario@acme.local",
+    ))
+    # 2) deny
+    await client.post("/v1/policy/tool-call", json=_payload(
+        principal_id="acme::user::anna@acme.local",
+    ))
+
+    # Read audit_log rows back.
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        result = await conn.execute(text(
+            "SELECT agent_id, action, status, tool_name "
+            "FROM audit_log WHERE action = 'policy.tool_call' "
+            "ORDER BY chain_seq ASC"
+        ))
+        rows = result.fetchall()
+
+    statuses = {r.agent_id: r.status for r in rows}
+    assert statuses.get("acme::user::mario@acme.local") == "allow"
+    assert statuses.get("acme::user::anna@acme.local") == "deny"
+    for r in rows:
+        assert r.tool_name == "acme.catalog.search"
+
+
+# ── HMAC signature gate ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hmac_required_when_secret_set(tmp_path, monkeypatch):
+    """When the proxy has MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET set, the
+    tool-call endpoint mirrors /pdp/policy: 401 without a valid
+    X-ATN-Signature, 200 with one."""
+    db_file = tmp_path / "tool_pdp_hmac.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "shared-secret-xyz")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            body = json.dumps(_payload()).encode()
+
+            # No signature: 401.
+            r1 = await client.post(
+                "/v1/policy/tool-call",
+                content=body,
+                headers={"content-type": "application/json"},
+            )
+            assert r1.status_code == 401
+
+            # Wrong signature: 401.
+            r2 = await client.post(
+                "/v1/policy/tool-call",
+                content=body,
+                headers={"content-type": "application/json", "x-atn-signature": "00" * 32},
+            )
+            assert r2.status_code == 401
+
+            # Valid signature: 200.
+            sig = hmac.new(b"shared-secret-xyz", body, hashlib.sha256).hexdigest()
+            r3 = await client.post(
+                "/v1/policy/tool-call",
+                content=body,
+                headers={"content-type": "application/json", "x-atn-signature": sig},
+            )
+            assert r3.status_code == 200
+    get_settings.cache_clear()


### PR DESCRIPTION
First two slices of ADR-029 (tool-level + model-aware PDP). The two phases land together because Phase C consumes the wire shape Phase B defines.

## Phase B, broker side (commit 1)

Extends the existing PDP webhook + OPA contract on the broker (Court). Outbound payload (all optional, only written when caller has the data):

- \`model\` (id, provider, via_gateway)
- \`invocation\` (kind=session_open|session_tool_call|oneshot, tool_name?, mcp_server_id?, capabilities_requested)
- \`context\` (trace_id?, parent_session_id?, request_idempotency_key?)

Inbound response (all optional, missing fields parse to None):

- \`scope\` (tools_allowed, tools_denied, max_session_duration_s)
- \`rate_limit\` (per_minute, per_day)
- \`obligations\` (require_user_confirmation, trace_visibility=full|redacted|off)

Dual-allow cross-org intersects scope (tools_allowed by intersection, tools_denied by union, duration by min), rate_limit (min per axis), obligations (require_user_confirmation by OR, trace_visibility clamps to more restrictive) per ADR-029 §Decision.

Backward compat assoluta: a PDP that returns the legacy \`{decision, reason}\` shape keeps working, and the 3 broker callsites (\`router.py\`, \`rfq.py\`, \`oneshot_router.py\`) only add \`invocation.kind\` so existing webhooks see the same payload otherwise.

## Phase C, Mastio side (commit 2)

New \`POST /v1/policy/tool-call\` endpoint that the Connector ambassador will call (Phase D) before executing each MCP tool the model emits during chat completion. Reads a new \`policy_rules.tool_rules\` subtree:

\`\`\`jsonc
{
  "tool_rules": {
    "acme.catalog.search": {
      "allowed_principals": ["acme::user::mario@acme.local"],
      "denied_principals":  [],
      "allowed_models":     ["claude-haiku-4-5", "qwen-72b-chat"],
      "allowed_mcp_servers": ["acme-catalog-prod"],
      "scope":              {...},
      "rate_limit":         {...},
      "obligations":        {...}
    }
  }
}
\`\`\`

Decision logic:
- \`tool_rules\` empty/absent: allow (legacy parity)
- tool not listed: deny (explicit-allow)
- denied_principals: deny (beats allow)
- principal not in allowed: deny (when allowed non-empty)
- model not in allowed_models: deny (when non-empty)
- mcp_server not in allowed_mcp_servers: deny (when non-empty)
- all checks pass: allow + echo optional scope/rate_limit/obligations

Every decision (allow AND deny) writes a hash-chained \`policy.tool_call\` audit row. HMAC signature gate mirrors \`/pdp/policy\`.

Feature flag \`MCP_PROXY_TOOL_PDP_ENABLED\` defaults to **false** so existing deployments keep working untouched. While off the endpoint returns 404. The endpoint reads \`get_settings()\` at request time, not at module import, so the flag can flip live without a worker restart.

## Why

Audit 2026-05-11 shows the current PDP is session-gated only. Once a session opens with a coarse capability (\`order.read\`), every tool inside is auto-allowed and the model in use has no policy visibility. This unlocks the pitch "Mario yes / Anna no / Haiku yes / Opus no on \`acme.catalog.search\`" without breaking any existing PDP webhook.

ADR-029 draft in \`imp/adrs/adr-029-tool-level-pdp.md\` (local). Founder approved the 5 design decisions on 2026-05-11.

## Test plan

- [x] 12 new cases in \`tests/test_pdp_webhook_extended_payload.py\` covering Phase B (payload shape legacy vs extended, response parsing, trace_visibility clamping, intersection helpers, dual-allow end-to-end).
- [x] 10 new cases in \`tests/test_tool_call_pdp_endpoint.py\` covering Phase C (404 when flag off, default-allow legacy, explicit-allow, principal allowlist/denylist, model allowlist, mcp_server allowlist, scope/rate_limit/obligations echo, audit rows on allow+deny, HMAC enforcement).
- [x] Full pre-existing policy + audit-chain suite stays green: **93 passed + 4 skipped** across \`test_policy.py\`, \`test_oneshot_policy_rules.py\`, \`test_policy_default_decision.py\`, \`test_pdp_webhook_hmac.py\`, \`test_opa.py\`, \`test_reach_policy.py\`, \`test_h4_audit_chain.py\`.
- [ ] CI full suite + \`./sandbox/smoke.sh full\` (touches \`app/\` + \`mcp_proxy/\`) before merge.
- [ ] \`/security-review\` pre-merge per repo policy (touches \`app/policy/\`, \`app/broker/\`, \`mcp_proxy/policy/\`, \`mcp_proxy/main.py\`).

## Out of scope

- **Phase D**: Connector ambassador wiring that actually calls \`POST /v1/policy/tool-call\` before tool execution, plus cross-org federation that proxies the call to the target-org Mastio. Tracked as Task #17.
- **Phase E**: dashboard Mastio policy authoring matrix (Task #19).
- **Phase F**: \`./sandbox/demo.sh policy-granular\` + YC video (Task #20).
- **OPA Rego bundle**: \`enterprise-kit/opa/policy/atn/session.rego\` extension for the new input fields. The dispatcher accepts the new fields, the bundle can start consuming them in a follow-up without breaking anything.

🔒 Touches \`app/policy/\`, \`app/broker/\`, \`mcp_proxy/policy/\`, \`mcp_proxy/main.py\`. Security-relevant. Backward compat asserted by both the legacy test suite and the new tests. Default-deny semantics preserved on the broker path; default-allow legacy preserved on the Mastio path until tool_rules is configured.