### PR TITLE
chore(frontdesk-bundle): pin cullis-chat-frontdesk to 0.2.0

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -104,7 +104,7 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
   CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0)
-  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.2.0-rc1)
+  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.2.0)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
   FRONTDESK_HTTP_PORT                Host port to bind nginx (default: 8080)
@@ -201,7 +201,7 @@ ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
 CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0}"
-CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.2.0-rc1}"
+CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.2.0}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"
 HTTP_PORT="$(_load_env FRONTDESK_HTTP_PORT)";         HTTP_PORT="${HTTP_PORT:-8080}"

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -185,7 +185,7 @@ services:
     # + bundled JS/CSS. /api/session/* and /v1/* proxying to the
     # Connector happens in the outer nginx layer below; this inner
     # container only serves static assets.
-    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.2.0-rc1}
+    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.2.0}
     expose:
       - "8080"
     depends_on:

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -47,7 +47,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on
 # every ``chat-vX.Y.Z`` tag (matrix build with CULLIS_BRAND=frontdesk).
-# CHAT_VERSION=0.2.0-rc1
+# CHAT_VERSION=0.2.0
 
 # -- Optional: bundle behaviour --------------------------------------------
 


### PR DESCRIPTION
Follow-up to tag \`chat-v0.2.0\`. Now that the release-chat workflow has published \`ghcr.io/cullis-security/cullis-chat-frontdesk:0.2.0\`, the Frontdesk bundle's three \`CHAT_VERSION\` defaults move off the rc1 pin.

## What changes

Three locations bumped \`0.2.0-rc1\` → \`0.2.0\` per \`feedback_release_pipeline_asymmetry_deploy_vs_compose\` (compose / deploy.sh / env.example must move together):

- \`packaging/frontdesk-bundle/docker-compose.yml\`: image default fallback in the \`cullis-chat\` service.
- \`packaging/frontdesk-bundle/deploy.sh\`: env default at runtime + help text.
- \`packaging/frontdesk-bundle/frontdesk.env.example\`: commented-out default.

Operators who set \`CHAT_VERSION\` explicitly are unaffected. Operators who deploy with stock defaults pick up \`0.2.0\` on their next \`deploy.sh\` run.

## Why

Sprint 1 Cullis Chat polish (#597 docs, #598 stop+retry, #599 copy buttons) is in main. \`chat-v0.2.0-rc1\` shipped 2026-05-10; today's tag promotes the snapshot to stable for the Frontdesk customer track per \`feedback_cullis_chat_is_primary_ui_repositioning\`.

## Test plan

- [x] grep for \`0.2.0-rc1\` in \`packaging/frontdesk-bundle/\` returns nothing post-change.
- [ ] CI smoke (modifiche solo a \`packaging/\`, niente codice).
- [ ] Manual: \`deploy.sh\` su VPS pulla \`cullis-chat-frontdesk:0.2.0\` invece di rc1.

🔒 Docs / packaging only. No code path touched. /security-review skippable per \`feedback_security_review_per_pr\` (docs / config carveout).