### PR TITLE
fix(bundles): wire ADR-029 PDP + local-auth env vars into compose

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -8,7 +8,7 @@ import logging
 import os
 from functools import lru_cache
 
-from pydantic import model_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 _log = logging.getLogger("mcp_proxy.startup")
@@ -400,6 +400,35 @@ class ProxySettings(BaseSettings):
     # page read-only (legacy behaviour).
     frontdesk_ambassador_url: str = ""
     frontdesk_admin_secret: str = ""
+
+    # Docker compose ``${VAR:-}`` substitutes to the empty string when
+    # the operator has not set the var in proxy.env. Pydantic v2's bool
+    # parser rejects "" with ``bool_parsing`` ValidationError, which
+    # crashes the container at startup and surfaces in CI as
+    # "mcp-proxy is unhealthy". For the bool flags that are wired into
+    # the bundle compose's ``environment:`` block, treat "" as
+    # "operator didn't set" → fall back to the field default. The
+    # subsequent ``_apply_routing_overrides`` model-validator re-reads
+    # via ``_env()`` (which also maps "" → None) so the standalone
+    # auto-flip for ``local_auth_enabled`` keeps working unchanged.
+    @field_validator(
+        "tool_pdp_enabled",
+        "force_local_password",
+        "local_auth_enabled",
+        mode="before",
+    )
+    @classmethod
+    def _empty_bool_str_to_false(cls, v):
+        # Targeted to the three bool flags the customer bundle compose
+        # exposes via ``${VAR:-}``. Each has ``default=False`` on the
+        # model, so returning False for the empty string preserves the
+        # "operator hasn't set this" intent. The
+        # ``_apply_routing_overrides`` model-validator re-reads
+        # ``MCP_PROXY_LOCAL_AUTH_ENABLED`` via ``_env()`` (which also
+        # maps "" → None) so the standalone auto-flip keeps firing.
+        if isinstance(v, str) and v.strip() == "":
+            return False
+        return v
 
     @model_validator(mode="after")
     def _apply_proxy_db_url_override(self):

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -140,6 +140,13 @@ services:
       # Where Mastio's CSR endpoint lives. Falls back to site_url when empty.
       CULLIS_FRONTDESK_MASTIO_URL: ${CULLIS_FRONTDESK_MASTIO_URL:-}
       CULLIS_SITE_URL: ${CULLIS_SITE_URL:-}
+      # ADR-029 — tool-call PDP gate. Pairs with
+      # ``MCP_PROXY_TOOL_PDP_ENABLED`` on the Mastio: both must be
+      # ``true`` for the model loop to refuse tools the org's
+      # ``policy_rules.tool_rules`` does not authorise for the caller.
+      # Off by default so existing customer deployments keep their
+      # chat working until they opt in.
+      CULLIS_CONNECTOR_TOOL_PDP_ENABLED: ${CULLIS_CONNECTOR_TOOL_PDP_ENABLED:-}
       # Trust anchor for the Mastio TLS handshake. Production uses the
       # corporate PKI; the sandbox/ ships a self-signed Org-CA so we
       # mount it as a CA bundle here. Honoured by Python's ssl module

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -94,3 +94,12 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Show the dev audit panel inside the SPA. Off by default — the audit
 # chain belongs to the Mastio admin dashboard, not the end user surface.
 # PUBLIC_DEV_AUDIT_PANEL=0
+
+# ── ADR-029 tool-call PDP ────────────────────────────────────────────
+#
+# Off by default. Flip to ``true`` to make the Connector's
+# ``run_tool_use_loop`` consult the Mastio's /v1/policy/tool-call
+# before invoking each tool. Pair with ``MCP_PROXY_TOOL_PDP_ENABLED``
+# on the sibling Mastio bundle; both must be on for the policy gate
+# to actually fire.
+# CULLIS_CONNECTOR_TOOL_PDP_ENABLED=true

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -94,6 +94,22 @@ services:
       # leave /proxy/users in read-only mode.
       MCP_PROXY_FRONTDESK_AMBASSADOR_URL: ${MCP_PROXY_FRONTDESK_AMBASSADOR_URL:-}
       MCP_PROXY_FRONTDESK_ADMIN_SECRET:   ${MCP_PROXY_FRONTDESK_ADMIN_SECRET:-}
+      # ADR-029 Phase C — tool-call PDP gate. When true, the Mastio's
+      # ``run_tool_use_loop`` calls /v1/policy/tool-call for every tool
+      # the model wants to invoke and refuses the tools the org's
+      # ``policy_rules.tool_rules`` does not authorise for the caller.
+      # The HMAC secret is the optional shared secret between the
+      # Mastio and an external PDP webhook; leave empty to skip HMAC
+      # signing (mTLS authenticates the SDK already).
+      MCP_PROXY_TOOL_PDP_ENABLED:        ${MCP_PROXY_TOOL_PDP_ENABLED:-}
+      MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET: ${MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET:-}
+      # ADR-025 Phase 1 — local password sign-in toggle. Leave unset
+      # (the default) on bundles that always pair with an OIDC IdP;
+      # flip to ``true`` for the single-Mastio operator demo where
+      # /proxy/login serves a username+password form. ``FORCE`` is a
+      # break-glass for emergency access when SSO is down.
+      MCP_PROXY_LOCAL_AUTH_ENABLED:      ${MCP_PROXY_LOCAL_AUTH_ENABLED:-}
+      MCP_PROXY_FORCE_LOCAL_PASSWORD:    ${MCP_PROXY_FORCE_LOCAL_PASSWORD:-}
       # AI gateway request timeout. The 30 s default is fine for
       # claude-haiku-4-5 (~3 s) but local Ollama models with chain-of-
       # thought (qwen3.5, deepseek-r1) routinely take 20-40 s.

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -173,3 +173,29 @@ MCP_PROXY_ANTHROPIC_API_KEY=
 
 # Per-request timeout to the upstream provider, seconds.
 #MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S=30
+
+# ── ADR-029 tool-call PDP ────────────────────────────────────────────
+#
+# Off by default. Flip to ``true`` to make ``run_tool_use_loop`` call
+# /v1/policy/tool-call before every tool invocation and refuse tools
+# the org's ``policy_rules.tool_rules`` does not authorise for the
+# caller. The Frontdesk Connector must flip the matching flag
+# ``CULLIS_CONNECTOR_TOOL_PDP_ENABLED=true`` in frontdesk.env.
+#MCP_PROXY_TOOL_PDP_ENABLED=true
+
+# Optional HMAC secret for an external PDP webhook (the in-process PDP
+# authenticates the SDK via mTLS already, so this is empty by default).
+# When set, the SDK signs every PDP request with HMAC-SHA256 and the
+# webhook rejects unsigned calls.
+#MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET=
+
+# ── ADR-025 local password sign-in ──────────────────────────────────
+#
+# Default-off bundles pair a Mastio with an OIDC IdP. Flip to ``true``
+# for the single-Mastio operator demo where ``/proxy/login`` serves a
+# username + password form (the password lives in ``proxy_config``,
+# bcrypt-hashed). The dashboard "Settings → Sign-in methods" page can
+# toggle the same flag at runtime; ``FORCE`` is a break-glass for
+# emergency access when SSO is misconfigured.
+#MCP_PROXY_LOCAL_AUTH_ENABLED=true
+#MCP_PROXY_FORCE_LOCAL_PASSWORD=

--- a/tests/test_proxy_config_empty_bool_env.py
+++ b/tests/test_proxy_config_empty_bool_env.py
@@ -23,8 +23,6 @@ from __future__ import annotations
 
 import importlib
 
-import pytest
-
 
 def _reload_settings(monkeypatch, **env):
     """Force a fresh ProxySettings() against the requested env."""

--- a/tests/test_proxy_config_empty_bool_env.py
+++ b/tests/test_proxy_config_empty_bool_env.py
@@ -1,0 +1,107 @@
+"""Regression: pydantic must tolerate docker-compose's `${VAR:-}` empty string.
+
+The Mastio bundle's ``docker-compose.yml`` exposes the customer-facing
+bool flags via ``${MCP_PROXY_TOOL_PDP_ENABLED:-}`` etc., which compose
+substitutes to the empty string when the operator hasn't set the var
+in proxy.env. Pydantic v2's bool parser rejects ``""`` with
+``bool_parsing`` ValidationError, which used to crash the container at
+startup and surface in CI as ``mcp-proxy is unhealthy``.
+
+The :class:`ProxySettings` field validator
+``_empty_bool_str_to_false`` maps ``""`` → ``False`` for the three
+bundle-exposed flags so the customer demo boots regardless of whether
+the operator set the values. The ``_apply_routing_overrides``
+model-validator re-reads via ``_env()`` (which also treats ``""`` as
+None) so the standalone auto-flip for ``local_auth_enabled`` keeps
+firing.
+
+VM dogfood 2026-05-12: customer-path smoke turned red on PR #658
+because empty-string env from the new mappings crashed pydantic
+before the post-init logic could even run.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+def _reload_settings(monkeypatch, **env):
+    """Force a fresh ProxySettings() against the requested env."""
+    for k in (
+        "MCP_PROXY_TOOL_PDP_ENABLED",
+        "MCP_PROXY_FORCE_LOCAL_PASSWORD",
+        "MCP_PROXY_LOCAL_AUTH_ENABLED",
+        "MCP_PROXY_STANDALONE",
+        "MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET",
+        "PROXY_LOCAL_AUTH",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    config = importlib.import_module("mcp_proxy.config")
+    return config.ProxySettings()
+
+
+def test_empty_bool_env_falls_back_to_default(monkeypatch):
+    """compose substitutes ${VAR:-} → "" when proxy.env omits the var.
+
+    Before the fix this raised ValidationError and the container died.
+    Now the validator collapses empty to False and pydantic accepts it.
+    """
+    settings = _reload_settings(
+        monkeypatch,
+        MCP_PROXY_TOOL_PDP_ENABLED="",
+        MCP_PROXY_FORCE_LOCAL_PASSWORD="",
+        MCP_PROXY_LOCAL_AUTH_ENABLED="",
+    )
+    assert settings.tool_pdp_enabled is False
+    assert settings.force_local_password is False
+
+
+def test_standalone_auto_flip_survives_empty_local_auth_env(monkeypatch):
+    """The bundle customer-demo runs in standalone mode and relies on
+    the post-init auto-flip to enable local auth. Empty string from
+    compose must NOT block the auto-flip (the previous code path
+    treated empty as "not set", and the new validator must not break
+    that contract).
+    """
+    settings = _reload_settings(
+        monkeypatch,
+        MCP_PROXY_STANDALONE="true",
+        MCP_PROXY_LOCAL_AUTH_ENABLED="",
+        MCP_PROXY_TOOL_PDP_ENABLED="",
+        MCP_PROXY_FORCE_LOCAL_PASSWORD="",
+    )
+    # Standalone mode set + operator did not opt out → auto-flip wins.
+    assert settings.standalone is True
+    assert settings.local_auth_enabled is True
+
+
+def test_explicit_true_propagates(monkeypatch):
+    settings = _reload_settings(
+        monkeypatch,
+        MCP_PROXY_TOOL_PDP_ENABLED="true",
+        MCP_PROXY_FORCE_LOCAL_PASSWORD="true",
+        MCP_PROXY_LOCAL_AUTH_ENABLED="true",
+    )
+    assert settings.tool_pdp_enabled is True
+    assert settings.force_local_password is True
+    assert settings.local_auth_enabled is True
+
+
+def test_explicit_false_propagates(monkeypatch):
+    """Regression: ``MCP_PROXY_LOCAL_AUTH_ENABLED=false`` set explicitly
+    means "operator chose to disable local auth". Standalone mode must
+    NOT auto-flip the value back to True — the operator's explicit
+    opt-out wins. The ``_env()`` helper accomplishes this by returning
+    the literal string ``"false"`` (not None) so the standalone branch
+    is skipped.
+    """
+    settings = _reload_settings(
+        monkeypatch,
+        MCP_PROXY_STANDALONE="true",
+        MCP_PROXY_LOCAL_AUTH_ENABLED="false",
+    )
+    assert settings.standalone is True
+    assert settings.local_auth_enabled is False


### PR DESCRIPTION
## Summary

The bundle compose ``environment:`` blocks must explicitly list every env var the container reads at runtime — ``--env-file`` substitutions populate proxy.env but the var never reaches the container unless it is mapped. VM dogfood 2026-05-12: enabling ADR-029 tool-call PDP needed a ``docker-compose.override.yml`` because the flags were missing from the bundle. A customer following the public README to flip the PDP from frontdesk.env would have silently ended up with the flag not active.

## What changed

**packaging/mastio-bundle/docker-compose.yml**
- ``MCP_PROXY_TOOL_PDP_ENABLED`` (ADR-029 Phase C)
- ``MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET`` (optional, pairs with the above)
- ``MCP_PROXY_LOCAL_AUTH_ENABLED`` (ADR-025 local password sign-in)
- ``MCP_PROXY_FORCE_LOCAL_PASSWORD`` (break-glass override)

**packaging/frontdesk-bundle/docker-compose.yml**
- ``CULLIS_CONNECTOR_TOOL_PDP_ENABLED`` (ADR-029 — Connector half of the pair)

All four default to empty so existing customer deployments are unaffected; the toggles only fire when the operator sets a value in ``proxy.env`` / ``frontdesk.env``.

**``proxy.env.example`` and ``frontdesk.env.example``** grow commented-out blocks that document the PDP / local-auth pairing contract (both sides must agree).

## Test plan

- [x] ``docker compose --env-file proxy.env.example config`` renders the four new vars with no yaml error.
- [x] ``docker compose --env-file frontdesk.env.example config`` renders the new var.
- [x] Pre-existing env vars unchanged in count + identity (25 MCP_PROXY_* on Mastio, 14 CULLIS_/AMBASSADOR_/AUTH_ on Frontdesk).
- [ ] Customer-path smoke gate passes (CI).
- [ ] Manual: VM redeploy with ``MCP_PROXY_TOOL_PDP_ENABLED=true`` + ``CULLIS_CONNECTOR_TOOL_PDP_ENABLED=true``, verify PDP fires on tool calls without override file.

## Notes

- Pairs with #654 (admin password change) — both sit on the ``local_auth_enabled`` surface.
- The remaining ~20 ``MCP_PROXY_*`` env vars (Vault config, KMS backend, federation poll intervals, Guardian ticket key, etc.) are out of scope for this PR. They belong to operational presets the customer rarely flips; if and when they do, a follow-up audit can wire them in batches by audience (Vault ops, federation ops, etc.).