### PR TITLE
fix(court): DB-level append-only enforcement on audit_log (Wave B PR5 / CRIT-3 Court)

### DIFF
--- a/alembic/versions/q7l8m9n0o1p2_audit_append_only.py
+++ b/alembic/versions/q7l8m9n0o1p2_audit_append_only.py
@@ -1,0 +1,130 @@
+"""Court-side audit_log append-only enforcement (Wave B PR5 / CRIT-3).
+
+Revision ID: q7l8m9n0o1p2
+Revises: p6k7l8m9n0o1
+Create Date: 2026-05-11 23:30:00.000000
+
+Audit ref: imp/audits/2026-05-11-track-3-audit-pdp.md F-2 (Court-side
+mirror — Mastio twin landed as ``0031_audit_append_only_v2``).
+
+Pre-fix the Court ``audit_log`` table claimed "append-only" but
+``_append_row`` inserted the row, ``flush()``'d to get the auto-
+assigned ``id``, then UPDATE'd to back-fill ``entry_hash``. An
+attacker with DB write credentials could rewrite or delete rows
+undetected; detection was opt-in (operator clicks "verify chain").
+
+This migration:
+1. Adds ``hash_format`` TEXT NULL on ``audit_log``. NULL or 'v1' for
+   legacy rows back-filled the old way; 'v2' for new rows inserted
+   atomically with the hash already computed (no UPDATE).
+2. Installs a BEFORE UPDATE OR DELETE trigger on ``audit_log`` that
+   raises an error, blocking both attacker mutation AND the pre-fix
+   back-fill code path. Implemented in dialect-aware SQL:
+   Postgres uses CREATE FUNCTION + CREATE TRIGGER; SQLite uses
+   CREATE TRIGGER ... SELECT RAISE(ABORT, ...).
+3. The same trigger is installed on ``audit_tsa_anchors`` because
+   the per-org TSA anchor row is similarly meant to be immutable
+   once written.
+
+The trigger fires AFTER ``app/db/audit.py:_append_row`` was
+refactored to write the hash atomically on INSERT. Existing v1 rows
+are untouched (no in-place migration to v2 — verify_chain dispatches
+on ``hash_format`` so legacy rows keep verifying with v1 inputs).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "q7l8m9n0o1p2"
+down_revision = "p6k7l8m9n0o1"
+branch_labels = None
+depends_on = None
+
+
+_TABLES = ("audit_log", "audit_tsa_anchors")
+
+
+def _pg_trigger_fn(table: str) -> str:
+    return f"""
+CREATE OR REPLACE FUNCTION {table}_no_mutate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION
+        '{table} is append-only (CRIT-3 Court): % is not permitted',
+        TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+def _pg_trigger(table: str) -> str:
+    return f"""
+CREATE TRIGGER {table}_no_update_or_delete
+BEFORE UPDATE OR DELETE ON {table}
+FOR EACH ROW EXECUTE FUNCTION {table}_no_mutate();
+"""
+
+
+def _sqlite_trigger(table: str, op_kind: str) -> str:
+    return f"""
+CREATE TRIGGER IF NOT EXISTS {table}_no_{op_kind.lower()}
+BEFORE {op_kind} ON {table}
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT, '{table} is append-only (CRIT-3 Court): {op_kind} not permitted');
+END;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    # 1. Add hash_format column on audit_log.
+    if "audit_log" in existing:
+        cols = {c["name"] for c in inspector.get_columns("audit_log")}
+        if "hash_format" not in cols:
+            op.add_column(
+                "audit_log",
+                sa.Column("hash_format", sa.String(length=8), nullable=True),
+            )
+
+    # 2. Install triggers per dialect.
+    dialect = bind.dialect.name
+    for table in _TABLES:
+        if table not in existing:
+            continue
+        if dialect == "postgresql":
+            op.execute(_pg_trigger_fn(table))
+            op.execute(
+                f"DROP TRIGGER IF EXISTS {table}_no_update_or_delete ON {table}"
+            )
+            op.execute(_pg_trigger(table))
+        elif dialect == "sqlite":
+            op.execute(_sqlite_trigger(table, "UPDATE"))
+            op.execute(_sqlite_trigger(table, "DELETE"))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    dialect = bind.dialect.name
+    for table in _TABLES:
+        if table not in existing:
+            continue
+        if dialect == "postgresql":
+            op.execute(
+                f"DROP TRIGGER IF EXISTS {table}_no_update_or_delete ON {table}"
+            )
+            op.execute(f"DROP FUNCTION IF EXISTS {table}_no_mutate()")
+        elif dialect == "sqlite":
+            op.execute(f"DROP TRIGGER IF EXISTS {table}_no_update")
+            op.execute(f"DROP TRIGGER IF EXISTS {table}_no_delete")
+
+    if "audit_log" in existing:
+        cols = {c["name"] for c in inspector.get_columns("audit_log")}
+        if "hash_format" in cols:
+            op.drop_column("audit_log", "hash_format")

--- a/alembic/versions/r8m9n0o1p2q3_audit_append_only.py
+++ b/alembic/versions/r8m9n0o1p2q3_audit_append_only.py
@@ -35,8 +35,8 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision = "q7l8m9n0o1p2"
-down_revision = "p6k7l8m9n0o1"
+revision = "r8m9n0o1p2q3_audit"
+down_revision = "q7l8m9n0o1p2"
 branch_labels = None
 depends_on = None
 

--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -91,6 +91,13 @@ class AuditLog(Base):
     principal_type = Column(
         String(16), nullable=False, server_default="agent", index=True,
     )
+    # Wave B PR5 / CRIT-3 Court-side mirror — discriminator for the
+    # canonical-form version. NULL or 'v1' = legacy entry_id-bound
+    # canonical (back-compat with rows from before the
+    # audit_log_append_only_trigger). 'v2' = new atomic-insert form
+    # that omits entry_id and starts with the literal "v2|", set by
+    # the refactored ``_append_row``.
+    hash_format = Column(String(8), nullable=True, index=False)
 
 
 class AuditTsaAnchor(Base):
@@ -172,6 +179,52 @@ def compute_entry_hash(
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+# Wave B PR5 (audit 2026-05-11 CRIT-3 Court-side mirror) — v2 hash
+# format omitting the auto-incremented entry_id. Same rationale as
+# the Mastio twin in mcp_proxy/local/audit_chain.py: removing
+# entry_id lets the row be inserted atomically with its final
+# entry_hash already computed, so the BEFORE UPDATE/DELETE trigger
+# installed by migration ``audit_log_append_only_trigger`` (Court
+# alembic) doesn't reject the back-fill UPDATE that pre-fix wrote
+# entry_hash after flush().
+#
+# (org_id, chain_seq) is UNIQUE since the per-org migration, so it
+# already uniquely identifies the row pre-INSERT. ``"v2|"`` prefix
+# in the canonical string makes a v1↔v2 collision cryptographically
+# impossible.
+
+HASH_FORMAT_V1 = "v1"
+HASH_FORMAT_V2 = "v2"
+
+
+def compute_entry_hash_v2(
+    *,
+    timestamp: datetime,
+    event_type: str,
+    agent_id: str | None,
+    session_id: str | None,
+    org_id: str | None,
+    result: str,
+    details: str | None,
+    previous_hash: str | None,
+    chain_seq: int,
+    peer_org_id: str | None = None,
+    principal_type: str | None = None,
+) -> str:
+    """Court-side v2 canonical form (no entry_id). Mirrors the Mastio
+    helper byte-for-byte so an export from one side replays cleanly
+    on the other."""
+    canonical = (
+        f"v2|{timestamp.isoformat()}|{event_type}|"
+        f"{agent_id or ''}|{session_id or ''}|{org_id or ''}|"
+        f"{result}|{details or ''}|{previous_hash or 'genesis'}|"
+        f"seq={chain_seq}|peer={peer_org_id or ''}"
+    )
+    if principal_type and principal_type != "agent":
+        canonical = f"{canonical}|pt={principal_type}"
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 async def _last_per_org(db: AsyncSession, org_id: str) -> tuple[str | None, int]:
     """Return (last_entry_hash, last_chain_seq) for the given org.
 
@@ -227,6 +280,30 @@ async def _append_row(
     previous_hash, last_seq = await _last_per_org(db, org_id)
     new_seq = last_seq + 1
 
+    # Wave B PR5 (audit 2026-05-11) — compute the v2 hash BEFORE the
+    # INSERT. Pre-fix the row was inserted, ``flush()``'d to get the
+    # auto-assigned ``id``, then UPDATE'd to back-fill the hash. The
+    # BEFORE UPDATE/DELETE trigger installed on ``audit_log`` rejects
+    # that back-fill UPDATE as a tamper attempt (which is exactly the
+    # point — the application proving the schema accepts UPDATE on the
+    # 'append-only' table was the audit finding). v2 omits entry_id
+    # (uses (org_id, chain_seq) which is already UNIQUE + known
+    # pre-INSERT). Mastio twin: ``mcp_proxy.local.audit_chain``.
+    ts = datetime.now(timezone.utc)
+    entry_hash = compute_entry_hash_v2(
+        timestamp=ts,
+        event_type=event_type,
+        agent_id=agent_id,
+        session_id=session_id,
+        org_id=org_id,
+        result=result,
+        details=details_json,
+        previous_hash=previous_hash,
+        chain_seq=new_seq,
+        peer_org_id=peer_org_id,
+        principal_type=principal_type,
+    )
+
     entry = AuditLog(
         event_type=event_type,
         agent_id=agent_id,
@@ -239,21 +316,13 @@ async def _append_row(
         peer_org_id=peer_org_id,
         peer_row_hash=peer_row_hash,
         principal_type=principal_type,
+        timestamp=ts,
+        entry_hash=entry_hash,
+        hash_format=HASH_FORMAT_V2,
     )
     db.add(entry)
-    await db.flush()  # assigns auto-incremented id
+    await db.flush()  # assigns auto-incremented id (informational only)
 
-    ts = entry.timestamp
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=timezone.utc)
-    entry.entry_hash = compute_entry_hash(
-        entry.id, ts, event_type,
-        agent_id, session_id, org_id, result,
-        details_json, previous_hash,
-        chain_seq=new_seq,
-        peer_org_id=peer_org_id,
-        principal_type=principal_type,
-    )
     return entry
 
 
@@ -399,18 +468,20 @@ async def log_event_cross_org(
                     peer_row_hash=row_first.entry_hash,
                     principal_type=principal_type,
                 )
-                # Back-fill peer_row_hash on the first row now that the
-                # second row's hash exists. This closes the
-                # cross-reference ring. The entry_hash of row_first was
-                # computed with peer_row_hash=None, so we must recompute
-                # after setting the link — otherwise the stored
-                # entry_hash would mismatch on verify. To preserve
-                # immutability of entry_hash post-commit, we include
-                # peer_row_hash in the hash computation only via
-                # peer_org_id (not the hash itself); the peer_row_hash
-                # column is thus informational/reference data, not part
-                # of the signed content.
-                row_first.peer_row_hash = row_second.entry_hash
+                # Wave B PR5 / CRIT-3 (audit 2026-05-11) — pre-fix this
+                # block back-filled ``row_first.peer_row_hash`` after
+                # row_second was inserted, which produced a second
+                # UPDATE on the audit_log row. The new BEFORE
+                # UPDATE/DELETE trigger rejects that as tamper. Since
+                # ``peer_row_hash`` is informational (not in the signed
+                # canonical hash — see compute_entry_hash docstring),
+                # we ALREADY embed enough cross-reference via row_second
+                # carrying ``peer_row_hash=row_first.entry_hash`` at
+                # INSERT time. Drop the back-fill on row_first; the
+                # cross-org linkage stays one-way and verifiable through
+                # row_second alone. T3-F7 (peer_row_hash binding) is a
+                # separate MEDIUM follow-up that would re-add a forward
+                # link via a v3 hash format if needed.
                 await db.commit()
                 break
             except IntegrityError as exc:
@@ -527,14 +598,34 @@ async def verify_chain(
             ts = entry.timestamp
             if ts.tzinfo is None:
                 ts = ts.replace(tzinfo=timezone.utc)
-            expected_hash = compute_entry_hash(
-                entry.id, ts, entry.event_type,
-                entry.agent_id, entry.session_id, entry.org_id,
-                entry.result, entry.details, entry.previous_hash,
-                chain_seq=entry.chain_seq,
-                peer_org_id=entry.peer_org_id,
-                principal_type=entry.principal_type,
-            )
+            # Wave B PR5 — dispatch on hash_format. NULL/'v1' rows
+            # use the legacy entry_id-bound canonical (preserves
+            # back-compat for rows written before this PR). 'v2' rows
+            # use the entry_id-free canonical (compute_entry_hash_v2).
+            row_format = entry.hash_format or HASH_FORMAT_V1
+            if row_format == HASH_FORMAT_V2:
+                expected_hash = compute_entry_hash_v2(
+                    timestamp=ts,
+                    event_type=entry.event_type,
+                    agent_id=entry.agent_id,
+                    session_id=entry.session_id,
+                    org_id=entry.org_id,
+                    result=entry.result,
+                    details=entry.details,
+                    previous_hash=entry.previous_hash,
+                    chain_seq=entry.chain_seq,
+                    peer_org_id=entry.peer_org_id,
+                    principal_type=entry.principal_type,
+                )
+            else:
+                expected_hash = compute_entry_hash(
+                    entry.id, ts, entry.event_type,
+                    entry.agent_id, entry.session_id, entry.org_id,
+                    entry.result, entry.details, entry.previous_hash,
+                    chain_seq=entry.chain_seq,
+                    peer_org_id=entry.peer_org_id,
+                    principal_type=entry.principal_type,
+                )
             if entry.entry_hash != expected_hash:
                 AUDIT_CHAIN_VERIFY_FAILED_COUNTER.add(
                     1, {"reason": "entry_hash_mismatch", "scope": "per_org"}

--- a/app/onboarding/router.py
+++ b/app/onboarding/router.py
@@ -1117,6 +1117,11 @@ async def export_audit_logs(
                 "chain_seq": e.chain_seq,
                 "peer_org_id": e.peer_org_id,
                 "peer_row_hash": e.peer_row_hash,
+                # Wave B PR5 (CRIT-3 Court) — needed by the CLI
+                # verifier so it dispatches to the right canonical
+                # form (v1 entry_id-bound vs v2 atomic-insert).
+                "principal_type": e.principal_type,
+                "hash_format": e.hash_format,
             }) + "\n"
         for a in anchors:
             yield json_mod.dumps({

--- a/demo_network/verify_audit_chain.py
+++ b/demo_network/verify_audit_chain.py
@@ -17,6 +17,27 @@ from collections import defaultdict
 
 
 def canonical(entry: dict, previous_hash: str | None) -> str:
+    """Canonical hash input. Dispatches on ``hash_format``:
+      - 'v2' (Wave B PR5 / CRIT-3) — atomic-insert form. Mirrors
+        ``app.db.audit.compute_entry_hash_v2`` byte-for-byte:
+        always carries seq= and peer= suffixes (v2 rows always have
+        chain_seq), optional |pt= suffix when principal_type is set
+        and not "agent".
+      - NULL or 'v1' — legacy form with entry_id, no prefix.
+    """
+    hf = entry.get("hash_format")
+    if hf == "v2":
+        canon = (
+            f"v2|{entry['timestamp'] or ''}|{entry['event_type']}|"
+            f"{entry.get('agent_id') or ''}|{entry.get('session_id') or ''}|"
+            f"{entry.get('org_id') or ''}|{entry['result']}|"
+            f"{entry.get('details') or ''}|{previous_hash or 'genesis'}|"
+            f"seq={entry.get('chain_seq')}|peer={entry.get('peer_org_id') or ''}"
+        )
+        pt = entry.get("principal_type")
+        if pt and pt != "agent":
+            canon = f"{canon}|pt={pt}"
+        return canon
     base = "|".join([
         str(entry["id"]),
         entry["timestamp"] or "",
@@ -40,7 +61,14 @@ with open("/in/audit.ndjson") as f:
         line = line.strip()
         if not line:
             continue
-        entries.append(json.loads(line))
+        obj = json.loads(line)
+        # Skip TSA anchor lines (kind="anchor"); they're append-only
+        # metadata for the offline verifier, not part of the chain
+        # itself. Default kind="entry" for back-compat with bundles
+        # that pre-date the kind tag.
+        if obj.get("kind", "entry") != "entry":
+            continue
+        entries.append(obj)
 
 # ── Legacy global chain (chain_seq is None) ───────────────────────
 prev = None

--- a/scripts/cullis-audit-verify.py
+++ b/scripts/cullis-audit-verify.py
@@ -48,21 +48,61 @@ _RFC3161_MAGIC = b"T1"
 
 
 def canonical(entry: dict[str, Any], previous_hash: str | None) -> str:
-    base = "|".join([
-        str(entry["id"]),
-        entry["timestamp"] or "",
-        entry["event_type"],
-        entry.get("agent_id") or "",
-        entry.get("session_id") or "",
-        entry.get("org_id") or "",
-        entry["result"],
-        entry.get("details") or "",
-        previous_hash or "genesis",
-    ])
+    """Reconstruct the canonical string used to compute ``entry_hash``.
+
+    Wave B PR5 (audit 2026-05-11 CRIT-3 Court) — dispatches on
+    ``hash_format``:
+      - NULL or 'v1' → legacy entry_id-bound canonical (unchanged)
+      - 'v2' → entry_id-free canonical, prefixed with literal ``v2|``;
+        chain_seq required (atomic-insert form, no back-fill UPDATE)
+
+    Both forms also append ``|pt=<x>`` when a non-default
+    ``principal_type`` is present (ADR-020 marker).
+    """
+    fmt = (entry.get("hash_format") or "v1").lower()
     chain_seq = entry.get("chain_seq")
-    if chain_seq is None:
-        return base
-    return f"{base}|seq={chain_seq}|peer={entry.get('peer_org_id') or ''}"
+
+    if fmt == "v2":
+        if chain_seq is None:
+            # v2 always uses chain_seq; refuse a malformed bundle
+            # explicitly so the verifier doesn't silently agree.
+            return "INVALID-V2-WITHOUT-CHAIN-SEQ"
+        canonical_str = "|".join([
+            "v2",
+            entry["timestamp"] or "",
+            entry["event_type"],
+            entry.get("agent_id") or "",
+            entry.get("session_id") or "",
+            entry.get("org_id") or "",
+            entry["result"],
+            entry.get("details") or "",
+            previous_hash or "genesis",
+            f"seq={chain_seq}",
+            f"peer={entry.get('peer_org_id') or ''}",
+        ])
+    else:
+        base = "|".join([
+            str(entry["id"]),
+            entry["timestamp"] or "",
+            entry["event_type"],
+            entry.get("agent_id") or "",
+            entry.get("session_id") or "",
+            entry.get("org_id") or "",
+            entry["result"],
+            entry.get("details") or "",
+            previous_hash or "genesis",
+        ])
+        if chain_seq is None:
+            canonical_str = base
+        else:
+            canonical_str = (
+                f"{base}|seq={chain_seq}|peer={entry.get('peer_org_id') or ''}"
+            )
+
+    pt = entry.get("principal_type")
+    if pt and pt != "agent":
+        canonical_str = f"{canonical_str}|pt={pt}"
+    return canonical_str
 
 
 def verify_token_against_digest(token_bytes: bytes, digest_hex: str) -> tuple[bool, str]:

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -3,7 +3,7 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import update
 
-from app.db.audit import AuditLog, log_event, verify_chain, compute_entry_hash
+from app.db.audit import AuditLog, log_event, verify_chain
 from tests.conftest import TestSessionLocal
 
 pytestmark = pytest.mark.asyncio

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -45,18 +45,32 @@ async def test_chain_linkage(audit_db):
 
 
 async def test_hash_determinism(audit_db):
-    """Recomputing the hash from entry fields must match entry_hash."""
+    """Recomputing the hash from entry fields must match entry_hash.
+
+    Wave B PR5 (CRIT-3 Court) — new rows are written with the v2
+    canonical (no entry_id, prefixed ``v2|``) and carry
+    ``hash_format='v2'``. Recompute via the v2 helper; the legacy
+    ``compute_entry_hash`` is still used for any v1 row that survives
+    in production but is never produced by ``log_event`` anymore.
+    """
     from datetime import timezone
+    from app.db.audit import HASH_FORMAT_V2, compute_entry_hash_v2
     entry = await log_event(audit_db, "test.determinism", "ok",
                            agent_id="org::agent", session_id="sess-1",
                            org_id="org", details={"foo": "bar"})
     ts = entry.timestamp
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
-    recomputed = compute_entry_hash(
-        entry.id, ts, entry.event_type,
-        entry.agent_id, entry.session_id, entry.org_id,
-        entry.result, entry.details, entry.previous_hash,
+    assert entry.hash_format == HASH_FORMAT_V2
+    recomputed = compute_entry_hash_v2(
+        timestamp=ts,
+        event_type=entry.event_type,
+        agent_id=entry.agent_id,
+        session_id=entry.session_id,
+        org_id=entry.org_id,
+        result=entry.result,
+        details=entry.details,
+        previous_hash=entry.previous_hash,
         chain_seq=entry.chain_seq,
         peer_org_id=entry.peer_org_id,
     )
@@ -193,11 +207,19 @@ async def test_cross_org_dual_write_creates_two_rows(audit_db):
     assert row_b.org_id == "bravo"
     assert row_a.chain_seq == 1
     assert row_b.chain_seq == 1
-    # Cross-reference linkage in both directions
+    # Cross-reference linkage. Wave B PR5 (CRIT-3 Court) — the
+    # back-fill of row_first.peer_row_hash is gone (the trigger
+    # rejects the second UPDATE), so only one of the two rows
+    # carries the cross-reference: whichever was inserted second
+    # has peer_row_hash = first.entry_hash. The asymmetry is
+    # accepted (peer_row_hash is informational, not in the signed
+    # canonical hash); T3-F7 is a separate MEDIUM follow-up that
+    # would re-add the forward link via a v3 hash format.
     assert row_a.peer_org_id == "bravo"
     assert row_b.peer_org_id == "acme"
-    assert row_a.peer_row_hash == row_b.entry_hash
-    assert row_b.peer_row_hash == row_a.entry_hash
+    assert (row_a.peer_row_hash is not None) or (
+        row_b.peer_row_hash is not None
+    ), "at least one side must carry the cross-org linkage"
 
 
 async def test_cross_org_both_chains_verify(audit_db):
@@ -276,10 +298,17 @@ async def test_adr020_explicit_workload_principal_type(audit_db):
 
 async def test_adr020_agent_hash_unchanged_vs_pre_adr020(audit_db):
     """Crucially: an 'agent' row's entry_hash is byte-for-byte equal
-    to what compute_entry_hash would produce WITHOUT principal_type
-    (i.e. the pre-ADR-020 algorithm). This is the back-compat property
-    that lets the column be added with no chain rewrite."""
+    to what compute_entry_hash_v2 would produce WITHOUT principal_type
+    (i.e. the back-compat property that lets the column be added with
+    no chain rewrite).
+
+    Wave B PR5 (CRIT-3 Court) — assertion now exercised against the
+    v2 helper since new rows are written with hash_format=v2.
+    Pre-ADR-020 rows still verify with the legacy ``compute_entry_hash``
+    (hash_format=NULL/v1, dispatched in verify_chain).
+    """
     from datetime import timezone
+    from app.db.audit import compute_entry_hash_v2
 
     entry = await log_event(audit_db, "test.compat", "ok", org_id="acme",
                             principal_type="agent")
@@ -287,18 +316,28 @@ async def test_adr020_agent_hash_unchanged_vs_pre_adr020(audit_db):
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
 
-    recomputed_pre_adr = compute_entry_hash(
-        entry.id, ts, entry.event_type,
-        entry.agent_id, entry.session_id, entry.org_id,
-        entry.result, entry.details, entry.previous_hash,
+    recomputed_pre_adr = compute_entry_hash_v2(
+        timestamp=ts,
+        event_type=entry.event_type,
+        agent_id=entry.agent_id,
+        session_id=entry.session_id,
+        org_id=entry.org_id,
+        result=entry.result,
+        details=entry.details,
+        previous_hash=entry.previous_hash,
         chain_seq=entry.chain_seq,
         peer_org_id=entry.peer_org_id,
-        # principal_type omitted — exactly the pre-ADR-020 call shape
+        # principal_type omitted — pre-ADR-020 call shape
     )
-    recomputed_agent = compute_entry_hash(
-        entry.id, ts, entry.event_type,
-        entry.agent_id, entry.session_id, entry.org_id,
-        entry.result, entry.details, entry.previous_hash,
+    recomputed_agent = compute_entry_hash_v2(
+        timestamp=ts,
+        event_type=entry.event_type,
+        agent_id=entry.agent_id,
+        session_id=entry.session_id,
+        org_id=entry.org_id,
+        result=entry.result,
+        details=entry.details,
+        previous_hash=entry.previous_hash,
         chain_seq=entry.chain_seq,
         peer_org_id=entry.peer_org_id,
         principal_type="agent",
@@ -308,8 +347,15 @@ async def test_adr020_agent_hash_unchanged_vs_pre_adr020(audit_db):
 
 async def test_adr020_user_hash_includes_principal_type_marker(audit_db):
     """A user row's canonical includes |pt=user, so its hash differs
-    from the same row hashed as 'agent'. This is the chain-v2 marker."""
+    from the same row hashed as 'agent'. This is the chain-v2 marker.
+
+    Wave B PR5 (CRIT-3 Court) — assertion exercised against
+    ``compute_entry_hash_v2`` (the new atomic-insert form). The
+    legacy ``compute_entry_hash`` keeps the same property for
+    pre-PR5 rows.
+    """
     from datetime import timezone
+    from app.db.audit import compute_entry_hash_v2
 
     entry = await log_event(
         audit_db, "test.usermark", "ok",
@@ -320,18 +366,28 @@ async def test_adr020_user_hash_includes_principal_type_marker(audit_db):
     if ts.tzinfo is None:
         ts = ts.replace(tzinfo=timezone.utc)
 
-    hash_user = compute_entry_hash(
-        entry.id, ts, entry.event_type,
-        entry.agent_id, entry.session_id, entry.org_id,
-        entry.result, entry.details, entry.previous_hash,
+    hash_user = compute_entry_hash_v2(
+        timestamp=ts,
+        event_type=entry.event_type,
+        agent_id=entry.agent_id,
+        session_id=entry.session_id,
+        org_id=entry.org_id,
+        result=entry.result,
+        details=entry.details,
+        previous_hash=entry.previous_hash,
         chain_seq=entry.chain_seq,
         peer_org_id=entry.peer_org_id,
         principal_type="user",
     )
-    hash_as_agent = compute_entry_hash(
-        entry.id, ts, entry.event_type,
-        entry.agent_id, entry.session_id, entry.org_id,
-        entry.result, entry.details, entry.previous_hash,
+    hash_as_agent = compute_entry_hash_v2(
+        timestamp=ts,
+        event_type=entry.event_type,
+        agent_id=entry.agent_id,
+        session_id=entry.session_id,
+        org_id=entry.org_id,
+        result=entry.result,
+        details=entry.details,
+        previous_hash=entry.previous_hash,
         chain_seq=entry.chain_seq,
         peer_org_id=entry.peer_org_id,
         principal_type="agent",

--- a/tests/test_audit_export_tsa.py
+++ b/tests/test_audit_export_tsa.py
@@ -172,21 +172,46 @@ async def test_cli_cross_verify_detects_content_divergence(client, tmp_path):
             # rather than chain stage). We re-canonicalize in the same
             # way the broker does.
             import hashlib
-            base = "|".join([
-                str(ln["id"]),
-                ln["timestamp"] or "",
-                ln["event_type"],
-                ln.get("agent_id") or "",
-                ln.get("session_id") or "",
-                ln.get("org_id") or "",
-                ln["result"],
-                ln.get("details") or "",
-                ln.get("previous_hash") or "genesis",
-            ])
-            if ln.get("chain_seq") is not None:
-                canon = f"{base}|seq={ln['chain_seq']}|peer={ln.get('peer_org_id') or ''}"
+            # Wave B PR5 (CRIT-3 Court) — recompute the hash with
+            # the same canonical the production code now uses. Rows
+            # written by ``log_event`` carry ``hash_format='v2'``;
+            # legacy rows (NULL/'v1') keep the entry_id-bound form.
+            fmt = (ln.get("hash_format") or "v1").lower()
+            chain_seq = ln.get("chain_seq")
+            if fmt == "v2":
+                assert chain_seq is not None, "v2 row without chain_seq"
+                canon = "|".join([
+                    "v2",
+                    ln["timestamp"] or "",
+                    ln["event_type"],
+                    ln.get("agent_id") or "",
+                    ln.get("session_id") or "",
+                    ln.get("org_id") or "",
+                    ln["result"],
+                    ln.get("details") or "",
+                    ln.get("previous_hash") or "genesis",
+                    f"seq={chain_seq}",
+                    f"peer={ln.get('peer_org_id') or ''}",
+                ])
             else:
-                canon = base
+                base = "|".join([
+                    str(ln["id"]),
+                    ln["timestamp"] or "",
+                    ln["event_type"],
+                    ln.get("agent_id") or "",
+                    ln.get("session_id") or "",
+                    ln.get("org_id") or "",
+                    ln["result"],
+                    ln.get("details") or "",
+                    ln.get("previous_hash") or "genesis",
+                ])
+                if chain_seq is not None:
+                    canon = f"{base}|seq={chain_seq}|peer={ln.get('peer_org_id') or ''}"
+                else:
+                    canon = base
+            pt = ln.get("principal_type")
+            if pt and pt != "agent":
+                canon = f"{canon}|pt={pt}"
             ln["entry_hash"] = hashlib.sha256(canon.encode()).hexdigest()
             break
 

--- a/tests/test_oneshot_cross.py
+++ b/tests/test_oneshot_cross.py
@@ -375,8 +375,16 @@ async def test_audit_dual_write_on_forward(client: AsyncClient):
     peer_map = {r.org_id: r.peer_org_id for r in rows}
     assert peer_map["acme10"] == "globex10"
     assert peer_map["globex10"] == "acme10"
-    for row in rows:
-        assert row.peer_row_hash is not None
+    # Wave B PR5 (CRIT-3) — atomic-insert audit chain dropped the
+    # post-insert back-fill of row_first.peer_row_hash (would trip the
+    # new append-only trigger). Cross-row linkage is now asymmetric:
+    # row_second carries peer_row_hash=row_first.entry_hash at INSERT
+    # time, row_first stays NULL. Cross-reconciliation still works via
+    # the single forward link.
+    peer_hashes = [r.peer_row_hash for r in rows]
+    assert sum(1 for h in peer_hashes if h) == 1, (
+        f"exactly one cross-row should carry peer_row_hash, got {peer_hashes}"
+    )
 
 
 async def test_sweeper_expires_ttl_rows(client: AsyncClient, monkeypatch):

--- a/tests/test_wave_b_pr5_court_audit_append_only.py
+++ b/tests/test_wave_b_pr5_court_audit_append_only.py
@@ -1,0 +1,192 @@
+"""Wave B PR5 — Court-side CRIT-3 mirror.
+
+Audit ref: imp/audits/2026-05-11-track-3-audit-pdp.md F-2 (Court half).
+
+Pre-fix the broker ``audit_log`` table back-filled ``entry_hash`` via
+UPDATE after a flush(). Post-fix the row is inserted atomically with
+the v2 hash already computed; a BEFORE UPDATE/DELETE trigger blocks
+both attacker mutation and the legacy back-fill simultaneously.
+
+Note on test setup: ``tests/conftest.py`` bypasses Alembic in test
+mode (``SKIP_ALEMBIC=1``) and bootstraps the schema via
+``Base.metadata.create_all``. That path does not run the
+``q7l8m9n0o1p2_audit_append_only`` migration's trigger DDL, so the
+trigger-coverage tests below install the triggers inline using the
+same SQL the migration emits for SQLite.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+
+
+pytestmark = pytest.mark.asyncio
+
+
+_SQLITE_TRIGGER_SQL = [
+    """
+    CREATE TRIGGER IF NOT EXISTS audit_log_no_update
+    BEFORE UPDATE ON audit_log
+    FOR EACH ROW
+    BEGIN
+        SELECT RAISE(ABORT, 'audit_log is append-only (CRIT-3 Court): UPDATE not permitted');
+    END
+    """,
+    """
+    CREATE TRIGGER IF NOT EXISTS audit_log_no_delete
+    BEFORE DELETE ON audit_log
+    FOR EACH ROW
+    BEGIN
+        SELECT RAISE(ABORT, 'audit_log is append-only (CRIT-3 Court): DELETE not permitted');
+    END
+    """,
+]
+
+
+async def _install_triggers(db) -> None:
+    """Install the SQLite trigger SQL the migration would have emitted.
+    No-op on Postgres (those tests would need the alembic chain).
+    Idempotent (uses CREATE TRIGGER IF NOT EXISTS)."""
+    bind = db.get_bind()
+    if bind.dialect.name != "sqlite":
+        return
+    for sql in _SQLITE_TRIGGER_SQL:
+        await db.execute(text(sql))
+    await db.commit()
+
+
+async def test_log_event_writes_v2_hash_format(client):
+    from app.db.audit import HASH_FORMAT_V2, log_event
+    from app.db.database import get_db
+
+    async for db in get_db():
+        entry = await log_event(
+            db,
+            event_type="court.test",
+            result="ok",
+            org_id="acme",
+        )
+        assert entry.entry_hash != ""
+        assert entry.hash_format == HASH_FORMAT_V2
+        break
+
+
+async def test_chain_seq_advances_per_org(client):
+    from app.db.audit import log_event, verify_chain
+    from app.db.database import get_db
+
+    # Use a fresh org id so this test doesn't interleave with rows
+    # from other tests sharing the in-memory DB.
+    org = "wave-b-pr5-chainseq"
+    async for db in get_db():
+        e1 = await log_event(db, event_type="e1", result="ok", org_id=org)
+        e2 = await log_event(db, event_type="e2", result="ok", org_id=org)
+        assert (e1.chain_seq, e2.chain_seq) == (1, 2)
+        assert e2.previous_hash == e1.entry_hash
+        ok, _checked, _broken = await verify_chain(db, org_id=org)
+        assert ok, _broken
+        break
+
+
+async def test_trigger_blocks_update_on_audit_log(client):
+    """Attacker with DB write tries to UPDATE entry_hash. Trigger
+    installed by the new Court migration must reject it."""
+    from sqlalchemy.exc import DBAPIError
+
+    from app.db.audit import log_event
+    from app.db.database import get_db
+
+    org = "wave-b-pr5-trigupd"
+    async for db in get_db():
+        await _install_triggers(db)
+        await log_event(db, event_type="seed", result="ok", org_id=org)
+        with pytest.raises(DBAPIError) as exc_info:
+            await db.execute(
+                text(
+                    "UPDATE audit_log SET entry_hash = 'tampered' "
+                    " WHERE org_id = :o"
+                ),
+                {"o": org},
+            )
+            await db.commit()
+        msg = str(exc_info.value).lower()
+        assert "append-only" in msg or "crit-3" in msg
+        await db.rollback()
+        break
+
+
+async def test_trigger_blocks_delete_on_audit_log(client):
+    from sqlalchemy.exc import DBAPIError
+
+    from app.db.audit import log_event
+    from app.db.database import get_db
+
+    org = "wave-b-pr5-trigdel"
+    async for db in get_db():
+        await _install_triggers(db)
+        await log_event(db, event_type="seed", result="ok", org_id=org)
+        with pytest.raises(DBAPIError) as exc_info:
+            await db.execute(
+                text(
+                    "DELETE FROM audit_log WHERE org_id = :o"
+                ),
+                {"o": org},
+            )
+            await db.commit()
+        msg = str(exc_info.value).lower()
+        assert "append-only" in msg or "crit-3" in msg
+        await db.rollback()
+        break
+
+
+async def test_v1_v2_hash_forms_are_distinct():
+    """The v2 canonical string starts with literal ``v2|``; v1 starts
+    with an integer entry_id. Cryptographic distinction by preimage
+    space, not just by SHA-256 collision resistance."""
+    from datetime import datetime, timezone
+
+    from app.db.audit import compute_entry_hash, compute_entry_hash_v2
+
+    ts = datetime(2026, 5, 11, 22, 0, 0, tzinfo=timezone.utc)
+    v1 = compute_entry_hash(
+        entry_id=42, timestamp=ts, event_type="x",
+        agent_id=None, session_id=None, org_id="o",
+        result="ok", details=None, previous_hash=None,
+        chain_seq=1, peer_org_id=None,
+    )
+    v2 = compute_entry_hash_v2(
+        timestamp=ts, event_type="x",
+        agent_id=None, session_id=None, org_id="o",
+        result="ok", details=None, previous_hash=None,
+        chain_seq=1, peer_org_id=None,
+    )
+    assert v1 != v2
+
+
+async def test_cross_org_dual_write_no_back_fill(client):
+    """Wave B PR5 (CRIT-3 Court) — log_event_cross_org used to back-fill
+    row_first.peer_row_hash after row_second was inserted. The trigger
+    blocked that UPDATE. Post-fix the back-fill is gone (peer_row_hash
+    on row_first stays NULL); row_second still carries the cross-ref
+    via peer_row_hash=row_first.entry_hash at INSERT time."""
+    from app.db.audit import log_event_cross_org
+    from app.db.database import get_db
+
+    async for db in get_db():
+        row_a, row_b = await log_event_cross_org(
+            db,
+            event_type="cross.test",
+            result="ok",
+            org_a="orga",
+            org_b="orgb",
+        )
+        # One side (whichever sorts second by org_id) carries the link.
+        # The other side stays NULL — accepted asymmetry per code
+        # comment block.
+        assert row_a.entry_hash is not None
+        assert row_b.entry_hash is not None
+        # At least one of the two has peer_row_hash filled.
+        assert (row_a.peer_row_hash is not None) or (
+            row_b.peer_row_hash is not None
+        )
+        break


### PR DESCRIPTION
## Summary

Closes the Court half of audit finding **CRIT-3** (\`imp/audits/2026-05-11-track-3-audit-pdp.md\` F-2). Mastio half landed as #614; this PR mirrors the same pattern to the broker \`audit_log\` + \`audit_tsa_anchors\` tables.

**Vector:** \`_append_row\` inserted with empty \`entry_hash\`, flushed for the auto-id, then \`entry.entry_hash = compute_entry_hash(entry.id, ...)\` — a UPDATE on the "append-only" table on every commit. Same SOC2 CC7.2 blocker as Mastio side. Plus \`log_event_cross_org\` did a second back-fill on \`row_first.peer_row_hash\`.

**Fix mirror of #614:**
- \`compute_entry_hash_v2\` (no entry_id, \`v2|\` discriminator)
- \`AuditLog.hash_format\` column + migration \`q7l8m9n0o1p2\`
- \`_append_row\` refactor: hash pre-computed, atomic INSERT
- \`log_event_cross_org\`: drop \`row_first.peer_row_hash\` back-fill (asymmetric linkage accepted, T3-F7 follow-up)
- Migration adds BEFORE UPDATE/DELETE trigger on both \`audit_log\` and \`audit_tsa_anchors\` (Postgres + SQLite dialects)
- \`verify_chain\` dispatches on \`hash_format\` (back-compat for v1 rows)
- \`audit/export\` ndjson now includes \`hash_format\` + \`principal_type\`
- \`scripts/cullis-audit-verify.py\` canonical() dispatches on hash_format

## Test plan

- [x] 6 new cases in \`tests/test_wave_b_pr5_court_audit_append_only.py\` (v2 format, chain advance, trigger blocks UPDATE/DELETE, cryptographic distinction, cross-org no back-fill)
- [x] 4 pre-existing \`tests/test_audit_chain.py\` tests updated to v2 helper + new cross-org asymmetry
- [x] \`tests/test_audit_export_tsa.py\` content-divergence test inline canonical updated to dispatch on hash_format
- [x] \`pytest tests/test_audit_chain.py tests/test_audit_race_safety.py tests/test_audit_export*.py tests/test_audit_oneshot_envelope_integrity.py tests/test_audit_r2*.py tests/test_audit_r3.py tests/test_wave_b_pr5_court_audit_append_only.py\` → all green

SQLite trigger coverage installed inline in test fixtures (conftest sets \`SKIP_ALEMBIC=1\`); Postgres coverage runs via existing Postgres CI smoke.

## SOC2 impact

Story complete. Both Mastio and Court audit_log tables are now DB-level append-only:
- Pre-fix: append-only-as-policy (application discipline)
- Post-fix: append-only-as-evidence (DB trigger blocks UPDATE/DELETE regardless of application bug or attacker DB access)

CC7.2 gap closed for both halves of the federation.

## Wave B status

| # | Finding | Status |
|---|---|---|
| 1 | G1+G2 dashboard | open #616 |
| 2 | F1+F3 supply chain | open #618 |
| 3 | C2+B3+D3 | open #619 |
| 4 | B1 AI keys at-rest | open #621 |
| 5 | **CRIT-3 Court + audit_log global** | **THIS PR** (Court half — Mastio audit_log global is follow-up) |
| 6 | E1 dead crypto helper | open #620 |
| 7 | C1 LOCAL_TOKEN cnf.jkt | next (user authorized DPoP-bind path) |
| 8 | D1 dual-write impl | next (user authorized impl path) |
| 9 | F2 git filter-repo | queued (user authorized) |