### PR TITLE
fix(connector): wire egress DPoP key into AmbassadorClient (PR #724 follow-up)

### DIFF
--- a/cullis_connector/ambassador/client.py
+++ b/cullis_connector/ambassador/client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from pathlib import Path
 from typing import Any
 
 _log = logging.getLogger("cullis_connector.ambassador.client")
@@ -40,6 +41,7 @@ class AmbassadorClient:
         cert_pem: str,
         key_pem: str,
         verify_tls: bool | str = True,
+        dpop_key_path: Path | None = None,
     ) -> None:
         self._site_url = site_url
         self._agent_id = agent_id
@@ -47,6 +49,14 @@ class AmbassadorClient:
         self._cert_pem = cert_pem
         self._key_pem = key_pem
         self._verify_tls = verify_tls
+        # ``dpop_key_path`` is the on-disk persistent egress DPoP key
+        # (``<config_dir>/identity/dpop.jwk``) whose thumbprint is
+        # pinned in ``internal_agents.dpop_jkt`` at enrollment time.
+        # The SDK's chat completion path (PR #724) signs with this key
+        # via ``_egress_dpop_key`` so the cert-pinned route on the
+        # Mastio accepts the call. ``None`` falls back to the legacy
+        # behaviour (bearer-DPoP path only) which 401s on chat.
+        self._dpop_key_path = dpop_key_path
         self._client: Any = None
         self._created_at: float = 0.0
         self._lock = threading.Lock()
@@ -73,6 +83,47 @@ class AmbassadorClient:
         client.login_from_pem(
             self._agent_id, self._org_id, self._cert_pem, self._key_pem,
         )
+        # PR #724 follow-up — populate the egress DPoP key the chat
+        # completion path now requires. ``login_from_pem`` only sets
+        # the ephemeral ``_dpop_privkey`` for the bearer-DPoP wrapper;
+        # ``_egress_dpop_key`` stays ``None`` on the basic constructor
+        # path, so a Mastio call to ``/v1/llm/chat`` would arrive
+        # without a DPoP header and be refused. Load the persistent
+        # key from disk so its thumbprint matches the pinned
+        # ``internal_agents.dpop_jkt``.
+        if self._dpop_key_path is not None:
+            try:
+                from cullis_sdk.dpop import DpopKey
+                # Mirror ``from_connector`` (cullis_sdk/client.py:1100-1107):
+                # load when the file exists, generate + persist on
+                # cold-start. ``DpopKey.load_or_generate`` takes an
+                # ``agent_id`` + ``base_dir`` form which doesn't match the
+                # Connector-laid-out ``identity/dpop.jwk`` path, so we
+                # use the explicit load/generate pair here.
+                if self._dpop_key_path.exists():
+                    client._egress_dpop_key = DpopKey.load(self._dpop_key_path)
+                else:
+                    client._egress_dpop_key = DpopKey.generate(
+                        path=self._dpop_key_path,
+                    )
+                _log.info(
+                    "ambassador egress DPoP key loaded "
+                    "(jkt=%s…)",
+                    client._egress_dpop_key.thumbprint()[:16],
+                )
+            except Exception as exc:
+                # Cert-pinned routes will 401 if this fails. Log loudly
+                # but don't refuse to build — bearer-DPoP routes like
+                # ``/v1/mcp`` still work, and a clear runtime error on
+                # the chat path is easier to diagnose than a silent
+                # build-time refusal.
+                _log.warning(
+                    "ambassador egress DPoP key load failed (%s): %s. "
+                    "Chat completions through this client will 401 on "
+                    "Mastio's cert-pinned path until the file is "
+                    "readable at %s.",
+                    type(exc).__name__, exc, self._dpop_key_path,
+                )
         self._client = client
         self._created_at = time.monotonic()
         _log.info(

--- a/cullis_connector/web.py
+++ b/cullis_connector/web.py
@@ -360,6 +360,13 @@ def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
 
+    # PR #724 follow-up — surface the on-disk DPoP key so the
+    # AmbassadorClient can populate _egress_dpop_key on the SDK
+    # instance. The chat completion path (cert-pinned on Mastio) signs
+    # with this persistent key; without it Mastio refuses with 401
+    # "DPoP proof was signed by a key not registered for this agent".
+    _dpop_key_path = config.config_dir / "identity" / "dpop.jwk"
+
     holder = AmbassadorClient(
         site_url=site_url,
         agent_id=agent_id,
@@ -367,6 +374,7 @@ def _maybe_install_ambassador(app: FastAPI, config: ConnectorConfig) -> None:
         cert_pem=bundle.cert_pem,
         key_pem=key_pem,
         verify_tls=config.verify_arg,
+        dpop_key_path=_dpop_key_path,
     )
     # Loopback enforcement defaults to True for the laptop topology
     # (Connector bound to 127.0.0.1, defence-in-depth on the bind). In

--- a/tests/connector/test_ambassador_client_egress_dpop.py
+++ b/tests/connector/test_ambassador_client_egress_dpop.py
@@ -1,0 +1,160 @@
+"""AmbassadorClient populates _egress_dpop_key on the SDK instance
+when a dpop_key_path is provided.
+
+Follow-up to PR #724 (SDK chat completion → egress path). Without
+this wiring, the Connector ambassador builds a CullisClient via the
+basic constructor + login_from_pem, leaving _egress_dpop_key None;
+the chat path then arrives at Mastio without a DPoP header and is
+refused on the cert-pinned route. Tests pin both branches:
+
+* dpop_key_path provided → SDK._egress_dpop_key set, thumbprint
+  matches the on-disk dpop.jwk
+* dpop_key_path absent → back-compat, _egress_dpop_key stays None
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeCullisClient:
+    """Stand-in that mirrors the relevant SDK surface AmbassadorClient
+    touches. Avoids spinning up the real CullisClient (which would
+    need an HTTPS Mastio reachable to complete login_from_pem)."""
+
+    def __init__(self, site_url, *, verify_tls=True, timeout=10.0):
+        self.site_url = site_url
+        self._verify_tls = verify_tls
+        self.token = None
+        self._egress_dpop_key = None
+        self._dpop_privkey = None
+        self.agent_id = None
+
+    def login_from_pem(self, agent_id, org_id, cert_pem, key_pem, **kw):
+        self.agent_id = agent_id
+        # Mirror the SDK behaviour: login mints an ephemeral DPoP for
+        # the bearer-DPoP path. _egress_dpop_key is untouched.
+        self._dpop_privkey = object()
+
+
+@pytest.fixture(autouse=True)
+def _patch_sdk(monkeypatch):
+    import cullis_sdk
+    monkeypatch.setattr(cullis_sdk, "CullisClient", _FakeCullisClient)
+    yield
+
+
+def _self_signed_pair(common_name: str) -> tuple[str, str]:
+    """Mint a self-signed cert + matching private key PEM for the
+    AmbassadorClient constructor. The cert content does not have to
+    be valid in this test; only the constructor arity matters."""
+    from datetime import datetime, timedelta, timezone
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject).issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+    cert_pem = cert.public_bytes(serialization.Encoding.PEM).decode()
+    key_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    return cert_pem, key_pem
+
+
+def test_egress_dpop_key_populated_when_path_given(tmp_path):
+    """Happy path: pass dpop_key_path to the holder, get() returns a
+    client whose _egress_dpop_key matches the on-disk file's
+    thumbprint."""
+    from cullis_connector.ambassador.client import AmbassadorClient
+    from cullis_sdk.dpop import DpopKey
+
+    dpop_path = tmp_path / "dpop.jwk"
+    # Pre-generate the file so the persistent thumbprint is fixed.
+    seeded = DpopKey.generate(path=dpop_path)
+    expected_jkt = seeded.thumbprint()
+
+    cert_pem, key_pem = _self_signed_pair("demo-org::alice")
+
+    holder = AmbassadorClient(
+        site_url="https://mastio.test",
+        agent_id="demo-org::alice",
+        org_id="demo-org",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        verify_tls=False,
+        dpop_key_path=dpop_path,
+    )
+    client = holder.get()
+
+    assert client._egress_dpop_key is not None, (
+        "_egress_dpop_key must be populated when dpop_key_path is given; "
+        "otherwise the SDK chat path 401s on Mastio's cert-pinned route"
+    )
+    assert client._egress_dpop_key.thumbprint() == expected_jkt
+
+
+def test_egress_dpop_key_none_when_path_absent(tmp_path):
+    """Back-compat: legacy callers that don't pass dpop_key_path
+    continue to get a client with _egress_dpop_key None (chat path
+    still won't work for them, but the bearer-DPoP routes do)."""
+    from cullis_connector.ambassador.client import AmbassadorClient
+
+    cert_pem, key_pem = _self_signed_pair("demo-org::alice")
+
+    holder = AmbassadorClient(
+        site_url="https://mastio.test",
+        agent_id="demo-org::alice",
+        org_id="demo-org",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        verify_tls=False,
+        # dpop_key_path intentionally omitted
+    )
+    client = holder.get()
+    assert client._egress_dpop_key is None
+
+
+def test_egress_dpop_key_load_failure_does_not_abort_build(
+    tmp_path, monkeypatch,
+):
+    """If the on-disk dpop.jwk is unreadable (permission denied,
+    corrupted file), build still returns a client so the bearer-DPoP
+    routes keep working. The operator sees a warning and the chat
+    path will 401 on its own with a clearer Mastio detail."""
+    from cullis_connector.ambassador.client import AmbassadorClient
+    from cullis_sdk import dpop as _dpop
+
+    def _boom(*a, **kw):
+        raise OSError("simulated: cannot read dpop.jwk")
+
+    # AmbassadorClient._build uses load() / generate() (not
+    # load_or_generate, whose signature is agent_id-based). Patch both
+    # so the failure surfaces regardless of whether the path exists.
+    monkeypatch.setattr(_dpop.DpopKey, "load", _boom)
+    monkeypatch.setattr(_dpop.DpopKey, "generate", _boom)
+
+    cert_pem, key_pem = _self_signed_pair("demo-org::alice")
+    holder = AmbassadorClient(
+        site_url="https://mastio.test",
+        agent_id="demo-org::alice",
+        org_id="demo-org",
+        cert_pem=cert_pem,
+        key_pem=key_pem,
+        verify_tls=False,
+        dpop_key_path=tmp_path / "dpop.jwk",
+    )
+    client = holder.get()
+    # Build succeeded; chat path is the only thing that will fail later.
+    assert client is not None
+    assert client._egress_dpop_key is None


### PR DESCRIPTION
## Summary

Companion of [#724](https://github.com/cullis-security/cullis/pull/724) (SDK chat methods routed via egress path with persistent ``_egress_dpop_key``). The SDK fix on its own was insufficient because ``AmbassadorClient._build`` constructs the SDK via the basic ``CullisClient(site_url)`` + ``login_from_pem`` flow. That path never populates ``_egress_dpop_key`` — only the factory entries (``from_connector`` / ``from_enrollment`` / ``from_identity_dir``) load it from ``identity/dpop.jwk``. End result: Mastio receives a chat POST without a DPoP header and refuses it on the cert-pinned route.

This PR threads the on-disk DPoP key path through the holder and assigns ``client._egress_dpop_key`` after ``login_from_pem``, mirroring the load/generate pair from ``cullis_sdk.client.from_connector`` lines 1100-1107.

## Wire-up

| File | Change |
|---|---|
| ``cullis_connector/ambassador/client.py`` | ``AmbassadorClient.__init__`` accepts ``dpop_key_path: Path \| None``; ``_build()`` loads or generates the DpopKey and assigns ``client._egress_dpop_key`` after login. Build failure logs warning + continues (bearer-DPoP routes keep working) |
| ``cullis_connector/web.py`` | Pass ``config.config_dir / \"identity\" / \"dpop.jwk\"`` to the holder. Laptop + Frontdesk bundles both pick up the persistent key without further configuration |

## Tests

- [x] ``pytest tests/connector/test_ambassador_client_egress_dpop.py -n0`` — 3 new verdi (populated path, absent path back-compat, load-failure fallback)
- [x] ``pytest tests/connector/ -n auto`` — 636 verdi, zero regression
- [ ] Dogfood end-to-end contro Mastio VM (next step after merge)
- [ ] /security-review pre-merge

## Net effect (with PR #724)

End-to-end Connector → Mastio ``/v1/chat/completions stream=true`` now passes a DPoP header signed by the enrollment-pinned key, the cert-pinned route accepts it, and the F1 named SSE events (tool_call_start / end / cullis_audit) reach the SPA for the first time against a real Mastio. ``fake_stream`` v0.1 in ``streaming.py`` becomes pure back-compat — operators flip ``CULLIS_CONNECTOR_STREAMING_LOOP=true`` (F2b PR #721) to switch to the live streaming path.

## Threat model

Coerente: il path egress firma con il DPoP key persistente di enrollment. ``internal_agents.dpop_jkt`` pinning fa il suo lavoro. Compromise di un solo asset (cert+key OR dpop.jwk) non basta a impersonate. Lo storytelling zero-trust per CISO sta in piedi.