### PR TITLE
fix(mastio): bind LOCAL_TOKEN to DPoP key (Wave B PR7 / C1)

### DIFF
--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -47,6 +47,89 @@ def _extract_bearer_or_dpop_token(request: Request) -> str | None:
     return None
 
 
+async def _enforce_local_token_dpop_binding(
+    request: Request,
+    payload,
+    token: str,
+) -> None:
+    """Wave B C1 — close the LOCAL_TOKEN replay window.
+
+    When the token carries ``cnf.jkt`` (post-fix mint), require a fresh
+    DPoP proof from the inbound request:
+      * proof must cover ``request.method`` + the request URL (htu)
+      * proof's jwk thumbprint must match the token's ``cnf.jkt``
+      * proof's ``ath`` must hash this LOCAL_TOKEN
+      * jti is consumed once (replay protection via the shared store)
+
+    When the token has NO ``cnf.jkt`` (legacy, minted before this fix):
+      * if ``local_token_require_dpop=true`` → 401
+      * else log WARN and accept (back-compat for in-flight tokens
+        within the existing TTL window)
+
+    Raises HTTPException(401) on any mismatch. Returns None on success
+    so callers stay terse.
+    """
+    cnf = payload.extra.get("cnf") if isinstance(payload.extra, dict) else None
+    expected_jkt = (cnf or {}).get("jkt") if isinstance(cnf, dict) else None
+
+    if expected_jkt is None:
+        if get_settings().local_token_require_dpop:
+            _log.warning(
+                "LOCAL_TOKEN sub=%s rejected: no cnf.jkt and "
+                "local_token_require_dpop=true",
+                payload.agent_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="LOCAL_TOKEN missing cnf.jkt — re-login required",
+                headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
+            )
+        _log.warning(
+            "LOCAL_TOKEN sub=%s accepted without DPoP binding (legacy "
+            "token; flip MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=true once "
+            "all clients have re-logged in)",
+            payload.agent_id,
+        )
+        return
+
+    proof = request.headers.get("DPoP")
+    if not proof:
+        _log.info(
+            "LOCAL_TOKEN sub=%s rejected: cnf.jkt present but no DPoP "
+            "proof header on request",
+            payload.agent_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="LOCAL_TOKEN is DPoP-bound but no DPoP proof presented",
+            headers={"WWW-Authenticate": 'DPoP realm="mcp-proxy"'},
+        )
+
+    from mcp_proxy.auth.dpop import verify_dpop_proof
+    htu = str(request.url).split("?", 1)[0]
+    try:
+        proof_jkt = await verify_dpop_proof(
+            proof, request.method, htu,
+            access_token=token, require_nonce=False,
+        )
+    except HTTPException:
+        # verify_dpop_proof already raises 401 with a meaningful detail
+        # (which is intentionally generic in upstream telemetry); just
+        # propagate.
+        raise
+    if proof_jkt != expected_jkt:
+        _log.info(
+            "LOCAL_TOKEN sub=%s rejected: DPoP proof jkt %s does not "
+            "match cnf.jkt %s",
+            payload.agent_id, proof_jkt, expected_jkt,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="DPoP proof key does not match LOCAL_TOKEN cnf.jkt",
+            headers={"WWW-Authenticate": 'DPoP realm="mcp-proxy"'},
+        )
+
+
 async def _is_known_local_kid(token: str, keystore) -> bool:
     """Pre-check: the token's ``kid`` matches a keystore row that is
     still valid for verification (active OR within the grace window).
@@ -117,6 +200,11 @@ async def _maybe_local_token(request: Request) -> TokenPayload | None:
             detail="local token rejected",
             headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
         ) from exc
+
+    # Wave B C1 (audit 2026-05-11) — enforce DPoP binding when the
+    # token carries cnf.jkt. Legacy tokens (no cnf.jkt) fall back per
+    # the local_token_require_dpop flag.
+    await _enforce_local_token_dpop_binding(request, payload, token)
 
     # ADR-020 — typed principals (user / workload) skip the
     # internal_agents lookup. Mirrors the analogous branch in
@@ -211,6 +299,11 @@ async def _maybe_local_internal_agent(request: Request) -> InternalAgent | None:
             detail="local token rejected",
             headers={"WWW-Authenticate": 'Bearer realm="mcp-proxy"'},
         ) from exc
+
+    # Wave B C1 (audit 2026-05-11) — same DPoP binding enforcement on
+    # the egress dep so /v1/egress/* doesn't accept replay of an
+    # exfiltrated LOCAL_TOKEN. Mirrors _maybe_local_token above.
+    await _enforce_local_token_dpop_binding(request, payload, token)
 
     # ADR-020 — typed principals (user / workload) authenticate via the
     # token's ``::user::`` / ``::workload::`` SPIFFE id, validated above

--- a/mcp_proxy/auth/local_token.py
+++ b/mcp_proxy/auth/local_token.py
@@ -234,10 +234,39 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
         raise _unauthorized("sub does not match client cert")
 
     ttl = _resolve_ttl(request)
-    token = issuer.issue(agent_id=agent_id, ttl_seconds=ttl)
+
+    # Wave B C1 (audit 2026-05-11) — bind the issued LOCAL_TOKEN to the
+    # DPoP key the SDK presented at mint time. The SDK already sends a
+    # ``DPoP`` proof header on every ``POST /v1/auth/token`` (matches the
+    # Court's flow), so we just verify it here, extract the jkt, and
+    # stamp it into the token's ``cnf.jkt`` claim. Replay of a leaked
+    # LOCAL_TOKEN without the bound private key is then rejected by the
+    # ingress dep (``_maybe_local_token``).
+    extra_claims: dict[str, Any] | None = None
+    cnf_jkt = await _maybe_extract_dpop_jkt_at_mint(request)
+    if cnf_jkt is not None:
+        extra_claims = {"cnf": {"jkt": cnf_jkt}}
+    else:
+        from mcp_proxy.config import get_settings as _gs
+        if _gs().local_token_require_dpop:
+            _log.warning(
+                "local /auth/token rejected sub=%s: DPoP proof missing or "
+                "invalid and local_token_require_dpop=true", agent_id,
+            )
+            raise _unauthorized("DPoP proof required for LOCAL_TOKEN binding")
+        _log.warning(
+            "local /auth/token sub=%s: no DPoP binding (legacy Bearer "
+            "fallback). Set MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=true once "
+            "the SDK has rolled out to enforce.", agent_id,
+        )
+
+    token = issuer.issue(
+        agent_id=agent_id, ttl_seconds=ttl, extra_claims=extra_claims,
+    )
     _log.info(
-        "local /auth/token issued sub=%s iss=%s kid=%s ttl=%ds",
+        "local /auth/token issued sub=%s iss=%s kid=%s ttl=%ds dpop=%s",
         agent_id, issuer.issuer, token.kid, ttl,
+        "bound" if cnf_jkt else "unbound",
     )
     return TokenResponse(
         access_token=token.token,
@@ -246,6 +275,41 @@ async def issue_local_token(body: TokenRequest, request: Request) -> TokenRespon
         scope=LOCAL_SCOPE,
         issued_by=issuer.issuer,
     )
+
+
+async def _maybe_extract_dpop_jkt_at_mint(request: Request) -> str | None:
+    """Verify the inbound DPoP proof against ``POST /v1/auth/token`` and
+    return its jkt. Returns ``None`` when no proof header is present or
+    the verification fails (the caller decides between fallback and 401
+    based on the ``local_token_require_dpop`` flag).
+
+    The proof must:
+      * cover ``htm=POST`` and ``htu=<request URL>``
+      * carry a fresh ``jti`` (one-time replay window enforced by the
+        shared JTI store)
+      * be signed by an asymmetric key (RFC 9449 §4.3)
+
+    No ``ath`` is required because the access token doesn't exist yet.
+    Server nonce is not required for the mint hop (the SDK only learns
+    the nonce after the first 401 response, which would brick mint).
+    """
+    proof = request.headers.get("DPoP")
+    if not proof:
+        return None
+    from mcp_proxy.auth.dpop import verify_dpop_proof
+    htu = str(request.url).split("?", 1)[0]
+    try:
+        return await verify_dpop_proof(
+            proof, request.method, htu,
+            access_token=None, require_nonce=False,
+        )
+    except HTTPException as exc:
+        _log.warning(
+            "local /auth/token: inbound DPoP proof invalid (%s) — "
+            "falling back to unbound mint",
+            getattr(exc, "detail", str(exc)),
+        )
+        return None
 
 
 def _resolve_ttl(request: Request) -> int:

--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -346,6 +346,23 @@ class ProxySettings(BaseSettings):
     # PROXY_LOCAL_AUTH.
     local_auth_enabled: bool = False
 
+    # Wave B C1 (audit 2026-05-11) — bind LOCAL_TOKEN to a DPoP key.
+    # When the SDK calls ``POST /v1/auth/token`` with a ``DPoP`` proof
+    # header the Mastio extracts the proof's jkt and stamps it into the
+    # token's ``cnf.jkt`` claim. Subsequent requests carrying the
+    # LOCAL_TOKEN must present a fresh DPoP proof signed by the same
+    # key — replay of an exfiltrated token alone is rejected.
+    #
+    # ``local_token_require_dpop`` controls strict mode:
+    #   * False (default): tokens minted without ``cnf.jkt`` (legacy)
+    #     still validate as plain Bearer with a WARN log. New tokens
+    #     get the binding; old ones expire within ``local_auth_token_
+    #     ttl_seconds`` (15 min default) and fall out naturally.
+    #   * True: any LOCAL_TOKEN without ``cnf.jkt`` is rejected at
+    #     mint AND at validation. Use after the SDK has rolled out and
+    #     the existing token TTL has fully expired.
+    local_token_require_dpop: bool = False
+
     # ADR-017 native AI gateway on Mastio. When the Mastio runs litellm
     # in-process (default: ``litellm_embedded``), every chat completion
     # is dispatched without a Court round trip. Set ``backend=portkey``

--- a/tests/test_wave_b_pr7_local_token_dpop_binding.py
+++ b/tests/test_wave_b_pr7_local_token_dpop_binding.py
@@ -1,0 +1,557 @@
+"""Wave B PR7 — C1 LOCAL_TOKEN cnf.jkt + DPoP binding.
+
+Audit ref: imp/audits/2026-05-11-track-2-auth.md H3.
+
+Pre-fix vector:
+  * SDK called ``POST /v1/auth/token`` with x509 client_assertion +
+    a DPoP proof header (the wire format is identical to the Court's
+    flow). The Mastio mint handler ignored the DPoP proof entirely
+    and issued a plain Bearer LOCAL_TOKEN (no ``cnf.jkt``).
+  * Subsequent requests carried ``Authorization: Bearer <token>``
+    (or ``Authorization: DPoP <token>`` with an SDK proof). The dep
+    validated the JWT signature + claims but never verified the
+    proof: any holder of the token bytes (e.g. an attacker who
+    exfiltrated ``~/.cullis/local.token``) could replay until the
+    token expired.
+
+Post-fix:
+  1. ``POST /v1/auth/token`` reads the inbound ``DPoP`` header,
+     verifies the proof against ``htm=POST`` + ``htu=<request URL>``,
+     extracts the JWK thumbprint (jkt) and stamps it into the issued
+     token's ``cnf.jkt`` claim.
+  2. The ingress dep (``_maybe_local_token``) and egress dep
+     (``_maybe_local_internal_agent``) require, when the token has
+     ``cnf.jkt``:
+       * a fresh DPoP proof header on the inbound request
+       * proof's jkt matches the token's ``cnf.jkt``
+       * proof's ``ath`` hashes the LOCAL_TOKEN
+     Mismatch / missing → 401.
+  3. Backward compat: tokens minted before this fix carry no
+     ``cnf.jkt``. They validate as Bearer with a WARN log, until
+     ``MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=true`` flips them to 401.
+"""
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import importlib
+import time
+import uuid
+
+import jwt as jose_jwt
+import pytest
+import pytest_asyncio
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+from cryptography.x509.oid import NameOID
+from httpx import ASGITransport, AsyncClient
+
+
+# ── Cert + assertion + DPoP helpers (mirror tests/test_proxy_local_token.py) ──
+
+
+def _gen_ca() -> tuple[bytes, str, str]:
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "acme-ca")])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_subject).issuer_name(ca_subject)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(ca_key, hashes.SHA256())
+    )
+    key_pem = ca_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = ca_cert.public_bytes(serialization.Encoding.PEM).decode()
+    return ca_key, key_pem, cert_pem
+
+
+def _issue_leaf(ca_key, ca_cert_pem: str, agent_id: str):
+    ca_cert = x509.load_pem_x509_certificate(ca_cert_pem.encode())
+    leaf_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    leaf_subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, agent_id)])
+    leaf = (
+        x509.CertificateBuilder()
+        .subject_name(leaf_subject).issuer_name(ca_cert.subject)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=5))
+        .not_valid_after(datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=30))
+        .sign(ca_key, hashes.SHA256())
+    )
+    key_pem = leaf_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    cert_pem = leaf.public_bytes(serialization.Encoding.PEM).decode()
+    x5c = [base64.b64encode(leaf.public_bytes(serialization.Encoding.DER)).decode()]
+    return key_pem, cert_pem, x5c
+
+
+def _build_assertion(agent_id: str, leaf_key_pem: str, x5c: list[str]) -> str:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    payload = {
+        "sub": agent_id,
+        "iss": agent_id,
+        "aud": "agent-trust-broker",
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(minutes=5)).timestamp()),
+        "jti": uuid.uuid4().hex,
+    }
+    return jose_jwt.encode(
+        payload, leaf_key_pem, algorithm="RS256", headers={"x5c": x5c}
+    )
+
+
+def _make_dpop_keypair():
+    """Generate an EC P-256 keypair + JWK suitable for DPoP proofs."""
+    priv = ec.generate_private_key(ec.SECP256R1())
+    nums = priv.public_key().public_numbers()
+    x = base64.urlsafe_b64encode(nums.x.to_bytes(32, "big")).rstrip(b"=").decode()
+    y = base64.urlsafe_b64encode(nums.y.to_bytes(32, "big")).rstrip(b"=").decode()
+    jwk = {"kty": "EC", "crv": "P-256", "x": x, "y": y}
+    return priv, jwk
+
+
+def _build_dpop_proof(
+    priv, jwk: dict, method: str, url: str, *,
+    access_token: str | None = None, jti: str | None = None,
+) -> str:
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    claims: dict = {
+        "jti": jti or uuid.uuid4().hex,
+        "htm": method.upper(),
+        "htu": url,
+        "iat": int(time.time()),
+    }
+    if access_token:
+        claims["ath"] = base64.urlsafe_b64encode(
+            hashlib.sha256(access_token.encode()).digest()
+        ).rstrip(b"=").decode()
+    return jose_jwt.encode(
+        claims, priv_pem, algorithm="ES256",
+        headers={"typ": "dpop+jwt", "jwk": jwk},
+    )
+
+
+def _compute_jkt(jwk: dict) -> str:
+    """RFC 7638 thumbprint matching ``mcp_proxy.auth.dpop.compute_jkt``."""
+    import json
+    raw = {k: jwk[k] for k in ("crv", "kty", "x", "y")}
+    canonical = json.dumps(raw, sort_keys=True, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(
+        hashlib.sha256(canonical).digest()
+    ).rstrip(b"=").decode()
+
+
+# ── Fixture (lifted from tests/test_proxy_local_token.py with require_dpop knob) ──
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("MCP_PROXY_BROKER_URL", "http://broker.invalid")
+    monkeypatch.setenv("MCP_PROXY_LOCAL_AUTH_ENABLED", "1")
+    # Disable DPoP iat freshness window pressure for deterministic tests.
+    monkeypatch.setenv("MCP_PROXY_DPOP_IAT_WINDOW", "120")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    import mcp_proxy.main as main_mod
+    importlib.reload(main_mod)
+    app = main_mod.app
+
+    async with app.router.lifespan_context(app):
+        from mcp_proxy.db import set_config
+        ca_key, ca_key_pem, ca_cert_pem = _gen_ca()
+        await set_config("org_ca_key", ca_key_pem)
+        await set_config("org_ca_cert", ca_cert_pem)
+
+        mgr = app.state.agent_manager
+        await mgr.load_org_ca(ca_key_pem, ca_cert_pem)
+        await mgr.ensure_mastio_identity()
+        from mcp_proxy.auth.local_issuer import build_from_keystore
+        from mcp_proxy.auth.local_keystore import LocalKeyStore
+        app.state.local_keystore = LocalKeyStore()
+        app.state.local_issuer = await build_from_keystore(
+            "acme", app.state.local_keystore,
+        )
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield {
+                "app": app, "client": client,
+                "ca_key": ca_key, "ca_cert_pem": ca_cert_pem,
+            }
+
+    get_settings.cache_clear()
+
+
+# ── Mint-side tests ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mint_with_dpop_header_stamps_cnf_jkt(proxy_app):
+    """Happy path — SDK sends DPoP proof on /v1/auth/token, the issued
+    LOCAL_TOKEN carries cnf.jkt = thumbprint of that DPoP key."""
+    ctx = proxy_app
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
+
+    priv, jwk = _make_dpop_keypair()
+    proof = _build_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/auth/token",
+    )
+
+    resp = await ctx["client"].post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+
+    issuer = ctx["app"].state.local_issuer
+    pub_pem = issuer.active_key.pubkey_pem
+    claims = jose_jwt.decode(
+        token, pub_pem, algorithms=["ES256"],
+        audience="cullis-local",
+        issuer="cullis-mastio:acme",
+    )
+    expected_jkt = _compute_jkt(jwk)
+    assert claims.get("cnf") == {"jkt": expected_jkt}
+
+
+@pytest.mark.asyncio
+async def test_mint_without_dpop_header_falls_back_to_unbound(proxy_app):
+    """Back-compat — when SDK omits DPoP header (legacy clients still
+    in flight), the mint succeeds but the token has no cnf.jkt and a
+    WARN is logged. Caller behaviour preserved until the flag flips."""
+    ctx = proxy_app
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
+
+    resp = await ctx["client"].post(
+        "/v1/auth/token", json={"client_assertion": assertion},
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+
+    issuer = ctx["app"].state.local_issuer
+    pub_pem = issuer.active_key.pubkey_pem
+    claims = jose_jwt.decode(
+        token, pub_pem, algorithms=["ES256"],
+        audience="cullis-local",
+        issuer="cullis-mastio:acme",
+    )
+    assert "cnf" not in claims
+
+
+@pytest.mark.asyncio
+async def test_mint_without_dpop_rejected_when_require_flag(proxy_app, monkeypatch):
+    """Strict mode — once the SDK has rolled out and the operator flips
+    MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP=true, mint without a DPoP proof
+    is 401 instead of falling back."""
+    ctx = proxy_app
+    from mcp_proxy.config import get_settings
+    monkeypatch.setattr(
+        get_settings(), "local_token_require_dpop", True,
+    )
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
+
+    resp = await ctx["client"].post(
+        "/v1/auth/token", json={"client_assertion": assertion},
+    )
+    assert resp.status_code == 401
+    assert "DPoP proof required" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_mint_with_invalid_dpop_falls_back(proxy_app):
+    """Tampered / wrong-method DPoP proof → mint falls back to unbound
+    (the caller may have opted out of DPoP). The require-flag closes
+    this gap when needed."""
+    ctx = proxy_app
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], "acme::alice")
+    assertion = _build_assertion("acme::alice", leaf_key_pem, x5c)
+
+    priv, jwk = _make_dpop_keypair()
+    # Sign for the wrong method — htm=GET ≠ POST
+    proof = _build_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/auth/token",
+    )
+
+    resp = await ctx["client"].post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+    assert resp.status_code == 200
+    issuer = ctx["app"].state.local_issuer
+    claims = jose_jwt.decode(
+        resp.json()["access_token"], issuer.active_key.pubkey_pem,
+        algorithms=["ES256"],
+        audience="cullis-local",
+        issuer="cullis-mastio:acme",
+    )
+    assert "cnf" not in claims
+
+
+# ── Validate-side helpers ──────────────────────────────────────────
+
+
+async def _mint_bound_token(ctx, agent_id="acme::user::alice"):
+    """Mint a fresh LOCAL_TOKEN bound to a new DPoP keypair. Returns
+    ``(token, priv, jwk, jkt)`` for the validation tests."""
+    leaf_key_pem, _, x5c = _issue_leaf(ctx["ca_key"], ctx["ca_cert_pem"], agent_id)
+    assertion = _build_assertion(agent_id, leaf_key_pem, x5c)
+    priv, jwk = _make_dpop_keypair()
+    proof = _build_dpop_proof(
+        priv, jwk, "POST", "http://test/v1/auth/token",
+    )
+    resp = await ctx["client"].post(
+        "/v1/auth/token",
+        json={"client_assertion": assertion},
+        headers={"DPoP": proof},
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return token, priv, jwk, _compute_jkt(jwk)
+
+
+# ── Validate-side tests ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_validation_accepts_correct_dpop_proof(proxy_app):
+    """Happy path — token bound to jkt_X, request carries fresh DPoP
+    proof signed by jkt_X. Dep accepts."""
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+
+    ctx = proxy_app
+    token, priv, jwk, _jkt = await _mint_bound_token(ctx)
+    proof = _build_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/proxy/agents/list",
+        access_token=token,
+    )
+
+    # Build a minimal Request stub via Starlette.
+    from starlette.requests import Request as StarletteRequest
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"dpop", proof.encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    payload = await _maybe_local_token(req)
+    assert payload is not None
+    assert payload.agent_id == "acme::user::alice"
+
+
+@pytest.mark.asyncio
+async def test_validation_rejects_missing_dpop_when_token_bound(proxy_app):
+    """Token has cnf.jkt; request omits DPoP header → 401."""
+    from fastapi import HTTPException
+
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+
+    ctx = proxy_app
+    token, _priv, _jwk, _jkt = await _mint_bound_token(ctx)
+
+    from starlette.requests import Request as StarletteRequest
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    with pytest.raises(HTTPException) as exc:
+        await _maybe_local_token(req)
+    assert exc.value.status_code == 401
+    assert "DPoP-bound" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_validation_rejects_dpop_signed_by_different_key(proxy_app):
+    """Token bound to jkt_X; request brings DPoP proof signed by jkt_Y
+    (attacker exfiltrated the LOCAL_TOKEN bytes but not the private
+    key) → 401. This is the headline replay-window closure."""
+    from fastapi import HTTPException
+
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+
+    ctx = proxy_app
+    token, _orig_priv, _orig_jwk, _ = await _mint_bound_token(ctx)
+
+    # Attacker generates their own DPoP key.
+    attacker_priv, attacker_jwk = _make_dpop_keypair()
+    attacker_proof = _build_dpop_proof(
+        attacker_priv, attacker_jwk, "GET",
+        "http://test/v1/proxy/agents/list",
+        access_token=token,
+    )
+
+    from starlette.requests import Request as StarletteRequest
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"dpop", attacker_proof.encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    with pytest.raises(HTTPException) as exc:
+        await _maybe_local_token(req)
+    assert exc.value.status_code == 401
+    assert "cnf.jkt" in exc.value.detail
+
+
+@pytest.mark.asyncio
+async def test_validation_rejects_dpop_with_wrong_ath(proxy_app):
+    """Token bound to jkt_X; request brings DPoP proof signed by jkt_X
+    but with the wrong access-token hash (proof recycled from a prior
+    different-token request) → 401."""
+    from fastapi import HTTPException
+
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+
+    ctx = proxy_app
+    token, priv, jwk, _ = await _mint_bound_token(ctx)
+    other_token = "this-is-some-other-token"
+    bad_ath_proof = _build_dpop_proof(
+        priv, jwk, "GET", "http://test/v1/proxy/agents/list",
+        access_token=other_token,
+    )
+
+    from starlette.requests import Request as StarletteRequest
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"dpop", bad_ath_proof.encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    with pytest.raises(HTTPException) as exc:
+        await _maybe_local_token(req)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_validation_legacy_unbound_token_accepted_by_default(proxy_app):
+    """Token minted before this fix has no cnf.jkt. With the require
+    flag off (default) the dep accepts it as plain Bearer + warns —
+    so in-flight tokens within the existing TTL window aren't bricked
+    by the upgrade."""
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+
+    ctx = proxy_app
+    issuer = ctx["app"].state.local_issuer
+    legacy_token = issuer.issue(agent_id="acme::user::alice", ttl_seconds=300)
+
+    from starlette.requests import Request as StarletteRequest
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {legacy_token.token}".encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    payload = await _maybe_local_token(req)
+    assert payload is not None
+    assert payload.agent_id == "acme::user::alice"
+
+
+@pytest.mark.asyncio
+async def test_validation_legacy_unbound_token_rejected_when_strict(
+    proxy_app, monkeypatch,
+):
+    """Strict mode — once operator flips local_token_require_dpop=true,
+    legacy unbound tokens are rejected so the migration is finite."""
+    from fastapi import HTTPException
+
+    from mcp_proxy.auth.local_agent_dep import _maybe_local_token
+    from mcp_proxy.config import get_settings
+
+    monkeypatch.setattr(
+        get_settings(), "local_token_require_dpop", True,
+    )
+
+    ctx = proxy_app
+    issuer = ctx["app"].state.local_issuer
+    legacy_token = issuer.issue(agent_id="acme::user::alice", ttl_seconds=300)
+
+    from starlette.requests import Request as StarletteRequest
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("test", 80),
+        "path": "/v1/proxy/agents/list",
+        "query_string": b"",
+        "headers": [
+            (b"authorization", f"Bearer {legacy_token.token}".encode()),
+        ],
+        "app": ctx["app"],
+    }
+    req = StarletteRequest(scope)
+    with pytest.raises(HTTPException) as exc:
+        await _maybe_local_token(req)
+    assert exc.value.status_code == 401
+    assert "re-login required" in exc.value.detail


### PR DESCRIPTION
## Summary

Closes audit C1 (Wave B PR7) — `imp/audits/2026-05-11-track-2-auth.md` H3 + `imp/audits/2026-05-11-MASTER.md`.

**Pre-fix vector:** SDK called `POST /v1/auth/token` with x509 client_assertion AND a DPoP proof header (the SDK already sends one — wire format mirrors the Court flow byte-for-byte). The Mastio mint handler ignored the DPoP proof entirely and issued a plain Bearer LOCAL_TOKEN with no `cnf.jkt` claim. Anyone holding the token bytes (exfiltrated `~/.cullis/local.token`, shell history, log capture) could replay until exp (15 min default). Contradicted CLAUDE.md ‟DPoP obbligatorio... mai plain Bearer”.

**Fix:**
1. `config.py` — new `MCP_PROXY_LOCAL_TOKEN_REQUIRE_DPOP` setting (default `false` for migration window; flip `true` after SDK rollout + TTL drain).
2. `local_token.py` — at mint time, verify inbound `DPoP` header against `POST` + htu of `/v1/auth/token`, extract jkt, stamp into issued token's `cnf.jkt`. Falls back to unbound + WARN when header absent (or 401 if require flag set).
3. `local_agent_dep.py` — new `_enforce_local_token_dpop_binding` called from both ingress + egress deps. When token has `cnf.jkt`: require DPoP proof on inbound request, verify proof's jkt matches, verify ath hashes the LOCAL_TOKEN. 401 on mismatch.

**Backward compat:** tokens minted before this PR carry no `cnf.jkt`; they validate as plain Bearer with WARN log until the require flag flips. Existing 15-min TTL drains the legacy population naturally.

## Test plan

- [x] 10 new unit tests in `tests/test_wave_b_pr7_local_token_dpop_binding.py`:
  - mint stamps cnf.jkt when DPoP present
  - mint fallback when DPoP absent (default)
  - mint 401 when DPoP absent + require flag
  - mint fallback on tampered DPoP (wrong htm)
  - validation accepts correct DPoP
  - validation rejects missing DPoP on bound token
  - **validation rejects DPoP signed by different key (headline replay-window closure)**
  - validation rejects DPoP with wrong ath
  - validation accepts legacy unbound token by default
  - validation rejects legacy unbound token when require flag set
- [x] `pytest tests/ -k 'local_token or local_validator or local_agent_dep or auth or dpop'` → 266 passed, 2 skipped (existing 256 continue to pass; dep changes are no-ops for legacy tokens + transparent for DPoP-equipped clients)
- [ ] CI demo_network smoke (covers SDK live login + ingress/egress round-trip with the DPoP header the SDK already sends)
- [ ] /security-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)