### PR TITLE
feat(mastio): ADR-029 Phase G, dynamic federation URL lookup via Court

### DIFF
--- a/alembic/versions/q7l8m9n0o1p2_org_mastio_url.py
+++ b/alembic/versions/q7l8m9n0o1p2_org_mastio_url.py
@@ -1,0 +1,37 @@
+"""ADR-029 Phase G — organizations.mastio_url
+
+Revision ID: q7l8m9n0o1p2
+Revises: p6k7l8m9n0o1
+Create Date: 2026-05-11 21:00:00.000000
+
+Per-org URL where the org's Mastio is reachable for cross-org PDP
+federation calls (POST /v1/policy/tool-call). Until Phase G this had
+to be wired into each originator Mastio's
+``MCP_PROXY_TOOL_PDP_FEDERATION_URLS`` env JSON map by hand; Phase G
+moves the source of truth into the Court registry so onboarding is
+the only place an operator types the URL.
+
+Nullable: orgs that have not yet published a URL are excluded from
+the catalog; the originator falls back to the env JSON map first
+and, on miss, default-denies the cross-org invocation (same
+conservative posture as before Phase G).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "q7l8m9n0o1p2"
+down_revision = "p6k7l8m9n0o1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "organizations",
+        sa.Column("mastio_url", sa.String(length=512), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("organizations", "mastio_url")

--- a/app/federation/read.py
+++ b/app/federation/read.py
@@ -17,6 +17,7 @@ import logging
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.primitives import serialization
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.jwt import get_current_agent
@@ -27,6 +28,7 @@ from app.registry.binding_store import get_approved_binding
 from app.registry.models import (
     AgentListResponse, AgentPublicKeyResponse, AgentResponse,
 )
+from app.registry.org_store import get_org_by_id
 from app.registry.store import get_agent_by_id, list_agents, search_agents
 from app.spiffe import internal_id_to_spiffe
 
@@ -197,3 +199,45 @@ async def get_federated_agent(
 
     trust_domain = get_settings().trust_domain
     return _as_agent_response(agent, trust_domain)
+
+
+class MastioUrlResponse(BaseModel):
+    """ADR-029 Phase G payload for cross-org Mastio URL discovery."""
+    org_id: str
+    mastio_url: str
+
+
+@router.get(
+    "/orgs/{org_id}/mastio-url",
+    response_model=MastioUrlResponse,
+    responses={404: {"description": "Org unknown or no URL published"}},
+)
+async def get_org_mastio_url(
+    org_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """ADR-029 Phase G — discover where a peer org's Mastio answers PDP
+    federation calls (``POST /v1/policy/tool-call``).
+
+    Unauthenticated, on purpose: this URL is operational metadata that
+    every federating Mastio needs to resolve before it can authenticate
+    a call to that peer. The same shape as ``/.well-known/jwks.json`` or
+    the A2A agent cards under ``/v1/a2a/agents/.../.well-known/agent.json``
+    — public infrastructure discovery, no secret material exposed.
+
+    Only orgs with status ``active`` AND a published ``mastio_url`` are
+    visible. Unknown orgs, pending/rejected orgs, and orgs that have not
+    set the URL collapse to a single 404 so the endpoint cannot be used
+    to enumerate the registry beyond what is already public.
+    """
+    org = await get_org_by_id(db, org_id)
+    if (
+        not org
+        or org.status != "active"
+        or not org.mastio_url
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="org unknown or no mastio_url published",
+        )
+    return MastioUrlResponse(org_id=org.org_id, mastio_url=org.mastio_url)

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -16,7 +16,7 @@ from typing import Any
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.primitives.asymmetric import rsa as rsa_types
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
@@ -579,6 +579,64 @@ async def patch_org_require_mastio_mtls(
     return {
         "org_id": org_id,
         "require_mastio_mtls": body.require_mastio_mtls,
+    }
+
+
+class MastioUrlPatchRequest(BaseModel):
+    """ADR-029 Phase G — set or clear the URL where this org's Mastio
+    answers cross-org tool-call PDP federation requests.
+    """
+    mastio_url: str | None = Field(default=None, max_length=512)
+
+    @field_validator("mastio_url")
+    @classmethod
+    def _normalise(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        v = v.strip()
+        if not v:
+            return None
+        if not (v.startswith("http://") or v.startswith("https://")):
+            raise ValueError("mastio_url must be an http:// or https:// URL")
+        return v.rstrip("/")
+
+
+@admin_router.patch("/orgs/{org_id}/mastio-url",
+                    dependencies=[Depends(_require_admin)])
+async def patch_org_mastio_url(
+    org_id: str,
+    body: MastioUrlPatchRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """ADR-029 Phase G — publish or clear the URL where this org's
+    Mastio answers cross-org tool-call PDP federation calls
+    (``POST /v1/policy/tool-call``).
+
+    The value is exposed unauthenticated through ``GET /v1/federation/
+    orgs/{org_id}/mastio-url`` so every peer Mastio discovers it at
+    PDP-evaluation time instead of being wired manually into each
+    peer's ``MCP_PROXY_TOOL_PDP_FEDERATION_URLS`` env JSON.
+
+    Body ``{mastio_url: null}`` clears the published value → callers
+    see 404 again and the federation catalog falls back to env-map +
+    default-deny.
+    """
+    org = await get_org_by_id(db, org_id)
+    if org is None:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND, detail="Organization not found",
+        )
+
+    org.mastio_url = body.mastio_url
+    await db.commit()
+    await log_event(
+        db, "admin.mastio_url_patched", "ok",
+        org_id=org_id,
+        details={"cleared": body.mastio_url is None},
+    )
+    return {
+        "org_id": org_id,
+        "mastio_url": body.mastio_url,
     }
 
 

--- a/app/registry/org_router.py
+++ b/app/registry/org_router.py
@@ -44,6 +44,9 @@ class OrgResponse(BaseModel):
     display_name: str
     status: str
     registered_at: datetime
+    # ADR-029 Phase G — URL where this org's Mastio answers cross-org
+    # tool-call PDP federation. None until the operator publishes it.
+    mastio_url: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -65,6 +68,7 @@ async def register_organization(
         display_name=org.display_name,
         status=org.status,
         registered_at=org.registered_at,
+        mastio_url=org.mastio_url,
     )
 
 
@@ -79,6 +83,7 @@ async def list_organizations(db: AsyncSession = Depends(get_db)):
             display_name=o.display_name,
             status=o.status,
             registered_at=o.registered_at,
+            mastio_url=o.mastio_url,
         )
         for o in orgs
     ]
@@ -111,6 +116,7 @@ async def get_own_organization(
         display_name=org.display_name,
         status=org.status,
         registered_at=org.registered_at,
+        mastio_url=org.mastio_url,
     )
 
 
@@ -126,6 +132,7 @@ async def get_organization(org_id: str, db: AsyncSession = Depends(get_db)):
         display_name=org.display_name,
         status=org.status,
         registered_at=org.registered_at,
+        mastio_url=org.mastio_url,
     )
 
 

--- a/app/registry/org_store.py
+++ b/app/registry/org_store.py
@@ -62,6 +62,14 @@ class OrganizationRecord(Base):
     require_mastio_mtls = Column(
         Boolean, nullable=False, default=False, server_default="0",
     )
+    # ADR-029 Phase G — URL where this org's Mastio answers cross-org
+    # tool-call PDP federation (POST /v1/policy/tool-call). The originator
+    # Mastio resolves this through Court (GET /v1/federation/orgs/{id}/
+    # mastio-url) so the operator does not have to wire it manually into
+    # every peer's MCP_PROXY_TOOL_PDP_FEDERATION_URLS env JSON. Nullable —
+    # orgs that have not published a URL fall through to the env-map
+    # fallback, then default-deny.
+    mastio_url = Column(String(512), nullable=True)
 
     def verify_secret(self, plain: str) -> bool:
         return bcrypt.checkpw(plain.encode(), self.secret_hash.encode())

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -1078,11 +1078,13 @@ async def policy_tool_call(request: Request):
         context=body.get("context") if isinstance(body.get("context"), dict) else None,
     )
 
-    # ADR-029 Phase D-2, cross-org federation. If the local decision is
-    # allow and the target lives in a different org, the originator must
-    # also clear the target org's PDP. Default-deny when no federation
-    # URL is configured for the target org so an admin cannot bypass the
-    # target by omission.
+    # ADR-029 Phase D-2 + Phase G, cross-org federation. If the local
+    # decision is allow and the target lives in a different org, the
+    # originator must also clear the target org's PDP. The URL is
+    # resolved via :class:`FederationCatalog` (env override first, then
+    # Court registry with TTL cache, then default-deny on miss) so a
+    # new peer joining the network does not require every other Mastio
+    # to redeploy with an updated env JSON map.
     federated_from_remote = False
     target_field = body.get("target") if isinstance(body.get("target"), dict) else {}
     target_org = (target_field or {}).get("org")
@@ -1098,9 +1100,24 @@ async def policy_tool_call(request: Request):
             call_remote_tool_call_policy,
             intersect_decisions,
         )
+        from mcp_proxy.policy.federation_catalog import FederationCatalog
 
-        fed_map = _runtime_settings.tool_pdp_federation_urls or {}
-        fed_url = fed_map.get(target_org)
+        catalog: FederationCatalog | None = getattr(
+            request.app.state, "federation_catalog", None,
+        )
+        if catalog is None:
+            # Lazy build on first cross-org call. The catalog is cheap
+            # to construct (no I/O until ``resolve``) so we avoid the
+            # startup-order coupling with broker_url initialisation.
+            catalog = FederationCatalog(
+                court_base_url=getattr(
+                    request.app.state, "reverse_proxy_broker_url", None,
+                ),
+                env_map=_runtime_settings.tool_pdp_federation_urls or {},
+            )
+            request.app.state.federation_catalog = catalog
+
+        fed_url = await catalog.resolve(target_org)
         if not fed_url:
             # Conservative default. The originator allowed locally, but
             # without a way to ask the target org we refuse the cross-org
@@ -1109,8 +1126,8 @@ async def policy_tool_call(request: Request):
                 allowed=False,
                 reason=(
                     f"cross-org target '{target_org}' has no federation URL "
-                    f"configured (MCP_PROXY_TOOL_PDP_FEDERATION_URLS); "
-                    f"default-deny"
+                    f"(env override missing AND Court registry has not "
+                    f"published one for this org); default-deny"
                 ),
             )
         else:

--- a/mcp_proxy/policy/federation_catalog.py
+++ b/mcp_proxy/policy/federation_catalog.py
@@ -1,0 +1,194 @@
+"""ADR-029 Phase G — dynamic peer-Mastio URL discovery via Court.
+
+Phase D-2 wired cross-org tool-call PDP federation by having each
+originator Mastio read a static JSON env map
+``MCP_PROXY_TOOL_PDP_FEDERATION_URLS`` (``{org_id: url}``). That works
+for two-org demos but does not scale: every operator has to update
+every peer's env file when a new org joins the network or moves its
+Mastio behind a new URL.
+
+Phase G moves the source of truth into the Court registry. The org
+admin sets the URL once (``PATCH /v1/registry/orgs/{id}/mastio-url``)
+and every other Mastio resolves it at PDP evaluation time via
+``GET /v1/federation/orgs/{id}/mastio-url``. Lookups are cached for
+:data:`_TTL_SECONDS` to bound the hot-path latency cost.
+
+Operator override remains: the env map is consulted **first** and the
+Court lookup only fires when the local config has no entry. This lets
+operators pin a URL temporarily (e.g. during a peer's blue/green
+rollout) without changing Court state.
+
+Failure mode is conservative. If the Court is unreachable, the entry
+is unknown, or the response is malformed, :meth:`resolve` returns
+``None`` and the caller treats it as default-deny — same posture as
+the pre-Phase-G "missing env entry" branch.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass
+
+import httpx
+
+_log = logging.getLogger("mcp_proxy.policy.federation_catalog")
+
+# Cache TTL. Short enough that a freshly published URL is picked up
+# within minutes without a Mastio restart; long enough that PDP
+# evaluation stays cheap under load. The same value is used for
+# negative caching ("Court said 404") so a peer that has not yet
+# published a URL does not flood Court with repeated lookups while
+# its admin is mid-onboarding.
+_TTL_SECONDS = 300.0
+_LOOKUP_TIMEOUT = 3.0  # seconds
+_MAX_URL_LENGTH = 512
+
+
+@dataclass
+class _CacheEntry:
+    """Memoised result of a peer URL resolution.
+
+    ``url`` is ``None`` for negative cache hits (org unknown to Court
+    or no URL published). ``expires_at`` is an absolute monotonic
+    timestamp; entries older than this are refreshed on next access.
+    """
+    url: str | None
+    expires_at: float
+
+
+class FederationCatalog:
+    """Thread-safe peer-URL resolver with TTL cache + env fallback.
+
+    Instances are intended to be long-lived; one per Mastio process
+    suffices. The cache is in-memory only (no Redis, no disk) so a
+    restart drops the cache, which is fine — the first PDP call for
+    each peer pays the Court round-trip once.
+    """
+
+    def __init__(
+        self,
+        *,
+        court_base_url: str | None,
+        env_map: dict[str, str] | None = None,
+        ttl_seconds: float = _TTL_SECONDS,
+    ) -> None:
+        self._court_base_url = (court_base_url or "").rstrip("/") or None
+        self._env_map = dict(env_map or {})
+        self._ttl = ttl_seconds
+        self._cache: dict[str, _CacheEntry] = {}
+        self._lock = asyncio.Lock()
+
+    async def resolve(self, target_org: str) -> str | None:
+        """Return the URL where ``target_org``'s Mastio answers tool-call
+        federation, or ``None`` if it cannot be determined.
+
+        Lookup order:
+
+        1. Env override (``MCP_PROXY_TOOL_PDP_FEDERATION_URLS``).
+        2. Memoised positive or negative cache entry (within TTL).
+        3. Live ``GET /v1/federation/orgs/{org}/mastio-url`` against Court.
+
+        Cache rules: definitive answers from Court (200 with a valid URL,
+        or 404) are cached for ``ttl_seconds``. Transport errors are
+        **not** cached — a flaky Court should not lock out cross-org
+        invocations for the whole TTL, the next PDP call retries.
+        """
+        if not target_org:
+            return None
+
+        env_url = self._env_map.get(target_org)
+        if env_url:
+            return env_url
+
+        if self._court_base_url is None:
+            # No Court uplink configured — cannot resolve dynamically.
+            return None
+
+        now = time.monotonic()
+        async with self._lock:
+            entry = self._cache.get(target_org)
+            if entry is not None and entry.expires_at > now:
+                return entry.url
+
+            url, definitive = await self._fetch_from_court(target_org)
+            if definitive:
+                self._cache[target_org] = _CacheEntry(
+                    url=url, expires_at=now + self._ttl,
+                )
+            return url
+
+    async def _fetch_from_court(
+        self, target_org: str,
+    ) -> tuple[str | None, bool]:
+        """Lookup ``target_org`` at Court.
+
+        Returns ``(url, definitive)``. ``definitive=True`` means the
+        Court answered (200 with a valid URL, or 404) and the result
+        is cacheable. ``definitive=False`` means the lookup failed in
+        a non-deterministic way (timeout, transport error, non-200,
+        malformed body) and the caller should not cache.
+        """
+        endpoint = (
+            f"{self._court_base_url}/v1/federation/orgs/{target_org}/mastio-url"
+        )
+        try:
+            async with httpx.AsyncClient(
+                timeout=_LOOKUP_TIMEOUT, follow_redirects=False,
+            ) as client:
+                resp = await client.get(endpoint)
+        except httpx.TimeoutException:
+            _log.warning(
+                "federation catalog lookup timeout target=%s url=%s",
+                target_org, endpoint,
+            )
+            return None, False
+        except Exception as exc:
+            _log.warning(
+                "federation catalog lookup transport error target=%s url=%s err=%s",
+                target_org, endpoint, exc,
+            )
+            return None, False
+
+        if resp.status_code == 404:
+            # Org unknown or has not published a URL. Negative cache.
+            return None, True
+        if resp.status_code != 200:
+            _log.warning(
+                "federation catalog lookup non-200 target=%s status=%s",
+                target_org, resp.status_code,
+            )
+            return None, False
+
+        try:
+            data = resp.json()
+        except Exception:
+            return None, False
+
+        url = data.get("mastio_url") if isinstance(data, dict) else None
+        if not isinstance(url, str):
+            return None, False
+        url = url.strip()
+        if not url or len(url) > _MAX_URL_LENGTH:
+            return None, False
+        if not (url.startswith("http://") or url.startswith("https://")):
+            # Defensive: should never happen because the admin PATCH
+            # validates the protocol, but the catalog is a security
+            # boundary and a malformed URL would propagate to httpx.
+            _log.warning(
+                "federation catalog rejected non-HTTP URL target=%s url=%s",
+                target_org, url,
+            )
+            return None, False
+        return url.rstrip("/"), True
+
+    def invalidate(self, target_org: str | None = None) -> None:
+        """Drop cache entries.
+
+        Called on admin-triggered events (e.g. an explicit refresh) or
+        by tests. Without an argument, drops the whole cache.
+        """
+        if target_org is None:
+            self._cache.clear()
+        else:
+            self._cache.pop(target_org, None)

--- a/tests/test_federation_catalog.py
+++ b/tests/test_federation_catalog.py
@@ -1,0 +1,272 @@
+"""ADR-029 Phase G, peer-Mastio URL discovery via Court.
+
+Pins :class:`mcp_proxy.policy.federation_catalog.FederationCatalog`:
+
+- Env override wins over Court.
+- Court 200 + valid URL caches a positive entry.
+- Court 404 caches a negative entry.
+- Transport errors do NOT cache (next call retries).
+- Malformed Court responses are treated as miss + non-definitive.
+- ``invalidate`` drops cached entries.
+- Empty target_org / missing Court base URL short-circuit to None.
+"""
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from mcp_proxy.policy.federation_catalog import FederationCatalog
+
+
+def _mock_transport(handler):
+    return httpx.MockTransport(handler)
+
+
+def _client_factory(transport):
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+    return _Client
+
+
+# ── env override ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_env_override_wins_over_court(monkeypatch):
+    """When env map has an entry for the target org, the catalog uses
+    it directly and never opens an HTTP client at all."""
+    hits = {"n": 0}
+
+    def _handler(req):
+        hits["n"] += 1
+        return httpx.Response(200, json={"org_id": "x", "mastio_url": "https://from-court"})
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(
+        court_base_url="https://court.local",
+        env_map={"acme": "https://env-override.local/v1/policy/tool-call"},
+    )
+    url = await cat.resolve("acme")
+    assert url == "https://env-override.local/v1/policy/tool-call"
+    assert hits["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_no_court_no_env_returns_none():
+    """No env entry and no Court uplink configured -> None."""
+    cat = FederationCatalog(court_base_url=None, env_map={})
+    assert await cat.resolve("acme") is None
+
+
+@pytest.mark.asyncio
+async def test_empty_target_org_returns_none():
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("") is None
+
+
+# ── positive Court lookup + caching ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_court_200_caches_positive(monkeypatch):
+    hits = {"n": 0}
+
+    def _handler(req):
+        hits["n"] += 1
+        assert req.url.path == "/v1/federation/orgs/acme/mastio-url"
+        return httpx.Response(
+            200, json={"org_id": "acme", "mastio_url": "https://acme.example/"},
+        )
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local/", env_map={})
+    assert await cat.resolve("acme") == "https://acme.example"  # trailing / stripped
+    assert hits["n"] == 1
+    # Second call hits cache, no HTTP.
+    assert await cat.resolve("acme") == "https://acme.example"
+    assert hits["n"] == 1
+
+
+# ── negative Court lookup + caching ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_court_404_caches_negative(monkeypatch):
+    """A 404 from Court means the org has not published a URL. The
+    catalog caches the miss so we do not flood Court for the whole TTL."""
+    hits = {"n": 0}
+
+    def _handler(req):
+        hits["n"] += 1
+        return httpx.Response(404, json={"detail": "no mastio_url"})
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("ghost") is None
+    assert hits["n"] == 1
+    assert await cat.resolve("ghost") is None
+    assert hits["n"] == 1
+
+
+# ── transport errors do NOT cache ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_transport_error_does_not_cache(monkeypatch):
+    """Flaky Court must not lock out cross-org calls for the TTL.
+    Each call retries until Court is back."""
+    hits = {"n": 0}
+
+    def _handler(req):
+        hits["n"] += 1
+        raise httpx.ConnectError("simulated", request=req)
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("acme") is None
+    assert hits["n"] == 1
+    assert await cat.resolve("acme") is None
+    assert hits["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_court_500_does_not_cache(monkeypatch):
+    """Non-200/404 (e.g. 500, 502) is treated as transient and retried."""
+    hits = {"n": 0}
+
+    def _handler(req):
+        hits["n"] += 1
+        return httpx.Response(500, json={"detail": "internal"})
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("acme") is None
+    assert hits["n"] == 1
+    assert await cat.resolve("acme") is None
+    assert hits["n"] == 2
+
+
+# ── malformed responses ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_json_body_returns_none(monkeypatch):
+    def _handler(req):
+        return httpx.Response(200, content=b"not-json")
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("acme") is None
+
+
+@pytest.mark.asyncio
+async def test_non_http_url_rejected(monkeypatch):
+    """If Court somehow returns ``javascript:...`` or another bogus
+    protocol, the catalog refuses to surface it — defense in depth on
+    top of the admin PATCH validator."""
+    def _handler(req):
+        return httpx.Response(
+            200, json={"org_id": "acme", "mastio_url": "javascript:alert(1)"},
+        )
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("acme") is None
+
+
+@pytest.mark.asyncio
+async def test_missing_mastio_url_field_returns_none(monkeypatch):
+    def _handler(req):
+        return httpx.Response(200, json={"org_id": "acme"})
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("acme") is None
+
+
+# ── invalidate ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_invalidate_specific_entry(monkeypatch):
+    hits = {"n": 0}
+    payloads = [
+        {"org_id": "acme", "mastio_url": "https://first.example"},
+        {"org_id": "acme", "mastio_url": "https://second.example"},
+    ]
+
+    def _handler(req):
+        n = hits["n"]
+        hits["n"] += 1
+        return httpx.Response(200, json=payloads[min(n, len(payloads) - 1)])
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    assert await cat.resolve("acme") == "https://first.example"
+    assert hits["n"] == 1
+    cat.invalidate("acme")
+    assert await cat.resolve("acme") == "https://second.example"
+    assert hits["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_invalidate_all(monkeypatch):
+    hits = {"n": 0}
+
+    def _handler(req):
+        hits["n"] += 1
+        return httpx.Response(
+            200, json={"org_id": "x", "mastio_url": "https://x.example"},
+        )
+
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient",
+        _client_factory(_mock_transport(_handler)),
+    )
+
+    cat = FederationCatalog(court_base_url="https://court.local", env_map={})
+    await cat.resolve("a")
+    await cat.resolve("b")
+    assert hits["n"] == 2
+    cat.invalidate()
+    await cat.resolve("a")
+    await cat.resolve("b")
+    assert hits["n"] == 4

--- a/tests/test_org_mastio_url.py
+++ b/tests/test_org_mastio_url.py
@@ -1,0 +1,170 @@
+"""ADR-029 Phase G — Court endpoints for peer-Mastio URL discovery.
+
+Pins:
+
+- ``PATCH /v1/admin/orgs/{org_id}/mastio-url`` requires admin
+  secret, validates the URL is http(s), normalises (strip + drop
+  trailing slash), and reflects on subsequent GETs.
+- ``GET /v1/federation/orgs/{org_id}/mastio-url`` is unauthenticated
+  and returns 404 collapsing 'org unknown' / 'pending' / 'rejected'
+  / 'no URL published' into a single response shape.
+- Non-active orgs (e.g. pending) never expose a URL even if one was
+  written.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import ADMIN_HEADERS, TestSessionLocal
+
+pytestmark = pytest.mark.asyncio
+
+
+def _unique_org_id(prefix: str = "phaseg") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+async def _register_org(client: AsyncClient, org_id: str) -> None:
+    resp = await client.post(
+        "/v1/registry/orgs",
+        json={
+            "org_id": org_id,
+            "display_name": org_id.upper(),
+            "secret": f"{org_id}-secret",
+        },
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 201, resp.text
+
+
+# ── PATCH happy paths ────────────────────────────────────────────────
+
+
+async def test_patch_sets_url_and_normalises(client):
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    resp = await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": f"  https://{org_id}.local/  "},
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["org_id"] == org_id
+    # Trim + trailing slash dropped.
+    assert body["mastio_url"] == f"https://{org_id}.local"
+
+    # Round-trip via admin GET.
+    resp_get = await client.get(
+        f"/v1/registry/orgs/{org_id}", headers=ADMIN_HEADERS,
+    )
+    assert resp_get.status_code == 200
+    assert resp_get.json()["mastio_url"] == f"https://{org_id}.local"
+
+
+async def test_patch_can_clear_url(client):
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": f"https://{org_id}.local"},
+        headers=ADMIN_HEADERS,
+    )
+    resp = await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": None},
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["mastio_url"] is None
+
+
+# ── PATCH error paths ────────────────────────────────────────────────
+
+
+async def test_patch_rejects_non_http(client):
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    resp = await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": "javascript:alert(1)"},
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 422
+
+
+async def test_patch_without_admin_secret_forbidden(client):
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    resp = await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": f"https://{org_id}.local"},
+        headers={"x-admin-secret": "wrong"},
+    )
+    assert resp.status_code == 403
+
+
+async def test_patch_unknown_org_404(client):
+    resp = await client.patch(
+        "/v1/admin/orgs/ghost-no-exist-12345/mastio-url",
+        json={"mastio_url": "https://ghost.local"},
+        headers=ADMIN_HEADERS,
+    )
+    assert resp.status_code == 404
+
+
+# ── public GET /v1/federation/orgs/{id}/mastio-url ──────────────────
+
+
+async def test_public_get_returns_url_for_active_org(client):
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": f"https://{org_id}.local"},
+        headers=ADMIN_HEADERS,
+    )
+    resp = await client.get(f"/v1/federation/orgs/{org_id}/mastio-url")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "org_id": org_id,
+        "mastio_url": f"https://{org_id}.local",
+    }
+
+
+async def test_public_get_unknown_org_404(client):
+    resp = await client.get("/v1/federation/orgs/ghost-unknown-9999/mastio-url")
+    assert resp.status_code == 404
+
+
+async def test_public_get_no_url_published_404(client):
+    """An org that exists but has not published a URL collapses to the
+    same 404 as 'org unknown' — non-enumerable."""
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    resp = await client.get(f"/v1/federation/orgs/{org_id}/mastio-url")
+    assert resp.status_code == 404
+
+
+async def test_public_get_pending_org_404(client):
+    """Non-active orgs never expose a URL, even if one was written."""
+    org_id = _unique_org_id()
+    await _register_org(client, org_id)
+    await client.patch(
+        f"/v1/admin/orgs/{org_id}/mastio-url",
+        json={"mastio_url": f"https://{org_id}.local"},
+        headers=ADMIN_HEADERS,
+    )
+    # Flip the org to 'pending' directly in DB.
+    from sqlalchemy import text
+    async with TestSessionLocal() as db:
+        await db.execute(
+            text(f"UPDATE organizations SET status='pending' WHERE org_id='{org_id}'"),
+        )
+        await db.commit()
+
+    resp = await client.get(f"/v1/federation/orgs/{org_id}/mastio-url")
+    assert resp.status_code == 404

--- a/tests/test_tool_call_pdp_federation.py
+++ b/tests/test_tool_call_pdp_federation.py
@@ -51,6 +51,42 @@ async def proxy_app(tmp_path, monkeypatch):
     get_settings.cache_clear()
 
 
+@pytest_asyncio.fixture
+async def proxy_app_phaseg(tmp_path, monkeypatch):
+    """Same as ``proxy_app`` but with an empty env map and a Court
+    base URL set on ``app.state.reverse_proxy_broker_url``. Exercises
+    ADR-029 Phase G — the catalog must resolve the peer URL through
+    Court rather than the env override.
+    """
+    db_file = tmp_path / "tool_pdp_fed_phaseg.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_ENABLED", "true")
+    monkeypatch.setenv("MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET", "")
+    monkeypatch.setenv("MCP_PROXY_TOOL_PDP_FEDERATION_URLS", "{}")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            # Override whatever the lifespan set (which is ``None`` for
+            # an unconfigured broker) with the fake Court base URL the
+            # tests want to hit.
+            app.state.reverse_proxy_broker_url = "https://court.test.local"
+            # Drop any cached catalog so the next PDP call picks up the
+            # fresh broker_url + empty env map.
+            if hasattr(app.state, "federation_catalog"):
+                delattr(app.state, "federation_catalog")
+            yield app, client
+    get_settings.cache_clear()
+
+
 def _payload_cross_org(
     *,
     principal_id: str = "acme::user::mario@acme.local",
@@ -372,3 +408,97 @@ def test_intersect_decisions_obligations_restrictive_wins():
     assert out.obligations is not None
     assert out.obligations["trace_visibility"] == "redacted"
     assert out.obligations["require_user_confirmation"] is True
+
+
+# ── ADR-029 Phase G, Court catalog ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_phaseg_court_catalog_publishes_url(proxy_app_phaseg, monkeypatch):
+    """No env entry for target org; Court returns the URL; the
+    federation peer allows. End-to-end: PDP final allow comes from the
+    catalog-resolved URL."""
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/v1/federation/orgs/competitor/mastio-url"):
+            return httpx.Response(200, json={
+                "org_id": "competitor",
+                "mastio_url": "https://mastio.competitor.dynamic/v1/policy/tool-call",
+            })
+        if "mastio.competitor.dynamic" in url:
+            captured["peer_url"] = url
+            captured["peer_body"] = json.loads(request.content)
+            return httpx.Response(200, json={
+                "decision": "allow",
+                "reason": "competitor approves",
+            })
+        return httpx.Response(500, content=b"unexpected")
+
+    transport = httpx.MockTransport(_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient", _Client,
+    )
+
+    _, client = proxy_app_phaseg
+    await _set_tool_rules({
+        "competitor.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_cross_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "allow", body
+    # The catalog-resolved peer received the call.
+    assert "mastio.competitor.dynamic" in captured["peer_url"]
+    assert captured["peer_body"]["target"]["org"] == "competitor"
+
+
+@pytest.mark.asyncio
+async def test_phaseg_court_404_default_deny(proxy_app_phaseg, monkeypatch):
+    """No env entry and Court has not published a URL for the target →
+    default-deny. The federation peer is never reached."""
+    peer_hit = {"n": 0}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        url = str(request.url)
+        if url.endswith("/v1/federation/orgs/competitor/mastio-url"):
+            return httpx.Response(404, json={"detail": "no mastio_url"})
+        peer_hit["n"] += 1
+        return httpx.Response(200, json={"decision": "allow"})
+
+    transport = httpx.MockTransport(_handler)
+
+    class _Client(httpx.AsyncClient):
+        def __init__(self, *args, **kwargs):
+            kwargs["transport"] = transport
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr("mcp_proxy.policy.federation.httpx.AsyncClient", _Client)
+    monkeypatch.setattr(
+        "mcp_proxy.policy.federation_catalog.httpx.AsyncClient", _Client,
+    )
+
+    _, client = proxy_app_phaseg
+    await _set_tool_rules({
+        "competitor.catalog.search": {
+            "allowed_principals": ["acme::user::mario@acme.local"],
+        }
+    })
+
+    resp = await client.post("/v1/policy/tool-call", json=_payload_cross_org())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["decision"] == "deny", body
+    assert "no federation URL" in body["reason"]
+    assert peer_hit["n"] == 0


### PR DESCRIPTION
## Summary

ADR-029 Phase G — replace the static ``MCP_PROXY_TOOL_PDP_FEDERATION_URLS`` env JSON map with a dynamic lookup against the Court registry. Onboarding now publishes the org's Mastio URL once, every other Mastio resolves it at PDP-evaluation time.

- New column `organizations.mastio_url` (Alembic `q7l8m9n0o1p2`, nullable).
- Admin endpoint: `PATCH /v1/admin/orgs/{org_id}/mastio-url` (validates http(s), strips trailing slash, audit row).
- Public endpoint: `GET /v1/federation/orgs/{org_id}/mastio-url` (unauthenticated, collapses 'unknown' / 'pending' / 'no URL' → 404).
- `mcp_proxy.policy.federation_catalog.FederationCatalog` — TTL-cached resolver, env-map override first, default-deny on miss.
- `/v1/policy/tool-call` wires the catalog in lazily; env-map path preserved for operator overrides (e.g. blue/green peer rollouts).

## Why

Phase D-2 worked for the 2-org demo but does not scale: every operator had to push a new env file to every peer Mastio whenever a new org joined. Phase G turns onboarding into the single source of truth.

## Design choices

- **Unauthenticated GET on the public endpoint.** The URL is operational metadata; the same posture as `/.well-known/jwks.json` and the existing A2A agent cards. Enumeration is bounded by collapsing 404s.
- **Transport errors are not cached.** Only definitive Court answers (200 with valid URL, 404) populate the TTL cache. A flaky Court must not lock out cross-org calls for 5 minutes.
- **Env map still wins.** Operators can pin a URL temporarily without touching Court state.
- **Default-deny on miss preserved.** Same conservative posture as pre-Phase-G "missing env entry".
- **PATCH lives under `/v1/admin/`** (next to `mastio-pubkey` and `require-mtls`), not `/v1/registry/`, so the admin gate is testable through the same fixture as the sibling admin endpoints.

## Test plan

- [x] `pytest tests/test_federation_catalog.py` — 11 unit specs ✓
- [x] `pytest tests/test_org_mastio_url.py` — 9 endpoint specs ✓
- [x] `pytest tests/test_tool_call_pdp_federation.py` — 15 specs (2 new Phase G integration: Court catalog resolves + peer allow → final allow; Court 404 → default-deny, peer never reached) ✓
- [x] `pytest tests/ -n auto --dist=loadfile` — 2477 passed, 2 pre-existing GUI gotchas (`feedback_gui_libs_ci_headless`, pystray/pywebview)
- [x] Alembic upgrade/downgrade roundtrip clean on a fresh SQLite
- [ ] **Smoke gate**: `./sandbox/smoke.sh full` required pre-merge — touches `app/` + `mcp_proxy/` + `alembic/` (`feedback_smoke_gate`). Not run from this worktree; founder to run manually.
- [ ] `/security-review` pre-merge (CLAUDE.md gate, runs after CI)

## Refs

- `imp/MEMORY.md` → `project_adr_029_pdp_pivot_2026_05_11`, `project_session_2026_05_11_sprint1_close_adr029`
- Phase D-2 (cross-org federation): PR #604
- Phase D-1 (Connector wiring): PR #602

## Follow-up

- Dashboard UI to edit `mastio_url` per org (admin page). Currently the operator hits the PATCH via `curl`.
- Federation peer auth (X-Cullis-Mastio-Signature on the catalog GET) if enumeration becomes a concern in production.