### PR TITLE
fix(bundles): openssl optional, /dev/urandom fallback (issue #638)

### DIFF
--- a/packaging/frontdesk-bundle/generate-frontdesk-env.sh
+++ b/packaging/frontdesk-bundle/generate-frontdesk-env.sh
@@ -177,7 +177,18 @@ esac
 # MCP_PROXY_ADMIN_SECRET, which is a different secret on a different
 # component (the Mastio dashboard) and cannot authenticate the Connector
 # admin API. See bug 1 in the v0.2.0 dogfood notes.
-ADMIN_SECRET="${CULLIS_CONNECTOR_ADMIN_SECRET:-$(openssl rand -hex 24)}"
+# gen_secret — prefer openssl, fall back to /dev/urandom + coreutils on
+# hosts that ship without openssl (minimal NixOS, Alpine, distroless,
+# trimmed WSL2 Ubuntu). Issue #638. Output: 48 lowercase hex chars,
+# matching the openssl rand -hex 24 shape.
+gen_admin_secret() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -hex 24
+    else
+        head -c 24 /dev/urandom | od -An -vtx1 | tr -d ' \n'
+    fi
+}
+ADMIN_SECRET="${CULLIS_CONNECTOR_ADMIN_SECRET:-$(gen_admin_secret)}"
 
 cp "$SCRIPT_DIR/frontdesk.env.example" "$OUT"
 sed -i "s|^CULLIS_FRONTDESK_ORG_ID=.*|CULLIS_FRONTDESK_ORG_ID=${ORG_ID}|"               "$OUT"

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -3,6 +3,12 @@
 Self-contained Mastio deploy. Pulls the published image from GHCR, no
 source tree required.
 
+## Prerequisites
+
+- **Docker** Engine 20.10+ with **docker compose v2** (`docker compose version`).
+- **bash** 4+, **curl**, **tar**, **gzip** — almost always already on the host.
+- **openssl** is optional. When present `deploy.sh` uses `openssl rand` for the admin secrets; when absent it falls back to `/dev/urandom + base64`, so minimal NixOS / Alpine / distroless hosts work out of the box.
+
 ## Quickstart (2 commands, you already have this tarball)
 
 ```bash

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -56,7 +56,6 @@ if [[ -f "$OUT" && "$FORCE" -eq 0 ]]; then
     [[ "$reply" =~ ^[Yy] ]] || { ok "Keeping existing proxy.env"; exit 0; }
 fi
 
-command -v openssl >/dev/null || die "openssl is required"
 [[ -f "$PROJECT_DIR/proxy.env.example" ]] || die "proxy.env.example not found"
 
 if [[ "$MODE" == "prod" ]]; then
@@ -64,7 +63,21 @@ if [[ "$MODE" == "prod" ]]; then
     [[ -n "${PROXY_PUBLIC_URL:-}" ]] || die "--prod requires PROXY_PUBLIC_URL env var"
 fi
 
-gen_secret() { openssl rand -base64 32 | tr -d '/+=' | head -c 32; }
+# Prefer openssl when available (well-tested, fast); fall back to
+# /dev/urandom + coreutils on hosts that ship without openssl —
+# minimal NixOS, Alpine, distroless, WSL2 trimmed Ubuntu, etc. Issue
+# #638: a customer on a Linux host without openssl pre-installed
+# previously hit ``openssl is required`` on the very first deploy.
+gen_secret() {
+    if command -v openssl >/dev/null 2>&1; then
+        openssl rand -base64 32 | tr -d '/+=' | head -c 32
+    else
+        # 64 random bytes → base64 → strip non-alphanum → take 32 chars.
+        # /dev/urandom + base64 + tr are coreutils, present on every
+        # Linux a docker host can boot on.
+        head -c 64 /dev/urandom | base64 | tr -d '/+=\n' | head -c 32
+    fi
+}
 
 ADMIN_SECRET="$(gen_secret)"
 SIGNING_KEY="$(gen_secret)"


### PR DESCRIPTION
Closes #638.

## Repro

Fresh NixOS minimal VM (simulating customer on Alpine / distroless / WSL2 trimmed Ubuntu — anywhere openssl is not in the base image). First step of the README quickstart:

```
$ curl -L https://github.com/cullis-security/cullis/releases/download/mastio-v0.3.3/cullis-mastio-bundle.tar.gz | tar xz
$ cd cullis-mastio-bundle
$ ./deploy.sh

── Environment configuration (proxy.env) ──
  !  proxy.env not found — generating one
  ✗  openssl is required
```

Dead-end with no in-band recovery (README does not list openssl as a prerequisite either). Same flank in `frontdesk-bundle/generate-frontdesk-env.sh`.

## Fix

Both bundle env generators now prefer openssl when available and fall back to `/dev/urandom + coreutils` when not. Output shape preserved:

- `gen_secret`: 32 alnum chars (was `openssl rand -base64 32 | tr -d '/+=' | head -c 32`)
- `gen_admin_secret`: 48 hex chars (was `openssl rand -hex 24`)

`README.md` of the Mastio bundle now lists prerequisites explicitly, with openssl called out as optional. Frontdesk bundle README is unchanged (Frontdesk inherits identity from the Connector enrollment, so its prerequisites are a subset of Mastio's).

## Validation

Locally with a stub that hides openssl from `command -v`:

```
secret: vT7VWuHmjliHtTPgbQGgc9xYKvV8ONbx | len=32
hex: 111cb048231a9bb94ec644799f256b599dc142bec11a8b60 | len=48
```

Both shapes match the openssl path. Downstream sed/awk parsing in the .env files is unchanged.

## Test plan

- [x] Stub-test fallback locally
- [x] `bash -n` clean on both scripts
- [ ] CI customer-path-smoke gate green (Ubuntu runner with openssl, exercises the openssl path)
- [ ] After merge: re-run customer install in the NixOS VM dogfood — no `nix-shell -p openssl` workaround needed

## Surfaces

Discovered 2026-05-12 during the VM dogfood follow-up to issue #634. Same "trova bug, fix, retry fino fine" pattern.