### PR TITLE
feat(mastio): --upgrade-bundle + bind-mount data layout (ADR-030)

### DIFF
--- a/.github/workflows/release-mastio.yml
+++ b/.github/workflows/release-mastio.yml
@@ -204,8 +204,52 @@ jobs:
           set -euo pipefail
           STAGING="dist/cullis-mastio-bundle-${VERSION}"
           mkdir -p "${STAGING}"
-          cp -r packaging/mastio-bundle/. "${STAGING}/"
-          ls -lah "${STAGING}/"
+
+          # ADR-030 — explicit allowlist mirrored from release-frontdesk-
+          # bundle.yml (which the v0.2.7 broken-tarball incident proved
+          # the value of). ``cp -r .`` was sweeping in any operator
+          # artefact that happened to appear during a dogfood run
+          # (proxy.env with real secrets, ./data, ./nginx-certs, backups/)
+          # — and the customer-facing tarball is the wrong place for any
+          # of those. Every file the operator needs at runtime is named
+          # below; everything else stays in the source tree.
+          cp packaging/mastio-bundle/docker-compose.yml               "${STAGING}/"
+          cp packaging/mastio-bundle/docker-compose.prod.yml          "${STAGING}/"
+          cp packaging/mastio-bundle/docker-compose.shared-broker.yml "${STAGING}/"
+          cp packaging/mastio-bundle/deploy.sh                        "${STAGING}/"
+          cp packaging/mastio-bundle/generate-proxy-env.sh            "${STAGING}/"
+          cp packaging/mastio-bundle/proxy.env.example                "${STAGING}/"
+          cp packaging/mastio-bundle/README.md                        "${STAGING}/"
+          cp -r packaging/mastio-bundle/nginx                         "${STAGING}/"
+
+          chmod +x "${STAGING}/deploy.sh" \
+                   "${STAGING}/generate-proxy-env.sh"
+
+          # Post-stage sanity check: every file the bundle's
+          # docker-compose.yml or deploy.sh references at runtime must
+          # exist in the staged tarball. Same defensive pattern as the
+          # Frontdesk bundle (PR #662) — catches "I forgot to add new
+          # file X to the cp list" regressions HERE at release time
+          # rather than on the customer's host post-download.
+          MISSING=0
+          for f in \
+              "docker-compose.yml" \
+              "docker-compose.prod.yml" \
+              "docker-compose.shared-broker.yml" \
+              "deploy.sh" \
+              "generate-proxy-env.sh" \
+              "proxy.env.example" \
+              "README.md" \
+              "nginx/mastio/00-maps.conf" \
+              "nginx/mastio/mastio.conf"; do
+              if [ ! -f "${STAGING}/${f}" ]; then
+                  echo "::error::staged bundle missing required file: ${f}"
+                  MISSING=1
+              fi
+          done
+          if [ "$MISSING" = "1" ]; then exit 1; fi
+
+          ls -lahR "${STAGING}/"
           # Stable-name top-level dir inside the archive: `cullis-mastio-bundle/`
           # (no version suffix) so the README quickstart `cd cullis-mastio-bundle/`
           # works against any release. The archive filename carries the version.

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ proxy-*.env
 .keys/
 postgresql+asyncpg:/
 
+# ADR-030 — Mastio bundle bind-mount targets (operator state, not source)
+packaging/mastio-bundle/data/
+packaging/mastio-bundle/nginx-certs/
+packaging/mastio-bundle/backups/
+
 # Nginx proxy (TLS private keys, per-VM configs)
 nginx-proxy/
 

--- a/mcp_proxy/Dockerfile
+++ b/mcp_proxy/Dockerfile
@@ -56,9 +56,14 @@ COPY --from=tailwind-build /out/tailwind.css /app/mcp_proxy/dashboard/static/css
 
 # Data directory for SQLite + ADR-014 nginx-cert directory shared with
 # the mastio-nginx sidecar (Mastio writes Org CA + server cert here at
-# first-boot; sidecar mounts read-only).
+# first-boot; sidecar mounts read-only). UID/GID pinned to 10001:10001
+# (ADR-030, aligned with Frontdesk bundle) so bind-mount host
+# directories can be chown'd to a fixed numeric pair at every
+# ``compose up`` via the init-permissions service, without having to
+# resolve the system-allocated UID of an opaque ``useradd --system``.
 RUN mkdir -p /data /var/lib/mastio/nginx-certs && \
-    useradd --no-create-home --system proxyuser && \
+    groupadd --system --gid 10001 proxyuser && \
+    useradd --no-create-home --system --uid 10001 --gid 10001 proxyuser && \
     chown proxyuser:proxyuser /data /var/lib/mastio/nginx-certs
 
 ENV PYTHONPATH=/app

--- a/mcp_proxy/dashboard/templates/update_banner.html
+++ b/mcp_proxy/dashboard/templates/update_banner.html
@@ -15,14 +15,26 @@
     </summary>
     <div class="px-6 py-4 bg-amber-950/30 text-amber-200/80 text-xs space-y-3 border-t border-amber-700/20">
         <p class="text-amber-300/90">
-            On the host where this Mastio runs, execute the four commands below.
-            Volumes (DB, Org CA, certs) are preserved.
-            The Mastio container restarts with the new image; the dashboard URL stays the same.
+            On the host where this Mastio runs, execute the one-liner below.
+            ``--upgrade-bundle`` downloads the new tarball, backs up your state,
+            updates the bundle scripts + image, and restarts the stack. Data
+            (DB, Org CA, certs) is preserved. Dashboard URL stays the same.
         </p>
-        <pre class="bg-surface-950 border border-gray-800 p-3 rounded overflow-x-auto"><code style="font-family: 'JetBrains Mono', monospace;">cd ~/cullis-mastio-bundle
+        <pre class="bg-surface-950 border border-gray-800 p-3 rounded overflow-x-auto"><code style="font-family: 'JetBrains Mono', monospace;">cd ~/cullis-mastio-bundle &amp;&amp; ./deploy.sh --upgrade-bundle {{ latest_stripped }} --from-banner</code></pre>
+        <details class="text-[10px] text-amber-400/60">
+            <summary class="cursor-pointer hover:text-amber-300/80">Advanced — step-by-step instead of the one-liner</summary>
+            <div class="mt-2 space-y-2">
+                <p>
+                    The four commands the one-liner above runs for you. Use this
+                    if you want to inspect each step or if your bundle's
+                    ``deploy.sh`` predates ADR-030 (Mastio &lt; v0.4.0):
+                </p>
+                <pre class="bg-surface-950 border border-gray-800 p-3 rounded overflow-x-auto"><code style="font-family: 'JetBrains Mono', monospace;">cd ~/cullis-mastio-bundle
 wget https://github.com/cullis-security/cullis/releases/download/{{ latest }}/cullis-mastio-bundle-{{ latest_stripped }}.tar.gz
 tar xzf cullis-mastio-bundle-{{ latest_stripped }}.tar.gz --strip-components=1 --overwrite
 ./deploy.sh --pull</code></pre>
+            </div>
+        </details>
         {% if latest_url %}
         <p class="text-[10px] text-amber-400/70">
             Release notes: <a href="{{ latest_url }}" target="_blank" rel="noopener noreferrer" class="underline hover:text-amber-200">{{ latest_url }}</a>

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -103,10 +103,17 @@ generate-proxy-env.sh               # config generator
 deploy.sh                           # entrypoint
 ```
 
-The Mastio writes its Org CA + nginx server cert into a docker volume
-on first boot; the `mastio-nginx` sidecar mounts the same volume
-read-only and serves TLS on host port 9443. No manual cert
-provisioning.
+The Mastio writes its Org CA + nginx server cert into `./nginx-certs/`
+(host bind mount, ADR-030) on first boot; the `mastio-nginx` sidecar
+mounts the same path read-only and serves TLS on host port 9443. The
+SQLite DB lives at `./data/mcp_proxy.db`. No manual cert provisioning,
+no `docker volume rm` indirection for backups — host filesystem is the
+source of truth.
+
+Customers upgrading from v0.3.x with legacy named volumes
+(`mcp_proxy_data`, `mastio_nginx_certs`) are auto-migrated to the bind
+layout the first time they run `./deploy.sh --upgrade-bundle <version>`;
+see the **Updating** section below.
 
 ## Kubernetes
 
@@ -131,7 +138,7 @@ full values reference.
 | `permission denied` on `./deploy.sh` | `chmod +x deploy.sh generate-proxy-env.sh` |
 | `docker compose is not installed` | Install Docker Engine 20.10+ with Compose v2 |
 | `network cullis-broker_default not found` (with `--shared-broker`) | Bring the Court compose project up first, or drop `--shared-broker` |
-| Browser warns "self-signed certificate" | Expected. The Org CA is local; accept once or extract `org-ca.crt` from the `mcp_proxy_data` volume and import it. |
+| Browser warns "self-signed certificate" | Expected. The Org CA is local; accept once or import `./nginx-certs/org-ca.crt` (also exported to `./certs/org-ca.pem` by `./deploy.sh` post-up). |
 | Agent gets `401 Invalid DPoP proof: htu mismatch` | The Mastio validates DPoP proofs against `MCP_PROXY_PROXY_PUBLIC_URL` (default `https://localhost:9443` for quickstart). Production deploys MUST override this in `proxy.env` to match the public hostname agents reach the Mastio at — e.g. `MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.myorg.example.com`. |
 | Agent fails with `SSL: CERTIFICATE_VERIFY_FAILED` or `hostname doesn't match` | The nginx sidecar's TLS cert is signed by the auto-generated Org CA and includes only the SAN entries listed in `MCP_PROXY_NGINX_SAN` (default `mastio.local,localhost`). `./deploy.sh` auto-extracts the hostname from your prompt answer and adds it to the SAN; if you set `MCP_PROXY_PROXY_PUBLIC_URL` manually after-the-fact, also append the hostname to `MCP_PROXY_NGINX_SAN` (e.g. `MCP_PROXY_NGINX_SAN=mastio.acme.local,mastio.local,localhost`) and `./deploy.sh --pull` to re-mint the cert. |
 | Agent fails with `getaddrinfo failed` / `Name or service not known` | The hostname you set as the public URL must resolve to the Mastio host's IP from the agent's machine. Three paths: (1) corporate DNS (e.g. Active Directory) — recommended; (2) public DNS A record if the Mastio is internet-reachable; (3) `/etc/hosts` line on each agent machine (`192.168.10.42  mastio.acme.local`) — okay for 2-3 employees, brittle past that. |
@@ -139,11 +146,45 @@ full values reference.
 
 ## Updating
 
+**Recommended — full bundle refresh (ADR-030):**
+
 ```bash
-./deploy.sh --pull           # pull latest, restart
-# or pin:
-CULLIS_MASTIO_VERSION=0.3.1 ./deploy.sh --pull
+./deploy.sh --upgrade-bundle 0.4.0
 ```
 
-Volumes (`mcp_proxy_data`, `mastio_nginx_certs`) survive restarts; Org
-CA and DB persist across image upgrades.
+Downloads the released tarball from GitHub, backs up `proxy.env` + `./data/` + `./nginx-certs/` to `./backups/pre-upgrade-<ts>/`, extracts the new bundle scripts in place (without touching your state), bumps `CULLIS_MASTIO_VERSION`, pulls the matching image, and restarts the stack with `compose up -d --wait`. The dashboard's "update available" banner shows the same command as a one-liner you can paste into the host shell.
+
+**Image-only bump (scripts stay at the bundle's original version):**
+
+```bash
+./deploy.sh --upgrade 0.4.0
+# or:
+./deploy.sh --pull
+```
+
+Use this if you trust the new image but want to keep your current `deploy.sh` / compose / scripts. Note: future env vars introduced by a release will NOT reach `proxy.env` until you do a full bundle refresh.
+
+**Migrate from legacy named volumes (one-shot, v0.3.x → v0.4.x):**
+
+```bash
+./deploy.sh --migrate-volumes
+```
+
+Stops the stack, copies `mcp_proxy_data` → `./data/` and `mastio_nginx_certs` → `./nginx-certs/` via a transient busybox container (so file ownership stays correct), and leaves the named volumes in place so you can confirm the new layout boots cleanly before deleting them with `docker volume rm`. Idempotent: safe to re-run.
+
+`--upgrade-bundle` triggers this automatically when it detects legacy volumes, prompting interactively unless you pass `--from-banner` (the banner one-liner does this for you).
+
+**Advanced — step-by-step fallback:**
+
+If your `deploy.sh` predates v0.4.0 and you cannot use `--upgrade-bundle` yet, you can do the upgrade by hand:
+
+```bash
+cd ~/cullis-mastio-bundle
+wget https://github.com/cullis-security/cullis/releases/download/mastio-v0.4.0/cullis-mastio-bundle-0.4.0.tar.gz
+tar xzf cullis-mastio-bundle-0.4.0.tar.gz --strip-components=1 --overwrite
+./deploy.sh --pull
+```
+
+The new `deploy.sh` will offer to run `--migrate-volumes` on the next invocation if it still finds named volumes.
+
+**Data preservation:** `./data/` (SQLite DB), `./nginx-certs/` (Org CA + server cert), and `proxy.env` are preserved across every upgrade path above. Org CA and admin password persist across image bumps.

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -41,6 +41,348 @@ err()  { echo -e "  ${RED}✗${RESET}  $1"; }
 die()  { err "$1"; exit 1; }
 step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
 
+# ═══════════════════════════════════════════════════════════════════════════
+# ADR-030 helpers — bundle-level upgrade + bind-mount data layout
+# ═══════════════════════════════════════════════════════════════════════════
+
+# Strict version validation. Mirror of ``_TAG_SAFE_RE`` in
+# mcp_proxy/dashboard/update_check.py (PR #668): only letters, digits,
+# dots, and hyphens. Refuses any shell metacharacter that could land in
+# a curl/tar argv. ``mastio-v`` prefix is added by the URL builder, not
+# the operator-supplied string.
+_validate_version() {
+    local v="$1"
+    [[ -n "$v" ]] || die "version is required"
+    if [[ ! "$v" =~ ^[A-Za-z0-9.\-]+$ ]]; then
+        die "refusing version with unsafe characters: ${v} (allowed: A-Z a-z 0-9 . -)"
+    fi
+}
+
+# Bundle dir sanity. ``_cmd_upgrade_bundle`` rewrites scripts in place; if
+# we're not actually in a bundle directory the tarball extract would
+# scatter unrelated files. Cheap pre-flight.
+_assert_bundle_pwd() {
+    [[ -f "$SCRIPT_DIR/docker-compose.yml" ]] \
+        || die "not a Mastio bundle directory (no docker-compose.yml at $SCRIPT_DIR)"
+    [[ -f "$SCRIPT_DIR/deploy.sh" ]] \
+        || die "not a Mastio bundle directory (no deploy.sh at $SCRIPT_DIR)"
+}
+
+# Does a named volume still exist? Used to decide whether a v0.3.x
+# customer needs the bind-mount migration before --upgrade-bundle.
+_named_volume_exists() {
+    docker volume inspect "$1" >/dev/null 2>&1
+}
+
+# Compose-aware named-volume name. docker-compose prefixes volume names
+# with ${COMPOSE_PROJECT_NAME}_ so the actual identifier on the host is
+# ``cullis-mastio_mcp_proxy_data``, not the bare ``mcp_proxy_data`` from
+# the compose stanza. We always export COMPOSE_PROJECT_NAME=cullis-mastio
+# above, so this is deterministic — but spell it out so the helper stays
+# correct if the project name ever changes.
+_volume_full_name() {
+    echo "${COMPOSE_PROJECT_NAME}_$1"
+}
+
+# Bind-mount targets resolved from proxy.env (with the compose-level
+# defaults baked in). Echoed as absolute paths so the rest of the script
+# does not have to care about relative-to-bundle semantics.
+_data_dir_host() {
+    local p
+    p="$(_load_env MASTIO_DATA_DIR 2>/dev/null || true)"
+    p="${p:-./data}"
+    [[ "$p" = /* ]] || p="$SCRIPT_DIR/${p#./}"
+    echo "$p"
+}
+_nginx_certs_dir_host() {
+    local p
+    p="$(_load_env MASTIO_NGINX_CERTS_DIR 2>/dev/null || true)"
+    p="${p:-./nginx-certs}"
+    [[ "$p" = /* ]] || p="$SCRIPT_DIR/${p#./}"
+    echo "$p"
+}
+
+# proxy.env value lookup. Mirrors the inline lambda used in the prod
+# validation block, hoisted here so the ADR-030 helpers can share it
+# without forward-references.
+_load_env() {
+    grep -E "^$1=" "$SCRIPT_DIR/proxy.env" 2>/dev/null | head -1 | cut -d= -f2- || true
+}
+
+# mkdir + chown the host bind targets. The chown is the same operation
+# the init-permissions compose service runs at boot, just earlier so a
+# fresh install does not have to wait for the first ``compose up`` for
+# the directories to exist with the right owner. Idempotent.
+_ensure_data_dirs() {
+    local data_dir nginx_certs_dir
+    data_dir="$(_data_dir_host)"
+    nginx_certs_dir="$(_nginx_certs_dir_host)"
+    mkdir -p "$data_dir" "$nginx_certs_dir"
+    # busybox chown matches the in-compose init-permissions service. We
+    # don't strictly need this on a fresh install (compose will do it)
+    # but it makes the --migrate-volumes audit trail honest: the host
+    # dir is correctly owned before the copy starts. Silently ignore
+    # failures — the compose init-permissions service is the backstop.
+    if command -v docker >/dev/null 2>&1; then
+        docker run --rm \
+            -v "$data_dir:/data" \
+            -v "$nginx_certs_dir:/nginx-certs" \
+            --user 0:0 \
+            busybox:stable sh -c "chown -R 10001:10001 /data /nginx-certs && chmod 0750 /data /nginx-certs" \
+            >/dev/null 2>&1 || true
+    fi
+}
+
+# Rewrite (or append) a single VAR=value line in proxy.env. Same sed
+# pattern as the legacy --upgrade flow, extracted so --upgrade-bundle
+# and any future caller share the same trailing-newline-safe behaviour.
+_rewrite_env_pin() {
+    local var="$1" value="$2" envfile="$SCRIPT_DIR/proxy.env"
+    [[ -f "$envfile" ]] || die "proxy.env not found — run ./deploy.sh once before pinning ${var}"
+    sed -i.bak "/^#*[[:space:]]*${var}=/d" "$envfile"
+    rm -f "${envfile}.bak"
+    echo "${var}=${value}" >> "$envfile"
+}
+
+# Tar-aware backup. Snapshots proxy.env + data dir + nginx-certs dir into
+# ./backups/<label>-<ts>/ so an operator who hits a regression mid-upgrade
+# has an obvious restore target. Cheap (rsync-style copy, not tar) so the
+# operator can ``cp -a`` it back without untar tooling.
+_backup_user_state() {
+    local label="$1" ts backup_dir data_dir nginx_certs_dir
+    ts="$(date -u +%Y%m%dT%H%M%SZ)"
+    backup_dir="$SCRIPT_DIR/backups/${label}-${ts}"
+    data_dir="$(_data_dir_host)"
+    nginx_certs_dir="$(_nginx_certs_dir_host)"
+    mkdir -p "$backup_dir"
+    if [[ -f "$SCRIPT_DIR/proxy.env" ]]; then
+        cp -a "$SCRIPT_DIR/proxy.env" "$backup_dir/proxy.env"
+    fi
+    if [[ -d "$data_dir" ]] && compgen -G "$data_dir/*" >/dev/null; then
+        cp -a "$data_dir" "$backup_dir/data"
+    fi
+    if [[ -d "$nginx_certs_dir" ]] && compgen -G "$nginx_certs_dir/*" >/dev/null; then
+        cp -a "$nginx_certs_dir" "$backup_dir/nginx-certs"
+    fi
+    ok "Backup written to ${backup_dir#$SCRIPT_DIR/}"
+    BACKUP_DIR="$backup_dir"
+}
+
+# Move a single legacy named volume's contents into a host bind dir.
+# Safety: refuses if the destination bind dir already has files in it
+# (that would suggest a partial migration the operator should resolve by
+# hand). The named volume is left in place — the operator decides when
+# to ``docker volume rm`` after verifying the new layout boots clean.
+_migrate_single_volume() {
+    local volume_short="$1" volume_full bind_target log_line size_before size_after files_after
+    volume_full="$(_volume_full_name "$volume_short")"
+    bind_target="$2"
+
+    if ! _named_volume_exists "$volume_full"; then
+        ok "${volume_full} — no legacy named volume, skipping"
+        return 0
+    fi
+
+    if [[ -d "$bind_target" ]] && compgen -G "$bind_target/*" >/dev/null 2>&1; then
+        warn "${bind_target} already has content; skipping ${volume_full} migration"
+        warn "  resolve manually: inspect both, ``docker volume rm ${volume_full}`` only after confirming"
+        return 0
+    fi
+
+    mkdir -p "$bind_target"
+    size_before="$(docker run --rm -v "$volume_full:/src:ro" busybox:stable sh -c 'du -sk /src 2>/dev/null | cut -f1' || echo 0)"
+    docker run --rm \
+        -v "$volume_full:/src:ro" \
+        -v "$bind_target:/dst" \
+        --user 0:0 \
+        busybox:stable sh -c "cp -a /src/. /dst/ && chown -R 10001:10001 /dst" \
+        >/dev/null
+    size_after="$(du -sk "$bind_target" 2>/dev/null | cut -f1 || echo 0)"
+    files_after="$(find "$bind_target" -mindepth 1 | wc -l)"
+    log_line="${volume_full} → ${bind_target}  size_before=${size_before}K size_after=${size_after}K files=${files_after}"
+    echo "$log_line" >> "${BACKUP_DIR:-$SCRIPT_DIR/backups/last-migration}/migration.log"
+    ok "Migrated ${volume_full} → ${bind_target#$SCRIPT_DIR/} (${files_after} files, ${size_after}K)"
+    MIGRATED_VOLUMES+=("$volume_full")
+}
+
+# Idempotent: re-running after a successful migration is a no-op (bind
+# dirs are populated, every _migrate_single_volume hits the "destination
+# already has content" guard).
+_cmd_migrate_volumes() {
+    _assert_bundle_pwd
+    step "Migrating Cullis Mastio data to bind mounts (ADR-030)"
+
+    local data_dir nginx_certs_dir mcp_full nginx_full any=0
+    data_dir="$(_data_dir_host)"
+    nginx_certs_dir="$(_nginx_certs_dir_host)"
+    mcp_full="$(_volume_full_name mcp_proxy_data)"
+    nginx_full="$(_volume_full_name mastio_nginx_certs)"
+
+    if ! _named_volume_exists "$mcp_full" && ! _named_volume_exists "$nginx_full"; then
+        ok "No legacy named volumes found — bundle is already on the bind-mount layout"
+        return 0
+    fi
+
+    # Stop the running stack before copying — a running mcp-proxy can hold
+    # an open SQLite WAL on /data and a half-copied DB is the worst kind
+    # of corruption to debug after the fact.
+    if docker ps --filter "label=com.docker.compose.project=${COMPOSE_PROJECT_NAME}" --format '{{.Names}}' 2>/dev/null | grep -q .; then
+        warn "Stopping running stack before migration (open WALs would corrupt the copy)"
+        $COMPOSE $COMPOSE_FILES --env-file proxy.env down 2>/dev/null \
+            || $COMPOSE $COMPOSE_FILES down 2>/dev/null \
+            || true
+    fi
+
+    _backup_user_state "pre-bind-migration"
+    mkdir -p "$BACKUP_DIR"
+    : > "$BACKUP_DIR/migration.log"
+
+    MIGRATED_VOLUMES=()
+    _migrate_single_volume mcp_proxy_data "$data_dir" && any=1
+    _migrate_single_volume mastio_nginx_certs "$nginx_certs_dir" && any=1
+
+    if [[ ${#MIGRATED_VOLUMES[@]} -gt 0 ]]; then
+        echo ""
+        echo -e "  ${BOLD}Migration complete.${RESET} The named volumes are left in place so you can"
+        echo -e "  verify the new layout boots cleanly before deleting them."
+        echo ""
+        echo -e "  Once the next ``./deploy.sh`` (or ``--upgrade-bundle``) brings the stack up"
+        echo -e "  and the dashboard answers, remove the obsolete volumes with:"
+        echo ""
+        for v in "${MIGRATED_VOLUMES[@]}"; do
+            echo -e "    ${GRAY}docker volume rm ${v}${RESET}"
+        done
+        echo ""
+        echo -e "  Backup of pre-migration state: ${GRAY}${BACKUP_DIR#$SCRIPT_DIR/}/${RESET}"
+    else
+        ok "Nothing to migrate (named volumes were empty or destinations already populated)"
+    fi
+}
+
+# Full bundle refresh: download the released tarball, extract over the
+# current bundle, bump CULLIS_MASTIO_VERSION, pull the matching image,
+# restart with healthcheck wait. ``--from-banner`` skips the migration
+# prompt for the banner-driven one-liner.
+_cmd_upgrade_bundle() {
+    local version="$1" tarball_url tarball_local backup_dir
+    _validate_version "$version"
+    _assert_bundle_pwd
+
+    step "Upgrading Cullis Mastio bundle to ${version}"
+
+    # 1. Decide whether the migration is needed first. Doing it before the
+    # tarball download keeps the failure surface predictable: if the
+    # operator says no to the migration we have not yet touched anything.
+    local mcp_full nginx_full needs_migration=0
+    mcp_full="$(_volume_full_name mcp_proxy_data)"
+    nginx_full="$(_volume_full_name mastio_nginx_certs)"
+    if _named_volume_exists "$mcp_full" || _named_volume_exists "$nginx_full"; then
+        needs_migration=1
+        if [[ $FROM_BANNER -eq 1 ]]; then
+            warn "Legacy named volumes detected — auto-migrating (--from-banner)"
+        else
+            echo ""
+            warn "Legacy named volumes detected (${mcp_full}, ${nginx_full})."
+            warn "ADR-030 moves data to host bind dirs (./data, ./nginx-certs)."
+            warn "This is automatic, idempotent, and leaves the named volumes intact"
+            warn "until you remove them manually after a clean boot."
+            read -rp "  Migrate now? [Y/n]: " _reply
+            if [[ "$_reply" =~ ^[Nn] ]]; then
+                die "Aborted by operator — re-run with --from-banner to skip this prompt or run ./deploy.sh --migrate-volumes separately"
+            fi
+        fi
+        _cmd_migrate_volumes
+    fi
+
+    # 2. Backup current scripts + user state so a regression mid-extract
+    # has a clear restore target. _backup_user_state already grabs
+    # proxy.env + data + nginx-certs; here we also snapshot the bundle
+    # scripts the extract is about to overwrite.
+    _backup_user_state "pre-upgrade-${version}"
+    mkdir -p "$BACKUP_DIR/scripts"
+    for f in docker-compose.yml docker-compose.prod.yml docker-compose.shared-broker.yml \
+             deploy.sh generate-proxy-env.sh README.md; do
+        if [[ -f "$SCRIPT_DIR/$f" ]]; then
+            cp -a "$SCRIPT_DIR/$f" "$BACKUP_DIR/scripts/$f"
+        fi
+    done
+    if [[ -d "$SCRIPT_DIR/nginx" ]]; then
+        cp -a "$SCRIPT_DIR/nginx" "$BACKUP_DIR/scripts/nginx"
+    fi
+
+    # 3. Download tarball. URL host is hardcoded — version is the only
+    # variable input and is regex-validated above so it cannot smuggle a
+    # path traversal or shell metacharacter.
+    tarball_url="https://github.com/cullis-security/cullis/releases/download/mastio-v${version}/cullis-mastio-bundle-${version}.tar.gz"
+    tarball_local="$(mktemp -t cullis-mastio-bundle-XXXXXX.tar.gz)"
+    step "Downloading ${tarball_url}"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fSL --proto '=https' --tlsv1.2 -o "$tarball_local" "$tarball_url" \
+            || die "Download failed: ${tarball_url}"
+    elif command -v wget >/dev/null 2>&1; then
+        wget --https-only -qO "$tarball_local" "$tarball_url" \
+            || die "Download failed: ${tarball_url}"
+    else
+        die "Need curl or wget to download the bundle tarball"
+    fi
+    if [[ ! -s "$tarball_local" ]]; then
+        die "Downloaded tarball is empty: ${tarball_local}"
+    fi
+    ok "Downloaded $(du -h "$tarball_local" | cut -f1) to ${tarball_local}"
+
+    # 4. Extract over the current bundle. --strip-components=1 drops the
+    # top-level ``cullis-mastio-bundle-<version>/`` directory the release
+    # workflow stages with. --exclude protects proxy.env in the unlikely
+    # event a future release accidentally ships one; the bind-mount dirs
+    # (./data, ./nginx-certs) live OUTSIDE the tarball staging so they
+    # are not at risk regardless.
+    step "Extracting bundle"
+    tar xzf "$tarball_local" \
+        --strip-components=1 \
+        --overwrite \
+        --exclude='proxy.env' \
+        --exclude='backups' \
+        --exclude='data' \
+        --exclude='nginx-certs' \
+        -C "$SCRIPT_DIR"
+    chmod +x "$SCRIPT_DIR"/*.sh 2>/dev/null || true
+    ok "Bundle scripts updated"
+
+    # 5. Pin the new version in proxy.env so this run and every future
+    # ./deploy.sh sees the new tag without a re-source.
+    _rewrite_env_pin CULLIS_MASTIO_VERSION "$version"
+    export CULLIS_MASTIO_VERSION="$version"
+    ok "proxy.env: CULLIS_MASTIO_VERSION=${version}"
+
+    # 6. Pull + restart. ``--wait`` blocks until healthcheck passes,
+    # avoiding the race PR #663 fixed for the Frontdesk bundle (force-
+    # recreate returns when the container is spawned, NOT when uvicorn
+    # is bound).
+    step "Pulling image + restarting"
+    $COMPOSE $COMPOSE_FILES --env-file proxy.env pull
+    $COMPOSE $COMPOSE_FILES --env-file proxy.env up -d --wait \
+        || $COMPOSE $COMPOSE_FILES --env-file proxy.env up -d
+    ok "Stack restarted on ${version}"
+
+    rm -f "$tarball_local"
+
+    echo ""
+    echo -e "${GREEN}${BOLD}Cullis Mastio upgraded to ${version}.${RESET}"
+    echo ""
+    echo -e "  Backup: ${GRAY}${BACKUP_DIR#$SCRIPT_DIR/}/${RESET}"
+    if [[ $needs_migration -eq 1 ]]; then
+        echo -e "  Legacy named volumes are still around — delete them after verifying"
+        echo -e "  the dashboard answers normally."
+    fi
+    local proxy_port public_url
+    proxy_port="$(_load_env MCP_PROXY_PORT)"
+    proxy_port="${proxy_port:-9443}"
+    public_url="$(_load_env MCP_PROXY_PROXY_PUBLIC_URL)"
+    public_url="${public_url:-https://localhost:${proxy_port}}"
+    echo -e "  Dashboard: ${GRAY}${public_url}/proxy/login${RESET}"
+    echo ""
+}
+
 if docker compose version &>/dev/null 2>&1; then
     COMPOSE="docker compose"
 elif command -v docker-compose &>/dev/null; then
@@ -64,15 +406,30 @@ Options:
                               requires proxy.env pre-provisioned.
   --down                      Stop and remove containers.
   --pull                      Force-pull the image before starting.
-  --upgrade <version>         Pin CULLIS_MASTIO_VERSION in proxy.env to
-                              <version>, pull the new image, and recreate
-                              containers in-place. Volumes (DB, certs)
-                              are preserved. Equivalent to:
-                                  ./deploy.sh --down
-                                  edit proxy.env: CULLIS_MASTIO_VERSION=…
-                                  ./deploy.sh --pull
-                              packaged as one command so a non-tech
-                              operator never has to edit env by hand.
+  --upgrade <version>         Image-only bump: pin CULLIS_MASTIO_VERSION
+                              in proxy.env to <version>, pull the new
+                              image, recreate containers in-place. Bind-
+                              mount data is preserved. Scripts stay at
+                              the bundle's original version — use
+                              --upgrade-bundle for a full bundle refresh.
+  --upgrade-bundle <version>  Full bundle refresh: download the released
+                              tarball, extract over the current bundle
+                              (preserving proxy.env, ./data, ./nginx-
+                              certs), bump CULLIS_MASTIO_VERSION, pull
+                              the matching image, and restart with
+                              ``compose up -d --wait``. Auto-runs
+                              --migrate-volumes when legacy named volumes
+                              are detected. Backup of proxy.env + bind
+                              dirs goes under ./backups/pre-upgrade-<ts>.
+  --migrate-volumes           Move legacy named volumes (mcp_proxy_data,
+                              mastio_nginx_certs) to host bind dirs
+                              (./data, ./nginx-certs). Idempotent: safe
+                              to re-run, never deletes the named volumes
+                              automatically — operator decides when.
+  --from-banner               Internal: skip the interactive prompt on
+                              named-volume migration during --upgrade-
+                              bundle. Used by the dashboard's update
+                              banner one-liner.
   --help, -h                  Show this help and exit.
 
 Environment:
@@ -84,7 +441,9 @@ Examples:
   CULLIS_MASTIO_VERSION=0.3.0 ./deploy.sh        # pinned version
   ./deploy.sh --shared-broker                    # join Court on same host
   ./deploy.sh --prod                             # standalone, prod safety
-  ./deploy.sh --upgrade 0.3.0-rc3                # bump image + restart
+  ./deploy.sh --upgrade 0.3.0-rc3                # image-only bump
+  ./deploy.sh --upgrade-bundle 0.4.0             # full bundle refresh
+  ./deploy.sh --migrate-volumes                  # one-shot bind migration
   ./deploy.sh --down                             # stop + remove
 EOF
 }
@@ -94,6 +453,8 @@ MODE="development"
 SHARED_BROKER=0
 FORCE_PULL=0
 UPGRADE_TO=""
+UPGRADE_BUNDLE_TO=""
+FROM_BANNER=0
 # Manual loop because ``--upgrade <version>`` needs to consume the
 # next positional arg. Keeps the existing single-token flags working
 # without pulling in getopt.
@@ -117,6 +478,21 @@ while [[ $# -gt 0 ]]; do
             FORCE_PULL=1
             shift
             ;;
+        --upgrade-bundle)
+            shift
+            [[ $# -gt 0 && "$1" != --* ]] || die "--upgrade-bundle requires a version (e.g. --upgrade-bundle 0.4.0)"
+            UPGRADE_BUNDLE_TO="$1"
+            ACTION="upgrade_bundle"
+            shift
+            ;;
+        --upgrade-bundle=*)
+            UPGRADE_BUNDLE_TO="${arg#--upgrade-bundle=}"
+            [[ -n "$UPGRADE_BUNDLE_TO" ]] || die "--upgrade-bundle= requires a value"
+            ACTION="upgrade_bundle"
+            shift
+            ;;
+        --migrate-volumes) ACTION="migrate_volumes"; shift ;;
+        --from-banner)     FROM_BANNER=1; shift ;;
         --help|-h)       print_help; exit 0 ;;
         *) die "Unknown argument: $arg (use --help)" ;;
     esac
@@ -131,6 +507,19 @@ if [[ "$ACTION" == "down" ]]; then
     $COMPOSE $COMPOSE_FILES --env-file proxy.env down 2>/dev/null \
         || $COMPOSE $COMPOSE_FILES down
     ok "Mastio stopped"
+    exit 0
+fi
+
+# ── ADR-030 — bundle-level upgrade + bind-mount migration dispatch ─────────
+# Dispatched here, before the long ``up`` body, so a customer running
+# --upgrade-bundle or --migrate-volumes doesn't pay for the env validation /
+# port preflight before the migration starts.
+if [[ "$ACTION" == "migrate_volumes" ]]; then
+    _cmd_migrate_volumes
+    exit 0
+fi
+if [[ "$ACTION" == "upgrade_bundle" ]]; then
+    _cmd_upgrade_bundle "$UPGRADE_BUNDLE_TO"
     exit 0
 fi
 
@@ -198,7 +587,7 @@ fi
 
 if [[ "$MODE" == "production" ]]; then
     _errors=()
-    _load_env() { grep -E "^$1=" "$SCRIPT_DIR/proxy.env" 2>/dev/null | head -1 | cut -d= -f2- || true; }
+    # _load_env is hoisted to the top of the script (ADR-030 helpers).
 
     _admin="$(_load_env MCP_PROXY_ADMIN_SECRET)"
     if [[ -z "$_admin" || "$_admin" == "change-me-in-production" ]]; then

--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -22,8 +22,33 @@
 
 services:
 
+  # ADR-030 — chown the host bind targets to the Mastio runtime UID/GID
+  # (10001:10001) at every ``compose up``. Runs as root, exits immediately.
+  # Idempotent: if ownership already matches, the chown is a no-op. Without
+  # this, host directories created as root (e.g. by an earlier ``docker
+  # compose up`` that auto-created an absent bind target) would lock the
+  # mcp-proxy user out of /data and the SQLite open would fail.
+  init-permissions:
+    image: busybox:stable
+    user: "0:0"
+    command:
+      - sh
+      - -c
+      - |
+        chown -R 10001:10001 /data /nginx-certs
+        chmod 0750 /data /nginx-certs
+    volumes:
+      - ${MASTIO_DATA_DIR:-./data}:/data
+      - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/nginx-certs
+    restart: "no"
+    networks:
+      - proxy_net
+
   mcp-proxy:
     image: ghcr.io/cullis-security/cullis-mastio:${CULLIS_MASTIO_VERSION:-latest}
+    depends_on:
+      init-permissions:
+        condition: service_completed_successfully
     # ADR-014 — no host port publish. The Mastio listens on 9100 only
     # on proxy_net; the mastio-nginx sidecar below publishes 9443.
     expose:
@@ -121,14 +146,23 @@ services:
       PROXY_FEDERATION_SYNC:       ${PROXY_FEDERATION_SYNC:-}
       CULLIS_EGRESS_DPOP_MODE:     ${CULLIS_EGRESS_DPOP_MODE:-}
     volumes:
-      - mcp_proxy_data:/data
+      # ADR-030 — bind mount on the host so /data sits next to deploy.sh
+      # (./data/mcp_proxy.db). Replaces the legacy ``mcp_proxy_data``
+      # named volume. Operators on v0.3.x migrate via
+      # ``./deploy.sh --migrate-volumes`` (or auto-triggered by
+      # ``--upgrade-bundle``).
+      - ${MASTIO_DATA_DIR:-./data}:/data
       # Optional corporate CA bundle. Mount a host directory at ./certs
       # if you need to trust an internal CA (env vars above point at
       # files under /certs only when MCP_PROXY_BROKER_CA_BUNDLE is set).
+      # Distinct from ``./nginx-certs`` below: ./certs is *read-only*
+      # corporate trust input; ./nginx-certs is the *read-write* Mastio
+      # output (Org CA + nginx server cert).
       - ${CULLIS_CERTS_DIR:-./certs}:/certs:ro
-      # ADR-014 — shared volume for nginx sidecar TLS material. Mastio
-      # writes; mastio-nginx mounts read-only.
-      - mastio_nginx_certs:/var/lib/mastio/nginx-certs:rw
+      # ADR-014 — Org CA + nginx server cert lives here; mastio-nginx
+      # mounts the same bind path read-only below. Replaces the legacy
+      # ``mastio_nginx_certs`` named volume (ADR-030).
+      - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/var/lib/mastio/nginx-certs:rw
     networks:
       - proxy_net
     # When the Mastio orchestrates user lifecycle on a sibling Frontdesk
@@ -152,7 +186,10 @@ services:
       - "${MCP_PROXY_PORT:-9443}:9443"
     volumes:
       - ./nginx/mastio:/etc/nginx/conf.d:ro
-      - mastio_nginx_certs:/etc/nginx/certs:ro
+      # ADR-030 — same bind dir as mcp-proxy's /var/lib/mastio/nginx-certs,
+      # mounted read-only here so the sidecar serves the cert without
+      # being able to mutate it.
+      - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/etc/nginx/certs:ro
     depends_on:
       mcp-proxy:
         condition: service_healthy
@@ -175,9 +212,3 @@ services:
 networks:
   proxy_net:
     driver: bridge
-
-volumes:
-  mcp_proxy_data:
-    driver: local
-  mastio_nginx_certs:
-    driver: local

--- a/packaging/mastio-bundle/generate-proxy-env.sh
+++ b/packaging/mastio-bundle/generate-proxy-env.sh
@@ -165,6 +165,12 @@ sed -i "s|^MCP_PROXY_DASHBOARD_SIGNING_KEY=.*|MCP_PROXY_DASHBOARD_SIGNING_KEY=${
 sed -i "s|^MCP_PROXY_BROKER_URL=.*|MCP_PROXY_BROKER_URL=${BROKER}|"                  "$OUT"
 sed -i "s|^MCP_PROXY_BROKER_JWKS_URL=.*|MCP_PROXY_BROKER_JWKS_URL=${JWKS}|"          "$OUT"
 sed -i "s|^MCP_PROXY_PROXY_PUBLIC_URL=.*|MCP_PROXY_PROXY_PUBLIC_URL=${PUBLIC}|"      "$OUT"
+
+# ADR-030 — the bundle bind-mount paths default to ./data and ./nginx-certs.
+# proxy.env.example ships them already, so no sed required here. The block
+# is intentionally idempotent: re-running this script never clobbers an
+# operator's custom path because the example carries the canonical value
+# and any override survives via --force-only overwrite.
 # proxy.env.example does not ship the seed line. Append only when the
 # operator asked for the auto-seed path; otherwise omit so the Mastio
 # main.py boot path correctly leaves the hash NULL and routes

--- a/packaging/mastio-bundle/proxy.env.example
+++ b/packaging/mastio-bundle/proxy.env.example
@@ -81,6 +81,25 @@ MCP_PROXY_ALLOWED_ORIGINS=
 # to the host — all external traffic enters via the sidecar.
 MCP_PROXY_PORT=9443
 
+# ─── ADR-030 — bind-mount data layout ────────────────────────────────────────
+#
+# Host directories bound into the mcp-proxy container. Default sits
+# next to deploy.sh so a single ``rm -rf ./data ./nginx-certs`` wipes
+# the Mastio state explicitly — no ``docker volume rm`` indirection,
+# no surprise data loss via ``docker system prune --volumes``.
+#
+# ./data            — SQLite DB (mcp_proxy.db) and any future state
+# ./nginx-certs     — Org CA + nginx server cert (ADR-014). Mastio writes;
+#                     mastio-nginx mounts the same path read-only.
+#
+# Override only if you want the state elsewhere (NFS share, encrypted
+# volume mounted under /mnt, etc). The init-permissions service chown's
+# the targets to 10001:10001 at every boot; any custom path must be
+# writable by uid 10001 or the chown step itself must succeed (it runs
+# as root in a busybox sidecar, so a writable parent is enough).
+MASTIO_DATA_DIR=./data
+MASTIO_NGINX_CERTS_DIR=./nginx-certs
+
 # ─── ADR-014 — nginx sidecar TLS ─────────────────────────────────────────────
 
 # Where the Mastio writes the Org CA + server cert + server key for the


### PR DESCRIPTION
## Summary

Closes two operational gaps in the Mastio bundle that surfaced after the update-available banner shipped in #668:

- **Update flow drift.** The banner hands the operator four manual commands, and `--pull` only refreshes the image — `deploy.sh` / `docker-compose.yml` / scripts stay frozen at the tarball's original version. A customer on `0.3.6` doing `--pull` got the `0.3.9` binary with stale scripts.
- **Asymmetric persistence vs Frontdesk.** Mastio kept its data in named volumes (`mcp_proxy_data`, `mastio_nginx_certs`) while the Frontdesk bundle moved to bind mounts months ago. `docker system prune --volumes` or a daemon reset wiped Org CA + DB silently.

Closes the gaps with:

- `./deploy.sh --upgrade-bundle <version>` — full bundle refresh (download tarball, backup, extract preserving state, bump version pin, pull image, restart `--wait`).
- `./deploy.sh --migrate-volumes` — idempotent named-volume → bind-mount migration via busybox `cp -a`.
- Bind-mount layout: `${MASTIO_DATA_DIR:-./data}` + `${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}` + `init-permissions` chown service. `Dockerfile` pins `proxyuser` to fixed `10001:10001`.
- Single-line banner one-liner: `./deploy.sh --upgrade-bundle {{ latest_stripped }} --from-banner`, with the original four commands kept in a `<details>` fallback for pre-v0.4.0 bundles.
- `release-mastio.yml` allowlist + post-stage sanity check (clone of #662 pattern from Frontdesk).
- `README.md` + `proxy.env.example` document the three upgrade paths.

Threat model: upgrade is operator-driven copy-paste, never self-execute. No `docker.sock` mount, no privileged sidecar updater. Version validation uses the same `_TAG_SAFE_RE` regex as `update_check.py` (PR #668) — shell metacharacters refused.

Maintainer note: `imp/adr-030-mastio-upgrade-and-data-layout.md` (gitignored) is the draft ADR; will be ratified to `docs/adrs/` after merge.

## Tag plan after merge

This is a breaking layout change (named volumes → bind mounts) but the migration is automatic + idempotent. Cut as `mastio-v0.4.0` + `frontdesk-bundle-v0.2.10` (only if the latter needs a `CULLIS_MASTIO_VERSION` default bump).

## Out of scope (Phase 2 follow-up)

- SHA-256 checksum verification of the downloaded tarball
- cosign/sigstore signature for full supply-chain hardening
- Same `--upgrade-bundle` pattern for the Frontdesk bundle (defer until Mastio pattern proves stable in dogfood)

## Test plan

- [x] `bash -n packaging/mastio-bundle/deploy.sh`
- [x] `docker compose -f packaging/mastio-bundle/docker-compose.yml config` — init-permissions + 3 bind mounts resolved correctly
- [x] `pytest tests/test_proxy_update_check.py` → 20 passed
- [x] Local `--migrate-volumes` against live `cullis-mastio_mcp_proxy_data` (416K, 2 files) + `cullis-mastio_mastio_nginx_certs` (16K, 3 files) — ownership normalised to `10001:10001`, named volumes left in place
- [x] Shell-injection refusal: `--upgrade-bundle '0.4.0; rm -rf /'` + `--upgrade-bundle='\$(id)'` → exit 1 with explicit error
- [x] `--help` output renders all new flags correctly
- [ ] VM `.170` dogfood (after release-mastio.yml validates the new release path on tag push)
- [ ] CI customer-path-smoke (PR #625 gate) on this PR