### PR TITLE
ci(release-frontdesk-bundle): include mint-tls-cert.sh + nginx-tls/

### DIFF
--- a/.github/workflows/release-frontdesk-bundle.yml
+++ b/.github/workflows/release-frontdesk-bundle.yml
@@ -65,10 +65,52 @@ jobs:
           cp packaging/frontdesk-bundle/README.md                   "${STAGING}/"
           cp packaging/frontdesk-bundle/deploy.sh                   "${STAGING}/"
           cp packaging/frontdesk-bundle/generate-frontdesk-env.sh   "${STAGING}/"
+          # #655 / ADR-024 — TLS sidecar cert mint + nginx config.
+          # mint-tls-cert.sh runs at deploy time to generate the self-
+          # signed cert under ./tls/; nginx-tls/ holds the TLS
+          # terminator config the frontdesk-nginx sidecar mounts. Both
+          # are referenced by docker-compose.yml + deploy.sh — missing
+          # either breaks the customer install with
+          # ``mint-tls-cert.sh: No such file or directory``. Pin
+          # explicitly here so a future ``rm`` of a file under those
+          # subdirs surfaces in the bundle build, not at deploy time
+          # on the customer host. v0.2.7 shipped with these files
+          # missing because the cp list was not updated; the
+          # post-stage check below now catches that class of
+          # regression.
+          cp packaging/frontdesk-bundle/mint-tls-cert.sh            "${STAGING}/"
           cp -r packaging/frontdesk-bundle/nginx                    "${STAGING}/"
+          cp -r packaging/frontdesk-bundle/nginx-tls                "${STAGING}/"
 
-          chmod +x "${STAGING}/deploy.sh" "${STAGING}/generate-frontdesk-env.sh"
-          ls -lah "${STAGING}/"
+          chmod +x "${STAGING}/deploy.sh" \
+                   "${STAGING}/generate-frontdesk-env.sh" \
+                   "${STAGING}/mint-tls-cert.sh"
+
+          # Post-stage sanity check: every file that deploy.sh and
+          # docker-compose.yml reference must exist in the staged
+          # bundle. Catches "I forgot to add new file X to the cp
+          # list" regressions at release time instead of on customer
+          # downloads. The list mirrors what deploy.sh and the compose
+          # bind-mount in production.
+          MISSING=0
+          for f in \
+              "docker-compose.yml" \
+              "deploy.sh" \
+              "generate-frontdesk-env.sh" \
+              "mint-tls-cert.sh" \
+              "frontdesk.env.example" \
+              "README.md" \
+              "nginx/default.conf" \
+              "nginx-tls/default.conf" \
+              "nginx-tls/00-maps.conf"; do
+              if [ ! -f "${STAGING}/${f}" ]; then
+                  echo "::error::staged bundle missing required file: ${f}"
+                  MISSING=1
+              fi
+          done
+          if [ "$MISSING" = "1" ]; then exit 1; fi
+
+          ls -lahR "${STAGING}/"
 
       - name: Package tar.gz + zip
         env:


### PR DESCRIPTION
## Why

`frontdesk-bundle-v0.2.7` (tagged 22:00 UTC tonight) shipped a **broken tarball** — customer downloads `cullis-frontdesk-bundle-0.2.7.tar.gz` and on the first `./deploy.sh` hits:

```
./deploy.sh: line N: mint-tls-cert.sh: No such file or directory
```

Root cause: the `Stage bundle` step in `release-frontdesk-bundle.yml` copies an explicit allowlist of files (deliberately, to avoid shipping operator artefacts from dogfood — `frontdesk.env` with real values, `connector_data/` with enrolled identity). The #655 PR added `mint-tls-cert.sh` + `nginx-tls/` to the bundle but did not update that allowlist.

## What this PR does

- Adds `mint-tls-cert.sh`, `nginx-tls/` to the staging `cp` list, plus `chmod +x` on the new script.
- Adds a post-stage sanity check that asserts every file `deploy.sh` + `docker-compose.yml` depend on landed in the staging dir. Fails the workflow with a clear `::error::` if a future PR introduces another file the bundle references that the allowlist doesn't enumerate.

## Follow-up

After merge:
1. Tag `frontdesk-bundle-v0.2.8` to publish the fixed tarball.
2. Mark `frontdesk-bundle-v0.2.7` as broken in its release notes (link to v0.2.8).

## Test plan

- [x] `yaml` syntax (workflow file parses)
- [ ] CI: the workflow itself only runs on tag-push, so the next `frontdesk-bundle-v0.2.8` tag exercises both the new cp lines and the sanity check
- [ ] Manual: extract `cullis-frontdesk-bundle-0.2.8.tar.gz` on a fresh dir, check `ls` shows `mint-tls-cert.sh` + `nginx-tls/` present and the new sanity-check `ls -lahR` output in the workflow logs lists all 9 required files