### PR TITLE
fix(spa): chat sender label reads from whoami, not hardcoded 'mario'

### DIFF
--- a/frontend/cullis-chat/src/components/ChatApp.tsx
+++ b/frontend/cullis-chat/src/components/ChatApp.tsx
@@ -9,6 +9,7 @@ import {
   renameConversation,
 } from '../lib/api';
 import { ensureSession } from '../lib/session-singleton';
+import { whoamiAuto } from '../lib/auth';
 import { readSelectedModel } from './ModelPicker';
 import type { ChatMessage, ConversationDetail, StoredMessage } from '../lib/types';
 import { ChatWindow } from './ChatWindow';
@@ -174,6 +175,12 @@ function reasonOf(err: unknown): string {
 export default function ChatApp() {
   const [state, dispatch] = useReducer(reducer, INITIAL);
   const [sessionReady, setSessionReady] = useState(false);
+  // Sender label for the chat bubble on the user side. Pre-fix this was
+  // hardcoded "mario" in Message.tsx and every customer saw "mario" as
+  // their own name no matter who logged in. We read it from whoami once
+  // at mount; the Message component falls back to "you" while this is
+  // still null (whoami in flight or unavailable).
+  const [userName, setUserName] = useState<string | null>(null);
   // One in-flight stream per chat instance. Stop button aborts via this.
   const abortRef = useRef<AbortController | null>(null);
   // Sprint 1 Step 6 PR-B, active conversation tied to /v1/conversations.
@@ -193,6 +200,28 @@ export default function ChatApp() {
       .catch((err) => {
         if (cancelled) return;
         dispatch({ type: 'error', message: `session_init: ${reasonOf(err)}` });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load the principal display name from whoami so Message.tsx can label
+  // the user bubble with the real signed-in user (was hardcoded "mario"
+  // pre-fix). Single best-effort fetch at mount; silent on failure (the
+  // chat bubble falls back to "you").
+  useEffect(() => {
+    let cancelled = false;
+    whoamiAuto()
+      .then((result) => {
+        if (cancelled) return;
+        const principal = result?.principal;
+        if (principal?.name) setUserName(principal.name);
+      })
+      .catch(() => {
+        // Intentionally ignored. The Message component renders "you"
+        // when userName is null, which is correct for the case where
+        // whoami fails or hasn't returned yet.
       });
     return () => {
       cancelled = true;
@@ -467,8 +496,9 @@ export default function ChatApp() {
       setDraft: (text) => dispatch({ type: 'set_draft', text }),
       consumeDraft: () => dispatch({ type: 'clear_draft' }),
       sessionReady,
+      userName,
     }),
-    [state, send, cancel, retry, sessionReady],
+    [state, send, cancel, retry, sessionReady, userName],
   );
 
   // Initial collapse state from localStorage. The TopBar toggle script

--- a/frontend/cullis-chat/src/components/Message.tsx
+++ b/frontend/cullis-chat/src/components/Message.tsx
@@ -21,7 +21,7 @@ interface Props {
  * marginalia chips above the body.
  */
 export function Message({ message, selected, onClick }: Props) {
-  const { retry } = useChat();
+  const { retry, userName } = useChat();
   const isUser = message.role === 'user';
   const ts = new Date(message.createdAt);
   const tsLabel = ts.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
@@ -39,7 +39,7 @@ export function Message({ message, selected, onClick }: Props) {
     >
       <header className="msg-meta">
         <span className={`msg-role ${isUser ? 'msg-role-user' : ''}`}>
-          {isUser ? 'mario' : 'cullis'}
+          {isUser ? (userName ?? 'you') : 'cullis'}
         </span>
         <span className="msg-folio">
           <em>{tsLabel}</em>

--- a/frontend/cullis-chat/src/components/MessageList.tsx
+++ b/frontend/cullis-chat/src/components/MessageList.tsx
@@ -10,7 +10,7 @@ interface Props {
 }
 
 const HINTS = [
-  'what is the gdpr training status of mario rossi?',
+  'show my latest audit log entries.',
   'list active sessions across the org.',
   'summarise the open compliance findings.',
 ];

--- a/frontend/cullis-chat/src/lib/chat-context.ts
+++ b/frontend/cullis-chat/src/lib/chat-context.ts
@@ -29,6 +29,11 @@ export interface ChatContextValue {
   consumeDraft: () => void;
   setDraft: (text: string) => void;
   sessionReady: boolean;
+  /** Display name of the signed-in principal. Used by Message.tsx for the
+   *  sender label on user turns. Null while whoami is in flight; the
+   *  Message component falls back to "you" in that case. Pre-fix this was
+   *  hardcoded to "mario" which leaked into every customer's chat. */
+  userName: string | null;
 }
 
 export const ChatContext = createContext<ChatContextValue | null>(null);


### PR DESCRIPTION
## Symptom

Customer dogfood: user logged in as `daniele`, sent `ciao` in chat, saw the message attributed to **MARIO** in the bubble while the TopBar correctly showed `PRINCIPAL · user · daniele`. Every customer who ever logged in saw the same mismatch.

Screenshot reported by the user is unambiguous: top right says `daniele`, bubble label says `MARIO`.

## Root cause

`frontend/cullis-chat/src/components/Message.tsx:42`:

```tsx
{isUser ? 'mario' : 'cullis'}
```

Inlined literal. Dev placeholder that survived into v0.4.0 because the TopBar's `IdentityBadge` already calls `whoamiAuto` (so the top bar is correct), and the chat bubble label was a second, parallel surface nobody had wired to the same source.

## Fix

- `chat-context.ts`: add `userName: string | null` to the context value.
- `ChatApp.tsx`: useEffect at mount calls `whoamiAuto`, stashes `principal.name` in local state, exposes via the context. Silent fallback on failure (whoami in flight or unavailable → component renders "you").
- `Message.tsx`: `{isUser ? (userName ?? 'you') : 'cullis'}`.
- `MessageList.tsx`: drop the 'mario rossi' placeholder from suggested hints — that was the other customer-visible leak of internal test data.

Test fixtures that intentionally use `'mario'` (mock ambassador, audit-panel e2e, auth.test) are unchanged — they drive the dev mock SPA and assert against a known principal, not customer-visible.

## Test plan

- [x] Manual: pulled the branch, the SPA shows the signed-in user's `principal.name` in the bubble. With `daniele` logged in, bubble reads `daniele`. With `alice`, bubble reads `alice`.
- [ ] e2e `chat-flow.spec.ts` (if present) updated to assert the dynamic label, not the literal 'mario'
- [ ] Customer-path-smoke gate green
- [ ] After merge: cut `chat-v0.4.1`, bump Frontdesk bundle pin

## Customer hotfix on `chat-v0.4.0`

The SPA is statically served by nginx in the published image; no in-place patch available. Customers currently running v0.4.0 will see `mario` until they pull `chat-v0.4.1` and `docker compose --env-file frontdesk.env up -d --force-recreate cullis-chat`.

## Surfaces

VM customer dogfood 2026-05-12, surfaced after #634/#638/#640/#642/#643/#644/#646. The single most jarring "this can't be right" customer moment in the whole flow.