### PR TITLE
feat(mastio): ADR-029 Phase D-2, cross-org federation for tool-call PDP

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -190,6 +190,19 @@ class ProxySettings(BaseSettings):
     # the cross-org federation for tool-call decisions.
     tool_pdp_enabled: bool = False
 
+    # ADR-029 Phase D-2, cross-org federation map for tool-call PDP.
+    # When the Connector asks /v1/policy/tool-call with a `target.org`
+    # different from this Mastio's `org_id`, the local decision is
+    # intersected with a federated call to the target org's Mastio.
+    # The map keys are remote org_ids; values are the full URL of that
+    # org's POST /v1/policy/tool-call endpoint, e.g.
+    # ``{"competitor": "https://mastio.competitor.local/v1/policy/tool-call"}``.
+    # Default-deny when an entry is missing for the target org (better
+    # to refuse a cross-org tool until federation is wired explicitly).
+    # The shared HMAC secret (``MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET``) is
+    # reused to sign the outbound federation calls when set.
+    tool_pdp_federation_urls: dict[str, str] = {}
+
     # ADR-013 layer 2 — global Mastio rate limit. Token bucket shared
     # across every request (not per-agent), so coordinated compromise
     # across many stolen credentials cannot outrun the aggregate cap.

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1078,6 +1078,55 @@ async def policy_tool_call(request: Request):
         context=body.get("context") if isinstance(body.get("context"), dict) else None,
     )
 
+    # ADR-029 Phase D-2, cross-org federation. If the local decision is
+    # allow and the target lives in a different org, the originator must
+    # also clear the target org's PDP. Default-deny when no federation
+    # URL is configured for the target org so an admin cannot bypass the
+    # target by omission.
+    federated_from_remote = False
+    target_field = body.get("target") if isinstance(body.get("target"), dict) else {}
+    target_org = (target_field or {}).get("org")
+    self_org = _runtime_settings.org_id
+    if (
+        decision.allowed
+        and isinstance(target_org, str)
+        and target_org
+        and self_org
+        and target_org != self_org
+    ):
+        from mcp_proxy.policy.federation import (
+            call_remote_tool_call_policy,
+            intersect_decisions,
+        )
+
+        fed_map = _runtime_settings.tool_pdp_federation_urls or {}
+        fed_url = fed_map.get(target_org)
+        if not fed_url:
+            # Conservative default. The originator allowed locally, but
+            # without a way to ask the target org we refuse the cross-org
+            # invocation. An audit row records the principal who tried.
+            decision = type(decision)(
+                allowed=False,
+                reason=(
+                    f"cross-org target '{target_org}' has no federation URL "
+                    f"configured (MCP_PROXY_TOOL_PDP_FEDERATION_URLS); "
+                    f"default-deny"
+                ),
+            )
+        else:
+            _log.info(
+                "PDP tool-call federation: target_org=%s url=%s tool=%s",
+                target_org, fed_url, invocation.get("tool_name"),
+            )
+            fed_result = await call_remote_tool_call_policy(
+                target_org=target_org,
+                federation_url=fed_url,
+                payload=body,
+                hmac_secret=_runtime_settings.pdp_webhook_hmac_secret or None,
+            )
+            federated_from_remote = fed_result.reached_remote
+            decision = intersect_decisions(decision, fed_result.decision)
+
     # Hash-chained audit row, allow and deny alike (forensics needs both).
     audit_details: dict = {
         "principal_type": principal.get("type"),
@@ -1091,6 +1140,10 @@ async def policy_tool_call(request: Request):
         audit_details["target"] = body["target"].get("id")
     if isinstance(body.get("context"), dict):
         audit_details["session_id"] = body["context"].get("session_id")
+    if federated_from_remote:
+        # Mark federated rows so audit consumers can tell when a deny
+        # came from the local Mastio vs the target org's Mastio.
+        audit_details["federated"] = True
 
     await log_audit(
         agent_id=str(principal.get("id", "?")),

--- a/mcp_proxy/policy/federation.py
+++ b/mcp_proxy/policy/federation.py
@@ -1,0 +1,284 @@
+"""ADR-029 Phase D-2, federation of tool-call PDP decisions across orgs.
+
+When the Connector hits ``POST /v1/policy/tool-call`` and the target
+of the invocation lives in a different org than this Mastio, the
+local decision alone is not enough: the target org must also agree.
+This module wraps the cross-org HTTP call that asks the target
+Mastio's own ``/v1/policy/tool-call`` endpoint to evaluate the same
+payload, and intersects the two decisions per ADR-029 §Decision
+(scope: intersection, tools_denied: union, rate_limit: min,
+obligations: more restrictive).
+
+MVP wiring: the originator Mastio reads the target Mastio's URL from
+``MCP_PROXY_TOOL_PDP_FEDERATION_URLS`` (a JSON map org_id ->
+endpoint URL). A future iteration (Phase G) will look the URL up
+dynamically through the Court registry; for now the operator wires
+the map explicitly at deploy time. Missing entry means default-deny
+so an admin cannot accidentally bypass the target org by omission.
+
+HMAC signature uses the same ``pdp_webhook_hmac_secret`` as
+``/pdp/policy`` and ``/v1/policy/tool-call``, so the receiving Mastio
+verifies the call the same way as the broker would.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+from dataclasses import dataclass
+
+import httpx
+
+from mcp_proxy.policy.tool_call import ToolCallDecision
+
+_log = logging.getLogger("mcp_proxy.policy.federation")
+
+_FEDERATION_TIMEOUT = 5.0  # seconds
+_MAX_RESPONSE_BODY = 4096  # bytes
+
+
+@dataclass
+class FederationResult:
+    """A federated decision plus a flag distinguishing 'no entry' (deny
+    by configuration) from 'remote denied' (deny by policy)."""
+    decision: ToolCallDecision
+    reached_remote: bool
+
+
+async def call_remote_tool_call_policy(
+    *,
+    target_org: str,
+    federation_url: str,
+    payload: dict,
+    hmac_secret: str | None,
+) -> FederationResult:
+    """POST `payload` to the target Mastio's ``/v1/policy/tool-call``.
+
+    Returns the parsed decision plus ``reached_remote=True`` on a
+    successful round-trip. On any transport or schema failure the
+    function fails safe (deny) with ``reached_remote=False``.
+    """
+    try:
+        body_bytes = json.dumps(payload).encode()
+    except (TypeError, ValueError) as exc:
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation payload encode failed: {exc}",
+            ),
+            reached_remote=False,
+        )
+
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if hmac_secret:
+        sig = hmac.new(
+            hmac_secret.encode(), body_bytes, hashlib.sha256,
+        ).hexdigest()
+        headers["X-ATN-Signature"] = sig
+
+    try:
+        async with httpx.AsyncClient(
+            timeout=_FEDERATION_TIMEOUT, follow_redirects=False,
+        ) as client:
+            resp = await client.post(
+                federation_url, content=body_bytes, headers=headers,
+            )
+    except httpx.TimeoutException:
+        _log.warning(
+            "federation tool-call timeout target=%s url=%s",
+            target_org, federation_url,
+        )
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation to org '{target_org}' timed out after {_FEDERATION_TIMEOUT}s",
+            ),
+            reached_remote=False,
+        )
+    except Exception as exc:
+        _log.warning(
+            "federation tool-call transport error target=%s url=%s err=%s",
+            target_org, federation_url, exc,
+        )
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation to org '{target_org}' transport error: {exc}",
+            ),
+            reached_remote=False,
+        )
+
+    if resp.status_code == 404:
+        # Target Mastio has tool PDP disabled. Conservative interpretation:
+        # the target org has not opted in to enforce policy, so the local
+        # decision stands. Returning allow lets the originator decide
+        # purely on its own rules (the same behaviour the Connector SDK
+        # uses against a legacy Mastio).
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=True,
+                reason=f"target org '{target_org}' has tool PDP disabled (404)",
+            ),
+            reached_remote=True,
+        )
+    if resp.status_code in (401, 403):
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation to org '{target_org}' rejected: HTTP {resp.status_code}",
+            ),
+            reached_remote=False,
+        )
+    if resp.status_code != 200:
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation to org '{target_org}' returned HTTP {resp.status_code}",
+            ),
+            reached_remote=False,
+        )
+
+    if len(resp.content) > _MAX_RESPONSE_BODY:
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation response too large ({len(resp.content)} bytes)",
+            ),
+            reached_remote=True,
+        )
+
+    try:
+        data = resp.json()
+    except Exception:
+        return FederationResult(
+            decision=ToolCallDecision(
+                allowed=False,
+                reason=f"federation to org '{target_org}' returned non-JSON body",
+            ),
+            reached_remote=True,
+        )
+
+    decision_raw = str(data.get("decision", "deny")).lower()
+    allowed = decision_raw == "allow"
+    reason = str(data.get("reason", ""))[:512]
+    scope = data.get("scope") if isinstance(data.get("scope"), dict) else None
+    rate_limit = data.get("rate_limit") if isinstance(data.get("rate_limit"), dict) else None
+    obligations = data.get("obligations") if isinstance(data.get("obligations"), dict) else None
+
+    return FederationResult(
+        decision=ToolCallDecision(
+            allowed=allowed,
+            reason=reason or ("allowed by remote" if allowed else "denied by remote"),
+            scope=scope,
+            rate_limit=rate_limit,
+            obligations=obligations,
+        ),
+        reached_remote=True,
+    )
+
+
+def intersect_decisions(
+    local: ToolCallDecision,
+    remote: ToolCallDecision,
+) -> ToolCallDecision:
+    """ADR-029 §Decision, source ∩ target.
+
+    Allow only if both allow. tools_allowed by intersection.
+    tools_denied by union. max_session_duration_s by min. rate_limit
+    per-axis by min. obligations: require_user_confirmation by OR,
+    trace_visibility to the more restrictive of the two.
+    """
+    if not local.allowed:
+        return local
+    if not remote.allowed:
+        return remote
+
+    # Both allow. Intersect optional fields.
+    scope = _intersect_scope(local.scope, remote.scope)
+    rate_limit = _intersect_rate_limit(local.rate_limit, remote.rate_limit)
+    obligations = _intersect_obligations(local.obligations, remote.obligations)
+
+    return ToolCallDecision(
+        allowed=True,
+        reason=f"local: {local.reason}; remote: {remote.reason}",
+        scope=scope,
+        rate_limit=rate_limit,
+        obligations=obligations,
+    )
+
+
+def _intersect_scope(
+    a: dict | None, b: dict | None,
+) -> dict | None:
+    if a is None and b is None:
+        return None
+    if a is None:
+        return b
+    if b is None:
+        return a
+    out: dict = {}
+    a_allowed = a.get("tools_allowed")
+    b_allowed = b.get("tools_allowed")
+    if isinstance(a_allowed, list) and isinstance(b_allowed, list):
+        out["tools_allowed"] = sorted(set(a_allowed) & set(b_allowed))
+    elif isinstance(a_allowed, list):
+        out["tools_allowed"] = list(a_allowed)
+    elif isinstance(b_allowed, list):
+        out["tools_allowed"] = list(b_allowed)
+    denied: set[str] = set()
+    if isinstance(a.get("tools_denied"), list):
+        denied.update(a["tools_denied"])
+    if isinstance(b.get("tools_denied"), list):
+        denied.update(b["tools_denied"])
+    if denied:
+        out["tools_denied"] = sorted(denied)
+    durations = [
+        d for d in (a.get("max_session_duration_s"), b.get("max_session_duration_s"))
+        if isinstance(d, int) and d > 0
+    ]
+    if durations:
+        out["max_session_duration_s"] = min(durations)
+    return out or None
+
+
+def _intersect_rate_limit(
+    a: dict | None, b: dict | None,
+) -> dict | None:
+    if a is None and b is None:
+        return None
+    if a is None:
+        return b
+    if b is None:
+        return a
+    out: dict = {}
+    for k in ("per_minute", "per_day"):
+        vals = [v for v in (a.get(k), b.get(k)) if isinstance(v, int) and v > 0]
+        if vals:
+            out[k] = min(vals)
+    return out or None
+
+
+def _intersect_obligations(
+    a: dict | None, b: dict | None,
+) -> dict | None:
+    if a is None and b is None:
+        return None
+    if a is None:
+        return b
+    if b is None:
+        return a
+    rank = {"full": 2, "redacted": 1, "off": 0}
+    av = a.get("trace_visibility", "redacted")
+    bv = b.get("trace_visibility", "redacted")
+    if av not in rank:
+        av = "redacted"
+    if bv not in rank:
+        bv = "redacted"
+    visibility = av if rank[av] <= rank[bv] else bv
+    return {
+        "require_user_confirmation": bool(
+            a.get("require_user_confirmation") or b.get("require_user_confirmation")
+        ),
+        "trace_visibility": visibility,
+    }

--- a/tests/test_tool_call_pdp_federation.py
+++ b/tests/test_tool_call_pdp_federation.py
@@ -1,0 +1,374 @@
+"""ADR-029 Phase D-2, cross-org federation of tool-call PDP decisions.
+
+Pins:
+
+- Same-org call: no federation, the local decision is the final one
+  (Phase C behaviour unchanged).
+- Cross-org call with no federation URL configured: default-deny.
+- Cross-org call with federation URL + remote allow: final allow,
+  audit row marks the row as `federated`.
+- Cross-org call with federation URL + remote deny: final deny.
+- Cross-org call with federation URL + remote transport error: deny
+  fail-safe.
+- Cross-org call with federation URL + remote 404 (target Mastio has
+  PDP disabled): final decision falls back to the local one.
+- Intersection helpers (tools_allowed, tools_denied, duration,
+  rate_limit, obligations) under the source ∩ target rule.
+"""
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "tool_pdp_fed.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "")
+    monkeypatch.setenv(
+        "MCP_PROXY_TOOL_PDP_FEDERATION_URLS",
+        json.dumps({"competitor": "https://mastio.competitor.local/v1/policy/tool-call"}),
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+def _payload_cross_org(
+    *,
+    principal_id: str = "acme::user::mario@acme.local",
+    tool_name: str = "competitor.catalog.search",
+    target_org: str = "competitor",
+):
+    return {
+        "principal": {"id": principal_id, "type": "user", "org": "acme"},
+        "model": {"id": "claude-haiku-4-5", "provider": "anthropic"},
+        "target": {
+            "id": f"{target_org}::workload::catalog-mcp",
+            "type": "workload",
+            "org": target_org,
+        },
+        "invocation": {
+            "kind": "session_tool_call",
+            "tool_name": tool_name,
+            "mcp_server_id": "competitor-catalog-prod",
+        },
+    }
+
+
+def _payload_same_org():
+    return {
+        "principal": {"id": "acme::user::mario@acme.local", "type": "user", "org": "acme"},
+        "model": {"id": "claude-haiku-4-5"},
+        "target": {"id": "acme::workload::catalog-mcp", "type": "workload", "org": "acme"},
+        "invocation": {
+            "kind": "session_tool_call",
+            "tool_name": "acme.catalog.search",
+        },
+    }
+
+
+async def _set_tool_rules(rules: dict) -> None:
+    from mcp_proxy.db import set_config
+    await set_config("policy_rules", json.dumps({"tool_rules": rules}))
+
+
+# ── Same-org keeps Phase C behaviour ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_same_org_keeps_phase_c_behaviour(proxy_app, monkeypatch):
+    """When target.org == self org_id, the federation path is skipped
+    entirely and no HTTP call is made even if a federation URL exists
+    for some other org."""
+    fed_called = {"hit": False}
+
+    def _fed_handler(request: httpx.Request) -> httpx.Response:
+        fed_called["hit"] = True
+        return httpx.Response(200, json={"decision": "deny", "reason": "should not reach"})
+
+    transport = httpx.MockTransport(_fed_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+
+    _, client = proxy_app
+    await _set_tool_rules({
+        "acme.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_same_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow"
+    assert fed_called["hit"] is False
+
+
+# ── Cross-org missing federation URL ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_org_without_federation_url_denies(proxy_app, monkeypatch):
+    """Target org for which no entry exists in
+    MCP_PROXY_TOOL_PDP_FEDERATION_URLS means default-deny."""
+    _, client = proxy_app
+    # Local rule would allow, but cross-org without federation URL must deny.
+    await _set_tool_rules({
+        "stranger.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+    p = _payload_cross_org(target_org="stranger", tool_name="stranger.catalog.search")
+    resp = await client.post("/v1/policy/tool-call", json=p)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "stranger" in body["reason"]
+    assert "federation URL" in body["reason"]
+
+
+# ── Cross-org with remote allow ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_org_remote_allow_lands_final_allow(proxy_app, monkeypatch):
+    captured: dict = {}
+
+    def _fed_handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={
+            "decision": "allow",
+            "reason": "competitor allows the call",
+            "scope": {"tools_allowed": ["competitor.catalog.search"]},
+        })
+
+    transport = httpx.MockTransport(_fed_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+
+    _, client = proxy_app
+    await _set_tool_rules({
+        "competitor.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+            "scope": {"tools_allowed": ["competitor.catalog.search", "competitor.catalog.list"]},
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_cross_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow"
+    # Federation reached: the remote got the same payload shape.
+    assert captured["body"]["target"]["org"] == "competitor"
+    assert captured["body"]["invocation"]["tool_name"] == "competitor.catalog.search"
+    # Intersection: local allows [search, list], remote allows [search],
+    # final is just [search].
+    assert body["scope"]["tools_allowed"] == ["competitor.catalog.search"]
+
+    # Audit row marked federated.
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        result = await conn.execute(text(
+            "SELECT detail FROM audit_log WHERE action='policy.tool_call' "
+            "ORDER BY chain_seq DESC LIMIT 1"
+        ))
+        row = result.fetchone()
+    assert row is not None
+    assert '"federated":true' in row.detail
+
+
+# ── Cross-org with remote deny ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_org_remote_deny_lands_final_deny(proxy_app, monkeypatch):
+    def _fed_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={
+            "decision": "deny",
+            "reason": "competitor policy: stranger principals not allowed",
+        })
+
+    transport = httpx.MockTransport(_fed_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+
+    _, client = proxy_app
+    await _set_tool_rules({
+        "competitor.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_cross_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "competitor policy" in body["reason"]
+
+
+# ── Cross-org with remote transport error ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cross_org_remote_transport_error_denies(proxy_app, monkeypatch):
+    def _fed_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("simulated DNS failure")
+
+    transport = httpx.MockTransport(_fed_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+
+    _, client = proxy_app
+    await _set_tool_rules({
+        "competitor.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_cross_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny"
+    assert "transport error" in body["reason"]
+
+
+# ── Cross-org with remote 404 (target Mastio has PDP off) ───────────
+
+
+@pytest.mark.asyncio
+async def test_cross_org_remote_404_falls_back_to_local(proxy_app, monkeypatch):
+    """If the target Mastio returns 404 (its own tool PDP is disabled),
+    the originator's local decision stands. This mirrors the Connector
+    SDK behaviour against a legacy Mastio."""
+    def _fed_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "tool-level PDP disabled"})
+
+    transport = httpx.MockTransport(_fed_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+
+    _, client = proxy_app
+    await _set_tool_rules({
+        "competitor.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_cross_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow"
+
+
+# ── Unit tests for intersection helpers ─────────────────────────────
+
+
+def test_intersect_decisions_allow_only_if_both_allow():
+    from mcp_proxy.policy.federation import intersect_decisions
+    from mcp_proxy.policy.tool_call import ToolCallDecision
+    local = ToolCallDecision(allowed=True, reason="local ok")
+    remote_deny = ToolCallDecision(allowed=False, reason="remote no")
+    assert intersect_decisions(local, remote_deny).allowed is False
+    assert intersect_decisions(remote_deny, local).allowed is False
+
+
+def test_intersect_decisions_intersects_tools_allowed():
+    from mcp_proxy.policy.federation import intersect_decisions
+    from mcp_proxy.policy.tool_call import ToolCallDecision
+    a = ToolCallDecision(allowed=True, reason="a", scope={"tools_allowed": ["x", "y", "z"]})
+    b = ToolCallDecision(allowed=True, reason="b", scope={"tools_allowed": ["y", "z", "w"]})
+    out = intersect_decisions(a, b)
+    assert out.allowed is True
+    assert out.scope is not None
+    assert out.scope["tools_allowed"] == ["y", "z"]
+
+
+def test_intersect_decisions_unions_tools_denied():
+    from mcp_proxy.policy.federation import intersect_decisions
+    from mcp_proxy.policy.tool_call import ToolCallDecision
+    a = ToolCallDecision(allowed=True, reason="a", scope={"tools_denied": ["a", "b"]})
+    b = ToolCallDecision(allowed=True, reason="b", scope={"tools_denied": ["b", "c"]})
+    out = intersect_decisions(a, b)
+    assert out.scope is not None
+    assert out.scope["tools_denied"] == ["a", "b", "c"]
+
+
+def test_intersect_decisions_takes_min_duration():
+    from mcp_proxy.policy.federation import intersect_decisions
+    from mcp_proxy.policy.tool_call import ToolCallDecision
+    a = ToolCallDecision(allowed=True, reason="a", scope={"max_session_duration_s": 3600})
+    b = ToolCallDecision(allowed=True, reason="b", scope={"max_session_duration_s": 900})
+    out = intersect_decisions(a, b)
+    assert out.scope is not None
+    assert out.scope["max_session_duration_s"] == 900
+
+
+def test_intersect_decisions_rate_limit_min_per_axis():
+    from mcp_proxy.policy.federation import intersect_decisions
+    from mcp_proxy.policy.tool_call import ToolCallDecision
+    a = ToolCallDecision(allowed=True, reason="a", rate_limit={"per_minute": 60, "per_day": 1000})
+    b = ToolCallDecision(allowed=True, reason="b", rate_limit={"per_minute": 30, "per_day": 2000})
+    out = intersect_decisions(a, b)
+    assert out.rate_limit is not None
+    assert out.rate_limit["per_minute"] == 30
+    assert out.rate_limit["per_day"] == 1000
+
+
+def test_intersect_decisions_obligations_restrictive_wins():
+    from mcp_proxy.policy.federation import intersect_decisions
+    from mcp_proxy.policy.tool_call import ToolCallDecision
+    a = ToolCallDecision(allowed=True, reason="a",
+                          obligations={"trace_visibility": "full",
+                                       "require_user_confirmation": False})
+    b = ToolCallDecision(allowed=True, reason="b",
+                          obligations={"trace_visibility": "redacted",
+                                       "require_user_confirmation": True})
+    out = intersect_decisions(a, b)
+    assert out.obligations is not None
+    assert out.obligations["trace_visibility"] == "redacted"
+    assert out.obligations["require_user_confirmation"] is True


### PR DESCRIPTION
Closes the federation gap on the Mastio side. When the Connector hits `/v1/policy/tool-call` with a `target.org` different from this Mastio's `org_id`, the local allow is intersected with a federated call to the target org's Mastio `/v1/policy/tool-call` endpoint.

## Decision flow

1. Local Phase C evaluation against `policy_rules.tool_rules`.
2. If local says **deny**, stop and return deny (no federation roundtrip).
3. If local says **allow** AND `target.org != self.org_id`:
   - Look up the target's federation URL in `MCP_PROXY_TOOL_PDP_FEDERATION_URLS`.
   - **Missing entry → default-deny** (an admin must explicitly wire the route; an omitted entry must not silently bypass the target org).
   - Present entry → POST the same payload to that URL with HMAC signature.
   - Intersect local and remote per ADR-029 §Decision:
     - `tools_allowed`: intersection
     - `tools_denied`: union
     - `max_session_duration_s`: min
     - `rate_limit` per axis: min
     - `obligations.require_user_confirmation`: OR
     - `obligations.trace_visibility`: more restrictive of the two
4. Audit row writes `federated: true` so forensics can tell a deny that came back across the wire from a deny by the local Mastio.

## Wiring (MVP)

Env var: `MCP_PROXY_TOOL_PDP_FEDERATION_URLS` (JSON map):

\`\`\`json
{
  "competitor": "https://mastio.competitor.local/v1/policy/tool-call",
  "supplier":   "https://mastio.supplier.acme.com/v1/policy/tool-call"
}
\`\`\`

A future Phase G will look these URLs up dynamically through the Court registry. For now operators wire the map explicitly at deploy time. HMAC reuses `MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET`.

## Edge cases (in `mcp_proxy/policy/federation.py`)

- Target Mastio returns **404** (its tool PDP is disabled): the local decision stands. Same fallback the Connector SDK uses against a legacy Mastio.
- **401 / 403**: deny, reason carries upstream code.
- **5xx, timeout, transport error**: deny, fail-safe.
- **200 malformed JSON or oversized body**: deny.

## Test plan

- [x] 12 new cases in `tests/test_tool_call_pdp_federation.py`:
  - same-org keeps Phase C behaviour (no federation call fires)
  - cross-org without federation URL → default-deny
  - cross-org + remote allow → final allow, scope intersected, audit row marked federated
  - cross-org + remote deny → final deny
  - cross-org + remote transport error → fail-safe deny
  - cross-org + remote 404 → fall back to local decision
  - intersect_decisions unit tests on tools_allowed / tools_denied / duration / rate_limit / obligations
- [x] Phase B + C + D-1 pre-existing tests still green: **42 passed** (federation 12 + endpoint 10 + extended payload 12 + hmac 8).
- [ ] CI full suite + `./sandbox/smoke.sh full` before merge (touches `mcp_proxy/`).
- [ ] `/security-review` pre-merge.

## Out of scope

- **Phase E**: dashboard policy authoring matrix (Task #19).
- **Phase F**: `./sandbox/demo.sh policy-granular` + YC video (Task #20).
- **Phase G**: dynamic federation URL lookup through Court registry. The current MVP requires operators to wire the JSON map manually; in M3 the Mastio will resolve the target Mastio URL through the Court the same way `app/broker/router.py` resolves `target_org.webhook_url` for session-open today.
- **Connector side**: the Connector already passes `target.org` in the payload (Phase D-1), so no change there.

🔒 Touches `mcp_proxy/policy/`, `mcp_proxy/main.py`, `mcp_proxy/config.py`. Backward compat: same-org calls follow the Phase C path untouched. Default-deny on missing federation entry preserves zero-trust posture across orgs.