### PR TITLE
fix(mastio): nginx sidecar healthcheck uses 127.0.0.1, not localhost

### DIFF
--- a/packaging/mastio-bundle/docker-compose.yml
+++ b/packaging/mastio-bundle/docker-compose.yml
@@ -197,13 +197,21 @@ services:
       - proxy_net
     restart: unless-stopped
     healthcheck:
+      # IPv4 literal on purpose: nginx:1.27-alpine ships musl libc, whose
+      # getaddrinfo prefers AAAA over A — ``localhost`` resolves to ``::1``
+      # first. Our ``listen 9443 ssl`` directive binds IPv4 only
+      # (``0.0.0.0:9443``), so a wget to ``localhost`` got Connection
+      # refused on the IPv6 attempt and never fell back to IPv4. nginx
+      # was serving traffic from the host fine, but compose reported the
+      # container ``unhealthy`` for every probe. ``127.0.0.1`` skips the
+      # resolver entirely.
       test:
         - CMD-SHELL
         - >-
           test -s /etc/nginx/certs/mastio-server.crt &&
           test -s /etc/nginx/certs/mastio-server.key &&
           test -s /etc/nginx/certs/org-ca.crt &&
-          wget -q --no-check-certificate -O /dev/null https://localhost:9443/health
+          wget -q --no-check-certificate -O /dev/null https://127.0.0.1:9443/health
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

Surfaced during the `v0.4.1` dogfood on VM `.170`: `docker inspect cullis-mastio-mastio-nginx-1` showed `unhealthy` across every probe with `wget: can't connect to remote host: Connection refused`, yet the sidecar served `/health` from the host fine.

**Root cause:** `nginx:1.27-alpine` ships musl libc. musl's `getaddrinfo` prefers AAAA over A — `localhost` resolves to `::1` first. Our nginx `listen 9443 ssl` directive binds IPv4-only (`0.0.0.0:9443`), so the wget probe got `Connection refused` on the IPv6 attempt and never fell back to IPv4.

```
$ docker exec cullis-mastio-mastio-nginx-1 wget --no-check-certificate -qSO- https://127.0.0.1:9443/health
HTTP/1.1 200 OK         ← works on IPv4
$ docker exec cullis-mastio-mastio-nginx-1 wget --no-check-certificate -qSO- https://[::1]:9443/health
wget: can't connect to remote host: Connection refused
$ docker exec cullis-mastio-mastio-nginx-1 wget --no-check-certificate -qSO- https://localhost:9443/health
wget: can't connect to remote host: Connection refused  ← musl picks ::1 first
```

Not caused by ADR-030 — the bug was silently present on every Mastio bundle deploy since the IPv4-only `listen` landed. Compose tolerates `unhealthy` so the sidecar kept serving traffic to clients, but the confusing `unhealthy` row in `docker ps` masked any future regression, and any `depends_on: { condition: service_healthy }` on the sidecar would block indefinitely.

## Fix

`localhost` → `127.0.0.1` in the healthcheck. Skips the resolver entirely so the IPv4 listener is reached first. The probe goes from "unhealthy on every iteration since v0.x.y" to "healthy in ~15s after compose up".

Alternative: add `listen [::]:9443 ssl` to nginx.conf for dual-stack. Kept as a possible future hardening when we add IPv6 ingress — not needed today for the healthcheck path.

## Files

- `packaging/mastio-bundle/docker-compose.yml` — 1-line literal swap + 8-line comment explaining the gotcha.

## Test plan

- [x] `docker compose config` clean.
- [x] Verified IPv4 vs IPv6 reachability inside the sidecar container on VM `.170`.
- [ ] Post-merge: cut `mastio-v0.4.2` and re-dogfood — `docker inspect ... mastio-nginx-1 --format '{{.State.Health.Status}}'` should report `healthy` within `start_period + interval`.