### PR TITLE
fix(mastio): backup helper reads bind dirs via root busybox

### DIFF
--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -144,10 +144,34 @@ _rewrite_env_pin() {
     echo "${var}=${value}" >> "$envfile"
 }
 
+# Copy a bind dir into the backup target. Must run as root through a
+# busybox sidecar because post-init-permissions the dir + sensitive
+# files (mastio-server.key 0600, mcp_proxy.db 0600) are owned by uid
+# 10001 and unreadable by the invoking ``cullis``/operator user. The
+# in-container cp also handles ownership preservation cleanly. Chown
+# the *backup copy* back to the invoking user so the operator can read
+# / restore it without sudo.
+_copy_bind_dir_for_backup() {
+    local src_dir="$1" dst_dir="$2"
+    [[ -d "$src_dir" ]] || return 0
+    compgen -G "$src_dir/*" >/dev/null 2>&1 || return 0
+    mkdir -p "$(dirname "$dst_dir")"
+    docker run --rm \
+        -v "$src_dir:/src:ro" \
+        -v "$(dirname "$dst_dir"):/dst-parent" \
+        --user 0:0 \
+        busybox:stable sh -c "
+            cp -a /src /dst-parent/$(basename "$dst_dir")
+            chown -R $(id -u):$(id -g) /dst-parent/$(basename "$dst_dir")
+        " >/dev/null
+}
+
 # Tar-aware backup. Snapshots proxy.env + data dir + nginx-certs dir into
 # ./backups/<label>-<ts>/ so an operator who hits a regression mid-upgrade
 # has an obvious restore target. Cheap (rsync-style copy, not tar) so the
-# operator can ``cp -a`` it back without untar tooling.
+# operator can ``cp -a`` it back without untar tooling. The bind-dir
+# copies route through a root busybox so 0600 files (mastio-server.key,
+# mcp_proxy.db) survive the read.
 _backup_user_state() {
     local label="$1" ts backup_dir data_dir nginx_certs_dir
     ts="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -158,12 +182,8 @@ _backup_user_state() {
     if [[ -f "$SCRIPT_DIR/proxy.env" ]]; then
         cp -a "$SCRIPT_DIR/proxy.env" "$backup_dir/proxy.env"
     fi
-    if [[ -d "$data_dir" ]] && compgen -G "$data_dir/*" >/dev/null; then
-        cp -a "$data_dir" "$backup_dir/data"
-    fi
-    if [[ -d "$nginx_certs_dir" ]] && compgen -G "$nginx_certs_dir/*" >/dev/null; then
-        cp -a "$nginx_certs_dir" "$backup_dir/nginx-certs"
-    fi
+    _copy_bind_dir_for_backup "$data_dir"         "$backup_dir/data"
+    _copy_bind_dir_for_backup "$nginx_certs_dir"  "$backup_dir/nginx-certs"
     ok "Backup written to ${backup_dir#$SCRIPT_DIR/}"
     BACKUP_DIR="$backup_dir"
 }


### PR DESCRIPTION
## Summary

Caught on the `.170` VM dogfood of `mastio-v0.4.0` (PR #669): `--upgrade-bundle 0.4.0 --from-banner` ran the named-volume → bind-mount migration cleanly, then `_backup_user_state` invoked `cp -a` as the invoking `cullis` user against `./nginx-certs/mastio-server.key` (perms 0600, owner uid 10001 after `init-permissions` chown), got `Permission denied`, and `set -e` aborted the script mid-flow. Stack ended up stopped with `proxy.env` still pinned at `0.3.9` — recovery was a manual `sed` + `docker compose up`, which is fine for me but lethal for a customer following the banner one-liner.

Fix: route the bind-dir copies through a transient `busybox:stable` container running as root (same pattern already used in `_migrate_single_volume`), then `chown -R` the destination back to the invoking user so the operator can read and restore the backup without `sudo`. `proxy.env` (owned by the invoking user) keeps the plain `cp -a`.

## Files

- `packaging/mastio-bundle/deploy.sh` — new `_copy_bind_dir_for_backup` helper, `_backup_user_state` swapped to use it for `./data` + `./nginx-certs`.

## Test plan

- [x] Local smoke: bind dir with `key.key` 0600 + `cert.crt` 0644 owned by `10001:10001` → new helper copies all files preserving perms, dest re-chown'd to invoking user, contents readable.
- [x] `bash -n deploy.sh` clean.
- [ ] Re-dogfood VM `.170` post-merge: `--upgrade-bundle 0.4.1 --from-banner` should now run end-to-end without the perm-denied abort. The Mastio there is already on `0.4.0`, so the migration step is a no-op (idempotent) — this exercises only the backup + version-pin + pull + restart path on a v0.4.0 baseline.

## Tag plan

Cut as `mastio-v0.4.1` patch immediately after merge. Bundle script alone changes, no image rebuild strictly required, but the release pipeline rebuilds anyway for consistency.