### PR TITLE
feat(frontdesk-bundle): built-in TLS sidecar default-on (#655 / ADR-024)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,10 @@ build/
 # Frontdesk Connector identity material (per-deployment, never committed)
 packaging/frontdesk-bundle/connector_data/
 packaging/frontdesk-bundle/frontdesk.env
+# #655 / ADR-024 — self-signed TLS material minted at deploy time by
+# mint-tls-cert.sh. Contains the local CA private key, never commit.
+# Operators rotate by deleting this dir and re-running ./deploy.sh.
+packaging/frontdesk-bundle/tls/
 
 # Local NixOS test artifacts (rooted to repo root only)
 /.nixos-test-history

--- a/packaging/frontdesk-bundle/README.md
+++ b/packaging/frontdesk-bundle/README.md
@@ -83,6 +83,40 @@ To opt out — useful in CI / scripted deploys where prompting a human is wrong 
 
 The bundle exposes nginx on the host port from `FRONTDESK_HTTP_PORT` (default `8080`).
 
+### HTTPS out-of-the-box (#655 / ADR-024)
+
+By default the bundle ships a **TLS sidecar** (`frontdesk-nginx`) that terminates HTTPS on `:8443` with a self-signed cert minted at deploy time. A fresh `./deploy.sh` on a clean VPS produces a publicly-reachable `https://<host>:8443/` surface, no manual Caddy / oauth2-proxy / Traefik install required for first-customer demos.
+
+```bash
+./deploy.sh                                    # mints cert + binds :8443 by default
+./deploy.sh --tls-san "frontdesk.acme.com"     # bake your public hostname into the cert
+open https://localhost:8443/login              # browser warns once, accept the self-signed cert
+                                               # (or import ./tls/frontdesk-ca.crt as a trust anchor)
+```
+
+The cert defaults cover `localhost`, `host.docker.internal`, `frontdesk.local`, `cullis-frontdesk-nginx`, `127.0.0.1`, `::1`. Add your VPS hostname / public IP via `FRONTDESK_TLS_SAN=…` in `frontdesk.env` (comma-separated) or `--tls-san "…"` on the CLI BEFORE the first deploy. Adding a SAN after the cert is already minted requires `rm -rf ./tls && ./deploy.sh` (or set the env / flag and re-run — `mint-tls-cert.sh` detects SAN drift and regenerates).
+
+Operators with an **external TLS terminator** (corporate ingress, Caddy + Let's Encrypt, Cloudflare Tunnel, Traefik, oauth2-proxy) flip the sidecar off:
+
+```bash
+./deploy.sh --no-tls
+# or persist in frontdesk.env:
+echo 'FRONTDESK_TLS=disabled' >> frontdesk.env
+```
+
+In `--no-tls` mode the legacy plain-HTTP `:8080` surface stays bound to `127.0.0.1` only. Point your external TLS terminator at `127.0.0.1:8080` and let it terminate HTTPS on `:443`. Example Caddyfile:
+
+```Caddyfile
+frontdesk.acme.com {
+    reverse_proxy http://127.0.0.1:8080
+    header X-Forwarded-Proto https
+}
+```
+
+The `X-Forwarded-Proto: https` header is what tells the Connector to flag ADR-025 session cookies `Secure=true` — without it the browser drops the cookie on every request after the first login.
+
+The cert + CA private key live under `./tls/` (gitignored). Rotate by `rm -rf ./tls && ./deploy.sh`; rotation forces every browser to re-accept the cert exception once.
+
 ### Image versions
 
 The compose file pins sensible defaults via env vars:

--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -83,6 +83,20 @@ Options:
                               frontdesk.env must exist with real values
   --down                      Stop and remove containers
   --pull                      Force-pull the images before starting
+  --tls                       Force the built-in TLS sidecar ON
+                              (default; mints a self-signed cert in
+                              ./tls/, terminates HTTPS on :8443)
+  --no-tls                    Skip the built-in TLS sidecar — use when
+                              you have an external TLS terminator
+                              (Caddy / oauth2-proxy / Traefik / corporate
+                              ingress) fronting the bundle
+  --tls-san <list>            Comma-separated extra SAN entries baked
+                              into the self-signed cert (DNS names + IP
+                              literals). Example:
+                              --tls-san "frontdesk.acme.com,1.2.3.4"
+                              Default SANs cover localhost +
+                              host.docker.internal + frontdesk.local +
+                              127.0.0.1 + ::1
   --requester-email <addr>    Email the Mastio admin sees in the pending
                               enrollment row. Default: frontdesk@<trust-domain>
   --requester-name <name>     Display name in the pending row.
@@ -119,6 +133,14 @@ CLI_REQUESTER_NAME=""
 CLI_SITE_URL=""
 SKIP_ENROLL=0
 NO_WIZARD=0
+# #655 / ADR-024 — built-in TLS sidecar. Defaults to ON (env value
+# resolves to "enabled" when nothing is set), customer-real out-of-
+# box HTTPS on :8443 with a self-signed cert. --no-tls / --tls flags
+# below let the operator override either way without editing
+# frontdesk.env. --tls-san appends extra SAN entries baked into the
+# minted cert (DNS names + IP literals, comma-separated).
+CLI_TLS_MODE=""
+CLI_TLS_SAN=""
 
 while [[ $# -gt 0 ]]; do
     arg="$1"
@@ -128,6 +150,13 @@ while [[ $# -gt 0 ]]; do
         --prod)             MODE="production"; shift ;;
         --skip-enroll)      SKIP_ENROLL=1; shift ;;
         --no-wizard)        NO_WIZARD=1; shift ;;
+        --no-tls)           CLI_TLS_MODE="disabled"; shift ;;
+        --tls)              CLI_TLS_MODE="enabled"; shift ;;
+        --tls-san)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--tls-san requires a comma-separated list"
+            CLI_TLS_SAN="$1"; shift ;;
+        --tls-san=*)        CLI_TLS_SAN="${arg#--tls-san=}"; shift ;;
         --requester-email)
             shift
             [[ $# -gt 0 && "$1" != --* ]] || die "--requester-email requires a value"
@@ -150,8 +179,12 @@ done
 
 if [[ "$ACTION" == "down" ]]; then
     step "Stopping Cullis Frontdesk"
-    $COMPOSE --env-file frontdesk.env down 2>/dev/null \
-        || $COMPOSE down
+    # ``--profile tls`` here so that ``docker compose down`` also tears
+    # down the frontdesk-nginx sidecar service. Without the flag,
+    # compose skips profile-gated services and leaves a dangling
+    # container bound to ${TLS_PORT} that blocks the next deploy.
+    $COMPOSE --env-file frontdesk.env --profile tls down 2>/dev/null \
+        || $COMPOSE --profile tls down
     ok "Frontdesk stopped"
     exit 0
 fi
@@ -205,6 +238,19 @@ CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSI
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"
 HTTP_PORT="$(_load_env FRONTDESK_HTTP_PORT)";         HTTP_PORT="${HTTP_PORT:-8080}"
+# #655 / ADR-024 — TLS sidecar config. CLI flag overrides env value
+# overrides the built-in default ("enabled"). The summary below honours
+# this same precedence to decide which URL block to print.
+TLS_MODE_RAW="${CLI_TLS_MODE:-$(_load_env FRONTDESK_TLS)}"
+TLS_MODE="${TLS_MODE_RAW:-enabled}"
+TLS_PORT="$(_load_env FRONTDESK_TLS_PORT)";           TLS_PORT="${TLS_PORT:-8443}"
+TLS_BIND="$(_load_env FRONTDESK_TLS_BIND)";           TLS_BIND="${TLS_BIND:-0.0.0.0}"
+TLS_SAN="${CLI_TLS_SAN:-$(_load_env FRONTDESK_TLS_SAN)}"
+# Export FRONTDESK_TLS_* so docker compose substitution picks them up
+# (compose reads from the process env *and* --env-file; we resolved
+# the precedence above and re-export the winners).
+export FRONTDESK_TLS_PORT="$TLS_PORT"
+export FRONTDESK_TLS_BIND="$TLS_BIND"
 ENV_SITE_URL="$(_load_env CULLIS_SITE_URL)"
 
 if [[ "$MODE" == "production" ]]; then
@@ -471,19 +517,56 @@ except Exception as e:
     fi
 fi
 
+# ── TLS sidecar cert mint (#655 / ADR-024) ──────────────────────────────────
+#
+# When the operator hasn't opted out via FRONTDESK_TLS=disabled / --no-tls,
+# mint a self-signed cert under ./tls/ so the frontdesk-nginx sidecar can
+# terminate HTTPS on ${TLS_PORT}. The mint script runs openssl in a
+# transient nginx:1.27-alpine container, so the host needs no openssl
+# install (matching the bundle's openssl-optional posture from issue
+# #638). Idempotent: if the cert exists and covers the requested SAN
+# list, no regeneration. --tls-san appends extra SAN entries; the
+# default list covers localhost + host.docker.internal + frontdesk.local
+# + IP loopback, sufficient for same-host evaluation.
+COMPOSE_PROFILE_FLAGS=()
+if [[ "$TLS_MODE" == "enabled" ]]; then
+    step "Provisioning TLS sidecar cert (./tls/)"
+    MINT_ARGS=()
+    if [[ -n "$TLS_SAN" ]]; then
+        MINT_ARGS+=(--san "$TLS_SAN")
+    fi
+    if [[ -x "$SCRIPT_DIR/mint-tls-cert.sh" ]]; then
+        "$SCRIPT_DIR/mint-tls-cert.sh" "${MINT_ARGS[@]}" \
+            || die "TLS cert mint failed — re-run with FRONTDESK_TLS=disabled to fall back to plain HTTP"
+    else
+        die "mint-tls-cert.sh missing or not executable at $SCRIPT_DIR/mint-tls-cert.sh"
+    fi
+    # ``--profile tls`` activates the frontdesk-nginx sidecar service in
+    # docker-compose.yml. Without this flag, ``docker compose up -d``
+    # skips any service tagged with ``profiles: [tls]`` and the bundle
+    # comes up plain-HTTP only — the customer surface on :8443 stays
+    # dark. Mirrored in the FORCE_PULL pull step + the up step below.
+    COMPOSE_PROFILE_FLAGS+=(--profile tls)
+else
+    echo -e "  ${GRAY}TLS sidecar disabled (FRONTDESK_TLS=${TLS_MODE}) — plain-HTTP :${HTTP_PORT} loopback only${RESET}"
+fi
+
 # ── Pull + Start ────────────────────────────────────────────────────────────
 step "Deploying Cullis Frontdesk (${MODE})"
 echo -e "  Connector image: ${GRAY}ghcr.io/cullis-security/cullis-connector:${CONNECTOR_VERSION}${RESET}"
 echo -e "  Chat image:      ${GRAY}ghcr.io/cullis-security/cullis-chat-frontdesk:${CHAT_VERSION}${RESET}"
+if [[ "$TLS_MODE" == "enabled" ]]; then
+    echo -e "  TLS sidecar:     ${GRAY}nginx:1.27-alpine on ${TLS_BIND}:${TLS_PORT} (self-signed)${RESET}"
+fi
 
 if [[ $FORCE_PULL -eq 1 ]]; then
-    echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env pull${RESET}"
-    $COMPOSE --env-file frontdesk.env pull
+    echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env ${COMPOSE_PROFILE_FLAGS[*]} pull${RESET}"
+    $COMPOSE --env-file frontdesk.env "${COMPOSE_PROFILE_FLAGS[@]}" pull
     ok "Images pulled"
 fi
 
-echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env up -d${RESET}"
-$COMPOSE --env-file frontdesk.env up -d
+echo -e "  ${GRAY}$COMPOSE --env-file frontdesk.env ${COMPOSE_PROFILE_FLAGS[*]} up -d${RESET}"
+$COMPOSE --env-file frontdesk.env "${COMPOSE_PROFILE_FLAGS[@]}" up -d
 ok "Containers started"
 
 # ── Attach sibling Mastio nginx to frontdesk_net ────────────────────────────
@@ -632,7 +715,15 @@ SITE_URL_DISPLAY="${CLI_SITE_URL:-${ENV_SITE_URL:-(see frontdesk.env CULLIS_SITE
 echo ""
 echo -e "${GREEN}${BOLD}Cullis Frontdesk deployed (${MODE}).${RESET}"
 echo ""
-echo -e "  ${BOLD}SPA URL${RESET}          ${GRAY}http://localhost:${HTTP_PORT}${RESET}"
+if [[ "$TLS_MODE" == "enabled" ]]; then
+    # HTTPS surface is the customer-public one. Plain :8080 stays
+    # loopback so siblings on the docker bridge keep working.
+    echo -e "  ${BOLD}HTTPS URL${RESET}        ${GRAY}https://localhost:${TLS_PORT}${RESET}"
+    echo -e "  ${BOLD}HTTP fallback${RESET}    ${GRAY}http://localhost:${HTTP_PORT} (loopback-only)${RESET}"
+    echo -e "  ${BOLD}TLS trust${RESET}        ${GRAY}./tls/frontdesk-ca.crt (import into browser to silence warning)${RESET}"
+else
+    echo -e "  ${BOLD}SPA URL${RESET}          ${GRAY}http://localhost:${HTTP_PORT}${RESET}"
+fi
 echo -e "  ${BOLD}Mastio target${RESET}    ${GRAY}${SITE_URL_DISPLAY}${RESET}"
 echo -e "  ${BOLD}Org${RESET}              ${GRAY}${ORG_ID} (${TRUST_DOMAIN})${RESET}"
 echo -e "  ${BOLD}Profile${RESET}          ${GRAY}${CONNECTOR_PROFILE} (data: ${DATA_DIR})${RESET}"

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -259,7 +259,14 @@ services:
     volumes:
       - ./nginx-tls/00-maps.conf:/etc/nginx/conf.d/00-maps.conf:ro
       - ./nginx-tls/default.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./tls:/etc/nginx/certs:ro
+      # Mount ONLY the leaf cert + key — never the CA private key
+      # (./tls/frontdesk-ca.key). nginx needs only the server material
+      # at runtime; the CA key is needed by mint-tls-cert.sh on the
+      # host filesystem and would be defense-in-depth-exposed if
+      # nginx is ever compromised. Two explicit binds instead of one
+      # broad ``./tls:/etc/nginx/certs:ro`` directory mount.
+      - ./tls/frontdesk-server.crt:/etc/nginx/certs/frontdesk-server.crt:ro
+      - ./tls/frontdesk-server.key:/etc/nginx/certs/frontdesk-server.key:ro
     depends_on:
       - nginx
     networks:

--- a/packaging/frontdesk-bundle/docker-compose.yml
+++ b/packaging/frontdesk-bundle/docker-compose.yml
@@ -208,11 +208,15 @@ services:
       # leaks the SPA session cookie on any non-loopback path. Localhost
       # is a W3C "secure context" (SPA crypto + Secure cookies + Service
       # Workers all work as if on HTTPS), so dogfood and single-user
-      # evaluations on the same host are safe. To expose on the LAN or
-      # the public internet, override FRONTDESK_HTTP_BIND to ``0.0.0.0``
-      # AND put a TLS terminator (oauth2-proxy / Caddy / Traefik / nginx)
-      # in front. Doing one without the other is incoherent with the
-      # zero-trust threat model — see README "Threat model & exposure".
+      # evaluations on the same host are safe. The HTTPS path is
+      # served by the ``frontdesk-nginx`` sidecar below on
+      # ``${FRONTDESK_TLS_PORT}`` (default 8443, profile ``tls``,
+      # enabled by ``./deploy.sh`` by default) — that's the
+      # customer-public surface. The ``:80 / :8080`` inner path
+      # stays loopback-bound for siblings on the same docker bridge
+      # and for operators who prefer an external TLS terminator
+      # (oauth2-proxy, Caddy, Traefik, corporate ingress) and flip
+      # the sidecar off with ``./deploy.sh --no-tls``.
       - "${FRONTDESK_HTTP_BIND:-127.0.0.1}:${FRONTDESK_HTTP_PORT:-8080}:80"
     volumes:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
@@ -221,6 +225,57 @@ services:
     networks:
       - frontdesk_net
     restart: unless-stopped
+
+  # ─────────────────────────────────────────────────────────────────
+  # Frontdesk TLS sidecar (#655 / ADR-024). Terminates HTTPS on
+  # ${FRONTDESK_TLS_PORT} (default 8443) with a self-signed cert
+  # minted at deploy time by ./mint-tls-cert.sh (runs openssl inside
+  # a transient nginx:1.27-alpine container so the host needs no
+  # openssl install). Reverse-proxies to the inner ``nginx`` service
+  # on port 80, so the SPA + Connector routing rules stay in one
+  # place. Activated via compose profile ``tls`` — ``deploy.sh``
+  # passes ``--profile tls`` by default (FRONTDESK_TLS=enabled);
+  # operators who put an external TLS terminator in front of the
+  # bundle run ``./deploy.sh --no-tls`` to omit the sidecar.
+  #
+  # The cert covers default SANs (localhost, host.docker.internal,
+  # frontdesk.local, cullis-frontdesk-nginx, 127.0.0.1, ::1) plus
+  # any operator-supplied entries via ``FRONTDESK_TLS_SAN`` (comma
+  # list). A custom public hostname goes there before the first
+  # deploy so the browser cert validates without re-mint.
+  # ─────────────────────────────────────────────────────────────────
+  frontdesk-nginx:
+    image: nginx:1.27-alpine
+    profiles:
+      - tls
+    ports:
+      # Public surface. Default ``0.0.0.0`` so the bundle is reachable
+      # from any host on the LAN / VPS network. Cookie-leak risk is
+      # gone here (TLS); the ``Secure`` flag travels via the
+      # X-Forwarded-Proto header the sidecar sets to ``https``, so
+      # the Connector flags every ADR-025 session cookie
+      # ``Secure`` and the browser refuses to send it back over HTTP.
+      - "${FRONTDESK_TLS_BIND:-0.0.0.0}:${FRONTDESK_TLS_PORT:-8443}:8443"
+    volumes:
+      - ./nginx-tls/00-maps.conf:/etc/nginx/conf.d/00-maps.conf:ro
+      - ./nginx-tls/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./tls:/etc/nginx/certs:ro
+    depends_on:
+      - nginx
+    networks:
+      - frontdesk_net
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          test -s /etc/nginx/certs/frontdesk-server.crt &&
+          test -s /etc/nginx/certs/frontdesk-server.key &&
+          wget -q --no-check-certificate -O /dev/null https://localhost:8443/tls-health
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
 
 volumes:
   # Persistent Connector identity. Survives `docker compose down`. Wipe

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -91,6 +91,39 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # this is the port you open in the browser.
 # FRONTDESK_HTTP_PORT=8080
 
+# -- Built-in TLS terminator (#655 / ADR-024) ------------------------------
+
+# The bundle ships a ``frontdesk-nginx`` sidecar that terminates HTTPS on
+# ${FRONTDESK_TLS_PORT}. Default ``enabled`` — fresh ./deploy.sh on a
+# clean checkout brings up an https:// surface out-of-the-box, no manual
+# Caddy / oauth2-proxy required for a first-customer deploy. Operators
+# with an external TLS terminator in front (corporate ingress, Caddy
+# with Let's Encrypt, Cloudflare Tunnel, Traefik) flip this to
+# ``disabled`` to skip the sidecar — the legacy plain-HTTP :8080 surface
+# stays bound to 127.0.0.1 in that case.
+# FRONTDESK_TLS=enabled
+
+# Host port the TLS sidecar listens on. Pick 443 if you want to skip
+# the :8443 suffix and have root permission to bind a privileged port.
+# FRONTDESK_TLS_PORT=8443
+
+# Host bind address. Default 0.0.0.0 makes the bundle reachable from
+# the LAN / VPS network. Tighten to 127.0.0.1 for local-only
+# evaluations or when fronting with another reverse proxy on the same
+# host that talks loopback.
+# FRONTDESK_TLS_BIND=0.0.0.0
+
+# Extra Subject Alternative Names (comma-separated DNS hostnames + IP
+# literals) baked into the self-signed cert. The default SAN list
+# already covers ``localhost``, ``host.docker.internal``,
+# ``frontdesk.local``, ``cullis-frontdesk-nginx``, ``127.0.0.1``,
+# ``::1``. Add the public hostname / VPS IP your employees reach the
+# bundle at so the browser cert validation succeeds without warning
+# after the operator imports ``tls/frontdesk-ca.crt`` as a trust
+# anchor. Set this BEFORE the first deploy (or pass ``--tls-san`` to
+# deploy.sh and re-mint).
+# FRONTDESK_TLS_SAN=frontdesk.acme.example.com,1.2.3.4
+
 # Show the dev audit panel inside the SPA. Off by default — the audit
 # chain belongs to the Mastio admin dashboard, not the end user surface.
 # PUBLIC_DEV_AUDIT_PANEL=0

--- a/packaging/frontdesk-bundle/mint-tls-cert.sh
+++ b/packaging/frontdesk-bundle/mint-tls-cert.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Frontdesk — Mint self-signed TLS cert for the nginx sidecar
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Generates a self-signed CA + server cert under ``./tls/``, used by
+# the frontdesk-nginx sidecar to terminate TLS on port 8443. Runs
+# inside a transient ``nginx:1.27-alpine`` container so the host needs
+# no openssl install (same dependency-free posture as the Mastio
+# bundle's ADR-014 cert lifecycle).
+#
+# Idempotent: if the cert already exists AND covers every SAN passed
+# in, do nothing. SAN drift triggers a fresh mint.
+#
+# Usage:
+#   ./mint-tls-cert.sh                              # uses default SAN
+#   ./mint-tls-cert.sh --san "vps.example.com,1.2.3.4"
+#   ./mint-tls-cert.sh --force                      # always remint
+#
+# Output (under ``./tls/``):
+#   frontdesk-ca.crt   trust anchor (operator imports into browser to
+#                      remove the self-signed warning, or just clicks
+#                      through once and accepts the cert exception)
+#   frontdesk-ca.key   CA private key (chmod 600, never published)
+#   frontdesk-server.crt  leaf cert nginx serves on 8443
+#   frontdesk-server.key  leaf private key (chmod 600)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GREEN=$'\033[32m'; YELLOW=$'\033[33m'; RED=$'\033[31m'
+BOLD=$'\033[1m'; GRAY=$'\033[90m'; RESET=$'\033[0m'
+ok()   { echo -e "  ${GREEN}\xe2\x9c\x93${RESET}  $1"; }
+warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
+err()  { echo -e "  ${RED}\xe2\x9c\x97${RESET}  $1"; }
+die()  { err "$1"; exit 1; }
+
+EXTRA_SAN=""
+FORCE=0
+NGINX_IMAGE="nginx:1.27-alpine"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --san)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--san requires a comma-separated list"
+            EXTRA_SAN="$1"; shift ;;
+        --san=*)   EXTRA_SAN="${1#--san=}"; shift ;;
+        --force)   FORCE=1; shift ;;
+        --help|-h)
+            cat <<EOF
+Usage: $0 [--san "host1,host2,1.2.3.4"] [--force]
+
+Mints a self-signed TLS cert under ./tls/ for the frontdesk-nginx
+sidecar to terminate HTTPS on port 8443.
+
+  --san LIST    Comma-separated extra SAN entries (DNS names + IP
+                literals). Default SANs always included:
+                localhost, host.docker.internal, frontdesk.local,
+                cullis-frontdesk-nginx, 127.0.0.1, ::1.
+  --force       Regenerate even if cert already exists.
+
+The cert is generated inside a transient ${NGINX_IMAGE} container
+so the host needs no openssl install. Run by ./deploy.sh as part
+of the standard bring-up when FRONTDESK_TLS=enabled (default).
+EOF
+            exit 0
+            ;;
+        *) die "Unknown argument: $1 (use --help)" ;;
+    esac
+done
+
+TLS_DIR="$SCRIPT_DIR/tls"
+CRT="$TLS_DIR/frontdesk-server.crt"
+KEY="$TLS_DIR/frontdesk-server.key"
+CA_CRT="$TLS_DIR/frontdesk-ca.crt"
+CA_KEY="$TLS_DIR/frontdesk-ca.key"
+
+# Build the SAN block. Default SANs cover every name a browser /
+# Connector / sibling container may reach this sidecar at on a
+# typical single-host deploy. EXTRA_SAN appended verbatim (operator
+# adds their public hostname, VPS IP, etc).
+DEFAULT_DNS="localhost host.docker.internal frontdesk.local cullis-frontdesk-nginx"
+# IPv4 loopback only. openssl normalises ``::1`` to the expanded
+# ``0:0:0:0:0:0:0:1`` form when reading the cert back, which breaks
+# the SAN-drift idempotence check below if we write the shorthand.
+# IPv6 loopback is rare on customer hosts; operators who need it
+# pass it via --tls-san "::1" and that round-trip stays stable
+# (--tls-san already classifies on ``*:*``).
+DEFAULT_IP="127.0.0.1"
+
+san_lines=""
+for dns in $DEFAULT_DNS; do
+    san_lines+="DNS:${dns},"
+done
+for ip in $DEFAULT_IP; do
+    san_lines+="IP:${ip},"
+done
+if [[ -n "$EXTRA_SAN" ]]; then
+    # Split on commas; each entry is classified as IP (parseable
+    # numeric IPv4/IPv6) or DNS name. Same logic the Mastio's
+    # agent_manager.emit_nginx_server_cert uses (RFC 5280: IP literals
+    # MUST go in iPAddress SAN, not dNSName, or Python's ssl module
+    # rejects them silently).
+    IFS=',' read -ra extras <<< "$EXTRA_SAN"
+    for raw in "${extras[@]}"; do
+        entry="$(echo "$raw" | xargs)"  # trim whitespace
+        [[ -z "$entry" ]] && continue
+        # crude ipv4/ipv6 detection — good enough for SAN classification
+        if [[ "$entry" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]] || [[ "$entry" == *:* ]]; then
+            san_lines+="IP:${entry},"
+        else
+            san_lines+="DNS:${entry},"
+        fi
+    done
+fi
+san_lines="${san_lines%,}"
+
+# Idempotence: if the cert exists, parse the SANs it carries and skip
+# the mint when they already cover everything we'd write. ``--force``
+# bypasses this. Runs openssl in the same nginx:alpine + apk-add path
+# the mint step uses (host openssl is optional; the customer-real
+# install path doesn't assume one).
+if [[ $FORCE -eq 0 && -f "$CRT" && -f "$KEY" && -f "$CA_CRT" ]]; then
+    existing_sans="$(
+        docker run --rm -v "$TLS_DIR:/tls:ro" --entrypoint sh "$NGINX_IMAGE" -c '
+            command -v openssl >/dev/null 2>&1 || apk add --no-cache openssl >/dev/null 2>&1
+            openssl x509 -in /tls/frontdesk-server.crt -noout -ext subjectAltName 2>/dev/null | tail -n +2
+        ' 2>/dev/null || true
+    )"
+    # openssl emits ``IP Address:`` but we write ``IP:`` in the
+    # extfile. Normalise both sides to the same shape (drop spaces,
+    # collapse ``IP Address:`` -> ``IP:``) so the comparison is
+    # apples-to-apples.
+    normalise() { echo "$1" | tr -d ' \n' | sed 's/IPAddress:/IP:/g'; }
+    want="$(normalise "$san_lines")"
+    have="$(normalise "$existing_sans")"
+    # Every entry from the requested list must already appear in the
+    # cert's SAN list. The cert may carry additional SANs from a past
+    # mint that requested more — that's a no-op, not a drift.
+    all_present=1
+    IFS=',' read -ra want_parts <<< "$want"
+    for part in "${want_parts[@]}"; do
+        [[ -z "$part" ]] && continue
+        case ",${have}," in
+            *",${part},"*) ;;
+            *) all_present=0; break ;;
+        esac
+    done
+    if [[ -n "$existing_sans" && $all_present -eq 1 ]]; then
+        ok "TLS cert already covers requested SANs, reusing ${CRT}"
+        exit 0
+    fi
+    warn "Existing TLS cert SAN list differs from request, regenerating"
+fi
+
+mkdir -p "$TLS_DIR"
+
+# Run openssl in nginx:alpine (already pulled by the bundle, has
+# openssl 3.x baked in). The container writes into the bind-mounted
+# /tls dir; chmod 0600 on the keys to satisfy nginx's strict-perm
+# warnings on hostpath mounts.
+#
+# Quoting note: the inner sh -c body is wrapped in single quotes so
+# the OUTER bash (which runs with set -u) does NOT try to expand
+# ``$SAN_LINES`` — that variable only exists inside the container, set
+# via ``-e``. The cert extension file is then rendered from a heredoc
+# expanded by the inner sh, which DOES see SAN_LINES.
+docker run --rm \
+    -v "$TLS_DIR:/tls" \
+    -e SAN_LINES="$san_lines" \
+    --entrypoint sh \
+    "$NGINX_IMAGE" -c '
+        set -e
+        # nginx:1.27-alpine ships busybox ssl_client only, not the
+        # full openssl binary we need for x509 + CSR signing. ``apk
+        # add openssl`` lands ~5 MB in the ephemeral container layer
+        # (gone the moment the --rm container exits). On a customer
+        # host with no openssl this is the same as installing it on
+        # the host, only without polluting /usr/bin.
+        if ! command -v openssl >/dev/null 2>&1; then
+            apk add --no-cache openssl >/dev/null 2>&1 \
+                || { echo "apk add openssl failed inside nginx:alpine"; exit 1; }
+        fi
+        cd /tls
+
+        # ── 1. Self-signed CA (10 years; not in any browser trust
+        #       store, the operator clicks through once or imports
+        #       frontdesk-ca.crt). ──
+        if [ ! -f frontdesk-ca.crt ] || [ ! -f frontdesk-ca.key ]; then
+            openssl req -x509 -nodes -newkey rsa:4096 -days 3650 \
+                -subj "/CN=Cullis Frontdesk Local CA" \
+                -keyout frontdesk-ca.key \
+                -out    frontdesk-ca.crt >/dev/null 2>&1
+        fi
+
+        # ── 2. Server CSR + leaf cert signed by the CA, 825 days
+        #       (Apple Safari rejects leaf certs with longer
+        #       validity since iOS 13). ──
+        openssl req -new -nodes -newkey rsa:2048 \
+            -subj "/CN=cullis-frontdesk" \
+            -keyout frontdesk-server.key \
+            -out    frontdesk-server.csr >/dev/null 2>&1
+
+        # Heredoc expands $SAN_LINES inside the container (env var
+        # passed via -e to docker run above). Unquoted EOF == expand.
+        cat > server-ext.cnf <<EOF
+authorityKeyIdentifier = keyid,issuer
+basicConstraints = critical,CA:FALSE
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = ${SAN_LINES}
+EOF
+
+        openssl x509 -req -in frontdesk-server.csr \
+            -CA  frontdesk-ca.crt \
+            -CAkey frontdesk-ca.key \
+            -CAcreateserial \
+            -days 825 \
+            -extfile server-ext.cnf \
+            -out frontdesk-server.crt >/dev/null 2>&1
+
+        rm -f frontdesk-server.csr frontdesk-ca.srl server-ext.cnf
+
+        chmod 0644 frontdesk-server.crt frontdesk-ca.crt
+        chmod 0600 frontdesk-server.key frontdesk-ca.key
+    ' || die "TLS cert generation failed inside ${NGINX_IMAGE} container"
+
+ok "Minted TLS cert under ${TLS_DIR}/"
+echo -e "    ${GRAY}frontdesk-server.crt    leaf cert (SAN: ${san_lines//,/, })${RESET}"
+echo -e "    ${GRAY}frontdesk-server.key    leaf key (chmod 600)${RESET}"
+echo -e "    ${GRAY}frontdesk-ca.crt        local CA — import into browser to silence the warning${RESET}"

--- a/packaging/frontdesk-bundle/nginx-tls/00-maps.conf
+++ b/packaging/frontdesk-bundle/nginx-tls/00-maps.conf
@@ -1,0 +1,20 @@
+# =============================================================================
+# Cullis Frontdesk TLS sidecar — http-level maps
+# =============================================================================
+#
+# Loaded before default.conf via lexicographic order in
+# /etc/nginx/conf.d/. ``map`` directives must live in the ``http {}``
+# context (which the nginx official image opens for us at the top
+# level), so they can't sit inside the ``server {}`` block in
+# default.conf.
+# =============================================================================
+
+# WebSocket Upgrade helper for SPA streaming endpoints (Cullis Chat
+# streams chat completions via SSE / WS via the Connector). Empty
+# Upgrade → close the upstream connection; anything else → forward
+# verbatim so nginx doesn't emit ``Connection: close`` and break the
+# stream mid-token.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/packaging/frontdesk-bundle/nginx-tls/default.conf
+++ b/packaging/frontdesk-bundle/nginx-tls/default.conf
@@ -1,0 +1,102 @@
+# =============================================================================
+# Cullis Frontdesk — TLS terminator sidecar (ADR-024 / issue #655)
+# =============================================================================
+#
+# Listens on 8443 with a self-signed cert minted at deploy time by
+# ``./deploy.sh`` (via ``docker run nginx:1.27-alpine openssl`` so the
+# host needs no openssl install). Reverse-proxies to the inner
+# ``nginx`` service on port 80, which keeps doing the SPA + Connector
+# fan-out it already does today.
+#
+# Why a separate sidecar instead of bolting TLS onto the inner nginx:
+#   * Additive — operators with an external TLS terminator (oauth2-
+#     proxy, Caddy, Traefik, corporate ingress) flip
+#     ``FRONTDESK_TLS=disabled`` and the inner :80 path stays
+#     unchanged. No behavioural drift between the two modes.
+#   * Mirrors the Mastio bundle's ``mastio-nginx`` pattern (ADR-014),
+#     so the operator sees one consistent topology across both
+#     bundles.
+#   * The X-Forwarded-Proto + Host headers travel through to the
+#     Connector so its ADR-025 session cookies pick up the
+#     ``Secure`` flag automatically when the request arrived via
+#     HTTPS. Without that the SPA loses cookies on every navigation.
+# =============================================================================
+
+server {
+    listen 8443 ssl;
+    http2 on;
+    server_name _;
+    server_tokens off;
+
+    ssl_certificate     /etc/nginx/certs/frontdesk-server.crt;
+    ssl_certificate_key /etc/nginx/certs/frontdesk-server.key;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5:!RC4;
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 10m;
+    ssl_session_cache   shared:SSL:10m;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options    "nosniff" always;
+    add_header X-Frame-Options           "DENY" always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+    client_max_body_size 16m;
+
+    # Docker's embedded DNS — required because the upstream is a
+    # docker service name resolved at runtime, not start. Without an
+    # explicit resolver nginx fails ``no resolver defined`` and
+    # surfaces 502 to the browser.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 3s;
+
+    # Health endpoint terminates here. Used by the docker healthcheck
+    # below and by ``./deploy.sh`` to confirm TLS came up before
+    # printing the success summary.
+    location = /tls-health {
+        access_log off;
+        default_type text/plain;
+        return 200 "ok\n";
+    }
+
+    # ───────────────────────────────────────────────────────────────
+    # Everything else: terminate TLS, hand to the inner nginx that
+    # already knows the SPA + Connector routing rules. The inner
+    # nginx listens on plain HTTP port 80 on the docker bridge — host
+    # port 8080 is unaffected.
+    # ───────────────────────────────────────────────────────────────
+    location / {
+        set $inner_upstream http://nginx:80;
+        proxy_pass $inner_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header X-Forwarded-Port  $server_port;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+
+        proxy_read_timeout    300s;
+        proxy_send_timeout    300s;
+        proxy_connect_timeout 5s;
+
+        proxy_buffering off;
+    }
+}
+
+# WebSocket Upgrade helper. Same map the inner nginx already declares,
+# repeated here because nginx's ``map`` directives don't propagate
+# across separate config files unless both files are loaded into the
+# same ``http {}`` context. nginx:alpine's default config opens
+# ``http {}`` at the top level + auto-loads ``/etc/nginx/conf.d/*.conf``
+# in lexicographic order, so this map ends up in the right context as
+# long as it lives in a file that loads before the ``server {}``
+# block above. Since both directives are in this single file and
+# nginx evaluates them in order within the ``http {}`` context, the
+# server block can reference ``$connection_upgrade`` declared above
+# only if the map sits ABOVE the server. Move the map to
+# ``00-maps.conf`` to make the load order explicit (alphabetical
+# matches the Mastio bundle).

--- a/packaging/smoke-customer-path.sh
+++ b/packaging/smoke-customer-path.sh
@@ -189,6 +189,35 @@ curl -sf http://localhost:8080/ -o /dev/null \
     || fail "Frontdesk SPA /"
 ok "Frontdesk SPA up on :8080"
 
+# ── TLS sidecar (#655 / ADR-024) ─────────────────────────────────────────
+#
+# deploy.sh runs with TLS enabled by default. Verify the self-signed cert
+# was minted under ./tls/ and that the HTTPS surface returns the SPA on
+# :8443. ``-k`` (no cert verification) is correct here — the cert is
+# self-signed by a local CA the smoke does not import into the system
+# trust store. The TLS handshake itself + the cert path + the proxy
+# header pass-through to the inner SPA are what the gate validates.
+test -s ./tls/frontdesk-server.crt \
+    || fail "TLS cert was not minted at ./tls/frontdesk-server.crt"
+test -s ./tls/frontdesk-ca.crt \
+    || fail "TLS CA cert was not minted at ./tls/frontdesk-ca.crt"
+ok "TLS cert + CA present under ./tls/"
+
+for i in $(seq 1 20); do
+    curl -skf https://localhost:8443/tls-health -o /dev/null && break
+    sleep 1
+done
+curl -skf https://localhost:8443/tls-health -o /dev/null \
+    || fail "Frontdesk TLS sidecar /tls-health not reachable on :8443"
+ok "TLS sidecar healthy on :8443"
+
+# Hit the SPA root through the TLS sidecar to confirm the reverse-proxy
+# to the inner nginx works end-to-end. nginx would return 200 with the
+# SPA HTML; we just check the status code.
+curl -skf https://localhost:8443/ -o /dev/null \
+    || fail "Frontdesk SPA / not reachable through TLS sidecar"
+ok "Frontdesk SPA reachable on https://localhost:8443/"
+
 # ── Enrollment wizard, end-to-end ────────────────────────────────────────
 
 step "Enrollment wizard — discover, submit, approve, poll"


### PR DESCRIPTION
Closes #655.

## Summary

A fresh `./deploy.sh` on a clean VPS now produces a publicly-reachable `https://<host>:8443/` surface out-of-the-box — no manual Caddy / oauth2-proxy / Traefik install required for first-customer demos.

Customer-real install path:

```bash
tar xzf cullis-frontdesk-bundle.tar.gz
cd cullis-frontdesk-bundle/
./deploy.sh --tls-san "frontdesk.acme.com"   # bake public hostname into the cert
open https://localhost:8443/login            # one-time self-signed warning
```

## Why now (P0 from 2026-05-12 dogfood)

VM dogfood 2026-05-12 sera. Operator extracted the bundle, ran `./deploy.sh`, and discovered that `localhost:8080` was unreachable from the host browser (correct by design — plain HTTP binding to `127.0.0.1` prevents cookie leak) with no documented path from there to "employee opens `https://corp.example.com/login`". ADR-024 already pinned the design as opt-in; the dogfood feedback promoted it to **default-on**.

## What ships

- **`mint-tls-cert.sh`** — generates a self-signed CA + server cert under `./tls/` at deploy time. Runs openssl inside a transient `nginx:1.27-alpine` container with a one-shot `apk add --no-cache openssl` (nginx:alpine ships only busybox `ssl_client`; the apk layer is ephemeral, gone with the `--rm` container). Same dependency-free posture as the Mastio bundle's ADR-014 cert lifecycle. Idempotent — detects SAN drift and skips regen when nothing changed.
- **`nginx-tls/`** — TLS terminator config for the sidecar, mirroring the `mastio-nginx` shape. Reverse-proxies to the inner `nginx` on port 80, sets `X-Forwarded-Proto: https` + HSTS + X-Frame-Options DENY + Referrer-Policy.
- **`docker-compose.yml`** — new `frontdesk-nginx` service behind compose profile `tls`. Bound `${FRONTDESK_TLS_BIND:-0.0.0.0}:${FRONTDESK_TLS_PORT:-8443}`, healthcheck on `/tls-health`.
- **`deploy.sh`** — new flags `--tls` / `--no-tls` / `--tls-san "list"`. Default is `--tls`. Pre-flight mints the cert, then `docker compose --profile tls up -d` activates the sidecar. `--down` also passes `--profile tls` so the sidecar gets torn down cleanly.
- **`frontdesk.env.example`** — `FRONTDESK_TLS=enabled` + `FRONTDESK_TLS_PORT` + `FRONTDESK_TLS_BIND` + `FRONTDESK_TLS_SAN` documented.
- **`README.md`** — "HTTPS out-of-the-box" section + Caddyfile snippet for operators who prefer Let's Encrypt (skip the built-in sidecar with `--no-tls`).
- **`.gitignore`** — `packaging/frontdesk-bundle/tls/` excluded.
- **`smoke-customer-path.sh`** — gate extended to verify cert files present + `/tls-health` returns 200 + SPA root reachable through the proxy.

## Opt-out for external TLS

```bash
./deploy.sh --no-tls
# or persist:
echo 'FRONTDESK_TLS=disabled' >> frontdesk.env
```

In `--no-tls` mode the legacy plain-HTTP `:8080` surface stays bound to `127.0.0.1` only, exactly as before this PR. Zero behavioural drift for existing deploys.

## Default SANs

Cover `localhost`, `host.docker.internal`, `frontdesk.local`, `cullis-frontdesk-nginx`, `127.0.0.1`. IPv6 `::1` omitted from defaults because openssl rewrites it to `0:0:0:0:0:0:0:1` when reading the cert back, breaking SAN-drift idempotence. Operators who need IPv6 loopback pass it via `--tls-san "::1"`.

## Test plan

- [x] `bash -n` syntax check on `deploy.sh`, `mint-tls-cert.sh`, `smoke-customer-path.sh`
- [x] `docker compose --profile tls config` validates with the new service
- [x] `nginx -t` inside `nginx:1.27-alpine` validates the new `nginx-tls/` config against a minted cert
- [x] `mint-tls-cert.sh` round-trip locally: mints valid x509 cert + CA, `openssl verify -CAfile` passes, idempotence respects identical SANs, regenerates on SAN drift, `--force` always regens
- [ ] **CI customer-path-smoke** — exercises the full path including the new TLS sidecar
- [ ] **Live VM dogfood** post-merge: `cullis@192.168.122.170`, redeploy with `./deploy.sh --pull --tls-san "192.168.122.170"`, verify `https://192.168.122.170:8443/login` reaches the SPA from the host browser without the SSH tunnel hack

## Pairs with

- 2026-05-12 release cut (mastio-v0.3.5 + connector-v0.4.4 + frontdesk-bundle-v0.2.6 already shipped). This PR is the next bundle bump, target `frontdesk-bundle-v0.2.7`.