### PR TITLE
fix(mastio): DB-level append-only enforcement on local_audit (CRIT-3)

### DIFF
--- a/mcp_proxy/alembic/versions/0031_audit_append_only_v2.py
+++ b/mcp_proxy/alembic/versions/0031_audit_append_only_v2.py
@@ -1,0 +1,133 @@
+"""Audit DB-level append-only enforcement + v2 hash format (CRIT-3).
+
+Revision ID: 0031_audit_append_only_v2
+Revises: 0030_user_pubkey_thumbprint
+Create Date: 2026-05-11 21:00:00.000000
+
+Audit ref: imp/audits/2026-05-11-MASTER.md CRIT-3 / Track 3 F-2.
+
+Pre-CRIT-3 the ``local_audit`` table claimed "append-only" but every
+row was inserted with a placeholder ``entry_hash=""`` and immediately
+back-filled via ``UPDATE local_audit SET entry_hash WHERE id`` — the
+application itself proved the schema accepted UPDATE on the
+"append-only" table. An attacker with DB write credentials could
+rewrite or delete rows undetected.
+
+This migration:
+1. Adds ``hash_format`` TEXT NULL — NULL or 'v1' for legacy rows that
+   were back-filled, 'v2' for new rows inserted atomically with the
+   hash already computed (no UPDATE).
+2. Installs a BEFORE UPDATE OR DELETE trigger on ``local_audit`` that
+   raises an error, blocking both attacker-driven mutation AND the
+   pre-fix back-fill code path. Implemented in dialect-aware SQL:
+   Postgres uses CREATE FUNCTION + CREATE TRIGGER; SQLite uses CREATE
+   TRIGGER ... FOR EACH ROW BEGIN SELECT RAISE(...) END.
+
+The trigger fires AFTER ``mcp_proxy/local/audit.py`` was refactored to
+write the hash atomically on INSERT. Existing v1 rows are untouched
+(no in-place migration to v2 — verify_local_chain dispatches on
+``hash_format`` so legacy rows keep verifying with v1 inputs).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0031_audit_append_only_v2"
+down_revision: Union[str, Sequence[str], None] = "0030_user_pubkey_thumbprint"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_TABLE = "local_audit"
+
+
+_PG_TRIGGER_FN = """
+CREATE OR REPLACE FUNCTION local_audit_no_mutate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION
+        'local_audit is append-only (CRIT-3): % is not permitted',
+        TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_PG_TRIGGER = """
+CREATE TRIGGER local_audit_no_update_or_delete
+BEFORE UPDATE OR DELETE ON local_audit
+FOR EACH ROW EXECUTE FUNCTION local_audit_no_mutate();
+"""
+
+_SQLITE_TRIGGER_UPDATE = """
+CREATE TRIGGER IF NOT EXISTS local_audit_no_update
+BEFORE UPDATE ON local_audit
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'local_audit is append-only (CRIT-3): UPDATE not permitted');
+END;
+"""
+
+_SQLITE_TRIGGER_DELETE = """
+CREATE TRIGGER IF NOT EXISTS local_audit_no_delete
+BEFORE DELETE ON local_audit
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, 'local_audit is append-only (CRIT-3): DELETE not permitted');
+END;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _TABLE not in existing:
+        # Cold-start install where 0009 never ran — nothing to harden,
+        # later migrations will rebuild the table from scratch.
+        return
+
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    if "hash_format" not in cols:
+        op.add_column(
+            _TABLE,
+            sa.Column("hash_format", sa.Text(), nullable=True),
+        )
+
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute(_PG_TRIGGER_FN)
+        # Drop any prior install of the trigger so this migration is
+        # idempotent on environments that re-stamp.
+        op.execute("DROP TRIGGER IF EXISTS local_audit_no_update_or_delete ON local_audit")
+        op.execute(_PG_TRIGGER)
+    elif dialect == "sqlite":
+        op.execute(_SQLITE_TRIGGER_UPDATE)
+        op.execute(_SQLITE_TRIGGER_DELETE)
+    else:
+        # Other dialects (mysql etc.) are not in scope for this audit
+        # finding; document and continue. Future PR can extend.
+        pass
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if _TABLE not in existing:
+        return
+
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        op.execute("DROP TRIGGER IF EXISTS local_audit_no_update_or_delete ON local_audit")
+        op.execute("DROP FUNCTION IF EXISTS local_audit_no_mutate()")
+    elif dialect == "sqlite":
+        op.execute("DROP TRIGGER IF EXISTS local_audit_no_update")
+        op.execute("DROP TRIGGER IF EXISTS local_audit_no_delete")
+
+    cols = {c["name"] for c in inspector.get_columns(_TABLE)}
+    if "hash_format" in cols:
+        op.drop_column(_TABLE, "hash_format")

--- a/mcp_proxy/local/audit.py
+++ b/mcp_proxy/local/audit.py
@@ -31,7 +31,13 @@ from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from mcp_proxy.db import get_db
-from mcp_proxy.local.audit_chain import SYSTEM_ORG, compute_entry_hash
+from mcp_proxy.local.audit_chain import (
+    HASH_FORMAT_V1,
+    HASH_FORMAT_V2,
+    SYSTEM_ORG,
+    compute_entry_hash,
+    compute_entry_hash_v2,
+)
 
 _log = logging.getLogger("mcp_proxy.local.audit")
 
@@ -106,20 +112,43 @@ async def append_local_audit(
                     last_seq = head[1] if head else 0
                     new_seq = last_seq + 1
 
-                    # 2. Insert with placeholder entry_hash; database auto-assigns id.
                     now = datetime.now(timezone.utc)
                     ts_iso = _iso(now)
+
+                    # CRIT-3 (audit 2026-05-11) — compute the hash
+                    # BEFORE the insert (v2 form, no entry_id) so the
+                    # row lands atomically with its final entry_hash.
+                    # Migration 0031 then installs a BEFORE
+                    # UPDATE/DELETE trigger on local_audit; no
+                    # application back-fill UPDATE remains. The
+                    # (org_id, chain_seq) pair already uniquely
+                    # identifies the row (UNIQUE since 0009), so the
+                    # auto-assigned PK is no longer load-bearing for
+                    # the chain integrity proof.
+                    entry_hash = compute_entry_hash_v2(
+                        timestamp=now,
+                        event_type=event_type,
+                        agent_id=agent_id,
+                        session_id=session_id,
+                        org_id=chain_org,
+                        result=result,
+                        details=details_json,
+                        previous_hash=previous_hash,
+                        chain_seq=new_seq,
+                        peer_org_id=None,
+                    )
+
                     insert_result = await conn.execute(
                         text(
                             """
                             INSERT INTO local_audit (
                                 timestamp, event_type, agent_id, session_id, org_id,
                                 details, result, previous_hash, chain_seq,
-                                peer_org_id, peer_row_hash, entry_hash
+                                peer_org_id, peer_row_hash, entry_hash, hash_format
                             ) VALUES (
                                 :timestamp, :event_type, :agent_id, :session_id, :org_id,
                                 :details, :result, :previous_hash, :chain_seq,
-                                NULL, NULL, :placeholder
+                                NULL, NULL, :entry_hash, :hash_format
                             )
                             """
                         ),
@@ -133,14 +162,13 @@ async def append_local_audit(
                             "result": result,
                             "previous_hash": previous_hash,
                             "chain_seq": new_seq,
-                            "placeholder": "",
+                            "entry_hash": entry_hash,
+                            "hash_format": HASH_FORMAT_V2,
                         },
                     )
-                    # SQLite drivers expose ``lastrowid`` on the CursorResult; asyncpg
-                    # *does not* have that attribute at all (raises AttributeError,
-                    # not returns None), so the ``is None`` check below never fires
-                    # on Postgres. ``getattr(..., None)`` normalises both dialects to
-                    # the same "unknown → query back" fallback path.
+                    # ``id`` is informational; some callers (tests,
+                    # structured logs) want the auto-assigned PK.
+                    # Same dialect-aware lookup as before.
                     row_id = getattr(insert_result, "lastrowid", None)
                     if row_id is None:
                         id_row = (await conn.execute(
@@ -151,27 +179,6 @@ async def append_local_audit(
                             {"org_id": chain_org, "chain_seq": new_seq},
                         )).first()
                         row_id = id_row[0]
-
-                    # 3. Compute the hash now that we know the row id.
-                    entry_hash = compute_entry_hash(
-                        entry_id=row_id,
-                        timestamp=now,
-                        event_type=event_type,
-                        agent_id=agent_id,
-                        session_id=session_id,
-                        org_id=chain_org,
-                        result=result,
-                        details=details_json,
-                        previous_hash=previous_hash,
-                        chain_seq=new_seq,
-                        peer_org_id=None,
-                    )
-
-                    # 4. Back-fill the hash. The row is immutable from here on.
-                    await conn.execute(
-                        text("UPDATE local_audit SET entry_hash = :h WHERE id = :id"),
-                        {"h": entry_hash, "id": row_id},
-                    )
                 # ``get_db()`` committed on clean exit. Return the summary.
                 return {
                     "id": row_id,
@@ -208,7 +215,7 @@ async def verify_local_chain(org_id: str) -> tuple[bool, str | None]:
                 """
                 SELECT id, timestamp, event_type, agent_id, session_id,
                        org_id, details, result, previous_hash, chain_seq,
-                       peer_org_id, entry_hash
+                       peer_org_id, entry_hash, hash_format
                   FROM local_audit
                  WHERE org_id = :org_id AND chain_seq IS NOT NULL
                  ORDER BY chain_seq ASC
@@ -227,22 +234,43 @@ async def verify_local_chain(org_id: str) -> tuple[bool, str | None]:
                     f"row chain_seq={row['chain_seq']} previous_hash mismatch: "
                     f"expected {expected_prev!r}, got {row['previous_hash']!r}"
                 )
-            expected = compute_entry_hash(
-                entry_id=row["id"],
-                timestamp=ts,
-                event_type=row["event_type"],
-                agent_id=row["agent_id"],
-                session_id=row["session_id"],
-                org_id=row["org_id"],
-                result=row["result"],
-                details=row["details"],
-                previous_hash=row["previous_hash"],
-                chain_seq=row["chain_seq"],
-                peer_org_id=row["peer_org_id"],
-            )
+            # CRIT-3 — dispatch on the row's stored hash_format. Pre-fix
+            # rows are NULL/'v1' and re-verify with the legacy entry_id
+            # form. New rows are 'v2' and verify with the entry_id-free
+            # form. The discriminator at the start of the v2 canonical
+            # string makes a v1↔v2 collision cryptographically impossible.
+            row_format = row["hash_format"] or HASH_FORMAT_V1
+            if row_format == HASH_FORMAT_V2:
+                expected = compute_entry_hash_v2(
+                    timestamp=ts,
+                    event_type=row["event_type"],
+                    agent_id=row["agent_id"],
+                    session_id=row["session_id"],
+                    org_id=row["org_id"],
+                    result=row["result"],
+                    details=row["details"],
+                    previous_hash=row["previous_hash"],
+                    chain_seq=row["chain_seq"],
+                    peer_org_id=row["peer_org_id"],
+                )
+            else:
+                expected = compute_entry_hash(
+                    entry_id=row["id"],
+                    timestamp=ts,
+                    event_type=row["event_type"],
+                    agent_id=row["agent_id"],
+                    session_id=row["session_id"],
+                    org_id=row["org_id"],
+                    result=row["result"],
+                    details=row["details"],
+                    previous_hash=row["previous_hash"],
+                    chain_seq=row["chain_seq"],
+                    peer_org_id=row["peer_org_id"],
+                )
             if expected != row["entry_hash"]:
                 return False, (
                     f"row id={row['id']} chain_seq={row['chain_seq']} "
+                    f"hash_format={row_format} "
                     f"entry_hash mismatch: expected {expected}, got "
                     f"{row['entry_hash']}"
                 )

--- a/mcp_proxy/local/audit_chain.py
+++ b/mcp_proxy/local/audit_chain.py
@@ -51,3 +51,55 @@ def compute_entry_hash(
     else:
         canonical = f"{base}|seq={chain_seq}|peer={peer_org_id or ''}"
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# Wave A PR5 (audit 2026-05-11 CRIT-3) — v2 hash format.
+#
+# v1 above includes ``entry_id`` (DB-assigned auto-increment) which forces
+# a back-fill UPDATE on the "append-only" table after the INSERT lands —
+# proving the schema accepts UPDATE on a row the docs claim is immutable.
+# v2 replaces the entry_id with the (org_id, chain_seq) pair which is
+# already UNIQUE per migration 0009 + already known BEFORE the INSERT
+# fires. The whole row can therefore be inserted atomically with the
+# hash already computed, and the migration 0031 trigger that forbids
+# UPDATE / DELETE on local_audit fires correctly.
+#
+# Rows on disk carry ``hash_format`` ('v1' or 'v2'); verify dispatches
+# on that column so legacy rows keep verifying with the old function.
+
+_V2_FORMAT_TAG = "v2"
+
+
+def compute_entry_hash_v2(
+    *,
+    timestamp: datetime,
+    event_type: str,
+    agent_id: str | None,
+    session_id: str | None,
+    org_id: str | None,
+    result: str,
+    details: str | None,
+    previous_hash: str | None,
+    chain_seq: int,
+    peer_org_id: str | None = None,
+) -> str:
+    """SHA-256 of the v2 canonical form (no entry_id).
+
+    Identical fields to ``compute_entry_hash`` minus ``entry_id``, plus
+    a ``v2`` discriminator at the start so a v1-vs-v2 collision is
+    cryptographically impossible (every v1 hash starts with an integer,
+    every v2 with the literal ``"v2|"``). chain_seq is required (a v2
+    row without per-org chain has no business being v2).
+    """
+    canonical = (
+        f"{_V2_FORMAT_TAG}|{timestamp.isoformat()}|{event_type}|"
+        f"{agent_id or ''}|{session_id or ''}|{org_id or ''}|"
+        f"{result}|{details or ''}|{previous_hash or 'genesis'}|"
+        f"seq={chain_seq}|peer={peer_org_id or ''}"
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# Constant exported for migration / dashboard / tests.
+HASH_FORMAT_V1 = "v1"
+HASH_FORMAT_V2 = "v2"

--- a/tests/test_crit3_audit_append_only.py
+++ b/tests/test_crit3_audit_append_only.py
@@ -1,0 +1,237 @@
+"""CRIT-3 — DB-level append-only enforcement on local_audit (Wave A PR5).
+
+Audit ref: imp/audits/2026-05-11-track-3-audit-pdp.md F-2.
+
+Pre-fix:
+- ``local_audit`` claimed "append-only" but every row was inserted
+  with placeholder ``entry_hash=""`` then back-filled via UPDATE in
+  ``mcp_proxy/local/audit.py:172``. The application itself proved the
+  schema accepted UPDATE on the table.
+- An attacker with DB write credentials could rewrite or delete rows
+  undetected.
+
+Post-fix:
+- ``compute_entry_hash_v2`` lets callers compute the hash without the
+  DB-assigned ``entry_id`` (uses ``(org_id, chain_seq)`` instead).
+- ``append_local_audit`` now writes the row atomically with the final
+  hash + ``hash_format='v2'``; no back-fill UPDATE remains.
+- Migration 0031 installs a BEFORE UPDATE / DELETE trigger on
+  ``local_audit`` that raises an error, blocking both attacker-driven
+  mutation AND any leftover application UPDATE attempt.
+- ``verify_local_chain`` dispatches on ``hash_format`` so legacy v1
+  rows keep verifying.
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+
+from mcp_proxy.db import dispose_db, get_db, init_db
+from mcp_proxy.local.audit import append_local_audit, verify_local_chain
+from mcp_proxy.local.audit_chain import (
+    HASH_FORMAT_V1,
+    HASH_FORMAT_V2,
+    compute_entry_hash_v2,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture
+async def fresh_db(tmp_path, monkeypatch):
+    db_file = tmp_path / "audit.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    try:
+        yield url
+    finally:
+        await dispose_db()
+
+
+# ─── append_local_audit writes atomically with v2 hash ───
+
+
+async def test_append_writes_v2_hash_format(fresh_db):
+    summary = await append_local_audit(
+        event_type="test.event",
+        result="ok",
+        org_id="acme",
+        details={"k": "v"},
+    )
+    assert summary["chain_seq"] == 1
+    assert summary["entry_hash"] != ""
+    # Row stored with hash_format='v2'
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT entry_hash, hash_format FROM local_audit "
+                " WHERE chain_seq = 1 AND org_id = 'acme'"
+            ),
+        )).first()
+    assert row[0] == summary["entry_hash"]
+    assert row[1] == HASH_FORMAT_V2
+
+
+async def test_chain_seq_advances_per_org(fresh_db):
+    s1 = await append_local_audit(event_type="e1", org_id="acme")
+    s2 = await append_local_audit(event_type="e2", org_id="acme")
+    s3 = await append_local_audit(event_type="e3", org_id="orga")
+    assert (s1["chain_seq"], s2["chain_seq"]) == (1, 2)
+    assert s3["chain_seq"] == 1  # different org, separate chain
+    assert s2["previous_hash"] == s1["entry_hash"]
+    # verify chain integrity
+    ok, reason = await verify_local_chain("acme")
+    assert ok, reason
+    ok, reason = await verify_local_chain("orga")
+    assert ok, reason
+
+
+# ─── trigger blocks UPDATE / DELETE ───
+
+
+async def test_trigger_blocks_update_on_local_audit(fresh_db):
+    """The DB trigger installed by 0031 must reject any UPDATE on
+    local_audit, even when the connecting role has write privilege.
+    SQLite RAISE(ABORT) surfaces as IntegrityError; Postgres RAISE
+    EXCEPTION surfaces as InternalError. Both subclass DBAPIError."""
+    await append_local_audit(event_type="seed", org_id="acme")
+    with pytest.raises(DBAPIError) as exc_info:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "UPDATE local_audit SET entry_hash = 'tampered' "
+                    " WHERE chain_seq = 1 AND org_id = 'acme'"
+                )
+            )
+    msg = str(exc_info.value).lower()
+    assert "append-only" in msg or "crit-3" in msg
+
+
+async def test_trigger_blocks_delete_on_local_audit(fresh_db):
+    """Same defence on DELETE."""
+    await append_local_audit(event_type="seed", org_id="acme")
+    with pytest.raises(DBAPIError) as exc_info:
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "DELETE FROM local_audit "
+                    " WHERE chain_seq = 1 AND org_id = 'acme'"
+                )
+            )
+    msg = str(exc_info.value).lower()
+    assert "append-only" in msg or "crit-3" in msg
+
+
+# ─── verify dispatches on hash_format ───
+
+
+async def test_verify_dispatches_to_v1_for_legacy_row(fresh_db):
+    """A row written with the v1 hash_format (entry_id-bound canonical
+    string) must continue verifying via compute_entry_hash. We can't
+    insert v1 directly through append_local_audit (which now writes v2),
+    so we craft one with raw SQL to mimic a row written by an older
+    Mastio. The trigger blocks UPDATE so we have to disable it for the
+    setup, exercise verify, then re-enable."""
+    from datetime import datetime, timezone
+    from mcp_proxy.local.audit_chain import compute_entry_hash
+    # Disable triggers for the setup-only insert (SQLite doesn't have
+    # session-level toggle, so we DROP+recreate the triggers around
+    # the legacy seed).
+    async with get_db() as conn:
+        await conn.execute(text("DROP TRIGGER IF EXISTS local_audit_no_update"))
+        await conn.execute(text("DROP TRIGGER IF EXISTS local_audit_no_delete"))
+    now = datetime.now(timezone.utc)
+    # Raw INSERT mimicking the legacy back-fill path: insert with
+    # placeholder, then UPDATE — produces a v1-style row.
+    async with get_db() as conn:
+        await conn.execute(
+            text(
+                "INSERT INTO local_audit "
+                "(timestamp, event_type, agent_id, session_id, org_id, "
+                " details, result, previous_hash, chain_seq, "
+                " peer_org_id, peer_row_hash, entry_hash, hash_format) "
+                "VALUES (:ts, 'legacy', NULL, NULL, 'legacyorg', NULL, "
+                " 'ok', NULL, 1, NULL, NULL, '', NULL)"
+            ),
+            {"ts": now.isoformat()},
+        )
+        row = (await conn.execute(
+            text(
+                "SELECT id FROM local_audit WHERE org_id = 'legacyorg' "
+                " AND chain_seq = 1"
+            )
+        )).first()
+        row_id = row[0]
+        v1_hash = compute_entry_hash(
+            entry_id=row_id, timestamp=now, event_type="legacy",
+            agent_id=None, session_id=None, org_id="legacyorg",
+            result="ok", details=None, previous_hash=None,
+            chain_seq=1, peer_org_id=None,
+        )
+        await conn.execute(
+            text(
+                "UPDATE local_audit SET entry_hash = :h WHERE id = :id"
+            ),
+            {"h": v1_hash, "id": row_id},
+        )
+    # verify dispatches to v1 for hash_format=NULL
+    ok, reason = await verify_local_chain("legacyorg")
+    assert ok, reason
+
+
+async def test_verify_dispatches_to_v2_for_new_row(fresh_db):
+    """A v2 row (default for new appends) must verify via compute_entry_hash_v2."""
+    s = await append_local_audit(event_type="new", org_id="newco")
+    ok, reason = await verify_local_chain("newco")
+    assert ok, reason
+    # Sanity check: the stored hash matches the v2 form
+    async with get_db() as conn:
+        row = (await conn.execute(
+            text(
+                "SELECT entry_hash, hash_format FROM local_audit "
+                " WHERE org_id = 'newco' AND chain_seq = 1"
+            )
+        )).first()
+    assert row[1] == HASH_FORMAT_V2
+    assert row[0] == s["entry_hash"]
+
+
+# ─── v1 vs v2 hash collision impossibility ───
+
+
+def test_v1_v2_hash_forms_cryptographically_distinct():
+    """The v2 canonical string starts with the literal ``"v2|"`` while
+    v1 starts with an integer entry_id. SHA-256 collisions across
+    distinct preimages are negligible — but the discriminator means
+    the preimage spaces don't even overlap."""
+    from datetime import datetime, timezone
+    from mcp_proxy.local.audit_chain import compute_entry_hash
+    ts = datetime(2026, 5, 11, 19, 0, 0, tzinfo=timezone.utc)
+    v1 = compute_entry_hash(
+        entry_id=42, timestamp=ts, event_type="x",
+        agent_id=None, session_id=None, org_id="o",
+        result="ok", details=None, previous_hash=None,
+        chain_seq=1, peer_org_id=None,
+    )
+    v2 = compute_entry_hash_v2(
+        timestamp=ts, event_type="x", agent_id=None, session_id=None,
+        org_id="o", result="ok", details=None, previous_hash=None,
+        chain_seq=1, peer_org_id=None,
+    )
+    assert v1 != v2

--- a/tests/test_crit3_audit_append_only.py
+++ b/tests/test_crit3_audit_append_only.py
@@ -41,7 +41,6 @@ from sqlalchemy.exc import DBAPIError
 from mcp_proxy.db import dispose_db, get_db, init_db
 from mcp_proxy.local.audit import append_local_audit, verify_local_chain
 from mcp_proxy.local.audit_chain import (
-    HASH_FORMAT_V1,
     HASH_FORMAT_V2,
     compute_entry_hash_v2,
 )

--- a/tests/test_culk_scope_enforcement.py
+++ b/tests/test_culk_scope_enforcement.py
@@ -62,6 +62,34 @@ async def app_with_real_dep(tmp_path, monkeypatch):
     get_settings.cache_clear()
     await init_db(url)
 
+    # CRIT-3 PR rebase note: PR #614 (this branch) merged main which
+    # now contains the C3 fix from PR #605 — mint_user_api_token
+    # refuses unknown principal_ids. Seed the orga::user::* names
+    # used by the tests in this file so the existing mints succeed.
+    # When PR #605 lands the shared helper in tests/_token_test_helpers.py
+    # supersedes this inline seed; until then keep the rows local.
+    from datetime import datetime, timezone
+    from sqlalchemy import text as _sql_text
+    from mcp_proxy.db import get_db as _get_db
+    _now = datetime.now(timezone.utc).isoformat()
+    async with _get_db() as _conn:
+        for _name in (
+            "alice", "bob", "carol", "dave", "eve", "erin",
+            "frank", "ferris", "grace", "heidi", "ivan",
+        ):
+            await _conn.execute(
+                _sql_text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, reach, surface, created_at) "
+                    "VALUES (:pid, :name, 'intra', NULL, :now)"
+                ),
+                {
+                    "pid": f"orga::user::{_name}",
+                    "name": _name,
+                    "now": _now,
+                },
+            )
+
     async def fake_list_available_models(enabled):
         return [
             {"id": "claude-haiku-4-5", "object": "model", "owned_by": "anthropic"},

--- a/tests/test_proxy_local_audit_chain.py
+++ b/tests/test_proxy_local_audit_chain.py
@@ -81,9 +81,15 @@ async def test_verify_local_chain_intact(fresh_db):
 async def test_verify_local_chain_detects_tampering(fresh_db):
     await append_local_audit(event_type="session_opened", org_id="acme")
     await append_local_audit(event_type="message_sent", org_id="acme")
-    # Tamper: rewrite details on the second row so the stored entry_hash
-    # no longer matches the canonical recomputation.
+    # Tamper: simulate an attacker with raw DB write that bypasses the
+    # CRIT-3 trigger (e.g. owns the DB host, dropped the trigger).
+    # We drop the SQLite triggers locally then mutate; on Postgres the
+    # equivalent owner-level DROP is the threat model. After the
+    # mutation, ``verify_local_chain`` must detect the entry_hash
+    # mismatch — the chain is the second layer of defence behind the
+    # trigger.
     async with get_db() as conn:
+        await conn.execute(text("DROP TRIGGER IF EXISTS local_audit_no_update"))
         await conn.execute(
             text("UPDATE local_audit SET details = :d WHERE chain_seq = 2"),
             {"d": '{"forged":true}'},

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0030_user_pubkey_thumbprint",)]
+    assert rows == [("0031_audit_append_only_v2",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0030_user_pubkey_thumbprint",)]
+    assert version == [("0031_audit_append_only_v2",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0030_user_pubkey_thumbprint"
+HEAD_REVISION = "0031_audit_append_only_v2"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0030_user_pubkey_thumbprint"
+HEAD_REVISION = "0031_audit_append_only_v2"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0030_user_pubkey_thumbprint"
+HEAD_REVISION = "0031_audit_append_only_v2"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

Closes audit finding **CRIT-3** (Wave A PR5/5) from \`imp/audits/2026-05-11-track-3-audit-pdp.md\` (F-2) — the largest SOC2 CC7.2 gap in the MASTER report.

**Vector before this PR:** \`local_audit\` claimed "append-only" but every row was inserted with placeholder \`entry_hash=""\` and immediately back-filled via \`UPDATE local_audit SET entry_hash WHERE id\`. The application itself proved the schema accepted UPDATE on the "append-only" table. An attacker with DB write credentials could rewrite or delete rows undetected; the chain only catches forward tamper, and only when an operator clicks "verify".

**Fix:**
1. **\`compute_entry_hash_v2\`** — new canonical form omits \`entry_id\` (uses \`(org_id, chain_seq)\` which is UNIQUE since 0009 + known BEFORE the INSERT). Starts with literal \`"v2|"\` discriminator → v1↔v2 hash collision is cryptographically impossible.
2. **\`append_local_audit\` refactor** — computes hash BEFORE INSERT and writes the row atomically with \`hash_format='v2'\`. Back-fill UPDATE step is **gone**.
3. **Migration 0031** — adds \`hash_format\` column (NULL = legacy v1) + installs BEFORE UPDATE OR DELETE trigger on \`local_audit\` (PostgreSQL \`RAISE EXCEPTION\` + SQLite \`RAISE(ABORT)\`). Trigger blocks both attacker mutation AND old back-fill simultaneously, so the refactor in step 2 is mandatory.
4. **\`verify_local_chain\` dispatch** — NULL/'v1' rows verify against legacy entry_id-bound canonical form; 'v2' rows verify against new form. Legacy rows from older Mastio installs keep verifying — no historical hash migration needed.

## Test plan

- [x] 7 new cases in \`tests/test_crit3_audit_append_only.py\`:
  - append writes hash_format=v2 atomically
  - chain_seq advances per-org, previous_hash links
  - **trigger blocks UPDATE** on local_audit (DBAPIError)
  - **trigger blocks DELETE** on local_audit (DBAPIError)
  - verify dispatches to v1 for legacy rows
  - verify dispatches to v2 for new rows
  - v1 vs v2 hashes cryptographically distinct
- [x] \`tests/test_proxy_local_audit_chain.py::test_verify_local_chain_detects_tampering\` updated: drops trigger first (simulates attacker who owns DB), then asserts \`verify_local_chain\` catches the resulting hash mismatch — the chain is the second layer of defence behind the trigger.
- [x] \`pytest tests/\` → **3222 passed** (8 pre-existing CI-only flakes — connector GUI headless + postgres binding + M3 sweeper TTL — none introduced by this PR; targeted run of the audit chain + crit3 files = 13/13 verde isolated)
- [x] \`./demo_network/smoke.sh full\` → all assertions PASS (cross-org A2A round-trip, dashboard signing key restart-survival, **audit hash chain across 38 entries — confirms new v2 hashes chain correctly across a real workload**)

## SOC2 impact

This was **the** SOC2 CC7.2 blocker per the audit MASTER report:

> "Append-only is application-only. No Postgres triggers, no GRANT separation. \`mcp_proxy/local/audit.py:172\` itself executes \`UPDATE local_audit SET entry_hash = ... WHERE id = ...\` on the 'append-only' table — proving the schema accepts UPDATE. CRIT-3 blocks CC7.2 in a way an assessor will flag immediately."

Post-merge: append-only is enforced at the DB layer (trigger), the application no longer needs UPDATE permission on \`local_audit\`, and the chain integrity proof is independent of any application-side good behaviour.

## Scope notes

- **Court-side equivalent** (\`app/db/audit.py\` global chain) is NOT touched here. Audit T3-F2 named both Mastio and Court tables; closing Court is a follow-up PR (parity test \`tests/test_proxy_audit_chain_parity.py\` would need v2-aware expectations on both sides).
- **Mastio \`audit_log\`** (separate from per-org \`local_audit\`, used by \`db.log_audit\`) — also flagged in the audit, lower-priority. Follow-up.
- **GRANT separation** — a future INSERT-only DB role for the app + DELETE-only role for retention purge would close the threat model where the attacker owns the connection string. Out of scope for this PR.

## Wave A status — COMPLETE

| # | Finding | Status |
|---|---|---|
| 1 | CRIT-1 cert mint + cert-pin | merged #601 |
| 2 | CRIT-2 ingress execute binding | merged #603 |
| 3 | culk_ scope_paths + scope_providers | open #609 |
| 4 | Quick wins D2+B2+C3 | open #605 |
| 4b | E1 delete dead crypto helper | follow-up |
| 5 | **CRIT-3 audit DB trigger + refactor** | **THIS PR** |

Wave B (CRIT-3 Court-side, B1 AI keys at-rest, dual-write Mastio→Court, etc.) tracked separately in MASTER report.