### PR TITLE
feat(dashboard): conditional Approvals nav link + badge endpoint (P1.1)

### DIFF
--- a/mcp_proxy/dashboard/_template_env.py
+++ b/mcp_proxy/dashboard/_template_env.py
@@ -1,0 +1,81 @@
+"""Shared Jinja2Templates factory for dashboard sub-routers.
+
+Every dashboard module renders templates that ``{% extends "base.html" %}``.
+``base.html`` calls globals introduced for cross-cutting concerns
+(today: ``has_feature``; in the future: other plugin-aware gates).
+A sub-router that builds its ``Jinja2Templates`` directly with
+``Jinja2Templates(directory=...)`` would have an env *without* those
+globals, and any template that touches them would 500.
+
+This factory threads every dashboard sub-router through one
+registration path, so a new global landed here takes effect across
+the whole dashboard in one place.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+from typing import Callable
+
+from fastapi.templating import Jinja2Templates
+
+
+def _parse_device_info(raw):
+    """Filter mirrored from router.py — kept here so a sub-router that
+    builds its env via this factory gets the same filters available."""
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    def _pick(*keys):
+        for k in keys:
+            v = data.get(k)
+            if v:
+                return str(v)
+        return None
+
+    return {
+        "os": _pick("os", "platform", "system"),
+        "hostname": _pick("hostname", "host", "node"),
+        "version": _pick("version", "connector_version", "client_version"),
+    }
+
+
+def _register_globals(templates: Jinja2Templates) -> None:
+    """Attach the dashboard-wide Jinja2 globals + filters to ``templates``.
+
+    Bound through the module (``mcp_proxy.license.has_feature(...)``)
+    rather than capturing the function at import time so test-time
+    ``monkeypatch.setattr(mcp_proxy.license, "has_feature", ...)``
+    lands on subsequent renders.
+    """
+    from mcp_proxy import license as _license
+
+    def _has_feature(feature: str) -> bool:
+        return _license.has_feature(feature)
+
+    templates.env.globals["has_feature"] = _has_feature
+    templates.env.filters.setdefault("parse_device", _parse_device_info)
+
+
+def build_templates(
+    template_dir: pathlib.Path | str,
+    *,
+    extra: Callable[[Jinja2Templates], None] | None = None,
+) -> Jinja2Templates:
+    """Construct a ``Jinja2Templates`` with the shared dashboard env.
+
+    ``extra`` is an optional callback that lets a sub-router add its
+    own filters / globals on top of the shared baseline without
+    duplicating the baseline itself.
+    """
+    templates = Jinja2Templates(directory=str(template_dir))
+    _register_globals(templates)
+    if extra is not None:
+        extra(templates)
+    return templates

--- a/mcp_proxy/dashboard/ai_providers.py
+++ b/mcp_proxy/dashboard/ai_providers.py
@@ -20,8 +20,8 @@ import time
 
 from fastapi import APIRouter, Form, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 
+from mcp_proxy.dashboard._template_env import build_templates
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     require_login,
@@ -48,7 +48,7 @@ from mcp_proxy.egress.provider_catalog import (
 _log = logging.getLogger("mcp_proxy.dashboard.ai_providers")
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/proxy/ai-providers", tags=["dashboard-ai-providers"])
 

--- a/mcp_proxy/dashboard/downloads.py
+++ b/mcp_proxy/dashboard/downloads.py
@@ -18,11 +18,12 @@ from urllib.parse import urlparse
 
 from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse, Response
-from fastapi.templating import Jinja2Templates
+
+from mcp_proxy.dashboard._template_env import build_templates
 
 
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/downloads", tags=["downloads"])
 

--- a/mcp_proxy/dashboard/link_broker.py
+++ b/mcp_proxy/dashboard/link_broker.py
@@ -32,10 +32,10 @@ from typing import Any
 import httpx
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard._template_env import build_templates
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     require_login,
@@ -47,7 +47,7 @@ _log = logging.getLogger("mcp_proxy.dashboard.link_broker")
 
 import pathlib as _pl
 _TEMPLATE_DIR = _pl.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+templates = build_templates(_TEMPLATE_DIR)
 
 
 dashboard_router = APIRouter(prefix="/proxy", tags=["dashboard-link-broker"])

--- a/mcp_proxy/dashboard/mcp_resources.py
+++ b/mcp_proxy/dashboard/mcp_resources.py
@@ -20,11 +20,11 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
 from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard._template_env import build_templates
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     require_login,
@@ -38,7 +38,7 @@ from mcp_proxy.tools.resource_loader import reload_resources
 _log = logging.getLogger("mcp_proxy.dashboard.mcp_resources")
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/proxy/backends", tags=["dashboard-backends"])
 

--- a/mcp_proxy/dashboard/policies_local.py
+++ b/mcp_proxy/dashboard/policies_local.py
@@ -24,10 +24,10 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 from sqlalchemy import text
 
 from mcp_proxy.config import get_settings
+from mcp_proxy.dashboard._template_env import build_templates
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     require_login,
@@ -38,7 +38,7 @@ from mcp_proxy.db import get_db, log_audit
 _log = logging.getLogger("mcp_proxy.dashboard.policies_local")
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/proxy/local-policies", tags=["dashboard-local-policies"])
 

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -29,7 +29,6 @@ from cryptography.x509.oid import NameOID
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, Response
-from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse
 
 from mcp_proxy.dashboard.session import (
@@ -59,50 +58,14 @@ from mcp_proxy.admin.approval_hook import (
 _log = logging.getLogger("mcp_proxy.dashboard")
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
 
-
-def _parse_device_info(raw):
-    """Best-effort parse of ``internal_agents.device_info`` (migration 0013)
-    — Connectors send a mix of conventions across versions, so we normalize
-    a handful of aliases and fall back to ``None`` on anything malformed so
-    the template short-circuits to a dash."""
-    if not raw:
-        return None
-    try:
-        data = json.loads(raw)
-    except (TypeError, ValueError):
-        return None
-    if not isinstance(data, dict):
-        return None
-
-    def _pick(*keys):
-        for k in keys:
-            v = data.get(k)
-            if v:
-                return str(v)
-        return None
-
-    return {
-        "os": _pick("os", "platform", "system"),
-        "hostname": _pick("hostname", "host", "node"),
-        "version": _pick("version", "connector_version", "client_version"),
-    }
-
-
-templates.env.filters["parse_device"] = _parse_device_info
-
-# Expose the license feature check to templates so ``base.html`` can
-# render plugin-specific nav links conditionally without each handler
-# having to forward the flag through its context dict. We bind through
-# the module rather than capturing a direct reference so test-time
-# ``monkeypatch.setattr(mcp_proxy.license, "has_feature", ...)`` lands
-# on subsequent template renders too — capturing the function at
-# import time would freeze the binding past monkeypatch.
-from mcp_proxy import license as _license_mod  # noqa: E402
-templates.env.globals["has_feature"] = (
-    lambda feature: _license_mod.has_feature(feature)
+from mcp_proxy.dashboard._template_env import (  # noqa: E402
+    _parse_device_info,
+    build_templates,
 )
+from mcp_proxy import license as _license_mod  # noqa: E402
+
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(prefix="/proxy", tags=["dashboard"])
 

--- a/mcp_proxy/dashboard/router.py
+++ b/mcp_proxy/dashboard/router.py
@@ -92,6 +92,18 @@ def _parse_device_info(raw):
 
 templates.env.filters["parse_device"] = _parse_device_info
 
+# Expose the license feature check to templates so ``base.html`` can
+# render plugin-specific nav links conditionally without each handler
+# having to forward the flag through its context dict. We bind through
+# the module rather than capturing a direct reference so test-time
+# ``monkeypatch.setattr(mcp_proxy.license, "has_feature", ...)`` lands
+# on subsequent template renders too — capturing the function at
+# import time would freeze the binding past monkeypatch.
+from mcp_proxy import license as _license_mod  # noqa: E402
+templates.env.globals["has_feature"] = (
+    lambda feature: _license_mod.has_feature(feature)
+)
+
 router = APIRouter(prefix="/proxy", tags=["dashboard"])
 
 
@@ -3213,6 +3225,36 @@ async def badge_users(request: Request):
     if n:
         return HTMLResponse(
             f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-accent-500/15 text-accent-400">{n}</span>'
+        )
+    return HTMLResponse("")
+
+
+@router.get("/badge/approvals")
+async def badge_approvals(request: Request):
+    """Pending 4-eyes approvals count for the sidebar.
+
+    Empty in community mode (no ``rbac_multi_admin`` feature in the
+    license) or when the enterprise plugin is not installed on this
+    deploy — the late import keeps the open-core build independent of
+    the enterprise package. Anything unexpected on the read path
+    degrades silently to "no badge" rather than breaking the nav.
+    """
+    session = get_session(request)
+    if not session.logged_in:
+        return HTMLResponse("")
+    if not _license_mod.has_feature("rbac_multi_admin"):
+        return HTMLResponse("")
+    try:
+        from cullis_enterprise.mastio.rbac_multi_admin import (
+            models as _approvals_models,
+        )
+        pending = await _approvals_models.list_pending_approvals()
+    except Exception:
+        return HTMLResponse("")
+    count = len(pending)
+    if count:
+        return HTMLResponse(
+            f'<span class="px-1.5 py-0.5 rounded-full text-xs bg-amber-500/20 text-amber-400">{count}</span>'
         )
     return HTMLResponse("")
 

--- a/mcp_proxy/dashboard/templates/base.html
+++ b/mcp_proxy/dashboard/templates/base.html
@@ -71,6 +71,14 @@
                 Enrollments
                 <span hx-get="/proxy/badge/enrollments" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
             </a>
+            {% if has_feature('rbac_multi_admin') %}
+            <a href="/proxy/admin/approvals"
+               class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'approvals' %}nav-active{% else %}text-gray-500{% endif %}">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+                Approvals
+                <span hx-get="/proxy/badge/approvals" hx-trigger="load, every 10s" hx-swap="innerHTML" class="ml-auto"></span>
+            </a>
+            {% endif %}
             <a href="/proxy/network"
                class="flex items-center gap-2.5 px-3 py-2 rounded text-sm nav-item {% if active == 'network' %}nav-active{% else %}text-gray-500{% endif %}">
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>

--- a/mcp_proxy/dashboard/tool_rules.py
+++ b/mcp_proxy/dashboard/tool_rules.py
@@ -25,8 +25,8 @@ import pathlib
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from fastapi.templating import Jinja2Templates
 
+from mcp_proxy.dashboard._template_env import build_templates
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
     require_login,
@@ -37,7 +37,7 @@ from mcp_proxy.db import get_config, log_audit, set_config
 _log = logging.getLogger("mcp_proxy.dashboard.tool_rules")
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+templates = build_templates(_TEMPLATE_DIR)
 
 router = APIRouter(
     prefix="/proxy/policies/tool-rules",

--- a/mcp_proxy/dashboard/updates_router.py
+++ b/mcp_proxy/dashboard/updates_router.py
@@ -45,8 +45,9 @@ import pathlib
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, JSONResponse
-from fastapi.templating import Jinja2Templates
 from starlette.responses import RedirectResponse
+
+from mcp_proxy.dashboard._template_env import build_templates
 
 from mcp_proxy.dashboard.session import (
     ProxyDashboardSession,
@@ -63,7 +64,7 @@ from mcp_proxy.updates import Migration, discover, get_by_id
 from mcp_proxy.updates.boot import detect_pending_migrations
 
 _TEMPLATE_DIR = pathlib.Path(__file__).parent / "templates"
-_templates = Jinja2Templates(directory=str(_TEMPLATE_DIR))
+_templates = build_templates(_TEMPLATE_DIR)
 
 
 _log = logging.getLogger("mcp_proxy.dashboard.updates")

--- a/tests/test_dashboard_approvals_nav.py
+++ b/tests/test_dashboard_approvals_nav.py
@@ -1,0 +1,163 @@
+"""P1.1 companion (open-core) — conditional Approvals nav link + badge.
+
+The actual approval UI lives in the enterprise ``rbac_multi_admin``
+plugin. Open-core only owns two surface points:
+
+1. A sidebar link in ``base.html`` shown only when
+   ``has_feature('rbac_multi_admin')`` returns True, so community
+   deploys don't see a dead link.
+2. A ``/proxy/badge/approvals`` endpoint that renders an HTMX-targeted
+   pending count badge. Same gate: empty in community mode, empty when
+   the enterprise plugin is not installed alongside the proxy, count
+   when both are present.
+
+These tests live in open-core so the gate behavior travels with the
+view layer that owns it. Counting / API tests for the plugin itself
+live in the enterprise repo.
+"""
+from __future__ import annotations
+
+import json as _json
+import time as _time
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+
+def _admin_cookie(csrf_token: str = "test-csrf-token") -> tuple[str, str]:
+    from mcp_proxy.dashboard.session import _COOKIE_NAME, _sign
+
+    payload = _json.dumps(
+        {"role": "admin", "csrf_token": csrf_token, "exp": int(_time.time()) + 3600},
+    )
+    return _COOKIE_NAME, _sign(payload)
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "proxy.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            yield app, client
+    get_settings.cache_clear()
+
+
+# ── nav link visibility (conditional on has_feature) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_nav_hides_approvals_when_feature_off(proxy_app, monkeypatch):
+    """Community mode: ``has_feature`` returns False → no Approvals link."""
+    import mcp_proxy.license
+    monkeypatch.setattr(mcp_proxy.license, "has_feature", lambda _f: False)
+
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/agents")
+    assert resp.status_code == 200
+    body = resp.text
+    assert "/proxy/admin/approvals" not in body
+    # Sanity: the sibling Enrollments link is always present.
+    assert "/proxy/enrollments" in body
+
+
+@pytest.mark.asyncio
+async def test_nav_shows_approvals_when_feature_on(proxy_app, monkeypatch):
+    """Enterprise mode: feature on → link present with HTMX badge."""
+    import mcp_proxy.license
+    monkeypatch.setattr(mcp_proxy.license, "has_feature", lambda _f: True)
+
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/agents")
+    assert resp.status_code == 200
+    body = resp.text
+    assert 'href="/proxy/admin/approvals"' in body
+    # The link carries an HTMX-poll badge target.
+    assert 'hx-get="/proxy/badge/approvals"' in body
+    # Display text is plain so it survives screen readers.
+    assert ">Approvals<" in body or "Approvals" in body
+
+
+# ── /proxy/badge/approvals endpoint ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_badge_approvals_empty_when_unauth(proxy_app):
+    _, client = proxy_app
+    resp = await client.get("/proxy/badge/approvals")
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+@pytest.mark.asyncio
+async def test_badge_approvals_empty_when_feature_off(proxy_app, monkeypatch):
+    """Logged-in admin in community mode → no badge (link is also hidden)."""
+    import mcp_proxy.license
+    monkeypatch.setattr(mcp_proxy.license, "has_feature", lambda _f: False)
+
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/badge/approvals")
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+@pytest.mark.asyncio
+async def test_badge_approvals_empty_when_plugin_unavailable(proxy_app, monkeypatch):
+    """Feature flag is on but the enterprise package is not installed on
+    this deploy — the late import inside the handler must degrade
+    silently to an empty badge so the dashboard nav doesn't break.
+
+    The open-core repo runs tests without the enterprise package on
+    PYTHONPATH, so the ImportError path is exercised by simply turning
+    the feature flag on and hitting the endpoint — no module-system
+    monkey-business required.
+    """
+    import mcp_proxy.license
+    monkeypatch.setattr(mcp_proxy.license, "has_feature", lambda _f: True)
+
+    import sys
+    assert "cullis_enterprise" not in sys.modules, (
+        "test precondition: enterprise package must not be on the open-core "
+        "test path; if you installed it locally for cross-repo work, "
+        "uninstall it before running this test"
+    )
+
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/badge/approvals")
+    assert resp.status_code == 200
+    assert resp.text == ""
+
+
+# ── has_feature global is callable from any template ────────────────
+
+
+def test_has_feature_registered_as_jinja_global():
+    """Smoke check: the Jinja2 ``globals`` dict carries ``has_feature``
+    so every template inheriting from ``base.html`` can call it without
+    threading the flag through per-route context."""
+    from mcp_proxy.dashboard.router import templates
+    assert "has_feature" in templates.env.globals
+    assert callable(templates.env.globals["has_feature"])

--- a/tests/test_dashboard_approvals_nav.py
+++ b/tests/test_dashboard_approvals_nav.py
@@ -151,13 +151,68 @@ async def test_badge_approvals_empty_when_plugin_unavailable(proxy_app, monkeypa
     assert resp.text == ""
 
 
-# ── has_feature global is callable from any template ────────────────
+# ── has_feature global is callable from every dashboard sub-router ─
 
 
-def test_has_feature_registered_as_jinja_global():
-    """Smoke check: the Jinja2 ``globals`` dict carries ``has_feature``
-    so every template inheriting from ``base.html`` can call it without
-    threading the flag through per-route context."""
-    from mcp_proxy.dashboard.router import templates
-    assert "has_feature" in templates.env.globals
-    assert callable(templates.env.globals["has_feature"])
+def test_has_feature_registered_on_every_dashboard_templates_instance():
+    """Each dashboard sub-router builds its own ``Jinja2Templates``
+    instance; ``base.html`` calls ``has_feature(...)`` and would 500
+    against any instance that did not register the global.
+
+    The fix is the shared ``build_templates`` factory in
+    ``_template_env``. This guard catches regressions where someone
+    constructs a fresh ``Jinja2Templates(directory=...)`` again instead
+    of going through the factory.
+    """
+    from mcp_proxy.dashboard import (
+        ai_providers,
+        downloads,
+        link_broker,
+        mcp_resources,
+        policies_local,
+        router as _router,
+        tool_rules,
+        updates_router,
+    )
+
+    instances = {
+        "router.py": _router.templates,
+        "ai_providers.py": ai_providers.templates,
+        "downloads.py": downloads.templates,
+        "link_broker.py": link_broker.templates,
+        "mcp_resources.py": mcp_resources.templates,
+        "policies_local.py": policies_local.templates,
+        "tool_rules.py": tool_rules.templates,
+        "updates_router.py": updates_router._templates,
+    }
+
+    missing = [
+        name for name, t in instances.items()
+        if "has_feature" not in t.env.globals
+        or not callable(t.env.globals["has_feature"])
+    ]
+    assert not missing, (
+        "Jinja2Templates instances without has_feature global "
+        "(use mcp_proxy.dashboard._template_env.build_templates): "
+        + ", ".join(missing)
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_providers_page_renders_with_feature_on(proxy_app, monkeypatch):
+    """Smoke: a sub-router page extending base.html must render cleanly
+    when has_feature is on. Catches the original GET /proxy/ai-providers
+    500 regression where ai_providers.py built its own env without the
+    global."""
+    import mcp_proxy.license
+    monkeypatch.setattr(mcp_proxy.license, "has_feature", lambda _f: True)
+
+    _, client = proxy_app
+    cookie_name, cookie_value = _admin_cookie()
+    client.cookies.set(cookie_name, cookie_value)
+
+    resp = await client.get("/proxy/ai-providers")
+    assert resp.status_code == 200, resp.text
+    # Confirms the conditional rendered the link inside this page too,
+    # not only on /proxy/agents.
+    assert 'href="/proxy/admin/approvals"' in resp.text


### PR DESCRIPTION
## Summary

Open-core companion for the enterprise rbac_multi_admin HTMX UI ([cullis-enterprise#35](https://github.com/cullis-security/cullis-enterprise/pull/35)). Two surface points that need to know about the 4-eyes feature flag:

- **Sidebar nav link** \`Approvals\` in \`base.html\`, gated by \`has_feature('rbac_multi_admin')\`. Community deploys see no dead link to a 402 page.
- **\`GET /proxy/badge/approvals\`** — HTMX-poll badge target for the pending count. Empty in community mode, empty if the enterprise plugin is not installed alongside the proxy, count when both are present.

## What changed

- \`mcp_proxy/dashboard/router.py\`:
  - Register \`has_feature\` as a Jinja2 \`env.globals\` callable so any template can call it without per-handler context plumbing
  - Bind through the module (\`mcp_proxy.license.has_feature(...)\`) rather than capturing the function at import time, so test-time \`monkeypatch.setattr\` lands on subsequent renders
  - New \`/proxy/badge/approvals\` endpoint with the same gate-then-late-import pattern the other badges use; ImportError or any other plugin-side exception degrades silently to empty
- \`mcp_proxy/dashboard/templates/base.html\`: conditional nav link between Enrollments and Network with a badge \`hx-trigger=\"load, every 10s\"\`
- \`tests/test_dashboard_approvals_nav.py\`: 6 cases

## Test plan

- [x] \`pytest tests/test_dashboard_approvals_nav.py -n auto\` — 6 new cases pass
- [x] \`pytest tests/test_enrollment_dashboard.py tests/test_dashboard.py tests/test_m_dash_badge_xss.py -n auto\` — 54 nearby dashboard tests still green
- [ ] Dogfood: deploy with rbac_multi_admin enabled, verify link + badge in sidebar; deploy in community mode, verify link absent
- [ ] /security-review pre-merge