### PR TITLE
feat(packaging): mastio-enterprise-bundle for licensed image deploys

### DIFF
--- a/.github/workflows/release-mastio-enterprise-bundle.yml
+++ b/.github/workflows/release-mastio-enterprise-bundle.yml
@@ -1,0 +1,204 @@
+# Release pipeline for the Cullis Mastio enterprise deploy bundle.
+#
+# Triggered by pushing a tag of the form `mastio-enterprise-bundle-vX.Y.Z`.
+# On tag push:
+#
+#   1. Stage `packaging/mastio-enterprise-bundle/` into a versioned dir.
+#   2. Pin `CULLIS_MASTIO_VERSION` default in the staged docker-compose.yml
+#      so `./deploy.sh` (no env var) gets a reproducible image instead
+#      of `latest`.
+#   3. Sanity-check that every file the bundle references at runtime
+#      is present in the staged tree (same defensive pattern as the
+#      Frontdesk bundle in PR #662 — catches "I forgot to add file X
+#      to the cp list" regressions HERE at release time).
+#   4. Package as tar.gz + zip, both versioned and unversioned filenames.
+#   5. Create a GitHub Release with the artefacts and a CISO-facing
+#      quickstart in the release notes.
+#
+# The release artefacts live on the PUBLIC `cullis-security/cullis`
+# repo. The image they pull (cullis-mastio-enterprise) is private; the
+# bundle itself is operator-facing recipe + nginx config and ships
+# openly. Anyone can download the bundle, but without an enterprise
+# license JWT + PAT for ghcr.io the deploy halts at the registry-auth
+# pre-flight.
+
+name: release-mastio-enterprise-bundle
+
+on:
+  push:
+    tags:
+      - "mastio-enterprise-bundle-v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-bundle:
+    name: Build deploy bundle
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: |
+          # mastio-enterprise-bundle-v1.2.3 → 1.2.3
+          value="${GITHUB_REF_NAME#mastio-enterprise-bundle-v}"
+          echo "value=${value}" >> "$GITHUB_OUTPUT"
+          echo "Releasing cullis-mastio-enterprise-bundle: ${value}"
+
+      - name: Stamp version into bundle
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          sed -i "s|CULLIS_MASTIO_VERSION:-latest|CULLIS_MASTIO_VERSION:-${VERSION}|" \
+            packaging/mastio-enterprise-bundle/docker-compose.yml
+
+      - name: Stage bundle
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          STAGING="dist/cullis-mastio-enterprise-bundle-${VERSION}"
+          mkdir -p "${STAGING}"
+
+          # Explicit allowlist — mirrors release-frontdesk-bundle.yml (the
+          # v0.2.7 broken-tarball incident motivated this pattern). A
+          # blanket cp -r would scoop up developer ./data/, ./proxy.env
+          # with real license JWT, etc.
+          cp packaging/mastio-enterprise-bundle/docker-compose.yml  "${STAGING}/"
+          cp packaging/mastio-enterprise-bundle/deploy.sh           "${STAGING}/"
+          cp packaging/mastio-enterprise-bundle/proxy.env.example   "${STAGING}/"
+          cp packaging/mastio-enterprise-bundle/README.md           "${STAGING}/"
+          cp -r packaging/mastio-enterprise-bundle/nginx            "${STAGING}/"
+
+          chmod +x "${STAGING}/deploy.sh"
+
+          # Post-stage sanity check: each file the docker-compose.yml or
+          # deploy.sh touches at runtime must exist in the staged tarball.
+          MISSING=0
+          for f in \
+              "docker-compose.yml" \
+              "deploy.sh" \
+              "proxy.env.example" \
+              "README.md" \
+              "nginx/mastio/00-maps.conf" \
+              "nginx/mastio/mastio.conf"; do
+              if [ ! -f "${STAGING}/${f}" ]; then
+                  echo "::error::staged bundle missing required file: ${f}"
+                  MISSING=1
+              fi
+          done
+          if [ "$MISSING" = "1" ]; then exit 1; fi
+
+          ls -lahR "${STAGING}/"
+          # Stable-name top-level dir inside the archive (no version
+          # suffix) so the README quickstart works against any release.
+          mv "${STAGING}" "dist/cullis-mastio-enterprise-bundle"
+
+      - name: Package tar.gz + zip
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          set -euo pipefail
+          cd dist
+          tar czf "cullis-mastio-enterprise-bundle-${VERSION}.tar.gz" cullis-mastio-enterprise-bundle
+          tar czf "cullis-mastio-enterprise-bundle.tar.gz" cullis-mastio-enterprise-bundle
+          zip -qr "cullis-mastio-enterprise-bundle-${VERSION}.zip" cullis-mastio-enterprise-bundle
+          zip -qr "cullis-mastio-enterprise-bundle.zip" cullis-mastio-enterprise-bundle
+          ls -lah *.tar.gz *.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle
+          path: |
+            dist/cullis-mastio-enterprise-bundle-*.tar.gz
+            dist/cullis-mastio-enterprise-bundle-*.zip
+            dist/cullis-mastio-enterprise-bundle.tar.gz
+            dist/cullis-mastio-enterprise-bundle.zip
+          retention-days: 7
+
+  release:
+    name: Create GitHub Release
+    needs: build-bundle
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download bundle artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle
+          path: dist
+
+      - name: Compose release notes
+        env:
+          VERSION: ${{ needs.build-bundle.outputs.version }}
+        run: |
+          set -euo pipefail
+          cat > release-notes.md <<NOTES
+          # Cullis Mastio Enterprise Bundle ${VERSION}
+
+          Image-based deploy bundle for the Mastio enterprise image. Pulls
+          \`ghcr.io/cullis-security/cullis-mastio-enterprise\` via Docker
+          Compose with the mTLS nginx sidecar. No source tree required.
+
+          ## Quickstart
+
+          \`\`\`bash
+          # 1. Authenticate to the private registry
+          echo <PAT> | docker login ghcr.io -u <github-user> --password-stdin
+
+          # 2. Download the bundle
+          curl -L https://github.com/${{ github.repository }}/releases/download/${GITHUB_REF_NAME}/cullis-mastio-enterprise-bundle.tar.gz | tar xz
+          cd cullis-mastio-enterprise-bundle/
+
+          # 3. Configure + deploy
+          cp proxy.env.example proxy.env
+          # edit proxy.env: paste license JWT, set MCP_PROXY_PROXY_PUBLIC_URL,
+          # set MCP_PROXY_ADMIN_SECRET + MCP_PROXY_DASHBOARD_SIGNING_KEY
+          ./deploy.sh
+          \`\`\`
+
+          The deploy script pre-flights the license JWT shape and the
+          registry pull before bringing the stack up. On success it
+          reports the active license tier and how many plugins loaded.
+
+          ## Artefacts
+
+          - **Bundle**: \`cullis-mastio-enterprise-bundle-${VERSION}.tar.gz\` / \`.zip\`
+          - **Image** (private, requires PAT): \`ghcr.io/cullis-security/cullis-mastio-enterprise\`
+
+          ## CISO verification
+
+          The bundled image is cosign-signed (Sigstore keyless) and
+          ships with a CycloneDX SBOM in the matching
+          \`mastio-enterprise-v${VERSION}\` release on the private
+          \`cullis-security/cullis-enterprise\` repo. See README.md
+          inside the bundle for the cosign verify command.
+
+          ## Need a PAT or a license
+
+          hello@cullis.io
+          NOTES
+          cat release-notes.md
+
+      - name: Create release
+        # Pinned to SHA — same pattern as release-mastio.yml.
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2.6.2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "Cullis Mastio Enterprise Bundle ${{ github.ref_name }}"
+          body_path: release-notes.md
+          files: |
+            dist/cullis-mastio-enterprise-bundle-*.tar.gz
+            dist/cullis-mastio-enterprise-bundle-*.zip
+            dist/cullis-mastio-enterprise-bundle.tar.gz
+            dist/cullis-mastio-enterprise-bundle.zip
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-rc') || contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') }}

--- a/packaging/mastio-enterprise-bundle/README.md
+++ b/packaging/mastio-enterprise-bundle/README.md
@@ -1,0 +1,113 @@
+# Cullis Mastio Enterprise — image-based bundle
+
+Self-contained Docker Compose deploy of the Mastio enterprise image
+plus its mTLS nginx sidecar. Same shape as the open-core
+`packaging/mastio-bundle`; the difference is the image (private,
+licensed) and the plugin env surface.
+
+## Prerequisites
+
+- Docker 24+ with Compose v2
+- A GitHub PAT issued by Cullis Security at deal close (read access to
+  `ghcr.io/cullis-security/cullis-mastio-enterprise`)
+- A license JWT issued by Cullis Security (RS256-signed, lists the
+  paid features your contract grants)
+
+## Quick start
+
+```bash
+# 1. Authenticate to the private registry (one-time per host)
+echo <PAT> | docker login ghcr.io -u <github-user> --password-stdin
+
+# 2. Configure the proxy
+cp proxy.env.example proxy.env
+# Edit proxy.env:
+#   - CULLIS_LICENSE_KEY=<paste the JWT here>
+#   - MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.yourorg.example.com:9443
+#   - MCP_PROXY_ADMIN_SECRET=<openssl rand -hex 32>
+#   - MCP_PROXY_DASHBOARD_SIGNING_KEY=<openssl rand -hex 32>
+#   - Plugin-specific envs for the features your license grants
+#     (see comments in proxy.env.example for the catalogue)
+
+# 3. Deploy
+./deploy.sh
+```
+
+`deploy.sh` runs two pre-flights before bringing the stack up:
+
+1. License JWT shape check (header.payload.signature base64url). The
+   container verifies the signature on boot against the pubkey baked
+   into the image.
+2. `docker pull` of the enterprise image. Fails fast with a clear
+   message if `docker login ghcr.io` has not been done.
+
+On `up` success the script reports how many plugins loaded and prints
+the active license tier. Expect `plugins loaded: N` matching the
+features in your license (1 plugin per granted feature).
+
+## Verifying the image (CISO checklist)
+
+The image is cosign-signed (Sigstore keyless) and ships with a
+CycloneDX SBOM. Customer CISO can verify either before deploying.
+
+### Verify the cosign signature
+
+```bash
+cosign verify \
+  --certificate-identity-regexp \
+  '^https://github.com/cullis-security/cullis-enterprise/.github/workflows/release-mastio-enterprise.yml@refs/tags/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/cullis-security/cullis-mastio-enterprise:<VERSION>
+```
+
+A green verify means: this image was built by the canonical Cullis
+Security release workflow on a tagged release, and the signature is
+discoverable in the public Sigstore Rekor transparency log.
+
+### Pull the SBOM
+
+The CycloneDX SBOM is attached to the corresponding GitHub Release in
+`cullis-security/cullis-enterprise` (private; needs PAT access). Look
+for `sbom.cdx.json` in the release assets.
+
+## Operations
+
+| Action | Command |
+|---|---|
+| Bring up | `./deploy.sh` |
+| Bring down | `./deploy.sh --down` |
+| Re-pull image then up | `./deploy.sh --pull` |
+| Logs | `docker compose -p cullis-mastio-enterprise logs -f mcp-proxy` |
+| Open dashboard | `https://<MCP_PROXY_PROXY_PUBLIC_URL>/proxy/login` |
+
+The first boot generates the Org CA and (if `MCP_PROXY_KMS_BACKEND` is
+not `local`) writes the Org CA private key to the configured KMS
+(Vault, AWS Secrets Manager, Azure Key Vault, or GCP Secret Manager).
+
+## Upgrading
+
+```bash
+# Edit proxy.env, bump CULLIS_MASTIO_VERSION to the new tag.
+sed -i 's/^CULLIS_MASTIO_VERSION=.*/CULLIS_MASTIO_VERSION=<new>/' proxy.env
+./deploy.sh --pull
+```
+
+Operator-side data (`./data/mcp_proxy.db`, `./nginx-certs/`,
+`./saml-keys/`) survives the image bump.
+
+## Where things live
+
+| Path | What |
+|---|---|
+| `./data/` | SQLite DB, runtime state. Owned by container UID 10001. |
+| `./nginx-certs/` | Org CA + nginx server cert. Read-write by mcp-proxy, read-only by mastio-nginx. |
+| `./certs/` | (Optional) corporate CA bundle to trust. Mount-only. |
+| `./saml-keys/` | (Optional) SAML SP signing keypair, generated on first saml_sso boot. |
+| `proxy.env` | All config + license JWT. NEVER commit. |
+
+## Support
+
+- Documentation: https://cullis.io/docs/operate/enterprise-install
+- License renewal / PAT rotation: hello@cullis.io
+- Bug reports: include `./deploy.sh --down` logs + `proxy.env` (license
+  REDACTED) + the cosign verify output of the failing image

--- a/packaging/mastio-enterprise-bundle/deploy.sh
+++ b/packaging/mastio-enterprise-bundle/deploy.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Mastio Enterprise — image-based deploy
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Pulls the private ghcr.io/cullis-security/cullis-mastio-enterprise
+# image and brings up the same Mastio + nginx-sidecar topology as the
+# open-core bundle, with two additions:
+#
+#   - Pre-flight validates the license JWT is present and parses (no
+#     signature verification client-side; the container does that on
+#     boot against the baked pubkey).
+#   - Pre-flight tests ``docker pull`` against the private registry.
+#     Operator must have run ``docker login ghcr.io`` first with the
+#     PAT issued at deal close.
+#
+# Modes:
+#   (default)         standalone enterprise Mastio
+#   --down            stop + remove containers
+#   --pull            re-pull image
+#
+# Usage:
+#   ./deploy.sh
+#   CULLIS_MASTIO_VERSION=0.4.2 ./deploy.sh
+#   ./deploy.sh --down
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# Pin compose project name so we never collide with a sibling
+# open-core ``cullis-mastio`` stack on the same docker host.
+export COMPOSE_PROJECT_NAME="cullis-mastio-enterprise"
+
+# ── colour helpers ──────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    BOLD="\033[1m"; RED="\033[31m"; GREEN="\033[32m"; YELLOW="\033[33m"; RESET="\033[0m"
+else
+    BOLD=""; RED=""; GREEN=""; YELLOW=""; RESET=""
+fi
+ok()   { echo -e "  ${GREEN}✓${RESET}  $1"; }
+warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
+err()  { echo -e "  ${RED}✗${RESET}  $1"; }
+die()  { err "$1"; exit 1; }
+step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
+
+MODE="up"
+PULL=0
+for arg in "$@"; do
+    case "$arg" in
+        --down)  MODE="down" ;;
+        --pull)  PULL=1 ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) die "unknown arg: $arg (use --help)" ;;
+    esac
+done
+
+# ── ensure proxy.env exists ─────────────────────────────────────────────────
+if [[ ! -f proxy.env ]]; then
+    if [[ -f proxy.env.example ]]; then
+        die "proxy.env missing. Copy 'proxy.env.example' to 'proxy.env', edit, then re-run."
+    else
+        die "proxy.env missing and proxy.env.example not found — bundle looks corrupted."
+    fi
+fi
+
+# Load env so the pre-flights can inspect CULLIS_LICENSE_KEY etc.
+# shellcheck disable=SC1091,SC2046
+set -a
+. ./proxy.env
+set +a
+
+# ── down ────────────────────────────────────────────────────────────────────
+if [[ "$MODE" == "down" ]]; then
+    step "stopping cullis-mastio-enterprise stack"
+    docker compose --env-file proxy.env down
+    ok "stack stopped"
+    exit 0
+fi
+
+# ── pre-flight: license JWT ─────────────────────────────────────────────────
+step "license pre-flight"
+
+_license_jwt=""
+if [[ -n "${CULLIS_LICENSE_KEY:-}" ]]; then
+    _license_jwt="$CULLIS_LICENSE_KEY"
+elif [[ -n "${CULLIS_LICENSE_PATH:-}" && -f "${CULLIS_LICENSE_PATH}" ]]; then
+    _license_jwt="$(cat "${CULLIS_LICENSE_PATH}")"
+fi
+
+if [[ -z "$_license_jwt" ]]; then
+    warn "no license configured (CULLIS_LICENSE_KEY / CULLIS_LICENSE_PATH)"
+    warn "the proxy will boot in community mode — no paid plugins will activate"
+else
+    # Shape check only. The container verifies signature + exp on boot.
+    if [[ "$_license_jwt" =~ ^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$ ]]; then
+        ok "license JWT shape valid"
+    else
+        die "license value is not a JWT (need 'header.payload.signature' base64url)"
+    fi
+fi
+
+# ── pre-flight: registry auth ───────────────────────────────────────────────
+step "registry auth pre-flight"
+IMG_BASE="ghcr.io/cullis-security/cullis-mastio-enterprise"
+VERSION_TAG="${CULLIS_MASTIO_VERSION:-latest}"
+IMG="${IMG_BASE}:${VERSION_TAG}"
+
+# ``docker pull --quiet`` against the private repo. If the operator has
+# not authenticated this fails fast with a clear message.
+if ! docker pull --quiet "$IMG" >/dev/null 2>&1; then
+    err "pull of ${IMG} failed"
+    err "have you run 'docker login ghcr.io' with your Cullis PAT?"
+    err "ask hello@cullis.io if your PAT has expired"
+    exit 1
+fi
+ok "${IMG} pull OK"
+
+# ── bring up ────────────────────────────────────────────────────────────────
+step "bringing up cullis-mastio-enterprise"
+if [[ "$PULL" == "1" ]]; then
+    docker compose --env-file proxy.env pull
+fi
+docker compose --env-file proxy.env up -d --wait
+ok "stack up"
+
+# ── post-up: plugin discovery report ────────────────────────────────────────
+step "plugin discovery"
+sleep 2
+loaded_count="$(docker compose --env-file proxy.env logs --no-color mcp-proxy 2>&1 | grep -c 'plugin loaded:' || true)"
+ok "${loaded_count} plugins loaded (expected up to 9 depending on license features)"
+
+license_line="$(docker compose --env-file proxy.env logs --no-color mcp-proxy 2>&1 | grep -m1 'license:' || true)"
+if [[ -n "$license_line" ]]; then
+    echo "  $license_line"
+else
+    warn "no license log line — proxy may still be starting"
+fi
+
+echo
+echo -e "${BOLD}Mastio Enterprise ready at: ${MCP_PROXY_PROXY_PUBLIC_URL:-https://localhost:${MCP_PROXY_PORT:-9443}}${RESET}"
+echo -e "  Logs:  docker compose -p ${COMPOSE_PROJECT_NAME} logs -f mcp-proxy"
+echo -e "  Stop:  ./deploy.sh --down"

--- a/packaging/mastio-enterprise-bundle/docker-compose.yml
+++ b/packaging/mastio-enterprise-bundle/docker-compose.yml
@@ -1,0 +1,195 @@
+# =============================================================================
+# Cullis Mastio Enterprise — image-based bundle for paid deployments
+# =============================================================================
+#
+# Same topology as packaging/mastio-bundle/docker-compose.yml (Mastio +
+# mTLS nginx sidecar, ADR-006/ADR-014/ADR-030) but with two enterprise
+# additions:
+#
+#   1. ``image:`` points at the private GHCR image
+#      ``ghcr.io/cullis-security/cullis-mastio-enterprise``. The operator
+#      must ``docker login ghcr.io`` first with a PAT issued by Cullis
+#      Security at deal close.
+#   2. ``CULLIS_LICENSE_*`` env vars plumbed through. Without a valid
+#      enterprise license JWT the container boots in community mode and
+#      none of the paid plugins activate (mcp_proxy/license.py + the
+#      plugin license gate enforce this).
+#
+# The remaining ``CULLIS_*`` plugin envs are paid-feature-specific:
+# operators enable each plugin on their license + provide the matching
+# backend config. See proxy.env.example for the full list with inline
+# pointers to the docs.
+#
+# Usage:
+#   ./deploy.sh                 # standalone enterprise (default)
+#   ./deploy.sh --down          # stop + remove
+#
+# Compose project name is pinned to ``cullis-mastio-enterprise`` so the
+# stack does not collide with a sibling open-core ``cullis-mastio``
+# bundle on the same docker host.
+# =============================================================================
+
+services:
+
+  # ADR-030 — same bind-target chown pattern as mastio-bundle.
+  init-permissions:
+    image: busybox:stable
+    user: "0:0"
+    command:
+      - sh
+      - -c
+      - |
+        chown -R 10001:10001 /data /nginx-certs
+        chmod 0750 /data /nginx-certs
+    volumes:
+      - ${MASTIO_DATA_DIR:-./data}:/data
+      - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/nginx-certs
+    restart: "no"
+    networks:
+      - proxy_net
+
+  mcp-proxy:
+    image: ghcr.io/cullis-security/cullis-mastio-enterprise:${CULLIS_MASTIO_VERSION:-latest}
+    depends_on:
+      init-permissions:
+        condition: service_completed_successfully
+    expose:
+      - "9100"
+    environment:
+      MCP_PROXY_VERSION:           ${CULLIS_MASTIO_VERSION:-unknown}
+      MCP_PROXY_ENVIRONMENT:       ${MCP_PROXY_ENVIRONMENT:-development}
+      MCP_PROXY_STANDALONE:        ${MCP_PROXY_STANDALONE:-true}
+      MCP_PROXY_ADMIN_SECRET:      ${MCP_PROXY_ADMIN_SECRET:-change-me-in-production}
+      MCP_PROXY_DASHBOARD_SIGNING_KEY: ${MCP_PROXY_DASHBOARD_SIGNING_KEY:-}
+      MCP_PROXY_INITIAL_ADMIN_PASSWORD: ${MCP_PROXY_INITIAL_ADMIN_PASSWORD:-}
+      MCP_PROXY_DATABASE_URL:      sqlite+aiosqlite:////data/mcp_proxy.db
+      MCP_PROXY_BROKER_URL:        ${MCP_PROXY_BROKER_URL:-}
+      MCP_PROXY_BROKER_JWKS_URL:   ${MCP_PROXY_BROKER_JWKS_URL:-}
+      MCP_PROXY_PDP_URL:           ${MCP_PROXY_PDP_URL:-http://mcp-proxy:9100/pdp/policy}
+      MCP_PROXY_PROXY_PUBLIC_URL:  ${MCP_PROXY_PROXY_PUBLIC_URL:-https://host.docker.internal:9443}
+      MCP_PROXY_ALLOWED_ORIGINS:   ${MCP_PROXY_ALLOWED_ORIGINS:-}
+      MCP_PROXY_NGINX_CERT_DIR:    ${MCP_PROXY_NGINX_CERT_DIR:-/var/lib/mastio/nginx-certs}
+      MCP_PROXY_NGINX_SAN:         ${MCP_PROXY_NGINX_SAN:-mastio.local,localhost,host.docker.internal,mastio-nginx,mcp-proxy}
+      SSL_CERT_FILE:               ${MCP_PROXY_BROKER_CA_BUNDLE:-}
+      REQUESTS_CA_BUNDLE:          ${MCP_PROXY_BROKER_CA_BUNDLE:-}
+      MCP_PROXY_SECRET_BACKEND:    ${MCP_PROXY_SECRET_BACKEND:-env}
+      MCP_PROXY_VAULT_ADDR:        ${MCP_PROXY_VAULT_ADDR:-}
+      MCP_PROXY_VAULT_TOKEN:       ${MCP_PROXY_VAULT_TOKEN:-}
+      MCP_PROXY_KMS_BACKEND:       ${MCP_PROXY_KMS_BACKEND:-local}
+      MCP_PROXY_ANTHROPIC_API_KEY: ${MCP_PROXY_ANTHROPIC_API_KEY:-}
+      MCP_PROXY_TOOL_PDP_ENABLED:        ${MCP_PROXY_TOOL_PDP_ENABLED:-}
+      MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET: ${MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET:-}
+      MCP_PROXY_LOCAL_AUTH_ENABLED:      ${MCP_PROXY_LOCAL_AUTH_ENABLED:-}
+      MCP_PROXY_FORCE_LOCAL_PASSWORD:    ${MCP_PROXY_FORCE_LOCAL_PASSWORD:-}
+      MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S: ${MCP_PROXY_AI_GATEWAY_REQUEST_TIMEOUT_S:-180}
+
+      # ──────────────────── enterprise: license ─────────────────────
+      # JWT (raw) takes precedence over the file path. The dashboard
+      # reads features from the active license at boot; mismatched +
+      # expired licenses degrade to community mode silently with a
+      # warning in the logs.
+      CULLIS_LICENSE_KEY:           ${CULLIS_LICENSE_KEY:-}
+      CULLIS_LICENSE_PATH:          ${CULLIS_LICENSE_PATH:-}
+      # Override pubkey only for operator-issued staging tokens. Leave
+      # empty in production: the image ships with the Cullis Security
+      # pubkey baked in (see mcp_proxy/license.py).
+      CULLIS_LICENSE_PUBKEY_PATH:   ${CULLIS_LICENSE_PUBKEY_PATH:-}
+
+      # ──────────── enterprise plugins: audit export ───────────────
+      CULLIS_AUDIT_EXPORT_S3_BUCKET:    ${CULLIS_AUDIT_EXPORT_S3_BUCKET:-}
+      CULLIS_AUDIT_EXPORT_S3_REGION:    ${CULLIS_AUDIT_EXPORT_S3_REGION:-}
+      CULLIS_AUDIT_EXPORT_S3_PREFIX:    ${CULLIS_AUDIT_EXPORT_S3_PREFIX:-}
+      AWS_ACCESS_KEY_ID:                ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY:            ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN:                ${AWS_SESSION_TOKEN:-}
+      CULLIS_AUDIT_EXPORT_DATADOG_API_KEY: ${CULLIS_AUDIT_EXPORT_DATADOG_API_KEY:-}
+      CULLIS_AUDIT_EXPORT_DATADOG_SITE:    ${CULLIS_AUDIT_EXPORT_DATADOG_SITE:-}
+
+      # ────────────── enterprise plugins: SAML SSO ─────────────────
+      CULLIS_SAML_SP_ENTITY_ID:    ${CULLIS_SAML_SP_ENTITY_ID:-}
+      CULLIS_SAML_SP_ACS_URL:      ${CULLIS_SAML_SP_ACS_URL:-}
+      CULLIS_SAML_IDP_ENTITY_ID:   ${CULLIS_SAML_IDP_ENTITY_ID:-}
+      CULLIS_SAML_IDP_SSO_URL:     ${CULLIS_SAML_IDP_SSO_URL:-}
+      CULLIS_SAML_IDP_CERT_PATH:   ${CULLIS_SAML_IDP_CERT_PATH:-}
+      CULLIS_SAML_SP_KEY_DIR:      ${CULLIS_SAML_SP_KEY_DIR:-/var/lib/cullis/saml}
+
+      # ─────────── enterprise plugins: cloud KMS (Org CA) ──────────
+      # AWS Secrets Manager (cloud_kms_aws): set _SECRET_ID + region +
+      # AWS creds above. Pick ONE of vault / aws / azure / gcp via
+      # MCP_PROXY_KMS_BACKEND. Mix-and-matching is undefined.
+      CULLIS_CLOUD_KMS_AWS_SECRET_ID: ${CULLIS_CLOUD_KMS_AWS_SECRET_ID:-}
+      CULLIS_CLOUD_KMS_AWS_REGION:    ${CULLIS_CLOUD_KMS_AWS_REGION:-}
+      # Azure Key Vault (cloud_kms_azure)
+      CULLIS_CLOUD_KMS_AZURE_VAULT_URL: ${CULLIS_CLOUD_KMS_AZURE_VAULT_URL:-}
+      CULLIS_CLOUD_KMS_AZURE_SECRET_NAME: ${CULLIS_CLOUD_KMS_AZURE_SECRET_NAME:-}
+      AZURE_CLIENT_ID:                ${AZURE_CLIENT_ID:-}
+      AZURE_TENANT_ID:                ${AZURE_TENANT_ID:-}
+      AZURE_CLIENT_SECRET:            ${AZURE_CLIENT_SECRET:-}
+      # GCP Secret Manager (cloud_kms_gcp)
+      CULLIS_CLOUD_KMS_GCP_PROJECT_ID: ${CULLIS_CLOUD_KMS_GCP_PROJECT_ID:-}
+      CULLIS_CLOUD_KMS_GCP_SECRET_ID:  ${CULLIS_CLOUD_KMS_GCP_SECRET_ID:-}
+      GOOGLE_APPLICATION_CREDENTIALS:  ${GOOGLE_APPLICATION_CREDENTIALS:-}
+
+      # ─────── enterprise plugins: scim 2.0 + multi-admin ──────────
+      CULLIS_SCIM_BEARER_TOKEN:       ${CULLIS_SCIM_BEARER_TOKEN:-}
+
+      # ────────────────── ADR-029 / pass-through ───────────────────
+      PROXY_TRUST_DOMAIN:          ${PROXY_TRUST_DOMAIN:-}
+      PROXY_INTRA_ORG:             ${PROXY_INTRA_ORG:-}
+      PROXY_TRANSPORT_INTRA_ORG:   ${PROXY_TRANSPORT_INTRA_ORG:-}
+      PROXY_EGRESS_INSPECTION_ENABLED: ${PROXY_EGRESS_INSPECTION_ENABLED:-}
+      PROXY_FEDERATION_SYNC:       ${PROXY_FEDERATION_SYNC:-}
+      CULLIS_EGRESS_DPOP_MODE:     ${CULLIS_EGRESS_DPOP_MODE:-}
+
+      MCP_PROXY_FRONTDESK_AMBASSADOR_URL: ${MCP_PROXY_FRONTDESK_AMBASSADOR_URL:-}
+      MCP_PROXY_FRONTDESK_ADMIN_SECRET:   ${MCP_PROXY_FRONTDESK_ADMIN_SECRET:-}
+
+    volumes:
+      - ${MASTIO_DATA_DIR:-./data}:/data
+      - ${CULLIS_CERTS_DIR:-./certs}:/certs:ro
+      - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/var/lib/mastio/nginx-certs:rw
+      # SAML SP key dir is plugin-managed but mounted on host so it
+      # survives container recreation. Empty until saml_sso plugin
+      # boots and writes the SP signing keypair.
+      - ${MASTIO_SAML_KEYS_DIR:-./saml-keys}:/var/lib/cullis/saml:rw
+    networks:
+      - proxy_net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9100/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+  mastio-nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "${MCP_PROXY_PORT:-9443}:9443"
+    volumes:
+      - ./nginx/mastio:/etc/nginx/conf.d:ro
+      - ${MASTIO_NGINX_CERTS_DIR:-./nginx-certs}:/etc/nginx/certs:ro
+    depends_on:
+      mcp-proxy:
+        condition: service_healthy
+    networks:
+      - proxy_net
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          test -s /etc/nginx/certs/mastio-server.crt &&
+          test -s /etc/nginx/certs/mastio-server.key &&
+          test -s /etc/nginx/certs/org-ca.crt &&
+          wget -q --no-check-certificate -O /dev/null https://127.0.0.1:9443/health
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+
+networks:
+  proxy_net:
+    driver: bridge

--- a/packaging/mastio-enterprise-bundle/nginx/mastio/00-maps.conf
+++ b/packaging/mastio-enterprise-bundle/nginx/mastio/00-maps.conf
@@ -1,0 +1,18 @@
+# =============================================================================
+# Cullis Mastio sidecar — http-level maps
+# =============================================================================
+#
+# Loaded before mastio.conf via lexicographic order in
+# /etc/nginx/conf.d/. ``map`` directives must live in the ``http {}``
+# context (which the nginx official image opens for us at the top
+# level), so they can't sit inside a ``server {}`` block.
+# =============================================================================
+
+# WebSocket Upgrade helper for the dashboard websocket route. Empty
+# Upgrade → close the upstream connection; anything else → forward
+# verbatim so nginx doesn't emit ``Connection: close`` and break
+# long-lived dashboard streams.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/packaging/mastio-enterprise-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-enterprise-bundle/nginx/mastio/mastio.conf
@@ -1,0 +1,243 @@
+# =============================================================================
+# Cullis Mastio nginx sidecar — ADR-014
+# =============================================================================
+#
+# Terminates TLS on 9443 in front of mcp-proxy (which keeps listening on
+# 9100 on the internal docker network only — never published to the
+# host). Routes carrying agent identity require a client certificate
+# signed by the Org CA. Routes that are anonymous by design (enrollment
+# bootstrap, dashboard browser login, health) terminate TLS but do not
+# require a client cert.
+#
+# Anti-spoofing on X-SSL-Client-Cert
+# ----------------------------------
+# nginx always overwrites X-SSL-Client-Cert with the verified cert from
+# the TLS handshake (proxy_set_header). The backend mcp-proxy is bound
+# to the internal ``broker_net`` docker network only, with no host port
+# publish, so a caller cannot reach 9100 directly to bypass nginx and
+# inject a forged header. If a future deploy ever publishes 9100, we
+# add a shared-secret edge header at that point — for now the network
+# binding is the defence.
+# =============================================================================
+
+server {
+    listen 9443 ssl;
+    http2 on;
+    server_name _;
+
+    # ── TLS server material ─────────────────────────────────────────
+    # Both files are written into /etc/nginx/certs by the Mastio at
+    # first-boot (and rotation), then mounted read-only here via the
+    # shared docker volume ``mastio_nginx_certs``.
+    ssl_certificate     /etc/nginx/certs/mastio-server.crt;
+    ssl_certificate_key /etc/nginx/certs/mastio-server.key;
+
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5:!RC4;
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 10m;
+    ssl_session_cache   shared:SSL:10m;
+
+    # ── Client cert verification ────────────────────────────────────
+    # The Org CA is the trust bundle for client certs. Same CA the
+    # Mastio uses to sign every Connector cert during enrollment, so
+    # presenting a valid Connector identity at the TLS layer is the
+    # whole point of the design. ``ssl_verify_client optional`` lets
+    # individual locations selectively require the cert below.
+    ssl_client_certificate /etc/nginx/certs/org-ca.crt;
+    ssl_verify_client      optional;
+
+    # ── Hardening headers ───────────────────────────────────────────
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options    "nosniff" always;
+    add_header X-Frame-Options           "DENY" always;
+    add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+
+    client_max_body_size 4m;
+
+    # ──────────────────────────────────────────────────────────────────
+    # mTLS-required (TLS-layer agent identity)
+    # ──────────────────────────────────────────────────────────────────
+    # /v1/egress + /v1/agents + /v1/audit are the surfaces where the
+    # *caller's identity* is what gates the action. The cert presented
+    # at the TLS handshake IS the identity. Without a verified cert
+    # nginx returns 401 before FastAPI sees the request.
+    #
+    # PR-C also moves the three agent-authenticated /v1/auth endpoints
+    # behind mTLS — login-challenge, sign-challenged-assertion, and
+    # sign-assertion all carried agent identity via X-API-Key before
+    # PR-C dropped that path. /v1/auth/token stays anonymous (it
+    # validates a client_assertion JWT, not a TLS cert) — see the
+    # /v1/* catch-all below.
+    location ~ ^/v1/(egress|agents|audit)(/.*)?$ {
+        if ($ssl_client_verify != SUCCESS) {
+            return 401;
+        }
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # Always overwrite — never trust a client-supplied value.
+        proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
+        proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+    }
+
+    location ~ ^/v1/auth/(login-challenge|sign-challenged-assertion|sign-assertion)$ {
+        if ($ssl_client_verify != SUCCESS) {
+            return 401;
+        }
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
+        proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+    }
+
+    # ADR-025 chat / MCP — Frontdesk Connectors call these with the
+    # per-user UserPrincipal cert minted via /v1/principals/csr. The
+    # backend dep (``get_agent_from_dpop_client_cert``) tries the
+    # LOCAL_TOKEN Bearer fallback first, so requests without a cert
+    # still work the legacy way (broker uplink, intra-org agent
+    # bearers); we just need to STOP stripping a verified cert when one
+    # is presented, otherwise typed-principal attribution falls back to
+    # the agent-wide bearer and audit rows lose the actual user.
+    # ``ssl_verify_client optional`` is set at the server scope so the
+    # cert is verified at the TLS handshake when offered, and the
+    # backend checks ``X-SSL-Client-Verify == SUCCESS`` before trusting
+    # ``X-SSL-Client-Cert``.
+    location ~ ^/v1/(llm|mcp)(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
+        proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
+        # SSE streaming on /v1/llm/chat — disable buffering + bump the
+        # read timeout so the proxy doesn't 504 on long completions.
+        proxy_buffering off;
+        proxy_read_timeout 600;
+    }
+
+    # ──────────────────────────────────────────────────────────────────
+    # TLS-only catch-all for /v1/*
+    # ──────────────────────────────────────────────────────────────────
+    # Everything else under /v1 is auth'd at the application layer:
+    # /v1/admin (session cookie / admin secret), /v1/enrollment
+    # (anonymous bootstrap), /v1/auth/token (anonymous, returns
+    # LOCAL_TOKEN), /v1/federation (public discovery), /v1/local +
+    # /v1/ingress + /v1/mcp + /v1/broker (broker-or-internal callers).
+    # All of these terminate TLS at nginx and forward without a client
+    # cert. Mounting them all here as a single regex avoids the trap
+    # where a new /v1/<thing> route ships without us adding a sidecar
+    # location and starts returning 404.
+    location ~ ^/v1/(.*)$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        # Strip any client-supplied cert header — anonymous endpoints
+        # must not be confusable with authenticated ones.
+        proxy_set_header X-SSL-Client-Cert "";
+        # WebSocket upgrades for /v1/local + /v1/broker.
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+        proxy_read_timeout                 86400;
+    }
+
+    # ──────────────────────────────────────────────────────────────────
+    # Health, dashboard, PDP, well-known — anonymous over TLS
+    # ──────────────────────────────────────────────────────────────────
+    location ~ ^/(health|healthz|readyz|live)$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Dashboard (browser admin) — auth is session cookie or OIDC at app.
+    location ~ ^/proxy(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
+        proxy_read_timeout                 86400;
+    }
+
+    # PDP webhook — broker calls this over the docker network.
+    location ~ ^/pdp(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # /.well-known (JWKS, security.txt, OIDC discovery, etc.)
+    location ~ ^/\.well-known(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Anonymous Org CA download for TOFU pinning during Connector
+    # first-contact. Exact path only — no path traversal possible.
+    location = /pki/ca.crt {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Dashboard static assets (tailwind.css, htmx, fonts, logo SVG…).
+    # The dashboard templates reference ``/static/...`` URLs verbatim;
+    # without this location nginx returns 404 and the dashboard renders
+    # unstyled (the inline logo SVG fills the viewport).
+    location ~ ^/static(/.*)?$ {
+        proxy_pass http://mcp-proxy:9100;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-SSL-Client-Cert "";
+    }
+
+    # Bare URL (https://host:9443/) → dashboard login. Without this an
+    # operator opening the host root sees nginx 404.
+    location = / {
+        return 302 /proxy/login;
+    }
+
+    # ──────────────────────────────────────────────────────────────────
+    # Catch-all — fail closed.
+    # ──────────────────────────────────────────────────────────────────
+    location / {
+        return 404;
+    }
+}

--- a/packaging/mastio-enterprise-bundle/proxy.env.example
+++ b/packaging/mastio-enterprise-bundle/proxy.env.example
@@ -1,0 +1,100 @@
+# =============================================================================
+# Cullis Mastio Enterprise — sample proxy.env
+# =============================================================================
+#
+# Copy to ``proxy.env``, edit, then ``./deploy.sh``. The deploy script
+# reads this file via ``--env-file proxy.env`` and the compose stack
+# substitutes the values into the running containers.
+#
+# Every uncommented line is a knob. Commented lines hint at the optional
+# extras; leave them commented until you actually enable that plugin.
+# =============================================================================
+
+# ─────────────────────────── image pinning ───────────────────────────
+# Image tag of cullis-mastio-enterprise to deploy. Bump on upgrade and
+# re-run ./deploy.sh. Leave at ``latest`` only in development.
+CULLIS_MASTIO_VERSION=latest
+
+# ─────────────────────────── license JWT ─────────────────────────────
+# Required. Cullis Security issues per-customer RS256 JWTs at deal
+# close. Paste the raw JWT here. Without it the proxy boots in
+# community mode (no paid plugins).
+CULLIS_LICENSE_KEY=
+
+# Alternative: path inside the container to a file holding the JWT.
+# Use one OR the other, not both. _KEY takes precedence.
+# CULLIS_LICENSE_PATH=/etc/cullis/keys/license.jwt
+
+# ───────────────────────── core Mastio config ────────────────────────
+MCP_PROXY_ENVIRONMENT=production
+MCP_PROXY_STANDALONE=true
+# Strong random secret. Generate with: openssl rand -hex 32
+MCP_PROXY_ADMIN_SECRET=
+# 32+ char value used to sign dashboard session cookies. Same generator.
+MCP_PROXY_DASHBOARD_SIGNING_KEY=
+
+# Public URL the agents reach the Mastio at (DPoP htu validation pins
+# to this exact URL). Defaults work for single-host dev only; prod
+# must override.
+MCP_PROXY_PROXY_PUBLIC_URL=https://mastio.yourorg.example.com:9443
+
+# Public TLS port (host side; container always binds 9443).
+MCP_PROXY_PORT=9443
+
+# AI gateway: paste Anthropic API key to enable /v1/chat/completions.
+# Leave empty to disable the embedded LLM gateway cleanly.
+MCP_PROXY_ANTHROPIC_API_KEY=
+
+# ───────────────── audit_export_s3 (license feature) ─────────────────
+# Required when the license grants audit_export_s3. The plugin batches
+# audit log rows to S3 NDJSON every 60s.
+# CULLIS_AUDIT_EXPORT_S3_BUCKET=cullis-audit-myorg
+# CULLIS_AUDIT_EXPORT_S3_REGION=eu-west-1
+# CULLIS_AUDIT_EXPORT_S3_PREFIX=mastio/2026/
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+
+# ─────────────── audit_export_datadog (license feature) ──────────────
+# CULLIS_AUDIT_EXPORT_DATADOG_API_KEY=
+# CULLIS_AUDIT_EXPORT_DATADOG_SITE=datadoghq.eu
+
+# ─────────────────── saml_sso (license feature) ──────────────────────
+# When set, ``/proxy/login`` becomes an SP-initiated SAML 2.0 redirect.
+# CULLIS_SAML_SP_ENTITY_ID=https://mastio.yourorg.example.com/saml/metadata
+# CULLIS_SAML_SP_ACS_URL=https://mastio.yourorg.example.com/saml/acs
+# CULLIS_SAML_IDP_ENTITY_ID=https://idp.yourorg.example.com
+# CULLIS_SAML_IDP_SSO_URL=https://idp.yourorg.example.com/sso
+# CULLIS_SAML_IDP_CERT_PATH=/etc/cullis/keys/idp.crt
+
+# ─────────── cloud_kms_* (Org CA storage, license feature) ────────────
+# Pick exactly one backend: local (default), vault, aws, azure, gcp.
+# vault is in-tree open-core; aws/azure/gcp require the enterprise
+# plugin extras (already in the cullis-mastio-enterprise image).
+MCP_PROXY_KMS_BACKEND=local
+# Vault (in-tree open-core)
+# MCP_PROXY_VAULT_ADDR=https://vault.yourorg.example.com:8200
+# MCP_PROXY_VAULT_TOKEN=
+# AWS Secrets Manager (cloud_kms_aws)
+# CULLIS_CLOUD_KMS_AWS_SECRET_ID=cullis/mastio/org-ca
+# CULLIS_CLOUD_KMS_AWS_REGION=eu-west-1
+# Azure Key Vault (cloud_kms_azure)
+# CULLIS_CLOUD_KMS_AZURE_VAULT_URL=https://kv-yourorg.vault.azure.net
+# CULLIS_CLOUD_KMS_AZURE_SECRET_NAME=cullis-mastio-org-ca
+# AZURE_CLIENT_ID=
+# AZURE_TENANT_ID=
+# AZURE_CLIENT_SECRET=
+# GCP Secret Manager (cloud_kms_gcp)
+# CULLIS_CLOUD_KMS_GCP_PROJECT_ID=yourorg-prod
+# CULLIS_CLOUD_KMS_GCP_SECRET_ID=cullis-mastio-org-ca
+# GOOGLE_APPLICATION_CREDENTIALS=/etc/cullis/keys/gcp-sa.json
+
+# ───────────────────── scim_2_0 (license feature) ────────────────────
+# Bearer token the IdP presents on /scim/v2/* calls. Strong random.
+# CULLIS_SCIM_BEARER_TOKEN=
+
+# ───────────────────────────── ADR-029 ───────────────────────────────
+# Tool-call PDP enforcement + optional webhook HMAC. Leave unset to
+# fall back to the in-process PDP (default-allow for messages,
+# default-deny for new sessions).
+# MCP_PROXY_TOOL_PDP_ENABLED=true
+# MCP_PROXY_PDP_WEBHOOK_HMAC_SECRET=


### PR DESCRIPTION
## Summary

P0 step 5 of the enterprise production-ready roadmap. Adds the operator-facing deploy bundle for the licensed Mastio enterprise image, plus a tag-triggered release workflow that packages it as a tar.gz/zip GitHub Release artefact.

## What ships

- `packaging/mastio-enterprise-bundle/`
  - `docker-compose.yml` — same topology as open-core mastio-bundle (Mastio + mTLS nginx sidecar, ADR-006/ADR-014/ADR-030 patterns) with three additions:
    - `image:` → `ghcr.io/cullis-security/cullis-mastio-enterprise:${CULLIS_MASTIO_VERSION:-latest}` (private)
    - `CULLIS_LICENSE_KEY` / `CULLIS_LICENSE_PATH` env plumbed through
    - Full enterprise plugin env catalogue (audit_export_s3, audit_export_datadog, saml_sso, cloud_kms_aws/azure/gcp, scim_2_0, KMS_BACKEND)
  - `deploy.sh` — focused script with 2 pre-flights (license JWT shape + `docker pull` against private registry) + plugin-discovery report on post-up. `COMPOSE_PROJECT_NAME=cullis-mastio-enterprise` pinned.
  - `proxy.env.example` — superset of open-core sample with license + plugin envs commented per feature (operator uncomments only what their license grants)
  - `nginx/mastio/` — copy of open-core nginx config (same TLS terminator)
  - `README.md` — CISO-grade quickstart including cosign verify command + SBOM pointer + operations table
- `.github/workflows/release-mastio-enterprise-bundle.yml`
  - Trigger: tag `mastio-enterprise-bundle-v*`
  - Mirrors `release-mastio.yml` bundle staging: explicit cp allowlist + post-stage sanity check (PR #662 pattern)
  - Outputs versioned + unversioned tar.gz/zip on GitHub Release

## Why

Without this bundle, an operator with a Cullis enterprise license has no canonical artefact to install. The open-core bundle hardcodes `cullis-mastio` (community) image. The enterprise customer needs:

1. Image pinned to the private enterprise registry
2. License JWT plumbed through the env
3. Plugin-specific env scaffolding ready to uncomment
4. Pre-flight that catches "no PAT for ghcr.io" before getting opaque docker errors
5. Verification path for CISO supply chain due-diligence (cosign + SBOM cross-reference)

## Validation

- YAML syntax green (`python3 yaml.safe_load`)
- bash syntax green (`bash -n deploy.sh`)
- Full end-to-end deploy validation deferred to the first `mastio-enterprise-bundle-v*-rc1` tag cut (post-merge). Cannot fully test against the private registry from this PR (registry doesn't exist yet — needs Step 2's enterprise release pipeline to be run at least once, which creates the first `cullis-mastio-enterprise:v0.3.0` image).

## Out of scope (deferred)

- Helm chart variant (P1 step 7)
- Air-gap install recipe (P1 step 8)
- `--upgrade <version>` subcommand on the enterprise deploy.sh (operator bumps `CULLIS_MASTIO_VERSION` in `proxy.env` + re-runs today)
- License renewal hot-swap endpoint on the dashboard (P1 step 9)
- Operator doc on `site/.../operate/enterprise-install.md` (Step 6 of this roadmap, next PR)