### PR TITLE
fix(frontdesk-bundle): auto-wire Mastio dashboard → Frontdesk admin bridge (issue #644)

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -524,6 +524,90 @@ else
     echo -e "  ${GRAY}No sibling Mastio nginx running locally — assuming remote Mastio at CULLIS_SITE_URL${RESET}"
 fi
 
+# ── Wire Mastio dashboard → Frontdesk admin API ─────────────────────────────
+#
+# The Mastio dashboard's "Create user" / "Reset password" / "Delete user"
+# flows already know how to delegate to the Frontdesk admin API
+# (mcp_proxy/dashboard/router.py: _frontdesk_admin_target). They just need
+# two env vars in the Mastio's proxy.env to find us:
+#
+#   MCP_PROXY_FRONTDESK_AMBASSADOR_URL=http://connector:7777
+#   MCP_PROXY_FRONTDESK_ADMIN_SECRET=<our CULLIS_CONNECTOR_ADMIN_SECRET>
+#
+# Plus the Mastio's ``mcp-proxy`` container needs to be on our
+# ``frontdesk_net`` so docker DNS resolves ``connector`` to our Connector.
+# Pre-fix, the Mastio dashboard fell back to **registry-only** user create
+# (writes the principal row, no password propagated, web login broken)
+# and the danger-zone Delete silently no-op'd. Issue #644.
+SIBLING_MASTIO_BUNDLE=""
+for cand in "$SCRIPT_DIR/../cullis-mastio-bundle" "$SCRIPT_DIR/../mastio-bundle"; do
+    if [[ -f "$cand/proxy.env" ]]; then
+        SIBLING_MASTIO_BUNDLE="$(cd "$cand" && pwd)"
+        break
+    fi
+done
+
+if [[ -n "$SIBLING_MASTIO_BUNDLE" && -n "$MASTIO_NGINX_CONTAINER" ]]; then
+    ADMIN_SECRET="$(_load_env CULLIS_CONNECTOR_ADMIN_SECRET)"
+    if [[ -z "$ADMIN_SECRET" ]]; then
+        warn "Could not read CULLIS_CONNECTOR_ADMIN_SECRET from frontdesk.env — skipping Mastio dashboard wiring"
+    else
+        MASTIO_PROXY_ENV="$SIBLING_MASTIO_BUNDLE/proxy.env"
+        # Locate the Mastio mcp-proxy container by compose-service label so
+        # we don't depend on a specific container name.
+        MASTIO_PROXY_CONTAINER="$(docker ps --filter 'label=com.docker.compose.service=mcp-proxy' --format '{{.Names}}' | head -1)"
+
+        # Attach mcp-proxy to our network so it can resolve ``connector``.
+        if [[ -n "$MASTIO_PROXY_CONTAINER" ]]; then
+            if docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' "$MASTIO_PROXY_CONTAINER" 2>/dev/null \
+                    | tr ' ' '\n' | grep -qx "$NETWORK_NAME"; then
+                : # already attached, no-op
+            else
+                docker network connect "$NETWORK_NAME" "$MASTIO_PROXY_CONTAINER" 2>/dev/null \
+                    || warn "Could not attach ${MASTIO_PROXY_CONTAINER} to ${NETWORK_NAME}"
+            fi
+        fi
+
+        # Append / update the two env vars in the sibling proxy.env.
+        # Idempotent: strip any existing lines first, then append.
+        TMP_ENV="$(mktemp)"
+        grep -v -E '^MCP_PROXY_FRONTDESK_(AMBASSADOR_URL|ADMIN_SECRET)=' "$MASTIO_PROXY_ENV" > "$TMP_ENV"
+        cat >> "$TMP_ENV" <<MASTIO_BRIDGE_EOF
+
+# Wired automatically by Frontdesk deploy.sh (issue #644) — lets the
+# Mastio dashboard's Create User / Reset / Delete flows propagate to
+# the sibling Frontdesk container's users.db. Remove these two lines
+# (or unset MCP_PROXY_FRONTDESK_AMBASSADOR_URL alone) to fall back to
+# registry-only user create.
+MCP_PROXY_FRONTDESK_AMBASSADOR_URL=http://connector:7777
+MCP_PROXY_FRONTDESK_ADMIN_SECRET=${ADMIN_SECRET}
+MASTIO_BRIDGE_EOF
+        mv "$TMP_ENV" "$MASTIO_PROXY_ENV"
+
+        # Force-recreate the Mastio mcp-proxy so the new env is loaded.
+        # ``docker compose restart`` does NOT re-read env from the file.
+        if [[ -n "$MASTIO_PROXY_CONTAINER" ]]; then
+            (
+                cd "$SIBLING_MASTIO_BUNDLE"
+                COMPOSE_PROJECT_NAME=cullis-mastio \
+                    $COMPOSE --env-file proxy.env up -d --force-recreate mcp-proxy \
+                    >/dev/null 2>&1 \
+                    || warn "Could not force-recreate Mastio mcp-proxy — bridge env will activate on next Mastio restart"
+            )
+            # The recreate detaches the container from custom networks; re-attach.
+            MASTIO_PROXY_CONTAINER_NEW="$(docker ps --filter 'label=com.docker.compose.service=mcp-proxy' --format '{{.Names}}' | head -1)"
+            if [[ -n "$MASTIO_PROXY_CONTAINER_NEW" ]]; then
+                if ! docker inspect -f '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}' "$MASTIO_PROXY_CONTAINER_NEW" 2>/dev/null \
+                        | tr ' ' '\n' | grep -qx "$NETWORK_NAME"; then
+                    docker network connect "$NETWORK_NAME" "$MASTIO_PROXY_CONTAINER_NEW" 2>/dev/null || true
+                fi
+            fi
+        fi
+
+        ok "Mastio dashboard ↔ Frontdesk admin bridge wired (Create / Reset / Delete user from $SIBLING_MASTIO_BUNDLE / )"
+    fi
+fi
+
 # ── Wait for health ─────────────────────────────────────────────────────────
 step "Waiting for services"
 


### PR DESCRIPTION
Closes #644.

## Symptom

Customer dogfood: operator clicks "Create user" in the Mastio dashboard, expects the user to be able to log in to Cullis Chat. Instead the dashboard goes into **registry-only fallback**: writes a `local_user_principals` row, gives the user no password, the user can never log in via web. Same for Reset password and the danger-zone Delete — both silently no-op against Frontdesk.

User reported (verbatim, very frustrated):
> "ristiamo da capo a dodici, l'hai creato tu non io, io da dashboard non ho modo di settare la password ... cioè è cosi difficile? sono 3 giorni che lo chiedo ma niente"

## Why

`mcp_proxy/dashboard/router.py:3382-3525` already implements the full Mastio→Frontdesk delegation: mint temp password, POST `/admin/users` to the Frontdesk Ambassador, one-shot ticket reveal back to the admin via `new_pw_ticket=`, audit attribution, etc. Reset + Delete use the same `_frontdesk_admin_call` plumbing. It activates only when the Mastio has these two env vars in its `proxy.env`:

```
MCP_PROXY_FRONTDESK_AMBASSADOR_URL=http://connector:7777
MCP_PROXY_FRONTDESK_ADMIN_SECRET=<connector admin secret>
```

Plus the Mastio's `mcp-proxy` container attached to `cullis-frontdesk_frontdesk_net` so docker DNS resolves `connector`.

The Frontdesk bundle has the secret. The Mastio bundle is the dependent component (Frontdesk learns about it at enrollment). Nothing today writes the bridge config across.

## Fix

After `compose up -d` of the Frontdesk, the deploy script now (idempotently):

1. Locates the sibling Mastio bundle (`../cullis-mastio-bundle/` or `../mastio-bundle/`).
2. Reads `CULLIS_CONNECTOR_ADMIN_SECRET` from our `frontdesk.env`.
3. Rewrites the two env vars in the sibling `proxy.env`.
4. Attaches the sibling Mastio's `mcp-proxy` container to `${COMPOSE_PROJECT_NAME}_frontdesk_net`.
5. Force-recreates the mcp-proxy so it picks up the new env.
6. Re-attaches the freshly recreated mcp-proxy to frontdesk_net (force-recreate detaches from custom networks).

Silent skip when there's no sibling Mastio (remote-Mastio scenario), operator points `MCP_PROXY_FRONTDESK_AMBASSADOR_URL` by hand in that case.

## Validation (live, VM dogfood)

After applying this branch's logic manually inside the running VM:

```
$ curl ... -X POST https://localhost:9443/proxy/users/create -d 'user_name=alice&display_name=Alice'
HTTP/2 303
location: /proxy/users/...::user::alice?new_pw_ticket=EXFu1VQGZgXJPPn9IeYYVKAhXkqK7ZTy

$ curl http://localhost:8080/admin/users -H "X-Admin-Secret: $SECRET"
{"users":[{"user_name":"alice","display_name":"Alice","must_change_password":true,...}],"total":1}
```

End-to-end: dashboard → temp password → propagated → Frontdesk users.db → web login works.

## Customer hotfix on `frontdesk-bundle-v0.2.4`

```bash
cd cullis-frontdesk-bundle
SECRET=$(grep CULLIS_CONNECTOR_ADMIN_SECRET frontdesk.env | cut -d= -f2)
cat >> ../cullis-mastio-bundle/proxy.env <<EOF2
MCP_PROXY_FRONTDESK_AMBASSADOR_URL=http://connector:7777
MCP_PROXY_FRONTDESK_ADMIN_SECRET=$SECRET
EOF2
docker network connect cullis-frontdesk_frontdesk_net cullis-mastio-mcp-proxy-1
cd ../cullis-mastio-bundle
COMPOSE_PROJECT_NAME=cullis-mastio docker compose --env-file proxy.env up -d --force-recreate mcp-proxy
docker network connect cullis-frontdesk_frontdesk_net cullis-mastio-mcp-proxy-1   # re-attach
```

## Test plan

- [x] `bash -n` clean
- [x] Manual validation in VM dogfood (Mastio dashboard Create user → 303 with `new_pw_ticket`, Frontdesk users.db row present)
- [ ] CI customer-path-smoke gate green (covers both bundles in one pass)
- [ ] After merge: tag `frontdesk-bundle-v0.2.5`, customer install from new tarball