### PR TITLE
feat(mcp-proxy): plugin approval hook for 4-eyes workflow

### DIFF
--- a/mcp_proxy/admin/approval_hook.py
+++ b/mcp_proxy/admin/approval_hook.py
@@ -1,0 +1,99 @@
+"""Helper for endpoint handlers that may be intercepted by an approval plugin.
+
+Endpoints that fall under 4-eyes / separation-of-duty workflows call
+:func:`maybe_intercept_for_approval` after authentication and CSRF check
+but before executing the mutation. If a plugin (e.g. the enterprise
+``rbac_multi_admin`` quorum extension) declares the action gated, the
+helper submits the pending approval and returns a redirect to the
+approval detail page. The endpoint then returns that redirect to the
+caller and skips its normal execution path.
+
+Community deploys without any opt-in plugin observe unchanged behavior:
+the helper returns ``None`` and the endpoint proceeds.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import Request
+from starlette.responses import RedirectResponse
+
+_log = logging.getLogger("mcp_proxy.admin.approval_hook")
+
+
+# Stable identifiers used to address actions across the core/plugin boundary.
+# Plugins keyed by these strings in their config. Do not rename without a
+# coordinated plugin release.
+ACTION_POLICIES_SAVE = "policies.save"
+ACTION_PKI_ROTATE_CA = "pki.rotate_ca"
+ACTION_MASTIO_KEY_ROTATE = "mastio_key.rotate"
+ACTION_VAULT_MIGRATE_KEYS = "vault.migrate_keys"
+ACTION_USERS_DELETE = "users.delete"
+ACTION_AGENTS_DELETE = "agents.delete"
+
+
+async def maybe_intercept_for_approval(
+    *,
+    session: Any,
+    action_type: str,
+    payload: dict[str, Any],
+) -> RedirectResponse | None:
+    """If a plugin gates ``action_type``, submit a pending approval.
+
+    Returns a :class:`RedirectResponse` to the plugin-managed approval
+    detail page (the endpoint should return this verbatim). Returns
+    ``None`` when no plugin opts in; the caller proceeds with normal
+    execution.
+
+    Parameters
+    ----------
+    session
+        Authenticated dashboard session. ``session.role`` is forwarded as
+        the submitter identifier for plugin storage and audit. Plugins
+        observe richer principal identity via their own session table.
+    action_type
+        One of the ``ACTION_*`` constants above. Stable identifier across
+        the core/plugin boundary.
+    payload
+        Opaque dict captured from the request body (form or JSON). The
+        plugin persists this verbatim and re-plays it when quorum is
+        reached.
+    """
+    # Local import: avoid bootstrapping the plugin registry at module load
+    # in tests that monkey-patch it.
+    from mcp_proxy.plugins import get_registry
+
+    plugin = get_registry().approval_required_for(action_type)
+    if plugin is None:
+        return None
+
+    submitter_id = getattr(session, "role", None) or "admin"
+    try:
+        approval_id = await plugin.submit_approval(
+            action_type=action_type,
+            payload=payload,
+            submitter_id=submitter_id,
+        )
+    except NotImplementedError:
+        _log.error(
+            "plugin %s gated %s but did not implement submit_approval; "
+            "falling through to direct execution",
+            plugin.name, action_type,
+        )
+        return None
+    except Exception as exc:
+        _log.exception(
+            "plugin %s submit_approval(%s) failed: %s — falling through",
+            plugin.name, action_type, exc,
+        )
+        return None
+
+    _log.info(
+        "action %s submitted for approval: id=%s by=%s plugin=%s",
+        action_type, approval_id, submitter_id, plugin.name,
+    )
+    return RedirectResponse(
+        url=f"/proxy/admin/approvals/{approval_id}",
+        status_code=303,
+    )

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -44,6 +44,15 @@ from mcp_proxy.dashboard.session import (
     verify_admin_password,
     MIN_PASSWORD_LENGTH,
 )
+from mcp_proxy.admin.approval_hook import (
+    ACTION_AGENTS_DELETE,
+    ACTION_MASTIO_KEY_ROTATE,
+    ACTION_PKI_ROTATE_CA,
+    ACTION_POLICIES_SAVE,
+    ACTION_USERS_DELETE,
+    ACTION_VAULT_MIGRATE_KEYS,
+    maybe_intercept_for_approval,
+)
 
 _log = logging.getLogger("mcp_proxy.dashboard")
 
@@ -1594,6 +1603,14 @@ async def agent_delete(request: Request, agent_id: str):
     if not await verify_csrf(request, session):
         raise HTTPException(status_code=403, detail="Invalid CSRF token")
 
+    intercept = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_AGENTS_DELETE,
+        payload={"agent_id": agent_id},
+    )
+    if intercept is not None:
+        return intercept
+
     from sqlalchemy import text
 
     from mcp_proxy.db import get_agent, get_db, log_audit
@@ -1805,9 +1822,16 @@ async def policies_save(request: Request):
     if not await verify_csrf(request, session):
         raise HTTPException(status_code=403, detail="Invalid CSRF token")
 
+    form = await request.form()
+    payload = {k: str(v) for k, v in form.items() if k != "csrf_token"}
+    intercept = await maybe_intercept_for_approval(
+        session=session, action_type=ACTION_POLICIES_SAVE, payload=payload,
+    )
+    if intercept is not None:
+        return intercept
+
     from mcp_proxy.db import set_config, get_config, log_audit
 
-    form = await request.form()
     tab = str(form.get("tab", "rules"))
 
     if tab == "rules":
@@ -2205,6 +2229,12 @@ async def pki_rotate_ca(request: Request):
     if not await verify_csrf(request, session):
         raise HTTPException(status_code=403, detail="Invalid CSRF token")
 
+    intercept = await maybe_intercept_for_approval(
+        session=session, action_type=ACTION_PKI_ROTATE_CA, payload={},
+    )
+    if intercept is not None:
+        return intercept
+
     from mcp_proxy.db import get_config, set_config, log_audit
 
     org_id = await get_config("org_id")
@@ -2448,6 +2478,13 @@ async def mastio_key_rotate(request: Request):
         raise HTTPException(status_code=403, detail="Invalid CSRF token")
 
     form = await request.form()
+    payload = {k: str(v) for k, v in form.items() if k != "csrf_token"}
+    intercept = await maybe_intercept_for_approval(
+        session=session, action_type=ACTION_MASTIO_KEY_ROTATE, payload=payload,
+    )
+    if intercept is not None:
+        return intercept
+
     if form.get("confirm_text") != "ROTATE":
         raise HTTPException(
             status_code=400,
@@ -2863,6 +2900,12 @@ async def vault_migrate_keys(request: Request):
         return session
     if not await verify_csrf(request, session):
         raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    intercept = await maybe_intercept_for_approval(
+        session=session, action_type=ACTION_VAULT_MIGRATE_KEYS, payload={},
+    )
+    if intercept is not None:
+        return intercept
 
     from mcp_proxy.db import get_config, get_db, log_audit
 
@@ -3859,6 +3902,15 @@ async def users_delete(principal_id: str, request: Request):
             f"/proxy/users/{principal_id}?error=csrf",
             status_code=303,
         )
+
+    intercept = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_USERS_DELETE,
+        payload={"principal_id": principal_id},
+    )
+    if intercept is not None:
+        return intercept
+
     if _frontdesk_admin_target() is None:
         return RedirectResponse(
             f"/proxy/users/{principal_id}?error=Frontdesk+not+configured",

--- a/mcp_proxy/plugins.py
+++ b/mcp_proxy/plugins.py
@@ -1,19 +1,27 @@
 """Mastio plugin registry — extension point for the cullis-enterprise package.
 
 Discovers plugins via Python entry points (group ``cullis.mastio_plugins``)
-and exposes 5 hook surfaces. Empty registry is the supported default: when
+and exposes 7 hook surfaces. Empty registry is the supported default: when
 no entry points are installed (community deploys) the proxy boots
 identically to a no-plugin build.
 
 Hook surfaces:
-  * ``routers()``         — list[APIRouter] mounted after core routers.
-  * ``middlewares()``     — list[(cls, kwargs)] added to the FastAPI app.
-  * ``kms_factory(name)`` — optional callable for a KMS provider name; the
-                            first plugin that returns non-None wins.
-  * ``startup(app)``      — coroutine awaited at lifespan startup, after
-                            core init has placed services on ``app.state``.
-  * ``shutdown(app)``     — coroutine awaited at lifespan shutdown, before
-                            core teardown disposes the engine + redis pool.
+  * ``routers()``                 — list[APIRouter] mounted after core routers.
+  * ``middlewares()``             — list[(cls, kwargs)] added to the FastAPI app.
+  * ``kms_factory(name)``         — optional callable for a KMS provider name; the
+                                    first plugin that returns non-None wins.
+  * ``startup(app)``              — coroutine awaited at lifespan startup, after
+                                    core init has placed services on ``app.state``.
+  * ``shutdown(app)``             — coroutine awaited at lifespan shutdown, before
+                                    core teardown disposes the engine + redis pool.
+  * ``approval_required(action)`` — return True if the plugin wants to gate the
+                                    given action_type (e.g. ``policies.save``)
+                                    behind its own approval workflow. The first
+                                    plugin that returns True wins.
+  * ``submit_approval(...)``      — coroutine that persists a pending approval
+                                    and returns its identifier. Called by core
+                                    endpoint handlers after ``approval_required``
+                                    returned True.
 
 Plugins override only the hooks they need; defaults are no-ops. Each plugin
 may declare ``requires_feature``: when set, ``filter_by_license`` drops the
@@ -59,6 +67,37 @@ class Plugin:
 
     async def shutdown(self, app: FastAPI) -> None:
         return None
+
+    def approval_required(self, action_type: str) -> bool:
+        """Whether this plugin gates ``action_type`` behind its approval flow.
+
+        Called by core endpoint handlers (policies.save, pki.rotate_ca, etc.)
+        before executing the action. The first plugin in registry order that
+        returns True wins; the action is intercepted and ``submit_approval``
+        is invoked instead of normal execution.
+
+        Default is False: community deploys without any plugin observe
+        unchanged behavior.
+        """
+        return False
+
+    async def submit_approval(
+        self,
+        action_type: str,
+        payload: dict[str, Any],
+        submitter_id: str,
+    ) -> str:
+        """Persist a pending approval and return its identifier (ULID).
+
+        The plugin is responsible for storage, quorum tracking, expiry, and
+        eventual execution of the action when quorum is reached. The core
+        endpoint that called this returns a redirect to the plugin-managed
+        approval detail page, e.g. ``/dashboard/approvals/{id}``.
+        """
+        raise NotImplementedError(
+            f"plugin {self.name} declared approval_required for "
+            f"{action_type!r} but did not implement submit_approval"
+        )
 
 
 @dataclass
@@ -142,6 +181,23 @@ class PluginRegistry:
                 await plugin.shutdown(app)
             except Exception as exc:
                 _log.warning("plugin %s shutdown raised: %s", plugin.name, exc)
+
+    def approval_required_for(self, action_type: str) -> Optional[Plugin]:
+        """First plugin that wants to gate ``action_type``, or None.
+
+        Endpoint handlers can use this to skip the body fully when no plugin
+        opts in (community deploy fast path).
+        """
+        for plugin in self.plugins:
+            try:
+                if plugin.approval_required(action_type):
+                    return plugin
+            except Exception as exc:
+                _log.warning(
+                    "plugin %s approval_required(%s) raised: %s",
+                    plugin.name, action_type, exc,
+                )
+        return None
 
 
 _registry: PluginRegistry | None = None

--- a/tests/test_approval_hook.py
+++ b/tests/test_approval_hook.py
@@ -1,0 +1,270 @@
+"""Unit tests for the plugin approval hook.
+
+Two scopes covered:
+  * Plugin base class + registry: default ``approval_required`` is False;
+    ``approval_required_for`` returns the first opted-in plugin.
+  * Helper ``maybe_intercept_for_approval``: returns None when no plugin
+    opts in (community fast path), returns a 303 RedirectResponse when a
+    plugin gates the action, and falls through to direct execution when
+    a misconfigured plugin opts in but cannot submit.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from starlette.responses import RedirectResponse
+
+from mcp_proxy import plugins as mp_plugins
+from mcp_proxy.admin.approval_hook import (
+    ACTION_AGENTS_DELETE,
+    ACTION_MASTIO_KEY_ROTATE,
+    ACTION_PKI_ROTATE_CA,
+    ACTION_POLICIES_SAVE,
+    ACTION_USERS_DELETE,
+    ACTION_VAULT_MIGRATE_KEYS,
+    maybe_intercept_for_approval,
+)
+from mcp_proxy.plugins import Plugin, PluginRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Each test starts with an empty registry; never leak global state."""
+    mp_plugins.reset_registry()
+    yield
+    mp_plugins.reset_registry()
+
+
+def _mock_session(role: str = "admin") -> Any:
+    s = MagicMock()
+    s.role = role
+    return s
+
+
+# ── Plugin base class ─────────────────────────────────────────────────────
+
+
+def test_default_plugin_does_not_gate():
+    """A plugin that does not override ``approval_required`` returns False."""
+    p = Plugin()
+    assert p.approval_required(ACTION_POLICIES_SAVE) is False
+    assert p.approval_required("anything.else") is False
+
+
+@pytest.mark.asyncio
+async def test_default_plugin_submit_raises():
+    """Default submit_approval raises NotImplementedError, naming the plugin."""
+    p = Plugin()
+    p.name = "test_plugin"
+    with pytest.raises(NotImplementedError, match="test_plugin"):
+        await p.submit_approval("policies.save", {}, "admin")
+
+
+# ── Registry ──────────────────────────────────────────────────────────────
+
+
+def test_registry_no_plugins_returns_none():
+    registry = PluginRegistry()
+    assert registry.approval_required_for(ACTION_POLICIES_SAVE) is None
+
+
+def test_registry_returns_first_opted_in_plugin():
+    class GatingPlugin(Plugin):
+        name = "gate"
+
+        def approval_required(self, action_type: str) -> bool:
+            return action_type == ACTION_POLICIES_SAVE
+
+    class PassthroughPlugin(Plugin):
+        name = "passthrough"
+
+    p_gate = GatingPlugin()
+    p_pass = PassthroughPlugin()
+    registry = PluginRegistry(plugins=[p_pass, p_gate])
+
+    assert registry.approval_required_for(ACTION_POLICIES_SAVE) is p_gate
+    assert registry.approval_required_for(ACTION_PKI_ROTATE_CA) is None
+
+
+def test_registry_swallows_plugin_exceptions_in_approval_check():
+    """A plugin that raises during approval_required must not break others."""
+    class BrokenPlugin(Plugin):
+        name = "broken"
+
+        def approval_required(self, action_type: str) -> bool:
+            raise RuntimeError("boom")
+
+    class WorkingPlugin(Plugin):
+        name = "working"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+    registry = PluginRegistry(plugins=[BrokenPlugin(), WorkingPlugin()])
+    result = registry.approval_required_for(ACTION_POLICIES_SAVE)
+    assert result is not None
+    assert result.name == "working"
+
+
+# ── Helper: maybe_intercept_for_approval ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intercept_returns_none_when_no_plugin_opts_in(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Community fast path: empty registry returns None, caller proceeds."""
+    monkeypatch.setattr(
+        mp_plugins, "get_registry", lambda: PluginRegistry(plugins=[]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_POLICIES_SAVE,
+        payload={"rules_json": "{}"},
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_intercept_redirects_when_plugin_opts_in(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """When a plugin gates the action, helper redirects to approval page."""
+    submitted_args: dict[str, Any] = {}
+
+    class QuorumPlugin(Plugin):
+        name = "quorum"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            submitted_args["action_type"] = action_type
+            submitted_args["payload"] = payload
+            submitted_args["submitter_id"] = submitter_id
+            return "01H7XYZ..."
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[QuorumPlugin()]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(role="compliance_admin"),
+        action_type=ACTION_PKI_ROTATE_CA,
+        payload={},
+    )
+
+    assert isinstance(result, RedirectResponse)
+    assert result.status_code == 303
+    assert result.headers["location"] == "/proxy/admin/approvals/01H7XYZ..."
+    assert submitted_args == {
+        "action_type": ACTION_PKI_ROTATE_CA,
+        "payload": {},
+        "submitter_id": "compliance_admin",
+    }
+
+
+@pytest.mark.asyncio
+async def test_intercept_falls_through_on_not_implemented(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Plugin that gates but does not implement submit_approval = no-op."""
+    class MisconfiguredPlugin(Plugin):
+        name = "misconfigured"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+        # Inherits default submit_approval that raises NotImplementedError.
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[MisconfiguredPlugin()]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_USERS_DELETE,
+        payload={"principal_id": "org-a::user::alice"},
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_intercept_falls_through_on_arbitrary_exception(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Plugin that crashes mid-submit must not break the original endpoint."""
+    class CrashyPlugin(Plugin):
+        name = "crashy"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            raise RuntimeError("storage backend down")
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[CrashyPlugin()]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_AGENTS_DELETE,
+        payload={"agent_id": "org-a::agent::bot-1"},
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_intercept_handles_session_without_role(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Session with empty role falls back to 'admin' as submitter id."""
+    captured: dict[str, str] = {}
+
+    class CapturingPlugin(Plugin):
+        name = "capturing"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            captured["submitter_id"] = submitter_id
+            return "01H_FALLBACK"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[CapturingPlugin()]),
+    )
+    session = _mock_session(role=None)
+    result = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_VAULT_MIGRATE_KEYS,
+        payload={},
+    )
+    assert isinstance(result, RedirectResponse)
+    assert captured["submitter_id"] == "admin"
+
+
+# ── Action constant stability ────────────────────────────────────────────
+
+
+def test_action_constants_are_stable_strings():
+    """Plugins key on these strings. Renaming requires a coordinated release."""
+    assert ACTION_POLICIES_SAVE == "policies.save"
+    assert ACTION_PKI_ROTATE_CA == "pki.rotate_ca"
+    assert ACTION_MASTIO_KEY_ROTATE == "mastio_key.rotate"
+    assert ACTION_VAULT_MIGRATE_KEYS == "vault.migrate_keys"
+    assert ACTION_USERS_DELETE == "users.delete"
+    assert ACTION_AGENTS_DELETE == "agents.delete"


### PR DESCRIPTION
## Summary
Add the plugin extension points (`approval_required`, `submit_approval`) that let an enterprise plugin gate critical admin actions behind its own quorum / 4-eyes workflow. Wraps 6 critical endpoints in dashboard/router.py to invoke the hook after auth+CSRF and before mutation.

## Why
Phase A2 sub-task. CISO simulation 2026-05-13 flagged the single-admin model as no-go-for-production for banking tier-2 EU. The matching enterprise plugin (sub-roles technical/compliance/super_admin, pending_admin_approvals table, quorum logic, UI HTMX) lives in cullis-enterprise repo and extends the existing `rbac_multi_admin` plugin. This PR ships only the OSS hook surface.

## Contract

```python
class Plugin:
    def approval_required(self, action_type: str) -> bool: ...
    async def submit_approval(self, action_type, payload, submitter_id) -> str: ...
```

Stable action_type constants (plugins key on these):

- `policies.save`
- `pki.rotate_ca`
- `mastio_key.rotate`
- `vault.migrate_keys`
- `agents.delete`
- `users.delete`

When no plugin opts in (community deploy), `maybe_intercept_for_approval` returns None and endpoints proceed unchanged. When a plugin opts in but its `submit_approval` raises, the helper logs and falls through to direct execution, preserving liveness for misconfigured installs.

## Test plan
- [x] `pytest tests/test_approval_hook.py` — 11 new unit tests pass
- [x] `pytest tests/test_mastio_plugin_system.py tests/test_mastio_kms.py` — 24 existing plugin tests pass (no regression)
- [x] `pytest tests/ -k 'policies or rotate or migrate_keys'` — 41 tests passing, 2 skipped
- [ ] `./sandbox/smoke.sh full` (CI gate)

## Scope
Touches `mcp_proxy/` so smoke gate applies (CI runs it). No alembic migration. No new dependency. Behavior unchanged for community / no-plugin deploys.

## Follow-ups (not in this PR)
- cullis-enterprise PR extending `rbac_multi_admin` with sub-roles + 4-eyes workflow + UI
- ADR-028 (multi-admin 4-eyes design)
- Customer doc `site/src/content/docs/operate/multi-admin-rbac`