### PR TITLE
feat(license): bake production RS256 pubkey for enterprise JWT verification

### DIFF
--- a/app/license.py
+++ b/app/license.py
@@ -39,9 +39,20 @@ _log = logging.getLogger("app.license")
 
 
 _PLACEHOLDER_MARKER = "CULLIS_PLACEHOLDER_PUBKEY"
-_DEV_PUBKEY_PEM = (
-    f"-----BEGIN PUBLIC KEY-----\n{_PLACEHOLDER_MARKER}\n-----END PUBLIC KEY-----\n"
-).encode()
+# Production RS256 public key for Cullis Enterprise license JWTs.
+# The matching private key is held offline by Cullis Security and is
+# never committed. Operators can override with CULLIS_LICENSE_PUBKEY_PATH
+# for self-issued test/staging tokens.
+_DEV_PUBKEY_PEM = b"""-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAokKvv5ycc25CZGAy34G0
+yMn7O5+kgWjC4s87OC7kvPw9rsrLrN+CItLI16DNf5UwPL0lvuPQCfgHKif0i2+R
+W2yzWwMktQcbf5SoFNI8381rjQ/JARaeJdanA59ZQS5+jjJbDD2OrCc27e42GVNR
+ka2hK4I76lm3xqaLVHCCMJ5KwlDlg8JlqwYFyBXYh/44hjVUGimF9WaUbF4gDK5/
+xiB1pKLkyyl/Alhg7dIVQk5e7zP6pUW65Sz7CIapqUY8PqPUwjE9izMTdcFkoRIW
+0QYRC6cFVjO5vKWAB0I9P4f31NAGcZzRbWduPhApykCy4RCnuGRoDyTn01032eEj
+fQIDAQAB
+-----END PUBLIC KEY-----
+"""
 
 
 @dataclass(frozen=True)

--- a/mcp_proxy/license.py
+++ b/mcp_proxy/license.py
@@ -37,9 +37,20 @@ _log = logging.getLogger("mcp_proxy.license")
 
 
 _PLACEHOLDER_MARKER = "CULLIS_PLACEHOLDER_PUBKEY"
-_DEV_PUBKEY_PEM = (
-    f"-----BEGIN PUBLIC KEY-----\n{_PLACEHOLDER_MARKER}\n-----END PUBLIC KEY-----\n"
-).encode()
+# Production RS256 public key for Cullis Enterprise license JWTs.
+# The matching private key is held offline by Cullis Security and is
+# never committed. Operators can override with CULLIS_LICENSE_PUBKEY_PATH
+# for self-issued test/staging tokens.
+_DEV_PUBKEY_PEM = b"""-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAokKvv5ycc25CZGAy34G0
+yMn7O5+kgWjC4s87OC7kvPw9rsrLrN+CItLI16DNf5UwPL0lvuPQCfgHKif0i2+R
+W2yzWwMktQcbf5SoFNI8381rjQ/JARaeJdanA59ZQS5+jjJbDD2OrCc27e42GVNR
+ka2hK4I76lm3xqaLVHCCMJ5KwlDlg8JlqwYFyBXYh/44hjVUGimF9WaUbF4gDK5/
+xiB1pKLkyyl/Alhg7dIVQk5e7zP6pUW65Sz7CIapqUY8PqPUwjE9izMTdcFkoRIW
+0QYRC6cFVjO5vKWAB0I9P4f31NAGcZzRbWduPhApykCy4RCnuGRoDyTn01032eEj
+fQIDAQAB
+-----END PUBLIC KEY-----
+"""
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary

P0 step 4 of the enterprise production-ready roadmap. Replaces the placeholder embedded license public key with the real production RS256 pubkey so enterprise-signed license JWTs verify successfully against any unmodified Mastio / Court binary.

## What changes

Two near-identical edits, in `mcp_proxy/license.py` and `app/license.py`:

- `_DEV_PUBKEY_PEM` constant now contains the real RS256 public key PEM (a 2048-bit RSA key, 451 bytes).
- The `_PLACEHOLDER_MARKER` constant is retained so the existing short-circuit in `_load_pubkey()` (community-mode fallback when forks still ship the placeholder) keeps working for anyone forking the public repo.
- Same key value in both files; same comment header documenting the offline-keypair model and the `CULLIS_LICENSE_PUBKEY_PATH` override path for staging/test tokens.

## Why

Until this swap, a syntactically valid enterprise license JWT could not unlock any paid feature in a default deploy because `_load_pubkey()` returned `None` whenever the placeholder marker was embedded. The README enterprise documents this as the gate to flip before the first contract.

The matching private key was generated offline today and stored in the Cullis Security 1Password vault. It never lived in the repo and never lives on a build machine.

## Validation

End-to-end loop validated locally:

1. Generated prod RS256 keypair via `cullis-license-gen keygen` (offline).
2. Stored priv key in 1Password vault. Pub PEM is the value baked here.
3. Rebuilt `cullis/mastio-enterprise` image on top of this change.
4. Minted a JWT with `cullis-license-gen issue` signing with the priv key.
5. Ran the container with `CULLIS_LICENSE_PATH=<jwt>` and **no** `CULLIS_LICENSE_PUBKEY_PATH` override.
6. Boot logs show: `license: tier=enterprise org=<...> features=9 exp=<...>` and all 9 enterprise plugins load (`requires_feature` gate passes against the baked pubkey).

## Test plan

- [x] Locally rebuilt enterprise image with the change and verified license tier=enterprise + all plugins loaded
- [x] Verified placeholder marker no longer appears in either `_DEV_PUBKEY_PEM` value (positive check pre-commit)
- [ ] `/security-review` on this PR
- [ ] CI green (test suite does not depend on the embedded pubkey value)

## Out of scope

- License rotation / revocation flow (P1 step 9)
- HSM-backed signing key (P2 step 11)
- Per-customer license tracker (P2 step 12)