### PR TITLE
feat(mastio): promote registry-only user to Frontdesk-backed

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3741,6 +3741,114 @@ async def users_reset_password(principal_id: str, request: Request):
     )
 
 
+@router.post("/users/{principal_id:path}/provision-to-frontdesk")
+async def users_provision_to_frontdesk(principal_id: str, request: Request):
+    """Promote a registry-only user to a Frontdesk-backed credential.
+
+    Closes the gap surfaced 2026-05-13: customer installs Mastio
+    standalone (no Frontdesk), creates users via the registry-only
+    fallback path (PR #596), then later attaches a Frontdesk bundle.
+    Pre-fix the operator had no way to mint a Frontdesk credential
+    for those existing users without ``delete + recreate`` or curling
+    the Frontdesk Ambassador admin API by hand.
+
+    Mints a 16-char temp password, forwards it to the Frontdesk via
+    POST ``/admin/users`` (same call path users_create uses on the
+    happy create-with-Frontdesk path), surfaces the password back to
+    the operator via a single-consume ticket so the cleartext never
+    rides in URL / nginx logs / browser history.
+
+    Refused when:
+      - Frontdesk Ambassador not configured (no target to call)
+      - User is already present in the Frontdesk (avoid silent rotate)
+      - principal_id cannot be parsed
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=csrf",
+            status_code=303,
+        )
+    if _frontdesk_admin_target() is None:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Frontdesk+not+configured",
+            status_code=303,
+        )
+
+    _, user_name = _split_principal_id(principal_id)
+    if not user_name:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=invalid+principal+id",
+            status_code=303,
+        )
+
+    new_pw = _generate_temp_password()
+    status_code, body, transport_err = await _frontdesk_admin_call(
+        "POST",
+        "/admin/users",
+        json_body={
+            "user_name": user_name,
+            "password": new_pw,
+            "must_change_password": True,
+        },
+    )
+    if transport_err:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Frontdesk+unreachable",
+            status_code=303,
+        )
+    if status_code == 409:
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=User+already+in+Frontdesk",
+            status_code=303,
+        )
+    if status_code >= 400:
+        _log.warning(
+            "users_provision_to_frontdesk: frontdesk rejected status=%s",
+            status_code,
+        )
+        return RedirectResponse(
+            f"/proxy/users/{principal_id}?error=Provision+failed",
+            status_code=303,
+        )
+
+    operator = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+    try:
+        from mcp_proxy.db import log_audit
+        await log_audit(
+            agent_id=principal_id,
+            action="user.provision_to_frontdesk",
+            status="success",
+            details={
+                "operator": operator,
+                "user_name": user_name,
+            },
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log.warning(
+            "users_provision_to_frontdesk: audit append failed for %s: %s",
+            principal_id, exc,
+        )
+
+    from urllib.parse import quote
+    from mcp_proxy.dashboard._pwd_tickets import mint_password_ticket
+    ticket = mint_password_ticket(new_pw)
+    # Reuse the new_pw_ticket query the create-user happy path already
+    # surfaces — the user_detail page renders the cleartext + copy
+    # button when it sees this ticket on GET, then burns the ticket so
+    # a refresh does not re-render.
+    return RedirectResponse(
+        f"/proxy/users/{quote(principal_id)}?new_pw_ticket={quote(ticket)}",
+        status_code=303,
+    )
+
+
 @router.post("/users/{principal_id:path}/delete")
 async def users_delete(principal_id: str, request: Request):
     session = require_login(request)

--- a/mcp_proxy/dashboard/templates/user_detail.html
+++ b/mcp_proxy/dashboard/templates/user_detail.html
@@ -368,7 +368,24 @@
                 <p class="text-[11px] text-gray-600">Operations on this principal are mostly irreversible. The audit chain keeps the history regardless. The Mastio forwards each action to the Frontdesk Ambassador (the canale that holds the credential).</p>
             </div>
 
-            <!-- Reset password -->
+            {% if not user.in_frontdesk %}
+            <!-- Provision to Frontdesk (registry-only → Frontdesk-backed) -->
+            <div class="border-t border-red-900/20 pt-5">
+                <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Provision to Frontdesk</p>
+                <p class="text-xs text-gray-500 mb-3">
+                    This user is registry-only (created while Frontdesk was offline, or never went through SSO). The Mastio knows the principal_id and can mint API tokens, but the user has no password to sign in via the Frontdesk SPA. Click to mint a 16-char temp credential, push it to the Frontdesk, and surface it here once.
+                </p>
+                <form method="post" action="/proxy/users/{{ user.principal_id|urlencode }}/provision-to-frontdesk"
+                      onsubmit="return confirm('Provision this user to the Frontdesk? A temp password will be minted, pushed to the Frontdesk, and shown to you once. Hand it over out-of-band and the user is forced to rotate at next sign-in.')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+                    <button type="submit"
+                            class="px-4 py-2 text-xs font-medium uppercase tracking-wider bg-emerald-600/20 border border-emerald-600/30 text-emerald-400 rounded hover:bg-emerald-600/30 transition-colors">
+                        Provision to Frontdesk
+                    </button>
+                </form>
+            </div>
+            {% else %}
+            <!-- Reset password (Frontdesk-backed user only) -->
             <div class="border-t border-red-900/20 pt-5">
                 <p class="text-xs font-medium text-gray-300 uppercase tracking-wider mb-1">Reset Password</p>
                 <p class="text-xs text-gray-500 mb-3">
@@ -383,6 +400,7 @@
                     </button>
                 </form>
             </div>
+            {% endif %}
 
             <!-- Reset TOFU pin -->
             <div class="border-t border-red-900/20 pt-5">

--- a/tests/test_dashboard_users_via_ambassador.py
+++ b/tests/test_dashboard_users_via_ambassador.py
@@ -414,6 +414,153 @@ async def test_users_delete_404_is_idempotent_and_still_scrubs(
     get_settings.cache_clear()
 
 
+# ── provision registry-only → Frontdesk ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_users_provision_to_frontdesk_happy_path(tmp_path, monkeypatch):
+    """Registry-only Mastio user + Frontdesk now wired → POST mints
+    temp pw, pushes to Frontdesk /admin/users, redirects with the
+    single-consume ticket so the cleartext shows up on the detail
+    page once."""
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        from mcp_proxy.db import get_db
+        from sqlalchemy import text
+        async with get_db() as conn:
+            await conn.execute(
+                text(
+                    "INSERT INTO local_user_principals "
+                    "(principal_id, user_name, display_name, reach, "
+                    " surface, created_at) "
+                    "VALUES (:pid, :uname, '', 'intra', 'registry', "
+                    "        datetime('now'))"
+                ),
+                {"pid": "td-org::user::alice", "uname": "alice"},
+            )
+        calls = _install_fake_frontdesk(
+            monkeypatch, responses=[(201, {"user_name": "alice"}, None)],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/provision-to-frontdesk",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303, r.text
+            loc = r.headers["location"]
+            assert "/proxy/users/" in loc
+            assert "new_pw_ticket=" in loc, (
+                "ticket must be in redirect so the detail page surfaces "
+                "the cleartext exactly once"
+            )
+    # Forwarded call shape
+    assert len(calls) == 1
+    c = calls[0]
+    assert c["method"] == "POST"
+    assert c["path"] == "/admin/users"
+    body = c["json_body"]
+    assert body["user_name"] == "alice"
+    assert body["must_change_password"] is True
+    assert isinstance(body["password"], str) and len(body["password"]) == 16
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_provision_to_frontdesk_409_already_in_frontdesk(
+    tmp_path, monkeypatch,
+):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        _install_fake_frontdesk(
+            monkeypatch, responses=[(409, {"detail": "exists"}, None)],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/provision-to-frontdesk",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "User+already+in+Frontdesk" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_provision_to_frontdesk_refuses_when_frontdesk_offline(
+    tmp_path, monkeypatch,
+):
+    """Without ``CULLIS_MASTIO_FRONTDESK_AMBASSADOR_URL`` there is
+    nothing to delegate to. Operator gets a clear error instead of a
+    transport timeout."""
+    app = await _spin(tmp_path, monkeypatch, frontdesk=False)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/provision-to-frontdesk",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "Frontdesk+not+configured" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_provision_to_frontdesk_transport_error(
+    tmp_path, monkeypatch,
+):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        _install_fake_frontdesk(
+            monkeypatch, responses=[(0, None, "transport_error")],
+        )
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            csrf = await _csrf(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/provision-to-frontdesk",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "Frontdesk+unreachable" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_users_provision_to_frontdesk_requires_csrf(tmp_path, monkeypatch):
+    app = await _spin(tmp_path, monkeypatch, frontdesk=True)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        _install_fake_frontdesk(monkeypatch, responses=[])
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _login(cli)
+            r = await cli.post(
+                "/proxy/users/td-org::user::alice/provision-to-frontdesk",
+                data={"csrf_token": "wrong"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "error=csrf" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
 # ── reset TOFU pin (Mastio-local, no Frontdesk bridge) ─────────────────
 
 


### PR DESCRIPTION
## Summary

Closes the gap surfaced by 2026-05-13 dogfood: a customer installs Mastio standalone (no Frontdesk), creates users via the registry-only fallback path (PR #596), then later attaches a Frontdesk bundle. Pre-fix the operator had no path to mint a Frontdesk credential for those existing users — only `delete + recreate` or `curl` to the Frontdesk Ambassador admin API.

- **Handler**: `POST /proxy/users/{principal_id}/provision-to-frontdesk` mirroring the `reset-password` pattern (require_login + CSRF, refuse when Frontdesk Ambassador not configured, mint 16-char temp pw, POST `/admin/users` on Frontdesk, ticket-driven cleartext surface, audit row `action=user.provision_to_frontdesk`).
- **UI**: Danger Zone swap. When `not user.in_frontdesk` and Frontdesk is wired, show emerald "Provision to Frontdesk" button. Frontdesk-backed users keep seeing the standard "Reset Password" button. Mutually exclusive — operators never see a button that would error out.

## Security review

`/security-review` — no findings. Same gating as `reset-password` (CSRF + require_login + Frontdesk-target check + `_split_principal_id` parse + `mint_password_ticket` for cleartext containment). httpx serializes the JSON body so any malicious chars in `user_name` are safely escaped. No new SQL, no new filesystem access, no new auth path.

## Test plan

- [x] `test_users_provision_to_frontdesk_happy_path` — registry-only user + Frontdesk wired → 303 + `new_pw_ticket=` in redirect, POST shape verified (16-char pw, `must_change_password=True`)
- [x] `test_users_provision_to_frontdesk_409_already_in_frontdesk` — Frontdesk 409 → `error=User+already+in+Frontdesk` (avoid silent rotate)
- [x] `test_users_provision_to_frontdesk_refuses_when_frontdesk_offline` — `error=Frontdesk+not+configured` instead of transport timeout
- [x] `test_users_provision_to_frontdesk_transport_error` — `error=Frontdesk+unreachable`
- [x] `test_users_provision_to_frontdesk_requires_csrf` — wrong CSRF → `error=csrf`
- [x] 101/101 green across test_dashboard_users_via_ambassador + test_admin_users + test_proxy_dashboard_oidc + test_proxy_local_password_toggle + test_proxy_initial_admin_password_seed + test_dashboard
- [x] `./sandbox/smoke.sh full` — 25 pass / 0 fail / 1 skip (B4.9 pre-existing)
- [ ] Live dogfood on VM: create registry-only user with Frontdesk offline, attach Frontdesk bundle, click "Provision to Frontdesk" on the user detail page, verify temp pw banner + Frontdesk users.db row created + user can sign in