### PR TITLE
fix(mastio): migration 0032 sync rewrite — Mastio bundle restart-loop (Bug #8)

### DIFF
--- a/mcp_proxy/alembic/versions/0032_ai_creds_at_rest_encrypt.py
+++ b/mcp_proxy/alembic/versions/0032_ai_creds_at_rest_encrypt.py
@@ -13,23 +13,50 @@ the SQLite file or a Postgres backup recovered every upstream LLM API
 key (Anthropic, OpenAI, AWS Bedrock, GCP service-account JSON, Gemini,
 Vertex) in cleartext.
 
-This migration walks every existing row, parses the JSON to confirm
-it is plaintext (already-enveloped rows are skipped — no double-wrap),
-and rewrites it through ``mcp_proxy.tools.secret_encrypt.encrypt_at_rest``
-so the column carries the ``enc:v1:<token>`` envelope. The KMS-derived
-master key is bootstrapped on first read; on a cold-install Mastio the
-helper mints + persists a per-deploy random into ``proxy_config``
-(env override available via ``MCP_PROXY_SECRET_ENCRYPTION_KEY_B64``).
+This migration walks every existing row, parses the envelope to
+confirm it is plaintext (already-enveloped rows are skipped — no
+double-wrap), and rewrites the column with the ``enc:v1:<token>``
+Fernet envelope. Reads at runtime go through
+``mcp_proxy.tools.secret_encrypt.decrypt_at_rest`` which already
+transparently handles legacy plaintext rows during rollout.
 
-Schema-only change: no DDL. The migration is a one-shot data rewrite.
-Rolls back safely (``decrypt_at_rest`` reads the envelope back to
-plaintext). Idempotent: a second forward run no-ops on rows that
-already start with ``enc:v1:``.
+Implementation note (Bug #8 fix-forward, 2026-05-11 sera): the
+original revision called the async ``encrypt_at_rest`` helper via
+``loop.run_until_complete(...)``. Inside alembic's
+``connection.run_sync(do_run_migrations)`` bridge the new event loop
+deadlocks against the outer ``asyncio.run`` driving the migration —
+the coroutine is created but never awaited (RuntimeWarning), the
+container exits with code 3, docker compose retries forever, and
+the customer-path Mastio bundle becomes unbootable
+(``project_dogfood_2026_05_11_vps_demo`` Bug #8, issue #626).
+
+This rewrite stays inside the alembic sync execution context the
+whole way:
+
+  - master key resolution reads ``MCP_PROXY_SECRET_ENCRYPTION_KEY_B64``
+    env first (operator override, common in production), falling back
+    to a sync ``SELECT value FROM proxy_config WHERE key = ...`` via
+    ``bind.execute``. Cold install mints + persists a fresh
+    ``secrets.token_bytes(32)`` into proxy_config the same way the
+    runtime helper does, just through the alembic bind.
+  - encryption/decryption use ``Fernet`` directly (synchronous).
+  - No ``asyncio``, no nested event loop, no coroutine creation.
+
+The runtime path (``mcp_proxy.tools.secret_encrypt``) is unchanged
+and remains async — only the one-shot migration goes sync. Forward
+and reverse are still idempotent on already-correct rows.
 """
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import secrets
 from typing import Sequence, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
+from cryptography.fernet import Fernet, InvalidToken
 
 
 revision: str = "0032_ai_creds_at_rest_enc"
@@ -39,61 +66,161 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 _TABLE = "ai_provider_credentials"
+_PROXY_CONFIG_TABLE = "proxy_config"
 _PREFIX = "enc:v1:"
+_PROXY_CONFIG_KEY = "secret_encryption_key_b64"
+
+_log = logging.getLogger("alembic.runtime.migration")
+
+
+# ── master key resolution (sync) ─────────────────────────────────────────
+
+
+def _bytes_to_fernet_key(raw: bytes) -> bytes:
+    """Same conversion contract as ``mcp_proxy.tools.secret_encrypt``:
+    accept either 32 raw bytes or the urlsafe-base64 form, normalise
+    to the form Fernet expects."""
+    if len(raw) == 32:
+        return base64.urlsafe_b64encode(raw)
+    if len(raw) == 44:
+        decoded = base64.urlsafe_b64decode(raw)
+        if len(decoded) != 32:
+            raise ValueError(
+                "secret_encryption_key_b64 decodes to non-32-byte material",
+            )
+        return raw
+    raise ValueError(
+        f"secret_encryption_key_b64 unexpected length {len(raw)}; "
+        "expected 32 raw bytes or 44 urlsafe-base64 chars",
+    )
+
+
+def _resolve_master_key(bind) -> bytes:
+    """Sync mirror of ``_load_or_create_master_key`` for migration use.
+
+    Precedence matches the runtime helper:
+      1. ``MCP_PROXY_SECRET_ENCRYPTION_KEY_B64`` env.
+      2. ``proxy_config`` row.
+      3. Mint + persist on cold install.
+    """
+    env_val = os.environ.get("MCP_PROXY_SECRET_ENCRYPTION_KEY_B64", "").strip()
+    if env_val:
+        try:
+            raw = base64.urlsafe_b64decode(env_val)
+        except Exception as exc:
+            raise RuntimeError(
+                "MCP_PROXY_SECRET_ENCRYPTION_KEY_B64 is not valid "
+                "urlsafe-base64",
+            ) from exc
+        return _bytes_to_fernet_key(raw)
+
+    row = bind.execute(
+        sa.text(
+            f"SELECT value FROM {_PROXY_CONFIG_TABLE} WHERE key = :k"
+        ),
+        {"k": _PROXY_CONFIG_KEY},
+    ).fetchone()
+
+    if row is not None and row[0]:
+        try:
+            raw = base64.urlsafe_b64decode(row[0])
+        except Exception as exc:
+            raise RuntimeError(
+                f"{_PROXY_CONFIG_KEY} in proxy_config is not valid "
+                "urlsafe-base64",
+            ) from exc
+        return _bytes_to_fernet_key(raw)
+
+    # Cold install — mint + persist. Same insert-or-update shape used
+    # by ``mcp_proxy.db.set_config`` so the runtime helper picks the
+    # value up on next boot.
+    raw = secrets.token_bytes(32)
+    encoded = base64.urlsafe_b64encode(raw).decode()
+    _log.info(
+        "secret_encryption_key minted by migration 0032 and persisted "
+        "to proxy_config. Override via MCP_PROXY_SECRET_ENCRYPTION_KEY_B64."
+    )
+    # Portable upsert: DELETE-then-INSERT inside the migration's
+    # transaction. Works on SQLite + Postgres without dialect branches.
+    bind.execute(
+        sa.text(
+            f"DELETE FROM {_PROXY_CONFIG_TABLE} WHERE key = :k"
+        ),
+        {"k": _PROXY_CONFIG_KEY},
+    )
+    bind.execute(
+        sa.text(
+            f"INSERT INTO {_PROXY_CONFIG_TABLE} (key, value) "
+            f"VALUES (:k, :v)"
+        ),
+        {"k": _PROXY_CONFIG_KEY, "v": encoded},
+    )
+    return _bytes_to_fernet_key(raw)
+
+
+# ── row walker ───────────────────────────────────────────────────────────
 
 
 def _migrate_rows(direction: str) -> None:
-    """Walk every row and upgrade / downgrade the envelope.
+    """Walk every row and upgrade / downgrade the envelope, synchronously.
 
     direction = "encrypt" → wrap plaintext in enc:v1:<token>
     direction = "decrypt" → unwrap enc:v1: back to plaintext
+
+    Idempotent: encrypt skips ``enc:v1:`` rows, decrypt skips plain rows.
     """
     bind = op.get_bind()
     inspector = sa.inspect(bind)
-    if _TABLE not in set(inspector.get_table_names()):
+    table_names = set(inspector.get_table_names())
+    if _TABLE not in table_names:
+        return
+    if _PROXY_CONFIG_TABLE not in table_names:
+        # Should never happen — proxy_config is part of the 0001
+        # initial snapshot — but bail rather than crash the bundle if
+        # an exotic legacy DB somehow lacks it.
+        _log.warning(
+            "0032: %s table missing, skipping data migration",
+            _PROXY_CONFIG_TABLE,
+        )
         return
 
     rows = bind.execute(
         sa.text(f"SELECT provider, creds_json FROM {_TABLE}"),
     ).fetchall()
-
     if not rows:
         return
 
-    # Late import — alembic's offline-mode renderer can run without
-    # the application package on the path; the data step requires it.
-    import asyncio
-    from mcp_proxy.tools.secret_encrypt import (
-        decrypt_at_rest,
-        encrypt_at_rest,
-    )
+    key = _resolve_master_key(bind)
+    fernet = Fernet(key)
 
-    async def _transform(value: str | None) -> str | None:
-        if value is None or value == "":
-            return value
+    for provider, blob in rows:
+        if blob is None or blob == "":
+            continue
         if direction == "encrypt":
-            if value.startswith(_PREFIX):
-                return value  # already enveloped, idempotent
-            return await encrypt_at_rest(value)
-        # downgrade
-        if not value.startswith(_PREFIX):
-            return value  # already plaintext
-        return await decrypt_at_rest(value)
-
-    loop = asyncio.new_event_loop()
-    try:
-        for provider, blob in rows:
-            new_blob = loop.run_until_complete(_transform(blob))
-            if new_blob != blob:
-                bind.execute(
-                    sa.text(
-                        f"UPDATE {_TABLE} SET creds_json = :c "
-                        f" WHERE provider = :p"
-                    ),
-                    {"c": new_blob, "p": provider},
-                )
-    finally:
-        loop.close()
+            if blob.startswith(_PREFIX):
+                continue  # already enveloped
+            token = fernet.encrypt(blob.encode("utf-8")).decode("utf-8")
+            new_blob = _PREFIX + token
+        else:
+            if not blob.startswith(_PREFIX):
+                continue  # already plaintext
+            try:
+                new_blob = fernet.decrypt(
+                    blob[len(_PREFIX):].encode("utf-8"),
+                ).decode("utf-8")
+            except InvalidToken as exc:
+                raise RuntimeError(
+                    f"0032 downgrade: row provider={provider!r} cannot "
+                    "be decrypted with the current master key — likely "
+                    "the key was rotated since upgrade ran"
+                ) from exc
+        bind.execute(
+            sa.text(
+                f"UPDATE {_TABLE} SET creds_json = :c "
+                f" WHERE provider = :p"
+            ),
+            {"c": new_blob, "p": provider},
+        )
 
 
 def upgrade() -> None:

--- a/mcp_proxy/alembic/versions/0032_ai_creds_at_rest_encrypt.py
+++ b/mcp_proxy/alembic/versions/0032_ai_creds_at_rest_encrypt.py
@@ -56,7 +56,15 @@ from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
-from cryptography.fernet import Fernet, InvalidToken
+
+# NOTE: ``cryptography`` is imported lazily inside ``_migrate_rows`` (and
+# only on the encrypt/decrypt branch, after the empty-rows early-exit) so
+# the module file parses in environments that have alembic but not the
+# full proxy runtime deps. Specifically ``demo_network/proxy-init`` is a
+# slim seed container that runs ``command.upgrade(cfg, "head")`` against
+# a fresh SQLite to pre-populate ``proxy_config``: there are zero rows in
+# ``ai_provider_credentials`` to migrate there, and we don't want to add
+# ``cryptography`` to its requirements just so this file can be parsed.
 
 
 revision: str = "0032_ai_creds_at_rest_enc"
@@ -189,6 +197,11 @@ def _migrate_rows(direction: str) -> None:
     ).fetchall()
     if not rows:
         return
+
+    # Lazy import — see module-level note. demo_network/proxy-init parses
+    # this file but never reaches this branch (its DB has no rows), so it
+    # must not need ``cryptography`` installed.
+    from cryptography.fernet import Fernet, InvalidToken
 
     key = _resolve_master_key(bind)
     fernet = Fernet(key)

--- a/tests/test_wave_b_pr4_ai_creds_at_rest.py
+++ b/tests/test_wave_b_pr4_ai_creds_at_rest.py
@@ -200,3 +200,202 @@ async def test_legacy_plaintext_row_still_readable(fresh_db):
     from mcp_proxy.db import get_ai_provider_creds
     fetched = await get_ai_provider_creds("legacyprov")
     assert fetched["creds"] == {"api_key": "sk-legacy-plain"}
+
+
+# ── Migration 0032 with rows present (Bug #8 regression) ────────────────
+
+
+def test_migration_0032_upgrades_rows_with_plaintext_payload(tmp_path):
+    """Bug #8 regression: pre-fix 0032 called the async ``encrypt_at_rest``
+    helper via ``loop.run_until_complete(...)`` inside alembic's
+    ``connection.run_sync(do_run_migrations)`` bridge. The new event loop
+    deadlocked against the outer ``asyncio.run`` driving the migration,
+    the coroutine was created but never awaited, the container exited
+    with code 3 the very first time ``ai_provider_credentials`` was
+    non-empty, and the Mastio bundle went into restart loop.
+
+    All existing 0032 tests run against a FRESH DB (no rows in
+    ``ai_provider_credentials``) so the buggy branch was never reached
+    — this is the gap the dogfood surfaced.
+
+    This test seeds two plaintext rows at revision 0031, runs alembic
+    upgrade head, and asserts both rows now carry the ``enc:v1:`` prefix.
+    A fresh master key is minted by the migration into ``proxy_config``
+    on cold-install; the test round-trips through that key to confirm
+    the ciphertext decrypts back to the original payload.
+    """
+    import asyncio
+    import sqlite3
+    from alembic import command
+    from alembic.config import Config as AlembicConfig
+
+    from mcp_proxy.db import _alembic_config  # type: ignore[attr-defined]
+    from mcp_proxy.tools.secret_encrypt import _PREFIX as RUNTIME_PREFIX
+
+    db_file = tmp_path / "migration-0032.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    sync_url = f"sqlite:///{db_file}"
+
+    # 1. Upgrade to 0031 only (before the encryption migration).
+    cfg: AlembicConfig = _alembic_config(url)
+    command.upgrade(cfg, "0031_audit_append_only_v2")
+
+    # 2. Seed plaintext rows directly in the table.
+    seed_payloads = {
+        "anthropic": '{"api_key":"sk-ant-plaintext"}',
+        "openai":    '{"api_key":"sk-openai-plaintext"}',
+    }
+    from datetime import datetime, timezone
+    with sqlite3.connect(str(db_file)) as conn:
+        for provider, payload in seed_payloads.items():
+            conn.execute(
+                "INSERT INTO ai_provider_credentials "
+                "(provider, creds_json, enabled, updated_at, updated_by) "
+                "VALUES (?, ?, 1, ?, 'test')",
+                (provider, payload, datetime.now(timezone.utc).isoformat()),
+            )
+        conn.commit()
+
+    # 3. Apply 0032. Pre-fix this raises RuntimeWarning and the bind
+    #    transaction never persists; post-fix it walks the rows sync.
+    command.upgrade(cfg, "head")
+
+    # 4. Confirm rows are now enveloped + decryptable with the persisted
+    #    master key.
+    with sqlite3.connect(str(db_file)) as conn:
+        rows = dict(
+            conn.execute(
+                "SELECT provider, creds_json FROM ai_provider_credentials"
+            ).fetchall(),
+        )
+        master_row = conn.execute(
+            "SELECT value FROM proxy_config WHERE key = 'secret_encryption_key_b64'",
+        ).fetchone()
+
+    assert master_row is not None, "migration must persist a fresh master key"
+    encoded_key = master_row[0]
+    import base64
+    raw_key = base64.urlsafe_b64decode(encoded_key)
+    assert len(raw_key) == 32, "master key must be 32 raw bytes"
+
+    from cryptography.fernet import Fernet
+    fernet = Fernet(base64.urlsafe_b64encode(raw_key))
+    for provider, original in seed_payloads.items():
+        stored = rows[provider]
+        assert stored.startswith(RUNTIME_PREFIX), (
+            f"row {provider} not enveloped: {stored[:32]}"
+        )
+        decrypted = fernet.decrypt(stored[len(RUNTIME_PREFIX):].encode()).decode()
+        assert decrypted == original, f"round-trip mismatch for {provider}"
+
+
+def test_migration_0032_idempotent_on_already_encrypted_rows(tmp_path):
+    """Running upgrade twice (or after a partial deploy that already
+    enveloped some rows) must not double-wrap."""
+    import sqlite3
+    import base64
+    from alembic import command
+    from cryptography.fernet import Fernet
+
+    from mcp_proxy.db import _alembic_config  # type: ignore[attr-defined]
+    from mcp_proxy.tools.secret_encrypt import _PREFIX as RUNTIME_PREFIX
+
+    db_file = tmp_path / "migration-0032-idem.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+
+    cfg = _alembic_config(url)
+    command.upgrade(cfg, "0031_audit_append_only_v2")
+
+    # Seed one row already enveloped with a known key + one plaintext.
+    raw_key = b"\x42" * 32
+    encoded_key = base64.urlsafe_b64encode(raw_key).decode()
+    fernet = Fernet(base64.urlsafe_b64encode(raw_key))
+    pre_encrypted = RUNTIME_PREFIX + fernet.encrypt(
+        b'{"api_key":"sk-already-wrapped"}',
+    ).decode()
+    from datetime import datetime, timezone
+    with sqlite3.connect(str(db_file)) as conn:
+        # Pin the master key in proxy_config so the migration uses it
+        # (not a random one). Both rows must round-trip with this key.
+        conn.execute(
+            "INSERT INTO proxy_config (key, value) VALUES (?, ?)",
+            ("secret_encryption_key_b64", encoded_key),
+        )
+        conn.execute(
+            "INSERT INTO ai_provider_credentials "
+            "(provider, creds_json, enabled, updated_at, updated_by) "
+            "VALUES ('prewrapped', ?, 1, ?, 'test')",
+            (pre_encrypted, datetime.now(timezone.utc).isoformat()),
+        )
+        conn.execute(
+            "INSERT INTO ai_provider_credentials "
+            "(provider, creds_json, enabled, updated_at, updated_by) "
+            "VALUES ('plainnew', ?, 1, ?, 'test')",
+            ('{"api_key":"sk-plain"}', datetime.now(timezone.utc).isoformat()),
+        )
+        conn.commit()
+
+    command.upgrade(cfg, "head")
+
+    with sqlite3.connect(str(db_file)) as conn:
+        rows = dict(
+            conn.execute(
+                "SELECT provider, creds_json FROM ai_provider_credentials"
+            ).fetchall(),
+        )
+
+    # The pre-wrapped row stays exactly as we left it (no double-wrap,
+    # no rewrap with a fresh nonce).
+    assert rows["prewrapped"] == pre_encrypted
+    # The plain row gets wrapped exactly once.
+    assert rows["plainnew"].startswith(RUNTIME_PREFIX)
+    inner = rows["plainnew"][len(RUNTIME_PREFIX):]
+    assert not inner.startswith(RUNTIME_PREFIX), "double-wrapped!"
+
+
+def test_migration_0032_downgrade_reverses_envelope(tmp_path):
+    """Downgrade unwraps enc:v1: back to plaintext for rollback paths.
+    Idempotent on rows that were already plain."""
+    import sqlite3
+    import base64
+    from alembic import command
+    from cryptography.fernet import Fernet
+
+    from mcp_proxy.db import _alembic_config  # type: ignore[attr-defined]
+    from mcp_proxy.tools.secret_encrypt import _PREFIX as RUNTIME_PREFIX
+
+    db_file = tmp_path / "migration-0032-down.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+
+    cfg = _alembic_config(url)
+    command.upgrade(cfg, "0031_audit_append_only_v2")
+
+    raw_key = b"\x37" * 32
+    encoded_key = base64.urlsafe_b64encode(raw_key).decode()
+    fernet = Fernet(base64.urlsafe_b64encode(raw_key))
+    original_payload = '{"api_key":"sk-roundtrip"}'
+    wrapped = RUNTIME_PREFIX + fernet.encrypt(
+        original_payload.encode(),
+    ).decode()
+    from datetime import datetime, timezone
+    with sqlite3.connect(str(db_file)) as conn:
+        conn.execute(
+            "INSERT INTO proxy_config (key, value) VALUES (?, ?)",
+            ("secret_encryption_key_b64", encoded_key),
+        )
+        conn.execute(
+            "INSERT INTO ai_provider_credentials "
+            "(provider, creds_json, enabled, updated_at, updated_by) "
+            "VALUES ('wrapped', ?, 1, ?, 'test')",
+            (wrapped, datetime.now(timezone.utc).isoformat()),
+        )
+        conn.commit()
+
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "0031_audit_append_only_v2")
+
+    with sqlite3.connect(str(db_file)) as conn:
+        stored = conn.execute(
+            "SELECT creds_json FROM ai_provider_credentials WHERE provider = 'wrapped'",
+        ).fetchone()[0]
+    assert stored == original_payload

--- a/tests/test_wave_b_pr4_ai_creds_at_rest.py
+++ b/tests/test_wave_b_pr4_ai_creds_at_rest.py
@@ -224,7 +224,6 @@ def test_migration_0032_upgrades_rows_with_plaintext_payload(tmp_path):
     on cold-install; the test round-trips through that key to confirm
     the ciphertext decrypts back to the original payload.
     """
-    import asyncio
     import sqlite3
     from alembic import command
     from alembic.config import Config as AlembicConfig
@@ -234,7 +233,6 @@ def test_migration_0032_upgrades_rows_with_plaintext_payload(tmp_path):
 
     db_file = tmp_path / "migration-0032.sqlite"
     url = f"sqlite+aiosqlite:///{db_file}"
-    sync_url = f"sqlite:///{db_file}"
 
     # 1. Upgrade to 0031 only (before the encryption migration).
     cfg: AlembicConfig = _alembic_config(url)

--- a/tests/test_wave_b_pr4_ai_creds_at_rest.py
+++ b/tests/test_wave_b_pr4_ai_creds_at_rest.py
@@ -399,3 +399,51 @@ def test_migration_0032_downgrade_reverses_envelope(tmp_path):
             "SELECT creds_json FROM ai_provider_credentials WHERE provider = 'wrapped'",
         ).fetchone()[0]
     assert stored == original_payload
+
+
+def test_migration_0032_parses_without_cryptography_at_import_time(tmp_path):
+    """``demo_network/proxy-init`` is a slim seed container without the
+    ``cryptography`` package. It still calls ``command.upgrade(cfg, "head")``
+    against a fresh DB to pre-populate ``proxy_config``. The migration file
+    therefore MUST parse and load even when ``cryptography`` is unavailable
+    — the actual Fernet import lives behind the ``if not rows: return``
+    guard and only fires when there is data to migrate.
+
+    Regression for the demo_network smoke fail observed on the first
+    Bug #8 fix attempt (PR #628): moving the import to the top of the file
+    broke ``proxy-a-init`` / ``proxy-b-init`` with
+    ``ModuleNotFoundError: No module named 'cryptography'``.
+    """
+    import sys
+    import importlib
+
+    # Drop cached module + simulate cryptography being unavailable.
+    sys.modules.pop(
+        "mcp_proxy.alembic.versions.0032_ai_creds_at_rest_encrypt", None,
+    )
+    real_crypto = sys.modules.get("cryptography")
+    real_fernet = sys.modules.get("cryptography.fernet")
+    sys.modules["cryptography"] = None  # type: ignore[assignment]
+    sys.modules["cryptography.fernet"] = None  # type: ignore[assignment]
+    try:
+        # If the migration imports cryptography at module scope, this raises
+        # ModuleNotFoundError. The fix lazy-imports inside _migrate_rows.
+        spec = importlib.util.spec_from_file_location(
+            "test_mig_0032",
+            "mcp_proxy/alembic/versions/0032_ai_creds_at_rest_encrypt.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        # Sanity: upgrade()/downgrade() functions exist; we don't call
+        # them (that would need a real alembic context + DB).
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+    finally:
+        if real_crypto is not None:
+            sys.modules["cryptography"] = real_crypto
+        else:
+            sys.modules.pop("cryptography", None)
+        if real_fernet is not None:
+            sys.modules["cryptography.fernet"] = real_fernet
+        else:
+            sys.modules.pop("cryptography.fernet", None)


### PR DESCRIPTION
## Summary

Fix-forward for **Bug #8** ([issue #626](https://github.com/cullis-security/cullis/issues/626)): PR #621's data migration \`0032_ai_creds_at_rest_encrypt\` deadlocks on the very first row, leaving the Mastio container in a restart loop and the customer-path bundle unbootable.

The audit finding behind #621 (AI provider creds plaintext at rest) stays closed — the runtime encryption helper is unchanged. Only the one-shot migration is rewritten to stay inside alembic's sync context.

## Root cause

PR #621's migration:
\`\`\`python
async def _transform(value):
    return await encrypt_at_rest(value)  # async helper

loop = asyncio.new_event_loop()
for provider, blob in rows:
    new_blob = loop.run_until_complete(_transform(blob))  # ← nested loop
\`\`\`

The migration runs inside \`connection.run_sync(do_run_migrations)\`, which is itself driven by alembic env.py's \`asyncio.run(run_async_migrations())\`. Creating a fresh event loop and trying to drive it inside that bridge deadlocks: the coroutine is created but never awaited (\`RuntimeWarning\`), the migration silently aborts, \`alembic_version\` never advances, container exits 3, docker compose restarts → loop forever.

## Why CI green

All existing 0032 tests in \`test_wave_b_pr4_ai_creds_at_rest.py\` ran against a **fresh DB** (no rows in \`ai_provider_credentials\`). The buggy branch is gated on \`if not rows: return\`, so the broken code path was never reached in test. Customer-path dogfood found it within minutes.

## Fix

\`_resolve_master_key(bind)\` is a sync mirror of the runtime helper's logic:
1. Read \`MCP_PROXY_SECRET_ENCRYPTION_KEY_B64\` from env (operator override).
2. Else read it from \`proxy_config\` via the migration's own bind.
3. Else mint \`secrets.token_bytes(32)\`, persist through bind, return.

The migration walks rows and calls \`Fernet(key).encrypt(...)\` / \`.decrypt(...)\` directly — no async helper imports, no event loop creation. The runtime path (\`mcp_proxy.tools.secret_encrypt\`) stays async and unchanged.

## Test plan

- [x] **\`test_migration_0032_upgrades_rows_with_plaintext_payload\`**: seeds plaintext rows at revision 0031, runs alembic upgrade head, asserts \`enc:v1:\` prefix + decrypts back to the original payload. This is the test the original PR was missing.
- [x] **\`test_migration_0032_idempotent_on_already_encrypted_rows\`**: no double-wrap on re-run.
- [x] **\`test_migration_0032_downgrade_reverses_envelope\`**: rollback unwraps cleanly.
- [x] Regression check: \`git checkout origin/main -- mcp_proxy/alembic/versions/0032_*.py\` → new test 1 flips to red (confirms the test catches the original bug).
- [x] \`pytest tests/test_wave_b_pr4_ai_creds_at_rest.py tests/test_proxy_migrations.py -n auto\` — 17 passed.
- [x] **Live verify**: rebuilt the Mastio image from this commit, deployed \`packaging/mastio-bundle\` standalone → container reaches Healthy on first boot, no restart loop, admin login OK.

## Refs

- Issue #626 — Bug #8 detail
- PR #625 — customer-path smoke gate that would have caught this pre-merge of #621
- PR #621 — introduced the broken migration
- \`project_dogfood_2026_05_11_vps_demo\` — full 8-bug list from the dogfood