### PR TITLE
chore(frontdesk-bundle): bump chat pin to 0.4.1

### DIFF
--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -185,7 +185,7 @@ services:
     # + bundled JS/CSS. /api/session/* and /v1/* proxying to the
     # Connector happens in the outer nginx layer below; this inner
     # container only serves static assets.
-    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.4.0}
+    image: ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION:-0.4.1}
     expose:
       - "8080"
     depends_on:

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -47,7 +47,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on
 # every ``chat-vX.Y.Z`` tag (matrix build with CULLIS_BRAND=frontdesk).
-# CHAT_VERSION=0.4.0
+# CHAT_VERSION=0.4.1
 
 # -- Optional: bundle behaviour --------------------------------------------
 


### PR DESCRIPTION
Bumps CHAT_VERSION default in docker-compose.yml + frontdesk.env.example from 0.4.0 to 0.4.1. Picks up PR #647 chat-bubble sender fix.

After merge: cut tag `frontdesk-bundle-v0.2.5` to ship the new pin in the release tarball.

Connector pin unchanged (0.4.2).