### PR TITLE
feat(site): nav restructure (Insurance, Pricing in; Components out)

### DIFF
--- a/site/src/components/Nav.astro
+++ b/site/src/components/Nav.astro
@@ -13,9 +13,10 @@ const isActive = (href: string) => {
       <span class="wordmark">Cullis</span>
     </a>
     <ul class="nav-links">
+      <li><a href="/insurance" class={isActive('/insurance') ? 'is-active' : ''}>Insurance</a></li>
+      <li><a href="/pricing" class={isActive('/pricing') ? 'is-active' : ''}>Pricing</a></li>
       <li><a href="/architecture" class={isActive('/architecture') ? 'is-active' : ''}>Architecture</a></li>
       <li><a href="/deployment" class={isActive('/deployment') ? 'is-active' : ''}>Deployment</a></li>
-      <li><a href="/components" class={isActive('/components') ? 'is-active' : ''}>Components</a></li>
       <li><a href="/docs" class={isActive('/docs') ? 'is-active' : ''}>Docs</a></li>
       <li><a href="/blog" class={isActive('/blog') ? 'is-active' : ''}>Blog</a></li>
       <li><a href="/download" class={isActive('/download') ? 'is-active' : ''}>Download</a></li>


### PR DESCRIPTION
## Summary
Repositions primary navigation to match the compliance-first landing pitch. Adds direct links to the new \`/insurance\` and \`/pricing\` pages; removes \`/components\` to de-emphasize Court as a top-level pillar.

## Why
Phase 0 sub-task 4. After PR #671 (landing), #677 (insurance), and #679 (pricing) shipped, the nav was still optimized for the old \"Two layers\" pitch with Court as a co-equal pillar. Buyer-facing pages were not in the nav at all.

## Changes

Before:
\`Architecture / Deployment / Components / Docs / Blog / Download / GitHub\`

After:
\`Insurance / Pricing / Architecture / Deployment / Docs / Blog / Download / GitHub\`

Ordering principle: buyer-facing pages first (Insurance, Pricing), then technical (Architecture, Deployment, Docs), then community (Blog, Download, GitHub). Eight items total, fits standard desktop widths. Mobile collapse threshold unchanged at 820px.

## What I did NOT do

- The \`/components\` page itself stays where it is (backlinks, search). It just exits the primary nav.
- Court remains discoverable via \`/architecture#federation\`.
- No font, no color, no layout change to the nav component.

## Test plan
- [x] \`npm run build\` — 28 pages, no errors
- [ ] Visit any page on CF Pages preview, verify new nav renders
- [ ] Verify active-state highlight works on Insurance / Pricing
- [ ] Verify mobile collapse at < 820px

## Scope
One-line change to \`Nav.astro\`. No CSS change.