### PR TITLE
fix(audit): stamp dpop_jkt contextvar on cert+DPoP egress path (P1.2 gap)

### DIFF
--- a/mcp_proxy/auth/dpop_client_cert.py
+++ b/mcp_proxy/auth/dpop_client_cert.py
@@ -166,6 +166,19 @@ async def get_agent_from_dpop_client_cert(request: Request) -> InternalAgent:
                    "Connector so it can publish its JWK thumbprint.",
         )
 
+    # P1.2 — stamp the verified jkt into the per-request contextvar so
+    # ``log_audit()`` downstream picks it up for the ``audit_log.dpop_jkt``
+    # column without each call site forwarding it. Only stamps on the
+    # success path (after pinning passed); a 401 above must not
+    # correlate the audit row to a thumbprint the verifier just rejected.
+    # Counterpart to the same wiring in ``dependencies.py`` (Bearer-DPoP)
+    # and ``local_agent_dep.py`` (LOCAL_TOKEN): without this branch every
+    # ``/v1/chat/completions``, ``/v1/llm/chat``, and ``/v1/egress/*`` row
+    # left the column NULL even though the proof key is the agent's
+    # pinned identity — exactly the lookup forensic queries need.
+    from mcp_proxy.auth.dpop_context import set_dpop_jkt
+    set_dpop_jkt(proof_jkt)
+
     _log.debug(
         "Egress mTLS+DPoP accepted (agent=%s, jkt=%s, mode=%s, bound=%s)",
         agent.agent_id, proof_jkt, mode, bool(stored_jkt),

--- a/tests/test_audit_dpop_jkt.py
+++ b/tests/test_audit_dpop_jkt.py
@@ -212,3 +212,167 @@ async def test_dpop_jkt_does_not_enter_chain_hash(proxy_app):
     assert recomputed1 == hash1, "row 1 hash changed under dpop_jkt"
     assert recomputed2 == hash2, "row 2 hash changed under dpop_jkt"
     assert jkt1 is None and jkt2 == "AA" * 32
+
+
+# ── #2 follow-up — cert+DPoP path stamps the contextvar ────────────
+
+
+@pytest.mark.asyncio
+async def test_get_agent_from_dpop_client_cert_stamps_contextvar(monkeypatch):
+    """The cert + DPoP egress dep must set the per-request contextvar
+    so ``log_audit()`` downstream picks the proof_jkt into
+    ``audit_log.dpop_jkt``. Before this wire-up only the Bearer-DPoP
+    (``dependencies.py``) and LOCAL_TOKEN (``local_agent_dep.py``)
+    paths set it; cert+DPoP requests on ``/v1/chat/completions`` etc.
+    landed audit rows with the column NULL.
+
+    Patches the chain of dependencies down to ``verify_dpop_proof``
+    so the test runs in-process without a real Mastio.
+    """
+    from unittest.mock import MagicMock
+
+    from mcp_proxy.auth import dpop_client_cert
+    from mcp_proxy.auth.dpop_context import (
+        current_dpop_jkt, reset_dpop_jkt, set_dpop_jkt,
+    )
+    from mcp_proxy.models import InternalAgent
+
+    # Isolate the test from any contextvar value leftover from a prior
+    # test in this worker.
+    token = set_dpop_jkt(None)
+    try:
+        fake_agent = InternalAgent(
+            agent_id="org-x::alice",
+            display_name="alice",
+            capabilities=[],
+            created_at="2026-05-15T00:00:00Z",
+            is_active=True,
+            cert_pem=None,
+            dpop_jkt="THUMBPRINT_FROM_DB" + "0" * 25,
+            reach="both",
+        )
+
+        async def _noop_api_token(_req):
+            return None
+
+        async def _noop_local_agent(_req):
+            return None
+
+        async def _fake_cert(_req):
+            return fake_agent
+
+        async def _fake_verify(*_a, **_kw):
+            # Same jkt as stored so the pinning passes.
+            return fake_agent.dpop_jkt
+
+        # ``_maybe_api_token_principal`` is imported locally inside
+        # the dep body (line 92), so patch the source module.
+        import mcp_proxy.auth.api_token as _api_token_mod
+        monkeypatch.setattr(
+            _api_token_mod, "_maybe_api_token_principal", _noop_api_token,
+        )
+        # _maybe_local_internal_agent is imported locally inside the dep
+        # at runtime, so patch its source module.
+        import mcp_proxy.auth.local_agent_dep as _lad
+        monkeypatch.setattr(
+            _lad, "_maybe_local_internal_agent", _noop_local_agent,
+        )
+        monkeypatch.setattr(
+            dpop_client_cert, "get_agent_from_client_cert", _fake_cert,
+        )
+        # Force ``optional`` so the missing-DPoP branch wouldn't short-
+        # circuit; we'll supply a DPoP header below.
+        monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "optional")
+        # Hide the original verify_dpop_proof behind a late-import shim
+        # by patching it on its source module.
+        import mcp_proxy.auth.dpop as _dpop_mod
+        monkeypatch.setattr(_dpop_mod, "verify_dpop_proof", _fake_verify)
+
+        req = MagicMock()
+        req.method = "POST"
+        req.headers = {"DPoP": "proof.proof.proof"}
+        req.url = MagicMock()
+        req.url.path = "/v1/llm/chat"
+
+        agent = await dpop_client_cert.get_agent_from_dpop_client_cert(req)
+        assert agent.agent_id == "org-x::alice"
+
+        # Contextvar now carries the verified jkt.
+        assert current_dpop_jkt() == fake_agent.dpop_jkt
+    finally:
+        reset_dpop_jkt(token)
+
+
+@pytest.mark.asyncio
+async def test_get_agent_from_dpop_client_cert_does_not_stamp_on_mismatch(
+    monkeypatch,
+):
+    """When the proof jkt does NOT match the pinned dpop_jkt, the dep
+    raises 401 BEFORE setting the contextvar. Audit rows for the
+    rejected request must not carry a thumbprint the verifier just
+    rejected — that would be misleading forensics."""
+    from unittest.mock import MagicMock
+
+    import pytest as _pytest
+    from fastapi import HTTPException
+
+    from mcp_proxy.auth import dpop_client_cert
+    from mcp_proxy.auth.dpop_context import (
+        current_dpop_jkt, reset_dpop_jkt, set_dpop_jkt,
+    )
+    from mcp_proxy.models import InternalAgent
+
+    token = set_dpop_jkt(None)
+    try:
+        fake_agent = InternalAgent(
+            agent_id="org-x::alice",
+            display_name="alice",
+            capabilities=[],
+            created_at="2026-05-15T00:00:00Z",
+            is_active=True,
+            cert_pem=None,
+            dpop_jkt="STORED_AND_PINNED" + "0" * 26,
+            reach="both",
+        )
+
+        async def _noop(_req):
+            return None
+
+        async def _fake_cert(_req):
+            return fake_agent
+
+        async def _fake_verify_mismatch(*_a, **_kw):
+            # Different jkt → pinning mismatch.
+            return "EPHEMERAL_DIFFERENT_KEY" + "0" * 20
+
+        import mcp_proxy.auth.api_token as _api_token_mod
+        monkeypatch.setattr(
+            _api_token_mod, "_maybe_api_token_principal", _noop,
+        )
+        import mcp_proxy.auth.local_agent_dep as _lad
+        monkeypatch.setattr(
+            _lad, "_maybe_local_internal_agent", _noop,
+        )
+        monkeypatch.setattr(
+            dpop_client_cert, "get_agent_from_client_cert", _fake_cert,
+        )
+        monkeypatch.setenv("MCP_PROXY_EGRESS_DPOP_MODE", "required")
+        import mcp_proxy.auth.dpop as _dpop_mod
+        monkeypatch.setattr(
+            _dpop_mod, "verify_dpop_proof", _fake_verify_mismatch,
+        )
+
+        req = MagicMock()
+        req.method = "POST"
+        req.headers = {"DPoP": "proof.proof.proof"}
+        req.url = MagicMock()
+        req.url.path = "/v1/llm/chat"
+
+        with _pytest.raises(HTTPException) as ei:
+            await dpop_client_cert.get_agent_from_dpop_client_cert(req)
+        assert ei.value.status_code == 401
+        # Contextvar still NOT stamped — the rejected jkt must not
+        # bleed into any audit row written by a sibling task.
+        assert current_dpop_jkt() is None
+    finally:
+        reset_dpop_jkt(token)


### PR DESCRIPTION
## Summary

PR [#715](https://github.com/cullis-security/cullis/pull/715) (P1.2) wired the per-request DPoP contextvar in two of the three auth deps that produce audit traffic — \`dependencies.py\` (Bearer-DPoP) and \`local_agent_dep.py\` (LOCAL_TOKEN). The third, \`get_agent_from_dpop_client_cert\` (cert + DPoP, used by every \`/v1/llm/chat\` + \`/v1/chat/completions\` + \`/v1/egress/*\` call) was missed.

End result: post PR [#724](https://github.com/cullis-security/cullis/pull/724) + [#726](https://github.com/cullis-security/cullis/pull/726), the customer's chat traffic finally reaches Mastio with the persistent DPoP key, audit rows write successfully (\`egress_llm_chat\`, \`llm.tool_call\`), but the \`dpop_jkt\` column stays NULL — the forensic correlation feature P1.2 promised is unwired exactly on the path that matters most.

## What changed

\`mcp_proxy/auth/dpop_client_cert.py\`: \`set_dpop_jkt(proof_jkt)\` after the pinning check passes (line 173-184). Mirrors the pattern from the other two deps: stamp ONLY on the success path so a 401-rejected request never bleeds a verified-but-rejected jkt into a sibling audit row.

## How was the gap found

Dogfood end-to-end 2026-05-15:

```sql
SELECT action, tool_name, dpop_jkt FROM audit_log WHERE chain_seq > N;
egress_llm_chat | NULL | NULL
llm.tool_call   | demo_search | NULL
```

Chip events worked, audit rows wrote, but jkt column was NULL on every cert+DPoP request. CISO forensic query "show every action signed by this specific key" would return empty.

## Tests

- [x] \`pytest tests/test_audit_dpop_jkt.py -n0\` — 7 verdi (5 pre-existing + 2 new)
- [x] New \`test_get_agent_from_dpop_client_cert_stamps_contextvar\` — success path stamps
- [x] New \`test_get_agent_from_dpop_client_cert_does_not_stamp_on_mismatch\` — pinning-mismatch 401 path does NOT stamp
- [x] \`pytest -k 'audit or dpop or auth' -n auto\` — 562 verdi, zero regression
- [ ] /security-review pre-merge

## Goes into the release

This fix lands together with [#724](https://github.com/cullis-security/cullis/pull/724) + [#726](https://github.com/cullis-security/cullis/pull/726) and the upcoming \`verify_tls=False skip cert\` SDK fix in the next \`cullis-mastio\` image tag so the customer gets the full Cullis Chat SSE + forensic-correlation story in one bundle.