### PR TITLE
fix(nginx): upstream keepalive pool + Connection plumbing (H6, RPS floor 600 to 1900)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,6 @@ packaging/frontdesk-bundle/tls/
 # bootstrap scripts on demand, MUST never be committed.
 /state/
 .gstack/
+
+# k6 stress test artefacts (transient summary dumps next to the scripts).
+scripts/stress/summary*.json

--- a/packaging/mastio-bundle/nginx/mastio/00-maps.conf
+++ b/packaging/mastio-bundle/nginx/mastio/00-maps.conf
@@ -1,5 +1,5 @@
 # =============================================================================
-# Cullis Mastio sidecar — http-level maps
+# Cullis Mastio sidecar: http-level maps
 # =============================================================================
 #
 # Loaded before mastio.conf via lexicographic order in
@@ -8,11 +8,16 @@
 # level), so they can't sit inside a ``server {}`` block.
 # =============================================================================
 
-# WebSocket Upgrade helper for the dashboard websocket route. Empty
-# Upgrade → close the upstream connection; anything else → forward
-# verbatim so nginx doesn't emit ``Connection: close`` and break
-# long-lived dashboard streams.
+# WebSocket Upgrade helper for the dashboard websocket route. When the
+# client sends ``Upgrade``, forward it verbatim so long-lived dashboard
+# streams survive. When the client does NOT send Upgrade (the common
+# case: every plain HTTP request), emit an empty Connection header so
+# nginx is free to keep the upstream socket alive in the
+# ``mcp_proxy_upstream`` keepalive pool. The pre-fix default of
+# ``close`` forced a fresh TCP connection to mcp-proxy on every
+# request, which exhausted ephemeral ports under sustained load
+# (ENADDRNOTAVAIL @ ~600 RPS on a 16-core box).
 map $http_upgrade $connection_upgrade {
     default upgrade;
-    ''      close;
+    ''      "";
 }

--- a/packaging/mastio-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-bundle/nginx/mastio/mastio.conf
@@ -1,9 +1,9 @@
 # =============================================================================
-# Cullis Mastio nginx sidecar — ADR-014
+# Cullis Mastio nginx sidecar: ADR-014
 # =============================================================================
 #
 # Terminates TLS on 9443 in front of mcp-proxy (which keeps listening on
-# 9100 on the internal docker network only — never published to the
+# 9100 on the internal docker network only: never published to the
 # host). Routes carrying agent identity require a client certificate
 # signed by the Org CA. Routes that are anonymous by design (enrollment
 # bootstrap, dashboard browser login, health) terminate TLS but do not
@@ -16,9 +16,26 @@
 # to the internal ``broker_net`` docker network only, with no host port
 # publish, so a caller cannot reach 9100 directly to bypass nginx and
 # inject a forged header. If a future deploy ever publishes 9100, we
-# add a shared-secret edge header at that point — for now the network
+# add a shared-secret edge header at that point: for now the network
 # binding is the defence.
+#
+# Upstream pool with keep-alive
+# -----------------------------
+# Without an explicit ``upstream { keepalive N; }`` block, nginx opens a
+# fresh TCP connection to mcp-proxy:9100 on every request. Under
+# sustained load the host exhausts the ephemeral port range
+# (ENADDRNOTAVAIL in nginx error log, roughly 600 RPS as a hard floor
+# on a 16-core box) before the application itself becomes the
+# bottleneck. The pool below keeps upstream sockets warm and lifts the
+# floor to multi-thousand RPS for cheap reads like /health.
 # =============================================================================
+
+upstream mcp_proxy_upstream {
+    server mcp-proxy:9100;
+    keepalive 64;
+    keepalive_requests 1000;
+    keepalive_timeout 60s;
+}
 
 server {
     listen 9443 ssl;
@@ -64,22 +81,23 @@ server {
     # nginx returns 401 before FastAPI sees the request.
     #
     # PR-C also moves the three agent-authenticated /v1/auth endpoints
-    # behind mTLS — login-challenge, sign-challenged-assertion, and
+    # behind mTLS: login-challenge, sign-challenged-assertion, and
     # sign-assertion all carried agent identity via X-API-Key before
     # PR-C dropped that path. /v1/auth/token stays anonymous (it
-    # validates a client_assertion JWT, not a TLS cert) — see the
+    # validates a client_assertion JWT, not a TLS cert): see the
     # /v1/* catch-all below.
     location ~ ^/v1/(egress|agents|audit)(/.*)?$ {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        # Always overwrite — never trust a client-supplied value.
+        # Always overwrite: never trust a client-supplied value.
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
     }
@@ -88,8 +106,9 @@ server {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -98,7 +117,7 @@ server {
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
     }
 
-    # ADR-025 chat / MCP — Frontdesk Connectors call these with the
+    # ADR-025 chat / MCP: Frontdesk Connectors call these with the
     # per-user UserPrincipal cert minted via /v1/principals/csr. The
     # backend dep (``get_agent_from_dpop_client_cert``) tries the
     # LOCAL_TOKEN Bearer fallback first, so requests without a cert
@@ -111,15 +130,16 @@ server {
     # backend checks ``X-SSL-Client-Verify == SUCCESS`` before trusting
     # ``X-SSL-Client-Cert``.
     location ~ ^/v1/(llm|mcp)(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
-        # SSE streaming on /v1/llm/chat — disable buffering + bump the
+        # SSE streaming on /v1/llm/chat: disable buffering + bump the
         # read timeout so the proxy doesn't 504 on long completions.
         proxy_buffering off;
         proxy_read_timeout 600;
@@ -138,27 +158,29 @@ server {
     # where a new /v1/<thing> route ships without us adding a sidecar
     # location and starts returning 404.
     location ~ ^/v1/(.*)$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        # Strip any client-supplied cert header — anonymous endpoints
+        # Strip any client-supplied cert header: anonymous endpoints
         # must not be confusable with authenticated ones.
         proxy_set_header X-SSL-Client-Cert "";
-        # WebSocket upgrades for /v1/local + /v1/broker.
+        # WebSocket upgrades for /v1/local + /v1/broker. Connection is
+        # already plumbed via the location-level header above.
         proxy_set_header Upgrade           $http_upgrade;
-        proxy_set_header Connection        $connection_upgrade;
         proxy_read_timeout                 86400;
     }
 
     # ──────────────────────────────────────────────────────────────────
-    # Health, dashboard, PDP, well-known — anonymous over TLS
+    # Health, dashboard, PDP, well-known: anonymous over TLS
     # ──────────────────────────────────────────────────────────────────
     location ~ ^/(health|healthz|readyz|live)$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -166,24 +188,25 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
-    # Dashboard (browser admin) — auth is session cookie or OIDC at app.
+    # Dashboard (browser admin): auth is session cookie or OIDC at app.
     location ~ ^/proxy(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-SSL-Client-Cert "";
         proxy_set_header Upgrade           $http_upgrade;
-        proxy_set_header Connection        $connection_upgrade;
         proxy_read_timeout                 86400;
     }
 
-    # PDP webhook — broker calls this over the docker network.
+    # PDP webhook: broker calls this over the docker network.
     location ~ ^/pdp(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -193,8 +216,9 @@ server {
 
     # /.well-known (JWKS, security.txt, OIDC discovery, etc.)
     location ~ ^/\.well-known(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -203,10 +227,11 @@ server {
     }
 
     # Anonymous Org CA download for TOFU pinning during Connector
-    # first-contact. Exact path only — no path traversal possible.
+    # first-contact. Exact path only: no path traversal possible.
     location = /pki/ca.crt {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -219,8 +244,9 @@ server {
     # without this location nginx returns 404 and the dashboard renders
     # unstyled (the inline logo SVG fills the viewport).
     location ~ ^/static(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -235,7 +261,7 @@ server {
     }
 
     # ──────────────────────────────────────────────────────────────────
-    # Catch-all — fail closed.
+    # Catch-all: fail closed.
     # ──────────────────────────────────────────────────────────────────
     location / {
         return 404;

--- a/packaging/mastio-enterprise-bundle/nginx/mastio/00-maps.conf
+++ b/packaging/mastio-enterprise-bundle/nginx/mastio/00-maps.conf
@@ -1,5 +1,5 @@
 # =============================================================================
-# Cullis Mastio sidecar — http-level maps
+# Cullis Mastio sidecar: http-level maps
 # =============================================================================
 #
 # Loaded before mastio.conf via lexicographic order in
@@ -8,11 +8,16 @@
 # level), so they can't sit inside a ``server {}`` block.
 # =============================================================================
 
-# WebSocket Upgrade helper for the dashboard websocket route. Empty
-# Upgrade → close the upstream connection; anything else → forward
-# verbatim so nginx doesn't emit ``Connection: close`` and break
-# long-lived dashboard streams.
+# WebSocket Upgrade helper for the dashboard websocket route. When the
+# client sends ``Upgrade``, forward it verbatim so long-lived dashboard
+# streams survive. When the client does NOT send Upgrade (the common
+# case: every plain HTTP request), emit an empty Connection header so
+# nginx is free to keep the upstream socket alive in the
+# ``mcp_proxy_upstream`` keepalive pool. The pre-fix default of
+# ``close`` forced a fresh TCP connection to mcp-proxy on every
+# request, which exhausted ephemeral ports under sustained load
+# (ENADDRNOTAVAIL @ ~600 RPS on a 16-core box).
 map $http_upgrade $connection_upgrade {
     default upgrade;
-    ''      close;
+    ''      "";
 }

--- a/packaging/mastio-enterprise-bundle/nginx/mastio/mastio.conf
+++ b/packaging/mastio-enterprise-bundle/nginx/mastio/mastio.conf
@@ -1,9 +1,9 @@
 # =============================================================================
-# Cullis Mastio nginx sidecar — ADR-014
+# Cullis Mastio nginx sidecar: ADR-014
 # =============================================================================
 #
 # Terminates TLS on 9443 in front of mcp-proxy (which keeps listening on
-# 9100 on the internal docker network only — never published to the
+# 9100 on the internal docker network only: never published to the
 # host). Routes carrying agent identity require a client certificate
 # signed by the Org CA. Routes that are anonymous by design (enrollment
 # bootstrap, dashboard browser login, health) terminate TLS but do not
@@ -16,9 +16,26 @@
 # to the internal ``broker_net`` docker network only, with no host port
 # publish, so a caller cannot reach 9100 directly to bypass nginx and
 # inject a forged header. If a future deploy ever publishes 9100, we
-# add a shared-secret edge header at that point — for now the network
+# add a shared-secret edge header at that point: for now the network
 # binding is the defence.
+#
+# Upstream pool with keep-alive
+# -----------------------------
+# Without an explicit ``upstream { keepalive N; }`` block, nginx opens a
+# fresh TCP connection to mcp-proxy:9100 on every request. Under
+# sustained load the host exhausts the ephemeral port range
+# (ENADDRNOTAVAIL in nginx error log, roughly 600 RPS as a hard floor
+# on a 16-core box) before the application itself becomes the
+# bottleneck. The pool below keeps upstream sockets warm and lifts the
+# floor to multi-thousand RPS for cheap reads like /health.
 # =============================================================================
+
+upstream mcp_proxy_upstream {
+    server mcp-proxy:9100;
+    keepalive 64;
+    keepalive_requests 1000;
+    keepalive_timeout 60s;
+}
 
 server {
     listen 9443 ssl;
@@ -64,22 +81,23 @@ server {
     # nginx returns 401 before FastAPI sees the request.
     #
     # PR-C also moves the three agent-authenticated /v1/auth endpoints
-    # behind mTLS — login-challenge, sign-challenged-assertion, and
+    # behind mTLS: login-challenge, sign-challenged-assertion, and
     # sign-assertion all carried agent identity via X-API-Key before
     # PR-C dropped that path. /v1/auth/token stays anonymous (it
-    # validates a client_assertion JWT, not a TLS cert) — see the
+    # validates a client_assertion JWT, not a TLS cert): see the
     # /v1/* catch-all below.
     location ~ ^/v1/(egress|agents|audit)(/.*)?$ {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        # Always overwrite — never trust a client-supplied value.
+        # Always overwrite: never trust a client-supplied value.
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
     }
@@ -88,8 +106,9 @@ server {
         if ($ssl_client_verify != SUCCESS) {
             return 401;
         }
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -98,7 +117,7 @@ server {
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
     }
 
-    # ADR-025 chat / MCP — Frontdesk Connectors call these with the
+    # ADR-025 chat / MCP: Frontdesk Connectors call these with the
     # per-user UserPrincipal cert minted via /v1/principals/csr. The
     # backend dep (``get_agent_from_dpop_client_cert``) tries the
     # LOCAL_TOKEN Bearer fallback first, so requests without a cert
@@ -111,15 +130,16 @@ server {
     # backend checks ``X-SSL-Client-Verify == SUCCESS`` before trusting
     # ``X-SSL-Client-Cert``.
     location ~ ^/v1/(llm|mcp)(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-SSL-Client-Cert   $ssl_client_escaped_cert;
         proxy_set_header X-SSL-Client-Verify $ssl_client_verify;
-        # SSE streaming on /v1/llm/chat — disable buffering + bump the
+        # SSE streaming on /v1/llm/chat: disable buffering + bump the
         # read timeout so the proxy doesn't 504 on long completions.
         proxy_buffering off;
         proxy_read_timeout 600;
@@ -138,27 +158,29 @@ server {
     # where a new /v1/<thing> route ships without us adding a sidecar
     # location and starts returning 404.
     location ~ ^/v1/(.*)$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
-        # Strip any client-supplied cert header — anonymous endpoints
+        # Strip any client-supplied cert header: anonymous endpoints
         # must not be confusable with authenticated ones.
         proxy_set_header X-SSL-Client-Cert "";
-        # WebSocket upgrades for /v1/local + /v1/broker.
+        # WebSocket upgrades for /v1/local + /v1/broker. Connection is
+        # already plumbed via the location-level header above.
         proxy_set_header Upgrade           $http_upgrade;
-        proxy_set_header Connection        $connection_upgrade;
         proxy_read_timeout                 86400;
     }
 
     # ──────────────────────────────────────────────────────────────────
-    # Health, dashboard, PDP, well-known — anonymous over TLS
+    # Health, dashboard, PDP, well-known: anonymous over TLS
     # ──────────────────────────────────────────────────────────────────
     location ~ ^/(health|healthz|readyz|live)$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -166,24 +188,25 @@ server {
         proxy_set_header X-SSL-Client-Cert "";
     }
 
-    # Dashboard (browser admin) — auth is session cookie or OIDC at app.
+    # Dashboard (browser admin): auth is session cookie or OIDC at app.
     location ~ ^/proxy(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-SSL-Client-Cert "";
         proxy_set_header Upgrade           $http_upgrade;
-        proxy_set_header Connection        $connection_upgrade;
         proxy_read_timeout                 86400;
     }
 
-    # PDP webhook — broker calls this over the docker network.
+    # PDP webhook: broker calls this over the docker network.
     location ~ ^/pdp(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -193,8 +216,9 @@ server {
 
     # /.well-known (JWKS, security.txt, OIDC discovery, etc.)
     location ~ ^/\.well-known(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -203,10 +227,11 @@ server {
     }
 
     # Anonymous Org CA download for TOFU pinning during Connector
-    # first-contact. Exact path only — no path traversal possible.
+    # first-contact. Exact path only: no path traversal possible.
     location = /pki/ca.crt {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -219,8 +244,9 @@ server {
     # without this location nginx returns 404 and the dashboard renders
     # unstyled (the inline logo SVG fills the viewport).
     location ~ ^/static(/.*)?$ {
-        proxy_pass http://mcp-proxy:9100;
+        proxy_pass http://mcp_proxy_upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
@@ -235,7 +261,7 @@ server {
     }
 
     # ──────────────────────────────────────────────────────────────────
-    # Catch-all — fail closed.
+    # Catch-all: fail closed.
     # ──────────────────────────────────────────────────────────────────
     location / {
         return 404;

--- a/scripts/stress/README.md
+++ b/scripts/stress/README.md
@@ -1,0 +1,71 @@
+# scripts/stress: Mastio stress test harness
+
+> k6 scripts for measuring how much load the Mastio bundle can sustain.
+> Shipped in the public repo so operators can re-run them on their own
+> hardware. The narrative summary lives in
+> `site/src/content/docs/operate/capacity-planning.md`.
+
+## Scenarios
+
+| Script | What it stresses | Status |
+|---|---|---|
+| `health-throughput.js` | TLS edge + nginx → mcp-proxy plumbing (cheap read) | live |
+| `dpop-egress.js` | DPoP signature verification + token issuance | TODO |
+| `a2a-routing.js` | Intra-org A2A message dispatch via PDP + broker | TODO |
+| `enrollment-burst.js` | Concurrent CSR issuance + DB insert | TODO |
+
+Only `health-throughput.js` is wired today. The remaining scenarios are
+listed so future work can land in one place. Each new scenario should
+keep the same conventions: human-readable `handleSummary` for the
+maintainer + a JSON dump (`summary.json`) for diffable artefacts.
+
+## How to run
+
+```bash
+# Bring up a Mastio stack (see operate/runbook.md for the full
+# walkthrough). The script targets the public TLS edge by default.
+./deploy.sh
+
+# Run the scenario (override BASE_URL when the stack is elsewhere).
+cd scripts/stress
+nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify health-throughput.js"
+
+# Or against a remote stack:
+BASE_URL=https://mastio.example.com:9443 \
+    k6 run --insecure-skip-tls-verify health-throughput.js
+```
+
+The script writes `summary.json` next to itself and prints a one-screen
+text summary to stdout. `summary.json` is gitignored.
+
+## When to re-run
+
+- After any change to `packaging/mastio-*/nginx/mastio/*.conf`: that's
+  the layer with the most measurable RPS impact.
+- After bumping the base image or upgrading nginx (regression check).
+- Before cutting a `mastio-v*` or `mastio-enterprise-v*` release that
+  ships nginx-layer changes.
+- When operators report latency spikes or ENADDRNOTAVAIL upstream
+  errors at scale.
+
+## How to read the output
+
+The `handleSummary` block prints:
+
+- **Requests total** + **Requests per sec**: gross throughput nginx
+  saw, including failures.
+- **Errors**: fraction of requests that did not get a 2xx response or
+  failed at the TCP layer. Anything above ~0.1 % is worth investigating.
+- **Latency (success-only)**: distribution of `http_req_duration` for
+  responses that passed the body+status check. Reported as avg / p50 /
+  p95 / p99 / max.
+
+The thresholds in `health-throughput.js` (p95 < 250 ms, error rate
+< 1 %) make k6 exit non-zero on breach, so the script doubles as a
+pre-release sanity gate.
+
+## Historical baselines
+
+Per-release baseline runs are kept in the operator docs at
+`site/src/content/docs/operate/capacity-planning.md` and in the
+maintainer notes (`imp/stress-test-baseline-*.md`, local-only).

--- a/scripts/stress/health-throughput.js
+++ b/scripts/stress/health-throughput.js
@@ -1,0 +1,92 @@
+// Cullis Mastio: /health throughput baseline.
+//
+// Run with:
+//   nix-shell -p k6 --run "k6 run --insecure-skip-tls-verify health-throughput.js"
+//
+// Default target is the bundled mastio-nginx sidecar at https://localhost:9443.
+// Override with: BASE_URL=https://example.com:9443 k6 run health-throughput.js
+//
+// Profile (cheap read-only probe: upper-bound RPS the public TLS edge can sustain):
+//   30s   ramp  0 → 50 VUs
+//   120s  plateau at 50 VUs
+//   60s   plateau at 100 VUs
+//   30s   ramp 100 → 0 VUs
+//
+// Threshold gates: p95 < 250 ms, error rate < 1 %.
+// k6 exits non-zero if either is breached, so this script doubles as a
+// pre-release sanity check.
+
+import http from "k6/http";
+import { check } from "k6";
+import { Rate, Trend } from "k6/metrics";
+
+const BASE_URL = __ENV.BASE_URL || "https://localhost:9443";
+
+export const options = {
+    insecureSkipTLSVerify: true,
+    scenarios: {
+        health_ramp: {
+            executor: "ramping-vus",
+            startVUs: 0,
+            stages: [
+                { duration: "30s", target: 50 },
+                { duration: "120s", target: 50 },
+                { duration: "60s", target: 100 },
+                { duration: "30s", target: 0 },
+            ],
+            gracefulRampDown: "10s",
+        },
+    },
+    thresholds: {
+        "http_req_failed": ["rate<0.01"],
+        "http_req_duration{expected_response:true}": ["p(95)<250", "p(99)<500"],
+    },
+};
+
+const failures = new Rate("cullis_health_failure_rate");
+const ok_latency = new Trend("cullis_health_ok_latency_ms");
+
+export default function () {
+    const res = http.get(`${BASE_URL}/health`, {
+        tags: { endpoint: "health" },
+    });
+
+    const ok = check(res, {
+        "status 200": (r) => r.status === 200,
+        "body has status": (r) => r.body && r.body.includes("\"status\""),
+    });
+
+    failures.add(!ok);
+    if (ok) {
+        ok_latency.add(res.timings.duration);
+    }
+}
+
+export function handleSummary(data) {
+    return {
+        stdout: textSummary(data),
+        "summary.json": JSON.stringify(data, null, 2),
+    };
+}
+
+function textSummary(data) {
+    const m = data.metrics;
+    const lines = [];
+    lines.push("");
+    lines.push("════ Cullis Mastio /health throughput summary ════");
+    lines.push("");
+    lines.push(`  Base URL:           ${BASE_URL}`);
+    lines.push(`  Requests total:     ${m.http_reqs?.values?.count ?? "?"}`);
+    lines.push(`  Requests per sec:   ${(m.http_reqs?.values?.rate ?? 0).toFixed(1)} RPS`);
+    lines.push(`  Errors:             ${((m.http_req_failed?.values?.rate ?? 0) * 100).toFixed(3)} %`);
+    lines.push("");
+    lines.push("  Latency (success-only):");
+    const okMs = m.cullis_health_ok_latency_ms?.values || {};
+    lines.push(`    avg     ${(okMs.avg ?? 0).toFixed(1)} ms`);
+    lines.push(`    p(50)   ${(okMs.med ?? 0).toFixed(1)} ms`);
+    lines.push(`    p(95)   ${(okMs["p(95)"] ?? 0).toFixed(1)} ms`);
+    lines.push(`    p(99)   ${(okMs["p(99)"] ?? 0).toFixed(1)} ms`);
+    lines.push(`    max     ${(okMs.max ?? 0).toFixed(1)} ms`);
+    lines.push("");
+    return lines.join("\n");
+}

--- a/site/src/content/docs/operate/capacity-planning.md
+++ b/site/src/content/docs/operate/capacity-planning.md
@@ -1,0 +1,169 @@
+---
+title: "Capacity planning"
+description: "Throughput and latency baseline for the Cullis Mastio bundle, measurement methodology, and a recipe to repeat the test on your own hardware."
+category: "Operate"
+order: 7
+updated: "2026-05-14"
+---
+
+# Capacity planning
+
+This page gives you a defensible floor for how much traffic a single
+Mastio container can take, plus the methodology to repeat the test on
+your own hardware. CISO due-diligence usually asks "what RPS does this
+sustain?": we answer with numbers, the script that produced them, and
+the explicit caveats.
+
+## Headline numbers
+
+Measured against `mastio-enterprise-bundle-v0.3.0` on a development
+workstation (AMD Ryzen 7 3700X, 16 logical cores, 31 GiB RAM, NixOS
+kernel 7.0.0), enterprise license active with all nine plugins loaded:
+
+- **Sustained throughput on `/health`:** ~ 1900 requests per second
+  with zero errors across a four-minute mixed-load profile (ramp to
+  50 VUs, hold, ramp to 100 VUs, ramp down).
+- **Latency at that load:** p(50) = 22 ms, p(95) = 74 ms, p(99) = 96 ms,
+  max = 106 ms: all measured end-to-end including TLS termination.
+- **CPU headroom at 100 VUs:** the bundle did not saturate the host;
+  nginx workers and the FastAPI process together stayed well under
+  full core utilisation.
+
+For a cloud VPS of similar shape (8+ cores, 8+ GiB RAM) we recommend
+planning around a conservative **floor of ~ 1500 RPS sustained reads**
+on the cheap path, and re-measuring on your own hardware before you
+commit to numbers in an SLA.
+
+## What the workload represents
+
+The `health-throughput.js` k6 scenario exercises the full TLS edge
+plus the nginx → mcp-proxy plumbing, but with the cheapest possible
+FastAPI handler at the end. That makes it a useful **upper-bound
+proxy** for "how many requests can the network layer of this stack
+move per second before something other than the app layer becomes the
+bottleneck".
+
+Mixed workloads with DPoP signature verification, audit log writes,
+or LLM gateway hops will be slower per request and will hit different
+limits (CPU on signature math, IOPS on SQLite writes, upstream
+provider rate limits respectively). Future revisions of this doc will
+add scenarios that measure those paths: see *Limitations* below.
+
+## Methodology
+
+We ship the k6 script and the run recipe in the repo:
+
+```bash
+# Bring up the bundle (see operate/runbook.md for the full first-boot
+# walkthrough).
+./deploy.sh
+
+# Clone the repo for the test harness: k6 scripts live in scripts/stress/
+git clone https://github.com/cullis-security/cullis.git
+cd cullis/scripts/stress
+
+# Run the scenario against your stack
+BASE_URL=https://your-mastio.example.com:9443 \
+    k6 run --insecure-skip-tls-verify health-throughput.js
+```
+
+The script prints a one-screen summary at the end:
+
+```
+════ Cullis Mastio /health throughput summary ════
+
+  Base URL:           https://your-mastio.example.com:9443
+  Requests total:     464,136
+  Requests per sec:   1933.9 RPS
+  Errors:             0.000 %
+
+  Latency (success-only):
+    avg     27.3 ms
+    p(50)   22.4 ms
+    p(95)   74.4 ms
+    p(99)   95.5 ms
+    max     106.3 ms
+```
+
+It also writes `summary.json` next to the script for diffable
+artefacts. The thresholds inside the script (p(95) < 250 ms, error
+rate < 1 %) make k6 exit non-zero on breach, so the same file doubles
+as a pre-release sanity gate you can wire into your own CI.
+
+## Profile details
+
+The default profile is a four-minute mixed shape:
+
+| Phase | Duration | Virtual users |
+|---|---|---|
+| Ramp up | 30 s | 0 → 50 |
+| Plateau | 120 s | 50 |
+| Plateau | 60 s | 50 → 100 |
+| Ramp down | 30 s | 100 → 0 |
+
+You can override the profile by editing the `stages` array near the
+top of the script. The shape is deliberately short so it fits inside a
+"between deploys" window; for soak tests (sustained leak detection
+over an hour or more), see the H7 follow-up below.
+
+## Limitations
+
+Two caveats worth quoting back to anyone asking for numbers:
+
+- **Locally measured.** Cloud VPS instances at similar core counts
+  typically run 20 - 30 % slower under the same workload. Re-measure
+  on the hardware you intend to ship on. The recipe above is one
+  command: there is no excuse not to.
+- **`/health` is the cheapest endpoint.** It does TLS, nginx routing,
+  and a FastAPI handler that returns immediately. Endpoints that do
+  real work: `/v1/egress/...` with DPoP verification, `/v1/llm/...`
+  through the embedded AI gateway, `/v1/agents/...` enrolment: are
+  bound by separate limits (signature math, IOPS, upstream provider
+  rate). We will publish per-scenario numbers as we add k6 scripts
+  for them.
+
+## Tuning levers we already pulled
+
+The default bundle has nginx upstream keep-alive configured (pool
+size 64, 1000 requests per connection, 60 s idle timeout) plus the
+matching `proxy_set_header Connection` plumbing across every
+location. Without those, the bundle hit a hard wall at about 600 RPS
+on the same host because nginx exhausted ephemeral ports opening a
+fresh TCP socket to mcp-proxy on every request. Upgrade from
+`mastio-bundle-v0.4.2` (or earlier) to pick up the fix: and watch
+your nginx error log for `Address not available` lines if you ever
+build a custom sidecar that re-opens this hole.
+
+## Followups (planned)
+
+- **DPoP egress throughput**: measure how many `/v1/egress/...`
+  calls per second the proxy can sign-and-verify. CPU-bound on the
+  RSA/ECDSA path.
+- **A2A intra-org routing**: measure end-to-end message dispatch
+  through PDP plus broker plus E2E encryption.
+- **Enrolment burst**: measure concurrent CSR issuance + DB insert.
+- **Soak / leak detection**: one-hour continuous run at 50 VUs,
+  watching RSS for drift.
+
+The placeholders for each scenario live alongside the live script in
+`scripts/stress/` in the repo.
+
+## Hardware sizing rule of thumb
+
+Until per-scenario numbers exist, we recommend sizing by the cheap
+path floor and applying a per-feature multiplier from operational
+experience rather than theory:
+
+- **Up to ~ 1500 sustained RPS** of read-shaped traffic on a single
+  Mastio container (~ 8 cores, ~ 8 GiB RAM).
+- **Halve** that floor if every request also involves a DPoP
+  signature verification.
+- **Halve again** if every request takes the AI gateway path
+  (upstream provider latency dominates anyway).
+- Scale horizontally: multiple Mastio containers behind a load
+  balancer, sharing the same Postgres: once you cross the floor.
+  Standalone SQLite mode tops out before that point; Postgres mode
+  scales linearly with replicas.
+
+We will replace the rule of thumb with measured numbers as the k6
+scenarios land.


### PR DESCRIPTION
## Summary

The Mastio nginx sidecar opened a fresh TCP socket to mcp-proxy on every request. Under sustained load the host runs out of ephemeral ports (`ENADDRNOTAVAIL` flood in the nginx error log, ~71% error rate at 100 VUs) before mcp-proxy itself becomes the bottleneck. The shipping sidecar was a hard cap on throughput, not a feature limit.

## What changed

1. **Upstream keepalive pool** in `packaging/mastio-bundle/nginx/mastio/mastio.conf` and `packaging/mastio-enterprise-bundle/nginx/mastio/mastio.conf` (the two files were already byte-for-byte equal and stay that way):
   ```nginx
   upstream mcp_proxy_upstream {
       server mcp-proxy:9100;
       keepalive 64;
       keepalive_requests 1000;
       keepalive_timeout 60s;
   }
   ```
   Every `proxy_pass http://mcp-proxy:9100;` becomes `proxy_pass http://mcp_proxy_upstream;`.
2. **`proxy_set_header Connection $connection_upgrade;` on each location** right after `proxy_http_version 1.1;`. The server-scope inheritance for `proxy_set_header` breaks the moment any per-location `proxy_set_header` is set, so making this explicit on each location is necessary.
3. **Map fix** in `00-maps.conf`: the no-Upgrade branch of `$connection_upgrade` was `close`, which actively vetoed the keepalive pool on every non-websocket call. Changed to `""`.

## Measured impact

Same 4-min k6 profile (50→100 VUs ramp, `/health` endpoint) on a Ryzen 7 3700X (16 cores, 31 GiB), enterprise bundle with all 9 plugins loaded:

| Metric | Pre-fix | Post-fix | Delta |
|---|---|---|---|
| Errors | 70.98% | 0.000% | -71 pp |
| Successful RPS | ~593 | ~1934 | **3.3x** |
| p(50) latency | 30 ms | 22 ms | -26% |
| max latency | 220 ms | 106 ms | -52% |

Reproducible on any host via the k6 scenario shipped in this PR.

## Also ships

- `scripts/stress/health-throughput.js`: the k6 scenario, parametrised by `BASE_URL` so operators can re-measure on their own deployment. Threshold gates (p95 < 250 ms, error rate < 1%) double as a CI smoke check.
- `scripts/stress/README.md`: run recipe, when to re-run, placeholders for the DPoP / A2A / enrollment scenarios that this PR does not wire yet.
- `site/src/content/docs/operate/capacity-planning.md`: operator-facing version of the numbers with explicit caveats (locally measured, re-measure on your hardware) and reproducible methodology.

Closes H6 in the enterprise-production-ready roadmap. Companion to:
- #695 (H1 backup/DR scripts, merged)
- #696 (H5 SECURITY.md expansion, merged)

## Test plan

- [x] Re-ran `k6 run health-throughput.js` twice: pre-fix (~71% errors) and post-fix (0.000% errors), same workload profile.
- [x] Stack came back up cleanly with the new conf via `docker compose restart mastio-nginx`. `/health` returned 200 immediately.
- [x] Websocket paths (catch-all `/v1/*` and `/proxy/*`) preserve `Connection: upgrade` because the per-location header is set ahead of the duplicate (which was removed).
- [x] DCO signed-off.
- [x] No em-dashes in prosa, code, or commit message.