### PR TITLE
fix(court): require workload caller for user CSR + rate-limit federation endpoints (H4)

### DIFF
--- a/app/federation/audit_replicate.py
+++ b/app/federation/audit_replicate.py
@@ -42,6 +42,7 @@ from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_counters
 from app.auth.mastio_mtls import enforce_if_required as enforce_mastio_mtls
 from app.db.audit import MastioAuditReplica, log_event
 from app.db.database import get_db
+from app.rate_limit.limiter import get_client_ip, rate_limiter
 from app.registry.org_store import get_org_by_id
 
 
@@ -90,6 +91,13 @@ async def replicate_audit_batch(
     db: AsyncSession = Depends(get_db),
 ) -> ReplicateResponse:
     """Receive a Mastio audit batch and persist it after verification."""
+    # Security review F-002 — rate-limit by client IP before any
+    # ECDSA verify or audit append. Mirrors the
+    # ``onboarding.rotate_mastio_pubkey`` bucket (issue #282).
+    await rate_limiter.check(
+        get_client_ip(request), "federation.audit_replicate",
+    )
+
     # 1. Resolve the publishing org + its pinned pubkey.
     org = await get_org_by_id(db, body.mastio_org_id)
     if org is None:

--- a/app/federation/publish.py
+++ b/app/federation/publish.py
@@ -34,6 +34,7 @@ from app.auth.mastio_countersig import COUNTERSIG_HEADER, verify_mastio_counters
 from app.auth.mastio_mtls import enforce_if_required as enforce_mastio_mtls
 from app.db.database import get_db
 from app.db.audit import log_event
+from app.rate_limit.limiter import get_client_ip, rate_limiter
 from app.registry.org_store import get_org_by_id
 from app.registry.store import (
     get_agent_by_id, register_agent, update_agent_cert,
@@ -136,6 +137,11 @@ async def publish_agent(
       (so Mastio X can't publish agents in Mastio Y's namespace).
     - The ``cert_pem`` must be signed by the org's CA.
     """
+    # Security review F-002 — rate-limit by client IP before any
+    # ECDSA verify or audit append. Mirrors the
+    # ``onboarding.rotate_mastio_pubkey`` bucket (issue #282).
+    await rate_limiter.check(get_client_ip(request), "federation.publish")
+
     # 1. Derive org_id from agent_id prefix and look up the mastio pubkey.
     org_id = body.agent_id.split("::", 1)[0]
     org = await get_org_by_id(db, org_id)
@@ -328,6 +334,10 @@ async def publish_stats(
     pubkey return 403 so an operator who forgot onboarding step 2 gets
     a clear message instead of a silent no-op.
     """
+    # Security review F-002 — rate-limit by client IP before any
+    # ECDSA verify or audit append.
+    await rate_limiter.check(get_client_ip(request), "federation.publish")
+
     org = await get_org_by_id(db, body.org_id)
     if org is None:
         raise HTTPException(

--- a/app/federation/read.py
+++ b/app/federation/read.py
@@ -16,7 +16,7 @@ import logging
 
 from cryptography import x509 as crypto_x509
 from cryptography.hazmat.primitives import serialization
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,6 +24,7 @@ from app.auth.jwt import get_current_agent
 from app.auth.models import TokenPayload
 from app.config import get_settings
 from app.db.database import get_db
+from app.rate_limit.limiter import get_client_ip, rate_limiter
 from app.registry.binding_store import get_approved_binding
 from app.registry.models import (
     AgentListResponse, AgentPublicKeyResponse, AgentResponse,
@@ -53,12 +54,17 @@ def _as_agent_response(agent, trust_domain: str) -> AgentResponse:
 
 @router.get("/agents", response_model=AgentListResponse)
 async def list_federated_agents(
+    request: Request,
     org_id: str | None = None,
     current_agent: TokenPayload = Depends(get_current_agent),
     db: AsyncSession = Depends(get_db),
 ):
     """List registered agents. An agent sees only its own org unless
     ``org_id`` matches its own — cross-org listing is refused."""
+    # Security review F-002 — federation reads are reachable from any
+    # authenticated agent in any peer org; rate-limit per client IP.
+    await rate_limiter.check(get_client_ip(request), "federation.read")
+
     filter_org = current_agent.org if org_id is None else org_id
     if filter_org != current_agent.org:
         raise HTTPException(
@@ -76,6 +82,7 @@ async def list_federated_agents(
 
 @router.get("/agents/search", response_model=AgentListResponse)
 async def search_federated_agents(
+    request: Request,
     capability: list[str] | None = Query(None, description="Filter by capabilities (AND)"),
     agent_id: str | None = Query(None, description="Direct lookup by agent_id"),
     agent_uri: str | None = Query(None, description="Direct lookup by SPIFFE URI"),
@@ -87,6 +94,10 @@ async def search_federated_agents(
     db: AsyncSession = Depends(get_db),
 ):
     """Cross-org discovery with flexible filters. At least one filter required."""
+    # Security review F-002 — federation reads are reachable from any
+    # authenticated agent in any peer org; rate-limit per client IP.
+    await rate_limiter.check(get_client_ip(request), "federation.read")
+
     if not any([capability, agent_id, agent_uri, org_id, pattern, q]):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -213,6 +224,7 @@ class MastioUrlResponse(BaseModel):
     responses={404: {"description": "Org unknown or no URL published"}},
 )
 async def get_org_mastio_url(
+    request: Request,
     org_id: str,
     db: AsyncSession = Depends(get_db),
 ):
@@ -230,6 +242,13 @@ async def get_org_mastio_url(
     set the URL collapse to a single 404 so the endpoint cannot be used
     to enumerate the registry beyond what is already public.
     """
+    # Security review F-002 — this endpoint is fully unauthenticated,
+    # so an attacker can poll discovery in a tight loop. Rate-limit by
+    # client IP to prevent CPU-burn / registry-enumeration flooding.
+    await rate_limiter.check(
+        get_client_ip(request), "federation.mastio_url_lookup",
+    )
+
     org = await get_org_by_id(db, org_id)
     if (
         not org

--- a/app/rate_limit/limiter.py
+++ b/app/rate_limit/limiter.py
@@ -257,3 +257,19 @@ rate_limiter.register("broker.poll",            window_seconds=60, max_requests=
 rate_limiter.register("onboarding.invite_inspect",
                                                 window_seconds=60,  max_requests=30)
 rate_limiter.register("onboarding.attach",      window_seconds=300, max_requests=5)
+# Federation surfaces — security review F-002 (security-review-app-
+# 2026-05-14.md). Federation endpoints are reachable from any internet
+# peer; an attacker who guesses an org_id could otherwise burn ECDSA
+# verify CPU and stuff the per-org audit chain with
+# ``federation.*_rejected`` rows via the countersig-failing publish
+# paths, or flood the unauthenticated mastio-url discovery in a tight
+# loop. Same cadence as ``onboarding.rotate_mastio_pubkey`` for the
+# heavyweight writes; reads get a higher ceiling since they're shaped
+# like ``/.well-known/`` style discovery.
+rate_limiter.register("federation.publish",
+                                                window_seconds=60,  max_requests=30)
+rate_limiter.register("federation.audit_replicate",
+                                                window_seconds=60,  max_requests=30)
+rate_limiter.register("federation.read",        window_seconds=60,  max_requests=60)
+rate_limiter.register("federation.mastio_url_lookup",
+                                                window_seconds=60,  max_requests=60)

--- a/app/registry/user_principals_router.py
+++ b/app/registry/user_principals_router.py
@@ -173,6 +173,36 @@ async def sign_csr(
             detail="cannot sign a CSR for a principal in a different org",
         )
 
+    # Security review F-001 (security-review-app-2026-05-14.md): the
+    # caller must be the org's Ambassador / Frontdesk workload, not a
+    # regular agent. Without this gate, any DPoP-authenticated agent
+    # in the org could mint a fresh user-principal cert (including
+    # ``user/admin``) and present it at ``/auth/token`` with
+    # ``principal_type=user`` to bypass the ADR-009 mastio counter-
+    # signature and the mTLS gate (auth/router.py:151,
+    # auth/mastio_countersig.enforce_on_token_request:118-119).
+    # Workload principals are provisioned by the Mastio out-of-band
+    # (Ambassador onboarding), so requiring this principal type pins
+    # the CSR endpoint to its intended caller.
+    principal_type_in_path = body.principal_id.split("/", 3)[2]
+    if (
+        principal_type_in_path == "user"
+        and token.principal_type != "workload"
+    ):
+        _log.warning(
+            "principals.csr: non-workload caller "
+            "[caller_agent_id=%s caller_principal_type=%s principal_id=%s] "
+            "refused to mint a user-principal cert",
+            token.agent_id, token.principal_type, body.principal_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "only a workload principal (Ambassador) may sign a "
+                "user-principal CSR"
+            ),
+        )
+
     try:
         cert_pem, thumbprint, not_after = await sign_user_csr(
             csr_pem=body.csr_pem,

--- a/tests/test_federation_rate_limit.py
+++ b/tests/test_federation_rate_limit.py
@@ -1,0 +1,233 @@
+"""Rate-limit regression for the Court federation surfaces.
+
+security-review-app-2026-05-14.md F-002 — federation endpoints
+(``publish-agent``, ``publish-stats``, ``audit/replicate``, ``agents``,
+``agents/search``, ``orgs/{id}/mastio-url``) are reachable from any
+internet peer. Without rate limiting, an attacker who guesses an
+``org_id`` can stage countersig-failing calls in a tight loop to burn
+ECDSA-verify CPU and flood the per-org audit chain with
+``federation.*_rejected`` rows; the unauthenticated ``mastio-url``
+discovery can be polled with zero auth at all.
+
+The fix wires the same per-IP bucket pattern that
+``onboarding.rotate_mastio_pubkey`` uses (issue #282) onto every
+federation surface. This file exercises the buckets to prove they
+trip before the heavyweight verify / audit-write paths.
+
+The tests monkeypatch ``get_client_ip`` (the per-module symbol that
+each handler imports) because httpx + ASGI does not flow X-Forwarded-
+For through uvicorn's ProxyHeadersMiddleware — same pattern as
+``test_broker_mastio_pubkey_rotate_rate_limit.py``.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from httpx import AsyncClient
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+async def _reset_rate_limit_between_tests():
+    """Clear the in-memory rate limiter window before each test so
+    shared state from prior tests does not poison the budget under
+    test (same shape as the rotate-pubkey rate-limit suite).
+    """
+    from app.rate_limit.limiter import rate_limiter
+    try:
+        rate_limiter._windows.clear()
+    except AttributeError:
+        pass
+    yield
+    try:
+        rate_limiter._windows.clear()
+    except AttributeError:
+        pass
+
+
+# ── federation.publish bucket (publish-agent) ────────────────────────
+
+
+async def test_publish_agent_rate_limit_blocks_burst(
+    client: AsyncClient, monkeypatch,
+):
+    """Burst past the per-IP ``federation.publish`` budget must trip
+    the limiter before any ECDSA verify / audit-write runs.
+
+    The body is intentionally minimal and the org is unknown, so the
+    handler would otherwise reach ``log_event("publish_rejected",
+    ...)`` on every call. With the rate-limit gate, the budget-th+1
+    request is rejected with 429 before it can pollute the chain.
+    """
+    from app.federation import publish as publish_mod
+    monkeypatch.setattr(
+        publish_mod, "get_client_ip", lambda req: "203.0.113.10",
+    )
+
+    # Bucket is registered at 30/min/IP. Drive the budget to the
+    # ceiling with malformed-but-shape-valid requests, then assert
+    # the next request is 429.
+    body = {
+        "agent_id": "unknown-org::ghost",
+        "cert_pem": "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----\n",
+        "capabilities": [],
+        "display_name": "ghost",
+    }
+    raw = json.dumps(body).encode()
+    saw_429 = False
+    for i in range(40):
+        r = await client.post(
+            "/v1/federation/publish-agent",
+            content=raw,
+            headers={
+                "Content-Type": "application/json",
+                "X-Cullis-Mastio-Signature": "AA",
+            },
+        )
+        if r.status_code == 429:
+            saw_429 = True
+            assert i >= 30, (
+                f"limiter tripped too early at call #{i+1} — expected "
+                f"after 30 calls/min, bucket may be misconfigured"
+            )
+            break
+    assert saw_429, (
+        "burst of 40 publish-agent calls from one IP never tripped "
+        "the federation.publish bucket — F-002 regression"
+    )
+
+
+async def test_publish_agent_rate_limit_is_per_ip(
+    client: AsyncClient, monkeypatch,
+):
+    """A second IP must NOT be penalised when the first IP has
+    consumed its budget. Proves the bucket is keyed on client IP, not
+    a global counter.
+    """
+    from app.federation import publish as publish_mod
+    body = {
+        "agent_id": "unknown-org::ghost",
+        "cert_pem": "-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----\n",
+        "capabilities": [],
+        "display_name": "ghost",
+    }
+    raw = json.dumps(body).encode()
+
+    # IP A — drain bucket past the ceiling.
+    monkeypatch.setattr(
+        publish_mod, "get_client_ip", lambda req: "203.0.113.20",
+    )
+    for _ in range(35):
+        await client.post(
+            "/v1/federation/publish-agent",
+            content=raw,
+            headers={
+                "Content-Type": "application/json",
+                "X-Cullis-Mastio-Signature": "AA",
+            },
+        )
+
+    # IP B — fresh bucket, must NOT see 429.
+    monkeypatch.setattr(
+        publish_mod, "get_client_ip", lambda req: "203.0.113.21",
+    )
+    r = await client.post(
+        "/v1/federation/publish-agent",
+        content=raw,
+        headers={
+            "Content-Type": "application/json",
+            "X-Cullis-Mastio-Signature": "AA",
+        },
+    )
+    assert r.status_code != 429, (
+        f"second IP saw a 429 — federation.publish bucket appears to "
+        f"be a global counter, not per-IP. Body: {r.text}"
+    )
+
+
+# ── federation.audit_replicate bucket ────────────────────────────────
+
+
+async def test_audit_replicate_rate_limit_blocks_burst(
+    client: AsyncClient, monkeypatch,
+):
+    """``audit/replicate`` accepts up to 1000 entries per batch, with
+    each rejected batch appending a ``federation.audit_replicate_rejected``
+    row to the per-org chain. The bucket caps unauthenticated bursts
+    well before the chain-write contention shows up.
+    """
+    from app.federation import audit_replicate as audit_mod
+    monkeypatch.setattr(
+        audit_mod, "get_client_ip", lambda req: "203.0.113.30",
+    )
+
+    body = {
+        "mastio_org_id": "unknown-org",
+        "entries": [
+            {
+                "chain_seq": 1,
+                "entry_hash": "a" * 64,
+                "previous_hash": None,
+                "timestamp": "2026-05-14T00:00:00Z",
+                "event_type": "test.event",
+                "result": "ok",
+            },
+        ],
+    }
+    raw = json.dumps(body).encode()
+    saw_429 = False
+    for i in range(40):
+        r = await client.post(
+            "/v1/federation/audit/replicate",
+            content=raw,
+            headers={
+                "Content-Type": "application/json",
+                "X-Cullis-Mastio-Signature": "AA",
+            },
+        )
+        if r.status_code == 429:
+            saw_429 = True
+            assert i >= 30, (
+                f"limiter tripped too early at call #{i+1} — expected "
+                f"after 30 calls/min for federation.audit_replicate"
+            )
+            break
+    assert saw_429, (
+        "burst of 40 audit/replicate calls from one IP never tripped "
+        "the federation.audit_replicate bucket — F-002 regression"
+    )
+
+
+# ── federation.mastio_url_lookup bucket (UNAUTH discovery) ───────────
+
+
+async def test_mastio_url_lookup_rate_limit_blocks_burst(
+    client: AsyncClient, monkeypatch,
+):
+    """``GET /v1/federation/orgs/{id}/mastio-url`` is fully
+    unauthenticated. Without rate-limiting an attacker can poll
+    discovery in a tight loop with zero auth at all. Bucket is
+    60/min/IP — burst of 80 must trip before the 80th.
+    """
+    from app.federation import read as read_mod
+    monkeypatch.setattr(
+        read_mod, "get_client_ip", lambda req: "203.0.113.40",
+    )
+
+    saw_429 = False
+    for i in range(80):
+        r = await client.get("/v1/federation/orgs/unknown-org/mastio-url")
+        if r.status_code == 429:
+            saw_429 = True
+            assert i >= 60, (
+                f"limiter tripped too early at call #{i+1} — expected "
+                f"after 60 calls/min for federation.mastio_url_lookup"
+            )
+            break
+    assert saw_429, (
+        "burst of 80 mastio-url-lookup calls from one IP never "
+        "tripped the federation.mastio_url_lookup bucket — F-002 "
+        "regression"
+    )

--- a/tests/test_frontdesk_shared_e2e.py
+++ b/tests/test_frontdesk_shared_e2e.py
@@ -43,7 +43,15 @@ SECRET = b"frontdesk-test-cookie-secret-32!"
 
 
 def _override_token(*, agent_id: str, org: str) -> TokenPayload:
-    """The Frontdesk Ambassador's own workload identity for CSR calls."""
+    """The Frontdesk Ambassador's own workload identity for CSR calls.
+
+    H4 H-001 fix in app/registry/user_principals_router.py requires the
+    caller's principal_type to be ``workload`` whenever the requested
+    CSR subject is a ``user/*`` principal. Frontdesk is the canonical
+    workload that mints user principals on behalf of authenticated
+    browsers, so this fixture sets ``principal_type="workload"``
+    explicitly instead of relying on the default ``agent``.
+    """
     return TokenPayload(
         sub=f"spiffe://cullis.test/{org}/agent/{agent_id.split('::', 1)[-1]}",
         agent_id=agent_id,
@@ -53,6 +61,7 @@ def _override_token(*, agent_id: str, org: str) -> TokenPayload:
         jti="frontdesk-jti",
         scope=[],
         cnf={"jkt": "x" * 43},
+        principal_type="workload",
     )
 
 

--- a/tests/test_principals_csr.py
+++ b/tests/test_principals_csr.py
@@ -181,9 +181,16 @@ async def test_sign_user_csr_malformed_pem_raises():
 # ── /v1/principals/csr endpoint (5 tests) ──────────────────────────
 
 
-def _override_token(*, agent_id: str, org: str) -> TokenPayload:
+def _override_token(
+    *, agent_id: str, org: str, principal_type: str = "workload",
+) -> TokenPayload:
+    # Security review F-001: only ``principal_type=workload`` (the
+    # Ambassador / Frontdesk) may sign a user-principal CSR. Default
+    # this helper to ``workload`` so the happy-path tests reflect the
+    # real caller; tests that need to exercise the gate pass
+    # ``principal_type="agent"`` explicitly.
     return TokenPayload(
-        sub=f"spiffe://cullis.test/{org}/agent/{agent_id.split('::', 1)[-1]}",
+        sub=f"spiffe://cullis.test/{org}/{principal_type}/{agent_id.split('::', 1)[-1]}",
         agent_id=agent_id,
         org=org,
         exp=2_000_000_000,
@@ -191,6 +198,7 @@ def _override_token(*, agent_id: str, org: str) -> TokenPayload:
         jti="test-jti",
         scope=[],
         cnf={"jkt": "x" * 43},
+        principal_type=principal_type,
     )
 
 
@@ -286,3 +294,122 @@ async def test_csr_endpoint_400_san_mismatch(client, auth_as_acme):
     # body must not echo it (audit lane H-IO-2 Phase A). Asserting the
     # masked surface keeps this guard in place against future regressions.
     assert r.json()["detail"] == "CSR validation failed"
+
+
+# ── F-001 regression: only workload caller may mint a user cert ───
+#
+# security-review-app-2026-05-14.md F-001: without this gate any DPoP-
+# authenticated principal in the org can submit a CSR for
+# ``<td>/<org>/user/<anyone>`` (including ``user/admin``) and get a
+# Mastio-CA-signed user cert valid for 1h, then present it at
+# ``/auth/token`` with ``principal_type=user`` to bypass the ADR-009
+# countersig + mTLS gates. The fix requires the caller to be a
+# ``principal_type=workload`` (the Ambassador / Frontdesk).
+
+
+@pytest_asyncio.fixture
+async def auth_as_acme_regular_agent():
+    """Caller is a regular agent in acme, NOT the Ambassador workload.
+
+    Models the F-001 attacker shape: a compromised low-privilege agent
+    (sales-bot, leaked SDK token) trying to escalate to a user cert.
+    """
+    app.dependency_overrides[get_current_agent] = (
+        lambda: _override_token(
+            agent_id="acme::sales-bot",
+            org="acme",
+            principal_type="agent",
+        )
+    )
+    yield
+    app.dependency_overrides.pop(get_current_agent, None)
+
+
+async def test_csr_endpoint_403_regular_agent_cannot_mint_user_cert(
+    client, auth_as_acme_regular_agent,
+):
+    """F-001 regression — a ``principal_type=agent`` caller in the same
+    org may NOT mint a user-principal cert. Without the workload gate,
+    this returned 201 with a freshly-signed Mastio-CA cert for
+    ``user/admin`` and let the agent escalate at /auth/token.
+    """
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/admin")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/user/admin",
+            "csr_pem": csr_pem,
+        },
+    )
+    assert r.status_code == 403, r.text
+    detail = r.json()["detail"].lower()
+    assert "workload" in detail or "ambassador" in detail
+
+
+async def test_csr_endpoint_403_user_principal_cannot_mint_user_cert(
+    client,
+):
+    """F-001 sister case — a ``principal_type=user`` caller (e.g. a
+    Frontdesk user impersonating the Ambassador) is also refused. The
+    gate is strictly ``workload``, not ``workload or user``.
+    """
+    app.dependency_overrides[get_current_agent] = (
+        lambda: _override_token(
+            agent_id="acme::mario",
+            org="acme",
+            principal_type="user",
+        )
+    )
+    try:
+        _, csr_pem = _make_csr("spiffe://acme.test/acme/user/admin")
+        r = await client.post(
+            "/v1/principals/csr",
+            json={
+                "principal_id": "acme.test/acme/user/admin",
+                "csr_pem": csr_pem,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_current_agent, None)
+    assert r.status_code == 403, r.text
+
+
+async def test_csr_endpoint_workload_caller_can_mint_user_cert(
+    client, auth_as_acme,
+):
+    """Sanity check that the legitimate Ambassador workload path
+    still succeeds. ``auth_as_acme`` now defaults to
+    ``principal_type=workload`` after the F-001 fix.
+    """
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/user/mario")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/user/mario",
+            "csr_pem": csr_pem,
+        },
+    )
+    assert r.status_code == 201, r.text
+
+
+async def test_csr_endpoint_403_caller_principal_type_workload_for_agent_cert_ok(
+    client, auth_as_acme_regular_agent,
+):
+    """The workload gate is scoped to user-principal CSRs. An
+    ``agent`` caller can still submit a CSR for an agent-principal
+    (legacy path) — the gate keys on the principal-type segment of
+    the requested principal_id, not on the caller type globally.
+    """
+    _, csr_pem = _make_csr("spiffe://acme.test/acme/agent/sales-bot")
+    r = await client.post(
+        "/v1/principals/csr",
+        json={
+            "principal_id": "acme.test/acme/agent/sales-bot",
+            "csr_pem": csr_pem,
+        },
+    )
+    # Hits ``sign_user_csr`` which still enforces SAN/CN shape and may
+    # 400 (the helper builds a SAN with the requested URI, so this
+    # should succeed and return 201 with a cert). The key assertion
+    # here is "not 403 due to workload gate".
+    assert r.status_code != 403, r.text


### PR DESCRIPTION
## Summary

Two HIGH severity findings from the Court security review
(`imp/security-review-app-2026-05-14.md`).

**F-001 — user-principal CSR escalation**
- Any DPoP-authenticated agent in an org could submit a CSR for
  `<td>/<org>/user/<anyone>` (including `user/admin`) and get a
  Mastio-CA-signed user cert valid for 1h.
- The resulting cert could be presented at `/auth/token` with
  `principal_type=user`, which explicitly skips the ADR-009 mastio
  counter-signature and the mTLS gate. Within-org escalation from any
  agent to any user identity.
- Fix: require `token.principal_type == "workload"` (the Ambassador /
  Frontdesk) when the CSR subject is a `user/*` principal. Workload
  principals are provisioned out-of-band by the Mastio, so pinning the
  caller type closes the escalation.

**F-002 — federation surfaces unrate-limited**
- `POST /v1/federation/publish-agent`, `publish-stats`,
  `audit/replicate`, `GET /v1/federation/agents{,/search}`, and the
  unauthenticated `GET /v1/federation/orgs/{org_id}/mastio-url` had no
  rate limiting. An attacker who guessed an `org_id` could stage
  countersig-failing publish calls to burn ECDSA-verify CPU and flood
  the per-org audit chain with `federation.*_rejected` rows; the
  unauthenticated mastio-url discovery could be polled with zero auth.
- The onboarding `rotate_mastio_pubkey` endpoint already had a per-IP
  bucket for exactly this attack (issue #282); the federation surfaces
  did not.
- Fix: register four new buckets in `app/rate_limit/limiter.py`
  (`federation.publish` 30/min/IP, `federation.audit_replicate`
  30/min/IP, `federation.read` 60/min/IP,
  `federation.mastio_url_lookup` 60/min/IP) and call
  `rate_limiter.check(client_ip, ...)` at the head of each handler,
  before any ECDSA verify or audit append. Mirrors the existing
  `onboarding.rotate_mastio_pubkey` pattern.

## Test plan

- [x] `tests/test_principals_csr.py` extended with four F-001
      regression tests: regular `agent` caller refused with 403,
      `user` caller refused with 403, workload happy-path 201,
      `agent`-CSR still works (gate is scoped to `user` principal-
      type only).
- [x] `tests/test_federation_rate_limit.py` (new) covers F-002:
      publish-agent burst trips 429 after budget, budget is per-IP
      (second IP unaffected), audit/replicate burst trips 429,
      mastio-url-lookup burst trips 429 unauthenticated.
- [x] All five regression tests fail on the unpatched `app/`
      (verified with `git stash push -- app/` + replay) and pass on
      the patched code.
- [x] Full related-test run green:
      `pytest tests/test_principals_csr.py
      tests/test_federation_rate_limit.py tests/test_federation_publish.py
      tests/test_federation_publish_stats.py tests/test_federation_read.py
      tests/test_wave_b_pr8_audit_publisher.py
      tests/test_broker_mastio_pubkey_rotate_rate_limit.py -n auto
      --dist=loadfile` => 69 passed.
- [x] Broader related-test run green:
      `pytest tests/test_user_principals_registry.py
      tests/test_user_principal_kms_embedded.py
      tests/test_federation_catalog.py tests/test_federation_events.py
      tests/test_federation_public_key_cert_pem.py
      tests/test_federation_publisher.py
      tests/test_proxy_federation_sync.py
      tests/test_tool_call_pdp_federation.py tests/test_h_csr_pop.py
      tests/test_h10_ca_chain_threading.py
      tests/test_crit1_csr_pubkey_tofu.py -n auto --dist=loadfile`
      => 131 passed.

Findings: Court H-001 and H-002 from `imp/security-review-app-2026-05-14.md`.