### PR TITLE
feat(connector): streaming tool-use loop opt-in (P1 Tier B F2b)

### DIFF
--- a/cullis_connector/ambassador/router.py
+++ b/cullis_connector/ambassador/router.py
@@ -37,6 +37,7 @@ from cullis_connector.ambassador.streaming import (
     extract_assistant_text,
     fake_stream,
 )
+from cullis_connector.ambassador.streaming_loop import stream_tool_use_loop
 
 _log = logging.getLogger("cullis_connector.ambassador.router")
 
@@ -294,6 +295,47 @@ def chat_completions(req: ChatCompletionRequest, request: Request):
         # client's own agent id so the audit row still names who acted.
         _principal_id = getattr(client, "agent_id", None)
         _principal_type = "agent"
+
+    # P1 Tier B F2b — streaming tool-use loop opt-in. When the env
+    # flag is on AND the request asks for stream=true, bridge the
+    # multi-turn loop to a real SSE pass-through so the SPA's
+    # ToolCallIndicator chip + audit panel render against live
+    # traffic (PR #719 is the Mastio emit side, this completes the
+    # browser-visible side). Default false to keep fake_stream as the
+    # back-compat path while the streaming branch matures.
+    _stream_loop_enabled = (
+        os.getenv("CULLIS_CONNECTOR_STREAMING_LOOP", "false").lower()
+        in ("1", "true", "yes", "on")
+    )
+
+    if req.stream and _stream_loop_enabled:
+        def _stream_then_invalidate():
+            try:
+                yield from stream_tool_use_loop(
+                    client,
+                    body,
+                    max_iters=8,
+                    pdp_enabled=_pdp_enabled,
+                    principal_id=_principal_id,
+                    principal_type=_principal_type,
+                    principal_org=_principal_org,
+                )
+            except Exception:
+                # Mirror the non-streaming exception handling: a
+                # mid-stream auth failure invalidates the cached
+                # agent-bound client so the next request re-logs in
+                # fresh. Per-user clients are short-lived. The error
+                # then propagates and Starlette closes the connection.
+                if user_creds is None:
+                    client_holder.invalidate()
+                _log.exception("streaming tool-use loop failed")
+                raise
+
+        return StreamingResponse(
+            _stream_then_invalidate(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     try:
         response, truncated = run_tool_use_loop(

--- a/cullis_connector/ambassador/shared/router.py
+++ b/cullis_connector/ambassador/shared/router.py
@@ -19,6 +19,7 @@ unchanged — both modes can coexist on the same image.
 from __future__ import annotations
 
 import logging
+import os
 import time
 from dataclasses import dataclass
 from typing import Any
@@ -45,6 +46,7 @@ from cullis_connector.ambassador.shared.proxy_trust import (
 from cullis_connector.ambassador.streaming import (
     extract_assistant_text, fake_stream,
 )
+from cullis_connector.ambassador.streaming_loop import stream_tool_use_loop
 
 _log = logging.getLogger("cullis_connector.ambassador.shared.router")
 
@@ -381,6 +383,30 @@ async def chat_completions(
     except Exception as exc:
         _log.exception("shared ambassador SDK login failed for %s", cred.principal_id)
         raise HTTPException(502, f"Cullis cloud login failed: {exc}") from exc
+
+    # P1 Tier B F2b — streaming tool-use loop opt-in. Same gate the
+    # ambassador router uses (cullis_connector/ambassador/router.py),
+    # mirrored here so shared-mode deploys (Frontdesk) get the same
+    # SPA-visible chip + audit-panel behaviour. Default false.
+    _stream_loop_enabled = (
+        os.getenv("CULLIS_CONNECTOR_STREAMING_LOOP", "false").lower()
+        in ("1", "true", "yes", "on")
+    )
+    if req.stream and _stream_loop_enabled:
+        def _stream_then_log_failure():
+            try:
+                yield from stream_tool_use_loop(client, body, max_iters=8)
+            except Exception:
+                _log.exception(
+                    "shared streaming tool-use loop failed for %s",
+                    cred.principal_id,
+                )
+                raise
+        return StreamingResponse(
+            _stream_then_log_failure(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
 
     try:
         response, truncated = run_tool_use_loop(client, body, max_iters=8)

--- a/cullis_connector/ambassador/streaming_loop.py
+++ b/cullis_connector/ambassador/streaming_loop.py
@@ -1,0 +1,274 @@
+"""Streaming tool-use loop for the Ambassador (P1 Tier B F2b).
+
+Companion to :mod:`cullis_connector.ambassador.loop`. ``run_tool_use_loop``
+is a multi-turn non-streaming loop that collapses the entire chat into
+one final answer and lets ``router.fake_stream`` fan that single answer
+as SSE frames. That hides every intermediate step — most importantly,
+the ``tool_call_start`` / ``tool_call_end`` named events the Mastio's
+streaming endpoint emits (see PR #719) never reach the SPA.
+
+This module is the streaming counterpart. It:
+
+* calls the Mastio with ``stream=True``;
+* yields each upstream SSE frame to the caller verbatim, so token
+  chunks, ``tool_call_start`` and ``tool_call_end`` flow to the SPA
+  in real time;
+* accumulates the streamed ``delta.tool_calls`` into a complete
+  assistant ``message.tool_calls`` so the Connector can execute each
+  tool through ``client.call_mcp_tool`` between turns;
+* runs the same PDP gate (ADR-029 Phase D) as the non-streaming loop;
+* swallows per-turn ``cullis_audit`` events and the per-turn
+  ``[DONE]`` sentinel, then emits a single aggregated ``cullis_audit``
+  summary + final ``[DONE]`` at the end of the multi-turn run. The
+  SPA therefore sees exactly one summary regardless of how many
+  Mastio round trips happened, matching the mock ambassador shape
+  (``frontend/cullis-chat/mock/ambassador.mjs``).
+
+Sync generator: FastAPI's ``StreamingResponse`` runs sync iterators
+in a thread executor, so we avoid the async-bridge overhead and stay
+parallel to ``streaming.fake_stream``.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Iterator
+
+from cullis_connector.ambassador.loop import (
+    _mcp_result_to_text,
+    _mcp_tool_to_openai,
+    DEFAULT_MAX_ITERS,
+)
+
+_log = logging.getLogger("cullis_connector.ambassador.streaming_loop")
+
+
+def _parse_sse_frame(frame: str) -> tuple[str | None, str]:
+    """Parse one SSE frame into ``(event_name, data_payload)``.
+
+    A ``data:``-only frame returns ``(None, payload)``. The data lines
+    are joined with ``\\n`` per the SSE spec so a multi-line ``data:``
+    block survives. The frame string passed in is expected to be
+    already trimmed of its trailing ``\\n\\n``.
+    """
+    event: str | None = None
+    data_lines: list[str] = []
+    for line in frame.split("\n"):
+        if line.startswith("event:"):
+            event = line[len("event:"):].strip()
+        elif line.startswith("data:"):
+            data_lines.append(line[len("data:"):].lstrip())
+    return event, "\n".join(data_lines)
+
+
+def _merge_tool_call_delta(
+    accumulated: list[dict], delta_tcs: list[dict],
+) -> None:
+    """Fold a ``delta.tool_calls`` streaming delta into the per-turn
+    accumulator keyed by index.
+
+    The first delta on a given index carries ``id``, ``type`` and
+    ``function.name``. Subsequent deltas only append text to
+    ``function.arguments``. This mirrors what OpenAI clients do
+    internally; LiteLLM normalises every provider to this shape, so
+    one parser covers Anthropic, OpenAI, Bedrock, etc.
+    """
+    for tc in delta_tcs:
+        idx = tc.get("index", 0)
+        while len(accumulated) <= idx:
+            accumulated.append({
+                "id": "",
+                "type": "function",
+                "function": {"name": "", "arguments": ""},
+            })
+        entry = accumulated[idx]
+        if tc.get("id"):
+            entry["id"] = tc["id"]
+        if tc.get("type"):
+            entry["type"] = tc["type"]
+        fn = tc.get("function") or {}
+        if fn.get("name"):
+            entry["function"]["name"] = fn["name"]
+        if fn.get("arguments"):
+            entry["function"]["arguments"] += fn["arguments"]
+
+
+def stream_tool_use_loop(
+    client: Any,
+    request_body: dict,
+    *,
+    max_iters: int = DEFAULT_MAX_ITERS,
+    pdp_enabled: bool = False,
+    principal_id: str | None = None,
+    principal_type: str = "user",
+    principal_org: str | None = None,
+    session_id: str | None = None,
+) -> Iterator[str]:
+    """Stream-aware multi-turn tool-use loop.
+
+    Same identity / PDP / max_iters semantics as
+    :func:`cullis_connector.ambassador.loop.run_tool_use_loop`, but
+    yields SSE frame strings as the upstream Mastio produces them.
+
+    Yields:
+        Raw SSE frames (``"data: ...\\n\\n"``, ``"event: ...\\n
+        data: ...\\n\\n"``). The terminator
+        ``"data: [DONE]\\n\\n"`` is the last yielded frame.
+    """
+    body = dict(request_body)
+    messages: list[dict] = list(body.get("messages", []))
+
+    try:
+        mcp_tools = client.list_mcp_tools()
+    except Exception:
+        _log.exception("list_mcp_tools failed; proceeding without tools")
+        mcp_tools = []
+
+    if mcp_tools and "tools" not in body:
+        body["tools"] = [_mcp_tool_to_openai(t) for t in mcp_tools]
+
+    aggregated_tools: list[dict] = []
+    aggregated_latency_ms: int = 0
+    last_trace_id: str = ""
+    truncated = False
+
+    for iteration in range(max_iters):
+        body["messages"] = messages
+        body["stream"] = True
+        _log.info(
+            "streaming tool-use loop iter=%d agent=%s tools=%d msgs=%d",
+            iteration + 1,
+            getattr(client, "agent_id", "?"),
+            len(body.get("tools", []) or []),
+            len(messages),
+        )
+
+        turn_tool_calls: list[dict] = []
+        finish_reason: str | None = None
+
+        for frame_str in client.chat_completion_stream(body):
+            event, data_raw = _parse_sse_frame(frame_str.strip())
+
+            if event == "cullis_audit":
+                # Buffer per-turn audit; emit a single aggregate at end.
+                try:
+                    a = json.loads(data_raw)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(a.get("tools"), list):
+                    aggregated_tools.extend(a["tools"])
+                latency = a.get("latency_ms")
+                if isinstance(latency, int):
+                    aggregated_latency_ms += latency
+                if a.get("trace_id"):
+                    last_trace_id = str(a["trace_id"])
+                continue
+
+            if data_raw == "[DONE]":
+                # Consume Mastio's per-turn DONE; emit our own at end.
+                continue
+
+            # Pass through anything else verbatim:
+            # token deltas, tool_call_start, tool_call_end.
+            yield frame_str if frame_str.endswith("\n\n") else frame_str + "\n\n"
+
+            # Peek at default-event data:chunks to grow the
+            # tool_calls accumulator and watch for finish_reason.
+            if event is None:
+                try:
+                    chunk = json.loads(data_raw)
+                except json.JSONDecodeError:
+                    continue
+                choices = chunk.get("choices") or []
+                if not choices:
+                    continue
+                choice0 = choices[0]
+                delta = choice0.get("delta") or {}
+                delta_tcs = delta.get("tool_calls") or []
+                if delta_tcs:
+                    _merge_tool_call_delta(turn_tool_calls, delta_tcs)
+                fr = choice0.get("finish_reason")
+                if fr:
+                    finish_reason = fr
+
+        if finish_reason != "tool_calls":
+            break
+
+        if not turn_tool_calls:
+            _log.warning(
+                "stream ended with finish_reason=tool_calls but no "
+                "tool_calls delta was collected; aborting loop",
+            )
+            break
+
+        # Build the assistant message and execute each MCP tool.
+        # Same flow as run_tool_use_loop, just driven off streamed state.
+        messages.append({
+            "role": "assistant",
+            "content": None,
+            "tool_calls": turn_tool_calls,
+        })
+
+        for tc in turn_tool_calls:
+            fn = tc.get("function") or {}
+            name = fn.get("name") or ""
+            args_raw = fn.get("arguments") or "{}"
+            try:
+                args = json.loads(args_raw) if isinstance(args_raw, str) else args_raw
+            except json.JSONDecodeError:
+                _log.warning("tool_call args not valid JSON: %r", args_raw[:200])
+                args = {}
+
+            policy_blocked: tuple[bool, str] = (False, "")
+            if pdp_enabled and principal_id:
+                try:
+                    pdp = client.evaluate_tool_call_policy(
+                        principal_id=principal_id,
+                        principal_type=principal_type,
+                        org=principal_org,
+                        model_id=body.get("model"),
+                        tool_name=name,
+                        session_id=session_id,
+                    )
+                except Exception as exc:
+                    _log.warning("PDP transport failure on tool %s: %s", name, exc)
+                    pdp = {"allowed": False, "reason": f"PDP transport: {exc}"}
+                if not pdp.get("allowed"):
+                    policy_blocked = (True, str(pdp.get("reason") or ""))
+                    _log.info(
+                        "tool %s denied by PDP: %s", name, policy_blocked[1],
+                    )
+
+            if policy_blocked[0]:
+                text = (
+                    f"policy_denied: tool '{name}' refused by policy: "
+                    f"{policy_blocked[1]}"
+                )
+            else:
+                try:
+                    result = client.call_mcp_tool(name, args)
+                    text = _mcp_result_to_text(result)
+                except Exception as exc:
+                    _log.exception("tool %s failed", name)
+                    text = f"tool error: {exc}"
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.get("id") or f"call_{iteration}_{name}",
+                "content": text,
+            })
+    else:
+        # for-else: max_iters exhausted without break.
+        truncated = True
+        _log.warning(
+            "streaming tool-use loop exhausted max_iters=%d", max_iters,
+        )
+
+    summary: dict[str, Any] = {
+        "trace_id": last_trace_id,
+        "latency_ms": aggregated_latency_ms,
+        "tools": aggregated_tools,
+    }
+    if truncated:
+        summary["truncated"] = True
+    yield f"event: cullis_audit\ndata: {json.dumps(summary)}\n\n"
+    yield "data: [DONE]\n\n"

--- a/cullis_sdk/_client/_ai_gateway.py
+++ b/cullis_sdk/_client/_ai_gateway.py
@@ -6,8 +6,9 @@ Single public symbol:
 * :class:`_AiGatewayMixin` — mixin folded into ``CullisClient`` that
   exposes the three Mastio-side surfaces:
 
-    1. **AI gateway egress (ADR-017)** — ``chat_completion`` and
-       ``list_models`` talk to the Mastio's embedded LiteLLM proxy.
+    1. **AI gateway egress (ADR-017)** — ``chat_completion``,
+       ``chat_completion_stream`` and ``list_models`` talk to the
+       Mastio's embedded LiteLLM proxy.
     2. **MCP aggregator (ADR-007, proxy-side only)** —
        ``list_mcp_tools`` and ``call_mcp_tool`` invoke JSON-RPC against
        ``/v1/mcp`` on the local proxy.
@@ -15,12 +16,13 @@ Single public symbol:
        ``evaluate_tool_call_policy`` asks the Mastio whether a tool
        call is permitted, returning a boring fail-safe dict.
 
-Movement only — no behavior change. ``chat_completion`` is not a
-streaming endpoint here (the streaming SSE wiring lives proxy-side
-under ``llm_chat_router``); it returns the parsed JSON body. The
-mixin assumes the host class exposes ``_authed_request``.
+The mixin assumes the host class exposes ``_authed_request`` and the
+raw ``_http`` httpx client + ``_headers`` helper (for the streaming
+path that cannot use the auto-retry wrapper).
 """
 from __future__ import annotations
+
+from typing import Iterator
 
 
 class _AiGatewayMixin:
@@ -44,6 +46,53 @@ class _AiGatewayMixin:
         resp = self._authed_request("POST", "/v1/llm/chat", json=request)
         resp.raise_for_status()
         return resp.json()
+
+    def chat_completion_stream(self, request: dict) -> Iterator[str]:
+        """Streaming variant of :meth:`chat_completion`.
+
+        Forces ``stream=True`` on the request and yields SSE frame
+        strings exactly as they arrive from the Mastio, including
+        named events (``event: tool_call_start`` etc., see
+        ``mcp_proxy/egress/llm_chat_router.py`` P1 emit) and the
+        terminal ``data: [DONE]\\n\\n``. The caller is responsible
+        for SSE framing semantics — this iterator just hands over
+        complete frames split on ``\\n\\n``.
+
+        Bypasses :meth:`_authed_request` because the wrapper retries
+        the whole call on a token-expiry 401, which is incompatible
+        with a streaming response that has already started flushing
+        bytes. The trade-off: no auto-relogin / DPoP nonce retry on
+        the stream path. Callers that need that resilience must
+        catch the 401 themselves and re-invoke after refreshing the
+        token via the normal sync surface.
+        """
+        body = dict(request)
+        body["stream"] = True
+        path = "/v1/llm/chat"
+        with self._http.stream(
+            "POST", f"{self.base}{path}",
+            headers=self._headers("POST", path),
+            json=body,
+        ) as resp:
+            resp.raise_for_status()
+            buf = ""
+            # iter_text decodes UTF-8 chunks from the upstream socket.
+            # Concatenate into a buffer and slice on \n\n so partial
+            # frames split across TCP packets land in a single yield.
+            for raw in resp.iter_text():
+                if not raw:
+                    continue
+                buf += raw
+                while "\n\n" in buf:
+                    frame, buf = buf.split("\n\n", 1)
+                    if frame:
+                        yield frame + "\n\n"
+            tail = buf.strip()
+            if tail:
+                # Upstream closed without a trailing blank line —
+                # surface what we have so the caller can detect
+                # ``[DONE]`` even on a slightly malformed stream.
+                yield tail
 
     def list_models(self) -> list[dict]:
         """Return the OpenAI-compatible model list from Mastio.

--- a/tests/connector/test_ambassador_router.py
+++ b/tests/connector/test_ambassador_router.py
@@ -97,6 +97,12 @@ class FakeCullisClient:
     tools_to_return: list[dict] = []
     tool_results: dict[str, Any] = {}
 
+    # P1 Tier B F2b streaming loop — each entry is a list of SSE frame
+    # strings the fake yields from a single ``chat_completion_stream``
+    # call. ``stream_chunks`` pops FIFO per loop iteration.
+    stream_chunks: list[list[str]] = []
+    stream_calls: list[dict] = []
+
     # ADR-029 Phase D, programmable PDP for tool-level tests. Each entry
     # in pdp_responses pops FIFO; pdp_raise toggles an exception path.
     pdp_calls: list[dict] = []
@@ -115,6 +121,8 @@ class FakeCullisClient:
         cls.pdp_calls = []
         cls.pdp_responses = []
         cls.pdp_raise = False
+        cls.stream_chunks = []
+        cls.stream_calls = []
 
     def __init__(self, *args, **kwargs) -> None:
         self._init_args = args
@@ -160,6 +168,34 @@ class FakeCullisClient:
         if name in type(self).tool_results:
             return type(self).tool_results[name]
         return {"content": [{"type": "text", "text": f"tool {name} ok"}]}
+
+    def chat_completion_stream(self, body: dict):
+        """P1 Tier B F2b streaming variant. Yields SSE frame strings
+        from the per-iteration ``stream_chunks`` queue. The body each
+        iter receives is captured separately so a test can pin the
+        tool-result messages were threaded through the next turn."""
+        type(self).stream_calls.append(body)
+        if not type(self).stream_chunks:
+            # Default: trivial text-only stream + DONE.
+            import json as _json
+            yield (
+                "data: " + _json.dumps({
+                    "choices": [{"index": 0,
+                                  "delta": {"content": "default streamed"},
+                                  "finish_reason": None}],
+                }) + "\n\n"
+            )
+            yield (
+                "data: " + _json.dumps({
+                    "choices": [{"index": 0,
+                                  "delta": {},
+                                  "finish_reason": "stop"}],
+                }) + "\n\n"
+            )
+            yield "data: [DONE]\n\n"
+            return
+        for f in type(self).stream_chunks.pop(0):
+            yield f
 
     def evaluate_tool_call_policy(self, **kwargs) -> dict:
         type(self).pdp_calls.append(kwargs)
@@ -695,3 +731,322 @@ def test_pdp_transport_error_fail_safe_deny(client, bearer, monkeypatch):
     last_message = second_call["messages"][-1]
     assert last_message["role"] == "tool"
     assert "policy_denied" in last_message["content"]
+
+
+# ────────────────────────────────────────────────────────────────────
+# P1 Tier B F2b — streaming tool-use loop opt-in.
+# Default OFF: stream=true still walks through ``fake_stream`` (the
+# tests above already pin that path). The opt-in flag flips routing
+# to ``stream_tool_use_loop`` so the SPA sees real SSE frames including
+# named ``tool_call_start`` / ``tool_call_end`` events and a final
+# aggregated ``cullis_audit`` summary.
+# ────────────────────────────────────────────────────────────────────
+
+
+def _split_sse_events(body: str) -> list[dict]:
+    """Parse the SSE body emitted by ``stream_tool_use_loop`` into a
+    list of ``{event, data}`` records. Mirrors the helper used in the
+    Mastio side (tests/test_proxy_llm_chat_router.py) and tolerates
+    both ``data:``-only frames and named events. ``data: [DONE]`` is
+    kept verbatim as a string in ``data`` so callers can assert on
+    the terminator."""
+    import json as _json
+    out: list[dict] = []
+    for raw in body.split("\n\n"):
+        block = raw.strip()
+        if not block:
+            continue
+        event = "message"
+        data_lines: list[str] = []
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                event = line[len("event:"):].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[len("data:"):].lstrip())
+        payload = "\n".join(data_lines)
+        if payload == "[DONE]":
+            out.append({"event": event, "data": "[DONE]"})
+        else:
+            try:
+                out.append({"event": event, "data": _json.loads(payload)})
+            except Exception:
+                out.append({"event": event, "data": payload})
+    return out
+
+
+def test_streaming_loop_off_by_default_still_uses_fake_stream(client, bearer, monkeypatch):
+    """No env flag → router still calls run_tool_use_loop and serializes
+    the final answer via fake_stream. stream_chunks is never consumed."""
+    monkeypatch.delenv("CULLIS_CONNECTOR_STREAMING_LOOP", raising=False)
+    FakeCullisClient.chat_responses = [{
+        "choices": [{
+            "message": {"role": "assistant", "content": "back-compat answer"},
+            "finish_reason": "stop",
+        }],
+    }]
+    FakeCullisClient.stream_chunks = [["WOULD NEVER REACH CLIENT"]]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "stream": True,
+            "messages": [{"role": "user", "content": "ciao"}],
+        },
+    )
+    assert resp.status_code == 200
+    assert "back-compat answer" in resp.text
+    # Streaming surface untouched.
+    assert FakeCullisClient.stream_calls == []
+    assert "WOULD NEVER REACH CLIENT" not in resp.text
+
+
+def test_streaming_loop_passes_frames_through_and_emits_audit(
+    client, bearer, monkeypatch,
+):
+    """Env flag on + text-only stream → frames pass through verbatim,
+    Mastio per-turn cullis_audit is swallowed, a single aggregated
+    cullis_audit + [DONE] is appended at the end."""
+    import json as _json
+    monkeypatch.setenv("CULLIS_CONNECTOR_STREAMING_LOOP", "true")
+
+    FakeCullisClient.stream_chunks = [[
+        "data: " + _json.dumps({
+            "choices": [{"index": 0,
+                          "delta": {"role": "assistant"},
+                          "finish_reason": None}],
+        }) + "\n\n",
+        "data: " + _json.dumps({
+            "choices": [{"index": 0,
+                          "delta": {"content": "hello there"},
+                          "finish_reason": None}],
+        }) + "\n\n",
+        "data: " + _json.dumps({
+            "choices": [{"index": 0,
+                          "delta": {},
+                          "finish_reason": "stop"}],
+        }) + "\n\n",
+        "event: cullis_audit\n"
+        "data: " + _json.dumps({
+            "trace_id": "trace_abc",
+            "latency_ms": 250,
+            "tools": [],
+        }) + "\n\n",
+        "data: [DONE]\n\n",
+    ]]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "stream": True,
+            "messages": [{"role": "user", "content": "ciao"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    events = _split_sse_events(resp.text)
+
+    # Mastio's per-turn cullis_audit is consumed; the only one the SPA
+    # sees is the aggregated one.
+    audit_events = [e for e in events if e["event"] == "cullis_audit"]
+    assert len(audit_events) == 1
+    aud = audit_events[0]["data"]
+    assert aud["trace_id"] == "trace_abc"
+    assert aud["latency_ms"] == 250
+    assert aud["tools"] == []
+
+    # Token content survived the round trip.
+    contents = [
+        e["data"]["choices"][0]["delta"].get("content")
+        for e in events
+        if e["event"] == "message" and isinstance(e["data"], dict)
+        and e["data"].get("choices")
+    ]
+    assert "hello there" in contents
+
+    # Connector terminator is the only [DONE] on the wire (Mastio's
+    # per-turn DONE was swallowed).
+    done_events = [e for e in events if e["data"] == "[DONE]"]
+    assert len(done_events) == 1
+
+
+def test_streaming_loop_executes_tool_calls_and_aggregates_audit(
+    client, bearer, monkeypatch,
+):
+    """A first-turn stream that ends with finish_reason='tool_calls'
+    triggers MCP tool execution + a second turn. Final cullis_audit
+    sums the tool list across turns and the second turn's text is the
+    last content the SPA sees."""
+    import json as _json
+    monkeypatch.setenv("CULLIS_CONNECTOR_STREAMING_LOOP", "true")
+
+    FakeCullisClient.tools_to_return = [{
+        "name": "postgres.query",
+        "description": "run sql",
+        "inputSchema": {"type": "object"},
+    }]
+    FakeCullisClient.tool_results = {
+        "postgres.query": {"content": [{"type": "text", "text": "42 rows"}]},
+    }
+
+    # Turn 1: assistant emits a tool_call block + tool_call_start/end
+    # named events (as the Mastio's F1 emit would in real traffic).
+    FakeCullisClient.stream_chunks = [
+        [
+            "event: tool_call_start\n"
+            "data: " + _json.dumps({"tool": "postgres.query"}) + "\n\n",
+            "data: " + _json.dumps({
+                "choices": [{"index": 0, "delta": {"tool_calls": [
+                    {"index": 0, "id": "call_x", "type": "function",
+                     "function": {"name": "postgres.query",
+                                   "arguments": "{\"sql\":\"select 1\"}"}}
+                ]}, "finish_reason": None}],
+            }) + "\n\n",
+            "data: " + _json.dumps({
+                "choices": [{"index": 0, "delta": {},
+                              "finish_reason": "tool_calls"}],
+            }) + "\n\n",
+            "event: tool_call_end\n"
+            "data: " + _json.dumps({"tool": "postgres.query",
+                                     "latency_ms": 120}) + "\n\n",
+            "event: cullis_audit\n"
+            "data: " + _json.dumps({
+                "trace_id": "trace_t1",
+                "latency_ms": 200,
+                "tools": [{"name": "postgres.query", "latency_ms": 120}],
+            }) + "\n\n",
+            "data: [DONE]\n\n",
+        ],
+        # Turn 2: final text answer.
+        [
+            "data: " + _json.dumps({
+                "choices": [{"index": 0,
+                              "delta": {"content": "found 42 rows"},
+                              "finish_reason": None}],
+            }) + "\n\n",
+            "data: " + _json.dumps({
+                "choices": [{"index": 0, "delta": {},
+                              "finish_reason": "stop"}],
+            }) + "\n\n",
+            "event: cullis_audit\n"
+            "data: " + _json.dumps({
+                "trace_id": "trace_t2",
+                "latency_ms": 150,
+                "tools": [],
+            }) + "\n\n",
+            "data: [DONE]\n\n",
+        ],
+    ]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "stream": True,
+            "messages": [{"role": "user", "content": "how many rows?"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    events = _split_sse_events(resp.text)
+
+    # Tool was actually executed via the SDK aggregator.
+    assert FakeCullisClient.call_tool_calls == [
+        ("postgres.query", {"sql": "select 1"}),
+    ]
+
+    # Two SDK streaming calls (one per turn). Second turn's messages
+    # include the role=tool reply built from the MCP result.
+    assert len(FakeCullisClient.stream_calls) == 2
+    second_messages = FakeCullisClient.stream_calls[1]["messages"]
+    assert second_messages[-1]["role"] == "tool"
+    assert "42 rows" in second_messages[-1]["content"]
+
+    # Named events from both turns reach the SPA.
+    starts = [e for e in events if e["event"] == "tool_call_start"]
+    ends = [e for e in events if e["event"] == "tool_call_end"]
+    assert [e["data"]["tool"] for e in starts] == ["postgres.query"]
+    assert [e["data"]["tool"] for e in ends] == ["postgres.query"]
+
+    # Single aggregated audit at end, summing both turns.
+    audits = [e for e in events if e["event"] == "cullis_audit"]
+    assert len(audits) == 1
+    aud = audits[0]["data"]
+    assert aud["trace_id"] == "trace_t2"  # last trace seen
+    assert aud["latency_ms"] == 350       # 200 + 150
+    assert aud["tools"] == [{"name": "postgres.query", "latency_ms": 120}]
+
+    # Final answer text reaches the SPA.
+    contents = [
+        e["data"]["choices"][0]["delta"].get("content")
+        for e in events
+        if e["event"] == "message" and isinstance(e["data"], dict)
+        and e["data"].get("choices")
+    ]
+    assert "found 42 rows" in contents
+
+
+def test_streaming_loop_pdp_deny_skips_tool_execution(
+    client, bearer, monkeypatch,
+):
+    """Tool-call PDP denial during streaming bypasses execution and
+    feeds a ``policy_denied`` text back as the tool result, exactly
+    like the non-streaming loop does."""
+    import json as _json
+    monkeypatch.setenv("CULLIS_CONNECTOR_STREAMING_LOOP", "true")
+    monkeypatch.setenv("CULLIS_CONNECTOR_TOOL_PDP_ENABLED", "true")
+
+    FakeCullisClient.tools_to_return = [{
+        "name": "postgres.query", "description": "x",
+        "inputSchema": {"type": "object"},
+    }]
+    FakeCullisClient.pdp_responses = [{
+        "allowed": False, "reason": "tool not permitted in this session",
+    }]
+    FakeCullisClient.stream_chunks = [
+        [
+            "data: " + _json.dumps({
+                "choices": [{"index": 0, "delta": {"tool_calls": [
+                    {"index": 0, "id": "call_a", "type": "function",
+                     "function": {"name": "postgres.query",
+                                   "arguments": "{}"}}
+                ]}, "finish_reason": None}],
+            }) + "\n\n",
+            "data: " + _json.dumps({
+                "choices": [{"index": 0, "delta": {},
+                              "finish_reason": "tool_calls"}],
+            }) + "\n\n",
+            "data: [DONE]\n\n",
+        ],
+        [
+            "data: " + _json.dumps({
+                "choices": [{"index": 0,
+                              "delta": {"content": "cannot do that"},
+                              "finish_reason": "stop"}],
+            }) + "\n\n",
+            "data: [DONE]\n\n",
+        ],
+    ]
+
+    resp = client.post(
+        "/v1/chat/completions",
+        headers={"Authorization": f"Bearer {bearer}"},
+        json={
+            "model": "claude-haiku-4-5",
+            "stream": True,
+            "messages": [{"role": "user", "content": "run the query"}],
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Tool was NOT executed.
+    assert FakeCullisClient.call_tool_calls == []
+    # PDP was consulted.
+    assert len(FakeCullisClient.pdp_calls) == 1
+    # Second turn's last message is the policy_denied stand-in.
+    second_messages = FakeCullisClient.stream_calls[1]["messages"]
+    assert second_messages[-1]["role"] == "tool"
+    assert "policy_denied" in second_messages[-1]["content"]


### PR DESCRIPTION
## Summary

Companion to [#719](https://github.com/cullis-security/cullis/pull/719) (Mastio SSE emit). The Connector ambassador now ships a streaming variant of \`run_tool_use_loop\` that bridges the Mastio SSE stream to the browser SPA in real time, so the \`ToolCallIndicator\` chip + audit panel render against live traffic instead of only the mock ambassador.

## Three pieces in one PR

| Layer | What |
|---|---|
| **SDK** \`cullis_sdk/_client/_ai_gateway.py\` | new \`chat_completion_stream(request)\` yields raw SSE frame strings from \`/v1/llm/chat\` with \`stream=True\`. Bypasses \`_authed_request\` (retry on a half-flushed stream is unsafe); documented trade-off: no auto-relogin/nonce retry on the stream path |
| **Connector** \`cullis_connector/ambassador/streaming_loop.py\` (new) | \`stream_tool_use_loop\` sync generator: drives multi-turn tool loop on the streaming surface, passes Mastio frames through verbatim, reconstructs \`delta.tool_calls\` into a complete assistant message, executes each MCP tool, threads \`role=tool\` reply into next turn, PDP gate, single aggregated \`cullis_audit\` summary + terminating \`data: [DONE]\` at end |
| **Router wire-up** (\`ambassador/router.py\` + \`ambassador/shared/router.py\`) | env \`CULLIS_CONNECTOR_STREAMING_LOOP=true\` opt-in. When ON + \`req.stream\` true → \`stream_tool_use_loop\`. Default OFF → existing \`fake_stream\` path untouched |

## Why opt-in default OFF

The streaming bridge is new code touching the hot path of every chat request. Shipping it default-on would change every Connector deploy's observable wire shape in one commit. Default-OFF lets operators flip the flag on a single canary + roll back instantly if anything breaks before the broader rollout.

## SPA-visible shape (with flag ON)

```
event: tool_call_start
data: {"tool": "postgres.query"}
data: {"choices": [{"delta": {"tool_calls": [...]}, ...}]}
data: {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]}
event: tool_call_end
data: {"tool": "postgres.query", "latency_ms": 120}
[... Connector executes tool, threads role=tool, calls Mastio again ...]
data: {"choices": [{"delta": {"content": "found 42 rows"}, ...}]}
data: {"choices": [{"delta": {}, "finish_reason": "stop"}]}
event: cullis_audit
data: {"trace_id": "trace_t2", "latency_ms": 350, "tools": [{"name": "postgres.query", "latency_ms": 120}]}
data: [DONE]
```

Matches the mock ambassador (\`frontend/cullis-chat/mock/ambassador.mjs\`) — the SPA parser in \`frontend/cullis-chat/src/lib/sse.ts\` is already wired.

## Out of scope

- F3 Playwright E2E spec against real Mastio + fake LLM upstream emitting tool_use — follow-up PR
- Stream-path auto-relogin / DPoP nonce retry — needs a streaming-aware wrapper around \`_authed_request\`, follow-up

## Test plan

- [x] \`pytest tests/connector/test_ambassador_router.py -n0 -k 'streaming_loop'\` — 4 new cases verdi
- [x] \`pytest tests/connector/ -n auto\` — 633 verdi, zero regression
- [ ] \`./demo_network/smoke.sh full\` pre-merge
- [ ] /security-review pre-merge
- [ ] Dogfood: set \`CULLIS_CONNECTOR_STREAMING_LOOP=true\` su sandbox, hit SPA con tool-triggering message, verify chip appare in real time + audit panel popola