### PR TITLE
fix(mastio): enforce MCP-resource binding gate on REST ingress (CRIT-2)

### DIFF
--- a/mcp_proxy/ingress/mcp_aggregator.py
+++ b/mcp_proxy/ingress/mcp_aggregator.py
@@ -30,10 +30,8 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from sqlalchemy import text
 
 from mcp_proxy.auth.dependencies import get_authenticated_agent
-from mcp_proxy.db import get_db
 from mcp_proxy.local.audit import append_local_audit
 from mcp_proxy.models import TokenPayload, ToolExecuteRequest
 from mcp_proxy.tools import executor
@@ -71,47 +69,10 @@ def _rpc_result(req_id: Any, result: Any) -> dict:
     return {"jsonrpc": "2.0", "id": req_id, "result": result}
 
 
-async def _bound_resource_ids(
-    principal_id: str, principal_type: str,
-) -> set[str]:
-    """Return the set of resource_ids this principal currently has active
-    bindings for. ADR-020 — keys on ``(agent_id, principal_type)`` so
-    a user named "daniele" never inherits an agent named "daniele"'s
-    bindings (or vice versa)."""
-    async with get_db() as conn:
-        result = await conn.execute(
-            text(
-                """
-                SELECT resource_id
-                  FROM local_agent_resource_bindings
-                 WHERE agent_id = :a
-                   AND principal_type = :pt
-                   AND revoked_at IS NULL
-                """
-            ),
-            {"a": principal_id, "pt": principal_type},
-        )
-        return {row[0] for row in result.all()}
-
-
-async def _has_active_binding(
-    principal_id: str, principal_type: str, resource_id: str,
-) -> bool:
-    async with get_db() as conn:
-        row = (await conn.execute(
-            text(
-                """
-                SELECT 1 FROM local_agent_resource_bindings
-                 WHERE agent_id = :a
-                   AND principal_type = :pt
-                   AND resource_id = :r
-                   AND revoked_at IS NULL
-                 LIMIT 1
-                """
-            ),
-            {"a": principal_id, "pt": principal_type, "r": resource_id},
-        )).first()
-        return row is not None
+# Shared with mcp_proxy.tools.executor (CRIT-2 fix); both call sites
+# enforce the same binding-gate semantics.
+from mcp_proxy.local.bindings import bound_resource_ids as _bound_resource_ids
+from mcp_proxy.local.bindings import has_active_binding as _has_active_binding
 
 
 def _stringify(result: Any) -> str:

--- a/mcp_proxy/local/bindings.py
+++ b/mcp_proxy/local/bindings.py
@@ -1,0 +1,62 @@
+"""Active-binding lookup for ``local_agent_resource_bindings`` (ADR-020).
+
+Shared by:
+  * ``mcp_proxy.ingress.mcp_aggregator`` — JSON-RPC ``tools/call`` path.
+  * ``mcp_proxy.tools.executor`` — REST ``POST /v1/ingress/execute``
+    path (CRIT-2 fix, audit T3-F1).
+
+Pre-CRIT-2 the executor short-circuited the binding check entirely for
+``principal_type != "agent"``; user / workload tokens hit MCP-resource
+tools without any per-resource grant. The fix wires this same lookup
+into the executor so both surfaces enforce the binding gate.
+
+The query is keyed on ``(agent_id, principal_type, resource_id)`` so a
+user named "daniele" never inherits an agent named "daniele"'s
+bindings (or vice versa).
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from mcp_proxy.db import get_db
+
+
+async def bound_resource_ids(
+    principal_id: str, principal_type: str,
+) -> set[str]:
+    """Set of resource_ids this principal currently has active bindings for."""
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                """
+                SELECT resource_id
+                  FROM local_agent_resource_bindings
+                 WHERE agent_id = :a
+                   AND principal_type = :pt
+                   AND revoked_at IS NULL
+                """
+            ),
+            {"a": principal_id, "pt": principal_type},
+        )
+        return {row[0] for row in result.all()}
+
+
+async def has_active_binding(
+    principal_id: str, principal_type: str, resource_id: str,
+) -> bool:
+    """True iff an unrevoked binding exists for this triple."""
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                """
+                SELECT 1 FROM local_agent_resource_bindings
+                 WHERE agent_id = :a
+                   AND principal_type = :pt
+                   AND resource_id = :r
+                   AND revoked_at IS NULL
+                 LIMIT 1
+                """
+            ),
+            {"a": principal_id, "pt": principal_type, "r": resource_id},
+        )).first()
+        return row is not None

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -64,15 +64,11 @@ async def run(
             execution_time_ms=duration_ms,
         )
 
-    # 2. Capability check
+    # 2. Capability check (agent-typed principals)
     # ADR-020 — typed principals (user / workload) authorise via the
     # ``local_agent_resource_bindings`` table on the proxy, NOT via the
-    # broker-issued JWT scope. The aggregator (``_handle_tools_call``)
-    # has already verified an active binding for ``(agent_id,
-    # principal_type, resource_id)`` before reaching here, so the
-    # legacy scope-based capability gate is redundant for typed
-    # principals and would fail closed (the broker's user-token flow
-    # ships an empty scope).
+    # broker-issued JWT scope (which they ship as empty). Agent-typed
+    # callers still go through the legacy scope-based gate.
     principal_type = getattr(agent, "principal_type", "agent")
     if principal_type == "agent" and not tool_registry.has_capability(
         tool_name, agent.scope,
@@ -100,6 +96,51 @@ async def run(
             error=f"Forbidden: missing capability '{tool_def.required_capability}'",
             execution_time_ms=duration_ms,
         )
+
+    # 2b. Binding check for MCP-resource tools (CRIT-2 fix, audit T3-F1).
+    # The JSON-RPC ``tools/call`` aggregator (``mcp_aggregator._handle_tools_call``)
+    # gates ``is_mcp_resource`` tools behind ``has_active_binding(...)``
+    # before it ever calls ``executor.run``. The REST surface
+    # ``POST /v1/ingress/execute`` calls ``executor.run`` directly; pre-fix
+    # the binding check was skipped entirely for any ``principal_type !=
+    # "agent"``, so a user / workload token could call any registered
+    # MCP-resource tool by name with no per-resource grant. Mirror the
+    # aggregator's gate here so both ingress paths enforce the same
+    # contract.
+    if tool_def.is_mcp_resource:
+        from mcp_proxy.local.bindings import has_active_binding
+        if not await has_active_binding(
+            agent.agent_id, principal_type, tool_def.resource_id,
+        ):
+            duration_ms = _elapsed_ms(t0)
+            _log.warning(
+                "Principal '%s' (type=%s) has no active binding for "
+                "MCP resource '%s' (tool '%s')",
+                agent.agent_id, principal_type,
+                tool_def.resource_id, tool_name,
+            )
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="tool_execute",
+                tool_name=tool_name,
+                status="denied",
+                detail=(
+                    f"No active binding for resource "
+                    f"'{tool_def.resource_id}' (principal_type={principal_type})"
+                ),
+                request_id=request_id,
+                duration_ms=duration_ms,
+            )
+            return ToolExecuteResponse(
+                request_id=request_id,
+                tool=tool_name,
+                status="error",
+                error=(
+                    f"Forbidden: no active binding for resource "
+                    f"'{tool_def.resource_id}'"
+                ),
+                execution_time_ms=duration_ms,
+            )
 
     # 3. Fetch secrets
     try:

--- a/tests/test_crit2_ingress_execute_binding.py
+++ b/tests/test_crit2_ingress_execute_binding.py
@@ -1,0 +1,363 @@
+"""CRIT-2 — REST /v1/ingress/execute MCP-resource binding gate.
+
+Audit ref: imp/audits/2026-05-11-track-3-audit-pdp.md finding F-1.
+
+Pre-fix the executor short-circuited the binding check entirely for
+``principal_type != "agent"``. A user / workload token could call any
+MCP-resource tool by name on the REST surface, regardless of which
+resources their admin had bound. The JSON-RPC ``tools/call`` aggregator
+already enforced the gate; the REST surface did not.
+
+These tests pin the post-fix contract on both ingress paths.
+"""
+from __future__ import annotations
+
+import os
+
+# Match the conftest env baseline so this file can run standalone.
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from mcp_proxy.auth.dependencies import get_authenticated_agent
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.models import TokenPayload
+from mcp_proxy.tools.registry import ToolDefinition, tool_registry
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+
+def _fake_agent(
+    *,
+    agent_id: str = "acme::daniele",
+    org: str = "acme",
+    scope: list[str] | None = None,
+    principal_type: str = "agent",
+) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=0,
+        jti=f"jti-{agent_id}-{principal_type}",
+        scope=scope or [],
+        cnf={"jkt": "fake-jkt"},
+        principal_type=principal_type,
+    )
+
+
+@pytest.fixture
+def clean_registry():
+    """Snapshot + restore the singleton registry to keep tests isolated."""
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "crit2.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def app_client_factory(proxy_db, clean_registry):
+    """Returns ``make_client(agent)`` helper — each test picks the
+    authenticated agent envelope it wants. The factory uses TestClient
+    as a context manager so the FastAPI lifespan fires (sets
+    ``app.state.secret_provider``, ``agent_manager``, etc.)."""
+    from mcp_proxy.main import app
+
+    clients: list[TestClient] = []
+
+    def _make(agent: TokenPayload) -> TestClient:
+        app.dependency_overrides[get_authenticated_agent] = lambda: agent
+        client = TestClient(app)
+        client.__enter__()  # start lifespan
+        clients.append(client)
+        return client
+
+    yield _make
+    for c in clients:
+        c.__exit__(None, None, None)
+    app.dependency_overrides.pop(get_authenticated_agent, None)
+
+
+async def _register_mcp_resource_tool(
+    *,
+    name: str = "github_mcp",
+    resource_id: str = "github",
+    capability: str = "github.read",
+) -> None:
+    """Register an MCP-resource-shaped tool with a no-op handler.
+
+    The handler is just enough to prove the executor reached step 5
+    (handler invocation) when the binding gate didn't block it.
+    """
+    async def _ok_handler(ctx):
+        return {"ok": True, "via": "mcp_resource_test_handler"}
+
+    tool_def = ToolDefinition(
+        name=name,
+        description="MCP resource test tool",
+        required_capability=capability,
+        allowed_domains=[],
+        handler=_ok_handler,
+        resource_id=resource_id,
+        endpoint_url="http://test-mcp:8080",
+    )
+    tool_registry.register_definition(tool_def)
+
+
+async def _register_builtin_tool(
+    *,
+    name: str = "builtin_echo",
+    capability: str = "echo.run",
+) -> None:
+    """Register a non-MCP-resource (builtin) tool — no resource_id, so
+    the binding gate must NOT apply, only the capability gate does."""
+    async def _echo_handler(ctx):
+        return {"echo": ctx.parameters}
+
+    tool_def = ToolDefinition(
+        name=name,
+        description="builtin echo",
+        required_capability=capability,
+        allowed_domains=[],
+        handler=_echo_handler,
+    )
+    tool_registry.register_definition(tool_def)
+
+
+async def _seed_binding(
+    *,
+    agent_id: str,
+    resource_id: str,
+    principal_type: str,
+    org_id: str = "acme",
+) -> None:
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                """
+                INSERT INTO local_agent_resource_bindings (
+                    binding_id, agent_id, principal_type, resource_id,
+                    org_id, granted_by, granted_at, revoked_at
+                ) VALUES (
+                    :bid, :aid, :pt, :rid, :org, 'admin',
+                    '2026-05-11T18:00:00Z', NULL
+                )
+                """
+            ),
+            {
+                "bid": f"bind-{principal_type}-{agent_id}-{resource_id}",
+                "aid": agent_id, "pt": principal_type,
+                "rid": resource_id, "org": org_id,
+            },
+        )
+
+
+# ── Tests ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_user_principal_no_binding_denied(app_client_factory):
+    """CRIT-2 — the headline gap. User token, MCP-resource tool, no
+    binding row. Pre-fix returned 200 (executor skipped binding check
+    for non-agent). Post-fix returns the "no active binding" error."""
+    await _register_mcp_resource_tool()
+    agent = _fake_agent(principal_type="user", scope=[])
+    client = app_client_factory(agent)
+
+    resp = client.post(
+        "/v1/ingress/execute",
+        json={
+            "tool": "github_mcp",
+            "parameters": {},
+            "request_id": "rq-user-noband",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "binding" in body["error"].lower()
+    assert "github" in body["error"]
+
+
+@pytest.mark.asyncio
+async def test_workload_principal_no_binding_denied(app_client_factory):
+    """CRIT-2 mirror for workload — same gap, same fix."""
+    await _register_mcp_resource_tool()
+    agent = _fake_agent(
+        agent_id="acme::workload::etl-job",
+        principal_type="workload", scope=[],
+    )
+    client = app_client_factory(agent)
+
+    resp = client.post(
+        "/v1/ingress/execute",
+        json={
+            "tool": "github_mcp",
+            "parameters": {},
+            "request_id": "rq-wl-noband",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    assert "binding" in body["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_user_principal_with_binding_proceeds(app_client_factory):
+    """User token with active binding for the resource — the binding
+    gate passes, the handler runs, response is success."""
+    await _register_mcp_resource_tool()
+    await _seed_binding(
+        agent_id="acme::user::daniele",
+        resource_id="github",
+        principal_type="user",
+    )
+    agent = _fake_agent(
+        agent_id="acme::user::daniele",
+        principal_type="user", scope=[],
+    )
+    client = app_client_factory(agent)
+
+    resp = client.post(
+        "/v1/ingress/execute",
+        json={
+            "tool": "github_mcp",
+            "parameters": {},
+            "request_id": "rq-user-bound",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "success", body
+    assert body["result"] == {
+        "ok": True, "via": "mcp_resource_test_handler",
+    }
+
+
+@pytest.mark.asyncio
+async def test_agent_principal_with_binding_but_no_capability_denied(
+    app_client_factory,
+):
+    """Agent-typed: capability gate runs first; even with a binding row
+    the agent without the capability is denied. Confirms the new
+    binding gate doesn't accidentally short-circuit the capability gate
+    for agent-typed callers."""
+    await _register_mcp_resource_tool(capability="github.read")
+    await _seed_binding(
+        agent_id="acme::daniele",
+        resource_id="github",
+        principal_type="agent",
+    )
+    agent = _fake_agent(
+        agent_id="acme::daniele",
+        principal_type="agent",
+        scope=[],  # missing github.read
+    )
+    client = app_client_factory(agent)
+
+    resp = client.post(
+        "/v1/ingress/execute",
+        json={
+            "tool": "github_mcp",
+            "parameters": {},
+            "request_id": "rq-agent-nocap",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "error"
+    # Capability gate runs before binding — error refers to capability.
+    assert "capability" in body["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_builtin_tool_no_binding_check_required(app_client_factory):
+    """Built-in tool (resource_id=None) — the binding gate must NOT
+    fire. Only the capability gate applies. With matching capability,
+    user-typed callers can run builtins (e.g. observability tools)
+    without any per-resource binding row."""
+    await _register_builtin_tool()
+    agent = _fake_agent(
+        agent_id="acme::user::ops",
+        principal_type="user",
+        scope=["echo.run"],
+    )
+    client = app_client_factory(agent)
+
+    resp = client.post(
+        "/v1/ingress/execute",
+        json={
+            "tool": "builtin_echo",
+            "parameters": {"hello": "world"},
+            "request_id": "rq-builtin",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "success", body
+    assert body["result"] == {"echo": {"hello": "world"}}
+
+
+@pytest.mark.asyncio
+async def test_audit_row_records_no_binding_reason(app_client_factory):
+    """The denied path writes an audit row with the resource_id and the
+    no-binding reason — actionable forensic signal for ops."""
+    await _register_mcp_resource_tool()
+    agent = _fake_agent(principal_type="user", scope=[])
+    client = app_client_factory(agent)
+
+    resp = client.post(
+        "/v1/ingress/execute",
+        json={
+            "tool": "github_mcp",
+            "parameters": {},
+            "request_id": "rq-audit",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+
+    async with get_db() as conn:
+        rows = (await conn.execute(
+            text(
+                "SELECT detail, status FROM audit_log "
+                " WHERE request_id = :rid"
+            ),
+            {"rid": "rq-audit"},
+        )).mappings().all()
+
+    # At least one denied row referencing the resource + reason.
+    denied = [r for r in rows if r["status"] == "denied"]
+    assert denied, f"expected denied audit row, got {list(rows)}"
+    detail = denied[0]["detail"] or ""
+    assert "github" in detail
+    assert "binding" in detail.lower()
+    assert "user" in detail


### PR DESCRIPTION
## Summary

Closes audit finding **CRIT-2** (Wave A PR2/5) from \`imp/audits/2026-05-11-track-3-audit-pdp.md\` (F-1) and \`imp/audits/2026-05-11-MASTER.md\`.

**Vector before this PR:** the JSON-RPC \`tools/call\` aggregator gated \`is_mcp_resource\` tools behind \`has_active_binding(...)\` before calling \`executor.run\`. The REST surface \`POST /v1/ingress/execute\` called \`executor.run\` directly. Inside the executor, the capability gate ran ONLY for \`principal_type == "agent"\`. For user/workload tokens the capability gate was skipped, and there was no fallback binding lookup — so a user/workload token could call any registered MCP-resource tool by name on the REST surface, regardless of which resources their admin had bound.

**Fix:**
1. Extract \`has_active_binding\` + \`bound_resource_ids\` to new shared module \`mcp_proxy/local/bindings.py\`. Aggregator imports them; back-compat aliases stay.
2. \`executor.run\` adds step 2b after capability gate: when \`tool_def.is_mcp_resource\`, call \`has_active_binding(agent_id, principal_type, resource_id)\`. On miss → log warning, write denied audit row with resource_id + principal_type + reason, return error response.

## Test plan

- [x] \`pytest tests/test_crit2_ingress_execute_binding.py tests/test_proxy_mcp_aggregator.py tests/test_proxy_resource_registry.py tests/test_dashboard_bindings.py tests/test_binding.py\` → 59 passed
- [x] \`pytest tests/\` → 3162 passed (8 pre-existing failures: connector GUI in CI headless + postgres binding KeyError, all in memory)
- [x] \`./demo_network/smoke.sh full\` → all assertions PASS (cross-org A2A round-trip, dashboard signing key restart-survival, audit hash chain across 38 entries, mcp-echo forwarding via the JSON-RPC aggregator path)
- [x] Local \`/security-review\` on the PR diff → 0 findings ≥0.7 confidence

## New tests

6 cases in \`tests/test_crit2_ingress_execute_binding.py\`:
- user / workload no-binding → denied (the headline gap)
- user with binding → handler runs, success
- agent with binding but no capability → still denied via the pre-existing capability gate
- built-in tool (no resource_id) → no binding check applies
- audit row records resource_id + principal_type + reason

## Scope notes

- Same denied-row contract as the aggregator: writes to global \`audit_log\` via \`log_audit\` (executor's existing audit channel), not the per-org chain via \`append_local_audit\` (aggregator's channel). Asymmetry pre-dates this PR; would close jointly with **CRIT-3** (Wave A PR5).
- Capability gate runs BEFORE binding gate so an agent-typed caller missing its capability still gets the capability-error message (back-compat with existing tests + audit rows).

## Wave A status

| # | Finding | Status |
|---|---|---|
| 1 | CRIT-1 cert mint + cert-pin | #601 |
| 2 | CRIT-2 ingress execute binding | **THIS PR** |
| 3 | culk_ scope_paths + scope_providers | queued |
| 4 | Quick wins bundle (D2 + B2 + C3 + E1) | queued |
| 5 | CRIT-3 audit DB trigger + back-fill | queued |