### PR TITLE
chore(bundles): bump version defaults to current releases

### DIFF
--- a/packaging/frontdesk-bundle/deploy.sh
+++ b/packaging/frontdesk-bundle/deploy.sh
@@ -117,7 +117,7 @@ generate-frontdesk-env.sh):
   CULLIS_FRONTDESK_ORG_ID            Org slug, must match Mastio
   CULLIS_FRONTDESK_TRUST_DOMAIN      SPIFFE trust domain, e.g. acme.test
   CULLIS_FRONTDESK_CA_BUNDLE_HOST    Host path to the Mastio CA chain PEM
-  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.4)
+  CONNECTOR_VERSION                  cullis-connector image tag (default: 0.4.6)
   CHAT_VERSION                       cullis-chat-frontdesk image tag (default: 0.4.1)
   CONNECTOR_PROFILE                  Connector profile name (default: frontdesk)
   CONNECTOR_DATA_DIR                 Local dir for enrolled identity (default: ./connector_data)
@@ -233,7 +233,7 @@ _load_env() { grep -E "^$1=" "$SCRIPT_DIR/frontdesk.env" 2>/dev/null | head -1 |
 ORG_ID="$(_load_env CULLIS_FRONTDESK_ORG_ID)"
 TRUST_DOMAIN="$(_load_env CULLIS_FRONTDESK_TRUST_DOMAIN)"
 CA_BUNDLE="$(_load_env CULLIS_FRONTDESK_CA_BUNDLE_HOST)"
-CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.4}"
+CONNECTOR_VERSION="$(_load_env CONNECTOR_VERSION)";   CONNECTOR_VERSION="${CONNECTOR_VERSION:-0.4.6}"
 CHAT_VERSION="$(_load_env CHAT_VERSION)";             CHAT_VERSION="${CHAT_VERSION:-0.4.1}"
 CONNECTOR_PROFILE="$(_load_env CONNECTOR_PROFILE)";   CONNECTOR_PROFILE="${CONNECTOR_PROFILE:-frontdesk}"
 DATA_DIR="$(_load_env CONNECTOR_DATA_DIR)";           DATA_DIR="${DATA_DIR:-./connector_data}"

--- a/packaging/frontdesk-bundle/frontdesk.env.example
+++ b/packaging/frontdesk-bundle/frontdesk.env.example
@@ -42,7 +42,7 @@ CULLIS_FRONTDESK_CA_BUNDLE_HOST=./mastio-ca-bundle.pem
 # Which version of the cullis-connector image to pull. Pin a release tag
 # in production rather than ``latest``. The default tracks the latest
 # release validated against this bundle.
-# CONNECTOR_VERSION=0.4.4
+# CONNECTOR_VERSION=0.4.6
 
 # Which version of the Frontdesk-branded Cullis Chat SPA image to pull.
 # The image is published by the cullis monorepo's release-chat.yml on

--- a/packaging/mastio-bundle/README.md
+++ b/packaging/mastio-bundle/README.md
@@ -63,7 +63,7 @@ list of tunables (backend, provider, sidecar URL, timeout).
 ## Pin a release
 
 ```bash
-CULLIS_MASTIO_VERSION=0.3.0 ./deploy.sh
+CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh
 ```
 
 `latest` is fine for a quick try; pin to a specific tag in production.
@@ -123,7 +123,7 @@ registry:
 ```bash
 helm install cullis-mastio \
   oci://ghcr.io/cullis-security/charts/cullis-mastio \
-  --version 0.3.0 \
+  --version 0.4.2 \
   --set nginx.san="mastio.myorg.example.com,mastio.local" \
   --set proxy.proxyPublicUrl=https://mastio.myorg.example.com
 ```

--- a/packaging/mastio-bundle/deploy.sh
+++ b/packaging/mastio-bundle/deploy.sh
@@ -9,7 +9,7 @@
 # --shared-broker overlay opts into federation when a Court is up on
 # the same docker host.
 #
-# Pin a release with CULLIS_MASTIO_VERSION=0.3.0 ./deploy.sh
+# Pin a release with CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh
 # (defaults to "latest" — fine for dev, pin in production).
 #
 # Modes (combinable):
@@ -21,7 +21,7 @@
 #
 # Examples:
 #   ./deploy.sh                                # standalone (default)
-#   CULLIS_MASTIO_VERSION=0.3.0 ./deploy.sh    # pinned version
+#   CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh    # pinned version
 #   ./deploy.sh --shared-broker                # join Court on same host
 #   ./deploy.sh --prod                         # standalone, prod safety
 #   ./deploy.sh --down                         # stop + remove
@@ -458,11 +458,11 @@ Environment:
 
 Examples:
   ./deploy.sh                                    # standalone (default)
-  CULLIS_MASTIO_VERSION=0.3.0 ./deploy.sh        # pinned version
+  CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh        # pinned version
   ./deploy.sh --shared-broker                    # join Court on same host
   ./deploy.sh --prod                             # standalone, prod safety
-  ./deploy.sh --upgrade 0.3.0-rc3                # image-only bump
-  ./deploy.sh --upgrade-bundle 0.4.0             # full bundle refresh
+  ./deploy.sh --upgrade 0.4.2                    # image-only bump
+  ./deploy.sh --upgrade-bundle 0.4.2             # full bundle refresh
   ./deploy.sh --migrate-volumes                  # one-shot bind migration
   ./deploy.sh --down                             # stop + remove
 EOF


### PR DESCRIPTION
## Summary

Stale version pins in Mastio + Frontdesk bundle docs/defaults. Cosmetic refresh after the 2026-05-12/13 release marathon.

**Frontdesk bundle**
- `CONNECTOR_VERSION` default `0.4.4` → `0.4.6` (latest connector with show-token CLI + dashboard `/api-keys` page).
- `frontdesk.env.example` comment matched.

**Mastio bundle**
- README pin sample + Helm sample: `0.3.0` → `0.4.2`.
- `deploy.sh` header comment + `--help` examples: `0.3.0` → `0.4.2`.
- `--upgrade` / `--upgrade-bundle` examples updated to `0.4.2`.

No `compose.yml` change. No runtime behaviour change. Users overriding via env stay unaffected.

## Test plan

- [x] `bash -n` on both `deploy.sh` files (clean).
- [x] Diff confined to 4 files, 10 lines changed.
- [x] No code path touched, no smoke needed (docs/defaults only).