### PR TITLE
fix(mastio): enforce culk_ token scope_paths + scope_providers (Wave A PR3)

### DIFF
--- a/mcp_proxy/auth/api_token.py
+++ b/mcp_proxy/auth/api_token.py
@@ -43,9 +43,10 @@ Audit:
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 
-from fastapi import Request
+from fastapi import HTTPException, Request, status
 
 from mcp_proxy.db import (
     touch_user_api_token,
@@ -54,6 +55,29 @@ from mcp_proxy.db import (
 from mcp_proxy.models import InternalAgent
 
 _log = logging.getLogger("mcp_proxy.auth.api_token")
+
+
+def _path_matches_globs(request_path: str, patterns: list[str]) -> bool:
+    """True if ``request_path`` matches any glob in ``patterns``.
+
+    Glob semantics: ``*`` matches any character including ``/`` (so
+    ``/v1/*`` matches the entire ``/v1/...`` subtree). This is the
+    permissive shape operators expect when they mint a token "for the
+    OpenAI-compat surface" — a stricter ``no-slash`` glob would force
+    them to enumerate every nested route.
+
+    Empty ``patterns`` is treated as "unscoped" (caller should have
+    short-circuited that case before calling this helper).
+    """
+    if not patterns:
+        return True
+    for pattern in patterns:
+        # Translate glob → regex: escape every literal char, then
+        # replace the escaped ``\*`` with ``.*``. Anchor full match.
+        regex = "^" + re.escape(pattern).replace(r"\*", ".*") + "$"
+        if re.fullmatch(regex, request_path):
+            return True
+    return False
 
 # Header name + scheme — case-insensitive parse below. ``culk_`` is the
 # stable prefix documented in ADR-027 §wire format.
@@ -157,6 +181,29 @@ async def _maybe_api_token_principal(request: Request) -> InternalAgent | None:
         # that happens to share the Bearer scheme.
         return None
 
+    # Wave A PR3 (audit 2026-05-11 Tema A) — enforce ``scope_paths``
+    # at the resolver. Pre-fix the field was stored at mint time and
+    # never read; a token "scoped" to ``/v1/chat/completions`` worked
+    # on every endpoint guarded by ``get_agent_from_dpop_client_cert``,
+    # i.e. the entire egress + A2A surface. Now: if the token has
+    # non-empty ``scope_paths``, the request path MUST match at least
+    # one glob, else 403. Default mint sets ``["/v1/*"]`` so any
+    # non-OpenAI-compat call from a culk_-only client is refused.
+    scope_paths = row.get("scope_paths") or []
+    if scope_paths and not _path_matches_globs(request.url.path, scope_paths):
+        _log.warning(
+            "culk_ token denied: path %r not in scope_paths %r "
+            "(token id=%s, principal=%s)",
+            request.url.path, scope_paths,
+            row.get("id"), row.get("principal_id"),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "API token scope_paths does not allow this request path"
+            ),
+        )
+
     # Best-effort last_used touch. Never raises (see helper docstring).
     await touch_user_api_token(row["id"], client_ip=_client_ip(request))
 
@@ -175,4 +222,9 @@ async def _maybe_api_token_principal(request: Request) -> InternalAgent | None:
         # without forcing scope here; egress paths don't enforce reach.
         reach="both",
         principal_type=_principal_type_for(principal_id),
+        # Pass scope down to the AI gateway dispatcher (PR3) so it can
+        # enforce scope_providers on /v1/chat/completions. Other auth
+        # paths (cert+DPoP, LOCAL_TOKEN) leave these as None.
+        scope_providers=row.get("scope_providers") or [],
+        scope_paths=scope_paths,
     )

--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -41,6 +41,7 @@ from mcp_proxy.egress.ai_gateway import (
 from mcp_proxy.egress.provider_catalog import (
     PROVIDERS,
     list_available_models,
+    parse_provider_from_model,
 )
 from mcp_proxy.egress.schemas import ChatCompletionRequest
 from mcp_proxy.models import InternalAgent
@@ -63,6 +64,46 @@ async def chat_completions(
 ):
     settings = get_settings()
     trace_id = f"trace_{uuid.uuid4().hex[:16]}"
+
+    # Wave A PR3 (audit 2026-05-11 Tema A) — enforce ``scope_providers``
+    # on culk_-authed callers. Pre-fix this field was stored at mint
+    # time and never read; a token "anthropic only" worked on every
+    # provider configured on this Mastio. Now: when the caller's
+    # InternalAgent envelope carries a non-empty ``scope_providers``,
+    # the resolved provider for the request model MUST be in the list,
+    # else 403. Cert+DPoP / LOCAL_TOKEN auth leaves
+    # ``agent.scope_providers`` as ``None`` so this gate is a no-op
+    # for them.
+    if agent.scope_providers:
+        try:
+            req_provider = parse_provider_from_model(req.model)
+        except Exception:  # noqa: BLE001 — parse failure → deny
+            req_provider = None
+        if req_provider is None or req_provider not in agent.scope_providers:
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="egress_llm_chat",
+                status="denied",
+                details={
+                    "event": "llm.chat_completion",
+                    "principal_id": agent.agent_id,
+                    "principal_type": agent.principal_type,
+                    "model": req.model,
+                    "trace_id": trace_id,
+                    "reason": "token_scope_provider_mismatch",
+                    "requested_provider": req_provider,
+                    "scope_providers": agent.scope_providers,
+                },
+            )
+            raise HTTPException(
+                status_code=403,
+                detail={
+                    "reason": "token_scope_provider_mismatch",
+                    "trace_id": trace_id,
+                    "requested_provider": req_provider,
+                    "allowed_providers": agent.scope_providers,
+                },
+            )
 
     if settings.llm_tokens_per_minute > 0:
         token_limiter = get_token_sum_limiter()

--- a/mcp_proxy/models.py
+++ b/mcp_proxy/models.py
@@ -76,6 +76,17 @@ class InternalAgent(BaseModel):
     # key on this so a user named "daniele" never collides with an
     # agent named "daniele".
     principal_type: str = "agent"
+    # Wave A PR3 (audit 2026-05-11 Tema A) — culk_ token scope.
+    # ``None`` = caller did not auth via a culk_ token (cert / DPoP
+    # path); these scope fields don't apply. Empty list ``[]`` from a
+    # culk_ token = "no providers explicitly listed", interpreted as
+    # "no AI provider gate". A non-empty list of provider names (e.g.
+    # ``["anthropic"]``) restricts /v1/chat/completions to those
+    # providers. ``scope_paths`` defaults to ``["/v1/*"]`` at mint
+    # time so the OpenAI-compat surface is the only allowed reach
+    # unless the operator widens it explicitly.
+    scope_providers: list[str] | None = None
+    scope_paths: list[str] | None = None
 
 
 class AuditEntry(BaseModel):

--- a/tests/test_culk_scope_enforcement.py
+++ b/tests/test_culk_scope_enforcement.py
@@ -171,7 +171,6 @@ async def test_scope_providers_match_anthropic_succeeds(
     """Token scoped to ['anthropic']. Request model claude-haiku-4-5 →
     parse_provider returns 'anthropic' → in list → resolver allows.
     We mock ai_gateway.dispatch so the test doesn't touch upstream."""
-    from mcp_proxy.egress import ai_gateway
 
     async def fake_dispatch(**kwargs):
         from mcp_proxy.egress.schemas import ChatCompletionResponse

--- a/tests/test_culk_scope_enforcement.py
+++ b/tests/test_culk_scope_enforcement.py
@@ -1,0 +1,291 @@
+"""Wave A PR3 — culk_ token scope_paths + scope_providers enforcement.
+
+Audit ref: imp/audits/2026-05-11-MASTER.md Tema A (Track 1 HIGH /
+Track 2 H1 / Track 6 M-1 — found by 3 audit subagents independently).
+
+Pre-fix:
+- ``scope_paths`` was stored at mint time, displayed in the dashboard,
+  but never read at request time. A token "for /v1/chat/completions
+  only" worked on every endpoint guarded by
+  ``get_agent_from_dpop_client_cert`` (the entire egress + A2A
+  surface).
+- ``scope_providers`` ditto: a token "anthropic only" worked on every
+  provider configured on this Mastio.
+
+Post-fix:
+- Resolver enforces ``scope_paths`` glob match against
+  ``request.url.path`` and 403s on miss.
+- ``llm_chat_router.chat_completions`` enforces ``scope_providers``
+  against the provider parsed from the request model and 403s on
+  miss with reason ``token_scope_provider_mismatch``.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from mcp_proxy.db import (
+    dispose_db,
+    init_db,
+    mint_user_api_token,
+)
+from mcp_proxy.egress import llm_chat_router as router_module
+from mcp_proxy.egress.llm_chat_router import router as llm_chat_router
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def app_with_real_dep(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.setenv("MCP_PROXY_ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_BACKEND", "litellm_embedded")
+    monkeypatch.setenv("MCP_PROXY_AI_GATEWAY_PROVIDER", "anthropic")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "orga")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+
+    async def fake_list_available_models(enabled):
+        return [
+            {"id": "claude-haiku-4-5", "object": "model", "owned_by": "anthropic"},
+            {"id": "gpt-4o-mini", "object": "model", "owned_by": "openai"},
+        ]
+    monkeypatch.setattr(
+        router_module, "list_available_models", fake_list_available_models,
+    )
+
+    test_app = FastAPI()
+    test_app.include_router(llm_chat_router)
+    yield test_app
+    get_settings.cache_clear()
+    await dispose_db()
+
+
+# ─── scope_paths ───
+
+
+async def test_scope_paths_default_v1_glob_allows_v1_models(app_with_real_dep):
+    """Default mint sets scope_paths=['/v1/*']. /v1/models is on that
+    subtree → resolver lets it through → 200."""
+    minted = await mint_user_api_token(
+        principal_id="orga::user::alice",
+        label="default-scope",
+        created_by="orga::admin",
+    )
+    token = minted["token"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+
+
+async def test_scope_paths_narrow_blocks_other_v1_endpoint(app_with_real_dep):
+    """Token minted with scope_paths=['/v1/chat/completions'] (a
+    legitimate "OpenAI-compat only" intent). Calling /v1/models is
+    refused 403 with the resolver's deny message."""
+    minted = await mint_user_api_token(
+        principal_id="orga::user::bob",
+        label="chat-only",
+        created_by="orga::admin",
+        scope_paths=["/v1/chat/completions"],
+    )
+    token = minted["token"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403, r.text
+    assert "scope_paths" in r.text or "scope" in r.text.lower()
+
+
+async def test_scope_paths_empty_list_unscoped(app_with_real_dep):
+    """An explicit empty ``scope_paths=[]`` means "no path restriction"
+    — same effect as None (unscoped). Useful when an admin wants a
+    token that can hit anything."""
+    minted = await mint_user_api_token(
+        principal_id="orga::user::carol",
+        label="unscoped",
+        created_by="orga::admin",
+        scope_paths=[],
+    )
+    token = minted["token"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+
+
+async def test_scope_paths_glob_matches_full_subtree(app_with_real_dep):
+    """The ``*`` glob crosses ``/`` so ``/v1/*`` matches every nested
+    /v1/... route. Confirms the permissive-glob design vs a strict
+    no-slash interpretation."""
+    minted = await mint_user_api_token(
+        principal_id="orga::user::dave",
+        label="default",
+        created_by="orga::admin",
+        # explicit default
+        scope_paths=["/v1/*"],
+    )
+    token = minted["token"]
+    # Both /v1/models and any deeper /v1/foo/bar should pass at the
+    # resolver level (downstream may 404 on unknown route, that's OK).
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r1 = await c.get("/v1/models", headers={"Authorization": f"Bearer {token}"})
+        r2 = await c.get(
+            "/v1/nonexistent/path",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert r1.status_code == 200
+    # 404 means the resolver passed and the route is just unknown —
+    # not a 403 from the scope gate.
+    assert r2.status_code in (404,), r2.text
+
+
+# ─── scope_providers ───
+
+
+async def test_scope_providers_match_anthropic_succeeds(
+    app_with_real_dep, monkeypatch,
+):
+    """Token scoped to ['anthropic']. Request model claude-haiku-4-5 →
+    parse_provider returns 'anthropic' → in list → resolver allows.
+    We mock ai_gateway.dispatch so the test doesn't touch upstream."""
+    from mcp_proxy.egress import ai_gateway
+
+    async def fake_dispatch(**kwargs):
+        from mcp_proxy.egress.schemas import ChatCompletionResponse
+        from types import SimpleNamespace
+        # Minimal valid response shape.
+        resp = ChatCompletionResponse.model_validate({
+            "id": "chatcmpl-test", "object": "chat.completion",
+            "created": 1, "model": kwargs["req"].model,
+            "cullis_trace_id": kwargs["trace_id"],
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        })
+        return SimpleNamespace(
+            response=resp, latency_ms=10, upstream_request_id="req-x",
+            backend="litellm_embedded", provider="anthropic",
+            prompt_tokens=1, completion_tokens=1, cost_usd=None,
+        )
+    monkeypatch.setattr(router_module, "dispatch", fake_dispatch)
+
+    minted = await mint_user_api_token(
+        principal_id="orga::user::eve",
+        label="anthropic-only",
+        created_by="orga::admin",
+        scope_providers=["anthropic"],
+    )
+    token = minted["token"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "model": "claude-haiku-4-5",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert r.status_code == 200, r.text
+
+
+async def test_scope_providers_mismatch_denied(app_with_real_dep, monkeypatch):
+    """Token scoped to ['anthropic']. Request model gpt-4o-mini →
+    parse_provider returns 'openai' → NOT in list → 403 with
+    ``token_scope_provider_mismatch`` reason."""
+    minted = await mint_user_api_token(
+        principal_id="orga::user::frank",
+        label="anthropic-only-tries-openai",
+        created_by="orga::admin",
+        scope_providers=["anthropic"],
+    )
+    token = minted["token"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert r.status_code == 403, r.text
+    body = r.json()
+    detail = body.get("detail") or body
+    # detail is a dict here per the router's structured 403 body.
+    assert detail.get("reason") == "token_scope_provider_mismatch", body
+    assert "anthropic" in detail.get("allowed_providers", [])
+
+
+async def test_scope_providers_empty_no_gate(app_with_real_dep, monkeypatch):
+    """Token with scope_providers=[] (default mint state) → provider
+    gate skipped entirely. Any model goes through to dispatch."""
+    from types import SimpleNamespace
+    async def fake_dispatch(**kwargs):
+        from mcp_proxy.egress.schemas import ChatCompletionResponse
+        resp = ChatCompletionResponse.model_validate({
+            "id": "chatcmpl-test", "object": "chat.completion",
+            "created": 1, "model": kwargs["req"].model,
+            "cullis_trace_id": kwargs["trace_id"],
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": "ok"},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        })
+        return SimpleNamespace(
+            response=resp, latency_ms=10, upstream_request_id="req-x",
+            backend="litellm_embedded", provider="openai",
+            prompt_tokens=1, completion_tokens=1, cost_usd=None,
+        )
+    monkeypatch.setattr(router_module, "dispatch", fake_dispatch)
+
+    minted = await mint_user_api_token(
+        principal_id="orga::user::grace",
+        label="any-provider",
+        created_by="orga::admin",
+        scope_providers=[],
+    )
+    token = minted["token"]
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_real_dep), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {token}"},
+            json={
+                "model": "gpt-4o-mini",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+    assert r.status_code == 200, r.text


### PR DESCRIPTION
## Summary

Closes **Tema A** from \`imp/audits/2026-05-11-MASTER.md\` — found by 3 audit subagents independently (Track 1 HIGH, Track 2 H1, Track 6 M-1). Wave A PR3 of 5.

**Vector before this PR:**
- \`scope_paths\` and \`scope_providers\` were stored at mint time + displayed in the dashboard, but **never read at request time**.
- A token "for /v1/chat/completions only" worked on every endpoint guarded by \`get_agent_from_dpop_client_cert\` — the entire egress + A2A surface (oneshot send, sessions, peers, discover, tools/invoke, inbox, Guardian).
- A token "anthropic only" worked on every provider configured on this Mastio.
- A leaked LibreChat / Cursor culk_ token was therefore equivalent to **full user impersonation** across the Mastio's entire reachable surface, including cross-org A2A.

**Fix:**
1. Add \`scope_providers\` + \`scope_paths\` (both \`list[str] | None\`) to \`InternalAgent\` so the resolver carries the constraint downstream.
2. \`api_token._maybe_api_token_principal\`: glob-match \`request.url.path\` against the token's \`scope_paths\`; on miss raise 403 with structured detail.
3. \`llm_chat_router.chat_completions\`: when \`agent.scope_providers\` is non-empty, parse provider via \`parse_provider_from_model\` and refuse with 403 + reason \`token_scope_provider_mismatch\` if not in allow-list. Audit row written before raising.

Glob semantics: \`*\` matches any character including \`/\` — operators expect this when minting "OpenAI-compat only" tokens (\`/v1/*\` should permit the whole subtree).

## Test plan

- [x] 7 new cases in \`tests/test_culk_scope_enforcement.py\` (default v1 glob allows; narrow scope blocks; empty list unscoped; glob crosses /; provider match succeeds; mismatch denied with correct reason; empty providers no gate)
- [x] \`pytest tests/\` → **3214 passed**, 10 pre-existing/flaky failures (connector GUI in CI headless + postgres binding KeyError + M3 sweeper TTL flake — all reproduce on main + pass when isolated)
- [x] \`./demo_network/smoke.sh full\` → all assertions PASS

## Operator-visible behavior change

Existing minted tokens with \`scope_paths\` set are now **load-bearing** — operators should audit their admin/UI mints if they expected the scope hint to be cosmetic. Tokens minted with default settings get \`scope_paths=['/v1/*']\` (the OpenAI-compat surface), unchanged from the existing dashboard default.

## Wave A status

| # | Finding | Status |
|---|---|---|
| 1 | CRIT-1 cert mint + cert-pin | merged #601 |
| 2 | CRIT-2 ingress execute binding | merged #603 |
| 3 | culk_ scope_paths + scope_providers | **THIS PR** |
| 4 | Quick wins D2 + B2 + C3 | open #605 |
| 4b | E1 delete dead app/e2e_crypto.verify_inner_signature | follow-up |
| 5 | CRIT-3 audit DB trigger + back-fill refactor | queued |