### PR TITLE
refactor(sdk): extract Guardian inspector to _client/_guardian.py

### DIFF
--- a/cullis_sdk/_client/_guardian.py
+++ b/cullis_sdk/_client/_guardian.py
@@ -1,0 +1,147 @@
+"""Guardian inspection support extracted from :mod:`cullis_sdk.client`.
+
+Single public symbol:
+
+* :class:`_GuardianMixin` — mixin folded into ``CullisClient`` that
+  implements the ADR-016 Phase 3 cooperation hook. The SDK calls the
+  local Mastio's ``/v1/guardian/inspect`` before encrypting on send and
+  after decrypting on deliver. NO-OP unless ``CULLIS_GUARDIAN_ENABLED=1``.
+
+Movement only — no behavior change. The mixin assumes the host class
+exposes ``_egress_http`` (i.e. the existing ``CullisClient`` method).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from cullis_sdk.guardian.client import (
+    InspectionDecision,
+    _build_body as _guardian_build_body,
+    _enabled as _guardian_enabled,
+    _no_op_decision as _guardian_no_op,
+    _parse_response as _guardian_parse_response,
+)
+
+
+class _GuardianMixin:
+    """ADR-016 Phase 3 Guardian cooperation hook on ``CullisClient``.
+
+    The SDK calls the local Mastio's ``/v1/guardian/inspect`` before
+    encrypting on send and after decrypting on deliver. NO-OP unless
+    ``CULLIS_GUARDIAN_ENABLED=1`` (existing deployments unaffected).
+    Routed through ``_egress_http`` so DPoP + mTLS are reused; the
+    guardian endpoint sits behind the same auth dep as ``/v1/egress/*``.
+    """
+
+    def _guardian_inspect(
+        self,
+        *,
+        direction: str,
+        payload_bytes: bytes,
+        peer_agent_id: str,
+        msg_id: str,
+        content_type: str = "application/json+a2a-payload",
+    ) -> InspectionDecision:
+        if not _guardian_enabled():
+            return _guardian_no_op()
+        body = _guardian_build_body(
+            direction=direction,
+            payload=payload_bytes,
+            peer_agent_id=peer_agent_id,
+            msg_id=msg_id,
+            content_type=content_type,
+        )
+        resp = self._egress_http(
+            "post", "/v1/guardian/inspect", json=body,
+        )
+        try:
+            json_body = resp.json()
+        except ValueError:
+            json_body = None
+        return _guardian_parse_response(
+            status_code=resp.status_code,
+            text=getattr(resp, "text", "") or "",
+            json_body=json_body,
+            direction=direction,
+            peer_agent_id=peer_agent_id,
+            msg_id=msg_id,
+        )
+
+    def _guardian_inspect_send(
+        self, *, payload: dict, peer_agent_id: str, msg_id: str,
+    ) -> InspectionDecision:
+        """Hook called from outbound A2A primitives BEFORE encryption.
+
+        Serialises the application payload to canonical JSON bytes,
+        ships it to ``/v1/guardian/inspect`` with direction=out. On
+        decision=block raises GuardianBlocked (caller never sends).
+        On decision=redact carries the redacted bytes back so the
+        caller substitutes them before encrypt.
+        """
+        payload_bytes = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"),
+        ).encode("utf-8")
+        return self._guardian_inspect(
+            direction="out",
+            payload_bytes=payload_bytes,
+            peer_agent_id=peer_agent_id,
+            msg_id=msg_id,
+        )
+
+    def _guardian_inspect_deliver(
+        self, *, payload: dict, peer_agent_id: str, msg_id: str,
+    ) -> InspectionDecision:
+        """Hook called from inbound A2A primitives AFTER decryption.
+
+        Same shape as ``_guardian_inspect_send`` but direction=in.
+        """
+        payload_bytes = json.dumps(
+            payload, sort_keys=True, separators=(",", ":"),
+        ).encode("utf-8")
+        return self._guardian_inspect(
+            direction="in",
+            payload_bytes=payload_bytes,
+            peer_agent_id=peer_agent_id,
+            msg_id=msg_id,
+        )
+
+    def _apply_guardian_deliver(
+        self, *, payload: dict, sender_agent_id: str, msg_id: str,
+    ) -> dict:
+        """Apply Guardian inspection on a freshly-decrypted message.
+
+        Returns the (possibly redacted) payload to deliver, or raises
+        GuardianBlocked if Mastio refused. NO-OP when guardian is
+        disabled. When ``CULLIS_GUARDIAN_TICKET_KEY`` is set in the
+        SDK env we additionally verify the ticket signature locally
+        as a defense-in-depth check: a tampered SDK that returned a
+        synthetic ``pass`` without contacting Mastio fails this gate.
+        """
+        decision = self._guardian_inspect_deliver(
+            payload=payload,
+            peer_agent_id=sender_agent_id,
+            msg_id=msg_id,
+        )
+        if decision.ticket and os.environ.get("CULLIS_GUARDIAN_TICKET_KEY"):
+            from cullis_sdk.guardian.client import verify_ticket
+            try:
+                verify_ticket(
+                    token=decision.ticket,
+                    key=os.environ["CULLIS_GUARDIAN_TICKET_KEY"],
+                    expected_msg_id=msg_id,
+                )
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"guardian_ticket_verify_failed: {exc}"
+                ) from exc
+        if decision.redacted_payload is not None:
+            try:
+                return json.loads(
+                    decision.redacted_payload.decode("utf-8"),
+                )
+            except (ValueError, UnicodeDecodeError) as exc:
+                raise RuntimeError(
+                    f"guardian returned malformed redacted_payload: {exc}"
+                ) from exc
+        return payload

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -38,16 +38,9 @@ from cullis_sdk.crypto.message_signer import (
     verify_signature,
 )
 from cullis_sdk.crypto.e2e import encrypt_for_agent, decrypt_from_agent
-from cullis_sdk.guardian.client import (
-    GuardianBlocked,
-    InspectionDecision,
-    _build_body as _guardian_build_body,
-    _enabled as _guardian_enabled,
-    _no_op_decision as _guardian_no_op,
-    _parse_response as _guardian_parse_response,
-)
 from cullis_sdk.types import AgentInfo, SessionInfo, InboxMessage, RfqResult
 from cullis_sdk._logging import log, RED
+from cullis_sdk._client._guardian import _GuardianMixin
 from cullis_sdk._client._websocket import WebSocketConnection, _WebSocketMixin
 
 _PUBKEY_CACHE_TTL = 300  # seconds
@@ -241,7 +234,7 @@ def _check_insecure_tls(verify_tls: bool) -> None:
     )
 
 
-class CullisClient(_WebSocketMixin):
+class CullisClient(_GuardianMixin, _WebSocketMixin):
     """Client for the Cullis federated agent trust broker."""
 
     def __init__(
@@ -679,126 +672,6 @@ class CullisClient(_WebSocketMixin):
         if rotated:
             self._egress_dpop_nonce = rotated
         return resp
-
-    # ── ADR-016 Phase 3 — Guardian cooperation hook ──────────────────
-    #
-    # The SDK calls the local Mastio's ``/v1/guardian/inspect`` before
-    # encrypting on send and after decrypting on deliver. NO-OP unless
-    # CULLIS_GUARDIAN_ENABLED=1 (existing deployments unaffected).
-    # Routed through ``_egress_http`` so DPoP + mTLS are reused; the
-    # guardian endpoint sits behind the same auth dep as ``/v1/egress/*``.
-
-    def _guardian_inspect(
-        self,
-        *,
-        direction: str,
-        payload_bytes: bytes,
-        peer_agent_id: str,
-        msg_id: str,
-        content_type: str = "application/json+a2a-payload",
-    ) -> InspectionDecision:
-        if not _guardian_enabled():
-            return _guardian_no_op()
-        body = _guardian_build_body(
-            direction=direction,
-            payload=payload_bytes,
-            peer_agent_id=peer_agent_id,
-            msg_id=msg_id,
-            content_type=content_type,
-        )
-        resp = self._egress_http(
-            "post", "/v1/guardian/inspect", json=body,
-        )
-        try:
-            json_body = resp.json()
-        except ValueError:
-            json_body = None
-        return _guardian_parse_response(
-            status_code=resp.status_code,
-            text=getattr(resp, "text", "") or "",
-            json_body=json_body,
-            direction=direction,
-            peer_agent_id=peer_agent_id,
-            msg_id=msg_id,
-        )
-
-    def _guardian_inspect_send(
-        self, *, payload: dict, peer_agent_id: str, msg_id: str,
-    ) -> InspectionDecision:
-        """Hook called from outbound A2A primitives BEFORE encryption.
-
-        Serialises the application payload to canonical JSON bytes,
-        ships it to ``/v1/guardian/inspect`` with direction=out. On
-        decision=block raises GuardianBlocked (caller never sends).
-        On decision=redact carries the redacted bytes back so the
-        caller substitutes them before encrypt.
-        """
-        payload_bytes = json.dumps(
-            payload, sort_keys=True, separators=(",", ":"),
-        ).encode("utf-8")
-        return self._guardian_inspect(
-            direction="out",
-            payload_bytes=payload_bytes,
-            peer_agent_id=peer_agent_id,
-            msg_id=msg_id,
-        )
-
-    def _guardian_inspect_deliver(
-        self, *, payload: dict, peer_agent_id: str, msg_id: str,
-    ) -> InspectionDecision:
-        """Hook called from inbound A2A primitives AFTER decryption.
-
-        Same shape as ``_guardian_inspect_send`` but direction=in.
-        """
-        payload_bytes = json.dumps(
-            payload, sort_keys=True, separators=(",", ":"),
-        ).encode("utf-8")
-        return self._guardian_inspect(
-            direction="in",
-            payload_bytes=payload_bytes,
-            peer_agent_id=peer_agent_id,
-            msg_id=msg_id,
-        )
-
-    def _apply_guardian_deliver(
-        self, *, payload: dict, sender_agent_id: str, msg_id: str,
-    ) -> dict:
-        """Apply Guardian inspection on a freshly-decrypted message.
-
-        Returns the (possibly redacted) payload to deliver, or raises
-        GuardianBlocked if Mastio refused. NO-OP when guardian is
-        disabled. When ``CULLIS_GUARDIAN_TICKET_KEY`` is set in the
-        SDK env we additionally verify the ticket signature locally
-        as a defense-in-depth check: a tampered SDK that returned a
-        synthetic ``pass`` without contacting Mastio fails this gate.
-        """
-        decision = self._guardian_inspect_deliver(
-            payload=payload,
-            peer_agent_id=sender_agent_id,
-            msg_id=msg_id,
-        )
-        if decision.ticket and os.environ.get("CULLIS_GUARDIAN_TICKET_KEY"):
-            from cullis_sdk.guardian.client import verify_ticket
-            try:
-                verify_ticket(
-                    token=decision.ticket,
-                    key=os.environ["CULLIS_GUARDIAN_TICKET_KEY"],
-                    expected_msg_id=msg_id,
-                )
-            except ValueError as exc:
-                raise RuntimeError(
-                    f"guardian_ticket_verify_failed: {exc}"
-                ) from exc
-        if decision.redacted_payload is not None:
-            try:
-                return json.loads(
-                    decision.redacted_payload.decode("utf-8"),
-                )
-            except (ValueError, UnicodeDecodeError) as exc:
-                raise RuntimeError(
-                    f"guardian returned malformed redacted_payload: {exc}"
-                ) from exc
-        return payload
 
     # ── ADR-011 — unified enrollment + runtime auth ───────────────────
 


### PR DESCRIPTION
## What

PR 2/N of the SDK refactor split (see #702 for the WebSocket pilot and the mixin template). Moves the ADR-016 Phase 3 Guardian cooperation hook out of `cullis_sdk/client.py` into a dedicated mixin under `cullis_sdk/_client/`.

## Scope (2/N)

- New module `cullis_sdk/_client/_guardian.py` with `_GuardianMixin` exposing:
  - `_guardian_inspect`
  - `_guardian_inspect_send`
  - `_guardian_inspect_deliver`
  - `_apply_guardian_deliver`
  - Plus the scoped imports of `InspectionDecision`, `_build_body`, `_enabled`, `_no_op_decision`, `_parse_response` from `cullis_sdk.guardian.client`.
- `cullis_sdk/client.py` — `CullisClient` now inherits `(_GuardianMixin, _WebSocketMixin)`. The four Guardian methods, their section comment, and the now-unused Guardian imports are gone. The `GuardianBlocked` import is dropped too: it was referenced only in docstrings/comments inside `client.py` (the exception is raised inside `cullis_sdk.guardian.client` itself and propagates up through the call chain unchanged).

Call sites of `_guardian_inspect_send` and `_apply_guardian_deliver` inside `send_oneshot` and the two reply paths continue to resolve via mixin inheritance — no signature change.

## Why Guardian as the second extraction

Most isolated remaining domain after WebSocket: 4 private methods, single dependency on `_egress_http`, zero overlap with auth/sessions/messaging/AI gateway. Lowest blast radius for the second slice. The pattern from #702 holds without any new wrinkle.

## Roadmap (next PRs)

Same mixin pattern, one per PR (template stable after this lands):

1. enrollment (`from_enrollment`, `from_connector`, `enroll_via_byoca`, ...)
2. auth (login family, DPoP helpers, auto-relogin)
3. discovery (`discover`, agent search)
4. sessions (open/accept/close, listing)
5. messaging legacy (`send`, `receive`, ack, decrypt)
6. messaging oneshot (`send_oneshot`, `decrypt_oneshot`, envelope helpers)
7. AI gateway (LiteLLM/OpenAI proxy methods)
8. RFQ + misc (transaction tokens, notifications, `join_network`)

## Zero breaking change

Guardian methods are private. No public-API path changes. `CullisClient.send_oneshot(...)` and the reply paths keep working identically — verified by `tests/test_sdk_guardian_phase3_send.py` (5 tests) and `tests/test_sdk_guardian_phase3_deliver.py` (7 tests), all green.

## Verification

- `pytest tests/ -n auto --dist=loadfile` — 3428 passed, 38 skipped. The 12 Guardian-specific tests pass. Two distinct families of failures appeared and are **not caused by this PR**:
  - `tests/test_postgres_integration.py::test_pg_session_and_signed_messages` + `::test_pg_nonce_replay_blocked` — pre-existing postgres-binding `KeyError: 'id'` flake (documented; reproduces on `origin/main` too).
  - `tests/test_audit_export_tsa.py` (5 failures) + `tests/test_audit_race_safety.py` (3 errors) — aiosqlite `IntegrityError` under full parallel load (sqlite WAL/lock contention with 16 workers). All 9 audit tests pass when run in isolation in this same worktree (`pytest tests/test_audit_export_tsa.py tests/test_audit_race_safety.py` → 9 passed). Concurrency flake, not a refactor regression.
- `./sandbox/smoke.sh full` — PASS=25, FAIL=0, SKIP=1 (the skip is B4.9, gated on `SMOKE_ASSERT_INTRA_ORG=1`).
- Manual import sanity:
  ```python
  from cullis_sdk import CullisClient
  from cullis_sdk._client._guardian import _GuardianMixin
  from cullis_sdk._client._websocket import _WebSocketMixin
  assert issubclass(CullisClient, _GuardianMixin)
  assert issubclass(CullisClient, _WebSocketMixin)
  for m in ('_guardian_inspect', '_guardian_inspect_send',
            '_guardian_inspect_deliver', '_apply_guardian_deliver'):
      assert hasattr(CullisClient, m)
  # MRO: (CullisClient, _GuardianMixin, _WebSocketMixin, object)
  ```

## Test plan

- [x] Parallel pytest green for Guardian + all SDK code paths (modulo unrelated audit/postgres flakes documented above)
- [x] Sandbox smoke green
- [x] Guardian-specific test files (`test_sdk_guardian_phase3_send.py`, `test_sdk_guardian_phase3_deliver.py`) all pass
- [x] CullisClient MRO contains both `_GuardianMixin` and `_WebSocketMixin`
- [ ] `/security-review` (Daniele will run pre-merge)