### PR TITLE
fix(mastio): admin password rotation via dashboard (issue #653)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -4225,6 +4225,93 @@ async def settings_local_password(request: Request):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Admin password rotation (issue #653)
+#
+# The Mastio admin password used to be rotate-only via ``python -m
+# mcp_proxy.cli reset-password`` over docker exec, which every first-time
+# operator hit as "I logged in with MCP_PROXY_INITIAL_ADMIN_PASSWORD and
+# now there's no way to change it from the dashboard". This handler
+# exposes the same helper (``set_admin_password``) via a small form on
+# the Settings page.
+#
+# Auth: requires an existing dashboard session (the helper assumes the
+# caller already authenticated). The CSRF token gates POSTs from the
+# same browser session. Current-password re-check ensures a stolen
+# cookie alone is not enough to rotate.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.post("/settings/admin-password/change")
+async def settings_admin_password_change(request: Request):
+    """Rotate the dashboard admin password from the Settings page."""
+    from mcp_proxy.db import log_audit
+
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    current = str(form.get("current_password", ""))
+    new = str(form.get("new_password", ""))
+    confirm = str(form.get("new_password_confirm", ""))
+
+    if not current or not new or not confirm:
+        return RedirectResponse(
+            "/proxy/settings?error=All+three+password+fields+are+required",
+            status_code=303,
+        )
+
+    if new != confirm:
+        return RedirectResponse(
+            "/proxy/settings?error=New+passwords+do+not+match",
+            status_code=303,
+        )
+
+    # Generic 401 on bad current password — don't leak whether the value
+    # was wrong vs the session was somehow detached from the persisted
+    # admin row. Same pattern as the /proxy/login error handler.
+    if not await verify_admin_password(current):
+        _log.warning(
+            "admin password change rejected: wrong current password "
+            "(actor=%s)", getattr(session, "username", "?"),
+        )
+        return RedirectResponse(
+            "/proxy/settings?error=Current+password+is+wrong",
+            status_code=303,
+        )
+
+    try:
+        await set_admin_password(new)
+    except ValueError as exc:
+        # set_admin_password enforces MIN_PASSWORD_LENGTH and possibly
+        # other complexity rules; surface the constraint to the operator.
+        from urllib.parse import quote
+        return RedirectResponse(
+            f"/proxy/settings?error={quote(str(exc))}",
+            status_code=303,
+        )
+
+    actor = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "admin"
+    )
+    await log_audit(
+        agent_id=actor,
+        action="admin_password_rotated",
+        status="success",
+        detail=f"source=dashboard actor={actor}",
+    )
+    return RedirectResponse(
+        "/proxy/settings?ok=Admin+password+rotated."
+        "+Re-login+required+on+next+session.",
+        status_code=303,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # OIDC login (Sign-in with SSO)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/dashboard/templates/settings.html
+++ b/mcp_proxy/dashboard/templates/settings.html
@@ -155,6 +155,62 @@
             </code>
         </div>
         {% endif %}
+
+        {% if local_password_enabled %}
+        <!-- Admin password rotation (issue #653) -->
+        <div class="mt-8 pt-6 border-t border-gray-800/60">
+            <h2 class="text-sm font-semibold mb-2 text-gray-300" style="font-family: 'Chakra Petch', sans-serif; letter-spacing: 0.05em;">
+                Change admin password
+            </h2>
+            <p class="text-xs text-gray-500 mb-4">
+                Replaces the bcrypt hash stored on this Mastio. Requires the current password
+                so a stolen session cookie alone cannot rotate it. The CLI fallback
+                <code class="text-[10px] text-accent-400" style="font-family: 'JetBrains Mono', monospace;">python -m mcp_proxy.cli reset-password</code>
+                stays available for break-glass.
+            </p>
+
+            <form method="post" action="/proxy/settings/admin-password/change" class="space-y-4">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+
+                <div>
+                    <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-[0.15em]">
+                        Current password
+                    </label>
+                    <input type="password" name="current_password" required autocomplete="current-password"
+                           class="w-full px-3 py-2 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                           style="font-family: 'JetBrains Mono', monospace;">
+                </div>
+
+                <div>
+                    <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-[0.15em]">
+                        New password
+                    </label>
+                    <input type="password" name="new_password" required autocomplete="new-password" minlength="12"
+                           class="w-full px-3 py-2 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                           style="font-family: 'JetBrains Mono', monospace;">
+                </div>
+
+                <div>
+                    <label class="block text-[10px] font-medium text-gray-500 mb-1.5 uppercase tracking-[0.15em]">
+                        Confirm new password
+                    </label>
+                    <input type="password" name="new_password_confirm" required autocomplete="new-password" minlength="12"
+                           class="w-full px-3 py-2 bg-surface-900 border border-gray-700 rounded text-white text-sm"
+                           style="font-family: 'JetBrains Mono', monospace;">
+                </div>
+
+                <div class="pt-2">
+                    <button type="submit"
+                            class="px-5 py-2.5 text-xs font-semibold rounded transition-all"
+                            style="font-family: 'Chakra Petch', sans-serif; background: #00e5c7; color: #0a0f1a; letter-spacing: 0.1em; text-transform: uppercase;"
+                            onmouseover="this.style.background='#fff'"
+                            onmouseout="this.style.background='#00e5c7'">
+                        Change Password
+                    </button>
+                </div>
+            </form>
+        </div>
+        {% endif %}
     </div>
 
 </div>


### PR DESCRIPTION
Closes #653.

## Customer feedback (verbatim, frustrated)

> "non ci credo il mastio non ha modo di cambiare la password tramite dashboard, ma scherziamo?"

VM dogfood 2026-05-12 sera. Operator logs in with the seed password from \`MCP_PROXY_INITIAL_ADMIN_PASSWORD\`, looks for Settings → Change Password, finds nothing.

## Pre-fix

Only path to rotate the admin bcrypt hash was the CLI subcommand:

\`\`\`bash
docker exec -it cullis-mastio-mcp-proxy-1 python -m mcp_proxy.cli reset-password
\`\`\`

Helpers existed (\`set_admin_password\` + \`verify_admin_password\` in \`mcp_proxy/dashboard/session.py\`), they just were not exposed via HTTP.

## Fix

1. New \`POST /proxy/settings/admin-password/change\` handler. Re-verifies the current password before swapping the hash. Generic 401-equivalent on wrong current. Logs \`admin_password_rotated\` audit row.
2. Change Password form in Settings page, gated on \`local_password_enabled\` (no point rotating a disabled password login). Current + New + Confirm fields with autocomplete attrs.
3. CSRF token re-used from the existing Settings POST.
4. CLI \`reset-password\` stays as the break-glass for forgotten-password recovery — mentioned inline in the form copy.

## Test plan

- [ ] Settings page shows Change Password section when local password login is enabled
- [ ] Wrong current password → 303 redirect with generic error (no enumeration)
- [ ] New password mismatch (confirm differs) → 303 with "do not match"
- [ ] New password too short (< MIN_PASSWORD_LENGTH = 12) → 303 with set_admin_password's ValueError
- [ ] Successful change → 303 with success message in query string
- [ ] Audit log row written: \`action=admin_password_rotated\`, source=dashboard
- [ ] Smoke gate green

## Nice-to-have follow-up

\`/proxy/settings\` GET handler doesn't currently parse \`?ok=\` / \`?error=\` query strings to render an inline banner. Today the operator sees the URL with the message in the query string but no visual flash on the page. That's an inline-banner template tweak, separate PR.

## Surfaces

Same family as #634/#638/#640/#642/#643/#644/#646/#647/#648/#649/#650/#651. VM customer dogfood 2026-05-12.