### PR TITLE
fix: Wave A quick wins — D2 (policy gate) + B2 (audit scrub) + C3 (mint validation)

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -271,6 +271,25 @@ def validate_config(settings: "Settings") -> None:
             )
             raise SystemExit(1)
 
+        # Audit Wave A D2 (2026-05-11) — POLICY_ENFORCEMENT=false in
+        # production silently disables every PDP check. The runtime
+        # toggle (``set_policy_enforcement(False)``) is already blocked
+        # in production at the function boundary, but a boot-time env
+        # var ``POLICY_ENFORCEMENT=false`` (e.g. .env / Helm value /
+        # ConfigMap accident) would boot, log nothing critical, and
+        # allow every cross-org session. Mirror the
+        # POLICY_DEFAULT_DECISION gate above so the misconfig surfaces
+        # at startup, not silently in production traffic.
+        if not settings.policy_enforcement:
+            _startup_logger.critical(
+                "POLICY_ENFORCEMENT=false is not permitted in production "
+                "— this disables every PDP check globally and lets "
+                "every cross-org session through with no policy gate. "
+                "Set POLICY_ENFORCEMENT=true (the default) and rely "
+                "on per-org PDP webhooks for the actual decision.",
+            )
+            raise SystemExit(1)
+
         if not settings.database_url or settings.database_url.startswith("sqlite"):
             _startup_logger.critical(
                 "DATABASE_URL is not set or points to SQLite ('%s'). "

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -1553,6 +1553,47 @@ async def mint_user_api_token(
     if not created_by:
         raise ValueError("created_by is required")
 
+    # Audit Wave A C3 (2026-05-11) — pre-fix the mint accepted ANY
+    # ``principal_id``, including foreign-org or non-existent values.
+    # Combined with CRIT-1 that let an attacker mint synthetic
+    # identities and drive both the cert + culk_ surfaces as the same
+    # phantom user. Validate now: principal_id must exist in
+    # ``local_user_principals`` AND its inferred ``::user::`` shape
+    # must point at this Mastio's own org. We deliberately accept
+    # rows regardless of ``surface`` / ``reach`` — those are display
+    # metadata, not authority.
+    from mcp_proxy.config import get_settings
+    settings = get_settings()
+    own_org = (settings.org_id or "").strip()
+    if "::user::" not in principal_id:
+        # culk_ tokens are user-only by ADR-027 Phase 1; refuse
+        # workload / agent / unknown shapes here so the audit trail
+        # cannot point at a phantom typed identity.
+        raise ValueError(
+            f"principal_id must be a user principal "
+            f"(``<org>::user::<name>``); got {principal_id!r}",
+        )
+    if own_org and not principal_id.startswith(f"{own_org}::"):
+        raise ValueError(
+            f"principal_id {principal_id!r} is not in this Mastio's "
+            f"org ({own_org!r}); cannot mint cross-org culk_ tokens",
+        )
+    async with get_db() as _check_conn:
+        existing = (await _check_conn.execute(
+            text(
+                "SELECT 1 FROM local_user_principals "
+                " WHERE principal_id = :pid LIMIT 1"
+            ),
+            {"pid": principal_id},
+        )).first()
+    if existing is None:
+        raise ValueError(
+            f"principal_id {principal_id!r} is not registered in "
+            "local_user_principals; pre-create the user via "
+            "POST /v1/admin/users or via Frontdesk SSO before minting "
+            "tokens for it",
+        )
+
     plaintext = _new_api_token_plaintext()
     token_hash = _hash_api_token(plaintext)
     last4 = plaintext[-4:]

--- a/mcp_proxy/egress/ai_gateway.py
+++ b/mcp_proxy/egress/ai_gateway.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -41,6 +42,46 @@ _log = logging.getLogger("agent_trust.egress")
 
 
 CULLIS_FORWARD_HEADERS = "X-Cullis-Agent,X-Cullis-Org,X-Cullis-Trace"
+
+
+# Audit Wave A B2 (2026-05-11) — provider error bodies routinely echo
+# back the rejected API key prefix (e.g. ``Incorrect API key provided:
+# sk-ant-abc...``). Without scrubbing, those keys land in the immutable
+# hash-chained Mastio audit log via ``upstream_detail``. Same class of
+# leak as the third-party-gateway pattern flagged in
+# ``feedback_third_party_ai_gateway_key_leak.md``. Patterns cover the
+# common provider key shapes; the substitution preserves the field
+# enough for ops debugging (provider, error class) without keeping
+# the live secret.
+_SECRET_SCRUB_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Anthropic console keys (``sk-ant-api03-...``) and project keys
+    # (``sk-ant-...``). Match the prefix + non-whitespace tail.
+    re.compile(r"sk-ant-[A-Za-z0-9_\-]{8,}"),
+    # OpenAI legacy + project keys.
+    re.compile(r"sk-(?:proj-)?[A-Za-z0-9_\-]{16,}"),
+    # Google AI Studio (Gemini) API keys.
+    re.compile(r"AIza[0-9A-Za-z_\-]{35}"),
+    # AWS Access Key IDs (Bedrock callers paste these into provider
+    # creds when misconfiguring the secret as the access key).
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    # Bearer / Authorization headers leaked verbatim into bodies.
+    re.compile(r"(?i)Bearer\s+[A-Za-z0-9._\-]{12,}"),
+    # Cullis user API tokens.
+    re.compile(r"culk_[A-Za-z0-9_\-]{16,}"),
+)
+
+
+def scrub_secrets(text: str | None) -> str | None:
+    """Replace API key shapes with ``[REDACTED]`` before persisting text
+    that may contain provider error echoes. Idempotent on already-scrubbed
+    or secret-free input. Returns the input unchanged when None / empty
+    so callers don't need to re-check."""
+    if not text:
+        return text
+    out = text
+    for pat in _SECRET_SCRUB_PATTERNS:
+        out = pat.sub("[REDACTED]", out)
+    return out
 
 
 @dataclass
@@ -230,8 +271,11 @@ async def _call_portkey(
 
     if resp.status_code // 100 != 2:
         # Surface the upstream body in the audit detail (capped) so
-        # operators can debug without re-running the call.
-        detail = resp.text[:512] if resp.text else None
+        # operators can debug without re-running the call. Scrub
+        # provider key shapes (B2) so a 401 echo like "Incorrect API
+        # key provided: sk-ant-..." doesn't immortalise the rejected
+        # key in the hash-chained audit log.
+        detail = scrub_secrets(resp.text[:512]) if resp.text else None
         raise GatewayError(
             502,
             f"upstream_status_{resp.status_code}",
@@ -309,7 +353,10 @@ _LITELLM_ERROR_MAP: dict[str, tuple[int, str]] = {
 def _map_litellm_exception(exc: Exception) -> GatewayError:
     cls = type(exc).__name__
     status, reason = _LITELLM_ERROR_MAP.get(cls, (502, "provider_unknown_error"))
-    detail = (str(exc) or cls)[:512]
+    # B2 — LiteLLM stringifies provider 4xx/5xx into ``str(exc)`` and
+    # those bodies frequently echo the rejected API key prefix. Scrub
+    # before the detail flows into ``upstream_detail`` on the audit row.
+    detail = scrub_secrets((str(exc) or cls)[:512])
     return GatewayError(status, reason, detail=detail)
 
 

--- a/tests/_token_test_helpers.py
+++ b/tests/_token_test_helpers.py
@@ -1,0 +1,89 @@
+"""Shared helpers for ``user_api_tokens`` test files.
+
+The Wave A C3 fix (audit 2026-05-11 MASTER) makes
+``mint_user_api_token`` refuse any ``principal_id`` that does not
+already exist in ``local_user_principals`` AND is not in the same org
+as the Mastio. The 4 token-related test files in this directory
+rely on minting tokens for ad-hoc test users (alice, bob, ..., mia)
+without going through the admin pre-create API.
+
+This helper centralises the pre-seed: every test that mints can rely
+on the standard principals being present. New tests that need a
+non-standard name should call ``seed_test_principal()`` in their
+fixture before minting.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+from sqlalchemy import text
+
+
+# Default principal names used by the existing tests in
+# test_user_api_tokens_db.py / test_admin_api_tokens.py /
+# test_api_token_resolver.py / test_dashboard_api_tokens.py. Add new
+# names here when a new test references them. Org defaults to ``acme``
+# so the seed matches the Mastio test fixture's ``MCP_PROXY_ORG_ID``.
+DEFAULT_TEST_USER_NAMES: tuple[str, ...] = (
+    "alice", "bob", "carol", "dave", "erin",
+    "frank", "grace", "heidi", "ivan", "jane",
+    "ken", "leo", "mia",
+)
+DEFAULT_TEST_ORG: str = "acme"
+
+
+def _principal_id(org: str, user_name: str) -> str:
+    return f"{org}::user::{user_name}"
+
+
+async def seed_test_principal(
+    user_name_or_pid: str,
+    *,
+    org: str = DEFAULT_TEST_ORG,
+) -> str:
+    """Insert a single user principal row, idempotent.
+
+    Accepts either a bare user_name (``"alice"``) — then prefixed with
+    ``{org}::user::`` — or a full canonical principal_id
+    (``"orga::user::alice@orga.test"``). Returns the resulting
+    principal_id."""
+    from mcp_proxy.db import get_db
+    if "::user::" in user_name_or_pid:
+        pid = user_name_or_pid
+        # Pull the trailing component as the display user_name.
+        user_name = pid.split("::user::", 1)[1]
+    else:
+        pid = _principal_id(org, user_name_or_pid)
+        user_name = user_name_or_pid
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_db() as conn:
+        existing = (await conn.execute(
+            text(
+                "SELECT principal_id FROM local_user_principals "
+                " WHERE principal_id = :pid"
+            ),
+            {"pid": pid},
+        )).first()
+        if existing is None:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, reach, surface, "
+                    " created_at) "
+                    "VALUES (:pid, :name, 'intra', NULL, :now)"
+                ),
+                {"pid": pid, "name": user_name, "now": now},
+            )
+    return pid
+
+
+async def seed_default_test_principals(
+    names: Iterable[str] = DEFAULT_TEST_USER_NAMES,
+    *,
+    org: str = DEFAULT_TEST_ORG,
+) -> None:
+    """Seed every name in ``names`` (default: the well-known set used
+    by the four token test files). Idempotent on row collisions."""
+    for name in names:
+        await seed_test_principal(name, org=org)

--- a/tests/test_admin_api_tokens.py
+++ b/tests/test_admin_api_tokens.py
@@ -36,6 +36,26 @@ async def _spin_proxy(tmp_path, monkeypatch, org_id: str):
     return app
 
 
+async def _seed_common_users(org_id: str | None = None) -> None:
+    """Wave A C3 (audit 2026-05-11) — mint_user_api_token now requires
+    the principal_id row to exist. Seed the common test names against
+    the current org (from ``get_settings().org_id`` when not passed)
+    so existing mint POSTs continue to work without each test
+    pre-creating the row via /v1/admin/users. Call inside the
+    ``async with app.router.lifespan_context(app):`` block (after
+    init_db has fired) and before the first mint."""
+    if org_id is None:
+        from mcp_proxy.config import get_settings
+        org_id = get_settings().org_id
+    from tests._token_test_helpers import seed_test_principal
+    for name in (
+        "alice", "bob", "carol", "dave", "eve", "erin",
+        "frank", "ferris", "grace", "heidi", "ivan",
+        "jane", "ken", "leo", "mia",
+    ):
+        await seed_test_principal(f"{org_id}::user::{name}")
+
+
 async def _headers():
     from mcp_proxy.config import get_settings
     return {"X-Admin-Secret": get_settings().admin_secret}
@@ -74,6 +94,7 @@ async def test_mint_returns_cleartext_token_once(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             r = await cli.post(
                 "/v1/admin/api-tokens",
@@ -106,6 +127,7 @@ async def test_mint_with_scope_and_expiry(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             r = await cli.post(
                 "/v1/admin/api-tokens",
@@ -128,6 +150,7 @@ async def test_mint_rejects_empty_label(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             r = await cli.post(
                 "/v1/admin/api-tokens",
@@ -149,6 +172,7 @@ async def test_list_filters_by_principal(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             await cli.post(
                 "/v1/admin/api-tokens",
@@ -179,6 +203,7 @@ async def test_list_excludes_revoked_by_default(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             r1 = await cli.post(
                 "/v1/admin/api-tokens",
@@ -216,6 +241,7 @@ async def test_revoke_204_and_idempotent(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             r = await cli.post(
                 "/v1/admin/api-tokens",
@@ -237,6 +263,7 @@ async def test_revoke_unknown_returns_404(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             d = await cli.delete("/v1/admin/api-tokens/nonexistent-id", headers=h)
             assert d.status_code == 404
@@ -250,6 +277,7 @@ async def test_mint_writes_audit_row(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             await cli.post(
                 "/v1/admin/api-tokens",
@@ -304,6 +332,7 @@ async def test_mint_via_rest_then_auth_v1_models(tmp_path, monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as cli:
         async with app.router.lifespan_context(app):
+            await _seed_common_users()
             h = await _headers()
             r = await cli.post(
                 "/v1/admin/api-tokens",

--- a/tests/test_api_token_resolver.py
+++ b/tests/test_api_token_resolver.py
@@ -45,6 +45,17 @@ async def app_with_real_dep(tmp_path, monkeypatch):
     get_settings.cache_clear()
     await init_db(url)
 
+    # Wave A C3 (audit 2026-05-11) — mint_user_api_token now requires
+    # the principal_id to exist in ``local_user_principals``. Seed the
+    # principals used by tests in this file (orga::user::<name>@orga.test).
+    from tests._token_test_helpers import seed_test_principal
+    for _name in (
+        "alice@orga.test", "bob@orga.test", "carol@orga.test",
+        "dave@orga.test", "erin@orga.test", "frank@orga.test",
+        "grace@orga.test", "heidi@orga.test",
+    ):
+        await seed_test_principal(f"orga::user::{_name}")
+
     # Avoid touching upstream catalogue endpoints — return a static list
     # the assertions can verify.
     async def fake_list_available_models(enabled):

--- a/tests/test_user_api_tokens_db.py
+++ b/tests/test_user_api_tokens_db.py
@@ -46,6 +46,12 @@ async def fresh_db(tmp_path, monkeypatch):
     get_settings.cache_clear()
 
     await init_db(url)
+    # Wave A C3 (audit 2026-05-11) — mint_user_api_token now requires
+    # the principal_id to exist in ``local_user_principals``. Seed the
+    # standard set so existing test mints (``acme::user::alice``..mia)
+    # work without each test pre-creating the row.
+    from tests._token_test_helpers import seed_default_test_principals
+    await seed_default_test_principals()
     try:
         yield url
     finally:

--- a/tests/test_wave_a_quick_wins.py
+++ b/tests/test_wave_a_quick_wins.py
@@ -1,0 +1,282 @@
+"""Wave A quick wins — D2 + B2 + C3.
+
+Audit refs: imp/audits/2026-05-11-MASTER.md (Wave A PR4).
+
+  D2 — POLICY_ENFORCEMENT=false must SystemExit in production
+       (app/config.py validate_config).
+  B2 — AI gateway upstream error body is scrubbed for provider key
+       shapes before flowing into audit detail
+       (mcp_proxy/egress/ai_gateway.scrub_secrets).
+  C3 — admin mint refuses non-user / foreign-org / non-existent
+       principal_id (mcp_proxy/db.mint_user_api_token).
+
+E1 (delete dead app/e2e_crypto.verify_inner_signature) was deferred:
+the function is referenced by tests/test_oneshot_cross_envelope.py and
+removing it requires migrating that test to the SDK twin first. Will
+land as a separate PR.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+import pytest_asyncio
+
+
+# ─── D2 — POLICY_ENFORCEMENT=false production gate ───
+
+
+def _make_prod_settings(monkeypatch, **overrides):
+    """Build a Settings instance with the minimum prod-shaped env to
+    pass every other gate, so we can isolate the policy_enforcement
+    check. Returns the constructed Settings + the validate_config
+    callable to invoke."""
+    from app import config as app_config
+
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("POLICY_DEFAULT_DECISION", "deny")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://prod:prod@prod/prod")
+    monkeypatch.setenv("KMS_BACKEND", "vault")
+    monkeypatch.setenv("VAULT_TOKEN", "prod-token")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.prod")
+    monkeypatch.setenv("REDIS_URL", "redis://prod-redis:6379/0")
+    monkeypatch.setenv("ADMIN_SECRET", "a-production-grade-secret-not-default")
+    # broker_ca_key_path needs to exist on disk; point at /etc/hosts as
+    # a stand-in (the prod gate just checks Path.exists).
+    monkeypatch.setenv("BROKER_CA_KEY_PATH", "/etc/hosts")
+    for k, v in overrides.items():
+        if v is None:
+            monkeypatch.delenv(k, raising=False)
+        else:
+            monkeypatch.setenv(k, v)
+    # Force a fresh Settings — pydantic_settings caches defaults at
+    # class scope, so we re-import the module to re-evaluate.
+    settings = app_config.Settings()
+    return settings, app_config.validate_config
+
+
+def test_d2_policy_enforcement_false_blocks_production_boot(monkeypatch):
+    """The headline D2 fix: ``POLICY_ENFORCEMENT=false`` in prod must
+    SystemExit at startup, mirroring the POLICY_DEFAULT_DECISION gate."""
+    settings, validate_config = _make_prod_settings(
+        monkeypatch, POLICY_ENFORCEMENT="false",
+    )
+    with pytest.raises(SystemExit):
+        validate_config(settings)
+
+
+def test_d2_policy_enforcement_true_passes_production_boot(monkeypatch):
+    """Negative control — default ``POLICY_ENFORCEMENT=true`` does not
+    trip the new gate. The prod-shaped fixture passes every other gate
+    so the call returns cleanly; the new gate must not be the one that
+    breaks it."""
+    settings, validate_config = _make_prod_settings(
+        monkeypatch, POLICY_ENFORCEMENT="true",
+    )
+    # Should not raise. If the gate accidentally fired on True we'd
+    # SystemExit here.
+    validate_config(settings)
+
+
+def test_d2_policy_enforcement_dev_default_no_gate(monkeypatch):
+    """D2 only fires in production. In dev, POLICY_ENFORCEMENT=false
+    is allowed (developers may need it for repro). Validate that the
+    dev path does NOT exit on this env var."""
+    from app import config as app_config
+
+    monkeypatch.setenv("ENVIRONMENT", "development")
+    monkeypatch.setenv("POLICY_ENFORCEMENT", "false")
+    monkeypatch.setenv("ADMIN_SECRET", "dev-grade-secret-not-default")
+    settings = app_config.Settings()
+    # Dev path doesn't enforce the policy_enforcement gate; the only
+    # exits in dev are ADMIN_SECRET-default and BROKER_PUBLIC_URL.
+    # We don't strictly assert no-exit (other dev gates may fire) —
+    # we assert that the prod-only critical message is NOT logged.
+    import logging
+    caplog_records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.emit = caplog_records.append  # type: ignore[assignment]
+    root = logging.getLogger()
+    root.addHandler(handler)
+    try:
+        try:
+            app_config.validate_config(settings)
+        except SystemExit:
+            pass  # acceptable — other dev gates can fire
+    finally:
+        root.removeHandler(handler)
+    msgs = [r.getMessage() for r in caplog_records]
+    assert not any(
+        "POLICY_ENFORCEMENT=false is not permitted in production" in m
+        for m in msgs
+    )
+
+
+# ─── B2 — AI gateway upstream error body scrubber ───
+
+
+def test_b2_scrub_strips_anthropic_key_prefix():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = (
+        '{"error":{"type":"authentication_error","message":'
+        '"Incorrect API key provided: sk-ant-api03-DEADBEEFDEADBEEFDEADBEEFDEADBEEF"}}'
+    )
+    out = scrub_secrets(body)
+    assert "sk-ant-" not in out
+    assert "[REDACTED]" in out
+    # Non-secret context preserved for ops debugging.
+    assert "authentication_error" in out
+
+
+def test_b2_scrub_strips_openai_project_key():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = "Incorrect API key: sk-proj-abc123def456ghi789jkl012mno345"
+    out = scrub_secrets(body)
+    assert "sk-proj-" not in out
+    assert "[REDACTED]" in out
+
+
+def test_b2_scrub_strips_gemini_key():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = "Bad key: AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI"
+    out = scrub_secrets(body)
+    assert "AIza" not in out
+    assert "[REDACTED]" in out
+
+
+def test_b2_scrub_strips_aws_access_key_id():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = "Invalid AKIAIOSFODNN7EXAMPLE in request"
+    out = scrub_secrets(body)
+    assert "AKIA" not in out
+    assert "[REDACTED]" in out
+
+
+def test_b2_scrub_strips_bearer_header():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = "Authorization header was Bearer eyJhbGciOiJIUzI1NiJ9.foo.bar"
+    out = scrub_secrets(body)
+    assert "Bearer eyJ" not in out
+    assert "[REDACTED]" in out
+
+
+def test_b2_scrub_strips_culk_token():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = "Token culk_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789 rejected"
+    out = scrub_secrets(body)
+    assert "culk_" not in out
+    assert "[REDACTED]" in out
+
+
+def test_b2_scrub_idempotent_on_non_secret_body():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    body = '{"error":"rate_limit_exceeded","retry_after":42}'
+    assert scrub_secrets(body) == body
+
+
+def test_b2_scrub_handles_none_and_empty():
+    from mcp_proxy.egress.ai_gateway import scrub_secrets
+    assert scrub_secrets(None) is None
+    assert scrub_secrets("") == ""
+
+
+# ─── C3 — admin mint principal_id validation ───
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "qw.db"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("PROXY_DB_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import init_db, dispose_db
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+        get_settings.cache_clear()
+
+
+async def _seed_user(principal_id: str = "acme::user::alice") -> None:
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from mcp_proxy.db import get_db
+    name = principal_id.split("::")[-1]
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_user_principals "
+                "(principal_id, user_name, reach, surface, created_at) "
+                "VALUES (:pid, :name, 'intra', NULL, :now)"
+            ),
+            {
+                "pid": principal_id, "name": name,
+                "now": datetime.now(timezone.utc).isoformat(),
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_c3_mint_rejects_unknown_principal(proxy_db):
+    """Pre-fix: any principal_id minted. Post-fix: 400 if no row."""
+    from mcp_proxy.db import mint_user_api_token
+    with pytest.raises(ValueError, match="not registered"):
+        await mint_user_api_token(
+            principal_id="acme::user::ghost",
+            label="cursor",
+            created_by="admin",
+        )
+
+
+@pytest.mark.asyncio
+async def test_c3_mint_rejects_non_user_principal(proxy_db):
+    """ADR-027 Phase 1 = user-only. Workload / agent shapes refuse."""
+    from mcp_proxy.db import mint_user_api_token
+    for bad in ("acme::workload::etl", "acme::daniele", "acme", "ghost"):
+        with pytest.raises(ValueError, match="user principal"):
+            await mint_user_api_token(
+                principal_id=bad,
+                label="cursor",
+                created_by="admin",
+            )
+
+
+@pytest.mark.asyncio
+async def test_c3_mint_rejects_foreign_org_principal(proxy_db):
+    """Mastio is org=acme; minting for orgB user is impersonation in
+    audit trail."""
+    await _seed_user("acme::user::alice")  # populate so the row check passes if reached
+    from mcp_proxy.db import mint_user_api_token
+    with pytest.raises(ValueError, match="not in this Mastio's org"):
+        await mint_user_api_token(
+            principal_id="orgb::user::alice",
+            label="cursor",
+            created_by="admin",
+        )
+
+
+@pytest.mark.asyncio
+async def test_c3_mint_succeeds_for_registered_user_in_own_org(proxy_db):
+    """Happy path — user pre-created via /v1/admin/users, same org,
+    user shape — mint returns the cleartext token once."""
+    await _seed_user("acme::user::alice")
+    from mcp_proxy.db import mint_user_api_token
+    minted = await mint_user_api_token(
+        principal_id="acme::user::alice",
+        label="cursor laptop",
+        created_by="admin",
+    )
+    assert minted["principal_id"] == "acme::user::alice"
+    assert minted["token"].startswith("culk_")
+    assert len(minted["token_last4"]) == 4

--- a/tests/test_wave_a_quick_wins.py
+++ b/tests/test_wave_a_quick_wins.py
@@ -73,17 +73,27 @@ def test_d2_policy_enforcement_false_blocks_production_boot(monkeypatch):
         validate_config(settings)
 
 
-def test_d2_policy_enforcement_true_passes_production_boot(monkeypatch):
-    """Negative control — default ``POLICY_ENFORCEMENT=true`` does not
-    trip the new gate. The prod-shaped fixture passes every other gate
-    so the call returns cleanly; the new gate must not be the one that
-    breaks it."""
+def test_d2_policy_enforcement_true_does_not_trip_gate(monkeypatch, caplog):
+    """Negative control — default ``POLICY_ENFORCEMENT=true`` does NOT
+    trip the new D2 gate. We don't assert "no SystemExit" because the
+    prod-shaped fixture may trip a downstream gate on a CI runner where
+    BROKER_CA_KEY_PATH stand-in or some other env var differs (caught
+    in CI shard 3). What this test pins: the new D2 gate's critical
+    log message must NOT fire when policy_enforcement is true."""
+    import logging
     settings, validate_config = _make_prod_settings(
         monkeypatch, POLICY_ENFORCEMENT="true",
     )
-    # Should not raise. If the gate accidentally fired on True we'd
-    # SystemExit here.
-    validate_config(settings)
+    caplog.set_level(logging.CRITICAL)
+    try:
+        validate_config(settings)
+    except SystemExit:
+        pass  # other prod gate fired; not our concern for D2
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any(
+        "POLICY_ENFORCEMENT=false is not permitted in production" in m
+        for m in msgs
+    ), f"D2 gate fired incorrectly on True; logs: {msgs}"
 
 
 def test_d2_policy_enforcement_dev_default_no_gate(monkeypatch):


### PR DESCRIPTION
## Summary

Closes 3 of the 4 quick-win findings bundled as **Wave A PR4** from \`imp/audits/2026-05-11-MASTER.md\`. E1 (delete dead \`app/e2e_crypto.verify_inner_signature\`) is **deferred** — the function is referenced by \`tests/test_oneshot_cross_envelope.py\` and removing it requires migrating the test to the SDK twin first.

### D2 — \`POLICY_ENFORCEMENT=false\` production startup gate
\`app/config.py:validate_config\` now SystemExits when \`POLICY_ENFORCEMENT=false\` in production. Mirrors the existing \`POLICY_DEFAULT_DECISION='allow'\` gate. Pre-fix a misconfigured .env / Helm value bumping the env would silently disable every PDP check. Tracks audit finding **T3-F5**.

### B2 — AI gateway upstream error body secret scrubber
\`scrub_secrets()\` in \`mcp_proxy/egress/ai_gateway.py\` strips Anthropic (\`sk-ant-\`), OpenAI (\`sk-\` / \`sk-proj-\`), Gemini (\`AIza…\`), AWS (\`AKIA…\`), Bearer headers, and \`culk_\` tokens before text flows into the immutable hash-chained audit log via \`upstream_detail\`. Provider 4xx echoes routinely include the rejected key prefix; pre-fix the rejected keys lived forever in the chain. Tracks **T3-F6 / T4-M-05 / T6-L-2**.

### C3 — admin token mint validates \`principal_id\`
\`mint_user_api_token\` now refuses any \`principal_id\` that is (a) not a \`<org>::user::<name>\` shape, (b) not in this Mastio's own \`org_id\`, or (c) not in \`local_user_principals\`. Pre-fix the mint accepted any string including foreign-org or non-existent principals, polluting audit attribution and (combined with the CRIT-1 vector that just merged in #601) enabling synthetic-identity walk through both cert + culk_ surfaces. Tracks **T2-H2 / T6-M-4**.

## Test plan

- [x] 15 new cases in \`tests/test_wave_a_quick_wins.py\`:
  - D2: prod exit on false, prod pass on true, dev allows false
  - B2: 5 key-shape scrubs + idempotent + None/empty handling
  - C3: unknown principal / non-user shape / foreign-org / happy path
- [x] Shared helper \`tests/_token_test_helpers.py\` (\`seed_test_principal\` / \`seed_default_test_principals\`) wires the 4 pre-existing token test files into the now-stricter C3 path. Each affected fixture seeds the standard names; ad-hoc tests can call \`seed_test_principal()\` directly.
- [x] \`pytest tests/test_admin_api_tokens.py tests/test_api_token_resolver.py tests/test_user_api_tokens_db.py tests/test_dashboard_api_tokens.py tests/test_wave_a_quick_wins.py\` → 61 passed
- [x] \`pytest tests/\` → **3212 passed** (8 pre-existing failures: connector GUI in CI headless + postgres binding KeyError, all documented in memory)
- [x] \`./demo_network/smoke.sh full\` → all assertions PASS (cross-org A2A round-trip, dashboard signing key restart-survival, audit hash chain across 38 entries, mcp-echo forwarding)

## Wave A status

| # | Finding | Status |
|---|---|---|
| 1 | CRIT-1 cert mint + cert-pin | merged #601 |
| 2 | CRIT-2 ingress execute binding | merged #603 |
| 3 | culk_ scope_paths + scope_providers enforcement | queued |
| 4 | Quick wins D2 + B2 + C3 | **THIS PR** |
| 4b | E1 delete dead app/e2e_crypto.verify_inner_signature | follow-up |
| 5 | CRIT-3 audit DB trigger + back-fill refactor | queued |