### PR TITLE
feat(dashboard): plumb session.user_id + plugin replay-bypass hook

### DIFF
--- a/mcp_proxy/admin/approval_hook.py
+++ b/mcp_proxy/admin/approval_hook.py
@@ -38,6 +38,7 @@ async def maybe_intercept_for_approval(
     session: Any,
     action_type: str,
     payload: dict[str, Any],
+    request: Request | None = None,
 ) -> RedirectResponse | None:
     """If a plugin gates ``action_type``, submit a pending approval.
 
@@ -49,9 +50,10 @@ async def maybe_intercept_for_approval(
     Parameters
     ----------
     session
-        Authenticated dashboard session. ``session.role`` is forwarded as
-        the submitter identifier for plugin storage and audit. Plugins
-        observe richer principal identity via their own session table.
+        Authenticated dashboard session. ``session.user_id`` (when set by
+        a multi-user login plugin) is forwarded as the submitter
+        identifier; otherwise the helper falls back to ``session.role``
+        so legacy single-admin deploys keep working unchanged.
     action_type
         One of the ``ACTION_*`` constants above. Stable identifier across
         the core/plugin boundary.
@@ -59,6 +61,13 @@ async def maybe_intercept_for_approval(
         Opaque dict captured from the request body (form or JSON). The
         plugin persists this verbatim and re-plays it when quorum is
         reached.
+    request
+        The originating FastAPI request. Forwarded to
+        :meth:`Plugin.is_internal_replay` so the plugin can recognize
+        post-quorum self-issued requests and bypass interception.
+        Optional for back-compat with callers not yet updated; without
+        it the replay-bypass path is unavailable but normal interception
+        still works.
     """
     # Local import: avoid bootstrapping the plugin registry at module load
     # in tests that monkey-patch it.
@@ -68,7 +77,32 @@ async def maybe_intercept_for_approval(
     if plugin is None:
         return None
 
-    submitter_id = getattr(session, "role", None) or "admin"
+    # Replay bypass: when the gating plugin recognizes this request as a
+    # post-approval replay it issued itself, the hook steps aside and the
+    # endpoint executes normally. The plugin proves authenticity its own
+    # way (signed header, DB lookup against the approval row, etc.); the
+    # hook just trusts the boolean answer. is_internal_replay defaults to
+    # False so community deploys without a plugin override see no change.
+    if request is not None:
+        try:
+            if await plugin.is_internal_replay(request, action_type):
+                _log.info(
+                    "action %s replay bypass: plugin=%s",
+                    action_type, plugin.name,
+                )
+                return None
+        except Exception as exc:
+            _log.warning(
+                "plugin %s is_internal_replay(%s) raised: %s, "
+                "treating as not-a-replay",
+                plugin.name, action_type, exc,
+            )
+
+    raw_user_id = getattr(session, "user_id", None)
+    if isinstance(raw_user_id, int) and raw_user_id > 0:
+        submitter_id: str = str(raw_user_id)
+    else:
+        submitter_id = getattr(session, "role", None) or "admin"
     try:
         approval_id = await plugin.submit_approval(
             action_type=action_type,

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -1607,6 +1607,7 @@ async def agent_delete(request: Request, agent_id: str):
         session=session,
         action_type=ACTION_AGENTS_DELETE,
         payload={"agent_id": agent_id},
+        request=request,
     )
     if intercept is not None:
         return intercept
@@ -1826,6 +1827,7 @@ async def policies_save(request: Request):
     payload = {k: str(v) for k, v in form.items() if k != "csrf_token"}
     intercept = await maybe_intercept_for_approval(
         session=session, action_type=ACTION_POLICIES_SAVE, payload=payload,
+        request=request,
     )
     if intercept is not None:
         return intercept
@@ -2231,6 +2233,7 @@ async def pki_rotate_ca(request: Request):
 
     intercept = await maybe_intercept_for_approval(
         session=session, action_type=ACTION_PKI_ROTATE_CA, payload={},
+        request=request,
     )
     if intercept is not None:
         return intercept
@@ -2481,6 +2484,7 @@ async def mastio_key_rotate(request: Request):
     payload = {k: str(v) for k, v in form.items() if k != "csrf_token"}
     intercept = await maybe_intercept_for_approval(
         session=session, action_type=ACTION_MASTIO_KEY_ROTATE, payload=payload,
+        request=request,
     )
     if intercept is not None:
         return intercept
@@ -2903,6 +2907,7 @@ async def vault_migrate_keys(request: Request):
 
     intercept = await maybe_intercept_for_approval(
         session=session, action_type=ACTION_VAULT_MIGRATE_KEYS, payload={},
+        request=request,
     )
     if intercept is not None:
         return intercept
@@ -3907,6 +3912,7 @@ async def users_delete(principal_id: str, request: Request):
         session=session,
         action_type=ACTION_USERS_DELETE,
         payload={"principal_id": principal_id},
+        request=request,
     )
     if intercept is not None:
         return intercept

--- a/mcp_proxy/dashboard/session.py
+++ b/mcp_proxy/dashboard/session.py
@@ -41,11 +41,18 @@ class ProxyDashboardSession:
     (see ``mcp_proxy.rbac``). Default ``roles=()`` is filled to ``(role,)``
     in ``__post_init__`` so single-role callers (community deploys, legacy
     cookies issued before multi-role) keep working unchanged.
+
+    ``user_id`` is optional and only populated by multi-user login plugins
+    (e.g. cullis_enterprise ``rbac_multi_admin``). Single-admin community
+    deploys leave it as ``None``. Plumbed end-to-end so the 4-eyes
+    approval hook can record the actual submitter identity instead of
+    falling back to the role name.
     """
     role: str
     csrf_token: str = ""
     logged_in: bool = True
     roles: tuple[str, ...] = ()
+    user_id: int | None = None
 
     def __post_init__(self) -> None:
         if not self.roles:
@@ -53,7 +60,7 @@ class ProxyDashboardSession:
 
 
 _NO_SESSION = ProxyDashboardSession(
-    role="none", csrf_token="", logged_in=False, roles=(),
+    role="none", csrf_token="", logged_in=False, roles=(), user_id=None,
 )
 
 _auto_key: str = ""
@@ -170,11 +177,17 @@ def get_session(request: Request) -> ProxyDashboardSession:
     if isinstance(raw_roles, list):
         parsed_roles = tuple(str(r) for r in raw_roles if isinstance(r, str) and r)
 
+    raw_user_id = data.get("user_id")
+    parsed_user_id: int | None = None
+    if isinstance(raw_user_id, int) and raw_user_id > 0:
+        parsed_user_id = raw_user_id
+
     return ProxyDashboardSession(
         role=data.get("role", "none"),
         csrf_token=data.get("csrf_token", ""),
         logged_in=True,
         roles=parsed_roles,
+        user_id=parsed_user_id,
     )
 
 
@@ -202,6 +215,7 @@ def set_session(
     response: Response,
     role: str = "admin",
     roles: tuple[str, ...] | list[str] | None = None,
+    user_id: int | None = None,
 ) -> str:
     """Set a signed session cookie on the response. Returns the CSRF token.
 
@@ -210,18 +224,27 @@ def set_session(
     pre-existing behaviour. When provided, ``role`` remains the primary
     display role; the dashboard UI shows it in the badge while
     ``require_role`` checks against the wider ``roles`` tuple.
+
+    ``user_id`` is optional and identifies the row in the calling plugin's
+    user table (e.g. ``admin_users.id`` for cullis_enterprise
+    ``rbac_multi_admin``). Plumbed through the cookie so the 4-eyes
+    approval hook can record the real submitter identity. Single-admin
+    community deploys leave it as ``None``.
     """
     csrf_token = os.urandom(16).hex()
     if roles is None:
         roles_tuple: tuple[str, ...] = (role,) if role else ()
     else:
         roles_tuple = tuple(str(r) for r in roles if r)
-    payload = json.dumps({
+    payload_data: dict[str, object] = {
         "role": role,
         "roles": list(roles_tuple),
         "csrf_token": csrf_token,
         "exp": int(time.time()) + _COOKIE_MAX_AGE,
-    })
+    }
+    if user_id is not None and user_id > 0:
+        payload_data["user_id"] = int(user_id)
+    payload = json.dumps(payload_data)
     signed = _sign(payload)
     _use_secure = _should_set_secure_cookie()
     response.set_cookie(

--- a/mcp_proxy/plugins.py
+++ b/mcp_proxy/plugins.py
@@ -22,6 +22,10 @@ Hook surfaces:
                                     and returns its identifier. Called by core
                                     endpoint handlers after ``approval_required``
                                     returned True.
+  * ``is_internal_replay(...)``   — coroutine returning True when the incoming
+                                    request is a post-quorum replay the plugin
+                                    itself issued. When True the approval hook
+                                    steps aside and the endpoint runs normally.
 
 Plugins override only the hooks they need; defaults are no-ops. Each plugin
 may declare ``requires_feature``: when set, ``filter_by_license`` drops the
@@ -98,6 +102,25 @@ class Plugin:
             f"plugin {self.name} declared approval_required for "
             f"{action_type!r} but did not implement submit_approval"
         )
+
+    async def is_internal_replay(
+        self,
+        request: Any,
+        action_type: str,
+    ) -> bool:
+        """Whether ``request`` is a post-quorum replay this plugin issued itself.
+
+        Called by the approval hook BEFORE ``submit_approval`` so a plugin
+        that has already collected enough signoffs and is now replaying
+        the original mutation against its own endpoint can bypass the
+        gating loop. The plugin proves authenticity its own way: a
+        signed header, a server-only shared secret, a DB lookup against
+        the approval row, etc. The hook trusts the boolean.
+
+        Default is False: plugins that do not implement replay leave
+        every request subject to normal interception.
+        """
+        return False
 
 
 @dataclass

--- a/tests/test_approval_hook.py
+++ b/tests/test_approval_hook.py
@@ -37,10 +37,23 @@ def _reset_registry():
     mp_plugins.reset_registry()
 
 
-def _mock_session(role: str = "admin") -> Any:
+def _mock_session(role: str = "admin", user_id: int | None = None) -> Any:
     s = MagicMock()
     s.role = role
+    s.user_id = user_id
     return s
+
+
+def _mock_request() -> Any:
+    """Build a minimal Request-like mock for is_internal_replay calls.
+
+    The hook only forwards the request to ``plugin.is_internal_replay`` so
+    a plain ``MagicMock`` is enough — the plugin under test gets to decide
+    what attributes it reads.
+    """
+    r = MagicMock()
+    r.headers = {}
+    return r
 
 
 # ── Plugin base class ─────────────────────────────────────────────────────
@@ -268,3 +281,246 @@ def test_action_constants_are_stable_strings():
     assert ACTION_VAULT_MIGRATE_KEYS == "vault.migrate_keys"
     assert ACTION_USERS_DELETE == "users.delete"
     assert ACTION_AGENTS_DELETE == "agents.delete"
+
+
+# ── submitter_id sourcing: user_id wins over role ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intercept_forwards_user_id_when_session_has_one(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Sessions with a user_id forward it (stringified) as submitter_id.
+
+    Multi-user login plugins (rbac_multi_admin) populate
+    ``session.user_id``; the hook prefers it over the role so audit and
+    quorum can identify which user submitted, not just which role.
+    """
+    captured: dict[str, str] = {}
+
+    class CapturingPlugin(Plugin):
+        name = "capturing"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            captured["submitter_id"] = submitter_id
+            return "01H_UID_TEST"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[CapturingPlugin()]),
+    )
+    session = _mock_session(role="technical_admin", user_id=42)
+    result = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_POLICIES_SAVE,
+        payload={},
+    )
+    assert isinstance(result, RedirectResponse)
+    assert captured["submitter_id"] == "42"
+
+
+@pytest.mark.asyncio
+async def test_intercept_falls_back_to_role_when_user_id_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Sessions without a user_id keep the legacy role-based submitter_id."""
+    captured: dict[str, str] = {}
+
+    class CapturingPlugin(Plugin):
+        name = "capturing"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            captured["submitter_id"] = submitter_id
+            return "01H_ROLE_FALLBACK"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[CapturingPlugin()]),
+    )
+    session = _mock_session(role="compliance_admin", user_id=None)
+    result = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_POLICIES_SAVE,
+        payload={},
+    )
+    assert isinstance(result, RedirectResponse)
+    assert captured["submitter_id"] == "compliance_admin"
+
+
+@pytest.mark.asyncio
+async def test_intercept_rejects_non_positive_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Defensive: zero / negative user_id falls back to role.
+
+    Avoids producing nonsense submitter ids like '0' or '-1' if a buggy
+    upstream session loader leaks a sentinel value.
+    """
+    captured: dict[str, str] = {}
+
+    class CapturingPlugin(Plugin):
+        name = "capturing"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            captured["submitter_id"] = submitter_id
+            return "01H_DEFENSIVE"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[CapturingPlugin()]),
+    )
+    session = _mock_session(role="super_admin", user_id=0)
+    result = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_PKI_ROTATE_CA,
+        payload={},
+    )
+    assert isinstance(result, RedirectResponse)
+    assert captured["submitter_id"] == "super_admin"
+
+
+# ── is_internal_replay: post-quorum bypass ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_intercept_skips_when_plugin_recognizes_replay(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Plugin can mark a request as a post-quorum replay and bypass interception."""
+    submitted: dict[str, str] = {}
+
+    class ReplayingPlugin(Plugin):
+        name = "replaying"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def is_internal_replay(self, request, action_type: str) -> bool:
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            submitted["should_not_run"] = action_type
+            return "01H_NEVER"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[ReplayingPlugin()]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_USERS_DELETE,
+        payload={},
+        request=_mock_request(),
+    )
+    assert result is None
+    assert "should_not_run" not in submitted
+
+
+@pytest.mark.asyncio
+async def test_intercept_treats_replay_check_error_as_not_a_replay(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If is_internal_replay raises, the hook proceeds with normal interception."""
+    submitted: dict[str, str] = {}
+
+    class FlakyPlugin(Plugin):
+        name = "flaky"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def is_internal_replay(self, request, action_type: str) -> bool:
+            raise RuntimeError("DB lookup failed")
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            submitted["action_type"] = action_type
+            return "01H_NORMAL"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[FlakyPlugin()]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_AGENTS_DELETE,
+        payload={},
+        request=_mock_request(),
+    )
+    assert isinstance(result, RedirectResponse)
+    assert submitted["action_type"] == ACTION_AGENTS_DELETE
+
+
+@pytest.mark.asyncio
+async def test_intercept_skips_replay_check_when_request_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Back-compat: callers that have not been updated to pass request.
+
+    Without ``request`` the hook cannot consult is_internal_replay, so it
+    treats every call as a fresh action and proceeds with interception.
+    """
+    submitted: dict[str, str] = {}
+
+    class ReplayingPlugin(Plugin):
+        name = "replaying"
+
+        def approval_required(self, action_type: str) -> bool:
+            return True
+
+        async def is_internal_replay(self, request, action_type: str) -> bool:
+            # Should not be invoked when the caller did not pass request.
+            return True
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            submitted["action_type"] = action_type
+            return "01H_NO_REQUEST"
+
+    monkeypatch.setattr(
+        mp_plugins,
+        "get_registry",
+        lambda: PluginRegistry(plugins=[ReplayingPlugin()]),
+    )
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_POLICIES_SAVE,
+        payload={},
+    )
+    assert isinstance(result, RedirectResponse)
+    assert submitted["action_type"] == ACTION_POLICIES_SAVE
+
+
+# ── Default base-class is_internal_replay ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_default_plugin_is_internal_replay_false():
+    """Base class returns False so plugins that don't implement replay
+    keep seeing every request as a fresh action."""
+    p = Plugin()
+    assert await p.is_internal_replay(_mock_request(), ACTION_POLICIES_SAVE) is False

--- a/tests/test_proxy_rbac.py
+++ b/tests/test_proxy_rbac.py
@@ -144,6 +144,106 @@ def test_set_session_explicit_roles(monkeypatch):
     get_settings.cache_clear()
 
 
+def test_set_session_user_id_round_trip(monkeypatch):
+    """``user_id`` kwarg round-trips through the cookie payload.
+
+    Multi-user login plugins (e.g. cullis_enterprise rbac_multi_admin)
+    pass the admin_users.id row id at login time; the 4-eyes approval
+    hook consumes ``session.user_id`` to record the real submitter
+    identity instead of just the role name.
+    """
+    from fastapi import Response
+    from mcp_proxy.dashboard.session import (
+        _COOKIE_NAME, get_session, set_session,
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+
+    response = Response()
+    set_session(
+        response, role="technical_admin", roles=("technical_admin",), user_id=42,
+    )
+    cookie_value = response.headers["set-cookie"].split(";", 1)[0].split("=", 1)[1]
+
+    from starlette.requests import Request
+    scope = {
+        "type": "http",
+        "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+    }
+    s = get_session(Request(scope))
+    assert s.role == "technical_admin"
+    assert s.user_id == 42
+    get_settings.cache_clear()
+
+
+def test_set_session_without_user_id_leaves_field_none(monkeypatch):
+    """Legacy single-admin set_session() calls produce sessions with
+    ``user_id=None``. Community deploys observe unchanged behaviour."""
+    from fastapi import Response
+    from mcp_proxy.dashboard.session import (
+        _COOKIE_NAME, get_session, set_session,
+    )
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+
+    response = Response()
+    set_session(response, role="admin")
+    cookie_value = response.headers["set-cookie"].split(";", 1)[0].split("=", 1)[1]
+
+    from starlette.requests import Request
+    scope = {
+        "type": "http",
+        "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+    }
+    s = get_session(Request(scope))
+    assert s.role == "admin"
+    assert s.user_id is None
+    get_settings.cache_clear()
+
+
+def test_get_session_rejects_invalid_user_id(monkeypatch):
+    """Cookies with non-integer or non-positive user_id values yield None.
+
+    Defends against a downgrade attack where a forged cookie carries
+    ``user_id=0`` or ``user_id="../etc/passwd"`` hoping to be propagated
+    as a stringified submitter id to the approval hook.
+    """
+    import hashlib
+    import hmac
+    import json
+    import time
+
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, get_session
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+    monkeypatch.setenv("MCP_PROXY_DASHBOARD_SIGNING_KEY", "k" * 32)
+    secret = ("k" * 32).encode()
+
+    from starlette.requests import Request
+
+    for bad in (0, -7, "42", None, [42]):
+        payload_dict = {
+            "role": "admin",
+            "roles": ["admin"],
+            "csrf_token": "tok",
+            "exp": int(time.time()) + 3600,
+            "user_id": bad,
+        }
+        payload = json.dumps(payload_dict)
+        sig = hmac.new(secret, payload.encode(), hashlib.sha256).hexdigest()
+        cookie_value = f"{payload}.{sig}"
+        scope = {
+            "type": "http",
+            "headers": [(b"cookie", f"{_COOKIE_NAME}={cookie_value}".encode())],
+        }
+        s = get_session(Request(scope))
+        assert s.role == "admin", f"bad={bad!r} unexpectedly broke session"
+        assert s.user_id is None, f"bad user_id {bad!r} should be rejected"
+    get_settings.cache_clear()
+
+
 # ── require_role gate behaviour ──────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Open-core preparatory PR for CISO Phase A blocker #2 — wire-up of the existing 4-eyes scaffold in `cullis-enterprise` (PR #25 already merged). Adds two seams the quorum plugin needs to record real submitter identity and replay post-quorum actions without re-entering the approval loop.

- **Session user identity**: `ProxyDashboardSession` gains optional `user_id: int | None` round-tripped via the signed cookie. Multi-user login plugins (rbac_multi_admin) populate it at login via the new `set_session(user_id=...)` kwarg. Community single-admin deploys leave it `None` and observe unchanged cookie shape.
- **Plugin replay bypass**: New `Plugin.is_internal_replay(request, action_type) -> bool` (default `False`). `maybe_intercept_for_approval` now accepts `request` and calls the hook before submitting; a gating plugin can recognize its own post-quorum replays and step aside so the endpoint runs normally. Proof-of-authenticity (signed header, DB lookup) is the plugin's call.
- **Submitter id**: `approval_hook` prefers `str(session.user_id)` over `session.role` so quorum/audit store a stable per-user id instead of a role name. Zero/negative ids fall back to role for defence in depth.
- 6 callsites in `dashboard/router.py` updated to pass `request=request`.

## Test plan

- [x] `pytest tests/test_approval_hook.py tests/test_proxy_rbac.py` — 36/36 pass
- [x] Broader dashboard/approval/session/rbac slice — 492 pass (3 known-flake failures pre-existing on main: `test_e2e.py::test_step5/6` + `test_postgres_integration.py::test_pg_session_and_signed_messages`)
- [x] Import + signature sanity check on touched modules
- [ ] CI: pytest + ban-insecure-tls + ruff
- [ ] `/security-review` (will run before merge)

## Follow-up

- Enterprise PR (`cullis-enterprise`): extend `rbac_multi_admin` plugin with `approval_required`/`submit_approval`/`is_internal_replay` implementations + HTMX approval UI + quorum policy + replay dispatch. Targeted off `main` once this lands.
- Deferred to separate PRs: helper extraction for the 6 gated endpoint bodies (so replay can call extracted functions instead of internal HTTP self-call), fail-closed mode for plugin crashes.

## Compatibility

- Cookie payload: extends with an optional `user_id` field. Old cookies without it parse as `user_id=None`. Forged invalid types are rejected.
- `set_session`: new kwarg is keyword-only with default `None`. Existing callsites unchanged.
- `maybe_intercept_for_approval`: `request` is keyword-only optional. Existing callsites (none outside `mcp_proxy/dashboard/router.py`) continue to work without the kwarg; the replay-bypass path simply isn't available.
- `Plugin.is_internal_replay`: new base-class method returns `False`. Existing plugins (audit_export_s3, cloud_kms_*, saml_sso, rbac_multi_admin, scim_2_0, llm_guardian sub-plugins) inherit the safe default.