### PR TITLE
feat(config): refuse kms_backend=local in production (H3 P0.1)

### DIFF
--- a/mcp_proxy/config.py
+++ b/mcp_proxy/config.py
@@ -613,9 +613,30 @@ def validate_config(settings: ProxySettings) -> None:
                 "MCP_PROXY_SECRET_BACKEND=%r is not supported in production. "
                 "Set MCP_PROXY_SECRET_BACKEND=vault and configure "
                 "MCP_PROXY_VAULT_ADDR + MCP_PROXY_VAULT_TOKEN. 'env' keeps "
-                "agent private keys at rest in the process environment — "
+                "agent private keys at rest in the process environment, "
                 "dev/test only.",
                 settings.secret_backend,
+            )
+            raise SystemExit(1)
+
+        # H3 P0.1 — kms_backend=local stores the Org CA private key in the
+        # Mastio's own database (proxy_config table). A host compromise
+        # that reaches the DB file recovers the key material directly. In
+        # production we require a vault-backed or HSM-backed KMS so the
+        # key never lives on disk in cleartext. Closes the gap surfaced by
+        # the 2026-05-15 threat-model verification pass: the old code
+        # refused secret_backend=env but silently accepted kms_backend=
+        # local, contradicting the threat-model claim of "production
+        # refuses local KMS backend".
+        if settings.kms_backend.lower() == "local":
+            _log.critical(
+                "MCP_PROXY_KMS_BACKEND=%r is not supported in production. "
+                "Set MCP_PROXY_KMS_BACKEND=vault (open-core, see "
+                "operate/vault-org-ca.md) or one of the enterprise cloud "
+                "KMS plugins (aws/azure/gcp). 'local' keeps the Org CA "
+                "private key in the Mastio database, with no HSM-grade "
+                "protection — dev/test only.",
+                settings.kms_backend,
             )
             raise SystemExit(1)
 
@@ -681,9 +702,10 @@ def validate_config(settings: ProxySettings) -> None:
 
     _log.info(
         "Startup validation passed (environment=%s, secret_backend=%s, "
-        "standalone=%s).",
+        "kms_backend=%s, standalone=%s).",
         settings.environment,
         settings.secret_backend,
+        settings.kms_backend,
         settings.standalone,
     )
 

--- a/tests/test_dashboard_signing_key.py
+++ b/tests/test_dashboard_signing_key.py
@@ -32,6 +32,7 @@ def _prod_proxy_settings(**overrides) -> ProxySettings:
         admin_secret="strong-random-admin-secret",
         broker_jwks_url="https://broker.example.com/.well-known/jwks.json",
         secret_backend="vault",
+        kms_backend="vault",  # H3 P0.1 — prod refuses local KMS backend
         vault_verify_tls=True,
         dashboard_signing_key="strong-signing-key",
     )

--- a/tests/test_proxy_tls_verify.py
+++ b/tests/test_proxy_tls_verify.py
@@ -40,6 +40,10 @@ def _prod_settings(**overrides) -> ProxySettings:
         admin_secret="strong-random-admin-secret",
         broker_jwks_url="https://broker.example.com/.well-known/jwks.json",
         standalone=False,
+        # H3 P0.1 — prod refuses kms_backend=local; pin so the SystemExit
+        # in TLS-focused tests comes from the TLS knob under test, not
+        # from KMS.
+        kms_backend="vault",
         # Audit F-B-10 — prod now refuses empty signing key.
         dashboard_signing_key="strong-signing-key",
     )

--- a/tests/test_secrets_hardening.py
+++ b/tests/test_secrets_hardening.py
@@ -115,6 +115,10 @@ def _prod_proxy_settings(**overrides) -> ProxySettings:
         standalone=False,
         broker_verify_tls=True,
         secret_backend="vault",
+        # H3 P0.1 — production refuses kms_backend=local; the
+        # prod-shaped helper therefore declares vault by default. Tests
+        # that need to exercise the local-rejection branch override it.
+        kms_backend="vault",
         vault_verify_tls=True,
         # Audit F-B-10 — prod now refuses empty signing key, so every
         # prod-shaped helper has to provide one.
@@ -147,12 +151,62 @@ def test_proxy_validate_config_prod_allows_vault_backend():
 
 def test_proxy_validate_config_rejects_standalone_prod_with_env_backend():
     """Standalone mode skips broker checks but the secret backend refusal
-    still applies — agent keys live in the proxy regardless of uplink."""
+    still applies, agent keys live in the proxy regardless of uplink."""
     settings = ProxySettings(
         environment="production",
         admin_secret="strong-random-admin-secret",
         standalone=True,
         secret_backend="env",
+        kms_backend="vault",  # H3 P0.1: pin so the SystemExit is from secret_backend only
+        vault_verify_tls=True,
+        dashboard_signing_key="strong-signing-key",  # F-B-10
+    )
+    with pytest.raises(SystemExit):
+        proxy_validate_config(settings)
+
+
+# ── Proxy: H3 P0.1 kms_backend ──────────────────────────────────────
+
+def test_proxy_validate_config_rejects_prod_with_kms_backend_local():
+    """Production refuses kms_backend=local because the Org CA private
+    key would live in the Mastio database with no HSM-grade protection.
+    Closes the gap surfaced by the 2026-05-15 threat-model verification
+    pass."""
+    settings = _prod_proxy_settings(kms_backend="local")
+    with pytest.raises(SystemExit):
+        proxy_validate_config(settings)
+
+
+def test_proxy_validate_config_dev_tolerates_kms_backend_local():
+    """Development keeps kms_backend=local working for sandbox / first-
+    boot dogfood scenarios."""
+    settings = ProxySettings(
+        environment="development",
+        secret_backend="env",
+        kms_backend="local",
+    )
+    # Must not raise.
+    proxy_validate_config(settings)
+
+
+def test_proxy_validate_config_prod_allows_vault_kms():
+    """The shipping production posture (kms_backend=vault) must continue
+    to pass after the local-rejection branch lands."""
+    settings = _prod_proxy_settings(kms_backend="vault")
+    # Must not raise.
+    proxy_validate_config(settings)
+
+
+def test_proxy_validate_config_rejects_standalone_prod_with_kms_local():
+    """Standalone mode does not exempt the Org CA: standalone Mastios
+    sign agent certs with the same key, so kms_backend=local still
+    leaks the key on host compromise."""
+    settings = ProxySettings(
+        environment="production",
+        admin_secret="strong-random-admin-secret",
+        standalone=True,
+        secret_backend="vault",  # pin so the SystemExit is from kms_backend only
+        kms_backend="local",
         vault_verify_tls=True,
         dashboard_signing_key="strong-signing-key",  # F-B-10
     )

--- a/tests/test_ws_origin.py
+++ b/tests/test_ws_origin.py
@@ -228,6 +228,7 @@ def test_proxy_validate_config_prod_refuses_wildcard_allowed_origins():
         admin_secret="strong-random-admin-secret",
         broker_jwks_url="https://broker.example.com/.well-known/jwks.json",
         secret_backend="vault",
+        kms_backend="vault",  # H3 P0.1: pin so SystemExit is from wildcard origin only
         vault_verify_tls=True,
         dashboard_signing_key="strong-signing-key",
         allowed_origins="*",


### PR DESCRIPTION
## Summary

First P0 of the post-verification-pass first-deal-ready set. Closes the FALSE claim flagged by the 2026-05-15 threat-model verification pass: the production-mode startup validator already refused \`secret_backend=env\` but silently accepted \`kms_backend=local\`. With \`local\` KMS the Org CA private key lives in the Mastio's own database (\`proxy_config\` table); a host compromise that reaches the DB file recovers the key material directly, contradicting the threat-model claim of \"production refuses local KMS backend\".

Validation now raises \`SystemExit\` with a pointer to the Vault / cloud-KMS migration path (\`operate/vault-org-ca.md\`). Dev mode keeps \`local\` working for sandbox / first-boot scenarios.

Mirrors the broker-side validate_config check on \`kms_backend\` that has been in place since the Vault Org CA rollout (ADR-031).

## Diff highlights

- \`mcp_proxy/config.py::validate_config\`: new branch inside the \`if is_production:\` block that refuses \`kms_backend.lower() == \"local\"\`. Log message points the operator at \`vault\` (open-core) or the enterprise cloud-KMS plugins.
- Log line at end of validate_config now includes \`kms_backend=\` so operators can confirm the backend that booted.

## Tests

- 4 new unit tests in \`tests/test_secrets_hardening.py\`:
  - prod refuses \`kms_backend=local\`
  - standalone-prod refuses \`kms_backend=local\` (the Org CA still lives in the proxy)
  - dev tolerates \`kms_backend=local\`
  - prod with \`kms_backend=vault\` still passes
- Updates to \`_prod_proxy_settings\` helpers in \`test_proxy_tls_verify.py\`, \`test_dashboard_signing_key.py\`, \`test_ws_origin.py\`, \`test_secrets_hardening.py\`: pin \`kms_backend=\"vault\"\` so their SystemExit-expecting tests still fail for the knob under test, not for the new KMS check that would otherwise preempt them.

## Coverage

- Targeted batch (4 files affected): **73 passed**.
- Full parallel suite: **3460 passed**, 7 known flakes (5x \`test_audit_export_tsa\` test-isolation flake, 2x \`test_postgres_integration\` pre-existing KeyError per \`feedback_ci_known_failures.md\`). All 5 \`audit_export_tsa\` tests pass when run in isolation against this branch.

## Smoke gate

Intentionally skipped. The new branch fires only in \`environment=production\`; \`sandbox/demo.sh\` runs in \`development\`. Smoke would add no incremental coverage. Targeted unit tests + parallel suite are the coverage path.

## Test plan

- [x] Unit tests for the new branch (4 added)
- [x] Existing \`_prod_proxy_settings\` helpers updated to keep their SystemExit tests semantically correct
- [x] Full parallel suite green except known flakes
- [x] DCO \`Signed-off-by\`
- [x] Threat-model open-items entry \"production-mode validator: refuse \`MCP_PROXY_KMS_BACKEND=local\`\" can be removed in a follow-up doc PR once this merges