### PR TITLE
chore(frontdesk-bundle): bump pins to connector 0.4.2 + chat 0.4.0

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - frontdesk_net
 
   connector:
-    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.0}
+    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.2}
     # ``dashboard`` mounts the local-auth router (ADR-025) by default; the
     # legacy fake-SSO Ambassador shared-mode is reachable by setting
     # ``AMBASSADOR_MODE=shared`` explicitly in frontdesk.env. ADR-025
@@ -185,7 +185,7 @@ services:
     # + bundled JS/CSS. /api/session/* and /v1/* proxying to the
     # Connector happens in the outer nginx layer below; this inner
     # container only serves static assets.
-    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.3.0}
+    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.4.0}
     expose:
       - "8080"
     depends_on:

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -42,12 +42,12 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the cullis-connector image to pull. Pin a release tag
 # in production rather than ``latest``. The default tracks the latest
 # release validated against this bundle.
-# CONNECTOR_VERSION=0.4.0
+# CONNECTOR_VERSION=0.4.2
 
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on
 # every ``chat-vX.Y.Z`` tag (matrix build with CULLIS_BRAND=frontdesk).
-# CHAT_VERSION=0.3.0
+# CHAT_VERSION=0.4.0
 
 # -- Optional: bundle behaviour --------------------------------------------
 


### PR DESCRIPTION
## Summary

Bumps the Frontdesk bundle's default image pins:

- `CONNECTOR_VERSION`: 0.4.0 → **0.4.2** (Bug #5/#10 fixes, conv history REST, ADR-029 Phase D-1)
- `CHAT_VERSION`: 0.3.0 → **0.4.0** (M3 MarkdownView refactor)

Both 0.4.2 and 0.4.0 are published on ghcr.io by `release-connector.yml` (PR #632 → tag `connector-v0.4.2`) and `release-chat.yml` (tag `chat-v0.4.0`).

After merge: push tag `frontdesk-bundle-v0.2.2` to fire the bundle release pipeline (stage → tar.gz + zip → GitHub Release).

## Test plan

- [ ] CI smoke gate green (customer-path-smoke.yml builds locally, env-overrides the pins, so this passes regardless of ghcr.io state)
- [ ] After both upstream releases settle: `docker compose -f packaging/frontdesk-bundle/docker-compose.yml pull` resolves both images
- [ ] After merge: cut tag `frontdesk-bundle-v0.2.2`