### PR TITLE
feat(mastio): cullis-proxy migrate-org-ca-to-vault CLI (ADR-031 follow-up)

### DIFF
--- a/mcp_proxy/cli/__init__.py
+++ b/mcp_proxy/cli/__init__.py
@@ -3,8 +3,10 @@
 Entry point: `python -m mcp_proxy.cli <subcommand>`.
 
 Subcommands:
-  rebuild-cache    Drop and re-fetch the federation cache from the broker.
-  reset-password   Overwrite the admin bcrypt hash and re-enable local sign-in.
+  rebuild-cache              Drop + re-fetch the federation cache.
+  reset-password             Overwrite the admin bcrypt hash.
+  migrate-org-ca-to-vault    Copy Org CA from proxy_config DB into Vault
+                             (ADR-031 follow-up to PR #684).
 
 Each subcommand is a thin async wrapper around helpers that live next
 to the runtime code (e.g. mcp_proxy.sync.cache_admin) so the CLI itself
@@ -55,6 +57,37 @@ def _build_parser() -> argparse.ArgumentParser:
         help="New password (skip the interactive prompt). Length must "
         "meet the proxy's MIN_PASSWORD_LENGTH. If omitted the CLI "
         "prompts twice on stderr.",
+    )
+
+    migrate = sub.add_parser(
+        "migrate-org-ca-to-vault",
+        help="One-shot copy of the Org CA keypair from proxy_config DB "
+        "to Vault KV v2 (ADR-031). Reads org_ca_key + org_ca_cert via "
+        "the local source, writes them via the in-tree VaultKMSProvider, "
+        "verifies by read-back, optionally clears the DB rows.",
+    )
+    migrate.add_argument(
+        "--yes", action="store_true",
+        help="Skip the interactive confirmation prompt.",
+    )
+    migrate.add_argument(
+        "--dry-run", action="store_true",
+        help="Validate end-to-end (DB has the keys, Vault is reachable, "
+        "target path either empty or --force) without writing to Vault "
+        "or touching the DB.",
+    )
+    migrate.add_argument(
+        "--clear-db", action="store_true",
+        help="After a successful write + read-back verification, NULL "
+        "out org_ca_key and org_ca_cert in proxy_config. Recommended "
+        "as the final operator step; omit when running a staged copy.",
+    )
+    migrate.add_argument(
+        "--force", action="store_true",
+        help="Overwrite the Vault path even if it already holds an "
+        "Org CA. Without this flag the CLI refuses to write when Vault "
+        "already has key_pem + cert_pem to avoid clobbering a prior "
+        "migration.",
     )
 
     return parser
@@ -143,6 +176,188 @@ async def _cmd_reset_password(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _cmd_migrate_org_ca_to_vault(args: argparse.Namespace) -> int:
+    """Copy the Org CA from proxy_config DB to Vault KV v2 (ADR-031).
+
+    Uses the in-tree LocalKMSProvider as the read source and a fresh
+    VaultKMSProvider as the write target. We instantiate both
+    explicitly rather than going through the factory because the
+    operator typically runs this CLI while the Mastio is still on
+    ``kms_backend=local`` (otherwise the running Mastio would already
+    read from Vault and there is nothing to migrate). The factory's
+    cached provider is bypassed entirely.
+    """
+    from mcp_proxy.db import log_audit
+    from mcp_proxy.kms.local import LocalKMSProvider
+    from mcp_proxy.kms.vault import VaultKMSProvider
+
+    settings = get_settings()
+
+    # Vault settings must be present — VaultKMSProvider() raises
+    # ValueError otherwise, but a clearer up-front message helps.
+    missing = [
+        name for name, value in (
+            ("MCP_PROXY_VAULT_ADDR", settings.vault_addr),
+            ("MCP_PROXY_VAULT_TOKEN", settings.vault_token),
+            ("MCP_PROXY_VAULT_ORG_CA_PATH", settings.vault_org_ca_path),
+        ) if not value
+    ]
+    if missing:
+        sys.stderr.write(
+            "Vault settings missing: " + ", ".join(missing) + ". "
+            "Set them in proxy.env or via the dashboard /proxy/vault "
+            "page before running this migration.\n"
+        )
+        return 1
+
+    await init_db(settings.database_url)
+    try:
+        src = LocalKMSProvider()
+        dst = VaultKMSProvider(
+            vault_addr=settings.vault_addr,
+            vault_token=settings.vault_token,
+            org_ca_path=settings.vault_org_ca_path,
+            verify_tls=settings.vault_verify_tls,
+            ca_cert_path=settings.vault_ca_cert_path,
+        )
+
+        source = await src.load_org_ca()
+        if source is None:
+            sys.stderr.write(
+                "proxy_config has no Org CA to migrate (org_ca_key / "
+                "org_ca_cert are empty). This Mastio either never "
+                "generated a CA, or was already migrated.\n"
+            )
+            return 1
+        key_pem, cert_pem = source
+
+        existing = await dst.load_org_ca()
+        if existing is not None and not args.force:
+            sys.stderr.write(
+                f"Vault path {settings.vault_org_ca_path} already holds "
+                "an Org CA (key_pem + cert_pem present). Refusing to "
+                "overwrite without --force. If you intentionally want "
+                "to replace it (e.g. after a rotation), re-run with "
+                "--force.\n"
+            )
+            return 1
+
+        if args.dry_run:
+            sys.stdout.write(
+                f"DRY RUN: would write Org CA "
+                f"(key_pem={len(key_pem)} bytes, "
+                f"cert_pem={len(cert_pem)} bytes) to "
+                f"{settings.vault_addr}/v1/{settings.vault_org_ca_path}\n"
+            )
+            if existing is not None:
+                sys.stdout.write(
+                    "DRY RUN: target path is non-empty; --force is set, "
+                    "so the real run would overwrite.\n"
+                )
+            if args.clear_db:
+                sys.stdout.write(
+                    "DRY RUN: --clear-db is set; the real run would "
+                    "clear proxy_config.org_ca_key and org_ca_cert "
+                    "after read-back verification.\n"
+                )
+            return 0
+
+        if not args.yes:
+            sys.stderr.write(
+                f"This will write the Org CA private key + cert to "
+                f"{settings.vault_addr}/v1/{settings.vault_org_ca_path}"
+            )
+            if existing is not None:
+                sys.stderr.write(" (OVERWRITING existing value, --force)")
+            if args.clear_db:
+                sys.stderr.write(
+                    " and then clear proxy_config.org_ca_key + "
+                    "org_ca_cert"
+                )
+            sys.stderr.write(".\nContinue? [y/N]: ")
+            sys.stderr.flush()
+            ans = sys.stdin.readline().strip().lower()
+            if ans not in ("y", "yes"):
+                sys.stderr.write("aborted\n")
+                return 1
+
+        await dst.store_org_ca(key_pem, cert_pem)
+
+        # Read-back verification — the whole point of this CLI is to
+        # be safe to follow with --clear-db. We must be certain the
+        # write landed and that what came back matches what we sent.
+        verify = await dst.load_org_ca()
+        if verify is None:
+            await log_audit(
+                agent_id="admin",
+                action="kms.org_ca_migrate_to_vault",
+                status="failure",
+                detail="read-back returned None after store",
+            )
+            sys.stderr.write(
+                "ABORT: read-back from Vault returned None after the "
+                "write. The DB still holds the original Org CA — "
+                "nothing was cleared. Inspect the Vault path manually "
+                "before retrying.\n"
+            )
+            return 2
+        verify_key, verify_cert = verify
+        if verify_key != key_pem or verify_cert != cert_pem:
+            await log_audit(
+                agent_id="admin",
+                action="kms.org_ca_migrate_to_vault",
+                status="failure",
+                detail="read-back mismatch",
+            )
+            sys.stderr.write(
+                "ABORT: read-back from Vault does not match what was "
+                "written. The DB still holds the original Org CA — "
+                "nothing was cleared. Inspect the Vault path manually "
+                "before retrying.\n"
+            )
+            return 2
+
+        cleared = False
+        if args.clear_db:
+            # Set to empty string rather than DELETE the row, so the
+            # LocalKMSProvider treats it as unseeded (its truthiness
+            # check is ``if key_pem and cert_pem``) without disturbing
+            # the proxy_config schema. Operators who later flip back
+            # to local mode are forced to re-seed explicitly.
+            from mcp_proxy.db import set_config
+            await set_config("org_ca_key", "")
+            await set_config("org_ca_cert", "")
+            cleared = True
+
+        await log_audit(
+            agent_id="admin",
+            action="kms.org_ca_migrate_to_vault",
+            status="success",
+            detail=(
+                f"target={settings.vault_org_ca_path} "
+                f"overwrote={existing is not None} "
+                f"cleared_db={cleared}"
+            ),
+        )
+
+        sys.stdout.write(
+            f"Org CA migrated to Vault at {settings.vault_org_ca_path}. "
+            f"Read-back verified. "
+        )
+        if cleared:
+            sys.stdout.write(
+                "proxy_config.org_ca_key + org_ca_cert have been "
+                "cleared. "
+            )
+        sys.stdout.write(
+            "Restart the Mastio with MCP_PROXY_KMS_BACKEND=vault to "
+            "switch the live key source.\n"
+        )
+        return 0
+    finally:
+        await dispose_db()
+
+
 def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(
         level=logging.INFO,
@@ -155,6 +370,8 @@ def main(argv: list[str] | None = None) -> int:
         return asyncio.run(_cmd_rebuild_cache(args))
     if args.command == "reset-password":
         return asyncio.run(_cmd_reset_password(args))
+    if args.command == "migrate-org-ca-to-vault":
+        return asyncio.run(_cmd_migrate_org_ca_to_vault(args))
 
     parser.print_help(sys.stderr)
     return 2

--- a/tests/test_proxy_cli_migrate_org_ca.py
+++ b/tests/test_proxy_cli_migrate_org_ca.py
@@ -1,0 +1,330 @@
+"""``cullis-proxy migrate-org-ca-to-vault`` CLI tests (ADR-031 follow-up).
+
+Drives the subcommand end-to-end with:
+- SQLite proxy DB seeded with ``org_ca_key`` + ``org_ca_cert`` in
+  ``proxy_config``,
+- ``httpx.AsyncClient`` patched with a ``MockTransport`` so the
+  ``VaultKMSProvider`` writes go against an in-memory KV v2 fixture.
+
+Covers: happy path with ``--clear-db``, dry-run (no write, no clear),
+empty source (nothing to migrate), Vault path already populated
+without ``--force`` (refuse), read-back mismatch (abort, DB
+preserved), missing Vault settings (clear error).
+"""
+from __future__ import annotations
+
+import io
+import json
+
+import httpx
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+from mcp_proxy.cli import main as cli_main
+from mcp_proxy.db import dispose_db, get_config, get_db, init_db, set_config
+
+
+_VAULT_ADDR = "https://vault.example:8200"
+_TOKEN = "hvs.test-token"
+_PATH = "secret/data/cullis-mastio/org-ca"
+
+
+# ── Test fixtures ──────────────────────────────────────────────────
+
+
+@pytest_asyncio.fixture
+async def proxy_db(tmp_path, monkeypatch):
+    """Hermetic SQLite proxy DB + flushed settings cache + Vault env."""
+    db_file = tmp_path / "proxy.sqlite"
+    url = f"sqlite+aiosqlite:///{db_file}"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", url)
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_VAULT_ADDR", _VAULT_ADDR)
+    monkeypatch.setenv("MCP_PROXY_VAULT_TOKEN", _TOKEN)
+    monkeypatch.setenv("MCP_PROXY_VAULT_ORG_CA_PATH", _PATH)
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    await init_db(url)
+    yield url
+    await dispose_db()
+    get_settings.cache_clear()
+
+
+class _FakeVault:
+    """In-memory KV v2 fixture for the mocked Vault endpoint."""
+
+    def __init__(self, initial: dict | None = None) -> None:
+        # None means "404 on GET" (path not seeded).
+        self.data: dict | None = initial
+        self.version = 1 if initial else 0
+        self.writes: list[dict] = []
+        self.write_response: tuple[int, str] = (200, "")
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if not path.startswith(f"/v1/{_PATH}"):
+            return httpx.Response(404, json={"errors": ["unknown path"]})
+        if request.method == "GET":
+            if self.data is None:
+                return httpx.Response(404, json={"errors": []})
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "data": self.data,
+                        "metadata": {"version": self.version},
+                    },
+                },
+            )
+        # POST: capture body + update fixture.
+        body = json.loads(request.content)
+        self.writes.append(body)
+        if self.write_response[0] >= 400:
+            return httpx.Response(self.write_response[0], text=self.write_response[1])
+        self.data = body["data"]
+        self.version += 1
+        return httpx.Response(200, json={"data": {"version": self.version}})
+
+
+@pytest.fixture
+def patch_vault(monkeypatch):
+    """Returns a factory that wires the FakeVault into httpx.AsyncClient."""
+    def _apply(fake: _FakeVault) -> None:
+        transport = httpx.MockTransport(fake.handler)
+        real = httpx.AsyncClient
+
+        def patched(*args, **kwargs):
+            kwargs.setdefault("transport", transport)
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "AsyncClient", patched)
+    return _apply
+
+
+async def _seed_db_ca(key: str = "KEY_PEM", cert: str = "CERT_PEM") -> None:
+    await set_config("org_ca_key", key)
+    await set_config("org_ca_cert", cert)
+
+
+# ── Happy path ─────────────────────────────────────────────────────
+
+
+def test_cli_migrate_happy_path_with_clear_db(proxy_db, patch_vault, capsys):
+    import asyncio
+    url = proxy_db
+    asyncio.run(_seed_db_ca("MY_KEY", "MY_CERT"))
+
+    fake = _FakeVault(initial=None)
+    patch_vault(fake)
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes", "--clear-db"])
+    assert rc == 0
+
+    # Vault now holds the keypair.
+    assert fake.data == {"key_pem": "MY_KEY", "cert_pem": "MY_CERT"}
+    # First write must omit CAS (path was unseeded).
+    assert "options" not in fake.writes[0]
+
+    # DB rows have been cleared. ``cli_main`` already disposed the
+    # engine; re-init for the post-check so we hit the SQLite file
+    # again with a fresh loop-bound engine.
+    async def _check_cleared():
+        await init_db(url)
+        try:
+            assert await get_config("org_ca_key") == ""
+            assert await get_config("org_ca_cert") == ""
+        finally:
+            await dispose_db()
+    asyncio.run(_check_cleared())
+
+    out = capsys.readouterr().out
+    assert "migrated to Vault" in out
+    assert "cleared" in out
+
+
+# ── Dry-run ────────────────────────────────────────────────────────
+
+
+def test_cli_migrate_dry_run_does_not_write_or_clear(proxy_db, patch_vault, capsys):
+    import asyncio
+    url = proxy_db
+    asyncio.run(_seed_db_ca("X", "Y"))
+
+    fake = _FakeVault(initial=None)
+    patch_vault(fake)
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes", "--clear-db", "--dry-run"])
+    assert rc == 0
+
+    # No POST issued.
+    assert fake.writes == []
+    assert fake.data is None
+    # DB untouched.
+    async def _check_kept():
+        await init_db(url)
+        try:
+            assert await get_config("org_ca_key") == "X"
+            assert await get_config("org_ca_cert") == "Y"
+        finally:
+            await dispose_db()
+    asyncio.run(_check_kept())
+
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+
+
+# ── Empty source ───────────────────────────────────────────────────
+
+
+def test_cli_migrate_refuses_empty_db(proxy_db, patch_vault, capsys):
+    fake = _FakeVault(initial=None)
+    patch_vault(fake)
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes"])
+    assert rc == 1
+
+    err = capsys.readouterr().err
+    assert "no Org CA to migrate" in err
+    assert fake.writes == []
+
+
+# ── Existing target without --force ───────────────────────────────
+
+
+def test_cli_migrate_refuses_to_overwrite_without_force(proxy_db, patch_vault, capsys):
+    import asyncio
+    asyncio.run(_seed_db_ca())
+
+    fake = _FakeVault(initial={"key_pem": "PRIOR_KEY", "cert_pem": "PRIOR_CERT"})
+    patch_vault(fake)
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes"])
+    assert rc == 1
+
+    err = capsys.readouterr().err
+    assert "already holds" in err
+    assert "--force" in err
+    # Vault contents unchanged.
+    assert fake.data == {"key_pem": "PRIOR_KEY", "cert_pem": "PRIOR_CERT"}
+    assert fake.writes == []
+
+
+def test_cli_migrate_overwrites_with_force(proxy_db, patch_vault):
+    import asyncio
+    asyncio.run(_seed_db_ca("NEW_KEY", "NEW_CERT"))
+
+    fake = _FakeVault(initial={"key_pem": "OLD_KEY", "cert_pem": "OLD_CERT"})
+    patch_vault(fake)
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes", "--force"])
+    assert rc == 0
+    assert fake.data["key_pem"] == "NEW_KEY"
+    assert fake.data["cert_pem"] == "NEW_CERT"
+    # CAS write merged with prior version.
+    assert fake.writes[0]["options"]["cas"] == 1
+
+
+# ── Read-back mismatch ─────────────────────────────────────────────
+
+
+def test_cli_migrate_aborts_on_readback_mismatch_and_preserves_db(
+    proxy_db, monkeypatch, capsys,
+):
+    import asyncio
+    asyncio.run(_seed_db_ca("WANT_KEY", "WANT_CERT"))
+
+    # Custom transport that "writes" successfully but returns different
+    # content on the post-write read-back, simulating a Vault path that
+    # silently rewrites or a misconfigured replication target.
+    state = {"phase": "pre-write"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "GET":
+            if state["phase"] == "pre-write":
+                return httpx.Response(404, json={"errors": []})
+            # Read-back returns CORRUPTED content.
+            return httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "data": {"key_pem": "CORRUPTED", "cert_pem": "CORRUPTED"},
+                        "metadata": {"version": 1},
+                    },
+                },
+            )
+        # POST: accept, then flip state for the next read.
+        state["phase"] = "post-write"
+        return httpx.Response(200, json={"data": {"version": 1}})
+
+    transport = httpx.MockTransport(handler)
+    real = httpx.AsyncClient
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda *a, **kw: real(*a, **{**kw, "transport": transport}),
+    )
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes", "--clear-db"])
+    assert rc == 2
+
+    err = capsys.readouterr().err
+    assert "read-back" in err
+
+    # Crucially, the DB was NOT cleared — preserves recovery surface.
+    url = proxy_db
+    async def _check_kept():
+        await init_db(url)
+        try:
+            assert await get_config("org_ca_key") == "WANT_KEY"
+            assert await get_config("org_ca_cert") == "WANT_CERT"
+        finally:
+            await dispose_db()
+    asyncio.run(_check_kept())
+
+
+# ── Missing settings ───────────────────────────────────────────────
+
+
+def test_cli_migrate_refuses_when_vault_settings_missing(
+    proxy_db, monkeypatch, capsys,
+):
+    monkeypatch.delenv("MCP_PROXY_VAULT_TOKEN", raising=False)
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    rc = cli_main(["migrate-org-ca-to-vault", "--yes"])
+    assert rc == 1
+
+    err = capsys.readouterr().err
+    assert "MCP_PROXY_VAULT_TOKEN" in err
+
+
+# ── Help surface ───────────────────────────────────────────────────
+
+
+def test_cli_migrate_appears_in_help(capsys):
+    with pytest.raises(SystemExit):
+        cli_main(["--help"])
+    out = capsys.readouterr().out
+    assert "migrate-org-ca-to-vault" in out
+
+
+# ── Interactive abort ──────────────────────────────────────────────
+
+
+def test_cli_migrate_aborts_without_yes(proxy_db, patch_vault, monkeypatch, capsys):
+    import asyncio
+    asyncio.run(_seed_db_ca())
+
+    fake = _FakeVault(initial=None)
+    patch_vault(fake)
+
+    monkeypatch.setattr("sys.stdin", io.StringIO("n\n"))
+    rc = cli_main(["migrate-org-ca-to-vault"])
+    assert rc == 1
+
+    err = capsys.readouterr().err
+    assert "Continue?" in err
+    assert "aborted" in err
+    assert fake.writes == []

--- a/tests/test_proxy_cli_migrate_org_ca.py
+++ b/tests/test_proxy_cli_migrate_org_ca.py
@@ -19,10 +19,9 @@ import json
 import httpx
 import pytest
 import pytest_asyncio
-from sqlalchemy import text
 
 from mcp_proxy.cli import main as cli_main
-from mcp_proxy.db import dispose_db, get_config, get_db, init_db, set_config
+from mcp_proxy.db import dispose_db, get_config, init_db, set_config
 
 
 _VAULT_ADDR = "https://vault.example:8200"


### PR DESCRIPTION
## Summary

Follow-up to PR #684 (ADR-031 Vault as Org CA private key store). PR #684 shipped the read-write provider but explicitly deferred migration: new deploys can flip \`MCP_PROXY_KMS_BACKEND=vault\` from day one, but existing customers on \`local\` had no documented path to move their trust root into Vault without hand-rolling curl + DB SQL.

This PR adds the safe operator handover: a one-shot \`cullis-proxy migrate-org-ca-to-vault\` subcommand that copies the Org CA keypair from \`proxy_config\` DB (\`LocalKMSProvider\` source) to Vault KV v2 (\`VaultKMSProvider\` target), with read-back verification before any DB clear.

### What ships
- New subcommand \`cullis-proxy migrate-org-ca-to-vault\` in \`mcp_proxy/cli/__init__.py\`.
- Flags:
  - \`--yes\` — skip interactive confirm
  - \`--dry-run\` — validate end-to-end without writing
  - \`--clear-db\` — NULL out \`proxy_config.org_ca_key\` + \`org_ca_cert\` rows after read-back verification
  - \`--force\` — overwrite an already-populated Vault path (e.g. after a rotation)
- Refuses to start when Vault settings missing, with a clear list of which env vars are unset.
- Refuses to overwrite an existing Vault Org CA without \`--force\` (protects against double-migration on the same path).
- **Read-back verification before any DB clear**: if Vault returns None or mismatched content after the write, abort with exit code 2 and leave the DB untouched so the operator has a recovery path.
- Audit row on every terminal state (\`kms.org_ca_migrate_to_vault\`, status=success or failure with detail).
- \`--clear-db\` writes empty string rather than DELETE row, so the schema stays intact and \`LocalKMSProvider\` treats it as unseeded if the operator ever flips back.

### Why this design
- **No automatic flip of \`kms_backend\`**: the CLI does not touch \`MCP_PROXY_KMS_BACKEND\`. The operator runs the migration while the Mastio is still on \`local\`, then restarts with \`vault\` once the migration is verified. Decouples the data move from the live-traffic switch.
- **DB cleared only after read-back**: matches the safety bar of the trust root. The whole point of migrating the Org CA is that it remains the only valid signing identity for every agent + user cert in the org. Losing it via a half-written Vault put would brick the deploy.

### Out of scope (deliberate)
- Reverse migration (\`migrate-org-ca-from-vault\`): can be added later if a customer needs to roll back; for now the original DB row is preserved unless \`--clear-db\` is passed.
- Cloud KMS migration (AWS / Azure / GCP): enterprise plugins, separate CLI subcommands.

## Test plan

- [x] 9 new hermetic tests pass: \`pytest tests/test_proxy_cli_migrate_org_ca.py -o addopts=\"\" -q\` (happy path + clear-db, dry-run no-write, empty DB refusal, existing-Vault-path refusal, --force overwrite with CAS, read-back mismatch → DB preserved, missing settings → clear error, help surface, interactive abort)
- [x] Existing CLI + KMS tests still green: \`tests/test_proxy_cli_rebuild_cache.py\` + \`tests/test_kms_vault_provider.py\` (20 passed)
- [x] No ban-insecure-tls regex hits in new files
- [x] Mental ruff check on the two changed files
- [ ] CI: full test (3.11), demo_network smoke, customer-path smoke, security
- [ ] \`/security-review\` to run pre-merge (DB write + Vault token handling + audit emit)
- [ ] Follow-up PR: \`site/src/content/docs/operate/vault-org-ca.md\` operator guide with the full migration recipe (stop Mastio, run CLI, restart with kms_backend=vault)