### PR TITLE
chore(frontdesk-bundle): pin cullis-chat-frontdesk to 0.3.0

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -104,7 +104,7 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
   CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0)
-  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.2.0)
+  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.3.0)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
   FRONTDESK_HTTP_PORT                Host port to bind nginx (default: 8080)
@@ -201,7 +201,7 @@ ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
 CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0}"
-CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.2.0}"
+CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.3.0}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"
 HTTP_PORT="$(_load_env FRONTDESK_HTTP_PORT)";         HTTP_PORT="${HTTP_PORT:-8080}"

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -185,7 +185,7 @@ services:
     # + bundled JS/CSS. /api/session/* and /v1/* proxying to the
     # Connector happens in the outer nginx layer below; this inner
     # container only serves static assets.
-    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.2.0}
+    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.3.0}
     expose:
       - "8080"
     depends_on:

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -47,7 +47,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on
 # every ``chat-vX.Y.Z`` tag (matrix build with CULLIS_BRAND=frontdesk).
-# CHAT_VERSION=0.2.0
+# CHAT_VERSION=0.3.0
 
 # -- Optional: bundle behaviour --------------------------------------------
 


### PR DESCRIPTION
Follow-up to tag \`chat-v0.3.0\`. Now that the release-chat workflow has published \`ghcr.io/cullis-security/cullis-chat-frontdesk:0.3.0\`, the three CHAT_VERSION defaults in the Frontdesk bundle move off the 0.2.0 pin.

## What changes

Three locations bumped \`0.2.0\` → \`0.3.0\` per \`feedback_release_pipeline_asymmetry_deploy_vs_compose\` (compose / deploy.sh / env.example must move together):

- \`packaging/frontdesk-bundle/docker-compose.yml\`: image default fallback in the \`cullis-chat\` service.
- \`packaging/frontdesk-bundle/deploy.sh\`: env default at runtime + help text.
- \`packaging/frontdesk-bundle/frontdesk.env.example\`: commented-out default.

Operators with \`CHAT_VERSION\` pinned explicitly are unaffected. Stock-defaults operators pick up \`0.3.0\` on the next \`deploy.sh\` run, which includes:

- Sprint 1 conversation history sidebar + auto-persist (#610, #611, #612 e2e)
- Phone breakpoint + WCAG touch targets (#613)
- ADR-029 sandbox demo wiring (#608, sandbox-only env vars, no impact on Frontdesk bundle behaviour)

## Test plan

- [x] grep for \`0.2.0\` in \`packaging/frontdesk-bundle/\` returns only historical doc references (pre-v0.2.0 compat notes), no live pin.
- [ ] CI smoke (modifiche solo a \`packaging/\`, niente codice).
- [ ] Manual: \`deploy.sh\` su VPS pulla \`cullis-chat-frontdesk:0.3.0\`.

🔒 Docs / packaging only. /security-review skippable per \`feedback_security_review_per_pr\`.