### PR TITLE
feat(spa): conversation history sidebar + auto-persist on send (Step 6 PR-B)

### DIFF
--- a/frontend/cullis-chat/src/components/ChatApp.tsx
+++ b/frontend/cullis-chat/src/components/ChatApp.tsx
@@ -1,12 +1,56 @@
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { ChatContext, type ChatContextValue } from '../lib/chat-context';
-import { ApiError, chatCompletionStream } from '../lib/api';
+import {
+  ApiError,
+  appendConversationMessage,
+  chatCompletionStream,
+  createConversation,
+  getConversation,
+  renameConversation,
+} from '../lib/api';
 import { ensureSession } from '../lib/session-singleton';
 import { readSelectedModel } from './ModelPicker';
-import type { ChatMessage } from '../lib/types';
+import type { ChatMessage, ConversationDetail, StoredMessage } from '../lib/types';
 import { ChatWindow } from './ChatWindow';
 import { AuditPanel } from './AuditPanel';
 import '../styles/chat-window.css';
+
+const CONV_ID_KEY = 'cullis-chat:conv-id';
+const MAX_TITLE_LEN = 60;
+
+function readPersistedConvId(): string | null {
+  try {
+    return window.sessionStorage.getItem(CONV_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function persistConvId(id: string | null) {
+  try {
+    if (id) window.sessionStorage.setItem(CONV_ID_KEY, id);
+    else window.sessionStorage.removeItem(CONV_ID_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+function storedToChatMessage(s: StoredMessage): ChatMessage {
+  return {
+    id: `loaded_${Math.random().toString(36).slice(2, 10)}`,
+    role: s.role,
+    content: s.content,
+    trace_id: s.trace_id ?? undefined,
+    toolCalls: s.tool_calls ?? undefined,
+    createdAt: new Date(s.created_at).getTime() || Date.now(),
+  };
+}
+
+function truncateTitle(text: string): string {
+  const clean = text.trim().replace(/\s+/g, ' ');
+  if (clean.length <= MAX_TITLE_LEN) return clean;
+  return clean.slice(0, MAX_TITLE_LEN - 1) + '…';
+}
 
 // In production the audit chain belongs to the CISO/admin dashboard,
 // not to the end-user chat surface. The inline panel is dev-only and
@@ -32,7 +76,8 @@ type Action =
   | { type: 'select_message'; id: string | null }
   | { type: 'set_draft'; text: string }
   | { type: 'clear_draft' }
-  | { type: 'truncate_at'; index: number };
+  | { type: 'truncate_at'; index: number }
+  | { type: 'replace_messages'; messages: ChatMessage[] };
 
 function reducer(state: ChatState, action: Action): ChatState {
   switch (action.type) {
@@ -84,6 +129,8 @@ function reducer(state: ChatState, action: Action): ChatState {
       return { ...state, draft: undefined };
     case 'truncate_at':
       return { ...state, messages: state.messages.slice(0, Math.max(0, action.index)) };
+    case 'replace_messages':
+      return { ...state, messages: action.messages };
   }
 }
 
@@ -129,6 +176,14 @@ export default function ChatApp() {
   const [sessionReady, setSessionReady] = useState(false);
   // One in-flight stream per chat instance. Stop button aborts via this.
   const abortRef = useRef<AbortController | null>(null);
+  // Sprint 1 Step 6 PR-B, active conversation tied to /v1/conversations.
+  // Lives in a ref because `send()` reads + writes it inside an async
+  // function and we do not want a re-render every time the id flips
+  // (the ConversationsList sibling React island re-fetches via custom
+  // window event instead, no shared state needed here).
+  const convIdRef = useRef<string | null>(
+    typeof window !== 'undefined' ? readPersistedConvId() : null,
+  );
 
   // Session init at mount.
   useEffect(() => {
@@ -141,6 +196,73 @@ export default function ChatApp() {
       });
     return () => {
       cancelled = true;
+    };
+  }, []);
+
+  // Restore the persisted conversation at mount: fetch it from the
+  // Connector and rehydrate `state.messages`. A 404 means the row is
+  // gone (admin DELETE, profile reset); we drop the stale id silently.
+  useEffect(() => {
+    const id = convIdRef.current;
+    if (!id) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const conv: ConversationDetail = await getConversation(id);
+        if (cancelled) return;
+        dispatch({
+          type: 'replace_messages',
+          messages: conv.messages.map(storedToChatMessage),
+        });
+        window.dispatchEvent(
+          new CustomEvent('cullis:conversation-active', { detail: { id } }),
+        );
+      } catch (err) {
+        // Stale id, drop it. We deliberately do not surface this as
+        // an error banner: a missing conversation is recoverable by
+        // just starting a new one.
+        if (err instanceof ApiError && err.status === 404) {
+          convIdRef.current = null;
+          persistConvId(null);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Cross-island events: ConversationsList -> ChatApp.
+  useEffect(() => {
+    async function onLoad(e: Event) {
+      const detail = (e as CustomEvent).detail || {};
+      const id = typeof detail.id === 'string' ? detail.id : null;
+      if (!id) return;
+      try {
+        const conv = await getConversation(id);
+        convIdRef.current = id;
+        persistConvId(id);
+        dispatch({
+          type: 'replace_messages',
+          messages: conv.messages.map(storedToChatMessage),
+        });
+        window.dispatchEvent(
+          new CustomEvent('cullis:conversation-active', { detail: { id } }),
+        );
+      } catch (err) {
+        dispatch({ type: 'error', message: `Load failed: ${reasonOf(err)}` });
+      }
+    }
+    function onCleared() {
+      convIdRef.current = null;
+      persistConvId(null);
+      dispatch({ type: 'replace_messages', messages: [] });
+    }
+    window.addEventListener('cullis:load-conversation', onLoad);
+    window.addEventListener('cullis:conversation-cleared', onCleared);
+    return () => {
+      window.removeEventListener('cullis:load-conversation', onLoad);
+      window.removeEventListener('cullis:conversation-cleared', onCleared);
     };
   }, []);
 
@@ -159,6 +281,38 @@ export default function ChatApp() {
     // If a previous stream is still in flight, abort it before starting a new one.
     // Prevents two concurrent streams stepping on the same placeholder id space.
     abortRef.current?.abort();
+
+    // Sprint 1 Step 6 PR-B, lazy-create a conversation row on the
+    // first send. The id is captured here in a local so any subsequent
+    // change to convIdRef during this turn does not corrupt the writes
+    // we issue at the end.
+    const baseHistoryEarly = historyOverride ?? state.messages;
+    const isFirstTurn = baseHistoryEarly.length === 0;
+    let convId = convIdRef.current;
+    if (!convId) {
+      try {
+        const conv = await createConversation();
+        convId = conv.id;
+        convIdRef.current = conv.id;
+        persistConvId(conv.id);
+        window.dispatchEvent(
+          new CustomEvent('cullis:conversation-created', {
+            detail: { id: conv.id },
+          }),
+        );
+        window.dispatchEvent(
+          new CustomEvent('cullis:conversation-active', {
+            detail: { id: conv.id },
+          }),
+        );
+      } catch (err) {
+        // The conversation row is a nice-to-have for the sidebar, not
+        // a prerequisite for the chat itself. If it fails we still
+        // stream the answer; the user just loses sidebar persistence.
+        // eslint-disable-next-line no-console
+        console.warn('createConversation failed, streaming without persistence:', err);
+      }
+    }
 
     const userMsg: ChatMessage = {
       id: newId('m'),
@@ -191,7 +345,7 @@ export default function ChatApp() {
     }
 
     try {
-      const baseHistory = historyOverride ?? state.messages;
+      const baseHistory = baseHistoryEarly;
       const history = baseHistory.concat(userMsg).map((m) => ({ role: m.role, content: m.content }));
       const events = chatCompletionStream(
         { model: readSelectedModel(), messages: history },
@@ -232,6 +386,34 @@ export default function ChatApp() {
       flush(true);
       dispatch({ type: 'patch', id: placeholder.id, patch: { pending: false, trace_id: traceId } });
       dispatch({ type: 'idle' });
+
+      // Persist the turn into the conversation history. Fire-and-forget,
+      // a 5xx here does not justify wiping the in-memory transcript.
+      if (convId) {
+        const fc = convId; // const so the captured id survives later edits
+        void appendConversationMessage(fc, { role: 'user', content: text }).catch(
+          (err) => console.warn('appendConversationMessage user failed:', err),
+        );
+        void appendConversationMessage(fc, {
+          role: 'assistant',
+          content: accumulator.content,
+          trace_id: traceId,
+        }).catch((err) =>
+          console.warn('appendConversationMessage assistant failed:', err),
+        );
+        if (isFirstTurn) {
+          void renameConversation(fc, truncateTitle(text)).then(() => {
+            // Climbs the new title to the top of the sidebar.
+            window.dispatchEvent(
+              new CustomEvent('cullis:conversation-active', {
+                detail: { id: fc },
+              }),
+            );
+          }).catch((err) =>
+            console.warn('renameConversation failed:', err),
+          );
+        }
+      }
     } catch (err) {
       flush(true);
       if (isAbortError(err)) {

--- a/frontend/cullis-chat/src/components/ConversationsList.tsx
+++ b/frontend/cullis-chat/src/components/ConversationsList.tsx
@@ -1,0 +1,164 @@
+/**
+ * Sprint 1 Step 6 PR-B, dynamic sidebar history.
+ *
+ * Reads /v1/conversations on mount and renders the principal-scoped
+ * list returned by the Connector. Clicking a row dispatches a
+ * `cullis:load-conversation` window event that ChatApp's listener
+ * picks up to fetch the messages and rehydrate the chat surface.
+ * Deletes call DELETE /v1/conversations/{id} and refresh the list.
+ *
+ * Coordination with ChatApp happens entirely through three custom
+ * window events so this component stays a sibling React island
+ * inside the Astro static layout instead of being smuggled into
+ * the ChatApp tree.
+ *
+ *   cullis:conversation-created   { id, title }  emitted by ChatApp
+ *                                                after the first POST
+ *                                                /v1/conversations of
+ *                                                a fresh chat.
+ *   cullis:conversation-active    { id }         emitted by ChatApp
+ *                                                whenever it
+ *                                                switches active id
+ *                                                (load / new).
+ *   cullis:conversation-cleared   no detail      emitted by ChatApp
+ *                                                after the user
+ *                                                deletes the active
+ *                                                conversation.
+ */
+import { useEffect, useState } from 'react';
+import { deleteConversation, listConversations } from '../lib/api';
+import type { ConversationSummary } from '../lib/types';
+
+const ACTIVE_ID_KEY = 'cullis-chat:conv-id';
+
+function readActiveId(): string | null {
+  try {
+    return window.sessionStorage.getItem(ACTIVE_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function clearActiveId() {
+  try {
+    window.sessionStorage.removeItem(ACTIVE_ID_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function ConversationsList() {
+  const [items, setItems] = useState<ConversationSummary[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(() => readActiveId());
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  async function refresh() {
+    try {
+      const list = await listConversations({ limit: 20 });
+      setItems(list);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoaded(true);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+    const onCreated = () => void refresh();
+    const onCleared = () => {
+      setActiveId(null);
+      void refresh();
+    };
+    const onActive = (e: Event) => {
+      const detail = (e as CustomEvent).detail || {};
+      setActiveId(typeof detail.id === 'string' ? detail.id : null);
+      // Refresh so a freshly-titled conv climbs to the top of the list.
+      void refresh();
+    };
+    window.addEventListener('cullis:conversation-created', onCreated);
+    window.addEventListener('cullis:conversation-cleared', onCleared);
+    window.addEventListener('cullis:conversation-active', onActive);
+    return () => {
+      window.removeEventListener('cullis:conversation-created', onCreated);
+      window.removeEventListener('cullis:conversation-cleared', onCleared);
+      window.removeEventListener('cullis:conversation-active', onActive);
+    };
+  }, []);
+
+  function handleOpen(id: string) {
+    setActiveId(id);
+    window.dispatchEvent(
+      new CustomEvent('cullis:load-conversation', { detail: { id } }),
+    );
+  }
+
+  async function handleDelete(id: string, evt: React.MouseEvent) {
+    evt.stopPropagation();
+    if (!window.confirm('Delete this conversation?')) return;
+    try {
+      await deleteConversation(id);
+      if (activeId === id) {
+        setActiveId(null);
+        clearActiveId();
+        window.dispatchEvent(new CustomEvent('cullis:conversation-cleared'));
+      }
+      void refresh();
+    } catch (err) {
+      // Surface but do not crash the sidebar.
+      // eslint-disable-next-line no-console
+      console.warn('delete conversation failed:', err);
+    }
+  }
+
+  if (error) {
+    return (
+      <div className="conv-list-error" role="alert">
+        <p className="conv-list-error-body">history unavailable</p>
+        <p className="conv-list-error-detail">{error}</p>
+      </div>
+    );
+  }
+
+  if (loaded && items.length === 0) {
+    return (
+      <div className="conv-list-empty">
+        <p className="conv-list-empty-body">
+          No saved conversations yet. Send a message to start one.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="conv-list" aria-label="Recent conversations">
+      {items.map((c) => (
+        <li
+          key={c.id}
+          className={
+            'conv-item' + (c.id === activeId ? ' conv-item-active' : '')
+          }
+        >
+          <button
+            type="button"
+            className="conv-item-title"
+            onClick={() => handleOpen(c.id)}
+            title={c.title || 'untitled'}
+          >
+            {c.title || <em>untitled</em>}
+          </button>
+          <button
+            type="button"
+            className="conv-item-delete"
+            onClick={(e) => void handleDelete(c.id, e)}
+            aria-label={`Delete conversation ${c.title || c.id}`}
+          >
+            ×
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/cullis-chat/src/components/SidebarLeft.astro
+++ b/frontend/cullis-chat/src/components/SidebarLeft.astro
@@ -13,6 +13,7 @@
 // the matching surface link in the in-rail navigation.
 
 import brand from '@brand/config';
+import { ConversationsList } from './ConversationsList.tsx';
 
 interface Props {
   active?: 'chat' | 'inbox';
@@ -25,11 +26,27 @@ const inboxHref = `${base}inbox`;
 
 <aside class="sidebar-left" aria-label="Sidebar">
   <nav class="sl-nav">
-    <a class="sl-item" href={chatHref} aria-label="Start a new chat" title="New chat">
+    <a class="sl-item sl-new-chat" href={chatHref} aria-label="Start a new chat" title="New chat">
       <svg class="sl-item-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
       <span class="sl-item-label">New chat</span>
     </a>
   </nav>
+
+  <!-- Sprint 1 Step 6 PR-B: the New chat link still reloads, but we
+       clear the persisted active conversation id first so the
+       reloaded ChatApp starts in a fresh state instead of trying
+       to rehydrate the previous conv. -->
+  <script is:inline>
+    (function () {
+      var newChat = document.querySelector('.sl-new-chat');
+      if (!newChat) return;
+      newChat.addEventListener('click', function () {
+        try {
+          window.sessionStorage.removeItem('cullis-chat:conv-id');
+        } catch (e) { /* ignore */ }
+      });
+    })();
+  </script>
 
   <nav class="sl-surfaces" aria-label="Surfaces">
     <a
@@ -50,12 +67,13 @@ const inboxHref = `${base}inbox`;
     </a>
   </nav>
 
-  <div class="sl-empty">
-    <p class="sl-empty-body">
-      Conversation history lands in <span class="ver">v0.5</span>.
-      Until then every reload starts a fresh thread.
-    </p>
-    <p class="folio">{brand.sidebarFolio} · <em>v0.1</em></p>
+  <div class="sl-history">
+    <p class="sl-history-heading">Recent</p>
+    <ConversationsList client:load />
+  </div>
+
+  <div class="sl-footer">
+    <p class="folio">{brand.sidebarFolio} · <em>v0.2</em></p>
   </div>
 </aside>
 
@@ -197,5 +215,124 @@ const inboxHref = `${base}inbox`;
     background: var(--accent-cyan-glow);
     border: 1px solid var(--accent-cyan-dim);
     border-radius: var(--radius-sm);
+  }
+
+  /* Sprint 1 Step 6 PR-B, dynamic conversation history. */
+  .sl-history {
+    flex: 1;
+    overflow-y: auto;
+    padding: 1rem 0.6rem 0.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 0;
+  }
+
+  .sl-history-heading {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    margin: 0 0.4rem 0.2rem;
+  }
+
+  .sl-footer {
+    padding: 0.5rem 1.25rem 1rem;
+    border-top: 1px solid var(--border-subtle);
+  }
+
+  :global(.conv-list) {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+  }
+
+  :global(.conv-item) {
+    display: flex;
+    align-items: stretch;
+    border-radius: var(--radius-sm);
+    border-left: 2px solid transparent;
+    transition: background var(--t-fast) var(--ease-soft),
+                border-color var(--t-fast) var(--ease-soft);
+  }
+
+  :global(.conv-item:hover) {
+    background: rgba(255, 255, 255, 0.03);
+  }
+
+  :global(.conv-item-active) {
+    border-left-color: var(--accent-cyan);
+    background: color-mix(in srgb, var(--accent-cyan) 5%, transparent);
+  }
+
+  :global(.conv-item-title) {
+    flex: 1;
+    text-align: left;
+    background: none;
+    border: none;
+    padding: 0.45rem 0.6rem 0.45rem 0.7rem;
+    font-family: var(--font-body);
+    font-size: 0.82rem;
+    line-height: 1.3;
+    color: var(--text-secondary);
+    cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  :global(.conv-item-title:hover) {
+    color: var(--text-primary);
+  }
+
+  :global(.conv-item-active .conv-item-title) {
+    color: var(--accent-cyan);
+  }
+
+  :global(.conv-item-delete) {
+    background: none;
+    border: none;
+    padding: 0 0.55rem;
+    color: var(--text-tertiary);
+    cursor: pointer;
+    font-size: 1.1rem;
+    line-height: 1;
+    opacity: 0;
+    transition: opacity var(--t-fast) var(--ease-soft),
+                color var(--t-fast) var(--ease-soft);
+  }
+
+  :global(.conv-item:hover .conv-item-delete),
+  :global(.conv-item-delete:focus-visible) {
+    opacity: 1;
+  }
+
+  :global(.conv-item-delete:hover) {
+    color: var(--accent-amber);
+  }
+
+  :global(.conv-list-empty),
+  :global(.conv-list-error) {
+    padding: 0.6rem 0.7rem;
+    font-family: var(--font-body);
+    font-size: 0.78rem;
+    line-height: 1.5;
+    color: var(--text-tertiary);
+  }
+
+  :global(.conv-list-empty-body),
+  :global(.conv-list-error-body) {
+    margin: 0;
+  }
+
+  :global(.conv-list-error-detail) {
+    margin: 0.25rem 0 0;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    color: var(--accent-amber);
   }
 </style>

--- a/frontend/cullis-chat/src/lib/api.ts
+++ b/frontend/cullis-chat/src/lib/api.ts
@@ -23,11 +23,14 @@ import { parseSSE, type SSEEvent } from './sse';
 import type {
   ChatCompletionRequest,
   ChatCompletionResponse,
+  ConversationDetail,
+  ConversationSummary,
   InboxMessage,
   InboxSendRequest,
   InboxSendResponse,
   Model,
   Principal,
+  StoredMessage,
 } from './types';
 
 /**
@@ -171,6 +174,74 @@ export async function archiveInboxMessage(
   return jsonFetch<{ archived: boolean; msg_id: string }>(
     `${INBOX_BASE}/${encodeURIComponent(msgId)}/archive`,
     { method: 'POST' },
+  );
+}
+
+// ─── Conversation history (Sprint 1 Step 6 PR-B) ─────────────────────
+
+const CONVERSATIONS_BASE = '/v1/conversations';
+
+/** GET /v1/conversations, sidebar list, principal-scoped. */
+export async function listConversations(
+  opts?: { limit?: number; offset?: number },
+): Promise<ConversationSummary[]> {
+  const qs = new URLSearchParams();
+  if (opts?.limit !== undefined) qs.set('limit', String(opts.limit));
+  if (opts?.offset !== undefined) qs.set('offset', String(opts.offset));
+  const suffix = qs.toString();
+  const url = suffix ? `${CONVERSATIONS_BASE}?${suffix}` : CONVERSATIONS_BASE;
+  return jsonFetch<ConversationSummary[]>(url);
+}
+
+/** POST /v1/conversations, create empty conversation. */
+export async function createConversation(): Promise<ConversationSummary> {
+  return jsonFetch<ConversationSummary>(CONVERSATIONS_BASE, {
+    method: 'POST',
+    body: '{}',
+  });
+}
+
+/** GET /v1/conversations/{id}, fetch one + its messages. */
+export async function getConversation(id: string): Promise<ConversationDetail> {
+  return jsonFetch<ConversationDetail>(
+    `${CONVERSATIONS_BASE}/${encodeURIComponent(id)}`,
+  );
+}
+
+/** PATCH /v1/conversations/{id}, rename title. */
+export async function renameConversation(
+  id: string, title: string | null,
+): Promise<ConversationSummary> {
+  return jsonFetch<ConversationSummary>(
+    `${CONVERSATIONS_BASE}/${encodeURIComponent(id)}`,
+    { method: 'PATCH', body: JSON.stringify({ title }) },
+  );
+}
+
+/** DELETE /v1/conversations/{id}, soft delete. */
+export async function deleteConversation(id: string): Promise<void> {
+  const res = await fetch(
+    `${CONVERSATIONS_BASE}/${encodeURIComponent(id)}`,
+    { method: 'DELETE', credentials: 'same-origin' },
+  );
+  if (!res.ok && res.status !== 204) {
+    throw new ApiError(res.status, await res.text());
+  }
+}
+
+/** POST /v1/conversations/{id}/messages, append one message. */
+export async function appendConversationMessage(
+  id: string,
+  msg: {
+    role: 'user' | 'assistant' | 'tool' | 'system';
+    content: string;
+    tool_calls?: Array<{ name: string; latency_ms?: number; status?: string }>;
+    trace_id?: string;
+  },
+): Promise<StoredMessage> {
+  return jsonFetch<StoredMessage>(
+    `${CONVERSATIONS_BASE}/${encodeURIComponent(id)}/messages`,
+    { method: 'POST', body: JSON.stringify(msg) },
   );
 }
 

--- a/frontend/cullis-chat/src/lib/types.ts
+++ b/frontend/cullis-chat/src/lib/types.ts
@@ -111,5 +111,27 @@ export interface InboxSendResponse {
   quadrant: string;
 }
 
-/** Inbox UI tabs — drives client-side filtering, not a server param. */
+/** Inbox UI tabs, drives client-side filtering, not a server param. */
 export type InboxTab = 'all' | 'unread' | 'sent' | 'drafts';
+
+
+// ── Sprint 1 Step 6, conversation history (PR-A backend, PR-B SPA) ──
+
+export interface ConversationSummary {
+  id: string;
+  title: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface StoredMessage {
+  role: ChatRole;
+  content: string;
+  tool_calls: ToolCallEvent[] | null;
+  trace_id: string | null;
+  created_at: string;
+}
+
+export interface ConversationDetail extends ConversationSummary {
+  messages: StoredMessage[];
+}


### PR DESCRIPTION
Consumes the \`/v1/conversations\` REST surface shipped in #610. The SPA left rail now shows the principal's recent conversations live, clicking one rehydrates the chat, and the New chat link clears the persisted active id so a reload starts fresh.

## What lands

### \`lib/api.ts\` + \`lib/types.ts\`

Typed helpers and DTOs for the five new REST endpoints:
\`listConversations\` / \`createConversation\` / \`getConversation\` / \`renameConversation\` / \`deleteConversation\` / \`appendConversationMessage\`.

### \`components/ConversationsList.tsx\` (new React island)

- Reads the list at mount.
- Listens for window events to revalidate: \`cullis:conversation-created\`, \`cullis:conversation-active\`, \`cullis:conversation-cleared\`.
- Click on a row dispatches \`cullis:load-conversation\` which ChatApp picks up.
- Delete button per row with browser confirm + DELETE call.
- Empty / error states inline.

### \`components/SidebarLeft.astro\`

- Drops the \"Conversation history lands in v0.5\" blurb.
- Mounts \`<ConversationsList client:load />\` in its place.
- New chat link is still an \`<a>\` reload, but a tiny inline script clears the sessionStorage active id first so the reload picks up a fresh state instead of re-hydrating the previous conversation.
- New CSS: \`conv-list\` / \`conv-item\` / \`conv-item-active\` / \`conv-item-delete\` / empty + error states.

### \`components/ChatApp.tsx\`

- New ref-tracked active conversation id with sessionStorage round-trip (\`cullis-chat:conv-id\`).
- Restores messages on mount when a persisted id is present. 404 silently drops the stale id (admin deleted the row, profile reset, etc).
- Listens for the cross-island window events:
  - \`cullis:load-conversation\` → fetch + \`replace_messages\` + persist + emit \`cullis:conversation-active\`.
  - \`cullis:conversation-cleared\` → clear messages + clear sessionStorage.
- \`send()\` lazy-creates a conversation row on the first send of a fresh thread, emits \`cullis:conversation-created\` so the sidebar refreshes.
- After the stream completes: \`appendConversationMessage\` fire-and-forget for user + assistant turns; the chat itself does not block on persistence failures.
- On the first turn it also \`renameConversation(id, truncate(text, 60))\` so the sidebar shows something meaningful instead of \"untitled\".

## Coordination model

The two React islands (ChatApp in the main column, ConversationsList in the sidebar) live under the same Astro static layout but in two separate React roots. Rather than promote them under a single root (which would have churned the layout grid), they coordinate through three custom window events. Each event is bidirectional in shape but unidirectional in flow:

| Event | Emitter | Listener | Detail |
|---|---|---|---|
| \`cullis:conversation-created\` | ChatApp | ConversationsList | \`{ id }\` |
| \`cullis:conversation-active\` | ChatApp | ConversationsList | \`{ id }\` |
| \`cullis:conversation-cleared\` | ConversationsList | ChatApp | — |
| \`cullis:load-conversation\` | ConversationsList | ChatApp | \`{ id }\` |

## Test plan

- [x] \`npm run build\` clean.
- [x] No new em-dashes / en-dashes on the touched files.
- [ ] Manual on the dev mock: send → conversation row appears + gets renamed → reload → messages rehydrate → click another row → swap → New chat → fresh thread.
- [ ] Playwright e2e: deferred to Step 13 PR-C so this PR stays reviewable.

## Out of scope

- **Step 13 PR-C**: Playwright e2e for the full sidebar flow.
- **Step 8b**: responsive sidebar collapse for mobile (blocked until conv list layout is final, which this PR makes it).
- Server-side LLM title generation: the first user prompt truncated to 60 chars is enough for v0.2. Operators can rename via a future Mastio dashboard view if they want richer labels.
- Streaming append-as-you-go: tool calls and assistant content are persisted only after the stream completes. A streaming-into-DB pattern is overkill for v0.2 and would couple the persistence layer to the SSE shape.

🔒 SPA + Connector loopback REST only. Per-principal scoping enforced server-side in #610. No new auth or trust boundary on this side.