### PR TITLE
fix(connector): persist user keypair so Mastio TOFU pin survives restarts

### DIFF
--- a/cullis_connector/ambassador/shared/keystore.py
+++ b/cullis_connector/ambassador/shared/keystore.py
@@ -1,0 +1,160 @@
+"""On-disk private-key store for provisioned user principals.
+
+ADR-021 v0.1 kept the per-user EC keypair only in process memory inside
+``UserCredentialCache``. The cache evicts on container restart, on TTL
+expiry (1h), or on explicit invalidate. When Mastio's CRIT-1 TOFU pin
+landed (``mcp_proxy/registry/principals_csr.py``), every cache miss
+started minting a fresh keypair which then failed the pin check, so
+the second provisioning attempt for the same user — restart, idle 1h,
+or admin password reset — broke with ``CSR validation failed``.
+
+This keystore decouples key persistence from the in-memory cred cache:
+
+  - one PEM file per principal_id, deterministic filename keyed by the
+    SHA-256 of the principal_id (no filesystem injection from user
+    names; same principal_id always lands on the same path)
+  - ``chmod 0600`` matches ``identity/agent.key``
+  - atomic write via tmp+rename so a crash mid-write leaves the prior
+    PEM intact (or no file at all)
+  - async-safe per-principal access through a single asyncio lock that
+    serialises read-then-create for the same principal
+
+Cert lifetime stays short (~1h) and is always refreshed against
+Mastio. The keypair survives across restarts so Mastio's TOFU pin keeps
+matching.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+_log = logging.getLogger("cullis_connector.ambassador.shared.keystore")
+
+
+_KEY_DIRNAME = "user_keys"
+_KEY_SUFFIX = ".key.pem"
+
+
+def _principal_to_filename(principal_id: str) -> str:
+    """Return the deterministic filename for ``principal_id``.
+
+    SHA-256 hex over the UTF-8 bytes — collision-resistant and avoids
+    encoding the raw principal name (which may contain ``/``, ``::``,
+    ``@`` or shell-unfriendly characters) on disk.
+    """
+    digest = hashlib.sha256(principal_id.encode("utf-8")).hexdigest()
+    return f"{digest}{_KEY_SUFFIX}"
+
+
+def _key_pem_from_priv(priv: ec.EllipticCurvePrivateKey) -> str:
+    return priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+
+
+class UserKeyStore:
+    """Persist per-principal EC P-256 keypairs under a base directory.
+
+    Layout::
+
+        <base_dir>/
+        ├── <sha256(principal_a)>.key.pem
+        └── <sha256(principal_b)>.key.pem
+
+    Files are ``chmod 0600``. The store is async-safe; concurrent
+    ``get_or_create`` for the same principal returns the same PEM.
+    """
+
+    def __init__(self, base_dir: Path) -> None:
+        if not isinstance(base_dir, Path):
+            base_dir = Path(base_dir)
+        self._base_dir = base_dir
+        self._lock = asyncio.Lock()
+
+    @property
+    def base_dir(self) -> Path:
+        return self._base_dir
+
+    async def get_or_create(self, principal_id: str) -> str:
+        """Return the PEM-encoded private key for ``principal_id``.
+
+        Creates and persists a fresh EC P-256 keypair on first call;
+        every subsequent call returns the bytes read from disk so the
+        Mastio TOFU pin keeps matching.
+
+        Raises:
+            ValueError: empty / whitespace ``principal_id``.
+        """
+        if not isinstance(principal_id, str) or not principal_id.strip():
+            raise ValueError("principal_id must be a non-empty string")
+        path = self._base_dir / _principal_to_filename(principal_id)
+        async with self._lock:
+            if path.exists():
+                try:
+                    pem = path.read_text(encoding="utf-8")
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"failed to read user keypair at {path}: {exc}",
+                    ) from exc
+                _log.debug(
+                    "keystore hit principal_id=%s path=%s", principal_id, path,
+                )
+                return pem
+
+            priv = ec.generate_private_key(ec.SECP256R1())
+            pem = _key_pem_from_priv(priv)
+            self._base_dir.mkdir(parents=True, exist_ok=True)
+            tmp = path.with_suffix(path.suffix + ".tmp")
+            tmp.write_text(pem, encoding="utf-8")
+            os.chmod(tmp, 0o600)
+            os.replace(tmp, path)
+            _log.info(
+                "keystore created principal_id=%s path=%s",
+                principal_id, path,
+            )
+            return pem
+
+    async def invalidate(self, principal_id: str) -> bool:
+        """Remove the persisted key for ``principal_id``.
+
+        Returns True if a file was deleted, False if none existed.
+        Used by admin "revoke user" actions that should also clear the
+        Mastio TOFU pin — caller is responsible for the Mastio side.
+        """
+        if not isinstance(principal_id, str) or not principal_id.strip():
+            raise ValueError("principal_id must be a non-empty string")
+        path = self._base_dir / _principal_to_filename(principal_id)
+        async with self._lock:
+            if not path.exists():
+                return False
+            try:
+                path.unlink()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"failed to delete user keypair at {path}: {exc}",
+                ) from exc
+            _log.info(
+                "keystore invalidated principal_id=%s path=%s",
+                principal_id, path,
+            )
+            return True
+
+
+def keystore_dir_for(config_dir: Path) -> Path:
+    """Conventional location: ``<config_dir>/user_keys``."""
+    return Path(config_dir) / _KEY_DIRNAME
+
+
+__all__ = [
+    "UserKeyStore",
+    "keystore_dir_for",
+]

--- a/cullis_connector/ambassador/shared/provisioning.py
+++ b/cullis_connector/ambassador/shared/provisioning.py
@@ -4,7 +4,8 @@ Orchestrates the steps that turn a fresh SSO subject into a usable
 credential the Ambassador can sign DPoP+x509 proofs with:
 
     1. Cache hit? → return cached ``UserCredentials``.
-    2. Generate an ECC P-256 keypair in process memory.
+    2. Resolve the keypair: read the persisted PEM from the
+       :class:`UserKeyStore` if present, else generate fresh + persist.
     3. Build a CSR around the public key, with a SPIFFE SAN matching
        the principal_id (``spiffe://<td>/<org>/user/<name>``).
     4. POST the CSR to Mastio's ``/v1/principals/csr`` endpoint
@@ -12,12 +13,15 @@ credential the Ambassador can sign DPoP+x509 proofs with:
     5. Populate the in-process ``UserCredentialCache`` so subsequent
        Ambassador requests skip the whole roundtrip.
 
-v0.1 simplification: the keypair lives in process memory for the
-TTL of the cache entry (1h, matches the cert lifetime). v0.2 will
-plug the embedded KMS (PR1) and refactor ``CullisClient`` to take
-a signer callable so the private key never leaves the KMS. The
-cross-package boundary stays clean: this module talks to Mastio
-via HTTPS only.
+The keystore decouples key persistence from the cred cache so Mastio's
+CRIT-1 TOFU pin keeps matching across container restarts, TTL expiry,
+and admin password reset (every cache miss otherwise minted a fresh
+keypair that the pin rejected with ``CSR validation failed``).
+
+When the provisioner is constructed without a keystore (legacy tests,
+embedded usage with no on-disk identity dir), it falls back to the
+original in-memory keypair generation. v0.2 will move signing to a
+KMS adapter behind the same Protocol surface.
 """
 from __future__ import annotations
 
@@ -26,7 +30,7 @@ import logging
 import threading
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Protocol
+from typing import Any, Optional, Protocol
 
 import httpx
 from cryptography import x509
@@ -38,6 +42,7 @@ from cullis_connector.ambassador.shared.credentials import (
     UserCredentialCache,
     UserCredentials,
 )
+from cullis_connector.ambassador.shared.keystore import UserKeyStore
 
 _log = logging.getLogger("cullis_connector.ambassador.shared.provisioning")
 
@@ -283,16 +288,24 @@ def _build_csr_pem(
 
 
 class UserProvisioner:
-    """Compose keypair + Mastio CSR + cache to obtain user credentials."""
+    """Compose keypair + Mastio CSR + cache to obtain user credentials.
+
+    The optional ``keystore`` persists per-principal keypairs on disk
+    so Mastio's CRIT-1 TOFU pin keeps matching across restarts. When
+    omitted, falls back to the legacy v0.1 fresh-keypair-per-miss
+    behaviour (used by unit tests that have no on-disk identity dir).
+    """
 
     def __init__(
         self,
         *,
         mastio: MastioCsrTransport,
         cache: UserCredentialCache,
+        keystore: Optional[UserKeyStore] = None,
     ) -> None:
         self._mastio = mastio
         self._cache = cache
+        self._keystore = keystore
 
     async def get_or_provision(
         self,
@@ -314,12 +327,33 @@ class UserProvisioner:
         await self._cache.put(cred)
         return cred
 
+    async def _resolve_keypair(
+        self, principal_id: str,
+    ) -> tuple[str, ec.EllipticCurvePrivateKey]:
+        """Return (key_pem, priv) for the principal.
+
+        Reads from the keystore when configured so the keypair stays
+        stable across cache misses; otherwise generates fresh.
+        """
+        if self._keystore is None:
+            return _generate_keypair_pem()
+        key_pem = await self._keystore.get_or_create(principal_id)
+        priv = serialization.load_pem_private_key(
+            key_pem.encode("utf-8"), password=None,
+        )
+        if not isinstance(priv, ec.EllipticCurvePrivateKey):
+            raise MastioCsrError(
+                "persisted user key is not an EC private key — refusing "
+                "to sign a CSR with it (delete the file and retry)",
+            )
+        return key_pem, priv
+
     async def _provision(
         self, *, principal_id: str, sso_subject: str,
     ) -> UserCredentials:
         spiffe_uri = f"spiffe://{principal_id}"
 
-        key_pem, priv = _generate_keypair_pem()
+        key_pem, priv = await self._resolve_keypair(principal_id)
         csr_pem = _build_csr_pem(
             priv, principal_id=principal_id, spiffe_uri=spiffe_uri,
         )
@@ -335,8 +369,10 @@ class UserProvisioner:
             cert_not_after=not_after,
         )
         _log.info(
-            "ambassador provisioned principal=%s sso=%s not_after=%s",
+            "ambassador provisioned principal=%s sso=%s not_after=%s "
+            "key_persisted=%s",
             principal_id, sso_subject, not_after.isoformat(),
+            self._keystore is not None,
         )
         return cred
 

--- a/cullis_connector/identity/csr_flow.py
+++ b/cullis_connector/identity/csr_flow.py
@@ -45,6 +45,7 @@ from cullis_connector.ambassador.shared.credentials import (
     UserCredentialCache,
     UserCredentials,
 )
+from cullis_connector.ambassador.shared.keystore import UserKeyStore
 from cullis_connector.ambassador.shared.provisioning import (
     MastioCsrError,
     MastioCsrTransport,
@@ -203,11 +204,15 @@ class LocalUserProvisioner:
         mastio: MastioCsrTransport,
         cache: UserCredentialCache,
         env: Optional[dict[str, str]] = None,
+        keystore: Optional[UserKeyStore] = None,
     ) -> None:
         self._mastio = mastio
         self._cache = cache
         self._env = env
-        self._provisioner = UserProvisioner(mastio=mastio, cache=cache)
+        self._keystore = keystore
+        self._provisioner = UserProvisioner(
+            mastio=mastio, cache=cache, keystore=keystore,
+        )
 
     @property
     def cache(self) -> UserCredentialCache:

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -422,6 +422,9 @@ def _maybe_install_local_user_provisioner(
         from cullis_connector.ambassador.shared.credentials import (
             UserCredentialCache,
         )
+        from cullis_connector.ambassador.shared.keystore import (
+            UserKeyStore, keystore_dir_for,
+        )
         from cullis_connector.ambassador.shared.provisioning import (
             SdkMastioCsrTransport,
         )
@@ -462,10 +465,14 @@ def _maybe_install_local_user_provisioner(
         verify_tls=config.verify_arg,
     )
     cache = UserCredentialCache()
-    provisioner = LocalUserProvisioner(mastio=transport, cache=cache)
+    keystore = UserKeyStore(keystore_dir_for(config.config_dir))
+    provisioner = LocalUserProvisioner(
+        mastio=transport, cache=cache, keystore=keystore,
+    )
 
     app.state.local_csr_transport = transport
     app.state.local_user_cache = cache
+    app.state.local_keystore = keystore
     app.state.local_provisioner = provisioner
 
     # Cert middleware reads the same config_dir as the login router so
@@ -509,6 +516,9 @@ def _maybe_install_shared_ambassador(
     try:
         from cullis_connector.ambassador.shared.credentials import (
             UserCredentialCache,
+        )
+        from cullis_connector.ambassador.shared.keystore import (
+            UserKeyStore, keystore_dir_for,
         )
         from cullis_connector.ambassador.shared.provisioning import (
             SdkMastioCsrTransport, UserProvisioner,
@@ -572,7 +582,11 @@ def _maybe_install_shared_ambassador(
     app.state.shared_ambassador_csr_transport = transport  # keep alive
 
     cache = UserCredentialCache()
-    provisioner = UserProvisioner(mastio=transport, cache=cache)
+    keystore = UserKeyStore(keystore_dir_for(config.config_dir))
+    provisioner = UserProvisioner(
+        mastio=transport, cache=cache, keystore=keystore,
+    )
+    app.state.shared_ambassador_keystore = keystore  # keep alive
 
     # ADR-020 Phase 4 — broker URL for the user-inbox passthrough
     # (issue #488). Read from env so the deployment can route the

--- a/tests/connector/test_ambassador_shared.py
+++ b/tests/connector/test_ambassador_shared.py
@@ -315,6 +315,98 @@ async def test_provisioner_cache_hit_skips_mastio():
 
 
 @pytest.mark.asyncio
+async def test_provisioner_with_keystore_reuses_keypair_across_cache_miss(
+    tmp_path,
+):
+    """Regression for the TOFU pin mismatch (issue #655-adjacent).
+
+    Without the keystore, every cache miss minted a fresh keypair which
+    Mastio's CRIT-1 TOFU pin then rejected with ``CSR validation
+    failed``. With the keystore wired in, two cache misses for the same
+    principal must produce CSRs signed with the SAME pubkey so Mastio's
+    pin keeps matching.
+    """
+    from cryptography import x509
+
+    from cullis_connector.ambassador.shared.keystore import UserKeyStore
+
+    cache = UserCredentialCache()
+    mastio = _StubMastio()
+    keystore = UserKeyStore(tmp_path)
+    p = UserProvisioner(mastio=mastio, cache=cache, keystore=keystore)
+
+    await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+    # Force a cache miss the way a container restart / TTL expiry would.
+    await cache.invalidate("acme.test/acme/user/mario")
+    await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+
+    # Two CSRs reached Mastio.
+    assert len(mastio.calls) == 2
+    csr_a = x509.load_pem_x509_csr(mastio.calls[0][1].encode())
+    csr_b = x509.load_pem_x509_csr(mastio.calls[1][1].encode())
+    # Pubkey identical → Mastio TOFU pin would still match.
+    from cryptography.hazmat.primitives import serialization
+
+    spki_a = csr_a.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    spki_b = csr_b.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    assert spki_a == spki_b
+
+
+@pytest.mark.asyncio
+async def test_provisioner_without_keystore_mints_fresh_keypair_per_miss(
+    tmp_path,
+):
+    """Legacy v0.1 behaviour: no keystore → every miss = fresh keypair.
+
+    Documents the regression we are fixing: this assertion describes
+    the broken state. Pinned here so a future "always require keystore"
+    refactor doesn't silently change the contract for callers that pass
+    ``keystore=None``.
+    """
+    from cryptography import x509
+
+    cache = UserCredentialCache()
+    mastio = _StubMastio()
+    p = UserProvisioner(mastio=mastio, cache=cache)  # keystore=None
+
+    await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+    await cache.invalidate("acme.test/acme/user/mario")
+    await p.get_or_provision(
+        principal_id="acme.test/acme/user/mario",
+        sso_subject="mario@acme.it",
+    )
+
+    csr_a = x509.load_pem_x509_csr(mastio.calls[0][1].encode())
+    csr_b = x509.load_pem_x509_csr(mastio.calls[1][1].encode())
+    from cryptography.hazmat.primitives import serialization
+
+    spki_a = csr_a.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    spki_b = csr_b.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    assert spki_a != spki_b
+
+
+@pytest.mark.asyncio
 async def test_provisioner_propagates_mastio_failure():
     cache = UserCredentialCache()
     mastio = _StubMastio(fail_with=MastioCsrError("Mastio said no"))

--- a/tests/connector/test_user_keystore.py
+++ b/tests/connector/test_user_keystore.py
@@ -1,0 +1,128 @@
+"""Tests for :class:`UserKeyStore` (cullis_connector.ambassador.shared.keystore).
+
+Covers:
+  - get_or_create persists on first call, hits cache on second
+  - same principal_id round-trips to the same PEM bytes
+  - different principal_ids land on different files
+  - chmod 0600 on the persisted PEM
+  - invalidate() removes the file
+  - empty / non-string principal_id rejected
+  - concurrent get_or_create for the same principal returns the same PEM
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from cullis_connector.ambassador.shared.keystore import (
+    UserKeyStore,
+    keystore_dir_for,
+)
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_persists_and_returns_same_pem(tmp_path: Path):
+    store = UserKeyStore(tmp_path)
+    pem1 = await store.get_or_create("acme.test/acme/user/mario")
+    pem2 = await store.get_or_create("acme.test/acme/user/mario")
+    assert pem1 == pem2
+    assert "BEGIN PRIVATE KEY" in pem1
+    priv = serialization.load_pem_private_key(pem1.encode(), password=None)
+    assert isinstance(priv, ec.EllipticCurvePrivateKey)
+
+
+@pytest.mark.asyncio
+async def test_different_principals_get_different_keys(tmp_path: Path):
+    store = UserKeyStore(tmp_path)
+    a = await store.get_or_create("acme.test/acme/user/mario")
+    b = await store.get_or_create("acme.test/acme/user/alice")
+    assert a != b
+    # Two files on disk now.
+    files = list(tmp_path.glob("*.key.pem"))
+    assert len(files) == 2
+
+
+@pytest.mark.asyncio
+async def test_persistence_survives_new_instance(tmp_path: Path):
+    """The whole point of the fix: a fresh UserKeyStore instance over
+    the same base_dir returns the same key as the previous instance.
+
+    This is the exact scenario that breaks today — container restart =
+    fresh process = fresh in-memory cache, and without the keystore the
+    Mastio TOFU pin rejects the next CSR."""
+    store1 = UserKeyStore(tmp_path)
+    pem1 = await store1.get_or_create("acme.test/acme/user/mario")
+    store2 = UserKeyStore(tmp_path)
+    pem2 = await store2.get_or_create("acme.test/acme/user/mario")
+    assert pem1 == pem2
+
+
+@pytest.mark.asyncio
+async def test_chmod_0600_on_persisted_key(tmp_path: Path):
+    if os.name != "posix":
+        pytest.skip("POSIX-only permission check")
+    store = UserKeyStore(tmp_path)
+    await store.get_or_create("acme.test/acme/user/mario")
+    files = list(tmp_path.glob("*.key.pem"))
+    assert len(files) == 1
+    mode = files[0].stat().st_mode
+    # No group/other read/write/execute bits.
+    assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0
+    # Owner can read+write.
+    assert mode & stat.S_IRUSR
+    assert mode & stat.S_IWUSR
+
+
+@pytest.mark.asyncio
+async def test_invalidate_removes_file(tmp_path: Path):
+    store = UserKeyStore(tmp_path)
+    await store.get_or_create("acme.test/acme/user/mario")
+    assert len(list(tmp_path.glob("*.key.pem"))) == 1
+    removed = await store.invalidate("acme.test/acme/user/mario")
+    assert removed is True
+    assert len(list(tmp_path.glob("*.key.pem"))) == 0
+    # Invalidating again returns False.
+    again = await store.invalidate("acme.test/acme/user/mario")
+    assert again is False
+
+
+@pytest.mark.asyncio
+async def test_invalidate_then_recreate_yields_fresh_key(tmp_path: Path):
+    store = UserKeyStore(tmp_path)
+    pem1 = await store.get_or_create("acme.test/acme/user/mario")
+    await store.invalidate("acme.test/acme/user/mario")
+    pem2 = await store.get_or_create("acme.test/acme/user/mario")
+    assert pem1 != pem2
+
+
+@pytest.mark.asyncio
+async def test_empty_principal_id_rejected(tmp_path: Path):
+    store = UserKeyStore(tmp_path)
+    with pytest.raises(ValueError):
+        await store.get_or_create("")
+    with pytest.raises(ValueError):
+        await store.get_or_create("   ")
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_or_create_returns_same_pem(tmp_path: Path):
+    """The lock must serialise create-then-read so two coroutines hitting
+    a cold cache for the same principal don't end up with different keys
+    persisted (the second write would clobber the first)."""
+    store = UserKeyStore(tmp_path)
+    results = await asyncio.gather(
+        *[store.get_or_create("acme.test/acme/user/mario") for _ in range(20)],
+    )
+    assert all(r == results[0] for r in results)
+    # Exactly one file persisted.
+    assert len(list(tmp_path.glob("*.key.pem"))) == 1
+
+
+def test_keystore_dir_for_returns_user_keys_subdir(tmp_path: Path):
+    assert keystore_dir_for(tmp_path) == tmp_path / "user_keys"


### PR DESCRIPTION
## Summary

ADR-021 v0.1 kept the per-user EC keypair only in `UserCredentialCache` (in-memory, 1h TTL). When Mastio's CRIT-1 TOFU pubkey pin landed in `mcp_proxy/registry/principals_csr.py`, every cache miss minted a fresh keypair that the pin then rejected with `CSR validation failed`, breaking the user on:

- container restart (cache empty)
- 1h TTL expiry (cache empty)
- admin password reset (cache invalidated)

P0 blocker for production deploys of the Frontdesk bundle: customer demo dies after the first restart or 1h idle.

## What changed

- `cullis_connector/ambassador/shared/keystore.py` — new `UserKeyStore` persists one EC P-256 PEM per principal under `<config_dir>/user_keys/` at `chmod 0600`. Deterministic filename via `sha256(principal_id)` keeps user names off the filesystem. Async-safe via a single asyncio.Lock.
- `UserProvisioner.__init__` accepts an optional `keystore` parameter. When wired, the second cache miss for the same principal reuses the persisted keypair so Mastio's TOFU pin stays matching. Backward-compatible: when omitted, falls back to the legacy v0.1 fresh-keypair-per-miss behaviour.
- `web.py` wires the keystore into both `UserProvisioner` (shared ambassador) and `LocalUserProvisioner` (ADR-025 Phase 3).

Cert lifetime stays short (~1h) and is always refreshed against Mastio. Only the keypair persists, on the trajectory toward v0.2 KMS-backed signing.

## Surfaces

VM customer dogfood 2026-05-12: `mdaniele` lost cert after admin password reset, `/v1/models` silently fell back to the hardcoded Anthropic list, Ollama models never appeared in the SPA dropdown despite a healthy provider row. With this fix the customer demo flow survives restart and admin operations end-to-end.

## Test plan

- [x] `tests/connector/test_user_keystore.py` — 9 cases: round-trip, distinct principals → distinct keys, **persistence survives a new instance over the same base_dir (regression scenario)**, chmod 0600, invalidate, fresh keypair after invalidate, empty principal rejected, 20-way concurrent get_or_create returns same PEM.
- [x] `tests/connector/test_ambassador_shared.py` — two new regression tests pin the contract: with the keystore, two cache misses produce CSRs with the same pubkey (TOFU passes); without the keystore, two cache misses produce different pubkeys (the broken state — pinned so a future refactor cannot silently change behaviour for `keystore=None` callers).
- [x] `pytest tests/connector/ tests/test_principals_csr.py -n auto`: 645 passed, 4 skipped.
- [ ] Customer-path smoke gate exercises restart + re-login flow.
- [ ] Manual: VM redeploy, create user, restart Connector container, verify user can still chat (TOFU pin matched).

## Notes

- The docstring in `credentials.py:41-45` already pointed to v0.2 KMS as the proper home for private key material. This PR is an incremental step toward that — same Protocol surface, just persisted instead of in-memory.
- Admin "revoke user" actions should also clear the keystore + Mastio TOFU pin. That is a follow-up.