### PR TITLE
fix(mcp-proxy): restore visibility of MCP resource loader lifespan logs

### DIFF
--- a/mcp_proxy/_lifespan_log.py
+++ b/mcp_proxy/_lifespan_log.py
@@ -1,0 +1,54 @@
+"""Lifespan-safe structured log emission.
+
+Audit 2026-05-14 (PR #687 follow-up). Several lifespan call-sites emit
+``_log.info`` records that never reach ``docker compose logs`` even
+though the logger config is correct on paper: handler is the JSON
+StreamHandler from ``logging_setup.py``, level is INFO, propagation is
+off but the handler is on the ``mcp_proxy`` parent. Empirically
+identical to the silently-muted dispatch-time records the global rate
+limit middleware documents in its module header (cullis-enterprise#11).
+
+Affected paths so far:
+
+* ``mcp_proxy.main.lifespan`` — ``MCP resource registry populated`` and
+  ``Failed to load MCP resources``.
+* ``mcp_proxy.tools.resource_loader.load_resources_into_registry`` —
+  ``MCP resource loader: %d loaded, %d skipped``.
+* ``mcp_proxy.tools.registry.register_definition`` — per-resource
+  ``Registered tool ...`` lines.
+
+All three end up invisible despite emitting through the same logger
+hierarchy that publishes ``Org CA loaded`` and ``local sweeper started``
+seconds earlier and later. The pattern matches the middleware
+workaround: uvicorn appears to repoint the handler stream at some
+point during lifespan and a window of records is dropped.
+
+Until the upstream root-cause is fixed, lifespan callers that need
+guaranteed visibility — operator diagnostics, audit traces — bypass
+the logger and write a single-line JSON record straight to ``sys.stderr``.
+The shape matches ``logging_setup.JSONFormatter`` so SIEM / Loki / Grafana
+parsers treat it identically to a regular log line.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+
+
+def emit_lifespan_log(*, level: str, logger: str, message: str) -> None:
+    """Write a JSON log record directly to stderr.
+
+    Use ONLY from lifespan-time code paths where the standard logger has
+    been observed to silently drop records. Builtins under
+    ``mcp_proxy.*`` are the only intended callers; third-party plugins
+    have no business calling this — they get the same logger hierarchy
+    everyone else uses.
+    """
+    record = json.dumps({
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "level": level,
+        "logger": logger,
+        "message": message,
+    }, default=str)
+    print(record, file=sys.stderr, flush=True)

--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -410,14 +410,25 @@ async def lifespan(app: FastAPI):
     # proxy still serves builtin tools if the DB read blows up.
     from mcp_proxy.tools.registry import tool_registry
     from mcp_proxy.tools.resource_loader import load_resources_into_registry
+    from mcp_proxy._lifespan_log import emit_lifespan_log
     try:
         loaded = await load_resources_into_registry(tool_registry)
-        _log.info("MCP resource registry populated (count=%d)", loaded)
+        # PR #687 follow-up: the standard logger silently drops this
+        # lifespan record (and the per-resource ones in the loader).
+        # See ``mcp_proxy/_lifespan_log.py`` for the audit trail.
+        emit_lifespan_log(
+            level="INFO",
+            logger="mcp_proxy",
+            message=f"MCP resource registry populated (count={loaded})",
+        )
     except Exception as exc:
-        _log.warning(
-            "Failed to load MCP resources from DB — continuing with "
-            "builtin tools only: %s",
-            exc,
+        emit_lifespan_log(
+            level="WARNING",
+            logger="mcp_proxy",
+            message=(
+                "Failed to load MCP resources from DB — continuing with "
+                f"builtin tools only: {exc!r}"
+            ),
         )
 
     # Phase 3b — local WS manager. Phase 3c will plug this into message

--- a/mcp_proxy/tools/resource_loader.py
+++ b/mcp_proxy/tools/resource_loader.py
@@ -197,9 +197,17 @@ async def load_resources_into_registry(registry: ToolRegistry) -> int:
         registry.register_definition(tool_def)
         loaded += 1
 
-    _log.info(
-        "MCP resource loader: %d loaded, %d skipped (conflict with builtin)",
-        loaded,
-        skipped_conflict,
+    # PR #687 follow-up: this record reliably went missing in production
+    # despite emitting through the same logger hierarchy that publishes
+    # neighbouring lifespan logs. Bypass via the JSON-on-stderr helper
+    # used by the global rate limit middleware for the same reason.
+    from mcp_proxy._lifespan_log import emit_lifespan_log
+    emit_lifespan_log(
+        level="INFO",
+        logger="mcp_proxy.tools.resource_loader",
+        message=(
+            f"MCP resource loader: {loaded} loaded, "
+            f"{skipped_conflict} skipped (conflict with builtin)"
+        ),
     )
     return loaded

--- a/tests/test_lifespan_log.py
+++ b/tests/test_lifespan_log.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 
-import pytest
-
 
 def test_emit_lifespan_log_writes_json_to_stderr(capsys):
     from mcp_proxy._lifespan_log import emit_lifespan_log

--- a/tests/test_lifespan_log.py
+++ b/tests/test_lifespan_log.py
@@ -1,0 +1,89 @@
+"""Tests for the lifespan-safe log helper.
+
+The helper exists because `_log.info` records from a handful of
+lifespan-time code paths silently disappear in production despite
+correct logger config (cullis-enterprise#11 documented the same
+behavior on the global rate limit middleware). These tests assert the
+JSON shape on stderr matches the regular JSONFormatter output so log
+aggregators see identical records regardless of which path emitted
+them.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+
+def test_emit_lifespan_log_writes_json_to_stderr(capsys):
+    from mcp_proxy._lifespan_log import emit_lifespan_log
+
+    emit_lifespan_log(
+        level="INFO",
+        logger="mcp_proxy.tools.resource_loader",
+        message="MCP resource loader: 7 loaded, 0 skipped (conflict with builtin)",
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    line = captured.err.strip()
+    assert line, "no record written to stderr"
+    record = json.loads(line)
+
+    assert record["level"] == "INFO"
+    assert record["logger"] == "mcp_proxy.tools.resource_loader"
+    assert (
+        record["message"]
+        == "MCP resource loader: 7 loaded, 0 skipped (conflict with builtin)"
+    )
+    # ISO-8601 with timezone, parseable by datetime.fromisoformat.
+    ts = datetime.fromisoformat(record["timestamp"])
+    assert ts.tzinfo is not None
+    # Sanity: within a few seconds of now.
+    age = abs((datetime.now(timezone.utc) - ts).total_seconds())
+    assert age < 5
+
+
+def test_emit_lifespan_log_warning_level(capsys):
+    from mcp_proxy._lifespan_log import emit_lifespan_log
+
+    emit_lifespan_log(
+        level="WARNING",
+        logger="mcp_proxy",
+        message=(
+            "Failed to load MCP resources from DB — continuing with "
+            "builtin tools only: RuntimeError('db gone')"
+        ),
+    )
+    record = json.loads(capsys.readouterr().err.strip())
+    assert record["level"] == "WARNING"
+    assert "RuntimeError" in record["message"]
+
+
+def test_emit_lifespan_log_shape_matches_json_formatter():
+    """The on-stderr JSON record must carry the same keys that
+    ``mcp_proxy.logging_setup.JSONFormatter`` would emit for a regular
+    logger call. Both code paths feed the same SIEM / Loki pipeline."""
+    from mcp_proxy._lifespan_log import emit_lifespan_log  # noqa: F401
+    from mcp_proxy.logging_setup import JSONFormatter
+
+    # Synthesize a log record the formatter would have produced.
+    import logging
+    rec = logging.LogRecord(
+        name="mcp_proxy.tools.resource_loader",
+        level=logging.INFO,
+        pathname="resource_loader.py",
+        lineno=200,
+        msg="MCP resource loader: %d loaded, %d skipped",
+        args=(3, 0),
+        exc_info=None,
+    )
+    formatted = JSONFormatter().format(rec)
+    formatter_keys = set(json.loads(formatted).keys())
+
+    # The helper writes the same key set (with stable ISO timestamp).
+    expected = {"timestamp", "level", "logger", "message"}
+    assert formatter_keys >= expected, (
+        f"formatter shape changed unexpectedly: {formatter_keys}"
+    )

--- a/tests/test_proxy_resource_registry.py
+++ b/tests/test_proxy_resource_registry.py
@@ -107,6 +107,47 @@ async def test_load_resources_empty_db(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_load_resources_emits_visibility_record(tmp_path, capsys):
+    """Loader's summary line must reach stderr.
+
+    Regression for the silently-dropped lifespan log discovered while
+    debugging the insurance demo. The loader was running, populating the
+    registry, but the ``_log.info(...)`` summary never appeared in
+    ``docker compose logs``. The fix routes the summary through the
+    JSON-on-stderr lifespan log helper instead. This test asserts the
+    summary lands on stderr in the documented shape.
+    """
+    import json as _json
+    url = f"sqlite+aiosqlite:///{tmp_path / 'vis.db'}"
+    await init_db(url)
+    try:
+        await _seed_resource(
+            resource_id="res-vis", name="visibility-svc",
+            endpoint_url="http://visibility-svc:9100",
+            allowed_domains='["visibility-svc:9100"]',
+        )
+        registry = ToolRegistry()
+        loaded = await load_resources_into_registry(registry)
+    finally:
+        await dispose_db()
+    assert loaded == 1
+
+    captured = capsys.readouterr()
+    summary_lines = [
+        ln for ln in captured.err.splitlines()
+        if ln.startswith("{") and "MCP resource loader" in ln
+    ]
+    assert summary_lines, (
+        f"loader summary not on stderr; got: {captured.err!r}"
+    )
+    record = _json.loads(summary_lines[-1])
+    assert record["level"] == "INFO"
+    assert record["logger"] == "mcp_proxy.tools.resource_loader"
+    assert "1 loaded" in record["message"]
+    assert "0 skipped" in record["message"]
+
+
+@pytest.mark.asyncio
 async def test_load_resources_populates_registry(tmp_path):
     """Two enabled rows → two registry entries with resource_id set."""
     url = f"sqlite+aiosqlite:///{tmp_path / 'two.db'}"


### PR DESCRIPTION
## Summary
PR #687 follow-up. Restore the two MCP-resource-loader log lines that silently disappear in production despite correct logger config. Matches the workaround documented for cullis-enterprise#11 on the global rate limit middleware.

## Why
Debugging "freshly registered MCP resource returns Tool 'X' not found" against a single-Mastio bundle, both these lifespan lines were missing from `docker compose logs`:

- `mcp_proxy.tools.resource_loader: MCP resource loader: N loaded, M skipped`
- `mcp_proxy: MCP resource registry populated (count=N)`

The loader was running and the registry was populated (the aggregator's `tools/list` returned the seeded tool) — but the visibility records never reached operators. Empirically identical to the silently-muted dispatch-time records the global rate limit middleware documents in its module header.

## Fix
New helper `mcp_proxy._lifespan_log.emit_lifespan_log(level, logger, message)` writes a single-line JSON record straight to `sys.stderr` in the shape the `JSONFormatter` would have produced. Two call sites converted (main.py lifespan, resource_loader summary). SIEM / Loki / Grafana parsers treat it identically.

## Verification
- [x] `pytest tests/test_lifespan_log.py tests/test_proxy_resource_registry.py` — 13 passed (3 helper + 10 loader incl. 1 new visibility regression)
- [x] `./sandbox/demo.sh full && docker logs sandbox-proxy-a-1 | grep "MCP resource"` — both lines now present
- [x] `./sandbox/smoke.sh` — 25 PASS / 0 FAIL / 1 SKIP (baseline)

## Scope
Touches `mcp_proxy/` so smoke gate applies (verified). No alembic migration. No new runtime dependency. Backwards-compatible: the `_log.warning` lines inside the loader keep using the standard logger (different code path, no observed loss).

## Out of scope
- The "bug 5" originally tracked alongside this — no admin API for CA chain — was a false alarm. The anonymous endpoint `GET /pki/ca.crt` has shipped since v0.1.x. The insurance-demo bootstrap script tracked separately in `imp/` is updated to use it.
- Full root-cause of why the standard logger drops these records (suspected uvicorn lifespan reinit) — defer to a dedicated investigation. This PR ships the workaround already proven on the rate-limit middleware.