### PR TITLE
fix(connector): dashboard /api/status missing X-Enrollment-Proof (Bug #5)

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -1217,10 +1217,20 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         poll_url = (
             f"{_pending.site_url}/v1/enrollment/{_pending.session_id}/status"
         )
+        # M-onb-1 audit fix — Mastio withholds ``cert_pem`` / ``agent_id`` /
+        # ``capabilities`` unless the poll carries a proof-of-possession over
+        # the enrollment keypair. The CLI path (``cullis_connector.enrollment``)
+        # already sends this header; before this fix the dashboard ``/api/status``
+        # path did not, so dashboard-driven enrollment got stuck in
+        # ``"Approved enrollment is missing cert_pem"`` forever once the
+        # admin approved the ticket. Same proof construction as the CLI.
+        from cullis_connector.enrollment import _build_enrollment_proof
+        proof = _build_enrollment_proof(_pending.private_key, _pending.session_id)
         try:
             from cullis_connector.config import verify_arg_for
             resp = httpx.get(
                 poll_url,
+                headers={"X-Enrollment-Proof": proof},
                 verify=verify_arg_for(_pending.verify_tls, config.ca_chain_path),
                 timeout=config.request_timeout_s,
             )

--- a/tests/connector/test_api_status_enrollment_proof.py
+++ b/tests/connector/test_api_status_enrollment_proof.py
@@ -1,0 +1,164 @@
+"""Regression test for the dashboard /api/status poll header.
+
+Pre-fix, the FastAPI dashboard's ``/api/status`` polling endpoint
+called Mastio's ``/v1/enrollment/{ticket}/status`` WITHOUT the
+``X-Enrollment-Proof`` header. The CLI poll path
+(``cullis_connector.enrollment``) had always sent it. Mastio's
+M-onb-1 audit hardening gates ``cert_pem`` / ``agent_id`` /
+``capabilities`` behind the proof, so the dashboard-driven enrollment
+got stuck reporting "Approved enrollment is missing cert_pem." even
+after the admin had approved the ticket — customer-path SPA chat
+never came online.
+
+These tests pin the contract: when ``_pending`` is set,
+``/api/status`` MUST include ``X-Enrollment-Proof``, and the proof
+must verify against the pending keypair so a future refactor that
+changes the canonical string also re-aligns the verifier.
+"""
+from __future__ import annotations
+
+import base64
+import time
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from fastapi.testclient import TestClient
+
+from cullis_connector import web as connector_web
+from cullis_connector.config import ConnectorConfig
+from cullis_connector.web import RequesterInfo, build_app
+
+
+@pytest.fixture
+def app(tmp_path):
+    cfg = ConnectorConfig(
+        site_url="https://mastio.test",
+        config_dir=tmp_path,
+        verify_tls=False,
+        request_timeout_s=2.0,
+    )
+    return build_app(cfg)
+
+
+@pytest.fixture
+def pending_session():
+    """Install a ``_Pending`` module-global as if the wizard had just
+    submitted the enrollment request."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    prev = connector_web._pending
+    connector_web._pending = connector_web._Pending(
+        session_id="ticket-abc-123",
+        enroll_url="https://mastio.test/v1/enrollment/ticket-abc-123",
+        site_url="https://mastio.test",
+        verify_tls=False,
+        private_key=key,
+        requester=RequesterInfo(name="demo", email="demo@cullis.local", reason="t"),
+        started_at=time.time(),
+    )
+    yield connector_web._pending
+    connector_web._pending = prev
+
+
+def _intercept_httpx_get(monkeypatch, body: dict):
+    """Replace ``cullis_connector.web.httpx.get`` with a stub that captures
+    the call and returns ``body`` as JSON. Returns the captured-call dict.
+
+    ``headers`` is wrapped in :class:`httpx.Headers` so the test can do
+    case-insensitive lookups (HTTP headers are case-insensitive on the
+    wire; the production code passes a plain dict with ``X-...`` casing
+    and we want either ``X-Enrollment-Proof`` or ``x-enrollment-proof``
+    to match in assertions)."""
+    captured: dict = {}
+
+    def _fake_get(url, *, headers=None, verify=None, timeout=None, **kwargs):
+        captured["url"] = url
+        captured["headers"] = httpx.Headers(headers or {})
+        return httpx.Response(200, json=body, request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(connector_web.httpx, "get", _fake_get)
+    return captured
+
+
+def test_api_status_sends_enrollment_proof_header(monkeypatch, app, pending_session):
+    """Mastio gets the PoP header on every dashboard poll. This is the
+    direct regression test for Bug #5 — pre-fix the header was missing
+    and Mastio withheld ``cert_pem``."""
+    captured = _intercept_httpx_get(
+        monkeypatch,
+        body={"session_id": pending_session.session_id, "status": "pending"},
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/status")
+
+    assert resp.status_code == 200
+    assert captured["url"].endswith(
+        f"/v1/enrollment/{pending_session.session_id}/status",
+    )
+    proof = captured["headers"].get("x-enrollment-proof")
+    assert proof, (
+        "/api/status MUST send X-Enrollment-Proof; without it Mastio "
+        "withholds cert_pem and the dashboard loops forever on "
+        "'Approved enrollment is missing cert_pem' (Bug #5)"
+    )
+    assert len(proof) >= 32
+
+
+def test_api_status_proof_verifies_against_pending_pubkey(
+    monkeypatch, app, pending_session,
+):
+    """The proof we send must be the same shape Mastio's
+    ``_verify_enrollment_proof`` accepts: P-256 ECDSA, base64url-encoded,
+    over ``enrollment-status:v1|{session_id}``. Round-trip verify the
+    signature so future refactors to the canonical string fail loud."""
+    captured = _intercept_httpx_get(
+        monkeypatch,
+        body={"session_id": pending_session.session_id, "status": "pending"},
+    )
+
+    with TestClient(app) as client:
+        client.get("/api/status")
+
+    proof_b64 = captured["headers"].get("x-enrollment-proof", "")
+    # base64url with optional padding.
+    pad = "=" * (-len(proof_b64) % 4)
+    sig = base64.urlsafe_b64decode(proof_b64 + pad)
+    canonical = f"enrollment-status:v1|{pending_session.session_id}".encode()
+    pubkey = pending_session.private_key.public_key()
+    pubkey.verify(sig, canonical, ec.ECDSA(hashes.SHA256()))
+
+
+def test_api_status_approved_path_persists_identity(
+    monkeypatch, app, pending_session,
+):
+    """When Mastio returns the approved record with ``cert_pem``
+    (which it only does when the proof verifies), the dashboard
+    writes the identity to disk and the endpoint flips to
+    ``status=approved``. Pre-fix, ``cert_pem`` came back null forever
+    and the endpoint surfaced the 'missing cert_pem' error string."""
+    cert_pem = (
+        "-----BEGIN CERTIFICATE-----\n"
+        "MIIBkDCCATagAwIBAgIUf+pVLzc8H9DZbm6FvCnD+sUEMcMwCgYIKoZIzj0EAwIw\n"
+        "-----END CERTIFICATE-----\n"
+    )
+    _intercept_httpx_get(
+        monkeypatch,
+        body={
+            "session_id": pending_session.session_id,
+            "status": "approved",
+            "agent_id": "test-org::test-agent",
+            "cert_pem": cert_pem,
+            "capabilities": ["chat.query"],
+        },
+    )
+
+    with TestClient(app) as client:
+        resp = client.get("/api/status")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "approved", body
+    # ``_pending`` is cleared once the identity hits disk.
+    assert connector_web._pending is None


### PR DESCRIPTION
## Summary

Customer-path onboarding **P0 blocker**: the FastAPI dashboard \`/api/status\` polling endpoint in \`cullis_connector.web\` was calling Mastio's \`/v1/enrollment/{ticket}/status\` without the \`X-Enrollment-Proof\` header. The CLI poll path had always sent it; the dashboard never did. Mastio's M-onb-1 audit gating (\`app/registry/.../enrollment/router.py:243\`) withholds \`cert_pem\` / \`agent_id\` / \`capabilities\` without the proof, so dashboard-driven enrollment got stuck reporting "Approved enrollment is missing cert_pem." forever after the admin approved the ticket. The customer SPA chat never came online.

Found during the 2026-05-11 sera VPS dogfood (\`project_dogfood_2026_05_11_vps_demo\` memo, Bug #5).

## Fix

\`cullis_connector/web.py\`:1218-1230 — import the existing \`_build_enrollment_proof\` helper from the CLI module, sign the canonical string \`enrollment-status:v1|{session_id}\` with the pending P-256 keypair the wizard installed at \`/setup\` submission, pass the base64url proof as \`X-Enrollment-Proof\` header on the \`httpx.get\` call.

Same shape as Mastio's \`_verify_enrollment_proof\` and the CLI path at \`cullis_connector/enrollment.py:342-343\`.

## Test plan

- [x] \`pytest tests/connector/test_api_status_enrollment_proof.py\` — 3 new regression specs ✓
  - pins the header on every dashboard poll
  - round-trip verifies the ECDSA signature
  - approved branch writes the cert to disk and clears \`_pending\`
- [x] Regression check: \`git stash\` the fix → 2/3 specs flip to red on \`proof = None\`, confirming the tests guard the contract
- [ ] CI green
- [ ] Manual VPS dogfood after merge (follows up the same scenario that found Bug #5)

## Refs

- \`project_dogfood_2026_05_11_vps_demo\` — full 7-bug list from the VPS dogfood
- M-onb-1 audit: \`app/onboarding/router.py\` \`_ENROLLMENT_STATUS_PROOF_HEADER\` gate

## Follow-up

Smoke gate \`packaging/smoke-customer-path.sh\` (separate PR) will exercise the full bundle path end-to-end so this class of regression cannot reach main again.