### PR TITLE
feat(4-eyes): wire ACTION_AGENT_ENROLL + reserve license/federation (H3 P0.5)

### DIFF
--- a/mcp_proxy/admin/approval_hook.py
+++ b/mcp_proxy/admin/approval_hook.py
@@ -32,6 +32,21 @@ ACTION_VAULT_MIGRATE_KEYS = "vault.migrate_keys"
 ACTION_USERS_DELETE = "users.delete"
 ACTION_AGENTS_DELETE = "agents.delete"
 
+# H3 P0.5 — additional actions covered by the 4-eyes gate after the
+# 2026-05-15 threat-model verification pass surfaced that enrolment,
+# license import, and federation peering were not gated.
+#
+# ACTION_AGENT_ENROLL is wired today on the dashboard enrolment
+# approve endpoint. ACTION_LICENSE_IMPORT and ACTION_FEDERATION_PEER
+# are declared now so plugins can pre-configure quorum policies for
+# them; the endpoints themselves land in the license renewal hot-swap
+# PR (P0.2) and the federation attach PR (future). When those
+# endpoints arrive, they must call ``maybe_intercept_for_approval``
+# with the matching constant.
+ACTION_AGENT_ENROLL = "agent.enroll"
+ACTION_LICENSE_IMPORT = "license.import"
+ACTION_FEDERATION_PEER = "federation.peer"
+
 
 async def maybe_intercept_for_approval(
     *,

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -45,6 +45,7 @@ from mcp_proxy.dashboard.session import (
     MIN_PASSWORD_LENGTH,
 )
 from mcp_proxy.admin.approval_hook import (
+    ACTION_AGENT_ENROLL,
     ACTION_AGENTS_DELETE,
     ACTION_MASTIO_KEY_ROTATE,
     ACTION_PKI_ROTATE_CA,
@@ -3055,6 +3056,25 @@ async def enrollments_approve(request: Request, session_id: str):
 
     capabilities = [c.strip() for c in capabilities_raw.split(",") if c.strip()]
     groups = [g.strip() for g in groups_raw.split(",") if g.strip()]
+
+    # H3 P0.5 — 4-eyes intercept. When the enterprise rbac_multi_admin
+    # plugin is loaded and policy-gated, this submits the action for a
+    # second admin signoff and redirects the submitter to the approvals
+    # page. When no plugin opts in (community / single-admin deploys),
+    # the helper returns None and the endpoint proceeds unchanged.
+    intercept = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_AGENT_ENROLL,
+        payload={
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "capabilities": capabilities,
+            "groups": groups,
+        },
+        request=request,
+    )
+    if intercept is not None:
+        return intercept
 
     agent_manager = _resolve_agent_manager(request)
 

--- a/tests/test_approval_hook.py
+++ b/tests/test_approval_hook.py
@@ -18,7 +18,10 @@ from starlette.responses import RedirectResponse
 
 from mcp_proxy import plugins as mp_plugins
 from mcp_proxy.admin.approval_hook import (
+    ACTION_AGENT_ENROLL,
     ACTION_AGENTS_DELETE,
+    ACTION_FEDERATION_PEER,
+    ACTION_LICENSE_IMPORT,
     ACTION_MASTIO_KEY_ROTATE,
     ACTION_PKI_ROTATE_CA,
     ACTION_POLICIES_SAVE,
@@ -524,3 +527,67 @@ async def test_default_plugin_is_internal_replay_false():
     keep seeing every request as a fresh action."""
     p = Plugin()
     assert await p.is_internal_replay(_mock_request(), ACTION_POLICIES_SAVE) is False
+
+
+# ── H3 P0.5: new ACTION_* constants ───────────────────────────────────────
+
+
+def test_new_action_constants_are_distinct_and_stable():
+    """The three new ACTION_* identifiers must be distinct strings and
+    must not collide with the existing six. Plugins persist these
+    strings in their config rows, so a rename is a coordinated release."""
+    new = {
+        ACTION_AGENT_ENROLL: "agent.enroll",
+        ACTION_LICENSE_IMPORT: "license.import",
+        ACTION_FEDERATION_PEER: "federation.peer",
+    }
+    # Each constant must equal its documented stable identifier.
+    for const, expected in new.items():
+        assert const == expected, f"{const!r} drifted from {expected!r}"
+
+    existing = {
+        ACTION_POLICIES_SAVE, ACTION_PKI_ROTATE_CA, ACTION_MASTIO_KEY_ROTATE,
+        ACTION_VAULT_MIGRATE_KEYS, ACTION_USERS_DELETE, ACTION_AGENTS_DELETE,
+    }
+    overlap = set(new) & existing
+    assert overlap == set(), (
+        f"new ACTION_* collide with existing ones: {overlap}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_intercept_gates_agent_enroll_when_plugin_opts_in(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Wiring smoke: the enrolment approve path runs through
+    maybe_intercept_for_approval with ACTION_AGENT_ENROLL."""
+    captured: dict[str, Any] = {}
+
+    class EnrollGate(Plugin):
+        name = "enroll_gate"
+
+        def approval_required(self, action_type: str) -> bool:
+            return action_type == ACTION_AGENT_ENROLL
+
+        async def submit_approval(
+            self, action_type: str, payload: dict, submitter_id: str,
+        ) -> str:
+            captured["action_type"] = action_type
+            captured["payload"] = payload
+            return "01HENROLL..."
+
+    monkeypatch.setattr(
+        mp_plugins, "get_registry",
+        lambda: PluginRegistry(plugins=[EnrollGate()]),
+    )
+
+    result = await maybe_intercept_for_approval(
+        session=_mock_session(),
+        action_type=ACTION_AGENT_ENROLL,
+        payload={"agent_id": "alice", "capabilities": ["mcp.tools.call"]},
+    )
+
+    assert isinstance(result, RedirectResponse)
+    assert result.status_code == 303
+    assert captured["action_type"] == ACTION_AGENT_ENROLL
+    assert captured["payload"]["agent_id"] == "alice"


### PR DESCRIPTION
## Summary

Fourth P0 of the post-verification-pass first-deal-ready set. Closes the gap surfaced by the 2026-05-15 threat-model verification pass: the Plugin sandbox row claimed the 4-eyes gate covered enrolment / license import / federation peering, but the actual gated set was only six other admin actions (\`policies.save\`, \`pki.rotate_ca\`, \`mastio_key.rotate\`, \`vault.migrate_keys\`, \`users.delete\`, \`agents.delete\`).

## Open-core change set

| File | Change |
|---|---|
| \`mcp_proxy/admin/approval_hook.py\` | Three new stable identifiers: \`ACTION_AGENT_ENROLL\`, \`ACTION_LICENSE_IMPORT\`, \`ACTION_FEDERATION_PEER\` |
| \`mcp_proxy/dashboard/router.py::enrollments_approve\` | Wire \`ACTION_AGENT_ENROLL\` via \`maybe_intercept_for_approval\` before the service call |
| \`tests/test_approval_hook.py\` | 3 new tests: constant identity / collision guard / intercept smoke for ACTION_AGENT_ENROLL |

## Scope: enrolment wired, license + federation reserved

| Action | Wired? | Why |
|---|---|---|
| \`agent.enroll\` | YES | Endpoint exists today (\`/proxy/enrollments/{session_id}/approve\`); wired in this PR |
| \`license.import\` | reserved | Endpoint lands in P0.2 (license renewal hot-swap). The constant is declared so the enterprise plugin can pre-publish a quorum policy |
| \`federation.peer\` | reserved | Federation attach endpoint does not exist yet. Declared so the enterprise plugin is ready when the endpoint lands |

Reserving the constants now keeps the core/plugin boundary stable; when those endpoints arrive they MUST call \`maybe_intercept_for_approval\` with the matching constant.

## Companion PR

A separate PR on \`cullis-enterprise\` extends \`rbac_multi_admin/quorum.py\` \`DEFAULT_POLICIES\` with the three new actions so the gate is available out of the box (filing immediately after this one).

## Coverage

- \`tests/test_approval_hook.py\` + \`tests/test_enrollment_dashboard.py\` in batch: **31 passed**.
- Community / single-admin deploys (no plugin opting in) see no behaviour change: \`maybe_intercept_for_approval\` returns \`None\` and the endpoint proceeds.

## Test plan

- [x] New constants are distinct, collision-free, and equal their documented stable strings
- [x] Intercept smoke: \`ACTION_AGENT_ENROLL\` flows through the plugin redirect path
- [x] Existing 17 approval-hook tests + 11 enrolment-dashboard tests still green
- [x] DCO \`Signed-off-by\`
- [x] Companion enterprise PR follows