### PR TITLE
chore(release): bump connector to 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ The connector follows its own release cadence, independent from the
 broker and proxy components of the Cullis monorepo. Connector releases
 are tagged `connector-vX.Y.Z`.
 
+## [v0.4.3] — 2026-05-12
+
+Customer-path bug fix for Linux native deployments (issue #634).
+Closes the ADR-025 `/api/auth/login` regression that crashed uvicorn
+mid-response with `RuntimeError: Invalid HTTP header value` when CSR
+provisioning failed.
+
+### Fixed
+
+- **`/api/auth/login` no longer crashes when CSR is unreachable**
+  ([#635]): `_bind_login_cert` collapses CSR failures into
+  `("deferred", str(MastioCsrError(...)))`. httpx multi-line error
+  messages leak LF straight into the `X-Cullis-Provisioning-Detail`
+  response header, which uvicorn rejects. The fix introduces a new
+  `_sanitize_header_value` helper (strips CR/LF/control bytes, forces
+  latin-1, truncates to 256 chars) applied at all three call sites:
+  `/api/auth/login`, `/api/auth/change-password`, and
+  `/api/auth/reprovision`. Regression test covers the helper directly
+  + the deferred-with-multiline-detail path end-to-end. Bug surfaced
+  in the 2026-05-12 VPS demo dogfood on NixOS, where
+  `host.docker.internal` did not resolve from inside the Connector
+  container and every CSR call deferred with a multi-line httpx error.
+
+### Not in this release
+
+- The complementary deploy-side fix that makes
+  `host.docker.internal` resolve from the Connector container on
+  Linux native ships as `frontdesk-bundle-v0.2.3` rather than a
+  Connector release — it lives in
+  `packaging/frontdesk-bundle/deploy.sh`.
+
+[#635]: https://github.com/cullis-security/cullis/pull/635
+
 ## [v0.4.2] — 2026-05-12
 
 Bug-fix release that ships two crash-class fixes uncovered during the

--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __all__ = ["__version__"]

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.2"
+version = "0.4.3"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Cuts `cullis-connector` **v0.4.3** with the issue #634 customer-path fix that landed in #635. Lockstep bump of `pyproject.toml` + `cullis_connector/__init__.py` + `CHANGELOG.md`. After merge, push tag `connector-v0.4.3` to fire `release-connector.yml`.

## What's new in 0.4.3

Customer-path bug fix for Linux native (NixOS) deployments. `/api/auth/login` no longer crashes uvicorn mid-response with `RuntimeError: Invalid HTTP header value` when CSR provisioning is unreachable. The deploy-side complement (`deploy.sh` attaches sibling Mastio nginx to `frontdesk_net`) ships separately as `frontdesk-bundle-v0.2.3` (tagged in parallel).

## Test plan

- [x] CI customer-path-smoke green on #635 with the bundled fix
- [ ] After merge: tag `connector-v0.4.3`, `release-connector.yml` exits 0
- [ ] `pip install cullis-connector==0.4.3` in clean venv, `cullis-connector --version` reports 0.4.3
- [ ] Re-run Fase 0 of `imp/runbook-customer-ready.md` end-to-end on Linux native, confirm no manual `docker network connect` workaround needed