### PR TITLE
fix(mcp-proxy): MCP aggregator double-wrap + admin reload + allow-list default

### DIFF
--- a/mcp_proxy/admin/mcp_resources.py
+++ b/mcp_proxy/admin/mcp_resources.py
@@ -25,6 +25,7 @@ from sqlalchemy.exc import IntegrityError
 
 from mcp_proxy.config import get_settings
 from mcp_proxy.db import get_db, log_audit
+from mcp_proxy.tools.registry import tool_registry
 from mcp_proxy.tools.resource_loader import reload_resources
 
 
@@ -160,6 +161,20 @@ async def create_resource(body: MCPResourceCreate):
     resource_id = str(uuid.uuid4())
     ts = _iso_now()
 
+    # Default the domain whitelist to the endpoint's own hostname when
+    # the caller didn't provide one. The WhitelistedTransport blocks all
+    # outbound calls on an empty list — registering a resource without
+    # any whitelist used to look healthy until the first tools/call hit
+    # the agent with "Domain 'X' not in whitelist: []" — which is
+    # surprising default behavior. Operators who actually want a
+    # locked-down configuration can still pass an explicit list.
+    allowed_domains = list(body.allowed_domains)
+    if not allowed_domains:
+        from urllib.parse import urlparse
+        host = urlparse(endpoint_url).hostname
+        if host:
+            allowed_domains = [host]
+
     try:
         async with get_db() as conn:
             await conn.execute(
@@ -186,7 +201,7 @@ async def create_resource(body: MCPResourceCreate):
                     "auth_secret_ref": body.auth_secret_ref,
                     "required_capability": body.required_capability,
                     "allowed_domains": json.dumps(
-                        body.allowed_domains, separators=(",", ":"), sort_keys=True,
+                        allowed_domains, separators=(",", ":"), sort_keys=True,
                     ),
                     "enabled": 1 if body.enabled else 0,
                     "ts": ts,
@@ -199,7 +214,7 @@ async def create_resource(body: MCPResourceCreate):
         ) from exc
 
     try:
-        await reload_resources()
+        await reload_resources(tool_registry)
     except Exception as exc:  # defensive
         _log.warning("reload_resources failed after create: %s", exc)
 
@@ -248,8 +263,8 @@ async def delete_resource(resource_id: str):
         )
 
     try:
-        await reload_resources()
-    except Exception as exc:
+        await reload_resources(tool_registry)
+    except Exception as exc:  # defensive
         _log.warning("reload_resources failed after delete: %s", exc)
 
     await log_audit(

--- a/mcp_proxy/ingress/mcp_aggregator.py
+++ b/mcp_proxy/ingress/mcp_aggregator.py
@@ -190,8 +190,22 @@ async def _handle_tools_call(
     )
 
     if resp.status == "success":
+        payload = resp.result
+        # Pass-through when the upstream already returned an MCP-shaped
+        # envelope ({"content": [...], "isError": bool}). The MCP resource
+        # forwarder returns the upstream RPC ``result`` verbatim — wrapping
+        # it again here produced a content[0].text that was a stringified
+        # MCP envelope, which callers then had to peel manually. Builtin
+        # tool handlers return arbitrary Python objects, so the fall-through
+        # path still wraps them as before.
+        if (
+            isinstance(payload, dict)
+            and isinstance(payload.get("content"), list)
+            and "isError" in payload
+        ):
+            return _rpc_result(req_id, payload)
         return _rpc_result(req_id, {
-            "content": [{"type": "text", "text": _stringify(resp.result)}],
+            "content": [{"type": "text", "text": _stringify(payload)}],
             "isError": False,
         })
     # executor.run always returns status="error" on failure; map to a

--- a/tests/test_proxy_admin_mcp_resources.py
+++ b/tests/test_proxy_admin_mcp_resources.py
@@ -75,6 +75,93 @@ async def test_create_list_delete_resource(tmp_path, monkeypatch):
     get_settings.cache_clear()
 
 
+async def test_create_auto_whitelists_endpoint_hostname(tmp_path, monkeypatch):
+    """When the caller omits allowed_domains, the endpoint's own hostname
+    is added automatically. Without this default the WhitelistedTransport
+    refuses every outbound call (audit footgun: register a resource, no
+    error, first tools/call fails with 'Domain X not in whitelist: []')."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-wl-default")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={
+                    "name": "get_policy",
+                    "endpoint_url": "http://mcp-insurance:9301/",
+                    "description": "no whitelist supplied",
+                    "org_id": "mcp-wl-default",
+                    "enabled": True,
+                },
+            )
+            assert r.status_code == 201, r.text
+            resource_id = r.json()["resource_id"]
+
+            # Inspect the DB row directly — the response shape doesn't
+            # echo allowed_domains. Walk the loader's storage to confirm
+            # the default hostname landed in the whitelist column.
+            from mcp_proxy.db import get_db
+            from sqlalchemy import text as _text
+            async with get_db() as conn:
+                row = (await conn.execute(
+                    _text(
+                        "SELECT allowed_domains "
+                        "FROM local_mcp_resources WHERE resource_id = :rid"
+                    ),
+                    {"rid": resource_id},
+                )).first()
+            import json as _json
+            stored = _json.loads(row[0])
+            assert stored == ["mcp-insurance"], (
+                f"expected ['mcp-insurance'], got {stored}"
+            )
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
+async def test_create_preserves_explicit_allowed_domains(tmp_path, monkeypatch):
+    """An explicit allowed_domains list is preserved verbatim."""
+    app = await _spin_proxy(tmp_path, monkeypatch, "mcp-wl-explicit")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as cli:
+        async with app.router.lifespan_context(app):
+            h = await _admin_headers()
+            r = await cli.post(
+                "/v1/admin/mcp-resources",
+                headers=h,
+                json={
+                    "name": "with_wl",
+                    "endpoint_url": "http://primary:9301/",
+                    "allowed_domains": ["primary", "fallback.example.com"],
+                    "org_id": "mcp-wl-explicit",
+                    "enabled": True,
+                },
+            )
+            assert r.status_code == 201, r.text
+            resource_id = r.json()["resource_id"]
+
+            from mcp_proxy.db import get_db
+            from sqlalchemy import text as _text
+            async with get_db() as conn:
+                row = (await conn.execute(
+                    _text(
+                        "SELECT allowed_domains "
+                        "FROM local_mcp_resources WHERE resource_id = :rid"
+                    ),
+                    {"rid": resource_id},
+                )).first()
+            import json as _json
+            stored = _json.loads(row[0])
+            assert set(stored) == {"primary", "fallback.example.com"}
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+
 async def test_create_rejects_invalid(tmp_path, monkeypatch):
     app = await _spin_proxy(tmp_path, monkeypatch, "mcp-invalid")
     transport = ASGITransport(app=app)

--- a/tests/test_proxy_mcp_aggregator.py
+++ b/tests/test_proxy_mcp_aggregator.py
@@ -511,6 +511,96 @@ async def test_tools_call_forwards_to_mock_mcp_server(
 
 
 @pytest.mark.asyncio
+async def test_tools_call_passes_through_full_mcp_envelope(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    """Regression test for the double-wrap bug.
+
+    Upstream MCP servers that return a full envelope
+    ({"content": [...], "isError": false}) used to be re-wrapped by the
+    aggregator: the caller would see ``content[0].text`` carrying a
+    stringified envelope instead of the raw tool payload, forcing every
+    SDK to peel two layers. The aggregator now detects the envelope shape
+    and passes it through verbatim.
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        # Full, well-formed MCP envelope from upstream.
+        return httpx.Response(200, json={
+            "jsonrpc": "2.0",
+            "id": body["id"],
+            "result": {
+                "content": [{"type": "text", "text": "raw-payload"}],
+                "isError": False,
+            },
+        })
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-pt", name="passthrough-svc",
+        endpoint_url="http://passthrough-svc:8080/",
+        allowed_domains='["passthrough-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-pt")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 21, "method": "tools/call",
+        "params": {"name": "passthrough-svc", "arguments": {}},
+    })
+    body = resp.json()
+    assert body["result"]["isError"] is False
+    text_out = body["result"]["content"][0]["text"]
+    # Must be the raw payload, not a stringified envelope.
+    assert text_out == "raw-payload", (
+        f"double-wrap regression: got {text_out!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tools_call_wraps_non_envelope_upstream(
+    proxy_db, clean_registry, app_client, monkeypatch,
+):
+    """Upstream returning a non-MCP-shaped result still gets wrapped.
+
+    Builtin tools and older / partial MCP servers may return arbitrary
+    objects in the JSON-RPC result. The aggregator still serialises
+    those into a content[0].text payload so the response shape is
+    consistent for callers.
+    """
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        return httpx.Response(200, json={
+            "jsonrpc": "2.0", "id": body["id"],
+            "result": {"ok": True, "answer": 42},  # no content/isError
+        })
+
+    _patch_whitelist_transport(monkeypatch, handler)
+
+    await _seed_resource(
+        resource_id="res-nb-shape", name="nonenvelope-svc",
+        endpoint_url="http://nonenvelope-svc:8080/",
+        allowed_domains='["nonenvelope-svc:8080"]',
+    )
+    await _seed_binding(agent_id="acme::buyer", resource_id="res-nb-shape")
+    await load_resources_into_registry(clean_registry)
+
+    client, _ = app_client
+    resp = client.post("/v1/mcp", json={
+        "jsonrpc": "2.0", "id": 22, "method": "tools/call",
+        "params": {"name": "nonenvelope-svc", "arguments": {}},
+    })
+    body = resp.json()
+    assert body["result"]["isError"] is False
+    text_out = body["result"]["content"][0]["text"]
+    # Stringified object, NOT a passthrough.
+    parsed = json.loads(text_out)
+    assert parsed == {"ok": True, "answer": 42}
+
+
+@pytest.mark.asyncio
 async def test_tools_call_injects_bearer_auth_header(
     proxy_db, clean_registry, app_client, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
Three latent bugs in the Mastio MCP aggregator path, all surfaced while wiring an autonomous insurance agent + custom MCP server against a single-Mastio bundle. Each was a silent footgun with no useful log trail.

## Bugs fixed

### 1. Aggregator double-wraps the upstream MCP envelope

`mcp_resource_forwarder` returns the upstream RPC `result` verbatim — a full MCP envelope (`{"content": [...], "isError": ...}`). The aggregator's `_handle_tools_call` *always* re-wrapped that into another `{"content": [{"text": _stringify(result)}], "isError": False}`. Callers had to peel two layers; every SDK grew its own unwrap helper.

Fix: aggregator detects the envelope shape and passes it through. Builtin tools returning arbitrary Python objects still flow through the wrap path (regression-tested).

### 2. `admin/mcp_resources.py`: `reload_resources()` called without `tool_registry` arg

Both create and delete handlers called `await reload_resources()` while the function signature is `reload_resources(registry)`. The `TypeError: missing 1 required positional argument` got swallowed by the surrounding `except Exception`; the in-memory tool registry never updated after a CRUD operation. A freshly registered resource was invisible to `tools/call` until a full Mastio restart.

Fix: import the shared `tool_registry` singleton and pass it explicitly. Matches the dashboard sibling at `dashboard/mcp_resources.py:198` which had the correct call already.

### 3. `allowed_domains` defaults to `[]` — `WhitelistedTransport` blocks all

`MCPResourceCreate.allowed_domains` is `Field(default_factory=list)`, and `WhitelistedTransport` treats an empty allow-list as "block all". Result: any resource registered without an explicit whitelist failed every `tools/call` with `Domain 'mcp-X' not in whitelist: []`. Lots of "looks healthy until first call" UX damage.

Fix: when the caller omits `allowed_domains`, the endpoint's own hostname is added implicitly. Operators who want a locked-down config can still pass `[]` explicitly.

## Test plan
- [x] `pytest tests/test_proxy_mcp_aggregator.py tests/test_proxy_admin_mcp_resources.py`: 38 passed (33 existing + 3 new + 2 fix-driven additions)
- [x] `./sandbox/demo.sh full && ./sandbox/smoke.sh`: 25 PASS / 0 FAIL / 1 SKIP (matches baseline)
- [x] Live verification: cullis-vm KVM bundle + 4-tool insurance MCP server + 2 autonomous agents (`claim-intake`, `fraud-detection`) → end-to-end claim flow producing real audit chain entries and JSONL payout/review ledgers.

## Scope
Touches `mcp_proxy/` so smoke gate applies (verified locally). No alembic migration. No new dependency. Backwards-compatible: callers passing explicit `allowed_domains=[]` keep the previous block-all behavior; callers receiving the old double-wrapped envelope keep working (the inner payload was still parseable).

## Out of scope
- Startup log line `MCP resource registry populated` reportedly absent on some v0.4.x deployments — diagnostic rather than functional, deferred.
- `dashboard/mcp_resources.py` HTML form's auto-whitelist default — not touched here; the dashboard takes the same `MCPResourceCreate` schema indirectly so the fix carries over via the model, but the form template could surface this default explicitly. Follow-up.