### PR TITLE
feat(middleware): strip X-Cullis-* from incoming client requests (P1.3)

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -963,6 +963,26 @@ _log.info(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# X-Cullis-* request header strip (P1.3)
+#
+# Mastio derives trust state from the DPoP token + verified principal cert,
+# never from incoming X-Cullis-* headers. The strip makes that contract
+# explicit at the request boundary so a future refactor that accidentally
+# reads ``request.headers["X-Cullis-Trust"]`` can't be tricked into trusting
+# a forged value. Registered last so Starlette's LIFO order runs it FIRST
+# on every inbound request — strip happens before any other middleware /
+# handler observes the headers.
+# ─────────────────────────────────────────────────────────────────────────────
+
+from mcp_proxy.middleware.strip_x_cullis_headers import (
+    StripXCullisHeadersMiddleware,
+)
+
+app.add_middleware(StripXCullisHeadersMiddleware)
+_log.info("X-Cullis-* incoming header strip middleware registered (P1.3)")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # Routers
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/mcp_proxy/middleware/strip_x_cullis_headers.py
+++ b/mcp_proxy/middleware/strip_x_cullis_headers.py
@@ -1,0 +1,95 @@
+"""Strip X-Cullis-* headers from incoming client requests (P1.3).
+
+Mastio's auth dependencies derive trust state from the DPoP token's
+claim set and the verified principal cert chain; no handler reads
+``X-Cullis-*`` off an inbound request. This middleware makes that
+contract explicit at the request boundary: any ``X-Cullis-*``
+header on an inbound HTTP request is dropped from the ASGI scope
+before any downstream handler — including the auth dep — can
+observe it. A future refactor that accidentally splices in
+``request.headers["X-Cullis-Trust"]`` can therefore not be tricked
+into believing a forged value.
+
+Out of scope for the strip:
+
+* Response headers. Mastio sets ``x-cullis-mode`` and a handful of
+  ``x-cullis-shed-reason`` shedding annotations on its own
+  responses; those flow server → client and the strip lives at the
+  request entry, so they are unaffected.
+* Outgoing requests Mastio originates (egress to upstream LLM,
+  federation publisher to Court, MCP resource forwarder). Those
+  build their own header dicts and are governed by their own
+  allow-lists / deny-lists (e.g. ``_strip_dangerous_upstream_headers``).
+* Inter-Mastio / Mastio→Court trust headers like
+  ``X-Cullis-Mastio-Signature`` arriving at the Court. Those are
+  Court business — this middleware lives on the Mastio side.
+
+Logging is opt-in via ``CULLIS_LOG_STRIPPED_HEADERS=1``. The
+default is silent because a noisy client that always sets a custom
+``X-Cullis-*`` header would otherwise generate an entry per
+request.
+
+The strip is a pure ASGI op — modifying ``scope["headers"]`` —
+rather than a ``BaseHTTPMiddleware`` so the rewrite lands before
+any header-reading dep runs. Same rationale as
+``global_rate_limit.py``.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+
+_log = logging.getLogger("mcp_proxy")
+
+# Lower-cased bytes for fast prefix compare on the ASGI raw header
+# tuples (the wire is bytes and case-insensitive per RFC 9110 §5.1).
+_PREFIX = b"x-cullis-"
+
+
+def _should_log_stripped() -> bool:
+    return os.environ.get("CULLIS_LOG_STRIPPED_HEADERS", "0").strip() in {
+        "1", "true", "yes", "on",
+    }
+
+
+class StripXCullisHeadersMiddleware:
+    """Pure ASGI middleware. Wired via ``app.add_middleware(...)``."""
+
+    def __init__(self, app):
+        self.app = app
+        # Snapshot at construction: tests can flip the env before
+        # mounting the app and see the change without an os.environ
+        # read on every request hot path.
+        self._log_stripped = _should_log_stripped()
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        stripped: list[bytes] = []
+        kept: list[tuple[bytes, bytes]] = []
+        for name, value in scope["headers"]:
+            if name.lower().startswith(_PREFIX):
+                stripped.append(name)
+                continue
+            kept.append((name, value))
+
+        if stripped:
+            # Shallow copy: ASGI scope is shared with the rest of the
+            # stack, and mutating it in place would leak a no-X-Cullis
+            # view of the same request to siblings.
+            scope = dict(scope)
+            scope["headers"] = kept
+            if self._log_stripped:
+                _log.info(
+                    "stripped %d X-Cullis-* request header(s): %s "
+                    "method=%s path=%s",
+                    len(stripped),
+                    [n.decode("ascii", "replace") for n in stripped],
+                    scope.get("method"),
+                    scope.get("path"),
+                )
+
+        await self.app(scope, receive, send)

--- a/tests/test_strip_x_cullis_headers.py
+++ b/tests/test_strip_x_cullis_headers.py
@@ -23,8 +23,6 @@ and assert that:
 """
 from __future__ import annotations
 
-import logging
-
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI, Request

--- a/tests/test_strip_x_cullis_headers.py
+++ b/tests/test_strip_x_cullis_headers.py
@@ -140,38 +140,32 @@ async def test_log_silent_by_default(monkeypatch):
     """Default config: silent. A noisy client must not flood the log
     with one entry per request.
 
-    Verified by hooking the mcp_proxy logger's records list directly:
-    ``caplog`` is unreliable here because the production logger
-    setup runs with ``propagate=False`` and rewires handlers under
-    uvicorn, so a normal ``caplog.at_level`` misses the records.
-    Same pattern the global rate limit logging takes (see memory
-    ``mastio_logger_silently_muted_in_lifespan``).
+    Verified by monkey-patching the module-level ``_log`` so we
+    capture the calls directly. ``caplog`` is unreliable here because
+    the production logger setup runs with ``propagate=False`` and
+    uvicorn rewires its handlers, dropping caplog hooks mid-run on CI
+    (see memory ``mastio_logger_silently_muted_in_lifespan``).
     """
     monkeypatch.delenv("CULLIS_LOG_STRIPPED_HEADERS", raising=False)
+    from mcp_proxy.middleware import strip_x_cullis_headers as mod
+
+    captured: list[tuple[str, tuple]] = []
+
+    class _FakeLog:
+        def info(self, msg, *args):
+            captured.append((msg, args))
+
+    monkeypatch.setattr(mod, "_log", _FakeLog())
+
     app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
 
-    captured: list[logging.LogRecord] = []
-
-    class _CollectHandler(logging.Handler):
-        def emit(self, record):
-            captured.append(record)
-
-    logger = logging.getLogger("mcp_proxy")
-    handler = _CollectHandler(level=logging.INFO)
-    logger.addHandler(handler)
-    prev_level = logger.level
-    logger.setLevel(logging.INFO)
-    try:
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
-    finally:
-        logger.removeHandler(handler)
-        logger.setLevel(prev_level)
-
+    rendered = [(msg % args) if args else msg for msg, args in captured]
     assert not any(
-        "stripped" in (r.getMessage() or "") and "x-cullis" in r.getMessage().lower()
-        for r in captured
+        "stripped" in line and "x-cullis" in line.lower()
+        for line in rendered
     )
 
 
@@ -180,42 +174,37 @@ async def test_log_fires_under_opt_in(monkeypatch):
     """``CULLIS_LOG_STRIPPED_HEADERS=1`` → INFO record per stripped
     request, with the stripped names visible for forensic correlation.
 
-    Same handler-attached collector pattern as the silent test —
+    Same module-level monkey-patch pattern as the silent test —
     pytest's ``caplog`` fixture misses records when ``propagate=False``
     + uvicorn's logging reinit drop them mid-test on CI runners.
     """
     monkeypatch.setenv("CULLIS_LOG_STRIPPED_HEADERS", "1")
+    from mcp_proxy.middleware import strip_x_cullis_headers as mod
+
+    captured: list[tuple[str, tuple]] = []
+
+    class _FakeLog:
+        def info(self, msg, *args):
+            captured.append((msg, args))
+
+    monkeypatch.setattr(mod, "_log", _FakeLog())
+
     # Snapshot env at construction (see middleware docstring); rebuild
     # the app after setenv.
     app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
 
-    captured: list[logging.LogRecord] = []
-
-    class _CollectHandler(logging.Handler):
-        def emit(self, record):
-            captured.append(record)
-
-    logger = logging.getLogger("mcp_proxy")
-    handler = _CollectHandler(level=logging.INFO)
-    logger.addHandler(handler)
-    prev_level = logger.level
-    logger.setLevel(logging.INFO)
-    try:
-        transport = ASGITransport(app=app)
-        async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
-    finally:
-        logger.removeHandler(handler)
-        logger.setLevel(prev_level)
-
-    msgs = [r.getMessage() for r in captured]
+    rendered = [(msg % args) if args else msg for msg, args in captured]
     # ASGI normalises header names to lower-case on the wire, so the
     # log message records the lower form regardless of how the client
     # spelled it. The forensic correlation point is the header family
     # ("x-cullis-trust"), not the exact casing.
     assert any(
-        "stripped" in m and "x-cullis-trust" in m.lower() for m in msgs
-    ), msgs
+        "stripped" in line and "x-cullis-trust" in line.lower()
+        for line in rendered
+    ), rendered
 
 
 # ── pass-through when no X-Cullis-* present ────────────────────────

--- a/tests/test_strip_x_cullis_headers.py
+++ b/tests/test_strip_x_cullis_headers.py
@@ -136,46 +136,79 @@ async def test_non_cullis_headers_pass_through(client):
 
 
 @pytest.mark.asyncio
-async def test_log_silent_by_default(caplog, monkeypatch):
+async def test_log_silent_by_default(monkeypatch):
     """Default config: silent. A noisy client must not flood the log
-    with one entry per request."""
+    with one entry per request.
+
+    Verified by hooking the mcp_proxy logger's records list directly:
+    ``caplog`` is unreliable here because the production logger
+    setup runs with ``propagate=False`` and rewires handlers under
+    uvicorn, so a normal ``caplog.at_level`` misses the records.
+    Same pattern the global rate limit logging takes (see memory
+    ``mastio_logger_silently_muted_in_lifespan``).
+    """
     monkeypatch.delenv("CULLIS_LOG_STRIPPED_HEADERS", raising=False)
     app = _build_app()
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        with caplog.at_level(logging.INFO, logger="mcp_proxy"):
+
+    captured: list[logging.LogRecord] = []
+
+    class _CollectHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    logger = logging.getLogger("mcp_proxy")
+    handler = _CollectHandler(level=logging.INFO)
+    logger.addHandler(handler)
+    prev_level = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
             await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
+
     assert not any(
-        "stripped" in r.message and "x-cullis" in r.message.lower()
-        for r in caplog.records
+        "stripped" in (r.getMessage() or "") and "x-cullis" in r.getMessage().lower()
+        for r in captured
     )
 
 
 @pytest.mark.asyncio
-async def test_log_fires_under_opt_in(caplog, monkeypatch):
+async def test_log_fires_under_opt_in(monkeypatch):
     """``CULLIS_LOG_STRIPPED_HEADERS=1`` → INFO record per stripped
-    request, with the stripped names visible for forensic correlation."""
-    monkeypatch.setenv("CULLIS_LOG_STRIPPED_HEADERS", "1")
-    # Snapshot env at construction (see middleware docstring); we
-    # therefore have to rebuild the app under the new env.
-    app = _build_app()
-    transport = ASGITransport(app=app)
+    request, with the stripped names visible for forensic correlation.
 
-    # Configure the mcp_proxy logger so caplog captures records that
-    # do not propagate. The middleware logs at INFO via the bare
-    # ``logging.getLogger("mcp_proxy")``, which is silenced by the
-    # logging_setup module in prod; tests rewire to caplog directly.
+    Same handler-attached collector pattern as the silent test —
+    pytest's ``caplog`` fixture misses records when ``propagate=False``
+    + uvicorn's logging reinit drop them mid-test on CI runners.
+    """
+    monkeypatch.setenv("CULLIS_LOG_STRIPPED_HEADERS", "1")
+    # Snapshot env at construction (see middleware docstring); rebuild
+    # the app after setenv.
+    app = _build_app()
+
+    captured: list[logging.LogRecord] = []
+
+    class _CollectHandler(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
     logger = logging.getLogger("mcp_proxy")
-    logger.addHandler(caplog.handler)
+    handler = _CollectHandler(level=logging.INFO)
+    logger.addHandler(handler)
+    prev_level = logger.level
     logger.setLevel(logging.INFO)
     try:
+        transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as ac:
-            with caplog.at_level(logging.INFO, logger="mcp_proxy"):
-                await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
+            await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
     finally:
-        logger.removeHandler(caplog.handler)
+        logger.removeHandler(handler)
+        logger.setLevel(prev_level)
 
-    msgs = [r.message for r in caplog.records]
+    msgs = [r.getMessage() for r in captured]
     # ASGI normalises header names to lower-case on the wire, so the
     # log message records the lower form regardless of how the client
     # spelled it. The forensic correlation point is the header family

--- a/tests/test_strip_x_cullis_headers.py
+++ b/tests/test_strip_x_cullis_headers.py
@@ -1,0 +1,201 @@
+"""P1.3 — X-Cullis-* incoming request header strip.
+
+Mastio's auth deps derive trust state from the DPoP token + the
+verified principal cert chain; no handler reads ``X-Cullis-*`` off
+an inbound request. The middleware enforces that contract at the
+request boundary so a future refactor cannot be tricked into
+trusting a forged value.
+
+These tests register a one-route FastAPI app behind the middleware
+and assert that:
+
+* Any incoming ``X-Cullis-*`` header is missing by the time the
+  handler reads the request — covers the canonical attacker
+  injection paths ("X-Cullis-Trust", "X-Cullis-Admin",
+  "X-Cullis-Agent-Id", "X-Cullis-Org-Id", "X-Cullis-Mastio-Signature").
+* Case is irrelevant: ``X-CULLIS-Foo`` and ``x-cullis-foo`` both
+  drop.
+* Non-cullis headers pass through untouched.
+* The middleware is opt-out via configuration only — there is no
+  client-supplied header that can keep an X-Cullis-* on the wire.
+* The opt-in logging gate fires when env is set and is silent when
+  unset, so a busy dashboard doesn't flood the log.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+
+def _build_app():
+    """Single-route FastAPI app behind the strip middleware.
+
+    The handler echoes the headers the ASGI scope hands it (i.e. the
+    post-strip view) as JSON so each test can assert ``X-Cullis-*``
+    absence directly.
+    """
+    from mcp_proxy.middleware.strip_x_cullis_headers import (
+        StripXCullisHeadersMiddleware,
+    )
+
+    app = FastAPI()
+    app.add_middleware(StripXCullisHeadersMiddleware)
+
+    @app.get("/echo")
+    async def echo(request: Request):
+        return {
+            "headers": [
+                [k, v] for k, v in request.headers.items()
+                if k.lower() != "host"
+            ],
+        }
+
+    return app
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=_build_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+# ── strip on canonical attacker injection vectors ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_strip_drops_x_cullis_trust_spoof(client):
+    """The flagship attack: client sets X-Cullis-Trust to spoof a
+    trust state. Handler must not see it."""
+    resp = await client.get(
+        "/echo",
+        headers={"X-Cullis-Trust": "spoofed-admin"},
+    )
+    assert resp.status_code == 200
+    seen = {k.lower() for k, _ in resp.json()["headers"]}
+    assert "x-cullis-trust" not in seen
+
+
+@pytest.mark.asyncio
+async def test_strip_drops_every_x_cullis_variant(client):
+    """Cover the names a real attacker would reach for first."""
+    resp = await client.get(
+        "/echo",
+        headers={
+            "X-Cullis-Admin": "true",
+            "X-Cullis-Agent-Id": "spoofed::agent::root",
+            "X-Cullis-Org-Id": "victim-org",
+            "X-Cullis-Mastio-Signature": "deadbeef",
+            "X-Cullis-Trace": "phantom-trace",
+        },
+    )
+    seen = {k.lower() for k, _ in resp.json()["headers"]}
+    assert not any(name.startswith("x-cullis-") for name in seen), seen
+
+
+@pytest.mark.asyncio
+async def test_strip_is_case_insensitive(client):
+    """RFC 9110 §5.1: header names are case-insensitive. The strip
+    must follow."""
+    resp = await client.get(
+        "/echo",
+        headers={
+            "x-cullis-lowered": "1",
+            "X-CULLIS-UPPERED": "2",
+            "X-Cullis-Mixed": "3",
+        },
+    )
+    seen = {k.lower() for k, _ in resp.json()["headers"]}
+    assert not any(name.startswith("x-cullis-") for name in seen), seen
+
+
+@pytest.mark.asyncio
+async def test_non_cullis_headers_pass_through(client):
+    """Headers outside the X-Cullis-* family must reach the handler
+    unchanged — strip is targeted, not a denylist sweep."""
+    resp = await client.get(
+        "/echo",
+        headers={
+            "Authorization": "Bearer abc",
+            "DPoP": "proof.proof.proof",
+            "X-Request-Id": "req-1",
+            "User-Agent": "cullis-sdk-test/0.1",
+        },
+    )
+    headers = {k.lower(): v for k, v in resp.json()["headers"]}
+    assert headers["authorization"] == "Bearer abc"
+    assert headers["dpop"] == "proof.proof.proof"
+    assert headers["x-request-id"] == "req-1"
+
+
+# ── opt-in audit log ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_log_silent_by_default(caplog, monkeypatch):
+    """Default config: silent. A noisy client must not flood the log
+    with one entry per request."""
+    monkeypatch.delenv("CULLIS_LOG_STRIPPED_HEADERS", raising=False)
+    app = _build_app()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        with caplog.at_level(logging.INFO, logger="mcp_proxy"):
+            await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
+    assert not any(
+        "stripped" in r.message and "x-cullis" in r.message.lower()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_log_fires_under_opt_in(caplog, monkeypatch):
+    """``CULLIS_LOG_STRIPPED_HEADERS=1`` → INFO record per stripped
+    request, with the stripped names visible for forensic correlation."""
+    monkeypatch.setenv("CULLIS_LOG_STRIPPED_HEADERS", "1")
+    # Snapshot env at construction (see middleware docstring); we
+    # therefore have to rebuild the app under the new env.
+    app = _build_app()
+    transport = ASGITransport(app=app)
+
+    # Configure the mcp_proxy logger so caplog captures records that
+    # do not propagate. The middleware logs at INFO via the bare
+    # ``logging.getLogger("mcp_proxy")``, which is silenced by the
+    # logging_setup module in prod; tests rewire to caplog directly.
+    logger = logging.getLogger("mcp_proxy")
+    logger.addHandler(caplog.handler)
+    logger.setLevel(logging.INFO)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            with caplog.at_level(logging.INFO, logger="mcp_proxy"):
+                await ac.get("/echo", headers={"X-Cullis-Trust": "x"})
+    finally:
+        logger.removeHandler(caplog.handler)
+
+    msgs = [r.message for r in caplog.records]
+    # ASGI normalises header names to lower-case on the wire, so the
+    # log message records the lower form regardless of how the client
+    # spelled it. The forensic correlation point is the header family
+    # ("x-cullis-trust"), not the exact casing.
+    assert any(
+        "stripped" in m and "x-cullis-trust" in m.lower() for m in msgs
+    ), msgs
+
+
+# ── pass-through when no X-Cullis-* present ────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_x_cullis_no_changes(client):
+    """A request with zero X-Cullis-* headers must traverse the
+    middleware without scope copy or log event."""
+    resp = await client.get(
+        "/echo",
+        headers={"Accept": "application/json"},
+    )
+    assert resp.status_code == 200
+    headers = {k.lower() for k, _ in resp.json()["headers"]}
+    assert "accept" in headers


### PR DESCRIPTION
## Summary

Pure ASGI middleware on the Mastio that drops any \`X-Cullis-*\` header off inbound HTTP requests before any other middleware / auth dep / handler can observe it. Defence-in-depth: today's auth deps derive trust from the DPoP token + verified principal cert chain (no X-Cullis-* read), and this PR turns that contract into something the request boundary enforces.

## Out of scope

- **Response headers**: Mastio sets \`x-cullis-mode\` + shed annotations on its own responses. Strip lives at request entry, so they are unaffected.
- **Outgoing requests Mastio originates**: egress to upstream LLM, federation publisher → Court, MCP resource forwarder. Those build their own header dicts and have their own allow / deny-lists (see [#708](https://github.com/cullis-security/cullis/pull/708) for the forwarder side).
- **Court-side**: \`X-Cullis-Mastio-Signature\` etc. arriving at the Court is Court business, not Mastio middleware. A parallel Court-side allow-list can land in a follow-up if forensic / hardening review asks for it.

## Why pure ASGI

\`BaseHTTPMiddleware\` runs too late for the auth dep, which reads headers at route entry. The pure ASGI form rewrites \`scope[\"headers\"]\` before any downstream code sees the request. Same pattern as \`global_rate_limit.py\`.

## Why opt-in logging

Default silent. A noisy client that always sets a custom \`X-Cullis-*\` header would otherwise produce one INFO record per request. \`CULLIS_LOG_STRIPPED_HEADERS=1\` flips the gate on for forensic / customer-debug scenarios.

## Test plan

- [x] \`pytest tests/test_strip_x_cullis_headers.py -n0\` — 7 verdi (canonical attacker vectors, case-insensitivity, non-cullis pass-through, silent-by-default log, opt-in log emission)
- [x] \`pytest -k 'forwarder or federation or auth or middleware or reverse_proxy or rate_limit' -n auto\` — 384 verdi, zero regression
- [ ] \`./demo_network/smoke.sh full\` pre-merge (auth path touched)
- [ ] /security-review pre-merge

## P1 roadmap

P1.3 from \`imp/enterprise-production-ready-plan.md\`. Closes Tier A (P1.1 + P1.4 + P1.2 + P1.3). After all four land, the first-deal-ready gate moves from open-core code to outreach / dogfood.