### PR TITLE
fix(connector): /api/status must be async def — inbox poller crash (Bug #10)

### DIFF
--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -18,6 +18,7 @@ until the server has approved.
 """
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import html
 import logging
@@ -1196,11 +1197,25 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         return JSONResponse({"app": "cullis-connector"})
 
     @app.get("/api/status")
-    def api_status(request: Request) -> JSONResponse:
+    async def api_status(request: Request) -> JSONResponse:
         """Single-shot poll of the remote enrollment status.
 
         Returns JSON so the waiting page's HTMX can route to the next
         screen on its own.
+
+        Bug #10 fix-forward (2026-05-11 sera) — this endpoint MUST be
+        ``async def``. The two ``_ensure_inbox_poller_running`` call
+        sites (the ``has_identity`` early-return below and the
+        post-``save_identity`` lazy-spawn after a successful poll)
+        end up calling ``poller.start()`` → ``asyncio.create_task``,
+        which requires a running event loop in the current thread.
+        FastAPI runs ``def`` handlers in an anyio worker thread that
+        has NO event loop, so the create_task call raises
+        ``RuntimeError: no running event loop`` and the dashboard
+        loops on broken /api/status responses forever. Pre-fix this
+        was unreachable (Bug #5 stopped the dashboard from ever
+        flipping to ``has_identity``); after #624 unlocked that path
+        the customer-path smoke gate caught it immediately.
         """
         if has_identity(config.config_dir):
             # Lazy-spawn the inbox poller — the dashboard may have
@@ -1228,7 +1243,11 @@ def build_app(config: ConnectorConfig) -> FastAPI:
         proof = _build_enrollment_proof(_pending.private_key, _pending.session_id)
         try:
             from cullis_connector.config import verify_arg_for
-            resp = httpx.get(
+            # ``httpx.get`` is synchronous; offload to a worker thread
+            # so the FastAPI event loop stays free for other handlers
+            # (we are now an ``async def`` after the Bug #10 fix).
+            resp = await asyncio.to_thread(
+                httpx.get,
                 poll_url,
                 headers={"X-Enrollment-Proof": proof},
                 verify=verify_arg_for(_pending.verify_tls, config.ca_chain_path),

--- a/tests/connector/test_api_status_enrollment_proof.py
+++ b/tests/connector/test_api_status_enrollment_proof.py
@@ -162,3 +162,46 @@ def test_api_status_approved_path_persists_identity(
     assert body["status"] == "approved", body
     # ``_pending`` is cleared once the identity hits disk.
     assert connector_web._pending is None
+
+
+def test_api_status_is_async_def():
+    """Bug #10 regression: the ``/api/status`` endpoint MUST be
+    ``async def``, not ``def``. The handler calls
+    ``_ensure_inbox_poller_running`` which in turn does
+    ``poller.start()`` → ``asyncio.create_task(...)``. ``create_task``
+    requires a running event loop in the current thread. FastAPI runs
+    ``def`` (sync) handlers in an anyio worker thread that has NO
+    event loop, so the call raises ``RuntimeError: no running event
+    loop`` and every poll returns 500 forever once the dashboard
+    flips to ``has_identity=True``.
+
+    Pre-fix this path was unreachable because Bug #5 stopped the
+    dashboard from ever flipping to ``has_identity``. After #624
+    unlocked that path the customer-path smoke gate (PR #625) caught
+    Bug #10 immediately on the run after #628 merged, proving the
+    gate catches "fix one bug, expose another" sequences.
+
+    Sentinel check: assert the endpoint is a coroutine function so a
+    future regression (someone removes ``async`` thinking the
+    handler is simple enough to be sync) fails loud."""
+    import inspect
+    from cullis_connector.config import ConnectorConfig
+
+    cfg = ConnectorConfig(
+        site_url="https://mastio.test",
+        config_dir=__import__("pathlib").Path("/tmp"),
+        verify_tls=False,
+        request_timeout_s=2.0,
+    )
+    app = build_app(cfg)
+
+    # Locate the ``/api/status`` GET route and verify its endpoint
+    # function is a coroutine function.
+    routes = [r for r in app.routes if getattr(r, "path", "") == "/api/status"]
+    assert routes, "no /api/status route registered"
+    route = routes[0]
+    assert inspect.iscoroutinefunction(route.endpoint), (
+        f"/api/status MUST be async def — pre-fix it was sync and "
+        f"crashed on inbox poller spawn (Bug #10 regression). "
+        f"Endpoint: {route.endpoint!r}"
+    )


### PR DESCRIPTION
## Summary

Found by the customer-path smoke gate (PR #625) on its first green-stack run after Bug #5 (#624) and Bug #8 (#628) merged: ``cullis_connector.web.api_status`` was declared ``def`` (sync). FastAPI runs sync handlers in an anyio worker thread with no running event loop. The handler reaches ``_ensure_inbox_poller_running`` → ``poller.start()`` → ``asyncio.create_task(...)``, which raises ``RuntimeError: no running event loop``.

Pre-fix the path was unreachable (Bug #5 kept the dashboard from ever flipping to ``has_identity=True``). After #624 unlocked it, every /api/status call after enrollment landed in this trap and the SPA looped forever.

## Fix

- ``api_status`` → ``async def``.
- The existing ``httpx.get`` poll to Mastio is wrapped in ``asyncio.to_thread`` to keep it off the event loop (same call semantics, same proof header, same response shape).
- ``import asyncio`` added.

The docstring on ``_ensure_inbox_poller_running`` already promised the call sites would run inside the event loop ("lifespan + async handler") — the handler simply wasn't async, contradicting the invariant. This patch makes the code match the docstring.

## Test plan

- [x] ``test_api_status_is_async_def`` — sentinel that asserts ``inspect.iscoroutinefunction(route.endpoint)``. Pre-fix this test fails (endpoint is plain ``def``); post-fix passes. Cheap regression guard so someone who later thinks the handler is simple enough to be sync gets a loud failure.
- [x] Existing Bug #5 regression tests still pass (header propagation, proof verification, approved-branch persistence).
- [ ] CI green
- [ ] Customer-path smoke (#625) reaches "Connector identity on disk, /api/status=approved" on a run after this lands.

## Refs

- ``project_dogfood_2026_05_11_vps_demo`` (Bug #10)
- PR #624 (Bug #5 fix that unlocked the path)
- PR #628 (Bug #8 fix needed before the smoke gate could even boot the Mastio bundle far enough to exercise this)
- PR #625 (customer-path smoke gate that found it)