### PR TITLE
fix(mcp): close capability bypass for typed principals on builtins (post-#729 hotfix)

### DIFF
--- a/mcp_proxy/tools/executor.py
+++ b/mcp_proxy/tools/executor.py
@@ -24,6 +24,43 @@ _log = logging.getLogger("mcp_proxy.tools.executor")
 DEFAULT_TOOL_TIMEOUT = 30.0
 
 
+async def _load_principal_capabilities(
+    agent: TokenPayload,
+    app_state: Any | None,
+) -> set[str]:
+    """Return the capability set the principal carries into the
+    capability gate.
+
+    Today the source is the JWT ``scope`` claim — same data the
+    pre-#730 ``has_capability`` call used for agents. The helper
+    exists as the single extension point for richer authz stores
+    that are out of scope for this hotfix:
+
+    * ADR-021 — per-user capability grants from the Mastio user
+      store. The schema exists (``local_user_principals``) but the
+      capability column does not yet; once added, fetch the row by
+      ``agent.agent_id`` and union the result here.
+    * ADR-020 — workload SPIRE binding richer claims. Today a
+      workload's capabilities ride through the JWT ``scope`` itself
+      (SPIRE entry → broker JWT issuance → here); the helper
+      already covers that path. A direct-bind table that the
+      Mastio honours independently of the JWT could plug in here.
+
+    The function is async by design so future stores (DB / Vault /
+    HTTP service) can plug in without refactoring every callsite.
+    Any exception propagates to the executor, which fails closed —
+    deny + audit "capability lookup failed". Never assume "if I
+    can't load the row, let it pass".
+
+    ``app_state`` is the FastAPI ``request.app.state`` proxy; today
+    it is unused, kept in the signature so the helper can resolve
+    DB sessions / cache references from there without changing
+    callers.
+    """
+    del app_state  # reserved for the future per-principal-store path
+    return set(agent.scope or [])
+
+
 async def run(
     request: ToolExecuteRequest,
     agent: TokenPayload,
@@ -71,38 +108,111 @@ async def run(
             execution_time_ms=duration_ms,
         )
 
-    # 2. Capability check (agent-typed principals)
-    # ADR-020 — typed principals (user / workload) authorise via the
-    # ``local_agent_resource_bindings`` table on the proxy, NOT via the
-    # broker-issued JWT scope (which they ship as empty). Agent-typed
-    # callers still go through the legacy scope-based gate.
+    # 2. Capability gate.
+    #
+    # Pre-#730 this block was guarded by ``principal_type == "agent"``,
+    # so user- and workload-typed principals silently bypassed the
+    # capability check on every builtin. The reasoning at the time
+    # (see ADR-020 + the CRIT-2 comment at step 2b below) was that
+    # typed principals authorise via ``local_agent_resource_bindings``
+    # instead of JWT scope. That's correct for **MCP resources** (the
+    # binding table is authoritative there) but it doesn't apply to
+    # builtins — builtins have no binding row, so "no binding check"
+    # meant "no check at all" for typed callers.
+    #
+    # PR #729 weaponised the gap by adding the first privileged
+    # builtin (``cullis_send_to_agent``). Subagent security review
+    # surfaced it post-merge. The hotfix:
+    #
+    # * Agent-typed callers: capability gate runs unchanged — same
+    #   coverage as before, for both builtins and MCP resources. The
+    #   existing CRIT-2 regression (``test_agent_principal_with_
+    #   binding_but_no_capability_denied``) pins this.
+    # * Typed callers (user / workload) on **builtins**: capability
+    #   gate now runs, sourced from
+    #   :func:`_load_principal_capabilities`. Today the helper just
+    #   wraps ``agent.scope``; future ADR-021 per-user grants + ADR-020
+    #   workload-binding richer claims plug in there, single point of
+    #   extension.
+    # * Typed callers on **MCP resources**: behaviour unchanged. The
+    #   binding gate at step 2b is the authoritative authz path
+    #   (ADR-007); capability stays optional metadata for discovery
+    #   filtering.
+    #
+    # Fail-closed: if ``_load_principal_capabilities`` raises (e.g.
+    # an ADR-021 user-store outage in a future iteration), the
+    # executor denies and audits "capability lookup failed". No
+    # silent grant.
     principal_type = getattr(agent, "principal_type", "agent")
-    if principal_type == "agent" and not tool_registry.has_capability(
-        tool_name, agent.scope,
-    ):
-        duration_ms = _elapsed_ms(t0)
-        _log.warning(
-            "Agent '%s' lacks capability '%s' for tool '%s'",
-            agent.agent_id,
-            tool_def.required_capability,
-            tool_name,
+    capability_gate_applies = (
+        principal_type == "agent"
+        or (
+            principal_type in ("user", "workload")
+            and not tool_def.is_mcp_resource
         )
-        await log_audit(
-            agent_id=agent.agent_id,
-            action="tool_execute",
-            tool_name=tool_name,
-            status="denied",
-            detail=f"Missing capability: {tool_def.required_capability}",
-            request_id=request_id,
-            duration_ms=duration_ms,
-        )
-        return ToolExecuteResponse(
-            request_id=request_id,
-            tool=tool_name,
-            status="error",
-            error=f"Forbidden: missing capability '{tool_def.required_capability}'",
-            execution_time_ms=duration_ms,
-        )
+    )
+
+    if capability_gate_applies and tool_def.required_capability:
+        try:
+            principal_caps = await _load_principal_capabilities(
+                agent, app_state,
+            )
+        except Exception as exc:
+            duration_ms = _elapsed_ms(t0)
+            _log.warning(
+                "Capability lookup failed for principal '%s' (type=%s, "
+                "tool='%s'): %s",
+                agent.agent_id, principal_type, tool_name, exc,
+            )
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="tool_execute",
+                tool_name=tool_name,
+                status="denied",
+                detail=f"capability lookup failed ({type(exc).__name__})",
+                request_id=request_id,
+                duration_ms=duration_ms,
+            )
+            return ToolExecuteResponse(
+                request_id=request_id,
+                tool=tool_name,
+                status="error",
+                error="Forbidden: capability lookup failed",
+                execution_time_ms=duration_ms,
+            )
+
+        if tool_def.required_capability not in principal_caps:
+            duration_ms = _elapsed_ms(t0)
+            _log.warning(
+                "Principal '%s' (type=%s) lacks capability '%s' for "
+                "tool '%s'",
+                agent.agent_id,
+                principal_type,
+                tool_def.required_capability,
+                tool_name,
+            )
+            await log_audit(
+                agent_id=agent.agent_id,
+                action="tool_execute",
+                tool_name=tool_name,
+                status="denied",
+                detail=(
+                    f"Missing capability: {tool_def.required_capability} "
+                    f"(principal_type={principal_type})"
+                ),
+                request_id=request_id,
+                duration_ms=duration_ms,
+            )
+            return ToolExecuteResponse(
+                request_id=request_id,
+                tool=tool_name,
+                status="error",
+                error=(
+                    f"Forbidden: missing capability "
+                    f"'{tool_def.required_capability}'"
+                ),
+                execution_time_ms=duration_ms,
+            )
 
     # 2b. Binding check for MCP-resource tools (CRIT-2 fix, audit T3-F1).
     # The JSON-RPC ``tools/call`` aggregator (``mcp_aggregator._handle_tools_call``)

--- a/tests/test_mcp_tool_executor_capability.py
+++ b/tests/test_mcp_tool_executor_capability.py
@@ -1,0 +1,312 @@
+"""Regression test for the typed-principal capability-bypass hotfix.
+
+Audit ref: PR #729 post-merge subagent review finding
+(https://github.com/cullis-security/cullis/pull/729#issuecomment-4463659987).
+
+Pre-#730 the executor's capability check was guarded by
+``principal_type == "agent"``. User- and workload-typed principals
+silently bypassed the gate on every builtin. PR #729 added the
+first privileged builtin (``cullis_send_to_agent``), making the
+gap exploitable.
+
+These tests pin the post-fix contract:
+
+* every principal type now goes through the capability gate on
+  builtins (agent / user / workload),
+* the agent-typed regression path is unchanged (existing CRIT-2
+  test_agent_principal_with_binding_but_no_capability_denied
+  must still pass — exercised under the full suite),
+* typed-principal MCP-resource access stays binding-only (the
+  ADR-007 design),
+* the gate fails closed when the capability-lookup helper raises.
+"""
+from __future__ import annotations
+
+import os
+
+# Mirror the conftest baseline so this file runs standalone.
+os.environ.setdefault("OTEL_ENABLED", "false")
+os.environ.setdefault("KMS_BACKEND", "local")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("ALLOWED_ORIGINS", "")
+os.environ.setdefault("ADMIN_SECRET", "test-secret-not-default")
+os.environ.setdefault("SKIP_ALEMBIC", "1")
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from mcp_proxy.models import TokenPayload, ToolExecuteRequest
+from mcp_proxy.tools import executor
+from mcp_proxy.tools.registry import ToolDefinition, tool_registry
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+
+
+_BUILTIN_NAME = "test_builtin_with_capability"
+_BUILTIN_CAP = "test.privileged"
+
+
+@pytest.fixture
+def clean_registry():
+    """Snapshot + restore the singleton registry to keep tests isolated."""
+    saved = dict(tool_registry._tools)
+    tool_registry._tools.clear()
+    yield tool_registry
+    tool_registry._tools.clear()
+    tool_registry._tools.update(saved)
+
+
+def _register_builtin(handler=None) -> AsyncMock:
+    """Register a no-op builtin with a non-empty required_capability.
+
+    Returns the AsyncMock so the test can assert whether the handler
+    fired (gate passed) vs not (gate rejected).
+    """
+    handler_mock = AsyncMock(return_value={"ok": True})
+    if handler is not None:
+        handler_mock = handler
+
+    tool_registry.register_definition(ToolDefinition(
+        name=_BUILTIN_NAME,
+        description="Privileged builtin used to pin the gate behaviour",
+        required_capability=_BUILTIN_CAP,
+        allowed_domains=[],
+        handler=handler_mock,
+        # is_mcp_resource stays False — builtins have no resource_id.
+    ))
+    return handler_mock
+
+
+def _make_agent(
+    *,
+    agent_id: str = "acme::daniele",
+    org: str = "acme",
+    scope: list[str] | None = None,
+    principal_type: str = "agent",
+) -> TokenPayload:
+    return TokenPayload(
+        sub=f"spiffe://cullis.test/{agent_id}",
+        agent_id=agent_id,
+        org=org,
+        exp=9_999_999_999,
+        iat=0,
+        jti=f"jti-{agent_id}-{principal_type}",
+        scope=scope or [],
+        cnf={"jkt": "fake-jkt"},
+        principal_type=principal_type,
+    )
+
+
+class _FakeSecretProvider:
+    """Minimal SecretProvider shim — returns no secrets, never raises."""
+
+    async def get_tool_secrets(self, tool_name: str) -> dict[str, str]:
+        return {}
+
+
+def _exec_request(parameters: dict[str, Any] | None = None) -> ToolExecuteRequest:
+    """Build a permissive ToolExecuteRequest. The aggregator uses
+    ``model_construct`` to bypass the strict ``tool`` regex; mirror
+    that here so the tool name's underscore convention doesn't trip
+    Pydantic before we even reach the gate."""
+    return ToolExecuteRequest.model_construct(
+        tool=_BUILTIN_NAME,
+        parameters=parameters or {},
+        request_id="rq-test",
+    )
+
+
+async def _run_executor(agent: TokenPayload):
+    """Drive ``executor.run`` with the minimum surface every test
+    needs. ``log_audit`` is patched to a no-op so the test stays
+    independent of the DB lifecycle."""
+    with patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        return await executor.run(
+            request=_exec_request(),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecretProvider(),
+        )
+
+
+# ── Negative path: typed principals without the capability ──────────
+
+
+@pytest.mark.parametrize("principal_type", ["user", "workload"])
+@pytest.mark.asyncio
+async def test_typed_principal_without_capability_is_rejected(
+    principal_type: str, clean_registry,
+) -> None:
+    """REGRESSION (post-PR #729): typed principals without the tool's
+    declared capability MUST be rejected, not silently authorized."""
+    handler = _register_builtin()
+    agent = _make_agent(scope=[], principal_type=principal_type)
+
+    resp = await _run_executor(agent)
+
+    assert resp.status == "error", (
+        f"{principal_type} principal with empty scope should be denied; "
+        f"got {resp.status}"
+    )
+    assert "missing capability" in (resp.error or "").lower()
+    assert _BUILTIN_CAP in (resp.error or "")
+    handler.assert_not_awaited()
+
+
+# ── Positive path: typed principals WITH the capability ──────────────
+
+
+@pytest.mark.parametrize("principal_type", ["user", "workload"])
+@pytest.mark.asyncio
+async def test_typed_principal_with_capability_is_allowed(
+    principal_type: str, clean_registry,
+) -> None:
+    """Positive control: when the typed principal carries the
+    capability in scope, the executor reaches the handler."""
+    handler = _register_builtin()
+    agent = _make_agent(scope=[_BUILTIN_CAP], principal_type=principal_type)
+
+    resp = await _run_executor(agent)
+
+    assert resp.status == "success", (
+        f"{principal_type} principal with capability should pass the "
+        f"gate; got status={resp.status} error={resp.error!r}"
+    )
+    handler.assert_awaited_once()
+
+
+# ── Agent-typed regression (must stay unchanged) ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_agent_without_capability_still_rejected(clean_registry) -> None:
+    """The agent-typed gate must be untouched by this change. Pre-fix
+    agents without the capability were denied; post-fix the same is
+    true (and the existing CRIT-2 suite also pins it)."""
+    handler = _register_builtin()
+    agent = _make_agent(scope=[], principal_type="agent")
+
+    resp = await _run_executor(agent)
+
+    assert resp.status == "error"
+    assert "missing capability" in (resp.error or "").lower()
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_agent_with_capability_still_allowed(clean_registry) -> None:
+    """Mirror of the negative agent test — capability in scope means
+    the gate lets the handler run, no behaviour change vs pre-fix."""
+    handler = _register_builtin()
+    agent = _make_agent(scope=[_BUILTIN_CAP], principal_type="agent")
+
+    resp = await _run_executor(agent)
+
+    assert resp.status == "success", (resp.status, resp.error)
+    handler.assert_awaited_once()
+
+
+# ── Fail-closed when the lookup helper raises ────────────────────────
+
+
+@pytest.mark.parametrize(
+    "principal_type", ["agent", "user", "workload"],
+)
+@pytest.mark.asyncio
+async def test_capability_check_fails_closed_on_provider_error(
+    principal_type: str, clean_registry,
+) -> None:
+    """When ``_load_principal_capabilities`` raises (e.g. an ADR-021
+    user-store outage once that helper grows real lookups), the
+    executor MUST deny and audit "capability lookup failed". Silent
+    grant on lookup failure is exactly the class of bug this hotfix
+    closes — pin the fail-closed contract for every principal type."""
+    handler = _register_builtin()
+    agent = _make_agent(
+        scope=[_BUILTIN_CAP],   # would normally pass — but the helper raises
+        principal_type=principal_type,
+    )
+
+    raising = AsyncMock(side_effect=RuntimeError("user store offline"))
+    with patch(
+        "mcp_proxy.tools.executor._load_principal_capabilities", raising,
+    ), patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=_exec_request(),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecretProvider(),
+        )
+
+    assert resp.status == "error"
+    assert "capability lookup failed" in (resp.error or "").lower()
+    handler.assert_not_awaited()
+
+
+# ── Default helper sources from JWT scope (no behaviour drift) ──────
+
+
+@pytest.mark.asyncio
+async def test_load_principal_capabilities_sources_from_jwt_scope() -> None:
+    """Today the helper just wraps ``agent.scope``. Pin that
+    contract so a future extension (ADR-021 user store / ADR-020
+    richer workload bindings) is a deliberate additive change with
+    a test update, not an accidental drift."""
+    agent = _make_agent(scope=["cap.a", "cap.b"], principal_type="user")
+    caps = await executor._load_principal_capabilities(agent, app_state=None)
+    assert caps == {"cap.a", "cap.b"}
+
+
+# ── MCP resources still gated by bindings, not capability ───────────
+
+
+@pytest.mark.asyncio
+async def test_typed_principal_mcp_resource_not_capability_gated(
+    clean_registry, monkeypatch,
+) -> None:
+    """ADR-007 invariant: for MCP resources, the binding table is
+    authoritative. Capability is optional discovery-time metadata.
+    Even after the hotfix, typed callers on MCP resources are
+    gated by the binding table only — not by a capability the
+    JWT happens not to carry. (Agents continue to be gated by
+    BOTH on MCP resources; see CRIT-2 suite.)"""
+    handler = AsyncMock(return_value={"ok": True, "via": "mcp_resource"})
+    tool_registry.register_definition(ToolDefinition(
+        name="mcp_resource_with_cap",
+        description="Resource tool with declared capability metadata",
+        required_capability="github.read",
+        allowed_domains=[],
+        handler=handler,
+        resource_id="github",   # makes ``is_mcp_resource`` True
+        endpoint_url="https://example.invalid/mcp",
+    ))
+
+    agent = _make_agent(
+        scope=[],   # no github.read — but for typed callers the gate skips
+        principal_type="user",
+    )
+
+    # Active binding exists, so the binding gate at step 2b lets it through.
+    async def _binding_ok(*_a, **_k):
+        return True
+
+    with patch(
+        "mcp_proxy.local.bindings.has_active_binding", _binding_ok,
+    ), patch("mcp_proxy.tools.executor.log_audit", AsyncMock()):
+        resp = await executor.run(
+            request=ToolExecuteRequest.model_construct(
+                tool="mcp_resource_with_cap",
+                parameters={},
+                request_id="rq-mcp",
+            ),
+            agent=agent,
+            db=None,
+            secret_provider=_FakeSecretProvider(),
+        )
+
+    assert resp.status == "success", (resp.status, resp.error)
+    handler.assert_awaited_once()


### PR DESCRIPTION
## Summary

**HIGH severity hotfix.** PR #729 (commit 253e66d6, merged 2026-05-15) introduced the first privileged MCP tool builtin (``cullis_send_to_agent`` — real A2A egress with audit chain). Subagent security review post-merge surfaced a **pre-existing** capability bypass in the executor that the new tool weaponised:

> https://github.com/cullis-security/cullis/pull/729#issuecomment-4463659987

## Root cause

``mcp_proxy/tools/executor.py:79-82`` guarded the capability check with ``principal_type == "agent"``. Typed principals (``user`` / ``workload``) silently bypassed the gate on every builtin. The ADR-007 binding gate at step 2b only covers ``tool_def.is_mcp_resource`` tools — builtins have no resource row, so "no binding check" meant **"no check at all"** for typed callers.

Pre-#729 the only privileged builtin was ``query_salesforce`` (stub returning mock data). After #729 a user / workload token could call ``cullis_send_to_agent`` and emit real one-shot messages on behalf of the Mastio without ever holding ``cullis.a2a.send`` in scope.

## Fix

The capability gate now runs for **all** principal types on builtins. The original agent-typed path stays intact (the existing CRIT-2 regression ``test_agent_principal_with_binding_but_no_capability_denied`` pins the agent + MCP-resource behaviour); the new gate adds typed principals **only when** ``not tool_def.is_mcp_resource``, so MCP resources continue to authorise via the binding table (ADR-007 design, unchanged).

New module-level helper ``mcp_proxy.tools.executor._load_principal_capabilities(agent, app_state) -> set[str]`` is the single extension point. Today it wraps ``agent.scope`` (same data ``has_capability`` consumed pre-fix). Future ADR-021 per-user grants + ADR-020 workload-binding richer claims plug in there without churning the gate callsite. The helper is async so future stores (DB / Vault / HTTP service) drop in transparently.

## Fail-closed semantics

Any exception from ``_load_principal_capabilities`` lands in the executor's audit row as ``capability lookup failed`` and returns ``Forbidden`` to the caller. **No silent grant on lookup failure** — this is the security policy a future ADR-021 store outage MUST respect.

## Backward compatibility note

Existing typed-principal callers of ``check_erp_inventory`` / ``query_salesforce`` that previously slipped through the bypass will start hitting ``Forbidden: missing capability '<...>'`` if they never carried the declared capability in scope. That access was a bug (silent over-grant); operators noticing the new denial should grant the capability through whatever scope-emission path the principal authenticated through (API token mint, SSO scoped claim, SPIRE entry scope).

## Verification

- ``tests/test_mcp_tool_executor_capability.py`` — **11 new cases**, parametrized over user / workload:
  - typed without capability → denied (the regression),
  - typed with capability → allowed,
  - agent without capability → still denied (unchanged),
  - agent with capability → still allowed (unchanged),
  - helper raises → denied with "capability lookup failed" audit, **for all three principal types** (agent / user / workload),
  - helper today sources from JWT scope (drift detector for the eventual ADR-021 plug-in),
  - typed + MCP resource stays binding-gated, not capability-gated.
- ``tests/test_crit2_ingress_execute_binding.py`` — full suite green; the existing agent + MCP-resource + missing-capability case still rejects.
- ``tests/test_mcp_tool_cullis_send_to_agent.py`` — all 21 PR #729 builtin tests pass unchanged.
- ``pytest tests/ -n auto --dist=loadfile`` → **3577 passed**, 38 skipped, 449s. The 2 failures are the pre-existing postgres binding flakes (``test_pg_session_and_signed_messages``, ``test_pg_nonce_replay_blocked``) documented in memory.
- ``./sandbox/smoke.sh full`` → **PASS=25 FAIL=0 SKIP=1**.
- Ruff mental check (NixOS, no local runner): no F401 / F541 / F841.

## Test plan
- [x] 11 regression tests cover all three principal types (agent / user / workload) on the positive, negative, and fail-closed paths
- [x] No regression in CRIT-2 suite (agent path unchanged)
- [x] No regression in PR #729 builtin suite (21 tests pass)
- [x] Full pytest + sandbox smoke green
- [x] DCO signed-off
- [x] No Co-Authored-By trailer