### PR TITLE
chore(release): bump connector to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.4.2] — 2026-05-12
+
+Bug-fix release that ships two crash-class fixes uncovered during the
+2026-05-11 VPS demo dogfood, plus the ADR-029 tool-call PDP gate on the
+Connector and the conversation-history REST surface the SPA needs.
+
+### Fixed
+
+- **Bug #10 — `/api/status` MUST be async def** ([#631]): the Connector
+  dashboard inbox poller spawned a background task at import time
+  against a sync `def` handler. On any worker that re-imported the
+  module (autoreload, multi-worker uvicorn) the spawn raised
+  `RuntimeError: no running event loop`. Customer-path smoke caught it
+  before the merge, but the class of regression was real.
+- **Bug #5 — `X-Enrollment-Proof` on dashboard `/api/status` poll**
+  ([#624]): the dashboard health poll talks to the Mastio with the
+  enrollment token but did not attach the DPoP-bound enrollment proof.
+  Mastio rejected with 401 once Wave B PR7 ([#627]) tightened
+  `LOCAL_TOKEN` DPoP binding.
+
+### Added
+
+- **Conversation history REST + SQLite store** ([#610]): Sprint 1
+  Step 6 PR-A. The Connector now persists chat conversations locally
+  and exposes them via REST so the Cullis Chat SPA can render a
+  sidebar history. Per-user attribution is preserved (ADR-021 KMS path).
+- **ADR-029 Phase D-1 — Connector PDP gate per tool call** ([#602]):
+  the Connector now enforces the tool-level PDP decision returned by
+  the Mastio when an MCP client invokes a tool. Closes the last
+  cross-org enforcement gap in the ADR-029 tool-call DAG.
+
+[#631]: https://github.com/cullis-security/cullis/pull/631
+[#624]: https://github.com/cullis-security/cullis/pull/624
+[#610]: https://github.com/cullis-security/cullis/pull/610
+[#602]: https://github.com/cullis-security/cullis/pull/602
+
 ## [v0.4.1] — 2026-05-11
 
 Patch release. Restores the PyInstaller binary distribution path that was

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.1"
+version = "0.4.2"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Bumps `cullis-connector` to **0.4.2** in lockstep across `pyproject.toml`, `cullis_connector/__init__.py`, `CHANGELOG.md`, and the staged `packaging/pypi/CHANGELOG.md` (gitignored, regenerated by the build).

Once merged, push tag `connector-v0.4.2` to fire `release-connector.yml` (test → wheel/sdist → docker → PyInstaller binaries → GitHub Release → PyPI trusted publish).

## What's new in 0.4.2

Bug-fix release from the 2026-05-11 VPS demo dogfood, plus ADR-029 tool-call PDP gate and conversation-history REST.

- Bug #10 (#631): `/api/status` MUST be async def, inbox poller spawn crash
- Bug #5 (#624): X-Enrollment-Proof on dashboard `/api/status` poll
- Conversation history REST + SQLite store (#610)
- ADR-029 Phase D-1 Connector PDP gate per tool call (#602)

## Test plan

- [ ] CI smoke gate green (customer-path-smoke.yml on push)
- [ ] After merge: tag `connector-v0.4.2`, verify release workflow exits 0
- [ ] After release: `pip install cullis-connector==0.4.2` in clean venv, `cullis-connector --version` reports 0.4.2