### PR TITLE
refactor(sdk): extract Sessions lifecycle to _client/_sessions.py

### DIFF
--- a/cullis_sdk/_client/_sessions.py
+++ b/cullis_sdk/_client/_sessions.py
@@ -1,0 +1,114 @@
+"""Session lifecycle support extracted from :mod:`cullis_sdk.client`.
+
+Single public symbol:
+
+* :class:`_SessionsMixin` — mixin folded into ``CullisClient`` that
+  exposes the five A2A session lifecycle calls: ``open_session``,
+  ``accept_session``, ``reject_session``, ``close_session`` and
+  ``list_sessions``. Each one routes to ``/v1/egress/sessions`` when
+  the client is proxy-bound (``from_connector`` /
+  ``from_enrollment`` / ``from_identity_dir``) and to
+  ``/v1/broker/sessions`` for direct-broker clients.
+
+Movement only — no behavior change. The mixin assumes the host class
+exposes ``_authed_request``, ``_egress_http`` and the boolean
+``_use_egress_for_sessions`` flag.
+"""
+from __future__ import annotations
+
+from cullis_sdk.types import SessionInfo
+
+
+class _SessionsMixin:
+    """A2A session lifecycle on ``CullisClient``."""
+
+    def open_session(self, target_agent_id: str, target_org_id: str,
+                     capabilities: list[str]) -> str:
+        """Open a new session with a target agent. Returns session_id.
+
+        Proxy-bound clients (``from_connector``, ``from_enrollment``,
+        ``from_identity_dir``) route through ``/v1/egress/sessions`` —
+        the proxy's local mini-broker handles intra-org and falls
+        through to the broker bridge for cross-org. Direct-broker
+        clients keep using ``/v1/broker/sessions``.
+        """
+        if self._use_egress_for_sessions:
+            resp = self._egress_http("post", "/v1/egress/sessions", json={
+                "target_agent_id": target_agent_id,
+                "target_org_id": target_org_id,
+                "capabilities": capabilities,
+            })
+            resp.raise_for_status()
+            return resp.json()["session_id"]
+        path = "/v1/broker/sessions"
+        resp = self._authed_request("POST", path, json={
+            "target_agent_id": target_agent_id,
+            "target_org_id": target_org_id,
+            "requested_capabilities": capabilities,
+        })
+        resp.raise_for_status()
+        return resp.json()["session_id"]
+
+    def accept_session(self, session_id: str) -> None:
+        """Accept a pending session."""
+        if self._use_egress_for_sessions:
+            resp = self._egress_http(
+                "post", f"/v1/egress/sessions/{session_id}/accept"
+            )
+            resp.raise_for_status()
+            return
+        path = f"/v1/broker/sessions/{session_id}/accept"
+        resp = self._authed_request("POST", path)
+        resp.raise_for_status()
+
+    def reject_session(self, session_id: str) -> None:
+        """Reject a pending session.
+
+        The egress router has no dedicated reject endpoint — it folds
+        rejection into ``/close`` (the local store treats both as a
+        terminal state with the same semantics for the initiator).
+        Direct-broker clients still get the reject path so the broker
+        can distinguish 'rejected by target' from 'closed'.
+        """
+        if self._use_egress_for_sessions:
+            resp = self._egress_http(
+                "post", f"/v1/egress/sessions/{session_id}/close"
+            )
+            resp.raise_for_status()
+            return
+        path = f"/v1/broker/sessions/{session_id}/reject"
+        resp = self._authed_request("POST", path)
+        resp.raise_for_status()
+
+    def close_session(self, session_id: str) -> None:
+        """Close an active session."""
+        if self._use_egress_for_sessions:
+            resp = self._egress_http(
+                "post", f"/v1/egress/sessions/{session_id}/close"
+            )
+            resp.raise_for_status()
+            return
+        path = f"/v1/broker/sessions/{session_id}/close"
+        resp = self._authed_request("POST", path)
+        resp.raise_for_status()
+
+    def list_sessions(self, status: str | None = None) -> list[SessionInfo]:
+        """List sessions, optionally filtered by status.
+
+        The egress shape wraps the list in ``{"sessions": [...]}`` and
+        the broker shape returns a flat list — unwrap on the egress
+        side so callers see the same return type.
+        """
+        params = {}
+        if status:
+            params["status"] = status
+        if self._use_egress_for_sessions:
+            resp = self._egress_http("get", "/v1/egress/sessions", params=params)
+            resp.raise_for_status()
+            body = resp.json()
+            sessions = body.get("sessions", []) if isinstance(body, dict) else body
+            return [SessionInfo.from_dict(s) for s in sessions]
+        path = "/v1/broker/sessions"
+        resp = self._authed_request("GET", path, params=params)
+        resp.raise_for_status()
+        return [SessionInfo.from_dict(s) for s in resp.json()]

--- a/cullis_sdk/client.py
+++ b/cullis_sdk/client.py
@@ -38,12 +38,13 @@ from cullis_sdk.crypto.message_signer import (
     verify_signature,
 )
 from cullis_sdk.crypto.e2e import encrypt_for_agent, decrypt_from_agent
-from cullis_sdk.types import AgentInfo, SessionInfo, InboxMessage
+from cullis_sdk.types import AgentInfo, InboxMessage
 from cullis_sdk._logging import log, RED
 from cullis_sdk._client._ai_gateway import _AiGatewayMixin
 from cullis_sdk._client._discovery import PubkeyFetchError, _DiscoveryMixin
 from cullis_sdk._client._guardian import _GuardianMixin
 from cullis_sdk._client._rfq import _RfqMixin
+from cullis_sdk._client._sessions import _SessionsMixin
 from cullis_sdk._client._websocket import WebSocketConnection, _WebSocketMixin
 
 
@@ -223,7 +224,7 @@ def _check_insecure_tls(verify_tls: bool) -> None:
     )
 
 
-class CullisClient(_AiGatewayMixin, _DiscoveryMixin, _GuardianMixin, _RfqMixin, _WebSocketMixin):
+class CullisClient(_AiGatewayMixin, _DiscoveryMixin, _GuardianMixin, _RfqMixin, _SessionsMixin, _WebSocketMixin):
     """Client for the Cullis federated agent trust broker."""
 
     def __init__(
@@ -1666,99 +1667,6 @@ class CullisClient(_AiGatewayMixin, _DiscoveryMixin, _GuardianMixin, _RfqMixin, 
                 f"[{agent_id}] login_via_proxy_with_local_key failed "
                 f"(HTTP {e.response.status_code}): {e.response.text}"
             ) from e
-
-    # ── Sessions ────────────────────────────────────────────────────
-
-    def open_session(self, target_agent_id: str, target_org_id: str,
-                     capabilities: list[str]) -> str:
-        """Open a new session with a target agent. Returns session_id.
-
-        Proxy-bound clients (``from_connector``, ``from_enrollment``,
-        ``from_identity_dir``) route through ``/v1/egress/sessions`` —
-        the proxy's local mini-broker handles intra-org and falls
-        through to the broker bridge for cross-org. Direct-broker
-        clients keep using ``/v1/broker/sessions``.
-        """
-        if self._use_egress_for_sessions:
-            resp = self._egress_http("post", "/v1/egress/sessions", json={
-                "target_agent_id": target_agent_id,
-                "target_org_id": target_org_id,
-                "capabilities": capabilities,
-            })
-            resp.raise_for_status()
-            return resp.json()["session_id"]
-        path = "/v1/broker/sessions"
-        resp = self._authed_request("POST", path, json={
-            "target_agent_id": target_agent_id,
-            "target_org_id": target_org_id,
-            "requested_capabilities": capabilities,
-        })
-        resp.raise_for_status()
-        return resp.json()["session_id"]
-
-    def accept_session(self, session_id: str) -> None:
-        """Accept a pending session."""
-        if self._use_egress_for_sessions:
-            resp = self._egress_http(
-                "post", f"/v1/egress/sessions/{session_id}/accept"
-            )
-            resp.raise_for_status()
-            return
-        path = f"/v1/broker/sessions/{session_id}/accept"
-        resp = self._authed_request("POST", path)
-        resp.raise_for_status()
-
-    def reject_session(self, session_id: str) -> None:
-        """Reject a pending session.
-
-        The egress router has no dedicated reject endpoint — it folds
-        rejection into ``/close`` (the local store treats both as a
-        terminal state with the same semantics for the initiator).
-        Direct-broker clients still get the reject path so the broker
-        can distinguish 'rejected by target' from 'closed'.
-        """
-        if self._use_egress_for_sessions:
-            resp = self._egress_http(
-                "post", f"/v1/egress/sessions/{session_id}/close"
-            )
-            resp.raise_for_status()
-            return
-        path = f"/v1/broker/sessions/{session_id}/reject"
-        resp = self._authed_request("POST", path)
-        resp.raise_for_status()
-
-    def close_session(self, session_id: str) -> None:
-        """Close an active session."""
-        if self._use_egress_for_sessions:
-            resp = self._egress_http(
-                "post", f"/v1/egress/sessions/{session_id}/close"
-            )
-            resp.raise_for_status()
-            return
-        path = f"/v1/broker/sessions/{session_id}/close"
-        resp = self._authed_request("POST", path)
-        resp.raise_for_status()
-
-    def list_sessions(self, status: str | None = None) -> list[SessionInfo]:
-        """List sessions, optionally filtered by status.
-
-        The egress shape wraps the list in ``{"sessions": [...]}`` and
-        the broker shape returns a flat list — unwrap on the egress
-        side so callers see the same return type.
-        """
-        params = {}
-        if status:
-            params["status"] = status
-        if self._use_egress_for_sessions:
-            resp = self._egress_http("get", "/v1/egress/sessions", params=params)
-            resp.raise_for_status()
-            body = resp.json()
-            sessions = body.get("sessions", []) if isinstance(body, dict) else body
-            return [SessionInfo.from_dict(s) for s in sessions]
-        path = "/v1/broker/sessions"
-        resp = self._authed_request("GET", path, params=params)
-        resp.raise_for_status()
-        return [SessionInfo.from_dict(s) for s in resp.json()]
 
     # ── Messaging ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

PR 6/N of the SDK refactor split (see #702 WebSocket, #706 Guardian, #711 Discovery, #713 RFQ, #716 AI gateway for the mixin template). Moves the A2A session lifecycle calls out of `cullis_sdk/client.py` into a dedicated mixin under `cullis_sdk/_client/`.

## Scope (6/N)

- New module `cullis_sdk/_client/_sessions.py` with `_SessionsMixin` exposing the five lifecycle methods:
  - `open_session`
  - `accept_session`
  - `reject_session`
  - `close_session`
  - `list_sessions`
  - Plus the scoped import of `SessionInfo` from `cullis_sdk.types`.
- `cullis_sdk/client.py`:
  - `CullisClient` now inherits `(_AiGatewayMixin, _DiscoveryMixin, _GuardianMixin, _RfqMixin, _SessionsMixin, _WebSocketMixin)` in alphabetical order (A < D < G < R < S < W).
  - Five methods, their `# ── Sessions ──` section header, and the now-unused `SessionInfo` import are removed from `client.py`.
- `cullis_sdk/__init__.py` — unchanged. `SessionInfo` continues to be re-exported via `from cullis_sdk.types import …`, same public path as before.

## No deprecation in this PR

Project memory has the long-term decision "only `send_oneshot`, no session — A2A is oneshot+reply until the public video" — so these five methods are candidates for `@deprecated` eventually. **That is explicitly out of scope here.** The deprecation lands in a dedicated PR after the `client.py` split finishes, so the diffs stay reviewable as pure movement. No `@deprecated`, no warning emissions, no signature changes.

## Preserved routing logic (byte-identical)

The four egress/broker switches are reproduced exactly:

- Proxy-bound clients (`from_connector` / `from_enrollment` / `from_identity_dir`) → `/v1/egress/sessions` (the proxy's mini-broker handles intra-org, falls through to the broker bridge for cross-org).
- Direct-broker clients → `/v1/broker/sessions`.
- `reject_session` on the egress path folds into `/close` (terminal state with the same semantics for the initiator); direct-broker keeps the dedicated `/reject` so the broker can distinguish 'rejected by target' from 'closed'.
- `list_sessions` on the egress shape unwraps `{"sessions": [...]}` so callers see the same `list[SessionInfo]` whichever path they came in through.

## Roadmap (next PRs)

Same mixin pattern, alphabetical inheritance order. Remaining domains in `client.py`:

1. enrollment (`from_enrollment`, `from_connector`, `enroll_via_byoca`, `from_identity_dir`, …)
2. auth (login family, DPoP helpers, auto-relogin)
3. messaging legacy (`send`, `receive`, ack, decrypt)
4. messaging oneshot (`send_oneshot`, `decrypt_oneshot`, envelope helpers)

Then a separate PR adds `@deprecated` to the session methods + appropriate runtime warning, per the "oneshot-only until video" guidance.

## Zero breaking change

All public paths preserved:

```python
from cullis_sdk import CullisClient, SessionInfo
c = CullisClient(...)
sid = c.open_session("peer", "org", ["cap"])
c.accept_session(sid)
c.list_sessions(status="active")
c.close_session(sid)
```

## Verification

- `pytest tests/ -n auto --dist=loadfile` — 3486 passed, 38 skipped. Only the 2 documented unrelated flakes failed:
  - `tests/test_postgres_integration.py::test_pg_session_and_signed_messages` + `::test_pg_nonce_replay_blocked` — pre-existing postgres binding `KeyError: 'id'` flake. (Audit-race-safety flakes did not surface in this run.)
- `./sandbox/smoke.sh full` — PASS=25, FAIL=0, SKIP=1 (B4.9 gated on `SMOKE_ASSERT_INTRA_ORG=1`).
- Manual import sanity:
  ```python
  from cullis_sdk import CullisClient, SessionInfo
  from cullis_sdk._client._sessions import _SessionsMixin
  assert issubclass(CullisClient, _SessionsMixin)
  # MRO: (CullisClient, _AiGatewayMixin, _DiscoveryMixin, _GuardianMixin, _RfqMixin, _SessionsMixin, _WebSocketMixin, object)
  ```

## Test plan

- [x] Parallel pytest green for all session lifecycle paths (modulo documented pre-existing flake)
- [x] Sandbox smoke green
- [x] `SessionInfo` reachable from both `cullis_sdk` and `cullis_sdk.types`
- [x] Proxy-bound vs direct-broker routing preserved byte-identically
- [x] `CullisClient` MRO contains the six mixins in alphabetical order
- [x] No `@deprecated` annotations added — pure movement only
- [ ] `/security-review` (Daniele will run pre-merge)