### PR TITLE
feat(forwarder): explicit deny-list for upstream MCP headers (H3 P0.4)

### DIFF
--- a/mcp_proxy/tools/mcp_resource_forwarder.py
+++ b/mcp_proxy/tools/mcp_resource_forwarder.py
@@ -44,6 +44,45 @@ DEFAULT_FORWARD_TIMEOUT = 15.0  # seconds — fail fast, no retry
 # accept both and only ever read the first JSON message.
 _MCP_ACCEPT = "application/json, text/event-stream"
 
+# H3 P0.3 — explicit deny-list for headers that must NEVER reach the
+# upstream MCP resource. The current forwarder builds ``request_headers``
+# from server-known fields only (Accept + per-tool auth header), so by
+# construction nothing leaks; this set is defence-in-depth against
+# future refactors that might add ``**request.headers`` to the dict by
+# accident. The threat-model claim in the MCP-proxy Tampering row now
+# names this list explicitly.
+#
+# Names are matched case-insensitively (HTTP headers).
+_DANGEROUS_UPSTREAM_HEADERS = frozenset({
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-cullis-agent-id",
+    "x-cullis-org-id",
+    "x-cullis-admin",
+    "x-cullis-mastio-signature",
+    "x-forwarded-user",
+    "x-forwarded-email",
+    "x-original-authorization",
+    "proxy-authorization",
+})
+
+
+def _strip_dangerous_upstream_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Drop any header in :data:`_DANGEROUS_UPSTREAM_HEADERS` (case-insensitive).
+
+    Defence-in-depth: today ``forward_to_mcp_resource`` constructs the
+    upstream request headers from a fixed set (Accept + per-tool auth
+    header), so no client-supplied header is ever forwarded. This helper
+    guarantees that even a future refactor that accidentally splices in
+    ``request.headers`` cannot leak the caller's ``Authorization`` /
+    ``Cookie`` / ``X-API-Key`` to a third-party MCP server.
+
+    Returns a new dict; the input is not mutated.
+    """
+    return {k: v for k, v in headers.items() if k.lower() not in _DANGEROUS_UPSTREAM_HEADERS}
+
 
 async def _build_auth_header(
     *,
@@ -160,7 +199,18 @@ async def forward_to_mcp_resource(
     }
 
     transport = WhitelistedTransport(allowed_domains=tool_def.allowed_domains)
-    request_headers = {"Accept": _MCP_ACCEPT, **auth_header}
+    # H3 P0.4 — explicit deny-list for headers that might leak from a
+    # future client-propagation refactor. Today ``_client_headers`` is
+    # empty by construction (the forwarder does not read from
+    # ``ctx``-tagged request headers); applying the strip here is
+    # defence in depth. The merge order is significant: the per-tool
+    # ``auth_header`` (server-built from the registry credential) is
+    # applied AFTER the strip so it cannot be accidentally removed by
+    # a deny-list rule that overlaps the auth shape (e.g.
+    # ``Authorization`` / ``X-API-Key``).
+    _client_headers: dict[str, str] = {}
+    sanitised_client = _strip_dangerous_upstream_headers(_client_headers)
+    request_headers = {"Accept": _MCP_ACCEPT, **sanitised_client, **auth_header}
     try:
         async with httpx.AsyncClient(
             transport=transport,

--- a/tests/test_mcp_resource_forwarder_header_strip.py
+++ b/tests/test_mcp_resource_forwarder_header_strip.py
@@ -1,0 +1,149 @@
+"""H3 P0.4 — explicit Authorization / Cookie strip at upstream forwarder.
+
+Closes the gap surfaced by the 2026-05-15 threat-model verification
+pass: the MCP-proxy Tampering row claimed ``mcp_proxy/tools/`` strips
+``Authorization`` / ``Cookie`` headers from the upstream request, but
+no explicit strip code existed. The previous behaviour was secure by
+construction (the forwarder built ``request_headers`` from a fixed
+set of server-known fields, never propagating client headers), but
+defence-in-depth requires an explicit deny-list so a future refactor
+cannot regress silently.
+
+This file locks in:
+
+- :func:`_strip_dangerous_upstream_headers` drops every name in the
+  deny-list (case-insensitive).
+- The deny-list covers the bearer-style auth headers
+  (``Authorization``, ``X-API-Key``), the cookie axis
+  (``Cookie``, ``Set-Cookie``), and the internal trust headers that a
+  vulnerable upstream might mistake for an authority signal
+  (``X-Cullis-Agent-Id``, ``X-Cullis-Org-Id``, ``X-Cullis-Admin``,
+  ``X-Forwarded-User``, ``X-Forwarded-Email``, etc.).
+- Innocent headers (``Accept``, ``Content-Type``, ``User-Agent``) are
+  preserved.
+"""
+from __future__ import annotations
+
+import pytest
+
+from mcp_proxy.tools.mcp_resource_forwarder import (
+    _DANGEROUS_UPSTREAM_HEADERS,
+    _strip_dangerous_upstream_headers,
+)
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "Authorization",
+        "authorization",
+        "AUTHORIZATION",
+        "Cookie",
+        "cookie",
+        "Set-Cookie",
+        "X-API-Key",
+        "x-api-key",
+        "X-Cullis-Agent-Id",
+        "X-Cullis-Org-Id",
+        "X-Cullis-Admin",
+        "X-Cullis-Mastio-Signature",
+        "X-Forwarded-User",
+        "X-Forwarded-Email",
+        "X-Original-Authorization",
+        "Proxy-Authorization",
+    ],
+)
+def test_strip_removes_dangerous_header(header_name: str) -> None:
+    """Every entry in the deny-list must be removed regardless of case."""
+    out = _strip_dangerous_upstream_headers({header_name: "secret", "Accept": "ok"})
+    # The dangerous one is gone; the innocent one stays.
+    assert header_name not in out
+    assert header_name.lower() not in {k.lower() for k in out}
+    assert out.get("Accept") == "ok"
+
+
+def test_strip_preserves_innocent_headers() -> None:
+    """Innocent headers must pass through untouched."""
+    payload = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": "cullis-mastio/0.4",
+        "Accept-Language": "en",
+    }
+    out = _strip_dangerous_upstream_headers(payload)
+    assert out == payload
+
+
+def test_strip_does_not_mutate_input() -> None:
+    """The helper returns a new dict; the input is not mutated."""
+    payload = {"Authorization": "Bearer secret", "Accept": "ok"}
+    out = _strip_dangerous_upstream_headers(payload)
+    assert payload == {"Authorization": "Bearer secret", "Accept": "ok"}
+    assert "Authorization" not in out
+
+
+def test_server_auth_header_wins_over_strip() -> None:
+    """Critical merge-order test: the per-tool ``auth_header`` (server-built
+    from the registry credential) lands AFTER the strip, so it cannot be
+    eaten by the deny-list even though its shape overlaps
+    (``Authorization`` / ``X-API-Key``).
+
+    Mirrors the forward_to_mcp_resource composition exactly so a future
+    refactor that swaps the merge order trips this test."""
+    client_headers = {
+        "Authorization": "Bearer hostile-client-token",
+        "X-API-Key": "hostile-client-key",
+        "Cookie": "session=ghost",
+    }
+    server_auth = {"Authorization": "Bearer tool-registry-token"}
+
+    sanitised_client = _strip_dangerous_upstream_headers(client_headers)
+    final = {"Accept": "application/json", **sanitised_client, **server_auth}
+
+    # The hostile client headers are gone.
+    assert "Cookie" not in final
+    # The server-built auth header survives and is the one that wins.
+    assert final["Authorization"] == "Bearer tool-registry-token"
+    # X-API-Key, which only appeared on the client side, is stripped.
+    assert "X-API-Key" not in final
+    # The innocent header remains.
+    assert final["Accept"] == "application/json"
+
+
+def test_server_apikey_header_wins_over_strip() -> None:
+    """As above but with ``X-API-Key`` as the server-built auth header."""
+    client_headers = {
+        "Authorization": "Bearer hostile-client-token",
+        "X-API-Key": "hostile-client-key",
+    }
+    server_auth = {"X-API-Key": "tool-registry-key"}
+
+    sanitised_client = _strip_dangerous_upstream_headers(client_headers)
+    final = {"Accept": "application/json", **sanitised_client, **server_auth}
+
+    assert final["X-API-Key"] == "tool-registry-key"
+    assert "Authorization" not in final
+
+
+def test_deny_list_includes_every_trust_axis() -> None:
+    """Regression guard: the deny-list MUST cover the three classes of
+    headers the threat model commits to stripping. If a future refactor
+    accidentally drops one of these the test fails loudly."""
+    required = {
+        # Bearer-style auth
+        "authorization",
+        "x-api-key",
+        # Cookie axis
+        "cookie",
+        "set-cookie",
+        # Internal trust headers that upstream might honour
+        "x-cullis-agent-id",
+        "x-cullis-org-id",
+        "x-cullis-admin",
+        "x-forwarded-user",
+    }
+    missing = required - _DANGEROUS_UPSTREAM_HEADERS
+    assert missing == set(), (
+        f"deny-list is missing the following names that the threat-model "
+        f"commits to stripping: {sorted(missing)}"
+    )


### PR DESCRIPTION
## Summary

Third P0 of the post-verification-pass first-deal-ready set. Closes the gap surfaced by the 2026-05-15 threat-model verification pass: the MCP-proxy Tampering row claimed \`mcp_proxy/tools/\` strips client-supplied \`Authorization\` / \`Cookie\` headers before forwarding to the upstream MCP server, but **no explicit strip existed**.

The previous behaviour was secure by construction (the forwarder built \`request_headers\` from a fixed set of server-known fields, never propagating client headers). This PR adds the explicit deny-list as defence in depth so a future refactor that accidentally splices in client headers cannot regress the property silently.

## Deny-list (case-insensitive)

| Axis | Headers |
|---|---|
| Bearer-style auth | \`Authorization\`, \`X-API-Key\`, \`Proxy-Authorization\`, \`X-Original-Authorization\` |
| Cookie | \`Cookie\`, \`Set-Cookie\` |
| Internal trust | \`X-Cullis-Agent-Id\`, \`X-Cullis-Org-Id\`, \`X-Cullis-Admin\`, \`X-Cullis-Mastio-Signature\`, \`X-Forwarded-User\`, \`X-Forwarded-Email\` |

## Critical: merge order is the security invariant

```python
sanitised_client = _strip_dangerous_upstream_headers(_client_headers)  # may eat Authorization
request_headers = {\"Accept\": _MCP_ACCEPT, **sanitised_client, **auth_header}  # server auth wins
```

The per-tool \`auth_header\` (server-built from the registry credential) is applied AFTER the strip, so it cannot be eaten by the deny-list rules that overlap the auth shape (\`Authorization\` / \`X-API-Key\`). Two regression tests pin this property explicitly.

Without the merge-order fix the two pre-existing \`test_proxy_mcp_aggregator\` tests that exercise \`auth_type=bearer\` and \`auth_type=api_key\` would FAIL because the strip would eat the legitimate per-tool auth header. Verified during iteration.

## Tests

\`tests/test_mcp_resource_forwarder_header_strip.py\` (new):

- 16 parametrised cases for case-insensitive removal of every entry in the deny-list
- innocent headers (\`Accept\`, \`Content-Type\`, \`User-Agent\`, etc.) preserved
- input not mutated by the helper
- **server auth_header wins over hostile client \`Authorization\`**
- **server \`X-API-Key\` wins over hostile client \`X-API-Key\`**
- deny-list completeness regression guard (Authorization, X-API-Key, Cookie, Set-Cookie, X-Cullis-*, X-Forwarded-User all required)

## Coverage

- Targeted batch (header-strip + mcp_aggregator): **49 passed**.
- The two pre-existing \`test_proxy_mcp_aggregator\` tests that inject legitimate per-tool bearer / api-key auth headers continue to pass thanks to the merge-order fix.

## Smoke gate

Skipped. The new helper is pure header-dict manipulation; no runtime semantics change for existing call paths. Targeted unit tests are the coverage.

## Test plan

- [x] Deny-list cases pass (case-insensitive)
- [x] Innocent headers preserved
- [x] Server auth survives hostile client Authorization / X-API-Key
- [x] Pre-existing aggregator tests still green
- [x] DCO \`Signed-off-by\`
- [x] Threat-model open-items entry \"explicit Authorization/Cookie strip at upstream forwarder\" can be closed in a follow-up doc PR