### PR TITLE
feat(mcp): expose cullis_send_to_agent as MCP tool builtin

### DIFF
--- a/mcp_proxy/README.md
+++ b/mcp_proxy/README.md
@@ -63,6 +63,60 @@ sync/              Federation sync workers
 tools/             CLI helpers
 ```
 
+## MCP builtin: `cullis_send_to_agent`
+
+The Mastio's MCP aggregator (`POST /v1/mcp`) ships with a builtin tool
+that lets any MCP client (Frontdesk SPA, Claude Code, Codex, Cursor,
+LibreChat, ...) ask the model to send a one-shot message to another
+Cullis agent without writing transport code. Identity propagation +
+audit chain are handled server-side — the model only supplies
+recipient and content.
+
+```jsonc
+// JSON-RPC tools/call body
+{
+  "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+  "params": {
+    "name": "cullis_send_to_agent",
+    "arguments": {
+      "target_agent_id": "mario",              // bare name, or "orgb::mario", or "spiffe://..."
+      "target_org_id": "orgb",                  // optional; defaults to caller's org
+      "content": "lavoro finito",               // string → {"text": ...}, or pass a dict
+      "correlation_id": "corr-abc",             // optional; server generates one when omitted
+      "reply_to": "msg-prev",                   // optional
+      "ttl_seconds": 300                        // optional; default 5 min, max 1 h
+    }
+  }
+}
+```
+
+Response shape (success):
+
+```jsonc
+{
+  "correlation_id": "...", "msg_id": "...",
+  "status": "enqueued", "target_agent_id": "...", "target_org_id": "..."
+}
+```
+
+Errors come back as `{ "error": "reach_denied" | "policy_denied" |
+"invalid_recipient" | "broker_unavailable" | "broker_forward_failed" |
+"send_failed" | "invalid_parameters", "reason": "..." }` so the model
+can branch in-band. The Mastio audit chain still captures the specific
+detail for ops.
+
+Capability gate: agents need `cullis.a2a.send` in their scope. Typed
+principals (user / workload) bypass the scope check — their binding
+table is the authoritative authz — but the same reach + policy +
+audit gates apply.
+
+Implementation note: the tool invokes
+`mcp_proxy.egress.oneshot.send_oneshot_internal` directly. There is
+no loopback HTTP + ephemeral DPoP (the pattern that broke
+`chat_completion`). The HTTP route `POST /v1/egress/message/send` is
+now a thin wrapper around the same helper, so the two surfaces share
+one implementation.
+
 ## Running
 
 For local dev and demos, use the sandbox stack at the repo root:

--- a/mcp_proxy/egress/oneshot.py
+++ b/mcp_proxy/egress/oneshot.py
@@ -159,24 +159,37 @@ def _serialize_envelope(body: SendOneShotRequest) -> str:
     return json.dumps(envelope, separators=(",", ":"), sort_keys=True)
 
 
-# ── POST /v1/egress/message/send ────────────────────────────────────
+# ── send_oneshot helpers — Python-callable + HTTP route ─────────────
+#
+# Refactor 2026-05-15 (scope #5 of the session roadmap): the body of the
+# original ``send_oneshot`` route handler is now ``send_oneshot_internal``,
+# a pure async function that takes already-resolved state. The HTTP
+# route is a thin wrapper that pulls dependencies via FastAPI's DI and
+# forwards. The MCP tool builtin ``cullis_send_to_agent`` invokes the
+# internal helper directly — no loopback HTTP + ephemeral DPoP (which
+# would trip the chat_completion DPoP-pinning bug pattern).
 
-@router.post("/message/send", response_model=SendOneShotResponse)
-async def send_oneshot(
+async def send_oneshot_internal(
+    *,
+    agent: InternalAgent,
     body: SendOneShotRequest,
-    request: Request,
-    agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
+    broker_bridge: Any | None,
+    ws_manager: Any | None,
+    settings: Any,
 ) -> SendOneShotResponse:
-    """Enqueue a sessionless message for delivery to ``recipient_id``.
+    """Enqueue a sessionless message — Python-callable form.
 
-    Intra-org recipients land in ``local_messages`` with ``is_oneshot=1``
-    and get pushed via the local WS manager if the recipient is online,
-    queued otherwise.
+    Identical semantics to the ``POST /v1/egress/message/send`` route
+    (and used by it): reach gate → policy gate → local enqueue +
+    optional WS push, or cross-org forward via the broker bridge.
+    Audit rows are written through ``append_local_audit`` exactly as
+    the route used to.
 
-    Cross-org recipients return 501 until Phase 2 wires the broker-side
-    forwarder.
+    Raises ``HTTPException`` on reach-deny / policy-deny / missing
+    bridge / broker-forward failure — same status codes the route
+    surfaces to the SDK. In-process callers (the MCP tool runner)
+    catch ``HTTPException`` and translate to their own error envelope.
     """
-    settings = get_settings()
     local_org = settings.org_id or ""
     trust_domain = settings.trust_domain
 
@@ -247,7 +260,7 @@ async def send_oneshot(
         )
 
     if path == "cross":
-        bridge = getattr(request.app.state, "broker_bridge", None)
+        bridge = broker_bridge
         if bridge is None:
             await append_local_audit(
                 event_type="oneshot_denied",
@@ -354,7 +367,6 @@ async def send_oneshot(
     # Push via the local WS manager if the recipient is connected. The
     # session-based /send does this via app.state.local_ws_manager; same
     # hook works for one-shot. Offline recipients drain on next connect.
-    ws_manager = getattr(request.app.state, "local_ws_manager", None)
     if ws_manager is not None and inserted:
         try:
             await ws_manager.send_to_agent(
@@ -387,6 +399,28 @@ async def send_oneshot(
         correlation_id=corr_id,
         msg_id=msg_id,
         status="duplicate" if not inserted else "enqueued",
+    )
+
+
+@router.post("/message/send", response_model=SendOneShotResponse)
+async def send_oneshot(
+    body: SendOneShotRequest,
+    request: Request,
+    agent: InternalAgent = Depends(get_agent_from_dpop_client_cert),
+) -> SendOneShotResponse:
+    """HTTP entry point — thin wrapper around :func:`send_oneshot_internal`.
+
+    Resolves the FastAPI dependencies (settings, broker bridge, WS
+    manager, authenticated agent) and forwards everything to the
+    in-process helper so the MCP tool builtin and the HTTP route
+    share a single source of truth.
+    """
+    return await send_oneshot_internal(
+        agent=agent,
+        body=body,
+        broker_bridge=getattr(request.app.state, "broker_bridge", None),
+        ws_manager=getattr(request.app.state, "local_ws_manager", None),
+        settings=get_settings(),
     )
 
 

--- a/mcp_proxy/ingress/mcp_aggregator.py
+++ b/mcp_proxy/ingress/mcp_aggregator.py
@@ -187,6 +187,7 @@ async def _handle_tools_call(
         agent=agent,
         db=None,
         secret_provider=secret_provider,
+        app_state=request.app.state,
     )
 
     if resp.status == "success":

--- a/mcp_proxy/ingress/router.py
+++ b/mcp_proxy/ingress/router.py
@@ -57,6 +57,7 @@ async def execute_tool(
         agent=agent,
         db=db,
         secret_provider=secret_provider,
+        app_state=request.app.state,
     )
     return response
 

--- a/mcp_proxy/tools/builtins/__init__.py
+++ b/mcp_proxy/tools/builtins/__init__.py
@@ -2,4 +2,5 @@
 Builtin tools — auto-import all modules to trigger @register decorators.
 """
 from mcp_proxy.tools.builtins import check_erp_inventory  # noqa: F401
+from mcp_proxy.tools.builtins import cullis_send_to_agent  # noqa: F401
 from mcp_proxy.tools.builtins import query_salesforce  # noqa: F401

--- a/mcp_proxy/tools/builtins/cullis_send_to_agent.py
+++ b/mcp_proxy/tools/builtins/cullis_send_to_agent.py
@@ -1,0 +1,297 @@
+"""Builtin tool: ``cullis_send_to_agent`` — sessionless A2A messaging.
+
+Roadmap session 2026-05-15 scope #5. Exposes the same code path that
+backs ``POST /v1/egress/message/send`` as an MCP tool, so any client
+of the Mastio's MCP aggregator (Frontdesk SPA, Claude Code, Codex,
+Cursor, LibreChat, ...) can ask the model to send a one-shot message
+to another Cullis agent without writing transport code.
+
+Naming: underscored — ``cullis_send_to_agent`` — to match existing
+builtins (``query_salesforce``, ``check_erp_inventory``) and dodge
+MCP clients that misparse dotted tool names.
+
+The implementation invokes :func:`mcp_proxy.egress.oneshot.send_oneshot_internal`
+directly. **No loopback HTTP, no ephemeral DPoP** — the chat_completion
+DPoP-pinning pattern (memory feedback ``chat_completion_dpop_pinning_bug``)
+is exactly what we are avoiding here. Identity propagation comes for
+free: ``ctx.agent_id`` from the tool context is the sender, and we
+let the helper apply the same reach / policy / audit gates the HTTP
+route applies.
+
+Errors that the helper raises as ``HTTPException`` are translated to
+a structured ``{"error": "...", "reason": "..."}`` dict so the model
+can react in-band. Anything else (DB outage, asyncio plumbing) is
+re-raised so the executor surfaces it through the JSON-RPC error
+envelope.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from fastapi import HTTPException
+
+from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.registry import tool_registry
+
+_log = logging.getLogger("mcp_proxy.tools.builtins.cullis_send_to_agent")
+
+
+_DESCRIPTION = (
+    "Send a one-shot message to another Cullis agent. Routes through "
+    "the Mastio's intra-org egress for same-org recipients and through "
+    "the broker bridge for cross-org. Identity (sender) + audit chain "
+    "are handled by the Mastio — the caller just supplies recipient "
+    "and content."
+)
+
+
+_PARAMETERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "target_agent_id": {
+            "type": "string",
+            "description": (
+                "Recipient principal identifier. Accepts a bare agent "
+                "name (e.g. 'mario' — interpreted in the caller's org), "
+                "the canonical ``<org>::<name>`` form, or a SPIFFE URI "
+                "(e.g. 'spiffe://other-org.example/agent/mario') for "
+                "cross-org delivery."
+            ),
+        },
+        "target_org_id": {
+            "type": "string",
+            "description": (
+                "Optional recipient org id. Defaults to the caller's "
+                "org for intra-org routing. Ignored when "
+                "``target_agent_id`` is a fully qualified ``<org>::name`` "
+                "or SPIFFE URI."
+            ),
+        },
+        "content": {
+            "description": (
+                "Message body. Pass a string for plaintext (wrapped as "
+                "``{\"text\": <content>}`` server-side) or a JSON object "
+                "for a structured payload."
+            ),
+        },
+        "correlation_id": {
+            "type": "string",
+            "description": (
+                "Optional correlation id for matching replies. Server "
+                "generates one when omitted."
+            ),
+        },
+        "reply_to": {
+            "type": "string",
+            "description": (
+                "Optional correlation_id of the message this one is a "
+                "reply to."
+            ),
+        },
+        "ttl_seconds": {
+            "type": "integer",
+            "default": 300,
+            "minimum": 10,
+            "maximum": 3600,
+            "description": (
+                "Server-side TTL for offline delivery (default 5 min, "
+                "max 1 h)."
+            ),
+        },
+    },
+    "required": ["target_agent_id", "content"],
+}
+
+
+def _normalize_payload(content: Any) -> dict:
+    """Wrap a plaintext string in ``{"text": content}``; pass dicts
+    through; raise ``ValueError`` for anything else.
+
+    The route handler accepts only ``dict`` payloads via Pydantic;
+    keeping the same contract here ensures the tool surface matches
+    the HTTP surface exactly.
+    """
+    if isinstance(content, dict):
+        return content
+    if isinstance(content, str):
+        return {"text": content}
+    raise ValueError(
+        f"content must be a string or JSON object, got {type(content).__name__}"
+    )
+
+
+def _qualify_recipient(target_agent_id: str, target_org_id: str | None, caller_org: str) -> str:
+    """Build the ``recipient_id`` that ``send_oneshot_internal`` expects.
+
+    The helper accepts ``org::agent``, SPIFFE URIs, or bare names
+    (which it interprets within the caller's org). We pre-qualify
+    bare names with ``target_org_id`` (or the caller's org if absent)
+    so cross-org U2U sends route correctly without forcing the model
+    to know the canonical form.
+    """
+    if target_agent_id.startswith("spiffe://"):
+        return target_agent_id
+    if "::" in target_agent_id:
+        return target_agent_id
+    org = target_org_id or caller_org
+    if not org:
+        # No way to qualify — let the helper see the bare name and
+        # 400 with its own canonical "invalid recipient_id" message.
+        return target_agent_id
+    return f"{org}::{target_agent_id}"
+
+
+@tool_registry.register(
+    name="cullis_send_to_agent",
+    capability="cullis.a2a.send",
+    allowed_domains=[],
+    description=_DESCRIPTION,
+    parameters_schema=_PARAMETERS_SCHEMA,
+)
+async def cullis_send_to_agent(ctx: ToolContext) -> dict:
+    """Send a one-shot message via the in-process ``send_oneshot_internal``.
+
+    Identity (``sender_agent_id``, ``sender_org_id``) comes from the
+    ToolContext — no way for the model to spoof a different sender.
+    The helper handles reach, policy, audit, and broker forwarding.
+    """
+    # Lazy imports keep the module cheap to import at registration time
+    # (the registry decorator fires on every Mastio startup), and dodge
+    # the egress/oneshot ↔ tools cycle in case one ever appears.
+    from mcp_proxy.config import get_settings
+    from mcp_proxy.db import get_agent
+    from mcp_proxy.egress.oneshot import (
+        SendOneShotRequest,
+        send_oneshot_internal,
+    )
+    from mcp_proxy.models import InternalAgent
+
+    params = ctx.parameters or {}
+
+    target_agent_id = params.get("target_agent_id")
+    if not isinstance(target_agent_id, str) or not target_agent_id:
+        return {
+            "error": "invalid_parameters",
+            "reason": "target_agent_id is required (string)",
+        }
+
+    content = params.get("content")
+    if content is None:
+        return {
+            "error": "invalid_parameters",
+            "reason": "content is required",
+        }
+    try:
+        payload = _normalize_payload(content)
+    except ValueError as exc:
+        return {"error": "invalid_parameters", "reason": str(exc)}
+
+    target_org_id = params.get("target_org_id")
+    correlation_id = params.get("correlation_id") or str(uuid.uuid4())
+    reply_to = params.get("reply_to")
+    ttl_seconds = int(params.get("ttl_seconds", 300) or 300)
+
+    recipient_id = _qualify_recipient(target_agent_id, target_org_id, ctx.org_id)
+
+    # Resolve the sender's InternalAgent row so ``send_oneshot_internal``
+    # can apply the reach gate (``agent.reach``) the same way the HTTP
+    # route does. Typed principals (user / workload) don't live in
+    # ``internal_agents``; build a minimal envelope from the
+    # ToolContext for those, mirroring ``_maybe_local_internal_agent``.
+    agent_record = await get_agent(ctx.agent_id)
+    if agent_record is not None and agent_record.get("is_active", True):
+        capabilities = agent_record.get("capabilities") or []
+        if isinstance(capabilities, str):
+            import json
+            try:
+                capabilities = json.loads(capabilities)
+            except Exception:
+                capabilities = [c for c in capabilities.split(",") if c]
+        sender_agent = InternalAgent(
+            agent_id=ctx.agent_id,
+            display_name=agent_record.get("display_name") or ctx.agent_id,
+            capabilities=list(capabilities),
+            created_at=str(agent_record.get("created_at") or ""),
+            is_active=bool(agent_record.get("is_active", True)),
+            cert_pem=agent_record.get("cert_pem"),
+            dpop_jkt=agent_record.get("dpop_jkt"),
+            reach=agent_record.get("reach") or "both",
+        )
+    else:
+        # Typed principal (user / workload) — the row isn't in
+        # ``internal_agents``. The reach gate is intentionally
+        # ``intra`` for these callers; cross-org sends raise at the
+        # reach check, surfacing the right error envelope below.
+        from datetime import datetime, timezone
+        principal_type = "agent"
+        if "::user::" in ctx.agent_id:
+            principal_type = "user"
+        elif "::workload::" in ctx.agent_id:
+            principal_type = "workload"
+        sender_agent = InternalAgent(
+            agent_id=ctx.agent_id,
+            display_name=ctx.agent_id,
+            capabilities=list(ctx.capabilities or []),
+            created_at=datetime.now(timezone.utc).isoformat(),
+            is_active=True,
+            cert_pem=None,
+            dpop_jkt=None,
+            reach="intra",
+            principal_type=principal_type,
+        )
+
+    body = SendOneShotRequest(
+        recipient_id=recipient_id,
+        payload=payload,
+        correlation_id=correlation_id,
+        reply_to=reply_to,
+        ttl_seconds=ttl_seconds,
+    )
+
+    # Pull the cross-subsystem dependencies from the FastAPI app state
+    # the executor stashed on ``ctx``. ``None`` here just means the
+    # tool was invoked outside a route (CLI / test); the helper raises
+    # a clean 503 for the cross-org branch in that case, which we map
+    # below.
+    broker_bridge = getattr(ctx.app_state, "broker_bridge", None) if ctx.app_state else None
+    ws_manager = getattr(ctx.app_state, "local_ws_manager", None) if ctx.app_state else None
+
+    try:
+        response = await send_oneshot_internal(
+            agent=sender_agent,
+            body=body,
+            broker_bridge=broker_bridge,
+            ws_manager=ws_manager,
+            settings=get_settings(),
+        )
+    except HTTPException as exc:
+        # Map the helper's HTTP-shaped errors to a structured dict so
+        # the MCP model can branch in-band without parsing prose. The
+        # route handler audit row already captured the specific
+        # reason for ops.
+        reason = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        if exc.status_code == 403:
+            error_kind = "reach_denied" if "reach" in reason.lower() else "policy_denied"
+        elif exc.status_code == 400:
+            error_kind = "invalid_recipient"
+        elif exc.status_code == 503:
+            error_kind = "broker_unavailable"
+        elif exc.status_code == 502:
+            error_kind = "broker_forward_failed"
+        else:
+            error_kind = "send_failed"
+        _log.info(
+            "cullis_send_to_agent: %s (status=%d, sender=%s, recipient=%s)",
+            error_kind, exc.status_code, ctx.agent_id, recipient_id,
+        )
+        return {"error": error_kind, "reason": reason}
+
+    return {
+        "correlation_id": response.correlation_id,
+        "msg_id": response.msg_id,
+        "status": response.status,
+        "target_agent_id": recipient_id,
+        "target_org_id": target_org_id or ctx.org_id,
+    }

--- a/mcp_proxy/tools/context.py
+++ b/mcp_proxy/tools/context.py
@@ -27,3 +27,11 @@ class ToolContext:
     # resolve ``auth_secret_ref`` (env://... or vault://...). Optional so
     # builtin handlers don't have to care.
     secret_provider: Any | None = None
+    # Scope #5 (session 2026-05-15) — handlers that need to call into
+    # other Mastio subsystems (broker bridge, local WS manager, audit
+    # chain) can pull them from the FastAPI app state. Populated by
+    # ``executor.run`` when invoked through a route that has a
+    # ``Request`` object; ``None`` when the executor was invoked
+    # without one (eg. CLI / tests). Builtin handlers that touch
+    # ``app_state`` must tolerate ``None`` for that test path.
+    app_state: Any | None = None

--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -31,12 +31,19 @@ async def run(
     secret_provider: SecretProvider,
     *,
     timeout: float = DEFAULT_TOOL_TIMEOUT,
+    app_state: Any | None = None,
 ) -> ToolExecuteResponse:
     """Execute a tool on behalf of an authenticated agent.
 
     The ``db`` parameter is retained for API compatibility but no longer
     used — ``log_audit`` opens its own connection via ``get_db()`` since
     the SQLAlchemy async refactor (#36).
+
+    ``app_state`` is the FastAPI ``request.app.state`` object (or
+    equivalent) so handlers that need cross-subsystem dependencies
+    (broker bridge, WS manager, audit chain) can fetch them from a
+    single well-known location. Callers that don't have one (CLI
+    paths, unit tests) pass ``None``.
     """
     del db  # kept in signature for backwards compatibility
     t0 = time.monotonic()
@@ -161,6 +168,7 @@ async def run(
             http_client=http_client,
             request_id=request_id,
             secret_provider=secret_provider,
+            app_state=app_state,
         )
 
         # 5. Execute handler with timeout

--- a/tests/test_mcp_tool_cullis_send_to_agent.py
+++ b/tests/test_mcp_tool_cullis_send_to_agent.py
@@ -1,0 +1,490 @@
+"""Tests for the ``cullis_send_to_agent`` MCP builtin (scope #5).
+
+The tool wraps :func:`mcp_proxy.egress.oneshot.send_oneshot_internal`,
+so every test mocks that helper with an ``AsyncMock`` (and
+:func:`mcp_proxy.db.get_agent` for the sender lookup) and asserts the
+contract the model sees:
+
+* the tool registers under the expected name + capability,
+* identity propagation (``ctx.agent_id`` → ``sender_agent.agent_id``)
+  is enforced server-side — the model cannot spoof a sender,
+* default ``target_org_id`` is the caller's org so bare names route
+  intra-org,
+* content normalization (``str`` → ``{"text": <content>}``),
+* ``HTTPException`` from the helper maps to a structured
+  ``{"error": ..., "reason": ...}`` dict for every supported status
+  code (403 reach / 400 invalid / 503 broker_unavailable / 502
+  broker_forward_failed),
+* parameter validation rejects bad input before any HTTP call.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from mcp_proxy.egress.oneshot import SendOneShotResponse
+from mcp_proxy.tools.context import ToolContext
+from mcp_proxy.tools.registry import tool_registry
+
+
+# ── Registry contract ──────────────────────────────────────────────────
+
+
+def test_cullis_send_to_agent_is_registered() -> None:
+    """The decorator must have run at import time of
+    ``mcp_proxy.tools.builtins`` (verified indirectly by importing
+    the module here — same import chain the Mastio uses)."""
+    import mcp_proxy.tools.builtins  # noqa: F401 — triggers registration
+    td = tool_registry.get("cullis_send_to_agent")
+    assert td is not None
+    assert td.required_capability == "cullis.a2a.send"
+    # External HTTP is forbidden — the tool only invokes in-process
+    # helpers, so the allowed_domains whitelist stays empty.
+    assert td.allowed_domains == []
+    schema = td.parameters_schema or {}
+    assert schema.get("required") == ["target_agent_id", "content"]
+    props = schema.get("properties", {})
+    for key in (
+        "target_agent_id", "target_org_id", "content",
+        "correlation_id", "reply_to", "ttl_seconds",
+    ):
+        assert key in props, f"missing schema property: {key}"
+
+
+# ── Test scaffolding ───────────────────────────────────────────────────
+
+
+def _agent_record(
+    agent_id: str = "orga::alice",
+    reach: str = "both",
+    is_active: bool = True,
+) -> dict:
+    return {
+        "agent_id": agent_id,
+        "display_name": agent_id.split("::", 1)[-1],
+        "capabilities": [],
+        "created_at": "2026-05-01T00:00:00+00:00",
+        "is_active": is_active,
+        "cert_pem": None,
+        "dpop_jkt": None,
+        "reach": reach,
+    }
+
+
+def _ctx(
+    parameters: dict[str, Any],
+    *,
+    agent_id: str = "orga::alice",
+    org_id: str = "orga",
+    capabilities: list[str] | None = None,
+    app_state: Any | None = None,
+) -> ToolContext:
+    """Build a ToolContext with a no-op httpx client."""
+    return ToolContext(
+        parameters=parameters,
+        agent_id=agent_id,
+        org_id=org_id,
+        capabilities=capabilities or ["cullis.a2a.send"],
+        secrets={},
+        http_client=httpx.AsyncClient(),
+        request_id="req-test",
+        app_state=app_state,
+    )
+
+
+def _ok_response() -> SendOneShotResponse:
+    return SendOneShotResponse(
+        correlation_id="corr-abc",
+        msg_id="msg-123",
+        status="enqueued",
+    )
+
+
+_DEFAULT_SENDER = object()
+
+
+def _patched_dependencies(
+    *,
+    sender: Any = _DEFAULT_SENDER,
+    send_result: Any = None,
+):
+    """Patch ``get_agent`` + ``send_oneshot_internal`` together so
+    every test gets the same mock surface. Pass ``sender=None``
+    explicitly to simulate a missing ``internal_agents`` row (typed
+    principal fallback path)."""
+    if sender is _DEFAULT_SENDER:
+        sender = _agent_record()
+    get_agent_mock = AsyncMock(return_value=sender)
+    if isinstance(send_result, Exception):
+        send_mock = AsyncMock(side_effect=send_result)
+    else:
+        send_mock = AsyncMock(
+            return_value=send_result if send_result is not None else _ok_response(),
+        )
+    return (
+        patch("mcp_proxy.db.get_agent", get_agent_mock),
+        patch(
+            "mcp_proxy.egress.oneshot.send_oneshot_internal",
+            send_mock,
+        ),
+        get_agent_mock,
+        send_mock,
+    )
+
+
+# ── Happy path ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_string_content_is_wrapped_as_text_payload() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, get_mock, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "ciao bob",
+        }))
+
+    assert result["msg_id"] == "msg-123"
+    assert result["correlation_id"] == "corr-abc"
+    assert result["status"] == "enqueued"
+    # Identity propagation: the helper got the body with the caller's
+    # org-qualified recipient and a string-wrapped payload.
+    sent_kwargs = send_mock.await_args.kwargs
+    body = sent_kwargs["body"]
+    assert body.recipient_id == "orga::bob"
+    assert body.payload == {"text": "ciao bob"}
+    # Sender identity is taken straight from ToolContext — never from
+    # the model parameters.
+    assert sent_kwargs["agent"].agent_id == "orga::alice"
+
+
+@pytest.mark.asyncio
+async def test_dict_content_passes_through_unchanged() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    payload = {"intent": "ping", "n": 7}
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": payload,
+        }))
+
+    assert send_mock.await_args.kwargs["body"].payload == payload
+
+
+@pytest.mark.asyncio
+async def test_fully_qualified_recipient_is_not_re_prefixed() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "orgb::bob",
+            "content": "hi",
+        }))
+
+    assert send_mock.await_args.kwargs["body"].recipient_id == "orgb::bob"
+
+
+@pytest.mark.asyncio
+async def test_spiffe_recipient_passes_through() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    spiffe = "spiffe://other.example/agent/mario"
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": spiffe,
+            "content": "hi",
+        }))
+
+    assert send_mock.await_args.kwargs["body"].recipient_id == spiffe
+
+
+@pytest.mark.asyncio
+async def test_explicit_target_org_id_qualifies_bare_name() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "mario",
+            "target_org_id": "orgb",
+            "content": "ciao",
+        }))
+
+    assert send_mock.await_args.kwargs["body"].recipient_id == "orgb::mario"
+    assert result["target_org_id"] == "orgb"
+
+
+@pytest.mark.asyncio
+async def test_target_org_id_defaults_to_caller_org() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "hi",
+        }, org_id="orga"))
+
+    assert send_mock.await_args.kwargs["body"].recipient_id == "orga::bob"
+    # Echoed back so the model can confirm where the send landed.
+    assert result["target_org_id"] == "orga"
+
+
+@pytest.mark.asyncio
+async def test_correlation_id_is_generated_when_omitted() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "x",
+        }))
+
+    body = send_mock.await_args.kwargs["body"]
+    assert body.correlation_id, "tool should backfill a correlation id"
+
+
+@pytest.mark.asyncio
+async def test_explicit_correlation_id_and_reply_to_are_propagated() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "x",
+            "correlation_id": "corr-9",
+            "reply_to": "msg-prev",
+            "ttl_seconds": 120,
+        }))
+
+    body = send_mock.await_args.kwargs["body"]
+    assert body.correlation_id == "corr-9"
+    assert body.reply_to == "msg-prev"
+    assert body.ttl_seconds == 120
+
+
+@pytest.mark.asyncio
+async def test_app_state_is_threaded_through_to_helper() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    fake_state = SimpleNamespace(
+        broker_bridge="BRIDGE-SENTINEL",
+        local_ws_manager="WS-SENTINEL",
+    )
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "x",
+        }, app_state=fake_state))
+
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs["broker_bridge"] == "BRIDGE-SENTINEL"
+    assert kwargs["ws_manager"] == "WS-SENTINEL"
+
+
+# ── Identity propagation: the model cannot impersonate ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_sender_identity_comes_from_ctx_not_parameters() -> None:
+    """Even if a malicious / confused model tries to set ``sender_*`` or
+    similar in the tool parameters, the helper only sees the
+    ToolContext-derived agent. There is no parameter the model can
+    set that ends up on ``send_oneshot_internal``'s ``agent``."""
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "x",
+            # Bogus impersonation attempts — the tool must ignore them.
+            "sender_agent_id": "orga::admin",
+            "sender": "orga::admin",
+            "agent_id": "orga::admin",
+        }, agent_id="orga::alice"))
+
+    assert send_mock.await_args.kwargs["agent"].agent_id == "orga::alice"
+
+
+@pytest.mark.asyncio
+async def test_typed_principal_falls_back_to_intra_reach() -> None:
+    """User / workload principals have no row in ``internal_agents``;
+    the tool synthesises a minimal envelope with ``reach='intra'`` so
+    cross-org sends from such callers raise at the reach gate."""
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies(sender=None)
+    with get_p, send_p:
+        await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "x",
+        }, agent_id="orga::user::alice"))
+
+    agent_sent = send_mock.await_args.kwargs["agent"]
+    assert agent_sent.agent_id == "orga::user::alice"
+    assert agent_sent.reach == "intra"
+    assert agent_sent.principal_type == "user"
+
+
+# ── Parameter validation ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_target_agent_id_returns_error_dict() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({"content": "hi"}))
+
+    assert result["error"] == "invalid_parameters"
+    assert "target_agent_id" in result["reason"]
+    send_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_content_returns_error_dict() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({"target_agent_id": "bob"}))
+
+    assert result["error"] == "invalid_parameters"
+    assert "content" in result["reason"]
+    send_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_string_non_dict_content_rejected() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    get_p, send_p, _, send_mock = _patched_dependencies()
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": 42,
+        }))
+
+    assert result["error"] == "invalid_parameters"
+    send_mock.assert_not_awaited()
+
+
+# ── Error mapping from the helper ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reach_denied_maps_to_reach_denied_error() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    deny = HTTPException(
+        status_code=403,
+        detail="reach: intra-only agent attempted cross-org send",
+    )
+    get_p, send_p, _, _ = _patched_dependencies(send_result=deny)
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "orgb::bob",
+            "content": "x",
+        }))
+
+    assert result["error"] == "reach_denied"
+    assert "reach" in result["reason"].lower()
+
+
+@pytest.mark.asyncio
+async def test_policy_denied_maps_to_policy_denied_error() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    deny = HTTPException(
+        status_code=403,
+        detail="Policy: payload contains forbidden field",
+    )
+    get_p, send_p, _, _ = _patched_dependencies(send_result=deny)
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "bob",
+            "content": "x",
+        }))
+
+    assert result["error"] == "policy_denied"
+
+
+@pytest.mark.asyncio
+async def test_invalid_recipient_maps_to_invalid_recipient_error() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    deny = HTTPException(status_code=400, detail="invalid recipient_id")
+    get_p, send_p, _, _ = _patched_dependencies(send_result=deny)
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "::malformed",
+            "content": "x",
+        }))
+
+    assert result["error"] == "invalid_recipient"
+
+
+@pytest.mark.asyncio
+async def test_broker_unavailable_maps_to_broker_unavailable() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    deny = HTTPException(
+        status_code=503,
+        detail="Broker uplink not configured — cross-org one-shot unavailable",
+    )
+    get_p, send_p, _, _ = _patched_dependencies(send_result=deny)
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "spiffe://other/agent/bob",
+            "content": "x",
+        }))
+
+    assert result["error"] == "broker_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_broker_forward_failed_maps_to_broker_forward_failed() -> None:
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    deny = HTTPException(status_code=502, detail="broker forward failed")
+    get_p, send_p, _, _ = _patched_dependencies(send_result=deny)
+    with get_p, send_p:
+        result = await cullis_send_to_agent(_ctx({
+            "target_agent_id": "spiffe://other/agent/bob",
+            "content": "x",
+        }))
+
+    assert result["error"] == "broker_forward_failed"
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_propagates_to_executor() -> None:
+    """Anything other than HTTPException is the executor's problem to
+    surface (audit + JSON-RPC error envelope), not the tool's to
+    translate."""
+    from mcp_proxy.tools.builtins.cullis_send_to_agent import cullis_send_to_agent
+
+    boom = RuntimeError("DB exploded")
+    get_p, send_p, _, _ = _patched_dependencies(send_result=boom)
+    with get_p, send_p:
+        with pytest.raises(RuntimeError, match="DB exploded"):
+            await cullis_send_to_agent(_ctx({
+                "target_agent_id": "bob",
+                "content": "x",
+            }))


### PR DESCRIPTION
## Summary

**Roadmap session 2026-05-15 scope #5.** Registers a builtin MCP tool that any client of the Mastio's aggregator (Frontdesk SPA, Claude Code, Codex, Cursor, LibreChat, ...) can call to send a one-shot message to another Cullis agent without writing transport code. Identity propagation + audit chain are handled server-side — the model only supplies recipient and content.

## Implementation strategy

The tool invokes the SAME code path that backs ``POST /v1/egress/message/send`` **via an in-process Python call**, NOT a loopback HTTP call with an ephemeral DPoP key. That pattern is exactly what broke ``chat_completion`` (memory feedback ``chat_completion_dpop_pinning_bug``); identity propagation here comes for free from ``ToolContext.agent_id``, and the audit chain in ``send_oneshot_internal`` writes the same rows the HTTP route would have.

To get one source of truth, the body of the old ``send_oneshot`` route was extracted into ``mcp_proxy.egress.oneshot.send_oneshot_internal``, a pure async function that takes already-resolved state (``agent``, ``body``, ``broker_bridge``, ``ws_manager``, ``settings``). The HTTP route is now a thin wrapper that pulls deps via FastAPI DI and forwards. **No behaviour change** for the route — every existing test continues to pass.

To let tool handlers reach cross-subsystem state (broker bridge, WS manager) from outside a FastAPI request frame, ``ToolContext`` gained an ``app_state: Any | None`` field, and ``executor.run()`` gained an ``app_state`` kwarg threaded from both the MCP aggregator and the REST ``POST /v1/ingress/execute`` callsites. ``None`` is tolerated everywhere so existing handlers and unit tests keep working unmodified.

## Tool surface

- **Name**: ``cullis_send_to_agent`` (snake_case, matches ``query_salesforce`` / ``check_erp_inventory``; dotted names trip some MCP clients).
- **Capability**: ``cullis.a2a.send``. Typed principals (user/workload) bypass the scope gate via the executor's existing logic; agents must have the capability in scope.
- **Parameters (6, ~280 schema tokens)**: ``target_agent_id`` (bare name / ``org::name`` / SPIFFE URI), ``target_org_id``, ``content`` (string → wrapped, dict → passthrough), ``correlation_id``, ``reply_to``, ``ttl_seconds`` (default 300, max 3600).
- **Compound** — single call, no atomic ``create_message`` + ``send_message`` split.

## Identity propagation

The sender's ``InternalAgent`` is loaded from ``internal_agents`` via ``ctx.agent_id``. The model has no way to spoof ``sender_*`` — any such parameters are ignored. For typed principals (no ``internal_agents`` row) the tool synthesises a minimal envelope with ``reach='intra'``, matching the contract ``_maybe_local_internal_agent`` uses on the HTTP path. Cross-org sends from typed principals raise at the reach gate, surfacing ``{"error": "reach_denied", "reason": ...}``.

## Error envelope

``HTTPException`` from the helper is translated to a structured dict so the model can branch in-band:

| Status / detail                | ``error``                   |
|--------------------------------|-----------------------------|
| 403 "reach: ..."               | ``reach_denied``            |
| 403 "Policy: ..."              | ``policy_denied``           |
| 400 "invalid recipient_id"     | ``invalid_recipient``       |
| 503 broker uplink absent       | ``broker_unavailable``      |
| 502 broker forward failed      | ``broker_forward_failed``   |
| anything else                  | ``send_failed``             |

Unexpected exceptions propagate to the executor, which writes a ``local_audit`` row and surfaces a JSON-RPC error envelope to the caller. The Mastio audit chain captures the specific reason for ops in every branch.

## Verification

- ``pytest tests/test_mcp_tool_cullis_send_to_agent.py`` → **21 passed**. Covers: registration metadata, content normalization (string / dict), recipient qualification (bare / ``org::`` prefix / SPIFFE URI), default ``target_org_id``, correlation id backfill, app_state threading, sender immutability against spoofing attempts, typed-principal fallback to intra reach, every error-status mapping, parameter validation, unexpected-exception propagation.
- ``pytest tests/ -n auto --dist=loadfile`` → **3566 passed**, 38 skipped, 457s. The 2 failures are the pre-existing postgres binding flakes (``test_pg_session_and_signed_messages``, ``test_pg_nonce_replay_blocked``) documented in memory.
- ``./sandbox/smoke.sh full`` → **PASS=25 FAIL=0 SKIP=1**. The one-shot send + receive path is exercised by B4.7 (intra-org A2A nonces) and B4.10 (cross-org reach enforcement); both still pass after the route handler was refactored to delegate to ``send_oneshot_internal``.
- Ruff mental check (NixOS, no local runner): no F401 / F541 / F841 introduced.

## Docs

New section in ``mcp_proxy/README.md`` with a copy-pasteable JSON-RPC ``tools/call`` example, response shape, error envelope, capability gate explanation, and a note on the in-process implementation strategy.

## Test plan
- [x] 21 builtin-tool tests cover registration, identity propagation, content normalization, all error paths
- [x] Existing oneshot HTTP route is unchanged in behaviour (delegates to extracted helper)
- [x] Full pytest suite green (minus documented pre-existing flakes)
- [x] Sandbox smoke green — A2A messaging round-trip + cross-org reach enforcement
- [x] DCO signed-off
- [x] No Co-Authored-By trailer