### PR TITLE
feat(connector): add cullis thin CLI alias for agent-targeted send/inbox

### DIFF
--- a/cullis_connector/README.md
+++ b/cullis_connector/README.md
@@ -291,6 +291,42 @@ separate rollout step.)
 
 ---
 
+## CLI alias `cullis`
+
+Shipped alongside `cullis-connector`. `cullis` is a thin command-line
+shortcut for the most common agent-targeted operations: send a
+one-shot message, list your inbox, check that the local daemon is up.
+It talks HTTP to the Connector daemon on `127.0.0.1:7777` — no
+crypto, no SDK, no direct call to the Mastio — so it works exactly
+where `cullis-connector dashboard` (or `serve`) is already running.
+
+```bash
+# Send a plaintext message
+cullis send --to chipfactory::mario --content "lavoro finito"
+
+# Or send a structured payload
+cullis send --to chipfactory::mario --payload-json '{"intent":"ping"}'
+
+# List recent inbox messages
+cullis inbox --limit 10
+
+# Check the daemon is reachable
+cullis health
+```
+
+**Token lookup.** Every command authenticates with the loopback
+Bearer token the Ambassador wrote at first start. Lookup order:
+`--token-file <path>` > `$CULLIS_BEARER_TOKEN_FILE` > the active
+profile's `<config_dir>/local.token` (resolved exactly like
+`cullis-connector --profile <name>`). If none of those land on an
+existing file, `cullis` prints how to start the daemon and exits
+with code 1 — so a missing daemon never silently degrades.
+
+**Out of scope for v1.** Agent discovery, sender-side cross-org
+delivery, and ack/archive shortcuts are not wired here yet; they
+need Broker-side routes that don't exist in this revision. Use the
+MCP tools (next section) for those flows in the meantime.
+
 ## Talking to other agents
 
 Once enrolled, the connector exposes a small set of natural-language

--- a/cullis_connector/cli.py
+++ b/cullis_connector/cli.py
@@ -824,3 +824,360 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":  # pragma: no cover
     sys.exit(main())
+
+
+# ── `cullis` thin CLI (agent-targeted send/inbox) ────────────────────────
+#
+# Roadmap session 2026-05-15 scope #4 v1. ``cullis`` is a separate
+# console script that talks HTTP to the local Connector daemon
+# (``http://127.0.0.1:7777``) and never touches the SDK directly. Every
+# subcommand resolves to one HTTP call against an existing Ambassador
+# route — no new server-side endpoints. Targets coding-CLI agents
+# (Claude Code / Codex / Cursor) that want a quick ``cullis send`` /
+# ``cullis inbox`` shortcut instead of curl + Bearer juggling.
+#
+# Out of scope for v1: ``discover`` / ``list-agents`` (need Broker
+# endpoints that don't exist yet) and ``send-to-user`` (different
+# Broker route shape).
+
+# Ambassador default bind from ``cullis_connector/web.py`` —
+# loopback-only, fixed port. Kept in sync there by the dashboard
+# command's ``--port`` default; if the user moved the daemon they
+# override with ``--connector-url``.
+_DEFAULT_CONNECTOR_URL = "http://127.0.0.1:7777"
+
+
+class _CullisCLIError(Exception):
+    """Friendly CLI failure. Message goes to stderr, exit code 1."""
+
+
+def _resolve_token_path(args: argparse.Namespace) -> "Path":
+    """Pick the file holding the loopback Bearer token.
+
+    Precedence (highest first):
+
+    * ``--token-file`` on the CLI.
+    * ``CULLIS_BEARER_TOKEN_FILE`` env var.
+    * The active profile's ``config_dir / "local.token"`` (the same
+      file ``cullis-connector show-token`` reads), so a user running
+      ``--profile north`` picks up the matching token without touching
+      the env.
+
+    The function does NOT read the file — it just decides where to
+    look. ``_get_bearer_token`` opens it and produces the friendly
+    error if it's missing.
+    """
+    from pathlib import Path
+    import os as _os
+
+    explicit = getattr(args, "token_file", None)
+    if explicit:
+        return Path(explicit).expanduser()
+    env_path = _os.environ.get("CULLIS_BEARER_TOKEN_FILE", "").strip()
+    if env_path:
+        return Path(env_path).expanduser()
+    cfg = load_config({
+        "profile": getattr(args, "profile", None),
+        "config_dir": getattr(args, "config_dir", None),
+    })
+    from cullis_connector.ambassador.auth import LOCAL_TOKEN_FILENAME
+    return cfg.config_dir / LOCAL_TOKEN_FILENAME
+
+
+def _get_bearer_token(args: argparse.Namespace) -> str:
+    """Read the loopback Bearer token from disk.
+
+    Raises ``_CullisCLIError`` with an actionable hint if the file
+    isn't there — the most likely cause is the daemon never started,
+    not a permissions issue.
+    """
+    token_path = _resolve_token_path(args)
+    if not token_path.exists():
+        raise _CullisCLIError(
+            f"No Cullis Connector token at {token_path}.\n"
+            "Start the daemon first:\n"
+            "    cullis-connector dashboard --profile <name>\n"
+            "or\n"
+            "    cullis-connector serve\n"
+            "then re-run this command. Override the path with "
+            "--token-file or $CULLIS_BEARER_TOKEN_FILE."
+        )
+    token = token_path.read_text(encoding="utf-8").strip()
+    if not token:
+        raise _CullisCLIError(
+            f"Cullis Connector token at {token_path} is empty. "
+            "Rotate it from the dashboard's API keys page or delete "
+            "the file and restart the daemon."
+        )
+    return token
+
+
+def _http_request(
+    args: argparse.Namespace,
+    method: str,
+    path: str,
+    *,
+    json_body: dict | None = None,
+    params: dict | None = None,
+) -> dict:
+    """Call the local Ambassador. Returns the parsed JSON body.
+
+    Network / 4xx / 5xx errors raise ``_CullisCLIError`` with a one-
+    line summary the caller can print verbatim. The daemon answers
+    JSON on every documented route; if it doesn't (eg. a reverse
+    proxy injected an HTML 502 page), we surface the status + the
+    first 200 bytes of the body so the user can diagnose.
+    """
+    import httpx
+
+    token = _get_bearer_token(args)
+    base = args.connector_url.rstrip("/")
+    url = f"{base}{path}"
+    headers = {"Authorization": f"Bearer {token}"}
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.request(
+                method, url, headers=headers, json=json_body, params=params,
+            )
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        raise _CullisCLIError(
+            f"Cannot reach Cullis Connector at {base} ({exc}). "
+            "Check the daemon is running: `cullis-connector dashboard` "
+            "or `cullis-connector serve`."
+        ) from exc
+
+    if resp.status_code >= 400:
+        # Mastio + Ambassador both speak JSON ``{detail: ...}`` on
+        # errors. Fall back to a truncated raw body for anything else.
+        try:
+            detail = resp.json().get("detail", resp.text[:200])
+        except Exception:
+            detail = resp.text[:200]
+        raise _CullisCLIError(
+            f"HTTP {resp.status_code} from {method} {path}: {detail}"
+        )
+
+    try:
+        body = resp.json()
+    except Exception as exc:
+        raise _CullisCLIError(
+            f"Cullis Connector returned non-JSON at {method} {path}: "
+            f"{resp.text[:200]}"
+        ) from exc
+    return body if isinstance(body, dict) else {"data": body}
+
+
+def _cullis_build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="cullis",
+        description=(
+            "Cullis CLI — thin alias for the local Connector daemon. "
+            "Wraps the loopback Ambassador's /v1/inbox + /v1/ambassador "
+            "routes; the daemon must already be running."
+        ),
+    )
+    parser.add_argument("--version", action="version", version=f"cullis {__version__}")
+    parser.add_argument(
+        "--connector-url",
+        dest="connector_url",
+        default=_DEFAULT_CONNECTOR_URL,
+        help=(
+            "Override the Connector daemon URL "
+            f"(default: {_DEFAULT_CONNECTOR_URL})."
+        ),
+    )
+    parser.add_argument(
+        "--token-file",
+        dest="token_file",
+        default=None,
+        help=(
+            "Path to the loopback Bearer token file. Defaults to "
+            "$CULLIS_BEARER_TOKEN_FILE if set, otherwise "
+            "<config_dir>/local.token resolved through --profile."
+        ),
+    )
+    parser.add_argument(
+        "--profile",
+        dest="profile",
+        default=None,
+        help=(
+            "Connector profile name (default: 'default'). Maps to "
+            "~/.cullis/profiles/<name>/ for token lookup. Mirrors the "
+            "cullis-connector --profile flag."
+        ),
+    )
+    parser.add_argument(
+        "--config-dir",
+        dest="config_dir",
+        default=None,
+        help=(
+            "Explicit config_dir override (escape hatch — usually "
+            "--profile is enough)."
+        ),
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    send = sub.add_parser(
+        "send",
+        help="Send a one-shot intra-org message to another principal.",
+        description=(
+            "POST /v1/inbox/send via the local Connector. The Ambassador "
+            "resolves the recipient through the Mastio's egress, signs + "
+            "envelopes the payload, and queues the delivery."
+        ),
+    )
+    send.add_argument(
+        "--to", dest="to", required=True,
+        help="Recipient principal id (e.g. orga::alice, user::mario).",
+    )
+    body_group = send.add_mutually_exclusive_group(required=True)
+    body_group.add_argument(
+        "--content", dest="content",
+        help="Plain-text message body — wrapped as {\"text\": <content>}.",
+    )
+    body_group.add_argument(
+        "--payload-json", dest="payload_json",
+        help="Structured JSON object payload (e.g. '{\"intent\":\"ping\"}').",
+    )
+    send.add_argument(
+        "--correlation-id", dest="correlation_id", default=None,
+        help="Optional correlation id propagated to the recipient.",
+    )
+    send.add_argument(
+        "--reply-to", dest="reply_to", default=None,
+        help="Optional msg_id this message replies to.",
+    )
+    send.add_argument(
+        "--ttl", dest="ttl_seconds", type=int, default=300,
+        help="Server-side TTL in seconds for offline delivery (default 300).",
+    )
+
+    inbox = sub.add_parser(
+        "inbox",
+        help="List recent inbox messages.",
+        description="GET /v1/inbox via the local Connector.",
+    )
+    inbox.add_argument(
+        "--since", dest="since", default=None,
+        help="Return only messages newer than this msg_id.",
+    )
+    inbox.add_argument(
+        "--limit", dest="limit", type=int, default=50,
+        help="Maximum messages to return (default 50).",
+    )
+    inbox.add_argument(
+        "--format", dest="format", choices=("text", "json"), default="text",
+        help="text (compact table, default) or json (raw response).",
+    )
+
+    sub.add_parser(
+        "health",
+        help="Check the local Connector daemon is reachable.",
+        description="GET /v1/ambassador/health via the local Connector.",
+    )
+
+    return parser
+
+
+def _cmd_cullis_send(args: argparse.Namespace) -> int:
+    if args.payload_json is not None:
+        import json as _json
+        try:
+            payload: dict = _json.loads(args.payload_json)
+        except _json.JSONDecodeError as exc:
+            raise _CullisCLIError(f"--payload-json is not valid JSON: {exc}")
+        if not isinstance(payload, dict):
+            raise _CullisCLIError("--payload-json must decode to a JSON object")
+    else:
+        payload = {"text": args.content}
+
+    body: dict = {
+        "recipient_id": args.to,
+        "payload": payload,
+        "ttl_seconds": int(args.ttl_seconds),
+    }
+    if args.correlation_id:
+        body["correlation_id"] = args.correlation_id
+    if args.reply_to:
+        body["reply_to"] = args.reply_to
+
+    result = _http_request(args, "POST", "/v1/inbox/send", json_body=body)
+    import json as _json
+    print(_json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def _cmd_cullis_inbox(args: argparse.Namespace) -> int:
+    params: dict = {"limit": int(args.limit)}
+    if args.since:
+        params["since"] = args.since
+    result = _http_request(args, "GET", "/v1/inbox", params=params)
+
+    if args.format == "json":
+        import json as _json
+        print(_json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    # Mastio + Ambassador wrap the rows under ``messages``. Tolerate the
+    # bare-list shape too in case a future Ambassador version drops the
+    # wrapper.
+    messages = result.get("messages")
+    if messages is None and isinstance(result.get("data"), list):
+        messages = result["data"]
+    if messages is None:
+        messages = []
+    if not messages:
+        print("(inbox empty)")
+        return 0
+
+    header = f"{'MSG_ID':<24}  {'SENDER':<28}  PAYLOAD"
+    print(header)
+    print("-" * len(header))
+    for m in messages:
+        msg_id = str(m.get("msg_id") or m.get("id") or "?")[:23]
+        sender = str(m.get("sender_id") or m.get("sender_agent_id") or "?")[:27]
+        payload = m.get("payload")
+        if isinstance(payload, dict):
+            preview = payload.get("text") or payload
+        else:
+            preview = payload
+        preview_str = str(preview)
+        if len(preview_str) > 60:
+            preview_str = preview_str[:57] + "..."
+        print(f"{msg_id:<24}  {sender:<28}  {preview_str}")
+    return 0
+
+
+def _cmd_cullis_health(args: argparse.Namespace) -> int:
+    result = _http_request(args, "GET", "/v1/ambassador/health")
+    profile = getattr(args, "profile", None) or "default"
+    agent = result.get("agent_id") or "(unbound)"
+    site = result.get("site_url") or "(unset)"
+    print(
+        f"Cullis Connector OK at {args.connector_url} "
+        f"(profile={profile}, agent={agent}, site={site})"
+    )
+    return 0
+
+
+def cullis_main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the ``cullis`` console script."""
+    parser = _cullis_build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else sys.argv[1:])
+
+    try:
+        if args.command == "send":
+            return _cmd_cullis_send(args)
+        if args.command == "inbox":
+            return _cmd_cullis_inbox(args)
+        if args.command == "health":
+            return _cmd_cullis_health(args)
+    except _CullisCLIError as exc:
+        print(f"cullis: {exc}", file=sys.stderr)
+        return 1
+    # argparse with ``required=True`` on the subparsers prevents this
+    # branch in practice, but keep an explicit fallback so the type
+    # checker can prove the function returns an int.
+    parser.print_help(sys.stderr)
+    return 2

--- a/packaging/pypi/pyproject.toml
+++ b/packaging/pypi/pyproject.toml
@@ -120,6 +120,9 @@ Changelog = "https://github.com/cullis-security/cullis/blob/main/CHANGELOG.md"
 
 [project.scripts]
 cullis-connector = "cullis_connector.cli:main"
+# Thin agent-targeted alias for send/inbox/health. Talks HTTP to the
+# loopback Ambassador on the Connector daemon — no SDK or crypto here.
+cullis = "cullis_connector.cli:cullis_main"
 
 # Hatchling defaults to consulting VCS (.gitignore) when selecting files.
 # That breaks us: `packaging/pypi/cullis_connector/` is intentionally

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ spiffe = [
 
 [project.scripts]
 cullis-connector = "cullis_connector.cli:main"
+# Thin agent-targeted alias for send/inbox/health. Talks HTTP to the
+# loopback Ambassador on the Connector daemon — no SDK or crypto here.
+cullis = "cullis_connector.cli:cullis_main"
 cullis-proxy = "mcp_proxy.cli:main"
 
 [tool.hatch.build.targets.wheel]

--- a/tests/connector/test_cli_cullis.py
+++ b/tests/connector/test_cli_cullis.py
@@ -1,0 +1,469 @@
+"""Tests for the ``cullis`` thin CLI alias.
+
+Targets ``cullis_connector.cli.cullis_main`` and its three subcommands
+(``send`` / ``inbox`` / ``health``). The CLI is intentionally a thin
+HTTP wrapper around the local Ambassador, so every test mocks
+``httpx.Client`` via ``httpx.MockTransport`` and asserts the wire
+contract (URL, headers, JSON body) plus the user-facing exit code +
+stdout/stderr behaviour. No real Connector daemon is booted.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from cullis_connector.cli import (
+    _CullisCLIError,
+    _cullis_build_parser,
+    _get_bearer_token,
+    _http_request,
+    _resolve_token_path,
+    cullis_main,
+)
+
+
+_TOKEN = "a" * 64
+
+
+@pytest.fixture()
+def token_file(tmp_path: Path) -> Path:
+    """Write a fake loopback bearer token to a per-test path."""
+    p = tmp_path / "local.token"
+    p.write_text(_TOKEN + "\n", encoding="utf-8")
+    return p
+
+
+class _PatchedHttpx:
+    """Test helper bundling captured requests + the canned response queue.
+
+    A subclass of ``object`` (not ``list``) so tests can attach attributes
+    — Python's builtin ``list`` rejects arbitrary attrs and we want both
+    the request log and the response queue on one fixture.
+    """
+
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+        self.responses: list[httpx.Response] = []
+
+    def __len__(self) -> int:
+        return len(self.requests)
+
+    def __getitem__(self, index: int) -> httpx.Request:
+        return self.requests[index]
+
+    def __bool__(self) -> bool:
+        return bool(self.requests)
+
+
+@pytest.fixture()
+def patched_httpx(monkeypatch: pytest.MonkeyPatch) -> _PatchedHttpx:
+    """Replace ``httpx.Client(timeout=...)`` with a MockTransport-backed
+    client. Tests append ``httpx.Response`` rows to ``.responses`` before
+    triggering the CLI, then inspect ``.requests`` afterwards.
+    """
+    state = _PatchedHttpx()
+
+    def _handler(req: httpx.Request) -> httpx.Response:
+        state.requests.append(req)
+        if not state.responses:
+            return httpx.Response(500, json={"detail": "no canned response"})
+        return state.responses.pop(0)
+
+    transport = httpx.MockTransport(_handler)
+    real_client_cls = httpx.Client
+
+    def _factory(*args, **kwargs):  # type: ignore[no-untyped-def]
+        kwargs.setdefault("transport", transport)
+        return real_client_cls(*args, **kwargs)
+
+    monkeypatch.setattr("httpx.Client", _factory)
+    return state
+
+
+def _stub_args(token_path: Path, connector_url: str = "http://127.0.0.1:7777"):
+    """Lightweight argparse Namespace stand-in for the helper tests."""
+    import argparse
+    return argparse.Namespace(
+        token_file=str(token_path),
+        connector_url=connector_url,
+        profile=None,
+        config_dir=None,
+    )
+
+
+# ── parser ─────────────────────────────────────────────────────────────
+
+
+def test_parser_accepts_three_subcommands() -> None:
+    parser = _cullis_build_parser()
+    for cmd in ("send", "inbox", "health"):
+        # ``health`` has no required args, the other two do — invoke
+        # ``--help`` on each to confirm the subparser exists without
+        # caring about which flags trip required-arg validation here.
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args([cmd, "--help"])
+        assert exc.value.code == 0
+
+
+def test_send_requires_content_or_payload_json() -> None:
+    parser = _cullis_build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["send", "--to", "orga::a"])
+    # argparse exits 2 on a parse error.
+    assert exc.value.code == 2
+
+
+def test_send_content_and_payload_json_are_mutually_exclusive() -> None:
+    parser = _cullis_build_parser()
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args([
+            "send", "--to", "orga::a",
+            "--content", "hi",
+            "--payload-json", "{}",
+        ])
+    assert exc.value.code == 2
+
+
+def test_inbox_format_validated() -> None:
+    parser = _cullis_build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["inbox", "--format", "yaml"])
+
+
+def test_shared_flags_apply_to_every_subcommand() -> None:
+    parser = _cullis_build_parser()
+    for cmd_args in (
+        ["health"],
+        ["inbox", "--limit", "1"],
+        ["send", "--to", "x", "--content", "hi"],
+    ):
+        ns = parser.parse_args([
+            "--connector-url", "http://localhost:9999",
+            "--token-file", "/tmp/test.token",
+            "--profile", "demo",
+            *cmd_args,
+        ])
+        assert ns.connector_url == "http://localhost:9999"
+        assert ns.token_file == "/tmp/test.token"
+        assert ns.profile == "demo"
+
+
+# ── token resolution ───────────────────────────────────────────────────
+
+
+def test_get_bearer_token_reads_explicit_file(token_file: Path) -> None:
+    args = _stub_args(token_file)
+    assert _get_bearer_token(args) == _TOKEN
+
+
+def test_get_bearer_token_strips_trailing_whitespace(tmp_path: Path) -> None:
+    p = tmp_path / "local.token"
+    p.write_text(f"  {_TOKEN}\n\n", encoding="utf-8")
+    args = _stub_args(p)
+    assert _get_bearer_token(args) == _TOKEN
+
+
+def test_get_bearer_token_missing_file_prints_actionable_message(
+    tmp_path: Path,
+) -> None:
+    args = _stub_args(tmp_path / "does-not-exist.token")
+    with pytest.raises(_CullisCLIError) as exc:
+        _get_bearer_token(args)
+    msg = str(exc.value)
+    # The user must learn (1) where we looked and (2) what to run next.
+    assert "does-not-exist.token" in msg
+    assert "cullis-connector" in msg
+
+
+def test_get_bearer_token_empty_file_raises(tmp_path: Path) -> None:
+    p = tmp_path / "local.token"
+    p.write_text("", encoding="utf-8")
+    args = _stub_args(p)
+    with pytest.raises(_CullisCLIError) as exc:
+        _get_bearer_token(args)
+    assert "empty" in str(exc.value).lower()
+
+
+def test_resolve_token_path_honours_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path,
+) -> None:
+    env_path = tmp_path / "env.token"
+    monkeypatch.setenv("CULLIS_BEARER_TOKEN_FILE", str(env_path))
+    import argparse
+    args = argparse.Namespace(
+        token_file=None, connector_url="x", profile=None, config_dir=None,
+    )
+    assert _resolve_token_path(args) == env_path
+
+
+# ── _http_request wire contract ────────────────────────────────────────
+
+
+def test_http_request_sends_bearer_header(
+    token_file: Path, patched_httpx: _PatchedHttpx,
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(200, json={"status": "ok"})
+    )
+    args = _stub_args(token_file)
+    body = _http_request(args, "GET", "/v1/ambassador/health")
+    assert body == {"status": "ok"}
+    sent = patched_httpx[0]
+    assert sent.headers.get("authorization") == f"Bearer {_TOKEN}"
+    assert sent.method == "GET"
+    assert str(sent.url) == "http://127.0.0.1:7777/v1/ambassador/health"
+
+
+def test_http_request_raises_on_4xx_with_detail(
+    token_file: Path, patched_httpx: _PatchedHttpx,
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(400, json={"detail": "recipient_id is required"})
+    )
+    args = _stub_args(token_file)
+    with pytest.raises(_CullisCLIError) as exc:
+        _http_request(args, "POST", "/v1/inbox/send", json_body={})
+    assert "400" in str(exc.value)
+    assert "recipient_id is required" in str(exc.value)
+
+
+def test_http_request_raises_on_connect_error(
+    token_file: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _explode(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("Connection refused", request=req)
+
+    transport = httpx.MockTransport(_explode)
+    real_cls = httpx.Client
+    monkeypatch.setattr(
+        "httpx.Client",
+        lambda *a, **k: real_cls(*a, **{**k, "transport": transport}),
+    )
+
+    args = _stub_args(token_file)
+    with pytest.raises(_CullisCLIError) as exc:
+        _http_request(args, "GET", "/v1/ambassador/health")
+    assert "Cannot reach" in str(exc.value)
+    assert "cullis-connector" in str(exc.value)
+
+
+# ── end-to-end subcommand smoke ────────────────────────────────────────
+
+
+def _run_cli(
+    argv: list[str],
+    token_file: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> tuple[int, str, str]:
+    rc = cullis_main([
+        "--connector-url", "http://127.0.0.1:7777",
+        "--token-file", str(token_file),
+        *argv,
+    ])
+    captured = capsys.readouterr()
+    return rc, captured.out, captured.err
+
+
+def test_cullis_health_happy_path(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(200, json={
+            "status": "ok",
+            "agent_id": "orga::ambassador",
+            "site_url": "https://mastio.local:9443",
+        })
+    )
+    rc, out, err = _run_cli(["health"], token_file, capsys)
+    assert rc == 0, err
+    assert "Cullis Connector OK" in out
+    assert "orga::ambassador" in out
+    assert "https://mastio.local:9443" in out
+
+
+def test_cullis_health_daemon_down_friendly_error(
+    token_file: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def _explode(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("Connection refused", request=req)
+
+    transport = httpx.MockTransport(_explode)
+    real_cls = httpx.Client
+    monkeypatch.setattr(
+        "httpx.Client",
+        lambda *a, **k: real_cls(*a, **{**k, "transport": transport}),
+    )
+    rc, out, err = _run_cli(["health"], token_file, capsys)
+    assert rc == 1
+    assert "Cannot reach Cullis Connector" in err
+
+
+def test_cullis_send_content_wraps_as_text_payload(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(200, json={"msg_id": "msg_123", "status": "accepted"})
+    )
+    rc, out, err = _run_cli(
+        ["send", "--to", "orga::alice", "--content", "ciao"],
+        token_file, capsys,
+    )
+    assert rc == 0, err
+    sent = patched_httpx[0]
+    assert sent.method == "POST"
+    assert sent.url.path == "/v1/inbox/send"
+    body = json.loads(sent.content.decode())
+    assert body["recipient_id"] == "orga::alice"
+    assert body["payload"] == {"text": "ciao"}
+    assert body["ttl_seconds"] == 300
+    # The response is rendered to stdout as pretty JSON.
+    parsed = json.loads(out)
+    assert parsed["msg_id"] == "msg_123"
+
+
+def test_cullis_send_payload_json_passthrough(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(200, json={"status": "accepted"})
+    )
+    rc, out, err = _run_cli(
+        [
+            "send", "--to", "orga::bob",
+            "--payload-json", '{"intent": "ping", "value": 7}',
+            "--correlation-id", "corr-9",
+            "--reply-to", "msg_prev",
+            "--ttl", "60",
+        ],
+        token_file, capsys,
+    )
+    assert rc == 0, err
+    sent_body = json.loads(patched_httpx[0].content.decode())
+    assert sent_body["payload"] == {"intent": "ping", "value": 7}
+    assert sent_body["correlation_id"] == "corr-9"
+    assert sent_body["reply_to"] == "msg_prev"
+    assert sent_body["ttl_seconds"] == 60
+
+
+def test_cullis_send_payload_json_rejects_non_object(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc, out, err = _run_cli(
+        [
+            "send", "--to", "orga::bob",
+            "--payload-json", '"just a string"',
+        ],
+        token_file, capsys,
+    )
+    assert rc == 1
+    assert "must decode to a JSON object" in err
+    # No HTTP call should have been made.
+    assert not patched_httpx
+
+
+def test_cullis_send_payload_json_rejects_invalid_json(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    rc, out, err = _run_cli(
+        ["send", "--to", "orga::bob", "--payload-json", "{not-json}"],
+        token_file, capsys,
+    )
+    assert rc == 1
+    assert "not valid JSON" in err
+    assert not patched_httpx
+
+
+def test_cullis_inbox_text_format_renders_compact_table(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(200, json={
+            "messages": [
+                {
+                    "msg_id": "msg_1",
+                    "sender_id": "orga::alice",
+                    "payload": {"text": "hi there"},
+                },
+                {
+                    "msg_id": "msg_2",
+                    "sender_agent_id": "orga::bob",
+                    "payload": {"text": "x" * 200},
+                },
+            ],
+        })
+    )
+    rc, out, err = _run_cli(
+        ["inbox", "--limit", "5", "--since", "msg_0"],
+        token_file, capsys,
+    )
+    assert rc == 0, err
+    sent = patched_httpx[0]
+    assert sent.url.path == "/v1/inbox"
+    assert dict(sent.url.params) == {"limit": "5", "since": "msg_0"}
+    assert "MSG_ID" in out
+    assert "msg_1" in out
+    assert "orga::alice" in out
+    assert "hi there" in out
+    # Long payload should be elided.
+    assert "..." in out
+
+
+def test_cullis_inbox_empty(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(200, json={"messages": []})
+    )
+    rc, out, err = _run_cli(["inbox"], token_file, capsys)
+    assert rc == 0
+    assert "(inbox empty)" in out
+
+
+def test_cullis_inbox_json_format_dumps_raw(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    raw = {"messages": [{"msg_id": "msg_1", "payload": {"text": "hi"}}]}
+    patched_httpx.responses.append(
+        httpx.Response(200, json=raw)
+    )
+    rc, out, err = _run_cli(["inbox", "--format", "json"], token_file, capsys)
+    assert rc == 0
+    assert json.loads(out) == raw
+
+
+def test_cullis_send_propagates_server_error(
+    token_file: Path,
+    patched_httpx: _PatchedHttpx,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    patched_httpx.responses.append(
+        httpx.Response(502, json={"detail": "Mastio unreachable"})
+    )
+    rc, out, err = _run_cli(
+        ["send", "--to", "orga::alice", "--content", "hi"],
+        token_file, capsys,
+    )
+    assert rc == 1
+    assert "502" in err
+    assert "Mastio unreachable" in err


### PR DESCRIPTION
## Summary

**Roadmap session 2026-05-15 scope #4 v1.** Ships a ``cullis`` console script that targets coding-CLI agents (Claude Code / Codex / Cursor) who want a quick ``cullis send`` / ``cullis inbox`` shortcut instead of curling the Ambassador with Bearer auth juggling.

Architecture is intentionally **thin**: ``cullis`` talks plain HTTP to ``http://127.0.0.1:7777`` (loopback Ambassador). Zero SDK, zero crypto, zero direct call to the Mastio. Every subcommand resolves to one HTTP call against an Ambassador route that already exists — **no new server-side endpoints land in this PR**.

## Subcommands (v1 scope)

```
cullis send --to <recipient_id> {--content <text> | --payload-json <obj>}
            [--correlation-id ID] [--reply-to MSG_ID] [--ttl SECONDS]
            → POST /v1/inbox/send

cullis inbox [--since msg_id] [--limit N] [--format text|json]
            → GET /v1/inbox

cullis health
            → GET /v1/ambassador/health
```

Shared flags on every subcommand:
- ``--connector-url`` (default ``http://127.0.0.1:7777``)
- ``--token-file`` — explicit path overrides the lookup chain
- ``--profile`` / ``--config-dir`` — mirror ``cullis-connector`` so ``--profile north`` picks up the matching ``local.token`` automatically
- ``--version``

## Bearer token resolution

Precedence (highest first):
1. ``--token-file <path>``
2. ``$CULLIS_BEARER_TOKEN_FILE``
3. ``<config_dir>/local.token`` resolved through ``--profile`` / ``--config-dir`` / ``$CULLIS_PROFILE`` — same file ``cullis-connector show-token`` reads.

Missing / empty token files raise ``_CullisCLIError`` naming the path AND telling the user to ``cullis-connector dashboard`` or ``serve`` first. Same friendly diagnostic on ``ConnectError`` / timeout when the daemon isn't running.

## Out of scope for v1

- ``discover`` / ``list-agents`` — need Broker endpoints that don't exist yet.
- ``send-to-user`` — different Broker route shape.
- ``ack`` / ``archive`` shortcuts — same.

These flows stay available via the existing MCP tools in the meantime, and the README's new ``## CLI alias `cullis``` section points readers there explicitly.

## Wiring

Entry point lives in ``cullis_connector/cli.py`` next to the existing ``main()``. Registered as ``cullis = "cullis_connector.cli:cullis_main"`` in both:
- the monorepo ``pyproject.toml``
- ``packaging/pypi/pyproject.toml`` (so ``pip install cullis-connector`` ships both scripts from the same wheel).

## Verification

- ``pytest tests/connector/test_cli_cullis.py`` → **23 passed**. Covers:
  - every subcommand parses (``--help`` exits cleanly);
  - ``--content`` ⊕ ``--payload-json`` mutual exclusion;
  - ``--format yaml`` rejected;
  - shared flags propagate to every subcommand;
  - bearer-token file precedence (explicit > env > profile-resolved);
  - friendly error messages on missing / empty token files;
  - wire contract (``Authorization: Bearer`` header, URL composition, JSON body shape) via ``httpx.MockTransport``;
  - ``httpx.ConnectError`` → user-friendly diagnostic with daemon-start hint;
  - payload string-wrapping vs JSON-object passthrough;
  - inbox table elision at 60 chars;
  - empty inbox messaging;
  - 5xx upstream errors surface the Mastio detail through to the user.
- ``pytest tests/ -n auto --dist=loadfile`` → **3544 passed**, 38 skipped, 453s. 3 failures, all pre-existing flakes that pass in isolation: 2 postgres binding (``test_pg_session_and_signed_messages``, ``test_pg_nonce_replay_blocked``) + 1 m3 sweeper TTL (state-contamination, same class as the ``test_mastio_version_defaults_to_dev`` flake documented in memory).
- ``./sandbox/smoke.sh full`` → **PASS=25 FAIL=0 SKIP=1**. Server-side untouched; smoke is a regression gate, not a positive proof for ``cullis`` itself.
- Ruff mental check (NixOS, no local runner): no F401 / F541 / F841.

## Docs

New ``## CLI alias `cullis``` section in ``cullis_connector/README.md`` with:
- the three example invocations;
- token-lookup precedence + env override;
- explicit out-of-scope-v1 note pointing readers at the MCP-tool flow for discovery / cross-org / ack today.

## Test plan
- [x] Unit + parser + wire-contract tests cover all three subcommands
- [x] Friendly error messages tested for daemon-down + missing-token paths
- [x] Full pytest suite green (minus documented pre-existing flakes)
- [x] Sandbox smoke green (regression gate)
- [x] DCO signed-off
- [x] No Co-Authored-By trailer