### PR TITLE
feat(connector): conversation history REST + SQLite store (Sprint 1 Step 6 PR-A)

### DIFF
--- a/cullis_connector/ambassador/conversations_router.py
+++ b/cullis_connector/ambassador/conversations_router.py
@@ -1,0 +1,333 @@
+"""ADR-019 Step 6, REST surface for the Connector-local chat history.
+
+The SPA's left sidebar lists past conversations and lets the user
+rename / delete / open one. This module is the REST backing it,
+mounted next to the rest of the ambassador on the same loopback +
+bearer auth gate so the surface is reachable only from the local
+host (or, in Frontdesk shared mode, from the cookie-authenticated
+user once the cert middleware has bound `request.state.user_credentials`).
+
+Endpoints, all under ``/v1/conversations``:
+
+    GET    /                    list (paginated, principal-scoped)
+    POST   /                    create empty conversation
+    GET    /{conv_id}           fetch one + its messages
+    PATCH  /{conv_id}           rename title
+    DELETE /{conv_id}           soft delete
+    POST   /{conv_id}/messages  append a message
+
+The append endpoint is what the SPA hits at the end of each chat
+completion turn so the history is captured by the Connector even if
+the SPA tab is closed before the next turn.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select, update
+
+from cullis_connector.ambassador.router import (
+    _enforce_bearer,
+    _enforce_loopback,
+    _per_user_credentials,
+)
+from cullis_connector.conversations.db import get_session
+from cullis_connector.conversations.models import Conversation, Message
+
+_log = logging.getLogger("cullis_connector.ambassador.conversations")
+
+router = APIRouter(prefix="/v1/conversations", tags=["conversations"])
+
+
+# ── auth + dependency helpers ───────────────────────────────────────
+
+
+def _ambassador_state(request: Request) -> dict:
+    state = getattr(request.app.state, "ambassador", None)
+    if state is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="ambassador not installed on this app",
+        )
+    return state
+
+
+def _config_dir(request: Request):
+    config = getattr(request.app.state, "connector_config", None)
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="connector_config not bound on app.state",
+        )
+    return config.config_dir
+
+
+def _authenticate(request: Request) -> str:
+    """Run the ambassador's loopback + bearer gate and return the
+    principal_id to scope the operation by.
+
+    The principal is the per-user credential when present (ADR-025
+    shared mode), otherwise the Connector agent id (single-user mode).
+    Conversations are always partitioned by principal so a user in
+    Frontdesk shared mode cannot see another user's history.
+    """
+    _enforce_loopback(request)
+    state = _ambassador_state(request)
+    _enforce_bearer(request, state)
+    creds = _per_user_credentials(request)
+    if creds is not None and getattr(creds, "principal_id", None):
+        return creds.principal_id
+    agent_id = state.get("agent_id") or ""
+    if not agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="no principal id available",
+        )
+    return agent_id
+
+
+def _new_id() -> str:
+    """40-char URL-safe random conversation id.
+
+    Random rather than autoincrement: an attacker on the loopback gate
+    cannot walk the id space, the SPA cannot accidentally probe other
+    users' conversations by guessing integers."""
+    return secrets.token_urlsafe(30)[:40]
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── pydantic IO models ──────────────────────────────────────────────
+
+
+class ConversationSummary(BaseModel):
+    id: str
+    title: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConversationMessage(BaseModel):
+    role: str
+    content: str
+    tool_calls: Optional[list[dict]] = None
+    trace_id: Optional[str] = None
+    created_at: datetime
+
+
+class ConversationDetail(BaseModel):
+    id: str
+    title: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+    messages: list[ConversationMessage]
+
+
+class RenameRequest(BaseModel):
+    title: Optional[str] = Field(default=None, max_length=200)
+
+
+class AppendMessageRequest(BaseModel):
+    role: str = Field(..., max_length=16)
+    content: str = Field(default="")
+    tool_calls: Optional[list[dict]] = None
+    trace_id: Optional[str] = Field(default=None, max_length=64)
+
+
+# ── endpoints ───────────────────────────────────────────────────────
+
+
+@router.get("", response_model=list[ConversationSummary])
+async def list_conversations(
+    request: Request, limit: int = 20, offset: int = 0,
+) -> list[ConversationSummary]:
+    """Sidebar list, principal-scoped, soft-delete-aware, paginated."""
+    principal_id = _authenticate(request)
+    if limit < 1 or limit > 100:
+        raise HTTPException(status_code=400, detail="limit must be 1..100")
+    if offset < 0:
+        raise HTTPException(status_code=400, detail="offset must be >= 0")
+    cd = _config_dir(request)
+    async with get_session(cd) as session:
+        rows = (await session.execute(
+            select(Conversation)
+            .where(
+                Conversation.principal_id == principal_id,
+                Conversation.deleted_at.is_(None),
+            )
+            .order_by(Conversation.updated_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )).scalars().all()
+    return [
+        ConversationSummary(
+            id=r.id, title=r.title,
+            created_at=r.created_at, updated_at=r.updated_at,
+        ) for r in rows
+    ]
+
+
+@router.post(
+    "",
+    response_model=ConversationSummary,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_conversation(request: Request) -> ConversationSummary:
+    """Mint an empty conversation, return its id so the SPA can start
+    appending messages."""
+    principal_id = _authenticate(request)
+    cd = _config_dir(request)
+    now = _utcnow()
+    conv = Conversation(
+        id=_new_id(),
+        principal_id=principal_id,
+        title=None,
+        created_at=now,
+        updated_at=now,
+    )
+    async with get_session(cd) as session:
+        session.add(conv)
+    return ConversationSummary(
+        id=conv.id, title=conv.title,
+        created_at=conv.created_at, updated_at=conv.updated_at,
+    )
+
+
+@router.get("/{conv_id}", response_model=ConversationDetail)
+async def get_conversation(conv_id: str, request: Request) -> ConversationDetail:
+    """Fetch one conversation + its messages. 404 when the id does not
+    exist or belongs to another principal (do not leak existence)."""
+    principal_id = _authenticate(request)
+    cd = _config_dir(request)
+    async with get_session(cd) as session:
+        row = (await session.execute(
+            select(Conversation).where(
+                Conversation.id == conv_id,
+                Conversation.principal_id == principal_id,
+                Conversation.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if row is None:
+            raise HTTPException(status_code=404, detail="conversation not found")
+        messages = (await session.execute(
+            select(Message).where(Message.conversation_id == conv_id)
+            .order_by(Message.created_at)
+        )).scalars().all()
+    return ConversationDetail(
+        id=row.id, title=row.title,
+        created_at=row.created_at, updated_at=row.updated_at,
+        messages=[
+            ConversationMessage(
+                role=m.role,
+                content=m.content,
+                tool_calls=json.loads(m.tool_calls_json) if m.tool_calls_json else None,
+                trace_id=m.trace_id,
+                created_at=m.created_at,
+            ) for m in messages
+        ],
+    )
+
+
+@router.patch("/{conv_id}", response_model=ConversationSummary)
+async def rename_conversation(
+    conv_id: str, body: RenameRequest, request: Request,
+) -> ConversationSummary:
+    """Update the title only. Any other field on the request is ignored
+    so the SPA cannot accidentally clobber principal_id / timestamps."""
+    principal_id = _authenticate(request)
+    cd = _config_dir(request)
+    now = _utcnow()
+    async with get_session(cd) as session:
+        row = (await session.execute(
+            select(Conversation).where(
+                Conversation.id == conv_id,
+                Conversation.principal_id == principal_id,
+                Conversation.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if row is None:
+            raise HTTPException(status_code=404, detail="conversation not found")
+        row.title = body.title
+        row.updated_at = now
+    return ConversationSummary(
+        id=row.id, title=row.title,
+        created_at=row.created_at, updated_at=row.updated_at,
+    )
+
+
+@router.delete("/{conv_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_conversation(conv_id: str, request: Request) -> None:
+    """Soft delete. The row stays in the DB so an undo path is possible
+    later; this endpoint just hides it from list / get."""
+    principal_id = _authenticate(request)
+    cd = _config_dir(request)
+    now = _utcnow()
+    async with get_session(cd) as session:
+        result = await session.execute(
+            update(Conversation)
+            .where(
+                Conversation.id == conv_id,
+                Conversation.principal_id == principal_id,
+                Conversation.deleted_at.is_(None),
+            )
+            .values(deleted_at=now, updated_at=now)
+        )
+        if result.rowcount == 0:
+            raise HTTPException(status_code=404, detail="conversation not found")
+    return None
+
+
+@router.post(
+    "/{conv_id}/messages",
+    response_model=ConversationMessage,
+    status_code=status.HTTP_201_CREATED,
+)
+async def append_message(
+    conv_id: str, body: AppendMessageRequest, request: Request,
+) -> ConversationMessage:
+    """Append one message to a conversation. The SPA calls this after
+    each chat completion turn (user prompt + assistant response, or
+    just the assistant when the prompt was already pushed)."""
+    principal_id = _authenticate(request)
+    if body.role not in ("user", "assistant", "tool", "system"):
+        raise HTTPException(status_code=400, detail="invalid role")
+    cd = _config_dir(request)
+    now = _utcnow()
+    tool_calls_blob: Optional[str] = None
+    if body.tool_calls is not None:
+        tool_calls_blob = json.dumps(body.tool_calls, separators=(",", ":"))
+    async with get_session(cd) as session:
+        conv = (await session.execute(
+            select(Conversation).where(
+                Conversation.id == conv_id,
+                Conversation.principal_id == principal_id,
+                Conversation.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if conv is None:
+            raise HTTPException(status_code=404, detail="conversation not found")
+        msg = Message(
+            conversation_id=conv_id,
+            role=body.role,
+            content=body.content,
+            tool_calls_json=tool_calls_blob,
+            trace_id=body.trace_id,
+            created_at=now,
+        )
+        session.add(msg)
+        conv.updated_at = now
+    return ConversationMessage(
+        role=msg.role,
+        content=msg.content,
+        tool_calls=body.tool_calls,
+        trace_id=msg.trace_id,
+        created_at=msg.created_at,
+    )

--- a/cullis_connector/conversations/__init__.py
+++ b/cullis_connector/conversations/__init__.py
@@ -1,0 +1,19 @@
+"""Connector-local chat conversation history (Sprint 1 Step 6 PR-A).
+
+Until now the SPA's left sidebar showed an editorial empty state
+("Conversation history lands in v0.5"). This module is the v0.5
+backing store: an async SQLite database living next to ``users.db``
+under the Connector ``config_dir``, exposing the CRUD primitives the
+ambassador's REST router consumes.
+
+Design notes mirror the users.db module (``cullis_connector.identity.users_db``):
+
+- Per-(config_dir, event_loop_id) engine cache.
+- WAL journaling + ``synchronous = NORMAL`` for the same reasons.
+- ``chmod 0600`` on the file because conversation contents include
+  user-typed text that may be PII; we treat them like credentials.
+- Schema is intentionally minimal for v0.5: ``conversations`` (title,
+  principal, timestamps, soft delete) and ``messages`` (role + content
+  + tool calls JSON + trace_id). Phase D-3 will add a richer
+  attribution column once the per-tool PDP audit row format settles.
+"""

--- a/cullis_connector/conversations/db.py
+++ b/cullis_connector/conversations/db.py
@@ -1,0 +1,126 @@
+"""Async SQLite engine + session factory for the conversations store.
+
+Mirrors ``cullis_connector.identity.users_db`` byte-for-byte on the
+caching + WAL + chmod logic so the two stores behave identically
+under pytest-asyncio (per-loop engine cache) and on disk (0600 file
+mode, WAL journal).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncIterator
+
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from cullis_connector.conversations.models import Base
+
+_log = logging.getLogger("cullis_connector.conversations.db")
+
+CONVERSATIONS_DB_FILENAME = "conversations.db"
+
+_engines: dict[tuple[Path, int], AsyncEngine] = {}
+
+
+def _current_loop_key() -> int:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return 0
+    return id(loop)
+
+
+def _db_path(config_dir: Path) -> Path:
+    return Path(config_dir) / CONVERSATIONS_DB_FILENAME
+
+
+def _engine(config_dir: Path) -> AsyncEngine:
+    key = (Path(config_dir).resolve(), _current_loop_key())
+    engine = _engines.get(key)
+    if engine is not None:
+        return engine
+
+    Path(config_dir).mkdir(parents=True, exist_ok=True)
+    url = f"sqlite+aiosqlite:///{_db_path(config_dir)}"
+    engine = create_async_engine(url, echo=False, future=True)
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _on_connect(dbapi_conn, _connection_record):  # type: ignore[no-untyped-def]
+        cursor = dbapi_conn.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.execute("PRAGMA foreign_keys=ON")
+        finally:
+            cursor.close()
+
+    _engines[key] = engine
+    return engine
+
+
+async def init_conversations_db(config_dir: Path) -> None:
+    """Create the schema if missing, enforce 0600 perms (POSIX only).
+    Idempotent on repeat calls."""
+    engine = _engine(config_dir)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    _enforce_db_perms(_db_path(config_dir))
+
+
+def _enforce_db_perms(db_path: Path) -> None:
+    if os.name != "posix":
+        return
+    try:
+        if db_path.exists():
+            os.chmod(db_path, 0o600)
+    except OSError as exc:
+        _log.warning(
+            "could not chmod 0600 %s: %s (continuing)", db_path, exc,
+        )
+
+
+@asynccontextmanager
+async def get_session(config_dir: Path) -> AsyncIterator[AsyncSession]:
+    """Async context manager yielding a transactional session.
+
+    Lazily initialises the schema on first use, so router handlers do
+    not need to call :func:`init_conversations_db` explicitly.
+    """
+    await init_conversations_db(config_dir)
+    engine = _engine(config_dir)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+
+
+async def dispose_engines() -> None:
+    """Test helper: tear down every cached engine. Only awaits engines
+    bound to the current loop; engines bound to a previous (closed)
+    loop are dropped without awaiting to avoid 'no current event loop'
+    errors during teardown."""
+    current = _current_loop_key()
+    keys = list(_engines.keys())
+    for key in keys:
+        engine = _engines.pop(key, None)
+        if engine is None:
+            continue
+        _, loop_id = key
+        if loop_id == current and current != 0:
+            try:
+                await engine.dispose()
+            except Exception:
+                pass

--- a/cullis_connector/conversations/models.py
+++ b/cullis_connector/conversations/models.py
@@ -1,0 +1,100 @@
+"""SQLAlchemy ORM for the Connector's chat conversation store."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    """Declarative base scoped to conversations.db.
+
+    Kept separate from ``cullis_connector.identity.users.Base`` so
+    ``Base.metadata.create_all`` on this module only touches the
+    conversation tables. Mirrors the users.db pattern.
+    """
+
+
+def _utcnow() -> datetime:
+    """Timezone-aware UTC default for created_at / updated_at."""
+    return datetime.now(timezone.utc)
+
+
+class Conversation(Base):
+    __tablename__ = "conversations"
+
+    # Random opaque id rather than autoincrement so the URL surface is
+    # not enumerable (an attacker on the loopback gets to /v1/
+    # conversations/{id} and would be able to walk the space otherwise).
+    id: Mapped[str] = mapped_column(String(40), primary_key=True)
+    # Principal who created the conversation. In single-user Connector
+    # mode this is the agent id; in shared mode (ADR-019) it's the
+    # user principal id resolved via cookie auth. Storing it gives
+    # the future multi-user UI the filter it needs.
+    principal_id: Mapped[str] = mapped_column(String(256), nullable=False, index=True)
+    # Optional title. Generated client-side from the first user turn
+    # (e.g. truncated 60 char) or left null for "untitled".
+    title: Mapped[Optional[str]] = mapped_column(String(200), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+    # Soft delete: a row stays in the DB but is hidden from list /
+    # fetch responses. Hard delete is reserved for an admin sweep.
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    messages: Mapped[list["Message"]] = relationship(
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        order_by="Message.created_at",
+    )
+
+    __table_args__ = (
+        # Sidebar list query: most recently updated conversations for
+        # this principal, excluding soft-deleted rows. Single composite
+        # index keeps that path index-only.
+        Index(
+            "ix_conversations_principal_updated",
+            "principal_id", "updated_at",
+        ),
+    )
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    conversation_id: Mapped[str] = mapped_column(
+        String(40),
+        ForeignKey("conversations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # OpenAI-style role. user | assistant | tool | system.
+    role: Mapped[str] = mapped_column(String(16), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # JSON-encoded list of tool calls observed during the turn. Null
+    # when no tool was invoked. Stored as text so SQLite can stay
+    # JSON1-agnostic; the router does the json.dumps / json.loads.
+    tool_calls_json: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Mastio trace_id propagated by the SSE stream. Lets the UI cross
+    # reference an assistant message with the audit dashboard.
+    trace_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+
+    conversation: Mapped[Conversation] = relationship(back_populates="messages")

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -372,6 +372,14 @@ def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
         advertised_models=config.ambassador.advertised_models,
         require_local_only=_require_loopback_effective,
     )
+    # Sprint 1 Step 6 PR-A, Connector-local conversation history. The
+    # router shares the ambassador's loopback + bearer gate, scopes
+    # every row by principal_id, and writes to <config_dir>/conversations.db
+    # via the SQLite module in cullis_connector.conversations.
+    from cullis_connector.ambassador.conversations_router import (
+        router as conversations_router,
+    )
+    app.include_router(conversations_router)
     log.info(
         "Ambassador mounted: agent=%s site=%s bearer=*** (saved at %s)",
         agent_id, site_url, config.config_dir / "local.token",

--- a/tests/connector/test_conversations_router.py
+++ b/tests/connector/test_conversations_router.py
@@ -1,0 +1,173 @@
+"""Sprint 1 Step 6 PR-A, Connector conversations REST.
+
+Covers the new ``/v1/conversations`` surface that backs the SPA's
+sidebar history. Each test exercises one CRUD primitive against a
+fresh ConnectorConfig + in-memory-style on-disk SQLite (the fixture
+points at tmp_path so each test sees its own database file).
+
+The fake CullisClient from ``test_ambassador_router`` is reused so
+the ambassador mounts cleanly without a real Mastio.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import build_app
+from tests.connector.test_ambassador_router import (
+    FakeCullisClient,
+    _seed_identity,
+)
+
+
+# ── fixtures ────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _patch_sdk(monkeypatch):
+    FakeCullisClient.reset()
+    monkeypatch.setattr("cullis_sdk.CullisClient", FakeCullisClient)
+    yield
+    FakeCullisClient.reset()
+
+
+@pytest.fixture
+def app(tmp_path: Path):
+    _seed_identity(tmp_path)
+    cfg = ConnectorConfig(
+        config_dir=tmp_path,
+        site_url="https://mastio.test",
+        verify_tls=False,
+    )
+    cfg.ambassador.require_local_only = False
+    return build_app(cfg)
+
+
+@pytest.fixture
+def client(app):
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def bearer(client, tmp_path: Path) -> str:
+    return (tmp_path / "local.token").read_text(encoding="utf-8").strip()
+
+
+@pytest.fixture
+def auth(bearer):
+    return {"Authorization": f"Bearer {bearer}"}
+
+
+# ── tests ───────────────────────────────────────────────────────────
+
+
+def test_create_returns_id_and_empty_title(client, auth):
+    r = client.post("/v1/conversations", headers=auth)
+    assert r.status_code == 201
+    body = r.json()
+    assert body["id"]
+    assert body["title"] is None
+    assert "created_at" in body
+    assert "updated_at" in body
+
+
+def test_list_empty_then_lists_created(client, auth):
+    r0 = client.get("/v1/conversations", headers=auth)
+    assert r0.status_code == 200
+    assert r0.json() == []
+
+    r1 = client.post("/v1/conversations", headers=auth)
+    conv_id = r1.json()["id"]
+
+    r2 = client.get("/v1/conversations", headers=auth)
+    assert r2.status_code == 200
+    ids = [c["id"] for c in r2.json()]
+    assert conv_id in ids
+
+
+def test_rename_updates_title_and_updated_at(client, auth):
+    conv_id = client.post("/v1/conversations", headers=auth).json()["id"]
+    r = client.patch(
+        f"/v1/conversations/{conv_id}",
+        headers=auth,
+        json={"title": "GDPR check on Anna"},
+    )
+    assert r.status_code == 200
+    assert r.json()["title"] == "GDPR check on Anna"
+
+    detail = client.get(f"/v1/conversations/{conv_id}", headers=auth).json()
+    assert detail["title"] == "GDPR check on Anna"
+
+
+def test_append_messages_persists_and_lists_in_order(client, auth):
+    conv_id = client.post("/v1/conversations", headers=auth).json()["id"]
+    client.post(
+        f"/v1/conversations/{conv_id}/messages",
+        headers=auth,
+        json={"role": "user", "content": "hi"},
+    )
+    client.post(
+        f"/v1/conversations/{conv_id}/messages",
+        headers=auth,
+        json={
+            "role": "assistant",
+            "content": "ciao",
+            "tool_calls": [{"name": "postgres.query", "latency_ms": 286}],
+            "trace_id": "t_xyz",
+        },
+    )
+
+    detail = client.get(f"/v1/conversations/{conv_id}", headers=auth).json()
+    assert [m["role"] for m in detail["messages"]] == ["user", "assistant"]
+    assert detail["messages"][1]["content"] == "ciao"
+    assert detail["messages"][1]["tool_calls"][0]["name"] == "postgres.query"
+    assert detail["messages"][1]["trace_id"] == "t_xyz"
+
+
+def test_append_rejects_invalid_role(client, auth):
+    conv_id = client.post("/v1/conversations", headers=auth).json()["id"]
+    r = client.post(
+        f"/v1/conversations/{conv_id}/messages",
+        headers=auth,
+        json={"role": "hacker", "content": "x"},
+    )
+    assert r.status_code == 400
+
+
+def test_delete_soft_removes_from_list(client, auth):
+    conv_id = client.post("/v1/conversations", headers=auth).json()["id"]
+    r = client.delete(f"/v1/conversations/{conv_id}", headers=auth)
+    assert r.status_code == 204
+
+    listing = client.get("/v1/conversations", headers=auth).json()
+    assert conv_id not in [c["id"] for c in listing]
+    # And direct fetch returns 404 (don't leak existence).
+    assert client.get(f"/v1/conversations/{conv_id}", headers=auth).status_code == 404
+
+
+def test_unknown_id_returns_404(client, auth):
+    r = client.get("/v1/conversations/does-not-exist", headers=auth)
+    assert r.status_code == 404
+    r2 = client.patch(
+        "/v1/conversations/does-not-exist",
+        headers=auth,
+        json={"title": "x"},
+    )
+    assert r2.status_code == 404
+    r3 = client.delete("/v1/conversations/does-not-exist", headers=auth)
+    assert r3.status_code == 404
+
+
+def test_missing_bearer_rejected(client):
+    r = client.post("/v1/conversations")
+    assert r.status_code == 401
+
+
+def test_list_pagination_bounds_validated(client, auth):
+    assert client.get("/v1/conversations?limit=0", headers=auth).status_code == 400
+    assert client.get("/v1/conversations?limit=101", headers=auth).status_code == 400
+    assert client.get("/v1/conversations?offset=-1", headers=auth).status_code == 400


### PR DESCRIPTION
The SPA sidebar has been showing _"Conversation history lands in v0.5"_ since ADR-019 Step 2. This PR is the v0.5 backing store: an async SQLite database next to \`users.db\` under the Connector \`config_dir\`, and a REST surface mounted alongside the rest of the ambassador.

## Storage (\`cullis_connector/conversations/\`)

- **models.py** — SQLAlchemy ORM:
  - \`Conversation\` has \`principal_id\` (Frontdesk shared mode keeps each user's history isolated), \`title\`, soft-delete column, created/updated timestamps, composite index on \`(principal_id, updated_at)\` for the sidebar list query.
  - \`Message\` has \`role\`, \`content\`, \`tool_calls\` JSON blob, \`trace_id\`, timestamp. \`ON DELETE CASCADE\` under the conversation.
- **db.py** — per-\`(config_dir, loop_id)\` \`AsyncEngine\` cache, WAL + \`synchronous=NORMAL\`, \`foreign_keys=ON\`, \`chmod 0600\` on the file (POSIX). Mirrors \`cullis_connector.identity.users_db\` so the two stores behave identically under pytest-asyncio shards.

## Router (\`cullis_connector/ambassador/conversations_router.py\`)

| Method | Path | Purpose |
|---|---|---|
| GET | \`/v1/conversations\` | List, paginated, principal-scoped, soft-delete-aware, ordered by \`updated_at DESC\` |
| POST | \`/v1/conversations\` | Create empty conversation |
| GET | \`/v1/conversations/{id}\` | Fetch one + its messages |
| PATCH | \`/v1/conversations/{id}\` | Rename title |
| DELETE | \`/v1/conversations/{id}\` | Soft delete (204) |
| POST | \`/v1/conversations/{id}/messages\` | Append a message |

Auth reuses the ambassador's loopback + bearer gate via a small \`_authenticate\` helper. The \`principal_id\` is taken from \`request.state.user_credentials\` when ADR-025 shared-mode auth is bound, otherwise from the Connector agent_id. Conversations are always partitioned by principal so a shared-mode user cannot see another user's history.

Wire in \`cullis_connector/web.py\` right after \`install_ambassador\` so the router rides the same lifespan and shares \`connector_config\` / \`app.state\`.

## Test plan

- [x] 9 new cases in \`tests/connector/test_conversations_router.py\`:
  - create returns id + null title
  - list empty → \`[]\`, list after create surfaces the row
  - rename updates title + updated_at
  - append two messages persists in order, tool_calls JSON round-trips, trace_id round-trips
  - append rejects invalid role (400)
  - soft delete hides from list AND from direct fetch (404 to avoid leaking existence)
  - unknown id → 404 on GET / PATCH / DELETE
  - missing Bearer rejected (401)
  - list pagination bounds validated (limit 1..100, offset >= 0)
- [x] Full \`tests/connector/\` suite: **625 passed**. 4 pre-existing failures in \`test_profile_runtime_switch.py\` are present on \`origin/main\` HEAD (\`63c5ef40\`) too, not introduced here.
- [ ] CI full suite.
- [ ] \`/security-review\` pre-merge (touches \`cullis_connector/\`).

## Out of scope

- **Step 12 PR-B**: the SPA changes that call \`POST /messages\` after each chat completion turn and render the sidebar from \`GET /v1/conversations\`. Ships only the backend so the SPA work can land cleanly without 404s.
- **Step 13 PR-C**: Playwright e2e for the full sidebar UX. After Step 12 lands.
- Title auto-generation (server-side LLM summarisation): can be added in a follow-up; for now the SPA generates a title client-side from the first user turn truncated to 60 chars, and the API just stores whatever string the client passes.

🔒 Connector-local storage only. Loopback + bearer auth on every endpoint. Per-principal scoping enforced server-side (no \`principal_id\` field accepted from clients). chmod 0600 on the DB file. No production code path on app/ or mcp_proxy/.