### PR TITLE
chore(release): bump frontdesk-bundle to 0.2.6

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -103,8 +103,8 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
-  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.0)
-  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.3.0)
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.4)
+  CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.4.1)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
   FRONTDESK_HTTP_PORT                Host port to bind nginx (default: 8080)
@@ -200,8 +200,8 @@ _load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 |
 ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
-CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.0}"
-CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.3.0}"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.4}"
+CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.4.1}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"
 HTTP_PORT="$(_load_env FRONTDESK_HTTP_PORT)";         HTTP_PORT="${HTTP_PORT:-8080}"

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - frontdesk_net
 
   connector:
-    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.2}
+    image: ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION:-0.4.4}
     # ``dashboard`` mounts the local-auth router (ADR-025) by default; the
     # legacy fake-SSO Ambassador shared-mode is reachable by setting
     # ``AMBASSADOR_MODE=shared`` explicitly in frontdesk.env. ADR-025

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -42,7 +42,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the cullis-connector image to pull. Pin a release tag
 # in production rather than ``latest``. The default tracks the latest
 # release validated against this bundle.
-# CONNECTOR_VERSION=0.4.2
+# CONNECTOR_VERSION=0.4.4
 
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on


### PR DESCRIPTION
## Summary

Bump `CONNECTOR_VERSION` default `0.4.2` → `0.4.4` across the bundle so a fresh `./deploy.sh` on a clean checkout picks up the two ambassador bug fixes shipping in `cullis-connector v0.4.4` (PR #659):

- **#656** UserKeyStore on-disk persistence — Mastio TOFU pubkey pin now survives Connector restarts / cookie TTL expiry / admin password resets.
- **#657** `/v1/models` `cullis_meta.source` fallback indicator — SPA warns the user when the dropdown shows compiled-in defaults instead of the live Mastio catalog.

Three source-of-truth touch points kept in lock-step (lesson from PR #586 where a stale `deploy.sh` default `rc2` shipped after `compose` was already bumped):

- `packaging/frontdesk-bundle/docker-compose.yml` — `${CONNECTOR_VERSION:-0.4.2}` → `:-0.4.4`
- `packaging/frontdesk-bundle/deploy.sh` — help text `default: 0.4.0` → `0.4.4` + runtime `${CONNECTOR_VERSION:-0.4.0}` → `:-0.4.4` + CHAT `0.3.0` → `0.4.1`
- `packaging/frontdesk-bundle/frontdesk.env.example` — commented `# CONNECTOR_VERSION=0.4.2` → `0.4.4`

`CHAT_VERSION` default in compose stays at `0.4.1` (no chat changes this cut); `deploy.sh` CHAT default also bumped from the stale `0.3.0` to match.

## Sequencing

This PR must merge AFTER #659 (`chore(release): bump connector to 0.4.4`) so that pulling `0.4.4` from GHCR works on first try. The `connector-v0.4.4` tag is what triggers the image publish.

## Test plan

- [ ] Wait for #659 merge + `connector-v0.4.4` tag + image publish (release-connector.yml green)
- [ ] Merge this PR
- [ ] Tag `frontdesk-bundle-v0.2.6` on the merge commit → release-frontdesk-bundle.yml publishes tarball + zip
- [ ] VM redeploy: edit `frontdesk.env` (or just `rm` it and re-run `deploy.sh`), `docker compose pull`, restart
- [ ] Verify `MCP_PROXY_TOOL_PDP_ENABLED=""` no longer crashes Mastio at boot (#658 + mastio-v0.3.5)
- [ ] Verify user can log in, log out, log back in, send a chat without hitting `403 TOFU pubkey mismatch` (#656)
- [ ] Verify Ollama provider configured in /proxy/ai-providers now shows up in the SPA model dropdown without an `offline` chip (or shows the chip with a useful tooltip if Ollama is unreachable, instead of silently lying — #657)

## Pairs with

- `mastio-v0.3.5` (already tagged, building now): server-side fixes #654 + #658
- PR #659: connector PyPI/Docker version bump