### PR TITLE
feat(connector): dashboard /api-keys page (Wave 2 show-token)

### DIFF
--- a/cullis_connector/__init__.py
+++ b/cullis_connector/__init__.py
@@ -13,5 +13,5 @@ Run standalone::
 Or configure in your MCP client of choice. See README for examples.
 """
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 __all__ = ["__version__"]

--- a/cullis_connector/ambassador/auth.py
+++ b/cullis_connector/ambassador/auth.py
@@ -57,9 +57,34 @@ def ensure_local_token(config_dir: Path) -> str:
         token = token_path.read_text(encoding="utf-8").strip()
         if token:
             return token
-        _log.warning("local token file at %s is empty — regenerating", token_path)
+        _log.warning("local token file at %s is empty, regenerating", token_path)
+    return _write_new_local_token(config_dir, reason="generated")
+
+
+def rotate_local_token(config_dir: Path) -> str:
+    """Force-regenerate the local Bearer token and return the new value.
+
+    Used by the dashboard's "Rotate" button on the API keys page. The
+    previous token is irretrievable once this returns; every external
+    client (LibreChat, Cherry Studio, AnythingLLM, OpenWebUI, ...) that
+    cached the old value must be re-pasted with the new one. No grace
+    window, no audit row for the old token: the file mode 0600 plus the
+    loopback-only acceptance is the only trust anchor, so there is
+    nothing to "revoke" beyond overwriting the disk content.
+    """
+    return _write_new_local_token(config_dir, reason="rotated")
+
+
+def _write_new_local_token(config_dir: Path, *, reason: str) -> str:
+    """Generate a fresh token, write it 0600, return it.
+
+    Shared body for ``ensure_local_token`` first-create path and the
+    ``rotate_local_token`` explicit overwrite path. ``reason`` is only
+    used for the log line.
+    """
     token = secrets.token_hex(32)
     config_dir.mkdir(parents=True, exist_ok=True)
+    token_path = config_dir / LOCAL_TOKEN_FILENAME
     token_path.write_text(token + "\n", encoding="utf-8")
     try:
         token_path.chmod(0o600)
@@ -68,7 +93,7 @@ def ensure_local_token(config_dir: Path) -> str:
         # info, not warning, because the local trust boundary is the
         # OS user not the file mode in those environments.
         _log.info("could not chmod 0600 on %s (filesystem may not support it)", token_path)
-    _log.info("generated new local token at %s", token_path)
+    _log.info("%s local token at %s", reason, token_path)
     return token
 
 

--- a/cullis_connector/templates/api_keys.html
+++ b/cullis_connector/templates/api_keys.html
@@ -1,0 +1,150 @@
+{% extends "base.html" %}
+{% block title %}API keys{% endblock %}
+{% block content %}
+
+<section class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Local Ambassador</div>
+        <h1 class="panel-title">API keys for OpenAI-compatible clients</h1>
+        <p class="panel-sub">
+            Paste this Bearer token into LibreChat, Cherry Studio, AnythingLLM,
+            OpenWebUI, or any other client that speaks the OpenAI API. The
+            Connector's Ambassador (running on this machine) accepts it only
+            from 127.0.0.1 loopback, so a leak off-host is harmless until an
+            attacker also has access to this machine.
+        </p>
+    </div>
+
+    <div class="identity-card" style="margin-top: 12px;">
+        <div class="identity-row">
+            <span class="identity-k">Endpoint</span>
+            <span class="identity-v mono">{{ ambassador_url }}/v1</span>
+        </div>
+        <div class="identity-row" style="align-items: center;">
+            <span class="identity-k">Bearer token</span>
+            <span class="identity-v mono"
+                  id="token-display"
+                  data-token-full="{{ token }}"
+                  data-token-masked="{{ token_masked }}"
+                  data-revealed="false"
+                  style="word-break: break-all;">{{ token_masked }}</span>
+        </div>
+        <div class="identity-row">
+            <span class="identity-k">File on disk</span>
+            <span class="identity-v mono" style="font-size: 11px; opacity: 0.7;">{{ token_path }} (0600)</span>
+        </div>
+    </div>
+
+    <div class="btn-row" style="margin-top: 16px;">
+        <button type="button"
+                id="reveal-btn"
+                class="btn btn-ghost"
+                onclick="toggleReveal()">
+            Reveal
+        </button>
+        <button type="button"
+                class="btn btn-ghost"
+                onclick="copyText(document.getElementById('token-display').dataset.tokenFull)">
+            Copy token
+        </button>
+        <button type="button"
+                id="rotate-btn"
+                class="btn btn-ghost"
+                hx-post="/api-keys/rotate"
+                hx-swap="none"
+                hx-confirm="Rotate token? Every client (LibreChat, Cherry Studio, ...) currently configured with the old token will stop working until you paste in the new one."
+                hx-on::after-request="handleRotateResult(this, event)">
+            Rotate
+        </button>
+    </div>
+</section>
+
+<section class="panel">
+    <div class="panel-head">
+        <div class="panel-eyebrow">Step-by-step</div>
+        <h2 class="panel-title" style="font-size: 18px;">How to use it</h2>
+        <p class="panel-sub">
+            Generic pattern across every OpenAI-compatible client. Concrete
+            screenshots for LibreChat / Cherry Studio / AnythingLLM /
+            OpenWebUI live at the docs link below.
+        </p>
+    </div>
+
+    <ol class="step-list" style="padding-left: 20px; line-height: 1.7;">
+        <li>
+            Open your client's <em>Custom OpenAI Provider</em> settings (label
+            varies: "OpenAI-compatible API", "Custom endpoint", "Base URL").
+        </li>
+        <li>
+            <strong>Base URL</strong>: paste <code class="mono">{{ ambassador_url }}/v1</code>
+            (or <code class="mono">{{ ambassador_url }}</code> if the client appends
+            <code>/v1</code> automatically).
+        </li>
+        <li>
+            <strong>API key</strong>: click <em>Copy token</em> above, paste into the
+            <code>API key</code> field. The client sends it as
+            <code class="mono">Authorization: Bearer &lt;token&gt;</code>.
+        </li>
+        <li>
+            <strong>Model</strong>: leave on default or pick from your Mastio's
+            configured providers. The Connector forwards to the Mastio you
+            enrolled at, so the model catalog mirrors what your org allows.
+        </li>
+    </ol>
+
+    <div class="btn-row" style="margin-top: 16px;">
+        <a class="btn btn-ghost" href="https://cullis.io/docs/connector/openai-clients" target="_blank" rel="noopener">
+            Per-client setup docs →
+        </a>
+        <a class="btn btn-ghost" href="/connected">
+            ← Back to overview
+        </a>
+    </div>
+</section>
+
+<p class="footer-hint">
+    Loopback-only acceptance: the token never authorizes a remote call.
+    For remote OpenAI-compatible access (Mastio-hosted) use ADR-027
+    <code class="mono">culk_*</code> tokens issued by your org admin.
+</p>
+
+{% endblock %}
+
+{% block after_body %}
+<script>
+function toggleReveal() {
+    const el = document.getElementById('token-display');
+    const btn = document.getElementById('reveal-btn');
+    const revealed = el.dataset.revealed === 'true';
+    if (revealed) {
+        el.textContent = el.dataset.tokenMasked;
+        el.dataset.revealed = 'false';
+        btn.textContent = 'Reveal';
+    } else {
+        el.textContent = el.dataset.tokenFull;
+        el.dataset.revealed = 'true';
+        btn.textContent = 'Hide';
+    }
+}
+
+function handleRotateResult(btn, event) {
+    btn.disabled = false;
+    let payload = {};
+    try { payload = JSON.parse(event.detail.xhr.responseText); } catch (e) {}
+    if (!event.detail.successful || !payload.token) {
+        showToast(payload.error || 'Rotate failed');
+        return;
+    }
+    const el = document.getElementById('token-display');
+    el.dataset.tokenFull = payload.token;
+    el.dataset.tokenMasked = payload.token_masked;
+    // Show the new token immediately so the operator can copy it before
+    // re-masking, but flip the Reveal button label so the state stays
+    // consistent on the next click.
+    el.textContent = payload.token;
+    el.dataset.revealed = 'true';
+    document.getElementById('reveal-btn').textContent = 'Hide';
+    showToast('New token generated. Re-paste it into every client.');
+}
+</script>
+{% endblock %}

--- a/cullis_connector/templates/connected.html
+++ b/cullis_connector/templates/connected.html
@@ -76,6 +76,9 @@
                 hx-on::after-request="handleTestPingResult(this, event)">
             Test connection
         </button>
+        <a href="/api-keys" class="btn btn-ghost">
+            API keys for clients
+        </a>
         <span id="test-ping-result" class="muted" style="font-size: 12px; align-self: center;"></span>
     </div>
 </section>

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -89,6 +89,19 @@ _CHAT_REPO_DEV_DIR = (
 )
 
 
+def _mask_token(token: str) -> str:
+    """Return a Stripe/OpenAI-style preview of a Bearer token.
+
+    First 8 chars + 8 middle bullets + last 4 chars. Long enough that
+    two distinct tokens are visually distinct in a screenshot, short
+    enough that the secret bulk is not on screen. Used by the API keys
+    dashboard page (the operator clicks ``Reveal`` for the full value).
+    """
+    if len(token) <= 12:
+        return "•" * len(token)
+    return f"{token[:8]}{'•' * 8}{token[-4:]}"
+
+
 def _resolve_chat_dist() -> Path | None:
     """Return the directory holding the built Cullis Chat SPA, or None.
 
@@ -1506,6 +1519,67 @@ def build_app(config: ConnectorConfig) -> FastAPI:
                 ),
             },
         )
+
+    @app.get("/api-keys", response_class=HTMLResponse)
+    def api_keys_get(request: Request) -> Response:
+        """Render the local Ambassador Bearer token + Reveal/Copy/Rotate UI.
+
+        Wave 2 of the show-token gap closure ([[gap-connector-show-token-cli]]).
+        The CLI ``cullis-connector show-token`` covers the script path; this
+        page covers the GUI path (LibreChat / Cherry Studio / AnythingLLM /
+        OpenWebUI operators who never open a terminal).
+        """
+        if not has_identity(config.config_dir):
+            return RedirectResponse("/setup", status_code=303)
+
+        from cullis_connector.ambassador.auth import (
+            LOCAL_TOKEN_FILENAME,
+            ensure_local_token,
+        )
+
+        token = ensure_local_token(config.config_dir)
+        token_masked = _mask_token(token)
+        token_path = config.config_dir / LOCAL_TOKEN_FILENAME
+
+        # The Ambassador binds to the same host:port as the dashboard. We
+        # already know the dashboard URL the operator just opened in the
+        # browser (request.base_url); re-use it so the snippet shown matches
+        # exactly the URL they will paste into LibreChat / Cherry Studio.
+        ambassador_url = str(request.base_url).rstrip("/")
+
+        return templates.TemplateResponse(
+            request,
+            "api_keys.html",
+            {
+                "token": token,
+                "token_masked": token_masked,
+                "token_path": str(token_path),
+                "ambassador_url": ambassador_url,
+            },
+        )
+
+    @app.post("/api-keys/rotate")
+    def api_keys_rotate() -> JSONResponse:
+        """Force-rotate the local Bearer token and return the new value.
+
+        Idempotent at the file level (file is overwritten atomically by
+        ``rotate_local_token``); not idempotent semantically — every external
+        client cached with the old value stops working until re-pasted. The
+        dashboard's HTMX form confirms this with a ``hx-confirm`` dialog
+        before firing the request. Same-origin protection comes from the
+        global ``_csrf_origin_guard`` middleware already in place; no extra
+        CSRF token because the Ambassador only listens on 127.0.0.1.
+        """
+        if not has_identity(config.config_dir):
+            return JSONResponse({"error": "no identity"}, status_code=400)
+
+        from cullis_connector.ambassador.auth import rotate_local_token
+
+        token = rotate_local_token(config.config_dir)
+        return JSONResponse({
+            "token": token,
+            "token_masked": _mask_token(token),
+        })
 
     @app.post("/autostart/toggle")
     def autostart_toggle() -> JSONResponse:

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -20,7 +20,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cullis-connector"
-version = "0.4.5"
+version = "0.4.6"
 description = "MCP server bridging local MCP clients (Claude Code, Cursor, Claude Desktop, ToolHive) to the Cullis federated agent-trust network."
 readme = "README_PKG.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Closes the GUI half of [[project_gap_connector_show_token_cli]]. PR #674 shipped the CLI (`cullis-connector show-token`) which covered the script path. This adds the dashboard surface for the LibreChat / Cherry Studio / AnythingLLM / OpenWebUI operator who never opens a terminal.

## What ships

- **GET `/api-keys`** — renders the local Bearer token Stripe/OpenAI-style (first 8 chars + 8 bullets + last 4 chars). Reveal toggle exposes the full value, Copy button writes it to the clipboard, Rotate button regenerates and updates the display in place via HTMX.
- **POST `/api-keys/rotate`** — overwrites `local.token` via the new `rotate_local_token()` helper, returns the new value + new mask in JSON. `hx-confirm` warns the operator that every existing client config stops working until re-pasted.
- **`rotate_local_token(config_dir)`** helper in `ambassador/auth.py` — explicit force-regenerate distinct from `ensure_local_token()`'s read-or-create. Both delegate to the shared `_write_new_local_token()` private writer so the chmod 0600 path stays in one place.
- **`_mask_token(token)`** module helper in `web.py` — first 8 + 8 bullets + last 4, falls back to all-bullets for tokens shorter than 12 chars.
- **Link "API keys for clients"** from the `/connected` post-enroll page so an operator finds the page without typing the URL.

## Files

- `cullis_connector/templates/api_keys.html` (new) — page with Reveal/Copy/Rotate UI + step-by-step setup guide + per-client docs link
- `cullis_connector/web.py` — 2 new routes + `_mask_token` helper
- `cullis_connector/ambassador/auth.py` — `rotate_local_token` + `_write_new_local_token` refactor
- `cullis_connector/templates/connected.html` — 1 button link
- `cullis_connector/__init__.py` — `__version__ = "0.4.6"`
- `packaging/pypi/pyproject.toml` — `version = "0.4.6"`

## Version sync

Both `__init__.py` AND `pyproject.toml` bumped 0.4.5 → 0.4.6 in lockstep — applying the lesson from [[feedback_connector_version_sync_all_files]] (PR #675 recovery). Pre-tag consistency check:

```
tag=0.4.6  init=0.4.6  pyproj=0.4.6  ✅ ALIGNED
```

## Test plan

- [x] `python -c "import ast; ast.parse(...)"` clean on web.py
- [x] `show-token` CLI still works (regression after auth.py refactor)
- [x] `rotate_local_token` changes the on-disk value and the in-memory return matches
- [x] `_mask_token('45974798bffbd...')` returns `45974798••••••••723d` (8 + 8 bullets + 4)
- [x] Jinja2 renders `api_keys.html` with all sections (Reveal, Rotate, HTMX form, docs link) present in the output
- [ ] Post-merge dogfood: open `http://127.0.0.1:7777/api-keys` in browser, click Reveal/Copy/Rotate, verify token changes on rotate + display swap

## Tag plan

Cut `connector-v0.4.6` after merge.

## Note

This PR was originally branched as `feat/connector-dashboard-api-keys` (commit `9e175a84`) but the branch got contaminated by a parallel `feat/site-insurance-page` work and reset by an external tool. Re-pushed cleanly here from the same `9e175a84` commit recovered via reflog.