### PR TITLE
chore(connector): bump pyproject.toml to 0.4.5 (match __init__ + tag)

### DIFF
--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.4"
+version = "0.4.5"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

PR #674 bumped `cullis_connector/__init__.py` from `0.4.4` → `0.4.5` but missed the sibling `packaging/pypi/pyproject.toml`. The `connector-v0.4.5` tag fired the release workflow, which gates on `tag == __init__ == pyproject` (the consistency check added in PR #589). Result:

```
ERROR: tag version (0.4.5) != packaging/pypi/pyproject.toml version (0.4.4)
Bump both files to match the tag before pushing the tag.
##[error]Process completed with exit code 1.
```

Every downstream job (GHCR, PyPI publish, GitHub Release) was `skipped`.

Same class of error as memories `feedback_pypi_label_skew_after_main_fixes` and `feedback_release_pipeline_asymmetry_deploy_vs_compose`: every version bump must touch ALL the version sites in lockstep, not just one.

## Fix

`packaging/pypi/pyproject.toml`: `version = "0.4.4"` → `"0.4.5"`. One line.

## Recovery plan after merge

1. Delete the broken `connector-v0.4.5` tag locally + on remote.
2. Re-tag `connector-v0.4.5` on the new `main` HEAD.
3. Push the new tag. Release workflow re-runs against the consistent tree.

## Test plan

- [x] `grep "^version" packaging/pypi/pyproject.toml` returns `0.4.5`.
- [ ] Post-merge re-tag: `Build Python distributions` job passes, downstream `Publish to PyPI` + `Build & push Docker image` + `Create GitHub Release` all run green.