### PR TITLE
refactor(sdk): emit DeprecationWarning on 13 legacy methods (closes refactor split)

### DIFF
--- a/cullis_sdk/_client/_auth.py
+++ b/cullis_sdk/_client/_auth.py
@@ -160,9 +160,26 @@ class _AuthMixin:
     def login(self, agent_id: str, org_id: str, cert_path: str, key_path: str,
               *,
               countersign_fn: Optional[Callable[[str], str]] = None) -> None:
-        """Authenticate via x509 + DPoP, reading cert and key from file paths."""
+        """Authenticate via x509 + DPoP, reading cert and key from file paths.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`from_api_key_file` (ADR-011 unified enrollment + runtime
+           auth) instead. Will be removed in v0.5.
+        """
+        import warnings
+        warnings.warn(
+            "CullisClient.login() is deprecated. Use from_api_key_file(...) "
+            "(ADR-011 unified enrollment + runtime auth) instead. "
+            "Will be removed in cullis-sdk v0.5 (~2026-08-15).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         cert_pem = Path(cert_path).read_text()
         key_pem = Path(key_path).read_text()
+        # ``login_from_pem`` itself emits a DeprecationWarning; ``login``
+        # callers will see both this and the inner one. They point at
+        # complementary stack frames (user → login, login → login_from_pem)
+        # which is the expected story.
         self.login_from_pem(
             agent_id, org_id, cert_pem, key_pem,
             countersign_fn=countersign_fn,

--- a/cullis_sdk/_client/_messaging_legacy.py
+++ b/cullis_sdk/_client/_messaging_legacy.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import time
 import uuid
+import warnings
 from typing import Any
 
 import httpx
@@ -64,6 +65,13 @@ from cullis_sdk._logging import RED, log
 from cullis_sdk.crypto.e2e import decrypt_from_agent, encrypt_for_agent
 from cullis_sdk.crypto.message_signer import sign_message, verify_signature
 from cullis_sdk.types import InboxMessage
+
+
+# Sunset target shared by every legacy session-based messaging method.
+# ADR-008 makes the oneshot fire-and-forget surface canonical (memory:
+# ``oneshot_only_for_demo``); these helpers stay around for one more
+# minor before removal.
+_SUNSET = "Will be removed in cullis-sdk v0.5 (~2026-08-15)."
 
 
 class _MessagingLegacyMixin:
@@ -90,7 +98,16 @@ class _MessagingLegacyMixin:
           ``{"status": "accepted", "session_id": ...}``  (direct push)
           ``{"status": "queued",   "msg_id": ..., "deduped": False, "session_id": ...}``
         so the caller can react to queued deliveries.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`send_oneshot` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.send() is deprecated. Use send_oneshot(...) instead "
+            f"for the canonical A2A surface. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not self._signing_key_pem:
             raise RuntimeError("Signing key not available — call login() first")
 
@@ -214,7 +231,16 @@ class _MessagingLegacyMixin:
         bundle) or assigned manually to ``_signing_key_pem`` after
         :meth:`from_api_key_file` — when the resolver picks
         ``mtls-only``.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`send_oneshot` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.send_via_proxy() is deprecated. Use send_oneshot(...) "
+            f"instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         resolve_resp = self._egress_http(
             "post",
             "/v1/egress/resolve",
@@ -317,7 +343,18 @@ class _MessagingLegacyMixin:
         ``envelope`` messages are handed back untouched; the existing
         ``decrypt_from_agent`` helper remains the caller's responsibility
         until the envelope-via-proxy pass-through lands in a follow-up.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`receive_oneshot` / :meth:`poll_oneshot_inbox` instead.
+           Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.receive_via_proxy() is deprecated. Use "
+            "receive_oneshot(...) or poll_oneshot_inbox(...) instead. "
+            f"{_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         resp = self._egress_http(
             "get",
             f"/v1/egress/messages/{session_id}",
@@ -391,7 +428,16 @@ class _MessagingLegacyMixin:
         Returns ``True`` on 204, ``False`` on 404/409 (terminal state —
         safe to continue; the broker has already moved on). Raises on
         transport failures so the caller can retry.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`ack_oneshot` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.ack_message() is deprecated. Use ack_oneshot(...) "
+            f"instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_egress_for_sessions:
             return self.ack_via_proxy(session_id, msg_id)
         path = f"/v1/broker/sessions/{session_id}/messages/{msg_id}/ack"
@@ -409,7 +455,16 @@ class _MessagingLegacyMixin:
 
         Returns the message dict with the payload replaced by the decrypted plaintext.
         Raises ValueError if decryption fails (integrity violation).
+
+        .. deprecated:: 0.4.x
+           Use :meth:`decrypt_oneshot` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.decrypt_payload() is deprecated. Use decrypt_oneshot(...) "
+            f"instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if not self._signing_key_pem:
             return msg
         p = msg.get("payload", {})
@@ -439,7 +494,16 @@ class _MessagingLegacyMixin:
         blob to a JSON string under ``payload_ciphertext``. Reverse
         both shape diffs so callers see the same ``list[InboxMessage]``
         as the broker path.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`poll_oneshot_inbox` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.poll() is deprecated. Use poll_oneshot_inbox(...) "
+            f"instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_egress_for_sessions:
             for attempt in range(5):
                 try:

--- a/cullis_sdk/_client/_sessions.py
+++ b/cullis_sdk/_client/_sessions.py
@@ -16,7 +16,16 @@ exposes ``_authed_request``, ``_egress_http`` and the boolean
 """
 from __future__ import annotations
 
+import warnings
+
 from cullis_sdk.types import SessionInfo
+
+
+# Sunset target shared by every session lifecycle method. ADR-008 makes
+# the oneshot fire-and-forget flow the canonical A2A surface (memory:
+# ``oneshot_only_for_demo``); these classical session helpers stay
+# around for one more minor before removal.
+_SUNSET = "Will be removed in cullis-sdk v0.5 (~2026-08-15)."
 
 
 class _SessionsMixin:
@@ -31,7 +40,16 @@ class _SessionsMixin:
         the proxy's local mini-broker handles intra-org and falls
         through to the broker bridge for cross-org. Direct-broker
         clients keep using ``/v1/broker/sessions``.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`send_oneshot` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.open_session() is deprecated. Use send_oneshot(...) "
+            f"instead for the canonical A2A surface. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_egress_for_sessions:
             resp = self._egress_http("post", "/v1/egress/sessions", json={
                 "target_agent_id": target_agent_id,
@@ -50,7 +68,18 @@ class _SessionsMixin:
         return resp.json()["session_id"]
 
     def accept_session(self, session_id: str) -> None:
-        """Accept a pending session."""
+        """Accept a pending session.
+
+        .. deprecated:: 0.4.x
+           Use an oneshot-based flow (``send_oneshot`` / ``receive_oneshot``)
+           instead. Will be removed in v0.5.
+        """
+        warnings.warn(
+            "CullisClient.accept_session() is deprecated. Use an oneshot-based "
+            f"flow (send_oneshot/receive_oneshot) instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_egress_for_sessions:
             resp = self._egress_http(
                 "post", f"/v1/egress/sessions/{session_id}/accept"
@@ -69,7 +98,16 @@ class _SessionsMixin:
         terminal state with the same semantics for the initiator).
         Direct-broker clients still get the reject path so the broker
         can distinguish 'rejected by target' from 'closed'.
+
+        .. deprecated:: 0.4.x
+           Use :meth:`send_oneshot` (sessionless) instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.reject_session() is deprecated. Use send_oneshot(...) "
+            f"(sessionless) instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_egress_for_sessions:
             resp = self._egress_http(
                 "post", f"/v1/egress/sessions/{session_id}/close"
@@ -81,7 +119,18 @@ class _SessionsMixin:
         resp.raise_for_status()
 
     def close_session(self, session_id: str) -> None:
-        """Close an active session."""
+        """Close an active session.
+
+        .. deprecated:: 0.4.x
+           Use an oneshot-based flow (``send_oneshot`` / ``receive_oneshot``)
+           instead. Will be removed in v0.5.
+        """
+        warnings.warn(
+            "CullisClient.close_session() is deprecated. Use an oneshot-based "
+            f"flow (send_oneshot/receive_oneshot) instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._use_egress_for_sessions:
             resp = self._egress_http(
                 "post", f"/v1/egress/sessions/{session_id}/close"
@@ -98,7 +147,16 @@ class _SessionsMixin:
         The egress shape wraps the list in ``{"sessions": [...]}`` and
         the broker shape returns a flat list — unwrap on the egress
         side so callers see the same return type.
+
+        .. deprecated:: 0.4.x
+           Use discovery + ``send_oneshot`` instead. Will be removed in v0.5.
         """
+        warnings.warn(
+            "CullisClient.list_sessions() is deprecated. Use discovery + "
+            f"send_oneshot(...) instead. {_SUNSET}",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         params = {}
         if status:
             params["status"] = status

--- a/cullis_sdk/_client/_websocket.py
+++ b/cullis_sdk/_client/_websocket.py
@@ -44,7 +44,20 @@ class _WebSocketMixin:
         carries ``queued: true``. Pass ``auto_ack=False`` if the
         application needs process-then-ack semantics (call
         :meth:`ack_message` manually).
+
+        .. deprecated:: 0.4.x
+           Use :meth:`poll_oneshot_inbox` for polling, or implement a native
+           WebSocket consumer against the broker. Will be removed in v0.5.
         """
+        import warnings
+        warnings.warn(
+            "CullisClient.connect_websocket() is deprecated. Use "
+            "poll_oneshot_inbox(...) for polling, or implement a native WS "
+            "consumer against the broker. "
+            "Will be removed in cullis-sdk v0.5 (~2026-08-15).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return WebSocketConnection(
             self,
             auto_ack=auto_ack,

--- a/tests/test_sdk_deprecation.py
+++ b/tests/test_sdk_deprecation.py
@@ -1,0 +1,162 @@
+"""Regression test for the v0.4.x deprecation pass (SDK refactor split
+closing PR).
+
+The SDK refactor moved every legacy session-based primitive into a
+dedicated mixin and tagged 13 methods for removal in v0.5
+(~2026-08-15). This test pins the contract:
+
+* every flagged method emits exactly one ``DeprecationWarning`` per
+  call, regardless of whether the underlying request succeeds;
+* the warning message names the method (so users can grep their
+  callsites) and includes the ``v0.5`` sunset marker;
+* ``stacklevel=2`` puts the warning on the caller's frame.
+
+When the v0.5 cut removes a method, drop its entry from
+``DEPRECATED_METHODS`` and the parametrized test will go with it.
+"""
+from __future__ import annotations
+
+import warnings
+from typing import Callable
+
+import pytest
+
+from cullis_sdk import CullisClient
+
+
+def _make_offline_client() -> CullisClient:
+    """Build a ``CullisClient`` that never touches the network.
+
+    The deprecation warnings fire BEFORE any HTTP call, so we can stub
+    the egress + authed-request shims with no-ops and exercise every
+    flagged method without booting a broker.
+    """
+    c = CullisClient.__new__(CullisClient)
+    c._use_egress_for_sessions = False
+    c._signing_key_pem = None
+    c.base = "http://test.invalid"
+    c._dpop_privkey = None
+    c._dpop_pubkey_jwk = None
+    c.token = None
+    c.server_role = None
+    c._dpop_nonce = None
+    c._relogin_callable = None
+    c._label = "test-deprecation"
+    c._client_seq = {}
+    c._pubkey_cache = {}
+
+    class _NoopResp:
+        status_code = 204
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {}
+
+        @property
+        def text(self) -> str:
+            return ""
+
+    def _noop_authed_request(*_a, **_k) -> _NoopResp:
+        return _NoopResp()
+
+    def _noop_egress_http(*_a, **_k) -> _NoopResp:
+        return _NoopResp()
+
+    c._authed_request = _noop_authed_request  # type: ignore[method-assign]
+    c._egress_http = _noop_egress_http  # type: ignore[method-assign]
+
+    class _NoopHttp:
+        def request(self, *_a, **_k) -> _NoopResp:
+            return _NoopResp()
+
+        def post(self, *_a, **_k) -> _NoopResp:
+            return _NoopResp()
+
+        def get(self, *_a, **_k) -> _NoopResp:
+            return _NoopResp()
+
+    c._http = _NoopHttp()  # type: ignore[attr-defined]
+    return c
+
+
+# Each entry maps a stable id → a lambda that invokes the method on a
+# CullisClient instance. The id is the canonical method name so the
+# parametrize report reads naturally.
+DEPRECATED_METHODS: dict[str, Callable[[CullisClient], object]] = {
+    # _AuthMixin
+    "login": lambda c: c.login("orga::a", "orga", "/dev/null", "/dev/null"),
+    # _MessagingLegacyMixin
+    "send": lambda c: c.send("s1", "orga::a", {}, recipient_agent_id="orga::b"),
+    "send_via_proxy": lambda c: c.send_via_proxy("s1", {}, "orga::b"),
+    "receive_via_proxy": lambda c: c.receive_via_proxy("s1"),
+    "poll": lambda c: c.poll("s1"),
+    "ack_message": lambda c: c.ack_message("s1", "m1"),
+    "decrypt_payload": lambda c: c.decrypt_payload({"payload": {}}, session_id="s1"),
+    # _SessionsMixin
+    "open_session": lambda c: c.open_session("orga::a", "orga", []),
+    "accept_session": lambda c: c.accept_session("s1"),
+    "reject_session": lambda c: c.reject_session("s1"),
+    "close_session": lambda c: c.close_session("s1"),
+    "list_sessions": lambda c: c.list_sessions(),
+    # _WebSocketMixin
+    "connect_websocket": lambda c: c.connect_websocket(),
+}
+
+
+@pytest.mark.parametrize("method_name", sorted(DEPRECATED_METHODS))
+def test_deprecated_methods_emit_warning(method_name: str) -> None:
+    """Every v0.5-sunset method emits exactly one ``DeprecationWarning``
+    naming the method and the cullis-sdk v0.5 sunset target."""
+    client = _make_offline_client()
+    invoke = DEPRECATED_METHODS[method_name]
+
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        try:
+            invoke(client)
+        except Exception:
+            # The downstream call may legitimately raise once the
+            # warning has been emitted (eg. login() tries to read a
+            # file). The warning emission is what we're pinning here,
+            # not the method's post-warning behaviour.
+            pass
+
+    # Match on ``CullisClient.<name>()`` so we don't conflate
+    # ``login()`` with the inner ``login_from_pem`` warning that login()
+    # cascades into.
+    needle = f"CullisClient.{method_name}()"
+    dep = [
+        w for w in recorded
+        if issubclass(w.category, DeprecationWarning)
+        and needle in str(w.message)
+    ]
+    assert len(dep) == 1, (
+        f"{method_name} should emit exactly one DeprecationWarning "
+        f"naming {needle!r}, got {len(dep)}: "
+        f"{[str(w.message) for w in recorded]}"
+    )
+    msg = str(dep[0].message)
+    assert "v0.5" in msg, f"{method_name} warning missing v0.5 sunset marker: {msg!r}"
+
+
+def test_login_emits_warning_with_callsite_stacklevel() -> None:
+    """``stacklevel=2`` puts the warning on the user's frame, not the
+    SDK internal frame — pin this on one representative method so a
+    future refactor that bumps stacklevel inadvertently gets caught."""
+    client = _make_offline_client()
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        try:
+            client.login("orga::a", "orga", "/dev/null", "/dev/null")
+        except Exception:
+            pass
+    dep = [w for w in recorded if issubclass(w.category, DeprecationWarning)
+           and "login()" in str(w.message)]
+    assert dep, "login() did not emit a DeprecationWarning"
+    # The warning's recorded filename should be THIS test file (the
+    # caller), not _auth.py — that's what stacklevel=2 buys us.
+    assert dep[0].filename.endswith("test_sdk_deprecation.py"), (
+        f"stacklevel=2 should point at the caller, got filename={dep[0].filename!r}"
+    )


### PR DESCRIPTION
## Summary

**PR 11/11 — the FINAL PR of the SDK refactor split.** The 10 movement PRs (#702 … #725) brought ``cullis_sdk/client.py`` down from 3624 → 453 LOC by extracting 9 domain mixins under ``cullis_sdk/_client/``. This closer tags 13 legacy methods with ``DeprecationWarning`` + a ``v0.5 (~2026-08-15)`` sunset target so consumers see one minor of runtime warnings before the cut.

Closes the refactor series: #702 (WebSocket) · #706 (Guardian) · #711 (Discovery) · #713 (RFQ + notifications + network) · #716 (AI gateway + MCP) · #718 (Sessions) · #720 (Messaging oneshot) · #722 (Auth + DPoP + headers) · #723 (Enrollment + factory) · #725 (Messaging legacy).

## The 13 methods, by mixin

**``_AuthMixin``**
- ``login`` → :meth:`from_api_key_file` (ADR-011 unified enrollment + runtime auth)

**``_MessagingLegacyMixin``**
- ``send`` → :meth:`send_oneshot`
- ``send_via_proxy`` → :meth:`send_oneshot`
- ``receive_via_proxy`` → :meth:`receive_oneshot` / :meth:`poll_oneshot_inbox`
- ``poll`` → :meth:`poll_oneshot_inbox`
- ``ack_message`` → :meth:`ack_oneshot`
- ``decrypt_payload`` → :meth:`decrypt_oneshot`

**``_SessionsMixin``**
- ``open_session`` → :meth:`send_oneshot`
- ``accept_session`` → oneshot-based flow
- ``reject_session`` → :meth:`send_oneshot` (sessionless)
- ``close_session`` → oneshot-based flow
- ``list_sessions`` → discovery + :meth:`send_oneshot`

**``_WebSocketMixin``**
- ``connect_websocket`` → :meth:`poll_oneshot_inbox` / native WS consumer

## Pattern

``warnings.warn(..., DeprecationWarning, stacklevel=2)`` as the FIRST statement of each method body. No ``@deprecated`` decorator — that's Python 3.13+ only, and CI Cullis runs 3.11/3.12. Same shape as the existing ``login_from_pem`` deprecation (PR #722 landed it pre-split).

Each docstring grew a ``.. deprecated:: 0.4.x`` block naming the replacement and the v0.5 sunset, so Sphinx-style consumers and IDE hover tooltips surface the migration target.

## Zero behaviour change

Every method continues to work identically; only a runtime ``DeprecationWarning`` is emitted on entry.

**Special case:** ``login`` delegates to ``login_from_pem`` (which was already deprecated in #722). Callers of ``login()`` therefore see two cascading warnings — one for each method, each with its own ``stacklevel=2``. That's intentional: each warning points at a different layer of the deprecation story and helps consumers migrate both the outer entry point and the inner BYOCA path.

## Verification

- **New test** ``tests/test_sdk_deprecation.py`` — parametrized over all 13 methods, asserts each emits exactly one ``DeprecationWarning`` naming itself (``CullisClient.<name>()`` substring match, to distinguish ``login`` from the inner ``login_from_pem`` warning) and contains the ``v0.5`` sunset marker. Plus a pinned test asserting ``stacklevel=2`` puts the warning on the caller's frame.
- ``pytest tests/ -n auto --dist=loadfile`` → **3519 passed**, 38 skipped, 457s. 2 failures are the pre-existing postgres binding flakes documented in memory.
- ``./sandbox/smoke.sh full`` → **PASS=25 FAIL=0 SKIP=1**. B4.7 still exercises the messaging path end-to-end; the legacy ``send`` / ``poll`` smoke containers tolerate the new warnings (``DeprecationWarning`` is the default warning class, not an exception).
- Ruff mental check (NixOS, no local runner): no F401 / F541 / F841 introduced. Added ``import warnings`` at module level in ``_sessions.py`` / ``_messaging_legacy.py``; ``_auth.py`` and ``_websocket.py`` keep the existing per-method inline import pattern.

## Maintenance note

When v0.5 cuts, drop the entry from ``DEPRECATED_METHODS`` in ``tests/test_sdk_deprecation.py`` and the parametrize will fall away with the method.

## Test plan
- [x] Parametric emission test covers all 13 methods (each warning fires exactly once, names itself, mentions v0.5)
- [x] ``stacklevel=2`` pinned (caller-frame attribution)
- [x] Full pytest suite green (minus documented pre-existing flakes)
- [x] Sandbox smoke green — messaging path tolerates warnings
- [x] DCO signed-off
- [x] No Co-Authored-By trailer