### PR TITLE
fix(mastio): dashboard SSRF/XSS + temp pwd ticket store (Wave B PR1)

### DIFF
--- a/mcp_proxy/dashboard/_pwd_tickets.py
+++ b/mcp_proxy/dashboard/_pwd_tickets.py
@@ -1,0 +1,84 @@
+"""One-shot temp-password ticket store (Wave B G2 fix).
+
+Audit ref: imp/audits/2026-05-11-track-6-ai-frontdesk.md H-1.
+
+Pre-fix the dashboard create-user / reset-password handlers redirected
+to ``/proxy/users/<pid>?new_pw=<cleartext>`` so the receiving page
+could render the temp password in a banner. The cleartext landed in
+nginx access logs, the admin's browser history, and Referer headers
+sent to any external link the dashboard contains.
+
+Post-fix the redirect carries an opaque ticket id; this module mints
+the ticket + stores the cleartext server-side with a short TTL +
+single-consume semantics. The detail page reads the ticket once, the
+store deletes it. Process-local dict is sufficient: Mastio runs
+single-process per container in the documented deployment shape; a
+future Frontdesk shared-mode deploy with workers > 1 would need to
+move this to Redis (the same store the DPoP JTI cache uses).
+"""
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass
+
+
+# Time-to-live for a minted ticket. 90 seconds is comfortable for
+# admin "click create → read banner" UX without giving a stolen ticket
+# a long replay window. Tickets are also single-consume — the dict
+# pop on read makes a second GET impossible.
+TICKET_TTL_SECONDS = 90.0
+
+
+@dataclass(frozen=True)
+class _StoredTicket:
+    cleartext: str
+    expires_at: float
+
+
+_store: dict[str, _StoredTicket] = {}
+
+
+def mint_password_ticket(cleartext: str) -> str:
+    """Return an opaque ticket id bound to ``cleartext`` for ``TICKET_TTL_SECONDS``.
+
+    Caller (mint flow) embeds the returned id in the redirect URL
+    instead of the cleartext password. The detail-page handler then
+    calls :func:`consume_password_ticket` to recover + render the
+    cleartext, and the store drops the ticket on read.
+    """
+    _evict_expired()
+    ticket = secrets.token_urlsafe(24)
+    _store[ticket] = _StoredTicket(
+        cleartext=cleartext,
+        expires_at=time.monotonic() + TICKET_TTL_SECONDS,
+    )
+    return ticket
+
+
+def consume_password_ticket(ticket: str | None) -> str | None:
+    """Pop + return the cleartext bound to ``ticket``, or None on miss.
+
+    Single-consume: the second call with the same ticket returns None.
+    Expired tickets also return None (and are dropped from the store
+    in the same call).
+    """
+    if not ticket:
+        return None
+    _evict_expired()
+    stored = _store.pop(ticket, None)
+    if stored is None:
+        return None
+    if stored.expires_at < time.monotonic():
+        return None
+    return stored.cleartext
+
+
+def _evict_expired() -> None:
+    """Drop entries past their TTL. Kept simple — O(n) in the size of
+    the store; in practice the store has at most a handful of entries
+    at any time."""
+    now = time.monotonic()
+    expired = [k for k, v in _store.items() if v.expires_at < now]
+    for k in expired:
+        _store.pop(k, None)

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -146,6 +146,53 @@ def generate_org_ca(org_id: str) -> tuple[str, str]:
     return cert_pem, key_pem
 
 
+# Wave B G1 (audit 2026-05-11) — SSRF guard for the dashboard's three
+# outbound-fetch test endpoints (test-connection / test-webhook /
+# vault/test). Refuses loopback / RFC1918 / link-local / reserved IPs
+# unless ``allow_private=True`` (the Vault case in docker-compose).
+# Resolves the hostname so a public DNS that points at 127.0.0.1
+# can't bypass the check via a CNAME.
+def _enforce_safe_outbound_url(url: str, *, allow_private: bool = False) -> None:
+    """Raise ValueError when ``url`` resolves to a forbidden target.
+
+    The check parses the URL, resolves the hostname, and inspects every
+    returned IP. ``allow_private=True`` skips the RFC1918/loopback ban
+    for legitimate same-network targets (Vault, dev fixtures); the
+    hostname-resolution + scheme check still fires."""
+    import ipaddress
+    import socket
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Only http(s) URLs are allowed (got scheme {parsed.scheme!r})"
+        )
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("URL has no hostname")
+    if not allow_private and hostname in (
+        "localhost", "127.0.0.1", "::1", "0.0.0.0",
+    ):
+        raise ValueError(f"URL points to loopback address: {hostname}")
+    try:
+        addrs = socket.getaddrinfo(
+            hostname, parsed.port or (443 if parsed.scheme == "https" else 80),
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve hostname: {hostname}") from exc
+    for _family, _type, _proto, _canonname, sockaddr in addrs:
+        ip = ipaddress.ip_address(sockaddr[0])
+        if not allow_private and (
+            ip.is_private or ip.is_loopback
+            or ip.is_link_local or ip.is_reserved
+        ):
+            raise ValueError(
+                f"URL resolves to private/reserved IP: {ip}"
+            )
+
+
 async def _test_vault_connectivity(vault_addr: str, vault_token: str) -> tuple[bool, str]:
     """Test Vault connectivity. Returns (success, message)."""
     import httpx
@@ -1126,9 +1173,22 @@ async def _setup_submit_standalone(
 @router.post("/setup/test-connection")
 async def setup_test_connection(request: Request):
     """HTMX endpoint: test broker connectivity."""
+    import html as _html
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
+
+    # Wave B G1 (audit 2026-05-11) — verify CSRF on this state-affecting
+    # outbound-fetch endpoint, refuse RFC1918 / loopback / link-local
+    # targets, and HTML-escape any exception text we render. Pre-fix
+    # the handler did none of the three: any cross-site page that the
+    # admin visited could trigger arbitrary outbound HTTP from the
+    # Mastio host; ``Connection failed: {exc}`` echoed httpx error
+    # text containing the URL into innerHTML which reflected XSS.
+    if not await verify_csrf(request, session):
+        return HTMLResponse(
+            '<span class="text-red-400">CSRF check failed</span>'
+        )
 
     form = await request.form()
     broker_url = str(form.get("broker_url", "")).strip()
@@ -1136,6 +1196,13 @@ async def setup_test_connection(request: Request):
     if not broker_url:
         return HTMLResponse(
             '<span class="text-red-400">Enter a broker URL first</span>'
+        )
+
+    try:
+        _enforce_safe_outbound_url(broker_url)
+    except ValueError as exc:
+        return HTMLResponse(
+            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
         )
 
     try:
@@ -1153,7 +1220,8 @@ async def setup_test_connection(request: Request):
             )
     except Exception as exc:
         return HTMLResponse(
-            f'<span class="text-red-400">Connection failed: {exc}</span>'
+            f'<span class="text-red-400">Connection failed: '
+            f'{_html.escape(str(exc))}</span>'
         )
 
 
@@ -1781,15 +1849,27 @@ async def policies_save(request: Request):
 @router.post("/policies/test-webhook")
 async def policies_test_webhook(request: Request):
     """HTMX endpoint: test PDP webhook connectivity."""
+    import html as _html
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
+
+    # Wave B G1 — verify CSRF + SSRF allow-list + escape exception text
+    if not await verify_csrf(request, session):
+        return HTMLResponse('<span class="text-red-400">CSRF check failed</span>')
 
     form = await request.form()
     webhook_url = str(form.get("pdp_url", "")).strip()
 
     if not webhook_url:
         return HTMLResponse('<span class="text-red-400">Enter a webhook URL first</span>')
+
+    try:
+        _enforce_safe_outbound_url(webhook_url)
+    except ValueError as exc:
+        return HTMLResponse(
+            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
+        )
 
     try:
         import httpx
@@ -1812,7 +1892,8 @@ async def policies_test_webhook(request: Request):
             )
     except Exception as exc:
         return HTMLResponse(
-            f'<span class="text-red-400">Connection failed: {exc}</span>'
+            f'<span class="text-red-400">Connection failed: '
+            f'{_html.escape(str(exc))}</span>'
         )
 
 
@@ -2726,9 +2807,17 @@ async def vault_save(request: Request):
 @router.post("/vault/test")
 async def vault_test(request: Request):
     """HTMX endpoint: test Vault connectivity."""
+    import html as _html
     session = require_login(request)
     if isinstance(session, RedirectResponse):
         return HTMLResponse('<span class="text-red-400">Not authenticated</span>')
+
+    # Wave B G1 — verify CSRF + SSRF allow-list (Vault behind a docker
+    # network is the legitimate case; ``allow_private=True`` honours
+    # the same flag that PDP webhooks use, so docker-compose vault://
+    # addresses keep working).
+    if not await verify_csrf(request, session):
+        return HTMLResponse('<span class="text-red-400">CSRF check failed</span>')
 
     form = await request.form()
     vault_addr = str(form.get("vault_addr", "")).strip()
@@ -2736,6 +2825,13 @@ async def vault_test(request: Request):
 
     if not vault_addr:
         return HTMLResponse('<span class="text-red-400">Enter a Vault address first</span>')
+
+    try:
+        _enforce_safe_outbound_url(vault_addr, allow_private=True)
+    except ValueError as exc:
+        return HTMLResponse(
+            f'<span class="text-red-400">{_html.escape(str(exc))}</span>'
+        )
 
     if not vault_token:
         # Try stored token
@@ -2752,7 +2848,7 @@ async def vault_test(request: Request):
             '<span class="w-2 h-2 rounded-full bg-emerald-500 inline-block"></span>'
             'Vault connected and unsealed</span>'
         )
-    return HTMLResponse(f'<span class="text-red-400">{msg}</span>')
+    return HTMLResponse(f'<span class="text-red-400">{_html.escape(msg)}</span>')
 
 
 @router.post("/vault/migrate-keys")
@@ -3457,13 +3553,18 @@ async def users_create(request: Request):
 
     # Redirect to the per-user detail page rather than the list — the
     # banner with the one-time temp password lands where the admin is
-    # most likely to dwell (and where they can click Reset Password
-    # again if they lose the value). On the list page the banner is
-    # easy to miss and gone the moment the admin clicks anywhere else.
+    # most likely to dwell. Wave B G2 (audit 2026-05-11): the cleartext
+    # password used to ride in ``?new_pw=`` and landed in nginx logs +
+    # browser history + Referer headers. Now the redirect carries an
+    # opaque single-consume ticket; the detail page resolves it
+    # server-side and renders the password without ever putting it on
+    # the wire as a URL parameter.
     from urllib.parse import quote
+    from mcp_proxy.dashboard._pwd_tickets import mint_password_ticket
     target_pid = f"{org_id}::user::{user_name}" if org_id else f"::user::{user_name}"
+    ticket = mint_password_ticket(temp_password)
     return RedirectResponse(
-        f"/proxy/users/{quote(target_pid, safe='')}?new_pw={quote(temp_password)}",
+        f"/proxy/users/{quote(target_pid, safe='')}?new_pw_ticket={quote(ticket)}",
         status_code=303,
     )
 
@@ -3512,8 +3613,32 @@ async def user_detail_page(principal_id: str, request: Request):
     except Exception:
         org_id, trust_domain = "", "cullis.local"
 
-    reset_temp_password = request.query_params.get("reset_pw")
-    new_user_temp_password = request.query_params.get("new_pw")
+    # Wave B G2 (audit 2026-05-11) — resolve the single-consume tickets
+    # carried in the redirect URL. Tickets pop on read; a refresh of
+    # this page does not re-render the cleartext. Pre-fix the
+    # cleartext rode in ``?new_pw=`` / ``?reset_pw=`` and landed in
+    # nginx logs / browser history / Referer headers.
+    from mcp_proxy.dashboard._pwd_tickets import consume_password_ticket
+    reset_temp_password = consume_password_ticket(
+        request.query_params.get("reset_pw_ticket")
+    )
+    new_user_temp_password = consume_password_ticket(
+        request.query_params.get("new_pw_ticket")
+    )
+    # Back-compat: if a stale page has the old URL shape, still render
+    # the cleartext but log a warning so operators notice.
+    if reset_temp_password is None and request.query_params.get("reset_pw"):
+        _log.warning(
+            "user_detail_page: legacy reset_pw URL parameter received "
+            "(post-G2 the create-user/reset-pwd handlers should redirect "
+            "with reset_pw_ticket instead)",
+        )
+        reset_temp_password = request.query_params.get("reset_pw")
+    if new_user_temp_password is None and request.query_params.get("new_pw"):
+        _log.warning(
+            "user_detail_page: legacy new_pw URL parameter received",
+        )
+        new_user_temp_password = request.query_params.get("new_pw")
     action_message = request.query_params.get("ok")
     error = request.query_params.get("error")
 
@@ -3600,9 +3725,12 @@ async def users_reset_password(principal_id: str, request: Request):
             status_code=303,
         )
 
+    # Wave B G2 — single-consume ticket instead of cleartext in URL.
     from urllib.parse import quote
+    from mcp_proxy.dashboard._pwd_tickets import mint_password_ticket
+    ticket = mint_password_ticket(new_pw)
     return RedirectResponse(
-        f"/proxy/users/{quote(principal_id)}?reset_pw={quote(new_pw)}",
+        f"/proxy/users/{quote(principal_id)}?reset_pw_ticket={quote(ticket)}",
         status_code=303,
     )
 

--- a/tests/test_dashboard_users_via_ambassador.py
+++ b/tests/test_dashboard_users_via_ambassador.py
@@ -210,7 +210,14 @@ async def test_users_create_forwards_to_ambassador_and_redirects_to_detail(
             assert r.status_code == 303, r.text
             loc = r.headers["location"]
             assert "/proxy/users/" in loc
-            assert "new_pw=" in loc, "temp password must be in redirect query"
+            # Wave B G2 (audit 2026-05-11) — redirect now carries an
+            # opaque single-consume ticket instead of the cleartext
+            # password. The detail page resolves the ticket to the
+            # cleartext server-side; pre-fix the cleartext was in the
+            # URL and landed in nginx logs / browser history / Referer.
+            assert "new_pw_ticket=" in loc, (
+                "temp password ticket must be in redirect query"
+            )
     # Forwarded call shape
     assert len(calls) == 1
     c = calls[0]
@@ -295,7 +302,8 @@ async def test_users_reset_password_forwards_and_surfaces_new_temp(
             )
             assert r.status_code == 303, r.text
             loc = r.headers["location"]
-            assert "reset_pw=" in loc
+            # Wave B G2 — opaque ticket replaces cleartext password.
+            assert "reset_pw_ticket=" in loc
     assert len(calls) == 1
     c = calls[0]
     assert c["method"] == "POST"
@@ -458,7 +466,10 @@ async def test_plaintext_temp_password_never_logged(tmp_path, monkeypatch):
             # with error), but for the leak check we just want to verify
             # that whatever 16-char strings might exist NEVER end up in
             # _log calls. So we synthesise a probe password too.
-            assert "new_pw=" in loc or "Frontdesk+rejected" in loc, loc
+            # Wave B G2 — opaque ticket replaces cleartext password.
+            assert (
+                "new_pw_ticket=" in loc or "Frontdesk+rejected" in loc
+            ), loc
 
     # No log entry may carry a 16-char unambiguous string that matches
     # the alphabet — that would be a leak. Heuristic: scan every arg

--- a/tests/test_wave_b_pr1_dashboard_security.py
+++ b/tests/test_wave_b_pr1_dashboard_security.py
@@ -1,0 +1,138 @@
+"""Wave B PR1 — G1 dashboard SSRF/XSS + G2 temp pwd URL leak.
+
+Audit refs:
+  - imp/audits/2026-05-11-track-7-owasp-frontend.md H-1 (SSRF + XSS
+    in 3 dashboard test endpoints)
+  - imp/audits/2026-05-11-track-6-ai-frontdesk.md H-1 (temp password
+    leak via URL query string)
+"""
+from __future__ import annotations
+
+import pytest
+import time
+
+from mcp_proxy.dashboard import _pwd_tickets
+
+
+# ─── G2 — one-shot password ticket store ───
+
+
+def test_g2_ticket_round_trip_returns_cleartext_once():
+    ticket = _pwd_tickets.mint_password_ticket("hunter2-DEMO")
+    assert ticket
+    assert _pwd_tickets.consume_password_ticket(ticket) == "hunter2-DEMO"
+    # Single-consume: second call returns None.
+    assert _pwd_tickets.consume_password_ticket(ticket) is None
+
+
+def test_g2_unknown_ticket_returns_none():
+    assert _pwd_tickets.consume_password_ticket("not-a-real-ticket") is None
+    assert _pwd_tickets.consume_password_ticket(None) is None
+    assert _pwd_tickets.consume_password_ticket("") is None
+
+
+def test_g2_ticket_expires_after_ttl(monkeypatch):
+    """Pre-fix the cleartext in ``?new_pw=`` had an unbounded
+    lifetime (every refresh re-rendered it). Post-fix the ticket
+    expires after TICKET_TTL_SECONDS."""
+    monkeypatch.setattr(_pwd_tickets, "TICKET_TTL_SECONDS", 0.05)
+    ticket = _pwd_tickets.mint_password_ticket("expires-fast")
+    time.sleep(0.1)
+    assert _pwd_tickets.consume_password_ticket(ticket) is None
+
+
+def test_g2_ticket_id_is_unguessable():
+    """The ticket id is the only thing on the wire. ``token_urlsafe(24)``
+    yields ~144 bits of entropy."""
+    tickets = {_pwd_tickets.mint_password_ticket("p") for _ in range(50)}
+    assert len(tickets) == 50  # zero collisions
+    for t in tickets:
+        assert len(t) >= 30  # base64-urlsafe of 24 bytes is 32 chars
+
+
+# ─── G1 — _enforce_safe_outbound_url helper ───
+
+
+def test_g1_helper_rejects_loopback():
+    from mcp_proxy.dashboard.router import _enforce_safe_outbound_url
+    for url in (
+        "http://127.0.0.1:8080/foo",
+        "http://localhost/foo",
+        "http://[::1]/foo",
+    ):
+        with pytest.raises(ValueError, match="loopback"):
+            _enforce_safe_outbound_url(url)
+
+
+def test_g1_helper_rejects_rfc1918_after_resolution(monkeypatch):
+    """A hostname that resolves to a private IP is refused. We
+    monkeypatch socket.getaddrinfo so the test does not depend on
+    real DNS."""
+    import socket
+    from mcp_proxy.dashboard import router
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "",
+                 ("10.0.0.5", port or 80))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    with pytest.raises(ValueError, match="private"):
+        router._enforce_safe_outbound_url("https://attacker.example.com/path")
+
+
+def test_g1_helper_rejects_link_local(monkeypatch):
+    import socket
+    from mcp_proxy.dashboard import router
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "",
+                 ("169.254.169.254", port or 80))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    # Cloud metadata — the textbook SSRF target.
+    with pytest.raises(ValueError, match="private|reserved"):
+        router._enforce_safe_outbound_url("http://metadata.example.com/")
+
+
+def test_g1_helper_rejects_non_http_scheme():
+    from mcp_proxy.dashboard.router import _enforce_safe_outbound_url
+    with pytest.raises(ValueError, match="scheme"):
+        _enforce_safe_outbound_url("file:///etc/passwd")
+    with pytest.raises(ValueError, match="scheme"):
+        _enforce_safe_outbound_url("gopher://attacker/")
+
+
+def test_g1_helper_allows_public_when_dns_returns_public(monkeypatch):
+    import socket
+    from mcp_proxy.dashboard import router
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        # 8.8.8.8 is unambiguously public (not reserved/private/loopback).
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "",
+                 ("8.8.8.8", port or 443))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    # No raise — public IP passes.
+    router._enforce_safe_outbound_url("https://api.example.com/")
+
+
+def test_g1_helper_allow_private_skips_rfc1918_check(monkeypatch):
+    """``allow_private=True`` is the legitimate Vault-in-docker case:
+    refuses scheme-mismatch but lets RFC1918 through."""
+    import socket
+    from mcp_proxy.dashboard import router
+
+    def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "",
+                 ("172.18.0.5", port or 8200))]
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    # Private IP allowed when explicitly opted in.
+    router._enforce_safe_outbound_url(
+        "http://vault:8200/", allow_private=True,
+    )
+    # But scheme check still fires.
+    with pytest.raises(ValueError, match="scheme"):
+        router._enforce_safe_outbound_url(
+            "file:///etc/shadow", allow_private=True,
+        )


### PR DESCRIPTION
## Summary

Closes 2 audit HIGH findings as **Wave B PR1**:

### G1 — dashboard SSRF + reflected XSS (audit T7-H-1)
\`POST /proxy/setup/test-connection\`, \`/proxy/policies/test-webhook\`, \`/proxy/vault/test\` fetched form-supplied URLs via httpx with **no CSRF**, **no SSRF allow-list**, and **no \`html.escape\`** on the reflected exception text.

**Fix:**
- \`verify_csrf\` on all three handlers
- New \`_enforce_safe_outbound_url(url, allow_private=False)\` helper in \`mcp_proxy/dashboard/router.py\`: scheme allow-list (http/https only), DNS-resolves the hostname, refuses every IP that's loopback / private / link-local / reserved (cloud metadata!). Vault path uses \`allow_private=True\` (docker-compose Vault is the legitimate case)
- \`html.escape(str(exc))\` on every reflected exception text

### G2 — temp password leak via URL query string (audit T6-H-1)
\`users_create\` + \`users_reset_password\` redirected with \`?new_pw=<cleartext>\` / \`?reset_pw=<cleartext>\`. The cleartext landed in nginx access logs, browser history, and Referer headers.

**Fix:**
- New \`mcp_proxy/dashboard/_pwd_tickets.py\` mints opaque single-consume tickets bound to cleartext server-side with **90s TTL**
- Redirects carry \`?new_pw_ticket=<opaque>\` / \`?reset_pw_ticket=<opaque>\`
- \`user_detail_page\` resolves once via \`consume_password_ticket\`; store deletes on read
- Page refresh after read does NOT re-render the cleartext
- Back-compat: legacy \`?new_pw=\`/\`?reset_pw=\` URLs still work but log a warning

## Test plan

- [x] 10 new cases in \`tests/test_wave_b_pr1_dashboard_security.py\`:
  - **G2:** ticket round-trip + single-consume, unknown ticket → None, expiry after TTL, ~144 bits entropy zero collisions over 50 mints
  - **G1:** rejects loopback (127.0.0.1, localhost, ::1), rejects RFC1918 after DNS, rejects link-local + reserved (cloud metadata), rejects non-http(s) schemes, allows true public IP, \`allow_private=True\` skips RFC1918 ban
- [x] \`pytest tests/test_dashboard_*.py tests/test_proxy_dashboard_mcp_resources.py tests/test_admin_users.py\` → **63 passed** (no regressions)

## Wave B status

| # | Finding | Status |
|---|---|---|
| 1 | G1 dashboard SSRF/XSS + G2 temp pwd URL | **THIS PR** |
| 2 | F1 Tailwind SHA + F3 Helm defaults | next |
| 3 | C2 mTLS header + B3 AI probe + D3 OPA SSRF | queued |
| 4 | B1 AI provider creds at-rest | queued |
| 5 | CRIT-3 Court + audit_log global | queued |
| 6 | E1 delete dead crypto helper | queued |
| 7 | C1 LOCAL_TOKEN decision | queued |
| 8 | D1 dual-write decision | queued |
| 9 | F2 git filter-repo demo secrets | queued (needs auth) |