### PR TITLE
docs(security): expand SECURITY.md with severity-tier SLA, component matrix, scope, safe harbour (H5)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,17 +29,103 @@ vulnerabilities before a coordinated disclosure window has passed.
 
 ### Response Timeline
 
-- **Acknowledgment:** Within 48 hours
-- **Initial assessment:** Within 7 days
-- **Fix timeline:** Depends on severity, typically within 30 days
-- **Public disclosure:** 90 days after report, or when fix is released (whichever comes first)
+We aim for the following service-level targets, measured from the moment
+we receive the report:
+
+| Phase | Target |
+|---|---|
+| Acknowledgment | within 48 hours |
+| Initial triage + severity assignment | within 7 days |
+| Fix for CRITICAL severity | within 7 days |
+| Fix for HIGH severity | within 14 days |
+| Fix for MEDIUM severity | within 30 days |
+| Fix for LOW severity | best effort, next minor release |
+| Public disclosure | 90 days after report, or upon coordinated release, whichever comes first |
+
+Severity follows [CVSS v3.1](https://www.first.org/cvss/v3.1/specification-document)
+base score:
+
+- **CRITICAL** — CVSS 9.0 - 10.0
+- **HIGH** — CVSS 7.0 - 8.9
+- **MEDIUM** — CVSS 4.0 - 6.9
+- **LOW** — CVSS 0.1 - 3.9
+
+If a fix will take longer than the target window (e.g. it requires a
+breaking change or a coordinated upstream release), we will say so in
+the acknowledgment and agree a revised timeline with the reporter.
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| Latest on `main` | Yes |
-| Older commits | No |
+Cullis ships several components, each released independently. We patch
+security issues on the **latest stable release of each release track**.
+Older tags are end-of-life unless explicitly listed below.
+
+| Component | Release tag prefix | Supported window |
+|---|---|---|
+| Cullis Court (federation broker) | `court-v*` | latest stable |
+| Cullis Mastio (open-core image) | `mastio-v*` | latest stable |
+| Cullis Mastio Enterprise (paid image) | `mastio-enterprise-v*` | latest stable + previous minor |
+| Cullis Mastio open-core bundle | `mastio-bundle-v*` | latest stable |
+| Cullis Mastio enterprise bundle | `mastio-enterprise-bundle-v*` | latest stable |
+| Cullis Frontdesk bundle | `frontdesk-bundle-v*` | latest stable |
+| Cullis Chat SPA | `chat-v*` | latest stable |
+| Cullis Connector (desktop / PyPI / Docker) | `connector-v*` | latest stable |
+| Python SDK (`cullis-sdk`) | PyPI semver | latest minor |
+| TypeScript SDK (`@cullis/sdk`) | npm semver | latest minor |
+
+While Cullis is pre-1.0, the "previous minor" support window is
+intentionally narrow — operators should expect to track the latest
+release. Once a paid component reaches 1.0, the support window will
+widen and the support policy will be re-published here in this file
+before the change takes effect.
+
+## Scope
+
+In scope for this policy:
+
+- This repository (`cullis-security/cullis`) — Court, Mastio open-core,
+  Connector, Cullis Chat, SDKs, deploy bundles, site sources.
+- The private companion repo (`cullis-security/cullis-enterprise`) —
+  paid plugins, signing pipeline. Reports there are handled through
+  the same channels.
+- The published container images on `ghcr.io/cullis-security/*`.
+- The published PyPI / npm packages (`cullis-sdk`, `cullis-connector`,
+  `@cullis/sdk`).
+- The published license verification pipeline (signing keys, JWT
+  verifier, supply-chain artefacts attached to GitHub Releases).
+
+Out of scope:
+
+- Customer-operated deployments (we ship images and bundles; operators
+  are responsible for runtime configuration). We are still happy to
+  receive reports about hardening defaults that make customer
+  misconfiguration easy.
+- Third-party AI providers reachable through the embedded AI gateway
+  (Anthropic, OpenAI, etc.). Report those upstream.
+- The `cullis.io` marketing site (`docs/` source + Cloudflare Pages)
+  for non-security cosmetic issues — open a regular GitHub issue
+  instead.
+
+## Safe Harbour
+
+We will not pursue legal action against researchers who:
+
+- Make a good-faith effort to follow this policy.
+- Avoid privacy violations, destruction of data, and disruption of our
+  services or others' services.
+- Only interact with accounts and infrastructure that they own, or for
+  which they have explicit permission from the owner.
+- Give us a reasonable time to respond before any public disclosure.
+
+If you are unsure whether your testing falls within these boundaries,
+contact us first at security@cullis.io and we will discuss before you
+start.
+
+## Acknowledgements
+
+We will credit reporters in the release notes of the fix unless they
+ask to remain anonymous. We currently do not run a paid bounty
+programme; this section will be updated here when that changes.
 
 ## Security Design
 


### PR DESCRIPTION
## Summary

- Expand SECURITY.md from single-paragraph sketch to a publishable CISO due-diligence artefact.
- Add per-CVSS-severity SLA table (CRITICAL ≤7d, HIGH ≤14d, MEDIUM ≤30d, LOW best-effort).
- Replace vague "latest on main" with explicit support-window matrix per release track (Court, Mastio open-core, Mastio Enterprise, three bundles, Cullis Chat, Connector, two SDKs).
- Document in-scope vs out-of-scope, safe-harbour clause for good-faith researchers, and acknowledgements / bounty stance.

Closes H5 (hardening track) in the enterprise-production-ready roadmap. Companion to the H1 backup/DR runbook merged in #695.

## Test plan

- [x] No code changes — single docs file.
- [x] DCO signed-off (`git commit -s`).
- [x] Manual rendering of the markdown table on GitHub.
- [x] Support window matches the actual release tag prefixes seen in the GH Releases tab.