### PR TITLE
fix(mcp): resolve mastio version at call time (close test flake)

### DIFF
--- a/mcp_proxy/main.py
+++ b/mcp_proxy/main.py
@@ -36,8 +36,14 @@ _log = logging.getLogger("mcp_proxy")
 # ``--build-arg VERSION=...`` (release-mastio.yml passes the tag-derived
 # version, e.g. ``0.3.2``). Falls back to ``dev`` for source-checkout runs
 # so curl on a developer laptop yields ``"version":"dev"`` rather than a
-# stale literal that drifts from the running tag.
-_MASTIO_VERSION = os.environ.get("CULLIS_MASTIO_VERSION", "dev")
+# stale literal that drifts from the running tag. Resolved at call time
+# so tests mutating ``CULLIS_MASTIO_VERSION`` cannot park a stale value
+# via import-time evaluation (caused 6+ flake reruns pre-PR #734).
+def _mastio_version() -> str:
+    """Read CULLIS_MASTIO_VERSION at call time so tests that mutate
+    env do not park a stale value via import-time resolution. Falls
+    back to 'dev' for source-checkout / pytest runs."""
+    return os.environ.get("CULLIS_MASTIO_VERSION", "dev")
 
 # ─────────────────────────────────────────────────────────────────────────────
 # JWKS client reference (set during lifespan)
@@ -1511,7 +1517,7 @@ async def health(request: Request):
         underneath. Stdlib-verifier cross-org federation silently
         401s; remediation is ``POST /pki/rotate-ca``.
     """
-    body: dict = {"status": "ok", "version": _MASTIO_VERSION}
+    body: dict = {"status": "ok", "version": _mastio_version()}
     warnings: list[str] = []
     agent_mgr = getattr(request.app.state, "agent_manager", None)
     if agent_mgr is not None and getattr(

--- a/tests/test_proxy_health_version.py
+++ b/tests/test_proxy_health_version.py
@@ -4,8 +4,10 @@ Bug #8 from the 2026-05-09 AI-as-customer dogfood: a customer that
 runs ``cullis-mastio:0.3.1`` and curls ``/health`` sees
 ``{"status":"ok","version":"0.1.0"}``. ``0.1.0`` was a literal in
 ``mcp_proxy/main.py`` that nobody bumped after mastio-v0.3.0 cut.
-The fix swaps the literal for ``_MASTIO_VERSION``, which is read
-from ``CULLIS_MASTIO_VERSION`` and falls back to ``dev``.
+The fix routes ``/health`` through ``_mastio_version()`` which reads
+``CULLIS_MASTIO_VERSION`` at call time (was an import-time constant,
+caused 6+ flake reruns due to cross-file env mutation), falling
+back to ``dev`` for source-checkout runs.
 ``release-mastio.yml`` passes ``--build-arg VERSION=<tag>`` so the
 running image labels and ``/health`` agree.
 """
@@ -14,34 +16,29 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.mark.serial
-@pytest.mark.xdist_group(name="serial_state_mutators")
-def test_mastio_version_defaults_to_dev_in_source_checkout():
+def test_mastio_version_defaults_to_dev_in_source_checkout(monkeypatch):
     """Without CULLIS_MASTIO_VERSION env (the default for a source
-    checkout / pytest run), ``_MASTIO_VERSION`` is ``dev`` so ops cannot
-    confuse a dev process with a tagged release.
+    checkout / pytest run), ``_mastio_version()`` returns ``dev`` so
+    ops cannot confuse a dev process with a tagged release.
 
-    Marked serial: ``mcp_proxy.main._MASTIO_VERSION`` is a module-level
-    constant resolved at first import. Any test in another file that
-    sets ``CULLIS_MASTIO_VERSION`` env + re-imports the module
-    (intentionally or by side-effect) parks a non-``dev`` value that
-    this test then sees. 6 reruns across PRs #720 / #722 / #723 / #727
-    / #728 / #730 traced to this pattern. The xdist_group marker is a
-    forward-looking pin for when the suite migrates to
-    ``--dist=loadgroup``; today it still lets ``pytest -m serial`` run
-    this test in isolation.
-    """
+    The function reads env at call time, so this assertion is
+    deterministic regardless of what other tests in the suite set on
+    ``CULLIS_MASTIO_VERSION`` before importing ``mcp_proxy.main``.
+    The explicit ``delenv`` guards against an operator-set value
+    leaking into the test process (CI runners, dev shells with the
+    var exported)."""
     import mcp_proxy.main as _m
-    assert _m._MASTIO_VERSION == "dev"
+    monkeypatch.delenv("CULLIS_MASTIO_VERSION", raising=False)
+    assert _m._mastio_version() == "dev"
 
 
 @pytest.mark.asyncio
 async def test_mastio_health_surfaces_module_version(monkeypatch):
-    """The ``/health`` handler reads ``_MASTIO_VERSION`` at call time
-    (not a baked literal), so a release image with VERSION=1.2.3 baked
-    in surfaces that exact value."""
+    """The ``/health`` handler calls ``_mastio_version()`` so a release
+    image with VERSION=1.2.3 baked in (and thus
+    ``CULLIS_MASTIO_VERSION=1.2.3``) surfaces that exact value."""
     import mcp_proxy.main as _m
-    monkeypatch.setattr(_m, "_MASTIO_VERSION", "1.2.3")
+    monkeypatch.setenv("CULLIS_MASTIO_VERSION", "1.2.3")
 
     class _Req:
         class _App:


### PR DESCRIPTION
## Summary

- Convert `_MASTIO_VERSION` from import-time module constant to `_mastio_version()` function reading env at call time
- `/health` handler calls the function instead of the constant
- Tests monkeypatch `CULLIS_MASTIO_VERSION` env instead of the module attribute
- Drop now-unnecessary `@pytest.mark.serial` + `xdist_group` markers from the default test

Closes the recurrent flake `test_mastio_version_defaults_to_dev_in_source_checkout` (6+ reruns observed across PRs #720, #722, #723, #727, #728, #730). Markers added in #733 were no-op under `--dist=loadfile`.

## Test plan

- [ ] `pytest tests/test_proxy_health_version.py tests/test_proxy_update_check.py -n 0 -v` — both files green
- [ ] `pytest tests/ -n auto --dist=loadfile` — full suite green
- [ ] CI: `test (3.11)` + `Signed-off-by check` + `security` all green
- [ ] CI: 3 consecutive runs of `test (3.11)` green (re-run to confirm flake closed). Manual via `gh run rerun <id>`.