### PR TITLE
feat(mastio): interactive admin password setup at first boot

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -495,7 +495,11 @@ async def register_submit(request: Request):
         agent_id="admin",
         action="auth.register",
         status="success",
-        detail="admin password initialized",
+        details={
+            "event": "admin_password_registered",
+            "client_ip": _login_client_ip(request),
+            "user_agent": (request.headers.get("user-agent") or "")[:200],
+        },
     )
 
     # Force a clean sign-in for the very first session.
@@ -4185,7 +4189,9 @@ async def settings_page(request: Request):
     if isinstance(session, RedirectResponse):
         return session
 
-    from mcp_proxy.dashboard.oidc import load_oidc_config
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.dashboard.oidc import is_oidc_configured, load_oidc_config
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
 
     cfg = await load_oidc_config()
     return templates.TemplateResponse("settings.html", _ctx(
@@ -4194,8 +4200,11 @@ async def settings_page(request: Request):
         issuer_url=cfg["issuer_url"],
         client_id=cfg["client_id"],
         has_client_secret=bool(cfg["client_secret"]),
-        error=None,
-        success=None,
+        local_password_enabled=await is_local_password_login_enabled(),
+        oidc_configured=await is_oidc_configured(),
+        force_local_password_env=get_settings().force_local_password,
+        error=request.query_params.get("error"),
+        success=request.query_params.get("ok"),
     ))
 
 
@@ -4224,6 +4233,9 @@ async def settings_submit(request: Request):
         errors.append("Client ID is required when issuer URL is set.")
 
     if errors:
+        from mcp_proxy.config import get_settings
+        from mcp_proxy.dashboard.oidc import is_oidc_configured
+        from mcp_proxy.dashboard.session import is_local_password_login_enabled
         cfg = await load_oidc_config()
         return templates.TemplateResponse("settings.html", _ctx(
             request, session,
@@ -4231,6 +4243,9 @@ async def settings_submit(request: Request):
             issuer_url=issuer_url or cfg["issuer_url"],
             client_id=client_id or cfg["client_id"],
             has_client_secret=bool(cfg["client_secret"]),
+            local_password_enabled=await is_local_password_login_enabled(),
+            oidc_configured=await is_oidc_configured(),
+            force_local_password_env=get_settings().force_local_password,
             error="; ".join(errors),
             success=None,
         ), status_code=400)
@@ -4248,6 +4263,9 @@ async def settings_submit(request: Request):
         detail=f"issuer={issuer_url or '(cleared)'}, client_id={client_id or '(cleared)'}",
     )
 
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.dashboard.oidc import is_oidc_configured
+    from mcp_proxy.dashboard.session import is_local_password_login_enabled
     cfg = await load_oidc_config()
     return templates.TemplateResponse("settings.html", _ctx(
         request, session,
@@ -4255,6 +4273,9 @@ async def settings_submit(request: Request):
         issuer_url=cfg["issuer_url"],
         client_id=cfg["client_id"],
         has_client_secret=bool(cfg["client_secret"]),
+        local_password_enabled=await is_local_password_login_enabled(),
+        oidc_configured=await is_oidc_configured(),
+        force_local_password_env=get_settings().force_local_password,
         error=None,
         success="OIDC configuration saved.",
     ))

--- a/mcp_proxy/dashboard/templates/register.html
+++ b/mcp_proxy/dashboard/templates/register.html
@@ -49,6 +49,18 @@
     </div>
     {% endif %}
 
+    <!-- First-boot security banner -->
+    <div class="mb-4 p-3 bg-amber-900/10 border border-amber-700/30 rounded fade-up delay-100">
+        <p class="text-[11px] text-amber-400/90 font-semibold mb-1 uppercase tracking-[0.15em]"
+           style="font-family: 'Chakra Petch', sans-serif;">
+            First-boot setup — single use
+        </p>
+        <p class="text-[10px] text-amber-500/70 leading-relaxed">
+            This form is the one-shot admin bootstrap for this Mastio. The first POST to register wins permanently.
+            Verify you are on the correct host (URL bar) and that no one else has access to this segment before submitting.
+        </p>
+    </div>
+
     <!-- Register card -->
     <div class="bg-surface-900/60 border border-gray-800/50 rounded-lg p-7 backdrop-blur-sm fade-up delay-100"
          style="box-shadow: 0 0 60px rgba(0,229,199,0.04), 0 8px 32px rgba(0,0,0,0.4);">

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -403,7 +403,10 @@ if [[ "$MODE" == "development" ]]; then
         echo "        env is ignored on subsequent boots; the persisted hash wins.)"
         echo "    3. Enroll agents via the Connector or paste an invite token"
     else
-        echo "    2. Complete the first-boot setup wizard"
+        echo "    2. First-boot setup: the dashboard will redirect to"
+        echo "         ${PUBLIC_URL}/proxy/register"
+        echo "       Pick the admin password there (typed once, never stored"
+        echo "        on disk in plaintext or surfaced on stdout)."
         echo "    3. Enroll agents via the Connector or paste an invite token"
     fi
 else

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -32,13 +32,36 @@ die()  { err "$1"; exit 1; }
 
 MODE="interactive"
 FORCE=0
+# Opt-in to auto-seed the first-boot admin password. Default behavior
+# (off) leaves ``admin_password_hash`` NULL on first boot so the
+# operator picks the password interactively at ``/proxy/register``.
+# Power users who script the install (Ansible / Terraform / CI smoke)
+# pass ``--auto-admin-pwd`` to retain the legacy seed-in-env flow.
+# Memory-wise: the dashboard is never publicly exposed on Cullis's
+# threat model (operator behind VPN / internal segment), so the
+# /register race-window is not a concern; the gain is one fewer
+# random-string-on-stdout to handle.
+AUTO_ADMIN_PWD="${MASTIO_AUTO_ADMIN_PWD:-0}"
 for arg in "$@"; do
     case "$arg" in
-        --defaults) MODE="defaults" ;;
-        --prod)     MODE="prod" ;;
-        --force)    FORCE=1 ;;
+        --defaults)        MODE="defaults" ;;
+        --prod)            MODE="prod" ;;
+        --force)           FORCE=1 ;;
+        --auto-admin-pwd)  AUTO_ADMIN_PWD=1 ;;
         --help|-h)
-            echo "Usage: $0 [--defaults|--prod] [--force]"
+            cat <<'USAGE'
+Usage: ./generate-proxy-env.sh [--defaults|--prod] [--force] [--auto-admin-pwd]
+
+  --defaults         Same-host localhost defaults (no prompts).
+  --prod             Needs BROKER_URL + PROXY_PUBLIC_URL env vars.
+  --force            Overwrite existing proxy.env.
+  --auto-admin-pwd   Auto-generate the first-boot admin password and
+                     write it to MCP_PROXY_INITIAL_ADMIN_PASSWORD.
+                     Default (without this flag) leaves the hash NULL
+                     so the operator chooses the password at
+                     /proxy/register on first sign-in.
+                     Equivalent env: MASTIO_AUTO_ADMIN_PWD=1
+USAGE
             exit 0
             ;;
         *) die "Unknown argument: $arg (use --help)" ;;
@@ -81,15 +104,29 @@ gen_secret() {
 
 ADMIN_SECRET="$(gen_secret)"
 SIGNING_KEY="$(gen_secret)"
-# Bcrypt seed for the very first lifespan: paired with the
-# MCP_PROXY_INITIAL_ADMIN_PASSWORD env that ``mcp_proxy/main.py`` reads
-# right after init_db. No-op on subsequent boots (the persisted hash
-# wins). Without this, a fresh tarball cannot come up self-serve;
-# Frontdesk + CI + customer quickstart all block on a /proxy/register
-# browser hop.
-INITIAL_ADMIN_PASSWORD="$(gen_secret)"
-
-ok "Generated random admin secret + signing key + first-boot password"
+# First-boot admin password.
+#
+# Default (AUTO_ADMIN_PWD=0): leave INITIAL_ADMIN_PASSWORD empty so
+# ``proxy.env`` does not seed the bcrypt hash at boot. The operator
+# hits ``/proxy/login`` on first sign-in, the dashboard redirects to
+# ``/proxy/register``, and the operator picks the password interactively
+# (typed once, never on stdout). Threat model: dashboard is never
+# publicly exposed (operator behind VPN / internal segment), so the
+# first-POST-wins race on /register is bounded by network access
+# control rather than internet exposure.
+#
+# Opt-in (--auto-admin-pwd | MASTIO_AUTO_ADMIN_PWD=1): keep the legacy
+# behavior — generate a random secret, write it into proxy.env, the
+# Mastio lifespan reads + hashes it on first boot. Use this for
+# scripted provisioning (Ansible / Terraform / CI smoke) where a
+# /register browser hop is not feasible.
+if [[ "$AUTO_ADMIN_PWD" -eq 1 ]]; then
+    INITIAL_ADMIN_PASSWORD="$(gen_secret)"
+    ok "Generated random admin secret + signing key + first-boot password (--auto-admin-pwd)"
+else
+    INITIAL_ADMIN_PASSWORD=""
+    ok "Generated random admin secret + signing key (admin password chosen interactively at /proxy/register on first sign-in)"
+fi
 
 case "$MODE" in
     prod)
@@ -128,16 +165,23 @@ sed -i "s|^MCP_PROXY_DASHBOARD_SIGNING_KEY=.*|MCP_PROXY_DASHBOARD_SIGNING_KEY=${
 sed -i "s|^MCP_PROXY_BROKER_URL=.*|MCP_PROXY_BROKER_URL=${BROKER}|"                  "$OUT"
 sed -i "s|^MCP_PROXY_BROKER_JWKS_URL=.*|MCP_PROXY_BROKER_JWKS_URL=${JWKS}|"          "$OUT"
 sed -i "s|^MCP_PROXY_PROXY_PUBLIC_URL=.*|MCP_PROXY_PROXY_PUBLIC_URL=${PUBLIC}|"      "$OUT"
-# proxy.env.example does not ship the seed line (we mint per-deploy);
-# append unconditionally. The Mastio lifespan ignores it once a hash
-# exists, so re-running --force does not surprise-reset the password.
-echo "MCP_PROXY_INITIAL_ADMIN_PASSWORD=${INITIAL_ADMIN_PASSWORD}" >> "$OUT"
+# proxy.env.example does not ship the seed line. Append only when the
+# operator asked for the auto-seed path; otherwise omit so the Mastio
+# main.py boot path correctly leaves the hash NULL and routes
+# /proxy/login → /proxy/register for interactive setup.
+if [[ -n "$INITIAL_ADMIN_PASSWORD" ]]; then
+    echo "MCP_PROXY_INITIAL_ADMIN_PASSWORD=${INITIAL_ADMIN_PASSWORD}" >> "$OUT"
+fi
 
 ok "Wrote ${OUT}"
 echo ""
 echo -e "  ${BOLD}MCP_PROXY_ADMIN_SECRET${RESET}            ${GRAY}${ADMIN_SECRET:0:8}…${RESET}"
-echo -e "  ${BOLD}MCP_PROXY_INITIAL_ADMIN_PASSWORD${RESET}  ${GRAY}${INITIAL_ADMIN_PASSWORD}${RESET}"
-echo -e "                                  ${GRAY}(login at /proxy/login as ``admin`` with this password, then rotate)${RESET}"
+if [[ -n "$INITIAL_ADMIN_PASSWORD" ]]; then
+    echo -e "  ${BOLD}MCP_PROXY_INITIAL_ADMIN_PASSWORD${RESET}  ${GRAY}${INITIAL_ADMIN_PASSWORD}${RESET}"
+    echo -e "                                  ${GRAY}(login at /proxy/login as ``admin`` with this password, then rotate)${RESET}"
+else
+    echo -e "  ${BOLD}MCP_PROXY_INITIAL_ADMIN_PASSWORD${RESET}  ${GRAY}(unset — pick interactively at /proxy/register on first sign-in)${RESET}"
+fi
 echo -e "  ${BOLD}MCP_PROXY_BROKER_URL${RESET}              ${GRAY}${BROKER}${RESET}"
 echo -e "  ${BOLD}MCP_PROXY_PROXY_PUBLIC_URL${RESET}        ${GRAY}${PUBLIC}${RESET}"
 echo -e "  ${BOLD}MCP_PROXY_ENVIRONMENT${RESET}             ${GRAY}${ENVIRONMENT}${RESET}"

--- a/tests/test_proxy_dashboard_oidc.py
+++ b/tests/test_proxy_dashboard_oidc.py
@@ -352,6 +352,37 @@ def _fake_request(base_url: str = "http://localhost:9100/"):
     return r
 
 
+@pytest.mark.asyncio
+async def test_settings_renders_change_admin_password_section(proxy_app):
+    """Regression test for the PR #654 follow-up: the ``Change admin
+    password`` section in settings.html is gated by
+    ``{% if local_password_enabled %}``. Pre-fix the GET handler at
+    ``/proxy/settings`` never passed that variable into the template
+    context, so Jinja treated it as undefined → falsy → the entire
+    section was hidden. Customer dogfood (2026-05-13) hit this when
+    looking for the rotation form. Fix: pass
+    ``local_password_enabled``, ``oidc_configured`` and
+    ``force_local_password_env`` to ``_ctx(...)`` so the conditional
+    branches in the template can render."""
+    _, client = proxy_app
+    # Default state: local password is enabled (no OIDC configured, no
+    # operator-driven disable). The dashboard.session helper returns
+    # True for this case so the section should render.
+    name, value = _admin_cookie()
+    client.cookies.set(name, value)
+    resp = await client.get("/proxy/settings")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "Change admin password" in body, (
+        "expected the Change admin password rotation form to render — "
+        "regression of the template-context bug surfaced 2026-05-13"
+    )
+    # The toggle copy from the sibling block (same gate) must also be
+    # present so we catch the case where someone passes the variable
+    # only at the inner block and forgets the outer.
+    assert "Local admin password" in body
+
+
 def test_oidc_redirect_uri_prefers_dedicated_setting(monkeypatch):
     from mcp_proxy import config as _config
     from mcp_proxy.dashboard.router import _oidc_redirect_uri


### PR DESCRIPTION
## Summary

Three coordinated fixes around first-boot admin password UX, surfaced by 2026-05-13 dogfood when the admin lost the password on the VM and had no recovery path short of `docker exec + bcrypt UPDATE`.

- **Fix 1 (regression)**: GET `/proxy/settings` now passes `local_password_enabled`, `oidc_configured`, `force_local_password_env` to the template. PR #654 added the rotation form but the GET handler never passed the gating flag, so the form was permanently invisible.
- **Fix 2 (UX)**: `generate-proxy-env.sh` no longer auto-seeds `MCP_PROXY_INITIAL_ADMIN_PASSWORD` by default. Operator picks the password interactively at `/proxy/register` on first sign-in (typed once, never on stdout, never in scrollback). New `--auto-admin-pwd` / `MASTIO_AUTO_ADMIN_PWD=1` opt-in retains the legacy seed for scripted provisioning.
- **Fix 3 (hardening)**: amber security banner on `/proxy/register` clarifies the one-shot bootstrap. Audit row carries `client_ip + user_agent` so a forensic investigator can answer "who claimed admin" without grepping nginx logs.

## Threat model rationale

The Mastio dashboard is never publicly exposed on the Cullis topology (operator behind VPN / internal corporate segment; the only public surface is the Frontdesk when the operator chooses to expose it). The `/register` first-POST-wins race is bounded by network access control rather than internet exposure, so the gain (no plaintext password on terminals / scrollback / screencaps) is the better tradeoff. The Court already uses a bootstrap-token pattern; aligning the Mastio toward operator-chosen credentials is a step in that direction without breaking the existing seed-via-env automation path.

## Security review

`/security-review` — no findings. Settings query params (`error`, `success`) flow through Jinja autoescape; banner on register.html is static HTML with no interpolation; `_login_client_ip` rejects untrusted XFF; audit details rendered escaped under `<pre>`; the `is_admin_password_set()` guard short-circuits before the bcrypt write; no shell-injection vector in the new `--auto-admin-pwd` flag.

## Test plan

- [x] `tests/test_proxy_dashboard_oidc.py::test_settings_renders_change_admin_password_section` regression-locks the gated-section render
- [x] 101/101 green on test_proxy_dashboard_oidc + test_proxy_local_password_toggle + test_proxy_initial_admin_password_seed + test_dashboard + test_dashboard_users_via_ambassador + test_admin_users + test_m_dash_break_glass_and_cookie
- [x] `./sandbox/smoke.sh full` — 25 pass / 0 fail / 1 skip (B4.9 pre-existing)
- [ ] Dogfood: fresh install of mastio bundle without `--auto-admin-pwd`, verify `/proxy/login` redirects to `/proxy/register`, complete the form, verify dashboard accessible and `Change admin password` section visible in Settings.
- [ ] Dogfood: fresh install with `--auto-admin-pwd`, verify legacy seed-from-env still works end-to-end.