### PR TITLE
feat(mastio): admin reset of TOFU-pinned user pubkey

### DIFF
--- a/mcp_proxy/admin/users.py
+++ b/mcp_proxy/admin/users.py
@@ -226,6 +226,67 @@ async def list_users(
     return UserListResponse(users=items, total=len(items))
 
 
+@router.post(
+    "/{user_name}/reset-tofu-pin",
+    dependencies=[Depends(_require_admin_secret)],
+)
+async def reset_tofu_pin(user_name: str, request: Request) -> dict:
+    """Clear the TOFU-pinned pubkey for a user principal.
+
+    Mirror of the dashboard Danger Zone button. Scripted recovery
+    path for the v0.1 keystore-loss case (Connector wiped its
+    on-disk keypair, pre-PR #656 Mastio kept user keys in-memory
+    and lost the pin on restart). Cert thumbprint is left alone —
+    only the SPKI hash is the load-bearing TOFU identifier.
+
+    Audit chain captures the reset with ``action=reset_tofu_pin``
+    and ``operator=admin-secret`` so an attacker who flips a real
+    user's pin to their own pubkey is recoverable forensically.
+
+    Returns:
+        ``200`` ``{"principal_id": ..., "cleared": true}`` on success.
+        ``404`` when principal_id missing OR the pin was already NULL
+        (idempotent caller can treat both as "nothing to do").
+    """
+    if not user_name or len(user_name) > 64:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid user_name",
+        )
+    mgr = getattr(request.app.state, "agent_manager", None)
+    if mgr is None or not getattr(mgr, "ca_loaded", False):
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="agent manager not initialized — Org CA not loaded",
+        )
+    pid = _principal_id(mgr.org_id, user_name)
+
+    from mcp_proxy.db import clear_user_principal_pubkey_thumbprint, log_audit
+    cleared = await clear_user_principal_pubkey_thumbprint(pid)
+    if not cleared:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="principal not found or pin already cleared",
+        )
+
+    try:
+        await log_audit(
+            agent_id=pid,
+            action="reset_tofu_pin",
+            status="success",
+            details={
+                "operator": "admin-secret",
+                "user_name": user_name,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "reset_tofu_pin: audit append failed for %s: %s", pid, exc,
+        )
+
+    return {"principal_id": pid, "cleared": True}
+
+
 # ── populator helper ────────────────────────────────────────────────────
 
 

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3299,6 +3299,7 @@ async def _build_user_view() -> tuple[list[dict], bool]:
             "reach": row.get("reach"),
             "surface": row.get("surface"),
             "cert_thumbprint": row.get("cert_thumbprint"),
+            "pubkey_thumbprint": row.get("pubkey_thumbprint"),
             "created_at": row.get("created_at"),
             "last_active_at": row.get("last_active_at"),
             "in_frontdesk": user_name in fd_users,
@@ -3322,6 +3323,7 @@ async def _build_user_view() -> tuple[list[dict], bool]:
             "reach": "intra",
             "surface": "frontdesk",
             "cert_thumbprint": None,
+            "pubkey_thumbprint": None,
             "created_at": fd.get("created_at"),
             "last_active_at": None,
             "in_frontdesk": True,
@@ -3796,6 +3798,85 @@ async def users_delete(principal_id: str, request: Request):
     from urllib.parse import quote
     return RedirectResponse(
         f"/proxy/users?ok=Deleted+{quote(user_name)}",
+        status_code=303,
+    )
+
+
+@router.post("/users/{principal_id:path}/reset-tofu-pin")
+async def users_reset_tofu_pin(principal_id: str, request: Request):
+    """Clear the TOFU-pinned pubkey for a user principal.
+
+    Recovery path for the v0.1 keystore-loss case: Connector wiped
+    its on-disk keypair, customer rebuilt the laptop, or an early
+    Mastio (pre-PR #656) ran with in-memory keys and lost the pin
+    on restart. Operator confirms identity out-of-band, hits this
+    button, the next CSR from the user is accepted regardless of
+    pubkey and the fresh thumb gets repinned at signature time.
+
+    Mastio-local: the TOFU pin lives only in ``local_user_principals``
+    (the Frontdesk doesn't carry it). No Frontdesk bridge required.
+    Audit chain captures the reset with action=``reset_tofu_pin``
+    so an attacker who flips a real user's pin to their own pubkey
+    is recoverable forensically.
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=csrf",
+            status_code=303,
+        )
+
+    _, user_name = _split_principal_id(principal_id)
+    if not user_name:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=invalid+principal+id",
+            status_code=303,
+        )
+
+    from mcp_proxy.db import clear_user_principal_pubkey_thumbprint, log_audit
+    try:
+        cleared = await clear_user_principal_pubkey_thumbprint(principal_id)
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "users_reset_tofu_pin: clear failed for %s: %s",
+            principal_id, exc,
+        )
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Reset+failed",
+            status_code=303,
+        )
+
+    if not cleared:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=No+pin+to+clear",
+            status_code=303,
+        )
+
+    operator = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+    try:
+        await log_audit(
+            agent_id=principal_id,
+            action="reset_tofu_pin",
+            status="success",
+            details={
+                "operator": operator,
+                "user_name": user_name,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "users_reset_tofu_pin: audit append failed for %s: %s",
+            principal_id, exc,
+        )
+
+    return RedirectResponse(
+        f"/proxy/users/{principal_id}?ok=TOFU+pin+cleared",
         status_code=303,
     )
 

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -384,6 +384,35 @@
                 </form>
             </div>
 
+            <!-- Reset TOFU pin -->
+            <div class="border-t border-red-900/20 pt-5">
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Reset TOFU Pin</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    Clears the pinned public key bound to this principal. The next CSR will be accepted regardless of key and the fresh key gets re-pinned at signature time. Use when the user's Connector lost its keystore (laptop rebuilt, profile wiped) and is now bouncing with a TOFU mismatch. Cert thumbprint and credentials are not affected.
+                </p>
+                <div class="mb-3 flex items-start gap-2 text-[11px]">
+                    <span class="text-gray-600 uppercase tracking-wider mt-0.5">Pubkey thumb:</span>
+                    {% if user.pubkey_thumbprint %}
+                    <code class="text-gray-400 font-mono break-all" title="{{ user.pubkey_thumbprint }}">{{ user.pubkey_thumbprint[:32] }}{% if user.pubkey_thumbprint|length > 32 %}…{% endif %}</code>
+                    {% else %}
+                    <span class="text-gray-700 italic">not pinned</span>
+                    {% endif %}
+                </div>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/reset-tofu-pin"
+                      onsubmit="return confirm('Clear the TOFU pin? The next sign-in from this user will be trusted on first touch again. Verify the user identity out-of-band before resetting.')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            {% if not user.pubkey_thumbprint %}disabled
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-gray-800/40 border border-gray-800 text-gray-600 rounded cursor-not-allowed"
+                            title="No pin to clear"
+                            {% else %}
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-amber-600/20 border border-amber-600/30 text-amber-400 rounded hover:bg-amber-600/30 transition-colors"
+                            {% endif %}>
+                        Reset TOFU Pin
+                    </button>
+                </form>
+            </div>
+
             <!-- Delete -->
             <div class="border-t border-red-900/20 pt-5">
                 <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Delete</p>

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -588,7 +588,8 @@ async def list_user_principals() -> list[dict]:
         result = await conn.execute(
             text(
                 "SELECT principal_id, user_name, display_name, reach, "
-                "       surface, cert_thumbprint, created_at, last_active_at "
+                "       surface, cert_thumbprint, pubkey_thumbprint, "
+                "       created_at, last_active_at "
                 "  FROM local_user_principals "
                 " ORDER BY created_at DESC"
             )
@@ -691,6 +692,37 @@ async def set_user_principal_pubkey_thumbprint_if_unset(
                 "   AND pubkey_thumbprint IS NULL"
             ),
             {"pid": principal_id, "thumb": pubkey_thumbprint},
+        )
+        return result.rowcount > 0
+
+
+async def clear_user_principal_pubkey_thumbprint(principal_id: str) -> bool:
+    """Null out the TOFU-pinned pubkey for a user principal.
+
+    Used by the admin "reset TOFU pin" path when the on-disk pubkey
+    pinned at first-touch has become stale (Connector wiped its
+    keystore, customer rebuilt the laptop, ADR-021 v0.1 in-memory keys
+    didn't survive a Mastio restart). After this call the next CSR
+    from this principal will be accepted regardless of pubkey and the
+    fresh thumb gets pinned on that signature via ``upsert_from_csr``.
+
+    Returns True iff a row was actually updated. False when the
+    principal_id doesn't exist OR ``pubkey_thumbprint`` was already
+    NULL (caller can decide whether that's a 404 or a no-op).
+
+    Cert thumbprint is left alone — it rotates every CSR refresh
+    anyway and is not the load-bearing TOFU identifier. Only the
+    SPKI hash matters.
+    """
+    async with get_db() as conn:
+        result = await conn.execute(
+            text(
+                "UPDATE local_user_principals "
+                "   SET pubkey_thumbprint = NULL "
+                " WHERE principal_id = :pid "
+                "   AND pubkey_thumbprint IS NOT NULL"
+            ),
+            {"pid": principal_id},
         )
         return result.rowcount > 0
 

--- a/tests/test_admin_users.py
+++ b/tests/test_admin_users.py
@@ -160,6 +160,135 @@ async def test_auth_required(tmp_path, monkeypatch):
 # ── upsert from CSR sign ───────────────────────────────────────────────
 
 
+# ── reset TOFU pin ─────────────────────────────────────────────────────
+
+
+async def test_reset_tofu_pin_clears_pubkey(tmp_path, monkeypatch):
+    """Happy path: pin set via CSR upsert, then cleared, then unset."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-tofu")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.admin.users import upsert_from_csr
+            await upsert_from_csr(
+                principal_id="users-tofu.cullis.test/users-tofu/user/jane",
+                org_id="users-tofu",
+                cert_thumbprint="sha256:" + "0" * 16,
+                pubkey_thumbprint="a" * 64,
+            )
+            from mcp_proxy.db import get_user_principal_pubkey_thumbprint
+            exists, thumb = await get_user_principal_pubkey_thumbprint(
+                "users-tofu::user::jane",
+            )
+            assert (exists, thumb) == (True, "a" * 64)
+
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users/jane/reset-tofu-pin", headers=h,
+            )
+            assert r.status_code == 200, r.text
+            assert r.json() == {
+                "principal_id": "users-tofu::user::jane",
+                "cleared": True,
+            }
+
+            exists, thumb = await get_user_principal_pubkey_thumbprint(
+                "users-tofu::user::jane",
+            )
+            assert (exists, thumb) == (True, None)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reset_tofu_pin_missing_user_returns_404(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-tofu-404")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users/ghost/reset-tofu-pin", headers=h,
+            )
+            assert r.status_code == 404
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reset_tofu_pin_already_null_returns_404(tmp_path, monkeypatch):
+    """Row exists, pubkey already NULL → 404 so the caller can treat
+    'nothing to do' the same way as 'principal missing'. Idempotent
+    from the caller's point of view."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-tofu-null")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _headers()
+            await cli.post(
+                "/v1/admin/users", headers=h,
+                json={"user_name": "jane"},
+            )
+            r = await cli.post(
+                "/v1/admin/users/jane/reset-tofu-pin", headers=h,
+            )
+            assert r.status_code == 404
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reset_tofu_pin_requires_admin_secret(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-tofu-auth")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            r = await cli.post("/v1/admin/users/jane/reset-tofu-pin")
+            assert r.status_code == 422
+            r = await cli.post(
+                "/v1/admin/users/jane/reset-tofu-pin",
+                headers={"X-Admin-Secret": "wrong"},
+            )
+            assert r.status_code == 403
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_reset_tofu_pin_writes_audit_row(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch, "users-tofu-audit")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            from mcp_proxy.admin.users import upsert_from_csr
+            await upsert_from_csr(
+                principal_id=(
+                    "users-tofu-audit.cullis.test/"
+                    "users-tofu-audit/user/jane"
+                ),
+                org_id="users-tofu-audit",
+                cert_thumbprint="sha256:" + "0" * 16,
+                pubkey_thumbprint="b" * 64,
+            )
+            h = await _headers()
+            r = await cli.post(
+                "/v1/admin/users/jane/reset-tofu-pin", headers=h,
+            )
+            assert r.status_code == 200
+
+            from sqlalchemy import text
+            from mcp_proxy.db import get_db
+            async with get_db() as conn:
+                rows = (await conn.execute(text(
+                    "SELECT action, status, agent_id FROM audit_log "
+                    " WHERE action = 'reset_tofu_pin'"
+                ))).mappings().all()
+            assert len(rows) == 1
+            assert rows[0]["status"] == "success"
+            assert rows[0]["agent_id"] == "users-tofu-audit::user::jane"
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── upsert from CSR ────────────────────────────────────────────────────
+
+
 async def test_upsert_from_csr_creates_row(tmp_path, monkeypatch):
     """``upsert_from_csr`` is the runtime helper the CSR endpoint calls
     after a successful signature. Verifies the side-effect directly,

--- a/tests/test_dashboard_users_via_ambassador.py
+++ b/tests/test_dashboard_users_via_ambassador.py
@@ -414,6 +414,111 @@ async def test_users_delete_404_is_idempotent_and_still_scrubs(
     get_settings.cache_clear()
 
 
+# ── reset TOFU pin (Mastio-local, no Frontdesk bridge) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_reset_tofu_pin_clears_and_redirects(tmp_path, monkeypatch):
+    """Pubkey thumbprint set → POST clears it, dashboard redirects with
+    ?ok=TOFU+pin+cleared, no Frontdesk Ambassador call."""
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, display_name, reach, "
+                    " surface, pubkey_thumbprint, created_at) "
+                    "VALUES (:pid, :uname, '', 'intra', 'frontdesk', "
+                    "        :thumb, datetime('now'))"
+                ),
+                {
+                    "pid": "td-org::user::alice", "uname": "alice",
+                    "thumb": "a" * 64,
+                },
+            )
+        # No Ambassador call expected — script empty responses and we
+        # assert nothing was popped.
+        calls = _install_fake_frontdesk(monkeypatch, responses=[])
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/reset-tofu-pin",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303, r.text
+            assert "TOFU+pin+cleared" in r.headers["location"]
+        assert calls == [], "no Frontdesk bridge expected for TOFU reset"
+        async with get_db() as conn:
+            row = (await conn.execute(
+                text(
+                    "SELECT pubkey_thumbprint FROM local_user_principals "
+                    "WHERE principal_id = 'td-org::user::alice'"
+                )
+            )).mappings().first()
+            assert row["pubkey_thumbprint"] is None
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_reset_tofu_pin_no_pin_redirects_error(tmp_path, monkeypatch):
+    """Row exists, pubkey already NULL → redirect with ?error=No+pin+to+clear
+    so the operator sees the helper was a no-op."""
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, display_name, reach, "
+                    " surface, created_at) "
+                    "VALUES ('td-org::user::bob', 'bob', '', 'intra', "
+                    "        'frontdesk', datetime('now'))"
+                )
+            )
+        _install_fake_frontdesk(monkeypatch, responses=[])
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::bob/reset-tofu-pin",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "No+pin+to+clear" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_reset_tofu_pin_requires_csrf(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        _install_fake_frontdesk(monkeypatch, responses=[])
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/reset-tofu-pin",
+                data={"csrf_token": "wrong"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "error=csrf" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
 # ── security: plaintext password never logged ──────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Recovery path for the v0.1 user-keystore loss case (Connector wiped its keypair, customer rebuilt the laptop, pre-PR #656 Mastio kept user keys in-memory and lost the pin on restart). Without this, every cache miss left the user bounced on TOFU mismatch with no operator escape valve.
- Three coordinated surfaces: admin REST (`POST /v1/admin/users/{user_name}/reset-tofu-pin`, X-Admin-Secret), dashboard handler (`POST /proxy/users/{principal_id}/reset-tofu-pin`, require_login + CSRF), and a Danger Zone button in the user detail page (shows the current pubkey thumbprint, disabled when nothing is pinned).
- Mastio-local by design: the pin lives only in ``local_user_principals``, the Frontdesk doesn't carry it. ``cert_thumbprint`` is untouched (rotates every CSR refresh anyway), only the SPKI hash that is the load-bearing TOFU identifier. The next CSR is accepted regardless of pubkey and the fresh thumb gets re-pinned via the existing ``upsert_from_csr`` COALESCE.

## Security review

`/security-review` — no findings. SQL bound param, dashboard CSRF + login guarded, admin endpoint scoped to ``mgr.org_id`` (cross-org reset impossible via REST), redirect URLs URL-encoded by RedirectResponse, audit chain captures every reset with ``action=reset_tofu_pin`` and the operator id (``session.username`` or ``admin-secret``) so a malicious flip is forensically recoverable.

## Test plan

- [x] 11 unit tests on `tests/test_admin_users.py` (happy, 404 missing, 404 already-null, auth 422+403, audit row written)
- [x] 3 dashboard handler tests on `tests/test_dashboard_users_via_ambassador.py` (clear+redirect with no Frontdesk bridge call, no-pin error, CSRF guard)
- [x] Cross-suite: 68/68 green on test_admin_users + test_dashboard_users_via_ambassador + test_crit1_csr_pubkey_tofu + test_principals_csr + test_dashboard_principals + test_h_csr_pop
- [x] `./sandbox/smoke.sh full` — 25 pass / 0 fail / 1 skip (B4.9 SDK JWT short-circuit, pre-existing skip)
- [ ] Dashboard dogfood: bring up the bundle, hit Danger Zone → Reset TOFU Pin on a user with a pinned pubkey, verify the next CSR mints + re-pins