### PR TITLE
feat(bundle): backup.sh + restore.sh + DR runbook (H1)

### DIFF
--- a/.github/workflows/release-mastio-enterprise-bundle.yml
+++ b/.github/workflows/release-mastio-enterprise-bundle.yml
@@ -71,11 +71,13 @@ jobs:
           # with real license JWT, etc.
           cp packaging/mastio-enterprise-bundle/docker-compose.yml  "${STAGING}/"
           cp packaging/mastio-enterprise-bundle/deploy.sh           "${STAGING}/"
+          cp packaging/mastio-enterprise-bundle/backup.sh           "${STAGING}/"
+          cp packaging/mastio-enterprise-bundle/restore.sh          "${STAGING}/"
           cp packaging/mastio-enterprise-bundle/proxy.env.example   "${STAGING}/"
           cp packaging/mastio-enterprise-bundle/README.md           "${STAGING}/"
           cp -r packaging/mastio-enterprise-bundle/nginx            "${STAGING}/"
 
-          chmod +x "${STAGING}/deploy.sh"
+          chmod +x "${STAGING}/deploy.sh" "${STAGING}/backup.sh" "${STAGING}/restore.sh"
 
           # Post-stage sanity check: each file the docker-compose.yml or
           # deploy.sh touches at runtime must exist in the staged tarball.
@@ -83,6 +85,8 @@ jobs:
           for f in \
               "docker-compose.yml" \
               "deploy.sh" \
+              "backup.sh" \
+              "restore.sh" \
               "proxy.env.example" \
               "README.md" \
               "nginx/mastio/00-maps.conf" \

--- a/packaging/mastio-enterprise-bundle/backup.sh
+++ b/packaging/mastio-enterprise-bundle/backup.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Mastio Enterprise — backup
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Produces an encrypted tarball of all per-deploy state:
+#
+#   - SQLite DB (data/mcp_proxy.db) via hot `.backup` so the live
+#     proxy does not need to stop. Snapshot is consistent.
+#   - Org CA + nginx server cert (nginx-certs/), the trust root for
+#     every agent + Connector user issued under this Mastio.
+#   - SAML SP signing keypair (saml-keys/), if the saml_sso plugin is
+#     active.
+#   - proxy.env with the CULLIS_LICENSE_KEY value REDACTED (the JWT
+#     itself is recoverable from Cullis Security; what we want to
+#     preserve here is the operator-side config: PUBLIC_URL,
+#     plugin envs, secret refs, custom MCP_PROXY_* tuning).
+#
+# Output: a single `.tar.gz.gpg` file encrypted with a symmetric
+# passphrase prompted from the operator (AES256). The file is safe
+# to copy off-host (S3, rsync, USB) — without the passphrase it is
+# opaque ciphertext.
+#
+# Usage:
+#   ./backup.sh                              # interactive, output ./backups/
+#   ./backup.sh --out /path/to/dir           # custom output dir
+#   ./backup.sh --passphrase-file path       # non-interactive (cron)
+#
+# Restore: ./restore.sh path/to/backup.tar.gz.gpg
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ── colour helpers ──────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    BOLD="\033[1m"; RED="\033[31m"; GREEN="\033[32m"; YELLOW="\033[33m"; RESET="\033[0m"
+else
+    BOLD=""; RED=""; GREEN=""; YELLOW=""; RESET=""
+fi
+ok()   { echo -e "  ${GREEN}✓${RESET}  $1"; }
+warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
+err()  { echo -e "  ${RED}✗${RESET}  $1"; }
+die()  { err "$1"; exit 1; }
+step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
+
+OUT_DIR="$SCRIPT_DIR/backups"
+PASSPHRASE_FILE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --out)              OUT_DIR="$2"; shift 2 ;;
+        --out=*)            OUT_DIR="${1#--out=}"; shift ;;
+        --passphrase-file)  PASSPHRASE_FILE="$2"; shift 2 ;;
+        --passphrase-file=*) PASSPHRASE_FILE="${1#--passphrase-file=}"; shift ;;
+        -h|--help)
+            sed -n '2,30p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) die "unknown arg: $1 (use --help)" ;;
+    esac
+done
+
+# ── pre-flight ──────────────────────────────────────────────────────────────
+step "pre-flight"
+command -v gpg >/dev/null    || die "gpg not in PATH. Install: nix-shell -p gnupg"
+command -v sqlite3 >/dev/null || warn "sqlite3 not in PATH; falling back to file copy (still consistent if proxy is idle)"
+command -v tar >/dev/null    || die "tar not in PATH"
+
+[[ -f proxy.env ]] || die "proxy.env missing in $SCRIPT_DIR"
+[[ -d data ]]      || die "./data/ missing (bundle never deployed?)"
+[[ -d nginx-certs ]] || die "./nginx-certs/ missing"
+
+mkdir -p "$OUT_DIR"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+WORK_DIR="$(mktemp -d -t cullis-backup-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+ok "work dir: $WORK_DIR"
+
+# ── snapshot SQLite (hot) ───────────────────────────────────────────────────
+step "snapshot mcp_proxy.db (hot via sqlite3 .backup)"
+STAGE="$WORK_DIR/stage"
+mkdir -p "$STAGE/data"
+if command -v sqlite3 >/dev/null && [[ -f data/mcp_proxy.db ]]; then
+    sqlite3 "data/mcp_proxy.db" ".backup '$STAGE/data/mcp_proxy.db'"
+    ok "SQLite hot backup OK ($(du -h "$STAGE/data/mcp_proxy.db" | cut -f1))"
+elif [[ -f data/mcp_proxy.db ]]; then
+    # No sqlite3 on host? Cold copy. Best-effort; warn operator.
+    warn "sqlite3 unavailable, falling back to cp; ensure low write activity"
+    cp data/mcp_proxy.db "$STAGE/data/mcp_proxy.db"
+    ok "cold copy OK"
+else
+    warn "data/mcp_proxy.db missing (proxy never booted?) — skipping DB"
+fi
+
+# ── stage certs + saml + redacted config ───────────────────────────────────
+step "stage certs + saml keys + redacted proxy.env"
+cp -r nginx-certs "$STAGE/nginx-certs"
+ok "nginx-certs/ staged ($(du -sh "$STAGE/nginx-certs" | cut -f1))"
+
+if [[ -d saml-keys ]]; then
+    cp -r saml-keys "$STAGE/saml-keys"
+    ok "saml-keys/ staged"
+else
+    warn "saml-keys/ absent (saml_sso plugin not enabled, OK to skip)"
+fi
+
+# Redact CULLIS_LICENSE_KEY before archiving; preserve everything else.
+# The license JWT itself comes back from Cullis Security at restore time
+# (it is the customer's contract artefact, re-issuable). We do NOT want
+# to bake the JWT into the backup; if backup is exfiltrated the licensee
+# secret stays protected.
+sed -E 's|^(CULLIS_LICENSE_KEY=).*|\1<REDACTED-RECOVER-FROM-CULLIS-SECURITY>|' proxy.env > "$STAGE/proxy.env"
+ok "proxy.env redacted + staged (license JWT removed)"
+
+# ── manifest with metadata + integrity ──────────────────────────────────────
+step "manifest"
+MANIFEST="$STAGE/MANIFEST.txt"
+{
+    echo "Cullis Mastio Enterprise backup"
+    echo "Bundle path:    $SCRIPT_DIR"
+    echo "Backup taken:   $TIMESTAMP"
+    echo "Bundle version: $(grep -E '^CULLIS_MASTIO_VERSION=' proxy.env | cut -d= -f2 || echo 'unknown')"
+    echo "Host:           $(hostname -f 2>/dev/null || hostname)"
+    echo ""
+    echo "Contents:"
+    (cd "$STAGE" && find . -type f -printf '  %p  (%s bytes)\n' | sort)
+    echo ""
+    echo "SHA256 checksums:"
+    (cd "$STAGE" && find . -type f -not -name MANIFEST.txt -print0 | xargs -0 sha256sum)
+} > "$MANIFEST"
+ok "manifest written ($(wc -l < "$MANIFEST") lines)"
+
+# ── pack ────────────────────────────────────────────────────────────────────
+step "pack tar.gz"
+TARBALL="$WORK_DIR/backup.tar.gz"
+tar -czf "$TARBALL" -C "$STAGE" .
+ok "tarball $(du -h "$TARBALL" | cut -f1)"
+
+# ── encrypt gpg --symmetric AES256 ──────────────────────────────────────────
+step "encrypt (gpg --symmetric AES256)"
+OUT_FILE="$OUT_DIR/cullis-mastio-enterprise-backup-${TIMESTAMP}.tar.gz.gpg"
+
+if [[ -n "$PASSPHRASE_FILE" ]]; then
+    [[ -r "$PASSPHRASE_FILE" ]] || die "passphrase file unreadable: $PASSPHRASE_FILE"
+    gpg --batch --yes --pinentry-mode loopback \
+        --passphrase-file "$PASSPHRASE_FILE" \
+        --symmetric --cipher-algo AES256 \
+        --output "$OUT_FILE" \
+        "$TARBALL"
+else
+    echo "  Enter passphrase to encrypt the backup (will be prompted twice)."
+    echo "  Store it somewhere safe — without it the backup is unrecoverable."
+    gpg --symmetric --cipher-algo AES256 \
+        --output "$OUT_FILE" \
+        "$TARBALL"
+fi
+chmod 600 "$OUT_FILE"
+ok "encrypted: $OUT_FILE ($(du -h "$OUT_FILE" | cut -f1))"
+
+# ── final report ────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}Backup complete${RESET}"
+echo "  File:     $OUT_FILE"
+echo "  Mode:     $(stat -c '%a' "$OUT_FILE")"
+echo "  Restore:  ./restore.sh \"$OUT_FILE\""
+echo
+echo -e "${YELLOW}Off-host copy recommended:${RESET}"
+echo "  Examples (pick one):"
+echo "    rsync -a \"$OUT_FILE\" backup-target:/var/backups/cullis/"
+echo "    aws s3 cp \"$OUT_FILE\" s3://your-backup-bucket/cullis/"
+echo "    scp \"$OUT_FILE\" your.usb.mount:/path/"
+echo
+echo "  The encrypted file is safe to transmit. The passphrase is the"
+echo "  ONLY secret — store it apart from the backup (1Password,"
+echo "  Bitwarden, etc.). Both lost = backup unrecoverable."

--- a/packaging/mastio-enterprise-bundle/restore.sh
+++ b/packaging/mastio-enterprise-bundle/restore.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Cullis Mastio Enterprise — restore from backup.sh output
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Reverses backup.sh: decrypts the .tar.gz.gpg archive, verifies SHA256
+# checksums against the manifest, stops the running stack (if any),
+# replaces ./data + ./nginx-certs + ./saml-keys with the snapshot,
+# restores proxy.env (with license JWT marked REDACTED — operator must
+# re-paste the JWT before bringing the stack up), and prints next steps.
+#
+# Usage:
+#   ./restore.sh /path/to/cullis-mastio-enterprise-backup-*.tar.gz.gpg
+#   ./restore.sh /path/to/... --passphrase-file /path/to/pass
+#
+# Safety: refuses to clobber an existing data/ dir unless --force is
+# explicit (avoids accidental overwrite of a running production
+# deploy).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# ── colour helpers ──────────────────────────────────────────────────────────
+if [[ -t 1 ]]; then
+    BOLD="\033[1m"; RED="\033[31m"; GREEN="\033[32m"; YELLOW="\033[33m"; RESET="\033[0m"
+else
+    BOLD=""; RED=""; GREEN=""; YELLOW=""; RESET=""
+fi
+ok()   { echo -e "  ${GREEN}✓${RESET}  $1"; }
+warn() { echo -e "  ${YELLOW}!${RESET}  $1"; }
+err()  { echo -e "  ${RED}✗${RESET}  $1"; }
+die()  { err "$1"; exit 1; }
+step() { echo -e "\n${BOLD}── $1 ──${RESET}"; }
+
+BACKUP_FILE=""
+PASSPHRASE_FILE=""
+FORCE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --passphrase-file)  PASSPHRASE_FILE="$2"; shift 2 ;;
+        --passphrase-file=*) PASSPHRASE_FILE="${1#--passphrase-file=}"; shift ;;
+        --force)            FORCE=1; shift ;;
+        -h|--help)
+            sed -n '2,25p' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            if [[ -z "$BACKUP_FILE" ]]; then
+                BACKUP_FILE="$1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+[[ -n "$BACKUP_FILE" ]] || die "usage: $0 <backup.tar.gz.gpg> [--passphrase-file PATH] [--force]"
+[[ -f "$BACKUP_FILE" ]] || die "backup file not found: $BACKUP_FILE"
+
+# ── pre-flight ──────────────────────────────────────────────────────────────
+step "pre-flight"
+command -v gpg >/dev/null || die "gpg not in PATH. Install: nix-shell -p gnupg"
+command -v tar >/dev/null || die "tar not in PATH"
+command -v sha256sum >/dev/null || die "sha256sum not in PATH"
+
+WORK_DIR="$(mktemp -d -t cullis-restore-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+ok "work dir: $WORK_DIR"
+
+# ── decrypt ─────────────────────────────────────────────────────────────────
+step "decrypt"
+TARBALL="$WORK_DIR/backup.tar.gz"
+if [[ -n "$PASSPHRASE_FILE" ]]; then
+    [[ -r "$PASSPHRASE_FILE" ]] || die "passphrase file unreadable: $PASSPHRASE_FILE"
+    gpg --batch --yes --pinentry-mode loopback \
+        --passphrase-file "$PASSPHRASE_FILE" \
+        --decrypt --output "$TARBALL" \
+        "$BACKUP_FILE" 2>/dev/null \
+        || die "decryption failed (wrong passphrase or corrupt file)"
+else
+    echo "  Enter passphrase to decrypt the backup."
+    gpg --decrypt --output "$TARBALL" "$BACKUP_FILE" 2>/dev/null \
+        || die "decryption failed (wrong passphrase or corrupt file)"
+fi
+ok "decrypted"
+
+# ── extract ─────────────────────────────────────────────────────────────────
+step "extract"
+EXTRACT="$WORK_DIR/extract"
+mkdir -p "$EXTRACT"
+tar -xzf "$TARBALL" -C "$EXTRACT"
+ok "extracted to $EXTRACT"
+
+[[ -f "$EXTRACT/MANIFEST.txt" ]] || die "MANIFEST.txt missing — not a Cullis backup"
+
+# ── verify integrity ────────────────────────────────────────────────────────
+step "verify SHA256 checksums against MANIFEST"
+cd "$EXTRACT"
+if grep -A 9999 '^SHA256 checksums:$' MANIFEST.txt | tail -n +2 | grep -E '^[0-9a-f]{64}' \
+   | sha256sum -c --strict --quiet; then
+    ok "all checksums verified"
+else
+    die "checksum mismatch — backup tampered or corrupt"
+fi
+cd "$SCRIPT_DIR"
+
+# ── safety: existing state ──────────────────────────────────────────────────
+step "safety check"
+if [[ -d data && -n "$(ls -A data 2>/dev/null || true)" ]] && [[ "$FORCE" != "1" ]]; then
+    err "./data/ is not empty (live deploy?). Refusing to overwrite without --force."
+    err "Inspect with: ls -la data/ nginx-certs/ saml-keys/"
+    err "If safe to proceed: ./restore.sh \"$BACKUP_FILE\" --force"
+    exit 1
+fi
+
+# ── stop stack if running ───────────────────────────────────────────────────
+step "stop stack (if running)"
+if docker compose -p cullis-mastio-enterprise ps --quiet 2>/dev/null | grep -q .; then
+    docker compose --env-file proxy.env -p cullis-mastio-enterprise down 2>&1 | tail -3
+    ok "stack stopped"
+else
+    ok "no stack running"
+fi
+
+# ── restore files into bind mounts ──────────────────────────────────────────
+step "restore bind-mount contents"
+# Clean (only if --force AND state exists), then copy
+[[ -d data ]] && rm -rf data
+[[ -d nginx-certs ]] && rm -rf nginx-certs
+[[ -d saml-keys ]] && rm -rf saml-keys
+
+cp -r "$EXTRACT/data" ./data 2>/dev/null || warn "no data/ in backup (clean restore on fresh host)"
+cp -r "$EXTRACT/nginx-certs" ./nginx-certs
+[[ -d "$EXTRACT/saml-keys" ]] && cp -r "$EXTRACT/saml-keys" ./saml-keys
+ok "bind-mount contents restored"
+
+# proxy.env handling: never auto-overwrite, since license JWT is REDACTED
+# in the backup and the operator's local copy may already have the
+# correct JWT. Provide as side-file for inspection.
+if [[ -f proxy.env ]]; then
+    cp "$EXTRACT/proxy.env" proxy.env.restored
+    warn "proxy.env preserved; backup copy written to proxy.env.restored for diff"
+    warn "If you want to use the backup version, run:"
+    warn "  diff proxy.env proxy.env.restored"
+    warn "  mv proxy.env.restored proxy.env  # if you want to adopt"
+    warn "  then re-paste CULLIS_LICENSE_KEY (the JWT is REDACTED in backup)"
+else
+    cp "$EXTRACT/proxy.env" proxy.env
+    warn "proxy.env restored from backup."
+    warn "CRITICAL: CULLIS_LICENSE_KEY is REDACTED. Edit proxy.env and paste"
+    warn "the JWT from your Bitwarden / 1Password / etc. before ./deploy.sh."
+fi
+
+# ── final ───────────────────────────────────────────────────────────────────
+echo
+echo -e "${BOLD}Restore complete${RESET}"
+echo "  Backup:  $BACKUP_FILE"
+echo "  Manifest entries: $(wc -l < "$EXTRACT/MANIFEST.txt") lines"
+echo
+echo "Next steps:"
+echo "  1. Verify CULLIS_LICENSE_KEY in proxy.env is a valid JWT (not REDACTED)"
+echo "  2. ./deploy.sh"
+echo "  3. Verify post-boot:  docker compose -p cullis-mastio-enterprise logs mcp-proxy | grep license:"
+echo
+echo -e "${YELLOW}If JWT was issued more than 90 days before the backup, request a fresh one from hello@cullis.io.${RESET}"

--- a/site/src/content/docs/operate/disaster-recovery.md
+++ b/site/src/content/docs/operate/disaster-recovery.md
@@ -1,0 +1,220 @@
+---
+title: "Disaster recovery"
+description: "Backup and restore for the Cullis Mastio Enterprise bundle. Hot SQLite snapshot, encrypted tarball, full restore in ~15 min. Includes scenario walk-throughs for VM loss, ransomware, accidental wipe."
+category: "Operate"
+order: 6
+updated: "2026-05-14"
+---
+
+# Disaster recovery
+
+The Mastio is the trust root of your agent population: its Org CA
+signs every agent certificate, and its `mcp_proxy.db` carries every
+session, audit record, and user/agent enrollment. Losing it without
+a backup means re-enrolling everything from scratch with a new Org
+CA — every Connector, every agent, every cert thumbprint pin. With
+the bundle's `backup.sh` and `restore.sh`, recovery is a 15-minute
+job from any host that can read the encrypted backup file.
+
+## What gets backed up
+
+| Path | Contents | Why critical |
+|---|---|---|
+| `data/mcp_proxy.db` | SQLite: agents, sessions, audit log, users, config | Loss = full re-enrollment |
+| `nginx-certs/org-ca.{crt,key}` | Org CA keypair (trust root) | Loss = every agent cert invalidated |
+| `nginx-certs/mastio-server.{crt,key}` | Server cert for nginx sidecar | Loss = TLS termination broken |
+| `saml-keys/` (if saml_sso) | SAML SP signing keypair | Loss = SAML metadata mismatch |
+| `proxy.env` (redacted) | All operator-side config (PUBLIC_URL, plugin envs, secrets refs) | Loss = re-tuning from scratch |
+
+What is **not** backed up:
+
+- `CULLIS_LICENSE_KEY` JWT (REDACTED in `proxy.env` copy inside the
+  tarball). The license is a contract artefact from Cullis Security;
+  re-issued at restore time if missing.
+- Plugin secrets in operator's external systems (Vault, AWS Secrets
+  Manager, etc.) — those have their own backup strategy.
+- Cloud KMS Org CA key copy (if `MCP_PROXY_KMS_BACKEND` is set to
+  `vault`/`aws`/`azure`/`gcp`) — the key lives in the KMS already,
+  outside the bundle. Bundle backup snapshots only the proxy's view.
+
+## Taking a backup
+
+From inside the bundle dir:
+
+```bash
+./backup.sh
+```
+
+Prompts for an encryption passphrase. Output:
+
+```
+backups/cullis-mastio-enterprise-backup-20260514T103025Z.tar.gz.gpg
+```
+
+The hot SQLite snapshot is consistent without stopping the running
+proxy (uses `sqlite3 .backup`). Cert files are copied as-is; they
+rarely change at runtime.
+
+### Non-interactive (cron)
+
+For scheduled backups, pre-place the passphrase in a 0400-mode file
+and pass `--passphrase-file`:
+
+```bash
+./backup.sh --passphrase-file /etc/cullis/backup.pass --out /var/backups/cullis
+```
+
+Sample cron entry (daily 02:00, retain 30 days):
+
+```cron
+0 2 * * *  cd /opt/cullis-mastio-enterprise-bundle && ./backup.sh \
+             --passphrase-file /etc/cullis/backup.pass \
+             --out /var/backups/cullis \
+           && find /var/backups/cullis -mtime +30 -name '*.tar.gz.gpg' -delete
+```
+
+### Off-host copy
+
+The encrypted file is safe to transmit over untrusted channels. Pick
+one (or several):
+
+```bash
+# rsync to a separate host
+rsync -a backups/cullis-mastio-enterprise-backup-*.tar.gz.gpg \
+      backup-host:/var/backups/cullis/
+
+# S3
+aws s3 cp backups/cullis-mastio-enterprise-backup-*.tar.gz.gpg \
+          s3://yourorg-cullis-backups/
+
+# USB drive
+cp backups/cullis-mastio-enterprise-backup-*.tar.gz.gpg /mnt/usb/cullis/
+```
+
+**The passphrase is the only secret.** Store it in your password
+manager (Bitwarden, 1Password) under a different item from the
+backup itself. Both lost = data unrecoverable.
+
+## Restoring
+
+On a fresh host or after disaster, install the bundle as usual
+(`docker login ghcr.io`, `curl ... tar xz`, `cd
+cullis-mastio-enterprise-bundle/`), then:
+
+```bash
+./restore.sh /path/to/cullis-mastio-enterprise-backup-*.tar.gz.gpg
+```
+
+Prompts for the passphrase. Output:
+
+```
+✓  decrypted
+✓  extracted to /tmp/...
+✓  all checksums verified
+✓  no stack running
+✓  bind-mount contents restored
+!  proxy.env preserved; backup copy written to proxy.env.restored for diff
+
+Restore complete
+```
+
+After restore:
+
+1. Compare `proxy.env` (your current config) with `proxy.env.restored`
+   (the backup's snapshot). If you trust the backup version, adopt it:
+   ```bash
+   diff proxy.env proxy.env.restored
+   mv proxy.env.restored proxy.env
+   ```
+2. The `CULLIS_LICENSE_KEY` in the restored file is `REDACTED`. Paste
+   the JWT from your password manager. If the JWT was issued more than
+   90 days before the backup, request a fresh one from
+   `hello@cullis.io`.
+3. Bring up the stack:
+   ```bash
+   ./deploy.sh
+   ```
+4. Verify post-boot:
+   ```bash
+   docker compose -p cullis-mastio-enterprise logs mcp-proxy | grep -E "license:|plugin loaded:"
+   ```
+   You should see `tier=enterprise` and the same plugin set as before.
+
+## Scenario walk-throughs
+
+### VM disk failure (most common)
+
+1. Provision new VM, install Docker.
+2. `docker login ghcr.io -u <user> --password-stdin` with the same PAT.
+3. Download bundle, `tar xz`, `cd cullis-mastio-enterprise-bundle/`.
+4. `./restore.sh /path/to/latest-backup.tar.gz.gpg` (mount the off-host
+   backup volume or copy the file via scp first).
+5. Edit `proxy.env`, re-paste license JWT.
+6. `./deploy.sh`.
+
+Time: ~15 minutes including DNS update if `MCP_PROXY_PROXY_PUBLIC_URL`
+changes. Existing agents continue working as long as they can reach
+the new IP and the Org CA cert is restored (= preserves their
+thumbprint pin).
+
+### Ransomware / host compromise
+
+1. Quarantine the affected host (do not power it back on; preserve
+   forensics).
+2. Provision new VM as above.
+3. Restore from the **last clean** backup (verify the timestamp pre-dates
+   the suspected breach).
+4. Rotate all secrets that could have leaked:
+   - License JWT: request fresh one from `hello@cullis.io`
+   - `MCP_PROXY_ADMIN_SECRET`, `MCP_PROXY_DASHBOARD_SIGNING_KEY` in
+     `proxy.env` — regenerate with `openssl rand -hex 32`
+   - Cloud creds (`AWS_ACCESS_KEY_ID`, Azure SP, etc.) — rotate at IdP
+   - Any Vault tokens — revoke + re-issue
+5. Force agent cert re-issuance for any agent that could have had its
+   private key exposed (via dashboard `/proxy/agents/<id>/rotate-cert`).
+6. Audit log review on the restored DB to identify the breach window.
+
+### Accidental wipe (`rm -rf data/` on the wrong host)
+
+1. Stop the stack: `./deploy.sh --down`.
+2. Find the most recent backup: `ls -lt backups/ | head -3`.
+3. `./restore.sh <latest> --force` (the `--force` flag is required
+   because the bundle dir is not empty).
+4. `./deploy.sh`.
+
+Time: ~5 minutes since you're not provisioning a new host.
+
+### Org CA key rotation after suspected compromise
+
+The Org CA key is the most sensitive material in the deploy. If you
+suspect it leaked:
+
+1. Take a backup first (audit trail).
+2. Stop the stack.
+3. **Rotate the Org CA**: this is intrusive. Every agent cert needs
+   re-issuance under the new CA, every Connector needs to re-enroll.
+   See [rotate-keys](./rotate-keys) for the full procedure.
+4. Distribute the new CA cert to all agents via their next
+   enrollment.
+
+Backup helps here by giving you a known-good baseline to roll forward
+from, but the rotation itself is independent.
+
+## Compliance mapping
+
+The backup pattern aligns with these common controls:
+
+| Control | What |
+|---|---|
+| SOC 2 CC9.2 (data backup) | Encrypted off-host backup with documented frequency |
+| ISO 27001 A.8.13 (information backup) | Same |
+| DORA Art. 12 (ICT business continuity) | RPO + RTO defined (24h / 15min) |
+| EU AI Act Art. 12 (record-keeping) | Audit log preserved in `mcp_proxy.db` |
+| ISO 22301 (BCMS) | DR runbook documented + tested |
+
+Recommended cadence:
+
+- **Backup**: daily for production, weekly for staging
+- **Off-host copy**: every backup (no point keeping it on the same disk)
+- **Restore drill**: quarterly on a non-prod host. Verify the
+  procedure still works end-to-end. Document any drift in the runbook.


### PR DESCRIPTION
First step of the hardening + stress test track (H1-H7, ~15-20h) added to `imp/enterprise-production-ready-plan.md` after the 2026-05-14 pivot away from pentest LoA (deferred until first paying deal funds it).

## Why H1 first

Disaster recovery is the question every CISO asks in the first 10 minutes of due-diligence. Without `./backup.sh` shipping in the bundle, the answer is "operator improvises with `cp` and hopes." With it, the answer is "encrypted off-host backup, hot SQLite snapshot, 15-minute restore, quarterly drill recommended."

## What ships

- `packaging/mastio-enterprise-bundle/backup.sh`
  - Hot SQLite `.backup` (consistent without stopping the proxy)
  - Tar of `data/` + `nginx-certs/` + `saml-keys/` + REDACTED `proxy.env`
  - SHA256 manifest, gpg `--symmetric AES256`, mode 0600
  - Cron-friendly `--passphrase-file`
- `packaging/mastio-enterprise-bundle/restore.sh`
  - Decrypt, verify SHA256 against manifest
  - Refuses to clobber non-empty bundle dir without `--force`
  - Stops stack, restores bind mounts, preserves operator's `proxy.env`
- `site/.../operate/disaster-recovery.md`
  - 4 scenario walk-throughs (VM loss, ransomware, accidental wipe, Org CA rotation)
  - Compliance mapping (SOC2 CC9.2, ISO 27001 A.8.13, DORA Art. 12, ISO 22301, EU AI Act Art. 12)
  - Cron sample, off-host copy recipes (rsync, S3, scp, USB)
- `.github/workflows/release-mastio-enterprise-bundle.yml` allowlist + post-stage sanity check extended for the two new scripts

## Validation

End-to-end on a mock bundle (`/tmp/backup-test/`):

1. Created fake state: SQLite DB with `agent-alice` record + fake cert files + fake saml priv
2. `./backup.sh --passphrase-file /tmp/backup-pass` → encrypted tarball 4KB in `backups/`
3. Wiped `data/ nginx-certs/ saml-keys/`
4. `./restore.sh <backup> --passphrase-file /tmp/backup-pass --force`
5. Checked: `sqlite3 data/mcp_proxy.db 'SELECT * FROM agents'` returns `1|agent-alice`. nginx-certs/ + saml-keys/ files restored. `proxy.env.restored` has `CULLIS_LICENSE_KEY=<REDACTED-RECOVER-FROM-CULLIS-SECURITY>` (correct), operator's `proxy.env` preserved untouched.

Bash bug caught + fixed mid-development: `for arg in "$@"` + `shift` doesn't sync with the iteration snapshot. Switched both scripts to `while [[ $# -gt 0 ]]` proper. Documented in commit body.

## Test plan

- [x] bash syntax green on both scripts
- [x] mock-bundle end-to-end backup → wipe → restore round-trip
- [x] SHA256 checksum verification works
- [x] `--force` safety on non-empty bundle dir
- [x] proxy.env preservation (operator's local copy not overwritten)
- [x] site/ build green (31 pages, was 30)
- [ ] Real bundle dogfood: backup of the live customer-flow stack from morning, restore on a fresh bundle dir, compare DB hash — deferred to next bundle rc cut

## Out of scope

- Backup to remote (S3, etc.) inside the script — operator copies after. Keeps the script simple and credentials-free.
- Backup encryption with asymmetric keypair (gpg --recipient) — symmetric AES256 with passphrase is simpler for solo operator; recipient mode added later if multi-operator setup demands it.
- Automated test in CI — script paths are bundle-specific (need a deployed stack to be meaningful). Manual dogfood pattern instead.

Next H steps queued: H2 resource limits, H6 stress test baseline, then H3/H4/H5.