### PR TITLE
fix: ADR-025 customer-path on Linux native (issue #634)

### DIFF
--- a/cullis_connector/auth/local_router.py
+++ b/cullis_connector/auth/local_router.py
@@ -177,6 +177,26 @@ class ReprovisionResponse(BaseModel):
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 
+def _sanitize_header_value(value: str, *, max_len: int = 256) -> str:
+    """Strip CR/LF/control bytes + truncate so the value is a legal HTTP header.
+
+    RFC 7230 §3.2.6 forbids CR/LF inside a header value; uvicorn rejects
+    such a value with ``RuntimeError: Invalid HTTP header value``. The
+    deferred-provisioning detail we echo back to the SPA comes from
+    ``str(exc)`` on an underlying httpx error, and httpx multi-line
+    error formatting (e.g. ``"... 400 Bad Request ...\\nFor more
+    information check: https://..."``) leaks the LF straight through.
+    """
+    sanitized = "".join(
+        " " if (ord(c) < 0x20 or ord(c) == 0x7F) else c
+        for c in value
+    )
+    # Latin-1 is uvicorn's wire encoding for headers. Replace any
+    # non-latin1 codepoint with '?' rather than blowing up.
+    sanitized = sanitized.encode("latin-1", errors="replace").decode("latin-1")
+    return sanitized[:max_len].strip()
+
+
 def _is_secure_cookie() -> bool:
     """Return True unless we're explicitly in dev mode.
 
@@ -482,10 +502,8 @@ async def login(body: LoginRequest, request: Request) -> JSONResponse:
         # that strips JSON fields it does not recognise.
         response.headers["X-Cullis-Provisioning-Failed"] = "true"
         if provisioning_detail:
-            # Truncate to keep the header well under 2KB; the full
-            # detail is in the audit log + Mastio side.
             response.headers["X-Cullis-Provisioning-Detail"] = (
-                provisioning_detail[:256]
+                _sanitize_header_value(provisioning_detail)
             )
     _set_cookie(response, cookie_value)
     _record_login_attempt(ip, body.user_name, success=True)
@@ -600,7 +618,7 @@ async def change_password(
         response.headers["X-Cullis-Provisioning-Failed"] = "true"
         if provisioning_detail:
             response.headers["X-Cullis-Provisioning-Detail"] = (
-                provisioning_detail[:256]
+                _sanitize_header_value(provisioning_detail)
             )
     _set_cookie(response, cookie_value)
     _log.info(
@@ -662,7 +680,7 @@ async def reprovision(request: Request) -> JSONResponse:
     )
     headers: dict[str, str] = {"X-Cullis-Provisioning-Failed": "true"}
     if detail:
-        headers["X-Cullis-Provisioning-Detail"] = detail[:256]
+        headers["X-Cullis-Provisioning-Detail"] = _sanitize_header_value(detail)
     return JSONResponse(
         body.model_dump(),
         status_code=502,

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -400,6 +400,44 @@ echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env up -d${RESET}"
 $COMPOSE --env-file frontdesk.env up -d
 ok "Containers started"
 
+# ── Attach sibling Mastio nginx to frontdesk_net ────────────────────────────
+#
+# Linux native (no Docker Desktop) doesn't resolve ``host.docker.internal``
+# inside containers and ``extra_hosts: host-gateway`` lands on the docker0
+# bridge IP which iptables FORWARD blocks across custom bridges. The
+# Connector here speaks to the Mastio at ``CULLIS_SITE_URL`` (defaulting to
+# ``https://host.docker.internal:9443``), so without an alias inside the
+# bridge the CSR provisioning call dies with ``[Errno -2] Name or service
+# not known``. Issue #634.
+#
+# Fix: if a sibling Mastio nginx container is running on this host, attach
+# it to our bridge as ``host.docker.internal`` + ``mastio-nginx``. Docker
+# DNS then resolves both names to the Mastio's address inside *this*
+# bridge, no extra_hosts / iptables magic required. Idempotent: skipped
+# when already attached. Silent when no sibling Mastio is found (remote
+# Mastio scenario: operator points ``CULLIS_SITE_URL`` at a real
+# hostname).
+NETWORK_NAME="${COMPOSE_PROJECT_NAME}_frontdesk_net"
+MASTIO_NGINX_CONTAINER="$(docker ps --filter 'label=com.docker.compose.service=mastio-nginx' --format '{{.Names}}' | head -1)"
+if [[ -n "$MASTIO_NGINX_CONTAINER" ]]; then
+    if docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' "$MASTIO_NGINX_CONTAINER" 2>/dev/null \
+            | tr ' ' '\n' | grep -qx "$NETWORK_NAME"; then
+        echo -e "  ${GRAY}Mastio nginx already attached to ${NETWORK_NAME}${RESET}"
+    else
+        if docker network connect \
+                --alias host.docker.internal \
+                --alias mastio-nginx \
+                "$NETWORK_NAME" "$MASTIO_NGINX_CONTAINER" 2>/dev/null; then
+            ok "Attached ${MASTIO_NGINX_CONTAINER} to ${NETWORK_NAME} (aliases: host.docker.internal, mastio-nginx)"
+        else
+            warn "Could not attach ${MASTIO_NGINX_CONTAINER} to ${NETWORK_NAME} — CSR may fail. Run manually:"
+            warn "  docker network connect ${NETWORK_NAME} ${MASTIO_NGINX_CONTAINER} --alias host.docker.internal --alias mastio-nginx"
+        fi
+    fi
+else
+    echo -e "  ${GRAY}No sibling Mastio nginx running locally — assuming remote Mastio at CULLIS_SITE_URL${RESET}"
+fi
+
 # ── Wait for health ─────────────────────────────────────────────────────────
 step "Waiting for services"
 

--- a/packaging/smoke-customer-path.sh
+++ b/packaging/smoke-customer-path.sh
@@ -195,13 +195,20 @@ step "Enrollment wizard — discover, submit, approve, poll"
 
 # 1. Discover should find the Mastio. Allow some time for the connector
 #    to probe; retry a few times.
+#
+# After issue #634 the Frontdesk deploy.sh attaches the sibling Mastio
+# nginx to frontdesk_net as ``host.docker.internal`` + ``mastio-nginx``
+# alias. The discover probe then reaches the same Mastio at both
+# ``host.docker.internal:9443`` and the docker0 gateway IP
+# ``172.17.0.1:9443`` and lists it twice. Check for at least one row,
+# not for the literal "Found one Mastio" wording.
 DISCOVER_HTML=""
 for i in $(seq 1 10); do
     DISCOVER_HTML="$(curl -sf http://localhost:8080/api/setup/discover/results 2>&1 || true)"
-    echo "$DISCOVER_HTML" | grep -q "Found one Mastio" && break
+    echo "$DISCOVER_HTML" | grep -q 'class="found-mastio-url"' && break
     sleep 2
 done
-echo "$DISCOVER_HTML" | grep -q "Found one Mastio" \
+echo "$DISCOVER_HTML" | grep -q 'class="found-mastio-url"' \
     || { echo "$DISCOVER_HTML"; fail "Discover did not find Mastio"; }
 
 BASE_URL=$(echo "$DISCOVER_HTML" | grep -oE 'name="base_url" value="[^"]+"' | head -1 | sed 's/.*value="\([^"]*\)".*/\1/')

--- a/packaging/smoke-customer-path.sh
+++ b/packaging/smoke-customer-path.sh
@@ -266,6 +266,83 @@ done
 [[ $APPROVED == 1 ]] || fail "Enrollment did not reach approved in 30s"
 ok "Connector identity on disk, /api/status=approved"
 
+# ── ADR-025 path guards (issue #634) ─────────────────────────────────────
+#
+# The legacy session/init path below uses the X-Forwarded-User flow that
+# bypasses CSR provisioning entirely. The ADR-025 local-auth path that
+# real customers use does NOT. Two bugs from the 2026-05-12 dogfood
+# (issue #634) shipped green through the old smoke because both bugs
+# only manifest on the ADR-025 path:
+#
+#   Bug A — Frontdesk deploy.sh did not attach sibling Mastio nginx to
+#           frontdesk_net, so host.docker.internal did not resolve from
+#           inside the Connector container on Linux native. CSR fails
+#           with "Name or service not known".
+#   Bug B — When CSR fails, the deferred-provisioning detail (a multi-
+#           line httpx error message) was placed verbatim in the
+#           X-Cullis-Provisioning-Detail response header. uvicorn
+#           rejects LF in header values, the response crashed mid-send,
+#           nginx returned 502.
+
+step "ADR-025 path guards — DNS + login round-trip"
+
+# Bug A guard: DNS resolution from inside the Connector container.
+CONNECTOR_CONTAINER="$(docker ps --filter 'label=com.docker.compose.service=connector' --filter 'label=com.docker.compose.project=cullis-frontdesk' --format '{{.Names}}' | head -1)"
+[[ -n "$CONNECTOR_CONTAINER" ]] \
+    || fail "Connector container not found by compose labels"
+docker exec "$CONNECTOR_CONTAINER" getent hosts host.docker.internal >/dev/null 2>&1 \
+    || fail "Bug A regression: host.docker.internal does not resolve inside $CONNECTOR_CONTAINER (deploy.sh did not attach sibling Mastio nginx to frontdesk_net)"
+ok "host.docker.internal resolves inside Connector"
+
+# Bug B guard: an /api/auth/login round-trip on the ADR-025 path must
+# return a well-formed response even when CSR provisioning fails (the
+# whole point of "deferred" semantics). Pre-fix, the response crashed
+# uvicorn mid-send.
+ADMIN_SECRET=$(grep '^CULLIS_CONNECTOR_ADMIN_SECRET=' "$REPO_ROOT/packaging/frontdesk-bundle/frontdesk.env" | cut -d= -f2)
+[[ -n "$ADMIN_SECRET" ]] || fail "could not read CULLIS_CONNECTOR_ADMIN_SECRET from frontdesk.env"
+
+curl -sf -X POST http://localhost:8080/admin/users \
+    -H "X-Admin-Secret: $ADMIN_SECRET" \
+    -H "Content-Type: application/json" \
+    -d '{"user_name":"smoke-adr025","password":"smoke-password-long","must_change_password":false}' \
+    -o /tmp/smoke-create-user.json \
+    || fail "admin create user (ADR-025 smoke)"
+
+LOGIN_HTTP=$(curl -s -o /tmp/smoke-login.json -D /tmp/smoke-login.headers \
+    -w "%{http_code}" \
+    -X POST http://localhost:8080/api/auth/login \
+    -H "Content-Type: application/json" \
+    -d '{"user_name":"smoke-adr025","password":"smoke-password-long"}')
+[[ "$LOGIN_HTTP" == "200" ]] \
+    || { echo "headers:"; cat /tmp/smoke-login.headers; echo "body:"; cat /tmp/smoke-login.json; fail "Bug B regression: /api/auth/login returned $LOGIN_HTTP (expected 200)"; }
+
+# Defense in depth — every response header value must be a single line.
+if grep -lE $'[\r\n]' /tmp/smoke-login.headers >/dev/null 2>&1; then
+    # grep -lE on the file matches if a line CONTAINS CR/LF mid-value.
+    # The header file itself uses CRLF terminators per HTTP, so this
+    # check fires only when a header value embeds an extra CR/LF.
+    : # placeholder, real check below
+fi
+# Stricter check: parse each header value, ensure none contains an
+# embedded \n after stripping the standard CRLF terminator.
+python3 - <<'PY' || fail "Bug B regression: response header carries embedded CR/LF"
+import sys
+with open("/tmp/smoke-login.headers", "rb") as f:
+    raw = f.read()
+# Split on CRLF, then look for any "header: value" line whose value
+# (after the colon) contains a bare \n or \r — would mean two distinct
+# headers got concatenated, which is exactly what the original Bug B
+# would have leaked.
+for line in raw.split(b"\r\n"):
+    if b":" not in line:
+        continue
+    name, _, value = line.partition(b":")
+    if b"\n" in value or b"\r" in value:
+        print(f"header {name!r} carries embedded CR/LF: {value!r}", file=sys.stderr)
+        sys.exit(1)
+PY
+ok "/api/auth/login returns 200 and headers are LF-free"
+
 # ── 1 chat turn against Claude (live) ────────────────────────────────────
 
 if [[ "${SKIP_CHAT_TURN:-0}" == "1" ]]; then

--- a/tests/connector/test_auth_local_router.py
+++ b/tests/connector/test_auth_local_router.py
@@ -408,3 +408,77 @@ def test_auth_local_router_not_mounted_when_oidc(connector_config, monkeypatch):
     assert r.status_code == 404
     r2 = tc.get("/api/auth/runtime-info")
     assert r2.status_code == 404
+
+
+# ── Issue #634 — deferred provisioning header sanitization ───────────────
+
+
+def test_sanitize_header_value_strips_lf_cr_and_truncates():
+    from cullis_connector.auth.local_router import _sanitize_header_value
+
+    assert _sanitize_header_value("one line") == "one line"
+    # LF / CR / tab / vertical-tab / null — every control byte goes
+    assert _sanitize_header_value("a\nb\rc\td\ve") == "a b c d e"
+    # Multi-line httpx-style error message (the real-world case from
+    # issue #634)
+    httpx_style = (
+        "transport failure calling Mastio /v1/principals/csr: "
+        "Client error '400 Bad Request' for url 'https://x/y'\n"
+        "For more information check: https://developer.mozilla.org/..."
+    )
+    out = _sanitize_header_value(httpx_style)
+    assert "\n" not in out and "\r" not in out
+    # Truncation honoured
+    long_value = "a" * 1000
+    assert len(_sanitize_header_value(long_value, max_len=256)) == 256
+    # Non-latin1 codepoints get replaced (uvicorn header writer is
+    # strict latin-1)
+    assert "?" in _sanitize_header_value("emoji 😀 here")
+
+
+def test_login_deferred_provisioning_header_does_not_crash_uvicorn(
+    client, monkeypatch,
+):
+    """Regression for issue #634.
+
+    When ``_bind_login_cert`` returns a ``deferred`` status with a
+    detail message that contains LF (real httpx errors look like
+    ``"... 400 Bad Request ...\\nFor more information check: ..."``),
+    the old code stuffed the raw multi-line string into
+    ``X-Cullis-Provisioning-Detail`` and uvicorn's header writer
+    aborted the response with
+    ``RuntimeError: Invalid HTTP header value``.
+
+    After the fix the detail flows through ``_sanitize_header_value``
+    and the response is well-formed.
+    """
+    from cullis_connector.auth import local_router as _lr
+
+    multiline_detail = (
+        "transport failure calling Mastio /v1/principals/csr: "
+        "Client error '400 Bad Request' for url 'https://x/y'\n"
+        "For more information check: https://developer.mozilla.org/Web/HTTP/Status/400"
+    )
+
+    async def fake_bind(request, payload):  # noqa: ARG001
+        return "deferred", multiline_detail
+
+    monkeypatch.setattr(_lr, "_bind_login_cert", fake_bind)
+
+    _create_user(
+        client, user_name="bob", password="longpassword", must_change=False,
+    )
+    r = client.post(
+        "/api/auth/login",
+        json={"user_name": "bob", "password": "longpassword"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["provisioning"] == "deferred"
+    assert r.headers.get("X-Cullis-Provisioning-Failed") == "true"
+    raw_detail = r.headers.get("X-Cullis-Provisioning-Detail", "")
+    assert raw_detail, "detail header should be present when detail provided"
+    # Critical invariant: NO control bytes in the wire-form header value
+    assert "\n" not in raw_detail
+    assert "\r" not in raw_detail
+    # Truncation honoured to keep header well under 2 KB
+    assert len(raw_detail) <= 256


### PR DESCRIPTION
Closes #634.

## Summary

Two cascading bugs surfaced during the 2026-05-12 VPS demo dogfood on Linux native (NixOS). Fix bundles both because the regression test for Bug B requires Bug A's network attach to be in place to repro reliably.

### Bug A — `frontdesk-bundle/deploy.sh` does not attach Mastio nginx to `frontdesk_net`

On Linux native (no Docker Desktop), `host.docker.internal` does not resolve from inside the Connector container and `extra_hosts: host-gateway` lands on the `docker0` bridge IP that iptables FORWARD blocks across custom bridges. The Mastio bundle uses its own bridge (`cullis-mastio_proxy_net`), so the Connector cannot reach the Mastio for CSR provisioning. Fail mode:
```
local provisioning failed user_name=X: Proxy unreachable: [Errno -2] Name or service not known
```

The `docker-compose.yml` comment already said "fix in deploy.sh"; this PR finally writes it. Idempotent `docker network connect` with aliases `host.docker.internal` + `mastio-nginx` when a sibling Mastio is detected. Silent skip when none is found (remote site at `CULLIS_SITE_URL`).

### Bug B — `/api/auth/login` crashes with `Invalid HTTP header value` on deferred provisioning

`_bind_login_cert` collapses CSR failures into `("deferred", str(MastioCsrError(...)))`. httpx multi-line error messages (`"... 400 Bad Request ...\nFor more information check: ..."`) leak the LF straight into the `X-Cullis-Provisioning-Detail` header. uvicorn's writer rejects it:
```
File "uvicorn/protocols/http/httptools_impl.py", line 500, in send
    raise RuntimeError("Invalid HTTP header value.")
```

Response crashes mid-send, nginx returns 502, the Connector log shows the stack but the SPA sees only a Bad Gateway.

New `_sanitize_header_value` helper:
- Replaces CR/LF/control bytes (< 0x20 + 0x7F) with a single space
- Coerces to latin-1 with `errors="replace"` (uvicorn's wire encoding)
- Truncates to 256 chars
- Applied at all 3 call sites: `/api/auth/login`, `/api/auth/change-password`, `/api/auth/reprovision`

### Smoke gate guard

`packaging/smoke-customer-path.sh` previously exercised only the legacy `/api/session/init` path with `X-Forwarded-User`. That path bypasses CSR provisioning entirely, which is exactly why both bugs shipped through the gate. Two new compact guards run AFTER enrollment:

1. **Bug A guard**: `docker exec` into the Connector container, `getent hosts host.docker.internal` must resolve. If `deploy.sh` did not attach the sibling Mastio nginx, this fails fast.
2. **Bug B guard**: pre-create an ADR-025 user, POST `/api/auth/login` with valid creds, expect HTTP 200, parse `/tmp/smoke-login.headers` and assert no header value carries embedded CR/LF.

## Test plan

- [x] `pytest tests/connector/test_auth_local_router.py` — 23/23 pass (2 new tests cover the helper + the deferred-with-multiline-detail path end-to-end)
- [x] `pytest tests/connector/` — 631/635 pass, 4 unrelated pre-existing pystray API failures
- [x] `bash -n packaging/frontdesk-bundle/deploy.sh` clean
- [x] `bash -n packaging/smoke-customer-path.sh` clean
- [ ] CI customer-path-smoke green on this PR (validates Bug A + Bug B guards against the fixed deploy.sh)
- [ ] After merge: re-run Fase 0 of `imp/runbook-customer-ready.md` on Linux native NixOS, confirm `/api/auth/login` → `/v1/chat/completions` round-trip returns Haiku output without manual network surgery