### PR TITLE
feat(registry): index cert_thumbprint on agents and user_principals (P1.4)

### DIFF
--- a/alembic/versions/t0o1p2q3r4s5_idx_thumbprint.py
+++ b/alembic/versions/t0o1p2q3r4s5_idx_thumbprint.py
@@ -1,0 +1,50 @@
+"""P1.4 — index cert_thumbprint on agents and user_principals.
+
+Revision ID: t0o1p2q3r4s5_idx_thumb
+Revises: s9n0o1p2q3r4_replica
+Create Date: 2026-05-15 12:30:00.000000
+
+Both registry tables carry a SHA-256 ``cert_thumbprint`` column used
+on the cert-rotation, revocation and TOFU-pin paths to find the row
+that owns a presented certificate. Until now the lookup was a full
+scan (the column was unindexed). A signed BTREE keeps the cost flat
+as the agent / user roster grows and shrinks the latency tail on
+cert verification — important once a deploy reaches ~10k+ identities.
+
+NULL is allowed (column is nullable: the cert is only attached after
+the CSR roundtrip), so NULL rows do not participate in the index.
+Non-unique because rotation transiently keeps two rows pointing at
+the same thumbprint during cutover; a UNIQUE constraint would
+spuriously reject the rotation write.
+"""
+from alembic import op
+
+
+revision = "t0o1p2q3r4s5_idx_thumb"
+down_revision = "s9n0o1p2q3r4_replica"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_agents_cert_thumbprint",
+        "agents",
+        ["cert_thumbprint"],
+    )
+    op.create_index(
+        "idx_user_principals_cert_thumbprint",
+        "user_principals",
+        ["cert_thumbprint"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_user_principals_cert_thumbprint",
+        table_name="user_principals",
+    )
+    op.drop_index(
+        "idx_agents_cert_thumbprint",
+        table_name="agents",
+    )

--- a/app/registry/store.py
+++ b/app/registry/store.py
@@ -9,7 +9,7 @@ from fnmatch import fnmatch
 from datetime import datetime, timezone
 from cryptography import x509
 from cryptography.hazmat.primitives.serialization import Encoding
-from sqlalchemy import Column, String, Boolean, DateTime, Text, select
+from sqlalchemy import Column, String, Boolean, DateTime, Index, Text, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.database import Base
@@ -26,6 +26,14 @@ def _verify_secret(plain: str, hashed: str) -> bool:
 
 class AgentRecord(Base):
     __tablename__ = "agents"
+    __table_args__ = (
+        # cert_thumbprint lookup powers cert-rotation, revocation and
+        # TOFU-pin verification; without an index every one of those
+        # paths does a full table scan. Non-unique because rotation can
+        # transiently keep two rows pointing at the same thumbprint.
+        # Mirrored in alembic/versions/t0o1p2q3r4s5_idx_thumbprint.py.
+        Index("idx_agents_cert_thumbprint", "cert_thumbprint"),
+    )
 
     agent_id = Column(String(256), primary_key=True, index=True)
     org_id = Column(String(128), nullable=False, index=True)

--- a/app/registry/user_principals.py
+++ b/app/registry/user_principals.py
@@ -59,6 +59,13 @@ class UserPrincipalRecord(Base):
             "idx_user_principals_lookup",
             "org_id", "sso_subject",
         ),
+        # cert_thumbprint lookup powers cert-rotation, revocation and
+        # TOFU-pin verification; mirrored in
+        # alembic/versions/t0o1p2q3r4s5_idx_thumbprint.py.
+        Index(
+            "idx_user_principals_cert_thumbprint",
+            "cert_thumbprint",
+        ),
     )
 
     principal_id     = Column(String(255), primary_key=True)

--- a/tests/test_cert_thumbprint_index.py
+++ b/tests/test_cert_thumbprint_index.py
@@ -1,0 +1,140 @@
+"""P1.4 — cert_thumbprint indices on ``agents`` and ``user_principals``.
+
+Both lookups (cert rotation, revocation check, TOFU pin verification)
+hit the column directly and have always done a full table scan. The
+indices are declared two places:
+
+* SQLAlchemy ``__table_args__`` so ``Base.metadata.create_all`` paths
+  (notably the test fixtures and the dev-mode bootstrap) get them.
+* Alembic ``t0o1p2q3r4s5_idx_thumbprint`` so production deploys that
+  go through the migration chain get them.
+
+This test asserts both code paths end up with the same index name on
+the same column.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import sysconfig
+import tempfile
+
+import pytest
+from sqlalchemy import inspect
+
+
+# ── Path A: ORM create_all (what test fixtures use) ────────────────
+
+
+@pytest.mark.asyncio
+async def test_orm_create_all_emits_thumbprint_index():
+    """The model-level Index entries must show up after create_all so
+    test fixtures that never run Alembic still cover queries that
+    rely on the index plan."""
+    from tests.conftest import test_engine
+
+    async with test_engine.begin() as conn:
+        agents_idx = await conn.run_sync(
+            lambda sc: {i["name"] for i in inspect(sc).get_indexes("agents")},
+        )
+        principals_idx = await conn.run_sync(
+            lambda sc: {
+                i["name"] for i in inspect(sc).get_indexes("user_principals")
+            },
+        )
+    assert "idx_agents_cert_thumbprint" in agents_idx, agents_idx
+    assert (
+        "idx_user_principals_cert_thumbprint" in principals_idx
+    ), principals_idx
+
+
+# ── Path B: Alembic chain (what prod deploys use) ──────────────────
+
+
+@pytest.mark.skipif(
+    os.environ.get("CI_SKIP_ALEMBIC_SUBPROCESS") == "1",
+    reason="alembic subprocess test disabled by env",
+)
+def test_alembic_upgrade_creates_thumbprint_indices():
+    """Run the full Alembic chain end-to-end on a fresh sqlite file and
+    verify both indices exist after ``upgrade head`` and disappear
+    after ``downgrade -1``. Catches typos in the migration file
+    (revision id, down_revision, index name) that the ORM path would
+    silently mask."""
+    import sqlite3
+
+    db_path = tempfile.NamedTemporaryFile(suffix=".sqlite", delete=False)
+    db_path.close()
+    url = f"sqlite+aiosqlite:///{db_path.name}"
+
+    env = dict(os.environ)
+    env["ADMIN_SECRET"] = "alembic-subprocess-test"
+    env["DATABASE_URL"] = url
+
+    cwd = _repo_root()
+    cmd = _alembic_cmd()
+    r = subprocess.run(
+        cmd + ["upgrade", "head"],
+        capture_output=True, text=True, env=env, cwd=cwd,
+    )
+    assert r.returncode == 0, (
+        f"alembic upgrade head failed: stderr={r.stderr[-1500:]}"
+    )
+
+    con = sqlite3.connect(db_path.name)
+    try:
+        rows = con.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND name LIKE '%cert_thumbprint%'"
+        ).fetchall()
+        names = {r[0] for r in rows}
+        assert "idx_agents_cert_thumbprint" in names, names
+        assert "idx_user_principals_cert_thumbprint" in names, names
+    finally:
+        con.close()
+
+    r = subprocess.run(
+        cmd + ["downgrade", "-1"],
+        capture_output=True, text=True, env=env, cwd=cwd,
+    )
+    assert r.returncode == 0, (
+        f"alembic downgrade -1 failed: stderr={r.stderr[-1500:]}"
+    )
+
+    con = sqlite3.connect(db_path.name)
+    try:
+        rows = con.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='index' AND name LIKE '%cert_thumbprint%'"
+        ).fetchall()
+        assert not rows, rows
+    finally:
+        con.close()
+
+
+def _repo_root() -> str:
+    """Find the repo root by walking up from this file until alembic.ini
+    sits next to us. Robust against being invoked from any cwd."""
+    import pathlib
+    here = pathlib.Path(__file__).resolve().parent
+    for candidate in [here, *here.parents]:
+        if (candidate / "alembic.ini").exists():
+            return str(candidate)
+    raise RuntimeError("alembic.ini not found from tests/ upwards")
+
+
+def _alembic_cmd() -> list[str]:
+    """Resolve the alembic invocation in the active environment.
+
+    ``sysconfig`` points at the interpreter's own scripts directory
+    (more portable than hard-coding ``.venv/bin/alembic`` or trusting
+    ``$PATH``). When the entry-point is missing we fall back to
+    ``python -m alembic``, which is always reachable as long as the
+    package is installed.
+    """
+    scripts = sysconfig.get_path("scripts")
+    cand = os.path.join(scripts, "alembic")
+    if os.path.exists(cand):
+        return [cand]
+    return [sys.executable, "-m", "alembic"]


### PR DESCRIPTION
## Summary

\`cert_thumbprint\` is the lookup key on three hot paths (cert rotation, revocation check, TOFU-pin verification). Both registry tables left the column unindexed since the initial schema → full table scan every time. Two non-unique BTREE indices close the gap.

## What changed

- \`alembic/versions/t0o1p2q3r4s5_idx_thumbprint.py\` — new migration, idempotent up/down/up
- \`app/registry/store.py\` — \`Index(\"idx_agents_cert_thumbprint\", \"cert_thumbprint\")\` in \`AgentRecord.__table_args__\`
- \`app/registry/user_principals.py\` — same on \`UserPrincipalRecord\`
- \`tests/test_cert_thumbprint_index.py\` — 2 cases: ORM \`create_all\` path + Alembic subprocess chain

## Why non-unique

Rotation transiently keeps two rows pointing at the same thumbprint during cutover; a UNIQUE constraint would reject the rotation write. NULL participates as expected on BTREE so in-flight CSR rows (\`cert_thumbprint NULL\`) stay out of the index without ceremony.

## Test plan

- [x] \`pytest tests/test_cert_thumbprint_index.py -n0\` — 2 verdi
- [x] Alembic round-trip on sqlite: \`upgrade head\` → indices present → \`downgrade -1\` → indices gone → \`upgrade head\` → indices back
- [x] \`pytest tests/test_audit_export_tsa.py tests/test_audit_race_safety.py -n0\` — 9 verdi serialmente (parallel run had xdist flakes unrelated to this PR)
- [ ] \`./demo_network/smoke.sh full\` pre-merge (alembic touched)
- [ ] /security-review pre-merge

## P1 roadmap

P1.4 from \`imp/enterprise-production-ready-plan.md\`. Quick-win 30min before P1.2 (DPoP jkt audit denorm) and P1.3 (X-Cullis-* header strip middleware).