### PR TITLE
feat(sandbox): ADR-029 Phase F, policy-granular end-to-end demo

### DIFF
--- a/sandbox/demo.sh
+++ b/sandbox/demo.sh
@@ -54,10 +54,11 @@ _print_dashboards() {
 
 _print_scenarios() {
     _header "Try it — send messages between agents"
-    echo -e "  ${GREEN}./demo.sh oneshot-a-to-b${RESET}   cross-org: orga::agent-a → orgb::agent-b (via Court)"
-    echo -e "  ${GREEN}./demo.sh oneshot-b-to-a${RESET}   cross-org: orgb::agent-b → orga::agent-a (via Court)"
-    echo -e "  ${GREEN}./demo.sh mcp-catalog${RESET}      intra-org MCP: orga::agent-a → get_catalog"
-    echo -e "  ${GREEN}./demo.sh mcp-inventory${RESET}    intra-org MCP: orgb::agent-b → check_inventory"
+    echo -e "  ${GREEN}./demo.sh oneshot-a-to-b${RESET}    cross-org: orga::agent-a → orgb::agent-b (via Court)"
+    echo -e "  ${GREEN}./demo.sh oneshot-b-to-a${RESET}    cross-org: orgb::agent-b → orga::agent-a (via Court)"
+    echo -e "  ${GREEN}./demo.sh mcp-catalog${RESET}       intra-org MCP: orga::agent-a → get_catalog"
+    echo -e "  ${GREEN}./demo.sh mcp-inventory${RESET}     intra-org MCP: orgb::agent-b → check_inventory"
+    echo -e "  ${GREEN}./demo.sh policy-granular${RESET}   ADR-029 tool-level PDP + cross-org federation"
 }
 
 _print_teardown() {
@@ -176,10 +177,11 @@ Inspection:
   bootstrap-logs  Replay the verbose Phase 1-7 bootstrap output.
 
 Scenarios (require 'full' mode — orga workloads must be running):
-  oneshot-a-to-b  Cross-org one-shot from orga::agent-a to orgb::agent-b.
-  oneshot-b-to-a  Cross-org one-shot from orgb::agent-b to orga::agent-a.
-  mcp-catalog     Intra-org MCP call: orga::agent-a → mcp-catalog (get_catalog).
-  mcp-inventory   Intra-org MCP call: orgb::agent-b → mcp-inventory (check_inventory).
+  oneshot-a-to-b   Cross-org one-shot from orga::agent-a to orgb::agent-b.
+  oneshot-b-to-a   Cross-org one-shot from orgb::agent-b to orga::agent-a.
+  mcp-catalog      Intra-org MCP call: orga::agent-a → mcp-catalog (get_catalog).
+  mcp-inventory    Intra-org MCP call: orgb::agent-b → mcp-inventory (check_inventory).
+  policy-granular  ADR-029 tool-level PDP gate + cross-org federation walkthrough.
 
 Guided onboarding (for 'up' mode — walks you through completing orga):
   guide           Open the step-by-step Markdown walkthrough.

--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -328,6 +328,11 @@ services:
       # which masks any client-cert presentation regression.
       MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"
       MCP_PROXY_NGINX_SAN: "mastio-nginx-a,proxy-a,localhost"
+      # ADR-029 Phase F, tool-level PDP gate active in the sandbox so
+      # the policy-granular demo can exercise allow / deny per tool
+      # and the cross-org federation against proxy-b.
+      MCP_PROXY_TOOL_PDP_ENABLED: "true"
+      MCP_PROXY_TOOL_PDP_FEDERATION_URLS: '{"orgb": "http://proxy-b:9100/v1/policy/tool-call"}'
     volumes:
       - proxy-a-data:/data
       - mastio-a-nginx-certs:/var/lib/mastio/nginx-certs:rw
@@ -626,6 +631,11 @@ services:
       # ``mastio-nginx-b`` (the hostname agents resolve to).
       MCP_PROXY_NGINX_CERT_DIR: "/var/lib/mastio/nginx-certs"
       MCP_PROXY_NGINX_SAN: "mastio-nginx-b,proxy-b,localhost"
+      # ADR-029 Phase F, tool-level PDP gate active in the sandbox so
+      # the policy-granular demo can exercise allow / deny per tool
+      # and the cross-org federation against proxy-a.
+      MCP_PROXY_TOOL_PDP_ENABLED: "true"
+      MCP_PROXY_TOOL_PDP_FEDERATION_URLS: '{"orga": "http://proxy-a:9100/v1/policy/tool-call"}'
     volumes:
       - proxy-b-data:/data
       - mastio-b-nginx-certs:/var/lib/mastio/nginx-certs:rw

--- a/sandbox/scenarios/policy_granular_demo.sh
+++ b/sandbox/scenarios/policy_granular_demo.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# ADR-029 Phase F, policy-granular end-to-end demo.
+#
+# Exercises the tool-level PDP gate (Phase C) + cross-org federation
+# (Phase D-2) against the running sandbox. Configures tool_rules on
+# both Mastios, then walks through a sequence of allow / deny calls
+# and tails the audit chain.
+#
+# Prerequisites:
+#   1. `./demo.sh full` has been run.
+#   2. MCP_PROXY_TOOL_PDP_ENABLED=true is set on proxy-a and proxy-b
+#      (the sandbox docker-compose.yml ships this on by default for
+#      the full profile after ADR-029 Phase F).
+#
+# Designed to read well on screen for the YC video: each scenario
+# prints the verdict and reason inline, the final audit dump shows
+# the hash-chained trail.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BOLD='\033[1m'
+GREEN='\033[32m'
+RED='\033[31m'
+YELLOW='\033[33m'
+CYAN='\033[36m'
+DIM='\033[2m'
+RESET='\033[0m'
+
+ALLOW_EMOJI=$'✅'
+DENY_EMOJI=$'❌'
+
+_step() { echo -e "\n${BOLD}${CYAN}── $1 ──${RESET}"; }
+_note() { echo -e "  ${DIM}$1${RESET}"; }
+
+
+_have_jq() { command -v jq >/dev/null 2>&1; }
+
+# proxy-a is mounted on host port 9100, proxy-b on 9200.
+PROXY_A_URL="http://localhost:9100"
+PROXY_B_URL="http://localhost:9200"
+
+
+# ── 0. Sanity check ───────────────────────────────────────────────────
+_step "0. Sanity check: both Mastios alive + tool PDP gate on"
+
+if ! curl -sf "${PROXY_A_URL}/readyz" >/dev/null; then
+    echo -e "${RED}proxy-a is not reachable at ${PROXY_A_URL}. Run ./demo.sh full first.${RESET}"
+    exit 1
+fi
+if ! curl -sf "${PROXY_B_URL}/readyz" >/dev/null; then
+    echo -e "${RED}proxy-b is not reachable at ${PROXY_B_URL}. Run ./demo.sh full first.${RESET}"
+    exit 1
+fi
+
+probe_a=$(curl -s -o /dev/null -w '%{http_code}' \
+    -X POST "${PROXY_A_URL}/v1/policy/tool-call" \
+    -H 'Content-Type: application/json' \
+    -d '{"principal":{"id":"probe","type":"user"},"invocation":{"tool_name":"probe"}}')
+if [ "${probe_a}" = "404" ]; then
+    echo -e "${RED}proxy-a tool PDP gate is OFF.${RESET}"
+    echo -e "${YELLOW}Restart the sandbox after the ADR-029 Phase F merge so MCP_PROXY_TOOL_PDP_ENABLED=true is picked up:${RESET}"
+    echo -e "  ./demo.sh down && ./demo.sh full"
+    exit 1
+fi
+
+_note "proxy-a tool PDP gate: ON (probe returned HTTP ${probe_a})"
+
+
+# ── 1. Configure tool_rules on both Mastios ───────────────────────────
+_step "1. Write tool_rules on proxy-a (orga) and proxy-b (orgb)"
+
+# proxy-a (orga) policy:
+#   acme.catalog.search   allowed for mario, denied for anna,
+#                         restricted to claude-haiku-4-5
+#   orgb.catalog.search   allowed for mario, no model lock (will federate
+#                         to proxy-b on call)
+docker compose exec -T proxy-a python - <<'PY'
+import asyncio, json
+from mcp_proxy.db import set_config
+async def main():
+    rules = {
+        "tool_rules": {
+            "acme.catalog.search": {
+                "allowed_principals": ["orga::user::mario"],
+                "denied_principals":  ["orga::user::anna"],
+                "allowed_models":     ["claude-haiku-4-5"],
+            },
+            "orgb.catalog.search": {
+                "allowed_principals": ["orga::user::mario"],
+            },
+        }
+    }
+    await set_config("policy_rules", json.dumps(rules, indent=2, sort_keys=True))
+    print("[proxy-a] policy_rules.tool_rules written")
+asyncio.run(main())
+PY
+
+# proxy-b (orgb) policy:
+#   orgb.catalog.search   open: any cross-org user that proxy-a
+#                         clears reaches the data.
+#   orgb.private.tool     listed but with empty allowed_principals,
+#                         so any incoming request is denied at the
+#                         target side (proxy-a's local allow gets
+#                         intersected with proxy-b's deny → final deny).
+docker compose exec -T proxy-b python - <<'PY'
+import asyncio, json
+from mcp_proxy.db import set_config
+async def main():
+    rules = {
+        "tool_rules": {
+            "orgb.catalog.search": {
+                # Empty allowlist → any principal accepted (legacy
+                # default-allow on this axis once tool_rules is non-empty).
+                # Phase D-2 expects the target Mastio to gate on its OWN
+                # policy; here we just open the door for the federation
+                # demo.
+            },
+            "orgb.private.tool": {
+                "allowed_principals": ["orgb::user::ceo"],
+            },
+        }
+    }
+    await set_config("policy_rules", json.dumps(rules, indent=2, sort_keys=True))
+    print("[proxy-b] policy_rules.tool_rules written")
+asyncio.run(main())
+PY
+
+
+# ── helper: pretty-call the gate + print verdict ──────────────────────
+call_gate() {
+    local label="$1"
+    local proxy_url="$2"
+    local payload="$3"
+
+    local resp http_code body decision reason
+    resp=$(curl -s -o /tmp/policy-resp.json -w '%{http_code}' \
+        -X POST "${proxy_url}/v1/policy/tool-call" \
+        -H 'Content-Type: application/json' \
+        -d "${payload}")
+    http_code="${resp}"
+    body=$(cat /tmp/policy-resp.json)
+    if _have_jq; then
+        decision=$(echo "${body}" | jq -r '.decision // "?"')
+        reason=$(echo "${body}" | jq -r '.reason // ""')
+    else
+        decision=$(echo "${body}" | grep -o '"decision":"[^"]*"' | head -1 | cut -d'"' -f4)
+        reason=$(echo "${body}" | sed -n 's/.*"reason":"\([^"]*\)".*/\1/p' | head -1)
+    fi
+    local emoji color
+    if [ "${decision}" = "allow" ]; then
+        emoji="${ALLOW_EMOJI}"
+        color="${GREEN}"
+    else
+        emoji="${DENY_EMOJI}"
+        color="${RED}"
+    fi
+    printf "  ${BOLD}%-58s${RESET} %s ${color}%-5s${RESET}  ${DIM}%s${RESET}\n" \
+        "${label}" "${emoji}" "${decision}" "${reason}"
+}
+
+
+# ── 2. Local Mastio gate (proxy-a) ────────────────────────────────────
+_step "2. proxy-a local gate: principal + model + tool"
+
+call_gate "mario + haiku → acme.catalog.search" "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::mario", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-haiku-4-5"},
+    "target":    {"id": "orga::workload::catalog", "type": "workload", "org": "orga"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "acme.catalog.search"}
+}'
+
+call_gate "anna  + haiku → acme.catalog.search" "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::anna", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-haiku-4-5"},
+    "target":    {"id": "orga::workload::catalog", "type": "workload", "org": "orga"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "acme.catalog.search"}
+}'
+
+call_gate "mario + opus  → acme.catalog.search" "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::mario", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-opus-4-7"},
+    "target":    {"id": "orga::workload::catalog", "type": "workload", "org": "orga"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "acme.catalog.search"}
+}'
+
+call_gate "mario + haiku → acme.unlisted.tool   " "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::mario", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-haiku-4-5"},
+    "target":    {"id": "orga::workload::catalog", "type": "workload", "org": "orga"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "acme.unlisted.tool"}
+}'
+
+
+# ── 3. Cross-org federation: proxy-a ↔ proxy-b ────────────────────────
+_step "3. Cross-org federation: proxy-a asks proxy-b"
+
+call_gate "mario → orgb.catalog.search          " "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::mario", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-haiku-4-5"},
+    "target":    {"id": "orgb::workload::catalog", "type": "workload", "org": "orgb"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "orgb.catalog.search"}
+}'
+
+call_gate "mario → orgb.private.tool            " "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::mario", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-haiku-4-5"},
+    "target":    {"id": "orgb::workload::secret", "type": "workload", "org": "orgb"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "orgb.private.tool"}
+}'
+
+call_gate "mario → stranger.tool (no fed URL)    " "${PROXY_A_URL}" '{
+    "principal": {"id": "orga::user::mario", "type": "user", "org": "orga"},
+    "model":     {"id": "claude-haiku-4-5"},
+    "target":    {"id": "stranger::workload::x", "type": "workload", "org": "stranger"},
+    "invocation":{"kind": "session_tool_call", "tool_name": "stranger.tool"}
+}'
+
+
+# ── 4. Audit chain ────────────────────────────────────────────────────
+_step "4. Hash-chained audit on proxy-a (last 8 rows, action=policy.tool_call)"
+
+docker compose exec -T proxy-a python - <<'PY'
+import asyncio, json
+from sqlalchemy import text
+from mcp_proxy.db import get_db
+async def main():
+    async with get_db() as conn:
+        rows = (await conn.execute(text(
+            "SELECT chain_seq, agent_id, status, tool_name, detail "
+            "FROM audit_log WHERE action='policy.tool_call' "
+            "ORDER BY chain_seq DESC LIMIT 8"
+        ))).fetchall()
+    for r in reversed(rows):
+        d = json.loads(r.detail or "{}")
+        tail = " ".join(
+            f"{k}={d[k]}" for k in ("model", "target", "federated") if k in d
+        )
+        print(f"  #{r.chain_seq:<3}  {r.status:<5}  {r.agent_id:<32}  {r.tool_name:<24}  {tail}")
+asyncio.run(main())
+PY
+
+
+# ── 5. Wrap-up ───────────────────────────────────────────────────────
+_step "5. Demo complete"
+
+cat <<EOF
+  ${BOLD}Recap${RESET}
+
+  Local gate (proxy-a, orga):
+    mario + haiku  → acme.catalog.search  allow  (in allowed_principals + allowed_models)
+    anna  + haiku  → acme.catalog.search  deny   (denied_principals beats allow)
+    mario + opus   → acme.catalog.search  deny   (model not in allowed_models)
+    mario + haiku  → acme.unlisted.tool   deny   (tool not in tool_rules: explicit-allow)
+
+  Cross-org federation (proxy-a → proxy-b):
+    mario → orgb.catalog.search           allow  (proxy-a allow ∩ proxy-b allow)
+    mario → orgb.private.tool             deny   (proxy-b explicit-allow refuses; final deny)
+    mario → stranger.tool                 deny   (no federation URL for that org)
+
+  ${BOLD}What this proves${RESET}
+  - PDP discriminates on principal + model + tool + target org, all on a
+    single uniform shape (ADR-029 §Decision).
+  - Cross-org calls are dual-allow: source AND target Mastio must agree.
+  - Default-deny when an org is not in the federation map; an admin
+    cannot bypass a peer by omission.
+  - Every decision lands hash-chained in audit_log; allow and deny
+    rows side by side make forensic queries trivial.
+
+  ${BOLD}Dashboard${RESET}
+  Open http://localhost:9100/proxy/policies/tool-rules to edit the rules
+  through the new authoring matrix (ADR-029 Phase E).
+EOF


### PR DESCRIPTION
Closes ADR-029 with a runnable proof point. Phase B/C/D-1/D-2/E shipped the gate, the Connector hook, the cross-org federation, and the dashboard authoring UI; this PR wires them together inside the sandbox so the whole loop can be watched in one shell command.

## What's in this PR

### 1. \`sandbox/docker-compose.yml\` — ADR-029 env on both Mastios

\`proxy-a\` and \`proxy-b\` (full profile) now boot with:

- \`MCP_PROXY_TOOL_PDP_ENABLED=true\` — the gate is on.
- \`MCP_PROXY_TOOL_PDP_FEDERATION_URLS\` — symmetric map: proxy-a federates to proxy-b for \`orgb\` targets, proxy-b federates to proxy-a for \`orga\` targets.

### 2. \`sandbox/scenarios/policy_granular_demo.sh\` — the walkthrough

Self-contained script that:

- Sanity-checks both Mastios are up and the tool PDP gate is on (404 vs 200 on a probe POST).
- Writes \`policy_rules.tool_rules\` on both proxies via \`docker compose exec proxy-X python\`.
- Exercises the **local gate** on proxy-a (4 cases):
  - \`mario + haiku → acme.catalog.search\` ✅ allow
  - \`anna + haiku → acme.catalog.search\` ❌ deny (denylist beats allowlist)
  - \`mario + opus → acme.catalog.search\` ❌ deny (model not in allowed_models)
  - \`mario + haiku → acme.unlisted.tool\` ❌ deny (explicit-allow mode)
- Exercises **cross-org federation** proxy-a → proxy-b (3 cases):
  - \`mario → orgb.catalog.search\` ✅ allow (proxy-a allow ∩ proxy-b allow)
  - \`mario → orgb.private.tool\` ❌ deny (proxy-b refuses; intersection denies)
  - \`mario → stranger.tool\` ❌ deny (no federation URL for that org)
- Tails the last 8 \`policy.tool_call\` hash-chained audit rows so the chain is visible in the same terminal.
- Prints a recap explaining what each row proves.

### 3. \`./demo.sh policy-granular\` subcommand

Runs the script. The help text and the post-\`full\` hint list now both surface it alongside \`oneshot-a-to-b\` / \`mcp-catalog\` / \`mcp-inventory\`.

## Operator flow for the YC video

1. \`./demo.sh full\` — sandbox up with both orgs wired.
2. Open \`http://localhost:9100/proxy/policies/tool-rules\` — Phase E authoring UI, edit a rule live.
3. \`./demo.sh policy-granular\` — script walk-through with the 7 scenarios above.
4. Open \`http://localhost:9100/proxy/audit\` — hash-chained proof of every decision.

Steps 2 and 4 are the visual cues for the recorded narrative. Step 3 stands on its own for the audit / CI angle (no human in the loop).

## Test plan

- [x] Script syntax check: \`bash -n sandbox/scenarios/policy_granular_demo.sh\`.
- [x] Help + scenarios print include \`policy-granular\`.
- [ ] **End-to-end manual run on the operator's machine**: \`./demo.sh full && ./demo.sh policy-granular\` produces the 7 expected verdicts (4 local + 3 federated) and 8 audit rows.
- [ ] CI smoke (sandbox is not built in CI for this workflow).
- [ ] \`/security-review\` not required: zero code in \`app/\`, \`mcp_proxy/\`, \`cullis_connector/\`, \`cullis_sdk/\`. Only sandbox config + demo script.

## ADR-029 status in main after this

| Phase | Component | Status |
|---|---|---|
| A | ADR draft | ✅ |
| B | Broker payload + response extended (#600) | ✅ |
| C | Mastio \`/v1/policy/tool-call\` endpoint (#600) | ✅ |
| D-1 | Connector wiring single-org (#602) | ✅ |
| D-2 | Federation cross-org Mastio→Mastio (#604) | ✅ |
| E | Dashboard tool-rules authoring UI (#607) | ✅ |
| **F** | **policy-granular end-to-end demo** | **this PR** |

🔒 Sandbox config + bash script only. No production code path touched.