### PR TITLE
feat(egress): emit tool_call_start/end + cullis_audit SSE events (P1 Tier B, Mastio)

### DIFF
--- a/mcp_proxy/egress/llm_chat_router.py
+++ b/mcp_proxy/egress/llm_chat_router.py
@@ -260,6 +260,53 @@ async def _handle_stream(
             detail={"reason": exc.reason, "trace_id": trace_id},
         ) from exc
 
+    # P1 Cullis Chat SSE backend — tool_call event emission.
+    # ``tool_call_start`` and ``tool_call_end`` are named SSE events the
+    # SPA's parser (frontend/cullis-chat/src/lib/sse.ts) listens to so
+    # the ``ToolCallIndicator`` chip renders against real traffic, not
+    # only against the mock ambassador. LiteLLM normalises every
+    # provider (Anthropic, OpenAI, Bedrock, …) to the OpenAI delta
+    # shape, so a single parser on ``delta.tool_calls`` covers them
+    # all. Per-tool audit rows mirror the local audit conventions
+    # established for ``egress_llm_chat`` and reuse the same trace_id.
+    tool_state: dict[int, dict] = {}   # index → {name, started_at}
+    tools_summary: list[dict] = []     # for the trailing cullis_audit event
+
+    async def _emit_tool_end(idx: int, st: dict):
+        latency_ms = int((time.monotonic() - st["started_at"]) * 1000)
+        tools_summary.append({"name": st["name"], "latency_ms": latency_ms})
+        try:
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="llm.tool_call",
+                status="success",
+                tool_name=st["name"],
+                duration_ms=float(latency_ms),
+                details={
+                    "event": "llm.tool_call",
+                    "principal_id": agent.agent_id,
+                    "principal_type": agent.principal_type,
+                    "backend": streamer.backend,
+                    "provider": streamer.provider,
+                    "model": req.model,
+                    "trace_id": trace_id,
+                    "tool": st["name"],
+                    "latency_ms": latency_ms,
+                },
+            )
+        except Exception as exc:
+            # Audit failure must not break the SSE stream — the
+            # surrounding ``egress_llm_chat`` row will still record
+            # the overall request, and the operator will see the
+            # log warning. ``audit_fail_deny`` decides whether the
+            # individual log_audit raises; we swallow at the boundary
+            # so a per-tool hiccup does not 500 the chat.
+            logger.warning(
+                "log_audit for tool_call %s failed: %s",
+                st["name"], exc,
+            )
+        return latency_ms
+
     async def sse():
         terminated_with_error: GatewayError | None = None
         try:
@@ -269,7 +316,64 @@ async def _handle_stream(
                 # mid-stream client disconnect. The backend stays
                 # trace-id-agnostic.
                 chunk.setdefault("cullis_trace_id", trace_id)
+
+                # Tool-call delta parser. Wrapped in a defensive
+                # try/except so a malformed chunk from a misbehaving
+                # provider does not poison the user-visible stream;
+                # the data: frame is still yielded below regardless.
+                try:
+                    choices = chunk.get("choices") or []
+                    if choices:
+                        choice0 = choices[0]
+                        delta = choice0.get("delta") or {}
+                        tc_list = delta.get("tool_calls") or []
+                        for tc in tc_list:
+                            idx = tc.get("index", 0)
+                            fn = tc.get("function") or {}
+                            name = fn.get("name")
+                            # ``name`` arrives on the first delta of a
+                            # tool block; subsequent deltas carry only
+                            # ``arguments`` increments. Emit
+                            # tool_call_start exactly once per index.
+                            if name and idx not in tool_state:
+                                tool_state[idx] = {
+                                    "name": name,
+                                    "started_at": time.monotonic(),
+                                }
+                                yield (
+                                    "event: tool_call_start\n"
+                                    f"data: {json.dumps({'tool': name})}\n\n"
+                                )
+
+                        # ``finish_reason='tool_calls'`` closes every
+                        # active tool block in this assistant turn.
+                        finish = choice0.get("finish_reason")
+                        if finish == "tool_calls" and tool_state:
+                            for idx, st in list(tool_state.items()):
+                                latency_ms = await _emit_tool_end(idx, st)
+                                yield (
+                                    "event: tool_call_end\n"
+                                    f"data: {json.dumps({'tool': st['name'], 'latency_ms': latency_ms})}\n\n"
+                                )
+                                del tool_state[idx]
+                except Exception as parser_exc:
+                    logger.warning(
+                        "tool_call SSE parser skipped chunk: %s",
+                        parser_exc,
+                    )
+
                 yield f"data: {json.dumps(chunk)}\n\n"
+
+            # Trailing summary event the SPA uses to populate the
+            # audit panel ("3 tools called in 470ms"). Shape mirrors
+            # the mock ambassador (frontend/cullis-chat/mock/ambassador.mjs).
+            if tools_summary:
+                summary = {
+                    "trace_id": trace_id,
+                    "latency_ms": int(streamer.latency_ms),
+                    "tools": tools_summary,
+                }
+                yield f"event: cullis_audit\ndata: {json.dumps(summary)}\n\n"
             yield "data: [DONE]\n\n"
         except GatewayError as exc:
             terminated_with_error = exc

--- a/tests/test_proxy_llm_chat_router.py
+++ b/tests/test_proxy_llm_chat_router.py
@@ -685,3 +685,257 @@ async def test_chat_completions_streaming_setup_error_returns_json(
     detail = json.loads(rows[0]["detail"])
     assert detail["reason"] == "provider_key_missing"
     assert detail["stream"] is True
+
+
+# ────────────────────────────────────────────────────────────────────
+# P1 Tier B — Cullis Chat SSE backend instrumentation
+#
+# The frontend SPA's parser (frontend/cullis-chat/src/lib/sse.ts)
+# expects named SSE events ``tool_call_start``, ``tool_call_end``,
+# and a trailing ``cullis_audit`` summary so the ToolCallIndicator
+# chip renders against real backend traffic, not only the mock
+# ambassador. These tests pin the Mastio emission shape.
+# ────────────────────────────────────────────────────────────────────
+
+
+def _parse_sse_events(body: str) -> list[dict]:
+    """Parse an SSE body that may include both ``data:``-only frames
+    and ``event: <name>\\ndata: ...`` named frames.
+
+    Returns a list of records ``{event: str, data: <parsed>}``.
+    Default event name is ``"message"`` per the SSE spec when only a
+    data line is present; the literal ``[DONE]`` sentinel is preserved
+    as a string in ``data``.
+    """
+    out: list[dict] = []
+    for raw in body.split("\n\n"):
+        block = raw.strip()
+        if not block:
+            continue
+        event_name = "message"
+        data_lines: list[str] = []
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                event_name = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:"):].lstrip())
+        payload_raw = "\n".join(data_lines)
+        if payload_raw == "[DONE]":
+            out.append({"event": event_name, "data": "[DONE]"})
+        else:
+            out.append({"event": event_name, "data": json.loads(payload_raw)})
+    return out
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_emits_tool_call_named_events(
+    app_with_router, monkeypatch,
+):
+    """A model that returns tool_calls must produce a paired
+    ``tool_call_start`` + ``tool_call_end`` named event per index,
+    interleaved with the regular ``data:`` chunk stream, and a
+    trailing ``cullis_audit`` summary."""
+    chunks = [
+        # First delta carries the role.
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None},
+        ]},
+        # Model emits the first tool block (name + arg fragment).
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"tool_calls": [
+                {"index": 0, "id": "call_a", "type": "function",
+                 "function": {"name": "search_docs", "arguments": "{\"q\":"}},
+            ]}, "finish_reason": None},
+        ]},
+        # Argument increment for the same tool (no name → no new start).
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"tool_calls": [
+                {"index": 0, "function": {"arguments": "\"gdpr\"}"}},
+            ]}, "finish_reason": None},
+        ]},
+        # Model emits a second parallel tool block.
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"tool_calls": [
+                {"index": 1, "id": "call_b", "type": "function",
+                 "function": {"name": "postgres.query", "arguments": "{}"}},
+            ]}, "finish_reason": None},
+        ]},
+        # Model finishes the tool_calls assistant turn.
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {}, "finish_reason": "tool_calls"},
+        ]},
+        {"id": "x", "choices": [],
+         "usage": {"prompt_tokens": 20, "completion_tokens": 10}},
+    ]
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", _build_fake_streamer(chunks=chunks),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 200, r.text
+    events = _parse_sse_events(r.text)
+
+    # Two distinct tool blocks → two start + two end events, in order.
+    starts = [e for e in events if e["event"] == "tool_call_start"]
+    ends = [e for e in events if e["event"] == "tool_call_end"]
+    assert [e["data"]["tool"] for e in starts] == ["search_docs", "postgres.query"]
+    assert [e["data"]["tool"] for e in ends] == ["search_docs", "postgres.query"]
+    for e in ends:
+        assert "latency_ms" in e["data"]
+        assert isinstance(e["data"]["latency_ms"], int)
+        assert e["data"]["latency_ms"] >= 0
+
+    # Trailing cullis_audit event sums up the turn.
+    audits = [e for e in events if e["event"] == "cullis_audit"]
+    assert len(audits) == 1, audits
+    audit = audits[0]["data"]
+    assert audit["trace_id"].startswith("trace_")
+    assert {t["name"] for t in audit["tools"]} == {"search_docs", "postgres.query"}
+
+    # Each tool_call writes its own audit row so the forensic chain
+    # carries one entry per tool, plus the overall egress_llm_chat row.
+    tool_rows = await _audit_rows("llm.tool_call", status="success")
+    tools_logged = {json.loads(r["detail"])["tool"] for r in tool_rows}
+    assert tools_logged == {"search_docs", "postgres.query"}
+    for row in tool_rows:
+        detail = json.loads(row["detail"])
+        assert detail["event"] == "llm.tool_call"
+        assert detail["principal_type"] == "agent"
+        assert detail["model"] == "claude-haiku-4-5"
+        assert detail["trace_id"].startswith("trace_")
+        assert detail["latency_ms"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_no_tool_calls_emits_no_named_events(
+    app_with_router, monkeypatch,
+):
+    """The pure-text path stays a plain data:-only stream so callers
+    that don't care about tool chips (CLI, raw curl) see no shape
+    change vs. the pre-P1 baseline."""
+    chunks = [
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"content": "hi"}, "finish_reason": None},
+        ]},
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {}, "finish_reason": "stop"},
+        ]},
+        {"id": "x", "choices": [],
+         "usage": {"prompt_tokens": 5, "completion_tokens": 1}},
+    ]
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", _build_fake_streamer(chunks=chunks),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 200, r.text
+    events = _parse_sse_events(r.text)
+    assert all(e["event"] == "message" for e in events), [
+        e["event"] for e in events
+    ]
+    tool_rows = await _audit_rows("llm.tool_call")
+    assert tool_rows == []
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_parallel_tool_calls_share_finish(
+    app_with_router, monkeypatch,
+):
+    """Two tool blocks emitted within the same assistant turn both
+    close out on the single ``finish_reason='tool_calls'`` chunk."""
+    chunks = [
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"tool_calls": [
+                {"index": 0, "id": "call_a", "type": "function",
+                 "function": {"name": "tool_a", "arguments": "{}"}},
+                {"index": 1, "id": "call_b", "type": "function",
+                 "function": {"name": "tool_b", "arguments": "{}"}},
+            ]}, "finish_reason": None},
+        ]},
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {}, "finish_reason": "tool_calls"},
+        ]},
+        {"id": "x", "choices": [],
+         "usage": {"prompt_tokens": 8, "completion_tokens": 4}},
+    ]
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", _build_fake_streamer(chunks=chunks),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    events = _parse_sse_events(r.text)
+    starts = [e["data"]["tool"] for e in events if e["event"] == "tool_call_start"]
+    ends = [e["data"]["tool"] for e in events if e["event"] == "tool_call_end"]
+    assert sorted(starts) == ["tool_a", "tool_b"]
+    assert sorted(ends) == ["tool_a", "tool_b"]
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_malformed_tool_chunk_does_not_break_stream(
+    app_with_router, monkeypatch,
+):
+    """A misshapen ``tool_calls`` payload from a misbehaving provider
+    must not poison the user-visible stream. The regular ``data:``
+    chunks keep flowing; only the parser entry is skipped."""
+    chunks = [
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"tool_calls": "not-a-list"},
+             "finish_reason": None},
+        ]},
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {"content": "fallback text"},
+             "finish_reason": None},
+        ]},
+        {"id": "x", "choices": [
+            {"index": 0, "delta": {}, "finish_reason": "stop"},
+        ]},
+        {"id": "x", "choices": [],
+         "usage": {"prompt_tokens": 5, "completion_tokens": 2}},
+    ]
+    monkeypatch.setattr(
+        router_module, "dispatch_stream", _build_fake_streamer(chunks=chunks),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app_with_router), base_url="http://test",
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={**_request_body(), "stream": True},
+        )
+
+    assert r.status_code == 200, r.text
+    events = _parse_sse_events(r.text)
+    # Text content survived.
+    text_chunks = [
+        e for e in events
+        if e["event"] == "message" and isinstance(e["data"], dict)
+        and e["data"].get("choices") and e["data"]["choices"][0]["delta"].get("content")
+    ]
+    assert any(
+        c["data"]["choices"][0]["delta"]["content"] == "fallback text"
+        for c in text_chunks
+    )
+    # No false tool events from the malformed payload.
+    assert not any(e["event"] == "tool_call_start" for e in events)


### PR DESCRIPTION
## Summary

Wires named SSE events on the Mastio's \`/v1/chat/completions\` stream so the Cullis Chat SPA's \`ToolCallIndicator\` chip renders against real backend traffic, not only the mock ambassador. Today the stream emits only OpenAI-shaped \`data:\` chunks + \`[DONE]\`; the SPA's parser at \`frontend/cullis-chat/src/lib/sse.ts\` already listens for \`tool_call_start\`, \`tool_call_end\` and \`cullis_audit\`, so this commit closes the contract gap on the backend side.

## What lands

- Parser inside \`_handle_stream::sse()\` tracks \`delta.tool_calls\` by index, emits a named \`tool_call_start\` the first time a tool name lands, and flushes paired \`tool_call_end\` events on \`finish_reason='tool_calls'\` with wall-clock \`latency_ms\`.
- Trailing \`cullis_audit\` event sums the turn (\`trace_id\`, \`latency_ms\`, \`tools\`) for the SPA's audit panel. Shape mirrors \`frontend/cullis-chat/mock/ambassador.mjs\`.
- Per-tool \`log_audit\` row (\`action='llm.tool_call'\`, \`tool_name\`, \`duration_ms\`, \`trace_id\`) alongside the overall \`egress_llm_chat\` row — forensic chain carries one entry per tool. Audit failure degrades silently to a \`logger.warning\` so a per-tool hiccup never 500s the chat.
- Parser wrapped in a defensive try/except so a misshapen \`tool_calls\` payload from a misbehaving provider does not poison the user-visible stream.

LiteLLM normalises every provider to OpenAI delta shape, so a single parser on \`delta.tool_calls[index].function.name\` covers Anthropic, OpenAI, Bedrock, Vertex, Gemini, Ollama.

## Out of scope (P1 follow-ups)

- **F2 Connector pass-through**: \`cullis_connector/ambassador/streaming.py\` is still a fake-stream wrapper (ADR-017 work). The named events reach a curl / SDK client today but not yet the browser SPA. F2 lands real streaming pass-through.
- **F3 E2E**: Playwright spec against real Mastio + fake LLM upstream emitting tool_use sequences.

## Test plan

- [x] \`pytest tests/test_proxy_llm_chat_router.py -n auto\` — 16/16 verdi (4 new + 12 pre-existing)
- [x] \`pytest -k 'egress or audit or llm or chat' -n auto\` — 459 verdi, zero regression
- [ ] \`./demo_network/smoke.sh full\` pre-merge
- [ ] /security-review pre-merge

## P1 roadmap

P1 Tier B step F1 from \`imp/enterprise-production-ready-plan.md\`. Memory \`feedback_tool_call_sse_backend_not_emitted\` documenta il gap chiuso da questa PR.