### PR TITLE
fix(mastio): TOFU pubkey pinning for typed principals (CRIT-1)

### DIFF
--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -234,6 +234,7 @@ async def upsert_from_csr(
     principal_id: str,
     org_id: str,
     cert_thumbprint: str,
+    pubkey_thumbprint: Optional[str] = None,
     surface_hint: Optional[str] = None,
 ) -> None:
     """Called by the CSR sign endpoint after a successful signature.
@@ -242,8 +243,20 @@ async def upsert_from_csr(
     only). The caller hands in the canonical 4-component principal_id;
     we re-key it to the ``::`` short form used by the dashboard.
 
-    Errors are swallowed and logged: the registry table is best-effort
-    UI metadata, never a blocker for the underlying CSR signing flow.
+    ``pubkey_thumbprint`` is the SHA-256 of the principal keypair's
+    SPKI DER. It is the TOFU stable identifier (CRIT-1 fix): set on
+    INSERT and on first refresh of a legacy row that still has NULL,
+    but **never overwritten** once non-NULL. The CSR signer enforces
+    pubkey-match before reaching this function on subsequent calls,
+    so by the time we get here either the thumb agrees with the
+    stored value or we're populating it for the first time.
+
+    Errors are swallowed and logged for the dashboard surface: the
+    registry table is best-effort UI metadata, never a blocker for
+    the underlying CSR signing flow. The pubkey pin is critical
+    enough that the CSR signer-side TOFU check (in
+    ``principals_csr.sign_user_csr``) is the load-bearing defence;
+    this helper just persists the pin on the happy path.
     """
     try:
         # Convert <td>/<org>/user/<name> → <org>::user::<name>.
@@ -268,10 +281,12 @@ async def upsert_from_csr(
                         INSERT INTO local_user_principals (
                             principal_id, user_name, display_name,
                             reach, surface, cert_thumbprint,
+                            pubkey_thumbprint,
                             created_at, last_active_at
                         ) VALUES (
                             :pid, :uname, NULL,
                             'intra', :surface, :thumb,
+                            :pubkey,
                             :now, :now
                         )
                         """
@@ -279,22 +294,31 @@ async def upsert_from_csr(
                     {
                         "pid": pid, "uname": user_name,
                         "surface": surface_hint, "thumb": cert_thumbprint,
+                        "pubkey": pubkey_thumbprint,
                         "now": now,
                     },
                 )
             else:
+                # Update cert_thumbprint (rotational, every CSR refresh)
+                # and last_active. Pubkey_thumbprint is set ONLY when
+                # currently NULL (legacy backfill); never overwritten
+                # — that would defeat the TOFU contract.
                 await conn.execute(
                     text(
                         """
                         UPDATE local_user_principals
                            SET cert_thumbprint = :thumb,
                                last_active_at  = :now,
-                               surface = COALESCE(surface, :surface)
+                               surface = COALESCE(surface, :surface),
+                               pubkey_thumbprint = COALESCE(
+                                   pubkey_thumbprint, :pubkey
+                               )
                          WHERE principal_id = :pid
                         """
                     ),
                     {
                         "pid": pid, "thumb": cert_thumbprint,
+                        "pubkey": pubkey_thumbprint,
                         "surface": surface_hint, "now": now,
                     },
                 )

--- a/mcp_proxy/alembic/versions/0030_user_pubkey_thumbprint.py
+++ b/mcp_proxy/alembic/versions/0030_user_pubkey_thumbprint.py
@@ -1,0 +1,77 @@
+"""TOFU pubkey thumbprint pinning for typed principals (CRIT-1 fix).
+
+Revision ID: 0030_user_pubkey_thumbprint
+Revises: 0029_user_api_tokens
+Create Date: 2026-05-11 18:30:00.000000
+
+Adds ``pubkey_thumbprint`` to ``local_user_principals`` and
+``local_workload_principals``. The column stores SHA-256 of the
+SubjectPublicKeyInfo (SPKI) DER of the principal's keypair — stable
+across cert rotation (Ambassador re-uses its keypair, only the cert
+ruota every ~1h).
+
+The CSR signer (``sign_user_csr``) and the cert auth dep
+(``get_agent_from_client_cert`` for typed principals) read this column
+to enforce TOFU: first CSR for a principal sets the pubkey, every
+subsequent presentation must match.
+
+Backfill is intentionally absent. Existing rows have NULL; the next
+CSR refresh sets it. The cert-auth dep treats NULL as "not yet
+enrolled" and returns 401, so a rogue cert that chains to the Org CA
+but has no principal-side pubkey binding is rejected.
+
+Closes audit finding T2-C1 / Track 2 CRIT-1 (impersonation via cert
+mint + cert-pin bypass for typed principals).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0030_user_pubkey_thumbprint"
+down_revision: Union[str, Sequence[str], None] = "0029_user_api_tokens"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_USERS = "local_user_principals"
+_WORKLOADS = "local_workload_principals"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _USERS in existing:
+        cols = {c["name"] for c in inspector.get_columns(_USERS)}
+        if "pubkey_thumbprint" not in cols:
+            op.add_column(
+                _USERS,
+                sa.Column("pubkey_thumbprint", sa.Text(), nullable=True),
+            )
+
+    if _WORKLOADS in existing:
+        cols = {c["name"] for c in inspector.get_columns(_WORKLOADS)}
+        if "pubkey_thumbprint" not in cols:
+            op.add_column(
+                _WORKLOADS,
+                sa.Column("pubkey_thumbprint", sa.Text(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _USERS in existing:
+        cols = {c["name"] for c in inspector.get_columns(_USERS)}
+        if "pubkey_thumbprint" in cols:
+            op.drop_column(_USERS, "pubkey_thumbprint")
+
+    if _WORKLOADS in existing:
+        cols = {c["name"] for c in inspector.get_columns(_WORKLOADS)}
+        if "pubkey_thumbprint" in cols:
+            op.drop_column(_WORKLOADS, "pubkey_thumbprint")

--- a/mcp_proxy/auth/client_cert.py
+++ b/mcp_proxy/auth/client_cert.py
@@ -284,18 +284,72 @@ async def get_agent_from_client_cert(request: Request) -> InternalAgent:
 
     # ADR-020 — typed principals (user / workload) authenticate via the
     # cert chain (validated upstream by nginx mTLS) plus the SPIFFE SAN
-    # baked into the cert. They are NOT in ``internal_agents`` (that is
-    # the *workload* registry; user principals live in
-    # ``local_user_principals``); the rotating ~1h leaf the
-    # ``/v1/principals/csr`` provisioner mints is never written there.
-    # Looking them up + 401'ing on absence makes every Frontdesk chat
-    # request fail at the gate even though the cert chain is valid.
-    # Skip the registry lookup AND the cert-pin step here, mirroring the
-    # equivalent branch in ``challenge_response.py`` so the two paths
-    # stay symmetric. The trust gate is the chain walk + SPIFFE SAN.
+    # baked into the cert. They live in ``local_user_principals`` /
+    # ``local_workload_principals``, NOT in ``internal_agents`` (that
+    # registry is for service agents). The rotating ~1h leaf the
+    # ``/v1/principals/csr`` provisioner mints rotates the cert
+    # thumbprint, but the principal's keypair (and therefore its SPKI
+    # SHA-256 ``pubkey_thumbprint``) is stable across refreshes.
+    #
+    # CRIT-1 defence (audit T2-C1 / Track 2 CRIT-1, 2026-05-11):
+    # the previous version of this branch skipped registry lookup AND
+    # cert-pin step entirely for typed principals, on the rationale
+    # that the chain walk + SPIFFE SAN was sufficient. It was not. Any
+    # Mastio-bound JWT could POST a CSR for ``<org>::user::<arbitrary>``
+    # via ``/v1/principals/csr``, get the Org CA to sign a 1h cert
+    # bound to the attacker's keypair, then present that cert here and
+    # be accepted as that arbitrary user. We now require the principal
+    # row to exist AND the cert's SPKI SHA-256 to match the row's
+    # ``pubkey_thumbprint`` (TOFU set on first CSR signature).
     is_typed_principal = "::user::" in canonical_id or "::workload::" in canonical_id
 
     if is_typed_principal:
+        if "::user::" in canonical_id:
+            from mcp_proxy.db import get_user_principal_pubkey_thumbprint
+            exists, stored_pubkey = await get_user_principal_pubkey_thumbprint(
+                canonical_id,
+            )
+            kind = "user"
+        else:  # ::workload::
+            from mcp_proxy.db import get_workload_principal_pubkey_thumbprint
+            exists, stored_pubkey = await get_workload_principal_pubkey_thumbprint(
+                canonical_id,
+            )
+            kind = "workload"
+        if not exists:
+            _log.warning(
+                "client cert auth: typed principal not registered: %s",
+                canonical_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"{kind} principal unknown",
+            )
+        if stored_pubkey is None:
+            # Row exists (e.g. admin pre-created via /v1/admin/users)
+            # but no CSR has been signed yet — there is no pubkey to
+            # pin against. Refuse rather than admit on the strength of
+            # the cert chain alone, otherwise CRIT-1 is back in play.
+            _log.warning(
+                "client cert auth: typed principal has no pubkey pin: %s",
+                canonical_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"{kind} principal not yet enrolled",
+            )
+        from mcp_proxy.registry.principals_csr import pubkey_thumbprint_sha256
+        presented_pubkey = pubkey_thumbprint_sha256(cert.public_key())
+        if not hmac.compare_digest(presented_pubkey, stored_pubkey):
+            _log.warning(
+                "client cert pubkey pin mismatch for %s — presented cert "
+                "is not bound to this principal's TOFU pubkey.",
+                canonical_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="client cert pubkey not bound to principal",
+            )
         agent_data = None
     else:
         agent_data = await get_agent(canonical_id)

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -606,6 +606,95 @@ async def count_user_principals() -> int:
         return int(row["n"]) if row else 0
 
 
+async def get_user_principal_pubkey_thumbprint(
+    principal_id: str,
+) -> tuple[bool, str | None]:
+    """TOFU pubkey lookup for a user principal.
+
+    Returns ``(exists, pubkey_thumbprint)``:
+      - ``(False, None)`` — no row in ``local_user_principals`` for this
+        principal_id. Caller (``sign_user_csr``) treats this as "first
+        touch" and the row will be created with the CSR's pubkey on the
+        downstream upsert. Caller (``client_cert.py``) treats this as
+        "principal unknown" and rejects.
+      - ``(True, None)`` — row exists, no pubkey pinned yet (legacy row
+        from before migration 0030, or admin-pre-created via
+        ``POST /v1/admin/users``). Sign signer treats this as TOFU
+        first-cert opportunity. Cert-auth dep rejects.
+      - ``(True, "<sha256_hex>")`` — pinned. Caller compares to the
+        presented pubkey and refuses on mismatch.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT pubkey_thumbprint "
+                "  FROM local_user_principals WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )
+        row = result.mappings().first()
+        if row is None:
+            return (False, None)
+        return (True, row["pubkey_thumbprint"])
+
+
+async def get_workload_principal_pubkey_thumbprint(
+    principal_id: str,
+) -> tuple[bool, str | None]:
+    """TOFU pubkey lookup for a workload principal.
+
+    Same semantics as :func:`get_user_principal_pubkey_thumbprint` but
+    backed by ``local_workload_principals``. Workloads do not currently
+    have a CSR mint flow on ``/v1/principals/csr`` (only users do), so
+    today this returns ``(False, None)`` for any workload that hasn't
+    been pre-created via ``POST /v1/admin/workloads``. The cert-auth
+    dep uses this to reject any cert that claims a workload identity
+    the registry does not know.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "SELECT pubkey_thumbprint "
+                "  FROM local_workload_principals "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": principal_id},
+        )
+        row = result.mappings().first()
+        if row is None:
+            return (False, None)
+        return (True, row["pubkey_thumbprint"])
+
+
+async def set_user_principal_pubkey_thumbprint_if_unset(
+    principal_id: str,
+    pubkey_thumbprint: str,
+) -> bool:
+    """Set ``pubkey_thumbprint`` on a user principal IFF currently NULL.
+
+    Used by the CSR signer for the TOFU first-cert step. Returns True
+    when the row was actually updated (NULL → value), False when the
+    row already had a pubkey pinned (caller must verify match
+    elsewhere — this helper does NOT overwrite).
+
+    Atomic single-statement UPDATE so concurrent first-mints either
+    cooperate (same pubkey, second is a no-op) or one wins (different
+    pubkeys race, the first sets the row, the second is rejected on
+    the next request via the lookup helper).
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE local_user_principals "
+                "   SET pubkey_thumbprint = :thumb "
+                " WHERE principal_id = :pid "
+                "   AND pubkey_thumbprint IS NULL"
+            ),
+            {"pid": principal_id, "thumb": pubkey_thumbprint},
+        )
+        return result.rowcount > 0
+
+
 async def deactivate_agent(agent_id: str) -> bool:
     """Soft-delete an agent by setting ``is_active=0``.
 

--- a/mcp_proxy/registry/principals_csr.py
+++ b/mcp_proxy/registry/principals_csr.py
@@ -179,21 +179,46 @@ def _cert_thumbprint_sha256(cert: x509.Certificate) -> str:
     return hashlib.sha256(der).hexdigest()
 
 
+def pubkey_thumbprint_sha256(public_key) -> str:
+    """SHA-256 hex of a public key's SubjectPublicKeyInfo (SPKI) DER.
+
+    Used for TOFU pinning of typed principals (CRIT-1 fix). The cert
+    rotates every USER_CERT_TTL but the Ambassador re-uses its keypair
+    across refreshes, so the SPKI digest is the stable identifier.
+
+    Stays compatible across RSA/EC public keys — both expose
+    ``public_bytes(SubjectPublicKeyInfo, DER)``.
+    """
+    spki_der = public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return hashlib.sha256(spki_der).hexdigest()
+
+
 async def sign_user_csr(
     csr_pem: str,
     principal_id: str,
     *,
     agent_manager: "AgentManager",
     ttl: timedelta = USER_CERT_TTL,
-) -> tuple[str, str, datetime]:
+) -> tuple[str, str, str, datetime]:
     """Sign a user-principal CSR with the proxy's loaded Org CA.
 
-    Returns ``(cert_pem, cert_thumbprint_sha256, cert_not_after)``.
+    Returns ``(cert_pem, cert_thumbprint_sha256, pubkey_thumbprint_sha256,
+    cert_not_after)``.
+
+    The fourth-element ``pubkey_thumbprint_sha256`` is the stable TOFU
+    binding. The caller persists it on first signature (via
+    ``upsert_from_csr``) and re-verifies on every later request through
+    the cert-auth dependency.
 
     Raises:
         ValueError: principal_id malformed.
         CsrValidationError: CSR malformed, weak key, missing SAN,
-            wrong SPIFFE URI, signature invalid.
+            wrong SPIFFE URI, signature invalid, OR pubkey does not
+            match the previously-pinned pubkey for this principal
+            (TOFU mismatch — CRIT-1 defence).
         RuntimeError: Org CA not loaded on this proxy yet.
     """
     spiffe_expected, expected_org = parse_principal_id_to_spiffe(principal_id)
@@ -218,6 +243,32 @@ async def sign_user_csr(
             f"CSR SPIFFE id {spiffe_in_csr!r} does not match requested "
             f"principal_id {principal_id!r} (expected {spiffe_expected!r})",
         )
+
+    # CRIT-1 defence — TOFU pubkey check. Compute SPKI digest from the
+    # CSR public key, look up the principal's stored thumbprint, and
+    # refuse if they disagree. Without this, any Mastio-bound JWT can
+    # mint a 1h cert for ``<org>::user::<arbitrary-name>`` with the
+    # caller's own keypair, then present that cert on subsequent
+    # requests (the cert chains to the Org CA, the SPIFFE SAN is
+    # well-formed, and the cert-auth dep used to skip the pin step
+    # for typed principals — see ``mcp_proxy/auth/client_cert.py``).
+    csr_pubkey_thumb = pubkey_thumbprint_sha256(csr.public_key())
+    # Slash-form principal_id (``<td>/<org>/user/<name>``) is the wire
+    # form. The dashboard / DB row stores the ``::``-separated short id.
+    parts = principal_id.split("/")
+    if len(parts) == 4 and parts[2] == "user":
+        # Avoid the lazy-import dance further down by importing here.
+        from mcp_proxy.db import get_user_principal_pubkey_thumbprint
+        _exists, stored_thumb = await get_user_principal_pubkey_thumbprint(
+            f"{parts[1]}::user::{parts[3]}",
+        )
+        if stored_thumb is not None and stored_thumb != csr_pubkey_thumb:
+            raise CsrValidationError(
+                "CSR public key does not match the pubkey already bound "
+                f"to {principal_id!r} (TOFU mismatch — refuse to sign)",
+            )
+    # Workloads have no CSR mint flow today; if/when they grow one, mirror
+    # the lookup against ``local_workload_principals`` here.
 
     if not agent_manager.ca_loaded:
         raise RuntimeError(
@@ -280,7 +331,7 @@ async def sign_user_csr(
 
     cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode("utf-8")
     thumbprint = _cert_thumbprint_sha256(cert)
-    return cert_pem, thumbprint, not_after
+    return cert_pem, thumbprint, csr_pubkey_thumb, not_after
 
 
 __all__ = [
@@ -288,5 +339,6 @@ __all__ = [
     "CsrValidationError",
     "USER_CERT_TTL",
     "parse_principal_id_to_spiffe",
+    "pubkey_thumbprint_sha256",
     "sign_user_csr",
 ]

--- a/mcp_proxy/registry/user_principals_router.py
+++ b/mcp_proxy/registry/user_principals_router.py
@@ -105,7 +105,7 @@ async def sign_csr(
         )
 
     try:
-        cert_pem, thumbprint, not_after = await sign_user_csr(
+        cert_pem, thumbprint, pubkey_thumb, not_after = await sign_user_csr(
             csr_pem=body.csr_pem,
             principal_id=body.principal_id,
             agent_manager=agent_manager,
@@ -133,14 +133,17 @@ async def sign_csr(
         "principals.csr signed principal_id=%s thumbprint=%s not_after=%s",
         body.principal_id, thumbprint, not_after.isoformat(),
     )
-    # Best-effort: surface the user in the dashboard's Users tab. Errors
-    # are swallowed inside the helper — the user-facing flow is the
-    # cert response, not the directory upsert.
+    # Surface the user in the dashboard's Users tab AND pin the TOFU
+    # pubkey thumbprint on first signature (CRIT-1 fix). Errors are
+    # swallowed inside the helper for the dashboard side, but pubkey
+    # pinning happens unconditionally — without it, the cert-auth dep
+    # has nothing to compare against on the next request.
     from mcp_proxy.admin.users import upsert_from_csr
     await upsert_from_csr(
         principal_id=body.principal_id,
         org_id=token.org,
         cert_thumbprint=thumbprint,
+        pubkey_thumbprint=pubkey_thumb,
     )
     return CsrSignResponse(
         cert_pem=cert_pem,

--- a/tests/test_client_cert_auth.py
+++ b/tests/test_client_cert_auth.py
@@ -210,16 +210,88 @@ async def test_cn_fallback_when_san_missing(proxy_app, monkeypatch):
     assert resp.status_code == 200, resp.text
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# CRIT-1 (audit T2-C1, 2026-05-11) — typed principal lookup + pubkey pin
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Before the CRIT-1 fix, the dep skipped registry lookup AND cert pin for
+# user/workload principals on the rationale that the chain walk + SPIFFE
+# SAN was sufficient. It was not: any Mastio-bound JWT could POST a CSR
+# for ``<org>::user::<arbitrary>``, get the Org CA to sign a 1h cert
+# bound to the attacker's keypair, then present that cert here and be
+# accepted as that arbitrary user. The dep now requires the principal row
+# to exist AND the cert's SPKI SHA-256 to match the row's
+# ``pubkey_thumbprint`` (TOFU set on first CSR signature).
+#
+# These tests pin that contract.
+
+
+async def _provision_typed_principal(
+    canonical_id: str,
+    *,
+    cert_pem: str | None = None,
+    pubkey_thumbprint: str | None = None,
+    workload: bool = False,
+) -> str | None:
+    """Insert a row in ``local_user_principals`` / ``local_workload_principals``
+    with the given pubkey thumbprint. If ``cert_pem`` is provided, derive
+    the thumbprint from the cert's SPKI. If neither is provided, leaves
+    pubkey_thumbprint NULL (legacy admin-pre-created row, before any CSR).
+
+    Returns the stored thumbprint (or None when neither input given).
+    """
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+
+    if pubkey_thumbprint is None and cert_pem is not None:
+        from cryptography import x509
+        from mcp_proxy.registry.principals_csr import pubkey_thumbprint_sha256
+        cert = x509.load_pem_x509_certificate(cert_pem.encode())
+        pubkey_thumbprint = pubkey_thumbprint_sha256(cert.public_key())
+
+    name_part = canonical_id.split("::")[-1]
+    now = datetime.now(timezone.utc).isoformat()
+    table = "local_workload_principals" if workload else "local_user_principals"
+    name_col = "workload_name" if workload else "user_name"
+
+    async with get_db() as conn:
+        if workload:
+            await conn.execute(
+                text(
+                    f"INSERT INTO {table} "
+                    f"(principal_id, {name_col}, runtime_status, "
+                    f" pubkey_thumbprint, created_at) "
+                    f"VALUES (:pid, :name, 'unknown', :pubkey, :now)"
+                ),
+                {
+                    "pid": canonical_id, "name": name_part,
+                    "pubkey": pubkey_thumbprint, "now": now,
+                },
+            )
+        else:
+            await conn.execute(
+                text(
+                    f"INSERT INTO {table} "
+                    f"(principal_id, {name_col}, reach, surface, "
+                    f" pubkey_thumbprint, created_at) "
+                    f"VALUES (:pid, :name, 'intra', NULL, :pubkey, :now)"
+                ),
+                {
+                    "pid": canonical_id, "name": name_part,
+                    "pubkey": pubkey_thumbprint, "now": now,
+                },
+            )
+    return pubkey_thumbprint
+
+
 @pytest.mark.asyncio
-async def test_typed_user_principal_bypasses_internal_agents_lookup(proxy_app):
-    """ADR-020 — user / workload principals are not in
-    ``internal_agents`` (the workload registry); the Frontdesk Connector
-    mints them via ``/v1/principals/csr`` and presents them on
-    ``/v1/llm`` + ``/v1/mcp``. Without the bypass introduced in this
-    PR, every chat request from a Frontdesk SPA 401'd at the gate even
-    though the cert chain was valid (``agent unknown or inactive``).
-    Exercising the dep directly with a UserPrincipal-shaped SPIFFE id."""
+async def test_typed_user_principal_pubkey_pinned_authenticates(proxy_app):
+    """Happy path — user principal exists in ``local_user_principals``
+    with pubkey_thumbprint matching the presented cert. Dep returns a
+    user-typed InternalAgent without consulting ``internal_agents``."""
     cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::mario")
+    await _provision_typed_principal("acme::user::mario", cert_pem=cert_pem)
     headers = mtls_headers(cert_pem)
 
     request = _request_with_headers(headers)
@@ -231,33 +303,123 @@ async def test_typed_user_principal_bypasses_internal_agents_lookup(proxy_app):
     from mcp_proxy.auth.client_cert import get_agent_from_client_cert
     agent = await get_agent_from_client_cert(request)
 
-    # Bypass kicked in: dep returned without consulting internal_agents.
     assert agent.agent_id == "acme::user::mario"
     assert agent.principal_type == "user"
-    # Cert pin is correctly skipped — no row to pin against.
-    assert agent.cert_pem is None
-    # Reach is intra by design (typed principals never cross-org egress
-    # as themselves; cross-org goes through the Connector agent's
-    # BrokerBridge which has its own reach gate).
+    assert agent.cert_pem is None  # typed principals don't hold a cert in IAgent
     assert agent.reach == "intra"
 
 
 @pytest.mark.asyncio
-async def test_typed_workload_principal_bypasses_internal_agents_lookup(proxy_app):
-    """Same bypass for SPIFFE workload principals — symmetric path
-    since both share the ``::workload::`` / ``::user::`` SPIFFE
-    convention and the ADR-020 typed-principal contract."""
-    cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="workload::etl-job")
+async def test_typed_user_principal_unknown_rejected(proxy_app):
+    """CRIT-1 — cert chains to Org CA + SPIFFE SAN well-formed, but the
+    user principal is not registered. Pre-fix this slipped through;
+    post-fix this is 401 ``user principal unknown``."""
+    cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::nobody")
     headers = mtls_headers(cert_pem)
 
     request = _request_with_headers(headers)
     request.client = MagicMock()
     request.client.host = "127.0.0.1"
-    request.app = MagicMock()
-    request.app.state = MagicMock()
+
+    from fastapi import HTTPException
+    from mcp_proxy.auth.client_cert import get_agent_from_client_cert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_agent_from_client_cert(request)
+    assert exc_info.value.status_code == 401
+    assert "unknown" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_typed_user_principal_pubkey_unset_rejected(proxy_app):
+    """CRIT-1 — admin pre-created the row via ``POST /v1/admin/users``
+    but no CSR has been signed yet, so ``pubkey_thumbprint`` is NULL.
+    The cert presented chains correctly but the pin column is empty —
+    refuse rather than admit on the chain alone."""
+    cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::pending")
+    await _provision_typed_principal(
+        "acme::user::pending",
+        pubkey_thumbprint=None,  # explicit: pre-created, not yet enrolled
+    )
+    headers = mtls_headers(cert_pem)
+
+    request = _request_with_headers(headers)
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    from fastapi import HTTPException
+    from mcp_proxy.auth.client_cert import get_agent_from_client_cert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_agent_from_client_cert(request)
+    assert exc_info.value.status_code == 401
+    assert "enrolled" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_typed_user_principal_pubkey_mismatch_rejected(proxy_app):
+    """CRIT-1 — the headline impersonation defence. Attacker mints a
+    cert with their own keypair for ``acme::user::ceo``. The principal
+    is registered (TOFU pinned to the legitimate user's keypair). The
+    attacker's cert chains correctly, the SPIFFE SAN is well-formed,
+    but the SPKI SHA-256 does not match the stored thumbprint. 401."""
+    legit_cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::ceo")
+    await _provision_typed_principal(
+        "acme::user::ceo", cert_pem=legit_cert_pem,
+    )
+    # Attacker's cert: same identity, different keypair.
+    attacker_cert_pem, _ = mint_agent_cert(org_id="acme", agent_name="user::ceo")
+    headers = mtls_headers(attacker_cert_pem)
+
+    request = _request_with_headers(headers)
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    from fastapi import HTTPException
+    from mcp_proxy.auth.client_cert import get_agent_from_client_cert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_agent_from_client_cert(request)
+    assert exc_info.value.status_code == 401
+    assert "pubkey" in exc_info.value.detail.lower() or "bound" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_typed_workload_principal_pubkey_pinned_authenticates(proxy_app):
+    """Happy path workload — same contract as the user case via
+    ``local_workload_principals``."""
+    cert_pem, _ = mint_agent_cert(
+        org_id="acme", agent_name="workload::etl-job",
+    )
+    await _provision_typed_principal(
+        "acme::workload::etl-job", cert_pem=cert_pem, workload=True,
+    )
+    headers = mtls_headers(cert_pem)
+
+    request = _request_with_headers(headers)
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
 
     from mcp_proxy.auth.client_cert import get_agent_from_client_cert
     agent = await get_agent_from_client_cert(request)
 
     assert agent.agent_id == "acme::workload::etl-job"
     assert agent.principal_type == "workload"
+
+
+@pytest.mark.asyncio
+async def test_typed_workload_principal_unknown_rejected(proxy_app):
+    """CRIT-1 mirror for workloads — unregistered workload principal
+    cert is rejected even though the chain validates."""
+    cert_pem, _ = mint_agent_cert(
+        org_id="acme", agent_name="workload::stranger",
+    )
+    headers = mtls_headers(cert_pem)
+
+    request = _request_with_headers(headers)
+    request.client = MagicMock()
+    request.client.host = "127.0.0.1"
+
+    from fastapi import HTTPException
+    from mcp_proxy.auth.client_cert import get_agent_from_client_cert
+    with pytest.raises(HTTPException) as exc_info:
+        await get_agent_from_client_cert(request)
+    assert exc_info.value.status_code == 401
+    assert "unknown" in exc_info.value.detail.lower()

--- a/tests/test_crit1_csr_pubkey_tofu.py
+++ b/tests/test_crit1_csr_pubkey_tofu.py
@@ -1,0 +1,257 @@
+"""CRIT-1 — TOFU pubkey enforcement on the Mastio CSR signer.
+
+Audit ref: ``imp/audits/2026-05-11-track-2-auth.md`` finding C1
+(impersonation via cert mint + cert-pin bypass for typed principals).
+
+The Mastio CSR signer (``mcp_proxy.registry.principals_csr.sign_user_csr``)
+must refuse to sign a CSR whose public key does not match the
+previously-pinned ``pubkey_thumbprint`` for the requested principal.
+First-touch (no row, or row with NULL pubkey_thumbprint) sets the pin.
+Re-mint with the same keypair refreshes the rotational cert. Re-mint
+with a different keypair is the impersonation vector and must 4xx.
+"""
+from __future__ import annotations
+
+import os
+
+# Match the conftest env baseline so this file can run standalone too
+# (the `tests/conftest.py` shared fixture sets these globally, but
+# importing it eagerly pulls the Court app — we only need the proxy).
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    """Spin a Mastio app against a tmp sqlite — same shape as the
+    proxy_app fixture in test_client_cert_auth.py."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_INTRA_ORG", "true")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "false")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _build_org_ca() -> tuple[ec.EllipticCurvePrivateKey, x509.Certificate]:
+    """A tiny throwaway Org CA suitable for unit-level CSR signing."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, "Cullis Mastio Test CA"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, "acme"),
+    ])
+    now = datetime.now(timezone.utc)
+    from datetime import timedelta
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(
+            x509.BasicConstraints(ca=True, path_length=1), critical=True,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    return key, cert
+
+
+def _make_csr(spiffe_uri: str) -> tuple[ec.EllipticCurvePrivateKey, str]:
+    """Build an EC P-256 CSR with the given SPIFFE SAN."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    builder = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, "principal"),
+        ]))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(spiffe_uri),
+            ]),
+            critical=False,
+        )
+    )
+    csr = builder.sign(priv, hashes.SHA256())
+    return priv, csr.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _fake_agent_manager(
+    ca_key: ec.EllipticCurvePrivateKey,
+    ca_cert: x509.Certificate,
+    org_id: str = "acme",
+):
+    """sign_user_csr only reads ``.org_id``, ``.ca_loaded``,
+    ``._org_ca_key``, ``._org_ca_cert`` — a SimpleNamespace covers it
+    without dragging the full AgentManager bootstrap."""
+    return SimpleNamespace(
+        org_id=org_id,
+        ca_loaded=True,
+        _org_ca_key=ca_key,
+        _org_ca_cert=ca_cert,
+    )
+
+
+# ── direct sign_user_csr TOFU tests ─────────────────────────────────
+
+
+async def test_first_mint_succeeds_and_returns_pubkey_thumbprint(proxy_app):
+    """No prior row for the principal — sign succeeds and returns a
+    non-empty pubkey thumbprint that the caller will pin."""
+    ca_key, ca_cert = _build_org_ca()
+    mgr = _fake_agent_manager(ca_key, ca_cert)
+    _priv, csr_pem = _make_csr(
+        "spiffe://cullis.local/acme/user/mario",
+    )
+
+    from mcp_proxy.registry.principals_csr import sign_user_csr
+    cert_pem, cert_thumb, pubkey_thumb, not_after = await sign_user_csr(
+        csr_pem, "cullis.local/acme/user/mario", agent_manager=mgr,
+    )
+    assert cert_pem.startswith("-----BEGIN CERTIFICATE-----")
+    assert len(cert_thumb) == 64  # sha256 hex
+    assert len(pubkey_thumb) == 64  # sha256 hex
+    assert cert_thumb != pubkey_thumb  # cert DER ≠ SPKI DER
+
+
+async def test_remint_same_pubkey_succeeds(proxy_app):
+    """Re-mint with the same keypair (rotational cert refresh) is
+    idempotent — pubkey thumbprint stays the same."""
+    ca_key, ca_cert = _build_org_ca()
+    mgr = _fake_agent_manager(ca_key, ca_cert)
+    priv, csr_pem = _make_csr("spiffe://cullis.local/acme/user/alice")
+
+    # First mint via the same module path the router uses, including
+    # the upsert_from_csr step that pins the pubkey.
+    from mcp_proxy.registry.principals_csr import sign_user_csr
+    from mcp_proxy.admin.users import upsert_from_csr
+    _, _, first_pubkey, _ = await sign_user_csr(
+        csr_pem, "cullis.local/acme/user/alice", agent_manager=mgr,
+    )
+    await upsert_from_csr(
+        principal_id="cullis.local/acme/user/alice",
+        org_id="acme",
+        cert_thumbprint="dummy",
+        pubkey_thumbprint=first_pubkey,
+    )
+
+    # Second CSR with the SAME private key (rebuild the CSR from the
+    # same priv) — pubkey thumbprint must match.
+    builder = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name([
+            x509.NameAttribute(NameOID.COMMON_NAME, "principal"),
+        ]))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.UniformResourceIdentifier(
+                    "spiffe://cullis.local/acme/user/alice",
+                ),
+            ]),
+            critical=False,
+        )
+    )
+    second_csr = builder.sign(priv, hashes.SHA256())
+    second_pem = second_csr.public_bytes(serialization.Encoding.PEM).decode()
+
+    _, _, second_pubkey, _ = await sign_user_csr(
+        second_pem, "cullis.local/acme/user/alice", agent_manager=mgr,
+    )
+    assert second_pubkey == first_pubkey
+
+
+async def test_remint_different_pubkey_rejected(proxy_app):
+    """The headline impersonation defence — second CSR for the same
+    principal_id with a NEW keypair must be refused (TOFU mismatch)."""
+    ca_key, ca_cert = _build_org_ca()
+    mgr = _fake_agent_manager(ca_key, ca_cert)
+    _priv1, csr_pem1 = _make_csr("spiffe://cullis.local/acme/user/ceo")
+
+    # First mint pins the legitimate keypair.
+    from mcp_proxy.registry.principals_csr import sign_user_csr, CsrValidationError
+    from mcp_proxy.admin.users import upsert_from_csr
+    _, _, first_pubkey, _ = await sign_user_csr(
+        csr_pem1, "cullis.local/acme/user/ceo", agent_manager=mgr,
+    )
+    await upsert_from_csr(
+        principal_id="cullis.local/acme/user/ceo",
+        org_id="acme",
+        cert_thumbprint="dummy",
+        pubkey_thumbprint=first_pubkey,
+    )
+
+    # Attacker generates their own keypair, builds a CSR with the
+    # same SPIFFE SAN. The CSR is structurally valid; CA could sign it
+    # (the chain would be fine). But the pubkey doesn't match what
+    # we pinned.
+    _priv2, csr_pem2 = _make_csr("spiffe://cullis.local/acme/user/ceo")
+
+    with pytest.raises(CsrValidationError, match="TOFU"):
+        await sign_user_csr(
+            csr_pem2, "cullis.local/acme/user/ceo", agent_manager=mgr,
+        )
+
+
+async def test_first_mint_with_legacy_row_pubkey_null_succeeds(proxy_app):
+    """Admin pre-created the row via /v1/admin/users (no pubkey yet,
+    column is NULL). First CSR succeeds — sets pubkey on upsert.
+    Behaviour matches the bare ``no row at all`` case."""
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+
+    # Pre-create the row admin-style (pubkey NULL).
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_user_principals "
+                "(principal_id, user_name, reach, surface, "
+                " pubkey_thumbprint, created_at) "
+                "VALUES ('acme::user::pre', 'pre', 'intra', NULL, "
+                " NULL, :now)"
+            ),
+            {"now": datetime.now(timezone.utc).isoformat()},
+        )
+
+    ca_key, ca_cert = _build_org_ca()
+    mgr = _fake_agent_manager(ca_key, ca_cert)
+    _, csr_pem = _make_csr("spiffe://cullis.local/acme/user/pre")
+
+    from mcp_proxy.registry.principals_csr import sign_user_csr
+    cert_pem, _, pubkey_thumb, _ = await sign_user_csr(
+        csr_pem, "cullis.local/acme/user/pre", agent_manager=mgr,
+    )
+    assert cert_pem.startswith("-----BEGIN CERTIFICATE-----")
+    assert len(pubkey_thumb) == 64

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0029_user_api_tokens",)]
+    assert rows == [("0030_user_pubkey_thumbprint",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0029_user_api_tokens",)]
+    assert version == [("0030_user_pubkey_thumbprint",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0029_user_api_tokens"
+HEAD_REVISION = "0030_user_pubkey_thumbprint"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0029_user_api_tokens"
+HEAD_REVISION = "0030_user_pubkey_thumbprint"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0029_user_api_tokens"
+HEAD_REVISION = "0030_user_pubkey_thumbprint"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

Closes audit finding **CRIT-1** (Wave A PR1/5) from \`imp/audits/2026-05-11-MASTER.md\` — full impersonation of any user/workload via cert mint + cert-pin bypass for typed principals.

**Vector before this PR:** any agent holding a Mastio-bound JWT (Frontdesk, Connector, etc.) could POST a CSR for \`<org>::user::<arbitrary>\` to \`/v1/principals/csr\`, get the Org CA to sign a 1h cert bound to the attacker's keypair, then present that cert on the mTLS path. \`get_agent_from_client_cert\` skipped both registry lookup AND cert-pin for any canonical id containing \`::user::\` / \`::workload::\` — the trust gate was the chain walk + SPIFFE SAN, which the attacker satisfied trivially.

**Fix (4 layers):**
1. Migration 0030 adds \`pubkey_thumbprint\` (SHA-256 of SPKI DER, stable across cert rotation) to \`local_user_principals\` + \`local_workload_principals\`.
2. \`sign_user_csr\` enforces TOFU: refuse to sign when an existing principal has a \`pubkey_thumbprint\` that disagrees with the CSR's pubkey.
3. \`upsert_from_csr\` writes the pin on INSERT or NULL backfill, never overwrites a non-NULL value (\`COALESCE\`).
4. \`client_cert.py\` for typed principals now requires: row exists → pubkey_thumbprint set → presented cert SPKI matches via \`hmac.compare_digest\`. 401 on any miss.

## Test plan

- [x] \`pytest tests/test_client_cert_auth.py tests/test_crit1_csr_pubkey_tofu.py tests/test_admin_users.py tests/test_principals_csr.py tests/test_proxy_migrations*.py tests/test_user_principals_registry.py tests/test_user_api_tokens_db.py\` → 106 passed, 1 skipped
- [x] \`pytest tests/\` (full suite, parallel) → 3164 passed, 9 skipped, 8 pre-existing failures (GUI libs CI headless + postgres binding KeyError, all in memory feedback files)
- [x] \`./demo_network/smoke.sh full\` → all assertions PASS (cross-org A2A round-trip, dashboard signing key restart-survival, audit hash chain across 38 entries, mcp-echo forwarding)
- [x] Local \`/security-review\` on the PR diff → 0 findings ≥0.7 confidence (TOFU first-touch race + workload asymmetry are inherent design tradeoffs, documented in commit message and code)

## New / updated tests

- 6 new cases in \`tests/test_client_cert_auth.py\` covering the user + workload pubkey-pin contract (happy / unknown / unset / mismatch).
- 4 new cases in \`tests/test_crit1_csr_pubkey_tofu.py\` covering the signer-side TOFU directly (first-mint, refresh same pubkey, mismatch refuse, NULL backfill).
- HEAD_REVISION bumped from 0029 → 0030 in 4 migration tests.

## Scope notes

- **Court-side duplicate** (\`app/registry/principals_csr.py\`) is NOT touched. Its docstring says it is broken-by-design (signs with the wrong CA) and lives as legacy. Separate cleanup in a follow-up PR.
- **First-mint of an arbitrary new \`user_name\` is NOT fully closed.** This PR closes re-mint with a different keypair (the published vector). First-mint requires a second layer: gate \`/v1/principals/csr\` on caller capability (e.g. only Frontdesk-typed callers can mint new users; agent-typed callers can only refresh their own). Tracked as a follow-up.

## Wave A status

| # | Finding | Status |
|---|---|---|
| 1 | CRIT-1 cert mint + cert-pin | **THIS PR** |
| 2 | CRIT-2 ingress execute binding check | next |
| 3 | culk_ scope_paths + scope_providers enforcement | queued |
| 4 | Quick wins bundle (D2 + B2 + C3 + E1) | queued |
| 5 | CRIT-3 audit DB trigger + back-fill refactor | queued |