### PR TITLE
feat(spa): phone breakpoint + touch targets + iOS no-zoom (Step 8b)

### DIFF
--- a/frontend/cullis-chat/src/styles/globals.css
+++ b/frontend/cullis-chat/src/styles/globals.css
@@ -145,8 +145,19 @@ body {
   50%      { opacity: 0.5; box-shadow: 0 0 6px var(--pulse-color); }
 }
 
-/* Responsive — under 900px we'd collapse panes, but v0.1 only
- * supports desktop. We just narrow the audit pane, hide sidebar. */
+/* Responsive layout breakpoints.
+ *
+ * Three tiers:
+ *  - <= 1100px (small laptop, narrow window): trim sidebar + audit
+ *    widths so the chat surface still has room.
+ *  - <= 900px (tablet, portrait laptop): drop the sidebar and the
+ *    audit pane, chat takes the full width. Conversation history
+ *    stays reachable on a desktop reload (no mobile drawer in v0.2,
+ *    scope tracked as a follow-up polish PR).
+ *  - <= 640px (phone): tighten chat padding + raise touch targets +
+ *    raise textarea font-size to 16px so iOS Safari does not zoom
+ *    on focus.
+ */
 @media (max-width: 1100px) {
   .app-body { grid-template-columns: 200px minmax(0, 1fr); }
   .chat-app { grid-template-columns: minmax(0, 1fr) 280px; }
@@ -159,6 +170,52 @@ body {
   .chat-app > .audit-pane { display: none; }
 }
 
+@media (max-width: 640px) {
+  /* Compact the chat surface for portrait phones. */
+  .chat-shell { padding: 0.8rem 0.9rem 0.6rem; gap: 0.6rem; }
+  .chat-stream { padding: 0.5rem 0; }
+  .chat-stream-inner { max-width: 100%; }
+
+  /* Message bubbles read better with slightly tighter padding on
+   * narrow screens; tool-call chips wrap instead of overflowing. */
+  .msg-body-assistant { padding: 0.85rem 1rem; }
+  .msg-body-user { padding-left: 0.9rem; }
+  .msg-tools { gap: 0.3rem; }
+  .tool-chip { font-size: 0.74rem; padding: 0.35rem 0.6rem; }
+
+  /* Touch targets: WCAG 2.5.5 recommends >= 44x44 px for primary
+   * interactive controls. Send / Stop / Retry / Copy meet that on
+   * narrow screens; on desktop the originals stay tighter. */
+  .send,
+  .stop,
+  .msg-retry { min-height: 44px; padding-top: 0.65rem; padding-bottom: 0.65rem; }
+  .copy-btn,
+  .code-copy { min-width: 44px; min-height: 32px; opacity: 0.55; }
+
+  /* Prevent iOS Safari from auto-zooming on textarea focus when the
+   * computed font-size is under 16px. */
+  .chat-input textarea {
+    font-size: 16px;
+  }
+
+  /* Empty-state hero shrinks so the hint buttons stay above the
+   * fold on a 640x... iPhone-SE-shaped viewport. */
+  .chat-empty { padding-top: 0.8rem; gap: 0.7rem; }
+  .chat-empty-title { font-size: clamp(1.15rem, 5.5vw, 1.45rem); }
+  .chat-empty-sub { font-size: 0.88rem; }
+  .chat-empty-hints { gap: 0.4rem; margin-top: 1rem; }
+  .hint { font-size: 0.82rem; padding: 0.45rem 0; min-height: 44px; }
+
+  /* Footer disclaimer ("Bearer · cookie HttpOnly · …") wraps on
+   * mobile; let it. */
+  .chat-foot {
+    white-space: normal;
+    line-height: 1.5;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .pulse-dot { animation: none; }
+  .markdown-body.is-pending::after { animation: none; }
+  .chat-app { transition: none; }
 }


### PR DESCRIPTION
Closes the last Sprint 1 frontend item. Now that the sidebar history (#611) and the cancel/retry/copy footers (#598/#599) have settled their final layout, the responsive pass can lock them down for phones without churning further.

## Three tiers of breakpoints

The top of \`globals.css\` already had two breakpoints (1100px, 900px). This PR adds the third:

| Width | Tier | Behaviour |
|---|---|---|
| ≤ 1100px | small laptop / narrow window | sidebar 200px, audit 280px |
| ≤ 900px | tablet, portrait laptop | sidebar hidden, audit hidden, chat full-width |
| ≤ 640px (new) | phone | compact padding, tight bubbles, **44px touch targets**, **16px textarea** (no iOS zoom), shrunken hero |

## What changes inside the 640px block

- \`.chat-shell\` / \`.chat-stream\` padding tightened.
- \`.chat-stream-inner\` max-width drops to 100% so the bubbles fill the viewport instead of centering inside a 64ch column.
- Message bubbles shrink padding by ~0.4rem; tool-call chips wrap instead of overflowing.
- **WCAG 2.5.5 touch targets**: \`.send\`, \`.stop\`, \`.msg-retry\` all get \`min-height: 44px\`. \`.copy-btn\` and \`.code-copy\` overlays grow to \`min-width 44px / min-height 32px\` and baseline at 0.55 opacity (no hover state on touch).
- \`.chat-input textarea\` font-size bumps to **16px** so iOS Safari does not auto-zoom on focus.
- Empty-state hero, hints, and the footer disclaimer all shrink so the first send is reachable above the iPhone-SE fold.

## prefers-reduced-motion

Extended too: the streaming caret blink and the chat-app grid-template-columns transition both go static alongside the existing \`.pulse-dot\` rule. Catches the user who set the OS preference at the system level instead of the browser.

## Test plan

- [x] \`npm run build\` clean.
- [x] No new em-dashes on the touched lines.
- [ ] Manual on Chrome DevTools responsive emulator: iPhone SE / iPhone 12 / iPad Mini portrait. Send a message, exercise stop / retry / copy / code-copy on each viewport.
- [ ] Playwright spec for mobile viewport: deferred. Adding viewport-parameterised assertions would balloon the spec count; the visual check is enough for v0.2.

## Out of scope (tracked as tiny follow-ups if anyone asks)

- **Mobile drawer / hamburger** for the sidebar. v0.2 stays desktop-first on the history surface; on a phone the user reloads to see history or uses the New chat link to start a fresh thread.
- **WCAG AA contrast** for \`--text-tertiary\` on \`--bg-void\`. Sits at ~3.7:1 today, below the 4.5 AA target for body text. Tracked separately so the palette decision is reviewed on its own.

🔒 Pure CSS in one file. No production code path touched.