### PR TITLE
feat(connector): ADR-029 Phase D-1, Connector PDP gate per tool call

### DIFF
--- a/cullis_connector/ambassador/loop.py
+++ b/cullis_connector/ambassador/loop.py
@@ -58,6 +58,11 @@ def run_tool_use_loop(
     request_body: dict,
     *,
     max_iters: int = DEFAULT_MAX_ITERS,
+    pdp_enabled: bool = False,
+    principal_id: str | None = None,
+    principal_type: str = "user",
+    principal_org: str | None = None,
+    session_id: str | None = None,
 ) -> tuple[dict, bool]:
     """Drive an LLM tool-use loop through Cullis.
 
@@ -65,6 +70,17 @@ def run_tool_use_loop(
         client: an authenticated ``CullisClient``.
         request_body: the OpenAI ChatCompletion body the chat client sent.
         max_iters: cap on LLM ↔ tool-call round trips.
+        pdp_enabled: ADR-029 Phase D, when true call the Mastio
+            ``/v1/policy/tool-call`` endpoint before each tool dispatch.
+            On deny the tool is not executed; the loop emits a
+            ``policy_denied`` text back to the model so it can synthesise
+            an explanation for the user. Defaults to false so existing
+            Connector behaviour is unchanged.
+        principal_id / principal_type / principal_org: identity of the
+            principal driving the chat. Only consulted when
+            ``pdp_enabled`` is true.
+        session_id: chat session identifier propagated to the PDP so
+            audit rows can correlate tool calls within a turn.
 
     Returns:
         A tuple ``(final_response, truncated)``. ``final_response`` is the
@@ -132,12 +148,40 @@ def run_tool_use_loop(
             except json.JSONDecodeError:
                 _log.warning("tool_call args not valid JSON: %r", args_raw[:200])
                 args = {}
-            try:
-                result = client.call_mcp_tool(name, args)
-                text = _mcp_result_to_text(result)
-            except Exception as exc:  # broad: surface any tool error to the LLM
-                _log.exception("tool %s failed", name)
-                text = f"tool error: {exc}"
+            # ADR-029 Phase D, pre-execute PDP gate. When `pdp_enabled`
+            # is set we ask the Mastio whether this principal may invoke
+            # `name` with the current model. On deny the SDK call is
+            # skipped and the loop hands a `policy_denied` text back to
+            # the model, which then explains the refusal to the user.
+            policy_blocked: tuple[bool, str] = (False, "")
+            if pdp_enabled and principal_id:
+                try:
+                    pdp = client.evaluate_tool_call_policy(
+                        principal_id=principal_id,
+                        principal_type=principal_type,
+                        org=principal_org,
+                        model_id=body.get("model"),
+                        tool_name=name,
+                        session_id=session_id,
+                    )
+                except Exception as exc:  # never let PDP errors hang the loop
+                    _log.warning("PDP transport failure on tool %s: %s", name, exc)
+                    pdp = {"allowed": False, "reason": f"PDP transport: {exc}"}
+                if not pdp.get("allowed"):
+                    policy_blocked = (True, str(pdp.get("reason") or ""))
+                    _log.info(
+                        "tool %s denied by PDP: %s", name, policy_blocked[1],
+                    )
+
+            if policy_blocked[0]:
+                text = f"policy_denied: tool '{name}' refused by policy: {policy_blocked[1]}"
+            else:
+                try:
+                    result = client.call_mcp_tool(name, args)
+                    text = _mcp_result_to_text(result)
+                except Exception as exc:  # broad: surface any tool error to the LLM
+                    _log.exception("tool %s failed", name)
+                    text = f"tool error: {exc}"
             messages.append({
                 "role": "tool",
                 "tool_call_id": tc.get("id", f"call_{iteration}_{name}"),

--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 import uuid
 from typing import Any
@@ -243,8 +244,36 @@ def chat_completions(req: ChatCompletionRequest, request: Request):
             _log.exception("ambassador SDK login failed")
             raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
 
+    # ADR-029 Phase D, opt-in PDP gate on each tool call inside the loop.
+    # Off by default so existing deployments keep dispatching tools
+    # without a per-call PDP roundtrip; once an operator enables the
+    # flag on both sides (Connector and Mastio) the loop refuses tools
+    # the Mastio's policy_rules.tool_rules does not authorise.
+    _pdp_enabled = (os.getenv("CULLIS_CONNECTOR_TOOL_PDP_ENABLED", "false").lower()
+                    in ("1", "true", "yes", "on"))
+    _principal_id: str | None = None
+    _principal_type = "user"
+    _principal_org: str | None = None
+    if user_creds is not None:
+        _principal_id = user_creds.principal_id
+        _principal_type = getattr(user_creds, "principal_type", "user") or "user"
+        _principal_org = getattr(user_creds, "org", None)
+    elif _pdp_enabled:
+        # Agent-bound mode (no per-user credentials): fall back to the
+        # client's own agent id so the audit row still names who acted.
+        _principal_id = getattr(client, "agent_id", None)
+        _principal_type = "agent"
+
     try:
-        response, truncated = run_tool_use_loop(client, body, max_iters=8)
+        response, truncated = run_tool_use_loop(
+            client,
+            body,
+            max_iters=8,
+            pdp_enabled=_pdp_enabled,
+            principal_id=_principal_id,
+            principal_type=_principal_type,
+            principal_org=_principal_org,
+        )
     except Exception as exc:
         # Defensive: any auth-shaped error invalidates the cached
         # client so the next request re-logs in fresh. Per-user

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -3277,6 +3277,117 @@ class CullisClient:
             )
         return body.get("result", {})
 
+    def evaluate_tool_call_policy(
+        self,
+        *,
+        principal_id: str,
+        principal_type: str = "user",
+        org: str | None = None,
+        model_id: str | None = None,
+        model_provider: str | None = None,
+        tool_name: str,
+        mcp_server_id: str | None = None,
+        session_id: str | None = None,
+        target_id: str | None = None,
+        target_type: str | None = None,
+        target_org: str | None = None,
+    ) -> dict:
+        """ADR-029 Phase D, ask the Mastio whether a tool call is allowed.
+
+        Wraps ``POST /v1/policy/tool-call`` on the configured Mastio.
+        Returns a dict with at least ``allowed: bool`` and ``reason: str``;
+        when the Mastio echoes them, optional ``scope`` / ``rate_limit``
+        / ``obligations`` dicts are passed through.
+
+        Behaviour on edge cases (kept boring on purpose so callers in
+        hot paths can rely on a small surface):
+
+          - HTTP 404, the Mastio has ``MCP_PROXY_TOOL_PDP_ENABLED=false``,
+            we treat the gate as disabled and return ``{"allowed": True,
+            "reason": "tool-level PDP disabled (404 from Mastio)"}``.
+            That keeps legacy Mastios working when an upgraded Connector
+            enables its side first.
+          - HTTP 401 / 403, signature or auth problem; deny, the reason
+            string carries the upstream code so audits are useful.
+          - HTTP 5xx or transport error, deny, fail-safe.
+          - HTTP 200 with malformed JSON, deny.
+        """
+        payload: dict = {
+            "principal": {
+                "id": principal_id,
+                "type": principal_type,
+            },
+            "invocation": {
+                "kind": "session_tool_call",
+                "tool_name": tool_name,
+            },
+        }
+        if org:
+            payload["principal"]["org"] = org
+        if model_id or model_provider:
+            payload["model"] = {}
+            if model_id:
+                payload["model"]["id"] = model_id
+            if model_provider:
+                payload["model"]["provider"] = model_provider
+        if mcp_server_id:
+            payload["invocation"]["mcp_server_id"] = mcp_server_id
+        if target_id or target_type or target_org:
+            payload["target"] = {}
+            if target_id:
+                payload["target"]["id"] = target_id
+            if target_type:
+                payload["target"]["type"] = target_type
+            if target_org:
+                payload["target"]["org"] = target_org
+        if session_id:
+            payload["context"] = {"session_id": session_id}
+
+        try:
+            resp = self._authed_request(
+                "POST", "/v1/policy/tool-call", json=payload,
+            )
+        except Exception as exc:  # transport-level failure
+            return {
+                "allowed": False,
+                "reason": f"PDP transport error: {exc}",
+            }
+
+        if resp.status_code == 404:
+            return {
+                "allowed": True,
+                "reason": "tool-level PDP disabled (404 from Mastio)",
+            }
+        if resp.status_code in (401, 403):
+            return {
+                "allowed": False,
+                "reason": f"PDP rejected: HTTP {resp.status_code}",
+            }
+        if resp.status_code >= 500 or resp.status_code != 200:
+            return {
+                "allowed": False,
+                "reason": f"PDP unexpected status: HTTP {resp.status_code}",
+            }
+
+        try:
+            body = resp.json()
+        except Exception:
+            return {
+                "allowed": False,
+                "reason": "PDP returned non-JSON body",
+            }
+
+        decision = str(body.get("decision", "deny")).lower()
+        out: dict = {
+            "allowed": decision == "allow",
+            "reason": str(body.get("reason", ""))[:512],
+        }
+        for k in ("scope", "rate_limit", "obligations"):
+            v = body.get(k)
+            if isinstance(v, dict):
+                out[k] = v
+        return out
+
 
 class WebSocketConnection:
     """Authenticated WebSocket connection with heartbeat + auto-reconnect (M2).

--- a/tests/connector/test_ambassador_router.py
+++ b/tests/connector/test_ambassador_router.py
@@ -97,6 +97,12 @@ class FakeCullisClient:
     tools_to_return: list[dict] = []
     tool_results: dict[str, Any] = {}
 
+    # ADR-029 Phase D, programmable PDP for tool-level tests. Each entry
+    # in pdp_responses pops FIFO; pdp_raise toggles an exception path.
+    pdp_calls: list[dict] = []
+    pdp_responses: list[dict] = []
+    pdp_raise: bool = False
+
     @classmethod
     def reset(cls) -> None:
         cls.last_login = ()
@@ -106,6 +112,9 @@ class FakeCullisClient:
         cls.chat_responses = []
         cls.tools_to_return = []
         cls.tool_results = {}
+        cls.pdp_calls = []
+        cls.pdp_responses = []
+        cls.pdp_raise = False
 
     def __init__(self, *args, **kwargs) -> None:
         self._init_args = args
@@ -127,6 +136,9 @@ class FakeCullisClient:
 
     def login_from_pem(self, agent_id, org_id, cert_pem, key_pem, **kw) -> None:
         type(self).last_login = (agent_id, org_id, cert_pem[:30], key_pem[:30])
+        # ADR-029 Phase D: ambassador reads client.agent_id to populate
+        # the PDP principal field when no per-user credentials are set.
+        self.agent_id = agent_id
 
     def chat_completion(self, body: dict) -> dict:
         type(self).chat_calls.append(body)
@@ -148,6 +160,14 @@ class FakeCullisClient:
         if name in type(self).tool_results:
             return type(self).tool_results[name]
         return {"content": [{"type": "text", "text": f"tool {name} ok"}]}
+
+    def evaluate_tool_call_policy(self, **kwargs) -> dict:
+        type(self).pdp_calls.append(kwargs)
+        if type(self).pdp_raise:
+            raise RuntimeError("simulated PDP transport failure")
+        if type(self).pdp_responses:
+            return type(self).pdp_responses.pop(0)
+        return {"allowed": True, "reason": "default fake allow"}
 
 
 # ── fixtures ────────────────────────────────────────────────────────
@@ -510,3 +530,168 @@ def test_local_token_file_is_chmod_600(tmp_path: Path, client):
     if os.name == "posix":
         mode = stat.S_IMODE(token_path.stat().st_mode)
         assert mode == 0o600, f"local.token mode is {oct(mode)}, expected 0o600"
+
+
+# ── ADR-029 Phase D: per-call PDP gate inside the tool-use loop ─────
+
+
+def _gdpr_chat_responses_with_tool() -> list[dict]:
+    """Fixture: LLM emits one tool_call then a final answer."""
+    return [
+        {
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "query",
+                            "arguments": '{"sql": "SELECT 1"}',
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+        },
+        {
+            "choices": [{
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+        },
+    ]
+
+
+def test_pdp_off_keeps_legacy_behaviour(client, bearer, monkeypatch):
+    """With CULLIS_CONNECTOR_TOOL_PDP_ENABLED unset (default off) the
+    loop must not call evaluate_tool_call_policy at all and the tool
+    dispatch happens unchanged."""
+    monkeypatch.delenv("CULLIS_CONNECTOR_TOOL_PDP_ENABLED", raising=False)
+    FakeCullisClient.tools_to_return = [{
+        "name": "query",
+        "description": "run sql",
+        "inputSchema": {"type": "object"},
+    }]
+    FakeCullisClient.chat_responses = _gdpr_chat_responses_with_tool()
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "do the thing"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert FakeCullisClient.pdp_calls == []          # PDP NOT invoked
+    assert len(FakeCullisClient.call_tool_calls) == 1  # tool still ran
+
+
+def test_pdp_on_allow_executes_tool(client, bearer, monkeypatch):
+    """With the flag on and the PDP returning allow, the tool runs
+    and the PDP receives tool_name + model in the call kwargs."""
+    monkeypatch.setenv("CULLIS_CONNECTOR_TOOL_PDP_ENABLED", "true")
+    FakeCullisClient.tools_to_return = [{
+        "name": "query",
+        "description": "run sql",
+        "inputSchema": {"type": "object"},
+    }]
+    FakeCullisClient.chat_responses = _gdpr_chat_responses_with_tool()
+    FakeCullisClient.pdp_responses = [{"allowed": True, "reason": "ok"}]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "do the thing"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert len(FakeCullisClient.pdp_calls) == 1
+    pdp = FakeCullisClient.pdp_calls[0]
+    assert pdp["tool_name"] == "query"
+    assert pdp["model_id"] == "claude-haiku-4-5"
+    assert len(FakeCullisClient.call_tool_calls) == 1
+
+
+def test_pdp_on_deny_blocks_tool(client, bearer, monkeypatch):
+    """When the PDP denies, the SDK call_mcp_tool is NOT invoked and
+    the tool message handed back to the LLM carries `policy_denied`."""
+    monkeypatch.setenv("CULLIS_CONNECTOR_TOOL_PDP_ENABLED", "true")
+    FakeCullisClient.tools_to_return = [{
+        "name": "query",
+        "description": "run sql",
+        "inputSchema": {"type": "object"},
+    }]
+    final_text = "Sorry, I can't run that tool."
+    FakeCullisClient.chat_responses = [
+        _gdpr_chat_responses_with_tool()[0],
+        {
+            "choices": [{
+                "message": {"role": "assistant", "content": final_text},
+                "finish_reason": "stop",
+            }],
+        },
+    ]
+    FakeCullisClient.pdp_responses = [{
+        "allowed": False,
+        "reason": "principal 'acme::frontdesk' not in tool_rules.query.allowed_principals",
+    }]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "do the thing"}],
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["choices"][0]["message"]["content"] == final_text
+    # Tool was NOT executed.
+    assert FakeCullisClient.call_tool_calls == []
+    # The second LLM turn saw a role=tool message tagged policy_denied.
+    second_call = FakeCullisClient.chat_calls[1]
+    last_message = second_call["messages"][-1]
+    assert last_message["role"] == "tool"
+    assert "policy_denied" in last_message["content"]
+
+
+def test_pdp_transport_error_fail_safe_deny(client, bearer, monkeypatch):
+    """If evaluate_tool_call_policy raises, the loop treats it as a
+    deny rather than running the tool unsupervised."""
+    monkeypatch.setenv("CULLIS_CONNECTOR_TOOL_PDP_ENABLED", "true")
+    FakeCullisClient.tools_to_return = [{
+        "name": "query",
+        "description": "run sql",
+        "inputSchema": {"type": "object"},
+    }]
+    FakeCullisClient.chat_responses = [
+        _gdpr_chat_responses_with_tool()[0],
+        {
+            "choices": [{
+                "message": {"role": "assistant", "content": "blocked, retry later"},
+                "finish_reason": "stop",
+            }],
+        },
+    ]
+    FakeCullisClient.pdp_raise = True
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "messages": [{"role": "user", "content": "do the thing"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert FakeCullisClient.call_tool_calls == []
+    second_call = FakeCullisClient.chat_calls[1]
+    last_message = second_call["messages"][-1]
+    assert last_message["role"] == "tool"
+    assert "policy_denied" in last_message["content"]


### PR DESCRIPTION
Wires the Connector ambassador to the Mastio `/v1/policy/tool-call` endpoint added in #600 (Phase C). The tool-use loop now asks the Mastio whether each tool call is allowed BEFORE executing it through the SDK. On deny the SDK call is skipped and the loop hands a `policy_denied` tool message back to the model.

## Why

#600 ships the Mastio side but nothing calls the endpoint yet. This PR closes the loop on the originating side: with both flags flipped on, a misconfigured principal that tries to invoke an unauthorised tool sees the model itself refuse the operation, and the Mastio audit chain captures the deny.

Single-org only. Phase D-2 will add cross-org federation.

## Feature flag

`CULLIS_CONNECTOR_TOOL_PDP_ENABLED`, default **false**. Until both sides (Connector and Mastio) are flipped on, behaviour is identical to today's loop. Mastio side flag is `MCP_PROXY_TOOL_PDP_ENABLED` (also default false).

## Components

### SDK (`cullis_sdk/client.py`)

New `CullisClient.evaluate_tool_call_policy(...)` posts the ADR-029 Phase B payload to the Mastio and parses the extended response. Edge cases:

- `404` from Mastio (PDP disabled there) → treat as **allow** so a Connector that flips its flag first does not lock itself out against legacy Mastios.
- `401` / `403` → deny, reason carries the upstream code.
- `5xx` or transport error → deny (fail-safe).
- `200` malformed JSON → deny.
- `200` with extended response → decision plus optional `scope` / `rate_limit` / `obligations` passthrough.

### Loop hook (`cullis_connector/ambassador/loop.py`)

New optional kwargs: `pdp_enabled`, `principal_id`, `principal_type`, `principal_org`, `session_id`. When `pdp_enabled` is true and a `principal_id` is available, the loop calls `client.evaluate_tool_call_policy(...)` right before `client.call_mcp_tool(...)`. Errors from the PDP call itself never escape the loop: they collapse to a deny so an outage on the policy plane never silently grants access.

### Router wiring (`cullis_connector/ambassador/router.py`)

Reads `CULLIS_CONNECTOR_TOOL_PDP_ENABLED` at request time. Resolves the principal:
- ADR-025 per-user auth set: `request.state.user_credentials.principal_id` + `principal_type` + `org`
- Agent-bound mode (no per-user creds): `client.agent_id`, `principal_type=agent`

## Test plan

- [x] 4 new cases in `tests/connector/test_ambassador_router.py`:
  - flag off → zero PDP calls, tool runs as before (legacy parity)
  - flag on + PDP allow → tool runs, PDP gets tool_name + model_id
  - flag on + PDP deny → `call_mcp_tool` NOT invoked, second LLM turn sees `role=tool` tagged `policy_denied`
  - flag on + PDP transport error → fail-safe deny
- [x] Full ambassador suite green: 17 pre-existing + 4 new = **21 passed**.
- [ ] CI full suite + `./sandbox/smoke.sh full` before merge (touches `cullis_connector/` + `cullis_sdk/`).
- [ ] `/security-review` pre-merge.

## Depends on

#600 (Phase B + Phase C). End-to-end allow/deny only exercises against a Mastio that has #600 + `MCP_PROXY_TOOL_PDP_ENABLED=true` + a non-empty `policy_rules.tool_rules`.

## Out of scope

- **Phase D-2**: cross-org federation Mastio → Mastio when `target.org` differs from originator's.
- **Phase E**: dashboard policy authoring matrix.
- **Phase F**: `./sandbox/demo.sh policy-granular` + YC video.
- **Streaming SSE chat path** in the parallel router branch gets the same hook in a follow-up so this PR stays reviewable.

🔒 Touches `cullis_connector/ambassador/` and `cullis_sdk/`. Backward compat asserted by the legacy parity test. Default-deny on PDP transport errors.