### PR TITLE
feat(federation): Mastio audit replication to Court (Wave B PR8 / D1)

### DIFF
--- a/alembic/versions/s9n0o1p2q3r4_mastio_audit_replica.py
+++ b/alembic/versions/s9n0o1p2q3r4_mastio_audit_replica.py
@@ -1,0 +1,163 @@
+"""Court-side mastio_audit_replica table (Wave B PR8 / D1).
+
+Revision ID: s9n0o1p2q3r4_replica
+Revises: r8m9n0o1p2q3_audit
+Create Date: 2026-05-12 00:00:00.000000
+
+Closes audit finding D1 (Wave B PR8) from
+imp/audits/2026-05-11-track-3-audit-pdp.md F-3 and
+imp/audits/2026-05-11-MASTER.md.
+
+Pre-fix posture: CLAUDE.md + ADR-008 claim "non-ripudio cross-org dal
+dual-write Mastio". Federation publisher only forwarded agent records
+(``federation.publish-agent``). Cross-org dispute had no second source
+of truth: an assessor reading the ADR and grep-ing for the evidence
+would find nothing.
+
+Post-fix posture: each Mastio replicates its ``local_audit`` chain to
+the Court via ``POST /v1/federation/audit/replicate``. Each row carries
+an ECDSA signature by the Mastio's pinned leaf key. The Court stores
+a verbatim copy in ``mastio_audit_replica`` (append-only via the same
+trigger pattern as audit_log). On dispute, an admin queries
+``/v1/admin/audit/cross-org-verify`` which compares the Court's
+broker-observed audit_log row against both Mastios' replica rows and
+flags any divergence.
+
+Schema:
+  * ``mastio_org_id``     — the Mastio publishing this row
+  * ``chain_seq``         — Mastio's per-org local_audit chain_seq
+  * ``entry_hash``        — Mastio's local_audit row hash (verbatim)
+  * ``previous_hash``     — for chain continuity verification
+  * ``timestamp``         — Mastio's local timestamp (ISO8601 UTC)
+  * ``event_type, agent_id, session_id, details, result,
+     principal_type``  — verbatim Mastio fields for content-side
+     comparison
+  * ``hash_format``       — 'v1' or 'v2' (inherits Mastio's choice)
+  * ``signature_b64``     — ECDSA-P256 signature of the canonical
+                             payload, signed by the Mastio leaf key
+                             pinned in ``organizations.mastio_pubkey``
+  * ``received_at``       — Court's receive timestamp (audit trail)
+
+UNIQUE (mastio_org_id, chain_seq) — one row per Mastio chain slot,
+makes the receiver idempotent under retry.
+
+Append-only: BEFORE UPDATE OR DELETE trigger raises an error in both
+Postgres and SQLite, mirroring the ``audit_log`` trigger from
+PR5 (r8m9n0o1p2q3_audit).
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "s9n0o1p2q3r4_replica"
+down_revision: Union[str, Sequence[str], None] = "r8m9n0o1p2q3_audit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_PG_TRIGGER_FN = """
+CREATE OR REPLACE FUNCTION mastio_audit_replica_no_mutate()
+RETURNS trigger AS $$
+BEGIN
+    RAISE EXCEPTION 'mastio_audit_replica is append-only — UPDATE/DELETE blocked'
+      USING ERRCODE = 'check_violation';
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_PG_TRIGGER = """
+CREATE TRIGGER mastio_audit_replica_no_update_or_delete
+BEFORE UPDATE OR DELETE ON mastio_audit_replica
+FOR EACH ROW EXECUTE FUNCTION mastio_audit_replica_no_mutate();
+"""
+
+_SQLITE_UPDATE_TRIGGER = """
+CREATE TRIGGER IF NOT EXISTS mastio_audit_replica_no_update
+BEFORE UPDATE ON mastio_audit_replica
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT,
+        'mastio_audit_replica is append-only — UPDATE blocked');
+END;
+"""
+
+_SQLITE_DELETE_TRIGGER = """
+CREATE TRIGGER IF NOT EXISTS mastio_audit_replica_no_delete
+BEFORE DELETE ON mastio_audit_replica
+FOR EACH ROW
+BEGIN
+    SELECT RAISE(ABORT,
+        'mastio_audit_replica is append-only — DELETE blocked');
+END;
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+
+    if "mastio_audit_replica" not in existing:
+        op.create_table(
+            "mastio_audit_replica",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("mastio_org_id", sa.String(128), nullable=False),
+            sa.Column("chain_seq", sa.Integer(), nullable=False),
+            sa.Column("entry_hash", sa.String(64), nullable=False),
+            sa.Column("previous_hash", sa.String(64), nullable=True),
+            sa.Column("timestamp", sa.String(64), nullable=False),
+            sa.Column("event_type", sa.String(128), nullable=False),
+            sa.Column("agent_id", sa.String(256), nullable=True),
+            sa.Column("session_id", sa.String(128), nullable=True),
+            sa.Column("details", sa.Text(), nullable=True),
+            sa.Column("result", sa.String(32), nullable=False),
+            sa.Column("principal_type", sa.String(32), nullable=True),
+            sa.Column("hash_format", sa.String(8), nullable=True),
+            sa.Column("signature_b64", sa.Text(), nullable=False),
+            sa.Column("received_at", sa.String(64), nullable=False),
+            sa.UniqueConstraint(
+                "mastio_org_id", "chain_seq",
+                name="uq_mastio_audit_replica_org_seq",
+            ),
+        )
+        op.create_index(
+            "idx_mastio_audit_replica_org",
+            "mastio_audit_replica", ["mastio_org_id"],
+        )
+        op.create_index(
+            "idx_mastio_audit_replica_session",
+            "mastio_audit_replica", ["session_id"],
+        )
+
+    # Install triggers (idempotent shape per dialect).
+    is_pg = bind.dialect.name == "postgresql"
+    if is_pg:
+        op.execute(
+            "DROP TRIGGER IF EXISTS mastio_audit_replica_no_update_or_delete "
+            "ON mastio_audit_replica"
+        )
+        op.execute(_PG_TRIGGER_FN)
+        op.execute(_PG_TRIGGER)
+    else:
+        op.execute(_SQLITE_UPDATE_TRIGGER)
+        op.execute(_SQLITE_DELETE_TRIGGER)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    is_pg = bind.dialect.name == "postgresql"
+    if is_pg:
+        op.execute(
+            "DROP TRIGGER IF EXISTS mastio_audit_replica_no_update_or_delete "
+            "ON mastio_audit_replica"
+        )
+        op.execute("DROP FUNCTION IF EXISTS mastio_audit_replica_no_mutate()")
+    else:
+        op.execute("DROP TRIGGER IF EXISTS mastio_audit_replica_no_update")
+        op.execute("DROP TRIGGER IF EXISTS mastio_audit_replica_no_delete")
+
+    inspector = sa.inspect(bind)
+    if "mastio_audit_replica" in set(inspector.get_table_names()):
+        op.drop_table("mastio_audit_replica")

--- a/app/db/audit.py
+++ b/app/db/audit.py
@@ -126,6 +126,52 @@ class AuditTsaAnchor(Base):
     )
 
 
+class MastioAuditReplica(Base):
+    """Wave B PR8 / D1 — Court-side mirror of each Mastio's local_audit
+    chain. The Mastio publisher (``mcp_proxy.federation.audit_publisher``)
+    POSTs ECDSA-signed batches to ``/v1/federation/audit/replicate``;
+    the receiver verifies the signature against
+    ``organizations.mastio_pubkey`` and persists a verbatim copy here.
+
+    Append-only via the same trigger pattern as ``audit_log`` (see
+    migration ``s9n0o1p2q3r4_replica``). UNIQUE (mastio_org_id,
+    chain_seq) makes the receiver idempotent under retry.
+
+    Cross-org dispute resolution:
+      * Court's broker-observed event lands in ``audit_log`` (chain
+        Court).
+      * Each Mastio publishes its own per-org chain into this table.
+      * ``GET /v1/admin/audit/cross-org-verify?session_id=X`` joins the
+        three sources and flags content divergence.
+    """
+    __tablename__ = "mastio_audit_replica"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    mastio_org_id = Column(String(128), nullable=False, index=True)
+    chain_seq = Column(Integer, nullable=False)
+    entry_hash = Column(String(64), nullable=False)
+    previous_hash = Column(String(64), nullable=True)
+    # ISO8601 strings — keep verbatim so the canonical that the Mastio
+    # signed reproduces byte-for-byte at verify time.
+    timestamp = Column(String(64), nullable=False)
+    event_type = Column(String(128), nullable=False)
+    agent_id = Column(String(256), nullable=True)
+    session_id = Column(String(128), nullable=True, index=True)
+    details = Column(Text, nullable=True)
+    result = Column(String(32), nullable=False)
+    principal_type = Column(String(32), nullable=True)
+    hash_format = Column(String(8), nullable=True)
+    signature_b64 = Column(Text, nullable=False)
+    received_at = Column(String(64), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            "mastio_org_id", "chain_seq",
+            name="uq_mastio_audit_replica_org_seq",
+        ),
+    )
+
+
 def compute_entry_hash(
     entry_id: int,
     timestamp: datetime,

--- a/app/federation/audit_replicate.py
+++ b/app/federation/audit_replicate.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from pydantic import BaseModel, Field
@@ -181,7 +180,6 @@ async def replicate_audit_batch(
     ).scalar_one_or_none()
 
     if tail_row is not None:
-        first = entries[0]
         # We allow re-submission of already-stored rows (idempotency)
         # so the publisher can retry safely. Just require that the
         # FIRST not-yet-stored row's previous_hash links to the tail's

--- a/app/federation/audit_replicate.py
+++ b/app/federation/audit_replicate.py
@@ -1,0 +1,312 @@
+"""ADR-008 amendment / Wave B PR8 (audit D1) — Mastio audit replication.
+
+Each Mastio publishes its ``local_audit`` chain to the Court via
+``POST /v1/federation/audit/replicate``. The Court verifies the
+publisher's signature, enforces chain_seq continuity, and stores a
+verbatim copy in ``mastio_audit_replica`` (append-only via
+``alembic/versions/s9n0o1p2q3r4_mastio_audit_replica.py``).
+
+Threat model:
+  * **Repudiation** — every batch carries an ECDSA-P256 countersig
+    over the raw body (same primitive as ``federation/publish.py``).
+    Pinned in ``organizations.mastio_pubkey`` at onboarding. A Mastio
+    cannot deny it published a given batch.
+  * **Forgery** — the Mastio's per-org hash chain (each row carries
+    ``previous_hash``) provides forward integrity within the chain.
+    The receiver also enforces ``previous_hash[i] == entry_hash[i-1]``
+    on inbound rows so an attacker can't inject a synthetic row
+    without breaking the chain.
+  * **Replay** — ``UNIQUE(mastio_org_id, chain_seq)`` makes the
+    receiver idempotent: re-submitting the same batch produces a
+    200 with ``stored=0, already_present=N`` instead of duplicate
+    rows.
+  * **Cross-tenant injection** — the body's ``mastio_org_id`` must
+    match the org whose pubkey verified the countersig. A Mastio
+    publishing into another org's namespace gets a 403.
+
+Auth: mTLS gate (``enforce_mastio_mtls``) + countersig over the raw
+body. Same pattern as the existing ``federation/publish-agent``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_countersig
+from app.auth.mastio_mtls import enforce_if_required as enforce_mastio_mtls
+from app.db.audit import MastioAuditReplica, log_event
+from app.db.database import get_db
+from app.registry.org_store import get_org_by_id
+
+
+_log = logging.getLogger("agent_trust.federation.audit_replicate")
+
+router = APIRouter(prefix="/v1/federation", tags=["federation"])
+
+
+class ReplicaEntry(BaseModel):
+    chain_seq: int = Field(..., ge=1)
+    entry_hash: str = Field(..., min_length=64, max_length=64)
+    previous_hash: str | None = Field(None, min_length=64, max_length=64)
+    timestamp: str = Field(..., max_length=64)
+    event_type: str = Field(..., max_length=128)
+    agent_id: str | None = Field(None, max_length=256)
+    session_id: str | None = Field(None, max_length=128)
+    details: str | None = None
+    result: str = Field(..., max_length=32)
+    principal_type: str | None = Field(None, max_length=32)
+    hash_format: str | None = Field(None, max_length=8)
+
+
+class ReplicateRequest(BaseModel):
+    mastio_org_id: str = Field(..., pattern=r"^[a-z0-9][a-z0-9._-]{0,127}$")
+    entries: list[ReplicaEntry] = Field(..., min_length=1, max_length=1000)
+
+
+class ReplicateResponse(BaseModel):
+    mastio_org_id: str
+    stored: int
+    already_present: int
+    last_chain_seq: int
+
+
+@router.post(
+    "/audit/replicate",
+    response_model=ReplicateResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def replicate_audit_batch(
+    request: Request,
+    body: ReplicateRequest,
+    mastio_signature: str | None = Header(
+        default=None, alias=COUNTERSIG_HEADER,
+    ),
+    db: AsyncSession = Depends(get_db),
+) -> ReplicateResponse:
+    """Receive a Mastio audit batch and persist it after verification."""
+    # 1. Resolve the publishing org + its pinned pubkey.
+    org = await get_org_by_id(db, body.mastio_org_id)
+    if org is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="organization not found",
+        )
+    if not org.mastio_pubkey:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "organization has no pinned mastio_pubkey — onboarding "
+                "incomplete. Cannot verify audit replication signature."
+            ),
+        )
+
+    # 2. mTLS gate (Phase 2 of Wave 3 U4). Verify-if-present unless
+    #    organizations.require_mastio_mtls=true, mirroring publish.py.
+    enforce_mastio_mtls(
+        request, org.mastio_pubkey,
+        require=bool(org.require_mastio_mtls),
+    )
+
+    # 3. Verify the countersig over the raw body bytes. Same primitive
+    #    as ``federation/publish-agent``.
+    raw = await request.body()
+    try:
+        raw_text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="body is not valid UTF-8",
+        ) from exc
+    verify_mastio_countersig(
+        client_assertion=raw_text,
+        signature_b64=mastio_signature,
+        mastio_pubkey_pem=org.mastio_pubkey,
+    )
+
+    # 4. Sort entries by chain_seq and enforce continuity within the
+    #    batch (previous_hash[i] == entry_hash[i-1]).
+    entries = sorted(body.entries, key=lambda e: e.chain_seq)
+    for i in range(1, len(entries)):
+        if entries[i].chain_seq != entries[i - 1].chain_seq + 1:
+            await log_event(
+                db, "federation.audit_replicate_rejected", "denied",
+                org_id=body.mastio_org_id,
+                details={
+                    "reason": "chain_seq_gap",
+                    "expected": entries[i - 1].chain_seq + 1,
+                    "got": entries[i].chain_seq,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"chain_seq gap: expected "
+                    f"{entries[i - 1].chain_seq + 1}, got {entries[i].chain_seq}"
+                ),
+            )
+        if entries[i].previous_hash != entries[i - 1].entry_hash:
+            await log_event(
+                db, "federation.audit_replicate_rejected", "denied",
+                org_id=body.mastio_org_id,
+                details={
+                    "reason": "previous_hash_break",
+                    "chain_seq": entries[i].chain_seq,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"previous_hash break at chain_seq={entries[i].chain_seq}"
+                ),
+            )
+
+    # 5. Enforce continuity against the existing tail (no gap between
+    #    last stored row and the first new row). This blocks a Mastio
+    #    from skipping rows after a network blip — the publisher MUST
+    #    resume from its last cursor.
+    tail_row = (
+        await db.execute(
+            select(MastioAuditReplica)
+            .where(MastioAuditReplica.mastio_org_id == body.mastio_org_id)
+            .order_by(MastioAuditReplica.chain_seq.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+
+    if tail_row is not None:
+        first = entries[0]
+        # We allow re-submission of already-stored rows (idempotency)
+        # so the publisher can retry safely. Just require that the
+        # FIRST not-yet-stored row's previous_hash links to the tail's
+        # entry_hash. Rows with chain_seq <= tail get diff'd later
+        # against the existing rows and quietly counted as "already
+        # present" if they match byte-for-byte.
+        future = [e for e in entries if e.chain_seq > tail_row.chain_seq]
+        if future:
+            head = future[0]
+            if head.chain_seq != tail_row.chain_seq + 1:
+                await log_event(
+                    db, "federation.audit_replicate_rejected", "denied",
+                    org_id=body.mastio_org_id,
+                    details={
+                        "reason": "tail_gap",
+                        "stored_tail": tail_row.chain_seq,
+                        "batch_head": head.chain_seq,
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"chain_seq gap with stored tail: stored last "
+                        f"{tail_row.chain_seq}, batch starts at "
+                        f"{head.chain_seq}"
+                    ),
+                )
+            if head.previous_hash != tail_row.entry_hash:
+                await log_event(
+                    db, "federation.audit_replicate_rejected", "denied",
+                    org_id=body.mastio_org_id,
+                    details={
+                        "reason": "previous_hash_break_with_tail",
+                        "chain_seq": head.chain_seq,
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"previous_hash on chain_seq={head.chain_seq} does "
+                        f"not link to stored tail's entry_hash"
+                    ),
+                )
+
+    # 6. Persist. Each entry stores the batch signature (one sig per
+    #    batch is the per-row attribution: the row was in this signed
+    #    batch). On UNIQUE collision (already present), check content
+    #    equality and count as "already_present" — divergence is fatal.
+    sig_to_store = mastio_signature or ""
+    received_at = datetime.now(timezone.utc).isoformat()
+
+    stored_count = 0
+    already_present = 0
+    last_seq = tail_row.chain_seq if tail_row else 0
+    for e in entries:
+        replica = MastioAuditReplica(
+            mastio_org_id=body.mastio_org_id,
+            chain_seq=e.chain_seq,
+            entry_hash=e.entry_hash,
+            previous_hash=e.previous_hash,
+            timestamp=e.timestamp,
+            event_type=e.event_type,
+            agent_id=e.agent_id,
+            session_id=e.session_id,
+            details=e.details,
+            result=e.result,
+            principal_type=e.principal_type,
+            hash_format=e.hash_format,
+            signature_b64=sig_to_store,
+            received_at=received_at,
+        )
+        try:
+            async with db.begin_nested():
+                db.add(replica)
+                await db.flush()
+            stored_count += 1
+            last_seq = max(last_seq, e.chain_seq)
+        except IntegrityError:
+            # Already present — check for divergence (different
+            # entry_hash on the same chain_seq = a Mastio is forking
+            # its own chain, which is a fatal signal).
+            existing = (
+                await db.execute(
+                    select(MastioAuditReplica).where(
+                        MastioAuditReplica.mastio_org_id == body.mastio_org_id,
+                        MastioAuditReplica.chain_seq == e.chain_seq,
+                    )
+                )
+            ).scalar_one()
+            if existing.entry_hash != e.entry_hash:
+                await log_event(
+                    db, "federation.audit_replicate_rejected", "denied",
+                    org_id=body.mastio_org_id,
+                    details={
+                        "reason": "chain_fork",
+                        "chain_seq": e.chain_seq,
+                        "stored_hash": existing.entry_hash,
+                        "submitted_hash": e.entry_hash,
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"chain fork at chain_seq={e.chain_seq}: stored "
+                        f"hash differs from submitted hash"
+                    ),
+                ) from None
+            already_present += 1
+            last_seq = max(last_seq, e.chain_seq)
+
+    await db.commit()
+
+    await log_event(
+        db, "federation.audit_replicate_accepted", "ok",
+        org_id=body.mastio_org_id,
+        details={
+            "stored": stored_count,
+            "already_present": already_present,
+            "last_chain_seq": last_seq,
+        },
+    )
+
+    return ReplicateResponse(
+        mastio_org_id=body.mastio_org_id,
+        stored=stored_count,
+        already_present=already_present,
+        last_chain_seq=last_seq,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -416,6 +416,13 @@ app.include_router(federation_router)
 from app.federation.read import router as federation_read_router
 app.include_router(federation_read_router)
 
+# Wave B PR8 / D1 — Mastio audit replication endpoint
+# (POST /v1/federation/audit/replicate). Receives ECDSA-countersigned
+# batches of local_audit rows from each Mastio and persists them in
+# mastio_audit_replica for cross-org dispute reconciliation.
+from app.federation.audit_replicate import router as federation_audit_router
+app.include_router(federation_audit_router)
+
 # Enterprise plugin routers. Mounted after every core router so a plugin
 # can never shadow a core endpoint by registering a conflicting path;
 # FastAPI keeps registration order on routing.

--- a/mcp_proxy/federation/audit_publisher.py
+++ b/mcp_proxy/federation/audit_publisher.py
@@ -1,0 +1,289 @@
+"""Wave B PR8 / D1 — Mastio audit replication publisher.
+
+Background task that pushes ``local_audit`` rows to the Court via
+``POST /v1/federation/audit/replicate`` for cross-org dispute
+resolution (audit ref imp/audits/2026-05-11-track-3-audit-pdp.md F-3).
+
+Flow per tick:
+  1. Read ``proxy_config[last_replicated_local_audit_id]`` cursor.
+  2. SELECT new ``local_audit`` rows with ``id > cursor`` AND
+     ``chain_seq IS NOT NULL`` (skip pre-chain-migration rows).
+     Group by ``org_id`` so each batch covers exactly one chain.
+  3. For each batch: build canonical JSON, sign raw bytes via
+     ``AgentManager.countersign()`` (ADR-009 leaf key, same one
+     publish-agent uses), POST to Court.
+  4. On 2xx, advance cursor to max(id) in batch.
+  5. On 4xx: log + skip (re-pushing won't fix a structural error).
+     On 5xx / network: log + retry on next tick (cursor unchanged).
+
+The cursor is persisted on the Mastio's own DB (``proxy_config``)
+because the Court replica's UNIQUE(mastio_org_id, chain_seq) makes
+re-submission idempotent — even if the cursor lags, the next tick
+re-sends the same chain_seq and the Court counts them as
+``already_present``. Conservative side: at-least-once delivery.
+
+Standalone proxies (no broker_url) skip the loop. Federated proxies
+that haven't seeded their Mastio identity skip until the leaf key is
+loaded.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from datetime import datetime, timezone
+
+import httpx
+from sqlalchemy import text
+
+
+_log = logging.getLogger("mcp_proxy.federation.audit_publisher")
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        _log.warning("invalid %s=%r — using default %.1fs", name, raw, default)
+        return default
+    if value <= 0:
+        _log.warning("non-positive %s=%r — using default %.1fs", name, raw, default)
+        return default
+    return value
+
+
+# Audit replication is medium-frequency: latency on Court-side
+# dispute reconciliation is acceptable in the seconds-to-minutes
+# range, but we don't want a queue to grow unbounded between ticks.
+AUDIT_POLL_INTERVAL_S = _env_float(
+    "MCP_PROXY_AUDIT_REPLICATION_POLL_INTERVAL_S", 30.0,
+)
+HTTP_TIMEOUT_S = 15.0
+# Cap the number of rows per batch to bound the request body and the
+# Court's atomic transaction. The Mastio chain produces a few rows
+# per request handled, so 200 covers ~5-10 minutes of bursty traffic.
+MAX_BATCH_SIZE = 200
+
+_CURSOR_KEY = "last_replicated_local_audit_id"
+
+
+async def _read_cursor(conn) -> int:
+    """Return the last ``local_audit.id`` we successfully replicated.
+    Zero on first run (no row in proxy_config yet)."""
+    row = (
+        await conn.execute(
+            text("SELECT value FROM proxy_config WHERE key = :k"),
+            {"k": _CURSOR_KEY},
+        )
+    ).first()
+    if row is None:
+        return 0
+    try:
+        return int(row[0])
+    except (TypeError, ValueError):
+        _log.warning(
+            "audit cursor in proxy_config is not an int (%r) — resetting to 0",
+            row[0],
+        )
+        return 0
+
+
+async def _write_cursor(conn, value: int) -> None:
+    """Upsert the cursor. Same pattern as other proxy_config writes."""
+    # SQLite + Postgres both accept ON CONFLICT … DO UPDATE; the proxy
+    # config helper uses the same shape elsewhere.
+    await conn.execute(
+        text(
+            """
+            INSERT INTO proxy_config (key, value)
+            VALUES (:k, :v)
+            ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value
+            """
+        ),
+        {"k": _CURSOR_KEY, "v": str(value)},
+    )
+
+
+async def _fetch_pending(conn, *, after_id: int) -> list[dict]:
+    """All replicable rows newer than ``after_id``, ordered by id ASC.
+
+    Filter ``chain_seq IS NOT NULL`` so pre-chain rows (which can't be
+    Court-verified for continuity) stay local-only. Cap at
+    ``MAX_BATCH_SIZE``."""
+    result = await conn.execute(
+        text(
+            """
+            SELECT id, timestamp, event_type, agent_id, session_id, org_id,
+                   details, result, previous_hash, chain_seq, entry_hash,
+                   hash_format
+              FROM local_audit
+             WHERE id > :after_id
+               AND chain_seq IS NOT NULL
+             ORDER BY id ASC
+             LIMIT :lim
+            """
+        ),
+        {"after_id": after_id, "lim": MAX_BATCH_SIZE},
+    )
+    return [dict(row) for row in result.mappings().all()]
+
+
+def _group_by_org(rows: list[dict]) -> dict[str, list[dict]]:
+    """One Court request per org_id. Court endpoint expects all entries
+    in a batch to share ``mastio_org_id``."""
+    out: dict[str, list[dict]] = {}
+    for r in rows:
+        out.setdefault(r["org_id"], []).append(r)
+    # Sort each org group by chain_seq so the Court-side continuity
+    # check sees a monotonic sequence.
+    for batch in out.values():
+        batch.sort(key=lambda r: r["chain_seq"])
+    return out
+
+
+def _build_body(*, mastio_org_id: str, batch: list[dict]) -> bytes:
+    """Canonical JSON body — what the Court receives + countersig
+    covers. Field names mirror the Pydantic model on the receiver."""
+    payload = {
+        "mastio_org_id": mastio_org_id,
+        "entries": [
+            {
+                "chain_seq": int(r["chain_seq"]),
+                "entry_hash": r["entry_hash"],
+                "previous_hash": r["previous_hash"],
+                "timestamp": r["timestamp"],
+                "event_type": r["event_type"],
+                "agent_id": r["agent_id"],
+                "session_id": r["session_id"],
+                "details": r["details"],
+                "result": r["result"],
+                # local_audit doesn't carry principal_type today; once
+                # the column lands the publisher will pass it through.
+                "principal_type": None,
+                "hash_format": r.get("hash_format"),
+            }
+            for r in batch
+        ],
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+async def _publish_batch(
+    *, mastio_org_id: str, batch: list[dict], broker_url: str,
+    countersign, client: httpx.AsyncClient,
+) -> bool:
+    body = _build_body(mastio_org_id=mastio_org_id, batch=batch)
+    signature = countersign(body)
+    url = f"{broker_url.rstrip('/')}/v1/federation/audit/replicate"
+    try:
+        resp = await client.post(
+            url,
+            content=body,
+            headers={
+                "Content-Type": "application/json",
+                "X-Cullis-Mastio-Signature": signature,
+            },
+            timeout=HTTP_TIMEOUT_S,
+        )
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        _log.warning(
+            "audit replicate: Court unreachable for org=%s "
+            "chain_seq[%d..%d] (%s) — will retry",
+            mastio_org_id, batch[0]["chain_seq"], batch[-1]["chain_seq"],
+            exc,
+        )
+        return False
+
+    if resp.is_success:
+        body_json = {}
+        try:
+            body_json = resp.json() or {}
+        except Exception:
+            pass
+        _log.info(
+            "audit replicate OK: org=%s chain_seq[%d..%d] "
+            "stored=%s already_present=%s",
+            mastio_org_id, batch[0]["chain_seq"], batch[-1]["chain_seq"],
+            body_json.get("stored"), body_json.get("already_present"),
+        )
+        return True
+
+    _log.warning(
+        "audit replicate FAIL org=%s chain_seq[%d..%d] HTTP %d: %s",
+        mastio_org_id, batch[0]["chain_seq"], batch[-1]["chain_seq"],
+        resp.status_code, resp.text[:300],
+    )
+    # 4xx structural — advancing the cursor would skip rows forever.
+    # Block here; require operator inspection to proceed.
+    # 5xx transient — leave cursor in place and try again next tick.
+    return False
+
+
+async def _tick(app_state) -> int:
+    """One iteration. Returns total rows successfully Court-acked."""
+    broker_url = getattr(app_state, "reverse_proxy_broker_url", None)
+    mgr = getattr(app_state, "agent_manager", None)
+    http = getattr(app_state, "reverse_proxy_client", None)
+
+    if not broker_url or mgr is None or http is None:
+        return 0
+    if not getattr(mgr, "mastio_loaded", False):
+        return 0
+
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        cursor = await _read_cursor(conn)
+        pending = await _fetch_pending(conn, after_id=cursor)
+
+    if not pending:
+        return 0
+
+    grouped = _group_by_org(pending)
+    acked = 0
+    max_id_acked = cursor
+
+    for org, batch in grouped.items():
+        ok = await _publish_batch(
+            mastio_org_id=org, batch=batch, broker_url=broker_url,
+            countersign=mgr.countersign, client=http,
+        )
+        if ok:
+            acked += len(batch)
+            for r in batch:
+                if r["id"] > max_id_acked:
+                    max_id_acked = r["id"]
+
+    if max_id_acked > cursor:
+        async with get_db() as conn:
+            await _write_cursor(conn, max_id_acked)
+            await conn.commit() if hasattr(conn, "commit") else None
+    return acked
+
+
+async def run_audit_publisher(
+    app_state, *, stop_event: asyncio.Event,
+) -> None:
+    """Background task body. Exits when ``stop_event`` is set."""
+    _log.info(
+        "audit replication publisher started (poll=%.1fs, batch=%d)",
+        AUDIT_POLL_INTERVAL_S, MAX_BATCH_SIZE,
+    )
+    try:
+        while not stop_event.is_set():
+            try:
+                await _tick(app_state)
+            except Exception as exc:  # never let the loop die
+                _log.exception("audit replication tick failed: %s", exc)
+            try:
+                await asyncio.wait_for(
+                    stop_event.wait(), timeout=AUDIT_POLL_INTERVAL_S,
+                )
+            except asyncio.TimeoutError:
+                continue
+    finally:
+        _log.info("audit replication publisher stopped")

--- a/mcp_proxy/federation/audit_publisher.py
+++ b/mcp_proxy/federation/audit_publisher.py
@@ -32,7 +32,6 @@ import asyncio
 import json
 import logging
 import os
-from datetime import datetime, timezone
 
 import httpx
 from sqlalchemy import text

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -508,6 +508,20 @@ async def lifespan(app: FastAPI):
         app.state.federation_stats_task = stats_task
         _log.info("federation stats publisher started (org=%s)", org_id)
 
+        # Wave B PR8 / D1 — Mastio audit replication. Pushes
+        # local_audit rows to the Court (mastio_audit_replica) so
+        # cross-org disputes have a Mastio-attested source of truth
+        # alongside the Court's broker-observed audit_log.
+        from mcp_proxy.federation.audit_publisher import run_audit_publisher
+        audit_stop = asyncio.Event()
+        audit_task = asyncio.create_task(
+            run_audit_publisher(app.state, stop_event=audit_stop),
+            name="federation_audit_publisher",
+        )
+        app.state.federation_audit_stop = audit_stop
+        app.state.federation_audit_task = audit_task
+        _log.info("federation audit publisher started (org=%s)", org_id)
+
     # ADR-013 layer 6 — DB latency tracker + circuit breaker state.
     # Started after init_db (need the engine) and after the federation
     # task, so the probe's first ``SELECT 1`` runs against a fully
@@ -731,6 +745,23 @@ async def lifespan(app: FastAPI):
                 pass
         except ValueError as exc:
             _log.debug("federation publisher teardown loop mismatch (xdist): %s", exc)
+
+    # Wave B PR8 / D1 — audit replication publisher teardown.
+    audit_stop = getattr(app.state, "federation_audit_stop", None)
+    audit_task = getattr(app.state, "federation_audit_task", None)
+    if audit_stop is not None:
+        audit_stop.set()
+    if audit_task is not None:
+        try:
+            await asyncio.wait_for(audit_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            audit_task.cancel()
+            try:
+                await audit_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        except ValueError as exc:
+            _log.debug("audit publisher teardown loop mismatch (xdist): %s", exc)
 
     ws_manager = getattr(app.state, "local_ws_manager", None)
     if ws_manager is not None:

--- a/tests/test_wave_b_pr8_audit_publisher.py
+++ b/tests/test_wave_b_pr8_audit_publisher.py
@@ -1,0 +1,328 @@
+"""Wave B PR8 / D1 — Mastio audit replication publisher (Mastio side).
+
+Audit ref: imp/audits/2026-05-11-track-3-audit-pdp.md F-3.
+
+Tests the publisher loop in mcp_proxy/federation/audit_publisher.py:
+  * Reads ``proxy_config[last_replicated_local_audit_id]`` cursor
+  * SELECTs new local_audit rows ordered by id
+  * Groups by org_id (Court receiver expects single-org batches)
+  * POSTs ECDSA-countersigned bodies to Court
+  * Advances cursor on success
+  * Leaves cursor pinned on failure (retry safety)
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from sqlalchemy import text
+
+from mcp_proxy.federation.audit_publisher import _read_cursor, _tick
+
+
+pytestmark = pytest.mark.asyncio
+
+
+# ── helpers ────────────────────────────────────────────────────────────
+
+
+class _FakeMgr:
+    """Minimal AgentManager — only ``countersign`` + ``mastio_loaded``.
+    Mirrors tests/test_federation_publisher.py:_FakeMgr."""
+
+    def __init__(self):
+        self.mastio_loaded = True
+        self._key = ec.generate_private_key(ec.SECP256R1())
+
+    def countersign(self, data: bytes) -> str:
+        sig = self._key.sign(data, ec.ECDSA(hashes.SHA256()))
+        return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+class _AppState:
+    def __init__(self, mgr, broker_url: str, client: httpx.AsyncClient):
+        self.agent_manager = mgr
+        self.reverse_proxy_broker_url = broker_url
+        self.reverse_proxy_client = client
+
+
+def _make_local_audit_row(
+    chain_seq: int, *, org_id: str, previous_hash: str | None,
+    event_type: str = "session.opened",
+) -> dict:
+    """Build the row fields a real ``append_local_audit`` would write."""
+    canonical = (
+        f"v2|{datetime.now(timezone.utc).isoformat()}|{event_type}|"
+        f"||x|{org_id}|ok||{previous_hash or 'genesis'}|"
+        f"seq={chain_seq}|peer="
+    )
+    entry_hash = hashlib.sha256(canonical.encode()).hexdigest()
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": event_type,
+        "agent_id": None,
+        "session_id": "x",
+        "org_id": org_id,
+        "details": None,
+        "result": "ok",
+        "previous_hash": previous_hash,
+        "chain_seq": chain_seq,
+        "entry_hash": entry_hash,
+        "hash_format": "v2",
+    }
+
+
+async def _seed_local_audit(tmp_path, monkeypatch, rows: list[dict]):
+    """Boot an isolated proxy DB + insert local_audit rows in order."""
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.db import init_db, get_db
+    await init_db(f"sqlite+aiosqlite:///{db_file}")
+
+    async with get_db() as conn:
+        for r in rows:
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO local_audit (
+                        timestamp, event_type, agent_id, session_id, org_id,
+                        details, result, previous_hash, chain_seq,
+                        peer_org_id, peer_row_hash, entry_hash, hash_format
+                    ) VALUES (
+                        :timestamp, :event_type, :agent_id, :session_id, :org_id,
+                        :details, :result, :previous_hash, :chain_seq,
+                        NULL, NULL, :entry_hash, :hash_format
+                    )
+                    """
+                ),
+                r,
+            )
+
+
+async def _build_chain(rows_per_org: dict[str, int]) -> list[dict]:
+    """Build a fully-chained set of local_audit rows."""
+    out: list[dict] = []
+    for org_id, n in rows_per_org.items():
+        prev = None
+        for i in range(1, n + 1):
+            row = _make_local_audit_row(
+                chain_seq=i, org_id=org_id, previous_hash=prev,
+                event_type=f"e{i}",
+            )
+            out.append(row)
+            prev = row["entry_hash"]
+    return out
+
+
+# ── tests ──────────────────────────────────────────────────────────────
+
+
+async def test_first_run_sends_all_rows(tmp_path, monkeypatch):
+    """Cold start (no cursor) → all chained rows sent in one batch."""
+    rows = await _build_chain({"orga": 3})
+    await _seed_local_audit(tmp_path, monkeypatch, rows)
+
+    captured: list[dict] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        body = json.loads(req.content)
+        captured.append(body)
+        return httpx.Response(200, json={
+            "mastio_org_id": body["mastio_org_id"],
+            "stored": len(body["entries"]),
+            "already_present": 0,
+            "last_chain_seq": body["entries"][-1]["chain_seq"],
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 3
+    assert len(captured) == 1
+    assert captured[0]["mastio_org_id"] == "orga"
+    assert [e["chain_seq"] for e in captured[0]["entries"]] == [1, 2, 3]
+
+    # Cursor should now point at the last row's id (3).
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        cursor = await _read_cursor(conn)
+    assert cursor == 3
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_second_run_with_no_new_rows_is_noop(tmp_path, monkeypatch):
+    """Cursor already at tail → publisher posts nothing."""
+    rows = await _build_chain({"orga": 2})
+    await _seed_local_audit(tmp_path, monkeypatch, rows)
+
+    captured: list[dict] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(req.content))
+        return httpx.Response(200, json={
+            "mastio_org_id": "orga", "stored": 2,
+            "already_present": 0, "last_chain_seq": 2,
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked1 = await _tick(state)
+        # Second tick — no new rows
+        acked2 = await _tick(state)
+
+    assert acked1 == 2
+    assert acked2 == 0
+    assert len(captured) == 1  # only the first tick made an HTTP call
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_groups_per_org(tmp_path, monkeypatch):
+    """Two orgs with rows interleaved by id → one batch per org."""
+    chain_a = await _build_chain({"orga": 2})
+    chain_b = await _build_chain({"orgb": 2})
+    # Interleave so id ordering doesn't trivially preserve org order.
+    interleaved = [chain_a[0], chain_b[0], chain_a[1], chain_b[1]]
+    await _seed_local_audit(tmp_path, monkeypatch, interleaved)
+
+    captured: list[dict] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        body = json.loads(req.content)
+        captured.append(body)
+        return httpx.Response(200, json={
+            "mastio_org_id": body["mastio_org_id"],
+            "stored": len(body["entries"]),
+            "already_present": 0,
+            "last_chain_seq": body["entries"][-1]["chain_seq"],
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 4
+    assert len(captured) == 2
+    by_org = {b["mastio_org_id"]: b for b in captured}
+    assert set(by_org) == {"orga", "orgb"}
+    # Each batch should be sorted by chain_seq
+    assert [e["chain_seq"] for e in by_org["orga"]["entries"]] == [1, 2]
+    assert [e["chain_seq"] for e in by_org["orgb"]["entries"]] == [1, 2]
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_5xx_failure_leaves_cursor(tmp_path, monkeypatch):
+    """Court 5xx → cursor stays put for next-tick retry."""
+    rows = await _build_chain({"orga": 2})
+    await _seed_local_audit(tmp_path, monkeypatch, rows)
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="upstream busy")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 0
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        cursor = await _read_cursor(conn)
+    assert cursor == 0  # untouched
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_4xx_failure_leaves_cursor(tmp_path, monkeypatch):
+    """Court 4xx (e.g. countersig wrong) → cursor stays put. Operator
+    must inspect; advancing would skip rows forever."""
+    rows = await _build_chain({"orga": 1})
+    await _seed_local_audit(tmp_path, monkeypatch, rows)
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="bad signature")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 0
+    from mcp_proxy.db import get_db
+    async with get_db() as conn:
+        cursor = await _read_cursor(conn)
+    assert cursor == 0
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_skips_rows_without_chain_seq(tmp_path, monkeypatch):
+    """Pre-chain-migration rows (chain_seq IS NULL) are not replicated."""
+    rows = [
+        # legacy row (no chain_seq) — should be skipped
+        {
+            "timestamp": "2026-04-01T00:00:00+00:00",
+            "event_type": "legacy", "agent_id": None, "session_id": None,
+            "org_id": "orga", "details": None, "result": "ok",
+            "previous_hash": None, "chain_seq": None,
+            "entry_hash": None, "hash_format": None,
+        },
+        *await _build_chain({"orga": 1}),
+    ]
+    await _seed_local_audit(tmp_path, monkeypatch, rows)
+
+    captured: list[dict] = []
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        body = json.loads(req.content)
+        captured.append(body)
+        return httpx.Response(200, json={
+            "mastio_org_id": body["mastio_org_id"],
+            "stored": len(body["entries"]),
+            "already_present": 0,
+            "last_chain_seq": body["entries"][-1]["chain_seq"],
+        })
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as cli:
+        state = _AppState(_FakeMgr(), "http://broker", cli)
+        acked = await _tick(state)
+
+    assert acked == 1  # only the chained row, not the legacy one
+    assert len(captured) == 1
+    assert len(captured[0]["entries"]) == 1
+    assert captured[0]["entries"][0]["chain_seq"] == 1
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_standalone_proxy_skips(tmp_path, monkeypatch):
+    """Without broker_url (standalone proxy) the loop is a no-op."""
+    rows = await _build_chain({"orga": 1})
+    await _seed_local_audit(tmp_path, monkeypatch, rows)
+
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda r: httpx.Response(500))
+    ) as cli:
+        state = _AppState(_FakeMgr(), broker_url=None, client=cli)
+        acked = await _tick(state)
+
+    assert acked == 0
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()

--- a/tests/test_wave_b_pr8_audit_replication.py
+++ b/tests/test_wave_b_pr8_audit_replication.py
@@ -1,0 +1,550 @@
+"""Wave B PR8 / D1 — Court receiver for Mastio audit replication.
+
+Audit ref: imp/audits/2026-05-11-track-3-audit-pdp.md F-3.
+
+Pre-fix gap: CLAUDE.md + ADR-008 claimed "non-ripudio cross-org dal
+dual-write Mastio". The federation publisher only forwarded agent
+records (publish-agent). No Mastio audit dual-write existed; an
+assessor querying for the evidence would find none.
+
+Post-fix:
+  * Mastio publisher (mcp_proxy/federation/audit_publisher.py) reads
+    local_audit, ECDSA-signs the batch with the leaf key, POSTs to
+    POST /v1/federation/audit/replicate.
+  * Court (this module's tests) verifies the countersig, enforces
+    chain_seq continuity (within batch + against stored tail), and
+    persists into mastio_audit_replica.
+  * UNIQUE(mastio_org_id, chain_seq) keeps the receiver idempotent.
+  * Append-only via DB trigger from migration s9n0o1p2q3r4_replica.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import datetime, timezone
+
+import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from httpx import AsyncClient
+from sqlalchemy import select
+
+from tests.cert_factory import get_org_ca_pem
+from tests.conftest import ADMIN_HEADERS
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.mastio_strict]
+
+
+def _gen_mastio_keypair():
+    priv = ec.generate_private_key(ec.SECP256R1())
+    pub_pem = priv.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return priv, pub_pem
+
+
+def _sign(priv, data: bytes) -> str:
+    sig = priv.sign(data, ec.ECDSA(hashes.SHA256()))
+    return base64.urlsafe_b64encode(sig).rstrip(b"=").decode()
+
+
+async def _onboard_org_with_mastio(
+    client: AsyncClient, org_id: str, mastio_pubkey_pem: str,
+) -> None:
+    org_secret = f"{org_id}-secret"
+    r = await client.post(
+        "/v1/registry/orgs",
+        json={"org_id": org_id, "display_name": org_id, "secret": org_secret},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code in (201, 409), r.text
+    ca_pem = get_org_ca_pem(org_id)
+    r = await client.post(
+        f"/v1/registry/orgs/{org_id}/certificate",
+        json={"ca_certificate": ca_pem},
+        headers={"x-org-id": org_id, "x-org-secret": org_secret},
+    )
+    assert r.status_code in (200, 201), r.text
+    from app.db.database import AsyncSessionLocal
+    from app.registry.org_store import update_org_mastio_pubkey
+    async with AsyncSessionLocal() as db:
+        await update_org_mastio_pubkey(db, org_id, mastio_pubkey_pem)
+
+
+def _make_entry(
+    *, chain_seq: int, previous_hash: str | None,
+    org_id: str, event_type: str = "session.opened",
+    session_id: str | None = "sess-x", details: str | None = None,
+) -> dict:
+    """Build a mock local_audit-shaped entry. ``entry_hash`` is a
+    deterministic hash so the test can chain entries by feeding the
+    prior entry's hash into the next entry's previous_hash."""
+    canonical = (
+        f"v2|{datetime.now(timezone.utc).isoformat()}|{event_type}|"
+        f"|{session_id or ''}|{org_id}|ok|{details or ''}|"
+        f"{previous_hash or 'genesis'}|seq={chain_seq}|peer="
+    )
+    entry_hash = hashlib.sha256(canonical.encode()).hexdigest()
+    return {
+        "chain_seq": chain_seq,
+        "entry_hash": entry_hash,
+        "previous_hash": previous_hash,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "event_type": event_type,
+        "agent_id": None,
+        "session_id": session_id,
+        "details": details,
+        "result": "ok",
+        "principal_type": None,
+        "hash_format": "v2",
+    }
+
+
+def _build_chain(*, n: int, org_id: str, start_seq: int = 1,
+                 previous_hash: str | None = None) -> list[dict]:
+    entries = []
+    prev = previous_hash
+    for i in range(n):
+        e = _make_entry(
+            chain_seq=start_seq + i, previous_hash=prev, org_id=org_id,
+            event_type=f"event.{start_seq + i}",
+        )
+        entries.append(e)
+        prev = e["entry_hash"]
+    return entries
+
+
+async def _fetch_replicas(org_id: str) -> list:
+    from app.db.audit import MastioAuditReplica
+    from app.db.database import AsyncSessionLocal
+    async with AsyncSessionLocal() as db:
+        rows = (
+            await db.execute(
+                select(MastioAuditReplica)
+                .where(MastioAuditReplica.mastio_org_id == org_id)
+                .order_by(MastioAuditReplica.chain_seq.asc())
+            )
+        ).scalars().all()
+    return list(rows)
+
+
+# ── happy path ────────────────────────────────────────────────────────
+
+
+async def test_replicate_creates_rows(client: AsyncClient):
+    """Mastio publishes a fresh chain → Court stores all rows."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-create"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    entries = _build_chain(n=3, org_id=org_id)
+    body = {"mastio_org_id": org_id, "entries": entries}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["mastio_org_id"] == org_id
+    assert data["stored"] == 3
+    assert data["already_present"] == 0
+    assert data["last_chain_seq"] == 3
+
+    rows = await _fetch_replicas(org_id)
+    assert len(rows) == 3
+    assert [r.chain_seq for r in rows] == [1, 2, 3]
+    for stored, sent in zip(rows, entries, strict=True):
+        assert stored.entry_hash == sent["entry_hash"]
+        assert stored.previous_hash == sent["previous_hash"]
+
+
+async def test_replicate_is_idempotent(client: AsyncClient):
+    """Re-publishing the same batch returns already_present, no dups."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-idempo"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    entries = _build_chain(n=2, org_id=org_id)
+    body = {"mastio_org_id": org_id, "entries": entries}
+    raw = json.dumps(body).encode()
+    sig = _sign(priv, raw)
+
+    r1 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": sig,
+        },
+    )
+    assert r1.status_code == 200
+    assert r1.json()["stored"] == 2
+
+    # Same batch again — countersig is over the same body so resign
+    # produces the same payload (ECDSA is non-deterministic; we resign).
+    r2 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["stored"] == 0
+    assert body2["already_present"] == 2
+
+    rows = await _fetch_replicas(org_id)
+    assert len(rows) == 2  # no duplicates
+
+
+async def test_replicate_continues_from_tail(client: AsyncClient):
+    """Second batch chain_seq=3,4 builds on stored tail (seq=2)."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-tail"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    chain = _build_chain(n=4, org_id=org_id)
+    first_batch = chain[:2]
+    second_batch = chain[2:]
+
+    body1 = {"mastio_org_id": org_id, "entries": first_batch}
+    raw1 = json.dumps(body1).encode()
+    r1 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw1,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw1),
+        },
+    )
+    assert r1.status_code == 200
+
+    body2 = {"mastio_org_id": org_id, "entries": second_batch}
+    raw2 = json.dumps(body2).encode()
+    r2 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw2,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw2),
+        },
+    )
+    assert r2.status_code == 200
+    assert r2.json()["last_chain_seq"] == 4
+    rows = await _fetch_replicas(org_id)
+    assert [r.chain_seq for r in rows] == [1, 2, 3, 4]
+
+
+# ── negative paths ────────────────────────────────────────────────────
+
+
+async def test_missing_signature_rejected(client: AsyncClient):
+    _, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-nosig"
+    await _onboard_org_with_mastio(client, org_id, pub)
+    entries = _build_chain(n=1, org_id=org_id)
+    body = {"mastio_org_id": org_id, "entries": entries}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={"Content-Type": "application/json"},
+    )
+    assert r.status_code == 403
+    assert "signature" in r.text.lower() or "header" in r.text.lower()
+
+
+async def test_wrong_signature_key_rejected(client: AsyncClient):
+    _, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-badkey"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    # Sign with the wrong private key.
+    other_priv, _ = _gen_mastio_keypair()
+    entries = _build_chain(n=1, org_id=org_id)
+    body = {"mastio_org_id": org_id, "entries": entries}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(other_priv, raw),
+        },
+    )
+    assert r.status_code == 403
+
+
+async def test_chain_seq_gap_within_batch_rejected(client: AsyncClient):
+    """Batch with chain_seq=1,3 (missing 2) → 400."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-gap"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    # Build a 3-row chain then drop the middle row, keeping the third
+    # row's previous_hash pointing at the dropped second row's hash.
+    full = _build_chain(n=3, org_id=org_id)
+    bad_entries = [full[0], full[2]]
+    body = {"mastio_org_id": org_id, "entries": bad_entries}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 400
+    assert "chain_seq gap" in r.text or "gap" in r.text.lower()
+
+
+async def test_previous_hash_break_within_batch_rejected(client: AsyncClient):
+    """Two adjacent chain_seq but second's previous_hash doesn't match
+    first's entry_hash → 400."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-prevbreak"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    e1 = _make_entry(chain_seq=1, previous_hash=None, org_id=org_id,
+                     event_type="e1")
+    e2 = _make_entry(chain_seq=2,
+                     previous_hash="0" * 64,  # bogus — not e1.entry_hash
+                     org_id=org_id, event_type="e2")
+    body = {"mastio_org_id": org_id, "entries": [e1, e2]}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 400
+    assert "previous_hash" in r.text
+
+
+async def test_tail_gap_with_stored_rejected(client: AsyncClient):
+    """First batch lands seq=1,2. Second batch starts at seq=4 → 400."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-tailgap"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    full = _build_chain(n=4, org_id=org_id)
+    body1 = {"mastio_org_id": org_id, "entries": full[:2]}
+    raw1 = json.dumps(body1).encode()
+    r1 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw1,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw1),
+        },
+    )
+    assert r1.status_code == 200
+
+    # Skip seq=3 — try to land seq=4 directly. Use a fresh chain
+    # whose previous_hash links to "0"*64 (anything that isn't seq=2's
+    # entry_hash) so the tail check is what trips, not within-batch.
+    isolated = full[3:]
+    body2 = {"mastio_org_id": org_id, "entries": isolated}
+    raw2 = json.dumps(body2).encode()
+    r2 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw2,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw2),
+        },
+    )
+    assert r2.status_code == 400
+    assert "tail" in r2.text.lower() or "gap" in r2.text.lower()
+
+
+async def test_chain_fork_rejected(client: AsyncClient):
+    """Same chain_seq submitted with different entry_hash → 409
+    (chain fork). This is the fatal Mastio-side incoherence signal."""
+    priv, pub = _gen_mastio_keypair()
+    org_id = "fed-aud-fork"
+    await _onboard_org_with_mastio(client, org_id, pub)
+
+    e1 = _make_entry(chain_seq=1, previous_hash=None, org_id=org_id,
+                     event_type="real")
+    body1 = {"mastio_org_id": org_id, "entries": [e1]}
+    raw1 = json.dumps(body1).encode()
+    r1 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw1,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw1),
+        },
+    )
+    assert r1.status_code == 200
+
+    # A different entry at chain_seq=1 — same chain_seq, different hash.
+    e1_alt = _make_entry(chain_seq=1, previous_hash=None, org_id=org_id,
+                         event_type="forked")
+    assert e1_alt["entry_hash"] != e1["entry_hash"]
+    body2 = {"mastio_org_id": org_id, "entries": [e1_alt]}
+    raw2 = json.dumps(body2).encode()
+    r2 = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw2,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw2),
+        },
+    )
+    assert r2.status_code == 409
+    assert "fork" in r2.text.lower()
+
+
+async def test_unknown_org_rejected(client: AsyncClient):
+    """Mastio_org_id that doesn't exist on the Court → 404."""
+    priv, _ = _gen_mastio_keypair()
+    entries = _build_chain(n=1, org_id="fed-aud-unknown")
+    body = {"mastio_org_id": "fed-aud-unknown", "entries": entries}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 404
+
+
+async def test_org_without_pinned_pubkey_rejected(client: AsyncClient):
+    """Org exists but mastio_pubkey is NULL → 403."""
+    priv, _ = _gen_mastio_keypair()
+    org_id = "fed-aud-nopin"
+    org_secret = f"{org_id}-secret"
+    r = await client.post(
+        "/v1/registry/orgs",
+        json={"org_id": org_id, "display_name": org_id, "secret": org_secret},
+        headers=ADMIN_HEADERS,
+    )
+    assert r.status_code in (201, 409)
+    # No update_org_mastio_pubkey → pubkey stays NULL.
+
+    entries = _build_chain(n=1, org_id=org_id)
+    body = {"mastio_org_id": org_id, "entries": entries}
+    raw = json.dumps(body).encode()
+    r = await client.post(
+        "/v1/federation/audit/replicate",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": _sign(priv, raw),
+        },
+    )
+    assert r.status_code == 403
+    assert "pubkey" in r.text.lower() or "pinned" in r.text.lower()
+
+
+async def _install_replica_triggers():
+    """Install the append-only triggers from migration
+    ``s9n0o1p2q3r4_replica``. Required because the test conftest sets
+    ``SKIP_ALEMBIC=1`` and uses Base.metadata.create_all, which never
+    runs the migration's trigger DDL. Idempotent (CREATE TRIGGER IF
+    NOT EXISTS on SQLite, DROP+CREATE on Postgres)."""
+    from sqlalchemy import text
+    from app.db.database import engine
+
+    is_pg = engine.dialect.name == "postgresql"
+    async with engine.begin() as conn:
+        if is_pg:
+            await conn.execute(text("""
+                CREATE OR REPLACE FUNCTION mastio_audit_replica_no_mutate()
+                RETURNS trigger AS $$
+                BEGIN
+                    RAISE EXCEPTION 'mastio_audit_replica is append-only — UPDATE/DELETE blocked'
+                      USING ERRCODE = 'check_violation';
+                END;
+                $$ LANGUAGE plpgsql;
+            """))
+            await conn.execute(text(
+                "DROP TRIGGER IF EXISTS mastio_audit_replica_no_update_or_delete "
+                "ON mastio_audit_replica"
+            ))
+            await conn.execute(text("""
+                CREATE TRIGGER mastio_audit_replica_no_update_or_delete
+                BEFORE UPDATE OR DELETE ON mastio_audit_replica
+                FOR EACH ROW EXECUTE FUNCTION mastio_audit_replica_no_mutate();
+            """))
+        else:
+            await conn.execute(text("""
+                CREATE TRIGGER IF NOT EXISTS mastio_audit_replica_no_update
+                BEFORE UPDATE ON mastio_audit_replica
+                FOR EACH ROW
+                BEGIN
+                    SELECT RAISE(ABORT,
+                        'mastio_audit_replica is append-only — UPDATE blocked');
+                END;
+            """))
+            await conn.execute(text("""
+                CREATE TRIGGER IF NOT EXISTS mastio_audit_replica_no_delete
+                BEFORE DELETE ON mastio_audit_replica
+                FOR EACH ROW
+                BEGIN
+                    SELECT RAISE(ABORT,
+                        'mastio_audit_replica is append-only — DELETE blocked');
+                END;
+            """))
+
+
+async def test_append_only_trigger_blocks_update():
+    """The DB-level trigger from migration s9n0o1p2q3r4_replica blocks
+    UPDATE on a stored row. Same posture as audit_log."""
+    from sqlalchemy import update
+    from sqlalchemy.exc import DBAPIError
+
+    from app.db.audit import MastioAuditReplica
+    from app.db.database import AsyncSessionLocal
+
+    await _install_replica_triggers()
+
+    # Seed a row directly (bypass the endpoint — we're testing the
+    # trigger, not the receiver). Use a unique org id so this test
+    # doesn't collide with other tests in the shard.
+    async with AsyncSessionLocal() as db:
+        replica = MastioAuditReplica(
+            mastio_org_id="fed-aud-trigger-test",
+            chain_seq=1,
+            entry_hash="a" * 64,
+            previous_hash=None,
+            timestamp="2026-05-12T00:00:00+00:00",
+            event_type="trigger.test",
+            agent_id=None,
+            session_id=None,
+            details=None,
+            result="ok",
+            principal_type=None,
+            hash_format="v2",
+            signature_b64="sig",
+            received_at="2026-05-12T00:00:00+00:00",
+        )
+        db.add(replica)
+        await db.commit()
+
+    async with AsyncSessionLocal() as db:
+        with pytest.raises(DBAPIError):
+            await db.execute(
+                update(MastioAuditReplica)
+                .where(MastioAuditReplica.mastio_org_id == "fed-aud-trigger-test")
+                .values(entry_hash="b" * 64)
+            )
+            await db.commit()


### PR DESCRIPTION
## Summary

Closes audit D1 — `imp/audits/2026-05-11-track-3-audit-pdp.md` F-3 + `imp/audits/2026-05-11-MASTER.md`.

CLAUDE.md + ADR-008 claimed ‟non-ripudio cross-org dal dual-write Mastio”. The federation publisher only forwarded agent records; cross-org disputes had no Mastio-attested source of truth. This PR ships **option A** from the audit: actual replication.

**Court side**
- Migration `s9n0o1p2q3r4_replica` — new `mastio_audit_replica` table, append-only via DB trigger
- ORM `MastioAuditReplica` in `app/db/audit.py`
- Endpoint `POST /v1/federation/audit/replicate`:
  - Auth: mTLS gate + ECDSA countersig over the raw body (same primitives as `publish-agent`)
  - Continuity checks within batch (chain_seq monotonic + previous_hash links) and against stored tail
  - Idempotent re-submission (UNIQUE collision + content match)
  - Chain fork (same chain_seq, different hash) → 409 fatal

**Mastio side**
- Background loop `mcp_proxy/federation/audit_publisher.py` ticks every `MCP_PROXY_AUDIT_REPLICATION_POLL_INTERVAL_S` seconds (default 30s, batch ≤ 200). Reads cursor from `proxy_config[last_replicated_local_audit_id]`, signs each batch via leaf key, POSTs to Court. Cursor advances on 200 only; 4xx/5xx leave it pinned for retry.
- `mcp_proxy/main.py` lifespan wires it next to the existing publishers; standalone proxies skip.

**Threat model**
| Attack | Defense |
|---|---|
| Repudiation | ECDSA-P256 countersig pinned to `organizations.mastio_pubkey` |
| Forgery | Per-org hash chain enforced both within batch + against stored tail |
| Replay | UNIQUE(mastio_org_id, chain_seq) → idempotent receiver |
| Cross-tenant injection | Body's `mastio_org_id` must match countersig's pubkey |

## Test plan

- [x] 12 receiver tests (`tests/test_wave_b_pr8_audit_replication.py`): happy path, idempotent, tail continuity, missing/wrong sig, gap within batch, previous_hash break, tail gap, chain fork (409), unknown org (404), unpinned org (403), append-only trigger blocks UPDATE
- [x] 7 publisher tests (`tests/test_wave_b_pr8_audit_publisher.py`): cold start, no-op resume, per-org grouping with interleaved IDs, 5xx leaves cursor, 4xx leaves cursor, legacy rows (no chain_seq) skipped, standalone proxy no-ops
- [x] Targeted regression `pytest -k 'federation or audit'` on PR8-relevant files → 81 passed
- [ ] CI demo_network smoke (publisher loop runs in real Mastio, receiver in real Court)
- [ ] /security-review

## Follow-up

Cross-org admin verify endpoint (`GET /v1/admin/audit/cross-org-verify` joining `audit_log` + replicas with concordance report) is the next PR — this one lands the data plumbing first so the verify logic has something to query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)