### PR TITLE
fix(frontdesk-bundle): nginx /static/* → Connector wizard (issue #640)

### DIFF
--- a/packaging/frontdesk-bundle/nginx/default.conf
+++ b/packaging/frontdesk-bundle/nginx/default.conf
@@ -174,6 +174,30 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # ----- /static/*: Connector wizard assets (CSS, htmx, SVG) -----
+    #
+    # The Connector wizard templates (``setup_discovery.html`` etc.)
+    # reference ``/static/style.css``, ``/static/htmx.min.js``,
+    # ``/static/cullis-mark.svg``, ``/static/favicon.svg`` — those live
+    # in ``cullis_connector/static/`` and are served by the Connector
+    # on ``:7777``. Without this block, the catch-all ``location /``
+    # below would send ``/static/*`` to the Cullis Chat SPA, which has
+    # no concept of that path and returns its ``index.html`` fallback
+    # (12.5 KB of HTML, Content-Type: text/html). The wizard then
+    # renders unstyled with broken images. Issue #640.
+    #
+    # The Cullis Chat SPA itself uses ``/_astro/...`` for its hashed
+    # bundle and serves top-level ``cullis-mark.svg`` etc., never
+    # ``/static/``, so this namespace is free.
+    location /static/ {
+        proxy_pass http://connector:7777$request_uri;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # ----- everything else: static SPA via the cullis-chat container -----
     #
     # The cullis-chat container ships nginx-static (port 8080) serving


### PR DESCRIPTION
Closes #640.

## Symptom

In-browser enrollment wizard (`/setup/discover` and friends) renders as raw unstyled HTML with broken images and dead htmx. Customer on `frontdesk-bundle-v0.2.4` opens the very first onboarding screen and cannot proceed.

## Root cause

`packaging/frontdesk-bundle/nginx/default.conf`:

```
location ~ ^/(setup|api/setup|waiting|api/status)(/.*)?$  { → connector:7777 }
location /  { → cullis-chat:8080 }    # catch-all
```

Connector wizard templates reference `/static/style.css`, `/static/htmx.min.js`, `/static/cullis-mark.svg`, `/static/favicon.svg` — those live in `cullis_connector/static/` on the Connector. The catch-all routes `/static/*` to the Cullis Chat SPA, whose nginx-static returns `index.html` (12.5 KB, `Content-Type: text/html`) for any unknown path. Browser receives HTML instead of CSS / JS / SVG.

`curl` confirms before fix:

```
$ curl -sI http://localhost:8080/static/style.css | head -3
HTTP/1.1 200 OK
Content-Type: text/html
Content-Length: 12570
```

## Fix

Insert `location /static/` before the catch-all, routing to `connector:7777`. The Cullis Chat SPA's Astro build uses `/_astro/...` for its hashed bundle and serves top-level brand SVGs (`cullis-mark.svg` etc.) directly off `/`, never under `/static/`, so the namespace is free.

## Validation

Local nginx reload + recheck:

```
$ curl -sI http://localhost:8080/static/style.css | head -3
HTTP/1.1 200 OK
Content-Type: text/css; charset=utf-8
Content-Length: <real size>
```

Wizard renders styled, htmx polling reaches `/api/setup/discover/results`, CA fingerprint card visible. SPA `/` still loads (Cullis Chat post-login).

## Customer hotfix on v0.2.4

Drop-in patch to `packaging/frontdesk-bundle/nginx/default.conf`:

```nginx
location /static/ {
    proxy_pass http://connector:7777$request_uri;
    proxy_http_version 1.1;
    proxy_set_header Host $http_host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
}
```

Insert immediately before `location /`. Then `docker compose --env-file frontdesk.env restart nginx`.

## Test plan

- [x] `bash -n` / nginx syntax clean
- [ ] CI customer-path-smoke gate green
- [ ] After merge: tag `frontdesk-bundle-v0.2.5`, customer install from new tarball, wizard renders styled at the first try

## Surfaces

Discovered 2026-05-12 during VM customer dogfood. Third bug in the issue-#634 / #638 / #640 cascade — all of them hidden from the smoke gate because the smoke uses `--site` to bypass the in-browser wizard and never opens the page that loads `/static/*`.