### PR TITLE
feat(dashboard): ADR-029 Phase E, tool-rules authoring UI

### DIFF
--- a/mcp_proxy/dashboard/templates/tool_rules.html
+++ b/mcp_proxy/dashboard/templates/tool_rules.html
@@ -1,0 +1,169 @@
+{% extends "base.html" %}
+{% block title %}Tool Rules{% endblock %}
+{% block header_title %}Tool-level Policy Rules{% endblock %}
+{% block content %}
+<div class="max-w-5xl">
+
+    <!-- Tabs (mirror /proxy/policies) -->
+    <div class="flex items-center gap-0 mb-6 border-b border-gray-800/60">
+        <a href="/proxy/policies"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            Built-in Rules
+        </a>
+        <a href="/proxy/policies"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-transparent text-gray-500 hover:text-gray-300 transition-colors">
+            External PDP
+        </a>
+        <a href="/proxy/policies/tool-rules"
+           class="px-4 py-2.5 text-xs font-medium uppercase tracking-wider border-b-2 border-accent-400 text-accent-400 transition-colors">
+            Tool Rules
+        </a>
+    </div>
+
+    <!-- Intro -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 mb-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-1">ADR-029 tool-level PDP</h3>
+        <p class="text-xs text-gray-500 leading-relaxed">
+            Each rule below scopes a single tool name. The
+            <code class="text-accent-400">POST /v1/policy/tool-call</code> endpoint checks the
+            requesting <strong>principal</strong>, the <strong>model</strong> that asked for the
+            tool, and the <strong>MCP server</strong> the tool lives on against the lists below
+            before allowing the dispatch. Empty list means "no restriction on this axis".
+            A principal in <em>denied_principals</em> beats the allow list. When
+            <code class="text-accent-400">tool_rules</code> is non-empty the gate becomes
+            <strong>explicit-allow</strong>: tools that are not listed are denied.
+        </p>
+        <p class="text-[11px] text-gray-600 mt-3">
+            Requires <code class="text-accent-400">MCP_PROXY_TOOL_PDP_ENABLED=true</code> on the
+            Mastio and <code class="text-accent-400">CULLIS_CONNECTOR_TOOL_PDP_ENABLED=true</code>
+            on the Connector. Both default to false.
+        </p>
+    </div>
+
+    <!-- Existing rules table -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 mb-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-4">Current Rules</h3>
+        {% if rules %}
+        <table class="w-full text-xs">
+            <thead class="text-[10px] uppercase tracking-wider text-gray-500 border-b border-gray-800/60">
+                <tr>
+                    <th class="text-left py-2 px-2 font-medium">Tool</th>
+                    <th class="text-left py-2 px-2 font-medium">Allowed principals</th>
+                    <th class="text-left py-2 px-2 font-medium">Denied principals</th>
+                    <th class="text-left py-2 px-2 font-medium">Allowed models</th>
+                    <th class="text-left py-2 px-2 font-medium">Allowed servers</th>
+                    <th class="text-right py-2 px-2 font-medium">Actions</th>
+                </tr>
+            </thead>
+            <tbody class="text-gray-300 font-mono">
+                {% for r in rules %}
+                <tr class="border-b border-gray-800/30 hover:bg-gray-800/20">
+                    <td class="py-2 px-2 align-top text-accent-400">{{ r.tool_name }}</td>
+                    <td class="py-2 px-2 align-top text-[11px]">
+                        {% if r.allowed_principals %}
+                        <ul class="space-y-0.5">{% for p in r.allowed_principals %}<li>{{ p }}</li>{% endfor %}</ul>
+                        {% else %}<span class="text-gray-600">any</span>{% endif %}
+                    </td>
+                    <td class="py-2 px-2 align-top text-[11px]">
+                        {% if r.denied_principals %}
+                        <ul class="space-y-0.5">{% for p in r.denied_principals %}<li>{{ p }}</li>{% endfor %}</ul>
+                        {% else %}<span class="text-gray-600">none</span>{% endif %}
+                    </td>
+                    <td class="py-2 px-2 align-top text-[11px]">
+                        {% if r.allowed_models %}
+                        <ul class="space-y-0.5">{% for m in r.allowed_models %}<li>{{ m }}</li>{% endfor %}</ul>
+                        {% else %}<span class="text-gray-600">any</span>{% endif %}
+                    </td>
+                    <td class="py-2 px-2 align-top text-[11px]">
+                        {% if r.allowed_mcp_servers %}
+                        <ul class="space-y-0.5">{% for s in r.allowed_mcp_servers %}<li>{{ s }}</li>{% endfor %}</ul>
+                        {% else %}<span class="text-gray-600">any</span>{% endif %}
+                    </td>
+                    <td class="py-2 px-2 align-top text-right">
+                        <form method="post" action="/proxy/policies/tool-rules/{{ r.tool_name }}/delete" class="inline">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                            <button type="submit"
+                                    onclick="return confirm('Remove tool rule for {{ r.tool_name }}?');"
+                                    class="text-[10px] uppercase tracking-wider text-red-400 hover:text-red-300 transition-colors">
+                                Delete
+                            </button>
+                        </form>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p class="text-xs text-gray-500 italic">
+            No tool rules configured. With an empty list the tool-call gate runs in
+            legacy default-allow mode (every call is allowed). Add the first rule below
+            to switch to explicit-allow.
+        </p>
+        {% endif %}
+    </div>
+
+    <!-- Add / edit form -->
+    <div class="bg-surface-900/80 border border-gray-800/50 rounded-lg p-6 card-glow backdrop-blur-sm">
+        <h3 class="text-sm font-semibold text-white uppercase tracking-wider mb-1">Add or update a rule</h3>
+        <p class="text-xs text-gray-500 mb-5">
+            Saving with an existing tool name overwrites that rule. Lists accept comma or
+            newline separation; each token is trimmed.
+        </p>
+
+        <form method="post" action="/proxy/policies/tool-rules/save" class="space-y-4">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+            <div>
+                <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Tool name</label>
+                <input type="text" name="tool_name" required
+                       placeholder="acme.catalog.search"
+                       class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2.5 text-sm text-white placeholder-gray-600 font-mono transition-all">
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Allowed principals</label>
+                    <textarea name="allowed_principals" rows="3"
+                              placeholder="acme::user::mario@acme.local, acme::user::anna@acme.local"
+                              class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 placeholder-gray-700 font-mono"></textarea>
+                    <p class="text-[10px] text-gray-600 mt-1">Empty = any principal allowed.</p>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Denied principals</label>
+                    <textarea name="denied_principals" rows="3"
+                              placeholder="acme::user::contractor@acme.local"
+                              class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 placeholder-gray-700 font-mono"></textarea>
+                    <p class="text-[10px] text-gray-600 mt-1">Wins over Allowed principals.</p>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Allowed models</label>
+                    <textarea name="allowed_models" rows="3"
+                              placeholder="claude-haiku-4-5, qwen-72b-chat"
+                              class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 placeholder-gray-700 font-mono"></textarea>
+                    <p class="text-[10px] text-gray-600 mt-1">Empty = any model.</p>
+                </div>
+                <div>
+                    <label class="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wider">Allowed MCP servers</label>
+                    <textarea name="allowed_mcp_servers" rows="3"
+                              placeholder="acme-catalog-prod"
+                              class="w-full bg-surface-950 border border-gray-700/60 rounded px-3 py-2 text-xs text-gray-300 placeholder-gray-700 font-mono"></textarea>
+                    <p class="text-[10px] text-gray-600 mt-1">Empty = any MCP server.</p>
+                </div>
+            </div>
+
+            <div class="flex items-center justify-end pt-2">
+                <button type="submit"
+                        class="px-5 py-2 text-xs font-semibold rounded transition-all"
+                        style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.05em; text-transform: uppercase;"
+                        onmouseover="this.style.background='#fff'"
+                        onmouseout="this.style.background='#00e5c7'">
+                    Save Rule
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/mcp_proxy/dashboard/tool_rules.py
+++ b/mcp_proxy/dashboard/tool_rules.py
@@ -1,0 +1,187 @@
+"""ADR-029 Phase E, dashboard authoring for tool-level PDP rules.
+
+The Phase C endpoint ``POST /v1/policy/tool-call`` reads
+``policy_rules.tool_rules`` and decides allow/deny per tool. Until
+this module landed an admin had to hand-edit the JSON document on
+the existing ``/proxy/policies`` Built-in Rules tab. This router
+exposes a structured form-based UI so the operator can add, edit,
+and remove tool rules without touching JSON.
+
+Storage stays the same single ``policy_rules`` config row, so a
+policy authored here is identical to one written in the JSON
+editor; the two surfaces stay in sync because they read and write
+the same underlying document.
+
+Routes:
+  GET  /proxy/policies/tool-rules                 list + form
+  POST /proxy/policies/tool-rules/save            upsert one rule
+  POST /proxy/policies/tool-rules/{tool}/delete   remove one rule
+"""
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+
+from mcp_proxy.dashboard.session import (
+    ProxyDashboardSession,
+    require_login,
+    verify_csrf,
+)
+from mcp_proxy.db import get_config, log_audit, set_config
+
+_log = logging.getLogger("mcp_proxy.dashboard.tool_rules")
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
+templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+
+router = APIRouter(
+    prefix="/proxy/policies/tool-rules",
+    tags=["dashboard-tool-rules"],
+)
+
+
+def _ctx(request: Request, session: ProxyDashboardSession, **kwargs) -> dict:
+    return {
+        "request": request,
+        "session": session,
+        "csrf_token": session.csrf_token,
+        "active": "policies",
+        **kwargs,
+    }
+
+
+def _parse_csv_list(raw: str) -> list[str]:
+    """Take a comma-or-newline separated string and return the
+    trimmed non-empty tokens. Used to convert form fields like
+    ``allowed_principals="acme::user::mario, acme::user::anna"`` into
+    a list."""
+    if not raw:
+        return []
+    parts: list[str] = []
+    for chunk in raw.replace("\r", "").replace("\n", ",").split(","):
+        token = chunk.strip()
+        if token:
+            parts.append(token)
+    return parts
+
+
+async def _read_policy_rules() -> dict:
+    rules_raw = await get_config("policy_rules")
+    if not rules_raw:
+        return {}
+    try:
+        return json.loads(rules_raw)
+    except json.JSONDecodeError:
+        _log.warning("policy_rules JSON malformed, treating as empty doc")
+        return {}
+
+
+async def _write_policy_rules(doc: dict) -> None:
+    await set_config("policy_rules", json.dumps(doc, indent=2, sort_keys=True))
+
+
+@router.get("", response_class=HTMLResponse)
+async def tool_rules_page(request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+
+    doc = await _read_policy_rules()
+    tool_rules_raw = doc.get("tool_rules") if isinstance(doc.get("tool_rules"), dict) else {}
+    # Normalise for the template: stable ordering by tool name.
+    rules_list: list[dict] = []
+    for tool_name in sorted(tool_rules_raw.keys()):
+        rule = tool_rules_raw[tool_name]
+        if not isinstance(rule, dict):
+            continue
+        rules_list.append({
+            "tool_name": tool_name,
+            "allowed_principals": rule.get("allowed_principals") or [],
+            "denied_principals": rule.get("denied_principals") or [],
+            "allowed_models": rule.get("allowed_models") or [],
+            "allowed_mcp_servers": rule.get("allowed_mcp_servers") or [],
+        })
+
+    return templates.TemplateResponse(
+        "tool_rules.html",
+        _ctx(request, session, rules=rules_list),
+    )
+
+
+@router.post("/save")
+async def tool_rules_save(request: Request):
+    """Upsert a single tool rule keyed by its tool_name.
+
+    The form sends the four list-shaped fields as comma/newline
+    separated text for ergonomics; the handler parses them back into
+    lists before merging into the JSON document.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    tool_name = str(form.get("tool_name", "")).strip()
+    if not tool_name:
+        raise HTTPException(status_code=400, detail="tool_name is required")
+
+    rule: dict = {}
+    ap = _parse_csv_list(str(form.get("allowed_principals", "")))
+    if ap:
+        rule["allowed_principals"] = ap
+    dp = _parse_csv_list(str(form.get("denied_principals", "")))
+    if dp:
+        rule["denied_principals"] = dp
+    am = _parse_csv_list(str(form.get("allowed_models", "")))
+    if am:
+        rule["allowed_models"] = am
+    ams = _parse_csv_list(str(form.get("allowed_mcp_servers", "")))
+    if ams:
+        rule["allowed_mcp_servers"] = ams
+
+    doc = await _read_policy_rules()
+    tool_rules = doc.get("tool_rules") if isinstance(doc.get("tool_rules"), dict) else {}
+    tool_rules[tool_name] = rule
+    doc["tool_rules"] = tool_rules
+    await _write_policy_rules(doc)
+
+    await log_audit(
+        agent_id="admin",
+        action="policy.tool_rules_upsert",
+        status="success",
+        tool_name=tool_name,
+        details={"rule_keys": list(rule.keys())},
+    )
+
+    return RedirectResponse(url="/proxy/policies/tool-rules", status_code=303)
+
+
+@router.post("/{tool_name}/delete")
+async def tool_rules_delete(tool_name: str, request: Request):
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    doc = await _read_policy_rules()
+    tool_rules = doc.get("tool_rules") if isinstance(doc.get("tool_rules"), dict) else {}
+    if tool_name in tool_rules:
+        del tool_rules[tool_name]
+        doc["tool_rules"] = tool_rules
+        await _write_policy_rules(doc)
+        await log_audit(
+            agent_id="admin",
+            action="policy.tool_rules_delete",
+            status="success",
+            tool_name=tool_name,
+        )
+
+    return RedirectResponse(url="/proxy/policies/tool-rules", status_code=303)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1371,6 +1371,10 @@ app.include_router(link_broker_admin_router)
 from mcp_proxy.dashboard.policies_local import router as local_policies_router
 app.include_router(local_policies_router)
 
+# ADR-029 Phase E, dashboard authoring for tool-level PDP rules.
+from mcp_proxy.dashboard.tool_rules import router as tool_rules_router
+app.include_router(tool_rules_router)
+
 # ADR-017 Phase 4 — dashboard CRUD for AI provider credentials (the
 # admin secret API surface lives in mcp_proxy.admin.ai_providers).
 from mcp_proxy.dashboard.ai_providers import router as ai_providers_dashboard_router

--- a/tests/test_dashboard_tool_rules.py
+++ b/tests/test_dashboard_tool_rules.py
@@ -1,0 +1,219 @@
+"""ADR-029 Phase E, dashboard authoring for tool-level PDP rules.
+
+Covers the structured form-based UI that supersedes hand-editing the
+``policy_rules.tool_rules`` subtree in the JSON editor. The router
+sits at ``/proxy/policies/tool-rules`` and persists into the same
+``policy_rules`` config row that the Phase C ``/v1/policy/tool-call``
+endpoint reads, so a rule added here is enforced immediately by the
+existing gate.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest_asyncio.fixture
+async def proxy_logged_in(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.delenv("MCP_PROXY_BROKER_URL", raising=False)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            from mcp_proxy.dashboard.session import set_admin_password
+            await set_admin_password("test-password-1234")
+            await client.post(
+                "/proxy/login",
+                data={"password": "test-password-1234"},
+                follow_redirects=False,
+            )
+            yield client
+    get_settings.cache_clear()
+
+
+async def _csrf(client) -> str:
+    page = await client.get("/proxy/policies/tool-rules")
+    assert page.status_code == 200, page.text
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    assert m, "csrf_token not found on page"
+    return m.group(1)
+
+
+@pytest.mark.asyncio
+async def test_list_renders_empty_state(proxy_logged_in):
+    page = await proxy_logged_in.get("/proxy/policies/tool-rules")
+    assert page.status_code == 200
+    assert "ADR-029 tool-level PDP" in page.text
+    assert "No tool rules configured" in page.text
+
+
+@pytest.mark.asyncio
+async def test_save_upserts_and_lists_rule(proxy_logged_in):
+    csrf = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={
+            "csrf_token": csrf,
+            "tool_name": "acme.catalog.search",
+            "allowed_principals":
+                "acme::user::mario@acme.local, acme::user::anna@acme.local",
+            "allowed_models": "claude-haiku-4-5",
+            "allowed_mcp_servers": "acme-catalog-prod",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    # The same /v1/policy/tool-call gate will read this back; verify the
+    # JSON document was merged correctly.
+    from mcp_proxy.db import get_config
+    raw = await get_config("policy_rules")
+    doc = json.loads(raw)
+    assert "tool_rules" in doc
+    rule = doc["tool_rules"]["acme.catalog.search"]
+    assert rule["allowed_principals"] == [
+        "acme::user::mario@acme.local",
+        "acme::user::anna@acme.local",
+    ]
+    assert rule["allowed_models"] == ["claude-haiku-4-5"]
+    assert rule["allowed_mcp_servers"] == ["acme-catalog-prod"]
+
+    page = await proxy_logged_in.get("/proxy/policies/tool-rules")
+    assert "acme.catalog.search" in page.text
+    assert "mario@acme.local" in page.text
+
+
+@pytest.mark.asyncio
+async def test_save_overwrites_existing_rule(proxy_logged_in):
+    csrf = await _csrf(proxy_logged_in)
+    # First write
+    await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={
+            "csrf_token": csrf,
+            "tool_name": "acme.catalog.search",
+            "allowed_principals": "acme::user::mario@acme.local",
+        },
+        follow_redirects=False,
+    )
+    # Overwrite with denied_principals only
+    csrf2 = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={
+            "csrf_token": csrf2,
+            "tool_name": "acme.catalog.search",
+            "denied_principals": "acme::user::contractor@acme.local",
+        },
+        follow_redirects=False,
+    )
+
+    from mcp_proxy.db import get_config
+    doc = json.loads(await get_config("policy_rules"))
+    rule = doc["tool_rules"]["acme.catalog.search"]
+    assert "allowed_principals" not in rule
+    assert rule["denied_principals"] == ["acme::user::contractor@acme.local"]
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_rule(proxy_logged_in):
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={
+            "csrf_token": csrf,
+            "tool_name": "acme.catalog.search",
+            "allowed_principals": "acme::user::mario@acme.local",
+        },
+        follow_redirects=False,
+    )
+
+    csrf2 = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/acme.catalog.search/delete",
+        data={"csrf_token": csrf2},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 303
+
+    from mcp_proxy.db import get_config
+    doc = json.loads(await get_config("policy_rules"))
+    assert "acme.catalog.search" not in doc.get("tool_rules", {})
+
+
+@pytest.mark.asyncio
+async def test_csrf_required_on_save(proxy_logged_in):
+    resp = await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={
+            "csrf_token": "wrong-token",
+            "tool_name": "acme.catalog.search",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_save_rejects_empty_tool_name(proxy_logged_in):
+    csrf = await _csrf(proxy_logged_in)
+    resp = await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={"csrf_token": csrf, "tool_name": ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_round_trip_via_phase_c_endpoint(proxy_logged_in, monkeypatch):
+    """End-to-end: dashboard saves a rule, /v1/policy/tool-call enforces
+    it on the next call. Bridges Phase E (authoring) and Phase C
+    (enforcement) in a single test."""
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    csrf = await _csrf(proxy_logged_in)
+    await proxy_logged_in.post(
+        "/proxy/policies/tool-rules/save",
+        data={
+            "csrf_token": csrf,
+            "tool_name": "acme.catalog.search",
+            "allowed_principals": "acme::user::mario@acme.local",
+        },
+        follow_redirects=False,
+    )
+
+    # Mario gets allow.
+    r_allow = await proxy_logged_in.post("/v1/policy/tool-call", json={
+        "principal": {"id": "acme::user::mario@acme.local", "type": "user"},
+        "model": {"id": "claude-haiku-4-5"},
+        "target": {"id": "acme::workload::catalog", "type": "workload", "org": "acme"},
+        "invocation": {"kind": "session_tool_call", "tool_name": "acme.catalog.search"},
+    })
+    assert r_allow.status_code == 200
+    assert r_allow.json()["decision"] == "allow"
+
+    # Anna gets deny (not in allowed_principals).
+    r_deny = await proxy_logged_in.post("/v1/policy/tool-call", json={
+        "principal": {"id": "acme::user::anna@acme.local", "type": "user"},
+        "model": {"id": "claude-haiku-4-5"},
+        "target": {"id": "acme::workload::catalog", "type": "workload", "org": "acme"},
+        "invocation": {"kind": "session_tool_call", "tool_name": "acme.catalog.search"},
+    })
+    assert r_deny.status_code == 200
+    assert r_deny.json()["decision"] == "deny"


### PR DESCRIPTION
Closes ADR-029 on the operator side. Phase C endpoint `/v1/policy/tool-call` (#600) already reads `policy_rules.tool_rules` and enforces allow/deny per tool; until now an admin had to hand-edit the JSON on the existing `/proxy/policies` Built-in Rules tab. This PR ships a structured form-based page at `/proxy/policies/tool-rules` so an admin can add, edit, and remove tool rules without touching JSON.

## Routes

| Method | Path | Purpose |
|---|---|---|
| GET | `/proxy/policies/tool-rules` | List rules + add/edit form |
| POST | `/proxy/policies/tool-rules/save` | Upsert a single rule keyed by `tool_name` |
| POST | `/proxy/policies/tool-rules/{tool}/delete` | Remove a single rule |

## Form ergonomics

Each list-shaped field (`allowed_principals`, `denied_principals`, `allowed_models`, `allowed_mcp_servers`) accepts comma OR newline separated tokens. Pasted lists work, manual editing works, the handler trims and splits before merging into the JSON document.

Empty list means **no restriction on this axis**. `denied_principals` beats `allowed_principals`.

## Storage

Same single `policy_rules` config row that the JSON editor on `/proxy/policies` already writes. A rule authored here is read by the Phase C gate **immediately**, no restart needed. The two surfaces stay in sync because they share the underlying document.

## Audit

Every save / delete writes a hash-chained audit row:
- `policy.tool_rules_upsert` (with `details.rule_keys`)
- `policy.tool_rules_delete`

So the operator history stays traceable per ADR-029 §Threat model (insider abusing OPA / dashboard for unauthorised changes).

## Test plan

- [x] 7 new cases in `tests/test_dashboard_tool_rules.py`:
  - empty list page renders with the legacy default-allow advisory
  - save upserts and lists the new rule
  - save overwrites an existing rule cleanly (no stale keys leak)
  - delete removes the rule from the document
  - CSRF required on save (403 without)
  - empty `tool_name` rejected with 400
  - **round-trip end-to-end**: save a rule via the dashboard, the Phase C `/v1/policy/tool-call` endpoint enforces it on the next call (Mario allow, Anna deny against `acme.catalog.search`)
- [x] All 7 tests green locally.
- [ ] CI full suite + `./sandbox/smoke.sh full` before merge (touches `mcp_proxy/`).
- [ ] `/security-review` pre-merge.

## What ADR-029 looks like in main after this

| Phase | Component | Status |
|---|---|---|
| A | ADR draft, 5 decisions ratified | ✅ done |
| B | Broker payload + response extended | ✅ merged (#600) |
| C | Mastio `/v1/policy/tool-call` endpoint | ✅ merged (#600) |
| D-1 | Connector wiring single-org | ✅ merged (#602) |
| D-2 | Federation cross-org Mastio→Mastio | ✅ merged (#604) |
| **E** | **Dashboard tool-rules authoring UI** | **this PR** |
| F | `./sandbox/demo.sh policy-granular` + YC video | next |

🔒 Touches `mcp_proxy/dashboard/`. Backward compat: the existing `/proxy/policies` JSON editor still works against the same document, so an admin can edit either surface. CSRF protected; require_login enforced.