### PR TITLE
feat(connector): show-token CLI for OpenAI-client integration

### DIFF
--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 __all__ = ["__version__"]

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -247,6 +247,28 @@ def _build_parser() -> argparse.ArgumentParser:
              "scan every supported MCP client.",
     )
 
+    # show-token: print the loopback Ambassador Bearer token so the
+    # operator can paste it into a third-party OpenAI-compatible client
+    # (LibreChat, Cherry Studio, AnythingLLM, OpenWebUI, ...). The token
+    # already lives at ``<config_dir>/local.token`` mode 0600 but is
+    # invisible to anyone who does not know the path — this surfaces it
+    # in one command. ``--quiet`` suppresses the security warning on
+    # stderr so a script can ``$(cullis-connector show-token --quiet)``
+    # and grab just the token. ADR-027 culk_ tokens cover the remote
+    # /v1/* path; this is the local loopback equivalent.
+    show_token = subparsers.add_parser(
+        "show-token",
+        help="Print the local Ambassador Bearer token (treat as a password).",
+    )
+    _add_shared_args(show_token)
+    show_token.add_argument(
+        "--quiet", "-q",
+        dest="quiet",
+        action="store_true",
+        help="Print only the token (no security warning on stderr). "
+             "Use in scripts: TOKEN=$(cullis-connector show-token --quiet)",
+    )
+
     return parser
 
 
@@ -258,6 +280,7 @@ _KNOWN_SUBCOMMANDS = frozenset({
     "dashboard",
     "desktop",
     "doctor",
+    "show-token",
 })
 
 # Shared flags are parsed by the subparser that owns the chosen command.
@@ -701,6 +724,39 @@ def _cmd_desktop(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     return run_desktop_app(cfg, host=host, port=port)
 
 
+def _cmd_show_token(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
+    """Print the loopback Ambassador Bearer token.
+
+    Generates the token on first call (same behaviour as the Ambassador's
+    first startup), so an operator who installed the connector but never
+    ran ``dashboard``/``desktop`` still gets a token instead of an empty
+    file error. The token goes to stdout one line, no trailing extra
+    whitespace, so ``$(cullis-connector show-token --quiet)`` works in
+    a script. Security guidance goes to stderr so it does NOT pollute
+    stdout capture.
+    """
+    from cullis_connector.ambassador.auth import (
+        LOCAL_TOKEN_FILENAME,
+        ensure_local_token,
+    )
+
+    token = ensure_local_token(cfg.config_dir)
+    token_path = cfg.config_dir / LOCAL_TOKEN_FILENAME
+
+    if not args.quiet:
+        print(
+            f"# Local Ambassador Bearer token at {token_path}\n"
+            "# Treat as a password. Copy into your OpenAI-compatible client's\n"
+            "# Authorization: Bearer <token> setting, or paste below into the\n"
+            "# API key field (LibreChat / Cherry Studio / AnythingLLM / OpenWebUI / ...).\n"
+            "# The Ambassador only accepts this token from 127.0.0.1, so a leak\n"
+            "# off-host is harmless until an attacker also has loopback access.",
+            file=sys.stderr,
+        )
+    print(token)
+    return 0
+
+
 def _cmd_doctor(cfg: ConnectorConfig, args: argparse.Namespace) -> int:
     """Audit IDE MCP configs for stale Cullis entries (Finding #8)."""
     from cullis_connector.doctor import has_problems, scan
@@ -761,6 +817,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         return _cmd_desktop(cfg, args)
     if command == "doctor":
         return _cmd_doctor(cfg, args)
+    if command == "show-token":
+        return _cmd_show_token(cfg, args)
     return _cmd_serve(cfg)
 
 


### PR DESCRIPTION
## Summary

Closes the long-standing UX gap surfaced first by the Cherry Studio integration on 2026-05-11 ([[project_gap_connector_show_token_cli]]): a customer wiring **LibreChat / Cherry Studio / AnythingLLM / OpenWebUI / any OpenAI-compatible client** to the Connector Ambassador had to *know* that the Bearer token lived at `~/.cullis/profiles/<name>/local.token` and `cat` it themselves. Both the file path and the existence of a token were undiscoverable — the dashboard never surfaced them either.

## What ships

```
$ cullis-connector show-token
# Local Ambassador Bearer token at /home/me/.cullis/profiles/default/local.token
# Treat as a password. Copy into your OpenAI-compatible client's
# Authorization: Bearer <token> setting, or paste below into the
# API key field (LibreChat / Cherry Studio / AnythingLLM / OpenWebUI / ...).
# The Ambassador only accepts this token from 127.0.0.1, so a leak
# off-host is harmless until an attacker also has loopback access.
45974798bffbd4f319d53c3293f8fb9e2b440b9257b624cfe32a631d2fb0723d
```

- **Stdout**: token only, one line. Script-friendly: `TOKEN=$(cullis-connector show-token --quiet)`.
- **Stderr**: six-line security guidance. Suppressible with `--quiet` (or `-q`).
- **First-run idempotence**: generates `local.token` mode 0600 if missing (same path as the Ambassador's first startup, via the existing `ensure_local_token()` helper). Operator who installed the connector but never ran `dashboard`/`desktop` still gets a token.
- **Shared flags supported**: `--profile`, `--config-dir`, etc. — same surface as every other subcommand.

The token is the local-loopback equivalent of ADR-027's `culk_` tokens for the remote `/v1/*` path. Same UX shape (one command, copy-paste), distinct trust boundary (loopback-only vs DPoP+mTLS over the public Mastio).

## Files

- `cullis_connector/cli.py` — new `show-token` subparser + `_cmd_show_token` (~40 net lines) + dispatch.
- `cullis_connector/__init__.py` — version 0.4.4 → 0.4.5.

## Out of scope (Wave 2)

Dashboard `/api-keys` section that mirrors this with masked display + Copy + Rotate buttons. The CLI alone covers the 80% case — LibreChat / Cherry / AnythingLLM all support pasting Bearer into the API key field directly. Dashboard surface is a follow-up after we see real customer usage of this command.

## Test plan

- [x] Local smoke: fresh tempdir → `show-token` generates `local.token` mode 0600, prints token + stderr guidance.
- [x] Idempotency: second call returns the same token.
- [x] `--quiet` suppresses stderr (capture-friendly).
- [x] `--help` renders cleanly with shared flags inherited.
- [ ] Post-merge dogfood: wire Cherry Studio against the local Connector using `cullis-connector show-token --quiet` output as the API key field, verify a chat completion through the loopback Ambassador.

## Tag plan

Cut `connector-v0.4.5` after merge. Patch bump (additive subcommand, backward-compat preserved).