### PR TITLE
feat(audit): denormalize DPoP jkt into audit_log row (P1.2)

### DIFF
--- a/mcp_proxy/alembic/versions/0033_audit_dpop_jkt.py
+++ b/mcp_proxy/alembic/versions/0033_audit_dpop_jkt.py
@@ -1,0 +1,77 @@
+"""P1.2 — denormalize DPoP jkt into ``audit_log``.
+
+Revision ID: 0033_audit_dpop_jkt
+Revises: 0032_ai_creds_at_rest_enc
+Create Date: 2026-05-15 13:30:00.000000
+
+``audit_log.dpop_jkt`` carries the JWK thumbprint of the DPoP key
+that authenticated the request that produced the row. Today the same
+identity bits live in the egress / request log only and a forensic
+query has to JOIN against a different table by ``request_id``; the
+forensic gap closes once the thumbprint lives next to the action.
+
+Schema:
+
+  * ``dpop_jkt`` nullable so calls without a DPoP-bound auth context
+    (boot-time housekeeping, system actions, pre-rollout rows) keep
+    inserting cleanly.
+  * Indexed for the typical forensic query ("show me every action
+    signed by this key") so the lookup stays flat as the log grows.
+
+Not included in the audit hash chain. The chain locks the
+authoritative action fields (timestamp, agent_id, action, status,
+detail, request_id, …); ``dpop_jkt`` is auxiliary correlation
+metadata, derivable from the authenticated principal at write time,
+not a fact about the action itself. Including it would re-anchor
+every pre-rollout row's hash and force a chain rewrite, which is
+neither cheap nor risk-free for an append-only ledger. The
+``compute_audit_row_hash`` invariant therefore stays untouched.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0033_audit_dpop_jkt"
+down_revision = "0032_ai_creds_at_rest_enc"
+branch_labels = None
+depends_on = None
+
+
+def _has_column(table: str, column: str) -> bool:
+    """Defensive check so re-running the migration on a partially
+    upgraded schema (alembic stamp / manual SQL recovery) is a no-op
+    rather than a duplicate-column error."""
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return column in {c["name"] for c in insp.get_columns(table)}
+
+
+def _has_index(table: str, index: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return index in {i["name"] for i in insp.get_indexes(table)}
+
+
+def upgrade() -> None:
+    if not _has_column("audit_log", "dpop_jkt"):
+        with op.batch_alter_table("audit_log") as batch_op:
+            # 64 hex chars = SHA-256 thumbprint (RFC 7638). nullable
+            # because plenty of audit rows have no DPoP context.
+            batch_op.add_column(
+                sa.Column("dpop_jkt", sa.String(length=64), nullable=True),
+            )
+
+    if not _has_index("audit_log", "idx_audit_log_dpop_jkt"):
+        op.create_index(
+            "idx_audit_log_dpop_jkt",
+            "audit_log",
+            ["dpop_jkt"],
+        )
+
+
+def downgrade() -> None:
+    if _has_index("audit_log", "idx_audit_log_dpop_jkt"):
+        op.drop_index("idx_audit_log_dpop_jkt", table_name="audit_log")
+    if _has_column("audit_log", "dpop_jkt"):
+        with op.batch_alter_table("audit_log") as batch_op:
+            batch_op.drop_column("dpop_jkt")

--- a/mcp_proxy/auth/dependencies.py
+++ b/mcp_proxy/auth/dependencies.py
@@ -110,5 +110,13 @@ async def _get_authenticated_agent_dpop(request: Request) -> TokenPayload:
             headers={"WWW-Authenticate": _DPOP_WWW_AUTH},
         )
 
+    # P1.2 — stamp the verified jkt into the per-request contextvar so
+    # log_audit() picks it up downstream without threading the value
+    # through every call site. Stamp only on the success path: a 401
+    # before this point must not correlate the audit row to a
+    # thumbprint the verifier just rejected.
+    from mcp_proxy.auth.dpop_context import set_dpop_jkt
+    set_dpop_jkt(jkt)
+
     _log.debug("Authenticated agent: %s (org=%s)", payload.agent_id, payload.org)
     return payload

--- a/mcp_proxy/auth/dpop_context.py
+++ b/mcp_proxy/auth/dpop_context.py
@@ -1,0 +1,51 @@
+"""Per-request DPoP key thumbprint context (P1.2).
+
+The auth dependencies that verify a DPoP proof already compute the
+proof key's JWK thumbprint (``jkt``); the audit writer downstream
+needs the same value to populate ``audit_log.dpop_jkt`` without
+threading it through every call site. A :class:`ContextVar` is the
+cleanest fit:
+
+* set once per request by the auth dep (``verify_token`` and the
+  local-agent flow);
+* read by :func:`mcp_proxy.db.log_audit` as a default when the
+  caller doesn't pass it explicitly;
+* automatically scoped to the request task in asyncio.
+
+Set via :func:`set_dpop_jkt` and read via :func:`current_dpop_jkt`.
+Tests can reset between cases with :func:`reset_dpop_jkt`.
+
+The auth deps that ``raise`` after computing the jkt (e.g. the
+proof key did not match the token binding) intentionally do NOT
+stamp the contextvar — we don't want the audit row for the 401 to
+correlate to a thumbprint that the verifier just rejected. Only
+successful DPoP verifications stamp.
+"""
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+
+
+_dpop_jkt: ContextVar[str | None] = ContextVar("cullis_dpop_jkt", default=None)
+
+
+def set_dpop_jkt(jkt: str | None) -> Token[str | None]:
+    """Stamp the current request's DPoP JWK thumbprint.
+
+    Returns the ``Token`` so the caller can ``reset_dpop_jkt(token)``
+    in a ``finally`` block when needed (most call sites don't, since
+    the contextvar is naturally scoped to the request task).
+    """
+    return _dpop_jkt.set(jkt)
+
+
+def current_dpop_jkt() -> str | None:
+    """Read the JWK thumbprint stamped for the current request, or
+    ``None`` if no DPoP-bound auth dep ran on this task."""
+    return _dpop_jkt.get()
+
+
+def reset_dpop_jkt(token: Token[str | None]) -> None:
+    """Restore the contextvar to its previous value. Test-only;
+    request-task contextvars normally don't need explicit reset."""
+    _dpop_jkt.reset(token)

--- a/mcp_proxy/auth/local_agent_dep.py
+++ b/mcp_proxy/auth/local_agent_dep.py
@@ -129,6 +129,12 @@ async def _enforce_local_token_dpop_binding(
             headers={"WWW-Authenticate": 'DPoP realm="mcp-proxy"'},
         )
 
+    # P1.2 — stamp the verified jkt into the per-request contextvar.
+    # log_audit() reads it as a fallback so the row that records this
+    # request links to the DPoP key without per-callsite plumbing.
+    from mcp_proxy.auth.dpop_context import set_dpop_jkt
+    set_dpop_jkt(proof_jkt)
+
 
 async def _is_known_local_kid(token: str, keystore) -> bool:
     """Pre-check: the token's ``kid`` matches a keystore row that is

--- a/mcp_proxy/db.py
+++ b/mcp_proxy/db.py
@@ -358,6 +358,7 @@ async def log_audit(
     details: Mapping[str, Any] | None = None,
     request_id: str | None = None,
     duration_ms: float | None = None,
+    dpop_jkt: str | None = None,
 ) -> None:
     """Insert an immutable, hash-chained audit log entry.
 
@@ -382,6 +383,15 @@ async def log_audit(
             dict(details), separators=(",", ":"), sort_keys=True, default=str,
         )
 
+    # P1.2 — fall back to the per-request contextvar stamped by the
+    # DPoP auth deps so DPoP-bound paths populate the column without
+    # threading the value through every caller. The kwarg still wins
+    # when an explicit value is passed (audit replays / system tasks
+    # that want to assert a non-default jkt).
+    if dpop_jkt is None:
+        from mcp_proxy.auth.dpop_context import current_dpop_jkt
+        dpop_jkt = current_dpop_jkt()
+
     ts = datetime.now(timezone.utc).isoformat()
     async with _audit_chain_lock:
         for _attempt in range(_AUDIT_CHAIN_MAX_RETRIES):
@@ -405,11 +415,11 @@ async def log_audit(
                             """INSERT INTO audit_log (
                                    timestamp, agent_id, action, tool_name,
                                    status, detail, request_id, duration_ms,
-                                   chain_seq, prev_hash, row_hash
+                                   chain_seq, prev_hash, row_hash, dpop_jkt
                                ) VALUES (
                                    :timestamp, :agent_id, :action, :tool_name,
                                    :status, :detail, :request_id, :duration_ms,
-                                   :chain_seq, :prev_hash, :row_hash
+                                   :chain_seq, :prev_hash, :row_hash, :dpop_jkt
                                )"""
                         ),
                         {
@@ -424,6 +434,7 @@ async def log_audit(
                             "chain_seq": chain_seq,
                             "prev_hash": prev_hash,
                             "row_hash": row_hash,
+                            "dpop_jkt": dpop_jkt,
                         },
                     )
                     return

--- a/tests/test_audit_dpop_jkt.py
+++ b/tests/test_audit_dpop_jkt.py
@@ -1,0 +1,214 @@
+"""P1.2 — DPoP jkt denormalized into ``audit_log``.
+
+Two ways the column gets populated:
+
+* explicit kwarg ``log_audit(..., dpop_jkt=<value>)`` — for callers
+  that want to assert a specific thumbprint (audit replay, system
+  tasks that synthesise a row from an out-of-band source).
+* per-request contextvar set by the DPoP auth deps — the common path
+  for live traffic, no per-callsite plumbing required.
+
+These tests pin both. The forensic correlation column must never
+participate in the hash chain (chain rewrites are dangerous on an
+append-only ledger), so a parallel test asserts the chain hashes
+unchanged whether or not ``dpop_jkt`` is populated.
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+
+
+@pytest_asyncio.fixture
+async def proxy_app(tmp_path, monkeypatch):
+    db_file = tmp_path / "audit_jkt.sqlite"
+    monkeypatch.setenv("MCP_PROXY_DATABASE_URL", f"sqlite+aiosqlite:///{db_file}")
+    monkeypatch.delenv("PROXY_DB_URL", raising=False)
+    monkeypatch.setenv("MCP_PROXY_ORG_ID", "acme")
+    monkeypatch.setenv("PROXY_LOCAL_SWEEPER_DISABLED", "1")
+    monkeypatch.setenv("PROXY_TRUST_DOMAIN", "cullis.local")
+    from mcp_proxy.config import get_settings
+    get_settings.cache_clear()
+
+    from mcp_proxy.main import app
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as _:
+        async with app.router.lifespan_context(app):
+            yield app
+    get_settings.cache_clear()
+
+
+async def _read_jkts(action: str = "test.action") -> list[str | None]:
+    """Read the dpop_jkt column for every row produced by the test
+    actions. Returned in chain_seq order so the assertions can pin
+    "first row → expected, second row → expected" without sorting."""
+    from mcp_proxy.db import get_db
+
+    async with get_db() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT dpop_jkt FROM audit_log WHERE action=:a "
+                    "ORDER BY chain_seq ASC"
+                ),
+                {"a": action},
+            )
+        ).fetchall()
+    return [r[0] for r in rows]
+
+
+# ── kwarg path: caller passes an explicit jkt ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_audit_persists_explicit_dpop_jkt(proxy_app):
+    from mcp_proxy.db import log_audit
+
+    await log_audit(
+        agent_id="agent-1",
+        action="test.action",
+        status="success",
+        dpop_jkt="abcd" * 16,
+    )
+    assert await _read_jkts() == ["abcd" * 16]
+
+
+# ── contextvar path: auth dep stamps, log_audit reads ──────────────
+
+
+@pytest.mark.asyncio
+async def test_log_audit_reads_dpop_jkt_from_contextvar(proxy_app):
+    """When no kwarg is passed, the contextvar set by the DPoP auth
+    dependency wins. Simulates the live request path without spinning
+    up the full auth stack."""
+    from mcp_proxy.auth.dpop_context import set_dpop_jkt
+    from mcp_proxy.db import log_audit
+
+    set_dpop_jkt("deadbeef" * 8)
+    try:
+        await log_audit(
+            agent_id="agent-2",
+            action="test.action",
+            status="success",
+        )
+    finally:
+        set_dpop_jkt(None)
+
+    assert await _read_jkts() == ["deadbeef" * 8]
+
+
+@pytest.mark.asyncio
+async def test_log_audit_kwarg_wins_over_contextvar(proxy_app):
+    """When both are set, the explicit kwarg wins — useful for an
+    audit replay that wants to assert the historical jkt rather than
+    the current request's value."""
+    from mcp_proxy.auth.dpop_context import set_dpop_jkt
+    from mcp_proxy.db import log_audit
+
+    set_dpop_jkt("from-ctx-var" + "0" * 52)
+    try:
+        await log_audit(
+            agent_id="agent-3",
+            action="test.action",
+            status="success",
+            dpop_jkt="from-kwarg" + "0" * 54,
+        )
+    finally:
+        set_dpop_jkt(None)
+
+    assert await _read_jkts() == ["from-kwarg" + "0" * 54]
+
+
+@pytest.mark.asyncio
+async def test_log_audit_null_when_no_context(proxy_app):
+    """No kwarg, no contextvar → NULL. System / housekeeping rows
+    look the same as pre-rollout rows; nothing fakes a thumbprint
+    out of thin air."""
+    from mcp_proxy.db import log_audit
+
+    await log_audit(
+        agent_id="agent-4",
+        action="test.action",
+        status="success",
+    )
+    assert await _read_jkts() == [None]
+
+
+# ── chain invariant: dpop_jkt does NOT participate in the hash ─────
+
+
+@pytest.mark.asyncio
+async def test_dpop_jkt_does_not_enter_chain_hash(proxy_app):
+    """Two rows with the same action / agent / status but different
+    dpop_jkt values must produce identical row_hash values. Pinning
+    this stops a future drive-by from accidentally re-anchoring the
+    chain and breaking append-only verification on existing rows."""
+    from mcp_proxy.db import get_db, log_audit
+    from mcp_proxy.auth.dpop_context import set_dpop_jkt
+
+    # First row: no jkt, NULL.
+    await log_audit(
+        agent_id="agent-chain",
+        action="test.chain",
+        status="success",
+        request_id="req-1",
+    )
+
+    # Second row: with jkt set via contextvar.
+    set_dpop_jkt("AA" * 32)
+    try:
+        await log_audit(
+            agent_id="agent-chain",
+            action="test.chain",
+            status="success",
+            request_id="req-1",
+        )
+    finally:
+        set_dpop_jkt(None)
+
+    async with get_db() as conn:
+        rows = (
+            await conn.execute(
+                text(
+                    "SELECT chain_seq, row_hash, dpop_jkt FROM audit_log "
+                    "WHERE action='test.chain' ORDER BY chain_seq ASC"
+                )
+            )
+        ).fetchall()
+    assert len(rows) == 2
+    seq1, hash1, jkt1 = rows[0]
+    seq2, hash2, jkt2 = rows[1]
+    # Different jkt, same other inputs (plus prev_hash differs because
+    # of the chain). The strong invariant we want is: row_hash is
+    # *insensitive* to dpop_jkt. We assert it by recomputing the hash
+    # with each row's stored values and confirming the recompute
+    # agrees with the stored row_hash regardless of dpop_jkt.
+    from mcp_proxy.db import compute_audit_row_hash
+
+    async with get_db() as conn:
+        timestamps = (
+            await conn.execute(
+                text(
+                    "SELECT timestamp, prev_hash FROM audit_log "
+                    "WHERE action='test.chain' ORDER BY chain_seq ASC"
+                )
+            )
+        ).fetchall()
+    (ts1, prev1), (ts2, prev2) = timestamps
+
+    recomputed1 = compute_audit_row_hash(
+        chain_seq=seq1, timestamp=ts1, agent_id="agent-chain",
+        action="test.chain", tool_name=None, status="success",
+        detail=None, request_id="req-1", prev_hash=prev1,
+    )
+    recomputed2 = compute_audit_row_hash(
+        chain_seq=seq2, timestamp=ts2, agent_id="agent-chain",
+        action="test.chain", tool_name=None, status="success",
+        detail=None, request_id="req-1", prev_hash=prev2,
+    )
+    assert recomputed1 == hash1, "row 1 hash changed under dpop_jkt"
+    assert recomputed2 == hash2, "row 2 hash changed under dpop_jkt"
+    assert jkt1 is None and jkt2 == "AA" * 32

--- a/tests/test_proxy_migrations.py
+++ b/tests/test_proxy_migrations.py
@@ -72,7 +72,7 @@ async def test_init_db_fresh_sqlite_runs_alembic_upgrade(tmp_path):
         rows = conn.execute("SELECT version_num FROM alembic_version").fetchall()
     finally:
         conn.close()
-    assert rows == [("0032_ai_creds_at_rest_enc",)]
+    assert rows == [("0033_audit_dpop_jkt",)]
 
 
 @pytest.mark.asyncio
@@ -132,7 +132,7 @@ async def test_init_db_stamps_legacy_sqlite_then_upgrades(tmp_path):
         conn.close()
 
     assert rows == [("legacy-agent",)], "pre-existing row lost during stamp+upgrade"
-    assert version == [("0032_ai_creds_at_rest_enc",)]
+    assert version == [("0033_audit_dpop_jkt",)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxy_migrations_adr007.py
+++ b/tests/test_proxy_migrations_adr007.py
@@ -20,7 +20,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalAgentResourceBinding, LocalMCPResource
 
-HEAD_REVISION = "0032_ai_creds_at_rest_enc"
+HEAD_REVISION = "0033_audit_dpop_jkt"
 PREVIOUS_REVISION = "0006_enrollment_api_key_hash"
 
 

--- a/tests/test_proxy_migrations_adr008.py
+++ b/tests/test_proxy_migrations_adr008.py
@@ -19,7 +19,7 @@ from sqlalchemy.exc import IntegrityError
 from mcp_proxy.db import dispose_db, init_db
 from mcp_proxy.db_models import LocalMessage
 
-HEAD_REVISION = "0032_ai_creds_at_rest_enc"
+HEAD_REVISION = "0033_audit_dpop_jkt"
 PREVIOUS_REVISION = "0007_mcp_resources"
 
 

--- a/tests/test_proxy_migrations_adr011.py
+++ b/tests/test_proxy_migrations_adr011.py
@@ -18,7 +18,7 @@ from alembic.config import Config as AlembicConfig
 
 from mcp_proxy.db import create_agent, dispose_db, init_db
 
-HEAD_REVISION = "0032_ai_creds_at_rest_enc"
+HEAD_REVISION = "0033_audit_dpop_jkt"
 PREVIOUS_REVISION = "0015_enrollment_dpop_jkt"
 NEW_COLUMNS = {"enrollment_method", "spiffe_id", "enrolled_at"}
 


### PR DESCRIPTION
## Summary

\`audit_log.dpop_jkt\` carries the JWK thumbprint of the DPoP key that authenticated the request that produced the row. Today the same identity bits live only in the egress / request log → forensic queries have to JOIN on \`request_id\`. The new column closes the gap.

## Design

| Piece | What |
|---|---|
| Migration \`0033_audit_dpop_jkt\` | Nullable \`String(64)\` column + \`idx_audit_log_dpop_jkt\` index. Idempotent. |
| \`mcp_proxy/auth/dpop_context.py\` | Per-request \`ContextVar\` set by DPoP auth deps on success. |
| \`log_audit(dpop_jkt=…)\` | Optional kwarg + contextvar fallback. Kwarg wins for audit replays. |

## Why the contextvar

DPoP auth deps already compute the jkt to verify the proof against the token binding. Threading it through every \`log_audit\` call site is noisy and error-prone. A request-scoped contextvar set once on the success path lets every downstream \`log_audit\` see the value automatically — no plumbing change to existing callers.

## Hash chain invariant preserved

\`dpop_jkt\` is forensic correlation metadata, not authoritative action state. \`compute_audit_row_hash\` ignores it on purpose. Including it would re-anchor every pre-rollout row's hash and force a chain rewrite, which is not cheap or risk-free on an append-only ledger. A dedicated test pins the invariant.

## Court-side scope

Court \`audit_log\` (\`app/db/audit.py\`) deliberately not touched. Scope is the proxy local audit, where the DPoP-bound volume lives. Court can follow once the proxy column is in production and the migration shape is settled.

## Test plan

- [x] \`pytest tests/test_audit_dpop_jkt.py -n0\` — 5 verdi (kwarg, contextvar, kwarg-wins, NULL fallback, chain invariant)
- [x] \`pytest tests/test_audit_fail_deny.py tests/test_h4_audit_chain.py tests/test_audit_api.py tests/test_audit_race_safety.py tests/test_audit_export_tsa.py -n0\` — 27 verdi (no regression)
- [x] \`pytest -k 'dpop or auth or local_token or local_agent' -n auto\` — 284 verdi (no regression)
- [ ] \`./demo_network/smoke.sh full\` pre-merge (alembic + auth touched)
- [ ] /security-review pre-merge

## P1 roadmap

P1.2 from \`imp/enterprise-production-ready-plan.md\`. After this lands, P1.3 (X-Cullis-* header strip middleware) closes the Tier A flight.