### PR TITLE
fix(bundle): default MCP_PROXY_ENVIRONMENT to development for first-boot success

### DIFF
--- a/packaging/mastio-enterprise-bundle/proxy.env.example
+++ b/packaging/mastio-enterprise-bundle/proxy.env.example
@@ -26,7 +26,13 @@ CULLIS_LICENSE_KEY=
 # CULLIS_LICENSE_PATH=/etc/cullis/keys/license.jwt
 
 # ───────────────────────── core Mastio config ────────────────────────
-MCP_PROXY_ENVIRONMENT=production
+# Flip to ``production`` ONLY after wiring a real secret backend
+# (MCP_PROXY_SECRET_BACKEND=vault + MCP_PROXY_VAULT_ADDR + _VAULT_TOKEN
+# below). The default ``env`` backend keeps agent private keys at rest
+# in the process environment, which the proxy refuses to start with
+# under ENVIRONMENT=production. Bundle ships with ``development`` so
+# the first boot succeeds out of the box.
+MCP_PROXY_ENVIRONMENT=development
 MCP_PROXY_STANDALONE=true
 # Strong random secret. Generate with: openssl rand -hex 32
 MCP_PROXY_ADMIN_SECRET=


### PR DESCRIPTION
Found during live dogfood of `mastio-enterprise-bundle-v0.3.0-rc1`.

The template shipped with `ENVIRONMENT=production` AND `SECRET_BACKEND=env` (the default, not present in the template). `validate_config()` refuses to boot in that combination with a CRITICAL log line.

```
CRITICAL: MCP_PROXY_SECRET_BACKEND='env' is not supported in production.
Set MCP_PROXY_SECRET_BACKEND=vault ...
```

So the very first `./deploy.sh` against the bundle crashed at lifespan startup.

Default to `development` so the bundle is bootable as delivered. Comment block above the line documents the prod flip path (Vault first, then ENVIRONMENT).

This is the **second customer-blocker** uncovered by live validation; the first is enterprise PR #32 (proxyuser UID mismatch with bundle bind-mount).