### PR TITLE
feat(sdk): auto-relogin on token-expiry 401 in CullisClient._authed_request

### DIFF
--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -282,6 +282,19 @@ class CullisClient:
         # detect which role is in front of it without a config change.
         self.server_role: str | None = None
 
+        # ADR-NN auto-relogin on 401. Set by a login method when it
+        # successfully mints a token; ``_authed_request`` invokes it
+        # once on token-expiry 401 (LOCAL_TOKEN past TTL, typically
+        # 1h for autonomous agents) before propagating the failure.
+        # Without this an agent that runs longer than the token TTL
+        # crash-loops on the same request forever — observed live
+        # during the insurance-demo dogfood on cullis-vm.
+        #
+        # The callable must be parameter-less and idempotent: it
+        # re-runs the same login the agent originally used (e.g.
+        # ``login_via_proxy`` mints a fresh assertion + DPoP key).
+        self._relogin_callable: "Callable[[], None] | None" = None
+
         # Dogfood Finding #9 (2026-04-29): when the SDK is built
         # against a Mastio proxy (``from_connector`` / proxy-bound
         # factories), session ops route through ``/v1/egress/sessions*``
@@ -395,19 +408,59 @@ class CullisClient:
             "DPoP": self._dpop_proof(method, url, self.token),
         }
 
-    def _authed_request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        """Make an authenticated request with automatic DPoP nonce retry."""
+    def _authed_request(
+        self,
+        method: str,
+        path: str,
+        *,
+        _no_relogin: bool = False,
+        **kwargs: Any,
+    ) -> httpx.Response:
+        """Make an authenticated request with automatic DPoP nonce retry.
+
+        On a token-expiry 401 (LOCAL_TOKEN past TTL), the client invokes
+        ``self._relogin_callable`` once — populated by the login method
+        used at bootstrap — and retries the request. ``_no_relogin``
+        guards against infinite recursion if the re-login itself yields
+        another 401.
+        """
         resp = self._http.request(
             method, f"{self.base}{path}",
             headers=self._headers(method, path), **kwargs,
         )
         self._update_nonce(resp)
+
+        # Existing DPoP nonce challenge path (replays the same token).
         if resp.status_code == 401 and "use_dpop_nonce" in resp.text:
             resp = self._http.request(
                 method, f"{self.base}{path}",
                 headers=self._headers(method, path), **kwargs,
             )
             self._update_nonce(resp)
+            return resp
+
+        # Token-expiry 401: re-mint a fresh access token and retry once.
+        # No magic string match — any 401 that is NOT a DPoP nonce
+        # challenge can be a token expiry (the broker only returns 401
+        # in those two cases for an authed request).
+        if (
+            resp.status_code == 401
+            and not _no_relogin
+            and self._relogin_callable is not None
+        ):
+            try:
+                self._relogin_callable()
+            except Exception:
+                # Re-login itself failed — propagate the original 401 so
+                # the caller sees the same observable behavior they got
+                # before this auto-retry shipped. The login method's own
+                # exception type leaks context to logs but doesn't
+                # surface to the caller.
+                return resp
+            return self._authed_request(
+                method, path, _no_relogin=True, **kwargs,
+            )
+
         return resp
 
     def _ws_url(self) -> str:
@@ -1628,6 +1681,8 @@ class CullisClient:
             resp.raise_for_status()
             self._update_nonce(resp)
             self.token = resp.json()["access_token"]
+            # Auto-relogin on token expiry — replay the same flow.
+            self._relogin_callable = self.login_via_proxy
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             raise ConnectionError(f"[{agent_id}] Proxy unreachable: {e}") from e
         except httpx.HTTPStatusError as e:
@@ -1742,6 +1797,8 @@ class CullisClient:
             resp.raise_for_status()
             self._update_nonce(resp)
             self.token = resp.json()["access_token"]
+            # Auto-relogin on token expiry — replay the same flow.
+            self._relogin_callable = self.login_via_proxy_with_local_key
         except (httpx.ConnectError, httpx.TimeoutException) as e:
             raise ConnectionError(f"[{agent_id}] Proxy unreachable: {e}") from e
         except httpx.HTTPStatusError as e:

--- a/tests/test_sdk_auto_relogin.py
+++ b/tests/test_sdk_auto_relogin.py
@@ -12,11 +12,6 @@ minted the token), then retries the request. A second 401 propagates.
 """
 from __future__ import annotations
 
-from typing import Any
-
-import httpx
-import pytest
-
 from cullis_sdk.client import CullisClient
 
 

--- a/tests/test_sdk_auto_relogin.py
+++ b/tests/test_sdk_auto_relogin.py
@@ -1,0 +1,168 @@
+"""Tests for the CullisClient auto-relogin path on token-expiry 401.
+
+The Mastio's LOCAL_TOKEN has a finite TTL (typically 1h for
+autonomous agents). Before this PR, ``_authed_request`` returned the
+401 verbatim and the caller had to re-login + retry by hand. The
+insurance-demo agents on cullis-vm crash-looped on the same claim
+forever once the token expired — observed live on 2026-05-13.
+
+The new behavior: a 401 that is NOT a DPoP nonce challenge triggers
+``self._relogin_callable`` once (set by the login method that last
+minted the token), then retries the request. A second 401 propagates.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from cullis_sdk.client import CullisClient
+
+
+class _Resp:
+    def __init__(self, status_code: int, body: dict | None = None,
+                 text_body: str = "", headers: dict | None = None):
+        self.status_code = status_code
+        self._body = body or {}
+        self._text = text_body or ""
+        self.headers = headers or {}
+
+    def json(self):
+        return self._body
+
+    @property
+    def text(self):
+        return self._text or str(self._body)
+
+
+def _client_with_token(token: str = "TOKEN-1") -> CullisClient:
+    c = CullisClient("http://mastio.test", verify_tls=False)
+    c.token = token
+    # Stub DPoP so _headers() doesn't blow up at request time.
+    c._dpop_proof = lambda *_a, **_k: "fake-dpop-proof"  # type: ignore[method-assign]
+    return c
+
+
+def test_authed_request_success_does_not_relogin():
+    """200 on first try → relogin never invoked."""
+    c = _client_with_token()
+    relogin_calls = []
+    c._relogin_callable = lambda: relogin_calls.append("called")
+
+    sent = []
+    def _request(method, url, headers=None, **kw):
+        sent.append((method, url))
+        return _Resp(200, body={"ok": True})
+    c._http.request = _request  # type: ignore[method-assign]
+
+    resp = c._authed_request("GET", "/v1/mcp")
+    assert resp.status_code == 200
+    assert len(sent) == 1
+    assert relogin_calls == []
+
+
+def test_authed_request_401_token_expired_triggers_relogin_and_retries():
+    """First call 401 (no DPoP-nonce marker) → relogin fires → retry succeeds."""
+    c = _client_with_token()
+
+    relogin_calls = []
+    def _relogin():
+        relogin_calls.append("called")
+        c.token = "TOKEN-2"  # simulate fresh mint
+    c._relogin_callable = _relogin
+
+    responses = iter([
+        _Resp(401, body={"detail": "token expired"}, text_body="token expired"),
+        _Resp(200, body={"ok": True}),
+    ])
+    sent = []
+    def _request(method, url, headers=None, **kw):
+        sent.append((method, url, headers.get("Authorization") if headers else None))
+        return next(responses)
+    c._http.request = _request  # type: ignore[method-assign]
+
+    resp = c._authed_request("POST", "/v1/mcp")
+    assert resp.status_code == 200
+    assert relogin_calls == ["called"]
+    assert len(sent) == 2
+    # Second request used the freshly-minted token.
+    assert "TOKEN-2" in sent[1][2]
+
+
+def test_authed_request_401_after_relogin_propagates():
+    """If the retry ALSO 401s, the second 401 is returned (no infinite loop)."""
+    c = _client_with_token()
+    relogin_calls = []
+    def _relogin():
+        relogin_calls.append("called")
+        c.token = "TOKEN-2"
+    c._relogin_callable = _relogin
+
+    responses = iter([
+        _Resp(401, body={"detail": "expired"}, text_body="expired"),
+        _Resp(401, body={"detail": "still bad"}, text_body="still bad"),
+    ])
+    def _request(method, url, headers=None, **kw):
+        return next(responses)
+    c._http.request = _request  # type: ignore[method-assign]
+
+    resp = c._authed_request("POST", "/v1/mcp")
+    assert resp.status_code == 401
+    # Relogin was attempted exactly once, not twice.
+    assert relogin_calls == ["called"]
+
+
+def test_authed_request_dpop_nonce_path_does_not_relogin():
+    """The existing DPoP nonce challenge path must still work — the
+    response carries the marker and is replayed with the SAME token,
+    not relogged-in."""
+    c = _client_with_token()
+    relogin_calls = []
+    c._relogin_callable = lambda: relogin_calls.append("called")
+
+    responses = iter([
+        _Resp(401, body={"error": "use_dpop_nonce"},
+              text_body='{"error":"use_dpop_nonce"}'),
+        _Resp(200, body={"ok": True}),
+    ])
+    def _request(method, url, headers=None, **kw):
+        return next(responses)
+    c._http.request = _request  # type: ignore[method-assign]
+
+    resp = c._authed_request("POST", "/v1/mcp")
+    assert resp.status_code == 200
+    # Relogin must NOT have fired — DPoP nonce challenge replays
+    # with the same token, not a fresh one.
+    assert relogin_calls == []
+
+
+def test_authed_request_no_relogin_callable_propagates_401():
+    """Clients without a relogin callable (e.g. direct cert-only bootstraps)
+    see the 401 verbatim — backwards-compatible with the pre-fix path."""
+    c = _client_with_token()
+    assert c._relogin_callable is None
+
+    def _request(method, url, headers=None, **kw):
+        return _Resp(401, body={"detail": "expired"}, text_body="expired")
+    c._http.request = _request  # type: ignore[method-assign]
+
+    resp = c._authed_request("POST", "/v1/mcp")
+    assert resp.status_code == 401
+
+
+def test_authed_request_relogin_exception_propagates_original_401():
+    """If the relogin callable itself blows up (proxy unreachable, cert
+    revoked), the caller sees the ORIGINAL 401, not the secondary
+    exception — same observable behavior as before the auto-retry."""
+    c = _client_with_token()
+    def _relogin():
+        raise ConnectionError("proxy down")
+    c._relogin_callable = _relogin
+
+    def _request(method, url, headers=None, **kw):
+        return _Resp(401, body={"detail": "expired"}, text_body="expired")
+    c._http.request = _request  # type: ignore[method-assign]
+
+    resp = c._authed_request("POST", "/v1/mcp")
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
Long-running autonomous agents (insurance demo, batch workloads, anything that outlives the Mastio LOCAL_TOKEN TTL ~1h) used to crash-loop the same request once the token expired. The SDK now detects token-expiry 401, re-invokes the same login method that minted the token, and retries once.

## Why
PR #687 / #688 follow-up. Observed live 2026-05-13: `agent-claim-intake` and `agent-fraud-detection` on cullis-vm stopped processing exactly at the 1h mark, stuck on `httpx.HTTPStatusError: Client error '401 Unauthorized' for url '/v1/mcp'`. The inbox grew from 100 to 213 queued claims before manual restart. Same trap for any customer running a daemon-style agent.

## Mechanics
- New `CullisClient._relogin_callable` (default `None`). Each login method that succeeds registers itself there.
- `_authed_request` extended with a token-expiry 401 path: not a DPoP-nonce challenge + a callable is registered → invoke it once + retry. Private `_no_relogin` kwarg prevents recursion.
- Relogin raising → original 401 propagates (same observable shape as before this PR).

## Login methods covered
- `login_via_proxy` — proxy-enrolled, server-side key (`from_identity_dir` path, insurance demo uses this)
- `login_via_proxy_with_local_key` — Connector device-code, client-side key

`_legacy_login_from_pem` and broker-direct paths left untouched (deprecated or short-lived processes don't hit the bug).

## Test plan
- [x] `pytest tests/test_sdk_auto_relogin.py` — 6 new tests pass (success-no-retry, 401→relogin→success, 401→relogin→401 propagate, DPoP nonce path preserved, no-callable propagates, relogin-raises propagates original 401)
- [x] `pytest tests/ -k 'sdk_'` — 144 passed, 3 skipped (no regression in existing SDK tests)
- [x] `./sandbox/smoke.sh` — 25 PASS / 0 FAIL / 1 SKIP (baseline)

## Backwards compatibility
Pre-fix observable behavior: callers see 401. Post-fix:
- 401 that the relogin recovers → caller sees 200 (strictly an improvement)
- 401 that the relogin can't recover (revoked cert, proxy down) → caller still sees 401 with same body/headers
- DPoP nonce challenge → already-existing two-request retry path is unchanged

No new dependency. No public API change. `_relogin_callable` is private and `_no_relogin` is a keyword-only private kwarg.

## Operational impact
- Insurance-demo agents (and any autonomous customer integration) no longer need external restart-on-401 supervision.
- Token TTL on the Mastio side can stay short (security-positive) without breaking long-running agents.