### PR TITLE
fix(ambassador,spa): surface /v1/models fallback instead of silent lie

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -151,7 +151,10 @@ def _get_state(request: Request) -> dict:
 # stable per-deployment until an admin edits AI Providers, so a 30s
 # TTL keeps the chat sidebar snappy without hammering the egress.
 _MODELS_CACHE_TTL_S = 30.0
-_models_cache: dict[str, tuple[float, list[dict]]] = {}
+# Cached tuple is (cached_at, data, source) where source ∈ {"live",
+# "fallback"} so the SPA can surface "Model list unavailable, showing
+# cached defaults" instead of silently showing the wrong dropdown.
+_models_cache: dict[str, tuple[float, list[dict], str]] = {}
 
 
 def _fallback_models(state: dict) -> list[dict]:
@@ -172,22 +175,50 @@ def list_models(request: Request) -> dict:
     cached = _models_cache.get(cache_key)
     now = time.monotonic()
     if cached is not None and (now - cached[0]) < _MODELS_CACHE_TTL_S:
-        return {"object": "list", "data": cached[1]}
+        return _models_response(cached[1], cached[2])
 
     holder = state.get("client")
     data = _fallback_models(state)
+    source = "fallback"
+    error_reason: str | None = None
     if holder is not None:
         try:
             client = holder.get()
-            data = client.list_models() or data
+            live = client.list_models()
+            if live:
+                data = live
+                source = "live"
+            else:
+                error_reason = "Mastio returned empty model list"
         except Exception as exc:
+            error_reason = str(exc) or exc.__class__.__name__
             _log.debug(
                 "Mastio /v1/models fetch failed, using advertised fallback: %s",
                 exc,
             )
+    else:
+        error_reason = "Ambassador has no Mastio client wired"
 
-    _models_cache[cache_key] = (now, data)
-    return {"object": "list", "data": data}
+    _models_cache[cache_key] = (now, data, source)
+    return _models_response(data, source, error=error_reason)
+
+
+def _models_response(
+    data: list[dict], source: str, *, error: str | None = None,
+) -> dict:
+    """OpenAI-compatible body plus an additive ``cullis_meta`` block.
+
+    OpenAI clients ignore unknown top-level fields, so this stays a
+    drop-in for `api.openai.com/v1/models`. The Cullis SPA reads
+    ``cullis_meta.source`` to render a banner when the live fetch
+    failed and the dropdown is showing the hardcoded fallback list.
+    """
+    body: dict = {"object": "list", "data": data}
+    meta: dict = {"source": source}
+    if source == "fallback" and error:
+        meta["error"] = error
+    body["cullis_meta"] = meta
+    return body
 
 
 # ── /v1/chat/completions ────────────────────────────────────────────

--- a/cullis_connector/ambassador/shared/router.py
+++ b/cullis_connector/ambassador/shared/router.py
@@ -266,7 +266,10 @@ async def session_whoami(
 # stable per-org until an admin edits AI Providers, so a 30s TTL keeps
 # the SPA dropdown snappy even with 50 concurrent users.
 _SHARED_MODELS_CACHE_TTL_S = 30.0
-_shared_models_cache: dict[str, tuple[float, list[dict]]] = {}
+# Cached tuple is (cached_at, data, source) where source ∈ {"live",
+# "fallback"} so the SPA can render a warning when it is looking at
+# hardcoded defaults instead of the Mastio's real provider catalog.
+_shared_models_cache: dict[str, tuple[float, list[dict], str]] = {}
 
 
 def _shared_fallback_models(state: SharedAmbassadorState) -> list[dict]:
@@ -275,6 +278,21 @@ def _shared_fallback_models(state: SharedAmbassadorState) -> list[dict]:
         {"id": m, "object": "model", "owned_by": "cullis", "created": 0}
         for m in advertised
     ]
+
+
+def _shared_models_response(
+    data: list[dict], source: str, *, error: str | None = None,
+) -> dict:
+    """Same envelope as the standard ambassador: OpenAI-compatible top
+    level plus a ``cullis_meta.source`` field the SPA reads to decide
+    whether to surface "Model list unavailable" to the user.
+    """
+    body: dict = {"object": "list", "data": data}
+    meta: dict = {"source": source}
+    if source == "fallback" and error:
+        meta["error"] = error
+    body["cullis_meta"] = meta
+    return body
 
 
 @router.get("/v1/models")
@@ -287,13 +305,20 @@ async def list_models(
     cached = _shared_models_cache.get(cred.principal_id)
     now = time.monotonic()
     if cached is not None and (now - cached[0]) < _SHARED_MODELS_CACHE_TTL_S:
-        return {"object": "list", "data": cached[1]}
+        return _shared_models_response(cached[1], cached[2])
 
     data = _shared_fallback_models(state)
+    source = "fallback"
+    error_reason: str | None = None
     try:
         client = _build_user_client(state, cred)
         try:
-            data = client.list_models() or data
+            live = client.list_models()
+            if live:
+                data = live
+                source = "live"
+            else:
+                error_reason = "Mastio returned empty model list"
         finally:
             close = getattr(client, "close", None)
             if callable(close):
@@ -302,13 +327,14 @@ async def list_models(
                 except Exception:
                     pass
     except Exception as exc:
+        error_reason = str(exc) or exc.__class__.__name__
         _log.debug(
             "shared ambassador /v1/models fetch failed for %s: %s",
             cred.principal_id, exc,
         )
 
-    _shared_models_cache[cred.principal_id] = (now, data)
-    return {"object": "list", "data": data}
+    _shared_models_cache[cred.principal_id] = (now, data, source)
+    return _shared_models_response(data, source, error=error_reason)
 
 
 # ── /v1/chat/completions ─────────────────────────────────────────

--- a/frontend/cullis-chat/src/components/ModelPicker.tsx
+++ b/frontend/cullis-chat/src/components/ModelPicker.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { listModels } from '../lib/api';
+import { listModels, type ModelsSource } from '../lib/api';
 import { ensureSession } from '../lib/session-singleton';
 
 const STORAGE_KEY = 'cullis-chat:model';
@@ -21,20 +21,27 @@ export function readSelectedModel(): string {
 /**
  * Live model picker. Fetches `/v1/models` on mount; defaults to
  * the cached preference + the hard-coded fallback while loading.
+ *
+ * When the Ambassador couldn't reach Mastio it returns `source:
+ * "fallback"` plus the compiled-in `advertised_models`. We surface
+ * a warning so the user understands why "the model I configured
+ * isn't in the dropdown".
  */
 export default function ModelPicker() {
   const [models, setModels] = useState<string[]>([readSelectedModel(), FALLBACK_MODEL]);
   const [selected, setSelected] = useState<string>(readSelectedModel);
   const [loaded, setLoaded] = useState(false);
+  const [source, setSource] = useState<ModelsSource>('live');
+  const [fetchError, setFetchError] = useState<string | undefined>(undefined);
 
   useEffect(() => {
     let cancelled = false;
     (async () => {
       try {
         await ensureSession();
-        const list = await listModels();
+        const res = await listModels();
         if (cancelled) return;
-        const ids = Array.from(new Set(list.map((m) => m.id)));
+        const ids = Array.from(new Set(res.data.map((m) => m.id)));
         if (ids.length > 0) setModels(ids);
         if (!ids.includes(selected) && ids.length > 0) {
           // Cached preference no longer offered — reset to first.
@@ -45,9 +52,16 @@ export default function ModelPicker() {
             /* ignore */
           }
         }
+        setSource(res.source);
+        setFetchError(res.error);
         setLoaded(true);
-      } catch {
-        // keep fallback list
+      } catch (err) {
+        // Network-level failure (e.g. the ambassador itself is down).
+        // The dropdown keeps its local fallback, but we still tell the
+        // user the list is not authoritative.
+        if (cancelled) return;
+        setSource('fallback');
+        setFetchError(err instanceof Error ? err.message : 'fetch failed');
         setLoaded(true);
       }
     })();
@@ -68,8 +82,14 @@ export default function ModelPicker() {
     document.dispatchEvent(new CustomEvent('cullis:model-changed', { detail: id }));
   }
 
+  const isFallback = loaded && source === 'fallback';
+
   return (
-    <label className="model-picker" data-loaded={loaded ? 'true' : 'false'}>
+    <label
+      className="model-picker"
+      data-loaded={loaded ? 'true' : 'false'}
+      data-source={source}
+    >
       <span className="folio">model</span>
       <select
         value={selected}
@@ -80,6 +100,20 @@ export default function ModelPicker() {
           <option key={id} value={id}>{id}</option>
         ))}
       </select>
+      {isFallback && (
+        <span
+          className="model-picker__fallback"
+          role="status"
+          aria-live="polite"
+          title={
+            fetchError
+              ? `Live model list unavailable: ${fetchError}. Showing cached defaults.`
+              : 'Live model list unavailable. Showing cached defaults.'
+          }
+        >
+          offline
+        </span>
+      )}
     </label>
   );
 }

--- a/frontend/cullis-chat/src/components/TopBar.astro
+++ b/frontend/cullis-chat/src/components/TopBar.astro
@@ -166,6 +166,28 @@ const auditToggleEnabled = import.meta.env.PUBLIC_DEV_AUDIT_PANEL === '1';
     opacity: 0.65;
   }
 
+  /* The 'fallback' chip surfaces that the Ambassador's live `/v1/models`
+     fetch failed and the dropdown is showing the compiled-in defaults.
+     Hover/title reveals the underlying error. Amber, not red — the chat
+     still works against the fallback list, the user just can't see the
+     models they configured. */
+  :global(.model-picker[data-source='fallback']) {
+    border-color: rgba(245, 158, 11, 0.45);
+  }
+
+  :global(.model-picker__fallback) {
+    font-family: var(--font-body);
+    font-size: 0.62rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgb(245, 158, 11);
+    background: rgba(245, 158, 11, 0.12);
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-sm);
+    margin-left: 0.2rem;
+    cursor: help;
+  }
+
   /* Native <option> rendering ignores the parent <select> background
      in Chromium/WebKit, leaving the dropdown panel white-on-white on
      dark themes. Force the option styling explicitly. Firefox honours

--- a/frontend/cullis-chat/src/lib/api.ts
+++ b/frontend/cullis-chat/src/lib/api.ts
@@ -83,10 +83,50 @@ export async function whoami(): Promise<{ ok: boolean; principal: Principal }> {
   return jsonFetch<{ ok: boolean; principal: Principal }>('/api/session/whoami');
 }
 
-/** GET /v1/models — direct to Ambassador via session cookie auth. */
-export async function listModels(): Promise<Model[]> {
-  const res = await jsonFetch<{ object: string; data: Model[] }>('/v1/models');
-  return res.data;
+/** Source of the model list the Ambassador returned.
+ *
+ * `live` — the Mastio answered and the list reflects the org's
+ * configured AI providers (Anthropic catalog + dynamic Ollama tags +
+ * future Vertex/Bedrock/etc).
+ *
+ * `fallback` — the Mastio call failed (network, mTLS, no cert, etc.)
+ * and the dropdown is showing the hardcoded `advertised_models`
+ * compiled-in defaults. The SPA renders a warning so the user
+ * understands why "the model I configured isn't here".
+ */
+export type ModelsSource = 'live' | 'fallback';
+
+export interface ModelsResult {
+  data: Model[];
+  source: ModelsSource;
+  error?: string;
+}
+
+/** GET /v1/models — direct to Ambassador via session cookie auth.
+ *
+ * The Ambassador embeds a `cullis_meta.source` discriminator in the
+ * response (additive to the OpenAI envelope, ignored by upstream
+ * clients). When the live Mastio fetch fails the ambassador returns
+ * the hardcoded `advertised_models` with `source: "fallback"`; the
+ * SPA surfaces that to the user instead of silently lying.
+ */
+export async function listModels(): Promise<ModelsResult> {
+  const res = await jsonFetch<{
+    object: string;
+    data: Model[];
+    cullis_meta?: { source?: string; error?: string };
+  }>('/v1/models');
+  const rawSource = res.cullis_meta?.source;
+  const source: ModelsSource = rawSource === 'live' ? 'live' : 'fallback';
+  // Legacy ambassador builds (pre-#657) don't ship cullis_meta — treat
+  // the missing field as `live` to avoid spurious warnings on a stack
+  // that simply hasn't been upgraded yet.
+  const inferred: ModelsSource = rawSource === undefined ? 'live' : source;
+  return {
+    data: res.data,
+    source: inferred,
+    error: res.cullis_meta?.error,
+  };
 }
 
 /** POST /v1/chat/completions (non-streaming). Used as a fallback. */

--- a/tests/connector/test_ambassador_session_routes.py
+++ b/tests/connector/test_ambassador_session_routes.py
@@ -318,3 +318,22 @@ def test_init_then_models_via_cookie_jar(client):
     # TestClient sticky cookies — no manual cookie= needed.
     resp = client.get("/v1/models")
     assert resp.status_code == 200
+
+
+def test_models_envelope_carries_cullis_meta_source(client, bearer):
+    """The SPA reads ``cullis_meta.source`` to surface a warning when
+    the dropdown is showing compiled-in defaults instead of the live
+    Mastio catalog. The Ambassador must populate the field on every
+    response so the SPA can rely on it.
+    """
+    resp = client.get(
+        "/v1/models",
+        cookies={LOCAL_SESSION_COOKIE: bearer},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["object"] == "list"
+    assert "cullis_meta" in body
+    # The test client wires no Mastio holder, so we always serve the
+    # fallback envelope here.
+    assert body["cullis_meta"]["source"] in {"live", "fallback"}

--- a/tests/connector/test_ambassador_shared.py
+++ b/tests/connector/test_ambassador_shared.py
@@ -513,7 +513,18 @@ def test_v1_models_after_init():
         )
         r = cli.get("/v1/models")
         assert r.status_code == 200
-        assert r.json()["data"][0]["id"] == "claude-haiku-4-5"
+        body = r.json()
+        assert body["data"][0]["id"] == "claude-haiku-4-5"
+        # The stub builds an SDK client that can't actually reach a
+        # Mastio at testserver:443 — so `_build_user_client` either
+        # raises or returns an empty list, and the ambassador serves
+        # the compiled-in defaults. The SPA reads `cullis_meta.source`
+        # to surface that to the user.
+        assert "cullis_meta" in body
+        assert body["cullis_meta"]["source"] == "fallback"
+        # Best-effort error message accompanies the fallback so the SPA
+        # tooltip can hint at the underlying failure.
+        assert "error" in body["cullis_meta"]
 
 
 def test_install_twice_raises():


### PR DESCRIPTION
## Summary

When the Ambassador's live `client.list_models()` call to the Mastio fails (no cert, network error, expired cred, etc.) it silently returned the compiled-in `advertised_models` defaults and logged the exception at DEBUG only. The user sees three Anthropic models in the dropdown regardless of which providers the org actually configured.

VM dogfood 2026-05-12: an admin saved the Ollama provider, the live fetch failed (downstream of the TOFU mismatch fixed in #656), and the dropdown reported \"Anthropic-only\" with no hint that the list was not authoritative.

## What changed

**Server**
- Both `cullis_connector/ambassador/router.py` (single) and `cullis_connector/ambassador/shared/router.py` (Frontdesk) embed `cullis_meta.source` ∈ `{live, fallback}` in the `/v1/models` envelope. Additive to OpenAI shape, so Cursor / LibreChat / raw curl keep working unchanged.
- On fallback the envelope also carries `cullis_meta.error` with a short string the SPA can show on hover.
- Per-process TTL cache stores the source tag alongside the data so a stale fallback served from cache still flags itself.

**SPA**
- `lib/api.ts`: `listModels()` now returns `{ data, source, error }`. Legacy ambassador builds that don't ship `cullis_meta` are treated as `live` so a half-rolled stack doesn't flash spurious warnings.
- `components/ModelPicker.tsx`: renders an amber `offline` chip next to the dropdown when source is `fallback`, with the underlying error in the `title` tooltip.
- `components/TopBar.astro`: amber border + chip styling. Same folio aesthetic, no new colour token.

## Test plan

- [x] `tests/connector/test_ambassador_shared.py::test_v1_models_after_init` upgraded to assert `cullis_meta.source == \"fallback\"` plus the error breadcrumb.
- [x] `tests/connector/test_ambassador_session_routes.py::test_models_envelope_carries_cullis_meta_source` pins the contract for single-mode.
- [x] `pytest tests/connector -n auto`: 618 passed, 4 skipped.
- [ ] Manual SPA smoke: stop Mastio, reload `/chat`, verify amber `offline` chip appears + tooltip shows the underlying error.

## Notes

- Pairs with #656 (TOFU keypair persistence) — together they close the \"dropdown lies\" surface from the VM customer dogfood. With #656 alone the live fetch starts working; with this PR alone the user knows when it isn't.
- The `cullis_meta` namespace is reserved for additive Cullis-specific signals on otherwise OpenAI-compatible responses; documented in the function docstring so future contributors don't smuggle non-additive fields under that key.