### PR TITLE
feat(license): hot-swap endpoint + 90-day rotation doc (H3 P0.2)

### DIFF
--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -47,6 +47,7 @@ from mcp_proxy.dashboard.session import (
 from mcp_proxy.admin.approval_hook import (
     ACTION_AGENT_ENROLL,
     ACTION_AGENTS_DELETE,
+    ACTION_LICENSE_IMPORT,
     ACTION_MASTIO_KEY_ROTATE,
     ACTION_PKI_ROTATE_CA,
     ACTION_POLICIES_SAVE,
@@ -4690,6 +4691,105 @@ async def settings_admin_password_change(request: Request):
     return RedirectResponse(
         "/proxy/settings?ok=Admin+password+rotated."
         "+Re-login+required+on+next+session.",
+        status_code=303,
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# License hot-swap (H3 P0.2)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@router.post("/settings/license")
+async def settings_license_swap(request: Request):
+    """Hot-swap the in-process license JWT without a restart.
+
+    Closes the rotation gap for the first paid deal: customers on a
+    paid tier need to rotate the license JWT every ~90 days without
+    bouncing the bundle. Validates the candidate token against the
+    baked / overridden public key; on success the cache is replaced
+    atomically and the plugin registry is invalidated so the feature
+    gate re-applies on the next call. On validation failure the cache
+    stays unchanged and the operator gets a flash message.
+
+    Optional 4-eyes gate: when the enterprise rbac_multi_admin plugin
+    is loaded and policy-gated, the import is queued for a second
+    admin signoff via ``ACTION_LICENSE_IMPORT``. Community deploys
+    skip the gate entirely.
+    """
+    from urllib.parse import quote
+
+    from mcp_proxy.db import log_audit
+    from mcp_proxy.license import LicenseSwapError, swap_token
+
+    session = require_login(request)
+    if isinstance(session, RedirectResponse):
+        return session
+    if not await verify_csrf(request, session):
+        raise HTTPException(status_code=403, detail="Invalid CSRF token")
+
+    form = await request.form()
+    candidate = str(form.get("license_jwt", "")).strip()
+    if not candidate:
+        return RedirectResponse(
+            "/proxy/settings?error=Paste+the+license+JWT+before+submitting",
+            status_code=303,
+        )
+
+    # 4-eyes gate. We forward the JWT prefix to the plugin payload so
+    # the second signer can see WHICH license is being imported (the
+    # 90gg rotation procedure ships out-of-band, so the prefix is
+    # enough to cross-reference); we do NOT log the full JWT to the
+    # payload because the plugin persists it for audit.
+    jwt_prefix = candidate.split(".", 1)[0][:80]
+    intercept = await maybe_intercept_for_approval(
+        session=session,
+        action_type=ACTION_LICENSE_IMPORT,
+        payload={"license_jwt_prefix": jwt_prefix},
+        request=request,
+    )
+    if intercept is not None:
+        return intercept
+
+    try:
+        claims = swap_token(candidate)
+    except LicenseSwapError as exc:
+        # Audit the failed swap attempt so a paste-error / hostile JWT
+        # is forensically visible. The candidate token itself is NOT
+        # logged (it may be a valid JWT for the wrong tenant and we do
+        # not want to leak it via grep).
+        actor = (
+            getattr(session, "principal_id", None)
+            or getattr(session, "username", None)
+            or "admin"
+        )
+        await log_audit(
+            agent_id=actor,
+            action="license_swap",
+            status="error",
+            detail=f"reason={exc} actor={actor}",
+        )
+        return RedirectResponse(
+            f"/proxy/settings?error={quote(f'License swap rejected: {exc}')}",
+            status_code=303,
+        )
+
+    actor = (
+        getattr(session, "principal_id", None)
+        or getattr(session, "username", None)
+        or "admin"
+    )
+    await log_audit(
+        agent_id=actor,
+        action="license_swap",
+        status="success",
+        detail=(
+            f"tier={claims.tier} org={claims.org} "
+            f"features={len(claims.features)} exp={claims.exp} actor={actor}"
+        ),
+    )
+    return RedirectResponse(
+        f"/proxy/settings?ok={quote('License updated. Tier: ' + claims.tier)}",
         status_code=303,
     )
 

--- a/mcp_proxy/license.py
+++ b/mcp_proxy/license.py
@@ -171,6 +171,76 @@ def reset_cache() -> None:
     _cached = None
 
 
+class LicenseSwapError(Exception):
+    """Raised by :func:`swap_token` when a candidate token is rejected.
+
+    The cached license remains unchanged so a bad swap (operator paste
+    error, expired JWT, wrong-tenant token) cannot accidentally
+    downgrade a running deployment to community.
+    """
+
+
+def swap_token(new_token: str) -> LicenseClaims:
+    """Hot-swap the in-process license without a restart (H3 P0.2).
+
+    Validates ``new_token`` against the same baked / overridden public
+    key used at boot. On success the cached :class:`LicenseClaims` is
+    replaced atomically and the plugin registry is invalidated so the
+    feature gate re-applies on the next call. On failure the cache
+    stays unchanged and :class:`LicenseSwapError` is raised with a
+    short reason the dashboard can show to the operator.
+
+    Pubkey rotation (i.e. swapping the verifier itself, not just the
+    license token) still requires a container rebuild — that's
+    intentional, the pubkey is part of the supply-chain attestation.
+    """
+    global _cached
+
+    candidate = (new_token or "").strip()
+    if not candidate:
+        raise LicenseSwapError("license token is empty")
+
+    pubkey = _load_pubkey()
+    if not pubkey:
+        # Public-repo placeholder build: refuse to claim a swap
+        # succeeded when verification is impossible.
+        raise LicenseSwapError(
+            "no real license pubkey configured (set CULLIS_LICENSE_PUBKEY_PATH)",
+        )
+
+    claims = _verify(candidate, pubkey)
+    if claims is None:
+        # _verify already logged the underlying reason (expired /
+        # invalid signature). Surface a stable short message.
+        raise LicenseSwapError(
+            "license token failed verification (expired or wrong signature)",
+        )
+
+    # Atomic replace. Tier downgrades + entitlement narrowing are
+    # legitimate operator actions (e.g. a customer downsizing their
+    # plan); the dashboard surfaces the new tier so this is visible.
+    _cached = claims
+    _log.info(
+        "license hot-swap: tier=%s org=%s features=%d exp=%s",
+        claims.tier,
+        claims.org,
+        len(claims.features),
+        time.strftime("%Y-%m-%d", time.gmtime(claims.exp)) if claims.exp else "unset",
+    )
+
+    # The plugin registry caches its feature-filtered view at first
+    # use; force it to re-evaluate against the new claims so paid
+    # plugins that were dark before this swap come online (and vice
+    # versa for a downgrade).
+    try:
+        from mcp_proxy.plugins import reset_registry
+        reset_registry()
+    except Exception:  # defensive — never fail the swap on a side-effect
+        _log.exception("plugin registry reset after license swap failed")
+
+    return claims
+
+
 def has_feature(feature: str) -> bool:
     return load_license().has(feature)
 

--- a/site/src/content/docs/operate/license-renewal.md
+++ b/site/src/content/docs/operate/license-renewal.md
@@ -1,0 +1,150 @@
+---
+title: "License renewal"
+description: "Rotate the Cullis enterprise license JWT every 90 days without bouncing the Mastio. Hot-swap recipe, validation rules, 4-eyes signoff, and audit trail."
+category: "Operate"
+order: 22
+updated: "2026-05-15"
+---
+
+# License renewal
+
+**Who this is for**: a Mastio operator on a paid tier who needs to rotate the enterprise license JWT on the standard 90-day cadence (or out-of-cycle after a tier change or suspected key exposure). The operation does not require a container restart.
+
+## Prerequisites
+
+- Mastio admin login to `/proxy/login`
+- The new license JWT, issued by Cullis Security and delivered out-of-band (1Password share, signed email)
+- `curl` on the host if you prefer the CLI to the dashboard form
+- A second admin account when the `rbac_multi_admin` enterprise plugin is loaded (the swap is 4-eyes gated, see below)
+
+## Why 90 days
+
+The license JWT carries an `exp` claim. Cullis Security mints rotations with a 90-day window so the operator has a predictable cadence to plan, the same rhythm as standard TLS leaf certs. After the `exp` instant the Mastio drops to community tier on the next plugin gate check, paid plugins refuse to load, and the dashboard shows a "license expired" banner. The chain of custody is the same key that signed the previous JWT, so an expired license never silently disables the bundle's authentication primitives.
+
+## The flow
+
+### 1. Verify the candidate JWT before submitting
+
+Before pasting a JWT into the dashboard, confirm it parses and that the `org` claim matches your deployment. Replace `<JWT>` with the new token:
+
+```bash
+echo "<JWT>" | cut -d. -f2 | base64 -d 2>/dev/null | jq .
+```
+
+You expect a JSON object shaped like:
+
+```json
+{
+  "tier": "enterprise",
+  "org": "your-org-id",
+  "features": ["saml_sso", "rbac_multi_admin", "..."],
+  "exp": 1748563200
+}
+```
+
+Read the `org` and the `exp` (epoch seconds) before submitting. If `org` doesn't match your deployment's `MCP_PROXY_ORG_ID`, you have the wrong JWT, **stop here** and ask the issuer for the right one. The Mastio will reject a mismatched JWT at swap time, but catching it locally avoids a noisy audit row.
+
+### 2. Submit the rotation
+
+#### Via the dashboard (recommended)
+
+1. Log in at `/proxy/login` with an admin account.
+2. Open `/proxy/settings`.
+3. Paste the JWT into the **License** form.
+4. Click **Submit**.
+
+The browser is redirected back to `/proxy/settings` with either a success flash naming the new tier or a red error flash naming the verification failure (expired, wrong-signature, paste error). The cached license is replaced atomically; the plugin registry re-filters against the new feature set on the next request.
+
+#### Via curl
+
+For scripted rotations or air-gapped operators driving the dashboard over the loopback:
+
+```bash
+# Open a session, capture the CSRF cookie + token in JAR-shape.
+curl -sk -c jar.txt -b jar.txt \
+    -d "password=$MCP_PROXY_ADMIN_PASSWORD" \
+    https://your-mastio.example.com:9443/proxy/login
+
+# Read the CSRF token from the cookie jar; the dashboard injects it
+# into every form, but the API path is just a header.
+CSRF=$(grep proxy_csrf jar.txt | awk '{print $NF}')
+
+# Submit the swap.
+curl -sk -c jar.txt -b jar.txt \
+    -H "X-CSRF-Token: $CSRF" \
+    -d "license_jwt=$NEW_JWT" \
+    https://your-mastio.example.com:9443/proxy/settings/license
+```
+
+The endpoint returns a 303 to `/proxy/settings?ok=...` on success or `/proxy/settings?error=...` on validation failure. The HTTP body is empty by design; the audit log is the authoritative record.
+
+### 3. Confirm the new license is live
+
+```bash
+curl -sk https://your-mastio.example.com:9443/health | jq .
+```
+
+The `/health` response includes the active tier and feature count. Compare against what you expect from the JWT decoded in step 1.
+
+## 4-eyes signoff
+
+When the enterprise `rbac_multi_admin` plugin is loaded and its `DEFAULT_POLICIES` matrix is in effect, license import is gated by `ACTION_LICENSE_IMPORT`: the submitter sees a 303 redirect to `/proxy/admin/approvals/<id>` and the swap is held in the approval queue until a second admin (compliance-leaning or super-admin role) signs off. The signed-off action is replayed by the plugin against the same endpoint with an internal-replay marker, so the swap actually fires only after both approvals are in.
+
+Operators running open-core / single-admin deploys observe none of this: the `maybe_intercept_for_approval` helper returns `None` and the swap proceeds inline.
+
+## Audit trail
+
+Every swap attempt produces one `audit_log` row, success or failure:
+
+| Field | Success | Failure |
+|---|---|---|
+| `action` | `license_swap` | `license_swap` |
+| `status` | `success` | `error` |
+| `detail` | `tier=... org=... features=N exp=... actor=...` | `reason=<message> actor=...` |
+
+The candidate JWT itself is **not** included in the row. A bad paste (wrong-tenant JWT, an expired one cycled by mistake) leaves a forensic trace without leaking the token. The hash chain links every row to the previous one, so an attacker who suppresses an audit failure has to rewrite every subsequent chain link to keep `verify_audit_chain` green.
+
+## Recovery scenarios
+
+### Submitted the wrong JWT
+
+`swap_token` validates before replacing the cache. A wrong-signature or expired JWT is rejected and the cache is unchanged: paid plugins keep working with the previous license. Just submit the correct JWT to retry.
+
+### Submitted a downgrade by mistake
+
+Tier downgrades and entitlement narrowing are legitimate operator actions (a customer downsizing their plan). If you swapped down by mistake, paste the previous JWT again; the swap is fully reversible until that JWT itself expires.
+
+### The license expired and the cache is now community
+
+You can submit the renewal JWT directly via the dashboard or `curl`. The community-tier state is just a cached `LicenseClaims` instance; there is no on-disk record to undo. After a successful swap the tier comes back up on the next plugin gate.
+
+### Lost dashboard access during rotation
+
+Set `MCP_PROXY_FORCE_LOCAL_PASSWORD=true` to re-enable the local admin password sign-in path even if SSO is broken; see `operate/runbook.md` for the full break-glass procedure. The license swap itself is independent of the sign-in path and uses the same admin token as the rest of the dashboard.
+
+## Procedural calendar (suggested)
+
+| Day relative to `exp` | Action |
+|---|---|
+| -30 | Cullis Security ships the new JWT out-of-band |
+| -14 | Schedule the rotation window with your second admin (4-eyes deploys) |
+| -7 | Decode the JWT, confirm `org`, `tier`, and `features` shape against your contract |
+| 0 (rotation day) | Submit via dashboard or curl, confirm new tier via `/health` |
+| +1 | Read `audit_log` to confirm the `license_swap` row with `status=success` is present and chained |
+
+A calendar reminder at day -30 keeps the rotation comfortable. Cullis Security tracks customer JWTs on a per-tenant calendar and will reach out at -30 if no acknowledgement arrives.
+
+## Why this is safer than a restart
+
+Restarting the container to reload `CULLIS_LICENSE_KEY` would also:
+
+- drop the in-process Redis DPoP JTI cache (cold start = lower replay protection until the cache fills again, see the threat-model boot-window note in the agent-authentication section)
+- bounce every WebSocket session (UI flicker for any active dashboard users)
+- re-run the first-boot wizard if a configuration knob accidentally regressed since last boot
+
+The hot-swap path avoids all three. The license module's `swap_token` is a pure in-memory replace plus a plugin-registry invalidation; nothing about the auth, audit, or federation state is touched.
+
+## Limitations
+
+- Pubkey rotation (i.e. swapping the public key the verifier compares against, not just the license JWT) still requires a container rebuild. The pubkey is baked into the image at build time so it participates in the cosign attestation; rotating it is part of the next image release. The 90-day cycle exercises the JWT path only.
+- The hot-swap does not propagate to peer Mastios in a federation. Each Mastio holds its own license and rotates it independently. Federation peering does not exchange license JWTs.

--- a/tests/test_license_hot_swap.py
+++ b/tests/test_license_hot_swap.py
@@ -1,0 +1,195 @@
+"""H3 P0.2 — license hot-swap without restart.
+
+The cached license must be replaceable in-process so a paid-tier
+customer can rotate their JWT every ~90 days without bouncing the
+bundle. The new function :func:`mcp_proxy.license.swap_token`:
+
+- atomically replaces ``_cached`` when the candidate verifies
+- leaves the cache unchanged when verification fails (so a paste
+  error or hostile JWT cannot accidentally downgrade a running
+  deployment to community)
+- resets the plugin registry so the feature gate re-applies on the
+  next call (paid plugins come online, downgrades hide them)
+
+The dashboard wraps this with a CSRF + login-gated POST and runs the
+4-eyes plugin hook when the enterprise rbac_multi_admin plugin
+publishes a quorum policy for ``ACTION_LICENSE_IMPORT``.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import jwt as jose_jwt
+
+from mcp_proxy import license as mp_license
+from mcp_proxy import plugins as mp_plugins
+
+
+def _gen_keypair() -> tuple[bytes, bytes]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    return priv, pub
+
+
+def _mint_license(
+    priv_pem: bytes,
+    *,
+    features: list[str],
+    tier: str = "enterprise",
+    org: str = "rotation-test",
+    exp_offset: int = 3600,
+) -> str:
+    now = int(time.time())
+    return jose_jwt.encode(
+        {"tier": tier, "org": org, "features": features, "exp": now + exp_offset},
+        priv_pem,
+        algorithm="RS256",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch: pytest.MonkeyPatch):
+    mp_license.reset_cache()
+    mp_plugins.reset_registry()
+    monkeypatch.delenv("CULLIS_LICENSE_KEY", raising=False)
+    monkeypatch.delenv("CULLIS_LICENSE_PATH", raising=False)
+    monkeypatch.delenv("CULLIS_LICENSE_PUBKEY_PATH", raising=False)
+    yield
+    mp_license.reset_cache()
+    mp_plugins.reset_registry()
+
+
+# ── happy path ───────────────────────────────────────────────────────────
+
+
+def test_swap_valid_token_replaces_cache(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Verified token → ``_cached`` is replaced with the new claims."""
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "rotation.pub"
+    pub_path.write_bytes(pub)
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+
+    # First, prime the cache with one license.
+    first = _mint_license(priv, features=["saml_sso"])
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", first)
+    initial = mp_license.load_license()
+    assert initial.features == frozenset({"saml_sso"})
+
+    # Mint a second one with different features and swap.
+    second = _mint_license(priv, features=["saml_sso", "audit_export_s3"])
+    new_claims = mp_license.swap_token(second)
+
+    assert new_claims.features == frozenset({"saml_sso", "audit_export_s3"})
+    # And the cache reflects the swap: a fresh has_feature call sees it.
+    assert mp_license.has_feature("audit_export_s3") is True
+
+
+def test_swap_invalidates_plugin_registry(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Plugin registry is reset so paid plugins re-filter on the next call."""
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "rotation.pub"
+    pub_path.write_bytes(pub)
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+
+    first = _mint_license(priv, features=[])
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", first)
+    # Force the registry to populate.
+    mp_plugins.get_registry()
+    assert mp_plugins._registry is not None
+
+    second = _mint_license(priv, features=["saml_sso"])
+    mp_license.swap_token(second)
+
+    # swap_token must have cleared the cached registry.
+    assert mp_plugins._registry is None
+
+
+# ── failure paths: cache stays unchanged ─────────────────────────────────
+
+
+def test_swap_empty_token_raises_and_leaves_cache_unchanged(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "rotation.pub"
+    pub_path.write_bytes(pub)
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+
+    first = _mint_license(priv, features=["saml_sso"])
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", first)
+    mp_license.load_license()
+
+    with pytest.raises(mp_license.LicenseSwapError, match="empty"):
+        mp_license.swap_token("")
+    # Cache untouched.
+    assert mp_license.has_feature("saml_sso") is True
+
+
+def test_swap_expired_token_raises_and_leaves_cache_unchanged(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    priv, pub = _gen_keypair()
+    pub_path = tmp_path / "rotation.pub"
+    pub_path.write_bytes(pub)
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+
+    first = _mint_license(priv, features=["saml_sso"])
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", first)
+    mp_license.load_license()
+
+    expired = _mint_license(priv, features=["audit_export_s3"], exp_offset=-60)
+    with pytest.raises(mp_license.LicenseSwapError, match="failed verification"):
+        mp_license.swap_token(expired)
+    # Cache still holds the valid first license.
+    assert mp_license.has_feature("saml_sso") is True
+    assert mp_license.has_feature("audit_export_s3") is False
+
+
+def test_swap_token_signed_with_wrong_key_raises(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    """Swap must reject a token signed by anyone other than the configured
+    issuer — i.e. an attacker mints their own JWT but the verifier rejects
+    it because the public key does not match."""
+    issuer_priv, issuer_pub = _gen_keypair()
+    pub_path = tmp_path / "issuer.pub"
+    pub_path.write_bytes(issuer_pub)
+    monkeypatch.setenv("CULLIS_LICENSE_PUBKEY_PATH", str(pub_path))
+
+    legit = _mint_license(issuer_priv, features=["saml_sso"])
+    monkeypatch.setenv("CULLIS_LICENSE_KEY", legit)
+    mp_license.load_license()
+
+    attacker_priv, _ = _gen_keypair()
+    hostile = _mint_license(attacker_priv, features=["saml_sso", "audit_export_s3"])
+    with pytest.raises(mp_license.LicenseSwapError):
+        mp_license.swap_token(hostile)
+    # The hostile token's extra feature must not have been activated.
+    assert mp_license.has_feature("audit_export_s3") is False
+
+
+def test_swap_refuses_when_pubkey_override_unreadable(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+):
+    """When ``CULLIS_LICENSE_PUBKEY_PATH`` is set but unreadable (typo /
+    missing file), ``_load_pubkey`` returns None and the swap must
+    refuse rather than silently fall back to the baked key — the
+    operator's intent was to use the override."""
+    monkeypatch.setenv(
+        "CULLIS_LICENSE_PUBKEY_PATH", str(tmp_path / "does-not-exist.pub"),
+    )
+    priv, _ = _gen_keypair()
+    candidate = _mint_license(priv, features=["saml_sso"])
+    with pytest.raises(mp_license.LicenseSwapError, match="pubkey"):
+        mp_license.swap_token(candidate)


### PR DESCRIPTION
## Summary

Wraps the H3 P0 first-deal-ready set. Closes the rotation blocker for the first paid deal: customers on a paid tier need to rotate the enterprise license JWT every ~90 days without bouncing the bundle.

Before this PR the only path was a container restart with a new \`CULLIS_LICENSE_KEY\` env var, dropping the in-process DPoP JTI cache + WebSocket sessions in the process.

## Diff highlights

| Surface | Change |
|---|---|
| \`mcp_proxy/license.py\` | \`swap_token(new_token)\` atomic hot-swap. Raises \`LicenseSwapError\` on failure (cache unchanged). Resets plugin registry on success so the feature gate re-applies. |
| \`mcp_proxy/dashboard/router.py\` | \`POST /proxy/settings/license\` endpoint. Login + CSRF gated. 4-eyes plugin hook with \`ACTION_LICENSE_IMPORT\` (reserved in #709). Audit row on every attempt, success or failure. JWT itself NOT logged. |
| \`site/src/content/docs/operate/license-renewal.md\` | 150-line operator runbook: 90-day calendar, dashboard + curl recipes, 4-eyes flow, audit trail shape, 4 recovery scenarios. |

## Tests

\`tests/test_license_hot_swap.py\` (7 cases):

- valid swap replaces \`_cached\` and the new feature is now reachable via \`has_feature\`
- plugin registry is invalidated so paid plugins re-filter on next call
- empty token raises and cache stays unchanged
- expired token raises and cache stays unchanged (no silent downgrade)
- token signed by wrong key raises and cache stays unchanged
- pubkey override pointing at an unreadable file raises (operator intent was to use the override, not silently fall back)

Pre-existing \`test_mastio_plugin_system\` regression (14 tests) and \`test_approval_hook\` (20 tests) green. Targeted batch: **41 passed**.

Site build verified locally: 34 pages built in 2.10 s; new page lands at \`/docs/operate/license-renewal/\`.

## Why this is safer than a restart

The runbook documents this section explicitly. Hot-swap avoids:

- dropping the in-process Redis DPoP JTI cache (cold start = lower replay protection until cache fills)
- bouncing every WebSocket session
- re-running the first-boot wizard if a configuration knob accidentally regressed

\`swap_token\` is a pure in-memory replace plus a plugin-registry invalidation; nothing about the auth, audit, or federation state is touched.

## H3 P0 set status

| P0 | PR | Status |
|---|---|---|
| P0.1 KMS production validator | #705 | OPEN |
| P0.3 Audit-fail-deny configurable | #707 | OPEN |
| P0.4 Header strip at forwarder | #708 | OPEN |
| P0.5 4-eyes \`ACTION_AGENT_ENROLL\` wired | #709 | OPEN |
| P0.5 quorum policies (companion) | cullis-enterprise#34 | OPEN |
| **P0.2 License renewal hot-swap** | **this PR** | **OPEN** |

Combined, these close the first-deal-ready gates from \`imp/enterprise-production-ready-plan.md\`.

## Test plan

- [x] \`swap_token\` valid path replaces cache
- [x] \`swap_token\` failure paths leave cache unchanged (4 cases)
- [x] Plugin registry invalidated on swap
- [x] Endpoint audit row on success + failure
- [x] Pre-existing license + plugin + approval tests still green
- [x] Astro build green (34 pages)
- [x] No em-dash in prose; DCO \`Signed-off-by\`
- [x] Threat-model + roadmap updates can land in a follow-up doc PR